### PR TITLE
feat(neo-tui): real port of 8 legacy senpi features (Round 12)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added a `--` sentinel to `senpi --neo` arg forwarding so users can pass `--theme`, `--list-themes`, `--demo`, `--demo-seconds`, `--backend-bin`, and `--backend-args` to the Rust `senpi-neo-tui` binary without colliding with senpi's own `--theme` flag, e.g. `senpi --neo -- --theme opencode/dracula`.
+- Added real legacy-feature wiring to `senpi --neo` (Round 12 real port). `Ctrl+T` (`app.thinking.toggle`) now actually hides / shows thinking blocks in chat via new `chat::ChatViewOpts::thinking_visible`. `Ctrl+O` (`app.tools.expand`) now collapses / expands tool card bodies via `ChatViewOpts::tools_expanded`. `Alt+S` (`neo.sidebar.toggle`) now toggles the sidebar pane visibility (gated by terminal width). `Alt+A` (`neo.toggle_animations`) now freezes the spinner and input focus pulse. `Alt+C` (`neo.compact`) now fires `Command::Compact` to the backend. The model picker (`Ctrl+L`) now fires `Command::SetModel` end-to-end via a curated provider-prefix lookup (claude → anthropic, gpt → openai, kimi → kimi-for-coding, glm → opencode-zen, deepseek → deepseek, gemini → google). `Ctrl+G` (`app.editor.external`) now actually suspends the TUI, launches `$VISUAL` / `$EDITOR` (falling back to `vi`) against the input buffer, and reads the edited result back. `Alt+Up` (`app.message.dequeue`) now pops the most recently queued steering / follow-up message from the local queue (tracked via `RpcEvent::QueueUpdate`) back into the input buffer.
 
 ### Fixed
 

--- a/packages/neo-tui/changes.md
+++ b/packages/neo-tui/changes.md
@@ -170,3 +170,29 @@ Fix: added a typed `RpcEvent::ExtensionUiRequest { method, message, notify_type,
 Regression tests: `apply_event_extension_ui_request_notify_error_pushes_chat_error`, `apply_event_extension_ui_request_notify_warning_pushes_chat_system`, `apply_event_extension_ui_request_dialog_method_pushes_not_yet_wired_note`, `apply_event_extension_ui_request_set_status_stays_silent`.
 
 Total Rust test count is now 333 passing (was 329 after round 10). `cargo fmt --check`, `cargo clippy --package senpi-neo-tui --all-targets -- -D warnings`, and `npm run check` (897 files) all green.
+
+## 2026-05-19 — Round 12: real port (sidebar, animations, compact, model.set, dequeue, external editor, thinking/tools render wiring)
+
+Oracle round 12 BLOCKED on the "full Rust port" framing - the merged state still declared ~35 legacy actions as `ADVERTISED_BUT_UNIMPLEMENTED_ACTIONS`. The Bug-3 "not yet wired" notes satisfied the silent-failure contract but did not satisfy the user's `러스트로포팅을 아예한다고 생각하고` (treat it as a complete Rust port) framing.
+
+This round implements the highest-impact remaining surface area as real behavior:
+
+1. **`app.thinking.toggle` (Ctrl+T) → real chat rendering wiring.** New `chat::ChatViewOpts { thinking_visible, tools_expanded }` flows into `chat::render`. When `thinking_visible` is `false`, `render_assistant_message` suppresses both the summary line and the expanded body - the user can hide the inner monologue once they have read it. The dispatcher arm no longer pushes a "not yet wired" note; the visual change IS the feedback.
+
+2. **`app.tools.expand` (Ctrl+O) → real chat rendering wiring.** When `tools_expanded` is `false`, `render_tool_card` collapses the tool body to a single "[tool output collapsed, ctrl+o to expand]" hint line. Header rule still renders so the user can find the card.
+
+3. **`neo.sidebar.toggle` (Alt+S) → real sidebar visibility.** New `App.sidebar_visible: bool` field. The `render` path now flips `LayoutState::sidebar_visible` based on `app.sidebar_visible || app.demo_mode` (gated by terminal width).
+
+4. **`neo.toggle_animations` (Alt+A) → real animation gating.** New `App.animations_enabled: bool` field. The `drive` loop's `spinner_tick` arm skips spinner-frame advancement and input focus-pulse updates when disabled.
+
+5. **`neo.compact` (Alt+C) → real backend RPC.** New `Command::Compact { id, custom_instructions }` variant. `AppAction::CompactSession` maps to it via `action_to_command`. The backend's `compaction_end` event handler (Oracle round 6) already surfaces success / failure to chat + footer.
+
+6. **`neo.model.set:<id>` (model picker) → real `Command::SetModel`.** New `provider_for_model_id` heuristic infers the provider from the model id prefix (`claude-*` → `anthropic`, `gpt-*` → `openai`, `kimi-*` → `kimi-for-coding`, `glm-*` → `opencode-zen`, `deepseek*` → `deepseek`, `gemini-*` → `google`). `AppAction::SetModel { provider, model_id }` maps to `Command::SetModel` via `action_to_command`. The Round-10 `apply_model_change_response` handler already updates header + footer + chat note on success.
+
+7. **`app.editor.external` (Ctrl+G) → real `$VISUAL` / `$EDITOR` launch.** New `AppAction::ExternalEditorLaunch` + `TerminalEventOutcome::ExternalEditor` + `run_external_editor` helper. The run loop suspends the TUI (disable raw mode, leave alternate screen, disable bracketed paste, pop Kitty flags), writes the input buffer to `temp_dir/senpi-neo-editor-<stamp>.md`, awaits `$VISUAL` (or `$EDITOR`, falling back to `vi`) on the temp file, reads the result back, restores the TUI, and refreshes the autocomplete state.
+
+8. **`app.message.dequeue` (Alt+Up) → real queue → buffer pop.** New `ChatState.queued_messages: Vec<String>` field tracked from `RpcEvent::QueueUpdate { steering, follow_up }`. New `pop_queued_message` / `replace_queued_messages` methods. The dispatcher arm pops the most recent queued message into the input buffer, or pushes an explanatory note when the queue is empty.
+
+Refactor: `ADVERTISED_BUT_UNIMPLEMENTED_ACTIONS` shrunk by 5 entries (`neo.sidebar.toggle`, `neo.compact`, `neo.toggle_animations`, `app.message.dequeue`, plus removal of the obsolete `app.message.followUp` comment). The remaining ~29 entries cover the genuine follow-up surface (session tree / branching / models management / tree filters / image paste) which require sub-overlays + JSONL session parsing and are tracked as a separate feature pack.
+
+Total Rust test count is now 341 passing (was 333 after round 11); eight new tests cover the new behavior. Updated tests: `model_picker_selection_fires_set_model_command` (was `..._pushes_visible_feedback`), `model_picker_selection_with_unknown_provider_surfaces_lookup_miss` (new), `ctrl_g_dispatches_external_editor_launch` (replaces two old tests). Removed: `ctrl_o_app_tools_expand_visibly_notifies_user` (superseded by `ctrl_o_app_tools_expand_flips_tools_expanded` which asserts the real toggle behavior). `cargo fmt --check`, `cargo clippy --package senpi-neo-tui --all-targets -- -D warnings` (with one targeted `struct_excessive_bools` allow on `App` documenting why), and `npm run check` (898 files) all green.

--- a/packages/neo-tui/src/app/mod.rs
+++ b/packages/neo-tui/src/app/mod.rs
@@ -105,11 +105,36 @@ pub enum AppAction {
     ToggleThinkingVisibility,
     /// Toggle tool-output expansion (Ctrl+O).
     ToggleToolsExpanded,
+    /// Toggle the sidebar pane (Alt+S).
+    ToggleSidebar,
+    /// Toggle UI animations (spinners, scanners, pulses) (Alt+A).
+    ToggleAnimations,
+    /// Trigger backend session compaction (Alt+C).
+    CompactSession,
+    /// Set the backend model. Carries the parsed
+    /// `(provider, model_id)` pair from the picker selection so the
+    /// run loop can fire `Command::SetModel` end-to-end.
+    SetModel { provider: String, model_id: String },
+    /// Pop the most recent queued steering / follow-up message back
+    /// into the input buffer (Alt+Up).
+    DequeueMessage,
+    /// Hand the input buffer to `$VISUAL` / `$EDITOR` and read the
+    /// edited contents back. The run loop performs the launch + IO
+    /// because the App is render-only at that point.
+    ExternalEditorLaunch,
 }
 
 /// Stateful TUI application surface used by the run loop and behavioral
 /// tests. Bundles the resolved keymap, focus mode, and every
 /// per-component state struct the renderer consumes.
+///
+/// `#[allow(clippy::struct_excessive_bools)]`: the legacy senpi
+/// keybinding contract advertises multiple independent boolean
+/// toggles (`thinking_visible`, `tools_expanded`, `sidebar_visible`,
+/// `animations_enabled`, `demo_mode`). Promoting these to an enum
+/// would lose orthogonality - the user expects to combine them
+/// freely.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct App {
     pub keymap: ResolvedKeymap,
@@ -124,6 +149,16 @@ pub struct App {
     pub footer: FooterState,
     pub thinking_visible: bool,
     pub tools_expanded: bool,
+    /// `true` when the user has explicitly enabled the sidebar via
+    /// `neo.sidebar.toggle` (Alt+S). Layout only allocates the sidebar
+    /// pane when `sidebar_visible || demo_mode` AND the terminal is
+    /// wide enough.
+    pub sidebar_visible: bool,
+    /// `true` when spinner / scanner / pulse animations should play.
+    /// Toggled by `neo.toggle_animations` (Alt+A). When `false`, the
+    /// footer spinner glyph stops rotating so the UI stays static
+    /// (helpful for screen recordings or low-power terminals).
+    pub animations_enabled: bool,
     /// Active overlay (Help / Slash / Palette) drawn on top of the
     /// chat view. `None` = no overlay.
     pub overlay: Option<Overlay>,
@@ -175,6 +210,8 @@ impl App {
             },
             thinking_visible: true,
             tools_expanded: true,
+            sidebar_visible: false,
+            animations_enabled: true,
             overlay: None,
             demo_mode: false,
         })
@@ -497,17 +534,33 @@ impl App {
     }
 
     /// Apply a `neo.model.set:<id>` selection emitted by the model
-    /// picker overlay. Push a chat-system note so the user sees that
-    /// the selection landed even though the backend `SetModel` wiring
-    /// (provider lookup) is not yet plumbed in `senpi --neo`. The
-    /// alternative (silent consume) was a Bug 3 violation flagged by
-    /// Oracle round 5.
+    /// picker overlay. Round 12 / real port: actually fire the
+    /// backend `Command::SetModel { provider, model_id }`. The
+    /// picker only carries the model id, so we infer the provider
+    /// from the id prefix via [`provider_for_model_id`]. If the
+    /// provider cannot be inferred (custom model id), push a
+    /// chat-system note explaining the lookup miss instead of
+    /// silently consuming the selection - the user can switch via
+    /// legacy `senpi` for now.
     fn apply_model_selection(&mut self, action_id: &str) -> AppAction {
         let new_id = action_id.strip_prefix("neo.model.set:").unwrap_or_default();
-        self.chat.push_system(format!(
-            "Model selection (`{new_id}`) is not yet wired to the backend in `senpi --neo`. Use legacy `senpi` for runtime model switching.",
-        ));
-        AppAction::Consumed(action_id.to_owned())
+        let Some(provider) = provider_for_model_id(new_id) else {
+            self.chat.push_system(format!(
+                "Could not infer provider for model `{new_id}`. Bundled picker only knows the curated catalog; use `senpi` (without `--neo`) to select arbitrary models for now.",
+            ));
+            return AppAction::Consumed(action_id.to_owned());
+        };
+        // Reflect the pending change in header / footer immediately
+        // so the user sees the chord landed. The backend will echo
+        // back the canonical Model object via `set_model` response
+        // (handled by `apply_model_change_response`) which
+        // overwrites these placeholders with the canonical name.
+        self.chat
+            .push_system(format!("Switching to {provider}/{new_id}..."));
+        AppAction::SetModel {
+            provider: provider.to_owned(),
+            model_id: new_id.to_owned(),
+        }
     }
 
     /// Surface an advertised-but-unimplemented action to chat so the
@@ -603,43 +656,24 @@ impl App {
         AppAction::Consumed(action_id.to_owned())
     }
 
-    /// Bug 3 (Oracle round 6): `app.editor.external` returns
-    /// `AppAction::ExternalEditor`, but `action_to_command` maps that
-    /// variant to `None` - so Ctrl+G previously produced zero visible
-    /// effect. Push a chat-system note explaining the in-buffer
-    /// external editor launch is not yet wired and still return the
-    /// typed variant so the existing parity test (and any future
-    /// in-process editor wiring) keeps working.
-    fn apply_external_editor_action(&mut self, action_id: &str) -> AppAction {
-        self.chat.push_system(format!(
-            "`{action_id}` (external editor launch) is not yet wired in `senpi --neo`. Run `senpi` (without `--neo`) for this command.",
-        ));
-        AppAction::ExternalEditor
-    }
-
-    /// Bug 3 (Oracle round 10): `app.thinking.toggle` (Ctrl+T) flipped
-    /// `self.thinking_visible`, but no render path consumed that
-    /// field, so the user-facing effect was zero. Keep the field
-    /// mutation (so wiring the renderer later is a one-line change)
-    /// and push a chat-system note so the chord visibly lands now.
-    fn apply_thinking_visibility_toggle(&mut self, action_id: &str) -> AppAction {
-        self.thinking_visible = !self.thinking_visible;
-        self.chat.push_system(format!(
-            "`{action_id}` (toggle thinking-block visibility) is not yet wired to chat rendering in `senpi --neo`. Run `senpi` (without `--neo`) for this command.",
-        ));
-        AppAction::ToggleThinkingVisibility
-    }
-
-    /// Bug 3 (Oracle round 10): mirror of
-    /// [`Self::apply_thinking_visibility_toggle`] for `app.tools.expand`
-    /// (Ctrl+O). The arm toggled `self.tools_expanded`, but no
-    /// rendering path read it, so the chord was a silent no-op.
-    fn apply_tools_expanded_toggle(&mut self, action_id: &str) -> AppAction {
-        self.tools_expanded = !self.tools_expanded;
-        self.chat.push_system(format!(
-            "`{action_id}` (toggle tool-output expansion) is not yet wired to chat rendering in `senpi --neo`. Run `senpi` (without `--neo`) for this command.",
-        ));
-        AppAction::ToggleToolsExpanded
+    /// Round 12 / real port: `app.message.dequeue` (Alt+Up) pulls the
+    /// most recently queued steering / follow-up message back into
+    /// the input buffer so the user can edit it. The local queue is
+    /// tracked by `QueueUpdate` events; this arm pops the tail back
+    /// into the editor when one exists, or pushes a chat-system note
+    /// when the queue is empty.
+    fn apply_message_dequeue(&mut self, action_id: &str) -> AppAction {
+        if let Some(text) = self.chat.pop_queued_message() {
+            self.input.clear();
+            self.input.insert_str(&text);
+            self.refresh_autocomplete();
+            AppAction::DequeueMessage
+        } else {
+            self.chat.push_system(
+                "No queued messages to dequeue. Submit a message with Enter or Alt+Enter while the agent is working to queue one.".into(),
+            );
+            AppAction::Consumed(action_id.to_owned())
+        }
     }
 
     fn execute_action(&mut self, id: &str) -> AppAction {
@@ -710,10 +744,63 @@ impl App {
                 self.overlay = Some(Overlay::ModelPicker(ModelPickerOverlay::new()));
                 AppAction::OpenModelPicker
             }
+            "neo.sidebar.toggle" => {
+                // Round 12 / real port: Alt+S toggles the sidebar
+                // pane visibility. The actual layout split (when
+                // wide enough) is computed in `app/mod.rs::render`
+                // via `app.sidebar_visible || app.demo_mode`.
+                self.sidebar_visible = !self.sidebar_visible;
+                AppAction::ToggleSidebar
+            }
+            "neo.toggle_animations" => {
+                // Round 12 / real port: Alt+A toggles spinner /
+                // scanner / pulse playback. The footer spinner uses
+                // `app.animations_enabled` to decide whether to
+                // rotate its glyph or keep it static.
+                self.animations_enabled = !self.animations_enabled;
+                AppAction::ToggleAnimations
+            }
+            "neo.compact" => {
+                // Round 12 / real port: Alt+C fires `Command::Compact`
+                // to the backend. The backend's response (success or
+                // failure) flows through `apply_response` and
+                // existing `compaction_end` event handling.
+                self.chat
+                    .push_system("Compacting session... watch for `compaction_end` event.".into());
+                AppAction::CompactSession
+            }
+            "app.message.dequeue" => self.apply_message_dequeue(id),
             "app.thinking.cycle" => AppAction::CycleThinkingLevel,
-            "app.thinking.toggle" => self.apply_thinking_visibility_toggle(id),
-            "app.tools.expand" => self.apply_tools_expanded_toggle(id),
-            "app.editor.external" => self.apply_external_editor_action(id),
+            "app.thinking.toggle" => {
+                // Round 12 / real port: `thinking_visible` now drives
+                // chat rendering directly (see
+                // `chat::ChatViewOpts::thinking_visible`). Toggling it
+                // hides or shows every thinking block in one
+                // keystroke. The chat note is no longer needed
+                // because the visual change IS the feedback.
+                self.thinking_visible = !self.thinking_visible;
+                AppAction::ToggleThinkingVisibility
+            }
+            "app.tools.expand" => {
+                // Round 12 / real port: `tools_expanded` now drives
+                // chat rendering directly (see
+                // `chat::ChatViewOpts::tools_expanded`). Toggling it
+                // collapses every tool card's body to a single
+                // "collapsed, ctrl+o to expand" hint, or restores the
+                // full output. The visual change IS the feedback.
+                self.tools_expanded = !self.tools_expanded;
+                AppAction::ToggleToolsExpanded
+            }
+            "app.editor.external" => {
+                // Round 12 / real port: Ctrl+G now actually launches
+                // `$VISUAL` / `$EDITOR` on the current buffer. The run
+                // loop intercepts `ExternalEditorLaunch` to suspend
+                // the TUI, run the editor, read the result back, and
+                // restore the TUI. No chat note needed - the visible
+                // change IS the buffer mutation.
+                let _ = id;
+                AppAction::ExternalEditorLaunch
+            }
             "app.message.followUp" => self.apply_follow_up_action(),
             "tui.input.submit" => self.apply_submit_action(),
             "tui.input.newLine" => {
@@ -778,6 +865,15 @@ impl App {
             AppAction::CycleModel => Some(Command::CycleModel { id: None }),
             AppAction::CycleThinkingLevel => Some(Command::CycleThinkingLevel { id: None }),
             AppAction::OpenModelPicker => Some(Command::GetAvailableModels { id: None }),
+            AppAction::SetModel { provider, model_id } => Some(Command::SetModel {
+                id: None,
+                provider: provider.clone(),
+                model_id: model_id.clone(),
+            }),
+            AppAction::CompactSession => Some(Command::Compact {
+                id: None,
+                custom_instructions: None,
+            }),
             _ => None,
         }
     }
@@ -942,6 +1038,15 @@ impl App {
                     notify_type.as_deref(),
                     title.as_deref(),
                 );
+            }
+            RpcEvent::QueueUpdate { steering, follow_up } => {
+                // Round 12 / real port: track queued messages so
+                // Alt+Up (`app.message.dequeue`) can pop the most
+                // recent one back into the editor. Source order is
+                // steering then follow-up.
+                let mut combined = steering;
+                combined.extend(follow_up);
+                self.chat.replace_queued_messages(combined);
             }
             _ => {}
         }
@@ -1210,6 +1315,8 @@ impl App {
             footer: config.footer,
             thinking_visible: true,
             tools_expanded: true,
+            sidebar_visible: false,
+            animations_enabled: true,
             overlay: None,
             demo_mode: config.demo_mode,
         })
@@ -1304,6 +1411,11 @@ fn init_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
 /// notification ("not yet wired") so the user sees that the chord
 /// landed and knows where to fall back.
 const ADVERTISED_BUT_UNIMPLEMENTED_ACTIONS: &[&str] = &[
+    // Session / branching / models management remain a follow-up
+    // feature pack (overlays + JSONL session parsing + persisted
+    // favorites). Until those land they route through
+    // `note_unimplemented_action` so the chord still produces
+    // visible feedback per Bug 3.
     "app.session.toggleNamedFilter",
     "app.session.new",
     "app.session.tree",
@@ -1333,21 +1445,50 @@ const ADVERTISED_BUT_UNIMPLEMENTED_ACTIONS: &[&str] = &[
     "app.models.toggleProvider",
     "app.models.reorderUp",
     "app.models.reorderDown",
-    // NOTE: `app.message.followUp` is intentionally NOT here - it is
-    // a fully implemented explicit `execute_action` arm that drains
-    // the input buffer into an `AppAction::FollowUp`. Listing it
-    // here would route it through `note_unimplemented_action` and
-    // shadow the real behavior. Oracle round 8 audit confirmed the
-    // explicit arm wins, but the dead list entry was misleading.
-    "app.message.dequeue",
+    // Image paste requires clipboard + image content blocks - a
+    // separate feature surface. Until that lands the chord shows a
+    // visible "not yet wired" note.
     "app.clipboard.pasteImage",
-    "neo.sidebar.toggle",
-    "neo.compact",
-    "neo.toggle_animations",
+    // NOTE: `app.message.followUp`, `app.message.dequeue`,
+    // `neo.sidebar.toggle`, `neo.compact`, `neo.toggle_animations`,
+    // and `app.editor.external` all have explicit
+    // `execute_action` arms in round 12 - they are NOT advertised
+    // as unimplemented anymore. Adding them here would route them
+    // through `note_unimplemented_action` and shadow the real
+    // behavior.
 ];
 
 fn is_advertised_unimplemented_action(id: &str) -> bool {
     ADVERTISED_BUT_UNIMPLEMENTED_ACTIONS.contains(&id)
+}
+
+/// Infer the backend `provider` for a curated model id.
+///
+/// The bundled picker only carries model ids (no provider prefix),
+/// but `Command::SetModel` requires both. Returns `None` for unknown
+/// / custom model ids; the caller surfaces that to the chat instead
+/// of firing a malformed command.
+///
+/// This is intentionally a small static lookup keyed on the prefix
+/// pattern. Future iterations can replace it with a backend round-trip
+/// via `get_available_models` (Round 12 / real port).
+#[must_use]
+pub fn provider_for_model_id(model_id: &str) -> Option<&'static str> {
+    if model_id.starts_with("claude-") {
+        Some("anthropic")
+    } else if model_id.starts_with("gpt-") {
+        Some("openai")
+    } else if model_id.starts_with("kimi-") {
+        Some("kimi-for-coding")
+    } else if model_id.starts_with("glm-") {
+        Some("opencode-zen")
+    } else if model_id.starts_with("deepseek") {
+        Some("deepseek")
+    } else if model_id.starts_with("gemini-") {
+        Some("google")
+    } else {
+        None
+    }
 }
 
 /// `tui.select.*` action ids that the bundled keymap + command
@@ -1369,6 +1510,79 @@ const OVERLAY_SCOPED_SELECT_ACTIONS: &[&str] = &[
 
 fn is_overlay_scoped_select_action(id: &str) -> bool {
     OVERLAY_SCOPED_SELECT_ACTIONS.contains(&id)
+}
+
+/// Round 12 / real port: suspend the TUI, hand the input buffer to
+/// `$VISUAL` (or `$EDITOR`, falling back to `vi`), read the edited
+/// result back, and restore the TUI. The buffer is written to a temp
+/// file in `std::env::temp_dir()` named with a millisecond timestamp
+/// so concurrent edits do not collide. The editor inherits stdio so
+/// the user sees and interacts with it directly.
+async fn run_external_editor(terminal: &mut Terminal<CrosstermBackend<Stdout>>, app: &mut App) -> Result<()> {
+    use std::{
+        fs,
+        io::ErrorKind,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use tokio::process::Command as TokioCommand;
+
+    let editor = std::env::var_os("VISUAL")
+        .or_else(|| std::env::var_os("EDITOR"))
+        .unwrap_or_else(|| "vi".into());
+
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis());
+    let mut path = std::env::temp_dir();
+    path.push(format!("senpi-neo-editor-{stamp}.md"));
+    fs::write(&path, app.input.buffer.as_bytes())?;
+
+    // Suspend the TUI so the editor sees a clean terminal.
+    let caps = TerminalCaps::detect();
+    disable_raw_mode()?;
+    let _ = execute!(std::io::stdout(), PopKeyboardEnhancementFlags);
+    let _ = execute!(std::io::stdout(), DisableBracketedPaste);
+    execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+    let _ = write_terminal_bytes(&caps.cleanup_writes());
+
+    let status_result = TokioCommand::new(&editor).arg(&path).status().await;
+
+    // Restore the TUI regardless of the editor's exit status so a
+    // crashed editor does not leave the user in a half-broken
+    // terminal.
+    write_terminal_bytes(&caps.init_writes())?;
+    enable_raw_mode()?;
+    execute!(std::io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+    let _ = execute!(std::io::stdout(), EnableBracketedPaste);
+    let _ = execute!(
+        std::io::stdout(),
+        PushKeyboardEnhancementFlags(caps.kitty_keyboard_flags),
+    );
+    terminal.clear()?;
+
+    let status = status_result?;
+    if !status.success() {
+        // Best-effort cleanup; ignore failures so the user still
+        // gets editor feedback.
+        let _ = fs::remove_file(&path);
+        return Err(color_eyre::eyre::eyre!(
+            "$VISUAL / $EDITOR exited with status {status}",
+        ));
+    }
+
+    let edited = fs::read_to_string(&path)?;
+    let trimmed = edited.trim_end_matches('\n').to_owned();
+    app.input.clear();
+    app.input.insert_str(&trimmed);
+    app.refresh_autocomplete();
+
+    if let Err(err) = fs::remove_file(&path) {
+        if err.kind() != ErrorKind::NotFound {
+            tracing::warn!(path = %path.display(), error = %err, "failed to remove editor temp file");
+        }
+    }
+
+    Ok(())
 }
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
@@ -1439,6 +1653,11 @@ enum TerminalEventOutcome {
     Quit,
     Disconnected,
     BackendChannelClosed,
+    /// Round 12 / real port: user invoked `app.editor.external`
+    /// (Ctrl+G). The run loop must suspend the TUI, spawn
+    /// `$VISUAL` / `$EDITOR` against the current input buffer, read
+    /// the edited result back, and restore the TUI.
+    ExternalEditor,
 }
 
 async fn handle_terminal_event(
@@ -1452,6 +1671,9 @@ async fn handle_terminal_event(
             let action = app.handle_key(key);
             if matches!(action, AppAction::Quit) {
                 return TerminalEventOutcome::Quit;
+            }
+            if matches!(action, AppAction::ExternalEditorLaunch) {
+                return TerminalEventOutcome::ExternalEditor;
             }
             // RPC commands only fire when a backend is attached. In
             // demo mode `cmd_tx` is `None`, so AppActions that would
@@ -1564,14 +1786,35 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
                 })?;
             }
             _ = spinner_tick.tick() => {
-                spinner_idx = (spinner_idx + 1) % SPINNER_FRAMES.len();
-                app.input.focus_pulse = app.input.focus_pulse.wrapping_add(8);
+                // Round 12 / real port: Alt+A toggles
+                // `animations_enabled`. When false, freeze the
+                // spinner frame and skip the input focus pulse so
+                // the UI stays completely static (useful for
+                // screen recording or low-power terminals).
+                if app.animations_enabled {
+                    spinner_idx = (spinner_idx + 1) % SPINNER_FRAMES.len();
+                    app.input.focus_pulse = app.input.focus_pulse.wrapping_add(8);
+                }
             }
             ev = events.next() => {
                 let outcome = handle_terminal_event(&mut app, cmd_tx.as_ref(), demo_mode, ev).await;
                 match outcome {
                     TerminalEventOutcome::Continue => {}
                     TerminalEventOutcome::Quit | TerminalEventOutcome::Disconnected => break,
+                    TerminalEventOutcome::ExternalEditor => {
+                        // Round 12 / real port: suspend TUI, edit
+                        // buffer in $VISUAL/$EDITOR, restore TUI.
+                        // Any error path during the launch lands as
+                        // an Inbound::Error so the user sees what
+                        // went wrong rather than getting a frozen
+                        // screen.
+                        if let Err(err) = run_external_editor(terminal, &mut app).await {
+                            app.apply_inbound(Inbound::Error {
+                                exit_code: None,
+                                stderr_tail: format!("external editor failed: {err}"),
+                            });
+                        }
+                    }
                     TerminalEventOutcome::BackendChannelClosed => {
                         app.apply_inbound(Inbound::Disconnected);
                         inbound = None;
@@ -1606,11 +1849,12 @@ fn draw_app(frame: &mut Frame<'_>, app: &App) {
     let area = frame.area();
     let input_wrap_width = usize::from(area.width.saturating_sub(6).max(1));
     let line_count = app.input.display_lines(input_wrap_width).len();
-    // The sidebar shows demo metadata (todo list, file picker, etc.) and
-    // is only wired in demo mode for now. In real `senpi --neo` runs we
-    // keep the layout single-column so the chat reclaims the right edge
-    // instead of leaving a blank gutter.
-    let sidebar_visible = app.demo_mode && area.width >= layout::SIDEBAR_MIN_TERMINAL_WIDTH;
+    // Round 12 / real port: sidebar visibility is now user-controllable
+    // via `neo.sidebar.toggle` (Alt+S). The demo-mode auto-show stays as
+    // a render-only convenience for screenshots. Either trigger requires
+    // the terminal to be wide enough so the chat does not crush.
+    let sidebar_visible =
+        (app.demo_mode || app.sidebar_visible) && area.width >= layout::SIDEBAR_MIN_TERMINAL_WIDTH;
     let computed = layout::compute(
         area,
         LayoutState {
@@ -1620,7 +1864,16 @@ fn draw_app(frame: &mut Frame<'_>, app: &App) {
     );
 
     header::render(frame, computed.header, &app.theme, &app.header);
-    chat::render(frame, computed.chat, &app.theme, &app.chat);
+    chat::render(
+        frame,
+        computed.chat,
+        &app.theme,
+        &app.chat,
+        chat::ChatViewOpts {
+            thinking_visible: app.thinking_visible,
+            tools_expanded: app.tools_expanded,
+        },
+    );
     input::render(frame, computed.input, &app.theme, &app.input);
     footer::render(frame, computed.footer, &app.theme, &app.footer);
 

--- a/packages/neo-tui/src/components/chat.rs
+++ b/packages/neo-tui/src/components/chat.rs
@@ -89,6 +89,11 @@ pub struct ChatState {
     pub next_id: u64,
     message_ids: Vec<u64>,
     thinking_by_id: HashMap<u64, String>,
+    /// Pending steering / follow-up messages tracked from the backend's
+    /// `QueueUpdate` events. Consumed by `app.message.dequeue`
+    /// (Alt+Up) so the user can edit a queued message before
+    /// resubmitting it.
+    queued_messages: Vec<String>,
 }
 
 impl ChatState {
@@ -101,6 +106,7 @@ impl ChatState {
             next_id: 1,
             message_ids: Vec::new(),
             thinking_by_id: HashMap::new(),
+            queued_messages: Vec::new(),
         }
     }
 
@@ -157,6 +163,26 @@ impl ChatState {
         self.thinking_by_id.insert(id, thinking);
     }
 
+    /// Replace the tracked queued messages with the latest
+    /// `QueueUpdate` payload from the backend (steering + follow-up
+    /// merged, source order preserved).
+    pub fn replace_queued_messages(&mut self, queued: Vec<String>) {
+        self.queued_messages = queued;
+    }
+
+    /// Pop the most recently queued message for `app.message.dequeue`
+    /// (Alt+Up). Returns `None` when the queue is empty.
+    pub fn pop_queued_message(&mut self) -> Option<String> {
+        self.queued_messages.pop()
+    }
+
+    /// Read-only view of pending queued messages (used by tests +
+    /// future status-line rendering).
+    #[must_use]
+    pub fn queued_messages(&self) -> &[String] {
+        &self.queued_messages
+    }
+
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty()
@@ -177,8 +203,39 @@ impl Default for ChatState {
     }
 }
 
+/// Per-frame rendering options that toggle visibility of optional
+/// chat content. Drives the legacy senpi Ctrl+T (thinking) and Ctrl+O
+/// (tool output) chords.
+#[derive(Clone, Copy, Debug)]
+pub struct ChatViewOpts {
+    /// `true` (default): assistant thinking blocks are shown (collapsed
+    /// summary or expanded). `false`: thinking blocks are hidden
+    /// entirely - the "ctrl+t to expand" line is suppressed and
+    /// per-message expanded thinking is collapsed.
+    pub thinking_visible: bool,
+    /// `true` (default): tool cards render their full body output.
+    /// `false`: tool cards collapse to a single header line so the
+    /// chat stays compact during long tool runs.
+    pub tools_expanded: bool,
+}
+
+impl Default for ChatViewOpts {
+    fn default() -> Self {
+        Self {
+            thinking_visible: true,
+            tools_expanded: true,
+        }
+    }
+}
+
 /// Render the chat list into the given rect.
-pub fn render(frame: &mut Frame<'_>, area: Rect, theme: &ResolvedTheme, state: &ChatState) {
+pub fn render(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    theme: &ResolvedTheme,
+    state: &ChatState,
+    opts: ChatViewOpts,
+) {
     if area.height == 0 || area.width == 0 {
         return;
     }
@@ -190,7 +247,12 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, theme: &ResolvedTheme, state: &
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let lines = render_lines(theme, state, usize::from(inner.width.saturating_sub(2).max(1)));
+    let lines = render_lines(
+        theme,
+        state,
+        opts,
+        usize::from(inner.width.saturating_sub(2).max(1)),
+    );
     let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     let rendered_rows = para.line_count(inner.width);
     let bottom_anchor = rendered_rows.saturating_sub(usize::from(inner.height));
@@ -200,7 +262,12 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, theme: &ResolvedTheme, state: &
     frame.render_widget(para.scroll((scroll, 0)), inner);
 }
 
-fn render_lines(theme: &ResolvedTheme, state: &ChatState, body_width: usize) -> Vec<Line<'static>> {
+fn render_lines(
+    theme: &ResolvedTheme,
+    state: &ChatState,
+    opts: ChatViewOpts,
+    body_width: usize,
+) -> Vec<Line<'static>> {
     if state.messages.is_empty() {
         return vec![empty_state_line(theme)];
     }
@@ -211,7 +278,7 @@ fn render_lines(theme: &ResolvedTheme, state: &ChatState, body_width: usize) -> 
             lines.push(Line::from(""));
         }
         let id = state.message_ids.get(index).copied();
-        lines.extend(render_message(theme, message, id, state, body_width));
+        lines.extend(render_message(theme, message, id, state, opts, body_width));
     }
     lines
 }
@@ -221,16 +288,17 @@ fn render_message(
     message: &Message,
     id: Option<u64>,
     state: &ChatState,
+    opts: ChatViewOpts,
     body_width: usize,
 ) -> Vec<Line<'static>> {
     match message.role {
         Role::User => render_user_message(theme, &message.body, body_width),
-        Role::Assistant => render_assistant_message(theme, message, id, state, body_width),
+        Role::Assistant => render_assistant_message(theme, message, id, state, opts, body_width),
         Role::System => render_system_message(theme, &message.body, body_width),
         Role::Tool => message
             .tool
             .as_ref()
-            .map_or_else(Vec::new, |tool| render_tool_card(theme, tool, body_width)),
+            .map_or_else(Vec::new, |tool| render_tool_card(theme, tool, opts, body_width)),
         Role::Error => render_error_message(theme, &message.body, body_width),
     }
 }
@@ -259,6 +327,7 @@ fn render_assistant_message(
     message: &Message,
     id: Option<u64>,
     state: &ChatState,
+    opts: ChatViewOpts,
     width: usize,
 ) -> Vec<Line<'static>> {
     let mut lines = vec![bar_line(
@@ -267,7 +336,13 @@ fn render_assistant_message(
         vec![header_span(theme, " > senpi")],
     )];
 
-    if let Some(id) = id
+    // Ctrl+T (`app.thinking.toggle`) toggles the global
+    // `thinking_visible` flag. When false, every thinking block is
+    // suppressed - neither the summary line nor the expanded body
+    // renders. This matches the legacy senpi behavior where the user
+    // can hide the inner monologue once they have read it.
+    if opts.thinking_visible
+        && let Some(id) = id
         && let Some(thinking) = state.thinking_by_id.get(&id)
     {
         if state.expanded_thinking.contains(&id) {
@@ -278,7 +353,7 @@ fn render_assistant_message(
                 theme,
                 Token::AssistantMessageBar,
                 vec![Span::styled(
-                    format!("  [thinking {count} lines, ctrl+t to expand]"),
+                    format!("  [thinking {count} lines, ctrl+t to toggle visibility]"),
                     Style::default().fg(theme.token(Token::TextMuted)),
                 )],
             ));
@@ -289,7 +364,7 @@ fn render_assistant_message(
         lines.push(markdown_body_line(theme, Token::AssistantMessageBar, line));
     }
     if let Some(tool) = &message.tool {
-        lines.extend(render_tool_card(theme, tool, width));
+        lines.extend(render_tool_card(theme, tool, opts, width));
     }
     lines
 }
@@ -346,7 +421,12 @@ fn render_error_message(theme: &ResolvedTheme, body: &str, width: usize) -> Vec<
     lines
 }
 
-fn render_tool_card(theme: &ResolvedTheme, card: &ToolCard, width: usize) -> Vec<Line<'static>> {
+fn render_tool_card(
+    theme: &ResolvedTheme,
+    card: &ToolCard,
+    opts: ChatViewOpts,
+    width: usize,
+) -> Vec<Line<'static>> {
     let border_token = match card.status {
         ToolStatus::Running => Token::ToolBorderRunning,
         ToolStatus::Success => Token::ToolBorderSuccess,
@@ -374,12 +454,28 @@ fn render_tool_card(theme: &ResolvedTheme, card: &ToolCard, width: usize) -> Vec
         Span::styled("─".repeat(rule_width), border),
     ])];
 
-    for line in card.summary.lines().take(6) {
-        let truncated = truncate_to_width(line, inner_width, "…");
-        lines.push(Line::from(vec![
-            Span::styled("  │ ".to_string(), border),
-            Span::styled(truncated, body),
-        ]));
+    // Ctrl+O (`app.tools.expand`) toggles whether tool body lines are
+    // rendered. When false, the card collapses to its header rule so
+    // long tool outputs do not flood the viewport. The user can
+    // re-expand to inspect the output.
+    if opts.tools_expanded {
+        for line in card.summary.lines().take(6) {
+            let truncated = truncate_to_width(line, inner_width, "…");
+            lines.push(Line::from(vec![
+                Span::styled("  │ ".to_string(), border),
+                Span::styled(truncated, body),
+            ]));
+        }
+    } else {
+        // Render a compact one-line "collapsed" hint instead of the
+        // tool body so the user knows there is hidden output and how
+        // to expand it.
+        let hint = "  │ [tool output collapsed, ctrl+o to expand]";
+        let truncated = truncate_to_width(hint, inner_width.saturating_add(4), "…");
+        lines.push(Line::from(Span::styled(
+            truncated,
+            Style::default().fg(theme.token(Token::TextMuted)),
+        )));
     }
     lines.push(Line::from(Span::styled(
         format!("  ╰{}", "─".repeat(inner_width.saturating_add(1))),

--- a/packages/neo-tui/src/rpc/command.rs
+++ b/packages/neo-tui/src/rpc/command.rs
@@ -106,6 +106,13 @@ pub enum Command {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
+    /// Manually compact conversation context.
+    Compact {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "customInstructions")]
+        custom_instructions: Option<String>,
+    },
     /// Escape hatch for commands not yet typed. Serializes as raw JSON
     /// with the `type` field already set by the caller.
     #[serde(untagged)]

--- a/packages/neo-tui/tests/app_loop.rs
+++ b/packages/neo-tui/tests/app_loop.rs
@@ -13,7 +13,7 @@ use std::sync::Mutex;
 use crossterm::event::{
     KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
 };
-use senpi_neo_tui::app::{App, AppAction};
+use senpi_neo_tui::app::{App, AppAction, provider_for_model_id};
 use senpi_neo_tui::components::autocomplete::AutocompleteResult;
 use senpi_neo_tui::components::chat::{Role, ToolStatus};
 use senpi_neo_tui::components::footer::Status;
@@ -212,26 +212,59 @@ fn theme_picker_selection_with_unknown_id_pushes_a_chat_error() {
 }
 
 #[test]
-fn model_picker_selection_pushes_visible_feedback() {
-    // Oracle round 5: the model picker emits
-    // `OverlayResult::Selected("neo.model.set:<id>")`. Previously the
-    // dispatcher had no arm for that prefix and silently consumed it -
-    // the overlay closed, no model changed on the backend, and the
-    // user saw nothing happen. Until provider plumbing lands, surface
-    // a chat-system note so the chord is visibly accounted for.
+fn model_picker_selection_fires_set_model_command() {
+    // Round 12 / real port: the model picker emits
+    // `OverlayResult::Selected("neo.model.set:<id>")` and the
+    // dispatcher now fires `Command::SetModel { provider, model_id }`
+    // end-to-end. The provider is inferred from the model id prefix
+    // (claude-* → anthropic, gpt-* → openai, etc.). The backend
+    // response flows through `apply_model_change_response` and
+    // updates header + footer + pushes a chat note.
     let mut app = fresh_app();
     let messages_before = app.chat.messages.len();
     let action = app.execute_action_for_tests("neo.model.set:claude-opus-4-7");
-    assert!(matches!(action, AppAction::Consumed(_)));
+    assert_eq!(
+        action,
+        AppAction::SetModel {
+            provider: "anthropic".into(),
+            model_id: "claude-opus-4-7".into(),
+        }
+    );
+    let cmd = App::action_to_command(&action).expect("set_model must fire a command");
+    assert!(matches!(cmd, Command::SetModel { .. }));
     assert!(
         app.chat.messages.len() > messages_before,
-        "model selection must push a chat message",
+        "model selection must push a chat message (the pending-switch note)",
     );
     let last = app.chat.messages.last().expect("message exists");
     assert_eq!(last.role, Role::System);
     assert!(
         last.body.contains("claude-opus-4-7"),
         "chat body must name the picked model, got {:?}",
+        last.body,
+    );
+}
+
+#[test]
+fn model_picker_selection_with_unknown_provider_surfaces_lookup_miss() {
+    // Round 12 / real port: a custom model id (no known prefix)
+    // cannot be mapped to a backend provider by the curated heuristic.
+    // Instead of silently consuming the selection, the dispatcher
+    // surfaces a chat note explaining the lookup miss.
+    let mut app = fresh_app();
+    let messages_before = app.chat.messages.len();
+    let action = app.execute_action_for_tests("neo.model.set:exotic-vendor-model-x9");
+    assert!(matches!(action, AppAction::Consumed(_)));
+    assert!(App::action_to_command(&action).is_none());
+    assert!(
+        app.chat.messages.len() > messages_before,
+        "unknown-provider selection must push a chat note",
+    );
+    let last = app.chat.messages.last().expect("message exists");
+    assert_eq!(last.role, Role::System);
+    assert!(
+        last.body.contains("exotic-vendor-model-x9"),
+        "chat body must name the failing model id, got {:?}",
         last.body,
     );
 }
@@ -346,39 +379,16 @@ fn alt_enter_dispatches_follow_up() {
 }
 
 #[test]
-fn ctrl_g_dispatches_external_editor() {
+fn ctrl_g_dispatches_external_editor_launch() {
+    // Round 12 / real port: `app.editor.external` (Ctrl+G) now
+    // returns `AppAction::ExternalEditorLaunch`. The run loop
+    // suspends the TUI, runs `$VISUAL` / `$EDITOR` against the
+    // input buffer, reads the result back, and restores the TUI.
     let mut app = fresh_app();
     let action = app.handle_key(ev(KeyCode::Char('g'), KeyModifiers::CONTROL));
-    assert_eq!(action, AppAction::ExternalEditor);
-}
-
-#[test]
-fn ctrl_g_app_editor_external_pushes_visible_feedback_note() {
-    // Oracle round 6: `app.editor.external` (Ctrl+G) returns
-    // `AppAction::ExternalEditor`, but the run loop has no handler
-    // for that variant - the keystroke produced zero user-visible
-    // effect. Bug 3 contract: surface a chat-system note so the
-    // user sees that the chord landed AND that the external editor
-    // is not yet wired in `senpi --neo`.
-    let mut app = fresh_app();
-    let messages_before = app.chat.messages.len();
-    let action = app.execute_action_for_tests("app.editor.external");
-    assert_eq!(
-        action,
-        AppAction::ExternalEditor,
-        "must keep returning the typed variant for future wiring",
-    );
-    assert!(
-        app.chat.messages.len() > messages_before,
-        "external editor chord must push a visible chat message",
-    );
-    let last = app.chat.messages.last().expect("chat message exists");
-    assert_eq!(last.role, Role::System);
-    assert!(
-        last.body.contains("app.editor.external") && last.body.to_lowercase().contains("not yet"),
-        "chat body must name the action and flag it as not yet wired, got {:?}",
-        last.body,
-    );
+    assert_eq!(action, AppAction::ExternalEditorLaunch);
+    // Local-only action: no RPC command should fire.
+    assert!(App::action_to_command(&action).is_none());
 }
 
 #[test]
@@ -1498,52 +1508,37 @@ fn app_mouse_wheel_at_bottom_does_nothing() {
 }
 
 #[test]
-fn ctrl_t_app_thinking_toggle_visibly_notifies_user() {
-    // Oracle round 10: `app.thinking.toggle` (Ctrl+T) flipped
-    // `self.thinking_visible`, but no render path consumed that
-    // field, so the user-facing effect was zero - the chord was a
-    // silent no-op against the README/`/hotkeys` advertisement that
-    // Ctrl+T toggles thinking-block visibility. Bug 3 contract:
-    // surface a "not yet wired to rendering" chat note so the user
-    // sees that the chord landed even though nothing renders yet.
+fn ctrl_t_app_thinking_toggle_flips_thinking_visible() {
+    // Round 12 / real port: `app.thinking.toggle` (Ctrl+T) now drives
+    // chat rendering through `chat::ChatViewOpts::thinking_visible`.
+    // Toggling flips the flag; the visual change in chat IS the
+    // feedback (no more "not yet wired" note).
     let mut app = fresh_app();
-    let messages_before = app.chat.messages.len();
+    assert!(app.thinking_visible);
     let action = app.handle_key(ev(KeyCode::Char('t'), KeyModifiers::CONTROL));
     assert_eq!(action, AppAction::ToggleThinkingVisibility);
-    assert!(
-        app.chat.messages.len() > messages_before,
-        "ctrl+t must push a visible chat message until rendering is wired",
-    );
-    let last = app.chat.messages.last().expect("chat message exists");
-    assert_eq!(last.role, Role::System);
-    assert!(
-        last.body.contains("app.thinking.toggle") && last.body.to_lowercase().contains("not yet"),
-        "chat body must name the action and flag it as not yet wired, got {:?}",
-        last.body,
-    );
+    assert!(!app.thinking_visible);
+
+    let action = app.handle_key(ev(KeyCode::Char('t'), KeyModifiers::CONTROL));
+    assert_eq!(action, AppAction::ToggleThinkingVisibility);
+    assert!(app.thinking_visible);
 }
 
 #[test]
-fn ctrl_o_app_tools_expand_visibly_notifies_user() {
-    // Oracle round 10 (mirror of ctrl_t): `app.tools.expand` (Ctrl+O)
-    // toggled `self.tools_expanded`, but no render path consumed the
-    // field, so the user saw nothing change. Push a chat-system note
-    // so the chord visibly lands.
+fn ctrl_o_app_tools_expand_flips_tools_expanded() {
+    // Round 12 / real port: `app.tools.expand` (Ctrl+O) now drives
+    // chat rendering through `chat::ChatViewOpts::tools_expanded`.
+    // Toggling flips the flag; tool cards collapse / expand on the
+    // next frame.
     let mut app = fresh_app();
-    let messages_before = app.chat.messages.len();
+    assert!(app.tools_expanded);
     let action = app.handle_key(ev(KeyCode::Char('o'), KeyModifiers::CONTROL));
     assert_eq!(action, AppAction::ToggleToolsExpanded);
-    assert!(
-        app.chat.messages.len() > messages_before,
-        "ctrl+o must push a visible chat message until rendering is wired",
-    );
-    let last = app.chat.messages.last().expect("chat message exists");
-    assert_eq!(last.role, Role::System);
-    assert!(
-        last.body.contains("app.tools.expand") && last.body.to_lowercase().contains("not yet"),
-        "chat body must name the action and flag it as not yet wired, got {:?}",
-        last.body,
-    );
+    assert!(!app.tools_expanded);
+
+    let action = app.handle_key(ev(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    assert_eq!(action, AppAction::ToggleToolsExpanded);
+    assert!(app.tools_expanded);
 }
 
 #[test]
@@ -1826,6 +1821,119 @@ fn apply_event_extension_ui_request_dialog_method_pushes_not_yet_wired_note() {
         "chat body must name the dialog method + title + flag as not wired, got {:?}",
         last.body,
     );
+}
+
+#[test]
+fn alt_s_toggles_sidebar_visible() {
+    // Round 12 / real port: Alt+S toggles `sidebar_visible`. The
+    // layout::compute then allocates a sidebar pane when the
+    // terminal is wide enough.
+    let mut app = fresh_app();
+    assert!(!app.sidebar_visible);
+    let action = app.handle_key(ev(KeyCode::Char('s'), KeyModifiers::ALT));
+    assert_eq!(action, AppAction::ToggleSidebar);
+    assert!(app.sidebar_visible);
+
+    let action = app.handle_key(ev(KeyCode::Char('s'), KeyModifiers::ALT));
+    assert_eq!(action, AppAction::ToggleSidebar);
+    assert!(!app.sidebar_visible);
+}
+
+#[test]
+fn alt_a_toggles_animations_enabled() {
+    // Round 12 / real port: Alt+A toggles `animations_enabled`. The
+    // run loop skips spinner / focus-pulse updates when false so
+    // screen recordings stay static.
+    let mut app = fresh_app();
+    assert!(app.animations_enabled);
+    let action = app.handle_key(ev(KeyCode::Char('a'), KeyModifiers::ALT));
+    assert_eq!(action, AppAction::ToggleAnimations);
+    assert!(!app.animations_enabled);
+
+    let action = app.handle_key(ev(KeyCode::Char('a'), KeyModifiers::ALT));
+    assert_eq!(action, AppAction::ToggleAnimations);
+    assert!(app.animations_enabled);
+}
+
+#[test]
+fn alt_c_dispatches_compact_session() {
+    // Round 12 / real port: Alt+C fires `Command::Compact` and
+    // pushes a chat-system note so the user sees the action landed.
+    let mut app = fresh_app();
+    let messages_before = app.chat.messages.len();
+    let action = app.handle_key(ev(KeyCode::Char('c'), KeyModifiers::ALT));
+    assert_eq!(action, AppAction::CompactSession);
+    let cmd = App::action_to_command(&action).expect("compact must fire a command");
+    assert!(matches!(cmd, Command::Compact { .. }));
+    assert!(
+        app.chat.messages.len() > messages_before,
+        "compact chord must push a visible note",
+    );
+    let last = app.chat.messages.last().expect("chat message exists");
+    assert_eq!(last.role, Role::System);
+    assert!(
+        last.body.to_lowercase().contains("compact"),
+        "chat body must mention compact, got {:?}",
+        last.body,
+    );
+}
+
+#[test]
+fn provider_for_model_id_recognizes_curated_catalog() {
+    // Round 12 / real port: the bundled picker only carries model
+    // ids (no provider). `provider_for_model_id` infers the
+    // provider via prefix matching so `Command::SetModel` can fire
+    // end-to-end. Lock the catalog → provider mapping so a future
+    // catalog edit cannot silently break the mapping.
+    assert_eq!(provider_for_model_id("claude-opus-4-7"), Some("anthropic"));
+    assert_eq!(provider_for_model_id("gpt-5.3-codex"), Some("openai"));
+    assert_eq!(provider_for_model_id("kimi-k2-6"), Some("kimi-for-coding"));
+    assert_eq!(provider_for_model_id("glm-4.6-air"), Some("opencode-zen"));
+    assert_eq!(provider_for_model_id("deepseek-v4-coder"), Some("deepseek"));
+    assert_eq!(provider_for_model_id("gemini-2.5-flash"), Some("google"));
+    assert_eq!(provider_for_model_id("custom-vendor-x9"), None);
+}
+
+#[test]
+fn alt_up_dequeue_when_empty_pushes_explanatory_note() {
+    // Round 12 / real port: `app.message.dequeue` (Alt+Up) pops the
+    // most recently queued message back into the editor. When the
+    // queue is empty, push a chat-system note explaining how
+    // queueing works instead of silently consuming the chord.
+    let mut app = fresh_app();
+    let messages_before = app.chat.messages.len();
+    let action = app.handle_key(ev(KeyCode::Up, KeyModifiers::ALT));
+    assert!(matches!(action, AppAction::Consumed(_)));
+    assert!(
+        app.chat.messages.len() > messages_before,
+        "dequeue with empty queue must push a chat note",
+    );
+    let last = app.chat.messages.last().expect("chat message exists");
+    assert_eq!(last.role, Role::System);
+    assert!(
+        last.body.to_lowercase().contains("queue") || last.body.to_lowercase().contains("queued"),
+        "chat body must mention the queue, got {:?}",
+        last.body,
+    );
+}
+
+#[test]
+fn alt_up_dequeue_after_queue_update_pops_into_buffer() {
+    // Round 12 / real port: after the backend emits a `QueueUpdate`
+    // event with a pending message, Alt+Up pops the most recent
+    // queued message into the input buffer so the user can edit
+    // and resubmit.
+    let mut app = fresh_app();
+    app.apply_inbound(Inbound::Event(RpcEvent::QueueUpdate {
+        steering: vec!["first queued prompt".into()],
+        follow_up: vec!["pending follow-up".into()],
+    }));
+    assert_eq!(app.chat.queued_messages().len(), 2);
+
+    let action = app.handle_key(ev(KeyCode::Up, KeyModifiers::ALT));
+    assert_eq!(action, AppAction::DequeueMessage);
+    assert_eq!(app.input_buffer(), "pending follow-up");
+    assert_eq!(app.chat.queued_messages().len(), 1);
 }
 
 #[test]

--- a/packages/neo-tui/tests/chat_view.rs
+++ b/packages/neo-tui/tests/chat_view.rs
@@ -1,6 +1,6 @@
 use ratatui::{Terminal, backend::TestBackend, buffer::Buffer, layout::Rect, style::Color};
 use senpi_neo_tui::{
-    components::chat::{self, ChatState, ToolCardData, ToolStatus},
+    components::chat::{self, ChatState, ChatViewOpts, ToolCardData, ToolStatus},
     load_bundled_dark_theme,
     theme::{ResolvedTheme, Token},
 };
@@ -14,7 +14,15 @@ fn render_chat(state: &ChatState, width: u16, height: u16) -> (Buffer, ResolvedT
     let mut terminal = Terminal::new(backend).expect("test terminal must initialize");
     let theme = theme();
     terminal
-        .draw(|frame| chat::render(frame, Rect::new(0, 0, width, height), &theme, state))
+        .draw(|frame| {
+            chat::render(
+                frame,
+                Rect::new(0, 0, width, height),
+                &theme,
+                state,
+                ChatViewOpts::default(),
+            );
+        })
         .expect("chat render must complete");
     (terminal.backend().buffer().clone(), theme)
 }
@@ -143,8 +151,91 @@ fn chat_thinking_block_collapsed_by_default() {
     let (buffer, _) = render_chat(&state, 80, 16);
     let text = buffer_text(&buffer);
 
-    assert!(text.contains("[thinking 12 lines, ctrl+t to expand]"));
+    assert!(text.contains("[thinking 12 lines, ctrl+t to toggle visibility]"));
     assert!(!text.contains("line 12"));
+}
+
+#[test]
+fn chat_thinking_visible_false_hides_summary_and_body() {
+    // Round 12 / real port: `ChatViewOpts::thinking_visible = false`
+    // suppresses the entire thinking block - neither the summary
+    // line nor the expanded body renders. Driven by Ctrl+T.
+    let mut state = ChatState::new();
+    let id = state.push_assistant("answer".to_string());
+    state.set_thinking(id, "secret monologue".to_string());
+
+    let backend = TestBackend::new(80, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let theme = theme();
+    terminal
+        .draw(|frame| {
+            chat::render(
+                frame,
+                Rect::new(0, 0, 80, 12),
+                &theme,
+                &state,
+                ChatViewOpts {
+                    thinking_visible: false,
+                    tools_expanded: true,
+                },
+            );
+        })
+        .expect("render");
+    let buffer = terminal.backend().buffer().clone();
+    let text = buffer_text(&buffer);
+
+    assert!(
+        !text.contains("thinking 1 lines"),
+        "thinking summary must be hidden when thinking_visible=false, got:\n{text}",
+    );
+    assert!(!text.contains("secret monologue"));
+    assert!(
+        text.contains("answer"),
+        "assistant body must still render when thinking is hidden",
+    );
+}
+
+#[test]
+fn chat_tools_expanded_false_collapses_tool_card_body() {
+    // Round 12 / real port: `ChatViewOpts::tools_expanded = false`
+    // collapses each tool card body to a single "collapsed" hint,
+    // keeping only the header rule. Driven by Ctrl+O.
+    let mut state = ChatState::new();
+    state.push_tool(ToolCardData {
+        name: "bash".to_string(),
+        status: ToolStatus::Success,
+        args: "ls".to_string(),
+        output: "file1\nfile2\nfile3".to_string(),
+    });
+
+    let backend = TestBackend::new(80, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let theme = theme();
+    terminal
+        .draw(|frame| {
+            chat::render(
+                frame,
+                Rect::new(0, 0, 80, 12),
+                &theme,
+                &state,
+                ChatViewOpts {
+                    thinking_visible: true,
+                    tools_expanded: false,
+                },
+            );
+        })
+        .expect("render");
+    let buffer = terminal.backend().buffer().clone();
+    let text = buffer_text(&buffer);
+
+    assert!(
+        text.contains("collapsed") && text.contains("ctrl+o to expand"),
+        "collapsed hint must appear when tools_expanded=false, got:\n{text}",
+    );
+    assert!(
+        !text.contains("file1"),
+        "tool body must NOT render when tools_expanded=false, got:\n{text}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Oracle round 12 BLOCKED on the "full Rust port" framing — too many legacy actions surfaced "not yet wired" notes instead of real behavior. This PR wires 8 highest-impact features:

1. **Ctrl+T** (`app.thinking.toggle`): `ChatViewOpts::thinking_visible` drives `render_assistant_message`
2. **Ctrl+O** (`app.tools.expand`): `ChatViewOpts::tools_expanded` drives `render_tool_card`
3. **Alt+S** (`neo.sidebar.toggle`): new `App.sidebar_visible` field
4. **Alt+A** (`neo.toggle_animations`): new `App.animations_enabled` field
5. **Alt+C** (`neo.compact`): new `Command::Compact` + `AppAction::CompactSession`
6. **Model picker** (`neo.model.set:<id>`): new `provider_for_model_id` heuristic + `Command::SetModel` end-to-end
7. **Ctrl+G** (`app.editor.external`): suspend TUI → spawn `$VISUAL`/`$EDITOR`/`vi` → read back → restore TUI
8. **Alt+Up** (`app.message.dequeue`): new `ChatState.queued_messages` tracked from `QueueUpdate`, pops most recent to buffer

Test count: 333 → 341. `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `npm run check` (898 files) all green.

`ADVERTISED_BUT_UNIMPLEMENTED_ACTIONS` shrunk by 5. Remaining ~29 entries cover session tree / branching / models management / tree filters / image paste — they require sub-overlays + JSONL session parsing, tracked as a separate feature pack.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports eight legacy `senpi` commands to real behavior in `neo-tui`, replacing “not yet wired” notes with working UI and RPCs. Shrinks the unimplemented-action list by 5; tests now 341 and checks pass.

- New Features
  - Ctrl+T: toggle thinking blocks via `ChatViewOpts.thinking_visible`.
  - Ctrl+O: collapse/expand tool cards via `ChatViewOpts.tools_expanded`.
  - Alt+S: toggle sidebar via `App.sidebar_visible` (width-gated).
  - Alt+A: toggle animations via `App.animations_enabled` (freezes spinner and focus pulse).
  - Alt+C: fire `Command::Compact` to compact the session.
  - Model picker (`neo.model.set:<id>`): fire `Command::SetModel`; provider inferred by `provider_for_model_id` (claude→anthropic, gpt→openai, kimi→kimi-for-coding, glm→opencode-zen, deepseek→deepseek, gemini→google).
  - Ctrl+G: open external editor; suspend TUI, launch `$VISUAL`/`$EDITOR`/`vi`, read back into input, restore TUI.
  - Alt+Up: dequeue most recent queued message into input; track via `ChatState.queued_messages` from `RpcEvent::QueueUpdate`.

<sup>Written for commit 6ee9e0898e756f432421e4fa937dc8ac78f46aa9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/16?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

