### PR TITLE
feat: add kimi-web-search builtin extension

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -6,6 +6,7 @@ import compactionExtension from "./compaction/index.js";
 import diffExtension from "./diff.js";
 import filesExtension from "./files.js";
 import gptApplyPatchExtension from "./gpt-apply-patch/index.js";
+import kimiWebSearchExtension from "./kimi-web-search/index.js";
 import openaiWebSearchExtension from "./openai-web-search/index.js";
 import permissionSystemExtension from "./permission-system/index.js";
 import promptPresetExtension from "./prompt-preset/index.js";
@@ -43,4 +44,5 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "bash-timeout", factory: bashTimeoutExtension },
 	{ id: "tool-pair-guard", factory: toolPairGuardExtension },
 	{ id: "compaction", factory: compactionExtension },
+	{ id: "kimi-web-search", factory: kimiWebSearchExtension },
 ];

--- a/packages/coding-agent/src/core/extensions/builtin/kimi-web-search/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/kimi-web-search/index.ts
@@ -1,0 +1,275 @@
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { TextContent } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+import type { ExtensionAPI, ExtensionContext } from "../../types.js";
+
+const ENABLE_ENV = "PI_KIMI_WEB_SEARCH";
+const SEARCH_BASE_URL_ENV = "PI_KIMI_SEARCH_BASE_URL";
+const FETCH_BASE_URL_ENV = "PI_KIMI_FETCH_BASE_URL";
+const DEFAULT_SEARCH_URL = "https://api.kimi.com/coding/v1/search";
+const DEFAULT_FETCH_URL = "https://api.kimi.com/coding/v1/fetch";
+
+function parseEnableEnv(envVar: string): boolean {
+	const envValue = process.env[envVar];
+	if (!envValue) {
+		return true;
+	}
+	const normalized = envValue.trim().toLowerCase();
+	if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off") {
+		return false;
+	}
+	if (normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on") {
+		return true;
+	}
+	return true;
+}
+
+function isEnabled(): boolean {
+	return parseEnableEnv(ENABLE_ENV);
+}
+
+function getSearchBaseUrl(): string {
+	return process.env[SEARCH_BASE_URL_ENV] || DEFAULT_SEARCH_URL;
+}
+
+function getFetchBaseUrl(): string {
+	return process.env[FETCH_BASE_URL_ENV] || DEFAULT_FETCH_URL;
+}
+
+async function resolveApiKey(ctx: ExtensionContext): Promise<string | undefined> {
+	const model = ctx.model;
+	if (!model) {
+		return undefined;
+	}
+	try {
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+		if (auth.ok && auth.apiKey) {
+			return auth.apiKey;
+		}
+	} catch {
+		// ignore
+	}
+	return undefined;
+}
+
+const searchWebSchema = Type.Object({
+	query: Type.String({ description: "The query text to search for." }),
+	limit: Type.Optional(
+		Type.Number({
+			description:
+				"The number of results to return. Typically you do not need to set this value. When the results do not contain what you need, you probably want to give a more concrete query.",
+			default: 5,
+			minimum: 1,
+			maximum: 20,
+		}),
+	),
+	include_content: Type.Optional(
+		Type.Boolean({
+			description:
+				"Whether to include the content of the web pages in the results. It can consume a large amount of tokens when this is set to True. You should avoid enabling this when limit is set to a large value.",
+			default: false,
+		}),
+	),
+});
+
+type SearchWebInput = Static<typeof searchWebSchema>;
+
+const fetchUrlSchema = Type.Object({
+	url: Type.String({ description: "The URL to fetch content from." }),
+});
+
+type FetchUrlInput = Static<typeof fetchUrlSchema>;
+
+interface SearchResult {
+	title?: string;
+	url?: string;
+	summary?: string;
+	content?: string;
+}
+
+interface SearchResponse {
+	search_results?: SearchResult[];
+	answer?: string;
+	error?: string;
+}
+
+interface FetchResponse {
+	content?: string;
+	markdown?: string;
+	error?: string;
+}
+
+async function callKimiSearch(
+	apiKey: string,
+	toolCallId: string,
+	params: SearchWebInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<{ results: SearchResult[]; answer?: string }>> {
+	const baseUrl = getSearchBaseUrl();
+	const body = {
+		text_query: params.query,
+		limit: params.limit ?? 5,
+		enable_page_crawling: params.include_content ?? false,
+		timeout_seconds: 30,
+	};
+
+	const response = await fetch(baseUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+			"X-Msh-Tool-Call-Id": toolCallId,
+		},
+		body: JSON.stringify(body),
+		signal,
+	} as RequestInit);
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => "Unknown error");
+		throw new Error(`Search service HTTP ${response.status}: ${text}`);
+	}
+
+	const data = (await response.json()) as SearchResponse;
+
+	if (data.error) {
+		throw new Error(`Search service error: ${data.error}`);
+	}
+
+	const results = data.search_results ?? [];
+	const answer = data.answer;
+
+	let outputText = "";
+	if (answer) {
+		outputText += `Answer: ${answer}\n\n`;
+	}
+	if (results.length > 0) {
+		outputText += "Search results:\n";
+		for (const result of results) {
+			outputText += `- ${result.title || "Untitled"}\n`;
+			outputText += `  URL: ${result.url || "N/A"}\n`;
+			if (result.summary) {
+				outputText += `  Summary: ${result.summary}\n`;
+			}
+			if (result.content) {
+				outputText += `  Content: ${result.content}\n`;
+			}
+			outputText += "\n";
+		}
+	} else {
+		outputText += "No search results found.\n";
+	}
+
+	return {
+		content: [{ type: "text", text: outputText } as TextContent],
+		details: { results, answer },
+	};
+}
+
+async function callKimiFetch(
+	apiKey: string,
+	toolCallId: string,
+	params: FetchUrlInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<{ url: string; content: string }>> {
+	const baseUrl = getFetchBaseUrl();
+	const body = {
+		url: params.url,
+	};
+
+	const response = await fetch(baseUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+			"X-Msh-Tool-Call-Id": toolCallId,
+		},
+		body: JSON.stringify(body),
+		signal,
+	} as RequestInit);
+
+	if (!response.ok) {
+		// Fallback: try local fetch
+		const localResponse = await fetch(params.url, {
+			method: "GET",
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+			},
+			signal,
+		} as RequestInit);
+		if (!localResponse.ok) {
+			throw new Error(`Fetch URL failed: service HTTP ${response.status}, local HTTP ${localResponse.status}`);
+		}
+		const text = await localResponse.text();
+		return {
+			content: [{ type: "text", text } as TextContent],
+			details: { url: params.url, content: text },
+		};
+	}
+
+	const data = (await response.json()) as FetchResponse;
+
+	if (data.error) {
+		throw new Error(`Fetch service error: ${data.error}`);
+	}
+
+	const content = data.markdown || data.content || "";
+
+	return {
+		content: [{ type: "text", text: content } as TextContent],
+		details: { url: params.url, content },
+	};
+}
+
+export default function kimiWebSearchExtension(pi: ExtensionAPI): void {
+	if (!isEnabled()) {
+		return;
+	}
+
+	pi.registerTool({
+		name: "SearchWeb",
+		label: "SearchWeb",
+		description:
+			"WebSearch tool allows you to search on the internet to get latest information, including news, documents, release notes, blog posts, papers, etc.",
+		promptSnippet: "SearchWeb — search the internet for current information",
+		parameters: searchWebSchema,
+		async execute(toolCallId, params, signal, _onUpdate, ctx) {
+			const apiKey = await resolveApiKey(ctx);
+			if (!apiKey) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Search service is not configured. No API key found for Kimi provider.",
+						} as TextContent,
+					],
+					details: { results: [], error: "No API key" },
+				};
+			}
+			return callKimiSearch(apiKey, toolCallId, params, signal);
+		},
+	});
+
+	pi.registerTool({
+		name: "FetchURL",
+		label: "FetchURL",
+		description: "FetchURL tool allows you to fetch content from a URL.",
+		promptSnippet: "FetchURL — fetch web page content from a URL",
+		parameters: fetchUrlSchema,
+		async execute(toolCallId, params, signal, _onUpdate, ctx) {
+			const apiKey = await resolveApiKey(ctx);
+			if (!apiKey) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Fetch service is not configured. No API key found for Kimi provider.",
+						} as TextContent,
+					],
+					details: { url: params.url, content: "", error: "No API key" },
+				};
+			}
+			return callKimiFetch(apiKey, toolCallId, params, signal);
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -103,8 +103,105 @@
 ### Expected merge conflict zones
 
 - LOW: `builtin/system-messages.ts`, `builtin/todotools/system-messages.ts`, and `builtin/todotools/state.ts` if upstream or vendored builtins rename these helper surfaces.
+||||||| parent of 60039d29 (docs: document kimi-web-search builtin extension)
+## 2026-05-14 - Add kimi-web-search builtin extension
+
+### What changed
+
+- Added `builtin/kimi-web-search/index.ts`: New builtin extension that registers `SearchWeb` and `FetchURL` tools for Kimi Code platform.
+- Registers tools via `pi.registerTool()` (not provider-native injection like anthropic-web-search/openai-web-search).
+- Calls Kimi Code service endpoints:
+  - Search: `POST https://api.kimi.com/coding/v1/search` with `{text_query, limit, enable_page_crawling, timeout_seconds}`
+  - Fetch: `POST https://api.kimi.com/coding/v1/fetch` with `{url}`
+- Passes `Authorization: Bearer <api_key>` and `X-Msh-Tool-Call-Id` headers matching Kimi CLI behavior.
+- Fallback to local HTTP fetch when Kimi fetch service returns error.
+- Configurable via env vars: `PI_KIMI_WEB_SEARCH`, `PI_KIMI_SEARCH_BASE_URL`, `PI_KIMI_FETCH_BASE_URL`.
+- Registered in `builtin/index.ts` as builtin extension id `kimi-web-search`.
+
+### Why
+
+- Kimi Code platform provides official SearchWeb/FetchURL services (`moonshot_search`/`moonshot_fetch`), but senpi had no integration.
+- The existing `anthropic-web-search` extension incorrectly injected Anthropic-native `web_search_20250305` into kimi-coding requests (because both use `api: "anthropic-messages"`), which Kimi API does not support.
+
+### Why extension system couldn't handle this alone
+
+- While this *could* be a user extension, it requires deep integration with:
+  - `ctx.modelRegistry.getApiKeyAndHeaders()` for auth resolution
+  - Knowledge of Kimi Code service URL conventions
+  - Proper `X-Msh-Tool-Call-Id` header passing
+- As a builtin, it stays consistent with anthropic-web-search/openai-web-search and can be maintained alongside provider updates.
+
+### Expected merge conflict zones
+
+- LOW: `builtin/index.ts` extension registration list.
+- LOW: `builtin/kimi-web-search/index.ts` if Kimi Code service API changes.
 
 ## 2026-05-14 - Native Web Tool UI Cleanup Hooks
+## 2026-05-14 - Add kimi-web-search builtin extension
+
+
+
+### What changed
+
+
+
+- Added `builtin/kimi-web-search/index.ts`: New builtin extension that registers `SearchWeb` and `FetchURL` tools for Kimi Code platform.
+
+- Registers tools via `pi.registerTool()` (not provider-native injection like anthropic-web-search/openai-web-search).
+
+- Calls Kimi Code service endpoints:
+
+  - Search: `POST https://api.kimi.com/coding/v1/search` with `{text_query, limit, enable_page_crawling, timeout_seconds}`
+
+  - Fetch: `POST https://api.kimi.com/coding/v1/fetch` with `{url}`
+
+- Passes `Authorization: Bearer <api_key>` and `X-Msh-Tool-Call-Id` headers matching Kimi CLI behavior.
+
+- Fallback to local HTTP fetch when Kimi fetch service returns error.
+
+- Configurable via env vars: `PI_KIMI_WEB_SEARCH`, `PI_KIMI_SEARCH_BASE_URL`, `PI_KIMI_FETCH_BASE_URL`.
+
+- Registered in `builtin/index.ts` as builtin extension id `kimi-web-search`.
+
+
+
+### Why
+
+
+
+- Kimi Code platform provides official SearchWeb/FetchURL services (`moonshot_search`/`moonshot_fetch`), but senpi had no integration.
+
+- The existing `anthropic-web-search` extension incorrectly injected Anthropic-native `web_search_20250305` into kimi-coding requests (because both use `api: "anthropic-messages"`), which Kimi API does not support.
+
+
+
+### Why extension system couldn't handle this alone
+
+
+
+- While this *could* be a user extension, it requires deep integration with:
+
+  - `ctx.modelRegistry.getApiKeyAndHeaders()` for auth resolution
+
+  - Knowledge of Kimi Code service URL conventions
+
+  - Proper `X-Msh-Tool-Call-Id` header passing
+
+- As a builtin, it stays consistent with anthropic-web-search/openai-web-search and can be maintained alongside provider updates.
+
+
+
+### Expected merge conflict zones
+
+
+
+- LOW: `builtin/index.ts` extension registration list.
+
+- LOW: `builtin/kimi-web-search/index.ts` if Kimi Code service API changes.
+
+
+
+
 
 ### What changed
 


### PR DESCRIPTION
## Summary

Closes #9

This PR adds a new builtin extension `kimi-web-search` that integrates Kimi Code platform's official SearchWeb and FetchURL services into senpi.

## Problem

- senpi currently has no web search integration for the **kimi-coding** provider
- The existing `anthropic-web-search` extension incorrectly injects Anthropic-native `web_search_20250305` into kimi-coding requests (both use `api: "anthropic-messages"`), which Kimi API does not support
- Kimi Code platform provides official `moonshot_search`/`moonshot_fetch` tools that should be utilized

## Solution

### New Files
- `packages/coding-agent/src/core/extensions/builtin/kimi-web-search/index.ts` (278 lines)
  - Registers `SearchWeb` and `FetchURL` tools via `pi.registerTool()`
  - Calls Kimi Code service endpoints with proper headers (`Authorization`, `X-Msh-Tool-Call-Id`)
  - Falls back to local HTTP fetch on error
  - Configurable via `PI_KIMI_WEB_SEARCH`, `PI_KIMI_SEARCH_BASE_URL`, `PI_KIMI_FETCH_BASE_URL`

### Modified Files
- `packages/coding-agent/src/core/extensions/builtin/index.ts`
  - Registers `kimi-web-search` as builtin extension
- `packages/coding-agent/src/core/extensions/changes.md`
  - Documents the fork change and expected merge conflict zones

## Testing

- Verified `SearchWeb` returns search results with `text_query`, `limit`, `enable_page_crawling`
- Verified `FetchURL` fetches web pages with fallback to local HTTP
- Tested with `PI_ANTHROPIC_WEB_SEARCH=0` to ensure no conflict with anthropic-web-search

## Checklist

- [x] Extension follows existing builtin extension patterns
- [x] Fork change documented in `changes.md`
- [x] Pre-commit checks pass (Biome + tsgo + browser-smoke + web-ui)
- [x] Atomic commits: feature code separate from documentation
- [x] No generated files or lockfile changes included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a built-in `kimi-web-search` extension integrating Kimi Code’s SearchWeb and FetchURL for the `kimi-coding` provider, enabling web search and URL fetch via Kimi’s official APIs. Closes #9.

- **New Features**
  - Registers `SearchWeb` and `FetchURL` tools calling `https://api.kimi.com/coding/v1/search` and `/fetch` with `Authorization` and `X-Msh-Tool-Call-Id` (includes `timeout_seconds: 30`).
  - Config via `PI_KIMI_WEB_SEARCH`, `PI_KIMI_SEARCH_BASE_URL`, `PI_KIMI_FETCH_BASE_URL`; falls back to local HTTP fetch on service errors.
  - Resolves API key with `ctx.modelRegistry.getApiKeyAndHeaders()`; exposes results/content to the agent.
  - Registered in the builtin registry as id `kimi-web-search`.

- **Bug Fixes**
  - Stops injecting Anthropic `web_search_20250305` into `kimi-coding` requests; uses Kimi services instead.

<sup>Written for commit 9ce5adc0d8538851be81cec13f32969a6a92c210. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/10?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

