### PR TITLE
ci(upstream): run agent at top of hour

### DIFF
--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -2,7 +2,7 @@ name: Upstream Agent Merge
 
 'on':
   schedule:
-    - cron: '23 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
Change the upstream automation schedule to run at the top of every UTC hour.

Validation:
- `actionlint .github/workflows/upstream-agent-merge.yml`
- `npm run check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Upstream Agent Merge GitHub Actions workflow to run at 00 minutes of every UTC hour for more predictable, hourly execution timing.

<sup>Written for commit 92cc0ba1bdb65bba8d93ec0423fa4a49a82ab1f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

