### PR TITLE
fix(coding-agent): restore pending tool waiting render

### DIFF
--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -470,6 +470,7 @@ export interface ToolRenderContext<TState = any, TArgs = any> {
 	showImages: boolean;
 	/** Whether the current result is an error. */
 	isError: boolean;
+	spinnerFrame?: number;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -19,6 +19,7 @@ type ToolExecutionResult = Omit<AgentToolResult<unknown>, "details"> & {
 
 const FALLBACK_STRING_MAX_LENGTH = 160;
 const FALLBACK_JSON_MAX_LENGTH = 2000;
+const PENDING_RENDER_FRAME_INTERVAL_MS = 80;
 
 function sanitizeFallbackString(value: string, maxLength = FALLBACK_STRING_MAX_LENGTH): string {
 	const sanitized = stripAnsi(value)
@@ -63,6 +64,8 @@ export class ToolExecutionComponent extends Container {
 	private cwd: string;
 	private executionStarted = false;
 	private argsComplete = false;
+	private spinnerFrame?: number;
+	private spinnerInterval?: NodeJS.Timeout;
 	private result?: ToolExecutionResult;
 	private convertedImages: Map<number, { data: string; mimeType: string }> = new Map();
 	private hideComponent = false;
@@ -102,6 +105,7 @@ export class ToolExecutionComponent extends Container {
 			this.addChild(this.contentText);
 		}
 
+		this.updateSpinnerAnimation();
 		this.updateDisplay();
 	}
 
@@ -156,6 +160,7 @@ export class ToolExecutionComponent extends Container {
 			expanded: this.expanded,
 			showImages: this.showImages,
 			isError: this.result?.isError ?? false,
+			spinnerFrame: this.spinnerFrame,
 		};
 	}
 
@@ -173,17 +178,20 @@ export class ToolExecutionComponent extends Container {
 
 	updateArgs(args: any): void {
 		this.args = args;
+		this.updateSpinnerAnimation();
 		this.updateDisplay();
 	}
 
 	markExecutionStarted(): void {
 		this.executionStarted = true;
+		this.updateSpinnerAnimation();
 		this.updateDisplay();
 		this.ui.requestRender();
 	}
 
 	setArgsComplete(): void {
 		this.argsComplete = true;
+		this.updateSpinnerAnimation();
 		this.updateDisplay();
 		this.ui.requestRender();
 	}
@@ -191,8 +199,16 @@ export class ToolExecutionComponent extends Container {
 	updateResult(result: ToolExecutionResult, isPartial = false): void {
 		this.result = result;
 		this.isPartial = isPartial;
+		if (!isPartial) {
+			this.argsComplete = true;
+		}
+		this.updateSpinnerAnimation();
 		this.updateDisplay();
 		this.maybeConvertImagesForKitty();
+	}
+
+	stopAnimation(): void {
+		this.stopSpinnerAnimation();
 	}
 
 	private maybeConvertImagesForKitty(): void {
@@ -434,9 +450,45 @@ export class ToolExecutionComponent extends Container {
 			isPartial: this.isPartial,
 			result: this.result,
 			showImages: this.showImages,
+			spinnerFrame: this.spinnerFrame,
 			toolCallId: this.toolCallId,
 			toolName: this.toolName,
 		});
+	}
+
+	private updateSpinnerAnimation(): void {
+		const isStreamingArgs =
+			!this.argsComplete &&
+			(this.toolName === "edit" || this.toolName === "write" || this.toolName === "apply_patch");
+		const isPartialTask = this.isPartial && this.toolName === "task" && this.result !== undefined;
+		if (isStreamingArgs || isPartialTask) {
+			this.startSpinnerAnimation();
+			return;
+		}
+		this.stopSpinnerAnimation();
+	}
+
+	private startSpinnerAnimation(): void {
+		if (this.spinnerInterval) {
+			return;
+		}
+		this.spinnerInterval = setInterval(() => {
+			this.spinnerFrame = ((this.spinnerFrame ?? -1) + 1) % 10;
+			this.invalidateRenderCache();
+			this.updateDisplay();
+			this.ui.requestRender();
+		}, PENDING_RENDER_FRAME_INTERVAL_MS);
+		this.spinnerInterval.unref?.();
+	}
+
+	private stopSpinnerAnimation(): void {
+		if (!this.spinnerInterval) {
+			return;
+		}
+		clearInterval(this.spinnerInterval);
+		this.spinnerInterval = undefined;
+		this.spinnerFrame = undefined;
+		this.invalidateRenderCache();
 	}
 
 	private invalidateRenderCache(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1745,7 +1745,7 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
-		this.pendingTools.clear();
+		this.clearPendingTools();
 		this.clearToolHookStatuses();
 		this.renderInitialMessages();
 	}
@@ -1947,6 +1947,13 @@ export class InteractiveMode {
 		}
 		this.refreshWorkingLoaderMessage();
 		this.applyTerminalTitle();
+	}
+
+	private clearPendingTools(): void {
+		for (const component of this.pendingTools.values()) {
+			component.stopAnimation();
+		}
+		this.pendingTools.clear();
 	}
 
 	private clearActiveToolExecutionStatus(): void {
@@ -3037,7 +3044,7 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
-				this.pendingTools.clear();
+				this.clearPendingTools();
 				this.clearActiveToolExecutionStatus();
 				this.clearToolHookStatuses();
 				if (this.settingsManager.getShowTerminalProgress()) {
@@ -3171,7 +3178,7 @@ export class InteractiveMode {
 								isError: true,
 							});
 						}
-						this.pendingTools.clear();
+						this.clearPendingTools();
 					} else {
 						// Args are now complete - trigger diff computation for edit tools
 						for (const [, component] of this.pendingTools.entries()) {
@@ -3246,7 +3253,7 @@ export class InteractiveMode {
 					this.streamingComponent = undefined;
 					this.streamingMessage = undefined;
 				}
-				this.pendingTools.clear();
+				this.clearPendingTools();
 
 				await this.checkShutdownRequested();
 
@@ -3543,7 +3550,7 @@ export class InteractiveMode {
 		sessionContext: SessionContext,
 		options: { updateFooter?: boolean; populateHistory?: boolean } = {},
 	): void {
-		this.pendingTools.clear();
+		this.clearPendingTools();
 		const renderedPendingTools = new Map<string, ToolExecutionComponent>();
 
 		if (options.updateFooter) {
@@ -6099,6 +6106,7 @@ export class InteractiveMode {
 			this.ui.terminal.setProgress(false);
 		}
 		this.stopWorkingLoader();
+		this.clearPendingTools();
 		this.clearActiveToolExecutionStatus();
 		this.clearToolHookStatuses();
 		this.clearExtensionTerminalInputListeners();

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -43,6 +43,7 @@ type RenderSessionContextThis = {
 	isInitialized: boolean;
 	updateEditorBorderColor(): void;
 	getRegisteredToolDefinition(toolName: string): undefined;
+	clearPendingTools(): void;
 	handleToolExecutionEnd(event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>): void;
 	addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void;
 };
@@ -73,6 +74,7 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 		isInitialized: true,
 		updateEditorBorderColor: vi.fn(),
 		getRegisteredToolDefinition: (_toolName: string) => undefined,
+		clearPendingTools: Reflect.get(InteractiveMode.prototype, "clearPendingTools"),
 		handleToolExecutionEnd: Reflect.get(InteractiveMode.prototype, "handleToolExecutionEnd"),
 		addMessageToChat(message: AgentMessage) {
 			chatContainer.addChild(new Text(message.role, 0, 0));

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -31,6 +31,12 @@ function createFakeTui(): TUI {
 	} as TUI;
 }
 
+function createFakeTuiWithRenderSpy(requestRender: () => void): TUI {
+	return {
+		requestRender,
+	} as TUI;
+}
+
 const markerTheme = {
 	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
 	bg: (name: string, text: string) => `<bg:${name}>${text}</bg:${name}>`,
@@ -104,6 +110,46 @@ describe("ToolExecutionComponent parity", () => {
 		);
 
 		expect(component.render(120)).toEqual([]);
+	});
+
+	test("advances pending render frames for self-rendered write calls while args stream", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const toolDefinition: ToolDefinition = {
+				...createBaseToolDefinition("write"),
+				renderShell: "self",
+				renderCall: (_args, _theme, context) => {
+					const frame = Reflect.get(context, "spinnerFrame");
+					return new Text(`waiting frame:${String(frame ?? "none")}`, 0, 0);
+				},
+			};
+
+			const component = new ToolExecutionComponent(
+				"write",
+				"tool-pending-write-frame",
+				{ path: "notes.txt", content: "partial" },
+				{},
+				toolDefinition,
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
+
+			expect(stripAnsi(component.render(120).join("\n"))).toContain("waiting frame:none");
+
+			vi.advanceTimersByTime(90);
+
+			expect(requestRender).toHaveBeenCalled();
+			expect(stripAnsi(component.render(120).join("\n"))).toContain("waiting frame:0");
+
+			component.setArgsComplete();
+			requestRender.mockClear();
+			vi.advanceTimersByTime(90);
+
+			expect(requestRender).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test("uses built-in rendering for built-in overrides without custom renderers", () => {


### PR DESCRIPTION
## Summary

Restores pending tool-call waiting rendering for self-rendered tool rows after the PR530 optimization port.

The regression was that self-rendered pending tools could render a static waiting row while arguments streamed because the renderer context had no frame state and the render cache had no frame-changing signature. This adds `spinnerFrame` to `ToolRenderContext`, advances it while `edit` / `write` / `apply_patch` args stream or `task` partial results are pending, and invalidates/rerenders on each frame.

It also makes every bulk pending-tool clear path stop component animations before clearing the map, while preserving the existing behavior from the empty self-render row fix.

Shoutout to Fable Power and thanks to @Yeachan-Heo for gajae-code PR 530: https://github.com/Yeachan-Heo/gajae-code/pull/530. I re-read that PR and used its retained pending animation behavior as the reference point while adapting it to senpi's extension renderer context.

## Validation

- tmux manual QA: `.omo/ulw-loop/senpi-tool-wait-render-20260612/evidence/manual-tool-wait-render.tmux.final.plain.txt` shows `OBSERVED_FRAMES:none,0,1,2,3,4,none,none`, `QA_DONE`, `QA_EXIT:0`.
- Targeted vitest from `packages/coding-agent`: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/tool-execution-component.test.ts test/interactive-mode-status.test.ts test/interactive-mode-working-status.test.ts test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts test/suite/regressions/tui-apply-patch-rendering.test.ts test/suite/gpt-apply-patch-rich-render.test.ts test/suite/gpt-apply-patch-extension.test.ts` passed 7 files / 102 tests.
- `npm run check` from repo root passed. Existing Biome schema version info only; no fixes applied.
- Reviewer agent: `APPROVE / architectStatus CLEAR`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores animated waiting rows for self-rendered pending tool calls during argument streaming. Also stops pending-tool animations on clear to prevent stuck spinners.

- **Bug Fixes**
  - Added `spinnerFrame` to `ToolRenderContext` and advanced it every 80ms while `edit`, `write`, or `apply_patch` args stream, or while `task` has partial results.
  - Invalidates render cache and requests re-render on each frame so self-rendered pending tools animate instead of staying static.
  - Introduced `clearPendingTools()` to stop each component’s animation before clearing; used across agent start, tool-end, cancel, and reset paths.

<sup>Written for commit 2f3619c582c7179c92256ce71270875fe533b251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

