### PR TITLE
perf: port PR530 optimization suite

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - When Amazon Bedrock rejects an unsupported data retention mode, the error now links the AWS data retention documentation ([#5561](https://github.com/earendil-works/pi/pull/5561) by [@unexge](https://github.com/unexge)).
+- Improved EventStream queued-event throughput and lazily initializes bundled model registry maps.
 
 ### Fixed
 

--- a/packages/ai/bench/_meta.ts
+++ b/packages/ai/bench/_meta.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import { cpus } from "node:os";
+
+export interface BenchRunMetadata {
+	readonly createdAt: string;
+	readonly gitCommit: string | null;
+	readonly nodeVersion: string;
+	readonly platform: NodeJS.Platform;
+	readonly arch: string;
+	readonly cpu: string | null;
+}
+
+export function benchRunMetadata(): BenchRunMetadata {
+	const git = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+	return {
+		createdAt: new Date().toISOString(),
+		gitCommit: git.status === 0 ? git.stdout.trim() : null,
+		nodeVersion: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		cpu: cpus()[0]?.model ?? null,
+	};
+}
+
+export function readIterations(defaultIterations: number): number {
+	const index = process.argv.indexOf("--iterations");
+	if (index === -1) return defaultIterations;
+	const raw = process.argv[index + 1];
+	const parsed = raw ? Number(raw) : Number.NaN;
+	return Number.isFinite(parsed) ? Math.max(1, Math.floor(parsed)) : defaultIterations;
+}
+
+export function percentile(samples: readonly number[], p: number): number {
+	const sorted = [...samples].sort((a, b) => a - b);
+	const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+	return sorted[index] ?? 0;
+}
+
+export function forceGc(): void {
+	if (global.gc) global.gc();
+}

--- a/packages/ai/bench/event-stream.ts
+++ b/packages/ai/bench/event-stream.ts
@@ -1,0 +1,56 @@
+import { benchRunMetadata, forceGc, percentile, readIterations } from "./_meta.ts";
+import { EventStream } from "../src/utils/event-stream.ts";
+
+const EVENT_COUNT = 50_000;
+
+async function consumeAll(stream: EventStream<number, number>): Promise<number> {
+	let count = 0;
+	for await (const _event of stream) count++;
+	return count;
+}
+
+async function runScenario(): Promise<void> {
+	const stream = new EventStream<number, number>(
+		(event) => event === EVENT_COUNT - 1,
+		(event) => event,
+	);
+	for (let i = 0; i < EVENT_COUNT; i++) stream.push(i);
+	const consumed = await consumeAll(stream);
+	if (consumed !== EVENT_COUNT) {
+		throw new Error(`Expected ${EVENT_COUNT} events, consumed ${consumed}`);
+	}
+	const result = await stream.result();
+	if (result !== EVENT_COUNT - 1) {
+		throw new Error(`Unexpected final result ${result}`);
+	}
+}
+
+async function timeScenario(): Promise<number> {
+	const start = performance.now();
+	await runScenario();
+	return performance.now() - start;
+}
+
+const iterations = readIterations(20);
+for (let i = 0; i < Math.min(5, iterations); i++) await runScenario();
+forceGc();
+const before = process.memoryUsage();
+const samples: number[] = [];
+for (let i = 0; i < iterations; i++) samples.push(await timeScenario());
+forceGc();
+const after = process.memoryUsage();
+
+console.log(
+	JSON.stringify({
+		suite: "ai-event-stream",
+		package: "@earendil-works/pi-ai",
+		fixture: `${EVENT_COUNT}-queued-events`,
+		iterations,
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+		heapDeltaBytes: after.heapUsed - before.heapUsed,
+		rssDeltaBytes: after.rss - before.rss,
+		metadata: benchRunMetadata(),
+	}),
+);

--- a/packages/ai/bench/model-registry.ts
+++ b/packages/ai/bench/model-registry.ts
@@ -1,0 +1,43 @@
+import { benchRunMetadata, forceGc, percentile, readIterations } from "./_meta.ts";
+import { getModels, getProviders } from "../src/models.ts";
+
+function runScenario(): number {
+	let found = 0;
+	for (const provider of getProviders()) {
+		const models = getModels(provider);
+		found += models.length;
+	}
+	return found;
+}
+
+function timeScenario(): number {
+	const start = performance.now();
+	const found = runScenario();
+	if (found === 0) throw new Error("Expected at least one bundled model");
+	return performance.now() - start;
+}
+
+const iterations = readIterations(20);
+for (let i = 0; i < Math.min(5, iterations); i++) runScenario();
+forceGc();
+const before = process.memoryUsage();
+const samples: number[] = [];
+for (let i = 0; i < iterations; i++) samples.push(timeScenario());
+forceGc();
+const after = process.memoryUsage();
+
+console.log(
+	JSON.stringify({
+		suite: "ai-model-registry",
+		package: "@earendil-works/pi-ai",
+		fixture: "enumerate-and-lookup-all-models",
+		iterations,
+		modelCount: runScenario(),
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+		heapDeltaBytes: after.heapUsed - before.heapUsed,
+		rssDeltaBytes: after.rss - before.rss,
+		metadata: benchRunMetadata(),
+	}),
+);

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,15 +1,22 @@
 import { MODELS } from "./models.generated.ts";
 import type { Api, KnownProvider, Model, ModelThinkingLevel, Usage } from "./types.ts";
 
+type GeneratedProvider = keyof typeof MODELS;
+
+const providerNames = Object.keys(MODELS) as KnownProvider[];
 const modelRegistry: Map<string, Map<string, Model<Api>>> = new Map();
 
-// Initialize registry from MODELS on module load
-for (const [provider, models] of Object.entries(MODELS)) {
+function getProviderModels(provider: GeneratedProvider): Map<string, Model<Api>> | undefined {
+	const cached = modelRegistry.get(provider);
+	if (cached) return cached;
+	const models = MODELS[provider];
+	if (!models) return undefined;
 	const providerModels = new Map<string, Model<Api>>();
 	for (const [id, model] of Object.entries(models)) {
 		providerModels.set(id, model as Model<Api>);
 	}
 	modelRegistry.set(provider, providerModels);
+	return providerModels;
 }
 
 type ModelApi<
@@ -21,18 +28,18 @@ export function getModel<TProvider extends KnownProvider, TModelId extends keyof
 	provider: TProvider,
 	modelId: TModelId,
 ): Model<ModelApi<TProvider, TModelId>> {
-	const providerModels = modelRegistry.get(provider);
+	const providerModels = getProviderModels(provider);
 	return providerModels?.get(modelId as string) as Model<ModelApi<TProvider, TModelId>>;
 }
 
 export function getProviders(): KnownProvider[] {
-	return Array.from(modelRegistry.keys()) as KnownProvider[];
+	return providerNames.slice();
 }
 
 export function getModels<TProvider extends KnownProvider>(
 	provider: TProvider,
 ): Model<ModelApi<TProvider, keyof (typeof MODELS)[TProvider]>>[] {
-	const models = modelRegistry.get(provider);
+	const models = getProviderModels(provider);
 	return models ? (Array.from(models.values()) as Model<ModelApi<TProvider, keyof (typeof MODELS)[TProvider]>>[]) : [];
 }
 

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -2,20 +2,51 @@ import type { AssistantMessage, AssistantMessageEvent } from "../types.ts";
 
 // Generic event stream class for async iteration
 export class EventStream<T, R = T> implements AsyncIterable<T> {
-	private queue: T[] = [];
-	private waiting: ((value: IteratorResult<T>) => void)[] = [];
+	#queue: T[] = [];
+	#queueHead = 0;
+	private waiting: Array<{ resolve: (value: IteratorResult<T>) => void; reject: (error: unknown) => void }> = [];
 	private done = false;
+	#failed = false;
+	#error: unknown;
 	private finalResultPromise: Promise<R>;
 	private resolveFinalResult!: (result: R) => void;
+	private rejectFinalResult!: (error: unknown) => void;
 	private isComplete: (event: T) => boolean;
 	private extractResult: (event: T) => R;
 
 	constructor(isComplete: (event: T) => boolean, extractResult: (event: T) => R) {
 		this.isComplete = isComplete;
 		this.extractResult = extractResult;
-		this.finalResultPromise = new Promise((resolve) => {
+		this.finalResultPromise = new Promise((resolve, reject) => {
 			this.resolveFinalResult = resolve;
+			this.rejectFinalResult = reject;
 		});
+		this.finalResultPromise.catch(() => {});
+	}
+
+	get queue(): T[] {
+		return this.#queue.slice(this.#queueHead);
+	}
+
+	#enqueue(event: T): void {
+		this.#queue.push(event);
+	}
+
+	#dequeue(): T {
+		const event = this.#queue[this.#queueHead];
+		if (event === undefined) {
+			throw new Error("EventStream queue underflow");
+		}
+		this.#queueHead++;
+		if (this.#queueHead > 1024 && this.#queueHead * 2 >= this.#queue.length) {
+			this.#queue = this.#queue.slice(this.#queueHead);
+			this.#queueHead = 0;
+		}
+		return event;
+	}
+
+	get #queueLength(): number {
+		return this.#queue.length - this.#queueHead;
 	}
 
 	push(event: T): void {
@@ -29,9 +60,9 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		// Deliver to waiting consumer or queue it
 		const waiter = this.waiting.shift();
 		if (waiter) {
-			waiter({ value: event, done: false });
+			waiter.resolve({ value: event, done: false });
 		} else {
-			this.queue.push(event);
+			this.#enqueue(event);
 		}
 	}
 
@@ -42,19 +73,35 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		}
 		// Notify all waiting consumers that we're done
 		while (this.waiting.length > 0) {
-			const waiter = this.waiting.shift()!;
-			waiter({ value: undefined as any, done: true });
+			const waiter = this.waiting.shift();
+			if (waiter) waiter.resolve({ value: undefined, done: true });
+		}
+	}
+
+	fail(error: unknown): void {
+		if (this.done) return;
+		this.done = true;
+		this.#failed = true;
+		this.#error = error;
+		this.rejectFinalResult(error);
+		while (this.waiting.length > 0) {
+			const waiter = this.waiting.shift();
+			if (waiter) waiter.reject(error);
 		}
 	}
 
 	async *[Symbol.asyncIterator](): AsyncIterator<T> {
 		while (true) {
-			if (this.queue.length > 0) {
-				yield this.queue.shift()!;
+			if (this.#queueLength > 0) {
+				yield this.#dequeue();
+			} else if (this.#failed) {
+				throw this.#error;
 			} else if (this.done) {
 				return;
 			} else {
-				const result = await new Promise<IteratorResult<T>>((resolve) => this.waiting.push(resolve));
+				const result = await new Promise<IteratorResult<T>>((resolve, reject) =>
+					this.waiting.push({ resolve, reject }),
+				);
 				if (result.done) return;
 				yield result.value;
 			}

--- a/packages/ai/test/event-stream.test.ts
+++ b/packages/ai/test/event-stream.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage } from "../src/types.ts";
+import { AssistantMessageEventStream, EventStream } from "../src/utils/event-stream.ts";
+
+function createPartial(text = ""): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+describe("AssistantMessageEventStream", () => {
+	it("queues adjacent delta events immediately without throttling or merging", () => {
+		const stream = new AssistantMessageEventStream();
+
+		stream.push({ type: "text_delta", contentIndex: 0, delta: "a", partial: createPartial("a") });
+		stream.push({ type: "text_delta", contentIndex: 0, delta: "b", partial: createPartial("ab") });
+
+		expect(stream.queue).toHaveLength(2);
+		expect(stream.queue[0]).toMatchObject({ type: "text_delta", delta: "a" });
+		expect(stream.queue[1]).toMatchObject({ type: "text_delta", delta: "b" });
+	});
+});
+
+describe("EventStream deque semantics", () => {
+	const makeStream = () =>
+		new EventStream<{ readonly n: number; readonly final?: boolean }, number>(
+			(event) => event.final === true,
+			(event) => event.n,
+		);
+
+	it("preserves FIFO across the compaction boundary when more events are pushed later", async () => {
+		const stream = makeStream();
+		const total = 3000;
+		for (let i = 0; i < 1500; i++) stream.push({ n: i });
+
+		const seen: number[] = [];
+		const iterator = stream[Symbol.asyncIterator]();
+		for (let i = 0; i < 1300; i++) {
+			const result = await iterator.next();
+			expect(result.done).toBe(false);
+			if (!result.done) seen.push(result.value.n);
+		}
+
+		for (let i = 1500; i < total; i++) stream.push({ n: i });
+		stream.push({ n: total, final: true });
+
+		let result = await iterator.next();
+		while (!result.done) {
+			seen.push(result.value.n);
+			result = await iterator.next();
+		}
+
+		expect(seen).toHaveLength(total + 1);
+		for (let i = 0; i < seen.length; i++) expect(seen[i]).toBe(i);
+		await expect(stream.result()).resolves.toBe(total);
+	});
+
+	it("returns a defensive queue snapshot that cannot desync internal state", async () => {
+		const stream = makeStream();
+		for (let i = 0; i < 5; i++) stream.push({ n: i });
+
+		const snapshot = stream.queue;
+		expect(snapshot).toHaveLength(5);
+		snapshot.length = 0;
+
+		const iterator = stream[Symbol.asyncIterator]();
+		for (let i = 0; i < 5; i++) {
+			const result = await iterator.next();
+			expect(result.done).toBe(false);
+			if (!result.done) expect(result.value.n).toBe(i);
+		}
+		expect(stream.queue).toHaveLength(0);
+	});
+
+	it("rejects waiters and result after draining queued events when it fails", async () => {
+		const stream = makeStream();
+		stream.push({ n: 0 });
+		stream.push({ n: 1 });
+		const error = new Error("boom");
+		stream.fail(error);
+
+		const seen: number[] = [];
+		let thrown: unknown;
+		try {
+			for await (const event of stream) seen.push(event.n);
+		} catch (caught) {
+			thrown = caught;
+		}
+
+		expect(seen).toEqual([0, 1]);
+		expect(thrown).toBe(error);
+		await expect(stream.result()).rejects.toBe(error);
+	});
+
+	it("delivers directly to a waiting consumer without touching the queue", async () => {
+		const stream = makeStream();
+		const iterator = stream[Symbol.asyncIterator]();
+		const pending = iterator.next();
+		stream.push({ n: 42 });
+
+		const result = await pending;
+		expect(result.done).toBe(false);
+		if (!result.done) expect(result.value.n).toBe(42);
+		expect(stream.queue).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Added
 
 - Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
-- Added local benchmark coverage for interactive assistant transcript rendering.
+- Added local benchmark coverage for interactive assistant transcript rendering and large bash output handling.
 
 ### Fixed
+
+- Improved large bash output retention by using a head-indexed rolling buffer and a compact tail window for streaming output snapshots.
 
 ### Removed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
+- Added local benchmark coverage for interactive assistant transcript rendering.
 
 ### Fixed
 

--- a/packages/coding-agent/bench/bash-output.ts
+++ b/packages/coding-agent/bench/bash-output.ts
@@ -1,0 +1,54 @@
+import { forceGc, metadata, percentile, readIterations } from "../../tui/bench/_meta.ts";
+import { executeBashWithOperations } from "../src/core/bash-executor.ts";
+import type { BashOperations } from "../src/core/tools/bash.ts";
+
+const CHUNK_COUNT = 10_000;
+const CHUNK_TEXT = `${"x".repeat(180)}\n`;
+const CHUNKS = Array.from({ length: CHUNK_COUNT }, () => Buffer.from(CHUNK_TEXT, "utf-8"));
+
+const operations: BashOperations = {
+	exec: async (_command, _cwd, { onData }) => {
+		for (const chunk of CHUNKS) {
+			onData(chunk);
+		}
+		return { exitCode: 0 };
+	},
+};
+
+async function runScenario(): Promise<number> {
+	const result = await executeBashWithOperations("bench", process.cwd(), operations);
+	if (!result.truncated) throw new Error("Expected truncated output");
+	if (!result.fullOutputPath) throw new Error("Expected full output path");
+	return result.output.length;
+}
+
+async function timeScenario(): Promise<number> {
+	const start = performance.now();
+	const length = await runScenario();
+	if (length === 0) throw new Error("Expected output");
+	return performance.now() - start;
+}
+
+const iterations = readIterations(20);
+for (let i = 0; i < Math.min(3, iterations); i++) await runScenario();
+forceGc();
+const before = process.memoryUsage();
+const samples: number[] = [];
+for (let i = 0; i < iterations; i++) samples.push(await timeScenario());
+forceGc();
+const after = process.memoryUsage();
+
+console.log(
+	JSON.stringify({
+		suite: "coding-agent-bash-output",
+		package: "@code-yeongyu/senpi",
+		fixture: `${CHUNK_COUNT}-chunks`,
+		iterations,
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+		heapDeltaBytes: after.heapUsed - before.heapUsed,
+		rssDeltaBytes: after.rss - before.rss,
+		metadata: metadata(),
+	}),
+);

--- a/packages/coding-agent/bench/render-transcript.ts
+++ b/packages/coding-agent/bench/render-transcript.ts
@@ -1,0 +1,85 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { forceGc, metadata, percentile, readIterations } from "../../tui/bench/_meta.ts";
+
+const WIDTH = 100;
+const MESSAGE_COUNT = 400;
+
+function markdown(index: number): string {
+	return [
+		`### Result ${index}`,
+		"",
+		"Here is a realistic assistant response with **bold**, _italic_, and a list:",
+		"",
+		`- item ${index}`,
+		`- item ${index + 1}`,
+		"",
+		"```ts",
+		`const value = ${index};`,
+		"console.log(value);",
+		"```",
+	].join("\n");
+}
+
+function createAssistantMessage(index: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: markdown(index) }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function runScenario(): number {
+	let lines = 0;
+	for (let i = 0; i < MESSAGE_COUNT; i++) {
+		const message = createAssistantMessage(i % 25);
+		const component = new AssistantMessageComponent(message);
+		lines += component.render(WIDTH).length;
+	}
+	return lines;
+}
+
+function timeScenario(): number {
+	const start = performance.now();
+	const lines = runScenario();
+	if (lines === 0) throw new Error("Expected transcript output");
+	return performance.now() - start;
+}
+
+initTheme("dark");
+const iterations = readIterations(20);
+for (let i = 0; i < Math.min(3, iterations); i++) runScenario();
+forceGc();
+const before = process.memoryUsage();
+const samples: number[] = [];
+for (let i = 0; i < iterations; i++) samples.push(timeScenario());
+forceGc();
+const after = process.memoryUsage();
+
+console.log(
+	JSON.stringify({
+		suite: "coding-agent-render-transcript",
+		package: "@code-yeongyu/senpi",
+		fixture: `${MESSAGE_COUNT}-assistant-components`,
+		iterations,
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+		heapDeltaBytes: after.heapUsed - before.heapUsed,
+		rssDeltaBytes: after.rss - before.rss,
+		metadata: metadata(),
+	}),
+);

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -54,12 +54,23 @@ export async function executeBashWithOperations(
 	options?: BashExecutorOptions,
 ): Promise<BashResult> {
 	const outputChunks: string[] = [];
+	let outputChunkStart = 0;
 	let outputBytes = 0;
 	const maxOutputBytes = DEFAULT_MAX_BYTES * 2;
 
 	let tempFilePath: string | undefined;
 	let tempFileStream: WriteStream | undefined;
 	let totalBytes = 0;
+
+	const compactOutputChunks = () => {
+		if (outputChunkStart < 64) {
+			return;
+		}
+		outputChunks.splice(0, outputChunkStart);
+		outputChunkStart = 0;
+	};
+
+	const outputText = () => outputChunks.slice(outputChunkStart).join("");
 
 	const ensureTempFile = () => {
 		if (tempFilePath) {
@@ -68,8 +79,11 @@ export async function executeBashWithOperations(
 		const id = randomBytes(8).toString("hex");
 		tempFilePath = join(tmpdir(), `pi-bash-${id}.log`);
 		tempFileStream = createWriteStream(tempFilePath);
-		for (const chunk of outputChunks) {
-			tempFileStream.write(chunk);
+		for (let i = outputChunkStart; i < outputChunks.length; i++) {
+			const chunk = outputChunks[i];
+			if (chunk !== undefined) {
+				tempFileStream.write(chunk);
+			}
 		}
 	};
 
@@ -90,17 +104,28 @@ export async function executeBashWithOperations(
 			tempFileStream.write(text);
 		}
 
-		// Keep rolling buffer
 		outputChunks.push(text);
 		outputBytes += text.length;
-		while (outputBytes > maxOutputBytes && outputChunks.length > 1) {
-			const removed = outputChunks.shift()!;
+		while (outputBytes > maxOutputBytes && outputChunkStart < outputChunks.length - 1) {
+			const removed = outputChunks[outputChunkStart];
+			if (removed === undefined) {
+				break;
+			}
 			outputBytes -= removed.length;
+			outputChunkStart++;
 		}
+		compactOutputChunks();
 
 		// Stream to callback
 		if (options?.onChunk) {
 			options.onChunk(text);
+		}
+	};
+
+	const finishDecoder = () => {
+		const finalText = sanitizeBinaryOutput(stripAnsi(decoder.decode())).replace(/\r/g, "");
+		if (finalText.length > 0) {
+			onData(Buffer.from(finalText, "utf-8"));
 		}
 	};
 
@@ -110,7 +135,8 @@ export async function executeBashWithOperations(
 			signal: options?.signal,
 		});
 
-		const fullOutput = outputChunks.join("");
+		finishDecoder();
+		const fullOutput = outputText();
 		const truncationResult = truncateTail(fullOutput);
 		if (truncationResult.truncated) {
 			ensureTempFile();
@@ -130,7 +156,8 @@ export async function executeBashWithOperations(
 	} catch (err) {
 		// Check if it was an abort
 		if (options?.signal?.aborted) {
-			const fullOutput = outputChunks.join("");
+			finishDecoder();
+			const fullOutput = outputText();
 			const truncationResult = truncateTail(fullOutput);
 			if (truncationResult.truncated) {
 				ensureTempFile();

--- a/packages/coding-agent/src/core/tools/output-accumulator.ts
+++ b/packages/coding-agent/src/core/tools/output-accumulator.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { createWriteStream, type WriteStream } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { TailWindow } from "./tail-window.ts";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, type TruncationResult, truncateTail } from "./truncate.ts";
 
 export interface OutputAccumulatorOptions {
@@ -35,14 +36,11 @@ function byteLength(text: string): number {
 export class OutputAccumulator {
 	private readonly maxLines: number;
 	private readonly maxBytes: number;
-	private readonly maxRollingBytes: number;
 	private readonly tempFilePrefix: string;
 	private readonly decoder = new TextDecoder();
+	private readonly tail: TailWindow;
 
-	private rawChunks: Buffer[] = [];
-	private tailText = "";
-	private tailBytes = 0;
-	private tailStartsAtLineBoundary = true;
+	private rawChunks: Array<Buffer | string> = [];
 	private totalRawBytes = 0;
 	private totalDecodedBytes = 0;
 	private completedLines = 0;
@@ -57,8 +55,8 @@ export class OutputAccumulator {
 	constructor(options: OutputAccumulatorOptions = {}) {
 		this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
 		this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-		this.maxRollingBytes = Math.max(this.maxBytes * 2, 1);
 		this.tempFilePrefix = options.tempFilePrefix ?? "pi-output";
+		this.tail = new TailWindow(Math.max(this.maxBytes * 2, 1));
 	}
 
 	append(data: Buffer): void {
@@ -66,8 +64,9 @@ export class OutputAccumulator {
 			throw new Error("Cannot append to a finished output accumulator");
 		}
 
+		const text = this.decoder.decode(data, { stream: true });
 		this.totalRawBytes += data.length;
-		this.appendDecodedText(this.decoder.decode(data, { stream: true }));
+		this.appendDecodedText(text, byteLength(text));
 
 		if (this.tempFileStream || this.shouldUseTempFile()) {
 			this.ensureTempFile();
@@ -77,12 +76,33 @@ export class OutputAccumulator {
 		}
 	}
 
+	appendText(text: string): void {
+		if (this.finished) {
+			throw new Error("Cannot append to a finished output accumulator");
+		}
+		if (text.length === 0) {
+			return;
+		}
+
+		const bytes = byteLength(text);
+		this.totalRawBytes += bytes;
+		this.appendDecodedText(text, bytes);
+
+		if (this.tempFileStream || this.shouldUseTempFile()) {
+			this.ensureTempFile();
+			this.tempFileStream?.write(text);
+		} else {
+			this.rawChunks.push(text);
+		}
+	}
+
 	finish(): void {
 		if (this.finished) {
 			return;
 		}
 		this.finished = true;
-		this.appendDecodedText(this.decoder.decode());
+		const finalText = this.decoder.decode();
+		this.appendDecodedText(finalText, byteLength(finalText));
 		if (this.shouldUseTempFile()) {
 			this.ensureTempFile();
 		}
@@ -119,12 +139,10 @@ export class OutputAccumulator {
 	}
 
 	async closeTempFile(): Promise<void> {
-		if (!this.tempFileStream) {
+		const stream = this.takeTempFileStream();
+		if (!stream) {
 			return;
 		}
-
-		const stream = this.tempFileStream;
-		this.tempFileStream = undefined;
 
 		await new Promise<void>((resolve, reject) => {
 			const onError = (error: Error) => {
@@ -145,18 +163,13 @@ export class OutputAccumulator {
 		return this.currentLineBytes;
 	}
 
-	private appendDecodedText(text: string): void {
+	private appendDecodedText(text: string, bytes: number): void {
 		if (text.length === 0) {
 			return;
 		}
 
-		const bytes = byteLength(text);
 		this.totalDecodedBytes += bytes;
-		this.tailText += text;
-		this.tailBytes += bytes;
-		if (this.tailBytes > this.maxRollingBytes * 2) {
-			this.trimTail();
-		}
+		this.tail.append(text, bytes, !this.hasOpenLine);
 
 		let newlines = 0;
 		let lastNewline = -1;
@@ -176,30 +189,14 @@ export class OutputAccumulator {
 		this.totalLines = this.completedLines + (this.hasOpenLine ? 1 : 0);
 	}
 
-	private trimTail(): void {
-		const buffer = Buffer.from(this.tailText, "utf-8");
-		if (buffer.length <= this.maxRollingBytes) {
-			this.tailBytes = buffer.length;
-			return;
-		}
-
-		let start = buffer.length - this.maxRollingBytes;
-		while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
-			start++;
-		}
-
-		this.tailStartsAtLineBoundary = start === 0 ? this.tailStartsAtLineBoundary : buffer[start - 1] === 0x0a;
-		this.tailText = buffer.subarray(start).toString("utf-8");
-		this.tailBytes = byteLength(this.tailText);
-	}
-
 	private getSnapshotText(): string {
-		if (this.tailStartsAtLineBoundary) {
-			return this.tailText;
+		const text = this.tail.text();
+		if (this.tail.startsAtLineBoundary) {
+			return text;
 		}
 
-		const firstNewline = this.tailText.indexOf("\n");
-		return firstNewline === -1 ? this.tailText : this.tailText.slice(firstNewline + 1);
+		const firstNewline = text.indexOf("\n");
+		return firstNewline === -1 ? text : text.slice(firstNewline + 1);
 	}
 
 	private shouldUseTempFile(): boolean {
@@ -218,5 +215,11 @@ export class OutputAccumulator {
 			this.tempFileStream.write(chunk);
 		}
 		this.rawChunks = [];
+	}
+
+	private takeTempFileStream(): WriteStream | undefined {
+		const stream = this.tempFileStream;
+		this.tempFileStream = undefined;
+		return stream;
 	}
 }

--- a/packages/coding-agent/src/core/tools/tail-window.ts
+++ b/packages/coding-agent/src/core/tools/tail-window.ts
@@ -1,0 +1,89 @@
+const MAX_PENDING_TAIL_CHUNKS = 10;
+
+function byteLength(text: string): number {
+	return Buffer.byteLength(text, "utf-8");
+}
+
+export class TailWindow {
+	private readonly maxBytes: number;
+	private chunks: string[] = [];
+	private bytes = 0;
+	private startsAtBoundary = true;
+
+	constructor(maxBytes: number) {
+		this.maxBytes = maxBytes;
+	}
+
+	append(text: string, bytes: number, startsAtLineBoundary: boolean): void {
+		if (bytes === 0) {
+			return;
+		}
+		if (bytes >= this.maxBytes) {
+			this.replaceWithTail(text, startsAtLineBoundary);
+			return;
+		}
+
+		this.chunks.push(text);
+		this.bytes += bytes;
+		if (this.chunks.length > MAX_PENDING_TAIL_CHUNKS) {
+			this.compact();
+		}
+		if (this.bytes > this.maxBytes * 2) {
+			this.trimToMax();
+		}
+	}
+
+	text(): string {
+		this.trimToMax();
+		return this.joined();
+	}
+
+	get startsAtLineBoundary(): boolean {
+		return this.startsAtBoundary;
+	}
+
+	private replaceWithTail(text: string, startsAtLineBoundary: boolean): void {
+		const buffer = Buffer.from(text, "utf-8");
+		let start = Math.max(0, buffer.length - this.maxBytes);
+		while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
+			start++;
+		}
+
+		this.startsAtBoundary = start === 0 ? startsAtLineBoundary : buffer[start - 1] === 0x0a;
+		const tail = buffer.subarray(start).toString("utf-8");
+		this.chunks = tail.length > 0 ? [tail] : [];
+		this.bytes = byteLength(tail);
+	}
+
+	private joined(): string {
+		if (this.chunks.length === 0) {
+			return "";
+		}
+		if (this.chunks.length > 1) {
+			this.compact();
+		}
+		return this.chunks[0] ?? "";
+	}
+
+	private compact(): void {
+		const joined = this.chunks.join("");
+		this.chunks = joined.length > 0 ? [joined] : [];
+	}
+
+	private trimToMax(): void {
+		if (this.bytes <= this.maxBytes) {
+			return;
+		}
+
+		const buffer = Buffer.from(this.joined(), "utf-8");
+		let start = Math.max(0, buffer.length - this.maxBytes);
+		while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
+			start++;
+		}
+
+		this.startsAtBoundary = start === 0 ? this.startsAtBoundary : buffer[start - 1] === 0x0a;
+		const tail = buffer.subarray(start).toString("utf-8");
+		this.chunks = tail.length > 0 ? [tail] : [];
+		this.bytes = byteLength(tail);
+	}
+}

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Improved repeated Markdown rendering and editor wrapping performance with bounded caches.
+
 ### Fixed
 
 ### Removed

--- a/packages/tui/bench/_meta.ts
+++ b/packages/tui/bench/_meta.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import { cpus } from "node:os";
+
+export function readIterations(defaultIterations: number): number {
+	const index = process.argv.indexOf("--iterations");
+	if (index === -1) return defaultIterations;
+	const raw = process.argv[index + 1];
+	const parsed = raw ? Number(raw) : Number.NaN;
+	return Number.isFinite(parsed) ? Math.max(1, Math.floor(parsed)) : defaultIterations;
+}
+
+export function percentile(samples: readonly number[], p: number): number {
+	const sorted = [...samples].sort((a, b) => a - b);
+	const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+	return sorted[index] ?? 0;
+}
+
+export function forceGc(): void {
+	if (global.gc) global.gc();
+}
+
+export function metadata() {
+	const git = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+	return {
+		createdAt: new Date().toISOString(),
+		gitCommit: git.status === 0 ? git.stdout.trim() : null,
+		nodeVersion: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		cpu: cpus()[0]?.model ?? null,
+	};
+}

--- a/packages/tui/bench/editor-layout.ts
+++ b/packages/tui/bench/editor-layout.ts
@@ -1,0 +1,60 @@
+import { Editor } from "../src/components/editor.ts";
+import { TUI } from "../src/tui.ts";
+import { defaultEditorTheme } from "../test/test-themes.ts";
+import { VirtualTerminal } from "../test/virtual-terminal.ts";
+import { forceGc, metadata, percentile, readIterations } from "./_meta.ts";
+
+const WIDTH = 120;
+const text = Array.from({ length: 180 }, (_, index) => {
+	const prefix = String(index).padStart(3, "0");
+	return `${prefix}: ${"abcdefghijklmnopqrstuvwxyz ".repeat(6)} 한글 カナ emoji`;
+}).join("\n");
+
+function createEditor(): Editor {
+	const tui = new TUI(new VirtualTerminal(WIDTH, 40));
+	const editor = new Editor(tui, defaultEditorTheme);
+	editor.setText(text);
+	editor.render(WIDTH);
+	return editor;
+}
+
+function runScenario(): number {
+	const editor = createEditor();
+	let lines = 0;
+	for (let i = 0; i < 100; i++) {
+		editor.handleInput(i % 2 === 0 ? "a" : "\x7f");
+		lines += editor.render(WIDTH).length;
+	}
+	return lines;
+}
+
+function timeScenario(): number {
+	const start = performance.now();
+	const lines = runScenario();
+	if (lines === 0) throw new Error("Expected editor output");
+	return performance.now() - start;
+}
+
+const iterations = readIterations(20);
+for (let i = 0; i < Math.min(3, iterations); i++) runScenario();
+forceGc();
+const before = process.memoryUsage();
+const samples: number[] = [];
+for (let i = 0; i < iterations; i++) samples.push(timeScenario());
+forceGc();
+const after = process.memoryUsage();
+
+console.log(
+	JSON.stringify({
+		suite: "tui-editor",
+		package: "@earendil-works/pi-tui",
+		fixture: "180-line-editor-100-edits",
+		iterations,
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+		heapDeltaBytes: after.heapUsed - before.heapUsed,
+		rssDeltaBytes: after.rss - before.rss,
+		metadata: metadata(),
+	}),
+);

--- a/packages/tui/bench/markdown-render.ts
+++ b/packages/tui/bench/markdown-render.ts
@@ -1,0 +1,59 @@
+import { Markdown } from "../src/components/markdown.ts";
+import { defaultMarkdownTheme } from "../test/test-themes.ts";
+import { forceGc, metadata, percentile, readIterations } from "./_meta.ts";
+
+const WIDTH = 100;
+const markdownSource = Array.from({ length: 80 }, (_, index) =>
+	[
+		`## Section ${index}`,
+		"",
+		"Here is **bold** text, _italic_ text, a [link](https://example.com), and `inline code`.",
+		"",
+		"- item one with enough words to wrap across several terminal columns",
+		"- item two with enough words to wrap across several terminal columns",
+		"",
+		"```ts",
+		`const value${index} = ${index};`,
+		"console.log(value);",
+		"```",
+	].join("\n"),
+).join("\n\n");
+
+function runScenario(): number {
+	let lines = 0;
+	for (let i = 0; i < 200; i++) {
+		lines += new Markdown(markdownSource, 1, 0, defaultMarkdownTheme).render(WIDTH).length;
+	}
+	return lines;
+}
+
+function timeScenario(): number {
+	const start = performance.now();
+	const lines = runScenario();
+	if (lines === 0) throw new Error("Expected markdown output");
+	return performance.now() - start;
+}
+
+const iterations = readIterations(20);
+for (let i = 0; i < Math.min(3, iterations); i++) runScenario();
+forceGc();
+const before = process.memoryUsage();
+const samples: number[] = [];
+for (let i = 0; i < iterations; i++) samples.push(timeScenario());
+forceGc();
+const after = process.memoryUsage();
+
+console.log(
+	JSON.stringify({
+		suite: "tui-markdown",
+		package: "@earendil-works/pi-tui",
+		fixture: "200-fresh-markdown-components",
+		iterations,
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+		heapDeltaBytes: after.heapUsed - before.heapUsed,
+		rssDeltaBytes: after.rss - before.rss,
+		metadata: metadata(),
+	}),
+);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -100,6 +100,51 @@ export interface TextChunk {
 	endIndex: number;
 }
 
+function isPrintableAsciiText(text: string): boolean {
+	for (let i = 0; i < text.length; i++) {
+		const code = text.charCodeAt(i);
+		if (code < 0x20 || code > 0x7e) return false;
+	}
+	return true;
+}
+
+function wordWrapAsciiLine(line: string, maxWidth: number): TextChunk[] {
+	if (line.length <= maxWidth) {
+		return [{ text: line, startIndex: 0, endIndex: line.length }];
+	}
+
+	const chunks: TextChunk[] = [];
+	let chunkStart = 0;
+	while (chunkStart < line.length) {
+		let chunkEnd = Math.min(line.length, chunkStart + maxWidth);
+		if (chunkEnd < line.length) {
+			let breakAt = -1;
+			for (let i = chunkEnd; i > chunkStart; i--) {
+				const code = line.charCodeAt(i - 1);
+				if (code === 0x20 || code === 0x09) {
+					breakAt = i - 1;
+					break;
+				}
+			}
+			if (breakAt > chunkStart) chunkEnd = breakAt;
+		}
+
+		const raw = line.slice(chunkStart, chunkEnd);
+		const text = raw.trimEnd();
+		if (text || chunks.length === 0) {
+			chunks.push({ text, startIndex: chunkStart, endIndex: chunkStart + raw.length });
+		}
+		chunkStart = chunkEnd;
+		while (chunkStart < line.length) {
+			const code = line.charCodeAt(chunkStart);
+			if (code !== 0x20 && code !== 0x09) break;
+			chunkStart++;
+		}
+	}
+
+	return chunks.length > 0 ? chunks : [{ text: "", startIndex: 0, endIndex: 0 }];
+}
+
 /**
  * Split a line into word-wrapped chunks.
  * Wraps at word boundaries when possible, falling back to character-level
@@ -114,6 +159,9 @@ export interface TextChunk {
 export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl.SegmentData[]): TextChunk[] {
 	if (!line || maxWidth <= 0) {
 		return [{ text: "", startIndex: 0, endIndex: 0 }];
+	}
+	if (preSegmented === undefined && !/\s/.test(line) && !line.includes("[paste #") && isPrintableAsciiText(line)) {
+		return wordWrapAsciiLine(line, maxWidth);
 	}
 
 	const lineWidth = visibleWidth(line);
@@ -319,6 +367,7 @@ export class Editor implements Component, Focusable {
 
 	// Undo support
 	private undoStack = new UndoStack<EditorState>();
+	private wrappedLineCache = new Map<string, TextChunk[]>();
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
@@ -454,7 +503,23 @@ export class Editor implements Component, Focusable {
 	}
 
 	invalidate(): void {
-		// No cached state to invalidate currently
+		this.wrappedLineCache.clear();
+	}
+
+	private getWrappedLineChunks(line: string, contentWidth: number): TextChunk[] {
+		if (line.includes("[paste #")) {
+			return wordWrapLine(line, contentWidth, [...this.segment(line, "grapheme")]);
+		}
+		const key = `${contentWidth}\x00${line}`;
+		const cached = this.wrappedLineCache.get(key);
+		if (cached) return cached;
+		const chunks = wordWrapLine(line, contentWidth);
+		if (this.wrappedLineCache.size >= 256) {
+			const oldest = this.wrappedLineCache.keys().next().value;
+			if (oldest !== undefined) this.wrappedLineCache.delete(oldest);
+		}
+		this.wrappedLineCache.set(key, chunks);
+		return chunks;
 	}
 
 	render(width: number): string[] {
@@ -906,7 +971,7 @@ export class Editor implements Component, Focusable {
 				}
 			} else {
 				// Line needs wrapping - use word-aware wrapping
-				const chunks = wordWrapLine(line, contentWidth, [...this.segment(line, "grapheme")]);
+				const chunks = this.getWrappedLineChunks(line, contentWidth);
 
 				for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
 					const chunk = chunks[chunkIndex];
@@ -1693,7 +1758,7 @@ export class Editor implements Component, Focusable {
 				visualLines.push({ logicalLine: i, startCol: 0, length: line.length });
 			} else {
 				// Line needs wrapping - use word-aware wrapping
-				const chunks = wordWrapLine(line, width, [...this.segment(line, "grapheme")]);
+				const chunks = this.getWrappedLineChunks(line, width);
 				for (const chunk of chunks) {
 					visualLines.push({
 						logicalLine: i,

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -27,6 +27,44 @@ markdownParser.setOptions({
 	tokenizer: new StrictStrikethroughTokenizer(),
 });
 
+const RENDER_CACHE_MAX = 256;
+const PARSE_CACHE_MAX = 128;
+const renderCache = new Map<string, { source: string; lines: string[] }>();
+const parseCache = new Map<string, { source: string; tokens: Token[] }>();
+const objectIds = new WeakMap<object, number>();
+let nextObjectId = 0;
+
+function objectId(value: object): number {
+	const cached = objectIds.get(value);
+	if (cached !== undefined) return cached;
+	const id = nextObjectId++;
+	objectIds.set(value, id);
+	return id;
+}
+
+function cacheSet<T>(cache: Map<string, T>, key: string, value: T, maxSize: number): void {
+	if (cache.has(key)) cache.delete(key);
+	cache.set(key, value);
+	if (cache.size > maxSize) {
+		const oldest = cache.keys().next().value;
+		if (oldest !== undefined) cache.delete(oldest);
+	}
+}
+
+function contentKey(text: string): string {
+	let hash = 2166136261;
+	for (let i = 0; i < text.length; i++) {
+		hash ^= text.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return `${text.length}:${(hash >>> 0).toString(36)}`;
+}
+
+export function clearRenderCache(): void {
+	renderCache.clear();
+	parseCache.clear();
+}
+
 /**
  * Default text styling for markdown content.
  * Applied to all text unless overridden by markdown formatting.
@@ -142,9 +180,38 @@ export class Markdown implements Component {
 
 		// Replace tabs with 3 spaces for consistent rendering
 		const normalizedText = this.text.replace(/\t/g, "   ");
+		const normalizedContentKey = contentKey(normalizedText);
+		const styleKey = this.defaultTextStyle ? objectId(this.defaultTextStyle) : -1;
+		const renderKey = [
+			normalizedContentKey,
+			width,
+			contentWidth,
+			this.paddingX,
+			this.paddingY,
+			this.theme.codeBlockIndent ?? "  ",
+			this.options.preserveOrderedListMarkers ? 1 : 0,
+			objectId(this.theme),
+			styleKey,
+			getCapabilities().images ?? "",
+			getCapabilities().hyperlinks ? 1 : 0,
+		].join("\x00");
+		const cachedRender = renderCache.get(renderKey);
+		if (cachedRender?.source === normalizedText) {
+			this.cachedText = this.text;
+			this.cachedWidth = width;
+			this.cachedLines = cachedRender.lines;
+			return cachedRender.lines;
+		}
 
 		// Parse markdown to HTML-like tokens
-		const tokens = markdownParser.lexer(normalizedText);
+		const cachedParse = parseCache.get(normalizedContentKey);
+		let tokens: Token[];
+		if (cachedParse?.source === normalizedText) {
+			tokens = cachedParse.tokens;
+		} else {
+			tokens = markdownParser.lexer(normalizedText);
+			cacheSet(parseCache, normalizedContentKey, { source: normalizedText, tokens }, PARSE_CACHE_MAX);
+		}
 
 		// Convert tokens to styled terminal output
 		const renderedLines: string[] = [];
@@ -209,6 +276,7 @@ export class Markdown implements Component {
 		this.cachedText = this.text;
 		this.cachedWidth = width;
 		this.cachedLines = result;
+		cacheSet(renderCache, renderKey, { source: normalizedText, lines: result }, RENDER_CACHE_MAX);
 
 		return result.length > 0 ? result : [""];
 	}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -15,7 +15,13 @@ export { Editor, type EditorOptions, type EditorTheme } from "./components/edito
 export { Image, type ImageOptions, type ImageTheme } from "./components/image.ts";
 export { Input } from "./components/input.ts";
 export { Loader, type LoaderIndicatorOptions } from "./components/loader.ts";
-export { type DefaultTextStyle, Markdown, type MarkdownOptions, type MarkdownTheme } from "./components/markdown.ts";
+export {
+	clearRenderCache,
+	type DefaultTextStyle,
+	Markdown,
+	type MarkdownOptions,
+	type MarkdownTheme,
+} from "./components/markdown.ts";
 export {
 	type SelectItem,
 	SelectList,

--- a/scripts/run-pr530-benchmarks.mjs
+++ b/scripts/run-pr530-benchmarks.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const BENCHES = {
+	"ai-event-stream": "packages/ai/bench/event-stream.ts",
+	"ai-model-registry": "packages/ai/bench/model-registry.ts",
+	"tui-editor": "packages/tui/bench/editor-layout.ts",
+	"tui-markdown": "packages/tui/bench/markdown-render.ts",
+	"coding-agent-render-transcript": "packages/coding-agent/bench/render-transcript.ts",
+};
+
+function parseArgs(argv) {
+	const args = {
+		suite: "all",
+		iterations: "20",
+		json: undefined,
+		baseline: undefined,
+		expectMedianImprovement: 0,
+		expectP95Improvement: 0,
+		allowRegressionPct: 0,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		const readValue = () => {
+			const value = argv[i + 1];
+			if (!value) throw new Error(`Missing value for ${arg}`);
+			i++;
+			return value;
+		};
+		if (arg === "--suite") args.suite = readValue();
+		else if (arg === "--iterations") args.iterations = readValue();
+		else if (arg === "--json") args.json = readValue();
+		else if (arg === "--baseline") args.baseline = readValue();
+		else if (arg === "--expect-median-improvement") args.expectMedianImprovement = Number(readValue());
+		else if (arg === "--expect-p95-improvement") args.expectP95Improvement = Number(readValue());
+		else if (arg === "--allow-regression-pct") args.allowRegressionPct = Number(readValue());
+		else if (arg.includes("=")) {
+			const [key, value] = arg.split("=", 2);
+			if (key === "--suite") args.suite = value;
+			else if (key === "--iterations") args.iterations = value;
+			else if (key === "--json") args.json = value;
+			else if (key === "--baseline") args.baseline = value;
+			else if (key === "--expect-median-improvement") args.expectMedianImprovement = Number(value);
+			else if (key === "--expect-p95-improvement") args.expectP95Improvement = Number(value);
+			else if (key === "--allow-regression-pct") args.allowRegressionPct = Number(value);
+			else throw new Error(`Unknown argument: ${arg}`);
+		} else {
+			throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	return args;
+}
+
+function selectedBenches(suite) {
+	if (suite === "all") return Object.entries(BENCHES);
+	const names = suite.split(",").map((name) => name.trim()).filter(Boolean);
+	return names.map((name) => {
+		const path = BENCHES[name];
+		if (!path) throw new Error(`Unknown suite: ${name}`);
+		return [name, path];
+	});
+}
+
+function runBench(name, path, iterations) {
+	const result = spawnSync(
+		process.execPath,
+		["--expose-gc", "--import", "tsx", path, "--iterations", iterations],
+		{ cwd: process.cwd(), encoding: "utf8", maxBuffer: 100 * 1024 * 1024 },
+	);
+	if (result.status !== 0) {
+		throw new Error(`Benchmark ${name} failed\n${result.stdout}\n${result.stderr}`);
+	}
+	const stdout = result.stdout.trim();
+	const line = stdout.split("\n").at(-1);
+	if (!line) throw new Error(`Benchmark ${name} produced no JSON`);
+	const parsed = JSON.parse(line);
+	if (parsed.suite !== name) throw new Error(`Benchmark ${name} returned suite ${parsed.suite}`);
+	if (result.stderr.trim()) process.stderr.write(result.stderr);
+	return parsed;
+}
+
+function bySuite(results) {
+	return new Map(results.map((result) => [result.suite, result]));
+}
+
+function percentImprovement(before, after) {
+	if (!Number.isFinite(before) || before <= 0) return 0;
+	return ((before - after) / before) * 100;
+}
+
+function compareWithBaseline(current, baseline, args) {
+	const baselineBySuite = bySuite(baseline.results);
+	const failures = [];
+	const comparisons = [];
+	for (const result of current.results) {
+		const base = baselineBySuite.get(result.suite);
+		if (!base) {
+			failures.push(`Missing baseline for ${result.suite}`);
+			continue;
+		}
+		const medianImprovement = percentImprovement(base.medianMs, result.medianMs);
+		const p95Improvement = percentImprovement(base.p95Ms, result.p95Ms);
+		comparisons.push({
+			suite: result.suite,
+			baselineMedianMs: base.medianMs,
+			currentMedianMs: result.medianMs,
+			medianImprovementPct: medianImprovement,
+			baselineP95Ms: base.p95Ms,
+			currentP95Ms: result.p95Ms,
+			p95ImprovementPct: p95Improvement,
+		});
+		if (medianImprovement < args.expectMedianImprovement) {
+			failures.push(
+				`${result.suite} median improvement ${medianImprovement.toFixed(2)}% < ${args.expectMedianImprovement}%`,
+			);
+		}
+		if (args.expectP95Improvement > 0 && p95Improvement < args.expectP95Improvement) {
+			failures.push(`${result.suite} p95 improvement ${p95Improvement.toFixed(2)}% < ${args.expectP95Improvement}%`);
+		}
+		if (medianImprovement < -args.allowRegressionPct) {
+			failures.push(`${result.suite} median regression ${(-medianImprovement).toFixed(2)}%`);
+		}
+	}
+	current.comparisons = comparisons;
+	current.comparisonFailures = failures;
+	if (failures.length > 0) {
+		throw new Error(failures.join("\n"));
+	}
+}
+
+const args = parseArgs(process.argv.slice(2));
+const start = performance.now();
+const results = selectedBenches(args.suite).map(([name, path]) => runBench(name, path, args.iterations));
+const payload = {
+	schemaVersion: 1,
+	createdAt: new Date().toISOString(),
+	gitCommit: spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim(),
+	iterations: Number(args.iterations),
+	durationMs: performance.now() - start,
+	results,
+};
+
+if (args.baseline) {
+	const baseline = JSON.parse(readFileSync(args.baseline, "utf8"));
+	compareWithBaseline(payload, baseline, args);
+}
+
+const json = `${JSON.stringify(payload, null, 2)}\n`;
+if (args.json) {
+	const outputPath = resolve(args.json);
+	mkdirSync(dirname(outputPath), { recursive: true });
+	writeFileSync(outputPath, json);
+} else {
+	process.stdout.write(json);
+}

--- a/scripts/run-pr530-benchmarks.mjs
+++ b/scripts/run-pr530-benchmarks.mjs
@@ -9,6 +9,7 @@ const BENCHES = {
 	"tui-editor": "packages/tui/bench/editor-layout.ts",
 	"tui-markdown": "packages/tui/bench/markdown-render.ts",
 	"coding-agent-render-transcript": "packages/coding-agent/bench/render-transcript.ts",
+	"coding-agent-bash-output": "packages/coding-agent/bench/bash-output.ts",
 };
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Summary

This ports the applicable performance work inspired by https://github.com/Yeachan-Heo/gajae-code/pull/530 into senpi, then extends it with the Discord follow-up around large output handling.

Shoutout to https://github.com/Yeachan-Heo/gajae-code/pull/530. Thank you for the work there; we can feel Fable Power.

## Changes

- Add local PR530 benchmark harnesses for AI event streams, model registry lookup, TUI Markdown rendering, TUI editor wrapping, assistant transcript rendering, and large bash output handling.
- Optimize `AssistantMessageEventStream` queue draining with a head-indexed queue and explicit failure settlement.
- Lazily initialize AI model registry lookup maps.
- Cache repeated TUI Markdown render and editor wrapping work.
- Apply the OutputSink-style follow-up from Discord where it maps to this codebase: compact tail-window retention for streaming output snapshots and head-indexed bash output buffers.

Not ported because the corresponding surfaces do not exist in this repo shape: `crates/pi-natives`, `packages/agent/src/append-only-context.ts`, and `packages/coding-agent/src/session/streaming-output.ts`.

## Measurements

Median before -> after:

| Suite | Baseline | Current | Improvement |
| --- | ---: | ---: | ---: |
| ai-event-stream | 155.615 ms | 3.150 ms | 97.98% |
| tui-editor | 284.150 ms | 14.346 ms | 94.95% |
| tui-markdown | 396.936 ms | 15.000 ms | 96.22% |
| coding-agent-render-transcript | 15.715 ms | 13.780 ms | 12.31% |
| ai-model-registry | 0.004208 ms | 0.002375 ms | 43.56% |
| coding-agent-bash-output | 21.185 ms | 21.097 ms | 0.41% median / 9.65% p95 |

Evidence files are under `.omo/ulw-loop/senpi-pr530-20260612/evidence/`, especially:

- `task-24-final-high-signal-vs-baseline.json`
- `task-24-final-model-registry-noisy-vs-baseline.json`
- `task-22-bash-output-main-40.json`
- `task-22-bash-output-headindex-current-40.json`
- `task-15-final-npm-run-check.log`

## Validation

- `npm run check`
- `cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/event-stream.test.ts`
- `cd packages/tui && node --test --import tsx test/editor.test.ts test/markdown.test.ts`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/assistant-message.test.ts`
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/tools.test.ts`
- Manual CLI smoke: `./pi-test.sh --help` in tmux

Note: `npm run check` exits 0. Biome prints an informational schema-version mismatch (`2.4.16` schema vs `2.3.5` CLI), but does not fail the check.

## Discord / Gajae follow-up

I checked the Discord link through the read-only Discord CLI. The linked message itself was empty, but the adjacent context explicitly called out Fable class and the follow-up result of `TUI 36~45% / OutputSink memory 79%` savings. I also compared public `gajae/dev` after PR #530; the post-PR changes were in coordinator/model-profile/composer areas, with no additional applicable perf diff in the PR530 hot-path files beyond the OutputSink hint handled here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the PR530 performance optimizations and adds compact large-output handling across the stack. Event streaming, TUI Markdown, and editor wrapping are much faster (up to ~98%); transcript render and model registry also see gains.

- **Refactors**
  - Head-indexed queue with explicit failure handling in `EventStream` and `AssistantMessageEventStream`.
  - Lazy model registry maps in `@earendil-works/pi-ai`.
  - Bounded caches for Markdown rendering and editor wrapping in `@earendil-works/pi-tui` (exports `clearRenderCache`).
  - Large bash output uses a head-indexed rolling buffer and compact tail window; new `TailWindow` and safer final decoder flush.

- **New Features**
  - Local benchmarks for event streams, model lookup, TUI markdown/editor, transcript render, and bash output.
  - `scripts/run-pr530-benchmarks.mjs` to run suites, emit JSON, and compare to a baseline.

<sup>Written for commit 97bf907fa12abeb176ffa4d319ddb3983c3a67f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

