### PR TITLE
fix(coding-agent): patch gondolin undici audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -877,6 +877,22 @@
 				"@earendil-works/gondolin-krun-runner-linux-x64": "0.12.0"
 			}
 		},
+		"node_modules/@earendil-works/gondolin-krun-runner-darwin-arm64": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/gondolin-krun-runner-darwin-arm64/-/gondolin-krun-runner-darwin-arm64-0.12.0.tgz",
+			"integrity": "sha512-ftDlusht4PcT7Y3TuPrZIKrCXy3isiBTVMvlXYK0pcud2uXY6uwFTGeunYgP+8ND/60ddb+MImqbfmkcK8B84A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"bin": {
+				"gondolin-krun-runner": "bin/gondolin-krun-runner"
+			}
+		},
 		"node_modules/@earendil-works/gondolin-krun-runner-linux-x64": {
 			"version": "0.12.0",
 			"cpu": [
@@ -892,7 +908,9 @@
 			}
 		},
 		"node_modules/@earendil-works/gondolin/node_modules/undici": {
-			"version": "6.26.0",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
@@ -2179,6 +2197,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the Gondolin example dependency lockfiles to resolve the patched `undici` runtime version and keep production audit clean.
 - Fixed active goal continuation so aborted, errored, or aborting tool-execution turns do not queue another hidden follow-up after user interruption, and made retry cancellation catch Esc immediately when retry starts.
 
 ## [2026.6.21] - 2026-06-21

--- a/packages/coding-agent/examples/extensions/gondolin/package-lock.json
+++ b/packages/coding-agent/examples/extensions/gondolin/package-lock.json
@@ -173,9 +173,9 @@
 			"license": "Unlicense"
 		},
 		"node_modules/undici": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-			"integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"


### PR DESCRIPTION
## Summary

- Resolve the remaining production `npm audit --omit=dev` finding by refreshing Gondolin's transitive `undici` lock resolution from `6.26.0` to patched `6.27.0`.
- Keep the standalone Gondolin example lockfile in sync with the root workspace lockfile.
- Add an Unreleased changelog note for the production audit cleanup.

## RED -> GREEN Evidence

- RED baseline: `local-ignore/qa-evidence/20260622-prod-audit-clean/audit-red-summary.txt`
  - `npm audit --omit=dev --json` exited `1`.
  - Reported exactly one high vulnerability: `undici <=6.26.0` at `node_modules/@earendil-works/gondolin/node_modules/undici`.
- Dependency path: `local-ignore/qa-evidence/20260622-prod-audit-clean/lock-path-red.txt`
  - `@earendil-works/gondolin@0.12.0` depends on `undici: ^6.21.0`.
- GREEN final: `local-ignore/qa-evidence/20260622-prod-audit-clean/audit-green-final-summary.txt`
  - `npm audit --omit=dev --json` exited `0`.
  - Total vulnerabilities: `0`.
- Post-commit GREEN: `local-ignore/qa-evidence/20260622-prod-audit-clean/audit-green-after-commit-summary.txt`
  - Still exits `0` with total vulnerabilities `0`.

## QA

- `npm run check`
  - Evidence: `local-ignore/qa-evidence/20260622-prod-audit-clean/npm-check-final.txt`
- `node scripts/verify-package-managers.mjs`
  - Evidence: `local-ignore/qa-evidence/20260622-prod-audit-clean/verify-package-managers-final.txt`
  - Passed npm, bun, and pnpm isolated install+build.
- `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`
  - Evidence: `local-ignore/qa-evidence/20260622-prod-audit-clean/senpi-qa-common-self-check.txt`
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool`
  - Evidence: `local-ignore/qa-evidence/20260622-prod-audit-clean/senpi-qa-mock-loop-with-tool-final.txt`
- `npm audit --omit=dev --audit-level=moderate`
  - Evidence: `local-ignore/qa-evidence/20260622-prod-audit-clean/audit-level-moderate-final.txt`
- `npm audit signatures --omit=dev`
  - Evidence: `local-ignore/qa-evidence/20260622-prod-audit-clean/audit-signatures-final.txt`

## Review

- Independent review verdict: APPROVED / CLEAR.
- Reviewer verified root and standalone Gondolin production audits both exit `0` with total vulnerabilities `0`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patched `undici` to 6.27.0 in the `@earendil-works/gondolin` dependency path to clear the last production `npm audit --omit=dev` finding. Synced the Gondolin example lockfile with the root workspace and added a changelog entry.

<sup>Written for commit 1a9deb72c14d1584fa4394d87cce5c44d532298d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

