### PR TITLE
feat(prompt-preset): add Kimi K2.7 preset

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k2-7.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k2-7.ts
@@ -1,0 +1,11 @@
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+
+function buildKimiK27Tuning(): string {
+	return `You are running on Kimi K2.7 - restrained and outcome-first. Read the request for its outcome, decide one path, and act; reopen a settled choice only when new evidence contradicts it. Act directly on mechanical or already-specified work, and save deep reasoning for where correctness is genuinely at risk - ambiguity, failure, irreversible operations. None of this lowers the bar on verification: confirm behavior before you claim something is done.
+
+The intent gate routing line is required every turn. When the user has already chosen in plain words, acknowledge the choice and execute rather than re-litigating eliminated alternatives. Write lean - do not restate the request or re-derive what you already established this turn.`;
+}
+
+export function buildKimiK27Prompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK27Tuning() });
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -9,6 +9,7 @@ import { buildGpt54Prompt } from "./gpt-5.4.ts";
 import { buildGpt55Prompt } from "./gpt-5.5.ts";
 import { buildGpt5Prompt } from "./gpt-5.ts";
 import { buildKimiK26Prompt } from "./kimi-k2-6.ts";
+import { buildKimiK27Prompt } from "./kimi-k2-7.ts";
 import { type PromptPresetName, type PromptPresetSettings, parsePromptPreset } from "./settings.ts";
 
 export type { PromptPresetSettings } from "./settings.ts";
@@ -55,6 +56,14 @@ function isKimiK26Model(model: ModelWithPromptPresetMetadata): boolean {
 	return hasKimiK26Signal(model.id) || (model.name !== undefined && hasKimiK26Signal(model.name));
 }
 
+function hasKimiK27Signal(value: string): boolean {
+	return /(?:^|[/@._-])kimi-k2(?:[._-]|p)7(?:$|[/@._-])/.test(normalizeModelId(value));
+}
+
+function isKimiK27Model(model: ModelWithPromptPresetMetadata): boolean {
+	return hasKimiK27Signal(model.id) || (model.name !== undefined && hasKimiK27Signal(model.name));
+}
+
 type ClaudeOpusVersion = "claude-opus-4-7" | "claude-opus-4-6" | "claude-opus-4-5";
 
 function extractClaudeOpusVersion(modelId: string): ClaudeOpusVersion | undefined {
@@ -88,6 +97,9 @@ export function resolvePresetName(
 	if (gpt5Version) {
 		return gpt5Version;
 	}
+	if (isKimiK27Model(model)) {
+		return "kimi-k2-7";
+	}
 	if (isKimiK26Model(model)) {
 		return "kimi-k2-6";
 	}
@@ -110,6 +122,8 @@ function buildPreset(name: ResolvedPresetName, options: BuildDynamicSystemPrompt
 			return { name, prompt: buildGpt52Prompt(options) };
 		case "gpt-5":
 			return { name, prompt: buildGpt5Prompt(options) };
+		case "kimi-k2-7":
+			return { name, prompt: buildKimiK27Prompt(options) };
 		case "kimi-k2-6":
 			return { name, prompt: buildKimiK26Prompt(options) };
 		case "claude-opus-4-7":

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
@@ -5,6 +5,7 @@ export type PromptPresetName =
 	| "claude-opus-4-7"
 	| "claude-opus-4-6"
 	| "claude-opus-4-5"
+	| "kimi-k2-7"
 	| "kimi-k2-6"
 	| "gpt-5"
 	| "gpt-5.2"
@@ -23,6 +24,7 @@ const VALID_PRESETS: ReadonlySet<string> = new Set<PromptPresetName>([
 	"claude-opus-4-7",
 	"claude-opus-4-6",
 	"claude-opus-4-5",
+	"kimi-k2-7",
 	"kimi-k2-6",
 	"gpt-5",
 	"gpt-5.2",

--- a/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
@@ -160,6 +160,51 @@ describe("prompt preset resolver", () => {
 		expect(preset?.prompt.length).toBeGreaterThan(2_000);
 	});
 
+	it.each([
+		{ id: "kimi-k2.7-0711", provider: "moonshot", api: "openai-responses" as const },
+		{ id: "kimi-k2p7-turbo", provider: "moonshot", api: "openai-responses" as const },
+	])("returns kimi-k2-7 preset for $provider/$id", ({ id, provider, api }) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(id, provider, api);
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("kimi-k2-7");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt).toContain("running on Kimi K2.7");
+		expect(preset?.prompt).toContain("## Intent Gate");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it("keeps Kimi K2.6 on the kimi-k2-6 preset, distinct from K2.7", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const k26 = resolvePreset(createModel("kimi-k2.6-0528", "moonshot", "openai-responses"), settings);
+		const k27 = resolvePreset(createModel("kimi-k2.7-0711", "moonshot", "openai-responses"), settings);
+
+		// then
+		expect(k26?.name).toBe("kimi-k2-6");
+		expect(k26?.prompt).not.toContain("running on Kimi K2.7");
+		expect(k27?.name).toBe("kimi-k2-7");
+		expect(k27?.prompt).not.toContain("filler verification language");
+	});
+
+	it("allows settings.json to force kimi-k2-7 regardless of model id", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "kimi-k2-7" };
+		const model = createModel("gpt-5.5", "openai-codex", "openai-codex-responses");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("kimi-k2-7");
+		expect(preset?.prompt).toContain("running on Kimi K2.7");
+	});
+
 	it("returns kimi-k2-6 preset for every Kimi K2.6 built-in catalog model", () => {
 		// given
 		const settings: PromptPresetSettings = { promptPreset: "auto" };


### PR DESCRIPTION
## What

Adds a **Kimi K2.7** prompt preset, following senpi's thin-wrapper idiom (a model-specific tuning section on the shared `buildDynamicSystemPrompt`).

The tuning expresses K2.7's restrained, outcome-first character — commit once and reopen only on new evidence, act directly on mechanical or already-specified work, spend deep reasoning only where correctness is genuinely at risk, and verify before claiming done — mirroring the omo K2.7 agent prompts. It is authored fresh, not a reword of the K2.6 tuning.

## Changes

- New `prompt-preset/kimi-k2-7.ts` (`buildKimiK27Prompt` + native tuning).
- `presets.ts`: `kimi-k2-7` signal + matcher, routed **before** the generic K2.6 signal; dispatch case added.
- `settings.ts`: `kimi-k2-7` added to `PromptPresetName` and `VALID_PRESETS`.

The K2.7 signal regex is symmetric in strictness with the K2.6 one (both require the `kimi-k2` prefix). K2.6 models are unaffected.

## Verification

- 32/32 prompt-preset tests green (new tests lock K2.7→`kimi-k2-7` with its distinct marker, K2.6 stays on `kimi-k2-6`, and the settings override path).
- Full repo pre-commit checks (biome, tsgo) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `kimi-k2-7` prompt preset with model-specific tuning and routes K2.7 models to it ahead of K2.6. This targets K2.7’s outcome-first behavior while keeping K2.6 unchanged.

- **New Features**
  - `buildKimiK27Prompt` using `buildDynamicSystemPrompt` with K2.7’s restrained, outcome-first tuning.
  - Resolver detects K2.7 via a symmetric `kimi-k2`-prefixed regex and routes before `kimi-k2-6`.
  - `settings`: adds `kimi-k2-7` to `PromptPresetName` and `VALID_PRESETS`.
  - Tests cover K2.7 routing, separation from `kimi-k2-6`, and settings override to force `kimi-k2-7`.

<sup>Written for commit 12720d40c7ea3fe1ffa4a240e5e197eac73e739c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

