### PR TITLE
ci(upstream): automate codex pr merge releases

### DIFF
--- a/.github/agent/README.md
+++ b/.github/agent/README.md
@@ -1,0 +1,67 @@
+# Upstream Automation
+
+`.github/workflows/upstream-agent-merge.yml` checks `badlogic/pi-mono` hourly. When
+`scripts/check-upstream-release.mjs` finds a release that is not merged into `main`, the
+workflow runs Codex on an automation branch, opens a PR, waits for checks and QA evidence,
+merge-commits the PR, then runs a fresh `/cl` audit before deciding whether to release.
+
+## Required Repository Settings
+
+- Actions must be allowed to create pull requests.
+- The merge strategy must allow merge commits.
+- A dedicated token is recommended because pushes made with `GITHUB_TOKEN` do not reliably
+  trigger follow-up workflows.
+
+## Secrets
+
+- `UPSTREAM_AUTOMATION_TOKEN`: GitHub App installation token or PAT with contents write,
+  pull requests write, checks/actions read, and issues write. It is used for checkout,
+  branch push, PR merge, and release tag pushes.
+- `CODEX_CONFIG_TOML_B64`: base64 of the local-style Codex `config.toml`.
+- `CODEX_AUTH_JSON_B64`: base64 of the Codex `auth.json`. If the config uses only
+  `QUOTIO_API_KEY`, this can be omitted.
+- `CODEX_QUOTIO_CONFIG_TOML_B64`: optional base64 Codex `quotio.config.toml`.
+- `CODEX_CCAPI_CONFIG_TOML_B64`: optional base64 Codex proxy config.
+- `QUOTIO_API_KEY`: fallback key for a generated `quotio` provider config.
+- `SENPI_AUTH_JSON_B64`: optional base64 of `~/.senpi/agent/auth.json` for gated manual QA.
+- `SENPI_MODELS_JSON_B64`: optional base64 of `~/.senpi/agent/models.json`.
+- `SENPI_SETTINGS_JSON_B64`: optional base64 of `~/.senpi/agent/settings.json`.
+
+Generate base64 values without printing decoded contents:
+
+```bash
+base64 -i ~/.codex/config.toml | gh secret set CODEX_CONFIG_TOML_B64 --body-file -
+base64 -i ~/.codex/auth.json | gh secret set CODEX_AUTH_JSON_B64 --body-file -
+base64 -i ~/.senpi/agent/auth.json | gh secret set SENPI_AUTH_JSON_B64 --body-file -
+```
+
+## Runtime Tools
+
+The workflow installs `@openai/codex@latest`, `lazycodex-ai@latest`, and
+`oh-my-openagent@latest` at runtime. These stay out of `package.json` and lockfiles.
+
+## Terminal States
+
+Merge agent statuses:
+
+- `MERGE_RESULT: CLEAN_PR_READY`
+- `MERGE_RESULT: NO_RELEASE_NEEDED`
+- `MERGE_RESULT: CONFLICTS`
+- `MERGE_RESULT: QA_FAILED`
+- `MERGE_RESULT: AGENT_FAILED`
+
+Release audit statuses:
+
+- `RELEASE_DECISION: RELEASE`
+- `RELEASE_DECISION: SKIP`
+- `RELEASE_DECISION: FAILED`
+
+No-new-release and no-release-needed paths exit successfully. Conflict, QA, PR, and release
+failures write a report and open one `sync-conflict` issue.
+
+## Release Rule
+
+The release step runs only after the upstream PR has been merge-committed into `main`, a fresh
+`/cl` audit completes on that `main` tip, and `scripts/upstream-release-worthy.mjs` finds
+package changelog entries under `## [Unreleased]`. `workflow_dispatch.force_release=true`
+overrides the changelog-entry check.

--- a/.github/agent/merge-driver.md
+++ b/.github/agent/merge-driver.md
@@ -1,22 +1,25 @@
 # Upstream merge + changelog driver
 
-You are running headless inside GitHub Actions on the `senpi` fork
-(`code-yeongyu/senpi`). Your job: integrate the latest upstream release from
-`badlogic/pi-mono`, audit the changelog, and QA the result so the workflow can cut a
-release. Work only in the current repository checkout. Do not contact any external service
-other than git remotes and GitHub via `gh`.
+You are Codex running headless inside GitHub Actions on the `senpi` fork
+(`code-yeongyu/senpi`). Your job is to integrate the latest upstream release from
+`badlogic/pi-mono`, audit changelogs, and leave a PR-ready automation branch. Work only in
+the current repository checkout. Do not contact external services other than git remotes and
+GitHub through `gh`.
 
 The remotes `origin` (this fork) and `upstream` (`badlogic/pi-mono`) are already configured,
-and `upstream` has been fetched. The current branch is `main`.
+and `upstream` has been fetched. The current branch is a bot branch created from `main`.
 
 ## Procedure
 
 ### 1. Merge upstream
 
-Use the **merge-upstream** skill to sync `main` with `upstream/main` via a history-preserving
-merge (`git merge --no-ff`). Honor every skill invariant: NO rebase, NO force-push, NO
-`--no-verify`, NO history rewrite. Do **not** push and do **not** run the release here — the
-workflow handles release after QA.
+Use the **merge-upstream** skill semantics to sync the current bot branch with
+`upstream/main` via a history-preserving merge (`git merge --no-ff`). Honor every skill
+invariant: no rebase, no force-push, no `--no-verify`, and no history rewrite. Do not push,
+open pull requests, merge pull requests, create tags, or run the release.
+
+If the upstream release does not require any source, package, changelog, or pin change after
+inspection, write a short report and finish with `MERGE_RESULT: NO_RELEASE_NEEDED`.
 
 ### 2. Resolve conflicts (fork-aware)
 
@@ -26,14 +29,14 @@ what the fork preserves and why.
 
 | Path / pattern | Resolution |
 |---|---|
-| `package-lock.json` | take **upstream** (`--theirs`), then regenerate with `npm install` |
-| `bun.lock` | remove it, regenerate with `bun install` (or take upstream if bun is unavailable) |
+| `package-lock.json` | take **upstream** (`--theirs`), then regenerate with `npm install --package-lock-only --ignore-scripts` |
+| `bun.lock` | remove it, regenerate with `bun install --ignore-scripts` (or take upstream if bun is unavailable) |
 | `**/changes.md` | keep **ours** (fork notes) |
 | other `*.md` (docs, READMEs) | take **upstream** unless the fork intentionally diverged |
-| `packages/coding-agent/src/core/extensions/builtin/**` | fork-only directory — prefer **ours** unless upstream improves the same path |
+| `packages/coding-agent/src/core/extensions/builtin/**` | fork-only directory; prefer **ours** unless upstream improves the same path |
 
-Known fork-modified source files — these are NOT auto-resolvable; read their `changes.md`
-and merge semantically, preserving fork behavior while adopting upstream improvements:
+Known fork-modified source files are not auto-resolvable; read their `changes.md` and merge
+semantically, preserving fork behavior while adopting upstream improvements:
 
 - `packages/agent/src/agent-loop.ts`
 - `packages/coding-agent/src/core/agent-session.ts`
@@ -43,10 +46,10 @@ and merge semantically, preserving fork behavior while adopting upstream improve
 - `packages/coding-agent/src/modes/interactive/interactive-mode.ts`
 - `packages/tui/src/tui.ts`
 
-If a conflict is genuinely ambiguous and you cannot resolve it with confidence, STOP: abort
-the merge (`git merge --abort`), write a report to `.github/agent/last-merge-report.md`
-describing the unresolved files and your analysis, print `MERGE_RESULT: CONFLICTS`, and exit.
-Do not guess on semantic conflicts.
+If a conflict is genuinely ambiguous and you cannot resolve it with confidence, abort the
+merge (`git merge --abort`), write `.github/agent/last-merge-report.md` with the unresolved
+files and analysis, print `MERGE_RESULT: CONFLICTS`, and exit. Do not guess on semantic
+conflicts.
 
 ### 3. Update the upstream pin
 
@@ -57,13 +60,13 @@ merge commit, or add a follow-up commit `sync: record upstream pin <short-sha>`.
 
 ### 4. Audit the changelog
 
-Run the `/cl` command to audit changelogs for every commit the merge introduced. Add any
-missing `## [Unreleased]` entries to the affected packages' `CHANGELOG.md` per the format in
-the command. Commit the changelog updates (`docs(changelog): audit upstream <short-sha>`).
+Run `/cl` by following `.github/agent/commands/cl.md`. Add missing `## [Unreleased]` entries
+to the affected packages' `CHANGELOG.md` files. Commit changelog updates as
+`docs(changelog): audit upstream <short-sha>`.
 
 ### 5. Hands-on QA
 
-Verify the merged tree actually builds and runs — do not trust the merge blindly:
+Verify the merged tree actually builds and runs:
 
 ```bash
 npm run build
@@ -76,32 +79,39 @@ node packages/coding-agent/dist/cli/index.js --version
 node packages/coding-agent/dist/cli/index.js --help
 ```
 
-(Use the actual built entrypoint if the path differs — locate it under
-`packages/coding-agent/dist`.)
+Use the actual built entrypoint if the path differs; locate it under
+`packages/coding-agent/dist`.
 
-Do NOT run `npm test` or the full `npm run check` here: provider API keys are present in this
-step's environment, which would activate live end-to-end tests against real model endpoints.
-The workflow runs the authoritative `build` + `check` + `test` gate in a credential-free step
-right after you finish, so those live tests skip there. Your job is to confirm the merge
-compiles and the CLI starts.
+Do not run `npm test` or the full `npm run check` here. The workflow runs the authoritative
+credential-free `build`, `check`, `test`, and senpi-qa evidence gates after you stop.
 
-If the build or smoke test fails, attempt a focused fix (the fix must stay faithful to both
-fork and upstream intent — never delete functionality to silence a type error). Re-run until
-green. If you cannot get a building tree, write `.github/agent/last-merge-report.md`, print
-`MERGE_RESULT: QA_FAILED`, and exit without leaving a broken tree staged for release.
+If the build or smoke test fails, attempt a focused fix that preserves both fork and upstream
+intent. Re-run until green. If you cannot get a building tree, write
+`.github/agent/last-merge-report.md`, print `MERGE_RESULT: QA_FAILED`, and exit without
+leaving a broken tree staged for release.
+
+When runtime packages changed (`packages/ai`, `packages/agent`, `packages/coding-agent`, or
+`packages/tui`), also run the matching `.agents/skills/senpi-qa/` channel and capture
+evidence under `local-ignore/qa-evidence/`.
 
 ### 6. Finish
 
-Leave `main` with the merge commit, pin update, and changelog commits in place — committed
-but NOT pushed. Write a concise summary to `.github/agent/last-merge-report.md` (upstream tag
-merged, fork commits preserved, conflicts resolved and how, changelog entries added, QA
-results). Print `MERGE_RESULT: CLEAN` as the final line so the workflow proceeds to release.
+Leave the bot branch with committed merge, pin, changelog, and focused fix commits in place.
+Write `.github/agent/last-merge-report.md` with the upstream tag, preserved fork commits,
+conflicts resolved and how, changelog entries added, and QA results.
+
+The final stdout line MUST be exactly one of:
+
+- `MERGE_RESULT: CLEAN_PR_READY`
+- `MERGE_RESULT: NO_RELEASE_NEEDED`
+- `MERGE_RESULT: CONFLICTS`
+- `MERGE_RESULT: QA_FAILED`
+- `MERGE_RESULT: AGENT_FAILED`
 
 ## Hard rules
 
 - Never `git push`, `git rebase`, `git push --force`, or `git reset --hard origin/*`.
-- Never bypass hooks/signing (`--no-verify`, `--no-gpg-sign`).
+- Never bypass hooks/signing with `--no-verify` or `--no-gpg-sign`.
+- Never create or merge pull requests, create tags, or run `scripts/release.mjs`.
 - Never edit already-released changelog version sections.
 - Never edit `packages/ai/src/models.generated.ts` or `image-models.generated.ts` by hand.
-- The final stdout line MUST be exactly one of:
-  `MERGE_RESULT: CLEAN`, `MERGE_RESULT: CONFLICTS`, or `MERGE_RESULT: QA_FAILED`.

--- a/.github/agent/release-driver.md
+++ b/.github/agent/release-driver.md
@@ -1,0 +1,32 @@
+# Release audit driver
+
+You are Codex running headless inside GitHub Actions on the `senpi` fork
+(`code-yeongyu/senpi`). The upstream sync PR has already been merge-committed into `main`.
+Your job is to run a fresh `/cl` changelog audit on this exact `main` tip, commit any
+missing changelog entries, and stop. Do not run `scripts/release.mjs`, create tags, push, or
+publish.
+
+## Procedure
+
+1. Confirm the current branch is `main`.
+2. Run `/cl` by following `.github/agent/commands/cl.md`.
+3. If `/cl` adds or edits changelog entries, review the diff and commit only those files with
+   `docs(changelog): audit upstream release`.
+4. If `/cl` finds no missing entries and the tree is clean, leave it clean.
+5. Write `.github/agent/last-release-audit-report.md` summarizing the audit.
+
+## Final Status
+
+The final stdout line MUST be exactly one of:
+
+- `RELEASE_DECISION: RELEASE` when the changelog audit completed and release-worthiness can
+  be evaluated by the workflow.
+- `RELEASE_DECISION: SKIP` when the audit proves there is no package-facing release work.
+- `RELEASE_DECISION: FAILED` when the audit cannot complete safely.
+
+## Hard Rules
+
+- Never run `scripts/release.mjs`.
+- Never create tags.
+- Never push.
+- Never edit already-released changelog sections.

--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -1,11 +1,8 @@
 name: Upstream Agent Merge
 
-# New upstream release -> Claude Code headless merges + audits changelog + QAs -> release.mjs
-# tags vX.Y.Z -> build-binaries.yml publishes. See plans/upstream-agent-merge.md.
-
 'on':
   schedule:
-    - cron: '23 */6 * * *'
+    - cron: '23 * * * *'
   workflow_dispatch:
     inputs:
       force:
@@ -13,13 +10,23 @@ name: Upstream Agent Merge
         required: false
         type: boolean
         default: false
+      force_release:
+        description: 'Release even when the fresh /cl audit finds no package changelog entries'
+        required: false
+        type: boolean
+        default: false
       model:
-        description: 'Claude Code model override (optional)'
+        description: 'Codex model override (optional)'
         required: false
         type: string
         default: ''
+      codex_profile:
+        description: 'Codex profile to use (defaults to quotio)'
+        required: false
+        type: string
+        default: 'quotio'
       dry_run:
-        description: 'Run merge + QA but preview the release only (no tag/push/publish)'
+        description: 'Run merge + QA locally, but do not push, merge, tag, or publish'
         required: false
         type: boolean
         default: false
@@ -27,6 +34,8 @@ name: Upstream Agent Merge
 permissions:
   contents: write
   issues: write
+  pull-requests: write
+  checks: read
 
 concurrency:
   group: upstream-agent-merge
@@ -35,22 +44,30 @@ concurrency:
 jobs:
   merge-and-release:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       UPSTREAM_URL: https://github.com/badlogic/pi-mono.git
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MODEL_INPUT: ${{ github.event.inputs.model }}
-      DEFAULT_MODEL: claude-opus-4-8
+      CODEX_PROFILE_INPUT: ${{ github.event.inputs.codex_profile }}
+      DEFAULT_MODEL: gpt-5.5
+      DEFAULT_CODEX_PROFILE: quotio
+      EVIDENCE_DIR: local-ignore/qa-evidence/upstream-agent
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: true
+          token: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
+          persist-credentials: false
 
       - name: Configure git and upstream remote
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
         run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::UPSTREAM_AUTOMATION_TOKEN is required so branch and tag pushes trigger follow-up workflows."
+            exit 1
+          fi
           git config user.name "senpi-merge-bot"
           git config user.email "actions@github.com"
           git remote add upstream "${UPSTREAM_URL}" 2>/dev/null || git remote set-url upstream "${UPSTREAM_URL}"
@@ -81,77 +98,310 @@ jobs:
         run: |
           sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
           sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
-            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep tmux
           sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
 
       - name: Install dependencies
         if: steps.detect.outputs.proceed == 'true'
-        run: npm install --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund
 
-      - name: Install Claude Code
+      - name: Install Codex and LazyCodex
         if: steps.detect.outputs.proceed == 'true'
         run: |
-          npm install -g @anthropic-ai/claude-code
-          claude --version
+          npm install -g --force --ignore-scripts @openai/codex@latest lazycodex-ai@latest oh-my-openagent@latest
+          mkdir -p "$EVIDENCE_DIR"
+          {
+            echo "codex: $(codex --version)"
+            echo "lazycodex: $(lazycodex --version)"
+            echo "lazycodex-ai: $(lazycodex-ai --version)"
+            npm view @openai/codex dist-tags.latest dist.integrity --json
+            npm view lazycodex-ai dist-tags.latest dist.integrity --json
+            npm view oh-my-openagent dist-tags.latest dist.integrity --json
+          } | tee "$EVIDENCE_DIR/tool-versions.txt"
 
-      - name: Stage agent resources into runtime
+      - name: Hydrate Codex and senpi secrets
         if: steps.detect.outputs.proceed == 'true'
+        env:
+          CODEX_AUTH_JSON_B64: ${{ secrets.CODEX_AUTH_JSON_B64 }}
+          CODEX_CONFIG_TOML_B64: ${{ secrets.CODEX_CONFIG_TOML_B64 }}
+          CODEX_QUOTIO_CONFIG_TOML_B64: ${{ secrets.CODEX_QUOTIO_CONFIG_TOML_B64 }}
+          CODEX_CCAPI_CONFIG_TOML_B64: ${{ secrets.CODEX_CCAPI_CONFIG_TOML_B64 }}
+          QUOTIO_API_KEY: ${{ secrets.QUOTIO_API_KEY }}
+          QUOTIO_BASE_URL: ${{ secrets.QUOTIO_BASE_URL }}
+          SENPI_AUTH_JSON_B64: ${{ secrets.SENPI_AUTH_JSON_B64 }}
+          SENPI_MODELS_JSON_B64: ${{ secrets.SENPI_MODELS_JSON_B64 }}
+          SENPI_SETTINGS_JSON_B64: ${{ secrets.SENPI_SETTINGS_JSON_B64 }}
         run: |
-          mkdir -p "$HOME/.claude/skills" "$HOME/.claude/commands"
-          cp -R .github/agent/skills/. "$HOME/.claude/skills/"
-          cp .github/agent/commands/*.md "$HOME/.claude/commands/"
-          ls -R "$HOME/.claude/skills" "$HOME/.claude/commands"
+          set -euo pipefail
+          umask 077
+          mkdir -p "$HOME/.codex" "$HOME/.senpi/agent" "$EVIDENCE_DIR"
 
-      - name: Run merge + changelog agent
+          write_secret_b64() {
+            local value="$1"
+            local path="$2"
+            if [ -n "$value" ]; then
+              printf '%s' "$value" | base64 -d > "$path"
+              chmod 600 "$path"
+            fi
+          }
+
+          write_secret_b64 "$CODEX_AUTH_JSON_B64" "$HOME/.codex/auth.json"
+          write_secret_b64 "$CODEX_CONFIG_TOML_B64" "$HOME/.codex/config.toml"
+          write_secret_b64 "$CODEX_QUOTIO_CONFIG_TOML_B64" "$HOME/.codex/quotio.config.toml"
+          write_secret_b64 "$CODEX_CCAPI_CONFIG_TOML_B64" "$HOME/.codex/ccapi.config.toml"
+          write_secret_b64 "$SENPI_AUTH_JSON_B64" "$HOME/.senpi/agent/auth.json"
+          write_secret_b64 "$SENPI_MODELS_JSON_B64" "$HOME/.senpi/agent/models.json"
+          write_secret_b64 "$SENPI_SETTINGS_JSON_B64" "$HOME/.senpi/agent/settings.json"
+
+          if [ ! -s "$HOME/.codex/config.toml" ]; then
+            if [ -z "$QUOTIO_API_KEY" ]; then
+              echo "::error::Provide CODEX_CONFIG_TOML_B64 or QUOTIO_API_KEY for the generated quotio profile."
+              exit 1
+            fi
+            {
+              echo 'model = "gpt-5.5"'
+              echo 'model_provider = "quotio"'
+              echo 'model_reasoning_effort = "high"'
+              echo 'approval_policy = "never"'
+              echo 'sandbox_mode = "danger-full-access"'
+              echo 'network_access = "enabled"'
+              echo 'shell_environment_policy = { inherit = "all" }'
+              echo
+              echo '[model_providers.quotio]'
+              echo 'name = "Quotio"'
+              echo "base_url = \"${QUOTIO_BASE_URL:-https://quotio.mengmota.com/v1}\""
+              echo 'env_key = "QUOTIO_API_KEY"'
+              echo 'wire_api = "responses"'
+              echo 'requires_openai_auth = false'
+            } > "$HOME/.codex/config.toml"
+            chmod 600 "$HOME/.codex/config.toml"
+          fi
+
+          if [ ! -s "$HOME/.codex/quotio.config.toml" ]; then
+            {
+              echo 'model = "gpt-5.5"'
+              echo 'model_provider = "quotio"'
+              echo 'service_tier = "fast"'
+              echo 'model_reasoning_effort = "high"'
+              echo 'approval_policy = "never"'
+              echo 'sandbox_mode = "danger-full-access"'
+              echo 'network_access = "enabled"'
+              echo 'shell_environment_policy = { inherit = "all" }'
+            } > "$HOME/.codex/quotio.config.toml"
+            chmod 600 "$HOME/.codex/quotio.config.toml"
+          fi
+
+          test -s "$HOME/.codex/config.toml"
+          if [ ! -s "$HOME/.codex/auth.json" ] && [ -z "$QUOTIO_API_KEY" ]; then
+            echo "::error::Provide CODEX_AUTH_JSON_B64 or QUOTIO_API_KEY."
+            exit 1
+          fi
+          find "$HOME/.codex" "$HOME/.senpi/agent" -maxdepth 1 -type f -printf '%p %m\n' \
+            | sed "s#${HOME}#~#" | tee "$EVIDENCE_DIR/secret-files.txt"
+
+      - name: Run Codex merge + changelog agent
         id: agent
         if: steps.detect.outputs.proceed == 'true'
         env:
           UPSTREAM_TAG: ${{ steps.detect.outputs.tag }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          QUOTIO_API_KEY: ${{ secrets.QUOTIO_API_KEY }}
         run: |
-          if [ -z "${ANTHROPIC_API_KEY}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
-            echo "::error::Neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN is set. Add one as a repository secret."
-            exit 1
-          fi
+          set -euo pipefail
+          BRANCH="automation/upstream-${UPSTREAM_TAG}"
+          git checkout -B "$BRANCH"
+
+          {
+            cat .github/agent/merge-driver.md
+            echo
+            echo "The latest upstream release tag to integrate is ${UPSTREAM_TAG}."
+          } > /tmp/codex-merge-driver.md
+
           MODEL="${MODEL_INPUT:-$DEFAULT_MODEL}"
-          MODEL_ARG=""
-          if [ -n "${MODEL}" ]; then MODEL_ARG="--model ${MODEL}"; fi
-          DRIVER="$(cat .github/agent/merge-driver.md)
-          The latest upstream release tag to integrate is ${UPSTREAM_TAG}."
-          set -o pipefail
-          claude -p "${DRIVER}" \
-            --permission-mode bypassPermissions \
-            --max-turns 200 \
-            $MODEL_ARG 2>&1 | tee /tmp/agent.log
-          RESULT="$(grep -E '^MERGE_RESULT:' /tmp/agent.log | tail -1 | awk '{print $2}')"
-          echo "result=${RESULT:-UNKNOWN}" >> "$GITHUB_OUTPUT"
-          echo "Agent result: ${RESULT:-UNKNOWN}"
+          PROFILE="${CODEX_PROFILE_INPUT:-$DEFAULT_CODEX_PROFILE}"
+          set +e
+          codex exec \
+            --profile "$PROFILE" \
+            --cd "$GITHUB_WORKSPACE" \
+            --dangerously-bypass-approvals-and-sandbox \
+            --dangerously-bypass-hook-trust \
+            --output-last-message /tmp/codex-last-message.md \
+            -m "$MODEL" \
+            - < /tmp/codex-merge-driver.md 2>&1 | tee /tmp/codex-agent.log
+          CODEX_STATUS="${PIPESTATUS[0]}"
+          set -e
 
-      - name: Verify merged tree (deterministic QA gate)
-        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN'
+          RESULT="$(grep -E '^MERGE_RESULT:' /tmp/codex-agent.log /tmp/codex-last-message.md 2>/dev/null | tail -1 | awk '{print $2}')"
+          if [ -z "$RESULT" ] && [ "$CODEX_STATUS" -ne 0 ]; then RESULT="AGENT_FAILED"; fi
+          if [ -f .github/agent/last-merge-report.md ]; then
+            mkdir -p "$EVIDENCE_DIR"
+            cp .github/agent/last-merge-report.md "$EVIDENCE_DIR/last-merge-report.md"
+            rm .github/agent/last-merge-report.md
+          fi
+          echo "result=${RESULT:-AGENT_FAILED}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Agent result: ${RESULT:-AGENT_FAILED}"
+
+      - name: Verify branch and capture QA evidence
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY'
+        env:
+          PI_OFFLINE: '1'
         run: |
-          git status --porcelain
-          npm run build
-          npm run check
-          npm test
+          set -euo pipefail
+          mkdir -p "$EVIDENCE_DIR"
+          git status --porcelain | tee "$EVIDENCE_DIR/git-status-before-qa.txt"
+          test ! -s "$EVIDENCE_DIR/git-status-before-qa.txt"
+          npm run build 2>&1 | tee "$EVIDENCE_DIR/npm-build.txt"
+          npm run check 2>&1 | tee "$EVIDENCE_DIR/npm-check.txt"
+          npm test 2>&1 | tee "$EVIDENCE_DIR/npm-test.txt"
+          node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-common.txt"
+          node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence upstream-agent-mock-loop 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-mock-loop.txt"
+          node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-cli-smoke.txt"
+          if command -v tmux >/dev/null 2>&1; then
+            node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence upstream-agent-tui 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-tui.txt"
+          fi
 
-      - name: Release
-        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN'
+      - name: Open and merge upstream PR
+        id: pr
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
+          UPSTREAM_TAG: ${{ steps.detect.outputs.tag }}
+          UPSTREAM_SHA: ${{ steps.detect.outputs.sha }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ steps.agent.outputs.branch }}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH:$BRANCH"
+
+          BODY_FILE=/tmp/upstream-pr-body.md
+          {
+            echo "Automated upstream sync for \`${UPSTREAM_TAG}\`."
+            echo
+            echo "- Upstream SHA: \`${UPSTREAM_SHA}\`"
+            echo "- Evidence artifact: \`upstream-agent-qa-${UPSTREAM_TAG}\`"
+            echo "- Release is evaluated only after this PR is merged with a merge commit."
+            echo
+            echo "QA completed before PR creation:"
+            echo "- \`npm run build\`"
+            echo "- \`npm run check\`"
+            echo "- \`npm test\`"
+            echo "- \`senpi-qa\` common, mock-loop, CLI smoke, and tmux TUI smoke when available"
+          } > "$BODY_FILE"
+
+          EXISTING="$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING" ]; then
+            PR_NUMBER="$EXISTING"
+            gh pr edit "$PR_NUMBER" --title "sync: upstream ${UPSTREAM_TAG}" --body-file "$BODY_FILE"
+          else
+            PR_URL="$(gh pr create --base main --head "$BRANCH" --title "sync: upstream ${UPSTREAM_TAG}" --body-file "$BODY_FILE")"
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "url=$(gh pr view "$PR_NUMBER" --json url --jq .url)" >> "$GITHUB_OUTPUT"
+
+          gh pr checks "$PR_NUMBER" --watch --fail-fast --interval 30
+          HEAD_SHA="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)"
+          gh pr merge "$PR_NUMBER" --merge --delete-branch --match-head-commit "$HEAD_SHA"
+
+      - name: Fresh /cl release audit
+        id: release_audit
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY' && github.event.inputs.dry_run != 'true'
+        env:
+          QUOTIO_API_KEY: ${{ secrets.QUOTIO_API_KEY }}
+        run: |
+          set -euo pipefail
+          git checkout main
+          git fetch origin main --tags
+          git merge --ff-only origin/main
+          MODEL="${MODEL_INPUT:-$DEFAULT_MODEL}"
+          PROFILE="${CODEX_PROFILE_INPUT:-$DEFAULT_CODEX_PROFILE}"
+          set +e
+          codex exec \
+            --profile "$PROFILE" \
+            --cd "$GITHUB_WORKSPACE" \
+            --dangerously-bypass-approvals-and-sandbox \
+            --dangerously-bypass-hook-trust \
+            --output-last-message /tmp/codex-release-last-message.md \
+            -m "$MODEL" \
+            - < .github/agent/release-driver.md 2>&1 | tee /tmp/codex-release-agent.log
+          CODEX_STATUS="${PIPESTATUS[0]}"
+          set -e
+          DECISION="$(grep -E '^RELEASE_DECISION:' /tmp/codex-release-agent.log /tmp/codex-release-last-message.md 2>/dev/null | tail -1 | awk '{print $2}')"
+          if [ -z "$DECISION" ] && [ "$CODEX_STATUS" -ne 0 ]; then DECISION="FAILED"; fi
+          if [ -f .github/agent/last-release-audit-report.md ]; then
+            mkdir -p "$EVIDENCE_DIR"
+            cp .github/agent/last-release-audit-report.md "$EVIDENCE_DIR/last-release-audit-report.md"
+            rm .github/agent/last-release-audit-report.md
+          fi
+          echo "decision=${DECISION:-FAILED}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide release worthiness
+        id: worthy
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY' && github.event.inputs.dry_run != 'true' && steps.release_audit.outputs.decision == 'RELEASE'
+        run: |
+          ARGS=()
+          if [ "${{ github.event.inputs.force_release }}" = "true" ]; then ARGS+=(--force-release); fi
+          node scripts/upstream-release-worthy.mjs "${ARGS[@]}" | tee "$EVIDENCE_DIR/release-worthy.txt"
+          node scripts/upstream-release-worthy.mjs "${ARGS[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Release after PR merge
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY' && github.event.inputs.dry_run != 'true' && steps.release_audit.outputs.decision == 'RELEASE' && (steps.worthy.outputs.release_worthy == 'true' || github.event.inputs.force_release == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
+          PI_ALLOW_LOCKFILE_CHANGE: '1'
+          npm_config_min_release_age: '0'
+          SENPI_SKIP_PM_VERIFY: '1'
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          node scripts/release.mjs
+
+      - name: Dry-run release preview
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY' && github.event.inputs.dry_run == 'true'
         env:
           PI_ALLOW_LOCKFILE_CHANGE: '1'
           npm_config_min_release_age: '0'
           SENPI_SKIP_PM_VERIFY: '1'
         run: |
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
-            node scripts/release.mjs --dry-run
-          else
-            node scripts/release.mjs
-          fi
+          git checkout main
+          git merge --no-ff --no-commit "${{ steps.agent.outputs.branch }}"
+          node scripts/release.mjs --dry-run
+
+      - name: Upload QA evidence
+        if: always() && steps.detect.outputs.proceed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-agent-qa-${{ steps.detect.outputs.tag || 'unknown' }}
+          path: local-ignore/qa-evidence/
+          if-no-files-found: warn
+
+      - name: Open release audit failure issue
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY' && github.event.inputs.dry_run != 'true' && (steps.release_audit.outputs.decision == 'FAILED' || steps.release_audit.outputs.decision == '')
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
+        run: |
+          TAG="${{ steps.detect.outputs.tag }}"
+          BODY_FILE=/tmp/release-issue-body.md
+          {
+            echo "Automated upstream release audit for \`${TAG}\` failed after the sync PR merged."
+            echo
+            echo "## Release audit report"
+            echo
+            if [ -f "$EVIDENCE_DIR/last-release-audit-report.md" ]; then cat "$EVIDENCE_DIR/last-release-audit-report.md"; else echo "(no report written)"; fi
+            echo
+            echo "Resolve manually, then re-run \`Upstream Agent Merge\` with \`force=true\` if needed."
+          } > "$BODY_FILE"
+          gh label create sync-conflict --color D73A4A --description "Automated upstream sync needs maintainer attention" || true
+          gh issue create \
+            --title "upstream release audit needs attention: ${TAG}" \
+            --label "sync-conflict" \
+            --body-file "$BODY_FILE" || gh issue create \
+            --title "upstream release audit needs attention: ${TAG}" \
+            --body-file "$BODY_FILE"
+          exit 1
 
       - name: Open conflict / failure issue
-        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result != 'CLEAN' && steps.agent.outputs.result != ''
+        if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result != 'CLEAN_PR_READY' && steps.agent.outputs.result != 'NO_RELEASE_NEEDED' && steps.agent.outputs.result != ''
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
         run: |
           TAG="${{ steps.detect.outputs.tag }}"
           RESULT="${{ steps.agent.outputs.result }}"
@@ -161,15 +411,23 @@ jobs:
             echo
             echo "## Agent report"
             echo
-            if [ -f .github/agent/last-merge-report.md ]; then cat .github/agent/last-merge-report.md; else echo "(no report written)"; fi
+            if [ -f "$EVIDENCE_DIR/last-merge-report.md" ]; then cat "$EVIDENCE_DIR/last-merge-report.md"; else echo "(no report written)"; fi
             echo
-            echo "Resolve manually, then re-run \`Upstream Agent Merge\` with \`force=true\` or cut the release by hand."
+            echo "Resolve manually, then re-run \`Upstream Agent Merge\` with \`force=true\`."
           } > "$BODY_FILE"
+          gh label create sync-conflict --color D73A4A --description "Automated upstream sync needs maintainer attention" || true
           gh issue create \
             --title "upstream merge needs attention: ${TAG} (${RESULT})" \
             --label "sync-conflict" \
-            --body-file "$BODY_FILE" || echo "::warning::failed to open issue"
+            --body-file "$BODY_FILE" || gh issue create \
+            --title "upstream merge needs attention: ${TAG} (${RESULT})" \
+            --body-file "$BODY_FILE"
           exit 1
+
+      - name: No release needed
+        if: steps.detect.outputs.proceed == 'true' && (steps.agent.outputs.result == 'NO_RELEASE_NEEDED' || steps.release_audit.outputs.decision == 'SKIP' || steps.worthy.outputs.release_worthy == 'false')
+        run: |
+          echo "NO_RELEASE_NEEDED: upstream sync completed without release-worthy package changes."
 
       - name: No new upstream release
         if: steps.detect.outputs.proceed != 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,14 +68,14 @@ The release script (`scripts/release.mjs`) imports `scripts/calver.mjs` to compu
 
 ### Upstream sync
 
-You do NOT manually merge upstream. `.github/workflows/upstream-agent-merge.yml` polls `badlogic/pi-mono` and, when a new upstream release lands, runs Claude Code headless inside the runner to merge it.
+You do NOT manually merge upstream. `.github/workflows/upstream-agent-merge.yml` polls `badlogic/pi-mono` hourly and, when a new upstream release lands, runs Codex headless inside the runner to merge it on an automation branch.
 
-The agent uses the committed `merge-upstream` skill and `/cl` changelog-audit command (under `.github/agent/`) plus the fork conflict-resolution rules in `.github/agent/merge-driver.md`. On a clean, building, changelog-audited merge it lets the release run (`scripts/release.mjs` tags `vX.Y.Z` and pushes; `build-binaries.yml` publishes from the tag).
+The agent uses the committed `merge-upstream` skill and `/cl` changelog-audit command (under `.github/agent/`) plus the fork conflict-resolution rules in `.github/agent/merge-driver.md`. On a clean, building, changelog-audited merge, the workflow opens a PR, waits for checks and QA evidence, merges it with a merge commit, runs a fresh `/cl` audit on `main`, and then lets the release run only when package changelog entries make it release-worthy (`scripts/release.mjs` tags `vX.Y.Z` and pushes; `build-binaries.yml` publishes from the tag).
 
-- **Clean merge** → merged into `main`, changelog audited, QA gates pass, a new release is cut automatically.
+- **Clean merge** → PR branch is merged into `main` with a merge commit, changelog audited, QA gates pass, and a new release is cut automatically when release-worthy.
 - **Conflicts / QA failure** → the agent aborts, writes `.github/agent/last-merge-report.md`, and the workflow opens an issue labeled `sync-conflict`. Resolve manually following the per-file rules in `.github/agent/merge-driver.md`; the `changes.md` files in fork-modified subdirectories tell you what the fork preserves and why.
 
-Requires the `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`) repository secret.
+Requires `UPSTREAM_AUTOMATION_TOKEN`, `CODEX_CONFIG_TOML_B64`, and either `CODEX_AUTH_JSON_B64` or `QUOTIO_API_KEY`. Optional QA/config secrets include `CODEX_QUOTIO_CONFIG_TOML_B64`, `CODEX_CCAPI_CONFIG_TOML_B64`, `SENPI_AUTH_JSON_B64`, `SENPI_MODELS_JSON_B64`, and `SENPI_SETTINGS_JSON_B64`. See `.github/agent/README.md`.
 
 To trigger manually:
 ```bash

--- a/scripts/upstream-release-worthy.mjs
+++ b/scripts/upstream-release-worthy.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const CHANGELOGS = [
+	"packages/ai/CHANGELOG.md",
+	"packages/agent/CHANGELOG.md",
+	"packages/coding-agent/CHANGELOG.md",
+	"packages/tui/CHANGELOG.md",
+	"packages/web-ui/CHANGELOG.md",
+];
+
+const ENTRY_RE = /^\s*-\s+\S/m;
+
+export function extractUnreleasedSection(text) {
+	const start = text.match(/^## \[Unreleased\]\s*$/m);
+	if (!start) return "";
+	const from = (start.index ?? 0) + start[0].length;
+	const rest = text.slice(from);
+	const next = rest.search(/^## \[/m);
+	return next === -1 ? rest : rest.slice(0, next);
+}
+
+export function hasUnreleasedEntries(text) {
+	return ENTRY_RE.test(extractUnreleasedSection(text));
+}
+
+export function decideReleaseWorthiness(files, options = {}) {
+	if (options.forceRelease) {
+		return { releaseWorthy: true, reason: "forced" };
+	}
+	const changed = files.filter((file) => hasUnreleasedEntries(file.content));
+	if (changed.length === 0) {
+		return { releaseWorthy: false, reason: "no-unreleased-package-entries" };
+	}
+	return { releaseWorthy: true, reason: `unreleased-entries:${changed.map((file) => file.path).join(",")}` };
+}
+
+function parseArgs(argv) {
+	const args = { forceRelease: false, selfTest: false, selfTestCase: "" };
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--force-release") {
+			args.forceRelease = true;
+		} else if (arg === "--self-test") {
+			args.selfTest = true;
+		} else if (arg === "--case") {
+			i += 1;
+			args.selfTestCase = argv[i] ?? "";
+		} else if (arg === "--help" || arg === "-h") {
+			process.stdout.write("Usage: node scripts/upstream-release-worthy.mjs [--force-release] [--self-test]\n");
+			process.exit(0);
+		} else {
+			throw new Error(`unknown argument: ${arg}`);
+		}
+	}
+	return args;
+}
+
+function runSelfTest(testCase) {
+	const fixtures = [
+		{ path: "packages/coding-agent/CHANGELOG.md", content: "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Fixed sync.\n" },
+	];
+	const docsOnly = [{ path: "packages/coding-agent/CHANGELOG.md", content: "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n" }];
+	const cases = [
+		["entry-release", decideReleaseWorthiness(fixtures), true],
+		["force-release", decideReleaseWorthiness(docsOnly, { forceRelease: true }), true],
+		["docs-only-skip", decideReleaseWorthiness(docsOnly), false],
+		["empty-skip", decideReleaseWorthiness([]), false],
+	];
+	for (const [name, result, expected] of cases) {
+		if (testCase && name !== testCase) continue;
+		if (result.releaseWorthy !== expected) {
+			throw new Error(`${name}: expected ${expected}, got ${result.releaseWorthy}`);
+		}
+		process.stdout.write(`${name}: release_worthy=${String(result.releaseWorthy)} reason=${result.reason}\n`);
+	}
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.selfTest) {
+		runSelfTest(args.selfTestCase);
+		return;
+	}
+	const files = CHANGELOGS.map((path) => ({ path, content: readFileSync(path, "utf8") }));
+	const result = decideReleaseWorthiness(files, { forceRelease: args.forceRelease });
+	process.stdout.write(`release_worthy=${String(result.releaseWorthy)}\n`);
+	process.stdout.write(`reason=${result.reason}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main();
+}

--- a/scripts/upstream-release-worthy.test.mjs
+++ b/scripts/upstream-release-worthy.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	decideReleaseWorthiness,
+	extractUnreleasedSection,
+	hasUnreleasedEntries,
+} from "./upstream-release-worthy.mjs";
+
+describe("upstream release worthiness", () => {
+	it("detects package changelog entries under Unreleased", () => {
+		const text = "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- Fixed upstream sync.\n\n## [2026.6.17]\n\n";
+		assert.equal(hasUnreleasedEntries(text), true);
+		assert.equal(extractUnreleasedSection(text).includes("Fixed upstream sync"), true);
+	});
+
+	it("skips empty Unreleased sections", () => {
+		const files = [{ path: "packages/coding-agent/CHANGELOG.md", content: "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n" }];
+		assert.deepEqual(decideReleaseWorthiness(files), {
+			releaseWorthy: false,
+			reason: "no-unreleased-package-entries",
+		});
+	});
+
+	it("releases when any package changelog has an Unreleased entry", () => {
+		const files = [
+			{ path: "packages/ai/CHANGELOG.md", content: "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n" },
+			{ path: "packages/tui/CHANGELOG.md", content: "# Changelog\n\n## [Unreleased]\n\n### Changed\n\n- Updated rendering.\n" },
+		];
+		assert.equal(decideReleaseWorthiness(files).releaseWorthy, true);
+	});
+
+	it("allows explicit forced release", () => {
+		const files = [{ path: "packages/coding-agent/CHANGELOG.md", content: "# Changelog\n\n## [Unreleased]\n\n" }];
+		assert.deepEqual(decideReleaseWorthiness(files, { forceRelease: true }), {
+			releaseWorthy: true,
+			reason: "forced",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Replace the six-hour Claude direct-to-main upstream workflow with hourly Codex automation on an upstream sync PR branch.
- Restore Codex/quotio and senpi QA config from GitHub secrets, install latest Codex/LazyCodex/OMO tooling at runtime with install scripts disabled, and keep write tokens scoped away from autonomous Codex steps.
- Merge upstream sync PRs with merge commits, run a fresh `/cl` audit on `main`, and release only when `scripts/upstream-release-worthy.mjs` finds package changelog entries or `force_release=true` is explicitly set.

## Required Secrets

- `UPSTREAM_AUTOMATION_TOKEN`
- `CODEX_CONFIG_TOML_B64`
- `CODEX_AUTH_JSON_B64` or `QUOTIO_API_KEY`
- Optional: `CODEX_QUOTIO_CONFIG_TOML_B64`, `CODEX_CCAPI_CONFIG_TOML_B64`, `SENPI_AUTH_JSON_B64`, `SENPI_MODELS_JSON_B64`, `SENPI_SETTINGS_JSON_B64`

## Validation

- `actionlint` on `.github/workflows/upstream-agent-merge.yml`
- `node --test scripts/upstream-release-worthy.test.mjs`
- `node scripts/check-upstream-release.mjs --help`
- `npm run check`
- Credential-boundary, report-cleanup, force-gating, and install-script safety evidence captured under `local-ignore/qa-evidence/20260617-hourly-upstream-codex-pr/`
- Reviewer: `UNCONDITIONAL APPROVAL`

Plan: .omo/plans/hourly-upstream-codex-pr-release.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates hourly upstream sync via Codex on a PR branch, then gates release on a fresh `/cl` audit and changelog entries. Replaces the 6‑hour direct-to-main flow with safer PR merges and explicit release-worthiness checks.

- **New Features**
  - Hourly workflow creates a bot branch, runs Codex merge/QA, opens a PR, waits for checks, then merges with a merge commit.
  - Runs a fresh `/cl` audit on `main` post-merge and releases only if `scripts/upstream-release-worthy.mjs` finds package changelog entries or `force_release=true`.
  - Captures QA evidence as artifacts; conflict/QA failures open a `sync-conflict` issue with the agent report.
  - Adds `scripts/upstream-release-worthy.mjs` + tests; new merge/release drivers document agent rules and terminal statuses.
  - Installs `@openai/codex`, `lazycodex-ai`, and `oh-my-openagent` at runtime with install scripts disabled; uses a dedicated `UPSTREAM_AUTOMATION_TOKEN`.

- **Migration**
  - Repo settings: allow Actions to create PRs and allow merge commits.
  - Secrets: `UPSTREAM_AUTOMATION_TOKEN`, `CODEX_CONFIG_TOML_B64`, and one of `CODEX_AUTH_JSON_B64` or `QUOTIO_API_KEY` (optional: `CODEX_QUOTIO_CONFIG_TOML_B64`, `CODEX_CCAPI_CONFIG_TOML_B64`, `SENPI_AUTH_JSON_B64`, `SENPI_MODELS_JSON_B64`, `SENPI_SETTINGS_JSON_B64`).

<sup>Written for commit bd3bf05595dbe522c83a346df0fa22f0cc7da8dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

