### PR TITLE
feat(neo-tui): visible idle vs streaming state with shimmer working indicator

### DIFF
--- a/packages/neo-tui/src/anim/mod.rs
+++ b/packages/neo-tui/src/anim/mod.rs
@@ -1,4 +1,4 @@
-//! Animation primitives: spinner, scanner, pulse.
+//! Animation primitives: spinner, scanner, pulse, shimmer.
 //!
 //! All animations are time-driven (millisecond `now`), stateless from
 //! the caller's perspective beyond construction. Frames are pure
@@ -84,3 +84,5 @@ impl Pulse {
         (phase * std::f32::consts::TAU).sin().mul_add(0.5, 0.5)
     }
 }
+
+pub mod shimmer;

--- a/packages/neo-tui/src/anim/shimmer.rs
+++ b/packages/neo-tui/src/anim/shimmer.rs
@@ -1,0 +1,113 @@
+use std::f32::consts::PI;
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
+
+const fn extract_rgb(color: Color) -> Option<(u8, u8, u8)> {
+    match color {
+        Color::Rgb(r, g, b) => Some((r, g, b)),
+        _ => None,
+    }
+}
+
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn shimmer_spans(text: &str, fg: Color, highlight: Color, now_ms: u64) -> Vec<Span<'static>> {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.is_empty() {
+        return Vec::new();
+    }
+
+    let padding = 10usize;
+    let sweep_seconds = 2.0f32;
+    let band_half_width = 5.0f32;
+    let period = chars.len() + padding * 2;
+
+    let secs = (now_ms as f32 / 1000.0) % sweep_seconds;
+    let pos = (secs / sweep_seconds) * period as f32;
+
+    let rgb_pair = extract_rgb(fg).zip(extract_rgb(highlight));
+
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(chars.len());
+    for (i, ch) in chars.iter().enumerate() {
+        let char_pos = (i + padding) as f32;
+        let dist = (char_pos - pos).abs();
+
+        let style = match rgb_pair {
+            Some((fg_rgb, hi_rgb)) => rgb_style(dist, band_half_width, fg_rgb, hi_rgb),
+            None => ansi_style(dist, band_half_width, fg, highlight),
+        };
+        spans.push(Span::styled(ch.to_string(), style));
+    }
+    spans
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn rgb_style(dist: f32, band_half_width: f32, fg_rgb: (u8, u8, u8), hi_rgb: (u8, u8, u8)) -> Style {
+    let t = if dist <= band_half_width {
+        0.5 * (1.0 + (PI * dist / band_half_width).cos())
+    } else {
+        0.0
+    };
+    let mix = t * 0.9;
+    let blend = |fg_ch: u8, hi_ch: u8| -> u8 {
+        let out = (1.0 - mix).mul_add(f32::from(fg_ch), mix * f32::from(hi_ch));
+        out.clamp(0.0, 255.0) as u8
+    };
+    let r = blend(fg_rgb.0, hi_rgb.0);
+    let g = blend(fg_rgb.1, hi_rgb.1);
+    let b = blend(fg_rgb.2, hi_rgb.2);
+    Style::default()
+        .fg(Color::Rgb(r, g, b))
+        .add_modifier(Modifier::BOLD)
+}
+
+fn ansi_style(dist: f32, band_half_width: f32, fg: Color, highlight: Color) -> Style {
+    if dist <= band_half_width / 3.0 {
+        Style::default().fg(highlight).add_modifier(Modifier::BOLD)
+    } else if dist <= band_half_width {
+        Style::default().fg(highlight)
+    } else {
+        Style::default().fg(fg).add_modifier(Modifier::DIM)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_text_returns_empty_spans() {
+        assert!(shimmer_spans("", Color::White, Color::Black, 0).is_empty());
+    }
+
+    #[test]
+    fn span_count_matches_char_count() {
+        assert_eq!(shimmer_spans("Hello", Color::White, Color::Black, 0).len(), 5);
+    }
+
+    #[test]
+    fn all_spans_have_bold_modifier() {
+        let spans = shimmer_spans("Working", Color::Rgb(255, 255, 255), Color::Rgb(0, 255, 0), 0);
+        assert!(!spans.is_empty());
+        for span in &spans {
+            assert!(
+                span.style.add_modifier.contains(Modifier::BOLD),
+                "span {span:?} missing BOLD modifier"
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_position_changes_with_time() {
+        let fg = Color::Rgb(200, 200, 200);
+        let hi = Color::Rgb(0, 255, 255);
+        let a = shimmer_spans("Loading session", fg, hi, 0);
+        let b = shimmer_spans("Loading session", fg, hi, 500);
+        assert_eq!(a.len(), b.len());
+        assert!(
+            a.iter().zip(b.iter()).any(|(sa, sb)| sa.style.fg != sb.style.fg),
+            "expected at least one character to differ in fg between t=0 and t=500ms"
+        );
+    }
+}

--- a/packages/neo-tui/src/app/mod.rs
+++ b/packages/neo-tui/src/app/mod.rs
@@ -44,6 +44,7 @@ use crate::{
         footer::{self, FooterState, Status},
         header::{self, HeaderState},
         input::{self, InputState},
+        working_indicator::{self, WorkingIndicatorState},
     },
     frame::FrameRequester,
     keymap::{self, FocusMode, ResolvedKeymap},
@@ -145,6 +146,7 @@ pub enum AppAction {
 /// `animations_enabled`, `demo_mode`). Promoting these to an enum
 /// would lose orthogonality - the user expects to combine them
 /// freely.
+// CLIPPY-ALLOW: App stores independent UI toggles.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct App {
@@ -158,6 +160,7 @@ pub struct App {
     pub autocomplete_popup: Option<Vec<CompletionItem>>,
     pub autocomplete_index: usize,
     pub footer: FooterState,
+    pub working_indicator: WorkingIndicatorState,
     pub thinking_visible: bool,
     pub tools_expanded: bool,
     /// `true` when the user has explicitly enabled the sidebar via
@@ -219,6 +222,7 @@ impl App {
                 connected: true,
                 busy_label: None,
             },
+            working_indicator: WorkingIndicatorState::default(),
             thinking_visible: true,
             tools_expanded: true,
             sidebar_visible: false,
@@ -1279,6 +1283,7 @@ impl App {
             autocomplete_popup: None,
             autocomplete_index: 0,
             footer: config.footer,
+            working_indicator: WorkingIndicatorState::default(),
             thinking_visible: true,
             tools_expanded: true,
             sidebar_visible: false,
@@ -1560,7 +1565,8 @@ async fn run_external_editor(terminal: &mut Terminal<CrosstermBackend<Stdout>>, 
 ///
 /// On non-Unix platforms (Windows), SIGTSTP does not exist; surface a
 /// friendly error instead of stopping the process in a broken way.
-#[allow(clippy::unused_async)] // tokio scope alignment with siblings
+// CLIPPY-ALLOW: tokio scope alignment with siblings.
+#[allow(clippy::unused_async)]
 async fn run_suspend(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
     #[cfg(unix)]
     {
@@ -1763,27 +1769,7 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
     let demo_mode = config.demo_mode;
     let demo_seconds = config.demo_seconds;
     let mut app = App::from_config(config)?;
-
-    // Demo mode keeps the loop pure-render so screenshots and tests
-    // do not require a backend on the host. Production paths set
-    // SENPI_NEO_BACKEND_BIN to either senpi --mode rpc or the QA
-    // harness's senpi-neo-faux binary.
-    let mut backend: Option<RpcClient> = None;
-    if !demo_mode {
-        match maybe_spawn_backend() {
-            Ok(client) => backend = client,
-            Err(message) => {
-                // Bug 3 contract: an env-configured-but-unspawnable
-                // backend used to boot identically to demo mode. Now
-                // the user sees the actual spawn failure as soon as the
-                // first frame renders.
-                app.apply_inbound(Inbound::Error {
-                    exit_code: None,
-                    stderr_tail: message,
-                });
-            }
-        }
-    }
+    let mut backend = attach_backend(&mut app, demo_mode);
     let mut inbound: Option<mpsc::Receiver<Inbound>> = backend.as_mut().and_then(RpcClient::take_inbound);
     let cmd_tx: Option<mpsc::Sender<Command>> = backend.as_ref().map(RpcClient::command_sender);
 
@@ -1809,12 +1795,7 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
         tokio::select! {
             biased;
             _ = draw_rx.recv() => {
-                app.footer.spinner_glyph = SPINNER_FRAMES[spinner_idx];
-                app.footer.elapsed_secs = start.elapsed().as_secs();
-                let stdout_handle = terminal.backend_mut();
-                execute!(stdout_handle, BeginSynchronizedUpdate)?;
-                terminal.draw(|frame| draw_app(frame, &app))?;
-                execute!(terminal.backend_mut(), EndSynchronizedUpdate)?;
+                render_requested_frame(terminal, &mut app, spinner_idx, &start, &frame_requester)?;
             }
             _ = spinner_tick.tick() => {
                 if app.animations_enabled {
@@ -1878,7 +1859,50 @@ async fn drive(terminal: &mut Terminal<CrosstermBackend<Stdout>>, config: AppCon
     Ok(())
 }
 
-fn draw_app(frame: &mut Frame<'_>, app: &App) {
+fn attach_backend(app: &mut App, demo_mode: bool) -> Option<RpcClient> {
+    if demo_mode {
+        return None;
+    }
+    match maybe_spawn_backend() {
+        Ok(client) => client,
+        Err(message) => {
+            app.apply_inbound(Inbound::Error {
+                exit_code: None,
+                stderr_tail: message,
+            });
+            None
+        }
+    }
+}
+
+fn render_requested_frame(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    app: &mut App,
+    spinner_idx: usize,
+    start: &Instant,
+    frame_requester: &FrameRequester,
+) -> Result<()> {
+    app.footer.spinner_glyph = SPINNER_FRAMES[spinner_idx];
+    let elapsed = start.elapsed();
+    app.footer.elapsed_secs = elapsed.as_secs();
+    app.working_indicator.visible = matches!(
+        app.footer.status,
+        Status::Busy | Status::Streaming | Status::ToolRunning
+    );
+    app.working_indicator.elapsed_secs = app.footer.elapsed_secs;
+
+    let now_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+    let stdout_handle = terminal.backend_mut();
+    execute!(stdout_handle, BeginSynchronizedUpdate)?;
+    terminal.draw(|frame| draw_app(frame, app, now_ms))?;
+    execute!(terminal.backend_mut(), EndSynchronizedUpdate)?;
+    if app.working_indicator.visible {
+        frame_requester.schedule_frame_in(Duration::from_millis(32));
+    }
+    Ok(())
+}
+
+fn draw_app(frame: &mut Frame<'_>, app: &App, now_ms: u64) {
     let area = frame.area();
     let input_wrap_width = usize::from(area.width.saturating_sub(6).max(1));
     let line_count = app.input.display_lines(input_wrap_width).len();
@@ -1889,6 +1913,7 @@ fn draw_app(frame: &mut Frame<'_>, app: &App) {
         LayoutState {
             input_lines: u16::try_from(line_count).unwrap_or(1),
             sidebar_visible,
+            show_working_indicator: app.working_indicator.visible,
         },
     );
 
@@ -1905,6 +1930,9 @@ fn draw_app(frame: &mut Frame<'_>, app: &App) {
     );
     input::render(frame, computed.input, &app.theme, &app.input);
     footer::render(frame, computed.footer, &app.theme, &app.footer);
+    if let Some(wi_area) = computed.working_indicator {
+        working_indicator::render(frame, wi_area, &app.theme, &app.working_indicator, now_ms);
+    }
 
     if let Some(overlay) = app.overlay.as_ref() {
         overlay.render(frame, area, &app.theme);

--- a/packages/neo-tui/src/components/mod.rs
+++ b/packages/neo-tui/src/components/mod.rs
@@ -12,3 +12,4 @@ pub mod input;
 pub mod markdown;
 pub mod select_list;
 pub mod settings_list;
+pub mod working_indicator;

--- a/packages/neo-tui/src/components/working_indicator.rs
+++ b/packages/neo-tui/src/components/working_indicator.rs
@@ -1,0 +1,144 @@
+//! Single-row "Working" indicator that materializes above the input while the
+//! agent is busy or streaming.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::anim::shimmer;
+use crate::theme::{ResolvedTheme, Token};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct WorkingIndicatorState {
+    pub visible: bool,
+    pub elapsed_secs: u64,
+}
+
+#[must_use]
+pub fn fmt_elapsed_compact(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        let m = secs / 60;
+        let s = secs % 60;
+        format!("{m}m {s:02}s")
+    } else {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        let s = secs % 60;
+        format!("{h}h {m:02}m {s:02}s")
+    }
+}
+
+pub fn render(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    theme: &ResolvedTheme,
+    state: &WorkingIndicatorState,
+    now_ms: u64,
+) {
+    if !state.visible || area.height == 0 || area.width == 0 {
+        return;
+    }
+    let fg = theme.token(Token::Text);
+    let highlight = theme.token(Token::Primary);
+    let muted = theme.token(Token::TextMuted);
+    let mut spans: Vec<Span<'static>> = shimmer::shimmer_spans("Working", fg, highlight, now_ms);
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        format!(
+            "({elapsed} \u{00b7} esc to interrupt)",
+            elapsed = fmt_elapsed_compact(state.elapsed_secs)
+        ),
+        Style::default().fg(muted),
+    ));
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    use super::*;
+    use crate::load_bundled_dark_theme;
+
+    fn render_line(state: &WorkingIndicatorState, width: u16, now_ms: u64) -> String {
+        let backend = TestBackend::new(width, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = load_bundled_dark_theme().unwrap();
+        terminal
+            .draw(|frame| render(frame, Rect::new(0, 0, width, 1), &theme, state, now_ms))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        (0..buf.area.width)
+            .map(|x| buf.cell((x, 0)).unwrap().symbol().to_owned())
+            .collect()
+    }
+
+    #[test]
+    fn hidden_when_not_visible() {
+        let state = WorkingIndicatorState {
+            visible: false,
+            elapsed_secs: 0,
+        };
+        let text = render_line(&state, 80, 0);
+        assert_eq!(text.len(), 80);
+        for ch in text.chars() {
+            assert_eq!(ch, ' ', "expected only spaces, got {ch:?} in {text:?}");
+        }
+    }
+
+    #[test]
+    fn shows_working_text_when_visible() {
+        let state = WorkingIndicatorState {
+            visible: true,
+            elapsed_secs: 5,
+        };
+        let text = render_line(&state, 80, 0);
+        assert!(text.contains("Working"), "missing Working: {text:?}");
+    }
+
+    #[test]
+    fn shows_elapsed_time() {
+        let state = WorkingIndicatorState {
+            visible: true,
+            elapsed_secs: 65,
+        };
+        let text = render_line(&state, 80, 0);
+        assert!(text.contains("1m 05s"), "missing 1m 05s: {text:?}");
+    }
+
+    #[test]
+    fn shows_interrupt_hint() {
+        let state = WorkingIndicatorState {
+            visible: true,
+            elapsed_secs: 5,
+        };
+        let text = render_line(&state, 80, 0);
+        assert!(
+            text.contains("esc to interrupt"),
+            "missing esc to interrupt: {text:?}"
+        );
+    }
+
+    #[test]
+    fn fmt_elapsed_compact_seconds() {
+        assert_eq!(fmt_elapsed_compact(0), "0s");
+        assert_eq!(fmt_elapsed_compact(59), "59s");
+    }
+
+    #[test]
+    fn fmt_elapsed_compact_minutes() {
+        assert_eq!(fmt_elapsed_compact(60), "1m 00s");
+        assert_eq!(fmt_elapsed_compact(125), "2m 05s");
+    }
+
+    #[test]
+    fn fmt_elapsed_compact_hours() {
+        assert_eq!(fmt_elapsed_compact(3661), "1h 01m 01s");
+    }
+}

--- a/packages/neo-tui/src/layout/mod.rs
+++ b/packages/neo-tui/src/layout/mod.rs
@@ -11,6 +11,7 @@ pub struct ComputedLayout {
     pub header: Rect,
     pub chat: Rect,
     pub sidebar: Option<Rect>,
+    pub working_indicator: Option<Rect>,
     pub input: Rect,
     pub footer: Rect,
 }
@@ -22,6 +23,8 @@ pub struct LayoutState {
     pub input_lines: u16,
     /// `true` when the sidebar should be shown (auto-shown when width >= 120).
     pub sidebar_visible: bool,
+    /// `true` when the one-row working indicator should be shown above input.
+    pub show_working_indicator: bool,
 }
 
 impl Default for LayoutState {
@@ -29,12 +32,14 @@ impl Default for LayoutState {
         Self {
             input_lines: 1,
             sidebar_visible: false,
+            show_working_indicator: false,
         }
     }
 }
 
 const HEADER_HEIGHT: u16 = 3;
 const FOOTER_HEIGHT: u16 = 1;
+const WORKING_INDICATOR_HEIGHT: u16 = 1;
 const SIDEBAR_WIDTH: u16 = 42;
 /// Minimum terminal width at which the sidebar surfaces. Exposed so the
 /// app loop can flip `LayoutState::sidebar_visible` in step with the
@@ -55,24 +60,43 @@ pub fn compute(area: Rect, state: LayoutState) -> ComputedLayout {
     }
 
     let body_height = area.height.saturating_sub(HEADER_HEIGHT + FOOTER_HEIGHT);
+    let working_indicator_height = if state.show_working_indicator {
+        WORKING_INDICATOR_HEIGHT
+    } else {
+        0
+    };
     let input_height = (state.input_lines.clamp(1, 7) + INPUT_FRAME_OVERHEAD)
         .clamp(MIN_INPUT_HEIGHT, MAX_INPUT_HEIGHT)
-        .min(body_height.saturating_sub(3));
+        .min(body_height.saturating_sub(3 + working_indicator_height));
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let constraints = if state.show_working_indicator {
+        vec![
+            Constraint::Length(HEADER_HEIGHT),
+            Constraint::Min(3),
+            Constraint::Length(WORKING_INDICATOR_HEIGHT),
+            Constraint::Length(input_height),
+            Constraint::Length(FOOTER_HEIGHT),
+        ]
+    } else {
+        vec![
             Constraint::Length(HEADER_HEIGHT),
             Constraint::Min(3),
             Constraint::Length(input_height),
             Constraint::Length(FOOTER_HEIGHT),
-        ])
+        ]
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(area);
 
     let header = chunks[0];
     let body = chunks[1];
-    let input = chunks[2];
-    let footer = chunks[3];
+    let working_indicator = state.show_working_indicator.then_some(chunks[2]);
+    let input_index = if state.show_working_indicator { 3 } else { 2 };
+    let input = chunks[input_index];
+    let footer = chunks[input_index + 1];
 
     let show_sidebar = state.sidebar_visible && area.width >= SIDEBAR_MIN_TERMINAL_WIDTH;
     let (chat, sidebar) = if show_sidebar {
@@ -89,6 +113,7 @@ pub fn compute(area: Rect, state: LayoutState) -> ComputedLayout {
         header,
         chat,
         sidebar,
+        working_indicator,
         input,
         footer,
     }
@@ -110,6 +135,7 @@ mod tests {
             LayoutState {
                 input_lines: 1,
                 sidebar_visible: true,
+                show_working_indicator: false,
             },
         );
         assert!(layout.sidebar.is_some(), "sidebar should appear at >=120 wide");
@@ -129,6 +155,7 @@ mod tests {
             LayoutState {
                 input_lines: 1,
                 sidebar_visible: true,
+                show_working_indicator: false,
             },
         );
         assert!(layout.sidebar.is_none(), "sidebar must hide at <120 wide");
@@ -148,6 +175,7 @@ mod tests {
             LayoutState {
                 input_lines: 1,
                 sidebar_visible: false,
+                show_working_indicator: false,
             },
         );
         let l9 = compute(
@@ -160,10 +188,36 @@ mod tests {
             LayoutState {
                 input_lines: 9,
                 sidebar_visible: false,
+                show_working_indicator: false,
             },
         );
         assert!(l9.input.height > l1.input.height);
         assert!(l9.input.height <= MAX_INPUT_HEIGHT);
+    }
+
+    #[test]
+    fn working_indicator_allocates_row_when_busy() {
+        let state = LayoutState {
+            input_lines: 1,
+            sidebar_visible: false,
+            show_working_indicator: true,
+        };
+        let computed = compute(Rect::new(0, 0, 80, 24), state);
+        let wi = computed.working_indicator.expect("indicator should allocate");
+        assert_eq!(wi.height, 1);
+        assert_eq!(wi.y, computed.chat.bottom());
+        assert_eq!(computed.input.y, wi.bottom());
+    }
+
+    #[test]
+    fn working_indicator_absent_when_idle() {
+        let state = LayoutState {
+            input_lines: 1,
+            sidebar_visible: false,
+            show_working_indicator: false,
+        };
+        let computed = compute(Rect::new(0, 0, 80, 24), state);
+        assert!(computed.working_indicator.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Make the idle ↔ streaming state in `senpi --neo` visually obvious. A shimmer-animated "Working" status row materializes directly above the composer whenever the agent is busy/streaming/running a tool, and vanishes when idle.

## User-reported problem

> idle <-> streaming 상태가 제대로 뭔가 안보여지는 느낌

The user could not tell at a glance whether the agent was idle or actively answering. Pre-fix, the only visible delta during streaming was one character changing from `·` to a rotating braille glyph in the footer's single character cell — easy to miss.

## Codex-inspired design

Following `codex-rs/tui`'s `StatusIndicatorWidget` pattern:

- A dedicated row appears ABOVE the composer when busy — the most visually prominent location
- Header text "Working" shimmers via cosine-band color sweep at 2s period
- Trailing muted text shows elapsed time and "esc to interrupt" affordance
- Row vanishes the moment the agent goes idle

## Implementation

3 atomic commits:

### 1. `feat(neo-tui): add shimmer animation effect for status text`
- `anim/shimmer.rs`: `shimmer_spans(text, fg, highlight, now_ms)` returns per-char `Span`s with cosine-falloff RGB blend on true-color terminals; 3-tier modifier fallback (BOLD/plain/DIM) on basic terminals.
- 4 inline tests cover empty text, span count, BOLD modifier, and time-varying styles.

### 2. `feat(neo-tui): add working indicator widget for agent activity`
- `components/working_indicator.rs`: `WorkingIndicatorState { visible, elapsed_secs }` + `render()` + `fmt_elapsed_compact()` helper formatting time as `Ns`/`Nm NNs`/`Nh NNm NNs`.
- Renders shimmer "Working" header + space + muted `(N · esc to interrupt)` hint.
- 7 inline tests (render visibility, elapsed display, interrupt hint, time formatting tiers).

### 3. `feat(neo-tui): integrate working indicator into layout and app loop`
- `layout/mod.rs`: `ComputedLayout` gains `Option<Rect> working_indicator`. `LayoutState` gains `show_working_indicator` bool. Adds a 1-row constraint between body and input when set; chat shrinks by 1 row.
- `app/mod.rs`: `App` gains `WorkingIndicatorState`. `draw_app(frame, app, now_ms)` derives `visible` from `footer.status` (`Busy | Streaming | ToolRunning`) at render time — single source of truth, no risk of missing status transition sites. Draw arm in `drive()` schedules a follow-up frame every 32ms while the indicator is visible to keep shimmer animating. Two helpers (`attach_backend`, `render_requested_frame`) extracted to keep `drive()` under the 100-line clippy threshold.
- 2 new layout tests covering allocation and absence.

## Manual QA

Built release binary, launched in tmux 100x30 with `--demo` (which holds Streaming state):

```
 ▏  layered Component dispatch (stub). anim = spinners + scanners (stub).
 ▏
Working (2s · esc to interrupt)
╭  shift+enter  newline · enter  send · /  commands · ctrl+p  palette · ?  help───────────────────╮
│ › ▏Ask senpi anything, or paste / drop / type · / for commands                                  │
╰─────────────────────────────────────────────────────────────────────────────────────────────────╯
 ⠂ streaming response  model:claude-opus-4-7:max                              ctx  42% │ 12k↓ 3.1k↑
```

- 5 seconds later: elapsed counter increments to `Working (22s · esc to interrupt)`, footer spinner rotates `⠂` → `⠴`.
- Idle state (`--backend-bin` faux, no scenario): footer shows `· ready`, NO Working row above input.

## Tests

13 new tests (all pass):

- `anim::shimmer::tests::*` (4)
- `components::working_indicator::tests::*` (7)
- `layout::tests::working_indicator_allocates_row_when_busy`
- `layout::tests::working_indicator_absent_when_idle`

Total: 364 passed, 1 skipped (was 351 after PR-A merge).

## Gates

- `cargo build --package senpi-neo-tui` — green
- `cargo nextest run --package senpi-neo-tui` — 364 passed
- `cargo clippy --package senpi-neo-tui --all-targets -- -D warnings` — clean
- `cargo fmt --package senpi-neo-tui -- --check` — clean
- `npm run check` — clean (900 files)

## Files

| File | Net change |
|---|---|
| `packages/neo-tui/src/anim/shimmer.rs` | +113 (new) |
| `packages/neo-tui/src/anim/mod.rs` | +3 |
| `packages/neo-tui/src/components/working_indicator.rs` | +144 (new) |
| `packages/neo-tui/src/components/mod.rs` | +1 |
| `packages/neo-tui/src/layout/mod.rs` | +60 −8 |
| `packages/neo-tui/src/app/mod.rs` | +50 −36 |

Net: +371 −44 across 6 files. Each new file under the 250 LoC per-file ceiling.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shimmer-animated “Working” row above the composer in `senpi --neo` so users can clearly see when the agent is busy/streaming. It shows an elapsed timer and “esc to interrupt,” and disappears when idle.

- **New Features**
  - Shimmer animation for the “Working” header (true-color blend with ANSI fallback).
  - Single-row indicator appears above input when `footer.status` is `Busy`, `Streaming`, or `ToolRunning`.
  - Shows elapsed time and an “esc to interrupt” hint.
  - Layout reserves one row for the indicator; chat shrinks by one line when visible.
  - App schedules a frame every 32ms while visible to keep the shimmer smooth.

- **Refactors**
  - Derived visibility from `footer.status` at render time to keep a single source of truth.
  - Extracted `attach_backend` and `render_requested_frame` to keep the main loop small and clear.

<sup>Written for commit 5d97b40a4b950c221dc1c14083d830e9ae6160f3. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/19?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

