### PR TITLE
feat(neo-tui): event-driven frame scheduling for instant keystroke feedback

### DIFF
--- a/packages/neo-tui/src/app/mod.rs
+++ b/packages/neo-tui/src/app/mod.rs
@@ -1,7 +1,7 @@
 //! Application loop and state container.
 //!
 //! Owns the terminal, drives a single `tokio::select!` loop multiplexing
-//! crossterm events + render ticks + inbound RPC frames, dispatches
+//! crossterm events + draw requests + inbound RPC frames, dispatches
 //! incoming keys through the keymap, mutates per-component state, and
 //! forwards user intents to the RPC backend.
 
@@ -19,7 +19,10 @@ use crossterm::{
         MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{
+        BeginSynchronizedUpdate, EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
+        disable_raw_mode, enable_raw_mode,
+    },
 };
 use futures::StreamExt;
 use ratatui::{
@@ -42,6 +45,7 @@ use crate::{
         header::{self, HeaderState},
         input::{self, InputState},
     },
+    frame::FrameRequester,
     keymap::{self, FocusMode, ResolvedKeymap},
     layout::{self, LayoutState},
     overlay::{
@@ -60,7 +64,6 @@ use crate::{
 
 const SPINNER_FRAMES: [char; 8] = ['⠂', '⠆', '⠒', '⠢', '⠖', '⠲', '⠴', '⠤'];
 const SPINNER_FRAME_MS: u64 = 80;
-const RENDER_INTERVAL_MS: u64 = 33;
 
 /// Concrete outcome of one dispatched key event.
 ///
@@ -1785,14 +1788,16 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
     let cmd_tx: Option<mpsc::Sender<Command>> = backend.as_ref().map(RpcClient::command_sender);
 
     let mut events = EventStream::new();
-    let mut render_tick = interval(Duration::from_millis(RENDER_INTERVAL_MS));
-    render_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let mut spinner_tick = interval(Duration::from_millis(SPINNER_FRAME_MS));
     spinner_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     let start = Instant::now();
     let mut spinner_idx: usize = 0;
     let demo_deadline = demo_seconds.map(|s| start + Duration::from_secs(s));
+    let (draw_tx, _) = tokio::sync::broadcast::channel::<()>(16);
+    let frame_requester = FrameRequester::new(draw_tx.clone());
+    let mut draw_rx = draw_tx.subscribe();
+    frame_requester.schedule_frame();
 
     loop {
         if let Some(deadline) = demo_deadline {
@@ -1803,17 +1808,19 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
 
         tokio::select! {
             biased;
-            _ = render_tick.tick() => {
+            _ = draw_rx.recv() => {
                 app.footer.spinner_glyph = SPINNER_FRAMES[spinner_idx];
                 app.footer.elapsed_secs = start.elapsed().as_secs();
-                terminal.draw(|frame| {
-                    draw_app(frame, &app);
-                })?;
+                let stdout_handle = terminal.backend_mut();
+                execute!(stdout_handle, BeginSynchronizedUpdate)?;
+                terminal.draw(|frame| draw_app(frame, &app))?;
+                execute!(terminal.backend_mut(), EndSynchronizedUpdate)?;
             }
             _ = spinner_tick.tick() => {
                 if app.animations_enabled {
                     spinner_idx = (spinner_idx + 1) % SPINNER_FRAMES.len();
                     app.input.focus_pulse = app.input.focus_pulse.wrapping_add(8);
+                    frame_requester.schedule_frame();
                 }
             }
             ev = events.next() => {
@@ -1842,6 +1849,7 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
                         inbound = None;
                     }
                 }
+                frame_requester.schedule_frame();
             }
             // 4th arm: drain inbound RPC frames when a backend is up.
             // The async block stays Pending forever when `inbound` is
@@ -1853,7 +1861,10 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
                 }
             } => {
                 match inbound_msg {
-                    Some(msg) => app.apply_inbound(msg),
+                    Some(msg) => {
+                        app.apply_inbound(msg);
+                        frame_requester.schedule_frame();
+                    }
                     // Channel closed: null out the receiver so future
                     // iterations skip this arm via the pending future.
                     None => inbound = None,

--- a/packages/neo-tui/src/frame/mod.rs
+++ b/packages/neo-tui/src/frame/mod.rs
@@ -1,0 +1,13 @@
+#![allow(
+    clippy::redundant_pub_crate,
+    reason = "frame items are pub(crate)-scoped; module itself is pub(crate) in lib.rs"
+)]
+#![allow(
+    unused_imports,
+    reason = "FrameRequester re-export is consumed by app integration in a follow-up change"
+)]
+
+pub(crate) mod rate_limiter;
+pub(crate) mod requester;
+
+pub(crate) use requester::FrameRequester;

--- a/packages/neo-tui/src/frame/rate_limiter.rs
+++ b/packages/neo-tui/src/frame/rate_limiter.rs
@@ -1,0 +1,74 @@
+//! Limits how frequently frame draw notifications may be emitted.
+//!
+//! Widgets sometimes request a redraw more frequently than a user can
+//! perceive. This limiter clamps draw notifications to a maximum of
+//! 120 FPS to avoid wasted work.
+//!
+//! Kept as a small, pure helper so it can be unit-tested in isolation and
+//! consumed by the async frame scheduler without adding complexity to the
+//! app or event loop.
+
+#![allow(
+    dead_code,
+    reason = "consumed by senpi-neo-tui app integration in a follow-up change"
+)]
+#![allow(
+    clippy::redundant_pub_crate,
+    reason = "frame is pub(crate) in lib.rs; pub(crate) items here mirror the crate-wide exposure intended for app integration"
+)]
+
+use std::time::{Duration, Instant};
+
+/// A 120 FPS minimum frame interval (~8.33 ms).
+pub(crate) const MIN_FRAME_INTERVAL: Duration = Duration::from_nanos(8_333_334);
+
+/// Remembers the most recent emitted draw, allowing deadlines to be clamped forward.
+#[derive(Debug, Default)]
+pub(crate) struct FrameRateLimiter {
+    last_emitted_at: Option<Instant>,
+}
+
+impl FrameRateLimiter {
+    /// Returns `requested`, clamped forward if it would exceed the maximum frame rate.
+    pub(crate) fn clamp_deadline(&self, requested: Instant) -> Instant {
+        self.last_emitted_at.map_or(requested, |last| {
+            let earliest = last.checked_add(MIN_FRAME_INTERVAL).unwrap_or(last);
+            requested.max(earliest)
+        })
+    }
+
+    /// Records that a draw notification was emitted at `emitted_at`.
+    pub(crate) const fn mark_emitted(&mut self, emitted_at: Instant) {
+        self.last_emitted_at = Some(emitted_at);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_does_not_clamp() {
+        let t0 = Instant::now();
+        let limiter = FrameRateLimiter::default();
+        assert_eq!(limiter.clamp_deadline(t0), t0);
+    }
+
+    #[test]
+    fn clamps_to_min_interval_since_last_emit() {
+        let t0 = Instant::now();
+        let mut limiter = FrameRateLimiter::default();
+        limiter.mark_emitted(t0);
+        let too_soon = t0 + Duration::from_millis(1);
+        assert_eq!(limiter.clamp_deadline(too_soon), t0 + MIN_FRAME_INTERVAL);
+    }
+
+    #[test]
+    fn does_not_clamp_far_future_deadline() {
+        let t0 = Instant::now();
+        let mut limiter = FrameRateLimiter::default();
+        limiter.mark_emitted(t0);
+        let far_future = t0 + Duration::from_millis(100);
+        assert_eq!(limiter.clamp_deadline(far_future), far_future);
+    }
+}

--- a/packages/neo-tui/src/frame/requester.rs
+++ b/packages/neo-tui/src/frame/requester.rs
@@ -1,0 +1,192 @@
+//! Coalescing frame draw scheduler.
+//!
+//! [`FrameRequester`] is a cheap clonable handle that anything in the TUI can
+//! use to ask for a redraw. Internally it talks to a [`FrameScheduler`] actor
+//! that coalesces many requests into a single broadcast notification while
+//! respecting the 120 FPS cap enforced by [`FrameRateLimiter`].
+
+#![allow(
+    clippy::redundant_pub_crate,
+    reason = "frame items are pub(crate)-scoped; module itself is pub(crate) in lib.rs"
+)]
+#![allow(
+    dead_code,
+    reason = "consumed by senpi-neo-tui app integration in a follow-up change"
+)]
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::{broadcast, mpsc};
+use tokio::time::sleep_until;
+
+use super::rate_limiter::FrameRateLimiter;
+
+const ONE_YEAR: Duration = Duration::from_secs(31_536_000);
+
+#[derive(Clone, Debug)]
+pub(crate) struct FrameRequester {
+    frame_schedule_tx: mpsc::UnboundedSender<Instant>,
+}
+
+impl FrameRequester {
+    pub(crate) fn new(draw_tx: broadcast::Sender<()>) -> Self {
+        let (frame_schedule_tx, frame_schedule_rx) = mpsc::unbounded_channel();
+        let scheduler = FrameScheduler::new(frame_schedule_rx, draw_tx);
+        tokio::spawn(scheduler.run());
+        Self { frame_schedule_tx }
+    }
+
+    pub(crate) fn schedule_frame(&self) {
+        let _ = self.frame_schedule_tx.send(Instant::now());
+    }
+
+    pub(crate) fn schedule_frame_in(&self, delay: Duration) {
+        let when = Instant::now().checked_add(delay).unwrap_or_else(Instant::now);
+        let _ = self.frame_schedule_tx.send(when);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_dummy() -> Self {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        Self {
+            frame_schedule_tx: tx,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FrameScheduler {
+    receiver: mpsc::UnboundedReceiver<Instant>,
+    draw_tx: broadcast::Sender<()>,
+    rate_limiter: FrameRateLimiter,
+}
+
+impl FrameScheduler {
+    fn new(receiver: mpsc::UnboundedReceiver<Instant>, draw_tx: broadcast::Sender<()>) -> Self {
+        Self {
+            receiver,
+            draw_tx,
+            rate_limiter: FrameRateLimiter::default(),
+        }
+    }
+
+    async fn run(mut self) {
+        let mut next_deadline: Option<Instant> = None;
+        loop {
+            let target = next_deadline
+                .unwrap_or_else(|| Instant::now().checked_add(ONE_YEAR).unwrap_or_else(Instant::now));
+            let sleep_fut = sleep_until(target.into());
+            tokio::pin!(sleep_fut);
+
+            tokio::select! {
+                draw_at = self.receiver.recv() => {
+                    match draw_at {
+                        Some(when) => {
+                            let clamped = self.rate_limiter.clamp_deadline(when);
+                            next_deadline = Some(
+                                next_deadline.map_or(clamped, |cur| cur.min(clamped)),
+                            );
+                        }
+                        None => break,
+                    }
+                }
+                () = &mut sleep_fut => {
+                    if next_deadline.is_some() {
+                        next_deadline = None;
+                        self.rate_limiter.mark_emitted(target);
+                        let _ = self.draw_tx.send(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::rate_limiter::MIN_FRAME_INTERVAL;
+    use super::*;
+    use tokio::time::{advance, timeout};
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn schedule_frame_immediate_triggers_once() {
+        let (draw_tx, mut draw_rx) = broadcast::channel(16);
+        let requester = FrameRequester::new(draw_tx);
+
+        requester.schedule_frame();
+        advance(Duration::from_millis(1)).await;
+
+        let first = timeout(Duration::from_millis(50), draw_rx.recv())
+            .await
+            .expect("timed out waiting for first draw");
+        assert!(first.is_ok(), "broadcast closed unexpectedly");
+
+        let second = timeout(Duration::from_millis(20), draw_rx.recv()).await;
+        assert!(second.is_err(), "unexpected extra draw received");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn coalesces_multiple_requests_into_single_draw() {
+        let (draw_tx, mut draw_rx) = broadcast::channel(16);
+        let requester = FrameRequester::new(draw_tx);
+
+        requester.schedule_frame();
+        requester.schedule_frame();
+        requester.schedule_frame();
+
+        advance(Duration::from_millis(1)).await;
+
+        let first = timeout(Duration::from_millis(50), draw_rx.recv())
+            .await
+            .expect("timed out waiting for coalesced draw");
+        assert!(first.is_ok(), "broadcast closed unexpectedly");
+
+        let second = timeout(Duration::from_millis(20), draw_rx.recv()).await;
+        assert!(second.is_err(), "unexpected extra draw received");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn rate_limits_to_120fps() {
+        let (draw_tx, mut draw_rx) = broadcast::channel(16);
+        let requester = FrameRequester::new(draw_tx);
+
+        requester.schedule_frame();
+        advance(Duration::from_millis(1)).await;
+        let first = timeout(Duration::from_millis(50), draw_rx.recv())
+            .await
+            .expect("timed out waiting for first draw");
+        assert!(first.is_ok(), "broadcast closed unexpectedly");
+
+        requester.schedule_frame();
+        advance(Duration::from_millis(1)).await;
+        let early = timeout(Duration::from_millis(1), draw_rx.recv()).await;
+        assert!(early.is_err(), "draw fired before rate-limit interval");
+
+        advance(MIN_FRAME_INTERVAL).await;
+        let second = timeout(Duration::from_millis(50), draw_rx.recv())
+            .await
+            .expect("timed out waiting for rate-limited draw");
+        assert!(second.is_ok(), "broadcast closed unexpectedly");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn schedule_frame_in_triggers_at_delay() {
+        let (draw_tx, mut draw_rx) = broadcast::channel(16);
+        let requester = FrameRequester::new(draw_tx);
+
+        requester.schedule_frame_in(Duration::from_millis(50));
+
+        advance(Duration::from_millis(30)).await;
+        let early = timeout(Duration::from_millis(1), draw_rx.recv()).await;
+        assert!(early.is_err(), "draw fired before delay elapsed");
+
+        advance(Duration::from_millis(25)).await;
+        let first = timeout(Duration::from_millis(50), draw_rx.recv())
+            .await
+            .expect("timed out waiting for delayed draw");
+        assert!(first.is_ok(), "broadcast closed unexpectedly");
+
+        let second = timeout(Duration::from_millis(20), draw_rx.recv()).await;
+        assert!(second.is_err(), "unexpected extra draw received");
+    }
+}

--- a/packages/neo-tui/src/lib.rs
+++ b/packages/neo-tui/src/lib.rs
@@ -13,6 +13,7 @@ pub mod anim;
 pub mod app;
 pub mod components;
 pub mod compositor;
+pub(crate) mod frame;
 pub mod keymap;
 pub mod layout;
 pub mod overlay;


### PR DESCRIPTION
## What

Replace the fixed 33ms render timer in `senpi --neo` with an event-driven 120fps frame scheduler so keystrokes (especially space bar) appear instantly. Inspired by the `codex-rs/tui` pattern.

## User-reported problem

> 입력창, 스페이스 바 바로 반영, 이런게 너무 어색함

The input box felt laggy — typing a space (or any character) had visible delay.

## Root cause

`packages/neo-tui/src/app/mod.rs:63` defined `RENDER_INTERVAL_MS = 33`. The main `tokio::select!` loop's `terminal.draw()` call lived only in the `render_tick.tick()` arm. Key events mutated state but did not trigger a draw — the user waited up to 33ms (~30fps, half the legacy TS pi-tui's 60fps target) for the next tick.

## Fix

Port the codex `FrameRequester` + `FrameScheduler` actor pattern:

- **`frame::rate_limiter`** — `FrameRateLimiter` with `MIN_FRAME_INTERVAL = 8.33ms` (120fps ceiling). `clamp_deadline(t)` pushes too-early deadlines forward.
- **`frame::requester`** — `FrameRequester` (cloneable handle) sends `Instant` deadlines through an mpsc channel. `FrameScheduler` runs as a tokio task with `tokio::select!` over `recv()` + `sleep_until()`, coalescing multiple requests into one `broadcast::Sender<()>` notification.
- **`app::drive()`** — removes the `render_tick.tick()` arm. Replaces with `draw_rx.recv()` wrapped in `crossterm::BeginSynchronizedUpdate` / `EndSynchronizedUpdate` (DECSET 2026) for tear-free atomic frames. Every state-mutating arm (`spinner_tick`, `events`, `inbound_msg`) calls `frame_requester.schedule_frame()` after processing.

Net effect: keystroke-to-pixel latency drops from up to 33ms to under 8.33ms. Multiple state changes within one frame coalesce into a single draw.

## Tests

7 new tests (all pass):

- `frame::rate_limiter::tests::default_does_not_clamp`
- `frame::rate_limiter::tests::clamps_to_min_interval_since_last_emit`
- `frame::rate_limiter::tests::does_not_clamp_far_future_deadline`
- `frame::requester::tests::schedule_frame_immediate_triggers_once`
- `frame::requester::tests::coalesces_multiple_requests_into_single_draw`
- `frame::requester::tests::rate_limits_to_120fps`
- `frame::requester::tests::schedule_frame_in_triggers_at_delay`

Total: 351 passed, 1 skipped (no regressions; was 345 before).

## Gates

- `cargo build --package senpi-neo-tui` — green
- `cargo nextest run --package senpi-neo-tui` — 351 passed
- `cargo clippy --package senpi-neo-tui --all-targets -- -D warnings` — clean
- `cargo fmt --package senpi-neo-tui -- --check` — clean

## Manual QA

Built release binary, launched in tmux 100x30 with `--demo`:

- Typed `the quick brown fox jumps over the lazy dog` rapidly → all 43 chars rendered instantly
- Typed `a b c d e f g h i j` (letters interleaved with spaces) → all rendered correctly
- Typed `안녕하세요 한글 테스트입니다` (Korean) → rendered correctly with proper cursor position

No perceptible lag. Space bar feels instant.

## Files

| File | Lines |
|---|---|
| `packages/neo-tui/src/frame/mod.rs` | +13 |
| `packages/neo-tui/src/frame/rate_limiter.rs` | +74 |
| `packages/neo-tui/src/frame/requester.rs` | +192 |
| `packages/neo-tui/src/lib.rs` | +1 |
| `packages/neo-tui/src/app/mod.rs` | +21 −10 |

Net: +291 −10. Each new file under the 250 LoC per-file ceiling.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the 33ms render timer in `senpi --neo` with an event-driven 120fps frame scheduler to make keystrokes render immediately. Frames are coalesced and drawn atomically for smoother visuals.

- **Performance**
  - Added `frame` module with `FrameRequester` and a 120fps rate limiter.
  - Switched the app loop to draw on demand; schedule a frame after key input, spinner ticks, and inbound RPCs.
  - Use `crossterm` synchronized updates for tear-free, atomic frames.
  - Keystroke latency drops from up to 33ms to ~8.33ms; spacebar feels instant.

<sup>Written for commit 1fe7eab1970d8802a121522166fa01f8eda007c0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/18?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

