### PR TITLE
fix: resolve Windows build/check crash and npm shrinkwrap registry 404

### DIFF
--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -487,7 +487,7 @@
 		},
 		"node_modules/@earendil-works/pi-agent-core": {
 			"version": "2026.6.15",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-2026.6.15.tgz",
+			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "^2026.6.15",
@@ -501,7 +501,7 @@
 		},
 		"node_modules/@earendil-works/pi-ai": {
 			"version": "2026.6.15",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-2026.6.15.tgz",
+			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
@@ -528,7 +528,7 @@
 		},
 		"node_modules/@earendil-works/pi-tui": {
 			"version": "2026.6.15",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-2026.6.15.tgz",
+			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -91,10 +91,10 @@ export function cleanEnv(envSource = process.env) {
 function spawnPmAsync(pm, args, cwd, env) {
 	// bun's execpath is a native binary so we invoke it directly.
 	// npm's and pnpm's execpaths are .js / .cjs entry points that have to
-	// be loaded through the current Node runtime.
+	// be loaded through the current Node runtime, unless they are native binaries (like pnpm.exe).
 	let command = pm.cmd;
 	let spawnArgs = args;
-	if (pm.execpath && pm.cmd === "bun") {
+	if (pm.execpath && (pm.cmd === "bun" || !/\.[cm]?js$/i.test(pm.execpath))) {
 		command = pm.execpath;
 	} else if (pm.execpath) {
 		command = process.execPath;

--- a/scripts/generate-coding-agent-shrinkwrap.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.mjs
@@ -46,6 +46,7 @@ function sortedPackageEntry(entry) {
 		"version",
 		"resolved",
 		"integrity",
+		"inBundle",
 		"license",
 		"dependencies",
 		"optionalDependencies",
@@ -196,7 +197,7 @@ function addInternalWorkspace(shrinkwrapPackages, addedPaths, queue, name, works
 	const packageJson = workspace.packageJson;
 	const outputPath = `node_modules/${name}`;
 	const entry = copyPackageJsonEntry(packageJson, { includeName: false });
-	entry.resolved = registryTarballUrl(name, packageJson.version);
+	entry.inBundle = true;
 
 	shrinkwrapPackages[outputPath] = sortedPackageEntry(entry);
 	addedPaths.add(outputPath);

--- a/scripts/run-web-ui-check.mjs
+++ b/scripts/run-web-ui-check.mjs
@@ -38,9 +38,9 @@ function detectPm() {
 }
 
 const pm = detectPm();
-// bun's execpath is a native binary, npm/pnpm are .js we load via Node.
+// bun's execpath is a native binary, npm/pnpm are .js we load via Node, unless they are native binaries (like pnpm.exe).
 function runCheck() {
-	if (pm.execpath && pm.cmd === "bun") {
+	if (pm.execpath && (pm.cmd === "bun" || !/\.[cm]?js$/i.test(pm.execpath))) {
 		return spawnSync(pm.execpath, ["run", "check"], { cwd: webUiDir, stdio: "inherit", env, shell: false });
 	}
 	if (pm.execpath) {


### PR DESCRIPTION
This PR fixes two issues:

1. **Windows build/check crash:**
   - In `scripts/build-all.mjs` and `scripts/run-web-ui-check.mjs`, the script was trying to evaluate native binaries (such as `pnpm.exe` on Windows, which is set in `npm_execpath` by newer pnpm installations) using Node.js, causing a `SyntaxError`. We fixed this by detecting if the execpath does not end in `.js`/`.cjs` (which indicates a native binary) and running it directly instead of wrapping it via Node.

2. **Package shrinkwrap dependency registry 404 error:**
   - The generated `npm-shrinkwrap.json` for `@code-yeongyu/senpi` contained registry references to internal, private workspace packages (like `@earendil-works/pi-tui`) which are bundled but not actually published to the public registry. This resulted in `404 Not Found` errors when users tried to install `@code-yeongyu/senpi`.
   - We updated `scripts/generate-coding-agent-shrinkwrap.mjs` to mark internal dependencies as `"inBundle": true` and omit `resolved` URL registry references, forcing npm to resolve them from the bundled contents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows build/check crashes by executing native package manager binaries directly. Also updates shrinkwrap generation to bundle internal packages, avoiding registry 404s when installing `@code-yeongyu/senpi`.

- **Bug Fixes**
  - Detect native package manager execpaths (e.g., `pnpm.exe`) and run them directly in build/check scripts; otherwise load `.js/.cjs` via Node.
  - Mark internal workspace deps (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`) as `"inBundle": true` and omit `resolved` URLs in the generated `npm-shrinkwrap.json`.

<sup>Written for commit 59e2becc97c0a20ed32078da9f4ea02ea5218e1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

