### PR TITLE
fix(tui): rank slash command prefixes

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -2,7 +2,7 @@ import { spawn } from "child_process";
 import { readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join } from "path";
-import { fuzzyFilter } from "./fuzzy.ts";
+import { getSlashCommandSuggestions } from "./slash-command-autocomplete.ts";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
@@ -307,23 +307,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			if (spaceIndex === -1) {
 				const prefix = textBeforeCursor.slice(1);
-				const commandItems = this.commands.map((cmd) => {
-					const name = "name" in cmd ? cmd.name : cmd.value;
-					const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-					const desc = cmd.description ?? "";
-					const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-					return {
-						name,
-						label: name,
-						description: fullDesc || undefined,
-					};
-				});
-
-				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name).map((item) => ({
-					value: item.name,
-					label: item.label,
-					...(item.description && { description: item.description }),
-				}));
+				const filtered = getSlashCommandSuggestions(this.commands, prefix);
 
 				if (filtered.length === 0) return null;
 

--- a/packages/tui/src/slash-command-autocomplete.ts
+++ b/packages/tui/src/slash-command-autocomplete.ts
@@ -1,0 +1,54 @@
+import type { AutocompleteItem, SlashCommand } from "./autocomplete.ts";
+import { fuzzyFilter } from "./fuzzy.ts";
+
+type CommandItem = {
+	readonly name: string;
+	readonly label: string;
+	readonly description?: string;
+};
+
+type RankedCommandItem = AutocompleteItem & {
+	readonly index: number;
+};
+
+function compareSlashCommandSuggestion(prefix: string, left: RankedCommandItem, right: RankedCommandItem): number {
+	const leftExact = left.value === prefix;
+	const rightExact = right.value === prefix;
+	if (leftExact !== rightExact) return leftExact ? -1 : 1;
+
+	const leftPrefix = left.value.startsWith(prefix);
+	const rightPrefix = right.value.startsWith(prefix);
+	if (leftPrefix !== rightPrefix) return leftPrefix ? -1 : 1;
+	if (leftPrefix && rightPrefix && left.value.length !== right.value.length) {
+		return right.value.length - left.value.length;
+	}
+
+	return left.index - right.index;
+}
+
+export function getSlashCommandSuggestions(
+	commands: readonly (SlashCommand | AutocompleteItem)[],
+	prefix: string,
+): AutocompleteItem[] {
+	const commandItems: CommandItem[] = commands.map((cmd) => {
+		const name = "name" in cmd ? cmd.name : cmd.value;
+		const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
+		const desc = cmd.description ?? "";
+		const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
+		return {
+			name,
+			label: name,
+			description: fullDesc || undefined,
+		};
+	});
+
+	return fuzzyFilter(commandItems, prefix, (item) => item.name)
+		.map((item, index) => ({
+			value: item.name,
+			label: item.label,
+			...(item.description && { description: item.description }),
+			index,
+		}))
+		.sort((left, right) => compareSlashCommandSuggestion(prefix, left, right))
+		.map(({ index: _index, ...item }) => item);
+}

--- a/packages/tui/test/autocomplete-slash.test.ts
+++ b/packages/tui/test/autocomplete-slash.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { CombinedAutocompleteProvider } from "../src/autocomplete.ts";
+
+const getSuggestions = (provider: CombinedAutocompleteProvider, line: string) =>
+	provider.getSuggestions([line], 0, line.length, { signal: new AbortController().signal });
+
+describe("CombinedAutocompleteProvider slash command suggestions", () => {
+	it("ranks longer prefix matches before shorter commands when the typed slash command is ambiguous", async () => {
+		// Given
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "session", description: "Show session info and stats" },
+				{ name: "sessions", description: "Peek at previous session transcripts in a HUD" },
+			],
+			"/tmp",
+		);
+
+		// When
+		const result = await getSuggestions(provider, "/sessio");
+
+		// Then
+		assert.deepStrictEqual(
+			result?.items.map((item) => item.value),
+			["sessions", "session"],
+		);
+	});
+
+	it("keeps exact slash command matches before longer commands", async () => {
+		// Given
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "session", description: "Show session info and stats" },
+				{ name: "sessions", description: "Peek at previous session transcripts in a HUD" },
+			],
+			"/tmp",
+		);
+
+		// When
+		const result = await getSuggestions(provider, "/session");
+
+		// Then
+		assert.deepStrictEqual(
+			result?.items.map((item) => item.value),
+			["session", "sessions"],
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- rank ambiguous slash-command prefix matches so `/sessio` selects `/sessions` before `/session`
- keep exact `/session` matching ahead of longer commands
- move slash-command autocomplete ranking into a small TUI module with regression coverage

## Root Cause

The editor autocomplete list showed both `session` and `sessions`, but the fuzzy result order highlighted `session` for `/sessio`. Pressing Enter accepted and submitted the highlighted singular command, so users saw session stats instead of opening the sessions HUD.

## Validation

- red: `node --test --import tsx test/autocomplete-slash.test.ts` failed with `actual: [ session, sessions ]`
- green: `node --test --import tsx test/autocomplete-slash.test.ts`
- package coverage: `node --test --import tsx test/autocomplete.test.ts test/autocomplete-slash.test.ts`
- full check: `npm run check`
- build: `npm --prefix packages/tui run build && npm --prefix packages/coding-agent run build`
- manual tmux QA: typed `/sessio`; autocomplete selected `sessions`; Enter invoked session-observer instead of `/session`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes slash-command autocomplete ranking in `packages/tui` so typing `/sessio` selects `sessions` before `session`. Exact `/session` still ranks first.

- **Bug Fixes**
  - Rank longer prefix matches ahead of shorter commands when the prefix is ambiguous.
  - Preserve exact match priority.

- **Refactors**
  - Extracted ranking into `packages/tui/src/slash-command-autocomplete.ts` and wired into `src/autocomplete.ts`.
  - Added regression tests in `packages/tui/test/autocomplete-slash.test.ts`.

<sup>Written for commit 4ce014c70282254dc6e55bde9887bae6a60f69a2. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

