### PR TITLE
fix: refresh native dependency lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -684,6 +684,22 @@
 				"@earendil-works/gondolin-krun-runner-linux-x64": "0.12.0"
 			}
 		},
+		"node_modules/@earendil-works/gondolin-krun-runner-darwin-arm64": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/gondolin-krun-runner-darwin-arm64/-/gondolin-krun-runner-darwin-arm64-0.12.0.tgz",
+			"integrity": "sha512-ftDlusht4PcT7Y3TuPrZIKrCXy3isiBTVMvlXYK0pcud2uXY6uwFTGeunYgP+8ND/60ddb+MImqbfmkcK8B84A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"bin": {
+				"gondolin-krun-runner": "bin/gondolin-krun-runner"
+			}
+		},
 		"node_modules/@earendil-works/gondolin-krun-runner-linux-x64": {
 			"version": "0.12.0",
 			"cpu": [
@@ -699,7 +715,9 @@
 			}
 		},
 		"node_modules/@earendil-works/gondolin/node_modules/undici": {
-			"version": "6.26.0",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
@@ -1548,6 +1566,26 @@
 				"@napi-rs/canvas-win32-x64-msvc": "0.1.100"
 			}
 		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+			"integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
 		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
 			"version": "0.1.100",
 			"cpu": [
@@ -1671,6 +1709,27 @@
 				"@parcel/watcher-win32-x64": "2.5.6"
 			}
 		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/watcher-linux-x64-glibc": {
 			"version": "2.5.6",
 			"cpu": [
@@ -1744,6 +1803,23 @@
 		"node_modules/@protobufjs/utf8": {
 			"version": "1.1.1",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
 			"version": "1.0.3",
@@ -1930,6 +2006,23 @@
 				"@tailwindcss/oxide-wasm32-wasi": "4.3.0",
 				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
 				"@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-darwin-arm64": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+			"integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
@@ -3466,6 +3559,27 @@
 				"lightningcss-linux-x64-musl": "1.32.0",
 				"lightningcss-win32-arm64-msvc": "1.32.0",
 				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/lightningcss-linux-x64-gnu": {


### PR DESCRIPTION
## Summary

- Refresh `package-lock.json` so `@earendil-works/gondolin` resolves nested `undici` to patched `6.27.0`.
- Add missing darwin-arm64 optional native package entries that npm needs for local macOS package-manager verification snapshots.

## Why

The latest failed `npm audit` run on `main` (`27899366299`, head `356319841`) reported high-severity `undici <=6.26.0` advisories under `node_modules/@earendil-works/gondolin/node_modules/undici`. Current `main` had already moved the top-level `undici` to `8.5.0`, but the Gondolin nested lock entry was still `6.26.0`.

Recent `Upstream Agent Merge` scheduled runs are green; earlier failures were from merge conflicts / PR check gating and are already addressed on current `main`.

## QA Evidence

Saved under `local-ignore/qa-evidence/20260622-npm-audit-undici/`:

- `npm-ci.txt`: `npm ci --ignore-scripts --no-audit --no-fund`
- `npm-audit.txt`: `npm audit --omit=dev --audit-level=moderate` -> `found 0 vulnerabilities`
- `npm-audit-signatures.txt`: `npm audit signatures --omit=dev` -> 193 registry signatures, 32 attestations
- `npm-check.txt`: `npm run check`
- `npm-verify-pms.txt`: `npm run verify:pms` -> `✓ npm`, `✓ bun`, `✓ pnpm`

The commit hook also reran `npm run check`, `npm run verify:pms`, and browser smoke successfully before commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `package-lock.json` to patch nested `undici` in `@earendil-works/gondolin` and add missing macOS arm64 optional native bindings. Fixes the npm audit failure and makes local package-manager verification consistent.

- **Dependencies**
  - Bumps nested `undici` to `6.27.0` under `@earendil-works/gondolin`.
  - Adds darwin-arm64 optional entries for `@earendil-works/gondolin-krun-runner`, `@napi-rs/canvas`, `@parcel/watcher`, `@rolldown/binding`, `@tailwindcss/oxide`, and `lightningcss`.

<sup>Written for commit 7a3306953912651a605fafb611e0dc8e6461f0f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

