### PR TITLE
merge: sync main with upstream/main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,9 +4731,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6125,9 +6125,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- When Amazon Bedrock rejects an unsupported data retention mode, the error now links the AWS data retention documentation ([#5561](https://github.com/earendil-works/pi/pull/5561) by [@unexge](https://github.com/unexge)).
+
 ### Fixed
 
 - Fixed Claude Fable 5 thinking-off requests to omit Anthropic's unsupported `thinking.type: "disabled"` payload ([#5567](https://github.com/earendil-works/pi/pull/5567) by [@tmustier](https://github.com/tmustier)).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Changed
 
+- When Amazon Bedrock rejects an unsupported data retention mode, the error now links the AWS data retention documentation ([#5561](https://github.com/earendil-works/pi/pull/5561) by [@unexge](https://github.com/unexge)).
+
 ### Fixed
+
+- Fixed Claude Fable 5 thinking-off requests to omit Anthropic's unsupported `thinking.type: "disabled"` payload ([#5567](https://github.com/earendil-works/pi/pull/5567) by [@tmustier](https://github.com/tmustier)).
 
 ### Removed
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -291,6 +291,13 @@ const BEDROCK_ERROR_PREFIXES: Record<string, string> = {
 };
 
 /**
+ * Some models reject the account/profile's configured Bedrock data retention mode
+ * (e.g. "data retention mode 'default' is not available for this model"). Point
+ * users at the AWS docs explaining how to configure a supported mode.
+ */
+const BEDROCK_DATA_RETENTION_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html";
+
+/**
  * Format a Bedrock error with a human-readable prefix.
  * AWS SDK exceptions (both from `client.send()` and from stream event items)
  * extend BedrockRuntimeServiceException. We map the `.name` to a stable
@@ -299,11 +306,14 @@ const BEDROCK_ERROR_PREFIXES: Record<string, string> = {
  */
 function formatBedrockError(error: unknown): string {
 	const message = error instanceof Error ? error.message : JSON.stringify(error);
+	const dataRetentionHint = /data retention mode/i.test(message)
+		? ` See ${BEDROCK_DATA_RETENTION_DOCS_URL} for supported data retention modes.`
+		: "";
 	if (error instanceof BedrockRuntimeServiceException) {
 		const prefix = BEDROCK_ERROR_PREFIXES[error.name] ?? error.name;
-		return `${prefix}: ${message}`;
+		return `${prefix}: ${message}${dataRetentionHint}`;
 	}
-	return message;
+	return `${message}${dataRetentionHint}`;
 }
 
 /**

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -301,6 +301,13 @@ const BEDROCK_ERROR_PREFIXES: Record<string, string> = {
 };
 
 /**
+ * Some models reject the account/profile's configured Bedrock data retention mode
+ * (e.g. "data retention mode 'default' is not available for this model"). Point
+ * users at the AWS docs explaining how to configure a supported mode.
+ */
+const BEDROCK_DATA_RETENTION_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html";
+
+/**
  * Format a Bedrock error with a human-readable prefix.
  * AWS SDK exceptions (both from `client.send()` and from stream event items)
  * extend BedrockRuntimeServiceException. We map the `.name` to a stable
@@ -309,11 +316,14 @@ const BEDROCK_ERROR_PREFIXES: Record<string, string> = {
  */
 function formatBedrockError(error: unknown): string {
 	const message = error instanceof Error ? error.message : JSON.stringify(error);
+	const dataRetentionHint = /data retention mode/i.test(message)
+		? ` See ${BEDROCK_DATA_RETENTION_DOCS_URL} for supported data retention modes.`
+		: "";
 	if (error instanceof BedrockRuntimeServiceException) {
 		const prefix = BEDROCK_ERROR_PREFIXES[error.name] ?? error.name;
-		return `${prefix}: ${message}`;
+		return `${prefix}: ${message}${dataRetentionHint}`;
 	}
-	return message;
+	return `${message}${dataRetentionHint}`;
 }
 
 /**

--- a/packages/ai/test/anthropic-on-payload-headers.test.ts
+++ b/packages/ai/test/anthropic-on-payload-headers.test.ts
@@ -88,40 +88,41 @@ describe("Anthropic onPayload request metadata", () => {
 		expect(mockState.createParams).not.toHaveProperty("extra_body");
 	});
 
-	it.each(
-		unsupportedNativeComputerToolModels,
-	)("strips native computer-use tools that %s rejects after payload hooks run", async (modelId) => {
-		const model = getModel("anthropic", modelId);
+	it.each(unsupportedNativeComputerToolModels)(
+		"strips native computer-use tools that %s rejects after payload hooks run",
+		async (modelId) => {
+			const model = getModel("anthropic", modelId);
 
-		const stream = streamAnthropic(model, context, {
-			apiKey: "fake-key",
-			onPayload: (payload) => ({
-				...(payload as Record<string, unknown>),
-				tools: [
-					{
-						type: "computer_20250124",
-						name: "computer",
-						display_width_px: 1024,
-						display_height_px: 768,
-						display_number: 1,
+			const stream = streamAnthropic(model, context, {
+				apiKey: "fake-key",
+				onPayload: (payload) => ({
+					...(payload as Record<string, unknown>),
+					tools: [
+						{
+							type: "computer_20250124",
+							name: "computer",
+							display_width_px: 1024,
+							display_height_px: 768,
+							display_number: 1,
+						},
+						{ type: "bash_20250124", name: "bash" },
+					],
+					headers: {
+						"anthropic-beta": "computer-use-2025-01-24, fine-grained-tool-streaming-2025-05-14",
 					},
-					{ type: "bash_20250124", name: "bash" },
-				],
-				headers: {
-					"anthropic-beta": "computer-use-2025-01-24, fine-grained-tool-streaming-2025-05-14",
-				},
-			}),
-		});
+				}),
+			});
 
-		await stream.result();
+			await stream.result();
 
-		const tools = mockState.createParams?.tools as Array<Record<string, unknown>>;
-		expect(tools.some((tool) => tool.type === "computer_20250124")).toBe(false);
-		expect(tools).toContainEqual({ type: "bash_20250124", name: "bash" });
-		expect(mockState.requestOptions?.headers).toEqual({
-			"anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
-		});
-	});
+			const tools = mockState.createParams?.tools as Array<Record<string, unknown>>;
+			expect(tools.some((tool) => tool.type === "computer_20250124")).toBe(false);
+			expect(tools).toContainEqual({ type: "bash_20250124", name: "bash" });
+			expect(mockState.requestOptions?.headers).toEqual({
+				"anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+			});
+		},
+	);
 
 	it("normalizes hook-returned legacy thinking for Claude Opus 4.6 before SDK request", async () => {
 		const model = getModel("anthropic", "claude-opus-4-6");

--- a/packages/ai/test/bedrock-thinking-payload.test.ts
+++ b/packages/ai/test/bedrock-thinking-payload.test.ts
@@ -190,35 +190,39 @@ describe("Bedrock thinking payload", () => {
 });
 
 describe.skipIf(!hasBedrockCredentials())("Bedrock Claude max tokens E2E", () => {
-	it("uses the model maxTokens cap instead of Bedrock's 4096-token default for adaptive Claude models", {
-		retry: 2,
-		timeout: 180000,
-	}, async () => {
-		const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6");
-		const model: Model<"bedrock-converse-stream"> = {
-			...baseModel,
-			maxTokens: 6000,
-		};
+	it(
+		"uses the model maxTokens cap instead of Bedrock's 4096-token default for adaptive Claude models",
+		{
+			retry: 2,
+			timeout: 180000,
+		},
+		async () => {
+			const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6");
+			const model: Model<"bedrock-converse-stream"> = {
+				...baseModel,
+				maxTokens: 6000,
+			};
 
-		const response = await streamBedrock(
-			model,
-			{
-				systemPrompt: "You are a deterministic text generator. Follow the requested output format exactly.",
-				messages: [
-					{
-						role: "user",
-						content:
-							"Output exactly 5200 repetitions of the token alpha, separated by single spaces. Do not number them. Do not use markdown. Do not add any other text.",
-						timestamp: Date.now(),
-					},
-				],
-			},
-			{ reasoning: "low" },
-		).result();
+			const response = await streamBedrock(
+				model,
+				{
+					systemPrompt: "You are a deterministic text generator. Follow the requested output format exactly.",
+					messages: [
+						{
+							role: "user",
+							content:
+								"Output exactly 5200 repetitions of the token alpha, separated by single spaces. Do not number them. Do not use markdown. Do not add any other text.",
+							timestamp: Date.now(),
+						},
+					],
+				},
+				{ reasoning: "low" },
+			).result();
 
-		expect(response.stopReason, response.errorMessage).not.toBe("error");
-		expect(response.usage.output).toBeGreaterThan(4096);
-	});
+			expect(response.stopReason, response.errorMessage).not.toBe("error");
+			expect(response.usage.output).toBeGreaterThan(4096);
+		},
+	);
 });
 
 describe("Application inference profile support", () => {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -795,96 +795,99 @@ describe("openai-codex streaming", () => {
 		["gpt-5.1-codex", "priority", 2],
 		["gpt-5.5", "flex", 0.5],
 		["gpt-5.5", "priority", 2.5],
-	] as const)("uses the client-sent %s service tier for %s when Codex echoes default", async (modelId, serviceTier, multiplier) => {
-		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
-		process.env.PI_CODING_AGENT_DIR = tempDir;
-		const token = mockToken();
-		const sse = `${[
-			`data: ${JSON.stringify({
-				type: "response.output_item.added",
-				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
-			})}`,
-			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
-			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
-			`data: ${JSON.stringify({
-				type: "response.output_item.done",
-				item: {
-					type: "message",
-					id: "msg_1",
-					role: "assistant",
-					status: "completed",
-					content: [{ type: "output_text", text: "Hello" }],
-				},
-			})}`,
-			`data: ${JSON.stringify({
-				type: "response.completed",
-				response: {
-					status: "completed",
-					service_tier: "default",
-					usage: {
-						input_tokens: 1000000,
-						output_tokens: 1000000,
-						total_tokens: 2000000,
-						input_tokens_details: { cached_tokens: 0 },
+	] as const)(
+		"uses the client-sent %s service tier for %s when Codex echoes default",
+		async (modelId, serviceTier, multiplier) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+			process.env.PI_CODING_AGENT_DIR = tempDir;
+			const token = mockToken();
+			const sse = `${[
+				`data: ${JSON.stringify({
+					type: "response.output_item.added",
+					item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+				})}`,
+				`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+				`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+				`data: ${JSON.stringify({
+					type: "response.output_item.done",
+					item: {
+						type: "message",
+						id: "msg_1",
+						role: "assistant",
+						status: "completed",
+						content: [{ type: "output_text", text: "Hello" }],
 					},
+				})}`,
+				`data: ${JSON.stringify({
+					type: "response.completed",
+					response: {
+						status: "completed",
+						service_tier: "default",
+						usage: {
+							input_tokens: 1000000,
+							output_tokens: 1000000,
+							total_tokens: 2000000,
+							input_tokens_details: { cached_tokens: 0 },
+						},
+					},
+				})}`,
+			].join("\n\n")}\n\n`;
+
+			const encoder = new TextEncoder();
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(encoder.encode(sse));
+					controller.close();
 				},
-			})}`,
-		].join("\n\n")}\n\n`;
+			});
 
-		const encoder = new TextEncoder();
-		const stream = new ReadableStream<Uint8Array>({
-			start(controller) {
-				controller.enqueue(encoder.encode(sse));
-				controller.close();
-			},
-		});
+			const fetchMock = vi.fn(async (input: string | URL) => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+					return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+				}
+				if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+					return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+				}
+				if (url === "https://chatgpt.com/backend-api/codex/responses") {
+					return new Response(stream, {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					});
+				}
+				return new Response("not found", { status: 404 });
+			});
+			vi.stubGlobal("fetch", fetchMock);
 
-		const fetchMock = vi.fn(async (input: string | URL) => {
-			const url = typeof input === "string" ? input : input.toString();
-			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
-				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
-			}
-			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
-				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
-			}
-			if (url === "https://chatgpt.com/backend-api/codex/responses") {
-				return new Response(stream, {
-					status: 200,
-					headers: { "content-type": "text/event-stream" },
-				});
-			}
-			return new Response("not found", { status: 404 });
-		});
-		vi.stubGlobal("fetch", fetchMock);
+			const model: Model<"openai-codex-responses"> = {
+				id: modelId,
+				name: modelId === "gpt-5.5" ? "GPT-5.5" : "GPT-5.1 Codex",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "https://chatgpt.com/backend-api",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 400000,
+				maxTokens: 128000,
+			};
 
-		const model: Model<"openai-codex-responses"> = {
-			id: modelId,
-			name: modelId === "gpt-5.5" ? "GPT-5.5" : "GPT-5.1 Codex",
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			baseUrl: "https://chatgpt.com/backend-api",
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 400000,
-			maxTokens: 128000,
-		};
+			const context: Context = {
+				systemPrompt: "You are a helpful assistant.",
+				messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+			};
 
-		const context: Context = {
-			systemPrompt: "You are a helpful assistant.",
-			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
-		};
+			const result = await streamOpenAICodexResponses(model, context, {
+				apiKey: token,
+				serviceTier,
+				transport: "sse",
+			}).result();
 
-		const result = await streamOpenAICodexResponses(model, context, {
-			apiKey: token,
-			serviceTier,
-			transport: "sse",
-		}).result();
-
-		expect(result.usage.cost.input).toBe(1 * multiplier);
-		expect(result.usage.cost.output).toBe(2 * multiplier);
-		expect(result.usage.cost.total).toBe(3 * multiplier);
-	});
+			expect(result.usage.cost.input).toBe(1 * multiplier);
+			expect(result.usage.cost.output).toBe(2 * multiplier);
+			expect(result.usage.cost.total).toBe(3 * multiplier);
+		},
+	);
 
 	it("does not set session-id/x-client-request-id headers when sessionId is not provided", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -890,11 +890,9 @@ describe("openai-completions tool_choice", () => {
 	});
 
 	it("stores OpenRouter Kimi K2.6 reasoning replay compat in built-in metadata", () => {
-		for (const modelId of ["moonshotai/kimi-k2.6", "moonshotai/kimi-k2.6:free"] as const) {
-			const model = getModel("openrouter", modelId)!;
-			expect(model.compat?.supportsDeveloperRole).toBe(false);
-			expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);
-		}
+		const model = getModel("openrouter", "moonshotai/kimi-k2.6")!;
+		expect(model.compat?.supportsDeveloperRole).toBe(false);
+		expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);
 	});
 
 	it("stores Xiaomi MiMo reasoning replay compat in built-in metadata", () => {

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -888,11 +888,9 @@ describe("openai-completions tool_choice", () => {
 	});
 
 	it("stores OpenRouter Kimi K2.6 reasoning replay compat in built-in metadata", () => {
-		for (const modelId of ["moonshotai/kimi-k2.6", "moonshotai/kimi-k2.6:free"] as const) {
-			const model = getModel("openrouter", modelId)!;
-			expect(model.compat?.supportsDeveloperRole).toBe(false);
-			expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);
-		}
+		const model = getModel("openrouter", "moonshotai/kimi-k2.6")!;
+		expect(model.compat?.supportsDeveloperRole).toBe(false);
+		expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);
 	});
 
 	it("stores Xiaomi MiMo reasoning replay compat in built-in metadata", () => {

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -153,89 +153,79 @@ describe("openai-responses provider defaults", () => {
 		expect(capturedPayload?.input?.some((item) => item.type === "reasoning")).toBe(false);
 	});
 
-	it.each([
-		"gpt-5.1",
-		"gpt-5.2",
-		"gpt-5.3-codex",
-		"gpt-5.4",
-		"gpt-5.4-mini",
-		"gpt-5.4-nano",
-		"gpt-5.5",
-	] as const)("sends none reasoning effort for OpenAI %s when no reasoning is requested", async (modelId) => {
-		const model = getModel("openai", modelId);
-		let capturedPayload: unknown;
+	it.each(["gpt-5.1", "gpt-5.2", "gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.5"] as const)(
+		"sends none reasoning effort for OpenAI %s when no reasoning is requested",
+		async (modelId) => {
+			const model = getModel("openai", modelId);
+			let capturedPayload: unknown;
 
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response("data: [DONE]\n\n", {
-				status: 200,
-				headers: { "content-type": "text/event-stream" },
-			}),
-		);
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("data: [DONE]\n\n", {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+			);
 
-		const stream = streamOpenAIResponses(
-			model,
-			{
-				systemPrompt: "sys",
-				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
-			},
-			{
-				apiKey: "test-key",
-				onPayload: (payload) => {
-					capturedPayload = payload;
+			const stream = streamOpenAIResponses(
+				model,
+				{
+					systemPrompt: "sys",
+					messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
 				},
-			},
-		);
-
-		for await (const event of stream) {
-			if (event.type === "done" || event.type === "error") break;
-		}
-
-		expect(capturedPayload).toMatchObject({
-			reasoning: { effort: "none" },
-		});
-	});
-
-	it.each([
-		"gpt-5",
-		"gpt-5-mini",
-		"gpt-5-nano",
-		"gpt-5-pro",
-		"gpt-5.2-pro",
-		"gpt-5.4-pro",
-		"gpt-5.5-pro",
-	] as const)("omits reasoning effort for OpenAI %s when off is unsupported", async (modelId) => {
-		const model = getModel("openai", modelId);
-		let capturedPayload: unknown;
-
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response("data: [DONE]\n\n", {
-				status: 200,
-				headers: { "content-type": "text/event-stream" },
-			}),
-		);
-
-		const stream = streamOpenAIResponses(
-			model,
-			{
-				systemPrompt: "sys",
-				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
-			},
-			{
-				apiKey: "test-key",
-				onPayload: (payload) => {
-					capturedPayload = payload;
+				{
+					apiKey: "test-key",
+					onPayload: (payload) => {
+						capturedPayload = payload;
+					},
 				},
-			},
-		);
+			);
 
-		for await (const event of stream) {
-			if (event.type === "done" || event.type === "error") break;
-		}
+			for await (const event of stream) {
+				if (event.type === "done" || event.type === "error") break;
+			}
 
-		expect(capturedPayload).not.toMatchObject({
-			reasoning: expect.anything(),
-		});
-	});
+			expect(capturedPayload).toMatchObject({
+				reasoning: { effort: "none" },
+			});
+		},
+	);
+
+	it.each(["gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro", "gpt-5.5-pro"] as const)(
+		"omits reasoning effort for OpenAI %s when off is unsupported",
+		async (modelId) => {
+			const model = getModel("openai", modelId);
+			let capturedPayload: unknown;
+
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response("data: [DONE]\n\n", {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+			);
+
+			const stream = streamOpenAIResponses(
+				model,
+				{
+					systemPrompt: "sys",
+					messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+				},
+				{
+					apiKey: "test-key",
+					onPayload: (payload) => {
+						capturedPayload = payload;
+					},
+				},
+			);
+
+			for await (const event of stream) {
+				if (event.type === "done" || event.type === "error") break;
+			}
+
+			expect(capturedPayload).not.toMatchObject({
+				reasoning: expect.anything(),
+			});
+		},
+	);
 
 	it("sets cache-affinity headers for official OpenAI Responses requests with a sessionId", async () => {
 		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" });

--- a/packages/ai/test/openrouter-cache-write-repro.test.ts
+++ b/packages/ai/test/openrouter-cache-write-repro.test.ts
@@ -14,67 +14,71 @@ function createLongSystemPrompt(): string {
 describe.skipIf(!process.env.OPENROUTER_API_KEY || process.env.PI_ENABLE_OPENROUTER_CACHE_WRITE_REPRO !== "1")(
 	"OpenRouter cache_write repro E2E",
 	() => {
-		it("regression: preserves cache_write_tokens on openai-completions stream path", {
-			retry: 2,
-			timeout: 90000,
-		}, async () => {
-			const model = getModel("openrouter", "google/gemini-2.5-flash");
-			const context = {
-				systemPrompt: createLongSystemPrompt(),
-				messages: [
-					{
-						role: "user" as const,
-						content: "Reply with exactly: OK",
-						timestamp: Date.now(),
-					},
-				],
-			};
+		it(
+			"regression: preserves cache_write_tokens on openai-completions stream path",
+			{
+				retry: 2,
+				timeout: 90000,
+			},
+			async () => {
+				const model = getModel("openrouter", "google/gemini-2.5-flash");
+				const context = {
+					systemPrompt: createLongSystemPrompt(),
+					messages: [
+						{
+							role: "user" as const,
+							content: "Reply with exactly: OK",
+							timestamp: Date.now(),
+						},
+					],
+				};
 
-			const options = {
-				apiKey: process.env.OPENROUTER_API_KEY!,
-				maxTokens: 32,
-				temperature: 0,
-				onPayload: (payload: unknown) => {
-					const params = payload as {
-						messages?: Array<{
-							role?: string;
-							content?: string | Array<{ type?: string; text?: string; cache_control?: { type: string } }>;
-						}>;
-					};
-					const messages = params.messages;
-					if (!Array.isArray(messages)) return payload;
+				const options = {
+					apiKey: process.env.OPENROUTER_API_KEY!,
+					maxTokens: 32,
+					temperature: 0,
+					onPayload: (payload: unknown) => {
+						const params = payload as {
+							messages?: Array<{
+								role?: string;
+								content?: string | Array<{ type?: string; text?: string; cache_control?: { type: string } }>;
+							}>;
+						};
+						const messages = params.messages;
+						if (!Array.isArray(messages)) return payload;
 
-					for (let i = messages.length - 1; i >= 0; i--) {
-						const msg = messages[i];
-						if (msg.role !== "user") continue;
-						if (typeof msg.content === "string") {
-							msg.content = [{ type: "text", text: msg.content, cache_control: { type: "ephemeral" } }];
-							break;
-						}
-						if (!Array.isArray(msg.content)) continue;
-						for (let j = msg.content.length - 1; j >= 0; j--) {
-							const part = msg.content[j];
-							if (part.type === "text") {
-								part.cache_control = { type: "ephemeral" };
+						for (let i = messages.length - 1; i >= 0; i--) {
+							const msg = messages[i];
+							if (msg.role !== "user") continue;
+							if (typeof msg.content === "string") {
+								msg.content = [{ type: "text", text: msg.content, cache_control: { type: "ephemeral" } }];
 								break;
 							}
+							if (!Array.isArray(msg.content)) continue;
+							for (let j = msg.content.length - 1; j >= 0; j--) {
+								const part = msg.content[j];
+								if (part.type === "text") {
+									part.cache_control = { type: "ephemeral" };
+									break;
+								}
+							}
+							break;
 						}
-						break;
-					}
-					return payload;
-				},
-			};
+						return payload;
+					},
+				};
 
-			const first = await completeSimple(model, context, options);
-			expect(first.stopReason, first.errorMessage).toBe("stop");
+				const first = await completeSimple(model, context, options);
+				expect(first.stopReason, first.errorMessage).toBe("stop");
 
-			const second = await completeSimple(model, context, options);
-			expect(second.stopReason, second.errorMessage).toBe("stop");
+				const second = await completeSimple(model, context, options);
+				expect(second.stopReason, second.errorMessage).toBe("stop");
 
-			// Regression expectation: cache_write_tokens from provider usage must be preserved.
-			// With the cache_control marker above, at least one of the two calls should create cache.
-			const hasCacheWrite = first.usage.cacheWrite > 0 || second.usage.cacheWrite > 0;
-			expect(hasCacheWrite).toBe(true);
-		});
+				// Regression expectation: cache_write_tokens from provider usage must be preserved.
+				// With the cache_control marker above, at least one of the two calls should create cache.
+				const hasCacheWrite = first.usage.cacheWrite > 0 || second.usage.cacheWrite > 0;
+				expect(hasCacheWrite).toBe(true);
+			},
+		);
 	},
 );

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -106,25 +106,29 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.ANTHROPIC_API_KEY)("Anthropic (API Key)", () => {
-		it("claude-sonnet-4-5 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("anthropic", "claude-sonnet-4-5");
+		it(
+			"claude-sonnet-4-5 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("anthropic", "claude-sonnet-4-5");
 
-			console.log(`\nAnthropic / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.ANTHROPIC_API_KEY });
+				console.log(`\nAnthropic / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.ANTHROPIC_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
 
-			// Anthropic should have cache activity
-			const hasCache = second.cacheRead > 0 || second.cacheWrite > 0 || first.cacheWrite > 0;
-			expect(hasCache).toBe(true);
-		});
+				// Anthropic should have cache activity
+				const hasCache = second.cacheRead > 0 || second.cacheWrite > 0 || first.cacheWrite > 0;
+				expect(hasCache).toBe(true);
+			},
+		);
 	});
 
 	describe("Anthropic (OAuth)", () => {
@@ -155,64 +159,76 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.OPENAI_API_KEY)("OpenAI Completions", () => {
-		it("gpt-4o-mini - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
-			void _compat;
-			const llm: Model<"openai-completions"> = {
-				...baseModel,
-				api: "openai-completions",
-			};
+		it(
+			"gpt-4o-mini - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+				void _compat;
+				const llm: Model<"openai-completions"> = {
+					...baseModel,
+					api: "openai-completions",
+				};
 
-			console.log(`\nOpenAI Completions / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm);
+				console.log(`\nOpenAI Completions / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm);
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	describe.skipIf(!process.env.OPENAI_API_KEY)("OpenAI Responses", () => {
-		it("claude-haiku-4.5 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("openai", "gpt-4o");
+		it(
+			"claude-haiku-4.5 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("openai", "gpt-4o");
 
-			console.log(`\nOpenAI Responses / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm);
+				console.log(`\nOpenAI Responses / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm);
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	describe.skipIf(!hasAzureOpenAICredentials())("Azure OpenAI Responses", () => {
-		it("gpt-4o-mini - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("azure-openai-responses", "gpt-4o-mini");
-			const azureDeploymentName = resolveAzureDeploymentName(llm.id);
-			const azureOptions = azureDeploymentName ? { azureDeploymentName } : {};
+		it(
+			"gpt-4o-mini - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("azure-openai-responses", "gpt-4o-mini");
+				const azureDeploymentName = resolveAzureDeploymentName(llm.id);
+				const azureOptions = azureDeploymentName ? { azureDeploymentName } : {};
 
-			console.log(`\nAzure OpenAI Responses / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, azureOptions);
+				console.log(`\nAzure OpenAI Responses / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, azureOptions);
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -220,21 +236,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.GEMINI_API_KEY)("Google", () => {
-		it("gemini-2.0-flash - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("google", "gemini-2.0-flash");
+		it(
+			"gemini-2.0-flash - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("google", "gemini-2.0-flash");
 
-			console.log(`\nGoogle / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm);
+				console.log(`\nGoogle / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm);
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -242,21 +262,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.XAI_API_KEY)("xAI", () => {
-		it("grok-code-fast-1 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("xai", "grok-code-fast-1");
+		it(
+			"grok-code-fast-1 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("xai", "grok-code-fast-1");
 
-			console.log(`\nxAI / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.XAI_API_KEY });
+				console.log(`\nxAI / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.XAI_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -264,21 +288,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.GROQ_API_KEY)("Groq", () => {
-		it("openai/gpt-oss-120b - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("groq", "openai/gpt-oss-120b");
+		it(
+			"openai/gpt-oss-120b - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("groq", "openai/gpt-oss-120b");
 
-			console.log(`\nGroq / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.GROQ_API_KEY });
+				console.log(`\nGroq / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.GROQ_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -286,21 +314,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.CEREBRAS_API_KEY)("Cerebras", () => {
-		it("gpt-oss-120b - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("cerebras", "gpt-oss-120b");
+		it(
+			"gpt-oss-120b - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("cerebras", "gpt-oss-120b");
 
-			console.log(`\nCerebras / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.CEREBRAS_API_KEY });
+				console.log(`\nCerebras / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.CEREBRAS_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -308,23 +340,27 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!hasCloudflareWorkersAICredentials())("Cloudflare Workers AI", () => {
-		it("@cf/moonshotai/kimi-k2.6 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("cloudflare-workers-ai", "@cf/moonshotai/kimi-k2.6");
+		it(
+			"@cf/moonshotai/kimi-k2.6 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("cloudflare-workers-ai", "@cf/moonshotai/kimi-k2.6");
 
-			console.log(`\nCloudflare Workers AI / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, {
-				apiKey: process.env.CLOUDFLARE_API_KEY,
-			});
+				console.log(`\nCloudflare Workers AI / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, {
+					apiKey: process.env.CLOUDFLARE_API_KEY,
+				});
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -332,23 +368,27 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!hasCloudflareAiGatewayCredentials())("Cloudflare AI Gateway", () => {
-		it("workers-ai/@cf/moonshotai/kimi-k2.6 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("cloudflare-ai-gateway", "workers-ai/@cf/moonshotai/kimi-k2.6");
+		it(
+			"workers-ai/@cf/moonshotai/kimi-k2.6 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("cloudflare-ai-gateway", "workers-ai/@cf/moonshotai/kimi-k2.6");
 
-			console.log(`\nCloudflare AI Gateway / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, {
-				apiKey: process.env.CLOUDFLARE_API_KEY,
-			});
+				console.log(`\nCloudflare AI Gateway / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, {
+					apiKey: process.env.CLOUDFLARE_API_KEY,
+				});
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -397,21 +437,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.ZAI_API_KEY)("z.ai", () => {
-		it("glm-4.5-air - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("zai", "glm-4.5-air");
+		it(
+			"glm-4.5-air - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("zai", "glm-4.5-air");
 
-			console.log(`\nz.ai / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.ZAI_API_KEY });
+				console.log(`\nz.ai / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.ZAI_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -419,21 +463,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.MISTRAL_API_KEY)("Mistral", () => {
-		it("devstral-medium-latest - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("mistral", "devstral-medium-latest");
+		it(
+			"devstral-medium-latest - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("mistral", "devstral-medium-latest");
 
-			console.log(`\nMistral / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.MISTRAL_API_KEY });
+				console.log(`\nMistral / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.MISTRAL_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -441,21 +489,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.MINIMAX_API_KEY)("MiniMax", () => {
-		it("MiniMax-M2.7 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("minimax", "MiniMax-M2.7");
+		it(
+			"MiniMax-M2.7 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("minimax", "MiniMax-M2.7");
 
-			console.log(`\nMiniMax / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.MINIMAX_API_KEY });
+				console.log(`\nMiniMax / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.MINIMAX_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -463,21 +515,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.XIAOMI_API_KEY)("Xiaomi MiMo (API billing)", () => {
-		it("mimo-v2.5-pro - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("xiaomi", "mimo-v2.5-pro");
+		it(
+			"mimo-v2.5-pro - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("xiaomi", "mimo-v2.5-pro");
 
-			console.log(`\nXiaomi MiMo / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.XIAOMI_API_KEY });
+				console.log(`\nXiaomi MiMo / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.XIAOMI_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -485,23 +541,27 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.XIAOMI_TOKEN_PLAN_CN_API_KEY)("Xiaomi MiMo Token Plan (CN)", () => {
-		it("mimo-v2.5-pro - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("xiaomi-token-plan-cn", "mimo-v2.5-pro");
+		it(
+			"mimo-v2.5-pro - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("xiaomi-token-plan-cn", "mimo-v2.5-pro");
 
-			console.log(`\nXiaomi MiMo Token Plan CN / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, {
-				apiKey: process.env.XIAOMI_TOKEN_PLAN_CN_API_KEY,
-			});
+				console.log(`\nXiaomi MiMo Token Plan CN / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, {
+					apiKey: process.env.XIAOMI_TOKEN_PLAN_CN_API_KEY,
+				});
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -509,23 +569,27 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.XIAOMI_TOKEN_PLAN_AMS_API_KEY)("Xiaomi MiMo Token Plan (AMS)", () => {
-		it("mimo-v2.5-pro - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("xiaomi-token-plan-ams", "mimo-v2.5-pro");
+		it(
+			"mimo-v2.5-pro - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("xiaomi-token-plan-ams", "mimo-v2.5-pro");
 
-			console.log(`\nXiaomi MiMo Token Plan AMS / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, {
-				apiKey: process.env.XIAOMI_TOKEN_PLAN_AMS_API_KEY,
-			});
+				console.log(`\nXiaomi MiMo Token Plan AMS / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, {
+					apiKey: process.env.XIAOMI_TOKEN_PLAN_AMS_API_KEY,
+				});
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -533,23 +597,27 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.XIAOMI_TOKEN_PLAN_SGP_API_KEY)("Xiaomi MiMo Token Plan (SGP)", () => {
-		it("mimo-v2.5-pro - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("xiaomi-token-plan-sgp", "mimo-v2.5-pro");
+		it(
+			"mimo-v2.5-pro - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("xiaomi-token-plan-sgp", "mimo-v2.5-pro");
 
-			console.log(`\nXiaomi MiMo Token Plan SGP / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, {
-				apiKey: process.env.XIAOMI_TOKEN_PLAN_SGP_API_KEY,
-			});
+				console.log(`\nXiaomi MiMo Token Plan SGP / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, {
+					apiKey: process.env.XIAOMI_TOKEN_PLAN_SGP_API_KEY,
+				});
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -557,21 +625,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.KIMI_API_KEY)("Kimi For Coding", () => {
-		it("kimi-k2-thinking - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("kimi-coding", "kimi-k2-thinking");
+		it(
+			"kimi-k2-thinking - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("kimi-coding", "kimi-k2-thinking");
 
-			console.log(`\nKimi For Coding / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.KIMI_API_KEY });
+				console.log(`\nKimi For Coding / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.KIMI_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -579,21 +651,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.AI_GATEWAY_API_KEY)("Vercel AI Gateway", () => {
-		it("google/gemini-2.5-flash - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("vercel-ai-gateway", "google/gemini-2.5-flash");
+		it(
+			"google/gemini-2.5-flash - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("vercel-ai-gateway", "google/gemini-2.5-flash");
 
-			console.log(`\nVercel AI Gateway / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.AI_GATEWAY_API_KEY });
+				console.log(`\nVercel AI Gateway / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.AI_GATEWAY_API_KEY });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -601,85 +677,105 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!openRouterApiKey)("OpenRouter", () => {
-		it("anthropic/claude-sonnet-4 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("openrouter", "anthropic/claude-sonnet-4");
+		it(
+			"anthropic/claude-sonnet-4 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("openrouter", "anthropic/claude-sonnet-4");
 
-			console.log(`\nOpenRouter / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
+				console.log(`\nOpenRouter / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 
-		it("deepseek/deepseek-chat - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("openrouter", "deepseek/deepseek-chat");
+		it(
+			"deepseek/deepseek-chat - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("openrouter", "deepseek/deepseek-chat");
 
-			console.log(`\nOpenRouter / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
+				console.log(`\nOpenRouter / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 
-		it("mistralai/mistral-small-3.2-24b-instruct - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("openrouter", "mistralai/mistral-small-3.2-24b-instruct");
+		it(
+			"mistralai/mistral-small-3.2-24b-instruct - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("openrouter", "mistralai/mistral-small-3.2-24b-instruct");
 
-			console.log(`\nOpenRouter / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
+				console.log(`\nOpenRouter / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 
-		it("google/gemini-2.5-flash - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("openrouter", "google/gemini-2.5-flash");
+		it(
+			"google/gemini-2.5-flash - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("openrouter", "google/gemini-2.5-flash");
 
-			console.log(`\nOpenRouter / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
+				console.log(`\nOpenRouter / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 
-		it("deepseek/deepseek-chat - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("openrouter", "deepseek/deepseek-chat");
+		it(
+			"deepseek/deepseek-chat - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("openrouter", "deepseek/deepseek-chat");
 
-			console.log(`\nOpenRouter / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
+				console.log(`\nOpenRouter / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: openRouterApiKey });
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================
@@ -729,21 +825,25 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!hasBedrockCredentials())("Amazon Bedrock", () => {
-		it("claude-sonnet-4-5 - should return totalTokens equal to sum of components", {
-			retry: 3,
-			timeout: 60000,
-		}, async () => {
-			const llm = getModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-5-20250929-v1:0");
+		it(
+			"claude-sonnet-4-5 - should return totalTokens equal to sum of components",
+			{
+				retry: 3,
+				timeout: 60000,
+			},
+			async () => {
+				const llm = getModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-5-20250929-v1:0");
 
-			console.log(`\nAmazon Bedrock / ${llm.id}:`);
-			const { first, second } = await testTotalTokensWithCache(llm);
+				console.log(`\nAmazon Bedrock / ${llm.id}:`);
+				const { first, second } = await testTotalTokensWithCache(llm);
 
-			logUsage("First request", first);
-			logUsage("Second request", second);
+				logUsage("First request", first);
+				logUsage("Second request", second);
 
-			assertTotalTokensEqualsComponents(first);
-			assertTotalTokensEqualsComponents(second);
-		});
+				assertTotalTokensEqualsComponents(first);
+				assertTotalTokensEqualsComponents(second);
+			},
+		);
 	});
 
 	// =========================================================================

--- a/packages/ai/test/unicode-surrogate.test.ts
+++ b/packages/ai/test/unicode-surrogate.test.ts
@@ -640,12 +640,16 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 				await testRealWorldLinkedInData(llm);
 			});
 
-			it("should handle unpaired high surrogate (0xD83D) in tool results", {
-				retry: 3,
-				timeout: 30000,
-			}, async () => {
-				await testUnpairedHighSurrogate(llm);
-			});
+			it(
+				"should handle unpaired high surrogate (0xD83D) in tool results",
+				{
+					retry: 3,
+					timeout: 30000,
+				},
+				async () => {
+					await testUnpairedHighSurrogate(llm);
+				},
+			);
 		},
 	);
 
@@ -662,12 +666,16 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 				await testRealWorldLinkedInData(llm);
 			});
 
-			it("should handle unpaired high surrogate (0xD83D) in tool results", {
-				retry: 3,
-				timeout: 30000,
-			}, async () => {
-				await testUnpairedHighSurrogate(llm);
-			});
+			it(
+				"should handle unpaired high surrogate (0xD83D) in tool results",
+				{
+					retry: 3,
+					timeout: 30000,
+				},
+				async () => {
+					await testUnpairedHighSurrogate(llm);
+				},
+			);
 		},
 	);
 
@@ -684,12 +692,16 @@ describe("AI Providers Unicode Surrogate Pair Tests", () => {
 				await testRealWorldLinkedInData(llm);
 			});
 
-			it("should handle unpaired high surrogate (0xD83D) in tool results", {
-				retry: 3,
-				timeout: 30000,
-			}, async () => {
-				await testUnpairedHighSurrogate(llm);
-			});
+			it(
+				"should handle unpaired high surrogate (0xD83D) in tool results",
+				{
+					retry: 3,
+					timeout: 30000,
+				},
+				async () => {
+					await testUnpairedHighSurrogate(llm);
+				},
+			);
 		},
 	);
 

--- a/packages/ai/test/xiaomi-models.test.ts
+++ b/packages/ai/test/xiaomi-models.test.ts
@@ -6,11 +6,10 @@ describe("Xiaomi MiMo models", () => {
 		expect(getModel("xiaomi", "mimo-v2-flash")).toBeDefined();
 	});
 
-	it.each([
-		"xiaomi-token-plan-cn",
-		"xiaomi-token-plan-ams",
-		"xiaomi-token-plan-sgp",
-	] as const)("omits mimo-v2-flash from %s", (provider) => {
-		expect(getModels(provider).some((model) => model.id === "mimo-v2-flash")).toBe(false);
-	});
+	it.each(["xiaomi-token-plan-cn", "xiaomi-token-plan-ams", "xiaomi-token-plan-sgp"] as const)(
+		"omits mimo-v2-flash from %s",
+		(provider) => {
+			expect(getModels(provider).some((model) => model.id === "mimo-v2-flash")).toBe(false);
+		},
+	);
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
+
 ## [0.79.1] - 2026-06-09
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
+
 ### Fixed
 
 ### Removed

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -55,6 +55,8 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 | `defaultProjectTrust` | string | `"ask"` | Fallback project trust behavior: `"ask"`, `"always"`, or `"never"`. Global setting only |
 | `collapseChangelog` | boolean | `false` | Show condensed changelog after updates |
 | `enableInstallTelemetry` | boolean | `true` | Send an anonymous install/update version ping after first install or changelog-detected updates. This does not control update checks |
+| `enableAnalytics` | boolean | `false` | Opt-in analytics data sharing. Currently only asked for during the experimental first-time setup (`PI_EXPERIMENTAL=1`) |
+| `trackingId` | string | - | Analytics tracking identifier, generated when `enableAnalytics` is turned on |
 | `doubleEscapeAction` | string | `"tree"` | Action for double-escape: `"tree"`, `"fork"`, or `"none"` |
 | `treeFilterMode` | string | `"default"` | Default filter for `/tree`: `"default"`, `"no-tools"`, `"user-only"`, `"labeled-only"`, `"all"` |
 | `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -69,6 +69,8 @@ When this value is anything other than `"auto"`, it overrides any model-level `p
 | `defaultProjectTrust` | string | `"ask"` | Fallback project trust behavior: `"ask"`, `"always"`, or `"never"`. Global setting only |
 | `collapseChangelog` | boolean | `false` | Show condensed changelog after updates |
 | `enableInstallTelemetry` | boolean | `true` | Send an anonymous install/update version ping after first install or changelog-detected updates. This does not control update checks |
+| `enableAnalytics` | boolean | `false` | Opt-in analytics data sharing. Currently only asked for during the experimental first-time setup (`PI_EXPERIMENTAL=1`) |
+| `trackingId` | string | - | Analytics tracking identifier, generated when `enableAnalytics` is turned on |
 | `doubleEscapeAction` | string | `"tree"` | Action for double-escape: `"tree"`, `"fork"`, or `"none"` |
 | `treeFilterMode` | string | `"default"` | Default filter for `/tree`: `"default"`, `"no-tools"`, `"user-only"`, `"labeled-only"`, `"all"` |
 | `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -1,9 +1,16 @@
 import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
+import { existsSync } from "fs";
+import { ENV_AGENT_DIR, getSettingsPath } from "../config.ts";
+import { areExperimentalFeaturesEnabled } from "../core/experimental.ts";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
 import { ExtensionInputComponent } from "../modes/interactive/components/extension-input.ts";
 import { ExtensionSelectorComponent } from "../modes/interactive/components/extension-selector.ts";
-import { initTheme } from "../modes/interactive/theme/theme.ts";
+import {
+	FirstTimeSetupComponent,
+	type FirstTimeSetupResult,
+} from "../modes/interactive/components/first-time-setup.ts";
+import { detectTerminalBackground, initTheme, setTheme } from "../modes/interactive/theme/theme.ts";
 
 function createStartupTui(settingsManager: SettingsManager): TUI {
 	initTheme(settingsManager.getTheme());
@@ -17,6 +24,22 @@ async function clearStartupTui(ui: TUI): Promise<void> {
 	ui.clear();
 	ui.requestRender();
 	await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+/**
+ * First-time setup runs when all of these hold:
+ * - experimental features are enabled (PI_EXPERIMENTAL=1)
+ * - the default agent directory is used (no custom agent dir override)
+ * - setup was not completed before (settings.json does not exist)
+ */
+export function shouldRunFirstTimeSetup(settingsPath: string = getSettingsPath()): boolean {
+	if (!areExperimentalFeaturesEnabled()) {
+		return false;
+	}
+	if (process.env[ENV_AGENT_DIR]) {
+		return false;
+	}
+	return !existsSync(settingsPath);
 }
 
 export async function showStartupSelector<T>(
@@ -47,6 +70,43 @@ export async function showStartupSelector<T>(
 		);
 		ui.addChild(selector);
 		ui.setFocus(selector);
+		ui.start();
+	});
+}
+
+/** Show the first-time setup dialog and persist the result */
+export async function showFirstTimeSetup(settingsManager: SettingsManager): Promise<void> {
+	return new Promise((resolve) => {
+		const ui = createStartupTui(settingsManager);
+
+		let settled = false;
+		const finish = async (result: FirstTimeSetupResult | undefined) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			if (result) {
+				settingsManager.setTheme(result.theme);
+				settingsManager.setEnableAnalytics(result.shareAnalytics);
+				await settingsManager.flush();
+			}
+			await clearStartupTui(ui);
+			ui.stop();
+			resolve();
+		};
+
+		const component = new FirstTimeSetupComponent({
+			detectedTheme: detectTerminalBackground().theme,
+			onThemePreview: (themeName) => {
+				setTheme(themeName);
+				ui.invalidate();
+				ui.requestRender();
+			},
+			onSubmit: (result) => void finish(result),
+			onCancel: () => void finish(undefined),
+		});
+		ui.addChild(component);
+		ui.setFocus(component);
 		ui.start();
 	});
 }

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -1,6 +1,6 @@
 import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
 import { existsSync } from "fs";
-import { ENV_AGENT_DIR, getSettingsPath } from "../config.ts";
+import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, getSettingsPath, PACKAGE_NAME } from "../config.ts";
 import { areExperimentalFeaturesEnabled } from "../core/experimental.ts";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
@@ -11,6 +11,24 @@ import {
 	type FirstTimeSetupResult,
 } from "../modes/interactive/components/first-time-setup.ts";
 import { detectTerminalBackground, initTheme, setTheme } from "../modes/interactive/theme/theme.ts";
+
+const OFFICIAL_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+const OFFICIAL_APP_NAME = "pi";
+const OFFICIAL_CONFIG_DIR_NAME = ".pi";
+
+interface DistributionMetadata {
+	packageName: string;
+	appName: string;
+	configDirName: string;
+}
+
+function isOfficialDistribution({ packageName, appName, configDirName }: DistributionMetadata): boolean {
+	return (
+		packageName === OFFICIAL_PACKAGE_NAME &&
+		appName === OFFICIAL_APP_NAME &&
+		configDirName === OFFICIAL_CONFIG_DIR_NAME
+	);
+}
 
 function createStartupTui(settingsManager: SettingsManager): TUI {
 	initTheme(settingsManager.getTheme());
@@ -28,11 +46,21 @@ async function clearStartupTui(ui: TUI): Promise<void> {
 
 /**
  * First-time setup runs when all of these hold:
+ * - this is the official Pi distribution (not a fork/rebrand)
  * - experimental features are enabled (PI_EXPERIMENTAL=1)
  * - the default agent directory is used (no custom agent dir override)
  * - setup was not completed before (settings.json does not exist)
  */
 export function shouldRunFirstTimeSetup(settingsPath: string = getSettingsPath()): boolean {
+	if (
+		!isOfficialDistribution({
+			packageName: PACKAGE_NAME,
+			appName: APP_NAME,
+			configDirName: CONFIG_DIR_NAME,
+		})
+	) {
+		return false;
+	}
 	if (!areExperimentalFeaturesEnabled()) {
 		return false;
 	}

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -1,9 +1,37 @@
 import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
+import { existsSync } from "fs";
+import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, getSettingsPath, PACKAGE_NAME } from "../config.ts";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
 import { ExtensionInputComponent } from "../modes/interactive/components/extension-input.ts";
 import { ExtensionSelectorComponent } from "../modes/interactive/components/extension-selector.ts";
-import { initTheme } from "../modes/interactive/theme/theme.ts";
+import {
+	FirstTimeSetupComponent,
+	type FirstTimeSetupResult,
+} from "../modes/interactive/components/first-time-setup.ts";
+import { detectTerminalBackground, initTheme, setTheme } from "../modes/interactive/theme/theme.ts";
+
+const OFFICIAL_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+const OFFICIAL_APP_NAME = "pi";
+const OFFICIAL_CONFIG_DIR_NAME = ".pi";
+
+interface DistributionMetadata {
+	packageName: string;
+	appName: string;
+	configDirName: string;
+}
+
+function isOfficialDistribution({ packageName, appName, configDirName }: DistributionMetadata): boolean {
+	return (
+		packageName === OFFICIAL_PACKAGE_NAME &&
+		appName === OFFICIAL_APP_NAME &&
+		configDirName === OFFICIAL_CONFIG_DIR_NAME
+	);
+}
+
+function areExperimentalFeaturesEnabled(): boolean {
+	return process.env.PI_EXPERIMENTAL === "1";
+}
 
 function createStartupTui(settingsManager: SettingsManager): TUI {
 	initTheme(settingsManager.getTheme());
@@ -17,6 +45,32 @@ async function clearStartupTui(ui: TUI): Promise<void> {
 	ui.clear();
 	ui.requestRender();
 	await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+/**
+ * First-time setup runs when all of these hold:
+ * - this is the official Pi distribution (not a fork/rebrand)
+ * - experimental features are enabled (PI_EXPERIMENTAL=1)
+ * - the default agent directory is used (no custom agent dir override)
+ * - setup was not completed before (settings.json does not exist)
+ */
+export function shouldRunFirstTimeSetup(settingsPath: string = getSettingsPath()): boolean {
+	if (
+		!isOfficialDistribution({
+			packageName: PACKAGE_NAME,
+			appName: APP_NAME,
+			configDirName: CONFIG_DIR_NAME,
+		})
+	) {
+		return false;
+	}
+	if (!areExperimentalFeaturesEnabled()) {
+		return false;
+	}
+	if (process.env[ENV_AGENT_DIR]) {
+		return false;
+	}
+	return !existsSync(settingsPath);
 }
 
 export async function showStartupSelector<T>(
@@ -47,6 +101,43 @@ export async function showStartupSelector<T>(
 		);
 		ui.addChild(selector);
 		ui.setFocus(selector);
+		ui.start();
+	});
+}
+
+/** Show the first-time setup dialog and persist the result */
+export async function showFirstTimeSetup(settingsManager: SettingsManager): Promise<void> {
+	return new Promise((resolve) => {
+		const ui = createStartupTui(settingsManager);
+
+		let settled = false;
+		const finish = async (result: FirstTimeSetupResult | undefined) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			if (result) {
+				settingsManager.setTheme(result.theme);
+				settingsManager.setEnableAnalytics(result.shareAnalytics);
+				await settingsManager.flush();
+			}
+			await clearStartupTui(ui);
+			ui.stop();
+			resolve();
+		};
+
+		const component = new FirstTimeSetupComponent({
+			detectedTheme: detectTerminalBackground().theme,
+			onThemePreview: (themeName) => {
+				setTheme(themeName);
+				ui.invalidate();
+				ui.requestRender();
+			},
+			onSubmit: (result) => void finish(result),
+			onCancel: () => void finish(undefined),
+		});
+		ui.addChild(component);
+		ui.setFocus(component);
 		ui.start();
 	});
 }

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -340,9 +340,10 @@ export interface ResolveCliModelResult {
 export function resolveCliModel(options: {
 	cliProvider?: string;
 	cliModel?: string;
+	cliThinking?: string;
 	modelRegistry: ModelRegistry;
 }): ResolveCliModelResult {
-	const { cliProvider, cliModel, modelRegistry } = options;
+	const { cliProvider, cliModel, cliThinking, modelRegistry } = options;
 
 	if (!cliModel) {
 		return { model: undefined, warning: undefined, error: undefined };
@@ -451,12 +452,28 @@ export function resolveCliModel(options: {
 	}
 
 	if (provider) {
-		const fallbackModel = buildFallbackModel(provider, pattern, availableModels);
+		// Parse thinking level suffix from the pattern before building the fallback model,
+		// but only when --thinking is not explicitly provided.
+		// e.g. "zai-org/GLM-5.1-FP8:high" → modelId="zai-org/GLM-5.1-FP8", fallbackThinking="high"
+		let fallbackPattern = pattern;
+		let fallbackThinking: ThinkingLevel | undefined;
+		if (!cliThinking) {
+			const lastColon = pattern.lastIndexOf(":");
+			if (lastColon !== -1) {
+				const suffix = pattern.substring(lastColon + 1);
+				if (isValidThinkingLevel(suffix)) {
+					fallbackPattern = pattern.substring(0, lastColon);
+					fallbackThinking = suffix;
+				}
+			}
+		}
+
+		const fallbackModel = buildFallbackModel(provider, fallbackPattern, availableModels);
 		if (fallbackModel) {
 			const fallbackWarning = warning
-				? `${warning} Model "${pattern}" not found for provider "${provider}". Using custom model id.`
-				: `Model "${pattern}" not found for provider "${provider}". Using custom model id.`;
-			return { model: fallbackModel, thinkingLevel: undefined, warning: fallbackWarning, error: undefined };
+				? `${warning} Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`
+				: `Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`;
+			return { model: fallbackModel, thinkingLevel: fallbackThinking, warning: fallbackWarning, error: undefined };
 		}
 	}
 

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -350,9 +350,10 @@ export interface ResolveCliModelResult {
 export function resolveCliModel(options: {
 	cliProvider?: string;
 	cliModel?: string;
+	cliThinking?: string;
 	modelRegistry: ModelRegistry;
 }): ResolveCliModelResult {
-	const { cliProvider, cliModel, modelRegistry } = options;
+	const { cliProvider, cliModel, cliThinking, modelRegistry } = options;
 
 	if (!cliModel) {
 		return { model: undefined, warning: undefined, error: undefined };
@@ -457,14 +458,30 @@ export function resolveCliModel(options: {
 	}
 
 	if (provider) {
-		const fallbackModel = buildFallbackModel(provider, pattern, availableModels);
+		// Parse thinking level suffix from the pattern before building the fallback model,
+		// but only when --thinking is not explicitly provided.
+		// e.g. "zai-org/GLM-5.1-FP8:high" → modelId="zai-org/GLM-5.1-FP8", fallbackThinking="high"
+		let fallbackPattern = pattern;
+		let fallbackThinking: ThinkingLevel | undefined;
+		if (!cliThinking) {
+			const lastColon = pattern.lastIndexOf(":");
+			if (lastColon !== -1) {
+				const suffix = pattern.substring(lastColon + 1);
+				if (isValidThinkingLevel(suffix)) {
+					fallbackPattern = pattern.substring(0, lastColon);
+					fallbackThinking = suffix;
+				}
+			}
+		}
+
+		const fallbackModel = buildFallbackModel(provider, fallbackPattern, availableModels);
 		if (fallbackModel) {
 			const fallbackWarning = warning
-				? `${warning} Model "${pattern}" not found for provider "${provider}". Using custom model id.`
-				: `Model "${pattern}" not found for provider "${provider}". Using custom model id.`;
+				? `${warning} Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`
+				: `Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`;
 			return {
 				model: fallbackModel,
-				thinkingLevel: undefined,
+				thinkingLevel: fallbackThinking,
 				serviceTier,
 				warning: fallbackWarning,
 				error: undefined,

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,4 +1,5 @@
 import type { Transport } from "@earendil-works/pi-ai";
+import { randomUUID } from "crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -96,6 +97,8 @@ export interface Settings {
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
 	collapseChangelog?: boolean; // Show condensed changelog after update (use /changelog for full)
 	enableInstallTelemetry?: boolean; // default: true - anonymous version/update ping after changelog-detected updates
+	enableAnalytics?: boolean; // default: false - opt-in analytics data sharing
+	trackingId?: string; // analytics tracking identifier, generated when analytics is enabled
 	packages?: PackageSource[]; // Array of npm/git package sources (string or object with filtering)
 	extensions?: string[]; // Array of local extension file paths or directories
 	skills?: string[]; // Array of local skill file paths or directories
@@ -904,6 +907,25 @@ export class SettingsManager {
 	setEnableInstallTelemetry(enabled: boolean): void {
 		this.globalSettings.enableInstallTelemetry = enabled;
 		this.markModified("enableInstallTelemetry");
+		this.save();
+	}
+
+	getEnableAnalytics(): boolean {
+		return this.settings.enableAnalytics ?? false;
+	}
+
+	getTrackingId(): string | undefined {
+		return this.settings.trackingId;
+	}
+
+	/** Set the analytics opt-in preference; generates a tracking identifier on first opt-in */
+	setEnableAnalytics(enabled: boolean): void {
+		this.globalSettings.enableAnalytics = enabled;
+		this.markModified("enableAnalytics");
+		if (enabled && !this.globalSettings.trackingId) {
+			this.globalSettings.trackingId = randomUUID();
+			this.markModified("trackingId");
+		}
 		this.save();
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,4 +1,5 @@
 import type { Transport } from "@earendil-works/pi-ai";
+import { randomUUID } from "crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -108,6 +109,8 @@ export interface Settings {
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
 	collapseChangelog?: boolean; // Show condensed changelog after update (use /changelog for full)
 	enableInstallTelemetry?: boolean; // default: true - anonymous version/update ping after changelog-detected updates
+	enableAnalytics?: boolean; // default: false - opt-in analytics data sharing
+	trackingId?: string; // analytics tracking identifier, generated when analytics is enabled
 	packages?: PackageSource[]; // Array of npm/git package sources (string or object with filtering)
 	enabledBuiltinExtensions?: string[]; // Optional allowlist of builtin extension ids to load (default: all)
 	disabledBuiltinExtensions?: string[]; // Builtin extension ids to skip loading
@@ -947,6 +950,25 @@ export class SettingsManager {
 	setEnableInstallTelemetry(enabled: boolean): void {
 		this.globalSettings.enableInstallTelemetry = enabled;
 		this.markModified("enableInstallTelemetry");
+		this.save();
+	}
+
+	getEnableAnalytics(): boolean {
+		return this.settings.enableAnalytics ?? false;
+	}
+
+	getTrackingId(): string | undefined {
+		return this.settings.trackingId;
+	}
+
+	/** Set the analytics opt-in preference; generates a tracking identifier on first opt-in */
+	setEnableAnalytics(enabled: boolean): void {
+		this.globalSettings.enableAnalytics = enabled;
+		this.markModified("enableAnalytics");
+		if (enabled && !this.globalSettings.trackingId) {
+			this.globalSettings.trackingId = randomUUID();
+			this.markModified("trackingId");
+		}
 		this.save();
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -14,7 +14,7 @@ import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
-import { showStartupSelector } from "./cli/startup-ui.ts";
+import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
 import { ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
 import {
@@ -527,6 +527,13 @@ export async function main(args: string[], options?: MainOptions) {
 	const agentDir = getAgentDir();
 	const startupSettingsManager = SettingsManager.create(cwd, agentDir);
 	reportDiagnostics(collectSettingsDiagnostics(startupSettingsManager, "startup session lookup"));
+
+	// Experimental first-time setup: theme choice and analytics opt-in.
+	// Runs before any runtime services are created so the chosen settings apply everywhere.
+	if (appMode === "interactive" && !parsed.help && parsed.listModels === undefined && shouldRunFirstTimeSetup()) {
+		await showFirstTimeSetup(startupSettingsManager);
+		time("firstTimeSetup");
+	}
 
 	// Decide the final runtime cwd before creating cwd-bound runtime services.
 	// --session and --resume may select a session from another project, so project-local

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -360,6 +360,7 @@ function buildSessionOptions(
 		const resolved = resolveCliModel({
 			cliProvider: parsed.provider,
 			cliModel: parsed.model,
+			cliThinking: parsed.thinking,
 			modelRegistry,
 		});
 		if (resolved.warning) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -14,7 +14,7 @@ import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
-import { showStartupSelector } from "./cli/startup-ui.ts";
+import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
 import { ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
 import {
@@ -365,6 +365,7 @@ function buildSessionOptions(
 		const resolved = resolveCliModel({
 			cliProvider: parsed.provider,
 			cliModel: parsed.model,
+			cliThinking: parsed.thinking,
 			modelRegistry,
 		});
 		if (resolved.warning) {
@@ -564,6 +565,13 @@ export async function main(args: string[], options?: MainOptions) {
 		const searchPattern = typeof parsed.listModels === "string" ? parsed.listModels : undefined;
 		await listModels(services.modelRegistry, searchPattern);
 		process.exit(0);
+	}
+
+	// Experimental first-time setup: theme choice and analytics opt-in.
+	// Runs before any runtime services are created so the chosen settings apply everywhere.
+	if (appMode === "interactive" && !parsed.help && parsed.listModels === undefined && shouldRunFirstTimeSetup()) {
+		await showFirstTimeSetup(startupSettingsManager);
+		time("firstTimeSetup");
 	}
 
 	// Decide the final runtime cwd before creating cwd-bound runtime services.

--- a/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
+++ b/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
@@ -1,0 +1,145 @@
+import { Container, getKeybindings, Spacer, Text } from "@earendil-works/pi-tui";
+import { APP_NAME } from "../../../config.ts";
+import { type TerminalTheme, theme } from "../theme/theme.ts";
+import { DynamicBorder } from "./dynamic-border.ts";
+import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
+
+export interface FirstTimeSetupResult {
+	theme: TerminalTheme;
+	shareAnalytics: boolean;
+}
+
+export interface FirstTimeSetupOptions {
+	detectedTheme: TerminalTheme;
+	onThemePreview: (themeName: TerminalTheme) => void;
+	onSubmit: (result: FirstTimeSetupResult) => void;
+	onCancel: () => void;
+}
+
+const THEME_OPTIONS: Array<{ value: TerminalTheme; label: string }> = [
+	{ value: "dark", label: "Dark" },
+	{ value: "light", label: "Light" },
+];
+
+const ANALYTICS_OPTIONS: Array<{ value: boolean; label: string }> = [
+	{ value: true, label: "Share anonymous usage data" },
+	{ value: false, label: "Don't share" },
+];
+
+const SETUP_LOGO_LINES = ["██████", "██  ██", "████  ██", "██    ██"];
+
+/** First-time setup dialog: theme choice and analytics opt-in. */
+export class FirstTimeSetupComponent extends Container {
+	private step: "theme" | "analytics" = "theme";
+	private themeIndex: number;
+	private analyticsIndex = 0;
+	private readonly options: FirstTimeSetupOptions;
+
+	constructor(options: FirstTimeSetupOptions) {
+		super();
+		this.options = options;
+		this.themeIndex = Math.max(
+			0,
+			THEME_OPTIONS.findIndex((option) => option.value === options.detectedTheme),
+		);
+		this.update();
+	}
+
+	// Rebuild the whole dialog on every change so theme previews recolor all text.
+	private update(): void {
+		this.clear();
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("accent", SETUP_LOGO_LINES.join("\n")), 1, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(
+			new Text(theme.fg("accent", theme.bold(`Welcome to ${APP_NAME}, the minimal coding agent.`)), 1, 0),
+		);
+		this.addChild(new Spacer(1));
+
+		if (this.step === "theme") {
+			this.addChild(new Text(theme.fg("text", "Pick a theme."), 1, 0));
+			this.addChild(new Text(theme.fg("muted", `Detected system appearance: ${this.options.detectedTheme}`), 1, 0));
+			this.addChild(new Spacer(1));
+			this.addOptionList(
+				THEME_OPTIONS.map((option) => option.label),
+				this.themeIndex,
+			);
+		} else {
+			this.addChild(new Text(theme.fg("text", `Help improve ${APP_NAME} by sharing anonymous usage data?`), 1, 0));
+			this.addChild(
+				new Text(
+					theme.fg(
+						"muted",
+						"Opting in stores a tracking identifier in settings.json and enables anonymous\nusage analytics. You can change this at any time in settings.json.",
+					),
+					1,
+					0,
+				),
+			);
+			this.addChild(new Spacer(1));
+			this.addOptionList(
+				ANALYTICS_OPTIONS.map((option) => option.label),
+				this.analyticsIndex,
+			);
+		}
+
+		this.addChild(new Spacer(1));
+		this.addChild(
+			new Text(
+				rawKeyHint("↑↓", "navigate") +
+					"  " +
+					keyHint("tui.select.confirm", this.step === "theme" ? "continue" : "finish") +
+					"  " +
+					keyHint("tui.select.cancel", "skip setup"),
+				1,
+				0,
+			),
+		);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+	}
+
+	private addOptionList(labels: string[], selectedIndex: number): void {
+		for (let i = 0; i < labels.length; i++) {
+			const isSelected = i === selectedIndex;
+			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
+			const label = isSelected ? theme.fg("accent", labels[i]) : theme.fg("text", labels[i]);
+			this.addChild(new Text(`${prefix}${label}`, 1, 0));
+		}
+	}
+
+	private moveSelection(delta: number): void {
+		if (this.step === "theme") {
+			const next = Math.max(0, Math.min(THEME_OPTIONS.length - 1, this.themeIndex + delta));
+			if (next !== this.themeIndex) {
+				this.themeIndex = next;
+				this.options.onThemePreview(THEME_OPTIONS[this.themeIndex].value);
+			}
+		} else {
+			this.analyticsIndex = Math.max(0, Math.min(ANALYTICS_OPTIONS.length - 1, this.analyticsIndex + delta));
+		}
+		this.update();
+	}
+
+	handleInput(keyData: string): void {
+		const kb = getKeybindings();
+		if (kb.matches(keyData, "tui.select.up") || keyData === "k") {
+			this.moveSelection(-1);
+		} else if (kb.matches(keyData, "tui.select.down") || keyData === "j") {
+			this.moveSelection(1);
+		} else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
+			if (this.step === "theme") {
+				this.step = "analytics";
+				this.update();
+			} else {
+				this.options.onSubmit({
+					theme: THEME_OPTIONS[this.themeIndex].value,
+					shareAnalytics: ANALYTICS_OPTIONS[this.analyticsIndex].value,
+				});
+			}
+		} else if (kb.matches(keyData, "tui.select.cancel")) {
+			this.options.onCancel();
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
+++ b/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
@@ -1,0 +1,145 @@
+import { Container, getKeybindings, Spacer, Text } from "@earendil-works/pi-tui";
+import { APP_NAME } from "../../../config.ts";
+import { type TerminalTheme, theme } from "../theme/theme.ts";
+import { DynamicBorder } from "./dynamic-border.ts";
+import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
+
+export interface FirstTimeSetupResult {
+	theme: TerminalTheme;
+	shareAnalytics: boolean;
+}
+
+export interface FirstTimeSetupOptions {
+	detectedTheme: TerminalTheme;
+	onThemePreview: (themeName: TerminalTheme) => void;
+	onSubmit: (result: FirstTimeSetupResult) => void;
+	onCancel: () => void;
+}
+
+const THEME_OPTIONS: Array<{ value: TerminalTheme; label: string }> = [
+	{ value: "dark", label: "Dark" },
+	{ value: "light", label: "Light" },
+];
+
+const ANALYTICS_OPTIONS: Array<{ value: boolean; label: string }> = [
+	{ value: true, label: "Share anonymous usage data" },
+	{ value: false, label: "Don't share" },
+];
+
+const SETUP_LOGO_LINES = ["██████", "██  ██", "████  ██", "██    ██"];
+
+/** First-time setup dialog: theme choice and analytics opt-in. */
+export class FirstTimeSetupComponent extends Container {
+	private step: "theme" | "analytics" = "theme";
+	private themeIndex: number;
+	private analyticsIndex = 0;
+	private readonly options: FirstTimeSetupOptions;
+
+	constructor(options: FirstTimeSetupOptions) {
+		super();
+		this.options = options;
+		this.themeIndex = Math.max(
+			0,
+			THEME_OPTIONS.findIndex((option) => option.value === options.detectedTheme),
+		);
+		this.update();
+	}
+
+	// Rebuild the whole dialog on every change so theme previews recolor all text.
+	private update(): void {
+		this.clear();
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("accent", SETUP_LOGO_LINES.join("\n")), 1, 0));
+		this.addChild(new Spacer(1));
+		this.addChild(
+			new Text(theme.fg("accent", theme.bold(`Welcome to ${APP_NAME}, the minimal coding agent.`)), 1, 0),
+		);
+		this.addChild(new Spacer(1));
+
+		if (this.step === "theme") {
+			this.addChild(new Text(theme.fg("text", "Pick a theme."), 1, 0));
+			this.addChild(new Text(theme.fg("muted", `Detected system appearance: ${this.options.detectedTheme}`), 1, 0));
+			this.addChild(new Spacer(1));
+			this.addOptionList(
+				THEME_OPTIONS.map((option) => option.label),
+				this.themeIndex,
+			);
+		} else {
+			this.addChild(new Text(theme.fg("text", "Opt-in to anonymous usage data sharing?"), 1, 0));
+			this.addChild(
+				new Text(
+					theme.fg(
+						"muted",
+						"Opting in stores a tracking identifier in settings.json and enables anonymous\nusage analytics. This helps us to better debug, reproduce, and resolve issues\nand bugs within Pi. You can observe what is shared using /privacy and make\nchanges anytime in settings.json.",
+					),
+					1,
+					0,
+				),
+			);
+			this.addChild(new Spacer(1));
+			this.addOptionList(
+				ANALYTICS_OPTIONS.map((option) => option.label),
+				this.analyticsIndex,
+			);
+		}
+
+		this.addChild(new Spacer(1));
+		this.addChild(
+			new Text(
+				rawKeyHint("↑↓", "navigate") +
+					"  " +
+					keyHint("tui.select.confirm", this.step === "theme" ? "continue" : "finish") +
+					"  " +
+					keyHint("tui.select.cancel", "skip setup"),
+				1,
+				0,
+			),
+		);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+	}
+
+	private addOptionList(labels: string[], selectedIndex: number): void {
+		for (let i = 0; i < labels.length; i++) {
+			const isSelected = i === selectedIndex;
+			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
+			const label = isSelected ? theme.fg("accent", labels[i]) : theme.fg("text", labels[i]);
+			this.addChild(new Text(`${prefix}${label}`, 1, 0));
+		}
+	}
+
+	private moveSelection(delta: number): void {
+		if (this.step === "theme") {
+			const next = Math.max(0, Math.min(THEME_OPTIONS.length - 1, this.themeIndex + delta));
+			if (next !== this.themeIndex) {
+				this.themeIndex = next;
+				this.options.onThemePreview(THEME_OPTIONS[this.themeIndex].value);
+			}
+		} else {
+			this.analyticsIndex = Math.max(0, Math.min(ANALYTICS_OPTIONS.length - 1, this.analyticsIndex + delta));
+		}
+		this.update();
+	}
+
+	handleInput(keyData: string): void {
+		const kb = getKeybindings();
+		if (kb.matches(keyData, "tui.select.up") || keyData === "k") {
+			this.moveSelection(-1);
+		} else if (kb.matches(keyData, "tui.select.down") || keyData === "j") {
+			this.moveSelection(1);
+		} else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
+			if (this.step === "theme") {
+				this.step = "analytics";
+				this.update();
+			} else {
+				this.options.onSubmit({
+					theme: THEME_OPTIONS[this.themeIndex].value,
+					shareAnalytics: ANALYTICS_OPTIONS[this.analyticsIndex].value,
+				});
+			}
+		} else if (kb.matches(keyData, "tui.select.cancel")) {
+			this.options.onCancel();
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
+++ b/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
@@ -66,12 +66,12 @@ export class FirstTimeSetupComponent extends Container {
 				this.themeIndex,
 			);
 		} else {
-			this.addChild(new Text(theme.fg("text", `Help improve ${APP_NAME} by sharing anonymous usage data?`), 1, 0));
+			this.addChild(new Text(theme.fg("text", "Opt-in to anonymous usage data sharing?"), 1, 0));
 			this.addChild(
 				new Text(
 					theme.fg(
 						"muted",
-						"Opting in stores a tracking identifier in settings.json and enables anonymous\nusage analytics. You can change this at any time in settings.json.",
+						"Opting in stores a tracking identifier in settings.json and enables anonymous\nusage analytics. This helps us to better debug, reproduce, and resolve issues\nand bugs within Pi. You can observe what is shared using /privacy and make\nchanges anytime in settings.json.",
 					),
 					1,
 					0,

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -13,6 +13,11 @@ export { DynamicBorder } from "./dynamic-border.ts";
 export { ExtensionEditorComponent } from "./extension-editor.ts";
 export { ExtensionInputComponent } from "./extension-input.ts";
 export { ExtensionSelectorComponent } from "./extension-selector.ts";
+export {
+	FirstTimeSetupComponent,
+	type FirstTimeSetupOptions,
+	type FirstTimeSetupResult,
+} from "./first-time-setup.ts";
 export { FooterComponent } from "./footer.ts";
 export { keyHint, keyText, rawKeyHint } from "./keybinding-hints.ts";
 export { LoginDialogComponent } from "./login-dialog.ts";

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -18,6 +18,11 @@ export {
 	type FavoriteModelsConfig,
 	FavoriteModelsSelectorComponent,
 } from "./favorite-models-selector.ts";
+export {
+	FirstTimeSetupComponent,
+	type FirstTimeSetupOptions,
+	type FirstTimeSetupResult,
+} from "./first-time-setup.ts";
 export { FooterComponent } from "./footer.ts";
 export { keyHint, keyText, rawKeyHint } from "./keybinding-hints.ts";
 export { LoginDialogComponent } from "./login-dialog.ts";

--- a/packages/coding-agent/test/first-time-setup-fork.test.ts
+++ b/packages/coding-agent/test/first-time-setup-fork.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.ts", async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...(actual as Record<string, unknown>),
+		PACKAGE_NAME: "@example/pi-coding-agent",
+	};
+});
+
+import { shouldRunFirstTimeSetup } from "../src/cli/startup-ui.ts";
+
+describe("shouldRunFirstTimeSetup in forked distributions", () => {
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-first-time-setup-fork-"));
+		settingsPath = join(tempDir, "settings.json");
+		process.env.PI_EXPERIMENTAL = "1";
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		if (originalPiExperimental === undefined) {
+			delete process.env.PI_EXPERIMENTAL;
+		} else {
+			process.env.PI_EXPERIMENTAL = originalPiExperimental;
+		}
+	});
+
+	it("returns false for a forked package", () => {
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/first-time-setup.test.ts
+++ b/packages/coding-agent/test/first-time-setup.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { shouldRunFirstTimeSetup } from "../src/cli/startup-ui.ts";
+import { ENV_AGENT_DIR } from "../src/config.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+describe("shouldRunFirstTimeSetup", () => {
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+	const originalAgentDir = process.env[ENV_AGENT_DIR];
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-first-time-setup-"));
+		settingsPath = join(tempDir, "settings.json");
+		process.env.PI_EXPERIMENTAL = "1";
+		delete process.env[ENV_AGENT_DIR];
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		if (originalPiExperimental === undefined) {
+			delete process.env.PI_EXPERIMENTAL;
+		} else {
+			process.env.PI_EXPERIMENTAL = originalPiExperimental;
+		}
+		if (originalAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
+	});
+
+	it("returns true when experimental, default agent dir, and no settings.json", () => {
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(true);
+	});
+
+	it("returns false when experimental features are disabled", () => {
+		delete process.env.PI_EXPERIMENTAL;
+
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+
+	it("returns false when a custom agent dir is set", () => {
+		process.env[ENV_AGENT_DIR] = tempDir;
+
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+
+	it("returns false when settings.json already exists", () => {
+		writeFileSync(settingsPath, "{}", "utf-8");
+
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+});
+
+describe("analytics settings", () => {
+	it("defaults to disabled with no tracking identifier", () => {
+		const manager = SettingsManager.inMemory();
+
+		expect(manager.getEnableAnalytics()).toBe(false);
+		expect(manager.getTrackingId()).toBeUndefined();
+	});
+
+	it("generates a tracking identifier on opt-in", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setEnableAnalytics(true);
+
+		expect(manager.getEnableAnalytics()).toBe(true);
+		expect(manager.getTrackingId()).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it("does not generate a tracking identifier on opt-out", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setEnableAnalytics(false);
+
+		expect(manager.getEnableAnalytics()).toBe(false);
+		expect(manager.getTrackingId()).toBeUndefined();
+	});
+
+	it("keeps the tracking identifier when toggling analytics", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setEnableAnalytics(true);
+		const trackingId = manager.getTrackingId();
+		manager.setEnableAnalytics(false);
+		manager.setEnableAnalytics(true);
+
+		expect(manager.getTrackingId()).toBe(trackingId);
+	});
+});

--- a/packages/coding-agent/test/first-time-setup.test.ts
+++ b/packages/coding-agent/test/first-time-setup.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.ts", async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...(actual as Record<string, unknown>),
+		APP_NAME: "pi",
+		CONFIG_DIR_NAME: ".pi",
+		PACKAGE_NAME: "@earendil-works/pi-coding-agent",
+	};
+});
+
+import { shouldRunFirstTimeSetup } from "../src/cli/startup-ui.ts";
+import { ENV_AGENT_DIR } from "../src/config.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+describe("shouldRunFirstTimeSetup", () => {
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+	const originalAgentDir = process.env[ENV_AGENT_DIR];
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-first-time-setup-"));
+		settingsPath = join(tempDir, "settings.json");
+		process.env.PI_EXPERIMENTAL = "1";
+		delete process.env[ENV_AGENT_DIR];
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		if (originalPiExperimental === undefined) {
+			delete process.env.PI_EXPERIMENTAL;
+		} else {
+			process.env.PI_EXPERIMENTAL = originalPiExperimental;
+		}
+		if (originalAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
+	});
+
+	it("returns true when experimental, default agent dir, and no settings.json", () => {
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(true);
+	});
+
+	it("returns false when experimental features are disabled", () => {
+		delete process.env.PI_EXPERIMENTAL;
+
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+
+	it("returns false when a custom agent dir is set", () => {
+		process.env[ENV_AGENT_DIR] = tempDir;
+
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+
+	it("returns false when settings.json already exists", () => {
+		writeFileSync(settingsPath, "{}", "utf-8");
+
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+});
+
+describe("analytics settings", () => {
+	it("defaults to disabled with no tracking identifier", () => {
+		const manager = SettingsManager.inMemory();
+
+		expect(manager.getEnableAnalytics()).toBe(false);
+		expect(manager.getTrackingId()).toBeUndefined();
+	});
+
+	it("generates a tracking identifier on opt-in", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setEnableAnalytics(true);
+
+		expect(manager.getEnableAnalytics()).toBe(true);
+		expect(manager.getTrackingId()).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it("does not generate a tracking identifier on opt-out", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setEnableAnalytics(false);
+
+		expect(manager.getEnableAnalytics()).toBe(false);
+		expect(manager.getTrackingId()).toBeUndefined();
+	});
+
+	it("keeps the tracking identifier when toggling analytics", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setEnableAnalytics(true);
+		const trackingId = manager.getTrackingId();
+		manager.setEnableAnalytics(false);
+		manager.setEnableAnalytics(true);
+
+		expect(manager.getTrackingId()).toBe(trackingId);
+	});
+});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -370,6 +370,127 @@ describe("resolveCliModel", () => {
 		expect(result.model?.provider).toBe("openrouter");
 		expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
 	});
+
+	describe("custom model fallback with :thinking suffix (#5552)", () => {
+		// Models for a provider that has registered models but the specific model ID
+		// is not in the registry (triggers buildFallbackModel path).
+		const neuralwattModel: Model<"anthropic-messages"> = {
+			id: "some-base-model",
+			name: "Some Base Model",
+			api: "anthropic-messages",
+			provider: "neuralwatt",
+			baseUrl: "https://api.neuralwatt.com",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+
+		const modelsWithNeuralwatt = [...allModels, neuralwattModel];
+
+		test("strips :thinking suffix from custom model id in fallback path", () => {
+			const registry = {
+				getAll: () => modelsWithNeuralwatt,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+			const result = resolveCliModel({
+				cliModel: "neuralwatt/zai-org/GLM-5.1-FP8:high",
+				modelRegistry: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("neuralwatt");
+			// The :high suffix must NOT leak into the model id sent to the API
+			expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8");
+			expect(result.thinkingLevel).toBe("high");
+		});
+
+		test("custom model without thinking suffix works normally in fallback path", () => {
+			const registry = {
+				getAll: () => modelsWithNeuralwatt,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+			const result = resolveCliModel({
+				cliModel: "neuralwatt/zai-org/GLM-5.1-FP8",
+				modelRegistry: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("neuralwatt");
+			expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8");
+			expect(result.thinkingLevel).toBeUndefined();
+		});
+
+		test("all valid thinking levels work in fallback path", () => {
+			const registry = {
+				getAll: () => modelsWithNeuralwatt,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+			for (const level of ["off", "minimal", "low", "medium", "high", "xhigh"]) {
+				const result = resolveCliModel({
+					cliModel: `neuralwatt/zai-org/GLM-5.1-FP8:${level}`,
+					modelRegistry: registry,
+				});
+
+				expect(result.error).toBeUndefined();
+				expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8");
+				expect(result.thinkingLevel).toBe(level);
+			}
+		});
+
+		test("invalid thinking suffix on custom model is treated as part of model id", () => {
+			const registry = {
+				getAll: () => modelsWithNeuralwatt,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+			const result = resolveCliModel({
+				cliModel: "neuralwatt/zai-org/GLM-5.1-FP8:banana",
+				modelRegistry: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("neuralwatt");
+			// Invalid suffix stays in the id (it's not a thinking level)
+			expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8:banana");
+			expect(result.thinkingLevel).toBeUndefined();
+		});
+
+		test("explicit --provider with custom model:thinking strips suffix correctly", () => {
+			const registry = {
+				getAll: () => modelsWithNeuralwatt,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+			const result = resolveCliModel({
+				cliProvider: "neuralwatt",
+				cliModel: "zai-org/GLM-5.1-FP8:high",
+				modelRegistry: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("neuralwatt");
+			expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8");
+			expect(result.thinkingLevel).toBe("high");
+		});
+
+		test("with explicit --thinking, :suffix is kept as part of model id", () => {
+			const registry = {
+				getAll: () => modelsWithNeuralwatt,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+			const result = resolveCliModel({
+				cliModel: "neuralwatt/zai-org/GLM-5.1-FP8:high",
+				cliThinking: "medium",
+				modelRegistry: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("neuralwatt");
+			// :high is kept as part of the model id since --thinking was explicit
+			expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8:high");
+			expect(result.thinkingLevel).toBeUndefined();
+		});
+	});
 });
 
 describe("default model selection", () => {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -4,7 +4,14 @@ import { decodePrintableKey, matchesKey } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
 import { type Component, CURSOR_MARKER, type Focusable, type TUI } from "../tui.ts";
 import { UndoStack } from "../undo-stack.ts";
-import { getGraphemeSegmenter, getWordSegmenter, isWhitespaceChar, truncateToWidth, visibleWidth } from "../utils.ts";
+import {
+	cjkBreakRegex,
+	getGraphemeSegmenter,
+	getWordSegmenter,
+	isWhitespaceChar,
+	truncateToWidth,
+	visibleWidth,
+} from "../utils.ts";
 import { findWordBackward, findWordForward } from "../word-navigation.ts";
 import { SelectList, type SelectListLayoutOptions, type SelectListTheme } from "./select-list.ts";
 
@@ -174,13 +181,21 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 		// Advance.
 		currentWidth += gWidth;
 
-		// Record wrap opportunity: whitespace followed by non-whitespace.
-		// Multiple spaces join (no break between them); the break point is
-		// after the last space before the next word.
+		// Record wrap opportunity: whitespace followed by non-whitespace
+		// (multiple spaces join; the break point is after the last space),
+		// or at a boundary where either side is CJK (CJK allows breaking
+		// between any adjacent characters).
 		const next = segments[i + 1];
 		if (isWs && next && (isPasteMarker(next.segment) || !isWhitespaceChar(next.segment))) {
 			wrapOppIndex = next.index;
 			wrapOppWidth = currentWidth;
+		} else if (!isWs && next && !isWhitespaceChar(next.segment)) {
+			const isCjk = !isPasteMarker(grapheme) && cjkBreakRegex.test(grapheme);
+			const nextIsCjk = !isPasteMarker(next.segment) && cjkBreakRegex.test(next.segment);
+			if (isCjk || nextIsCjk) {
+				wrapOppIndex = next.index;
+				wrapOppWidth = currentWidth;
+			}
 		}
 	}
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -572,6 +572,7 @@ export class Markdown implements Component {
 
 		for (let i = 0; i < token.items.length; i++) {
 			const item = token.items[i];
+			const isLastItem = i === token.items.length - 1;
 			const bullet = token.ordered
 				? this.options.preserveOrderedListMarkers
 					? (this.getOrderedListMarker(item) ?? `${startNumber + i}. `)
@@ -603,6 +604,10 @@ export class Markdown implements Component {
 
 			if (!renderedAnyLine) {
 				lines.push(firstPrefix);
+			}
+
+			if (token.loose && !isLastItem) {
+				lines.push("");
 			}
 		}
 

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -45,7 +45,7 @@ const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
 const WIDTH_CACHE_SIZE = 512;
 const widthCache = new Map<string, number>();
 
-const cjkBreakRegex =
+export const cjkBreakRegex =
 	/[\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\p{Script_Extensions=Katakana}\p{Script_Extensions=Hangul}\p{Script_Extensions=Bopomofo}]/u;
 
 function isPrintableAscii(str: string): boolean {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -149,6 +149,37 @@ describe("Markdown component", () => {
 			assert.ok(plainLines.some((line) => line.includes("2. Second ordered")));
 		});
 
+		it("should render blank lines between loose list items", () => {
+			const markdown = new Markdown(
+				`1. Lorem ipsum dolor sit amet.
+
+   Ut enim ad minim veniam.
+
+2. Duis aute irure dolor.
+
+   Excepteur sint occaecat cupidatat.
+
+3. Beep boop`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"1. Lorem ipsum dolor sit amet.",
+				"",
+				"   Ut enim ad minim veniam.",
+				"",
+				"2. Duis aute irure dolor.",
+				"",
+				"   Excepteur sint occaecat cupidatat.",
+				"",
+				"3. Beep boop",
+			]);
+		});
+
 		it("should render task list markers", () => {
 			const markdown = new Markdown("- [ ] beep\n- [x] boop", 0, 0, defaultMarkdownTheme);
 


### PR DESCRIPTION
## Summary

- Merge `upstream/main` into `main` with an explicit no-ff merge commit.
- Preserve fork history; no rebase or force push.
- Resolve upstream sync conflicts by keeping senpi CalVer changelog structure, fork first-time setup gating, and upstream model/TUI fixes.

## Verification

- Merge ancestry: `HEAD^1 = cb085c7fefd4eacc8de8f735f8f11c11977c14a0`, `HEAD^2 = 3f44d3e2eb0e1770157fab22cc842b6f53088605`.
- No merge/rebase state remains; `upstream/main...HEAD` reports `0 581`.
- Pre-commit hook ran `npm run check`, including package-manager install/build verification for npm, bun, and pnpm.
- Targeted tests: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/first-time-setup.test.ts test/first-time-setup-fork.test.ts test/model-resolver.test.ts`.
- Manual QA: tmux smoke `./pi-test.sh --help`, transcript saved locally at `.omo/ulw-loop/senpi-pr530-20260612/evidence/upstream-sync-cli-help.txt`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `main` with `upstream/main` to pull AI provider fixes and TUI improvements, and adds an experimental first-time setup flow to the coding agent. Keeps our fork’s CalVer changelog structure and first-time setup gating.

- New Features
  - Coding agent: experimental first-time setup behind `PI_EXPERIMENTAL=1` with theme choice (live preview) and analytics opt-in; saves `enableAnalytics` and a `trackingId`; runs only in the official build, default agent dir, and when no `settings.json` exists.
  - Amazon Bedrock: when a model rejects the configured data retention mode, the error now includes a link to AWS data retention docs.

- Bug Fixes
  - Coding agent: correctly parse `:thinking` suffix in custom model IDs on the CLI fallback path; applies the thinking level without altering the model ID.
  - TUI: wrap CJK text at character boundaries in the editor; insert blank lines between items in loose Markdown lists.
  - Tests/compat: refresh Anthropic/OpenAI/OpenRouter cases; remove a stale Kimi free model assertion.
  - Dependencies: bump `shell-quote` to `1.8.4`.

<sup>Written for commit d1d7192fbdf2119d4f7e5b1e4f29cd7a1533f6b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

