### PR TITLE
ci(upstream): require agent check parity

### DIFF
--- a/.github/agent/merge-driver.md
+++ b/.github/agent/merge-driver.md
@@ -66,10 +66,13 @@ to the affected packages' `CHANGELOG.md` files. Commit changelog updates as
 
 ### 5. Hands-on QA
 
-Verify the merged tree actually builds and runs:
+Verify the merged tree with the same credential-free gates the workflow treats as
+authoritative. Run each command from the repository root:
 
 ```bash
 npm run build
+npm run check
+npm test
 ```
 
 Then smoke-test the CLI from the built workspace:
@@ -82,8 +85,10 @@ node packages/coding-agent/dist/cli/index.js --help
 Use the actual built entrypoint if the path differs; locate it under
 `packages/coding-agent/dist`.
 
-Do not run `npm test` or the full `npm run check` here. The workflow runs the authoritative
-credential-free `build`, `check`, `test`, and senpi-qa evidence gates after you stop.
+If `npm run check` reports warnings, treat the tree as not PR-ready. Fix the warnings, rerun
+`npm run check`, and commit the focused fix before continuing. Because `npm run check` may
+write formatter fixes, run `git status --porcelain` after it and commit any intentional
+source changes it produced. Do not leave check-written files unstaged or uncommitted.
 
 If the build or smoke test fails, attempt a focused fix that preserves both fork and upstream
 intent. Re-run until green. If you cannot get a building tree, write
@@ -91,8 +96,20 @@ intent. Re-run until green. If you cannot get a building tree, write
 leaving a broken tree staged for release.
 
 When runtime packages changed (`packages/ai`, `packages/agent`, `packages/coding-agent`, or
-`packages/tui`), also run the matching `.agents/skills/senpi-qa/` channel and capture
-evidence under `local-ignore/qa-evidence/`.
+`packages/tui`), run the matching `.agents/skills/senpi-qa/` channel and capture evidence
+under `local-ignore/qa-evidence/`. At minimum, run the same self-tests as the workflow:
+
+```bash
+node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check
+node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence upstream-agent-mock-loop
+node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test
+```
+
+If `tmux` is available, also run:
+
+```bash
+node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence upstream-agent-tui
+```
 
 ### 6. Finish
 

--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -264,6 +264,8 @@ jobs:
           test ! -s "$EVIDENCE_DIR/git-status-before-qa.txt"
           npm run build 2>&1 | tee "$EVIDENCE_DIR/npm-build.txt"
           npm run check 2>&1 | tee "$EVIDENCE_DIR/npm-check.txt"
+          git status --porcelain | tee "$EVIDENCE_DIR/git-status-after-check.txt"
+          test ! -s "$EVIDENCE_DIR/git-status-after-check.txt"
           npm test 2>&1 | tee "$EVIDENCE_DIR/npm-test.txt"
           node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-common.txt"
           node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence upstream-agent-mock-loop 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-mock-loop.txt"


### PR DESCRIPTION
## Summary
- require the upstream merge agent to run the same build/check/test gates before declaring CLEAN_PR_READY
- fail the workflow if npm run check writes files after the initial clean-tree gate

## Verification
- actionlint .github/workflows/upstream-agent-merge.yml
- python3 YAML parse
- git diff --check
- pre-commit npm run check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the upstream merge agent with CI gates and prevent post-check diffs. The workflow now fails if `npm run check` writes files, and docs instruct running the same `build/check/test` and senpi-qa self-tests before marking CLEAN_PR_READY.

- **Bug Fixes**
  - CI: After `npm run check`, capture `git status` and fail if the tree is dirty; store evidence alongside existing logs.
  - Docs: Require running `npm run build`, `npm run check`, `npm test`, and senpi-qa self-tests; note that formatter changes from `check` must be committed; add optional TUI `tmux` self-test.

<sup>Written for commit 0fde54bdd14edb05ec5db71196f14887a5213ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

