### PR TITLE
ci(upstream): scope offline QA mode

### DIFF
--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -255,8 +255,6 @@ jobs:
 
       - name: Verify branch and capture QA evidence
         if: steps.detect.outputs.proceed == 'true' && steps.agent.outputs.result == 'CLEAN_PR_READY'
-        env:
-          PI_OFFLINE: '1'
         run: |
           set -euo pipefail
           mkdir -p "$EVIDENCE_DIR"
@@ -267,11 +265,11 @@ jobs:
           git status --porcelain | tee "$EVIDENCE_DIR/git-status-after-check.txt"
           test ! -s "$EVIDENCE_DIR/git-status-after-check.txt"
           npm test 2>&1 | tee "$EVIDENCE_DIR/npm-test.txt"
-          node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-common.txt"
-          node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence upstream-agent-mock-loop 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-mock-loop.txt"
-          node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-cli-smoke.txt"
+          PI_OFFLINE=1 node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-common.txt"
+          PI_OFFLINE=1 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence upstream-agent-mock-loop 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-mock-loop.txt"
+          PI_OFFLINE=1 node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-cli-smoke.txt"
           if command -v tmux >/dev/null 2>&1; then
-            node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence upstream-agent-tui 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-tui.txt"
+            PI_OFFLINE=1 node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence upstream-agent-tui 2>&1 | tee "$EVIDENCE_DIR/senpi-qa-tui.txt"
           fi
 
       - name: Open and merge upstream PR


### PR DESCRIPTION
## Summary
- run upstream verification build/check/test in the normal environment
- keep PI_OFFLINE=1 only on senpi-qa smoke/self-test commands

## Verification
- actionlint .github/workflows/upstream-agent-merge.yml
- python3 YAML parse
- git diff --check
- pre-commit npm run check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope offline QA mode to only `senpi-qa` self-tests in the upstream merge workflow. Normal build/check/test now run with network access; offline is applied only to QA scripts.

- **Bug Fixes**
  - Removed step-level `PI_OFFLINE=1`; set `PI_OFFLINE=1` inline for `common.mjs`, `mock-loop.mjs`, `cli-smoke.mjs`, and `tui-smoke.mjs` calls.

<sup>Written for commit c9881ae391a2eff37e1c8688e55df7624fb4406b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

