### PR TITLE
fix(coding-agent): route idle extension slash commands

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/session-observer/scanner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/session-observer/scanner.ts
@@ -80,6 +80,7 @@ async function discoverSessionFiles(root: string): Promise<readonly string[]> {
 function firstHeader(entries: readonly FileEntry[], filePath: string): SessionHeader | undefined {
 	const header = entries[0];
 	if (header?.type === "session") return header;
+	if (entries.length === 0) return undefined;
 	return { type: "session", id: basename(filePath, ".jsonl"), timestamp: new Date(0).toISOString(), cwd: "" };
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2801,6 +2801,12 @@ export class InteractiveMode {
 				await this.shutdown();
 				return;
 			}
+			if (this.isExtensionCommand(text)) {
+				this.editor.addToHistory?.(text);
+				this.editor.setText("");
+				await this.session.prompt(text);
+				return;
+			}
 
 			// Handle bash command (! for normal, !! for excluded from context)
 			if (text.startsWith("!")) {

--- a/packages/coding-agent/test/suite/session-observer-scanner.test.ts
+++ b/packages/coding-agent/test/suite/session-observer-scanner.test.ts
@@ -1,21 +1,104 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { AgentSessionRuntime } from "../../src/core/agent-session-runtime.ts";
 import sessionObserverExtension, {
 	resolveSessionHudRoot,
 	scanSessionHudEntries,
 } from "../../src/core/extensions/builtin/session-observer/index.ts";
+import type { ExtensionUIContext } from "../../src/core/extensions/types.ts";
+import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
 import { createHarness, type Harness } from "./harness.ts";
 import {
 	BASE_TIME,
 	createTempRootRegistry,
 	sessionLine,
+	testTheme,
 	userLine,
 	writeSessionFile,
 } from "./history-search-fixtures.ts";
 
 const tempRoots = createTempRootRegistry();
 const harnesses: Harness[] = [];
+
+interface RecordingUi {
+	readonly ui: ExtensionUIContext;
+	readonly notifications: readonly string[];
+	getCustomCallCount(): number;
+}
+
+function createRecordingUi(): RecordingUi {
+	const notifications: string[] = [];
+	let customCallCount = 0;
+	return {
+		notifications,
+		getCustomCallCount: () => customCallCount,
+		ui: {
+			select: async () => undefined,
+			confirm: async () => false,
+			input: async () => undefined,
+			notify: (message) => {
+				notifications.push(message);
+			},
+			onTerminalInput: () => () => {},
+			setStatus: () => {},
+			setWorkingMessage: () => {},
+			setWorkingVisible: () => {},
+			setWorkingIndicator: () => {},
+			setHiddenThinkingLabel: () => {},
+			setWidget: () => {},
+			setFooter: () => {},
+			setHeader: () => {},
+			setTitle: () => {},
+			custom: async <T>() => {
+				customCallCount += 1;
+				return undefined as T;
+			},
+			pasteToEditor: () => {},
+			setEditorText: () => {},
+			getEditorText: () => "",
+			editor: async () => undefined,
+			addAutocompleteProvider: () => {},
+			setEditorComponent: () => {},
+			getEditorComponent: () => undefined,
+			theme: testTheme,
+			getAllThemes: () => [],
+			getTheme: () => undefined,
+			setTheme: () => ({ success: false, error: "not implemented" }),
+			getToolsExpanded: () => false,
+			setToolsExpanded: () => {},
+		},
+	};
+}
+
+function createRuntime(harness: Harness): AgentSessionRuntime {
+	return new AgentSessionRuntime(
+		harness.session,
+		{
+			cwd: harness.tempDir,
+			agentDir: harness.tempDir,
+			authStorage: harness.authStorage,
+			settingsManager: harness.settingsManager,
+			modelRegistry: harness.session.modelRegistry,
+			resourceLoader: harness.session.resourceLoader,
+			diagnostics: [],
+		},
+		async () => {
+			throw new Error("test runtime replacement is not expected");
+		},
+	);
+}
+
+async function submitToInteractiveMode(mode: InteractiveMode, text: string): Promise<void> {
+	const setup = Reflect.get(mode, "setupEditorSubmitHandler");
+	if (typeof setup !== "function") throw new Error("InteractiveMode setup handler missing");
+	setup.call(mode);
+	const editor: unknown = Reflect.get(mode, "defaultEditor");
+	if (!editor || typeof editor !== "object") throw new Error("InteractiveMode editor missing");
+	const submit = Reflect.get(editor, "onSubmit");
+	if (typeof submit !== "function") throw new Error("InteractiveMode submit handler missing");
+	await submit(text);
+}
 
 afterEach(async () => {
 	for (const harness of harnesses.splice(0)) harness.cleanup();
@@ -78,6 +161,20 @@ describe("scanSessionHudEntries", () => {
 		expect(sessions[1]?.lastUserText).toBe("flat prompt");
 		expect(sessions[2]?.isCurrent).toBe(false);
 	});
+
+	it("ignores malformed session entries without disabling picker", async () => {
+		const root = await tempRoots.make();
+		const sessionsDir = join(root, "sessions");
+		await writeSessionFile(sessionsDir, "20260520_valid-session.jsonl", [
+			sessionLine("valid-session", "/repo-valid", BASE_TIME),
+			userLine(["valid prompt"], BASE_TIME + 1_000),
+		]);
+		await writeFile(join(sessionsDir, "20260520_broken-session.jsonl"), "{not json", "utf-8");
+
+		const sessions = await scanSessionHudEntries(sessionsDir);
+
+		expect(sessions.map((session) => session.id)).toEqual(["valid-session"]);
+	});
 });
 
 describe("sessionObserverExtension", () => {
@@ -90,5 +187,66 @@ describe("sessionObserverExtension", () => {
 
 		await harness.session.prompt("/sessions");
 		expect(harness.session.messages).toEqual([]);
+	});
+
+	it("opens session picker when sessions exist", async () => {
+		const root = await tempRoots.make();
+		const sessionsDir = join(root, "sessions");
+		await writeSessionFile(sessionsDir, "20260520_valid-session.jsonl", [
+			sessionLine("valid-session", "/repo-valid", BASE_TIME),
+			userLine(["valid prompt"], BASE_TIME + 1_000),
+		]);
+		const previousDir = process.env.SENPI_CODING_AGENT_DIR;
+		process.env.SENPI_CODING_AGENT_DIR = root;
+		try {
+			const harness = await createHarness({ extensionFactories: [sessionObserverExtension] });
+			harnesses.push(harness);
+			const recording = createRecordingUi();
+			harness.session.extensionRunner.setUIContext(recording.ui);
+			const mode = new InteractiveMode(createRuntime(harness), { verbose: false });
+
+			await submitToInteractiveMode(mode, "/sessions");
+
+			expect(recording.getCustomCallCount()).toBe(1);
+			expect(recording.notifications).toEqual([]);
+		} finally {
+			if (previousDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+			else process.env.SENPI_CODING_AGENT_DIR = previousDir;
+		}
+	});
+
+	it("shows empty state when no sessions exist", async () => {
+		const root = await tempRoots.make();
+		const previousDir = process.env.SENPI_CODING_AGENT_DIR;
+		process.env.SENPI_CODING_AGENT_DIR = root;
+		try {
+			const harness = await createHarness({ extensionFactories: [sessionObserverExtension] });
+			harnesses.push(harness);
+			const recording = createRecordingUi();
+			harness.session.extensionRunner.setUIContext(recording.ui);
+			const mode = new InteractiveMode(createRuntime(harness), { verbose: false });
+
+			await submitToInteractiveMode(mode, "/sessions");
+
+			expect(recording.notifications).toEqual(["No sessions found"]);
+			expect(recording.getCustomCallCount()).toBe(0);
+		} finally {
+			if (previousDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+			else process.env.SENPI_CODING_AGENT_DIR = previousDir;
+		}
+	});
+
+	it("keeps adjacent slash command dispatch behavior", async () => {
+		const harness = await createHarness({ extensionFactories: [sessionObserverExtension] });
+		harnesses.push(harness);
+		const mode = new InteractiveMode(createRuntime(harness), { verbose: false });
+		const submittedInputs: string[] = [];
+		Reflect.set(mode, "onInputCallback", (text: string) => {
+			submittedInputs.push(text);
+		});
+
+		await submitToInteractiveMode(mode, "/unknown-command");
+
+		expect(submittedInputs).toEqual(["/unknown-command"]);
 	});
 });


### PR DESCRIPTION
## Summary

- route idle builtin extension slash commands through the extension session prompt path
- keep adjacent slash commands such as `/resume` on the normal command path
- skip fully malformed empty session logs in the session observer scanner

## Root Cause

The interactive submit handler only dispatched extension commands while another response was streaming or compaction was active. When idle, `/sessions` fell through as regular user input, so the picker never opened.

## Validation

- targeted regression suite: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/session-observer-scanner.test.ts`
- full repository check: `npm run check`
- manual TUI QA for valid, empty, malformed, and adjacent `/resume` session states


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes idle routing for extension slash commands so `/sessions` opens the picker even when no response is streaming. Also ignores malformed session logs and keeps adjacent commands like `/resume` on the normal path.

- **Bug Fixes**
  - Route idle extension commands via the extension session prompt in `InteractiveMode` (preserves history and clears input).
  - Skip empty or malformed session logs in the session scanner to avoid blocking the picker.
  - Maintain pass-through for non-extension or adjacent slash commands (e.g., `/resume`, unknown commands).
  - Added tests for picker open, empty state, malformed files, and command pass-through.

<sup>Written for commit 896b9575ac35cc31ce8c358352c7b118bafee964. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/27?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

