### PR TITLE
fix(tui): stabilize nested background resets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,19 +2817,6 @@
 			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
 			"license": "Apache-2.0"
 		},
-		"node_modules/@smithy/abort-controller": {
-			"version": "4.2.15",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.15.tgz",
-			"integrity": "sha512-98zuTrdp06d5jhoIA7gBzEAh+4zZMywxdS1qiiUg0BOTq/EE4zc0bqgbSBKMcRKSNFZrpVFjspExiP7ScO2l5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@smithy/core": {
 			"version": "3.24.3",
 			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
@@ -2892,32 +2879,6 @@
 			"dependencies": {
 				"@smithy/core": "^3.24.3",
 				"@smithy/types": "^4.14.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/protocol-http": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.3.tgz",
-			"integrity": "sha512-P16TBD/d8ZcD9MHQ0ubQ9BbOYSd5HZKbHOLsyFWxKk2oBEoghbRFPfGOoqToZX1yrfLITXRylL16EyPP4IzLPg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.24.3",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.3.3.tgz",
-			"integrity": "sha512-2+/Nwh4OPVBW9snd6dYqgnSwy84kQOI8fnKv2kC6sW5BEv/qZMBRdZjMShwhtjUHHlnL+SZbYolFeDWTEVbHlA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.24.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -7872,10 +7833,10 @@
 		},
 		"packages/agent": {
 			"name": "@earendil-works/pi-agent-core",
-			"version": "2026.5.21-2",
+			"version": "2026.5.24",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^2026.5.21-2",
+				"@earendil-works/pi-ai": "^2026.5.24",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -7909,7 +7870,7 @@
 		},
 		"packages/ai": {
 			"name": "@earendil-works/pi-ai",
-			"version": "2026.5.21-2",
+			"version": "2026.5.24",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
@@ -7970,7 +7931,7 @@
 		},
 		"packages/coding-agent": {
 			"name": "@code-yeongyu/senpi",
-			"version": "2026.5.21-2",
+			"version": "2026.5.24",
 			"bundleDependencies": [
 				"@earendil-works/pi-agent-core",
 				"@earendil-works/pi-ai",
@@ -7980,12 +7941,12 @@
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
 				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
-				"@earendil-works/pi-agent-core": "^2026.5.21-2",
-				"@earendil-works/pi-ai": "^2026.5.21-2",
-				"@earendil-works/pi-tui": "^2026.5.21-2",
+				"@earendil-works/pi-agent-core": "^2026.5.24",
+				"@earendil-works/pi-ai": "^2026.5.24",
+				"@earendil-works/pi-tui": "^2026.5.24",
 				"@mistralai/mistralai": "2.2.1",
 				"@silvia-odwyer/photon-node": "0.3.4",
-				"@smithy/node-http-handler": "4.4.0",
+				"@smithy/node-http-handler": "4.7.3",
 				"@smithy/types": "4.8.0",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -8064,22 +8025,6 @@
 			},
 			"devDependencies": {
 				"@types/ms": "2.1.0"
-			}
-		},
-		"packages/coding-agent/node_modules/@smithy/node-http-handler": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.0.tgz",
-			"integrity": "sha512-E00fuesARqnmdc1vR4qurQjQH+QWcsKjmM6kYoJBWjxgqNfp1WHc1SwfC18EdVaYamgctxyXV6kWhHmanhYgCg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/abort-controller": "^4.2.1",
-				"@smithy/protocol-http": "^5.3.1",
-				"@smithy/querystring-builder": "^4.2.1",
-				"@smithy/types": "^4.7.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"packages/coding-agent/node_modules/@smithy/types": {
@@ -8184,7 +8129,7 @@
 		},
 		"packages/tui": {
 			"name": "@earendil-works/pi-tui",
-			"version": "2026.5.21-2",
+			"version": "2026.5.24",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -8212,12 +8157,12 @@
 		},
 		"packages/web-ui": {
 			"name": "@earendil-works/pi-web-ui",
-			"version": "2026.5.21-2",
+			"version": "2026.5.24",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^2026.5.21-2",
-				"@earendil-works/pi-ai": "^2026.5.21-2",
-				"@earendil-works/pi-tui": "^2026.5.21-2",
+				"@earendil-works/pi-agent-core": "^2026.5.24",
+				"@earendil-works/pi-ai": "^2026.5.24",
+				"@earendil-works/pi-tui": "^2026.5.24",
 				"@lmstudio/sdk": "1.5.0",
 				"docx-preview": "0.3.7",
 				"highlight.js": "11.11.1",

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -16,7 +16,7 @@
 				"@earendil-works/pi-tui": "^2026.5.24",
 				"@mistralai/mistralai": "2.2.1",
 				"@silvia-odwyer/photon-node": "0.3.4",
-				"@smithy/node-http-handler": "4.4.0",
+				"@smithy/node-http-handler": "4.7.3",
 				"@smithy/types": "4.8.0",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -49,7 +49,7 @@
 		"@earendil-works/pi-tui": "^2026.5.24",
 		"@mistralai/mistralai": "2.2.1",
 		"@silvia-odwyer/photon-node": "0.3.4",
-		"@smithy/node-http-handler": "4.4.0",
+		"@smithy/node-http-handler": "4.7.3",
 		"@smithy/types": "4.8.0",
 		"chalk": "5.6.2",
 		"cross-spawn": "7.0.6",

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -73,26 +73,44 @@ function getAliases(): Record<string, string> {
 	if (_aliases) return _aliases;
 
 	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const packageIndex = path.resolve(__dirname, "../..", "index.js");
-
 	const typeboxEntry = require.resolve("typebox");
 	const typeboxCompileEntry = require.resolve("typebox/compile");
 	const typeboxValueEntry = require.resolve("typebox/value");
 
 	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrImport = (workspaceRelativePath: string, specifier: string): string => {
+	const resolveWorkspaceOrImport = (
+		workspaceRelativePath: string,
+		sourceRelativePath: string,
+		specifier: string,
+	): string => {
 		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
 		if (fs.existsSync(workspacePath)) {
 			return workspacePath;
 		}
-		return fileURLToPath(import.meta.resolve(specifier));
+		const sourcePath = path.join(packagesRoot, sourceRelativePath);
+		if (fs.existsSync(sourcePath)) {
+			return sourcePath;
+		}
+		return require.resolve(specifier);
 	};
 
-	const piCodingAgentEntry = packageIndex;
-	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
-	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
-	const piAiEntry = resolveWorkspaceOrImport("ai/dist/index.js", "@earendil-works/pi-ai");
-	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai/oauth");
+	const piCodingAgentEntry = resolveWorkspaceOrImport(
+		"coding-agent/dist/index.js",
+		"coding-agent/src/index.ts",
+		"@code-yeongyu/senpi",
+	);
+	const piAgentCoreEntry = resolveWorkspaceOrImport(
+		"agent/dist/index.js",
+		"agent/src/index.ts",
+		"@earendil-works/pi-agent-core",
+	);
+	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "tui/src/index.ts", "@earendil-works/pi-tui");
+	const piAiEntry = resolveWorkspaceOrImport("ai/dist/index.js", "ai/src/index.ts", "@earendil-works/pi-ai");
+	const piAiOauthEntry = resolveWorkspaceOrImport(
+		"ai/dist/oauth.js",
+		"ai/src/oauth.ts",
+		"@earendil-works/pi-ai/oauth",
+	);
 
 	_aliases = {
 		"@code-yeongyu/senpi": piCodingAgentEntry,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -77,12 +77,19 @@ function getAliases(): Record<string, string> {
 	const typeboxCompileEntry = require.resolve("typebox/compile");
 	const typeboxValueEntry = require.resolve("typebox/value");
 
-	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrImport = (
+	const codingAgentPackageRoot = path.resolve(__dirname, "../../..");
+	const packagesRoot = path.dirname(codingAgentPackageRoot);
+	const resolveWorkspaceOrBundled = (
+		packageName: string,
+		packageEntryRelativePath: string,
 		workspaceRelativePath: string,
 		sourceRelativePath: string,
 		specifier: string,
 	): string => {
+		const bundledPath = path.join(codingAgentPackageRoot, "node_modules", packageName, packageEntryRelativePath);
+		if (fs.existsSync(bundledPath)) {
+			return bundledPath;
+		}
 		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
 		if (fs.existsSync(workspacePath)) {
 			return workspacePath;
@@ -91,22 +98,38 @@ function getAliases(): Record<string, string> {
 		if (fs.existsSync(sourcePath)) {
 			return sourcePath;
 		}
-		return require.resolve(specifier);
+		return typeof import.meta.resolve === "function"
+			? fileURLToPath(import.meta.resolve(specifier))
+			: require.resolve(specifier);
 	};
 
-	const piCodingAgentEntry = resolveWorkspaceOrImport(
-		"coding-agent/dist/index.js",
-		"coding-agent/src/index.ts",
-		"@code-yeongyu/senpi",
-	);
-	const piAgentCoreEntry = resolveWorkspaceOrImport(
+	const piCodingAgentDistEntry = path.join(codingAgentPackageRoot, "dist/index.js");
+	const piCodingAgentSourceEntry = path.join(codingAgentPackageRoot, "src/index.ts");
+	const piCodingAgentEntry = fs.existsSync(piCodingAgentDistEntry) ? piCodingAgentDistEntry : piCodingAgentSourceEntry;
+	const piAgentCoreEntry = resolveWorkspaceOrBundled(
+		"@earendil-works/pi-agent-core",
+		"dist/index.js",
 		"agent/dist/index.js",
 		"agent/src/index.ts",
 		"@earendil-works/pi-agent-core",
 	);
-	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "tui/src/index.ts", "@earendil-works/pi-tui");
-	const piAiEntry = resolveWorkspaceOrImport("ai/dist/index.js", "ai/src/index.ts", "@earendil-works/pi-ai");
-	const piAiOauthEntry = resolveWorkspaceOrImport(
+	const piTuiEntry = resolveWorkspaceOrBundled(
+		"@earendil-works/pi-tui",
+		"dist/index.js",
+		"tui/dist/index.js",
+		"tui/src/index.ts",
+		"@earendil-works/pi-tui",
+	);
+	const piAiEntry = resolveWorkspaceOrBundled(
+		"@earendil-works/pi-ai",
+		"dist/index.js",
+		"ai/dist/index.js",
+		"ai/src/index.ts",
+		"@earendil-works/pi-ai",
+	);
+	const piAiOauthEntry = resolveWorkspaceOrBundled(
+		"@earendil-works/pi-ai",
+		"dist/oauth.js",
 		"ai/dist/oauth.js",
 		"ai/src/oauth.ts",
 		"@earendil-works/pi-ai/oauth",

--- a/packages/coding-agent/test/extensions-loader.test.ts
+++ b/packages/coding-agent/test/extensions-loader.test.ts
@@ -1,8 +1,11 @@
+import type { PathLike } from "node:fs";
+import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionFactory } from "../src/core/extensions/types.ts";
 
 describe("extension loader", () => {
 	afterEach(() => {
+		vi.doUnmock("node:fs");
 		vi.doUnmock("jiti/static");
 		vi.resetModules();
 	});
@@ -27,5 +30,52 @@ describe("extension loader", () => {
 		expect(result.extensions).toHaveLength(2);
 		expect(importExtension).toHaveBeenCalledTimes(2);
 		expect(createJiti).toHaveBeenCalledTimes(1);
+	});
+
+	it("prefers bundled package aliases when the local coding-agent package carries dependencies", async () => {
+		// given a linked local senpi install where dependencies live under
+		// packages/coding-agent/node_modules instead of the workspace root
+		const extensionFactory: ExtensionFactory = (pi: ExtensionAPI) => {
+			pi.registerCommand("mock-command", {
+				handler: async () => {},
+			});
+		};
+		const importExtension = vi.fn(async () => extensionFactory);
+		let capturedOptions: { readonly alias?: Record<string, string> } | undefined;
+		const createJiti = vi.fn((_url: string, options: { readonly alias?: Record<string, string> }) => {
+			capturedOptions = options;
+			return {
+				import: importExtension,
+			};
+		});
+		const bundledTuiEntry = path.join(
+			"packages",
+			"coding-agent",
+			"node_modules",
+			"@earendil-works",
+			"pi-tui",
+			"dist",
+			"index.js",
+		);
+
+		vi.doMock("jiti/static", () => ({ createJiti }));
+		vi.doMock("node:fs", async () => {
+			const fs = await vi.importActual<typeof import("node:fs")>("node:fs");
+			return {
+				...fs,
+				existsSync(targetPath: PathLike): boolean {
+					return targetPath.toString().endsWith(bundledTuiEntry) || fs.existsSync(targetPath);
+				},
+			};
+		});
+		const { loadExtensions } = await import("../src/core/extensions/loader.ts");
+
+		// when extension loading creates the shared jiti importer
+		const result = await loadExtensions(["first.js"], "/tmp");
+
+		// then aliased upstream TUI imports resolve to the bundled copy whose
+		// transitive deps are installed beside the coding-agent package
+		expect(result.errors).toHaveLength(0);
+		expect(capturedOptions?.alias?.["@earendil-works/pi-tui"]).toContain(bundledTuiEntry);
 	});
 });

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -256,7 +256,7 @@ Project skill`,
 
 			const commands = runner.getRegisteredCommands();
 			const invocationNames = commands.map((command) => command.invocationName).filter((name) => name !== "tui");
-			expect(invocationNames).toEqual(["deploy:1", "project-only", "deploy:2", "user-only"]);
+			expect(invocationNames).toEqual(["history", "sessions", "deploy:1", "project-only", "deploy:2", "user-only"]);
 		});
 
 		it("should honor overrides for auto-discovered resources", async () => {
@@ -366,6 +366,8 @@ Content`,
 				"<builtin:bash-timeout>",
 				"<builtin:tool-pair-guard>",
 				"<builtin:compaction>",
+				"<builtin:history-search>",
+				"<builtin:session-observer>",
 				"<builtin:kimi-web-search>",
 			]);
 		});

--- a/packages/coding-agent/test/theme-picker.test.ts
+++ b/packages/coding-agent/test/theme-picker.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.ts";
 import {
 	getAvailableThemes,
 	getAvailableThemesWithPaths,
@@ -20,7 +21,7 @@ describe("theme picker", () => {
 	beforeEach(() => {
 		tempRoot = mkdtempSync(join(tmpdir(), "pi-theme-picker-"));
 		const agentDir = join(tempRoot, "agent");
-		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		vi.stubEnv(ENV_AGENT_DIR, agentDir);
 		mkdirSync(join(agentDir, "themes"), { recursive: true });
 		setRegisteredThemes([]);
 	});
@@ -40,7 +41,7 @@ describe("theme picker", () => {
 			name: "bar",
 		};
 
-		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "foo.json");
+		const themePath = join(process.env[ENV_AGENT_DIR]!, "themes", "foo.json");
 		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
 
 		expect(getAvailableThemes()).toContain("bar");

--- a/packages/neo-tui/assets/keymaps/default.json
+++ b/packages/neo-tui/assets/keymaps/default.json
@@ -47,6 +47,8 @@
     "app.model.cycleForward": ["ctrl+p"],
     "app.model.cycleBackward": ["shift+ctrl+p"],
     "app.model.select": ["ctrl+l"],
+    "app.history.search": ["ctrl+r"],
+    "app.sessions.observe": ["ctrl+s"],
     "app.tools.expand": ["ctrl+o"],
     "app.thinking.toggle": ["ctrl+t"],
     "app.session.toggleNamedFilter": ["ctrl+n"],

--- a/packages/neo-tui/tests/keymap.rs
+++ b/packages/neo-tui/tests/keymap.rs
@@ -69,6 +69,8 @@ const LEGACY_REGISTRY: &[(&str, &[&str])] = &[
     ("app.model.cycleForward", &["ctrl+p"]),
     ("app.model.cycleBackward", &["shift+ctrl+p"]),
     ("app.model.select", &["ctrl+l"]),
+    ("app.history.search", &["ctrl+r"]),
+    ("app.sessions.observe", &["ctrl+s"]),
     ("app.tools.expand", &["ctrl+o"]),
     ("app.thinking.toggle", &["ctrl+t"]),
     ("app.session.toggleNamedFilter", &["ctrl+n"]),

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -834,6 +834,48 @@ function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker): s
 	return lines.length > 0 ? lines : [""];
 }
 
+function sgrLeavesDefaultBackground(params: string): boolean {
+	if (params === "") {
+		return true;
+	}
+
+	const parts = params.split(";");
+	let backgroundIsDefault = false;
+	let index = 0;
+	while (index < parts.length) {
+		const part = parts[index] ?? "";
+		const code = part === "" ? 0 : Number.parseInt(part, 10);
+		if (Number.isNaN(code)) {
+			index++;
+			continue;
+		}
+		if (code === 0 || code === 49) {
+			backgroundIsDefault = true;
+			index++;
+			continue;
+		}
+		if ((code === 38 || code === 48) && parts[index + 1] === "5" && parts[index + 2] !== undefined) {
+			if (code === 48) {
+				backgroundIsDefault = false;
+			}
+			index += 3;
+			continue;
+		}
+		if ((code === 38 || code === 48) && parts[index + 1] === "2" && parts[index + 4] !== undefined) {
+			if (code === 48) {
+				backgroundIsDefault = false;
+			}
+			index += 5;
+			continue;
+		}
+		if ((code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+			backgroundIsDefault = false;
+		}
+		index++;
+	}
+	return backgroundIsDefault;
+}
+
 /**
  * Apply background color to a line, padding to full width.
  *
@@ -859,12 +901,18 @@ export function applyBackgroundToLine(line: string, width: number, bgFn: (text: 
 
 	const bgStart = wrappedMarker.slice(0, markerIndex);
 	const bgEnd = wrappedMarker.slice(markerIndex + marker.length);
-	const restored = withPadding.replace(/\x1b\[([0-9;]*)m/g, (sequence: string, params: string) => {
-		if (params === "" || params.split(";").some((param) => param === "0" || param === "49")) {
+	const restoredLine = line.replace(/\x1b\[([0-9;]*)m/g, (sequence: string, params: string) => {
+		if (sgrLeavesDefaultBackground(params)) {
 			return `${sequence}${bgStart}`;
 		}
 		return sequence;
 	});
+	const tracker = new AnsiCodeTracker();
+	updateTrackerFromText(line, tracker);
+	const restored =
+		paddingNeeded > 0 && tracker.hasActiveCodes()
+			? `${restoredLine}\x1b[0m${tracker.getLineEndReset()}${bgStart}${padding}`
+			: restoredLine + padding;
 	return `${bgStart}${restored}${bgEnd}`;
 }
 

--- a/packages/tui/test/tool-background.test.ts
+++ b/packages/tui/test/tool-background.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { Terminal as XtermTerminalType } from "@xterm/headless";
+import { Text } from "../src/components/text.ts";
+import { TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+type CellBackground = {
+	readonly color: number;
+	readonly isDefault: boolean;
+	readonly isRgb: boolean;
+};
+
+function getCellBackground(terminal: VirtualTerminal, row: number, col: number): CellBackground {
+	const xtermValue: unknown = Reflect.get(terminal, "xterm");
+	assert.ok(isXtermTerminal(xtermValue), "VirtualTerminal should expose an xterm instance in tests");
+	const xterm = xtermValue;
+	const buffer = xterm.buffer.active;
+	const line = buffer.getLine(buffer.viewportY + row);
+	assert.ok(line, `Missing buffer line at row ${row}`);
+	const cell = line.getCell(col);
+	assert.ok(cell, `Missing cell at row ${row} col ${col}`);
+	return {
+		color: cell.getBgColor(),
+		isDefault: cell.isBgDefault(),
+		isRgb: cell.isBgRGB(),
+	};
+}
+
+function isXtermTerminal(value: unknown): value is XtermTerminalType {
+	return typeof value === "object" && value !== null && "buffer" in value;
+}
+
+describe("TUI tool background rendering", () => {
+	it("#given tool background line with unclosed inner background #when rendering #then tail padding uses the tool background", async () => {
+		// given
+		const terminal = new VirtualTerminal(16, 4);
+		const tui = new TUI(terminal);
+		const toolBg = "\x1b[48;2;10;90;40m";
+		const toolBgColor = 0x0a5a28;
+		const innerBg = "\x1b[48;2;120;20;20m";
+		const innerBgColor = 0x781414;
+		tui.addChild(new Text(`${innerBg}tool`, 0, 0, (text) => `${toolBg}${text}\x1b[49m`));
+		tui.addChild(new Text("assistant", 0, 0));
+
+		try {
+			// when
+			tui.start();
+			await terminal.waitForRender();
+
+			// then
+			const contentBackground = getCellBackground(terminal, 0, 0);
+			const paddingBackground = getCellBackground(terminal, 0, 4);
+			const assistantBackground = getCellBackground(terminal, 1, 0);
+			assert.strictEqual(contentBackground.isRgb, true);
+			assert.strictEqual(contentBackground.color, innerBgColor);
+			assert.strictEqual(paddingBackground.isRgb, true);
+			assert.strictEqual(paddingBackground.color, toolBgColor);
+			assert.strictEqual(assistantBackground.isDefault, true);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("#given adjacent tool background lines with a separator #when rendering #then each padding region keeps its own background", async () => {
+		// given
+		const terminal = new VirtualTerminal(18, 5);
+		const tui = new TUI(terminal);
+		const successBg = "\x1b[48;2;10;90;40m";
+		const successBgColor = 0x0a5a28;
+		const errorBg = "\x1b[48;2;90;20;20m";
+		const errorBgColor = 0x5a1414;
+		const innerBg = "\x1b[48;2;20;20;120m";
+		tui.addChild(new Text(`${innerBg}first`, 0, 0, (text) => `${successBg}${text}\x1b[49m`));
+		tui.addChild(new Text("separator", 0, 0));
+		tui.addChild(new Text(`${innerBg}second`, 0, 0, (text) => `${errorBg}${text}\x1b[49m`));
+
+		try {
+			// when
+			tui.start();
+			await terminal.waitForRender();
+
+			// then
+			const firstPaddingBackground = getCellBackground(terminal, 0, 5);
+			const separatorBackground = getCellBackground(terminal, 1, 0);
+			const separatorTailBackground = getCellBackground(terminal, 1, 9);
+			const secondPaddingBackground = getCellBackground(terminal, 2, 6);
+			assert.strictEqual(firstPaddingBackground.color, successBgColor);
+			assert.strictEqual(separatorBackground.isDefault, true);
+			assert.strictEqual(separatorTailBackground.isDefault, true);
+			assert.strictEqual(secondPaddingBackground.color, errorBgColor);
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/wrap-ansi.test.ts
+++ b/packages/tui/test/wrap-ansi.test.ts
@@ -17,6 +17,89 @@ describe("wrapTextWithAnsi", () => {
 			// then
 			assert.ok(rendered.includes(`${bgReset}${outerBg} tail`));
 		});
+
+		it("#given full reset inside outer background #when applying line background #then outer background resumes", () => {
+			// given
+			const outerBg = "\x1b[48;2;40;50;40m";
+			const reset = "\x1b[0m";
+			const line = `left ${reset}tail`;
+
+			// when
+			const rendered = applyBackgroundToLine(line, 20, (text) => `${outerBg}${text}\x1b[49m`);
+
+			// then
+			assert.ok(rendered.includes(`${reset}${outerBg}tail`));
+		});
+
+		it("#given compound background reset inside outer background #when applying line background #then outer background resumes", () => {
+			// given
+			const outerBg = "\x1b[48;2;40;50;40m";
+			const compoundReset = "\x1b[39;49m";
+			const line = `left ${compoundReset}tail`;
+
+			// when
+			const rendered = applyBackgroundToLine(line, 20, (text) => `${outerBg}${text}\x1b[49m`);
+
+			// then
+			assert.ok(rendered.includes(`${compoundReset}${outerBg}tail`));
+		});
+
+		it("#given rgb inner background contains zero channels #when applying line background #then inner background is preserved", () => {
+			// given
+			const outerBg = "\x1b[48;2;40;50;40m";
+			const innerBg = "\x1b[48;2;0;30;30m";
+			const line = `${innerBg}chip`;
+
+			// when
+			const rendered = applyBackgroundToLine(line, 8, (text) => `${outerBg}${text}\x1b[49m`);
+
+			// then
+			assert.ok(rendered.includes(`${innerBg}chip`));
+			assert.ok(!rendered.includes(`${innerBg}${outerBg}chip`));
+		});
+
+		it("#given rgb foreground contains zero channels inside inner background #when applying line background #then inner background is preserved", () => {
+			// given
+			const outerBg = "\x1b[48;2;40;50;40m";
+			const innerBg = "\x1b[48;2;60;30;30m";
+			const foreground = "\x1b[38;2;0;200;0m";
+			const line = `${innerBg}${foreground}chip`;
+
+			// when
+			const rendered = applyBackgroundToLine(line, 8, (text) => `${outerBg}${text}\x1b[49m`);
+
+			// then
+			assert.ok(rendered.includes(`${foreground}chip`));
+			assert.ok(!rendered.includes(`${foreground}${outerBg}chip`));
+		});
+
+		it("#given sgr reset also sets a new background #when applying line background #then new background is preserved", () => {
+			// given
+			const outerBg = "\x1b[48;2;40;50;40m";
+			const resetThenInnerBg = "\x1b[0;48;2;0;30;30m";
+			const line = `${resetThenInnerBg}chip`;
+
+			// when
+			const rendered = applyBackgroundToLine(line, 8, (text) => `${outerBg}${text}\x1b[49m`);
+
+			// then
+			assert.ok(rendered.includes(`${resetThenInnerBg}chip`));
+			assert.ok(!rendered.includes(`${resetThenInnerBg}${outerBg}chip`));
+		});
+
+		it("#given unclosed inner background reaches line padding #when applying line background #then padding uses outer background", () => {
+			// given
+			const outerBg = "\x1b[48;2;40;50;40m";
+			const innerBg = "\x1b[48;2;60;30;30m";
+			const reset = "\x1b[0m";
+			const line = `${innerBg}tool`;
+
+			// when
+			const rendered = applyBackgroundToLine(line, 8, (text) => `${outerBg}${text}\x1b[49m`);
+
+			// then
+			assert.ok(rendered.includes(`${innerBg}tool${reset}${outerBg}    `));
+		});
 	});
 
 	describe("underline styling", () => {


### PR DESCRIPTION
## Summary

- Stabilize `applyBackgroundToLine` so inner SGR resets resume the outer TUI background without misreading RGB color channels as resets.
- Reset open child styles before right-side padding so tool-call padding uses the tool block background, not an unterminated inner background.
- Add string-level and xterm-backed regressions for reset, RGB, padding, adjacent tool block, and post-tool assistant-line behavior.

## Validation

- `node --test --import tsx test/wrap-ansi.test.ts test/tool-background.test.ts`
- `npm test` from `packages/tui`
- `npm run check`
- tmux surface capture with `capture-pane -e -p` for tool-like lines followed by normal assistant text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes nested SGR handling in the TUI so `applyBackgroundToLine` resumes the outer background correctly and padding/next lines render as intended. Also updates the coding agent to prefer bundled extension aliases and adds missing default keybindings in neo-tui.

- Bug Fixes
  - TUI: Added `sgrLeavesDefaultBackground` so only real resets (`0`, `49`, compounds) restore the outer background; RGB/256-color params no longer trigger false resets. Reset active styles before padding and restore them so padding uses the tool background and later lines return to default. Added regressions (string-level and `@xterm/headless`) for resets, RGB, padding, adjacent tool blocks, and post-tool lines.
  - Coding agent: Prefer bundled aliases under `packages/coding-agent/node_modules` when present; still resolve workspace dist/src entries and fall back to `import.meta.resolve` or `require.resolve`. Added tests to assert bundled preference.
  - Neo TUI: Add default keybindings for history search (`ctrl+r`) and session observer (`ctrl+s`), with tests.

- Dependencies
  - Bumped `@smithy/node-http-handler` to `4.7.3` and aligned lockfiles.

<sup>Written for commit 0cadee8eb4f5f81ab94a5694a38f2d3a13202cf1. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/21?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

