### PR TITLE
[codex] Allow neo TUI sentinel flag forwarding

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed `senpi --neo -- ...` so Rust TUI flags after the sentinel reach the native binary instead of being rejected by the Node CLI parser.
+
 ### Removed
 
 ## [2026.5.24] - 2026-05-24

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -170,6 +170,11 @@ export function parseArgs(args: string[]): Args {
 			result.offline = true;
 		} else if (arg === "--neo") {
 			result.neo = true;
+		} else if (arg === "--") {
+			if (!result.neo) {
+				result.messages.push(...args.slice(i + 1));
+			}
+			break;
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
 		} else if (arg.startsWith("--")) {

--- a/packages/coding-agent/test/suite/regressions/neo-tui-arg-forwarding.test.ts
+++ b/packages/coding-agent/test/suite/regressions/neo-tui-arg-forwarding.test.ts
@@ -3,10 +3,9 @@
  * caller to the Rust `senpi-neo-tui` binary via the `--` sentinel.
  *
  * Without the sentinel split, the senpi argparser eats `--theme`,
- * `--demo`, etc. and either errors out (they mean something completely
- * different on the senpi side, e.g. `--theme <path>` loads a theme file)
- * or silently swallows them, so the neo TUI never sees its own flags
- * and `senpi --neo --theme dracula` becomes a lie in the docs.
+ * `--demo`, etc. and either errors out (for unknown Rust-only flags)
+ * or treats them as senpi-side options, so the neo TUI never sees its own
+ * flags and `senpi --neo -- --theme dracula` becomes a lie in the docs.
  *
  * Source of truth: {@link splitNeoArgs} in
  * `packages/coding-agent/src/modes/neo-mode.ts`.

--- a/packages/coding-agent/test/suite/regressions/neo-tui-arg-parse.test.ts
+++ b/packages/coding-agent/test/suite/regressions/neo-tui-arg-parse.test.ts
@@ -2,9 +2,9 @@
  * Regression: `--neo` flag must round-trip through `parseArgs` cleanly and
  * coexist with the rest of the senpi CLI surface.
  *
- * The flag dispatch into the Rust binary lives in a later wave; this test
- * only locks the arg-parser contract so future renames or accidental
- * removals fail loudly.
+ * The sentinel split into backend args vs Rust TUI args lives in neo-mode;
+ * this file locks the parser contract so forwarded neo flags do not get
+ * rejected before that split can run.
  */
 
 import { describe, expect, test } from "vitest";
@@ -43,5 +43,13 @@ describe("--neo flag", () => {
 	test("--neo does not appear in unknownFlags", () => {
 		const parsed = parseArgs(["--neo"]);
 		expect(parsed.unknownFlags.has("neo")).toBe(false);
+	});
+
+	test("--neo allows a -- sentinel for Rust TUI flags", () => {
+		const parsed = parseArgs(["--neo", "--", "--list-themes", "--theme", "dracula"]);
+		expect(parsed.neo).toBe(true);
+		expect(parsed.diagnostics).toEqual([]);
+		expect(parsed.unknownFlags.size).toBe(0);
+		expect(parsed.messages).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What changed

- Fixed `parseArgs` so `senpi --neo -- ...` stops Node-side parsing at the sentinel and lets `neo-mode` forward the tail to the Rust binary.
- Added a regression test covering `--neo -- --list-themes --theme dracula` parser behavior.
- Updated the existing neo forwarding regression comment and changelog entry.

## Why

`splitNeoArgs` already documented and tested the backend-vs-Rust split, but the main CLI parser rejected Rust-only flags before `runNeoMode` could execute. This made documented commands like `senpi --neo -- --list-themes` fail at runtime.

## Validation

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/neo-tui-arg-parse.test.ts test/suite/regressions/neo-tui-arg-forwarding.test.ts`
- `npm run check`
- `npm run build`
- tmux runtime smoke: `SENPI_NEO_TUI_DEV=1 node packages/coding-agent/dist/cli.js --neo -- --list-themes` printed bundled theme ids and exited `0`.

## Not tested

- Full interactive agent session through the native TUI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `senpi --neo -- ...` so Rust TUI flags after the sentinel are passed through to the native binary instead of being rejected by the Node CLI parser. This restores the documented neo TUI contract and unblocks commands like `senpi --neo -- --list-themes`.

- **Bug Fixes**
  - Stop parsing at `--` when `--neo` is set; forward the tail to neo-mode for Rust TUI handling.
  - Preserve existing sentinel behavior when not in neo mode (tail collected as messages).
  - Added regression tests for `--neo -- --list-themes --theme dracula` and updated changelog.

<sup>Written for commit 7b2ac6cc5a9648be78a70855528f59b009720c21. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

