### PR TITLE
fix(coding-agent): surface active tool status in TUI

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -3,6 +3,7 @@ import { Box, type Component, Container, getCapabilities, Image, Spacer, Text, t
 import type { ToolDefinition, ToolRenderContext } from "../../../core/extensions/types.ts";
 import { createAllToolDefinitions, type ToolName } from "../../../core/tools/index.ts";
 import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/render-utils.ts";
+import { stripAnsi } from "../../../utils/ansi.ts";
 import { convertToPng } from "../../../utils/image-convert.ts";
 import { theme } from "../theme/theme.ts";
 
@@ -15,6 +16,27 @@ type ToolExecutionResult = Omit<AgentToolResult<unknown>, "details"> & {
 	details?: unknown;
 	isError: boolean;
 };
+
+const FALLBACK_STRING_MAX_LENGTH = 160;
+const FALLBACK_JSON_MAX_LENGTH = 2000;
+
+function sanitizeFallbackString(value: string, maxLength = FALLBACK_STRING_MAX_LENGTH): string {
+	const sanitized = stripAnsi(value)
+		.replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (sanitized.length <= maxLength) {
+		return sanitized;
+	}
+	return `${sanitized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function sanitizeFallbackJsonValue(_key: string, value: unknown): unknown {
+	if (typeof value === "string") {
+		return sanitizeFallbackString(value);
+	}
+	return value;
+}
 
 export class ToolExecutionComponent extends Container {
 	private cachedLines?: string[];
@@ -385,14 +407,18 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private formatToolExecution(): string {
-		let text = theme.fg("toolTitle", theme.bold(this.toolName));
-		const content = JSON.stringify(this.args, null, 2);
+		let text = theme.fg("toolTitle", theme.bold(sanitizeFallbackString(this.toolName)));
+		const content = JSON.stringify(this.args, sanitizeFallbackJsonValue, 2);
 		if (content) {
-			text += `\n\n${content}`;
+			const boundedContent =
+				content.length > FALLBACK_JSON_MAX_LENGTH
+					? `${content.slice(0, FALLBACK_JSON_MAX_LENGTH - 3)}...`
+					: content;
+			text += `\n\n${boundedContent}`;
 		}
 		const output = this.getTextOutput();
 		if (output) {
-			text += `\n${output}`;
+			text += `\n${sanitizeFallbackString(output, FALLBACK_JSON_MAX_LENGTH)}`;
 		}
 		return text;
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -149,8 +149,10 @@ import {
 } from "./theme/theme.ts";
 import {
 	blendWorkingStatusShimmerRgbColor,
+	formatActiveToolWorkingLabel,
 	formatToolHookStatusMessageFrame,
 	formatWorkingStatusMessageFrame,
+	sanitizeWorkingStatusPlainText,
 	type WorkingStatusRgbColor,
 } from "./working-status.ts";
 
@@ -189,8 +191,16 @@ type CompactionQueuedMessage = {
 	mode: "steer" | "followUp";
 };
 
+type ToolExecutionStartEvent = Extract<AgentSessionEvent, { type: "tool_execution_start" }>;
+type ToolExecutionEndEvent = Extract<AgentSessionEvent, { type: "tool_execution_end" }>;
 type ToolHookStatusStartEvent = Extract<AgentSessionEvent, { type: "tool_hook_status"; phase: "start" }>;
 type ToolHookStatusEvent = Extract<AgentSessionEvent, { type: "tool_hook_status" }>;
+
+function formatToolHookTerminalTitle(event: ToolHookStatusStartEvent): string {
+	const hookName = sanitizeWorkingStatusPlainText(event.hookName) || "hook";
+	const statusMessage = sanitizeWorkingStatusPlainText(event.statusMessage);
+	return `${APP_TITLE} - ${hookName}: ${statusMessage}`;
+}
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 const DEFAULT_WORKING_STATUS_REFRESH_INTERVAL_MS = 600;
@@ -356,8 +366,13 @@ export class InteractiveMode {
 	private readonly defaultWorkingMessage = "Working";
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
+	private activeToolExecutions = new Map<string, string>();
+	private activeToolExecutionTerminalTitle: string | undefined = undefined;
+	private workingMessageBeforeActiveTool: string | undefined = undefined;
 	private activeToolHooks = new Map<string, ToolHookStatusStartEvent>();
 	private hookStatusIntervalId: NodeJS.Timeout | undefined = undefined;
+	private activeToolTerminalTitle: string | undefined = undefined;
+	private extensionTerminalTitle: string | undefined = undefined;
 
 	private lastSigintTime = 0;
 	private lastEscapeTime = 0;
@@ -796,14 +811,26 @@ export class InteractiveMode {
 	/**
 	 * Update terminal title with session name and cwd.
 	 */
-	private updateTerminalTitle(): void {
+	private getNormalTerminalTitle(): string {
 		const cwdBasename = path.basename(this.sessionManager.getCwd());
 		const sessionName = this.sessionManager.getSessionName();
 		if (sessionName) {
-			this.ui.terminal.setTitle(`${APP_TITLE} - ${sessionName} - ${cwdBasename}`);
-		} else {
-			this.ui.terminal.setTitle(`${APP_TITLE} - ${cwdBasename}`);
+			return `${APP_TITLE} - ${sessionName} - ${cwdBasename}`;
 		}
+		return `${APP_TITLE} - ${cwdBasename}`;
+	}
+
+	private applyTerminalTitle(): void {
+		this.ui.terminal.setTitle(
+			this.activeToolTerminalTitle ??
+				this.activeToolExecutionTerminalTitle ??
+				this.extensionTerminalTitle ??
+				this.getNormalTerminalTitle(),
+		);
+	}
+
+	private updateTerminalTitle(): void {
+		this.applyTerminalTitle();
 	}
 
 	/**
@@ -1863,16 +1890,75 @@ export class InteractiveMode {
 	private handleToolHookStatusEvent(event: ToolHookStatusEvent): void {
 		if (event.phase === "start") {
 			this.activeToolHooks.set(event.hookRunId, event);
+			this.activeToolTerminalTitle = formatToolHookTerminalTitle(event);
+			if (this.ui.terminal) {
+				this.applyTerminalTitle();
+			}
 			this.startToolHookStatusTimer();
 			this.refreshToolHookStatuses();
 			return;
 		}
 		this.activeToolHooks.delete(event.hookRunId);
+		const nextHook = this.activeToolHooks.values().next().value;
+		this.activeToolTerminalTitle = nextHook ? formatToolHookTerminalTitle(nextHook) : undefined;
+		if (this.ui.terminal) {
+			this.applyTerminalTitle();
+		}
 		this.refreshToolHookStatuses();
+	}
+
+	private handleToolExecutionStart(event: ToolExecutionStartEvent): void {
+		const label = formatActiveToolWorkingLabel(event.toolName, event.args);
+		if (this.activeToolExecutions.size === 0) {
+			this.workingMessageBeforeActiveTool = this.workingMessage;
+		}
+		this.activeToolExecutions.set(event.toolCallId, label);
+		this.workingMessage = label;
+		this.activeToolExecutionTerminalTitle = `${APP_TITLE} - ${label}`;
+		this.refreshWorkingLoaderMessage();
+		this.applyTerminalTitle();
+	}
+
+	private handleToolExecutionEnd(event: ToolExecutionEndEvent): void {
+		if (!this.activeToolExecutions.delete(event.toolCallId)) {
+			return;
+		}
+
+		const nextExecution = this.activeToolExecutions.values().next();
+		if (!nextExecution.done) {
+			this.workingMessage = nextExecution.value;
+			this.activeToolExecutionTerminalTitle = `${APP_TITLE} - ${nextExecution.value}`;
+		} else {
+			this.workingMessage = this.workingMessageBeforeActiveTool;
+			this.workingMessageBeforeActiveTool = undefined;
+			this.activeToolExecutionTerminalTitle = undefined;
+		}
+		this.refreshWorkingLoaderMessage();
+		this.applyTerminalTitle();
+	}
+
+	private clearActiveToolExecutionStatus(): void {
+		if (
+			this.activeToolExecutions.size === 0 &&
+			this.activeToolExecutionTerminalTitle === undefined &&
+			this.workingMessageBeforeActiveTool === undefined
+		) {
+			return;
+		}
+		this.activeToolExecutions.clear();
+		this.activeToolExecutionTerminalTitle = undefined;
+		this.workingMessage = this.workingMessageBeforeActiveTool;
+		this.workingMessageBeforeActiveTool = undefined;
+		this.refreshWorkingLoaderMessage();
+		this.applyTerminalTitle();
 	}
 
 	private clearToolHookStatuses(): void {
 		this.activeToolHooks.clear();
+		this.activeToolTerminalTitle = undefined;
+		if (this.ui.terminal) {
+			this.applyTerminalTitle();
+		}
 		this.hookStatusContainer.clear();
 		this.stopToolHookStatusTimer();
 	}
@@ -2038,6 +2124,10 @@ export class InteractiveMode {
 		this.setCustomEditorComponent(undefined);
 		this.setupAutocompleteProvider();
 		this.defaultEditor.onExtensionShortcut = undefined;
+		this.activeToolExecutions.clear();
+		this.activeToolExecutionTerminalTitle = undefined;
+		this.workingMessageBeforeActiveTool = undefined;
+		this.extensionTerminalTitle = undefined;
 		this.updateTerminalTitle();
 		this.workingMessage = undefined;
 		this.workingVisible = true;
@@ -2203,7 +2293,10 @@ export class InteractiveMode {
 			) => this.setExtensionWidget(key, content, options),
 			setFooter: (factory) => this.setExtensionFooter(factory),
 			setHeader: (factory) => this.setExtensionHeader(factory),
-			setTitle: (title) => this.ui.terminal.setTitle(title),
+			setTitle: (title) => {
+				this.extensionTerminalTitle = title;
+				this.applyTerminalTitle();
+			},
 			custom: (factory, options) => this.showExtensionCustom(factory, options),
 			pasteToEditor: (text) => this.editor.handleInput(`\x1b[200~${text}\x1b[201~`),
 			setEditorText: (text) => this.editor.setText(text),
@@ -2918,6 +3011,7 @@ export class InteractiveMode {
 		switch (event.type) {
 			case "agent_start":
 				this.pendingTools.clear();
+				this.clearActiveToolExecutionStatus();
 				this.clearToolHookStatuses();
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(true);
@@ -3065,6 +3159,7 @@ export class InteractiveMode {
 				break;
 
 			case "tool_execution_start": {
+				this.handleToolExecutionStart(event);
 				let component = this.pendingTools.get(event.toolCallId);
 				if (!component) {
 					component = new ToolExecutionComponent(
@@ -3102,6 +3197,7 @@ export class InteractiveMode {
 			}
 
 			case "tool_execution_end": {
+				this.handleToolExecutionEnd(event);
 				const component = this.pendingTools.get(event.toolCallId);
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
@@ -3116,6 +3212,7 @@ export class InteractiveMode {
 					this.ui.terminal.setProgress(false);
 				}
 				this.stopWorkingLoader();
+				this.clearActiveToolExecutionStatus();
 				this.clearToolHookStatuses();
 				if (this.streamingComponent) {
 					this.chatContainer.removeChild(this.streamingComponent);
@@ -5938,6 +6035,7 @@ export class InteractiveMode {
 			this.ui.terminal.setProgress(false);
 		}
 		this.stopWorkingLoader();
+		this.clearActiveToolExecutionStatus();
 		this.clearToolHookStatuses();
 		this.clearExtensionTerminalInputListeners();
 		this.footer.dispose();

--- a/packages/coding-agent/src/modes/interactive/working-status.ts
+++ b/packages/coding-agent/src/modes/interactive/working-status.ts
@@ -1,6 +1,7 @@
 const WORKING_STATUS_MESSAGE_SHIMMER_PADDING = 10;
 const WORKING_STATUS_MESSAGE_SHIMMER_BAND_HALF_WIDTH = 5;
 const WORKING_STATUS_MESSAGE_SHIMMER_SWEEP_MS = 2_000;
+const ACTIVE_TOOL_WORKING_LABEL_MAX_LENGTH = 80;
 
 export type WorkingStatusRgbColor = {
 	r: number;
@@ -47,6 +48,43 @@ export function formatToolHookStatusMessage(
 ): string {
 	const suffix = statusMessage ? `: ${statusMessage}` : "";
 	return `Running ${hookName} hook${suffix} (${formatWorkingElapsedSeconds(elapsedSeconds)})`;
+}
+
+export function sanitizeWorkingStatusPlainText(value: string): string {
+	return value
+		.replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, "")
+		.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+		.replace(/[\r\n\t]+/g, " ")
+		.replace(/[\u0000-\u001f\u007f]+/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function truncateActiveToolWorkingLabel(value: string): string {
+	const chars = Array.from(value);
+	if (chars.length <= ACTIVE_TOOL_WORKING_LABEL_MAX_LENGTH) {
+		return value;
+	}
+	return `${chars.slice(0, ACTIVE_TOOL_WORKING_LABEL_MAX_LENGTH - 3).join("")}...`;
+}
+
+function getActiveToolWorkingDetail(input: unknown): string {
+	if (typeof input !== "object" || input === null || !("command" in input)) {
+		return "";
+	}
+	const command = input.command;
+	if (typeof command !== "string") {
+		return "";
+	}
+	return sanitizeWorkingStatusPlainText(command);
+}
+
+export function formatActiveToolWorkingLabel(toolName: string, input: unknown): string {
+	const sanitizedToolName = sanitizeWorkingStatusPlainText(toolName);
+	const labelToolName = sanitizedToolName || "tool";
+	const detail = getActiveToolWorkingDetail(input);
+	const label = detail ? `Running ${labelToolName}: ${detail}` : `Running ${labelToolName}`;
+	return truncateActiveToolWorkingLabel(label);
 }
 
 function clampColorChannel(value: number): number {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -10,6 +10,8 @@ import {
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { type Component, Container, type Focusable, TUI } from "../../tui/src/tui.ts";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.ts";
+import { APP_TITLE } from "../src/config.ts";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
 import type { AutocompleteProviderFactory } from "../src/core/extensions/types.ts";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
 import type { SourceInfo } from "../src/core/source-info.ts";
@@ -77,6 +79,92 @@ type ExtensionFixture = {
 	sourceInfo?: SourceInfo;
 };
 
+type ToolHookStatusEvent = Extract<AgentSessionEvent, { type: "tool_hook_status" }>;
+type UnsafeToolHookStatusStartEvent = Omit<Extract<ToolHookStatusEvent, { phase: "start" }>, "hookName"> & {
+	readonly hookName: string;
+};
+type TerminalTitleToolHookStatusEvent = ToolHookStatusEvent | UnsafeToolHookStatusStartEvent;
+type ToolExecutionStartEvent = Extract<AgentSessionEvent, { type: "tool_execution_start" }>;
+type ToolExecutionEndEvent = Extract<AgentSessionEvent, { type: "tool_execution_end" }>;
+
+type TerminalTitlePrototype = {
+	handleToolHookStatusEvent(this: TerminalTitleThis, event: TerminalTitleToolHookStatusEvent): void;
+	refreshToolHookStatuses(this: TerminalTitleThis): void;
+	applyTerminalTitle(this: TerminalTitleThis): void;
+	updateTerminalTitle(this: TerminalTitleThis): void;
+	getNormalTerminalTitle(this: TerminalTitleThis): string;
+};
+
+type TerminalTitleThis = {
+	activeToolHooks: Map<string, Extract<ToolHookStatusEvent, { phase: "start" }>>;
+	activeToolTerminalTitle: string | undefined;
+	extensionTerminalTitle: string | undefined;
+	hookStatusContainer: Container;
+	sessionManager: {
+		getCwd(): string;
+		getSessionName(): string | undefined;
+	};
+	startToolHookStatusTimer(): void;
+	stopToolHookStatusTimer(): void;
+	refreshToolHookStatuses(): void;
+	applyTerminalTitle(): void;
+	updateTerminalTitle(): void;
+	getNormalTerminalTitle(): string;
+	ui: {
+		requestRender(): void;
+		terminal: {
+			setTitle(title: string): void;
+		};
+	};
+};
+
+type ActiveToolLifecyclePrototype = TerminalTitlePrototype & {
+	getWorkingLoaderMessage(this: ActiveToolLifecycleThis): string;
+	handleEvent(this: ActiveToolLifecycleThis, event: ToolExecutionStartEvent | ToolExecutionEndEvent): Promise<void>;
+	handleToolExecutionEnd(this: ActiveToolLifecycleThis, event: ToolExecutionEndEvent): void;
+	handleToolExecutionStart(this: ActiveToolLifecycleThis, event: ToolExecutionStartEvent): void;
+	refreshWorkingLoaderMessage(this: ActiveToolLifecycleThis): void;
+};
+
+type ActiveToolLifecycleThis = TerminalTitleThis & {
+	activeToolExecutionTerminalTitle: string | undefined;
+	activeToolExecutions: Map<string, string>;
+	chatContainer: Container;
+	defaultWorkingMessage: string;
+	footer: {
+		invalidate(): void;
+	};
+	getRegisteredToolDefinition(toolName: string): undefined;
+	getWorkingLoaderMessage(): string;
+	handleToolExecutionEnd(event: ToolExecutionEndEvent): void;
+	handleToolExecutionStart(event: ToolExecutionStartEvent): void;
+	isInitialized: boolean;
+	loadingAnimation:
+		| {
+				setMessage(message: string): void;
+		  }
+		| undefined;
+	pendingTools: Map<
+		string,
+		{
+			markExecutionStarted(): void;
+			updateResult(result: unknown): void;
+		}
+	>;
+	refreshWorkingLoaderMessage(): void;
+	requestStreamingRender(): void;
+	session: {
+		isStreaming: boolean;
+	};
+	settingsManager: {
+		getImageWidthCells(): number;
+		getShowImages(): boolean;
+	};
+	toolOutputExpanded: boolean;
+	workingMessage: string | undefined;
+	workingMessageBeforeActiveTool: string | undefined;
+};
+
 describe("InteractiveMode.showStatus", () => {
 	beforeAll(() => {
 		// showStatus uses the global theme instance
@@ -121,6 +209,201 @@ describe("InteractiveMode.showStatus", () => {
 		// adds spacer + text
 		expect(fakeThis.chatContainer.children).toHaveLength(5);
 		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+	});
+});
+
+describe("InteractiveMode terminal title state", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("restores terminal title after active tool status", () => {
+		// Given
+		const prototype = InteractiveMode.prototype as unknown as TerminalTitlePrototype;
+		const setTitle = vi.fn();
+		const fakeThis: TerminalTitleThis = {
+			activeToolHooks: new Map(),
+			activeToolTerminalTitle: undefined,
+			extensionTerminalTitle: undefined,
+			hookStatusContainer: new Container(),
+			sessionManager: {
+				getCwd: () => "/tmp/senpi-project",
+				getSessionName: () => "Visible Session",
+			},
+			startToolHookStatusTimer: vi.fn(),
+			stopToolHookStatusTimer: vi.fn(),
+			refreshToolHookStatuses: prototype.refreshToolHookStatuses,
+			applyTerminalTitle: prototype.applyTerminalTitle,
+			updateTerminalTitle: prototype.updateTerminalTitle,
+			getNormalTerminalTitle: prototype.getNormalTerminalTitle,
+			ui: {
+				requestRender: vi.fn(),
+				terminal: { setTitle },
+			},
+		};
+
+		// When
+		prototype.handleToolHookStatusEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "start",
+			hookRunId: "run-1",
+			hookName: "PostToolUse",
+			toolName: "bash",
+			toolCallId: "call-1",
+			extensionPath: "<builtin:comment-checker>",
+			statusMessage: "checking generated comments",
+			startedAt: Date.now(),
+		});
+
+		// Then
+		expect(setTitle).toHaveBeenLastCalledWith(`${APP_TITLE} - PostToolUse: checking generated comments`);
+
+		// When
+		prototype.handleToolHookStatusEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "end",
+			hookRunId: "run-1",
+			hookName: "PostToolUse",
+			toolName: "bash",
+			toolCallId: "call-1",
+			extensionPath: "<builtin:comment-checker>",
+			statusMessage: "checking generated comments",
+			startedAt: Date.now(),
+			completedAt: Date.now(),
+			status: "completed",
+		});
+
+		// Then
+		expect(setTitle).toHaveBeenLastCalledWith(`${APP_TITLE} - Visible Session - senpi-project`);
+	});
+
+	test("sanitizes active tool hook terminal title", () => {
+		// Given
+		const prototype = InteractiveMode.prototype as unknown as TerminalTitlePrototype;
+		const setTitle = vi.fn();
+		const fakeThis: TerminalTitleThis = {
+			activeToolHooks: new Map(),
+			activeToolTerminalTitle: undefined,
+			extensionTerminalTitle: undefined,
+			hookStatusContainer: new Container(),
+			sessionManager: {
+				getCwd: () => "/tmp/senpi-project",
+				getSessionName: () => "Visible Session",
+			},
+			startToolHookStatusTimer: vi.fn(),
+			stopToolHookStatusTimer: vi.fn(),
+			refreshToolHookStatuses: prototype.refreshToolHookStatuses,
+			applyTerminalTitle: prototype.applyTerminalTitle,
+			updateTerminalTitle: prototype.updateTerminalTitle,
+			getNormalTerminalTitle: prototype.getNormalTerminalTitle,
+			ui: {
+				requestRender: vi.fn(),
+				terminal: { setTitle },
+			},
+		};
+
+		// When
+		prototype.handleToolHookStatusEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "start",
+			hookRunId: "run-hostile",
+			hookName: "PostToolUse\x1b]2;owned\x07\nPreToolUse",
+			toolName: "bash",
+			toolCallId: "call-1",
+			extensionPath: "<builtin:comment-checker>",
+			statusMessage: "checking\x1b]0;pwned\x07 comments\r\nnext\tpart\x1b[31mred",
+			startedAt: Date.now(),
+		});
+
+		// Then
+		const title = setTitle.mock.calls.at(-1)?.[0];
+		expect(title).toBe(`${APP_TITLE} - PostToolUse PreToolUse: checking comments next partred`);
+		expect(title).not.toMatch(/[\u0000-\u001f\u007f]/);
+		expect(title).not.toContain("owned");
+		expect(title).not.toContain("pwned");
+	});
+
+	test("shows active tool name in the working row", async () => {
+		// Given
+		const prototype = InteractiveMode.prototype as unknown as ActiveToolLifecyclePrototype;
+		const setTitle = vi.fn();
+		const setMessage = vi.fn();
+		const toolComponent = {
+			markExecutionStarted: vi.fn(),
+			updateResult: vi.fn(),
+		};
+		const fakeThis: ActiveToolLifecycleThis = {
+			activeToolExecutionTerminalTitle: undefined,
+			activeToolExecutions: new Map(),
+			activeToolHooks: new Map(),
+			activeToolTerminalTitle: undefined,
+			chatContainer: new Container(),
+			defaultWorkingMessage: "Working",
+			extensionTerminalTitle: undefined,
+			footer: { invalidate: vi.fn() },
+			getNormalTerminalTitle: prototype.getNormalTerminalTitle,
+			getRegisteredToolDefinition: () => undefined,
+			getWorkingLoaderMessage: prototype.getWorkingLoaderMessage,
+			handleToolExecutionEnd: prototype.handleToolExecutionEnd,
+			handleToolExecutionStart: prototype.handleToolExecutionStart,
+			hookStatusContainer: new Container(),
+			isInitialized: true,
+			loadingAnimation: { setMessage },
+			pendingTools: new Map([["call-1", toolComponent]]),
+			refreshToolHookStatuses: prototype.refreshToolHookStatuses,
+			refreshWorkingLoaderMessage: prototype.refreshWorkingLoaderMessage,
+			requestStreamingRender: vi.fn(),
+			session: { isStreaming: true },
+			sessionManager: {
+				getCwd: () => "/tmp/senpi-project",
+				getSessionName: () => "Visible Session",
+			},
+			settingsManager: {
+				getImageWidthCells: () => 80,
+				getShowImages: () => false,
+			},
+			startToolHookStatusTimer: vi.fn(),
+			stopToolHookStatusTimer: vi.fn(),
+			toolOutputExpanded: false,
+			workingMessage: "Thinking",
+			workingMessageBeforeActiveTool: undefined,
+			applyTerminalTitle: prototype.applyTerminalTitle,
+			updateTerminalTitle: prototype.updateTerminalTitle,
+			ui: {
+				requestRender: vi.fn(),
+				terminal: { setTitle },
+			},
+		};
+
+		const startEvent = {
+			type: "tool_execution_start",
+			toolCallId: "call-1",
+			toolName: "bash",
+			args: { command: "npm run check -- --watch" },
+		} satisfies ToolExecutionStartEvent;
+		const endEvent = {
+			type: "tool_execution_end",
+			toolCallId: "call-1",
+			toolName: "bash",
+			result: { content: [{ type: "text", text: "ok" }] },
+			isError: false,
+		} satisfies ToolExecutionEndEvent;
+
+		// When
+		await prototype.handleEvent.call(fakeThis, startEvent);
+
+		// Then
+		expect(fakeThis.workingMessage).toBe("Running bash: npm run check -- --watch");
+		expect(setMessage).toHaveBeenLastCalledWith("Running bash: npm run check -- --watch");
+		expect(setTitle).toHaveBeenLastCalledWith(`${APP_TITLE} - Running bash: npm run check -- --watch`);
+
+		// When
+		await prototype.handleEvent.call(fakeThis, endEvent);
+
+		// Then
+		expect(fakeThis.workingMessage).toBe("Thinking");
+		expect(setMessage).toHaveBeenLastCalledWith("Thinking");
+		expect(setTitle).toHaveBeenLastCalledWith(`${APP_TITLE} - Visible Session - senpi-project`);
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-working-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { formatKeyText } from "../src/modes/interactive/components/keybinding-hints.ts";
 import {
 	blendWorkingStatusShimmerRgbColor,
+	formatActiveToolWorkingLabel,
 	formatToolHookStatusMessage,
 	formatToolHookStatusMessageFrame,
 	formatWorkingElapsedSeconds,
@@ -40,6 +41,23 @@ describe("formatToolHookStatusMessage", () => {
 		expect(formatToolHookStatusMessage("PostToolUse", "matching project rules", 427)).toBe(
 			"Running PostToolUse hook: matching project rules (7m 07s)",
 		);
+	});
+});
+
+describe("formatActiveToolWorkingLabel", () => {
+	test("formats active tool working labels", () => {
+		expect(formatActiveToolWorkingLabel("bash", { command: "npm run check -- --watch" })).toBe(
+			"Running bash: npm run check -- --watch",
+		);
+		expect(formatActiveToolWorkingLabel("", {})).toBe("Running tool");
+
+		const maliciousLabel = formatActiveToolWorkingLabel("\x1b[31mbash\x1b]0;owned\x07\nnext", {
+			command: `printf '${"x".repeat(120)}'\nrm -rf /tmp/example`,
+		});
+
+		expect(maliciousLabel).toBe(`Running bash next: printf '${"x".repeat(50)}...`);
+		expect(maliciousLabel.length).toBeLessThanOrEqual(80);
+		expect(maliciousLabel).not.toMatch(/[\u001b\u0007\r\n]/);
 	});
 });
 

--- a/packages/coding-agent/test/list-models-fast-path.test.ts
+++ b/packages/coding-agent/test/list-models-fast-path.test.ts
@@ -20,6 +20,7 @@ class ProcessExitError extends Error {
 describe("--list-models fast path", () => {
 	const tempDirs: string[] = [];
 	let originalAgentDir: string | undefined;
+	let originalOpenaiApiKey: string | undefined;
 	let originalCwd = process.cwd();
 	let originalExitCode: typeof process.exitCode = process.exitCode;
 
@@ -31,6 +32,11 @@ describe("--list-models fast path", () => {
 			delete process.env[ENV_AGENT_DIR];
 		} else {
 			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
+		if (originalOpenaiApiKey === undefined) {
+			delete process.env.OPENAI_API_KEY;
+		} else {
+			process.env.OPENAI_API_KEY = originalOpenaiApiKey;
 		}
 		for (const dir of tempDirs.splice(0)) {
 			rmSync(dir, { recursive: true, force: true });
@@ -63,9 +69,11 @@ describe("--list-models fast path", () => {
 		mkdirSync(agentDir, { recursive: true });
 		mkdirSync(projectDir, { recursive: true });
 		originalAgentDir = process.env[ENV_AGENT_DIR];
+		originalOpenaiApiKey = process.env.OPENAI_API_KEY;
 		originalCwd = process.cwd();
 		originalExitCode = process.exitCode;
 		process.env[ENV_AGENT_DIR] = agentDir;
+		process.env.OPENAI_API_KEY = "fake-openai-key";
 		process.exitCode = undefined;
 		process.chdir(projectDir);
 

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -28,6 +28,7 @@ const EMPTY_USAGE: Usage = {
 };
 
 type RenderSessionContextThis = {
+	activeToolExecutions: Map<string, string>;
 	pendingTools: Map<string, ToolExecutionComponent>;
 	chatContainer: Container;
 	footer: { invalidate(): void };
@@ -42,6 +43,7 @@ type RenderSessionContextThis = {
 	isInitialized: boolean;
 	updateEditorBorderColor(): void;
 	getRegisteredToolDefinition(toolName: string): undefined;
+	handleToolExecutionEnd(event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>): void;
 	addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void;
 };
 
@@ -56,6 +58,7 @@ type HandleEvent = (this: RenderSessionContextThis, event: AgentSessionEvent) =>
 function createFakeInteractiveModeThis(): RenderSessionContextThis {
 	const chatContainer = new Container();
 	return {
+		activeToolExecutions: new Map<string, string>(),
 		pendingTools: new Map<string, ToolExecutionComponent>(),
 		chatContainer,
 		footer: { invalidate: vi.fn() },
@@ -70,6 +73,7 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 		isInitialized: true,
 		updateEditorBorderColor: vi.fn(),
 		getRegisteredToolDefinition: (_toolName: string) => undefined,
+		handleToolExecutionEnd: Reflect.get(InteractiveMode.prototype, "handleToolExecutionEnd"),
 		addMessageToChat(message: AgentMessage) {
 			chatContainer.addChild(new Text(message.role, 0, 0));
 		},

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -425,6 +425,33 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("done");
 	});
 
+	test("bounds running tool detail for hostile fallback metadata", () => {
+		const hostileToolName = `${"very-long-tool-name".repeat(20)}\nleaked-line\x1b[31mred\x1b]2;owned\x07`;
+		const hostilePath = "src/ok.ts\nsrc/hidden.ts\x1b[35mraw\x1b]8;;https://example.test\x07link\x1b]8;;\x07";
+		const component = new ToolExecutionComponent(
+			hostileToolName,
+			"tool-hostile-running-detail",
+			{ path: hostilePath, query: "needle".repeat(80) },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+
+		component.markExecutionStarted();
+
+		const renderedLines = component.render(60);
+		const rendered = renderedLines.join("\n");
+		const plain = stripAnsi(rendered);
+
+		expect(rendered).not.toContain("\x1b]2;");
+		expect(rendered).not.toContain("\x1b]8;");
+		expect(rendered).not.toContain("\x1b[31mred");
+		expect(plain).not.toContain("leaked-line");
+		expect(rendered).not.toContain("src/ok.ts\nsrc/hidden.ts");
+		expect(Math.max(...renderedLines.map((line) => stripAnsi(line).length))).toBeLessThanOrEqual(60);
+	});
+
 	test("trims trailing blank display lines from write previews", () => {
 		const component = new ToolExecutionComponent(
 			"write",


### PR DESCRIPTION
## Summary
- Show the active tool name/detail in the interactive Working row while tools run.
- Route terminal title updates through a priority funnel so active tool/hook titles restore cleanly.
- Sanitize and bound active-tool/hook/fallback tool detail text before rendering or title writes.

## Verification
- `cd packages/coding-agent && ../../node_modules/.bin/vitest --run test/interactive-mode-working-status.test.ts test/interactive-mode-status.test.ts test/interactive-mode-hook-status.test.ts test/tool-execution-component.test.ts test/bash-execution-width.test.ts test/assistant-message.test.ts`
- `npm run check`
- tmux real TUI QA: `./pi-test.sh --approve --session-dir /tmp/senpi-real-tool-qa-sessions --tools bash` captured active `Running bash` Working row/title and final title restoration.
- ultrawork reviewer: UNCONDITIONAL APPROVAL / APPROVE / CLEAR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the active tool in the TUI Working row and terminal title, with sanitized and bounded text. Adds prioritized title handling so tool and hook titles display while running and restore cleanly.

- New Features
  - Working row shows “Running <tool>: <detail>” from `args.command`; sanitized and trimmed to 80 chars.
  - Terminal title reflects active tool runs and tool hooks; respects extension `setTitle`; restores previous via a priority funnel.
  - Tool execution view sanitizes tool name/args/output; caps strings at 160/2,000 chars and JSON at 2,000 chars.

- Bug Fixes
  - Strip ANSI/OSC/control characters from working labels and titles to prevent leaks and injection.
  - Eliminate title flicker with a single title applier and priority: active hook > active tool run > extension > normal.
  - Preserve and restore the pre-tool Working message and title across overlapping tool executions; clear active tool state on agent start/end and session end.

<sup>Written for commit 8097ff9c4c8d97164b1c15b3ca75ef09600896ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

