### PR TITLE
fix(compaction): keep last valid cut point when recent-token budget overshoots

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `findCutPoint` now falls back to the last valid cut point when the recent-token budget overshoots it, instead of defaulting to the first cut point and retaining the entire history.
+
 ### Removed
 
 ## [2026.6.15] - 2026-06-15

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -346,11 +346,16 @@ export function findCutPoint(
 		const messageTokens = estimateTokens(entry.message as AgentMessage);
 		accumulatedTokens += messageTokens;
 		if (accumulatedTokens >= keepRecentTokens) {
+			let foundCutPoint = false;
 			for (let c = 0; c < cutPoints.length; c++) {
 				if (cutPoints[c] >= i) {
 					cutIndex = cutPoints[c];
+					foundCutPoint = true;
 					break;
 				}
+			}
+			if (!foundCutPoint) {
+				cutIndex = cutPoints[cutPoints.length - 1];
 			}
 			break;
 		}

--- a/packages/agent/test/harness/compaction.test.ts
+++ b/packages/agent/test/harness/compaction.test.ts
@@ -239,6 +239,41 @@ describe("harness compaction", () => {
 		expect(findCutPoint([user, compaction, assistant], 0, 3, 1).firstKeptEntryIndex).toBe(2);
 	});
 
+	it("falls back to the last valid cut point when the budget overshoots it", () => {
+		const tinyBudget = 100;
+		const toolResultExceedingBudgetAlone = "x".repeat(8000);
+		const lastValidCutPointIndex = 1;
+		const user = createMessageEntry(createUserMessage("u"));
+		const assistant = createMessageEntry(createAssistantMessage("a"), user.id);
+		const toolResult1 = createMessageEntry(
+			{
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read",
+				content: [{ type: "text", text: toolResultExceedingBudgetAlone }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+			assistant.id,
+		);
+		const toolResult2 = createMessageEntry(
+			{
+				role: "toolResult",
+				toolCallId: "call-2",
+				toolName: "read",
+				content: [{ type: "text", text: toolResultExceedingBudgetAlone }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+			toolResult1.id,
+		);
+		const entries = [user, assistant, toolResult1, toolResult2];
+
+		const result = findCutPoint(entries, 0, entries.length, tinyBudget);
+
+		expect(result.firstKeptEntryIndex).toBe(lastValidCutPointIndex);
+	});
+
 	it("estimates tokens and context usage across supported message roles", () => {
 		const usage = createMockUsage(10, 5, 3, 2);
 		const assistant = createAssistantMessage("assistant", usage);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Compaction now keeps the last valid cut point when the recent-token budget is exceeded entirely within trailing tool results, instead of silently retaining the whole history.
+
 ### Changed
 
 ### Removed

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -436,11 +436,16 @@ export function findCutPoint(
 		// Check if we've exceeded the budget
 		if (accumulatedTokens >= keepRecentTokens) {
 			// Find the closest valid cut point at or after this entry
+			let foundCutPoint = false;
 			for (let c = 0; c < cutPoints.length; c++) {
 				if (cutPoints[c] >= i) {
 					cutIndex = cutPoints[c];
+					foundCutPoint = true;
 					break;
 				}
+			}
+			if (!foundCutPoint) {
+				cutIndex = cutPoints[cutPoints.length - 1];
 			}
 			break;
 		}

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -519,6 +519,36 @@ describe("findCutPoint", () => {
 			expect(result.turnStartIndex).toBe(2); // Turn 2 starts at index 2
 		}
 	});
+
+	it("falls back to the last valid cut point when the budget is exceeded beyond it", () => {
+		const tinyBudget = 100;
+		const toolResultExceedingBudgetAlone = "x".repeat(8000);
+		const lastValidCutPointIndex = 1;
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("u")),
+			createMessageEntry(createAssistantMessage("a", createMockUsage(0, 50, 500, 0))),
+			createMessageEntry({
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read",
+				content: [{ type: "text", text: toolResultExceedingBudgetAlone }],
+				isError: false,
+				timestamp: Date.now(),
+			}),
+			createMessageEntry({
+				role: "toolResult",
+				toolCallId: "call-2",
+				toolName: "read",
+				content: [{ type: "text", text: toolResultExceedingBudgetAlone }],
+				isError: false,
+				timestamp: Date.now(),
+			}),
+		];
+
+		const result = findCutPoint(entries, 0, entries.length, tinyBudget);
+
+		expect(result.firstKeptEntryIndex).toBe(lastValidCutPointIndex);
+	});
 });
 
 describe("buildSessionContext", () => {


### PR DESCRIPTION
## What

`findCutPoint` (compaction) defaulted `cutIndex = cutPoints[0]` and only reassigned it when a valid cut point sat at or after the budget-crossing entry. When the recent-token budget was exceeded **entirely within trailing tool results** (which are never valid cut points), no branch fired and `cutIndex` stayed at `cutPoints[0]` — so compaction silently **kept the entire history** instead of the recent window.

Fix: when no cut point is `>= i`, fall back to the **last** valid cut point (`cutPoints[cutPoints.length - 1]`).

Applied to both definitions:
- `packages/coding-agent/src/core/compaction/compaction.ts`
- `packages/agent/src/harness/compaction/compaction.ts`

(Ported as a senpi-native fix from gajae-code `534b4f0a`; senpi keeps its `estimateTokens` char/4 estimator — gajae's native `estimateEntryTokens` was intentionally not adopted.)

## Why

Without the fallback, a turn whose recent budget is consumed by large tool outputs after the last user/assistant message would compact to "keep everything", defeating compaction exactly when the context is largest.

## Evidence (measured on this repo)

**RED → GREEN** (new tests, fail before / pass after):
- `packages/coding-agent/test/compaction.test.ts > findCutPoint > falls back to the last valid cut point when the budget is exceeded beyond it` — RED `expected +0 to be 1`, GREEN after fix.
- `packages/agent/test/harness/compaction.test.ts > harness compaction > falls back to the last valid cut point when the budget overshoots it` — RED `expected +0 to be 1`, GREEN after fix.

**Regression** (all green, no skips):
- coding-agent `test/compaction.test.ts`: 30/30
- agent `test/harness/compaction.test.ts`: 21/21
- coding-agent `test/compaction/` policy suite: 18 files, 125/125

**Gates**: full `npm run check` green via pre-commit (biome, `check:ts-imports`, `check:shrinkwrap`, `tsgo --noEmit`, browser/web-ui smoke). Repo-root `npm test` runs in CI.

This is a correctness fix (no perf delta), so the improvement is the bug repro above rather than a benchmark number.

Plan: `plans/port-gajae-3day-remaining-optimizations.md` (WI-1)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix compaction to keep the last valid cut point when the recent-token budget is overshot within trailing tool results, instead of keeping the entire history. Applied to both `packages/coding-agent` and `packages/agent` implementations with tests.

- **Bug Fixes**
  - `findCutPoint` now falls back to the last valid cut point when no cut point exists at or after the budget-crossing entry.
  - Prevents full-history retention when large trailing tool outputs consume the recent budget; added tests covering the overshoot case.

<sup>Written for commit f1546223eef033eeb0b53f9cd2b2e0671d21cc25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

