### PR TITLE
ci(upstream): keep merge report cleanup clean

### DIFF
--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -246,9 +246,7 @@ jobs:
           RESULT="$(grep -E '^MERGE_RESULT:' /tmp/codex-agent.log /tmp/codex-last-message.md 2>/dev/null | tail -1 | awk '{print $2}')"
           if [ -z "$RESULT" ] && [ "$CODEX_STATUS" -ne 0 ]; then RESULT="AGENT_FAILED"; fi
           if [ -f .github/agent/last-merge-report.md ]; then
-            mkdir -p "$EVIDENCE_DIR"
-            cp .github/agent/last-merge-report.md "$EVIDENCE_DIR/last-merge-report.md"
-            rm .github/agent/last-merge-report.md
+            node scripts/archive-upstream-agent-report.mjs
           fi
           echo "result=${RESULT:-AGENT_FAILED}" >> "$GITHUB_OUTPUT"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"

--- a/scripts/archive-upstream-agent-report.mjs
+++ b/scripts/archive-upstream-agent-report.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_REPORT_PATH = ".github/agent/last-merge-report.md";
+const DEFAULT_EVIDENCE_DIR = "local-ignore/qa-evidence/upstream-agent";
+
+function git(args, cwd, options = {}) {
+	const result = spawnSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		stdio: options.quiet ? "pipe" : "inherit",
+	});
+	if (!options.allowFailure && result.status !== 0) {
+		throw new Error(`git ${args.join(" ")} failed with status ${result.status ?? "unknown"}`);
+	}
+	return result;
+}
+
+function isTrackedInHead(cwd, reportPath) {
+	return git(["cat-file", "-e", `HEAD:${reportPath}`], cwd, { quiet: true, allowFailure: true }).status === 0;
+}
+
+function isTrackedInIndex(cwd, reportPath) {
+	return git(["ls-files", "--error-unmatch", "--", reportPath], cwd, { quiet: true, allowFailure: true }).status === 0;
+}
+
+export function archiveUpstreamAgentReport(options = {}) {
+	const cwd = options.cwd ?? process.cwd();
+	const reportPath = options.reportPath ?? DEFAULT_REPORT_PATH;
+	const evidenceDir = options.evidenceDir ?? process.env.EVIDENCE_DIR ?? DEFAULT_EVIDENCE_DIR;
+	const source = join(cwd, reportPath);
+	const destination = join(cwd, evidenceDir, "last-merge-report.md");
+
+	if (!existsSync(source)) {
+		return { archived: false, committedRemoval: false, destination };
+	}
+
+	mkdirSync(dirname(destination), { recursive: true });
+	copyFileSync(source, destination);
+
+	const trackedInHead = isTrackedInHead(cwd, reportPath);
+	const trackedInIndex = isTrackedInIndex(cwd, reportPath);
+
+	if (trackedInHead) {
+		git(["rm", "--quiet", "--", reportPath], cwd);
+		git(["commit", "--quiet", "--only", "-m", "chore: remove upstream agent report", "--", reportPath], cwd);
+		return { archived: true, committedRemoval: true, destination };
+	}
+
+	if (trackedInIndex) {
+		git(["rm", "--quiet", "--force", "--", reportPath], cwd);
+	} else {
+		unlinkSync(source);
+	}
+
+	return { archived: true, committedRemoval: false, destination };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	const result = archiveUpstreamAgentReport();
+	if (result.archived) {
+		process.stdout.write(
+			`Archived upstream agent report to ${result.destination}${result.committedRemoval ? " and committed report removal" : ""}.\n`,
+		);
+	} else {
+		process.stdout.write("No upstream agent report found.\n");
+	}
+}

--- a/scripts/archive-upstream-agent-report.test.mjs
+++ b/scripts/archive-upstream-agent-report.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, it } from "node:test";
+import { archiveUpstreamAgentReport } from "./archive-upstream-agent-report.mjs";
+
+let tempDir;
+
+function run(command, args, cwd, options = {}) {
+	const result = spawnSync(command, args, { cwd, encoding: "utf8" });
+	if (!options.allowFailure && result.status !== 0) {
+		throw new Error(`${command} ${args.join(" ")} failed: ${result.stderr}`);
+	}
+	return result;
+}
+
+function createRepo() {
+	tempDir = mkdtempSync(join(tmpdir(), "senpi-upstream-report-"));
+	run("git", ["init", "-q"], tempDir);
+	run("git", ["config", "user.name", "test"], tempDir);
+	run("git", ["config", "user.email", "test@example.com"], tempDir);
+	writeFileSync(join(tempDir, ".gitignore"), "local-ignore/\n");
+	run("git", ["add", ".gitignore"], tempDir);
+	run("git", ["commit", "-q", "-m", "test: base"], tempDir);
+	return tempDir;
+}
+
+function writeReport(repo, text = "report\n") {
+	const report = join(repo, ".github/agent/last-merge-report.md");
+	mkdirSync(join(repo, ".github/agent"), { recursive: true });
+	writeFileSync(report, text);
+	return report;
+}
+
+function status(repo) {
+	return run("git", ["status", "--porcelain"], repo).stdout;
+}
+
+afterEach(() => {
+	if (tempDir) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+describe("archiveUpstreamAgentReport", () => {
+	it("copies and removes an untracked report without dirtying the branch", () => {
+		// Given
+		const repo = createRepo();
+		writeReport(repo, "untracked report\n");
+
+		// When
+		const result = archiveUpstreamAgentReport({ cwd: repo, evidenceDir: "local-ignore/qa-evidence/upstream-agent" });
+
+		// Then
+		assert.equal(result.archived, true);
+		assert.equal(result.committedRemoval, false);
+		assert.equal(readFileSync(join(repo, "local-ignore/qa-evidence/upstream-agent/last-merge-report.md"), "utf8"), "untracked report\n");
+		assert.equal(existsSync(join(repo, ".github/agent/last-merge-report.md")), false);
+		assert.equal(status(repo), "");
+	});
+
+	it("removes a committed report from the final branch tree with a cleanup commit", () => {
+		// Given
+		const repo = createRepo();
+		writeReport(repo, "committed report\n");
+		run("git", ["add", ".github/agent/last-merge-report.md"], repo);
+		run("git", ["commit", "-q", "-m", "test: committed report"], repo);
+
+		// When
+		const result = archiveUpstreamAgentReport({ cwd: repo, evidenceDir: "local-ignore/qa-evidence/upstream-agent" });
+
+		// Then
+		assert.equal(result.archived, true);
+		assert.equal(result.committedRemoval, true);
+		assert.equal(readFileSync(join(repo, "local-ignore/qa-evidence/upstream-agent/last-merge-report.md"), "utf8"), "committed report\n");
+		assert.equal(status(repo), "");
+		assert.equal(run("git", ["log", "-1", "--pretty=%s"], repo).stdout.trim(), "chore: remove upstream agent report");
+		assert.notEqual(
+			run("git", ["cat-file", "-e", "HEAD:.github/agent/last-merge-report.md"], repo, { allowFailure: true }).status,
+			0,
+		);
+	});
+});


### PR DESCRIPTION
Fixes the upstream-agent merge workflow clean-tree failure from Actions run 27799681367.

## What changed

- Added `scripts/archive-upstream-agent-report.mjs` to copy `.github/agent/last-merge-report.md` into the QA evidence directory without leaving the automation branch dirty.
- If the report was accidentally committed by the merge agent, the helper removes it with a narrow cleanup commit before the workflow clean-tree gate runs.
- Updated `upstream-agent-merge.yml` to use the helper instead of `cp` + `rm`.

## Evidence

- RED: `local-ignore/qa-evidence/20260619-actions-27799681367/red-existing-report-rm.txt` reproduces `D .github/agent/last-merge-report.md` and old gate exit 1.
- GREEN targeted: `node --test scripts/archive-upstream-agent-report.test.mjs` passed.
- GREEN surface: `local-ignore/qa-evidence/20260619-actions-27799681367/green-archive-report-gate.txt` shows the helper preserves evidence and leaves `git status --porcelain` empty.
- `npm run check` passed locally and in the pre-commit hook.
- `npm run build` passed locally.

## Known caveat

- `npm test` was run; it failed on unrelated live-provider/auth-dependent tests (`401 invalid x-api-key`, missing Cloudflare env) plus existing coding-agent live/RPC/flaky failures. `packages/tui` tests passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the upstream-agent merge workflow’s clean-tree gate by archiving and cleanly removing the merge report so the branch stays clean and the gate stops failing.

- **Bug Fixes**
  - Added `scripts/archive-upstream-agent-report.mjs` to copy `.github/agent/last-merge-report.md` to the QA evidence dir (`$EVIDENCE_DIR` or `local-ignore/qa-evidence/upstream-agent`) and remove the source.
  - If the report was committed, makes a small cleanup commit; if untracked, deletes it without committing. Leaves `git status` empty for the clean-tree gate.
  - Updated `upstream-agent-merge.yml` to call the script instead of `cp` + `rm`.
  - Added `scripts/archive-upstream-agent-report.test.mjs` for coverage.

<sup>Written for commit 30980914403a71f036bf872a418a7007069fe470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

