### PR TITLE
fix(coding-agent): avoid fork-only pi-ai imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Check
         run: npm run check
 
+      - name: Build workspace package entries
+        run: npm run build
+
       - name: Test
         timeout-minutes: 50
         run: npm test

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -25,15 +25,7 @@ import type {
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@earendil-works/pi-ai";
-import {
-	cleanupSessionResources,
-	getSupportedThinkingLevels,
-	isContextOverflow,
-	modelsAreEqual,
-	resetApiProviders,
-	supportsMax,
-	supportsXhigh,
-} from "@earendil-works/pi-ai";
+import { cleanupSessionResources, isContextOverflow, modelsAreEqual, resetApiProviders } from "@earendil-works/pi-ai";
 import { expandTildePath } from "../config.js";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
@@ -104,6 +96,7 @@ import {
 import type { SettingsManager } from "./settings-manager.js";
 import type { SlashCommandInfo } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
+import { getSupportedThinkingLevels, supportsMax, supportsXhigh } from "./thinking-levels.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -119,6 +119,22 @@
 
 - LOW: `ModelDefinitionSchema`, `ModelOverrideSchema`, and `applyModelOverride()` in `src/core/model-registry.ts` if upstream adds more per-model metadata fields.
 
+## Packaged thinking-tier helpers stay local (2026-05-12)
+
+### What changed
+- Added `src/core/thinking-levels.ts` so coding-agent owns the senpi-specific `xhigh` / `max` tier detection and supported-level expansion.
+- Updated `src/core/agent-session.ts` and `src/core/sdk.ts` to import these helpers locally instead of from `@earendil-works/pi-ai`.
+
+### Why
+- The published `@code-yeongyu/senpi` package currently installs the registry `@earendil-works/pi-ai@0.74.0`, whose public exports do not include the fork-only `supportsXhigh` / `supportsMax` helpers.
+- Importing those names directly from `pi-ai` makes packaged senpi fail during module loading before any CLI command runs.
+
+### Why extension system couldn't handle this
+- Thinking-tier availability is consumed by core session/model logic (`AgentSession`, SDK helpers) during startup and model switching, before extensions can replace those imports.
+
+### Expected merge conflict zones on next upstream sync
+- LOW: `agent-session.ts` / `sdk.ts` import blocks and any future upstream move of thinking-level helpers.
+
 ## Configured upstream model id and service tier (2026-05-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -25,6 +25,22 @@ remote compaction protocol, or provider request events.
 
 Expected upstream conflict zones: `builtin/compaction/index.ts` around `applyBlockingCompaction()` and `core/agent-session.ts` around extension compaction context actions.
 
+## 2026-05-12 - Local tool-pair repair for packaged senpi
+
+### What changed
+- Added `repair-tool-pairs.ts` to keep compaction's tool-call/tool-result repair logic inside the coding-agent package.
+- Switched `builtin/compaction/index.ts` and the compaction repair tests to use the local helper instead of importing `repairOrphanedToolResults` from `@earendil-works/pi-ai`.
+
+### Why
+- The published `@code-yeongyu/senpi` package depends on the registry `@earendil-works/pi-ai@^0.74.0`, but the fork-only `repairOrphanedToolResults` export is not present in that published dependency.
+- That mismatch makes `senpi` crash during module loading with `SyntaxError: The requested module '@earendil-works/pi-ai' does not provide an export named 'repairOrphanedToolResults'` before any command can run.
+
+### Why extension system couldn't handle this
+- The failure happens at ESM module evaluation time while loading a builtin extension, before runtime hooks or settings can intervene.
+
+### Expected merge conflict zones
+- LOW: `builtin/compaction/index.ts` import block and any future attempt to re-share this helper from `pi-ai`.
+
 ## Post-compact restoration tracker
 
 - Added `restoration-tracker.ts` as a builtin-extension module so file and skill context can be restored without modifying core session flow.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -1,5 +1,4 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { repairOrphanedToolResults } from "@earendil-works/pi-ai";
 import { type CompactionResult, DEFAULT_COMPACTION_SETTINGS } from "../../../compaction/index.js";
 import { convertToLlm } from "../../../messages.js";
 import type { CompactionEntry } from "../../../session-manager.js";
@@ -21,6 +20,7 @@ import {
 import * as overflow from "./overflow-detection.js";
 import * as cap from "./per-turn-cap.js";
 import * as policy from "./policy.js";
+import { repairOrphanedToolResults } from "./repair-tool-pairs.js";
 import * as restoration from "./restoration-tracker.js";
 import {
 	applyGeneratedCompaction,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/repair-tool-pairs.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/repair-tool-pairs.ts
@@ -1,0 +1,51 @@
+import type { Message, TextContent } from "@earendil-works/pi-ai";
+
+export const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)";
+
+export function repairOrphanedToolResults(messages: Message[]): Message[] {
+	const toolCallIds = new Set<string>();
+	const toolResultIds = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			for (const block of message.content) {
+				if (block.type === "toolCall") toolCallIds.add(block.id);
+			}
+		}
+		if (message.role === "toolResult") toolResultIds.add(message.toolCallId);
+	}
+
+	const output: Message[] = [];
+	const dangling = new Set([...toolCallIds].filter((id) => !toolResultIds.has(id)));
+
+	for (const message of messages) {
+		if (message.role === "toolResult") {
+			if (!toolCallIds.has(message.toolCallId)) {
+				output.push({
+					...message,
+					content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }] satisfies TextContent[],
+				});
+				continue;
+			}
+			output.push(message);
+			continue;
+		}
+
+		output.push(message);
+		if (message.role === "assistant") {
+			for (const block of message.content) {
+				if (block.type !== "toolCall" || !dangling.has(block.id)) continue;
+				output.push({
+					role: "toolResult",
+					toolCallId: block.id,
+					toolName: block.name,
+					content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+					isError: false,
+					timestamp: message.timestamp ? message.timestamp + 1 : Date.now(),
+				});
+				dangling.delete(block.id);
+			}
+		}
+	}
+
+	return output;
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { Agent, type AgentMessage, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { type Api, type Message, type Model, streamSimple, supportsMax, supportsXhigh } from "@earendil-works/pi-ai";
+import { type Api, type Message, type Model, streamSimple } from "@earendil-works/pi-ai";
 import { APP_NAME, getAgentDir } from "../config.js";
 import { AgentSession } from "./agent-session.js";
 import { formatNoModelsAvailableMessage } from "./auth-guidance.js";
@@ -16,6 +16,7 @@ import { DefaultResourceLoader } from "./resource-loader.js";
 import { getDefaultSessionDir, SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 import { isInstallTelemetryEnabled } from "./telemetry.js";
+import { getSupportedThinkingLevels } from "./thinking-levels.js";
 import { time } from "./timings.js";
 import {
 	createBashTool,
@@ -30,10 +31,6 @@ import {
 	type ToolName,
 	withFileMutationQueue,
 } from "./tools/index.js";
-
-type ModelWithThinkingLevelMap = Model<Api> & {
-	thinkingLevelMap?: Partial<Record<ThinkingLevel, string | null>>;
-};
 
 export interface CreateAgentSessionOptions {
 	/** Working directory for project-local discovery. Default: process.cwd() */
@@ -113,17 +110,17 @@ export type { Skill } from "./skills.js";
 export type { Tool } from "./tools/index.js";
 
 export {
-	withFileMutationQueue,
 	// Tool factories (for custom cwd)
+	createBashTool,
 	createCodingTools,
+	createEditTool,
+	createFindTool,
+	createGrepTool,
+	createLsTool,
 	createReadOnlyTools,
 	createReadTool,
-	createBashTool,
-	createEditTool,
 	createWriteTool,
-	createGrepTool,
-	createFindTool,
-	createLsTool,
+	withFileMutationQueue,
 };
 
 // Helper Functions
@@ -447,7 +444,7 @@ export function clampThinkingLevelToModel(
 	level: ThinkingLevel | undefined,
 	model: Model<Api> | undefined,
 ): ThinkingLevel {
-	if (!model || !model.reasoning) return "off";
+	if (!model?.reasoning) return "off";
 
 	const requestedLevel = level ?? "off";
 	const availableLevels = getSupportedThinkingLevels(model);
@@ -459,28 +456,11 @@ export function clampThinkingLevelToModel(
 
 	for (let index = requestedIndex; index < clampedLevels.length; index++) {
 		const candidate = clampedLevels[index];
-		if (candidate && availableLevels.includes(candidate)) return candidate;
+		if (candidate !== undefined && availableLevels.includes(candidate)) return candidate;
 	}
 	for (let index = requestedIndex - 1; index >= 0; index--) {
 		const candidate = clampedLevels[index];
-		if (candidate && availableLevels.includes(candidate)) return candidate;
+		if (candidate !== undefined && availableLevels.includes(candidate)) return candidate;
 	}
 	return availableLevels[0] ?? "off";
-}
-
-function getSupportedThinkingLevels(model: Model<Api>): ThinkingLevel[] {
-	const modelWithThinkingLevelMap = model as ModelWithThinkingLevelMap;
-	const levels: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
-	const supportedLevels = levels.filter((level) => {
-		const mappedLevel = modelWithThinkingLevelMap.thinkingLevelMap?.[level];
-		if (mappedLevel === null) return false;
-		if (level === "xhigh") return mappedLevel !== undefined || supportsXhigh(model);
-		return true;
-	});
-
-	if (supportsMax(model)) {
-		supportedLevels.push("max");
-	}
-
-	return supportedLevels;
 }

--- a/packages/coding-agent/src/core/thinking-levels.ts
+++ b/packages/coding-agent/src/core/thinking-levels.ts
@@ -1,0 +1,47 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+const THINKING_LEVELS_WITH_MAX: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+type ModelWithThinkingLevelMap = Model<Api> & {
+	thinkingLevelMap?: Partial<Record<ThinkingLevel, string | null>>;
+};
+
+export function supportsXhigh(model: Model<Api>): boolean {
+	return (
+		model.id.includes("gpt-5.2") ||
+		model.id.includes("gpt-5.3") ||
+		model.id.includes("gpt-5.4") ||
+		model.id.includes("gpt-5.5") ||
+		model.id.includes("deepseek-v4-pro") ||
+		model.id.includes("deepseek-v4-flash") ||
+		model.id.includes("opus-4-6") ||
+		model.id.includes("opus-4.6") ||
+		model.id.includes("opus-4-7") ||
+		model.id.includes("opus-4.7")
+	);
+}
+
+export function supportsMax(model: Model<Api>): boolean {
+	return (
+		model.id.includes("opus-4-6") ||
+		model.id.includes("opus-4.6") ||
+		model.id.includes("opus-4-7") ||
+		model.id.includes("opus-4.7")
+	);
+}
+
+export function getSupportedThinkingLevels(model: Model<Api>): ThinkingLevel[] {
+	if (!model.reasoning) return ["off"];
+
+	const modelWithThinkingLevelMap = model as ModelWithThinkingLevelMap;
+	const supportedLevels = THINKING_LEVELS_WITH_MAX.filter((level) => {
+		const mappedLevel = modelWithThinkingLevelMap.thinkingLevelMap?.[level];
+		if (mappedLevel === null) return false;
+		if (level === "xhigh") return mappedLevel !== undefined || supportsXhigh(model);
+		if (level === "max") return mappedLevel !== undefined || supportsMax(model);
+		return true;
+	});
+
+	return supportedLevels.length > 0 ? supportedLevels : ["off"];
+}

--- a/packages/coding-agent/test/compaction/tool-pair-repair.test.ts
+++ b/packages/coding-agent/test/compaction/tool-pair-repair.test.ts
@@ -2,8 +2,12 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AssistantMessage, Context, Message, TextContent, ToolResultMessage } from "@earendil-works/pi-ai";
-import { complete, fauxAssistantMessage, registerFauxProvider, repairOrphanedToolResults } from "@earendil-works/pi-ai";
+import { complete, fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+	repairOrphanedToolResults,
+	TOOL_RESULT_PLACEHOLDER,
+} from "../../src/core/extensions/builtin/compaction/repair-tool-pairs.js";
 import {
 	type FileEntry,
 	migrateSessionEntries,
@@ -11,7 +15,6 @@ import {
 	type SessionMessageEntry,
 } from "../../src/core/session-manager.js";
 
-const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)";
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 
 const registrations: Array<{ unregister: () => void }> = [];

--- a/packages/coding-agent/test/interactive-mode-import-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-import-command.test.ts
@@ -14,6 +14,7 @@ type ImportCommandContext = {
 	loadingAnimation?: { stop: () => void };
 	statusContainer: { clear: () => void };
 	runtimeHost: { importFromJsonl: (inputPath: string, cwdOverride?: string) => Promise<{ cancelled: boolean }> };
+	stopWorkingLoader: () => void;
 	showError: (message: string) => void;
 	showStatus: (message: string) => void;
 	showExtensionConfirm: (title: string, message: string) => Promise<boolean>;
@@ -83,6 +84,7 @@ describe("InteractiveMode /import parsing", () => {
 		const context: ImportCommandContext = {
 			statusContainer: { clear: vi.fn() },
 			runtimeHost: { importFromJsonl },
+			stopWorkingLoader: vi.fn(),
 			showError,
 			showStatus,
 			showExtensionConfirm,
@@ -115,6 +117,7 @@ describe("InteractiveMode /import parsing", () => {
 		const context: ImportCommandContext = {
 			statusContainer: { clear: vi.fn() },
 			runtimeHost: { importFromJsonl },
+			stopWorkingLoader: vi.fn(),
 			showError,
 			showStatus,
 			showExtensionConfirm,
@@ -148,6 +151,7 @@ describe("InteractiveMode /import parsing", () => {
 		const context: ImportCommandContext = {
 			statusContainer: { clear: vi.fn() },
 			runtimeHost: { importFromJsonl },
+			stopWorkingLoader: vi.fn(),
 			showError,
 			showStatus,
 			showExtensionConfirm,

--- a/packages/web-ui/example/tsconfig.json
+++ b/packages/web-ui/example/tsconfig.json
@@ -6,10 +6,10 @@
 		"moduleResolution": "bundler",
 		"paths": {
 			"*": ["./*"],
-			"@earendil-works/pi-agent-core": ["../../agent/dist/index.d.ts"],
-			"@earendil-works/pi-ai": ["../../ai/dist/index.d.ts"],
-			"@earendil-works/pi-tui": ["../../tui/dist/index.d.ts"],
-			"@earendil-works/pi-web-ui": ["../dist/index.d.ts"]
+			"@earendil-works/pi-agent-core": ["../../agent/src/index.ts"],
+			"@earendil-works/pi-ai": ["../../ai/src/index.ts"],
+			"@earendil-works/pi-tui": ["../../tui/src/index.ts"],
+			"@earendil-works/pi-web-ui": ["../src/index.ts"]
 		},
 		"strict": true,
 		"skipLibCheck": true,

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,7 +1,13 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"noEmit": true,
+		"paths": {
+			"@earendil-works/pi-agent-core": ["../agent/src/index.ts"],
+			"@earendil-works/pi-ai": ["../ai/src/index.ts"],
+			"@earendil-works/pi-tui": ["../tui/src/index.ts"]
+		}
+	},
+	"include": ["src/**/*"]
 }


### PR DESCRIPTION
Closes #2

## Summary
- move senpi-specific thinking-tier helpers into `packages/coding-agent`
- move compaction tool-pair repair into `packages/coding-agent`
- stop importing fork-only helper exports from published `@earendil-works/pi-ai`

## Verification
- `npx biome check --error-on-warnings packages/coding-agent/src/core/agent-session.ts packages/coding-agent/src/core/sdk.ts packages/coding-agent/src/core/thinking-levels.ts packages/coding-agent/src/core/extensions/builtin/compaction/index.ts packages/coding-agent/src/core/extensions/builtin/compaction/repair-tool-pairs.ts packages/coding-agent/test/compaction/tool-pair-repair.test.ts`
- `npx tsgo --noEmit`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/compaction/tool-pair-repair.test.ts`
- `npm run check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ESM import errors in the packaged `@code-yeongyu/senpi` by internalizing fork-only helpers previously imported from `@earendil-works/pi-ai`. Stabilizes CI by typechecking the web UI against workspace sources and building workspace entries before tests.

- **Bug Fixes**
  - Moved thinking-tier helpers to `src/core/thinking-levels.ts` and compaction repair to `builtin/compaction/repair-tool-pairs.ts`; updated `agent-session.ts`, `sdk.ts`, and compaction code/tests; removed fork-only `@earendil-works/pi-ai` imports.
  - Updated `packages/web-ui` and example `tsconfig.json` to map `@earendil-works/*` to workspace `src` files and include DOM libs for CI typechecking.
  - CI: added a build step (`npm run build`) before tests.
  - Tests: added `stopWorkingLoader` stub in `interactive-mode-import-command.test.ts` to match the command context.

<sup>Written for commit 616ccd39cc219a268cbf410178ec4eb350a9b02f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

