### PR TITLE
feat(builtins): vendor websearch, webfetch, nested-agents-md, rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ If you're migrating from [OMO (oh-my-openagent)](https://github.com/code-yeongyu
 |---|---|
 | 🚪 **IntentGate** | [Dynamic system prompt](packages/coding-agent/src/core/dynamic-prompt/AGENTS.md) — every prompt opens with a forced intent gate before tool use. |
 | ✅ **Todo Enforcer** | [`todowrite`](packages/coding-agent/src/core/extensions/builtin/todotools/) + continuation loop that re-engages idle agents. |
-| **Persistent goal tracking** (Sisyphus-style) | [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) — `create_goal` / `update_goal` / `get_goal` + `/goal` command + continuation prompts; budget-free, file-based port of `pi-goal`. |
 | **Per-model tuning** ("Model Setup") | [`prompt-preset`](packages/coding-agent/src/core/extensions/builtin/prompt-preset/) — GPT-5.x / Claude Opus 4.{5,6,7} / Kimi K2.{6,7} presets. |
 | **Session recovery / context management** | [`compaction`](packages/coding-agent/src/core/extensions/builtin/compaction/) — adaptive thresholds, restoration tracker, emergency compaction, tool-result truncation. |
 | **Apply-patch on GPT models** | [`gpt-apply-patch`](packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/) — Codex-style freeform `apply_patch` with Lark grammar. |
@@ -41,6 +40,11 @@ If you're migrating from [OMO (oh-my-openagent)](https://github.com/code-yeongyu
 | **Bash timeout discipline** | [`bash-timeout`](packages/coding-agent/src/core/extensions/builtin/bash-timeout/) — default + max-timeout enforcement, policy in system prompt. |
 | **Compaction-safe tool pairing** | [`tool-pair-guard`](packages/coding-agent/src/core/extensions/builtin/tool-pair-guard/) — strips orphan `tool_result` blocks. |
 | **Permission system** (opencode-style allow/deny) | [`permission-system`](packages/coding-agent/src/core/extensions/builtin/permission-system/) — rules, JSONL storage, TUI prompts, parser-aware patterns. |
+| 📚 **Web search** (Exa-style slot) | [`websearch`](packages/coding-agent/src/core/extensions/builtin/websearch/) — provider-backed `web_search` tool, config-gated, defers to provider natives. |
+| **Web fetch** | [`webfetch`](packages/coding-agent/src/core/extensions/builtin/webfetch/) — `webfetch` tool: URL content as markdown / text / HTML, bounded time + size. |
+| **Rule loading** (`.claude/rules`, `AGENTS.md`, …) | [`rules`](packages/coding-agent/src/core/extensions/builtin/rules/) — auto-discovers `.sisyphus/rules`, `.claude/rules`, `.cursor/rules`, `.github/instructions`, `AGENTS.md`, `CLAUDE.md`. |
+| 🔍 **Nested AGENTS.md** (`/init-deep` runtime half) | [`nested-agents-md`](packages/coding-agent/src/core/extensions/builtin/nested-agents-md/) — auto-injects nearby `AGENTS.md` when reading from a nested directory. |
+| **Goal tracking** (Sisyphus-style discipline) | [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) — budget-free `create_goal` / `update_goal` / `get_goal` + `/goal`, persistent per-thread objective with continuation prompts. |
 
 ### Install these pi-extension packages for the OMO-shaped senpi
 
@@ -48,10 +52,9 @@ If you're migrating from [OMO (oh-my-openagent)](https://github.com/code-yeongyu
 senpi install git:github.com/code-yeongyu/pi-lsp-client            # 🛠️  LSP: rename / goto / refs / diagnostics + /lsp inspector
 senpi install git:github.com/code-yeongyu/pi-ast-grep              # 🛠️  AST-Grep across 25 languages (auto-downloads sg)
 senpi install git:github.com/code-yeongyu/pi-comment-checker       # 💬  Comment Checker — the standalone pi port of OMO's hook
-senpi install git:github.com/code-yeongyu/pi-rules                 #     Context injection: .claude/rules, .cursor/rules, .github/instructions, AGENTS.md, CLAUDE.md
-senpi install git:github.com/code-yeongyu/pi-nested-agents-md      # 🔍  Auto-injects nearby AGENTS.md (the runtime half of /init-deep)
-senpi install git:github.com/code-yeongyu/pi-websearch             # 📚  Provider-backed web search (fills the Exa-style slot)
-senpi install git:github.com/code-yeongyu/pi-webfetch              #     web_fetch tool (markdown / text / HTML, bounded time + size)
+
+# Web search / fetch, rule loading, nested AGENTS.md, and goal tracking are now senpi builtins —
+# nothing to install. See "Already builtin in senpi" above.
 
 # Optional — only if you used the matching OMO surface:
 senpi install git:github.com/code-yeongyu/pi-cua-integration                 # 🖥️  Computer-use bindings (desktop / browser)
@@ -68,6 +71,24 @@ senpi install git:github.com/code-yeongyu/pi-openai-api-parallel-tool-calls  #  
 ```
 
 Each package is also installable by git URL, e.g. `senpi install git:github.com/code-yeongyu/pi-comment-checker`. See [Senpi Packages](packages/coding-agent/README.md#pi-packages) for the full install / update / remove flow.
+
+### Recommended coding set
+
+The four extensions that pull the most weight on day-to-day coding work. `goal` is already a senpi builtin (nothing to install); the other three are one `senpi install` away.
+
+| Extension | Status | What it gives you |
+|---|---|---|
+| [`pi-ast-grep`](https://github.com/code-yeongyu/pi-ast-grep) | `senpi install` | AST-aware structural search/replace across 25 languages (auto-downloads `sg`). |
+| [`pi-lsp-client`](https://github.com/code-yeongyu/pi-lsp-client) | `senpi install` | Compiler-grade `lsp_rename` / `lsp_goto_definition` / `lsp_find_references` / `lsp_diagnostics` + `/lsp` inspector. |
+| [`pi-comment-checker`](https://github.com/code-yeongyu/pi-comment-checker) | `senpi install` | Comment-quality checks after every file edit, surfaced in the TUI. |
+| [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) | **builtin** | Budget-free persistent goal tracking with continuation prompts (synced from [`pi-goal`](https://github.com/code-yeongyu/pi-goal)). |
+
+```bash
+senpi install git:github.com/code-yeongyu/pi-ast-grep
+senpi install git:github.com/code-yeongyu/pi-lsp-client
+senpi install git:github.com/code-yeongyu/pi-comment-checker
+# goal is builtin — already on.
+```
 
 ### Allow all permissions (OMO-style)
 
@@ -97,7 +118,7 @@ These are part of OMO's opencode harness shape and are intentionally **not** in 
 - **Hashline / hash-anchored edit tool** — senpi stays with pi's standard `edit` / `multiedit` / `apply_patch`. `pi-comment-checker` covers the post-edit validation slot OMO uses Hashline for, just without `LINE#ID` content-hash identifiers.
 - **Skill system** and **skill-embedded MCPs** — skills as a first-class concept (`SKILL.md`, scoped per-skill MCP servers) do not exist in senpi.
 - **Prometheus interview-mode planner** and the **Ralph Loop / `/ulw-loop`** self-referential loop.
-- **`/init-deep`** — there is no in-tree generator. Generate the hierarchical `AGENTS.md` tree manually (or with a normal agent prompt), then install `pi-nested-agents-md` so the agent actually reads them.
+- **`/init-deep`** — there is no in-tree generator. Generate the hierarchical `AGENTS.md` tree manually (or with a normal agent prompt); the `nested-agents-md` builtin then reads them automatically (no install needed).
 - **Built-in `doctor` command**, **Claude Code hook/command/skill/plugin compatibility layer**, and the **agent category router** (`visual-engineering` / `deep` / `quick` / `ultrabrain`).
 
 ## Want more? Try the pi-extensions ecosystem
@@ -118,17 +139,14 @@ These [`code-yeongyu/pi-*`](https://github.com/code-yeongyu?tab=repositories&q=p
 | [`pi-ast-grep`](https://github.com/code-yeongyu/pi-ast-grep) | AST-aware code search/replace across 25 languages. Auto-downloads `sg` on first use. |
 | [`pi-comment-checker`](https://github.com/code-yeongyu/pi-comment-checker) | Runs comment-quality checks after file-editing tools and shows warnings in the TUI. |
 | [`pi-cua-integration`](https://github.com/code-yeongyu/pi-cua-integration) | Computer-use action wiring for desktop/browser interaction surfaces. |
-| [`pi-goal`](https://github.com/code-yeongyu/pi-goal) | Persistent goal tracking with Codex-style goal tools and continuation prompts. **Now shipped builtin** as the budget-free [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) extension. |
 | [`pi-google-code-execution`](https://github.com/code-yeongyu/pi-google-code-execution) | Google native code execution. |
 | [`pi-google-google-search`](https://github.com/code-yeongyu/pi-google-google-search) | Google Search grounding. |
 | [`pi-google-url-context`](https://github.com/code-yeongyu/pi-google-url-context) | Google URL grounding. |
 | [`pi-lsp-client`](https://github.com/code-yeongyu/pi-lsp-client) | LSP integration: `lsp_rename`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, plus a `/lsp` inspector. |
-| [`pi-nested-agents-md`](https://github.com/code-yeongyu/pi-nested-agents-md) | Auto-injects nearby `AGENTS.md` files when the agent reads from a nested directory. |
 | [`pi-openai-api-parallel-tool-calls`](https://github.com/code-yeongyu/pi-openai-api-parallel-tool-calls) | OpenAI `parallel_tool_calls` payload support. |
 | [`pi-openai-code-interpreter`](https://github.com/code-yeongyu/pi-openai-code-interpreter) | OpenAI Code Interpreter. |
-| [`pi-rules`](https://github.com/code-yeongyu/pi-rules) | Auto-discovers rule files from `.sisyphus/rules/`, `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, `AGENTS.md`, and `CLAUDE.md`. |
-| [`pi-webfetch`](https://github.com/code-yeongyu/pi-webfetch) | `web_fetch` tool: URL content as markdown, plain text, or HTML with bounded time and size. |
-| [`pi-websearch`](https://github.com/code-yeongyu/pi-websearch) | Provider-backed web search with config-gated activation, TUI status, and source-aware results. |
+
+> Web search/fetch (`websearch`, `webfetch`), rule loading (`rules`), nested `AGENTS.md` injection (`nested-agents-md`), and goal tracking (`goal`) used to live here — they are now senpi builtins. See [pi-extension packages already shipped as senpi builtins](#pi-extension-packages-already-shipped-as-senpi-builtins).
 
 Install any of them with:
 
@@ -149,8 +167,13 @@ You do **not** need to install these packages for normal senpi use; their functi
 | [`pi-anthropic-web-search`](https://github.com/code-yeongyu/pi-anthropic-web-search) | `anthropic-web-search` | Anthropic-native web search support. |
 | [`pi-apply-patch`](https://github.com/code-yeongyu/pi-apply-patch) | `gpt-apply-patch` | Codex-style `apply_patch` tool for GPT-family runs. |
 | [`pi-bash-timeout`](https://github.com/code-yeongyu/pi-bash-timeout) | `bash-timeout` | Bash timeout defaults, max timeout enforcement, and prompt policy. |
+| [`pi-goal`](https://github.com/code-yeongyu/pi-goal) | `goal` | Budget-free persistent goal tracking: `create_goal` / `update_goal` / `get_goal` + `/goal`, per-thread objective with continuation prompts. |
+| [`pi-nested-agents-md`](https://github.com/code-yeongyu/pi-nested-agents-md) | `nested-agents-md` | Auto-injects nearby `AGENTS.md` files when the agent reads from a nested directory. |
 | [`pi-openai-web-search`](https://github.com/code-yeongyu/pi-openai-web-search) | `openai-web-search` | OpenAI Responses native web search. |
+| [`pi-rules`](https://github.com/code-yeongyu/pi-rules) | `rules` | Auto-discovers rule files from `.sisyphus/rules/`, `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, `AGENTS.md`, and `CLAUDE.md`. |
 | [`pi-todotools`](https://github.com/code-yeongyu/pi-todotools) | `todowrite` | `todowrite` / `todoread`, todo sidebar state, workflow prompt guidance, and continuation follow-ups. |
+| [`pi-webfetch`](https://github.com/code-yeongyu/pi-webfetch) | `webfetch` | `webfetch` tool: URL content as markdown, plain text, or HTML with bounded time and size. |
+| [`pi-websearch`](https://github.com/code-yeongyu/pi-websearch) | `websearch` | Provider-backed web search with config-gated activation, TUI status, and source-aware results. |
 
 Other builtins such as `permission-system`, `prompt-preset`, `anthropic-bash`, `service-tier`, `tool-pair-guard`, `compaction`, `history-search`, `session-observer`, `kimi-web-search`, and `goal` are senpi-owned builtin extensions, not installable sibling packages.
 
@@ -194,8 +217,12 @@ In-tree, tightly coupled to senpi internals. Loaded in this exact registration o
 | 12 | [`compaction`](packages/coding-agent/src/core/extensions/builtin/compaction/) | Speculative + emergency compaction policy: degradation monitor, circuit breaker, per-turn cap, todo bridging, checkpoint state, restoration tracker, tool-result truncation | [AGENTS.md](packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md) · [changes.md](packages/coding-agent/src/core/extensions/builtin/compaction/changes.md) |
 | 13 | [`history-search`](packages/coding-agent/src/core/extensions/builtin/history-search/) | `/history` command — searches prompt history across sessions in an overlay | — |
 | 14 | [`session-observer`](packages/coding-agent/src/core/extensions/builtin/session-observer/) | `/sessions` command — peeks at previous session transcripts in a HUD overlay | — |
-| 15 | [`kimi-web-search`](packages/coding-agent/src/core/extensions/builtin/kimi-web-search/) | `SearchWeb` / `FetchURL` tools backed by the Kimi search/fetch API; toggled via `PI_KIMI_WEB_SEARCH` | — |
-| 16 | [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) | Persistent per-thread goal tracking: `create_goal` / `update_goal` / `get_goal` + `/goal` command + continuation prompts; budget-free, file-based port of `pi-goal` | [AGENTS.md](packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md) · [changes.md](packages/coding-agent/src/core/extensions/builtin/goal/changes.md) |
+| 15 | [`kimi-web-search`](packages/coding-agent/src/core/extensions/builtin/kimi-web-search/) | `kimi_search_web` / `kimi_fetch_url` tools backed by the Kimi search/fetch API; toggled via `PI_KIMI_WEB_SEARCH` | — |
+| 16 | [`websearch`](packages/coding-agent/src/core/extensions/builtin/websearch/) *(vendored)* | Provider-backed `web_search` tool + `/websearch` status command; config-gated, defers to provider natives. Synced from [`code-yeongyu/pi-websearch`](https://github.com/code-yeongyu/pi-websearch). | — |
+| 17 | [`webfetch`](packages/coding-agent/src/core/extensions/builtin/webfetch/) *(vendored)* | `webfetch` tool — URL content as markdown / text / HTML, bounded time + size; toggled via `PI_WEBFETCH`. Synced from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-webfetch). | — |
+| 18 | [`nested-agents-md`](packages/coding-agent/src/core/extensions/builtin/nested-agents-md/) *(vendored)* | Auto-injects nearby `AGENTS.md` files when the agent reads from a nested directory; `/nested-agents` toggle. Synced from [`code-yeongyu/pi-nested-agents-md`](https://github.com/code-yeongyu/pi-nested-agents-md). | — |
+| 19 | [`rules`](packages/coding-agent/src/core/extensions/builtin/rules/) *(vendored)* | Auto-discovers rule files (`.sisyphus/rules`, `.claude/rules`, `.cursor/rules`, `.github/instructions`, `AGENTS.md`, `CLAUDE.md`); `/rules` + `/reload-rules`. Synced from [`code-yeongyu/pi-rules`](https://github.com/code-yeongyu/pi-rules). | — |
+| 20 | [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) *(vendored)* | Budget-free persistent goal tracking — `create_goal` / `update_goal` / `get_goal` + `/goal`, per-thread objective with continuation prompts. Synced from [`code-yeongyu/pi-goal`](https://github.com/code-yeongyu/pi-goal). | [AGENTS.md](packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md) · [changes.md](packages/coding-agent/src/core/extensions/builtin/goal/changes.md) |
 
 > The builtin directories above are new vs upstream `pi-mono` — none exist in `badlogic/pi-mono`. Vendored versions are pinned in [`external-versions.json`](packages/coding-agent/src/core/extensions/builtin/external-versions.json) and synced from the sibling `pi-extensions` checkout with [`sync-builtin-extensions.mjs`](packages/coding-agent/scripts/sync-builtin-extensions.mjs).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,6 +1635,12 @@
 				"zod-to-json-schema": "^3.25.0"
 			}
 		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/@napi-rs/canvas": {
 			"version": "0.1.100",
 			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
@@ -3247,6 +3253,13 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
+		"node_modules/@types/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/proper-lockfile": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
@@ -3277,6 +3290,13 @@
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/@types/turndown": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+			"integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript/native-preview": {
 			"version": "7.0.0-dev.20260604.1",
@@ -5722,7 +5742,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -6589,6 +6608,19 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/turndown": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+			"integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=9"
 			}
 		},
 		"node_modules/tweetnacl": {
@@ -7674,9 +7706,11 @@
 				"minimatch": "10.2.5",
 				"openai": "6.26.0",
 				"partial-json": "0.1.7",
+				"picomatch": "4.0.4",
 				"proper-lockfile": "4.1.2",
 				"proxy-from-env": "1.1.0",
 				"semver": "7.8.0",
+				"turndown": "7.2.4",
 				"typebox": "1.1.38",
 				"undici": "8.3.0",
 				"yaml": "2.9.0"
@@ -7690,8 +7724,10 @@
 				"@types/hosted-git-info": "3.0.5",
 				"@types/ms": "2.1.0",
 				"@types/node": "25.9.1",
+				"@types/picomatch": "4.0.3",
 				"@types/proper-lockfile": "4.1.4",
 				"@types/semver": "7.7.1",
+				"@types/turndown": "5.0.6",
 				"shx": "0.4.0",
 				"typescript": "6.0.3",
 				"vitest": "4.1.8"

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -33,9 +33,11 @@
 				"minimatch": "10.2.5",
 				"openai": "6.26.0",
 				"partial-json": "0.1.7",
+				"picomatch": "4.0.4",
 				"proper-lockfile": "4.1.2",
 				"proxy-from-env": "1.1.0",
 				"semver": "7.8.0",
+				"turndown": "7.2.4",
 				"typebox": "1.1.38",
 				"undici": "8.3.0",
 				"yaml": "2.9.0"
@@ -766,6 +768,12 @@
 				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.25.0"
 			}
+		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/@nodable/entities": {
 			"version": "2.1.0",
@@ -1597,6 +1605,18 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/proper-lockfile": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -1738,6 +1758,19 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/turndown": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+			"integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=9"
+			}
 		},
 		"node_modules/typebox": {
 			"version": "1.1.38",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -62,9 +62,11 @@
 		"minimatch": "10.2.5",
 		"openai": "6.26.0",
 		"partial-json": "0.1.7",
+		"picomatch": "4.0.4",
 		"proper-lockfile": "4.1.2",
 		"proxy-from-env": "1.1.0",
 		"semver": "7.8.0",
+		"turndown": "7.2.4",
 		"typebox": "1.1.38",
 		"undici": "8.3.0",
 		"yaml": "2.9.0"
@@ -89,8 +91,10 @@
 		"@types/hosted-git-info": "3.0.5",
 		"@types/ms": "2.1.0",
 		"@types/node": "25.9.1",
+		"@types/picomatch": "4.0.3",
 		"@types/proper-lockfile": "4.1.4",
 		"@types/semver": "7.7.1",
+		"@types/turndown": "5.0.6",
 		"shx": "0.4.0",
 		"typescript": "6.0.3",
 		"vitest": "4.1.8"

--- a/packages/coding-agent/scripts/sync-builtin-extensions.mjs
+++ b/packages/coding-agent/scripts/sync-builtin-extensions.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { listSourceFiles, transformVendoredSource } from "./vendor-transform.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = resolve(scriptDir, "..");
@@ -10,37 +11,31 @@ const defaultSourceRoot = resolve(workspaceRoot, "..", "pi-extensions");
 const sourceRoot = resolve(process.env.SENPI_BUILTIN_EXTENSIONS_SOURCE ?? defaultSourceRoot);
 const builtinRoot = join(packageDir, "src", "core", "extensions", "builtin");
 
-const FILES = [
-	{
-		source: "pi-bash-timeout/src/index.ts",
-		target: "bash-timeout/index.ts",
-		transform: (content) =>
-			content.replace(
-				'import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";',
-				'import type { ExtensionAPI } from "../../types.js";',
-			),
-	},
-	{ source: "pi-bash-timeout/src/timeout.ts", target: "bash-timeout/timeout.ts" },
-	// pi-apply-patch has diverged: senpi maintains a refactored multi-file version under
-	// gpt-apply-patch/ (apply.ts, constants.ts, errors.ts, extension.ts, parser.ts, tool.ts, ...)
-	// while pi-apply-patch upstream is still a single src/index.ts monolith. Re-enabling the old
-	// monolithic sync would overwrite senpi's barrel index.ts and lose the refactor. Port
-	// behavior changes manually until the upstream package is restructured to match.
-	//
-	// pi-todotools has also diverged: senpi removed the todo continuation feature, so every
-	// vendored file under todotools/ differs from upstream (which still ships guards.ts and the
-	// continuation runtime). Regular file-copy sync would reintroduce the removed feature and
-	// overwrite senpi's changes. Port improvements manually.
-];
+// DIR_SYNCS auto-copy a package's src/ tree into builtin/<id>/, rewriting the standalone
+// package's published-API imports to senpi internals via transformVendoredSource. Only
+// packages whose senpi adaptation is FULLY captured by that mechanical transform belong here.
+const DIR_SYNCS = [{ id: "bash-timeout", packageDir: "pi-bash-timeout" }];
 
-// PACKAGES records upstream package versions in external-versions.json even when the FILES sync
-// is intentionally skipped for a package, so downstream consumers (and the
-// builtin-extension-sync test) still see the source-of-truth metadata for every vendored
-// builtin without us auto-overwriting the diverged files above.
-const PACKAGES = [
-	{ id: "bash-timeout", packageDir: "pi-bash-timeout" },
+// MANUAL_PACKAGES are vendored builtins whose senpi copy has diverged beyond the mechanical
+// import transform, so re-copying would clobber hand-maintained changes. We still record their
+// upstream version in external-versions.json (source-of-truth metadata + builtin-extension-sync
+// test) without auto-overwriting the files. Port behavior changes manually.
+//   - gpt-apply-patch (pi-apply-patch): senpi keeps a refactored multi-file layout vs the
+//     upstream single-file monolith.
+//   - todowrite (pi-todotools): senpi removed the todo continuation feature.
+//   - goal (pi-goal): senpi resolves the agent dir via config (getAgentDir) and types via
+//     ../../types.ts instead of the standalone package's local agentDir()/peer-dep imports.
+//   - websearch/webfetch/nested-agents-md/rules: vendored with transformVendoredSource, then
+//     hand-patched for senpi's erasableSyntaxOnly rule (no parameter properties) and the absence
+//     of DOM globals (HeadersInit).
+const MANUAL_PACKAGES = [
 	{ id: "gpt-apply-patch", packageDir: "pi-apply-patch" },
 	{ id: "todowrite", packageDir: "pi-todotools" },
+	{ id: "goal", packageDir: "pi-goal" },
+	{ id: "websearch", packageDir: "pi-websearch" },
+	{ id: "webfetch", packageDir: "pi-webfetch" },
+	{ id: "nested-agents-md", packageDir: "pi-nested-agents-md" },
+	{ id: "rules", packageDir: "pi-rules" },
 ];
 
 function readPackageMetadata(packageName) {
@@ -58,19 +53,20 @@ if (!existsSync(sourceRoot)) {
 	process.exit(0);
 }
 
-for (const entry of FILES) {
-	const sourcePath = join(sourceRoot, entry.source);
-	const targetPath = join(builtinRoot, entry.target);
-	if (!existsSync(sourcePath)) {
-		throw new Error(`missing source file: ${sourcePath}`);
+for (const entry of DIR_SYNCS) {
+	const srcDir = join(sourceRoot, entry.packageDir, "src");
+	if (!existsSync(srcDir)) {
+		throw new Error(`missing source dir: ${srcDir}`);
 	}
-	mkdirSync(dirname(targetPath), { recursive: true });
-	const content = readFileSync(sourcePath, "utf-8");
-	writeFileSync(targetPath, entry.transform ? entry.transform(content) : content, "utf-8");
+	for (const file of listSourceFiles(srcDir)) {
+		const target = join(builtinRoot, entry.id, relative(srcDir, file));
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileSync(target, transformVendoredSource(readFileSync(file, "utf-8"), target, builtinRoot), "utf-8");
+	}
 }
 
 const manifest = { extensions: {} };
-for (const packageEntry of PACKAGES) {
+for (const packageEntry of [...DIR_SYNCS, ...MANUAL_PACKAGES]) {
 	manifest.extensions[packageEntry.id] = readPackageMetadata(packageEntry.packageDir);
 }
 writeFileSync(join(builtinRoot, "external-versions.json"), `${JSON.stringify(manifest, null, "\t")}\n`, "utf-8");

--- a/packages/coding-agent/scripts/vendor-transform.mjs
+++ b/packages/coding-agent/scripts/vendor-transform.mjs
@@ -1,0 +1,68 @@
+// Shared transform for vendoring code-yeongyu/pi-* extension packages into senpi builtins.
+// Rewrites the standalone packages' published-API imports to senpi's in-tree equivalents:
+//   - relative imports: drop the `.js` suffix the packages publish with, use senpi's `.ts`
+//   - @mariozechner/pi-ai|pi-tui  -> @earendil-works/pi-ai|pi-tui (senpi's workspace names)
+//   - {@mariozechner,@earendil-works}/pi-coding-agent -> depth-relative core/extensions/types.ts,
+//     except `Theme`, which lives in modes/interactive/theme/theme.ts
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+function toImportSpecifier(fromDir, targetAbs) {
+	let spec = relative(fromDir, targetAbs).split("\\").join("/");
+	if (!spec.startsWith(".")) spec = `./${spec}`;
+	return spec;
+}
+
+function splitNamedImports(body) {
+	return body
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+}
+
+// builtinRoot = .../core/extensions/builtin ; targetFileAbs = absolute path of the vendored file.
+export function transformVendoredSource(content, targetFileAbs, builtinRoot) {
+	const fromDir = dirname(targetFileAbs);
+	const typesAbs = resolve(builtinRoot, "..", "types.ts");
+	const themeAbs = resolve(builtinRoot, "..", "..", "..", "modes", "interactive", "theme", "theme.ts");
+	const typesSpec = toImportSpecifier(fromDir, typesAbs);
+	const themeSpec = toImportSpecifier(fromDir, themeAbs);
+
+	let out = content;
+
+	// Relative imports: published `.js` -> senpi `.ts`.
+	out = out.replace(/(from\s+["'])(\.[^"']*?)\.js(["'])/g, "$1$2.ts$3");
+	out = out.replace(/(import\s+["'])(\.[^"']*?)\.js(["'])/g, "$1$2.ts$3");
+
+	// pi-ai / pi-tui workspace rename.
+	out = out.replace(/(["'])@mariozechner\/pi-ai(["'])/g, "$1@earendil-works/pi-ai$2");
+	out = out.replace(/(["'])@mariozechner\/pi-tui(["'])/g, "$1@earendil-works/pi-tui$2");
+
+	// pi-coding-agent: split Theme (theme module) from the rest (extensions/types.ts).
+	const codingAgentImport = /import\s+(type\s+)?\{([^}]*)\}\s+from\s+["'](?:@mariozechner|@earendil-works)\/pi-coding-agent["'];?/g;
+	out = out.replace(codingAgentImport, (_match, typeKeyword, body) => {
+		const isType = typeKeyword ? "type " : "";
+		const names = splitNamedImports(body);
+		const themeNames = names.filter((name) => name === "Theme" || name.startsWith("Theme ") || name.endsWith(" Theme"));
+		const restNames = names.filter((name) => !themeNames.includes(name));
+		const lines = [];
+		if (restNames.length > 0) lines.push(`import ${isType}{ ${restNames.join(", ")} } from "${typesSpec}";`);
+		if (themeNames.length > 0) lines.push(`import ${isType}{ ${themeNames.join(", ")} } from "${themeSpec}";`);
+		return lines.join("\n");
+	});
+
+	return out;
+}
+
+export function listSourceFiles(dir) {
+	const results = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			results.push(...listSourceFiles(full));
+		} else if (full.endsWith(".ts")) {
+			results.push(full);
+		}
+	}
+	return results;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions/builtin
 
-16 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
+20 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
 
 ## INVENTORY (registration order from `builtin/index.ts`)
 
@@ -21,7 +21,11 @@
 | 13 | `history-search` | `history-search/` | Cross-session transcript search overlay (indexes session files) |
 | 14 | `session-observer` | `session-observer/` | `/sessions` command — peek at previous session transcripts in a HUD |
 | 15 | `kimi-web-search` | `kimi-web-search/` | Kimi web search + fetch tools (gated by `PI_KIMI_WEB_SEARCH`) |
-| 16 | `goal` | `goal/` | Persistent per-thread goal tracking + continuation (budget-free file-based port of pi-goal) |
+| 16 | `websearch` | `websearch/` | Provider-backed `web_search` tool + `/websearch`; vendored from `../pi-extensions/pi-websearch` |
+| 17 | `webfetch` | `webfetch/` | `webfetch` tool (md/text/html, gated by `PI_WEBFETCH`); vendored from `../pi-extensions/pi-webfetch` |
+| 18 | `nested-agents-md` | `nested-agents-md/` | Auto-injects nearby `AGENTS.md` + `/nested-agents`; vendored from `../pi-extensions/pi-nested-agents-md` |
+| 19 | `rules` | `rules/` | Rule-file discovery + `/rules`/`/reload-rules`; vendored from `../pi-extensions/pi-rules` |
+| 20 | `goal` | `goal/` | Budget-free goal tools + `/goal`; vendored from `../pi-extensions/pi-goal` |
 
 Plus 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`).
 

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
@@ -26,7 +26,8 @@ export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 		const input = event.input as BashToolInputLike;
 		const updated = applyBashTimeout(input, defaults);
 		if (updated !== input) {
-			input.timeout = updated.timeout;
+			const timeout = updated.timeout;
+			if (timeout !== undefined) input.timeout = timeout;
 		}
 	});
 

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
@@ -16,8 +16,8 @@ function parsePositiveInt(value: string | undefined): number | undefined {
 }
 
 export function resolveBashTimeoutDefaults(env: EnvLike): BashTimeoutDefaults {
-	const defaultSeconds = parsePositiveInt(env.PI_BASH_DEFAULT_TIMEOUT_SECONDS) ?? BASH_DEFAULT_TIMEOUT_SECONDS;
-	const rawMax = parsePositiveInt(env.PI_BASH_MAX_TIMEOUT_SECONDS) ?? BASH_MAX_TIMEOUT_SECONDS;
+	const defaultSeconds = parsePositiveInt(env["PI_BASH_DEFAULT_TIMEOUT_SECONDS"]) ?? BASH_DEFAULT_TIMEOUT_SECONDS;
+	const rawMax = parsePositiveInt(env["PI_BASH_MAX_TIMEOUT_SECONDS"]) ?? BASH_MAX_TIMEOUT_SECONDS;
 	const maxSeconds = Math.max(rawMax, defaultSeconds);
 	return { defaultSeconds, maxSeconds };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/external-versions.json
+++ b/packages/coding-agent/src/core/extensions/builtin/external-versions.json
@@ -14,6 +14,31 @@
 			"packageName": "pi-todotools",
 			"version": "0.1.0",
 			"source": "../pi-extensions/pi-todotools"
+		},
+		"goal": {
+			"packageName": "pi-goal",
+			"version": "0.2.0",
+			"source": "../pi-extensions/pi-goal"
+		},
+		"websearch": {
+			"packageName": "pi-websearch",
+			"version": "0.1.0",
+			"source": "../pi-extensions/pi-websearch"
+		},
+		"webfetch": {
+			"packageName": "pi-webfetch",
+			"version": "0.1.0",
+			"source": "../pi-extensions/pi-webfetch"
+		},
+		"nested-agents-md": {
+			"packageName": "@code-yeongyu/pi-nested-agents-md",
+			"version": "0.1.0",
+			"source": "../pi-extensions/pi-nested-agents-md"
+		},
+		"rules": {
+			"packageName": "@code-yeongyu/pi-rules",
+			"version": "0.1.0",
+			"source": "../pi-extensions/pi-rules"
 		}
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -9,16 +9,20 @@ import goalExtension from "./goal/index.ts";
 import gptApplyPatchExtension from "./gpt-apply-patch/index.ts";
 import historySearchExtension from "./history-search/index.ts";
 import kimiWebSearchExtension from "./kimi-web-search/index.ts";
+import nestedAgentsMdExtension from "./nested-agents-md/index.ts";
 import openaiWebSearchExtension from "./openai-web-search/index.ts";
 import permissionSystemExtension from "./permission-system/index.ts";
 import promptPresetExtension from "./prompt-preset/index.ts";
 import promptUrlWidgetExtension from "./prompt-url-widget.ts";
 import redrawsExtension from "./redraws.ts";
+import piRulesExtension from "./rules/index.ts";
 import serviceTierExtension from "./service-tier.ts";
 import sessionObserverExtension from "./session-observer/index.ts";
 import todowriteExtension from "./todotools/index.ts";
 import toolPairGuardExtension from "./tool-pair-guard/index.ts";
 import tpsExtension from "./tps.ts";
+import webfetchExtension from "./webfetch/index.ts";
+import websearchExtension from "./websearch/index.ts";
 
 export interface BuiltinExtensionFactory {
 	id: string;
@@ -50,5 +54,9 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "history-search", factory: historySearchExtension },
 	{ id: "session-observer", factory: sessionObserverExtension },
 	{ id: "kimi-web-search", factory: kimiWebSearchExtension },
+	{ id: "websearch", factory: websearchExtension },
+	{ id: "webfetch", factory: webfetchExtension },
+	{ id: "nested-agents-md", factory: nestedAgentsMdExtension },
+	{ id: "rules", factory: piRulesExtension },
 	{ id: "goal", factory: goalExtension },
 ];

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/changes.md
@@ -1,0 +1,13 @@
+# changes.md — nested-agents-md (vendored)
+
+Vendored from [`code-yeongyu/pi-nested-agents-md`](https://github.com/code-yeongyu/pi-nested-agents-md) (see `external-versions.json`).
+
+## Senpi adaptations vs upstream
+
+- Imports rewritten by `scripts/vendor-transform.mjs`: `@earendil-works/pi-coding-agent` symbols -> `../../types.ts`; relative `.js` import suffixes -> `.ts`. (This package already used `@earendil-works/pi-*` upstream, so only the coding-agent symbols and suffixes moved.)
+- `core/errors.ts`: `InjectionFileReadError` constructor parameter property (`public readonly path`) -> explicit field + constructor assignment (senpi's root tsconfig is `erasableSyntaxOnly`; parameter properties are disallowed).
+- No behavior changes. Registers the `/nested-agents` command and injects nearby `AGENTS.md` on nested reads.
+
+## Conflict zones
+
+Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the parameter-property patch after re-running the transform, then re-check `npm run check`.

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/containment.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/containment.ts
@@ -1,0 +1,34 @@
+import { realpath } from "node:fs/promises";
+import { isAbsolute, resolve, sep } from "node:path";
+
+export interface ContainmentResult {
+	canonicalPath: string;
+	canonicalRoot: string;
+}
+
+export interface ResolveAndContainInput {
+	filePath: string;
+	rootDir: string;
+}
+
+export async function resolveAndContain(input: ResolveAndContainInput): Promise<ContainmentResult | null> {
+	if (!input.filePath) return null;
+
+	const resolvedPath = isAbsolute(input.filePath) ? input.filePath : resolve(input.rootDir, input.filePath);
+
+	let canonicalRoot: string;
+	let canonicalPath: string;
+	try {
+		canonicalRoot = await realpath(input.rootDir);
+		canonicalPath = await realpath(resolvedPath);
+	} catch {
+		return null;
+	}
+
+	if (canonicalPath === canonicalRoot) return null;
+
+	const rootBoundary = canonicalRoot.endsWith(sep) ? canonicalRoot : canonicalRoot + sep;
+	if (!canonicalPath.startsWith(rootBoundary)) return null;
+
+	return { canonicalPath, canonicalRoot };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/errors.ts
@@ -1,0 +1,10 @@
+export class InjectionFileReadError extends Error {
+	readonly path: string;
+
+	constructor(path: string, cause: unknown) {
+		const message = cause instanceof Error ? cause.message : String(cause);
+		super(`Failed to read ${path}: ${message}`);
+		this.name = "InjectionFileReadError";
+		this.path = path;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/find-agents-md-up.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/find-agents-md-up.ts
@@ -1,0 +1,50 @@
+import { constants, promises as fsPromises } from "node:fs";
+import { dirname, isAbsolute, join, relative } from "node:path";
+import { DEFAULT_FILE_NAMES } from "./types.ts";
+
+export interface FindAgentsMdUpInput {
+	startDir: string;
+	rootDir: string;
+	fileNames?: readonly string[];
+}
+
+export async function findAgentsMdUp(input: FindAgentsMdUpInput): Promise<string[]> {
+	const fileNames = input.fileNames ?? DEFAULT_FILE_NAMES;
+	const collected: string[] = [];
+	let current = input.startDir;
+
+	while (true) {
+		const isRoot = current === input.rootDir;
+		if (!isRoot) {
+			for (const name of fileNames) {
+				const candidate = join(current, name);
+				const exists = await fileExists(candidate);
+				if (exists) {
+					collected.push(candidate);
+					break;
+				}
+			}
+		}
+		if (isRoot) break;
+		const parent = dirname(current);
+		if (parent === current) break;
+		if (!isWithinRoot(input.rootDir, parent)) break;
+		current = parent;
+	}
+
+	return collected.reverse();
+}
+
+function isWithinRoot(rootDir: string, candidate: string): boolean {
+	const relativePath = relative(rootDir, candidate);
+	return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		await fsPromises.access(path, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/format.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/format.ts
@@ -1,0 +1,12 @@
+export interface FormatDirectoryContextInput {
+	absolutePath: string;
+	content: string;
+	truncated: boolean;
+}
+
+export function formatDirectoryContext(input: FormatDirectoryContextInput): string {
+	const notice = input.truncated
+		? `\n\n[Note: Content was truncated to save context window space. For full context, please read the file directly: ${input.absolutePath}]`
+		: "";
+	return `\n\n[Directory Context: ${input.absolutePath}]\n${input.content}${notice}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/inject-directory-context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/inject-directory-context.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { resolveAndContain } from "./containment.ts";
+import { InjectionFileReadError } from "./errors.ts";
+import { findAgentsMdUp } from "./find-agents-md-up.ts";
+import { formatDirectoryContext } from "./format.ts";
+import type { InjectionCache } from "./injection-cache.ts";
+import { truncateBytes } from "./truncate.ts";
+import {
+	DEFAULT_FILE_NAMES,
+	DEFAULT_MAX_BYTES_PER_FILE,
+	DEFAULT_MAX_BYTES_PER_READ,
+	type InjectedFileInfo,
+	type InjectionConfig,
+	type InjectionFileError,
+	type InjectionResult,
+} from "./types.ts";
+
+export interface InjectDirectoryContextInput {
+	filePath: string;
+	rootDir: string;
+	cache: InjectionCache;
+	sessionKey: string;
+	config?: Partial<InjectionConfig>;
+}
+
+const EMPTY_RESULT: InjectionResult = Object.freeze({
+	injectedText: "",
+	injectedFiles: [],
+	errors: [],
+} satisfies InjectionResult);
+
+export async function injectDirectoryContext(input: InjectDirectoryContextInput): Promise<InjectionResult> {
+	const config = resolveConfig(input.config);
+
+	const contained = await resolveAndContain({
+		filePath: input.filePath,
+		rootDir: input.rootDir,
+	});
+	if (!contained) return cloneEmpty();
+
+	const candidates = await findAgentsMdUp({
+		startDir: dirname(contained.canonicalPath),
+		rootDir: contained.canonicalRoot,
+		fileNames: config.fileNames,
+	});
+
+	const injectedFiles: InjectedFileInfo[] = [];
+	const errors: InjectionFileError[] = [];
+	let injectedText = "";
+	let bytesBudget = config.maxBytesPerRead;
+
+	for (const agentsPath of candidates) {
+		const agentsDir = dirname(agentsPath);
+		if (input.cache.hasInjected(input.sessionKey, agentsDir)) continue;
+		if (bytesBudget <= 0) break;
+
+		let content: string;
+		try {
+			content = await readFile(agentsPath, "utf-8");
+		} catch (error) {
+			errors.push({
+				path: agentsPath,
+				error: new InjectionFileReadError(agentsPath, error),
+			});
+			continue;
+		}
+
+		const perFileCap = Math.min(config.maxBytesPerFile, bytesBudget);
+		const truncated = truncateBytes(content, perFileCap);
+
+		injectedFiles.push({
+			absolutePath: agentsPath,
+			directory: agentsDir,
+			truncated: truncated.truncated,
+			originalBytes: truncated.originalBytes,
+			injectedBytes: truncated.resultBytes,
+		});
+
+		injectedText += formatDirectoryContext({
+			absolutePath: agentsPath,
+			content: truncated.result,
+			truncated: truncated.truncated,
+		});
+
+		input.cache.markInjected(input.sessionKey, agentsDir);
+		bytesBudget -= truncated.resultBytes;
+	}
+
+	return { injectedText, injectedFiles, errors };
+}
+
+function resolveConfig(partial: Partial<InjectionConfig> | undefined): InjectionConfig {
+	return {
+		fileNames: partial?.fileNames ?? DEFAULT_FILE_NAMES,
+		maxBytesPerFile: partial?.maxBytesPerFile ?? DEFAULT_MAX_BYTES_PER_FILE,
+		maxBytesPerRead: partial?.maxBytesPerRead ?? DEFAULT_MAX_BYTES_PER_READ,
+	};
+}
+
+function cloneEmpty(): InjectionResult {
+	return { injectedText: EMPTY_RESULT.injectedText, injectedFiles: [], errors: [] };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/injection-cache.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/injection-cache.ts
@@ -1,0 +1,37 @@
+export class InjectionCache {
+	private readonly sessions = new Map<string, Set<string>>();
+
+	private getOrCreate(sessionKey: string): Set<string> {
+		let set = this.sessions.get(sessionKey);
+		if (!set) {
+			set = new Set<string>();
+			this.sessions.set(sessionKey, set);
+		}
+		return set;
+	}
+
+	hasInjected(sessionKey: string, canonicalDir: string): boolean {
+		return this.sessions.get(sessionKey)?.has(canonicalDir) ?? false;
+	}
+
+	markInjected(sessionKey: string, canonicalDir: string): void {
+		this.getOrCreate(sessionKey).add(canonicalDir);
+	}
+
+	getCacheSize(sessionKey: string): number {
+		return this.sessions.get(sessionKey)?.size ?? 0;
+	}
+
+	listInjected(sessionKey: string): string[] {
+		const set = this.sessions.get(sessionKey);
+		return set ? Array.from(set) : [];
+	}
+
+	clearSession(sessionKey: string): void {
+		this.sessions.delete(sessionKey);
+	}
+
+	clearAll(): void {
+		this.sessions.clear();
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/session-key.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/session-key.ts
@@ -1,0 +1,13 @@
+export interface SessionKeyContext {
+	sessionManager?: {
+		getSessionFile?(): string | null | undefined;
+	};
+}
+
+export const SINGLETON_SESSION_KEY = "__pi_nested_agents_md_singleton__";
+
+export function getSessionKey(ctx: SessionKeyContext): string {
+	const file = ctx.sessionManager?.getSessionFile?.();
+	if (typeof file === "string" && file.length > 0) return file;
+	return SINGLETON_SESSION_KEY;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/truncate.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/truncate.ts
@@ -1,0 +1,35 @@
+const REPLACEMENT_CHAR = "\uFFFD";
+const TEXT_ENCODER = new TextEncoder();
+
+export interface TruncationResult {
+	result: string;
+	truncated: boolean;
+	originalBytes: number;
+	resultBytes: number;
+}
+
+export function truncateBytes(content: string, maxBytes: number): TruncationResult {
+	const bytes = TEXT_ENCODER.encode(content);
+	if (bytes.byteLength <= maxBytes) {
+		return {
+			result: content,
+			truncated: false,
+			originalBytes: bytes.byteLength,
+			resultBytes: bytes.byteLength,
+		};
+	}
+
+	const decoder = new TextDecoder("utf-8", { fatal: false });
+	let decoded = decoder.decode(bytes.subarray(0, maxBytes));
+	while (decoded.endsWith(REPLACEMENT_CHAR)) {
+		decoded = decoded.slice(0, -1);
+	}
+
+	const finalBytes = TEXT_ENCODER.encode(decoded).byteLength;
+	return {
+		result: decoded,
+		truncated: true,
+		originalBytes: bytes.byteLength,
+		resultBytes: finalBytes,
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/core/types.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_FILE_NAMES = ["AGENTS.md"] as const;
+export const DEFAULT_MAX_BYTES_PER_FILE = 32 * 1024;
+export const DEFAULT_MAX_BYTES_PER_READ = 128 * 1024;
+
+export interface InjectedFileInfo {
+	absolutePath: string;
+	directory: string;
+	truncated: boolean;
+	originalBytes: number;
+	injectedBytes: number;
+}
+
+export interface InjectionFileError {
+	path: string;
+	error: Error;
+}
+
+export interface InjectionResult {
+	injectedText: string;
+	injectedFiles: InjectedFileInfo[];
+	errors: InjectionFileError[];
+}
+
+export interface InjectionConfig {
+	fileNames: readonly string[];
+	maxBytesPerFile: number;
+	maxBytesPerRead: number;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/index.ts
@@ -1,0 +1,120 @@
+import type { TextContent } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "../../types.ts";
+import { isReadToolResult } from "../../types.ts";
+import { injectDirectoryContext } from "./core/inject-directory-context.ts";
+import { InjectionCache } from "./core/injection-cache.ts";
+import { getSessionKey } from "./core/session-key.ts";
+import {
+	buildDebugRecord,
+	clearStatus,
+	clearWidget,
+	type InjectedFileMeta,
+	updateStatus,
+	updateWidget,
+} from "./ui/reporter.ts";
+
+const FLAG_DISABLE = "no-nested-agents";
+const COMMAND_TOGGLE = "nested-agents";
+const ENTRY_TYPE_DEBUG = "nested-agents-md:debug";
+
+export default function nestedAgentsMd(pi: ExtensionAPI): void {
+	pi.registerFlag(FLAG_DISABLE, {
+		description: "Disable nested AGENTS.md context injection.",
+		type: "boolean",
+		default: false,
+	});
+
+	const cache = new InjectionCache();
+	const filesPerSession = new Map<string, Map<string, InjectedFileMeta>>();
+	const errorsPerSession = new Map<string, boolean>();
+	// Widget visibility is extension-scoped because command registration currently has no session-local state hook.
+	let widgetVisible = false;
+	let disabled = false;
+
+	pi.on("session_start", async (_event, ctx) => {
+		disabled = pi.getFlag(FLAG_DISABLE) === true;
+		if (disabled) {
+			clearStatus(ctx);
+			clearWidget(ctx);
+		}
+	});
+
+	pi.on("tool_result", async (event, ctx) => {
+		if (disabled) return undefined;
+		if (!isReadToolResult(event) || event.isError) return undefined;
+		const filePath = event.input["path"];
+		if (typeof filePath !== "string" || filePath.length === 0) return undefined;
+		const hasText = event.content.some((block) => block.type === "text");
+		if (!hasText) return undefined;
+
+		const sessionKey = getSessionKey(ctx);
+		const result = await injectDirectoryContext({
+			filePath,
+			rootDir: ctx.cwd,
+			cache,
+			sessionKey,
+		});
+
+		const errorsRecorded = errorsPerSession.get(sessionKey) === true;
+		const hasErrors = errorsRecorded || result.errors.length > 0;
+		if (result.errors.length > 0) errorsPerSession.set(sessionKey, true);
+
+		if (!result.injectedText) {
+			updateStatus(ctx, cache, sessionKey, hasErrors);
+			return undefined;
+		}
+
+		let metaMap = filesPerSession.get(sessionKey);
+		if (!metaMap) {
+			metaMap = new Map();
+			filesPerSession.set(sessionKey, metaMap);
+		}
+		for (const file of result.injectedFiles) {
+			metaMap.set(file.absolutePath, {
+				absolutePath: file.absolutePath,
+				truncated: file.truncated,
+			});
+		}
+
+		updateStatus(ctx, cache, sessionKey, hasErrors);
+		if (widgetVisible) updateWidget(ctx, true, [...metaMap.values()]);
+
+		const textBlock: TextContent = { type: "text", text: result.injectedText };
+		return { content: [...event.content, textBlock] };
+	});
+
+	pi.on("session_compact", async (_event, ctx) => {
+		const sessionKey = getSessionKey(ctx);
+		cache.clearSession(sessionKey);
+		filesPerSession.delete(sessionKey);
+		errorsPerSession.delete(sessionKey);
+		updateStatus(ctx, cache, sessionKey, false);
+		if (widgetVisible) updateWidget(ctx, true, []);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		const sessionKey = getSessionKey(ctx);
+		cache.clearSession(sessionKey);
+		filesPerSession.delete(sessionKey);
+		errorsPerSession.delete(sessionKey);
+	});
+
+	pi.registerCommand(COMMAND_TOGGLE, {
+		description: "Toggle the nested AGENTS.md context widget and dump cache state.",
+		handler: async (_args, ctx) => {
+			if (disabled) {
+				ctx.ui.notify("nested-agents-md is disabled via --no-nested-agents", "info");
+				return;
+			}
+			widgetVisible = !widgetVisible;
+			const sessionKey = getSessionKey(ctx);
+			const files = [...(filesPerSession.get(sessionKey)?.values() ?? [])];
+			updateWidget(ctx, widgetVisible, files);
+			pi.appendEntry(ENTRY_TYPE_DEBUG, buildDebugRecord({ cache, sessionKey, files }));
+			ctx.ui.notify(
+				widgetVisible ? "Nested AGENTS.md context widget shown" : "Nested AGENTS.md context widget hidden",
+				"info",
+			);
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/ui/reporter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/ui/reporter.ts
@@ -1,0 +1,95 @@
+import { isAbsolute, relative } from "node:path";
+import type { InjectionCache } from "../core/injection-cache.ts";
+
+export const STATUS_KEY = "ext:nested-agents:status";
+export const WIDGET_KEY = "ext:nested-agents:widget";
+
+export interface ThemeFn {
+	fg(color: string, text: string): string;
+}
+
+export interface UiSurface {
+	hasUI: boolean;
+	cwd: string;
+	ui?: {
+		theme?: ThemeFn;
+		setStatus?(key: string, text: string | undefined): void;
+		setWidget?(
+			key: string,
+			lines: string[] | undefined,
+			options?: { placement?: "aboveEditor" | "belowEditor" },
+		): void;
+		notify?(message: string, level?: "info" | "warn" | "warning" | "error"): void;
+	};
+}
+
+export interface InjectedFileMeta {
+	absolutePath: string;
+	truncated: boolean;
+}
+
+export function updateStatus(ctx: UiSurface, cache: InjectionCache, sessionKey: string, hasErrors: boolean): void {
+	if (!ctx.hasUI || !ctx.ui?.setStatus) return;
+	const count = cache.getCacheSize(sessionKey);
+	if (count === 0) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		return;
+	}
+	const theme = ctx.ui.theme ?? identityTheme;
+	let text = theme.fg("dim", `🤖 ${count}`);
+	if (hasErrors) text += theme.fg("warning", " ⚠️");
+	ctx.ui.setStatus(STATUS_KEY, text);
+}
+
+export function clearStatus(ctx: UiSurface): void {
+	if (!ctx.hasUI || !ctx.ui?.setStatus) return;
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+}
+
+export function updateWidget(ctx: UiSurface, visible: boolean, files: InjectedFileMeta[]): void {
+	if (!ctx.hasUI || !ctx.ui?.setWidget) return;
+	if (!visible || files.length === 0) {
+		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		return;
+	}
+	const theme = ctx.ui.theme ?? identityTheme;
+	const lines = [theme.fg("accent", "Nested Context:")];
+	for (const file of files) {
+		const display = displayPath(ctx.cwd, file.absolutePath);
+		const text = file.truncated ? `  ${display} (truncated)` : `  ${display}`;
+		lines.push(theme.fg(file.truncated ? "warning" : "dim", text));
+	}
+	ctx.ui.setWidget(WIDGET_KEY, lines, { placement: "aboveEditor" });
+}
+
+export function clearWidget(ctx: UiSurface): void {
+	if (!ctx.hasUI || !ctx.ui?.setWidget) return;
+	ctx.ui.setWidget(WIDGET_KEY, undefined);
+}
+
+export function buildDebugRecord(input: {
+	cache: InjectionCache;
+	sessionKey: string;
+	files: InjectedFileMeta[];
+}): Record<string, unknown> {
+	return {
+		sessionKey: input.sessionKey,
+		cacheSize: input.cache.getCacheSize(input.sessionKey),
+		injectedDirectories: input.cache.listInjected(input.sessionKey),
+		injectedFiles: input.files.map((f) => ({
+			path: f.absolutePath,
+			truncated: f.truncated,
+		})),
+	};
+}
+
+function displayPath(cwd: string, absolutePath: string): string {
+	if (!isAbsolute(absolutePath)) return absolutePath;
+	const rel = relative(cwd, absolutePath);
+	if (rel === "" || rel === ".." || rel.startsWith("../") || isAbsolute(rel)) return absolutePath;
+	return rel;
+}
+
+const identityTheme: ThemeFn = {
+	fg: (_color: string, text: string) => text,
+};

--- a/packages/coding-agent/src/core/extensions/builtin/rules/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/changes.md
@@ -1,0 +1,14 @@
+# changes.md — rules (vendored)
+
+Vendored from [`code-yeongyu/pi-rules`](https://github.com/code-yeongyu/pi-rules) (see `external-versions.json`).
+
+## Senpi adaptations vs upstream
+
+- Imports rewritten by `scripts/vendor-transform.mjs`: `@mariozechner/pi-tui` -> `@earendil-works/pi-tui`; `@mariozechner/pi-coding-agent` symbols -> `../../types.ts` (and `Theme` -> `modes/interactive/theme/theme.ts`); relative `.js` import suffixes -> `.ts`.
+- `ui/dynamic-border.ts` and `ui/rules-banner.ts`: constructor parameter properties (`private readonly …`) -> explicit fields + constructor assignment (senpi's root tsconfig is `erasableSyntaxOnly`; parameter properties are disallowed).
+- Runtime dep `picomatch` (+ `@types/picomatch`) added to `package.json`.
+- No behavior changes. Registers `/rules` and `/reload-rules` and discovers rule files from `.sisyphus/rules`, `.claude/rules`, `.cursor/rules`, `.github/instructions`, `AGENTS.md`, `CLAUDE.md`.
+
+## Conflict zones
+
+Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the parameter-property patches after re-running the transform, then re-check `npm run check`.

--- a/packages/coding-agent/src/core/extensions/builtin/rules/commands.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/commands.ts
@@ -1,0 +1,111 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "../../types.ts";
+
+import type { Engine } from "./rules/engine.ts";
+import type { LoadedRule, MatchReason, RuleDiagnostic } from "./rules/types.ts";
+
+const RULE_SUBCOMMANDS = ["list", "show", "paths", "status"] as const;
+
+export function registerSlashCommands(pi: ExtensionAPI, engine: Engine): void {
+	pi.registerCommand("rules", {
+		description: "Inspect loaded pi-rules.",
+		getArgumentCompletions: (prefix) => {
+			const completions = RULE_SUBCOMMANDS.filter((subcommand) => subcommand.startsWith(prefix)).map(
+				(subcommand) => ({
+					value: subcommand,
+					label: subcommand,
+				}),
+			);
+			return completions.length > 0 ? completions : null;
+		},
+		handler: async (args, ctx) => {
+			const tokens = args.trim().length === 0 ? [] : args.trim().split(/\s+/);
+			const subcommand = tokens[0] ?? "";
+			const loaded = engine.loadStaticRules(ctx.cwd);
+
+			if (subcommand === "" || subcommand === "status") {
+				notify(ctx, buildSummaryText(loaded.rules, loaded.diagnostics));
+				return;
+			}
+
+			if (subcommand === "list") {
+				notify(ctx, formatRuleList(loaded.rules));
+				return;
+			}
+
+			if (subcommand === "show") {
+				const id = tokens[1] ?? "";
+				const rule = findRuleById(loaded.rules, id);
+				if (rule === null) {
+					notify(ctx, `Rule not found: ${id}`, "error");
+					return;
+				}
+
+				notify(ctx, rule.body);
+				return;
+			}
+
+			if (subcommand === "paths") {
+				notify(ctx, loaded.rules.map((rule) => rule.path).join("\n"));
+				return;
+			}
+
+			notify(ctx, `Unknown /rules subcommand: ${subcommand}`, "error");
+		},
+	});
+
+	pi.registerCommand("reload-rules", {
+		description: "Reload pi-rules for the current session.",
+		handler: async (_args, ctx) => {
+			engine.resetSession(ctx.cwd);
+			const loaded = engine.loadStaticRules(ctx.cwd);
+			notify(ctx, buildReloadText(loaded.rules, loaded.diagnostics));
+		},
+	});
+}
+
+function notify(ctx: ExtensionCommandContext, message: string, severity: "info" | "warning" | "error" = "info"): void {
+	ctx.ui.notify(message, severity);
+}
+
+function buildSummaryText(rules: ReadonlyArray<LoadedRule>, diagnostics: ReadonlyArray<RuleDiagnostic>): string {
+	return appendDiagnostics(`pi-rules: ${rules.length} rules from ${countSources(rules)} sources`, diagnostics);
+}
+
+function buildReloadText(rules: ReadonlyArray<LoadedRule>, diagnostics: ReadonlyArray<RuleDiagnostic>): string {
+	return appendDiagnostics(`Reloaded ${rules.length} rules from ${countSources(rules)} sources`, diagnostics);
+}
+
+function appendDiagnostics(text: string, diagnostics: ReadonlyArray<RuleDiagnostic>): string {
+	return diagnostics.length === 0 ? text : `${text}, ${diagnostics.length} diagnostics`;
+}
+
+function countSources(rules: ReadonlyArray<LoadedRule>): number {
+	return new Set(rules.map((rule) => rule.source)).size;
+}
+
+function formatRuleList(rules: ReadonlyArray<LoadedRule>): string {
+	return rules
+		.map((rule) => `${rule.relativePath} [${rule.source}, ${formatMatchReason(rule.matchReason)}]`)
+		.join("\n");
+}
+
+function formatMatchReason(matchReason: MatchReason): string {
+	if (typeof matchReason === "string") {
+		return matchReason;
+	}
+	if (matchReason.kind === "no-match") {
+		return matchReason.kind;
+	}
+
+	return `${matchReason.kind}:${matchReason.pattern}`;
+}
+
+function findRuleById(rules: ReadonlyArray<LoadedRule>, id: string): LoadedRule | null {
+	const exactMatch = rules.find((rule) => rule.relativePath === id);
+	if (exactMatch !== undefined) {
+		return exactMatch;
+	}
+
+	const suffixMatches = rules.filter((rule) => rule.relativePath.endsWith(id));
+	return suffixMatches.length === 1 ? (suffixMatches[0] ?? null) : null;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
@@ -1,0 +1,161 @@
+import { readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, relative } from "node:path";
+
+import type { ExtensionAPI } from "../../types.ts";
+
+import { registerSlashCommands } from "./commands.ts";
+import { createEngine, defaultConfig } from "./rules/engine.ts";
+import { findRuleCandidates } from "./rules/finder.ts";
+import { findProjectRoot } from "./rules/project-root.ts";
+import { extractToolPaths } from "./rules/tool-paths.ts";
+import type { PiRulesConfig } from "./rules/types.ts";
+
+type PiRulesMode = PiRulesConfig["mode"];
+
+const MODE_VALUES = new Set<string>(["static", "dynamic", "both", "off"]);
+
+export default function piRulesExtension(pi: ExtensionAPI): void {
+	pi.registerFlag("pi-rules-disabled", {
+		type: "boolean",
+		default: false,
+		description: "Disable pi-rules hooks.",
+	});
+	pi.registerFlag("pi-rules-mode", {
+		type: "string",
+		default: "both",
+		description: "Rule injection mode: static, dynamic, both, or off.",
+	});
+	const config = defaultConfig();
+	const engine = createEngine(config, {
+		findCandidates: findRuleCandidates,
+		readFile: (path) => {
+			try {
+				return readFileSync(path, "utf-8");
+			} catch {
+				return null;
+			}
+		},
+		findProjectRoot,
+		extractToolPaths,
+	});
+	registerSlashCommands(pi, engine);
+
+	function syncConfigFromFlags(): void {
+		const disabled = pi.getFlag("pi-rules-disabled");
+		const mode = pi.getFlag("pi-rules-mode");
+
+		if (typeof disabled === "boolean") {
+			engine.config.disabled = disabled;
+		}
+		if (typeof mode === "string" && isPiRulesMode(mode)) {
+			engine.config.mode = mode;
+		}
+	}
+
+	pi.on("session_start", async (event, ctx) => {
+		syncConfigFromFlags();
+		if (engine.config.disabled) {
+			return undefined;
+		}
+
+		engine.resetSession(ctx.cwd);
+		pi.appendEntry("pi-rules.scan", { cwd: ctx.cwd, reason: event.reason });
+		return undefined;
+	});
+
+	pi.on("session_compact", async (_event, ctx) => {
+		engine.resetSession(ctx.cwd);
+		pi.appendEntry("pi-rules.scan", { cwd: ctx.cwd, reason: "compact" });
+		return undefined;
+	});
+
+	pi.on("before_agent_start", async (event, ctx) => {
+		syncConfigFromFlags();
+		if (engine.config.disabled || engine.config.mode === "off" || engine.config.mode === "dynamic") {
+			return undefined;
+		}
+
+		const loaded = engine.loadStaticRules(ctx.cwd);
+		const nativeContextPaths = new Set(
+			event.systemPromptOptions.contextFiles?.flatMap((contextFile) => pathKeys(contextFile.path)) ?? [],
+		);
+		for (const rule of loaded.rules) {
+			if (nativeContextPaths.has(rule.path) || nativeContextPaths.has(rule.realPath)) {
+				engine.markStaticInjected(rule);
+			}
+		}
+		const rules = loaded.rules.filter(
+			(rule) =>
+				!nativeContextPaths.has(rule.path) &&
+				!nativeContextPaths.has(rule.realPath) &&
+				!engine.isStaticInjected(rule),
+		);
+
+		if (rules.length === 0) {
+			return undefined;
+		}
+
+		const block = engine.formatStatic(rules);
+		for (const rule of rules) {
+			engine.markStaticInjected(rule);
+		}
+
+		return { systemPrompt: event.systemPrompt + block };
+	});
+
+	pi.on("tool_result", async (event, ctx) => {
+		syncConfigFromFlags();
+		if (engine.config.disabled || engine.config.mode === "off" || engine.config.mode === "static" || event.isError) {
+			return undefined;
+		}
+
+		const targetPaths = extractToolPaths(event, ctx.cwd);
+		const firstTargetPath = targetPaths[0];
+		if (firstTargetPath === undefined) {
+			return undefined;
+		}
+
+		const fingerprints = engine.fingerprintDynamicTargets(ctx.cwd, targetPaths);
+		const pendingFingerprints = fingerprints.filter((target) => !engine.isDynamicTargetFingerprintCurrent(target));
+		if (pendingFingerprints.length === 0) {
+			engine.commitDynamicTargetFingerprints(fingerprints);
+			return undefined;
+		}
+
+		const loaded = engine.loadDynamicRules(
+			ctx.cwd,
+			pendingFingerprints.map((target) => target.targetPath),
+		);
+		engine.commitDynamicTargetFingerprints(fingerprints);
+		const rules = loaded.rules.filter(
+			(rule) => !engine.isStaticInjected(rule) && !engine.isDynamicInjected(firstTargetPath, rule),
+		);
+		if (rules.length === 0) {
+			return undefined;
+		}
+
+		const firstPendingTarget = pendingFingerprints[0]?.targetPath ?? firstTargetPath;
+		const block = engine.formatDynamic(rules, displayPath(ctx.cwd, firstPendingTarget));
+		for (const rule of rules) {
+			engine.markDynamicInjected(firstTargetPath, rule);
+		}
+
+		return { content: [...event.content, { type: "text", text: block }] };
+	});
+}
+
+function isPiRulesMode(value: string): value is PiRulesMode {
+	return MODE_VALUES.has(value);
+}
+
+function pathKeys(filePath: string): string[] {
+	try {
+		return [filePath, realpathSync.native(filePath)];
+	} catch {
+		return [filePath];
+	}
+}
+
+function displayPath(cwd: string, filePath: string): string {
+	return isAbsolute(filePath) ? relative(cwd, filePath) : filePath;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/cache.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/cache.ts
@@ -1,0 +1,62 @@
+import type { LoadedRule, SessionState } from "./types.ts";
+
+export function createSessionState(cwd?: string): SessionState {
+	return {
+		cwd,
+		staticDedup: new Set(),
+		dynamicDedup: new Map(),
+		dynamicTargetFingerprints: new Map(),
+		loadedRules: [],
+		diagnostics: [],
+	};
+}
+
+export function staticDedupKey(cwd: string, rulePath: string, contentHash: string): string {
+	return `${cwd}::${rulePath}::${contentHash}`;
+}
+
+export function dynamicDedupKey(scopeKey: string, rulePath: string, contentHash: string): string {
+	return `${scopeKey}::${rulePath}::${contentHash}`;
+}
+
+export function markStaticInjected(state: SessionState, rule: LoadedRule): boolean {
+	const key = staticDedupKey(state.cwd ?? "", rule.realPath, rule.contentHash);
+	if (state.staticDedup.has(key)) {
+		return false;
+	}
+
+	state.staticDedup.add(key);
+	return true;
+}
+
+export function markDynamicInjected(state: SessionState, scopeKey: string, rule: LoadedRule): boolean {
+	let keys = state.dynamicDedup.get(scopeKey);
+	if (keys === undefined) {
+		keys = new Set();
+		state.dynamicDedup.set(scopeKey, keys);
+	}
+
+	const key = dynamicDedupKey(scopeKey, rule.realPath, rule.contentHash);
+	if (keys.has(key)) {
+		return false;
+	}
+
+	keys.add(key);
+	return true;
+}
+
+export function isStaticInjected(state: SessionState, rule: LoadedRule): boolean {
+	return state.staticDedup.has(staticDedupKey(state.cwd ?? "", rule.realPath, rule.contentHash));
+}
+
+export function isDynamicInjected(state: SessionState, scopeKey: string, rule: LoadedRule): boolean {
+	return state.dynamicDedup.get(scopeKey)?.has(dynamicDedupKey(scopeKey, rule.realPath, rule.contentHash)) === true;
+}
+
+export function clearSession(state: SessionState): void {
+	state.staticDedup.clear();
+	state.dynamicDedup.clear();
+	state.dynamicTargetFingerprints.clear();
+	state.loadedRules.length = 0;
+	state.diagnostics.length = 0;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/constants.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/constants.ts
@@ -1,0 +1,109 @@
+import type { RuleSource } from "./types.ts";
+
+/**
+ * Project root marker files / directories used by `findProjectRoot`.
+ * Walks UP from cwd until any of these is found in the directory.
+ */
+export const PROJECT_MARKERS: readonly string[] = [
+	".git",
+	"pnpm-workspace.yaml",
+	"package.json",
+	"pyproject.toml",
+	"Cargo.toml",
+	"go.mod",
+	".venv",
+];
+
+/**
+ * Project rule subdirectories. First tuple element is the parent dir under
+ * the project root, second is the subdir scanned recursively.
+ */
+export const PROJECT_RULE_SUBDIRS: ReadonlyArray<readonly [string, string]> = [
+	[".omo", "rules"],
+	[".claude", "rules"],
+	[".cursor", "rules"],
+	[".github", "instructions"],
+];
+
+/**
+ * Single-file project rules (always apply, frontmatter optional).
+ */
+export const PROJECT_SINGLE_FILES: readonly string[] = [
+	".github/copilot-instructions.md",
+	"AGENTS.md",
+	"CLAUDE.md",
+	"CONTEXT.md",
+];
+
+/**
+ * User-home rule directories.
+ */
+export const USER_HOME_RULE_SUBDIRS: readonly string[] = [".omo/rules", ".opencode/rules", ".claude/rules"];
+
+/**
+ * User-home single-file rules. The first one to exist wins per "first-match" semantics.
+ */
+export const USER_HOME_SINGLE_FILES: readonly string[] = [".config/opencode/AGENTS.md", ".claude/CLAUDE.md"];
+
+/**
+ * File extensions accepted as rule files in scanned directories.
+ */
+export const RULE_FILE_EXTENSIONS: readonly string[] = [".md", ".mdc"];
+
+/**
+ * Per-rule source priority for deterministic ordering. Lower = earlier.
+ */
+export const SOURCE_PRIORITY: ReadonlyMap<RuleSource, number> = new Map([
+	[".omo/rules", 0],
+	[".claude/rules", 1],
+	[".cursor/rules", 2],
+	[".github/instructions", 3],
+	[".github/copilot-instructions.md", 4],
+	["AGENTS.md", 5],
+	["CLAUDE.md", 6],
+	["CONTEXT.md", 7],
+	["~/.omo/rules", 100],
+	["~/.opencode/rules", 101],
+	["~/.claude/rules", 102],
+	["~/.config/opencode/AGENTS.md", 103],
+	["~/.claude/CLAUDE.md", 104],
+]);
+
+/**
+ * Distance value assigned to global / user-home rules.
+ */
+export const GLOBAL_DISTANCE = 9999;
+
+/**
+ * Per-rule body character cap (default).
+ */
+export const DEFAULT_MAX_RULE_CHARS = 12000;
+
+/**
+ * Total injected chars per tool result (default).
+ */
+export const DEFAULT_MAX_RESULT_CHARS = 40000;
+
+/**
+ * Truncation marker template. `{path}` is replaced with the relative path.
+ */
+export const TRUNCATION_NOTICE = "\n\n[Rule truncated. Read full rule: {path}]";
+
+/**
+ * Built-in tool names whose results trigger dynamic rule injection.
+ */
+export const TRACKED_BUILTIN_TOOLS: readonly string[] = ["read", "edit", "write"];
+export const TRACKED_BUILTIN_TOOL_SET: ReadonlySet<string> = new Set(TRACKED_BUILTIN_TOOLS);
+
+/**
+ * Directories excluded by the recursive scanner regardless of glob settings.
+ */
+export const SCANNER_EXCLUDED_DIRS: readonly string[] = [
+	"node_modules",
+	".git",
+	"dist",
+	"build",
+	".turbo",
+	".next",
+	"coverage",
+];

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/engine.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/engine.ts
@@ -1,0 +1,682 @@
+import { realpathSync, statSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+import type { ToolResultEvent } from "../../../types.ts";
+
+import {
+	clearSession,
+	createSessionState,
+	isDynamicInjected as isDynamicInjectedInState,
+	isStaticInjected as isStaticInjectedInState,
+	markDynamicInjected as markDynamicInjectedInState,
+	markStaticInjected as markStaticInjectedInState,
+} from "./cache.ts";
+import {
+	DEFAULT_MAX_RESULT_CHARS,
+	DEFAULT_MAX_RULE_CHARS,
+	PROJECT_SINGLE_FILES,
+	SOURCE_PRIORITY,
+} from "./constants.ts";
+import { createRuleDiscoveryCache, type RuleDiscoveryCache } from "./finder.ts";
+import { formatDynamicBlock, formatStaticBlock } from "./formatter.ts";
+import { hashContent, matchRule } from "./matcher.ts";
+import { sortCandidates } from "./ordering.ts";
+import { parseRule } from "./parser.ts";
+import type { LoadedRule, MatchReason, PiRulesConfig, RuleCandidate, RuleDiagnostic, SessionState } from "./types.ts";
+
+interface LoadedRuleContent {
+	frontmatter: LoadedRule["frontmatter"];
+	body: string;
+	contentHash: string;
+	diagnostic?: string;
+}
+
+interface LoadCandidateCaches {
+	readonly loadedRuleContent?: Map<string, LoadedRuleContent | null>;
+	readonly projectMembership?: CandidateProjectMembership;
+	readonly realPathCache?: RealPathCache;
+}
+
+type CandidateProjectMembership = Map<string, boolean>;
+type CandidateDiscoveryCache = Map<string, RuleCandidate[]>;
+type DynamicMatchCache = Map<string, MatchReason | null>;
+type RealPathCache = Map<string, string>;
+
+const MAX_DYNAMIC_MATCH_CACHE_ENTRIES = 4096;
+
+export interface EngineDeps {
+	findCandidates: (options: {
+		projectRoot: string | null;
+		targetFile: string | null;
+		homeDir?: string;
+		disabledSources?: ReadonlySet<string>;
+		skipUserHome?: boolean;
+		cache?: RuleDiscoveryCache;
+	}) => RuleCandidate[];
+	readFile: (path: string) => string | null;
+	findProjectRoot: (startPath: string) => string | null;
+	extractToolPaths: (event: ToolResultEvent, cwd: string) => string[];
+	matchRule?: typeof matchRule;
+	/**
+	 * Returns a stable identifier for a rule file. Default uses `statSync` mtime/ctime/size.
+	 * Tests may inject a content-based fingerprint when fixtures use synthetic paths.
+	 */
+	fileFingerprint?: (filePath: string) => string;
+}
+
+export interface DynamicTargetFingerprint {
+	targetPath: string;
+	cacheKey: string;
+	fingerprint: string;
+}
+
+export interface Engine {
+	state: SessionState;
+	config: PiRulesConfig;
+	loadStaticRules(cwd: string): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] };
+	loadDynamicRules(
+		cwd: string,
+		targetPaths: ReadonlyArray<string>,
+	): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] };
+	formatStatic(rules: ReadonlyArray<LoadedRule>): string;
+	formatDynamic(rules: ReadonlyArray<LoadedRule>, target: string): string;
+	resetSession(cwd?: string): void;
+	isStaticInjected(rule: LoadedRule): boolean;
+	isDynamicInjected(scopeKey: string, rule: LoadedRule): boolean;
+	markStaticInjected(rule: LoadedRule): boolean;
+	markDynamicInjected(scopeKey: string, rule: LoadedRule): boolean;
+	/**
+	 * Computes a fingerprint for each unique target derived from its discovered
+	 * candidates plus their on-disk fingerprints. Pure - does not mutate state.
+	 */
+	fingerprintDynamicTargets(cwd: string, targetPaths: ReadonlyArray<string>): DynamicTargetFingerprint[];
+	/**
+	 * Returns true when the fingerprint for a target already matches the value
+	 * stored on `state.dynamicTargetFingerprints`. The hook layer skips
+	 * `loadDynamicRules` entirely when every target is current.
+	 */
+	isDynamicTargetFingerprintCurrent(target: DynamicTargetFingerprint): boolean;
+	/**
+	 * Commits the supplied fingerprints to `state.dynamicTargetFingerprints`.
+	 * Always pass every fingerprint observed during a hook invocation so the
+	 * map mirrors the latest discovery.
+	 */
+	commitDynamicTargetFingerprints(fingerprints: ReadonlyArray<DynamicTargetFingerprint>): void;
+}
+
+const ROOT_SINGLE_FILE_SOURCES = new Set(PROJECT_SINGLE_FILES.filter((source) => !source.includes("/")));
+
+export function defaultConfig(): PiRulesConfig {
+	return {
+		disabled: false,
+		mode: "both",
+		maxRuleChars: DEFAULT_MAX_RULE_CHARS,
+		maxResultChars: DEFAULT_MAX_RESULT_CHARS,
+		enabledSources: "auto",
+	};
+}
+
+export function createEngine(config: PiRulesConfig, deps: EngineDeps): Engine {
+	const state = createSessionState();
+	const dynamicMatchCache: DynamicMatchCache = new Map();
+
+	function loadStaticRules(cwd: string): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] } {
+		state.cwd = cwd;
+		if (config.disabled || config.mode === "off" || config.mode === "dynamic") {
+			return emptyLoadResult(state);
+		}
+
+		const projectRoot = deps.findProjectRoot(cwd);
+		const disabledSources = disabledSourcesFor(config);
+		const candidates = deps.findCandidates({
+			projectRoot,
+			targetFile: null,
+			...(disabledSources === undefined ? {} : { disabledSources }),
+		});
+		const realPathCache: RealPathCache = new Map();
+		const result = loadStaticCandidates(candidates, deps, projectRoot, realPathCache);
+		storeLastLoad(state, result.rules, result.diagnostics);
+		return result;
+	}
+
+	function loadDynamicRules(
+		cwd: string,
+		targetPaths: ReadonlyArray<string>,
+	): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] } {
+		state.cwd = cwd;
+		if (config.disabled || config.mode === "off" || config.mode === "static" || targetPaths.length === 0) {
+			return emptyLoadResult(state);
+		}
+
+		const targetFiles = uniqueStrings(targetPaths);
+		const shouldCacheLookups = targetFiles.length > 1;
+		const rules: LoadedRule[] = [];
+		const diagnostics: RuleDiagnostic[] = [];
+		const seenRules = new Set<string>();
+		const loadedRuleContent = new Map<string, LoadedRuleContent | null>();
+		const projectMembership = new Map<string, boolean>();
+		const disabledSources = disabledSourcesFor(config);
+		const discoveryCache = shouldCacheLookups ? createRuleDiscoveryCache() : undefined;
+		const candidateDiscoveryCache: CandidateDiscoveryCache = new Map();
+		const projectRootCache = new Map<string, string | null>();
+		const realPathCache: RealPathCache = new Map();
+		for (const targetFile of targetFiles) {
+			const projectRoot = shouldCacheLookups
+				? findProjectRootCached(projectRootCache, targetFile, deps.findProjectRoot)
+				: deps.findProjectRoot(targetFile);
+			const findOptions: Parameters<EngineDeps["findCandidates"]>[0] = {
+				projectRoot,
+				targetFile,
+				...(discoveryCache === undefined ? {} : { cache: discoveryCache }),
+				...(disabledSources === undefined ? {} : { disabledSources }),
+			};
+			const candidates = shouldCacheLookups
+				? findSortedCandidatesCached(candidateDiscoveryCache, deps.findCandidates, findOptions)
+				: sortCandidates(deps.findCandidates(findOptions));
+
+			for (const candidate of candidates) {
+				const loadedRule = loadCandidate(candidate, deps, diagnostics, projectRoot, {
+					loadedRuleContent,
+					projectMembership,
+					realPathCache,
+				});
+				if (loadedRule === null) {
+					continue;
+				}
+
+				const matchReason = matchDynamicRuleCached(
+					dynamicMatchCache,
+					projectRoot,
+					targetFile,
+					candidate,
+					loadedRule,
+					deps.matchRule ?? matchRule,
+				);
+
+				if (matchReason === null) {
+					continue;
+				}
+
+				const dedupKey = ruleDedupKey(loadedRule);
+				if (seenRules.has(dedupKey)) {
+					continue;
+				}
+
+				seenRules.add(dedupKey);
+				rules.push({ ...loadedRule, matchReason });
+			}
+		}
+
+		const sortedRules = sortCandidates(rules);
+		storeLastLoad(state, sortedRules, diagnostics);
+		return { rules: sortedRules, diagnostics };
+	}
+
+	function fingerprintDynamicTargets(cwd: string, targetPaths: ReadonlyArray<string>): DynamicTargetFingerprint[] {
+		state.cwd = cwd;
+		if (config.disabled || config.mode === "off" || config.mode === "static" || targetPaths.length === 0) {
+			return [];
+		}
+
+		const fingerprintFn = deps.fileFingerprint ?? fileStatFingerprint;
+		const disabledSources = disabledSourcesFor(config);
+		const discoveryCache = createRuleDiscoveryCache();
+		const cwdProjectRoot = deps.findProjectRoot(cwd);
+		const fingerprints: DynamicTargetFingerprint[] = [];
+
+		for (const targetFile of uniqueStrings(targetPaths)) {
+			const projectRoot =
+				cwdProjectRoot !== null && isSameOrChildPath(targetFile, cwdProjectRoot)
+					? cwdProjectRoot
+					: deps.findProjectRoot(targetFile);
+			const findOptions: Parameters<EngineDeps["findCandidates"]>[0] = {
+				projectRoot,
+				targetFile,
+				cache: discoveryCache,
+				...(disabledSources === undefined ? {} : { disabledSources }),
+			};
+			const candidates = sortCandidates(deps.findCandidates(findOptions));
+			const cacheKey = dynamicTargetCacheKey(targetFile);
+			fingerprints.push({
+				targetPath: targetFile,
+				cacheKey,
+				fingerprint: computeDynamicTargetFingerprint(targetFile, projectRoot, candidates, config, fingerprintFn),
+			});
+		}
+
+		return fingerprints;
+	}
+
+	function commitDynamicTargetFingerprints(fingerprints: ReadonlyArray<DynamicTargetFingerprint>): void {
+		for (const target of fingerprints) {
+			state.dynamicTargetFingerprints.set(target.cacheKey, target.fingerprint);
+		}
+	}
+
+	function isDynamicTargetFingerprintCurrent(target: DynamicTargetFingerprint): boolean {
+		return state.dynamicTargetFingerprints.get(target.cacheKey) === target.fingerprint;
+	}
+
+	return {
+		state,
+		config,
+		loadStaticRules,
+		loadDynamicRules,
+		formatStatic: (rules) =>
+			formatStaticBlock(rules, { maxRuleChars: config.maxRuleChars, maxResultChars: config.maxResultChars }),
+		formatDynamic: (rules, target) =>
+			formatDynamicBlock(rules, target, {
+				maxRuleChars: config.maxRuleChars,
+				maxResultChars: config.maxResultChars,
+			}),
+		resetSession: (cwd) => {
+			clearSession(state);
+			dynamicMatchCache.clear();
+			if (cwd !== undefined) {
+				state.cwd = cwd;
+			}
+		},
+		isStaticInjected: (rule) => isStaticInjectedInState(state, rule),
+		isDynamicInjected: (scopeKey, rule) => isDynamicInjectedInState(state, scopeKey, rule),
+		markStaticInjected: (rule) => markStaticInjectedInState(state, rule),
+		markDynamicInjected: (scopeKey, rule) => markDynamicInjectedInState(state, scopeKey, rule),
+		fingerprintDynamicTargets,
+		isDynamicTargetFingerprintCurrent,
+		commitDynamicTargetFingerprints,
+	};
+}
+
+function isSameOrChildPath(childPath: string, parentPath: string): boolean {
+	const childRelativePath = relative(parentPath, resolve(childPath));
+	return childRelativePath === "" || (!childRelativePath.startsWith("..") && !isAbsolute(childRelativePath));
+}
+
+function matchDynamicRuleCached(
+	cache: DynamicMatchCache,
+	projectRoot: string | null,
+	targetFile: string,
+	candidate: RuleCandidate,
+	loadedRule: LoadedRule,
+	matchRuleImpl: typeof matchRule,
+): MatchReason | null {
+	const cacheKey = dynamicMatchCacheKey(projectRoot, targetFile, candidate, loadedRule.contentHash);
+	if (cache.has(cacheKey)) {
+		const cachedReason = cache.get(cacheKey) ?? null;
+		cache.delete(cacheKey);
+		cache.set(cacheKey, cachedReason);
+		return cachedReason;
+	}
+
+	const matchResult = matchRuleImpl({
+		frontmatter: loadedRule.frontmatter,
+		isSingleFile: candidate.isSingleFile,
+		pathBases: pathBasesForTarget(projectRoot, targetFile, candidate),
+	});
+	const reason = matchResult.matched ? matchResult.reason : null;
+	setDynamicMatchCacheEntry(cache, cacheKey, reason);
+	return reason;
+}
+
+function setDynamicMatchCacheEntry(cache: DynamicMatchCache, cacheKey: string, reason: MatchReason | null): void {
+	if (cache.size >= MAX_DYNAMIC_MATCH_CACHE_ENTRIES) {
+		const oldestCacheKey = cache.keys().next().value;
+		if (oldestCacheKey !== undefined) {
+			cache.delete(oldestCacheKey);
+		}
+	}
+	cache.set(cacheKey, reason);
+}
+
+function dynamicMatchCacheKey(
+	projectRoot: string | null,
+	targetFile: string,
+	candidate: RuleCandidate,
+	contentHash: string,
+): string {
+	return [
+		projectRoot ?? "",
+		toPosixPath(resolve(targetFile)),
+		candidate.realPath,
+		candidate.relativePath,
+		candidate.source,
+		candidate.isGlobal ? "global" : "project",
+		candidate.isSingleFile ? "single" : "multi",
+		String(candidate.distance),
+		contentHash,
+	].join("\0");
+}
+
+function loadStaticCandidates(
+	candidates: ReadonlyArray<RuleCandidate>,
+	deps: EngineDeps,
+	projectRoot: string | null,
+	realPathCache: RealPathCache,
+) {
+	const rules: LoadedRule[] = [];
+	const diagnostics: RuleDiagnostic[] = [];
+	let rootSingleFileSelected = false;
+
+	for (const candidate of sortCandidates(candidates)) {
+		if (isDedupedRootSingleFile(candidate, rootSingleFileSelected)) {
+			continue;
+		}
+
+		const loadedRule = loadCandidate(candidate, deps, diagnostics, projectRoot, { realPathCache });
+		if (loadedRule === null) {
+			continue;
+		}
+
+		const matchReason = staticMatchReason(loadedRule);
+		if (matchReason === null) {
+			continue;
+		}
+
+		if (isRootSingleFile(candidate)) {
+			rootSingleFileSelected = true;
+		}
+
+		rules.push({ ...loadedRule, matchReason });
+	}
+
+	return { rules: sortCandidates(rules), diagnostics };
+}
+
+function loadCandidate(
+	candidate: RuleCandidate,
+	deps: EngineDeps,
+	diagnostics: RuleDiagnostic[],
+	projectRoot: string | null,
+	caches: LoadCandidateCaches,
+): (LoadedRule & { matchReason: MatchReason }) | null {
+	if (!isCandidateWithinProjectCached(candidate, projectRoot, caches.projectMembership, caches.realPathCache)) {
+		diagnostics.push({
+			severity: "warning",
+			source: candidate.path,
+			message: "Rule file resolves outside project root",
+		});
+		return null;
+	}
+
+	const cachedContent = caches.loadedRuleContent?.get(candidate.realPath);
+	if (cachedContent !== undefined) {
+		return loadedRuleFromContent(candidate, cachedContent, diagnostics);
+	}
+
+	const content = deps.readFile(candidate.path);
+	if (content === null) {
+		caches.loadedRuleContent?.set(candidate.realPath, null);
+		diagnostics.push({ severity: "warning", source: candidate.path, message: "Unable to read rule file" });
+		return null;
+	}
+
+	const parsed = parseRule(content);
+	const loadedContent: LoadedRuleContent = {
+		frontmatter: parsed.frontmatter,
+		body: parsed.body,
+		contentHash: hashContent(content),
+	};
+	if (parsed.diagnostic !== undefined) loadedContent.diagnostic = parsed.diagnostic;
+	caches.loadedRuleContent?.set(candidate.realPath, loadedContent);
+	return loadedRuleFromContent(candidate, loadedContent, diagnostics);
+}
+
+function loadedRuleFromContent(
+	candidate: RuleCandidate,
+	content: LoadedRuleContent | null,
+	diagnostics: RuleDiagnostic[],
+): (LoadedRule & { matchReason: MatchReason }) | null {
+	if (content === null) {
+		diagnostics.push({ severity: "warning", source: candidate.path, message: "Unable to read rule file" });
+		return null;
+	}
+
+	if (content.diagnostic !== undefined) {
+		diagnostics.push({ severity: "warning", source: candidate.path, message: content.diagnostic });
+	}
+
+	return {
+		...candidate,
+		frontmatter: content.frontmatter,
+		body: content.body,
+		contentHash: content.contentHash,
+		matchReason: { kind: "no-match" },
+	};
+}
+
+function ruleDedupKey(rule: LoadedRule): string {
+	return `${rule.realPath}::${rule.contentHash}`;
+}
+
+function isCandidateWithinProject(
+	candidate: RuleCandidate,
+	projectRoot: string | null,
+	realPathCache: RealPathCache | undefined,
+): boolean {
+	if (candidate.isGlobal) {
+		return true;
+	}
+
+	if (projectRoot === null) {
+		return false;
+	}
+
+	const relativeRealPath = relative(realPathOrResolved(projectRoot, realPathCache), resolve(candidate.realPath));
+	return relativeRealPath === "" || (!relativeRealPath.startsWith("..") && !isAbsolute(relativeRealPath));
+}
+
+function realPathOrResolved(path: string, cache: RealPathCache | undefined): string {
+	const cached = cache?.get(path);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	try {
+		const realPath = realpathSync.native(path);
+		cache?.set(path, realPath);
+		return realPath;
+	} catch {
+		const resolvedPath = resolve(path);
+		cache?.set(path, resolvedPath);
+		return resolvedPath;
+	}
+}
+
+function isCandidateWithinProjectCached(
+	candidate: RuleCandidate,
+	projectRoot: string | null,
+	projectMembership: CandidateProjectMembership | undefined,
+	realPathCache: RealPathCache | undefined,
+): boolean {
+	if (projectMembership === undefined) {
+		return isCandidateWithinProject(candidate, projectRoot, realPathCache);
+	}
+
+	const cacheKey = `${projectRoot ?? ""}\0${candidate.realPath}`;
+	const cached = projectMembership.get(cacheKey);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const isWithinProject = isCandidateWithinProject(candidate, projectRoot, realPathCache);
+	projectMembership.set(cacheKey, isWithinProject);
+	return isWithinProject;
+}
+
+function findSortedCandidatesCached(
+	cache: CandidateDiscoveryCache,
+	findCandidates: EngineDeps["findCandidates"],
+	options: Parameters<EngineDeps["findCandidates"]>[0],
+): RuleCandidate[] {
+	const cacheKey = candidateDiscoveryCacheKey(options);
+	const cached = cache.get(cacheKey);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const candidates = sortCandidates(findCandidates(options));
+	cache.set(cacheKey, candidates);
+	return candidates;
+}
+
+function candidateDiscoveryCacheKey(options: Parameters<EngineDeps["findCandidates"]>[0]): string {
+	return [
+		options.projectRoot ?? "",
+		options.targetFile === null ? "" : dirname(resolve(options.targetFile)),
+		...[...(options.disabledSources ?? [])].sort(),
+	].join("\0");
+}
+
+function findProjectRootCached(
+	cache: Map<string, string | null>,
+	targetFile: string,
+	findProjectRoot: EngineDeps["findProjectRoot"],
+): string | null {
+	const cacheKey = dirname(resolve(targetFile));
+	if (cache.has(cacheKey)) {
+		return cache.get(cacheKey) ?? null;
+	}
+
+	const projectRoot = findProjectRoot(targetFile);
+	cache.set(cacheKey, projectRoot);
+	return projectRoot;
+}
+
+function staticMatchReason(rule: LoadedRule): MatchReason | null {
+	if (rule.frontmatter.alwaysApply === true) {
+		return "alwaysApply";
+	}
+
+	if (rule.isSingleFile) {
+		return "single-file";
+	}
+
+	return null;
+}
+
+function disabledSourcesFor(config: PiRulesConfig): ReadonlySet<string> | undefined {
+	if (config.enabledSources === "auto") {
+		return undefined;
+	}
+
+	const enabledSources = new Set(config.enabledSources);
+	return new Set([...SOURCE_PRIORITY.keys()].filter((source) => !enabledSources.has(source)));
+}
+
+function isDedupedRootSingleFile(candidate: RuleCandidate, rootSingleFileSelected: boolean): boolean {
+	return rootSingleFileSelected && isRootSingleFile(candidate);
+}
+
+function isRootSingleFile(candidate: RuleCandidate): boolean {
+	return candidate.distance === 0 && candidate.isSingleFile && ROOT_SINGLE_FILE_SOURCES.has(candidate.source);
+}
+
+function pathBasesForTarget(
+	projectRoot: string | null,
+	targetFile: string,
+	candidate: RuleCandidate,
+): { projectRelative: string; scopeRelative?: string; basename: string } {
+	const targetBasename = basename(targetFile);
+	if (projectRoot === null) {
+		return { projectRelative: targetBasename, basename: targetBasename };
+	}
+
+	const projectRelative = toPosixPath(relative(projectRoot, targetFile));
+	const scopeDirectory = scopeDirectoryForCandidate(projectRoot, candidate);
+	if (scopeDirectory === null) {
+		return { projectRelative, basename: targetBasename };
+	}
+
+	return {
+		projectRelative,
+		scopeRelative: toPosixPath(relative(scopeDirectory, targetFile)),
+		basename: targetBasename,
+	};
+}
+
+function scopeDirectoryForCandidate(projectRoot: string, candidate: RuleCandidate): string | null {
+	if (candidate.isGlobal) {
+		return null;
+	}
+
+	if (candidate.isSingleFile) {
+		return dirname(candidate.path);
+	}
+
+	const sourceIndex = candidate.relativePath.indexOf(candidate.source);
+	if (sourceIndex === -1) {
+		return projectRoot;
+	}
+
+	const scopeRelativeDirectory = candidate.relativePath.slice(0, sourceIndex).replace(/\/$/, "");
+	return scopeRelativeDirectory.length === 0 ? projectRoot : join(projectRoot, scopeRelativeDirectory);
+}
+
+function toPosixPath(path: string): string {
+	return path.replaceAll("\\", "/");
+}
+
+function dynamicTargetCacheKey(targetFile: string): string {
+	return toPosixPath(resolve(targetFile));
+}
+
+function computeDynamicTargetFingerprint(
+	targetFile: string,
+	projectRoot: string | null,
+	candidates: ReadonlyArray<RuleCandidate>,
+	config: PiRulesConfig,
+	fileFingerprintFn: (filePath: string) => string,
+): string {
+	const candidateFingerprint = candidates
+		.map((candidate) => fingerprintCandidate(candidate, fileFingerprintFn))
+		.join("\u0001");
+	return hashContent(
+		[
+			"v1",
+			config.enabledSources === "auto" ? "auto" : config.enabledSources.join(","),
+			projectRoot ?? "",
+			dynamicTargetCacheKey(targetFile),
+			candidateFingerprint,
+		].join("\u0000"),
+	);
+}
+
+function fingerprintCandidate(candidate: RuleCandidate, fileFingerprintFn: (filePath: string) => string): string {
+	return [
+		candidate.realPath,
+		candidate.relativePath,
+		candidate.source,
+		candidate.isGlobal ? "global" : "project",
+		candidate.isSingleFile ? "single" : "multi",
+		String(candidate.distance),
+		fileFingerprintFn(candidate.path),
+	].join("\u0000");
+}
+
+function fileStatFingerprint(filePath: string): string {
+	try {
+		const stats = statSync(filePath, { bigint: true });
+		return `${stats.mtimeNs}:${stats.ctimeNs}:${stats.size}`;
+	} catch {
+		return "missing";
+	}
+}
+
+function uniqueStrings(values: ReadonlyArray<string>): string[] {
+	return [...new Set(values)];
+}
+
+function storeLastLoad(
+	state: SessionState,
+	rules: ReadonlyArray<LoadedRule>,
+	diagnostics: ReadonlyArray<RuleDiagnostic>,
+): void {
+	state.loadedRules.length = 0;
+	state.loadedRules.push(...rules);
+	state.diagnostics.length = 0;
+	state.diagnostics.push(...diagnostics);
+}
+
+function emptyLoadResult(state: SessionState): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] } {
+	storeLastLoad(state, [], []);
+	return { rules: [], diagnostics: [] };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/errors.ts
@@ -1,0 +1,13 @@
+export class UnsupportedRuleSourceError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UnsupportedRuleSourceError";
+	}
+}
+
+export class RuleFrontmatterParseError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RuleFrontmatterParseError";
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/finder.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/finder.ts
@@ -1,0 +1,329 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, posix, relative, resolve } from "node:path";
+
+import {
+	GLOBAL_DISTANCE,
+	PROJECT_RULE_SUBDIRS,
+	PROJECT_SINGLE_FILES,
+	USER_HOME_RULE_SUBDIRS,
+	USER_HOME_SINGLE_FILES,
+} from "./constants.ts";
+import { UnsupportedRuleSourceError } from "./errors.ts";
+import { scanRuleFiles } from "./scanner.ts";
+import type { RuleCandidate, RuleSource } from "./types.ts";
+
+interface SingleFileInfo {
+	path: string;
+	realPath: string;
+}
+
+export interface RuleDiscoveryCache {
+	scannedRuleFiles: Map<string, ReturnType<typeof scanRuleFiles>>;
+	singleFileInfo: Map<string, SingleFileInfo | null>;
+}
+
+export interface FinderOptions {
+	/** Project root absolute path (use findProjectRoot to get this). */
+	projectRoot: string | null;
+	/** Target file path (used for distance calculation in dynamic injection mode). null for static mode. */
+	targetFile: string | null;
+	/** User home directory (default: os.homedir()). Injectable for tests. */
+	homeDir?: string;
+	/** Set of disabled sources to omit from discovery. Empty by default. */
+	disabledSources?: ReadonlySet<string>;
+	/** Whether to skip user-home rules. Default: false. */
+	skipUserHome?: boolean;
+	cache?: RuleDiscoveryCache;
+}
+
+interface WalkDirectory {
+	directory: string;
+	distance: number;
+}
+
+export function createRuleDiscoveryCache(): RuleDiscoveryCache {
+	return { scannedRuleFiles: new Map(), singleFileInfo: new Map() };
+}
+
+export function findRuleCandidates(options: FinderOptions): RuleCandidate[] {
+	const skipUserHome = options.skipUserHome ?? false;
+	if (options.projectRoot === null && skipUserHome) {
+		return [];
+	}
+
+	const disabledSources = options.disabledSources ?? new Set<string>();
+	const candidates: RuleCandidate[] = [];
+	const homeDirectory = resolve(options.homeDir ?? homedir());
+
+	if (options.projectRoot !== null) {
+		candidates.push(
+			...findProjectCandidates(options.projectRoot, options.targetFile, disabledSources, options.cache),
+		);
+	}
+
+	if (!skipUserHome) {
+		candidates.push(...findUserHomeCandidates(homeDirectory, disabledSources, options.cache));
+	}
+
+	return candidates;
+}
+
+function findProjectCandidates(
+	projectRoot: string,
+	targetFile: string | null,
+	disabledSources: ReadonlySet<string>,
+	cache: RuleDiscoveryCache | undefined,
+): RuleCandidate[] {
+	const rootDirectory = resolve(projectRoot);
+	const walkDirectories = getWalkDirectories(rootDirectory, targetFile);
+	const candidates: RuleCandidate[] = [];
+
+	for (const walkDirectory of walkDirectories) {
+		for (const [parentDirectory, subDirectory] of PROJECT_RULE_SUBDIRS) {
+			const source = toProjectRuleSource(parentDirectory, subDirectory);
+			if (disabledSources.has(source)) {
+				continue;
+			}
+
+			const ruleDirectory = join(walkDirectory.directory, parentDirectory, subDirectory);
+			for (const scannedFile of scanRuleFilesCached(ruleDirectory, cache)) {
+				candidates.push({
+					path: scannedFile.path,
+					realPath: resolveRealPath(scannedFile.path),
+					source,
+					distance: targetFile === null ? 0 : walkDirectory.distance,
+					isGlobal: false,
+					isSingleFile: false,
+					relativePath: toRelativePath(rootDirectory, scannedFile.path),
+				});
+			}
+		}
+	}
+
+	for (const walkDirectory of walkDirectories) {
+		for (const ruleFile of PROJECT_SINGLE_FILES) {
+			const source = toProjectSingleFileSource(ruleFile);
+			if (disabledSources.has(source)) {
+				continue;
+			}
+
+			const filePath = join(walkDirectory.directory, ruleFile);
+			const fileInfo = singleFileInfoCached(filePath, cache);
+			if (fileInfo === null) {
+				continue;
+			}
+
+			candidates.push({
+				path: fileInfo.path,
+				realPath: fileInfo.realPath,
+				source,
+				distance: targetFile === null ? 0 : walkDirectory.distance,
+				isGlobal: false,
+				isSingleFile: true,
+				relativePath: toRelativePath(rootDirectory, filePath),
+			});
+		}
+	}
+
+	return candidates;
+}
+
+function findUserHomeCandidates(
+	homeDirectory: string,
+	disabledSources: ReadonlySet<string>,
+	cache: RuleDiscoveryCache | undefined,
+): RuleCandidate[] {
+	const candidates: RuleCandidate[] = [];
+
+	for (const ruleSubdir of USER_HOME_RULE_SUBDIRS) {
+		const source = toUserHomeRuleSource(ruleSubdir);
+		if (disabledSources.has(source)) {
+			continue;
+		}
+
+		const ruleDirectory = join(homeDirectory, ruleSubdir);
+		for (const scannedFile of scanRuleFilesCached(ruleDirectory, cache)) {
+			candidates.push({
+				path: scannedFile.path,
+				realPath: resolveRealPath(scannedFile.path),
+				source,
+				distance: GLOBAL_DISTANCE,
+				isGlobal: true,
+				isSingleFile: false,
+				relativePath: toRelativePath(homeDirectory, scannedFile.path),
+			});
+		}
+	}
+
+	for (const ruleFile of USER_HOME_SINGLE_FILES) {
+		const source = toUserHomeSingleFileSource(ruleFile);
+		if (disabledSources.has(source)) {
+			continue;
+		}
+
+		const filePath = join(homeDirectory, ruleFile);
+		const fileInfo = singleFileInfoCached(filePath, cache);
+		if (fileInfo === null) {
+			continue;
+		}
+
+		candidates.push({
+			path: fileInfo.path,
+			realPath: fileInfo.realPath,
+			source,
+			distance: GLOBAL_DISTANCE,
+			isGlobal: true,
+			isSingleFile: true,
+			relativePath: toRelativePath(homeDirectory, filePath),
+		});
+	}
+
+	return candidates;
+}
+
+function scanRuleFilesCached(rootDir: string, cache: RuleDiscoveryCache | undefined): ReturnType<typeof scanRuleFiles> {
+	if (cache === undefined) {
+		return scanRuleFiles({ rootDir });
+	}
+
+	const cached = cache.scannedRuleFiles.get(rootDir);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const scannedFiles = scanRuleFiles({ rootDir });
+	cache.scannedRuleFiles.set(rootDir, scannedFiles);
+	return scannedFiles;
+}
+
+function singleFileInfoCached(filePath: string, cache: RuleDiscoveryCache | undefined): SingleFileInfo | null {
+	if (cache === undefined) {
+		return readSingleFileInfo(filePath);
+	}
+
+	const cached = cache.singleFileInfo.get(filePath);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const fileInfo = readSingleFileInfo(filePath);
+	cache.singleFileInfo.set(filePath, fileInfo);
+	return fileInfo;
+}
+
+function getWalkDirectories(projectRoot: string, targetFile: string | null): WalkDirectory[] {
+	if (targetFile === null) {
+		return [{ directory: projectRoot, distance: 0 }];
+	}
+
+	const startDirectory = dirname(resolve(targetFile));
+	if (!isSameOrChildPath(startDirectory, projectRoot)) {
+		return [{ directory: projectRoot, distance: 0 }];
+	}
+
+	const walkDirectories: WalkDirectory[] = [];
+	let currentDirectory = startDirectory;
+	let distance = 0;
+
+	while (true) {
+		walkDirectories.push({ directory: currentDirectory, distance });
+		if (currentDirectory === projectRoot) {
+			break;
+		}
+
+		const parentDirectory = dirname(currentDirectory);
+		if (parentDirectory === currentDirectory) {
+			break;
+		}
+
+		currentDirectory = parentDirectory;
+		distance += 1;
+	}
+
+	return walkDirectories;
+}
+
+function isSameOrChildPath(childPath: string, parentPath: string): boolean {
+	const childRelativePath = relative(parentPath, childPath);
+	return childRelativePath === "" || (!childRelativePath.startsWith("..") && !childRelativePath.startsWith("/"));
+}
+
+function readSingleFileInfo(filePath: string): SingleFileInfo | null {
+	if (!existsSync(filePath)) {
+		return null;
+	}
+
+	try {
+		if (!statSync(filePath).isFile()) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	return {
+		path: filePath,
+		realPath: resolveRealPath(filePath),
+	};
+}
+
+function resolveRealPath(filePath: string): string {
+	try {
+		return realpathSync.native(filePath);
+	} catch {
+		return filePath;
+	}
+}
+
+function toRelativePath(rootDirectory: string, filePath: string): string {
+	return posix.normalize(relative(rootDirectory, filePath).replace(/\\/g, "/"));
+}
+
+function toProjectRuleSource(parentDirectory: string, subDirectory: string): RuleSource {
+	const source = `${parentDirectory}/${subDirectory}`;
+	switch (source) {
+		case ".omo/rules":
+		case ".claude/rules":
+		case ".cursor/rules":
+		case ".github/instructions":
+			return source;
+		default:
+			throw new UnsupportedRuleSourceError(`Unsupported project rule source: ${source}`);
+	}
+}
+
+function toProjectSingleFileSource(ruleFile: string): RuleSource {
+	switch (ruleFile) {
+		case ".github/copilot-instructions.md":
+		case "AGENTS.md":
+		case "CLAUDE.md":
+		case "CONTEXT.md":
+			return ruleFile;
+		default:
+			throw new UnsupportedRuleSourceError(`Unsupported project single-file source: ${ruleFile}`);
+	}
+}
+
+function toUserHomeRuleSource(ruleSubdir: string): RuleSource {
+	const source = `~/${ruleSubdir}`;
+	switch (source) {
+		case "~/.omo/rules":
+		case "~/.opencode/rules":
+		case "~/.claude/rules":
+			return source;
+		default:
+			throw new UnsupportedRuleSourceError(`Unsupported user-home rule source: ${source}`);
+	}
+}
+
+function toUserHomeSingleFileSource(ruleFile: string): RuleSource {
+	const source = `~/${ruleFile}`;
+	switch (source) {
+		case "~/.config/opencode/AGENTS.md":
+		case "~/.claude/CLAUDE.md":
+			return source;
+		default:
+			throw new UnsupportedRuleSourceError(`Unsupported user-home single-file source: ${source}`);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/formatter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/formatter.ts
@@ -1,0 +1,68 @@
+import { truncateBudget, truncateRule } from "./truncator.ts";
+import type { LoadedRule } from "./types.ts";
+
+export interface FormatOptions {
+	maxRuleChars: number;
+	maxResultChars: number;
+}
+
+type TruncatedRule = {
+	path: string;
+	relativePath: string;
+	body: string;
+};
+
+function formatRule(rule: TruncatedRule): string {
+	return `Instructions from: ${rule.path}\n${rule.body}`;
+}
+
+function truncateRules(rules: ReadonlyArray<LoadedRule>, options: FormatOptions): TruncatedRule[] {
+	const perRuleTruncated = rules.map((rule) => ({
+		path: rule.path,
+		relativePath: rule.relativePath,
+		body: truncateRule(rule.body, { maxChars: options.maxRuleChars, relativePath: rule.relativePath }).body,
+	}));
+	const budgetedRules = truncateBudget({
+		rules: perRuleTruncated.map((rule) => ({ body: rule.body, relativePath: rule.relativePath })),
+		maxResultChars: options.maxResultChars,
+	});
+	const truncatedRules: TruncatedRule[] = [];
+
+	for (let index = 0; index < budgetedRules.length; index += 1) {
+		const sourceRule = perRuleTruncated[index];
+		const budgetedRule = budgetedRules[index];
+		if (sourceRule === undefined || budgetedRule === undefined) {
+			continue;
+		}
+
+		truncatedRules.push({
+			path: sourceRule.path,
+			relativePath: budgetedRule.relativePath,
+			body: budgetedRule.body,
+		});
+	}
+
+	return truncatedRules;
+}
+
+export function formatStaticBlock(rules: ReadonlyArray<LoadedRule>, options: FormatOptions): string {
+	if (rules.length === 0) {
+		return "";
+	}
+
+	return `\n\n## Project Instructions\n${truncateRules(rules, options).map(formatRule).join("\n\n")}`;
+}
+
+export function formatDynamicBlock(
+	rules: ReadonlyArray<LoadedRule>,
+	targetRelativePath: string,
+	options: FormatOptions,
+): string {
+	if (rules.length === 0) {
+		return "";
+	}
+
+	return `\n\nAdditional project instructions matched for ${targetRelativePath}:\n\n${truncateRules(rules, options)
+		.map(formatRule)
+		.join("\n\n")}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/matcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/matcher.ts
@@ -1,0 +1,158 @@
+import { createHash } from "node:crypto";
+import picomatch from "picomatch";
+import type { MatchReason, RuleFrontmatter } from "./types.ts";
+
+export interface MatcherInput {
+	frontmatter: RuleFrontmatter;
+	isSingleFile: boolean;
+	/** Path bases to try matching against (POSIX-normalized). */
+	pathBases: { projectRelative: string; scopeRelative?: string; basename: string };
+}
+
+export interface MatchResult {
+	matched: boolean;
+	reason: MatchReason;
+}
+
+interface CompiledPatternSet {
+	positiveMatchers: ReadonlyArray<{ pattern: string; isMatch: PathMatcher }>;
+	negativeMatchers: ReadonlyArray<PathMatcher>;
+}
+
+export interface MatcherCacheStats {
+	entries: number;
+	compiledPatterns: number;
+}
+
+type PathMatcher = (path: string) => boolean;
+
+const PICOMATCH_OPTIONS = { bash: true, dot: true };
+const MAX_COMPILED_PATTERN_SET_CACHE_ENTRIES = 256;
+const compiledPatternSets = new Map<string, CompiledPatternSet>();
+
+export function matchRule(input: MatcherInput): MatchResult {
+	if (input.isSingleFile) {
+		return { matched: true, reason: "single-file" };
+	}
+
+	if (input.frontmatter.alwaysApply === true) {
+		return { matched: true, reason: "alwaysApply" };
+	}
+
+	const patterns = normalizeGlobs(input.frontmatter);
+	if (patterns.length === 0) {
+		return noMatch();
+	}
+
+	const pathBases = [
+		normalizePath(input.pathBases.projectRelative),
+		input.pathBases.scopeRelative ? normalizePath(input.pathBases.scopeRelative) : undefined,
+		normalizePath(input.pathBases.basename),
+	].filter((pathBase): pathBase is string => pathBase !== undefined);
+
+	const { positiveMatchers, negativeMatchers } = compiledPatternSetFor(patterns);
+
+	for (const { pattern, isMatch } of positiveMatchers) {
+		for (const pathBase of pathBases) {
+			if (!isMatch(pathBase)) {
+				continue;
+			}
+
+			if (isExcluded(pathBase, negativeMatchers)) {
+				return noMatch();
+			}
+
+			return { matched: true, reason: { kind: "glob", pattern } };
+		}
+	}
+
+	return noMatch();
+}
+
+export function normalizeGlobs(frontmatter: RuleFrontmatter): string[] {
+	const patterns = [
+		...normalizePatternList(frontmatter.globs),
+		...normalizePatternList(frontmatter.paths),
+		...normalizePatternList(frontmatter.applyTo),
+	];
+
+	return [...new Set(patterns.map(normalizePath))];
+}
+
+export function hashContent(body: string): string {
+	return createHash("sha256").update(body).digest("hex");
+}
+
+export function resetMatcherCache(): void {
+	compiledPatternSets.clear();
+}
+
+export function getMatcherCacheStats(): MatcherCacheStats {
+	let compiledPatterns = 0;
+	for (const patternSet of compiledPatternSets.values()) {
+		compiledPatterns += patternSet.positiveMatchers.length + patternSet.negativeMatchers.length;
+	}
+
+	return { entries: compiledPatternSets.size, compiledPatterns };
+}
+
+function compiledPatternSetFor(patterns: ReadonlyArray<string>): CompiledPatternSet {
+	const cacheKey = patterns.join("\0");
+	const cached = compiledPatternSets.get(cacheKey);
+	if (cached !== undefined) {
+		compiledPatternSets.delete(cacheKey);
+		compiledPatternSets.set(cacheKey, cached);
+		return cached;
+	}
+
+	const positiveMatchers: Array<{ pattern: string; isMatch: PathMatcher }> = [];
+	const negativeMatchers: PathMatcher[] = [];
+	for (const pattern of patterns) {
+		if (pattern.startsWith("!")) {
+			negativeMatchers.push(picomatch(pattern.slice(1), PICOMATCH_OPTIONS));
+			continue;
+		}
+
+		positiveMatchers.push({ pattern, isMatch: picomatch(pattern, PICOMATCH_OPTIONS) });
+	}
+
+	const compiledPatternSet = { positiveMatchers, negativeMatchers } satisfies CompiledPatternSet;
+	setCompiledPatternSet(cacheKey, compiledPatternSet);
+	return compiledPatternSet;
+}
+
+function setCompiledPatternSet(cacheKey: string, compiledPatternSet: CompiledPatternSet): void {
+	if (compiledPatternSets.size >= MAX_COMPILED_PATTERN_SET_CACHE_ENTRIES) {
+		const oldestCacheKey = compiledPatternSets.keys().next().value;
+		if (oldestCacheKey !== undefined) {
+			compiledPatternSets.delete(oldestCacheKey);
+		}
+	}
+	compiledPatternSets.set(cacheKey, compiledPatternSet);
+}
+
+function normalizePatternList(patterns: string | string[] | undefined): string[] {
+	if (patterns === undefined) {
+		return [];
+	}
+
+	return Array.isArray(patterns) ? patterns : [patterns];
+}
+
+function normalizePath(path: string): string {
+	return path.replaceAll("\\", "/");
+}
+
+function isExcluded(pathBase: string, negativeMatchers: ReadonlyArray<(path: string) => boolean>): boolean {
+	for (const isMatch of negativeMatchers) {
+		if (isMatch(pathBase)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function noMatch(): MatchResult {
+	return { matched: false, reason: { kind: "no-match" } };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/ordering.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/ordering.ts
@@ -1,0 +1,33 @@
+import { SOURCE_PRIORITY } from "./constants.ts";
+import type { RuleCandidate } from "./types.ts";
+
+export function sortCandidates<T extends RuleCandidate>(candidates: ReadonlyArray<T>): T[] {
+	return candidates
+		.map((candidate, index) => ({ candidate, index }))
+		.sort((left, right) => compareCandidates(left.candidate, right.candidate) || left.index - right.index)
+		.map(({ candidate }) => candidate);
+}
+
+export function compareCandidates(a: RuleCandidate, b: RuleCandidate): number {
+	return (
+		compareBoolean(a.isGlobal, b.isGlobal) ||
+		compareNumber(a.distance, b.distance) ||
+		compareNumber(SOURCE_PRIORITY.get(a.source) ?? Infinity, SOURCE_PRIORITY.get(b.source) ?? Infinity) ||
+		compareString(a.relativePath, b.relativePath) ||
+		compareString(a.realPath, b.realPath)
+	);
+}
+
+function compareBoolean(a: boolean, b: boolean): number {
+	return Number(a) - Number(b);
+}
+
+function compareNumber(a: number, b: number): number {
+	return a - b;
+}
+
+function compareString(a: string, b: string): number {
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/parser.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/parser.ts
@@ -1,0 +1,326 @@
+import { RuleFrontmatterParseError } from "./errors.ts";
+import type { ParsedRule, RuleFrontmatter } from "./types.ts";
+
+const FRONTMATTER_OPENING = "---\n";
+const FRONTMATTER_OPENING_CRLF = "---\r\n";
+
+/** Parse markdown rule content and extract the supported YAML frontmatter subset. */
+export function parseRule(content: string): ParsedRule {
+	const normalizedContent = stripBom(content);
+	const openingLength = getOpeningDelimiterLength(normalizedContent);
+	if (openingLength === 0) {
+		return { frontmatter: {}, body: normalizedContent };
+	}
+
+	const closingDelimiter = findClosingDelimiter(normalizedContent, openingLength);
+	if (closingDelimiter === null) {
+		return {
+			frontmatter: {},
+			body: normalizedContent,
+			diagnostic: "Missing closing frontmatter delimiter",
+		};
+	}
+
+	const yamlContent = normalizedContent.slice(openingLength, closingDelimiter.start);
+	const body = normalizedContent.slice(closingDelimiter.bodyStart);
+
+	try {
+		return { frontmatter: parseYamlFrontmatter(yamlContent), body };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Invalid YAML frontmatter";
+		return {
+			frontmatter: {},
+			body: normalizedContent,
+			diagnostic: `Malformed frontmatter: ${message}`,
+		};
+	}
+}
+
+function stripBom(content: string): string {
+	return content.startsWith("\uFEFF") ? content.slice(1) : content;
+}
+
+function getOpeningDelimiterLength(content: string): number {
+	if (content.startsWith(FRONTMATTER_OPENING_CRLF)) return FRONTMATTER_OPENING_CRLF.length;
+	if (content.startsWith(FRONTMATTER_OPENING)) return FRONTMATTER_OPENING.length;
+	return 0;
+}
+
+function findClosingDelimiter(content: string, openingLength: number): { start: number; bodyStart: number } | null {
+	let lineStart = openingLength;
+
+	while (lineStart <= content.length) {
+		const nextNewline = content.indexOf("\n", lineStart);
+		const lineEnd = nextNewline === -1 ? content.length : nextNewline;
+		const line = content.slice(lineStart, lineEnd).replace(/\r$/, "");
+
+		if (line === "---") {
+			return {
+				start: lineStart,
+				bodyStart: nextNewline === -1 ? content.length : nextNewline + 1,
+			};
+		}
+
+		if (nextNewline === -1) break;
+		lineStart = nextNewline + 1;
+	}
+
+	return null;
+}
+
+function parseYamlFrontmatter(yamlContent: string): RuleFrontmatter {
+	const lines = yamlContent.replace(/\r\n/g, "\n").split("\n");
+	const frontmatter: RuleFrontmatter = {};
+	const globValues: string[] = [];
+	let lineIndex = 0;
+
+	while (lineIndex < lines.length) {
+		const rawLine = lines[lineIndex];
+		if (rawLine === undefined) break;
+
+		const line = stripComment(rawLine).trim();
+		if (line.length === 0) {
+			lineIndex += 1;
+			continue;
+		}
+
+		const colonIndex = line.indexOf(":");
+		if (colonIndex === -1) {
+			throw new RuleFrontmatterParseError(`Expected key-value pair on line ${lineIndex + 1}`);
+		}
+
+		const key = line.slice(0, colonIndex).trim();
+		const rawValue = line.slice(colonIndex + 1).trim();
+
+		if (key === "description") {
+			frontmatter.description = parseStringValue(rawValue);
+			lineIndex += 1;
+			continue;
+		}
+
+		if (key === "alwaysApply") {
+			frontmatter.alwaysApply = parseBooleanValue(rawValue, lineIndex + 1);
+			lineIndex += 1;
+			continue;
+		}
+
+		if (key === "globs" || key === "paths" || key === "applyTo") {
+			const parsed = parseGlobValue(rawValue, lines, lineIndex);
+			for (const glob of parsed.values) {
+				if (!globValues.includes(glob)) globValues.push(glob);
+			}
+			lineIndex += parsed.consumed;
+			continue;
+		}
+
+		lineIndex += 1;
+	}
+
+	if (globValues.length === 1) {
+		const singleGlob = globValues[0];
+		if (singleGlob !== undefined) frontmatter.globs = singleGlob;
+	} else if (globValues.length > 1) {
+		frontmatter.globs = globValues;
+	}
+
+	return frontmatter;
+}
+
+function parseBooleanValue(value: string, lineNumber: number): boolean {
+	if (value === "true") return true;
+	if (value === "false") return false;
+	throw new RuleFrontmatterParseError(`Expected boolean on line ${lineNumber}`);
+}
+
+function parseGlobValue(rawValue: string, lines: string[], lineIndex: number): { values: string[]; consumed: number } {
+	if (rawValue.startsWith("[")) {
+		return { values: parseInlineArray(rawValue), consumed: 1 };
+	}
+
+	if (rawValue.length === 0) {
+		return parseMultilineArray(lines, lineIndex);
+	}
+
+	const value = parseStringValue(rawValue);
+	if (value.includes(",")) {
+		return {
+			values: value
+				.split(",")
+				.map((item) => item.trim())
+				.filter(Boolean),
+			consumed: 1,
+		};
+	}
+
+	return { values: [value], consumed: 1 };
+}
+
+function parseMultilineArray(lines: string[], lineIndex: number): { values: string[]; consumed: number } {
+	const values: string[] = [];
+	let consumed = 1;
+
+	for (let index = lineIndex + 1; index < lines.length; index += 1) {
+		const rawLine = lines[index];
+		if (rawLine === undefined) break;
+
+		const lineWithoutComment = stripComment(rawLine);
+		if (lineWithoutComment.trim().length === 0) {
+			consumed += 1;
+			continue;
+		}
+
+		const arrayItem = lineWithoutComment.match(/^\s+-\s*(.*)$/);
+		if (arrayItem === null) break;
+
+		values.push(parseStringValue(arrayItem[1] ?? ""));
+		consumed += 1;
+	}
+
+	return { values: values.filter(Boolean), consumed };
+}
+
+function parseInlineArray(value: string): string[] {
+	const closingBracketIndex = findClosingBracket(value);
+	if (closingBracketIndex === -1) {
+		throw new RuleFrontmatterParseError("Unclosed inline array");
+	}
+
+	const trailing = value.slice(closingBracketIndex + 1).trim();
+	if (trailing.length > 0) {
+		throw new RuleFrontmatterParseError("Unexpected content after inline array");
+	}
+
+	const content = value.slice(1, closingBracketIndex).trim();
+	if (content.length === 0) return [];
+
+	return splitCommaSeparated(content).map(parseStringValue).filter(Boolean);
+}
+
+function findClosingBracket(value: string): number {
+	let quote: string | null = null;
+	let escaped = false;
+
+	for (let index = 0; index < value.length; index += 1) {
+		const character = value[index];
+		if (character === undefined) continue;
+
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+
+		if (quote !== null && character === "\\") {
+			escaped = true;
+			continue;
+		}
+
+		if (character === '"' || character === "'") {
+			if (quote === null) quote = character;
+			else if (quote === character) quote = null;
+			continue;
+		}
+
+		if (quote === null && character === "]") return index;
+	}
+
+	return -1;
+}
+
+function splitCommaSeparated(value: string): string[] {
+	const values: string[] = [];
+	let current = "";
+	let quote: string | null = null;
+	let escaped = false;
+
+	for (let index = 0; index < value.length; index += 1) {
+		const character = value[index];
+		if (character === undefined) continue;
+
+		if (escaped) {
+			current += character;
+			escaped = false;
+			continue;
+		}
+
+		if (quote !== null && character === "\\") {
+			current += character;
+			escaped = true;
+			continue;
+		}
+
+		if (character === '"' || character === "'") {
+			if (quote === null) quote = character;
+			else if (quote === character) quote = null;
+			current += character;
+			continue;
+		}
+
+		if (quote === null && character === ",") {
+			values.push(current.trim());
+			current = "";
+			continue;
+		}
+
+		current += character;
+	}
+
+	if (quote !== null) {
+		throw new RuleFrontmatterParseError("Unclosed quoted value");
+	}
+
+	values.push(current.trim());
+	return values.filter(Boolean);
+}
+
+function parseStringValue(value: string): string {
+	if (value.length === 0) return "";
+	if (value.startsWith('"')) return parseJsonString(value);
+	if (value.startsWith("'") && value.endsWith("'")) return value.slice(1, -1);
+	if (value.startsWith("'")) throw new RuleFrontmatterParseError("Unclosed quoted value");
+	return value;
+}
+
+function parseJsonString(value: string): string {
+	let parsedValue: unknown;
+	try {
+		parsedValue = JSON.parse(value);
+	} catch {
+		throw new RuleFrontmatterParseError("Invalid JSON-quoted string");
+	}
+
+	if (typeof parsedValue !== "string") {
+		throw new RuleFrontmatterParseError("Expected JSON-quoted string");
+	}
+
+	return parsedValue;
+}
+
+function stripComment(line: string): string {
+	let quote: string | null = null;
+	let escaped = false;
+
+	for (let index = 0; index < line.length; index += 1) {
+		const character = line[index];
+		if (character === undefined) continue;
+
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+
+		if (quote !== null && character === "\\") {
+			escaped = true;
+			continue;
+		}
+
+		if (character === '"' || character === "'") {
+			if (quote === null) quote = character;
+			else if (quote === character) quote = null;
+			continue;
+		}
+
+		if (quote === null && character === "#") return line.slice(0, index);
+	}
+
+	return line;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/project-root.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/project-root.ts
@@ -1,0 +1,30 @@
+import { existsSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { PROJECT_MARKERS } from "./constants.ts";
+
+export function findProjectRoot(startPath: string, markers: ReadonlyArray<string> = PROJECT_MARKERS): string | null {
+	const resolvedStartPath = resolve(startPath);
+
+	if (!existsSync(resolvedStartPath)) {
+		return null;
+	}
+
+	const startStats = statSync(resolvedStartPath);
+	let currentDirectory = startStats.isDirectory() ? resolvedStartPath : dirname(resolvedStartPath);
+	const filesystemRoot = resolve("/");
+
+	while (true) {
+		for (const marker of markers) {
+			if (existsSync(join(currentDirectory, marker))) {
+				return currentDirectory;
+			}
+		}
+
+		if (currentDirectory === filesystemRoot) {
+			return null;
+		}
+
+		currentDirectory = dirname(currentDirectory);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/scanner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/scanner.ts
@@ -1,0 +1,140 @@
+import { type Dirent, existsSync, lstatSync, readdirSync, realpathSync, type Stats, statSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+
+import { RULE_FILE_EXTENSIONS, SCANNER_EXCLUDED_DIRS } from "./constants.ts";
+
+export interface ScanOptions {
+	rootDir: string;
+	excludedDirs?: ReadonlyArray<string>;
+	/** Maximum recursion depth. Default: 10 */
+	maxDepth?: number;
+}
+
+export interface ScannedFile {
+	/** Absolute path as encountered (may be a symlink). */
+	path: string;
+	/** Real (resolved) path; same as path if not a symlink. */
+	realPath: string;
+}
+
+export function scanRuleFiles(options: ScanOptions): ScannedFile[] {
+	const rootPath = toAbsolutePath(options.rootDir);
+	if (!existsSync(rootPath)) {
+		return [];
+	}
+
+	let rootStats: Stats;
+	try {
+		rootStats = statSync(rootPath);
+	} catch {
+		return [];
+	}
+
+	if (!rootStats.isDirectory()) {
+		return [];
+	}
+
+	const results: ScannedFile[] = [];
+	const visitedDirectories = new Set<string>();
+	const excludedDirs = new Set(options.excludedDirs ?? SCANNER_EXCLUDED_DIRS);
+	const maxDepth = options.maxDepth ?? 10;
+
+	scanDirectory(rootPath, 0, maxDepth, excludedDirs, visitedDirectories, results);
+	return results;
+}
+
+function toAbsolutePath(filePath: string): string {
+	return isAbsolute(filePath) ? filePath : resolve(filePath);
+}
+
+function scanDirectory(
+	directoryPath: string,
+	depth: number,
+	maxDepth: number,
+	excludedDirs: ReadonlySet<string>,
+	visitedDirectories: Set<string>,
+	results: ScannedFile[],
+): void {
+	let realDirectoryPath: string;
+	try {
+		realDirectoryPath = realpathSync.native(directoryPath);
+	} catch {
+		return;
+	}
+
+	if (visitedDirectories.has(realDirectoryPath)) {
+		return;
+	}
+	visitedDirectories.add(realDirectoryPath);
+
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(directoryPath, { withFileTypes: true }).sort((leftEntry, rightEntry) =>
+			leftEntry.name.localeCompare(rightEntry.name),
+		);
+	} catch {
+		return;
+	}
+
+	for (const entry of entries) {
+		const entryPath = join(directoryPath, entry.name);
+
+		if (entry.isDirectory()) {
+			if (!excludedDirs.has(entry.name) && depth < maxDepth) {
+				scanDirectory(entryPath, depth + 1, maxDepth, excludedDirs, visitedDirectories, results);
+			}
+			continue;
+		}
+
+		if (entry.isSymbolicLink()) {
+			scanSymbolicLink(entryPath, entry.name, depth, maxDepth, excludedDirs, visitedDirectories, results);
+			continue;
+		}
+
+		if (entry.isFile() && isRuleFile(entry.name)) {
+			results.push({ path: entryPath, realPath: resolveRealPath(entryPath) });
+		}
+	}
+}
+
+function scanSymbolicLink(
+	linkPath: string,
+	linkName: string,
+	depth: number,
+	maxDepth: number,
+	excludedDirs: ReadonlySet<string>,
+	visitedDirectories: Set<string>,
+	results: ScannedFile[],
+): void {
+	let targetStats: Stats;
+	try {
+		targetStats = statSync(linkPath);
+	} catch {
+		return;
+	}
+
+	if (targetStats.isDirectory()) {
+		if (!excludedDirs.has(linkName) && depth < maxDepth) {
+			scanDirectory(linkPath, depth + 1, maxDepth, excludedDirs, visitedDirectories, results);
+		}
+		return;
+	}
+
+	if (targetStats.isFile() && isRuleFile(linkName)) {
+		results.push({ path: linkPath, realPath: resolveRealPath(linkPath) });
+	}
+}
+
+function isRuleFile(fileName: string): boolean {
+	return RULE_FILE_EXTENSIONS.some((extension) => fileName.endsWith(extension));
+}
+
+function resolveRealPath(filePath: string): string {
+	try {
+		const realPath = realpathSync.native(filePath);
+		const fileStats = lstatSync(filePath);
+		return fileStats.isSymbolicLink() ? realPath : filePath;
+	} catch {
+		return filePath;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/tool-paths.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/tool-paths.ts
@@ -1,0 +1,50 @@
+import { isAbsolute, resolve } from "node:path";
+
+import type { ToolResultEvent } from "../../../types.ts";
+
+import { TRACKED_BUILTIN_TOOL_SET } from "./constants.ts";
+
+export function isTrackedTool(toolName: string): boolean {
+	return TRACKED_BUILTIN_TOOL_SET.has(toolName);
+}
+
+export function extractToolPaths(event: ToolResultEvent, cwd: string): string[] {
+	if (event.isError || !isTrackedTool(event.toolName)) {
+		return [];
+	}
+
+	const filePaths = new Set<string>();
+
+	if (event.toolName === "read" || event.toolName === "edit") {
+		addPath(filePaths, getStringProperty(event.details, "filePath"), cwd);
+		addPath(filePaths, getStringProperty(event.input, "path"), cwd);
+	}
+
+	if (event.toolName === "write") {
+		addPath(filePaths, getStringProperty(event.input, "filePath"), cwd);
+		addPath(filePaths, getStringProperty(event.input, "path"), cwd);
+	}
+
+	return [...filePaths];
+}
+
+function addPath(filePaths: Set<string>, filePath: string | undefined, cwd: string): void {
+	if (filePath === undefined || filePath.length === 0) {
+		return;
+	}
+
+	filePaths.add(isAbsolute(filePath) ? filePath : resolve(cwd, filePath));
+}
+
+function getStringProperty(value: unknown, propertyName: string): string | undefined {
+	if (!isRecord(value)) {
+		return undefined;
+	}
+
+	const propertyValue = value[propertyName];
+	return typeof propertyValue === "string" ? propertyValue : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/truncator.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/truncator.ts
@@ -1,0 +1,67 @@
+import { TRUNCATION_NOTICE } from "./constants.ts";
+import type { TruncationResult } from "./types.ts";
+
+type BudgetRule = {
+	body: string;
+	relativePath: string;
+};
+
+type BudgetResult = BudgetRule & {
+	truncated: boolean;
+};
+
+function truncationNotice(relativePath: string): string {
+	return TRUNCATION_NOTICE.replace("{path}", relativePath);
+}
+
+function safeSliceEnd(body: string, end: number): number {
+	if (end <= 0) {
+		return 0;
+	}
+
+	const lastCodeUnit = body.charCodeAt(end - 1);
+	if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+		return end - 1;
+	}
+
+	return end;
+}
+
+export function truncateRule(body: string, options: { maxChars: number; relativePath: string }): TruncationResult {
+	if (body.length <= options.maxChars) {
+		return { body, truncated: false, originalLength: body.length };
+	}
+
+	const notice = truncationNotice(options.relativePath);
+	if (options.maxChars < notice.length) {
+		return { body: notice, truncated: true, originalLength: body.length };
+	}
+
+	const sliceEnd = safeSliceEnd(body, options.maxChars - notice.length);
+	return { body: `${body.slice(0, sliceEnd)}${notice}`, truncated: true, originalLength: body.length };
+}
+
+export function truncateBudget(input: { rules: ReadonlyArray<BudgetRule>; maxResultChars: number }): BudgetResult[] {
+	const results: BudgetResult[] = [];
+	let remainingBudget = input.maxResultChars;
+
+	for (const rule of input.rules) {
+		if (remainingBudget >= rule.body.length) {
+			results.push({ body: rule.body, truncated: false, relativePath: rule.relativePath });
+			remainingBudget -= rule.body.length;
+			continue;
+		}
+
+		const notice = truncationNotice(rule.relativePath);
+		if (remainingBudget <= notice.length) {
+			break;
+		}
+
+		const sliceEnd = safeSliceEnd(rule.body, remainingBudget - notice.length);
+		const body = `${rule.body.slice(0, sliceEnd)}${notice}`;
+		results.push({ body, truncated: true, relativePath: rule.relativePath });
+		remainingBudget -= body.length;
+	}
+
+	return results;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/rules/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/rules/types.ts
@@ -1,0 +1,141 @@
+/**
+ * Public types for pi-rules.
+ *
+ * These types are stable contracts between modules. The frontmatter type
+ * mirrors omo's `RuleMetadata` plus Claude (`paths`) and Copilot (`applyTo`)
+ * aliases that are normalized into `globs` internally.
+ */
+
+/**
+ * YAML frontmatter parsed from a rule markdown file.
+ * `paths` (Claude alias) and `applyTo` (Copilot alias) are normalized into
+ * `globs` by the parser before any matcher sees this struct.
+ */
+export interface RuleFrontmatter {
+	description?: string;
+	globs?: string | string[];
+	paths?: string | string[];
+	applyTo?: string | string[];
+	alwaysApply?: boolean;
+}
+
+/**
+ * Result of parsing a rule markdown file.
+ * `body` excludes the frontmatter delimiters and the YAML payload.
+ */
+export interface ParsedRule {
+	frontmatter: RuleFrontmatter;
+	body: string;
+	/**
+	 * Diagnostic message if frontmatter parsing failed but the body was salvaged.
+	 * Empty when parsing succeeded.
+	 */
+	diagnostic?: string;
+}
+
+/**
+ * A discovered rule file candidate before parsing/matching.
+ *
+ * `path` is the absolute path as discovered (possibly via symlink).
+ * `realPath` is the canonical resolved path used for dedup.
+ * `source` identifies which discovery source produced this candidate.
+ */
+export interface RuleCandidate {
+	path: string;
+	realPath: string;
+	source: RuleSource;
+	/**
+	 * Distance from the target file directory to the directory containing this rule.
+	 * 0 = same directory, 9999 = global/user-home rule.
+	 */
+	distance: number;
+	isGlobal: boolean;
+	/**
+	 * True when this candidate is a SINGLE-FILE rule like AGENTS.md or
+	 * `.github/copilot-instructions.md` (frontmatter optional, applies always).
+	 */
+	isSingleFile: boolean;
+	/**
+	 * Path relative to project root, POSIX-normalized. Used for matcher and display.
+	 * Empty string for user-home global rules.
+	 */
+	relativePath: string;
+}
+
+/**
+ * A fully-loaded rule ready for injection.
+ */
+export interface LoadedRule extends RuleCandidate {
+	frontmatter: RuleFrontmatter;
+	body: string;
+	contentHash: string;
+	matchReason: MatchReason;
+}
+
+/**
+ * Source identifier for rule files. Used for deterministic ordering and display.
+ */
+export type RuleSource =
+	| ".omo/rules"
+	| ".claude/rules"
+	| ".cursor/rules"
+	| ".github/instructions"
+	| ".github/copilot-instructions.md"
+	| "AGENTS.md"
+	| "CLAUDE.md"
+	| "CONTEXT.md"
+	| "~/.omo/rules"
+	| "~/.opencode/rules"
+	| "~/.claude/rules"
+	| "~/.config/opencode/AGENTS.md"
+	| "~/.claude/CLAUDE.md";
+
+/**
+ * Why a candidate matched the target file. Surfaced in the injection block so
+ * the model can attribute its behavior to a specific rule.
+ */
+export type MatchReason = "alwaysApply" | "single-file" | { kind: "glob"; pattern: string } | { kind: "no-match" };
+
+/**
+ * Truncation result.
+ */
+export interface TruncationResult {
+	body: string;
+	truncated: boolean;
+	originalLength: number;
+}
+
+/**
+ * Configuration knobs resolved from env vars and package.json.
+ */
+export interface PiRulesConfig {
+	disabled: boolean;
+	mode: "static" | "dynamic" | "both" | "off";
+	maxRuleChars: number;
+	maxResultChars: number;
+	enabledSources: RuleSource[] | "auto";
+}
+
+/**
+ * Per-session in-memory dedup state.
+ *
+ * `staticDedup` keys are `{cwd}::{rulePath}::{contentHash}` strings.
+ * `dynamicDedup` stores `{targetPath}::{rulePath}::{contentHash}` strings grouped by target file.
+ * `dynamicTargetFingerprints` maps a target file cache key to a digest of its
+ * discovered rule candidates + file stats; loadDynamicRules short-circuits
+ * targets whose fingerprint has not changed since the previous load.
+ */
+export interface SessionState {
+	cwd: string | undefined;
+	staticDedup: Set<string>;
+	dynamicDedup: Map<string, Set<string>>;
+	dynamicTargetFingerprints: Map<string, string>;
+	loadedRules: LoadedRule[];
+	diagnostics: RuleDiagnostic[];
+}
+
+export interface RuleDiagnostic {
+	severity: "warning" | "error";
+	source: string;
+	message: string;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/ui/dynamic-border.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/ui/dynamic-border.ts
@@ -1,0 +1,15 @@
+import type { Component } from "@earendil-works/pi-tui";
+
+export class DynamicBorder implements Component {
+	private readonly color: (str: string) => string;
+
+	constructor(color: (str: string) => string) {
+		this.color = color;
+	}
+
+	render(width: number): string[] {
+		return [this.color("─".repeat(Math.max(1, width)))];
+	}
+
+	invalidate(): void {}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/ui/rules-banner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/ui/rules-banner.ts
@@ -1,0 +1,81 @@
+import { Container } from "@earendil-works/pi-tui";
+import type { Theme } from "../../../../../modes/interactive/theme/theme.ts";
+import type { LoadedRule, RuleDiagnostic } from "../rules/types.ts";
+import { DynamicBorder } from "./dynamic-border.ts";
+
+export interface RulesBannerProps {
+	ruleCount: number;
+	diagnostics: ReadonlyArray<RuleDiagnostic>;
+	topRules?: ReadonlyArray<Pick<LoadedRule, "relativePath" | "matchReason">>;
+}
+
+export class RulesBanner extends Container {
+	private readonly props: RulesBannerProps;
+	private readonly theme: Theme;
+
+	constructor(props: RulesBannerProps, theme: Theme) {
+		super();
+		this.props = props;
+		this.theme = theme;
+	}
+
+	override render(width: number): string[] {
+		return renderBannerLines(this.props, this.theme, width);
+	}
+
+	override invalidate(): void {}
+}
+
+export function renderBannerLines(props: RulesBannerProps, theme: Theme, width: number): string[] {
+	const lines: string[] = [];
+	const border = new DynamicBorder((str) => theme.fg("border", str));
+
+	if (props.ruleCount === 0) {
+		lines.push(...border.render(width));
+		lines.push(`${theme.bold(theme.fg("accent", "[pi-rules]"))} No rules discovered`);
+		lines.push(...border.render(width));
+		return lines;
+	}
+
+	lines.push(...border.render(width));
+	lines.push(
+		`${theme.bold(theme.fg("accent", "[pi-rules]"))} ${theme.fg("muted", `${props.ruleCount} active rules`)}`,
+	);
+	lines.push("");
+
+	if (props.topRules) {
+		for (const rule of props.topRules) {
+			const hasDiagnostic = props.diagnostics.some((diagnostic) => diagnostic.source === rule.relativePath);
+			const indicator = hasDiagnostic ? theme.fg("error", "⚠") : theme.fg("success", "●");
+
+			let annotation = "";
+			if (typeof rule.matchReason === "object" && rule.matchReason.kind === "glob") {
+				annotation = ` ${theme.fg("muted", rule.matchReason.pattern)}`;
+			}
+
+			lines.push(`  ${indicator} ${rule.relativePath}${annotation}`);
+		}
+	}
+
+	if (props.diagnostics.length > 0) {
+		lines.push(`  ${theme.fg("warning", `⚠ ${props.diagnostics.length} warning(s)`)}`);
+	}
+
+	lines.push("");
+	lines.push(...border.render(width));
+
+	return lines;
+}
+
+export interface StatusLineInput {
+	ruleCount: number;
+	hasErrors: boolean;
+}
+
+export function statusLineText(input: StatusLineInput, theme: Theme): string {
+	const base = `[pi-rules] ${input.ruleCount} active`;
+	if (input.hasErrors) {
+		return theme.fg("muted", `${base} · `) + theme.fg("error", "⚠ errors");
+	}
+	return theme.fg("muted", base);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -1,0 +1,14 @@
+# changes.md — webfetch (vendored)
+
+Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-webfetch) (see `external-versions.json`).
+
+## Senpi adaptations vs upstream
+
+- Imports rewritten by `scripts/vendor-transform.mjs`: `@mariozechner/pi-{ai,tui}` -> `@earendil-works/pi-{ai,tui}`; `@mariozechner/pi-coding-agent` symbols -> `../../types.ts` (and `Theme` -> `modes/interactive/theme/theme.ts`); relative `.js` import suffixes -> `.ts`.
+- `webfetch/fetcher.ts`: `buildHeaders` return type `HeadersInit` -> `Record<string, string>` (senpi's root tsconfig has no DOM lib, so the `HeadersInit` global is unavailable; the value is already a plain string record).
+- Runtime dep `turndown` (+ `@types/turndown`) added to `package.json`.
+- No behavior changes. Registers the `webfetch` tool, gated by `PI_WEBFETCH` (default on).
+
+## Conflict zones
+
+Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the `HeadersInit` patch after re-running the transform, then re-check `npm run check`.

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/index.ts
@@ -1,0 +1,64 @@
+import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+
+import { renderWebfetchCall, renderWebfetchResult } from "./webfetch/renderers.ts";
+import { type WebfetchRenderDetails, webfetch } from "./webfetch/tool.ts";
+
+const ENABLE_ENV = "PI_WEBFETCH";
+const STATUS_KEY = "pi-webfetch";
+const WIDGET_KEY = "pi-webfetch";
+
+function parseEnableEnv(envVar: string): boolean {
+	const envValue = process.env[envVar];
+	if (!envValue) {
+		return true;
+	}
+
+	const normalized = envValue.trim().toLowerCase();
+	if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off") {
+		return false;
+	}
+
+	if (normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on") {
+		return true;
+	}
+
+	// Unknown values fall back to default-on behavior.
+	return true;
+}
+
+export function isWebfetchEnabled(): boolean {
+	return parseEnableEnv(ENABLE_ENV);
+}
+
+function clearUi(ctx: ExtensionContext): void {
+	if (!ctx.hasUI) return;
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+	ctx.ui.setWidget(WIDGET_KEY, undefined);
+}
+
+/**
+ * pi-webfetch — URL retrieval for the pi coding agent.
+ *
+ * Registers one LLM-callable tool:
+ *   - webfetch — fetch URL content as markdown, text, or html.
+ */
+export default function (pi: ExtensionAPI): void {
+	// When PI_WEBFETCH disables the extension, keep factory callable but skip all registration side effects.
+	if (!isWebfetchEnabled()) {
+		return;
+	}
+
+	pi.registerTool<typeof webfetch.parameters, WebfetchRenderDetails>({
+		...webfetch,
+		renderCall: renderWebfetchCall,
+		renderResult: renderWebfetchResult,
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		clearUi(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		clearUi(ctx);
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.ts
@@ -1,0 +1,67 @@
+import TurndownService from "turndown";
+
+const TAGS_TO_REMOVE = /<(script|style|noscript|iframe|object|embed|meta|link)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const VOID_TAGS_TO_REMOVE = /<(script|style|noscript|iframe|object|embed|meta|link)\b[^>]*\/?>/gi;
+const BLOCK_BREAK_TAGS =
+	/<\/?(address|article|aside|blockquote|br|dd|div|dl|dt|figcaption|figure|footer|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>/gi;
+const TAGS = /<[^>]+>/g;
+const WHITESPACE = /[\t\f\v ]+/g;
+const NEWLINE_RUN = /\n{3,}/g;
+
+const ENTITIES: Readonly<Record<string, string>> = {
+	amp: "&",
+	apos: "'",
+	gt: ">",
+	lt: "<",
+	nbsp: " ",
+	quot: '"',
+};
+
+const turndownService = new TurndownService({
+	headingStyle: "atx",
+	hr: "---",
+	bulletListMarker: "-",
+	codeBlockStyle: "fenced",
+	emDelimiter: "*",
+});
+turndownService.remove(["script", "style", "noscript", "iframe", "object", "embed", "meta", "link"]);
+
+export function htmlToMarkdown(html: string): string {
+	return turndownService.turndown(html).trim();
+}
+
+export function htmlToText(html: string): string {
+	return decodeHtmlEntities(
+		html
+			.replace(TAGS_TO_REMOVE, "")
+			.replace(VOID_TAGS_TO_REMOVE, "")
+			.replace(BLOCK_BREAK_TAGS, "\n")
+			.replace(TAGS, "")
+			.replace(WHITESPACE, " ")
+			.replace(/[ \t]+\n/g, "\n")
+			.replace(/\n[ \t]+/g, "\n")
+			.replace(NEWLINE_RUN, "\n\n")
+			.trim(),
+	);
+}
+
+export function decodeHtmlEntities(text: string): string {
+	return text.replace(/&(#x[\da-f]+|#\d+|[a-z]+);/gi, (_match, entity: string) => {
+		if (entity.startsWith("#x")) {
+			return decodeCodePoint(Number.parseInt(entity.slice(2), 16));
+		}
+		if (entity.startsWith("#")) {
+			return decodeCodePoint(Number.parseInt(entity.slice(1), 10));
+		}
+		return ENTITIES[entity.toLowerCase()] ?? `&${entity};`;
+	});
+}
+
+function decodeCodePoint(value: number): string {
+	if (!Number.isFinite(value)) return "";
+	try {
+		return String.fromCodePoint(value);
+	} catch {
+		return "";
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/errors.ts
@@ -1,0 +1,27 @@
+export class InvalidWebfetchUrlError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "InvalidWebfetchUrlError";
+	}
+}
+
+export class WebfetchTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "WebfetchTimeoutError";
+	}
+}
+
+export class WebfetchResponseTooLargeError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "WebfetchResponseTooLargeError";
+	}
+}
+
+export class WebfetchAbortError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "WebfetchAbortError";
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
@@ -1,0 +1,187 @@
+import {
+	InvalidWebfetchUrlError,
+	WebfetchAbortError,
+	WebfetchResponseTooLargeError,
+	WebfetchTimeoutError,
+} from "./errors.ts";
+
+export const MAX_RESPONSE_SIZE_BYTES = 5 * 1024 * 1024;
+export const DEFAULT_TIMEOUT_SECONDS = 30;
+export const MAX_TIMEOUT_SECONDS = 120;
+
+const BROWSER_USER_AGENT =
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
+
+export type WebfetchFormat = "markdown" | "text" | "html";
+
+export interface FetchOptions {
+	url: string;
+	format: WebfetchFormat;
+	timeoutSeconds?: number;
+	signal?: AbortSignal;
+}
+
+export interface FetchResult {
+	url: string;
+	status: number;
+	statusText: string;
+	contentType: string;
+	bytes: number;
+	body: Uint8Array;
+	truncated: boolean;
+}
+
+export async function fetchUrl(options: FetchOptions): Promise<FetchResult> {
+	validateUrl(options.url);
+
+	const timeoutSeconds = clampTimeout(options.timeoutSeconds);
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(new WebfetchTimeoutError(`Request timed out after ${timeoutSeconds}s`)),
+		timeoutSeconds * 1000,
+	);
+	const removeAbortForwarder = forwardAbort(options.signal, controller);
+
+	try {
+		const response = await fetch(options.url, {
+			headers: buildHeaders(options.format, BROWSER_USER_AGENT),
+			signal: controller.signal,
+		});
+
+		if (response.status === 403 && response.headers.get("cf-mitigated") === "challenge") {
+			await cancelBody(response);
+			const retry = await fetch(options.url, {
+				headers: buildHeaders(options.format, "pi-webfetch"),
+				signal: controller.signal,
+			});
+			return await readFetchResponse(options.url, retry, controller.signal);
+		}
+
+		return await readFetchResponse(options.url, response, controller.signal);
+	} finally {
+		clearTimeout(timeout);
+		removeAbortForwarder();
+	}
+}
+
+export function validateUrl(url: string): void {
+	if (!url.startsWith("http://") && !url.startsWith("https://")) {
+		throw new InvalidWebfetchUrlError("URL must start with http:// or https://");
+	}
+
+	try {
+		new URL(url);
+	} catch {
+		throw new InvalidWebfetchUrlError(`Invalid URL: ${url}`);
+	}
+}
+
+export function clampTimeout(timeoutSeconds: number | undefined): number {
+	if (timeoutSeconds === undefined) return DEFAULT_TIMEOUT_SECONDS;
+	if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) return DEFAULT_TIMEOUT_SECONDS;
+	return Math.min(Math.ceil(timeoutSeconds), MAX_TIMEOUT_SECONDS);
+}
+
+export function buildAcceptHeader(format: WebfetchFormat): string {
+	switch (format) {
+		case "markdown":
+			return "text/markdown;q=1.0, text/x-markdown;q=0.9, text/plain;q=0.8, text/html;q=0.7, */*;q=0.1";
+		case "text":
+			return "text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1";
+		case "html":
+			return "text/html;q=1.0, application/xhtml+xml;q=0.9, text/plain;q=0.8, text/markdown;q=0.7, */*;q=0.1";
+	}
+}
+
+function buildHeaders(format: WebfetchFormat, userAgent: string): Record<string, string> {
+	return {
+		Accept: buildAcceptHeader(format),
+		"Accept-Language": "en-US,en;q=0.9",
+		"User-Agent": userAgent,
+	};
+}
+
+async function readFetchResponse(url: string, response: Response, signal: AbortSignal): Promise<FetchResult> {
+	await rejectOversizedContentLength(response);
+	const body = await readResponseBody(response, signal);
+	return {
+		url: response.url || url,
+		status: response.status,
+		statusText: response.statusText,
+		contentType: response.headers.get("content-type") ?? "",
+		bytes: body.length,
+		body,
+		truncated: body.length === MAX_RESPONSE_SIZE_BYTES,
+	};
+}
+
+async function rejectOversizedContentLength(response: Response): Promise<void> {
+	const contentLength = response.headers.get("content-length");
+	if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_SIZE_BYTES) {
+		await cancelBody(response);
+		throw new WebfetchResponseTooLargeError("Response too large (exceeds 5MB limit)");
+	}
+}
+
+async function cancelBody(response: Response): Promise<void> {
+	try {
+		await response.body?.cancel();
+	} catch {
+		// Preserve the caller's original failure.
+	}
+}
+
+async function readResponseBody(response: Response, signal: AbortSignal): Promise<Uint8Array> {
+	if (!response.body) return new Uint8Array();
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+
+	try {
+		while (true) {
+			if (signal.aborted) {
+				await cancelReader(reader);
+				throw new WebfetchAbortError("Request aborted");
+			}
+			const read = await reader.read();
+			if (read.done) break;
+			chunks.push(read.value);
+			total += read.value.length;
+			if (total > MAX_RESPONSE_SIZE_BYTES) {
+				await cancelReader(reader);
+				throw new WebfetchResponseTooLargeError("Response too large (exceeds 5MB limit)");
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const body = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return body;
+}
+
+async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+	try {
+		await reader.cancel();
+	} catch {
+		// Preserve the caller's original failure.
+	}
+}
+
+function forwardAbort(signal: AbortSignal | undefined, controller: AbortController): () => void {
+	if (!signal) return () => {};
+	if (signal.aborted) {
+		controller.abort(signal.reason);
+		return () => {};
+	}
+
+	const listener = (): void => controller.abort(signal.reason);
+	signal.addEventListener("abort", listener, { once: true });
+	return () => signal.removeEventListener("abort", listener);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/renderers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/renderers.ts
@@ -1,0 +1,142 @@
+import { Text, truncateToWidth } from "@earendil-works/pi-tui";
+import type { Theme } from "../../../../../modes/interactive/theme/theme.ts";
+import type { ToolRenderResultOptions } from "../../../types.ts";
+
+import type { WebfetchDetails, WebfetchProgressDetails, WebfetchRenderDetails } from "./tool.ts";
+
+const URL_BUDGET = 92;
+const PREVIEW_LINES = 4;
+const PREVIEW_WIDTH = 120;
+
+interface WebfetchArgs {
+	url: string;
+	format?: string;
+	timeout?: number;
+}
+
+interface ResultLike<TDetails> {
+	content: ReadonlyArray<{ type: string; text?: string }>;
+	details?: TDetails;
+}
+
+export function renderWebfetchCall(args: unknown, theme: Theme): Text {
+	const webfetchArgs = parseWebfetchArgs(args);
+	const head = theme.fg("toolTitle", theme.bold("webfetch "));
+	const url = theme.fg("accent", shorten(webfetchArgs.url, URL_BUDGET));
+	const format = theme.fg("muted", ` [${webfetchArgs.format ?? "markdown"}]`);
+	const timeout = webfetchArgs.timeout === undefined ? "" : theme.fg("dim", ` ${webfetchArgs.timeout}s`);
+	return new Text(head + url + format + timeout, 0, 0);
+}
+
+export function renderWebfetchResult(
+	result: ResultLike<WebfetchRenderDetails>,
+	options: ToolRenderResultOptions,
+	theme: Theme,
+): Text {
+	if (options.isPartial) {
+		const details = result.details;
+		if (isWebfetchProgressDetails(details)) {
+			return new Text(
+				theme.fg(
+					"warning",
+					`Fetching ${shorten(details.url, URL_BUDGET)} as ${details.format} (${details.timeoutSeconds}s)`,
+				),
+				0,
+				0,
+			);
+		}
+		return new Text(theme.fg("warning", "Fetching..."), 0, 0);
+	}
+
+	const details = result.details;
+	const text = result.content.find((block) => block.type === "text")?.text ?? "";
+	if (!isWebfetchDetails(details)) {
+		return new Text(theme.fg("muted", truncateToWidth(text, PREVIEW_WIDTH)), 0, 0);
+	}
+
+	const statusKey = details.status >= 200 && details.status < 300 ? "success" : "warning";
+	const status = theme.fg(statusKey, `${details.status} ${details.statusText || "OK"}`);
+	const format = theme.fg("accent", details.format);
+	const size = theme.fg("muted", formatBytes(details.bytes));
+	const converted = details.converted ? theme.fg("dim", " converted") : "";
+	const header = `${status} ${theme.fg("muted", "•")} ${format} ${theme.fg("muted", "•")} ${size}${converted}`;
+
+	if (!options.expanded) {
+		const preview = previewText(text, theme);
+		return new Text([header, ...preview].join("\n"), 0, 0);
+	}
+
+	const lines = [
+		header,
+		theme.fg("dim", `URL: ${shorten(details.finalUrl, URL_BUDGET)}`),
+		theme.fg("dim", `Content-Type: ${details.contentType || "unknown"}`),
+		"",
+		...collectLines(text, 24).map((line) => theme.fg("toolOutput", truncateToWidth(line, PREVIEW_WIDTH))),
+	];
+	return new Text(lines.join("\n"), 0, 0);
+}
+
+function collectLines(text: string, limit: number): string[] {
+	const lines: string[] = [];
+	let start = 0;
+	while (lines.length < limit && start <= text.length) {
+		const newlineIndex = text.indexOf("\n", start);
+		if (newlineIndex === -1) {
+			lines.push(text.slice(start));
+			break;
+		}
+		lines.push(text.slice(start, newlineIndex));
+		start = newlineIndex + 1;
+	}
+	return lines;
+}
+
+function collectNonEmptyTrimmedLines(text: string, limit: number): string[] {
+	const lines: string[] = [];
+	let start = 0;
+	while (lines.length < limit && start <= text.length) {
+		const newlineIndex = text.indexOf("\n", start);
+		const line = (newlineIndex === -1 ? text.slice(start) : text.slice(start, newlineIndex)).trim();
+		if (line.length > 0) lines.push(line);
+		if (newlineIndex === -1) break;
+		start = newlineIndex + 1;
+	}
+	return lines;
+}
+
+function parseWebfetchArgs(args: unknown): WebfetchArgs {
+	if (typeof args !== "object" || args === null) {
+		return { url: "" };
+	}
+	const webfetchArgs: WebfetchArgs = {
+		url: "url" in args && typeof args.url === "string" ? args.url : "",
+	};
+	if ("format" in args && typeof args.format === "string") webfetchArgs.format = args.format;
+	if ("timeout" in args && typeof args.timeout === "number") webfetchArgs.timeout = args.timeout;
+	return webfetchArgs;
+}
+
+function isWebfetchProgressDetails(details: WebfetchRenderDetails | unknown): details is WebfetchProgressDetails {
+	return typeof details === "object" && details !== null && "phase" in details && details.phase === "fetching";
+}
+
+function isWebfetchDetails(details: WebfetchRenderDetails | unknown): details is WebfetchDetails {
+	return typeof details === "object" && details !== null && "status" in details && typeof details.status === "number";
+}
+
+function previewText(text: string, theme: Theme): string[] {
+	const lines = collectNonEmptyTrimmedLines(text, PREVIEW_LINES);
+	if (lines.length === 0) return [theme.fg("dim", "  empty response")];
+	return lines.map((line) => theme.fg("toolOutput", `  ${truncateToWidth(line, PREVIEW_WIDTH)}`));
+}
+
+function shorten(value: string, max: number): string {
+	if (value.length <= max) return value;
+	return `${value.slice(0, max - 1)}…`;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/tool.ts
@@ -1,0 +1,109 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { defineTool } from "../../../types.ts";
+
+import { htmlToMarkdown, htmlToText } from "./content.ts";
+import { clampTimeout, fetchUrl, type WebfetchFormat } from "./fetcher.ts";
+
+const WEBFETCH_FORMATS = ["markdown", "text", "html"] as const;
+
+const Params = Type.Object({
+	url: Type.String({ description: "The URL to fetch content from" }),
+	format: Type.Optional(
+		StringEnum(["markdown", "text", "html"] as const, {
+			description: "The format to return the content in. Defaults to markdown.",
+		}),
+	),
+	timeout: Type.Optional(Type.Number({ description: "Optional timeout in seconds. Maximum 120." })),
+});
+
+export interface WebfetchDetails {
+	url: string;
+	finalUrl: string;
+	format: WebfetchFormat;
+	status: number;
+	statusText: string;
+	contentType: string;
+	bytes: number;
+	timeoutSeconds: number;
+	converted: boolean;
+	truncated: boolean;
+}
+
+export interface WebfetchProgressDetails {
+	phase: "fetching";
+	url: string;
+	format: WebfetchFormat;
+	timeoutSeconds: number;
+}
+
+export type WebfetchRenderDetails = WebfetchDetails | WebfetchProgressDetails;
+
+export const webfetch = defineTool<typeof Params, WebfetchRenderDetails>({
+	name: "webfetch",
+	label: "Web Fetch",
+	description:
+		"Fetches content from a URL and returns it as markdown, plain text, or HTML. " +
+		"Network use is bounded by timeout and response size limits.",
+	promptSnippet: "webfetch: retrieve URL content as markdown, text, or html",
+	promptGuidelines: [
+		"Use webfetch when a specific URL must be retrieved.",
+		"Prefer markdown format unless raw HTML or plain text is explicitly needed.",
+		"The tool is read-only and does not modify files.",
+	],
+	parameters: Params,
+	async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+		const format = parseWebfetchFormat(params.format);
+		const timeoutSeconds = clampTimeout(params.timeout);
+		onUpdate?.({
+			content: [{ type: "text", text: `Fetching ${params.url} as ${format} (timeout ${timeoutSeconds}s)` }],
+			details: { phase: "fetching", url: params.url, format, timeoutSeconds },
+		});
+
+		const fetched = await fetchUrl({
+			url: params.url,
+			format,
+			timeoutSeconds,
+			...(signal === undefined ? {} : { signal }),
+		});
+		const raw = new TextDecoder().decode(fetched.body);
+		const contentType = fetched.contentType.toLowerCase();
+		const isHtml = contentType.includes("text/html") || contentType.includes("application/xhtml+xml");
+		let text = raw;
+		let converted = false;
+
+		if (isHtml && format === "markdown") {
+			text = htmlToMarkdown(raw);
+			converted = true;
+		} else if (isHtml && format === "text") {
+			text = htmlToText(raw);
+			converted = true;
+		}
+
+		const details: WebfetchDetails = {
+			url: params.url,
+			finalUrl: fetched.url,
+			format,
+			status: fetched.status,
+			statusText: fetched.statusText,
+			contentType: fetched.contentType,
+			bytes: fetched.bytes,
+			timeoutSeconds,
+			converted,
+			truncated: fetched.truncated,
+		};
+
+		return {
+			content: [{ type: "text", text }],
+			details,
+		};
+	},
+});
+
+export function parseWebfetchFormat(value: unknown): WebfetchFormat {
+	if (value === undefined) return "markdown";
+	for (const format of WEBFETCH_FORMATS) {
+		if (value === format) return format;
+	}
+	return "markdown";
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/changes.md
@@ -1,0 +1,12 @@
+# changes.md — websearch (vendored)
+
+Vendored from [`code-yeongyu/pi-websearch`](https://github.com/code-yeongyu/pi-websearch) (see `external-versions.json`).
+
+## Senpi adaptations vs upstream
+
+- Imports rewritten by `scripts/vendor-transform.mjs`: `@mariozechner/pi-{ai,tui}` -> `@earendil-works/pi-{ai,tui}`; `@mariozechner/pi-coding-agent` symbols -> `../../types.ts` (and `Theme` -> `modes/interactive/theme/theme.ts`); relative `.js` import suffixes -> `.ts`.
+- No behavior changes. Registers the `web_search` tool unconditionally and defers to provider-native web search (`anthropic-web-search` / `openai-web-search` inject at request level, so there is no tool-registry name clash).
+
+## Conflict zones
+
+Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Port upstream changes by re-running the transform, then re-check `npm run check`.

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/index.ts
@@ -1,0 +1,97 @@
+import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+
+import { loadWebsearchConfig } from "./websearch/config.ts";
+import { createWebSearchTool } from "./websearch/tool.ts";
+import type { ConfigLoadResult, WebsearchConfig } from "./websearch/types.ts";
+
+const STATUS_KEY = "pi-websearch";
+const WIDGET_KEY = "pi-websearch";
+const NATIVE_BYPASS_MESSAGE = "Native provider web search is handled by the built-in provider extension.";
+
+type ProviderModelContext = {
+	provider?: string;
+	api?: string;
+};
+
+function isProviderNativeBypass(model: ProviderModelContext | undefined): boolean {
+	return (
+		model?.provider === "openai" ||
+		model?.provider === "anthropic" ||
+		model?.api === "anthropic-messages" ||
+		model?.api === "openai-responses" ||
+		model?.api === "azure-openai-responses"
+	);
+}
+
+export default function (pi: ExtensionAPI): void {
+	let state: ConfigLoadResult = {
+		ok: false,
+		reason: "missing_config",
+		message: "Missing websearch config. Create .pi/websearch.json or ~/.pi/websearch.json before starting pi.",
+	};
+
+	function providerLabel(provider: WebsearchConfig["providers"][number]): string {
+		return provider.id ? `${provider.id}/${provider.provider}` : provider.provider;
+	}
+
+	function providerList(config: WebsearchConfig): string {
+		return config.providers.map(providerLabel).join(", ");
+	}
+
+	function clearUi(ctx: ExtensionContext): void {
+		if (ctx.hasUI === false) return;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.setWidget(WIDGET_KEY, undefined);
+	}
+
+	function updateUi(ctx: ExtensionContext): void {
+		if (ctx.hasUI === false) return;
+		if (state.ok) {
+			clearUi(ctx);
+			return;
+		}
+		if (state.reason === "provider_native_bypass") {
+			clearUi(ctx);
+			return;
+		}
+		clearUi(ctx);
+		ctx.ui.notify(state.message, "error");
+	}
+
+	pi.registerTool(createWebSearchTool(() => state));
+
+	pi.on("session_start", async (_event, ctx) => {
+		state = isProviderNativeBypass(ctx.model)
+			? { ok: false, reason: "provider_native_bypass", message: NATIVE_BYPASS_MESSAGE }
+			: await loadWebsearchConfig({ cwd: ctx.cwd });
+		updateUi(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		clearUi(ctx);
+	});
+
+	pi.registerCommand("websearch", {
+		description: "Show web search provider status",
+		handler: async (rawArgs, ctx) => {
+			const args = rawArgs.trim();
+			if (args !== "" && args !== "status") {
+				ctx.ui.notify("Usage: /websearch status", "warning");
+				return;
+			}
+			if (state.ok) {
+				ctx.ui.notify(
+					`Web search active: strategy=${state.config.strategy}, auto=${state.config.auto ? "enabled" : "disabled"}, providers=${providerList(state.config)}`,
+					"info",
+				);
+				return;
+			}
+			ctx.ui.notify(
+				state.reason === "provider_native_bypass"
+					? `Web search deferred: ${state.message}`
+					: `Web search inactive: ${state.message}`,
+				state.reason === "provider_native_bypass" ? "info" : "error",
+			);
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/config.ts
@@ -1,0 +1,277 @@
+import { access, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { isAllowedProviderBaseUrl } from "./provider-endpoints.ts";
+import type {
+	CodexSearchMode,
+	ConfigLoadResult,
+	JsonObject,
+	JsonValue,
+	ProviderValidationResult,
+	RoutingStrategy,
+	SearchContextSize,
+	SearchProvider,
+	SearchProviderConfig,
+	SearchProviderEntry,
+	SearchUserLocation,
+	WebsearchConfig,
+} from "./types.ts";
+
+const PROVIDERS: readonly SearchProvider[] = [
+	"exa",
+	"tavily",
+	"brave",
+	"duckduckgo-html",
+	"serper",
+	"google-cse",
+	"z-ai",
+	"openai",
+	"codex",
+	"anthropic",
+	"perplexity",
+	"xai",
+];
+const CONTEXT_SIZES: readonly SearchContextSize[] = ["low", "medium", "high"];
+const CODEX_MODES: readonly CodexSearchMode[] = ["cached", "live"];
+const STRATEGIES: readonly RoutingStrategy[] = ["priority", "round-robin", "fill-first"];
+const DEFAULT_FREE_CONFIG: WebsearchConfig = {
+	strategy: "priority",
+	fallback: true,
+	auto: true,
+	providers: [{ id: "default", provider: "duckduckgo-html", maxResults: 10 }],
+};
+
+export interface ConfigLoadOptions {
+	cwd: string;
+	homeDir?: string;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function oneOf<TValue extends string>(values: readonly TValue[], value: unknown): value is TValue {
+	return typeof value === "string" && (values as readonly string[]).includes(value);
+}
+
+function isStringArray(value: JsonValue | undefined): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function optionalString(value: JsonValue | undefined): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalNumber(value: JsonValue | undefined): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function optionalBoolean(value: JsonValue | undefined): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function optionalProvider(value: JsonValue | undefined): SearchProvider | undefined {
+	return oneOf(PROVIDERS, value) ? value : undefined;
+}
+
+function optionalContextSize(value: JsonValue | undefined): SearchContextSize | undefined {
+	return oneOf(CONTEXT_SIZES, value) ? value : undefined;
+}
+
+function optionalCodexMode(value: JsonValue | undefined): CodexSearchMode | undefined {
+	return oneOf(CODEX_MODES, value) ? value : undefined;
+}
+
+function optionalStrategy(value: JsonValue | undefined): RoutingStrategy | undefined {
+	return oneOf(STRATEGIES, value) ? value : undefined;
+}
+
+function optionalLocation(value: JsonValue | undefined): SearchUserLocation | undefined {
+	if (!isJsonObject(value)) return undefined;
+	const location: SearchUserLocation = {};
+	const country = optionalString(value["country"]);
+	const region = optionalString(value["region"]);
+	const city = optionalString(value["city"]);
+	const timezone = optionalString(value["timezone"]);
+	if (country) location.country = country;
+	if (region) location.region = region;
+	if (city) location.city = city;
+	if (timezone) location.timezone = timezone;
+	return Object.keys(location).length > 0 ? location : undefined;
+}
+
+function parseJsonObject(content: string): JsonObject | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(content);
+	} catch {
+		return null;
+	}
+	return isJsonObject(parsed) ? parsed : null;
+}
+
+function providerEntryFromObject(raw: JsonObject): SearchProviderEntry | null {
+	const provider = optionalProvider(raw["provider"]) ?? optionalProvider(raw["backend"]);
+	if (!provider) return null;
+
+	const config: SearchProviderEntry = { provider };
+	const id = optionalString(raw["id"]);
+	const apiKey = optionalString(raw["apiKey"]);
+	const baseUrl = optionalString(raw["baseUrl"]);
+	const searchEngineId = optionalString(raw["searchEngineId"]);
+	const maxResults = optionalNumber(raw["maxResults"]);
+	const model = optionalString(raw["model"]);
+	const codexMode = optionalCodexMode(raw["codexMode"]);
+	const searchContextSize = optionalContextSize(raw["searchContextSize"]);
+	const rawAllowedDomains = raw["allowedDomains"];
+	const rawBlockedDomains = raw["blockedDomains"];
+	const allowedDomains = isStringArray(rawAllowedDomains) ? rawAllowedDomains : undefined;
+	const blockedDomains = isStringArray(rawBlockedDomains) ? rawBlockedDomains : undefined;
+	const userLocation = optionalLocation(raw["userLocation"]);
+	const priority = optionalNumber(raw["priority"]);
+	const weight = optionalNumber(raw["weight"]);
+
+	if (id) config.id = id;
+	if (apiKey) config.apiKey = apiKey;
+	if (baseUrl) config.baseUrl = baseUrl;
+	if (searchEngineId) config.searchEngineId = searchEngineId;
+	if (maxResults) config.maxResults = maxResults;
+	if (model) config.model = model;
+	if (codexMode) config.codexMode = codexMode;
+	if (searchContextSize) config.searchContextSize = searchContextSize;
+	if (allowedDomains) config.allowedDomains = allowedDomains;
+	if (blockedDomains) config.blockedDomains = blockedDomains;
+	if (userLocation) config.userLocation = userLocation;
+	if (priority !== undefined) config.priority = priority;
+	if (weight !== undefined) config.weight = weight;
+
+	return config;
+}
+
+function configFromObject(raw: JsonObject): WebsearchConfig | null {
+	const auto = optionalBoolean(raw["auto"]) ?? true;
+	const providersValue = raw["providers"];
+	const rawProviders = Array.isArray(providersValue) ? providersValue : undefined;
+	if (rawProviders) {
+		if (optionalProvider(raw["provider"])) return null;
+		const providers = rawProviders
+			.map((value) => (isJsonObject(value) ? providerEntryFromObject(value) : null))
+			.filter((entry): entry is SearchProviderEntry => entry !== null);
+		const strategy = optionalStrategy(raw["strategy"]) ?? "priority";
+		const fallback = optionalBoolean(raw["fallback"]) ?? true;
+		return { strategy, fallback, auto, providers };
+	}
+
+	const provider = providerEntryFromObject(raw);
+	return provider ? { strategy: "priority", fallback: true, auto, providers: [provider] } : null;
+}
+
+function hasApiKey(config: SearchProviderConfig): boolean {
+	return typeof config.apiKey === "string" && config.apiKey.length > 0;
+}
+
+export function validateProviderConfig(config: SearchProviderEntry): ProviderValidationResult {
+	if (!PROVIDERS.includes(config.provider)) {
+		return { ok: false, reason: "invalid_config", message: `Unsupported provider: ${config.provider}` };
+	}
+
+	if (config.allowedDomains && config.blockedDomains) {
+		return {
+			ok: false,
+			reason: "invalid_config",
+			message: "Provider config cannot specify both allowedDomains and blockedDomains.",
+		};
+	}
+
+	if (config.weight !== undefined && config.weight <= 0) {
+		return { ok: false, reason: "invalid_config", message: "Provider weight must be greater than 0." };
+	}
+
+	if (config.baseUrl && !isAllowedProviderBaseUrl(config.baseUrl)) {
+		return {
+			ok: false,
+			reason: "invalid_config",
+			message: `Provider ${config.provider} baseUrl must be a public HTTPS URL without credentials.`,
+		};
+	}
+
+	if (config.provider === "google-cse" && !config.searchEngineId) {
+		return { ok: false, reason: "missing_api_key", message: "Provider google-cse requires searchEngineId." };
+	}
+
+	if ((config.provider === "codex" || config.provider === "openai") && !hasApiKey(config)) {
+		return {
+			ok: false,
+			reason: "missing_api_key",
+			message: `Provider ${config.provider} requires apiKey for hosted Responses API search.`,
+		};
+	}
+
+	if (
+		config.provider !== "codex" &&
+		config.provider !== "openai" &&
+		config.provider !== "duckduckgo-html" &&
+		!hasApiKey(config)
+	) {
+		return { ok: false, reason: "missing_api_key", message: `Provider ${config.provider} requires apiKey.` };
+	}
+
+	return { ok: true, config };
+}
+
+export function validateWebsearchConfig(
+	config: WebsearchConfig,
+): ProviderValidationResult | { ok: true; config: WebsearchConfig } {
+	if (!STRATEGIES.includes(config.strategy)) {
+		return { ok: false, reason: "invalid_config", message: `Unsupported routing strategy: ${config.strategy}` };
+	}
+	if (typeof config.auto !== "boolean") {
+		return { ok: false, reason: "invalid_config", message: "Websearch config auto must be a boolean." };
+	}
+	if (config.providers.length === 0) {
+		return { ok: false, reason: "invalid_config", message: "Websearch config requires at least one provider." };
+	}
+
+	for (const provider of config.providers) {
+		const validation = validateProviderConfig(provider);
+		if (!validation.ok) return validation;
+	}
+
+	return { ok: true, config };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function loadWebsearchConfig(options: ConfigLoadOptions): Promise<ConfigLoadResult> {
+	const home = options.homeDir ?? homedir();
+	const paths = [
+		join(options.cwd, ".pi", "websearch.json"),
+		join(home, "websearch.json"),
+		join(home, ".pi", "websearch.json"),
+	];
+
+	for (const path of paths) {
+		if (!(await fileExists(path))) continue;
+		const raw = parseJsonObject(await readFile(path, "utf8"));
+		if (!raw) {
+			return { ok: false, reason: "invalid_config", message: `Invalid JSON object in ${path}`, source: path };
+		}
+		const config = configFromObject(raw);
+		if (!config) {
+			return { ok: false, reason: "invalid_config", message: `Invalid provider config in ${path}`, source: path };
+		}
+		const validation = validateWebsearchConfig(config);
+		if (!validation.ok) return { ...validation, source: path };
+		return { ok: true, config, source: path };
+	}
+
+	return { ok: true, config: DEFAULT_FREE_CONFIG, source: "default:duckduckgo-html" };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/native.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/native.ts
@@ -1,0 +1,92 @@
+import { isAllowedProviderBaseUrl } from "./provider-endpoints.ts";
+import type { SearchProvider, SearchProviderEntry } from "./types.ts";
+
+export interface NativeModelInfo {
+	provider: string;
+	id: string;
+	baseUrl: string;
+}
+
+export type NativeAuthResult =
+	| { ok: true; apiKey?: string; headers?: Record<string, string> }
+	| { ok: false; error: string };
+
+export interface NativeModelRegistry {
+	getApiKeyAndHeaders(model: NativeModelInfo): Promise<NativeAuthResult>;
+}
+
+interface NativeProviderMapping {
+	provider: SearchProvider;
+	resource: string;
+}
+
+function nativeMapping(model: NativeModelInfo): NativeProviderMapping | null {
+	if (
+		model.provider === "openai" &&
+		(/^(gpt-5\.5(-fast)?|gpt-4\.1(-mini)?)$/.test(model.id) || /^gpt-4o(-mini)?(-\d{4}-\d{2}-\d{2})?$/.test(model.id))
+	) {
+		return { provider: "openai", resource: "responses" };
+	}
+
+	if (
+		model.provider === "anthropic" &&
+		(/^claude-(opus|sonnet)-4(-\d+)?$/.test(model.id) || /^claude-(opus|sonnet)-4-\d+-\d{8}$/.test(model.id))
+	) {
+		return { provider: "anthropic", resource: "messages" };
+	}
+
+	if (model.provider === "xai" && /^grok-/.test(model.id)) {
+		return { provider: "xai", resource: "responses" };
+	}
+
+	if (model.provider === "perplexity" && /^sonar/.test(model.id)) {
+		return { provider: "perplexity", resource: "chat/completions" };
+	}
+
+	if ((model.provider === "z-ai" || model.provider === "zai") && /^glm-/.test(model.id)) {
+		return { provider: "z-ai", resource: "chat/completions" };
+	}
+
+	if (model.provider === "openrouter") {
+		const slashIndex = model.id.indexOf("/");
+		if (slashIndex <= 0) return null;
+		const effectiveProvider = model.id.slice(0, slashIndex);
+		const effectiveId = model.id.slice(slashIndex + 1);
+		if (effectiveProvider === "openrouter") return null;
+		return nativeMapping({ ...model, provider: effectiveProvider, id: effectiveId });
+	}
+
+	return null;
+}
+
+function buildEndpointUrl(baseUrl: string, resource: string): string {
+	const trimmed = baseUrl.replace(/\/+$/, "");
+	const resourceSlash = `/${resource}`;
+	if (trimmed.endsWith(resourceSlash)) return trimmed;
+	if (/\/v\d+$/.test(trimmed)) return `${trimmed}${resourceSlash}`;
+	return `${trimmed}/v1${resourceSlash}`;
+}
+
+export async function buildNativeEntry(
+	model: NativeModelInfo | undefined,
+	modelRegistry: NativeModelRegistry | undefined,
+): Promise<SearchProviderEntry | null> {
+	if (!model || !modelRegistry) return null;
+
+	const mapping = nativeMapping(model);
+	if (!mapping) return null;
+	const baseUrl = buildEndpointUrl(model.baseUrl, mapping.resource);
+	if (!isAllowedProviderBaseUrl(baseUrl)) return null;
+
+	const auth = await modelRegistry.getApiKeyAndHeaders(model);
+	if (!auth.ok || !auth.apiKey) return null;
+
+	return {
+		id: "native",
+		provider: mapping.provider,
+		apiKey: auth.apiKey,
+		baseUrl,
+		model: model.id,
+		priority: -1,
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/provider-endpoints.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/provider-endpoints.ts
@@ -1,0 +1,63 @@
+import type { SearchProvider, SearchProviderConfig } from "./types.ts";
+
+const DEFAULT_PROVIDER_URLS: Record<SearchProvider, string> = {
+	exa: "https://api.exa.ai/search",
+	tavily: "https://api.tavily.com/search",
+	brave: "https://api.search.brave.com/res/v1/web/search",
+	"duckduckgo-html": "https://html.duckduckgo.com/html/",
+	serper: "https://google.serper.dev/search",
+	"google-cse": "https://customsearch.googleapis.com/customsearch/v1",
+	"z-ai": "https://api.z.ai/api/paas/v4/web_search",
+	openai: "https://api.openai.com/v1/responses",
+	codex: "https://api.openai.com/v1/responses",
+	anthropic: "https://api.anthropic.com/v1/messages",
+	perplexity: "https://api.perplexity.ai/search",
+	xai: "https://api.x.ai/v1/responses",
+};
+
+export function defaultProviderUrl(provider: SearchProvider): string {
+	return DEFAULT_PROVIDER_URLS[provider];
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+	const parts = hostname.split(".").map((part) => Number.parseInt(part, 10));
+	if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+	const first = parts[0] ?? -1;
+	const second = parts[1] ?? -1;
+	if (first === 10 || first === 127 || first === 0 || (first === 169 && second === 254)) return true;
+	if (first === 172 && second >= 16 && second <= 31) return true;
+	return first === 192 && second === 168;
+}
+
+function isPrivateHostname(hostname: string): boolean {
+	const normalized = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+	return (
+		normalized === "localhost" ||
+		normalized.endsWith(".localhost") ||
+		normalized.includes(":") ||
+		normalized === "::1" ||
+		normalized.startsWith("fc") ||
+		normalized.startsWith("fd") ||
+		/^fe[89ab][0-9a-f]:/.test(normalized) ||
+		isPrivateIpv4(normalized)
+	);
+}
+
+export function isAllowedProviderBaseUrl(baseUrl: string): boolean {
+	let configured: URL;
+	try {
+		configured = new URL(baseUrl);
+	} catch {
+		return false;
+	}
+	return (
+		configured.protocol === "https:" &&
+		configured.username === "" &&
+		configured.password === "" &&
+		!isPrivateHostname(configured.hostname)
+	);
+}
+
+export function providerUrl(config: SearchProviderConfig): string {
+	return config.baseUrl ?? defaultProviderUrl(config.provider);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/providers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/providers.ts
@@ -1,0 +1,548 @@
+import { providerUrl } from "./provider-endpoints.ts";
+import type {
+	BuiltSearchRequest,
+	JsonObject,
+	JsonValue,
+	SearchProvider,
+	SearchProviderConfig,
+	SearchRequest,
+	SearchResultItem,
+} from "./types.ts";
+
+const EMPTY_DOMAIN_SENTINEL = "invalid.invalid";
+
+function contentHeaders(extra?: Record<string, string>): Record<string, string> {
+	return { Accept: "application/json", "Content-Type": "application/json", ...(extra ?? {}) };
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+function appendDomainFilters(query: string, allowedDomains?: string[], blockedDomains?: string[]): string {
+	const parts = [query];
+	for (const domain of allowedDomains ?? []) parts.push(`site:${domain}`);
+	for (const domain of blockedDomains ?? []) parts.push(`-site:${domain}`);
+	return parts.join(" ");
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)];
+}
+
+function nonEmptyDomains(values: string[]): string[] {
+	return values.length > 0 ? values : [EMPTY_DOMAIN_SENTINEL];
+}
+
+function resolveDomainFilters(
+	config: SearchProviderConfig,
+	request: SearchRequest,
+): { allowedDomains?: string[]; blockedDomains?: string[] } {
+	const configAllowed = config.allowedDomains;
+	const configBlocked = config.blockedDomains;
+	const requestAllowed = request.allowedDomains;
+	const requestBlocked = request.blockedDomains;
+
+	if (configAllowed) {
+		const narrowed = requestAllowed
+			? configAllowed.filter((domain) => requestAllowed.includes(domain))
+			: configAllowed;
+		const allowed = requestBlocked ? narrowed.filter((domain) => !requestBlocked.includes(domain)) : narrowed;
+		return { allowedDomains: nonEmptyDomains(unique(allowed)) };
+	}
+
+	if (configBlocked) {
+		const blocked = unique([...configBlocked, ...(requestBlocked ?? [])]);
+		if (requestAllowed) {
+			return { allowedDomains: nonEmptyDomains(requestAllowed.filter((domain) => !blocked.includes(domain))) };
+		}
+		return { blockedDomains: blocked };
+	}
+
+	if (requestAllowed) return { allowedDomains: unique(requestAllowed) };
+	if (requestBlocked) return { blockedDomains: unique(requestBlocked) };
+	return {};
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getObject(value: JsonValue | undefined): JsonObject | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? value : undefined;
+}
+
+function getArray(value: JsonValue | undefined): JsonValue[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function getString(value: JsonValue | undefined): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function getNumber(value: JsonValue | undefined): number | undefined {
+	return typeof value === "number" ? value : undefined;
+}
+
+function result(
+	title: string | undefined,
+	url: string | undefined,
+	snippet?: string,
+	source?: string,
+	score?: number,
+): SearchResultItem | null {
+	if (!title || !url) return null;
+	const item: SearchResultItem = { title, url };
+	if (snippet) item.snippet = snippet;
+	if (source) item.source = source;
+	if (score !== undefined) item.score = score;
+	return item;
+}
+
+function htmlDecode(value: string): string {
+	return value
+		.replaceAll("&amp;", "&")
+		.replaceAll("&quot;", '"')
+		.replaceAll("&#39;", "'")
+		.replaceAll("&lt;", "<")
+		.replaceAll("&gt;", ">");
+}
+
+function stripHtml(value: string): string {
+	return htmlDecode(
+		value
+			.replace(/<[^>]*>/g, "")
+			.replace(/\s+/g, " ")
+			.trim(),
+	);
+}
+
+function duckDuckGoResultUrl(rawHref: string): string | undefined {
+	const decodedHref = htmlDecode(rawHref);
+	const absoluteHref = decodedHref.startsWith("//") ? `https:${decodedHref}` : decodedHref;
+	let url: URL;
+	try {
+		url = new URL(absoluteHref);
+	} catch {
+		return undefined;
+	}
+	const redirected = url.searchParams.get("uddg");
+	return redirected ?? absoluteHref;
+}
+
+function normalizeDuckDuckGoHtml(html: string): SearchResultItem[] {
+	const matches = [...html.matchAll(/<a\b[^>]*class="[^"]*result__a[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g)];
+	const snippets = [...html.matchAll(/<a\b[^>]*class="[^"]*result__snippet[^"]*"[^>]*>([\s\S]*?)<\/a>/g)].map(
+		(match) => stripHtml(match[1] ?? ""),
+	);
+	return collect(
+		matches.map((match, index) => {
+			const title = stripHtml(match[2] ?? "");
+			const url = duckDuckGoResultUrl(match[1] ?? "");
+			return result(title, url, snippets[index]);
+		}),
+	);
+}
+
+function resultsFromTextUrls(text: string | undefined): SearchResultItem[] {
+	if (!text) return [];
+	const urls = text.match(/https?:\/\/[^\s)\]}>"]+/g) ?? [];
+	return collect(
+		unique(urls).map((url) => {
+			const cleaned = url.replace(/[.,;:]+$/, "");
+			return result(cleaned, cleaned, text);
+		}),
+	);
+}
+
+function searchOnlyPrompt(query: string): string {
+	return `Find web pages matching any of these search terms or quoted phrases. If the query contains OR, search each alternative independently. Return only relevant source URLs, one per line. Query: ${query}`;
+}
+
+function collect(items: Array<SearchResultItem | null>, max = 50): SearchResultItem[] {
+	return items.filter((item): item is SearchResultItem => item !== null).slice(0, max);
+}
+
+function parseObjectPayload(payload: unknown): JsonObject {
+	if (isJsonObject(payload)) return payload;
+	return {};
+}
+
+export function buildSearchRequest(config: SearchProviderConfig, request: SearchRequest): BuiltSearchRequest {
+	const maxResults = config.maxResults ?? request.maxResults;
+	const { allowedDomains, blockedDomains } = resolveDomainFilters(config, request);
+
+	if (config.provider === "exa") {
+		const headers = contentHeaders({ "x-api-key": config.apiKey ?? "" });
+		const body: JsonObject = { query: request.query, numResults: clamp(maxResults, 1, 20) };
+		if (allowedDomains) body["includeDomains"] = allowedDomains;
+		if (blockedDomains) body["excludeDomains"] = blockedDomains;
+		return { url: providerUrl(config), init: { method: "POST", headers }, body };
+	}
+
+	if (config.provider === "tavily") {
+		const body: JsonObject = { query: request.query, max_results: clamp(maxResults, 1, 20) };
+		if (allowedDomains) body["include_domains"] = allowedDomains;
+		if (blockedDomains) body["exclude_domains"] = blockedDomains;
+		return {
+			url: providerUrl(config),
+			init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+			body,
+		};
+	}
+
+	if (config.provider === "brave") {
+		const url = new URL(providerUrl(config));
+		url.searchParams.set("q", appendDomainFilters(request.query, allowedDomains, blockedDomains));
+		url.searchParams.set("count", String(clamp(maxResults, 1, 20)));
+		return {
+			url: url.toString(),
+			init: { method: "GET", headers: { Accept: "application/json", "X-Subscription-Token": config.apiKey ?? "" } },
+		};
+	}
+
+	if (config.provider === "duckduckgo-html") {
+		const url = new URL(providerUrl(config));
+		url.searchParams.set("q", appendDomainFilters(request.query, allowedDomains, blockedDomains));
+		return { url: url.toString(), init: { method: "GET", headers: { Accept: "text/html" } } };
+	}
+
+	if (config.provider === "serper") {
+		const body: JsonObject = {
+			q: appendDomainFilters(request.query, allowedDomains, blockedDomains),
+			num: clamp(maxResults, 1, 20),
+		};
+		return {
+			url: providerUrl(config),
+			init: { method: "POST", headers: contentHeaders({ "X-API-KEY": config.apiKey ?? "" }) },
+			body,
+		};
+	}
+
+	if (config.provider === "google-cse") {
+		const url = new URL(providerUrl(config));
+		url.searchParams.set("q", appendDomainFilters(request.query, allowedDomains, blockedDomains));
+		url.searchParams.set("key", config.apiKey ?? "");
+		url.searchParams.set("cx", config.searchEngineId ?? "");
+		url.searchParams.set("num", String(clamp(maxResults, 1, 10)));
+		return { url: url.toString(), init: { method: "GET", headers: { Accept: "application/json" } } };
+	}
+
+	if (config.provider === "z-ai") {
+		if (config.model) {
+			const webSearch: JsonObject = {
+				enable: true,
+				search_engine: "search-prime",
+				search_result: true,
+				count: clamp(maxResults, 1, 50),
+			};
+			if (allowedDomains?.[0]) webSearch["search_domain_filter"] = allowedDomains[0];
+			if (config.searchContextSize) webSearch["content_size"] = config.searchContextSize;
+			return {
+				url: providerUrl(config),
+				init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+				body: {
+					model: config.model,
+					messages: [{ role: "user", content: request.query }],
+					tools: [{ type: "web_search", web_search: webSearch }],
+				},
+			};
+		}
+
+		const body: JsonObject = {
+			search_engine: "search-prime",
+			search_query: appendDomainFilters(request.query, undefined, blockedDomains),
+			count: clamp(maxResults, 1, 50),
+		};
+		if (allowedDomains?.[0]) body["search_domain_filter"] = allowedDomains[0];
+		return {
+			url: providerUrl(config),
+			init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+			body,
+		};
+	}
+
+	if (config.provider === "perplexity") {
+		if (config.model) {
+			const body: JsonObject = {
+				model: config.model,
+				messages: [{ role: "user", content: request.query }],
+			};
+			if (allowedDomains) body["search_domain_filter"] = allowedDomains;
+			if (!allowedDomains && blockedDomains)
+				body["search_domain_filter"] = blockedDomains.map((domain) => `-${domain}`);
+			if (config.searchContextSize) body["web_search_options"] = { search_context_size: config.searchContextSize };
+			return {
+				url: providerUrl(config),
+				init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+				body,
+			};
+		}
+
+		const body: JsonObject = { query: request.query, max_results: clamp(maxResults, 1, 20) };
+		if (allowedDomains) body["search_domain_filter"] = allowedDomains;
+		if (!allowedDomains && blockedDomains)
+			body["search_domain_filter"] = blockedDomains.map((domain) => `-${domain}`);
+		return {
+			url: providerUrl(config),
+			init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+			body,
+		};
+	}
+
+	if (config.provider === "xai") {
+		const webSearchTool: JsonObject = { type: "web_search" };
+		if (allowedDomains) webSearchTool["filters"] = { allowed_domains: allowedDomains.slice(0, 5) };
+		if (!allowedDomains && blockedDomains)
+			webSearchTool["filters"] = { excluded_domains: blockedDomains.slice(0, 5) };
+		return {
+			url: providerUrl(config),
+			init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+			body: {
+				model: config.model ?? "grok-4.3",
+				input: request.query,
+				tools: [webSearchTool],
+				tool_choice: "required",
+			},
+		};
+	}
+
+	if (config.provider === "anthropic") {
+		const webSearchTool: JsonObject = { type: "web_search_20250305", name: "web_search", max_uses: 8 };
+		if (allowedDomains) webSearchTool["allowed_domains"] = allowedDomains;
+		if (blockedDomains) webSearchTool["blocked_domains"] = blockedDomains;
+		return {
+			url: providerUrl(config),
+			init: {
+				method: "POST",
+				headers: contentHeaders({
+					"x-api-key": config.apiKey ?? "",
+					"anthropic-version": "2023-06-01",
+				}),
+			},
+			body: {
+				model: config.model ?? "claude-sonnet-4-5-20250929",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: request.query }],
+				tools: [webSearchTool],
+			},
+		};
+	}
+
+	const webSearchTool: JsonObject = {
+		type: "web_search",
+		external_web_access: (config.codexMode ?? "live") === "live",
+	};
+	if (config.searchContextSize) webSearchTool["search_context_size"] = config.searchContextSize;
+	if (allowedDomains) webSearchTool["filters"] = { allowed_domains: allowedDomains };
+	if (config.userLocation) webSearchTool["user_location"] = { type: "approximate", ...config.userLocation };
+	const input = searchOnlyPrompt(
+		blockedDomains ? appendDomainFilters(request.query, undefined, blockedDomains) : request.query,
+	);
+
+	return {
+		url: providerUrl(config),
+		init: { method: "POST", headers: contentHeaders({ Authorization: `Bearer ${config.apiKey ?? ""}` }) },
+		body: {
+			model: config.model ?? "gpt-5.5",
+			input,
+			tools: [webSearchTool],
+			include: ["web_search_call.action.sources"],
+			tool_choice: "required",
+		},
+	};
+}
+
+export function normalizeSearchResponse(provider: SearchProvider, payload: unknown): SearchResultItem[] {
+	const data = parseObjectPayload(payload);
+
+	if (provider === "exa") {
+		return collect(
+			getArray(data["results"]).map((raw) => {
+				const item = getObject(raw);
+				return result(
+					getString(item?.["title"]),
+					getString(item?.["url"]),
+					getString(item?.["text"]) ?? getString(item?.["snippet"]),
+					undefined,
+					getNumber(item?.["score"]),
+				);
+			}),
+		);
+	}
+
+	if (provider === "tavily") {
+		return collect(
+			getArray(data["results"]).map((raw) => {
+				const item = getObject(raw);
+				return result(
+					getString(item?.["title"]),
+					getString(item?.["url"]),
+					getString(item?.["content"]),
+					undefined,
+					getNumber(item?.["score"]),
+				);
+			}),
+		);
+	}
+
+	if (provider === "brave") {
+		const web = getObject(data["web"]);
+		return collect(
+			getArray(web?.["results"]).map((raw) => {
+				const item = getObject(raw);
+				return result(getString(item?.["title"]), getString(item?.["url"]), getString(item?.["description"]));
+			}),
+		);
+	}
+
+	if (provider === "duckduckgo-html") {
+		return normalizeDuckDuckGoHtml(getString(data["html"]) ?? "");
+	}
+
+	if (provider === "serper") {
+		return collect(
+			getArray(data["organic"]).map((raw) => {
+				const item = getObject(raw);
+				return result(getString(item?.["title"]), getString(item?.["link"]), getString(item?.["snippet"]));
+			}),
+		);
+	}
+
+	if (provider === "google-cse") {
+		return collect(
+			getArray(data["items"]).map((raw) => {
+				const item = getObject(raw);
+				return result(getString(item?.["title"]), getString(item?.["link"]), getString(item?.["snippet"]));
+			}),
+		);
+	}
+
+	if (provider === "z-ai") {
+		const chatResults = collect(
+			getArray(data["web_search"]).map((raw) => {
+				const item = getObject(raw);
+				return result(
+					getString(item?.["title"]),
+					getString(item?.["link"]),
+					getString(item?.["content"]),
+					getString(item?.["media"]),
+				);
+			}),
+		);
+		if (chatResults.length > 0) return chatResults;
+
+		return collect(
+			getArray(data["search_result"]).map((raw) => {
+				const item = getObject(raw);
+				return result(
+					getString(item?.["title"]),
+					getString(item?.["link"]),
+					getString(item?.["content"]),
+					getString(item?.["media"]),
+				);
+			}),
+		);
+	}
+
+	if (provider === "perplexity") {
+		const chatResults = collect(
+			getArray(data["search_results"]).map((raw) => {
+				const item = getObject(raw);
+				const searchResult = result(
+					getString(item?.["title"]),
+					getString(item?.["url"]),
+					getString(item?.["snippet"]),
+				);
+				if (searchResult) {
+					const publishedAt = getString(item?.["date"]) ?? getString(item?.["last_updated"]);
+					if (publishedAt) searchResult.publishedAt = publishedAt;
+				}
+				return searchResult;
+			}),
+		);
+		if (chatResults.length > 0) return chatResults;
+
+		return collect(
+			getArray(data["results"]).map((raw) => {
+				const item = getObject(raw);
+				const searchResult = result(
+					getString(item?.["title"]),
+					getString(item?.["url"]),
+					getString(item?.["snippet"]),
+				);
+				if (searchResult) {
+					const publishedAt = getString(item?.["date"]) ?? getString(item?.["last_updated"]);
+					if (publishedAt) searchResult.publishedAt = publishedAt;
+				}
+				return searchResult;
+			}),
+		);
+	}
+
+	if (provider === "anthropic") {
+		const content = getArray(data["content"]);
+		const text = content
+			.map(getObject)
+			.map((item) => getString(item?.["text"]))
+			.filter((value): value is string => value !== undefined)
+			.join("\n");
+		return collect(
+			content.flatMap((raw) => {
+				const item = getObject(raw);
+				if (item?.["type"] !== "web_search_tool_result") return [];
+				return getArray(item["content"]).map((searchRaw) => {
+					const searchItem = getObject(searchRaw);
+					return result(
+						getString(searchItem?.["title"]),
+						getString(searchItem?.["url"]),
+						getString(searchItem?.["page_age"]) ?? text,
+					);
+				});
+			}),
+		);
+	}
+
+	const output = getArray(data["output"]);
+	const sources = collect(
+		output.flatMap((raw) => {
+			const item = getObject(raw);
+			if (item?.["type"] !== "web_search_call") return [];
+			const action = getObject(item["action"]);
+			return getArray(action?.["sources"]).map((sourceRaw) => {
+				const source = getObject(sourceRaw);
+				const url = getString(source?.["url"]);
+				return result(url, url);
+			});
+		}),
+	);
+	const message = output.map(getObject).find((item) => item?.["type"] === "message");
+	const content = getArray(message?.["content"])
+		.map(getObject)
+		.find((item) => item?.["type"] === "output_text");
+	const text = getString(content?.["text"]);
+	const annotationResults = collect(
+		getArray(content?.["annotations"]).map((raw) => {
+			const item = getObject(raw);
+			return item?.["type"] === "url_citation"
+				? result(getString(item["title"]), getString(item["url"]), text)
+				: null;
+		}),
+	);
+	if (annotationResults.length > 0) return annotationResults;
+	if (sources.length > 0) {
+		return sources.map((source) => {
+			if (source.snippet || text === undefined) return source;
+			return { ...source, snippet: text };
+		});
+	}
+	const textUrls = resultsFromTextUrls(text);
+	if (textUrls.length > 0) return textUrls;
+	if (provider !== "xai") return annotationResults;
+	return collect(
+		getArray(data["citations"]).map((raw) => {
+			const url = getString(raw);
+			return result(url, url, text);
+		}),
+	);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/renderers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/renderers.ts
@@ -1,0 +1,108 @@
+import { Text } from "@earendil-works/pi-tui";
+
+import type { SearchDetails, SearchErrorDetails, SearchProgressDetails, SearchRenderDetails } from "./types.ts";
+
+interface ThemeLike {
+	bold(value: string): string;
+	fg(key: string, value: string): string;
+}
+
+interface SearchArgs {
+	query: string;
+	allowed_domains?: string[];
+	blocked_domains?: string[];
+}
+
+interface ResultLike<TDetails> {
+	content: ReadonlyArray<{ type: string; text?: string }>;
+	details?: TDetails;
+}
+
+interface RenderResultOptions {
+	expanded?: boolean;
+	isPartial?: boolean;
+}
+
+function shorten(value: string, max: number): string {
+	return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}
+
+function durationText(durationMs: number): string {
+	return durationMs >= 1000 ? `${Math.round(durationMs / 1000)}s` : `${durationMs}ms`;
+}
+
+function attemptLabel(details: SearchDetails): string {
+	return details.attempts
+		? details.attempts
+				.map(
+					(attempt) =>
+						`${attempt.entryId ? `${attempt.provider}/${attempt.entryId}` : attempt.provider}:${attempt.error ? "failed" : attempt.resultsCount}`,
+				)
+				.join(" -> ")
+		: "";
+}
+
+function isSearchProgressDetails(details: SearchRenderDetails | undefined): details is SearchProgressDetails {
+	return details !== undefined && "phase" in details && details.phase === "searching";
+}
+
+function isSearchErrorDetails(details: SearchRenderDetails): details is SearchErrorDetails {
+	return "phase" in details && details.phase === "error";
+}
+
+export function renderSearchCall(args: SearchArgs, theme: ThemeLike): Text {
+	const head = theme.fg("toolTitle", theme.bold("web_search "));
+	const query = theme.fg("accent", `"${shorten(args.query, 90)}"`);
+	const domains = args.allowed_domains ?? args.blocked_domains;
+	const filter = domains?.length ? theme.fg("muted", ` domains:${domains.length}`) : "";
+	return new Text(head + query + filter, 0, 0);
+}
+
+export function renderSearchResult(
+	result: ResultLike<SearchRenderDetails>,
+	options: RenderResultOptions,
+	theme: ThemeLike,
+): Text {
+	if (options.isPartial) {
+		const details = result.details;
+		if (isSearchProgressDetails(details)) {
+			const route = details.providerLabels.length > 0 ? details.providerLabels.join(" -> ") : "configured providers";
+			return new Text(
+				theme.fg("warning", `Searching "${shorten(details.query, 80)}" via ${route} (max ${details.maxResults})`),
+				0,
+				0,
+			);
+		}
+		return new Text(theme.fg("warning", result.content[0]?.text ?? "Searching the web..."), 0, 0);
+	}
+
+	const details = result.details;
+	if (!details) return new Text(theme.fg("muted", result.content[0]?.text ?? ""), 0, 0);
+	if (isSearchProgressDetails(details)) return new Text(theme.fg("muted", result.content[0]?.text ?? ""), 0, 0);
+	if (isSearchErrorDetails(details)) return new Text(theme.fg("error", details.error), 0, 0);
+	if (details.error) return new Text(theme.fg("error", details.error), 0, 0);
+
+	const count = details.results.length;
+	const provider = details.entryId ? `${details.provider}/${details.entryId}` : details.provider;
+	const summary =
+		theme.fg("success", `${count} result${count === 1 ? "" : "s"}`) +
+		theme.fg(
+			"muted",
+			` via ${provider}${details.strategy ? ` (${details.strategy})` : ""} in ${durationText(details.durationMs)}`,
+		) +
+		(details.truncated ? theme.fg("warning", " (truncated)") : "");
+
+	if (count === 0) return new Text(summary, 0, 0);
+
+	const attempts = attemptLabel(details);
+	const rows = options.expanded && attempts ? [summary, theme.fg("muted", `route ${attempts}`)] : [summary];
+	const visibleLimit = options.expanded ? 8 : 3;
+	for (const item of details.results.slice(0, visibleLimit)) {
+		rows.push(`${theme.fg("accent", shorten(item.title, 80))} ${theme.fg("dim", shorten(item.url, 100))}`);
+		if (item.snippet) rows.push(theme.fg("muted", `  ${shorten(item.snippet, 140)}`));
+	}
+	if (details.results.length > visibleLimit) {
+		rows.push(theme.fg("dim", `… ${details.results.length - visibleLimit} more sources`));
+	}
+	return new Text(rows.join("\n"), 0, 0);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/search.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/search.ts
@@ -1,0 +1,286 @@
+import { buildSearchRequest, normalizeSearchResponse } from "./providers.ts";
+import type {
+	JsonObject,
+	RoutingStrategy,
+	SearchAttempt,
+	SearchDetails,
+	SearchProviderEntry,
+	SearchRequest,
+	WebsearchConfig,
+} from "./types.ts";
+
+const MAX_ERROR_DETAIL_LENGTH = 500;
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function truncate(value: string, max: number): string {
+	return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function extractErrorDetail(payload: unknown, bodyText: string): string {
+	if (isJsonObject(payload)) {
+		const obj = payload;
+		const error = obj["error"];
+		if (typeof error === "string" && error.length > 0) return truncate(error, MAX_ERROR_DETAIL_LENGTH);
+		if (isJsonObject(error)) {
+			const message = error["message"];
+			if (typeof message === "string" && message.length > 0) return truncate(message, MAX_ERROR_DETAIL_LENGTH);
+		}
+		const message = obj["message"];
+		if (typeof message === "string" && message.length > 0) return truncate(message, MAX_ERROR_DETAIL_LENGTH);
+	}
+	const trimmed = bodyText.trim();
+	if (!trimmed) return "";
+	return truncate(trimmed, MAX_ERROR_DETAIL_LENGTH);
+}
+
+function httpErrorMessage(status: number, payload: unknown, bodyText: string): string {
+	const detail = extractErrorDetail(payload, bodyText);
+	return detail ? `Search failed with HTTP ${status}: ${detail}` : `Search failed with HTTP ${status}`;
+}
+
+export interface SearchRoutingState {
+	roundRobinCursor: number;
+	successCounts: number[];
+}
+
+export function createSearchRoutingState(providerCount: number): SearchRoutingState {
+	return { roundRobinCursor: 0, successCounts: Array.from({ length: providerCount }, () => 0) };
+}
+
+function entryLabel(entry: Pick<SearchProviderEntry, "provider" | "id"> | SearchAttempt): string {
+	if ("entryId" in entry && entry.entryId) return `${entry.provider}/${entry.entryId}`;
+	if ("id" in entry && entry.id) return `${entry.provider}/${entry.id}`;
+	return entry.provider;
+}
+
+function sortedPriorityIndices(providers: SearchProviderEntry[]): number[] {
+	return providers
+		.map((provider, index) => ({ index, priority: provider.priority ?? index }))
+		.sort((left, right) => left.priority - right.priority || left.index - right.index)
+		.map((item) => item.index);
+}
+
+function weightedIndices(providers: SearchProviderEntry[]): number[] {
+	const indices: number[] = [];
+	for (const [index, provider] of providers.entries()) {
+		const weight = Math.max(1, Math.trunc(provider.weight ?? 1));
+		for (let count = 0; count < weight; count += 1) indices.push(index);
+	}
+	return indices.length > 0 ? indices : providers.map((_provider, index) => index);
+}
+
+function rotateUnique(indices: number[], start: number, providerCount: number): number[] {
+	const order: number[] = [];
+	for (let offset = 0; offset < indices.length; offset += 1) {
+		const index = indices[(start + offset) % indices.length];
+		if (index !== undefined && !order.includes(index)) order.push(index);
+	}
+	for (let index = 0; index < providerCount; index += 1) {
+		if (!order.includes(index)) order.push(index);
+	}
+	return order;
+}
+
+function selectOrder(strategy: RoutingStrategy, providers: SearchProviderEntry[], state: SearchRoutingState): number[] {
+	if (strategy === "priority") return sortedPriorityIndices(providers);
+	if (strategy === "round-robin") {
+		const indices = weightedIndices(providers);
+		const order = rotateUnique(indices, state.roundRobinCursor % indices.length, providers.length);
+		state.roundRobinCursor = (state.roundRobinCursor + 1) % indices.length;
+		return order;
+	}
+
+	let selected = 0;
+	let selectedCount = state.successCounts[0] ?? 0;
+	for (let index = 1; index < providers.length; index += 1) {
+		const count = state.successCounts[index] ?? 0;
+		if (count < selectedCount) {
+			selected = index;
+			selectedCount = count;
+		}
+	}
+	return [selected, ...providers.map((_provider, index) => index).filter((index) => index !== selected)];
+}
+
+async function performProviderSearch(
+	config: SearchProviderEntry,
+	request: SearchRequest,
+	signal?: AbortSignal,
+): Promise<SearchDetails> {
+	const startedAt = Date.now();
+	const built = buildSearchRequest(config, request);
+	let response: Response;
+	try {
+		const init: RequestInit = {
+			...built.init,
+		};
+		if (built.body !== undefined) init.body = JSON.stringify(built.body);
+		if (signal !== undefined) init.signal = signal;
+		response = await fetch(built.url, init);
+	} catch (error) {
+		const details: SearchDetails = {
+			provider: config.provider,
+			query: request.query,
+			results: [],
+			durationMs: Date.now() - startedAt,
+			truncated: false,
+			error: error instanceof Error ? error.message : "Search request failed",
+		};
+		if (config.id !== undefined) details.entryId = config.id;
+		return details;
+	}
+
+	let bodyText = "";
+	try {
+		bodyText = await response.text();
+	} catch {
+		bodyText = "";
+	}
+	let payload: unknown = {};
+	if (config.provider === "duckduckgo-html") {
+		payload = { html: bodyText };
+	} else if (bodyText.length > 0) {
+		try {
+			payload = JSON.parse(bodyText);
+		} catch {
+			payload = {};
+		}
+	}
+	if (!response.ok) {
+		const details: SearchDetails = {
+			provider: config.provider,
+			query: request.query,
+			results: [],
+			durationMs: Date.now() - startedAt,
+			truncated: false,
+			error: httpErrorMessage(response.status, payload, bodyText),
+		};
+		if (config.id !== undefined) details.entryId = config.id;
+		return details;
+	}
+
+	const results = normalizeSearchResponse(config.provider, payload);
+	const max = request.maxResults;
+	const details: SearchDetails = {
+		provider: config.provider,
+		query: request.query,
+		results: results.slice(0, max),
+		durationMs: Date.now() - startedAt,
+		truncated: results.length > max,
+	};
+	if (config.id !== undefined) details.entryId = config.id;
+	return details;
+}
+
+function attemptFromDetails(details: SearchDetails): SearchAttempt {
+	const attempt: SearchAttempt = {
+		provider: details.provider,
+		durationMs: details.durationMs,
+		resultsCount: details.results.length,
+	};
+	if (details.entryId) attempt.entryId = details.entryId;
+	if (details.error) attempt.error = details.error;
+	return attempt;
+}
+
+export async function performSearch(
+	config: WebsearchConfig,
+	request: SearchRequest,
+	signal?: AbortSignal,
+	routingState?: SearchRoutingState,
+): Promise<SearchDetails> {
+	const startedAt = Date.now();
+	const state = routingState ?? createSearchRoutingState(config.providers.length);
+	const order = selectOrder(config.strategy, config.providers, state);
+	const attempts: SearchAttempt[] = [];
+	const collected = new Map<string, SearchDetails["results"][number]>();
+	let selectedDetails: SearchDetails | undefined;
+
+	for (const index of order) {
+		const provider = config.providers[index];
+		if (!provider) continue;
+		const details = await performProviderSearch(provider, request, signal);
+		attempts.push(attemptFromDetails(details));
+
+		if (details.error) {
+			if (!config.fallback) return { ...details, strategy: config.strategy, attempts };
+			selectedDetails = details;
+			continue;
+		}
+
+		state.successCounts[index] = (state.successCounts[index] ?? 0) + 1;
+
+		if (config.strategy !== "fill-first") {
+			return { ...details, strategy: config.strategy, attempts };
+		}
+
+		selectedDetails = details;
+		for (const item of details.results) {
+			if (collected.size >= request.maxResults) break;
+			collected.set(item.url, item);
+		}
+		if (collected.size >= request.maxResults) break;
+	}
+
+	if (collected.size > 0 && selectedDetails) {
+		const results = [...collected.values()];
+		const details: SearchDetails = {
+			provider: selectedDetails.provider,
+			query: request.query,
+			results,
+			durationMs: Date.now() - startedAt,
+			truncated: results.length >= request.maxResults,
+			strategy: config.strategy,
+			attempts,
+		};
+		if (selectedDetails.entryId !== undefined) details.entryId = selectedDetails.entryId;
+		return details;
+	}
+
+	const failed = selectedDetails ?? {
+		provider: config.providers[0]?.provider ?? "exa",
+		query: request.query,
+		results: [],
+		durationMs: Date.now() - startedAt,
+		truncated: false,
+		error: "All configured search providers failed.",
+	};
+	return {
+		...failed,
+		durationMs: Date.now() - startedAt,
+		strategy: config.strategy,
+		attempts,
+		error: `All configured search providers failed: ${attempts.map((attempt) => `${entryLabel(attempt)} ${attempt.error ?? "failed"}`).join("; ")}`,
+	};
+}
+
+export function formatSearchText(details: SearchDetails): string {
+	if (details.error) return details.error;
+	if (details.results.length === 0) return `No web search results found for "${details.query}".`;
+
+	const route = details.strategy
+		? ` via ${details.entryId ? `${details.provider}/${details.entryId}` : details.provider} (${details.strategy})`
+		: ` via ${details.provider}`;
+	const lines = [`Web search results for "${details.query}"${route}:`, ""];
+	if (details.attempts && details.attempts.length > 0) {
+		lines.push(
+			`Routing attempts: ${details.attempts
+				.map(
+					(attempt) =>
+						`${entryLabel(attempt)} ${attempt.error ? `failed: ${attempt.error}` : `${attempt.resultsCount} result${attempt.resultsCount === 1 ? "" : "s"}`}`,
+				)
+				.join(" -> ")}`,
+			"",
+		);
+	}
+	for (const [index, item] of details.results.entries()) {
+		lines.push(`${index + 1}. ${item.title}`);
+		lines.push(`   ${item.url}`);
+		if (item.snippet) lines.push(`   ${item.snippet}`);
+	}
+	lines.push("", "REMINDER: Include relevant sources from the URLs above in the final answer.");
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/tool.ts
@@ -1,0 +1,123 @@
+import { Type } from "typebox";
+import { defineTool } from "../../../types.ts";
+
+import { buildNativeEntry, type NativeModelInfo, type NativeModelRegistry } from "./native.ts";
+import { renderSearchCall, renderSearchResult } from "./renderers.ts";
+import { createSearchRoutingState, formatSearchText, performSearch, type SearchRoutingState } from "./search.ts";
+import type {
+	ConfigLoadResult,
+	SearchErrorDetails,
+	SearchProgressDetails,
+	SearchProviderEntry,
+	SearchRenderDetails,
+	WebsearchConfig,
+} from "./types.ts";
+
+const Params = Type.Object(
+	{
+		query: Type.String({ minLength: 2, description: "The search query to use" }),
+		allowed_domains: Type.Optional(
+			Type.Array(Type.String(), { description: "Only include search results from these domains" }),
+		),
+		blocked_domains: Type.Optional(
+			Type.Array(Type.String(), { description: "Never include search results from these domains" }),
+		),
+	},
+	{ additionalProperties: false },
+);
+
+export type ConfigProvider = () => ConfigLoadResult;
+type WebSearchTool = ReturnType<typeof defineTool<typeof Params, SearchRenderDetails>>;
+
+interface WebSearchToolContext {
+	model: NativeModelInfo | undefined;
+	modelRegistry: NativeModelRegistry;
+}
+
+async function configWithNativeRoute(config: WebsearchConfig, ctx?: WebSearchToolContext): Promise<WebsearchConfig> {
+	if (!config.auto) return config;
+	const nativeEntry = await buildNativeEntry(ctx?.model, ctx?.modelRegistry);
+	return nativeEntry ? { ...config, providers: [nativeEntry, ...config.providers] } : config;
+}
+
+function providerLabel(provider: SearchProviderEntry): string {
+	return provider.id ? `${provider.id}/${provider.provider}` : provider.provider;
+}
+
+function formatSearchProgressText(details: SearchProgressDetails): string {
+	const route = details.providerLabels.length > 0 ? details.providerLabels.join(" -> ") : "configured providers";
+	return `Searching "${details.query}" via ${route} (max ${details.maxResults})`;
+}
+
+function searchErrorDetails(query: string, error: string, reason?: SearchErrorDetails["reason"]): SearchErrorDetails {
+	return { phase: "error", query, error, ...(reason ? { reason } : {}) };
+}
+
+export function createWebSearchTool(getConfig: ConfigProvider): WebSearchTool {
+	let routingState: SearchRoutingState | undefined;
+	let routingKey = "";
+
+	return defineTool<typeof Params, SearchRenderDetails>({
+		name: "web_search",
+		label: "Web Search",
+		description: "Search the web for current information and return source URLs for citation.",
+		promptSnippet: "Search the web for current information, documentation, news, or external facts.",
+		promptGuidelines: ["After using web_search, cite relevant returned URLs in the final answer."],
+		parameters: Params,
+		async execute(_toolCallId, params, signal, onUpdate, ctx?: WebSearchToolContext) {
+			if (params.allowed_domains?.length && params.blocked_domains?.length) {
+				const message = "Error: Cannot specify both allowed_domains and blocked_domains in the same request";
+				const details = searchErrorDetails(params.query, message);
+				return { content: [{ type: "text", text: message }], details };
+			}
+
+			const loaded = getConfig();
+			if (!loaded.ok) {
+				const details = searchErrorDetails(params.query, loaded.message, loaded.reason);
+				return { content: [{ type: "text", text: loaded.message }], details };
+			}
+
+			const maxResults = loaded.config.providers[0]?.maxResults ?? 10;
+			const config = await configWithNativeRoute(loaded.config, ctx);
+			const progressDetails: SearchProgressDetails = {
+				phase: "searching",
+				query: params.query,
+				providerLabels: config.providers.map(providerLabel),
+				maxResults,
+				strategy: config.strategy,
+				...(params.allowed_domains ? { allowedDomains: params.allowed_domains } : {}),
+				...(params.blocked_domains ? { blockedDomains: params.blocked_domains } : {}),
+			};
+			onUpdate?.({
+				content: [{ type: "text", text: formatSearchProgressText(progressDetails) }],
+				details: progressDetails,
+			});
+
+			const nextRoutingKey = `${config.strategy}:${config.providers.map((provider) => provider.id ?? provider.provider).join("|")}`;
+			if (
+				!routingState ||
+				routingKey !== nextRoutingKey ||
+				routingState.successCounts.length !== config.providers.length
+			) {
+				routingState = createSearchRoutingState(config.providers.length);
+				routingKey = nextRoutingKey;
+			}
+			const request = {
+				query: params.query,
+				maxResults,
+				...(params.allowed_domains === undefined ? {} : { allowedDomains: params.allowed_domains }),
+				...(params.blocked_domains === undefined ? {} : { blockedDomains: params.blocked_domains }),
+			};
+			const details = await performSearch(config, request, signal, routingState);
+			return { content: [{ type: "text", text: formatSearchText(details) }], details };
+		},
+		renderCall: (args, theme) => renderSearchCall(args, theme),
+		renderResult: (result, options, theme) => renderSearchResult(result, options, theme),
+	});
+}
+
+export const web_search = createWebSearchTool(() => ({
+	ok: false,
+	reason: "missing_config",
+	message: "Missing websearch config. Create .pi/websearch.json or ~/.pi/websearch.json before starting pi.",
+}));

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/types.ts
@@ -1,0 +1,141 @@
+export type SearchProvider =
+	| "exa"
+	| "tavily"
+	| "brave"
+	| "duckduckgo-html"
+	| "serper"
+	| "google-cse"
+	| "z-ai"
+	| "openai"
+	| "codex"
+	| "anthropic"
+	| "perplexity"
+	| "xai";
+
+export type SearchContextSize = "low" | "medium" | "high";
+export type CodexSearchMode = "cached" | "live";
+export type RoutingStrategy = "priority" | "round-robin" | "fill-first";
+
+export interface SearchProviderConfig {
+	id?: string;
+	provider: SearchProvider;
+	apiKey?: string;
+	baseUrl?: string;
+	searchEngineId?: string;
+	maxResults?: number;
+	model?: string;
+	codexMode?: CodexSearchMode;
+	searchContextSize?: SearchContextSize;
+	allowedDomains?: string[];
+	blockedDomains?: string[];
+	userLocation?: SearchUserLocation;
+}
+
+export interface SearchProviderEntry extends SearchProviderConfig {
+	priority?: number;
+	weight?: number;
+}
+
+export interface WebsearchConfig {
+	strategy: RoutingStrategy;
+	fallback: boolean;
+	auto: boolean;
+	providers: SearchProviderEntry[];
+}
+
+export interface SearchUserLocation {
+	country?: string;
+	region?: string;
+	city?: string;
+	timezone?: string;
+}
+
+export interface SearchRequest {
+	query: string;
+	maxResults: number;
+	allowedDomains?: string[];
+	blockedDomains?: string[];
+}
+
+export interface BuiltSearchRequest {
+	url: string;
+	init: {
+		method: "GET" | "POST";
+		headers: Record<string, string>;
+	};
+	body?: JsonObject;
+}
+
+export interface SearchResultItem {
+	title: string;
+	url: string;
+	snippet?: string;
+	score?: number;
+	source?: string;
+	publishedAt?: string;
+}
+
+export interface SearchDetails {
+	provider: SearchProvider;
+	entryId?: string;
+	query: string;
+	results: SearchResultItem[];
+	durationMs: number;
+	truncated: boolean;
+	strategy?: RoutingStrategy;
+	attempts?: SearchAttempt[];
+	answer?: string;
+	error?: string;
+}
+
+export interface SearchProgressDetails {
+	phase: "searching";
+	query: string;
+	providerLabels: string[];
+	maxResults: number;
+	strategy?: RoutingStrategy;
+	allowedDomains?: string[];
+	blockedDomains?: string[];
+}
+
+export type ConfigLoadFailureReason =
+	| "missing_config"
+	| "invalid_config"
+	| "missing_api_key"
+	| "provider_native_bypass";
+
+export interface SearchErrorDetails {
+	phase: "error";
+	query: string;
+	error: string;
+	reason?: ConfigLoadFailureReason;
+}
+
+export type SearchRenderDetails = SearchDetails | SearchProgressDetails | SearchErrorDetails;
+
+export interface SearchAttempt {
+	provider: SearchProvider;
+	entryId?: string;
+	durationMs: number;
+	resultsCount: number;
+	error?: string;
+}
+
+export type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+
+export interface JsonObject {
+	[key: string]: JsonValue;
+}
+
+export type ConfigLoadResult =
+	| { ok: true; config: WebsearchConfig; source: string }
+	| {
+			ok: false;
+			reason: ConfigLoadFailureReason;
+			message: string;
+			source?: string;
+	  };
+
+export type ProviderValidationResult =
+	| { ok: true; config: SearchProviderEntry }
+	| { ok: false; reason: "invalid_config" | "missing_api_key"; message: string };

--- a/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
@@ -94,6 +94,8 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 			"todoread",
 			"todowrite",
 			"update_goal",
+			"web_search",
+			"webfetch",
 			"write",
 		]);
 		expect(session.getActiveToolNames()).toEqual([
@@ -101,6 +103,8 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 			"todoread",
 			"kimi_search_web",
 			"kimi_fetch_url",
+			"web_search",
+			"webfetch",
 			"create_goal",
 			"update_goal",
 			"get_goal",
@@ -143,6 +147,8 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 			"todoread",
 			"kimi_search_web",
 			"kimi_fetch_url",
+			"web_search",
+			"webfetch",
 			"create_goal",
 			"update_goal",
 			"get_goal",

--- a/packages/coding-agent/test/suite/vendored-builtins.test.ts
+++ b/packages/coding-agent/test/suite/vendored-builtins.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import type { ExtensionAPI, ExtensionFactory } from "../../src/core/extensions/types.ts";
+
+interface FactoryProbe {
+	tools: Set<string>;
+	commands: Set<string>;
+	events: Set<string>;
+}
+
+function runFactory(factory: ExtensionFactory): FactoryProbe {
+	const probe: FactoryProbe = { tools: new Set(), commands: new Set(), events: new Set() };
+	const pi = new Proxy(
+		{},
+		{
+			get(_target, prop) {
+				if (prop === "registerTool") return (tool: { name: string }) => probe.tools.add(tool.name);
+				if (prop === "registerCommand") return (name: string) => probe.commands.add(name);
+				if (prop === "on") return (event: string) => probe.events.add(event);
+				return () => undefined;
+			},
+		},
+	) as unknown as ExtensionAPI;
+	factory(pi);
+	return probe;
+}
+
+function factoryFor(id: string): ExtensionFactory {
+	const entry = builtinExtensions.find((extension) => extension.id === id);
+	if (!entry) throw new Error(`builtin extension not registered: ${id}`);
+	return entry.factory;
+}
+
+describe("vendored pi-* builtins", () => {
+	it("registers every vendored extension in the builtin registry", () => {
+		const ids = builtinExtensions.map((extension) => extension.id);
+
+		expect(ids).toEqual(expect.arrayContaining(["websearch", "webfetch", "nested-agents-md", "rules", "goal"]));
+	});
+
+	it("exposes the web_search tool and /websearch command from the websearch builtin", () => {
+		const probe = runFactory(factoryFor("websearch"));
+
+		expect(probe.tools.has("web_search")).toBe(true);
+		expect(probe.commands.has("websearch")).toBe(true);
+	});
+
+	it("exposes the webfetch tool when enabled by default", () => {
+		const probe = runFactory(factoryFor("webfetch"));
+
+		expect(probe.tools.has("webfetch")).toBe(true);
+	});
+
+	it("registers the /nested-agents command from the nested-agents-md builtin", () => {
+		const probe = runFactory(factoryFor("nested-agents-md"));
+
+		expect(probe.commands.has("nested-agents")).toBe(true);
+	});
+
+	it("registers the /rules and /reload-rules commands from the rules builtin", () => {
+		const probe = runFactory(factoryFor("rules"));
+
+		expect(probe.commands.has("rules")).toBe(true);
+		expect(probe.commands.has("reload-rules")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Vendor four `code-yeongyu/pi-*` extensions into senpi as in-tree builtins (the `goal` builtin already landed via #37; this rebases on top of it):

| Builtin | Source | Adds |
|---|---|---|
| `websearch` | pi-websearch | `web_search` tool + `/websearch` |
| `webfetch` | pi-webfetch | `webfetch` tool (md/text/html); dep `turndown` |
| `nested-agents-md` | pi-nested-agents-md | nearby `AGENTS.md` injection + `/nested-agents` |
| `rules` | pi-rules | rule-file discovery + `/rules` / `/reload-rules`; dep `picomatch` |

Registered after `kimi-web-search`, before `goal` (so order is kimi -> websearch -> webfetch -> nested-agents-md -> rules -> goal).

Imports are rewritten from the standalone packages' published API to senpi internals via `scripts/vendor-transform.mjs` (`@mariozechner/pi-*` -> `@earendil-works/pi-*` + `../../types.ts`; `Theme` -> `theme.ts`; `.js` -> `.ts`), then hand-patched for senpi's `erasableSyntaxOnly` rule (no parameter properties) and the absence of DOM globals (`HeadersInit`). Each vendored dir has a `changes.md`.

## pi-goal repo

The `goal` builtin's budget-free implementation is now also canonical in `code-yeongyu/pi-goal@0.2.0` (pushed to that repo's `main` separately, with its own `npm run check` + `npm test` green). Budget tracking removed entirely; `GoalStatus` is `active|paused|complete`. This PR records `goal` in `external-versions.json` (0.2.0).

## Sync + versions

`sync-builtin-extensions.mjs` now directory-syncs `bash-timeout` through the shared transform (pulling its "preserve explicit bash timeouts" fix) and records all eight vendored builtins in `external-versions.json`. The other seven are `MANUAL_PACKAGES` (metadata only, no auto file-sync) because their senpi copies diverge.

## Docs

- README: web search/fetch, rule loading, nested `AGENTS.md` moved from the installable tables into the builtin tables; new "Recommended coding set" section (pi-ast-grep, pi-lsp-client, pi-comment-checker, goal); kimi row corrected to `kimi_search_web` / `kimi_fetch_url`.
- builtin `AGENTS.md` inventory updated to 20.

## Notes / decisions

- `webfetch` was previously dropped in favor of provider natives; this re-adds it per request (default-on, gated by `PI_WEBFETCH`).
- `websearch` registers a custom `web_search` tool unconditionally; the native web-search builtins inject at request level, so there is no tool-registry name clash. It defers (bypass) for native providers.

## QA

- `npm run build`: green (all packages).
- `npm run check`: green (biome `--error-on-warnings`, pinned-deps, ts-imports, shrinkwrap up-to-date, tsgo, browser-smoke, web-ui).
- Tests: 2566 passed; the only failures are the two pre-existing `skipIf(!API_KEY)` live-API e2e files (`rpc.test.ts`, `agent-session-tree-navigation.test.ts`), which fail identically on the clean base.
- Real `AgentSession` against the built `dist` confirms `web_search`, `webfetch`, and the goal tools are registered.
- `#3592` tool-list regression updated for the new tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors `websearch`, `webfetch`, `nested-agents-md`, and `rules` as in-tree builtins and records `goal` v0.2.0. This adds `web_search`/`webfetch` tools, automatic rule and `AGENTS.md` context injection, and related commands.

- **New Features**
  - `websearch` (from `pi-websearch`): registers `web_search`; defers to native provider web search when available.
  - `webfetch` (from `pi-webfetch`): adds `webfetch` tool with markdown/text/html output; default on, gated by `PI_WEBFETCH`.
  - `nested-agents-md` (from `pi-nested-agents-md`): injects nearby `AGENTS.md` into read context; adds `/nested-agents`.
  - `rules` (from `pi-rules`): discovers project/home rule files; static/dynamic injection; adds `/rules` and `/reload-rules`.
  - Registration ordered after `kimi-web-search` to avoid tool name clashes; vendor transform added at `scripts/vendor-transform.mjs` and sync script updated to record external versions.
  - Docs: moved web search/fetch, rules, and nested `AGENTS.md` to builtin tables; builtin inventory now 20; tests updated for new tools.

- **Dependencies**
  - Runtime: `turndown` (for HTML→Markdown), `picomatch` (rule glob matching).
  - Dev types: `@types/turndown`, `@types/picomatch`.

<sup>Written for commit f1719d54966ca4bfa7593c9542b94c90e9ef365c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

