### PR TITLE
fix(coding-agent): pin @earendil-works/pi-* deps to upstream versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3806,6 +3806,12 @@
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"dev": true,
@@ -3847,6 +3853,12 @@
 			"dependencies": {
 				"@types/lodash": "*"
 			}
+		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT"
 		},
 		"node_modules/@types/ms": {
 			"version": "2.1.0",
@@ -4187,6 +4199,18 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/ast-v8-to-istanbul": {
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
@@ -4230,6 +4254,15 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
 		},
 		"node_modules/bignumber.js": {
 			"version": "9.3.1",
@@ -4583,6 +4616,20 @@
 				"node": ">=4.0.0"
 			}
 		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"dev": true,
@@ -4705,12 +4752,64 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/execa": {
@@ -5033,6 +5132,29 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/github-from-package": {
 			"version": "0.0.0",
 			"dev": true,
@@ -5217,6 +5339,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/is-core-module": {
@@ -5866,6 +5997,31 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/mimic-response": {
 			"version": "3.1.0",
 			"dev": true,
@@ -5943,6 +6099,15 @@
 			"version": "2.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/netmask": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
 		},
 		"node_modules/nice-try": {
 			"version": "1.0.5",
@@ -6065,6 +6230,38 @@
 		"node_modules/p-retry/node_modules/@types/retry": {
 			"version": "0.12.0",
 			"license": "MIT"
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
@@ -6272,6 +6469,34 @@
 			},
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/proxy-from-env": {
@@ -6618,6 +6843,54 @@
 				"decompress-response": "^6.0.0",
 				"once": "^1.3.1",
 				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -7540,10 +7813,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "2026.5.15-2",
+			"version": "2026.5.15-3",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^2026.5.15-2",
+				"@earendil-works/pi-ai": "^2026.5.15-3",
 				"ignore": "^7.0.5",
 				"typebox": "^1.1.24",
 				"yaml": "^2.8.2"
@@ -7573,7 +7846,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "2026.5.15-2",
+			"version": "2026.5.15-3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
@@ -7618,13 +7891,13 @@
 		},
 		"packages/coding-agent": {
 			"name": "@code-yeongyu/senpi",
-			"version": "2026.5.15-2",
+			"version": "2026.5.15-3",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.91.1",
-				"@earendil-works/pi-agent-core": "^2026.5.15-2",
-				"@earendil-works/pi-ai": "^2026.5.15-2",
-				"@earendil-works/pi-tui": "^2026.5.15-2",
+				"@earendil-works/pi-agent-core": "^0.74.0",
+				"@earendil-works/pi-ai": "^0.74.0",
+				"@earendil-works/pi-tui": "^0.74.0",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
 				"diff": "^8.0.2",
@@ -7755,6 +8028,83 @@
 				"anthropic-ai-sdk": "bin/cli"
 			}
 		},
+		"packages/coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+			"integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.74.0",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+			"integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/coding-agent/node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"packages/coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+			"integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
 		"packages/coding-agent/node_modules/@types/node": {
 			"version": "24.12.2",
 			"dev": true,
@@ -7770,7 +8120,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "2026.5.15-2",
+			"version": "2026.5.15-3",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "^1.3.0",
@@ -7790,12 +8140,12 @@
 		},
 		"packages/web-ui": {
 			"name": "@earendil-works/pi-web-ui",
-			"version": "2026.5.15-2",
+			"version": "2026.5.15-3",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^2026.5.15-2",
-				"@earendil-works/pi-ai": "^2026.5.15-2",
-				"@earendil-works/pi-tui": "^2026.5.15-2",
+				"@earendil-works/pi-agent-core": "^2026.5.15-3",
+				"@earendil-works/pi-ai": "^2026.5.15-3",
+				"@earendil-works/pi-tui": "^2026.5.15-3",
 				"@lmstudio/sdk": "^1.5.0",
 				"docx-preview": "^0.3.7",
 				"highlight.js": "^11.11.1",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -40,9 +40,9 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.91.1",
-		"@earendil-works/pi-agent-core": "^2026.5.15-3",
-		"@earendil-works/pi-ai": "^2026.5.15-3",
-		"@earendil-works/pi-tui": "^2026.5.15-3",
+		"@earendil-works/pi-agent-core": "^0.74.0",
+		"@earendil-works/pi-ai": "^0.74.0",
+		"@earendil-works/pi-tui": "^0.74.0",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",
 		"diff": "^8.0.2",

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -46,11 +46,12 @@ if (versions.size > 1) {
 
 console.log('\n✅ All packages at same version (lockstep)');
 
-// Packages under this prefix are published by upstream and use their own versioning.
-// Only the published @code-yeongyu/senpi should skip them -- other workspace packages
-// (agent, web-ui) need internal deps to stay in sync during release.
-const SKIP_SYNC_PREFIX = "@earendil-works/";
-const PUBLISHED_PACKAGE = "@code-yeongyu/senpi";
+// @earendil-works/ packages exist as both local workspaces (CalVer) and upstream npm
+// packages (semver). The published @code-yeongyu/senpi pins its @earendil-works/ deps
+// to upstream versions so global installs resolve correctly. Other workspace packages
+// (agent, web-ui) still sync their internal deps to the local lockstep version during release.
+const SKIP_SYNC_PREFIX = '@earendil-works/';
+const PUBLISHED_PACKAGE = '@code-yeongyu/senpi';
 
 // Update all inter-package dependencies
 let totalUpdates = 0;

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -46,15 +46,24 @@ if (versions.size > 1) {
 
 console.log('\n✅ All packages at same version (lockstep)');
 
+// Packages under this prefix are published by upstream and use their own versioning.
+// Only the published @code-yeongyu/senpi should skip them -- other workspace packages
+// (agent, web-ui) need internal deps to stay in sync during release.
+const SKIP_SYNC_PREFIX = "@earendil-works/";
+const PUBLISHED_PACKAGE = "@code-yeongyu/senpi";
+
 // Update all inter-package dependencies
 let totalUpdates = 0;
 for (const [dir, pkg] of Object.entries(packages)) {
+	const isPublishedPackage = pkg.data.name === PUBLISHED_PACKAGE;
 	let updated = false;
 	
 	// Check dependencies
 	if (pkg.data.dependencies) {
 		for (const [depName, currentVersion] of Object.entries(pkg.data.dependencies)) {
 			if (versionMap[depName]) {
+				// Skip upstream deps only in the published package
+				if (isPublishedPackage && depName.startsWith(SKIP_SYNC_PREFIX)) continue;
 				const newVersion = `^${versionMap[depName]}`;
 				if (currentVersion !== newVersion) {
 					console.log(`\n${pkg.data.name}:`);
@@ -71,6 +80,8 @@ for (const [dir, pkg] of Object.entries(packages)) {
 	if (pkg.data.devDependencies) {
 		for (const [depName, currentVersion] of Object.entries(pkg.data.devDependencies)) {
 			if (versionMap[depName]) {
+				// Skip upstream deps only in the published package
+				if (isPublishedPackage && depName.startsWith(SKIP_SYNC_PREFIX)) continue;
 				const newVersion = `^${versionMap[depName]}`;
 				if (currentVersion !== newVersion) {
 					console.log(`\n${pkg.data.name}:`);


### PR DESCRIPTION
## Summary

Pins `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` in `packages/coding-agent` from the fork's CalVer (`^2026.5.15-3`) to upstream npm versions (`^0.74.0`). Without this, `bun i -g @code-yeongyu/senpi` fails because the CalVer range doesn't exist on npm.

## Changes

1. **`packages/coding-agent/package.json`**: Changed dep ranges from `^2026.5.15-3` to `^0.74.0`
2. **`scripts/sync-versions.js`**: Added skip guard so future releases don't overwrite these pinned deps for `@code-yeongyu/senpi` (the published package only -- other workspace packages still get their internal deps synced)
3. **`package-lock.json`**: Regenerated to match new ranges

## Verification

- `npm install --ignore-scripts` succeeds
- All value-imports from `@earendil-works/pi-*` used by coding-agent exist in upstream `0.74.0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed installs of `@code-yeongyu/senpi` by aligning dependency versions with upstream npm releases instead of the fork’s CalVer range.

- **Dependencies**
  - Pinned `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` in `packages/coding-agent` to `^0.74.0`.
  - Updated `scripts/sync-versions.js` to skip syncing `@earendil-works/*` only for the published `@code-yeongyu/senpi` and clarified comments/quoting style.
  - Regenerated `package-lock.json`.

<sup>Written for commit 3386a327f3569f9e2c69770862988be529f4ba91. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/11?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

