### PR TITLE
refactor(kimi-web-search): rename tools to snake_case for consistency

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/kimi-web-search/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/kimi-web-search/index.ts
@@ -227,11 +227,11 @@ export default function kimiWebSearchExtension(pi: ExtensionAPI): void {
 	}
 
 	pi.registerTool({
-		name: "SearchWeb",
-		label: "SearchWeb",
+		name: "kimi_search_web",
+		label: "kimi_search_web",
 		description:
 			"WebSearch tool allows you to search on the internet to get latest information, including news, documents, release notes, blog posts, papers, etc.",
-		promptSnippet: "SearchWeb — search the internet for current information",
+		promptSnippet: "kimi_search_web — search the internet for current information",
 		parameters: searchWebSchema,
 		async execute(toolCallId, params, signal, _onUpdate, ctx) {
 			const apiKey = await resolveApiKey(ctx);
@@ -251,10 +251,10 @@ export default function kimiWebSearchExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.registerTool({
-		name: "FetchURL",
-		label: "FetchURL",
-		description: "FetchURL tool allows you to fetch content from a URL.",
-		promptSnippet: "FetchURL — fetch web page content from a URL",
+		name: "kimi_fetch_url",
+		label: "kimi_fetch_url",
+		description: "kimi_fetch_url tool allows you to fetch content from a URL.",
+		promptSnippet: "kimi_fetch_url — fetch web page content from a URL",
 		parameters: fetchUrlSchema,
 		async execute(toolCallId, params, signal, _onUpdate, ctx) {
 			const apiKey = await resolveApiKey(ctx);

--- a/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
@@ -79,21 +79,27 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 				.map((tool) => tool.name)
 				.sort(),
 		).toEqual([
-			"FetchURL",
-			"SearchWeb",
 			"apply_patch",
 			"bash",
 			"dynamic_tool",
 			"edit",
 			"find",
 			"grep",
+			"kimi_fetch_url",
+			"kimi_search_web",
 			"ls",
 			"read",
 			"todoread",
 			"todowrite",
 			"write",
 		]);
-		expect(session.getActiveToolNames()).toEqual(["todowrite", "todoread", "SearchWeb", "FetchURL", "dynamic_tool"]);
+		expect(session.getActiveToolNames()).toEqual([
+			"todowrite",
+			"todoread",
+			"kimi_search_web",
+			"kimi_fetch_url",
+			"dynamic_tool",
+		]);
 		expect(session.systemPrompt).toContain("- dynamic_tool: Run dynamic test behavior");
 		expect(session.systemPrompt).not.toContain("- read:");
 		expect(session.systemPrompt).not.toContain("- bash:");
@@ -125,7 +131,13 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 			noTools: "builtin",
 		});
 
-		expect(session.getActiveToolNames()).toEqual(["apply_patch", "todowrite", "todoread", "SearchWeb", "FetchURL"]);
+		expect(session.getActiveToolNames()).toEqual([
+			"apply_patch",
+			"todowrite",
+			"todoread",
+			"kimi_search_web",
+			"kimi_fetch_url",
+		]);
 		expect(session.systemPrompt).toContain("- todowrite:");
 		expect(session.systemPrompt).not.toContain("- read:");
 		session.dispose();


### PR DESCRIPTION
## Summary

Renames `SearchWeb`/`FetchURL` to `kimi_search_web`/`kimi_fetch_url` to align with senpi/pi-mono tool naming conventions.

## Problem

The current tool names use PascalCase (`SearchWeb`, `FetchURL`), inherited from Kimi CLI's class names. This is inconsistent with every other tool in the senpi ecosystem:

| Tool | Naming |
|------|--------|
| `read`, `write`, `edit`, `bash` | lowercase |
| `apply_patch`, `multiedit` | snake_case |
| `web_search` (anthropic-web-search) | snake_case |
| `todowrite`, `todoread` | lowercase |
| `SearchWeb`, `FetchURL` (kimi-web-search) | **PascalCase** ❌ |

## Solution

- `SearchWeb` → `kimi_search_web`
- `FetchURL` → `kimi_fetch_url`

This makes the tool names consistent with:
1. The rest of senpi's builtin extensions
2. Third-party extensions (e.g., `pi-websearch` uses `web_search`)
3. The general Unix/CLI convention of snake_case for identifiers

## Changes

- `packages/coding-agent/src/core/extensions/builtin/kimi-web-search/index.ts`
  - `name`, `label`, `description`, `promptSnippet` updated

## Checklist

- [x] Pre-commit checks pass (Biome + tsgo + browser-smoke + web-ui)
- [x] Atomic commit with clear rationale
- [x] No breaking changes to tool schema (only the tool name changed)

## Migration

Users with `permission` rules for `SearchWeb`/`FetchURL` need to update:
```json
"permission": {
  "kimi_search_web": "allow",
  "kimi_fetch_url": "allow"
}
```

Refs: #10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `SearchWeb` and `FetchURL` to `kimi_search_web` and `kimi_fetch_url` for consistent snake_case tool names across senpi/pi-mono, and updated regression tests. Aligns with #10; no schema or behavior changes.

- **Migration**
  - Update any `permission` rules or references: `SearchWeb` → `kimi_search_web`, `FetchURL` → `kimi_fetch_url`.

<sup>Written for commit ba84934011a3fa6e56480e7f51126df539ae93a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

