### PR TITLE
fix(coding-agent): send browser-like webfetch headers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Changed webfetch to send browser-shaped navigation request headers and avoid retrying challenge responses with a bot-specific identity.
+
 ### Fixed
 
 ## [2026.6.22] - 2026-06-22

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
@@ -1,3 +1,6 @@
+import type { IncomingHttpHeaders } from "node:http";
+import { request } from "undici";
+
 import {
 	InvalidWebfetchUrlError,
 	WebfetchAbortError,
@@ -8,9 +11,12 @@ import {
 export const MAX_RESPONSE_SIZE_BYTES = 5 * 1024 * 1024;
 export const DEFAULT_TIMEOUT_SECONDS = 30;
 export const MAX_TIMEOUT_SECONDS = 120;
+const MAX_REDIRECTS = 20;
 
 const BROWSER_USER_AGENT =
 	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
+const CHROME_MAJOR_VERSION = "143";
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 export type WebfetchFormat = "markdown" | "text" | "html";
 
@@ -31,33 +37,40 @@ export interface FetchResult {
 	truncated: boolean;
 }
 
+interface HttpResponse {
+	readonly url: string;
+	readonly status: number;
+	readonly statusText: string;
+	readonly headers: IncomingHttpHeaders;
+	readonly body: ResponseBodyStream;
+}
+
+interface ResponseBodyStream extends AsyncIterable<unknown> {
+	destroy(error?: Error): void;
+	dump(options?: { limit: number; signal?: AbortSignal }): Promise<void>;
+}
+
 export async function fetchUrl(options: FetchOptions): Promise<FetchResult> {
 	validateUrl(options.url);
 
 	const timeoutSeconds = clampTimeout(options.timeoutSeconds);
+	const timeoutMs = timeoutSeconds * 1000;
 	const controller = new AbortController();
 	const timeout = setTimeout(
 		() => controller.abort(new WebfetchTimeoutError(`Request timed out after ${timeoutSeconds}s`)),
-		timeoutSeconds * 1000,
+		timeoutMs,
 	);
 	const removeAbortForwarder = forwardAbort(options.signal, controller);
 
 	try {
-		const response = await fetch(options.url, {
-			headers: buildHeaders(options.format, BROWSER_USER_AGENT),
+		const response = await requestUrl({
+			url: options.url,
+			format: options.format,
 			signal: controller.signal,
+			timeoutMs,
 		});
 
-		if (response.status === 403 && response.headers.get("cf-mitigated") === "challenge") {
-			await cancelBody(response);
-			const retry = await fetch(options.url, {
-				headers: buildHeaders(options.format, "pi-webfetch"),
-				signal: controller.signal,
-			});
-			return await readFetchResponse(options.url, retry, controller.signal);
-		}
-
-		return await readFetchResponse(options.url, response, controller.signal);
+		return await readHttpResponse(response, controller.signal);
 	} finally {
 		clearTimeout(timeout);
 		removeAbortForwarder();
@@ -93,68 +106,139 @@ export function buildAcceptHeader(format: WebfetchFormat): string {
 	}
 }
 
-function buildHeaders(format: WebfetchFormat, userAgent: string): Record<string, string> {
+function buildHeaders(format: WebfetchFormat): Record<string, string> {
 	return {
 		Accept: buildAcceptHeader(format),
 		"Accept-Language": "en-US,en;q=0.9",
-		"User-Agent": userAgent,
+		"Sec-CH-UA": `"Google Chrome";v="${CHROME_MAJOR_VERSION}", "Chromium";v="${CHROME_MAJOR_VERSION}", "Not A(Brand";v="24"`,
+		"Sec-CH-UA-Mobile": "?0",
+		"Sec-CH-UA-Platform": '"Windows"',
+		"Sec-Fetch-Dest": "document",
+		"Sec-Fetch-Mode": "navigate",
+		"Sec-Fetch-Site": "none",
+		"Sec-Fetch-User": "?1",
+		"Upgrade-Insecure-Requests": "1",
+		"User-Agent": BROWSER_USER_AGENT,
 	};
 }
 
-async function readFetchResponse(url: string, response: Response, signal: AbortSignal): Promise<FetchResult> {
+interface RequestUrlOptions {
+	readonly url: string;
+	readonly format: WebfetchFormat;
+	readonly signal: AbortSignal;
+	readonly timeoutMs: number;
+}
+
+async function requestUrl(options: RequestUrlOptions): Promise<HttpResponse> {
+	const headers = buildHeaders(options.format);
+	let currentUrl = options.url;
+
+	for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+		const response = await request(currentUrl, {
+			method: "GET",
+			headers,
+			signal: options.signal,
+			headersTimeout: options.timeoutMs,
+			bodyTimeout: options.timeoutMs,
+		});
+
+		if (!REDIRECT_STATUSES.has(response.statusCode)) {
+			return {
+				url: currentUrl,
+				status: response.statusCode,
+				statusText: response.statusText,
+				headers: response.headers,
+				body: response.body,
+			};
+		}
+
+		const location = getHeader(response.headers, "location");
+		if (!location) {
+			return {
+				url: currentUrl,
+				status: response.statusCode,
+				statusText: response.statusText,
+				headers: response.headers,
+				body: response.body,
+			};
+		}
+
+		if (redirectCount === MAX_REDIRECTS) {
+			return {
+				url: currentUrl,
+				status: response.statusCode,
+				statusText: response.statusText,
+				headers: response.headers,
+				body: response.body,
+			};
+		}
+
+		await discardBody(response.body);
+		currentUrl = new URL(location, currentUrl).toString();
+	}
+
+	throw new WebfetchAbortError("Redirect resolution aborted");
+}
+
+async function readHttpResponse(response: HttpResponse, signal: AbortSignal): Promise<FetchResult> {
 	await rejectOversizedContentLength(response);
 	const body = await readResponseBody(response, signal);
 	return {
-		url: response.url || url,
+		url: response.url,
 		status: response.status,
 		statusText: response.statusText,
-		contentType: response.headers.get("content-type") ?? "",
+		contentType: getHeader(response.headers, "content-type"),
 		bytes: body.length,
 		body,
 		truncated: body.length === MAX_RESPONSE_SIZE_BYTES,
 	};
 }
 
-async function rejectOversizedContentLength(response: Response): Promise<void> {
-	const contentLength = response.headers.get("content-length");
+async function rejectOversizedContentLength(response: HttpResponse): Promise<void> {
+	const contentLength = getHeader(response.headers, "content-length");
 	if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_SIZE_BYTES) {
-		await cancelBody(response);
+		await discardBody(response.body);
 		throw new WebfetchResponseTooLargeError("Response too large (exceeds 5MB limit)");
 	}
 }
 
-async function cancelBody(response: Response): Promise<void> {
+function getHeader(headers: IncomingHttpHeaders, name: string): string {
+	const value = headers[name.toLowerCase()];
+	if (Array.isArray(value)) return value.join(", ");
+	return value ?? "";
+}
+
+async function discardBody(body: ResponseBodyStream): Promise<void> {
 	try {
-		await response.body?.cancel();
+		await body.dump({ limit: 1024 });
 	} catch {
 		// Preserve the caller's original failure.
 	}
 }
 
-async function readResponseBody(response: Response, signal: AbortSignal): Promise<Uint8Array> {
-	if (!response.body) return new Uint8Array();
-
-	const reader = response.body.getReader();
+async function readResponseBody(response: HttpResponse, signal: AbortSignal): Promise<Uint8Array> {
 	const chunks: Uint8Array[] = [];
 	let total = 0;
 
 	try {
-		while (true) {
+		for await (const chunk of response.body) {
 			if (signal.aborted) {
-				await cancelReader(reader);
+				response.body.destroy();
 				throw new WebfetchAbortError("Request aborted");
 			}
-			const read = await reader.read();
-			if (read.done) break;
-			chunks.push(read.value);
-			total += read.value.length;
+			const bytes = toUint8Array(chunk);
+			chunks.push(bytes);
+			total += bytes.length;
 			if (total > MAX_RESPONSE_SIZE_BYTES) {
-				await cancelReader(reader);
+				response.body.destroy();
 				throw new WebfetchResponseTooLargeError("Response too large (exceeds 5MB limit)");
 			}
 		}
-	} finally {
-		reader.releaseLock();
+	} catch (error) {
+		if (signal.aborted) {
+			throw new WebfetchAbortError("Request aborted");
+		}
+		throw error;
 	}
 
 	const body = new Uint8Array(total);
@@ -166,12 +250,10 @@ async function readResponseBody(response: Response, signal: AbortSignal): Promis
 	return body;
 }
 
-async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
-	try {
-		await reader.cancel();
-	} catch {
-		// Preserve the caller's original failure.
-	}
+function toUint8Array(chunk: unknown): Uint8Array {
+	if (chunk instanceof Uint8Array) return chunk;
+	if (typeof chunk === "string") return new TextEncoder().encode(chunk);
+	throw new Error("Unexpected response body chunk");
 }
 
 function forwardAbort(signal: AbortSignal | undefined, controller: AbortController): () => void {

--- a/packages/coding-agent/test/suite/webfetch-reader-mode.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-reader-mode.test.ts
@@ -6,6 +6,7 @@ import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 
 type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void;
 type WebfetchParams = Static<typeof webfetch.parameters>;
+type CapturedHeaders = IncomingMessage["headers"];
 
 const servers: Server[] = [];
 const context = {} as ExtensionContext;
@@ -33,6 +34,12 @@ function textContent(result: Awaited<ReturnType<typeof executeWebfetch>>): strin
 		throw new Error("Expected text content");
 	}
 	return first.text;
+}
+
+function headerValue(headers: CapturedHeaders, name: string): string {
+	const value = headers[name.toLowerCase()];
+	if (Array.isArray(value)) return value.join(", ");
+	return value ?? "";
 }
 
 afterEach(async () => {
@@ -113,5 +120,77 @@ describe("webfetch reader-mode cleanup", () => {
 		expect(text).not.toContain("Fixture sponsored sidebar");
 		expect(text).not.toContain("Fixture footer legal links");
 		expect(text).not.toContain("fixtureTracker");
+	});
+
+	it("#given a web page #when fetching markdown #then sends browser navigation headers", async () => {
+		// given
+		let capturedHeaders: CapturedHeaders | undefined;
+		const server = await createFixtureServer((request, response) => {
+			capturedHeaders = request.headers;
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(readerFixtureHtml());
+		});
+
+		// when
+		await executeWebfetch({ url: `${server.baseUrl}/article`, format: "markdown" });
+
+		// then
+		expect(capturedHeaders).toBeDefined();
+		if (!capturedHeaders) throw new Error("Expected captured request headers");
+		expect(headerValue(capturedHeaders, "user-agent")).toContain("Mozilla/5.0");
+		expect(headerValue(capturedHeaders, "accept")).toContain("text/markdown");
+		expect(headerValue(capturedHeaders, "accept-language")).toBe("en-US,en;q=0.9");
+		expect(headerValue(capturedHeaders, "sec-fetch-mode")).toBe("navigate");
+		expect(headerValue(capturedHeaders, "sec-fetch-dest")).toBe("document");
+		expect(headerValue(capturedHeaders, "sec-ch-ua-platform")).toBe('"Windows"');
+	});
+
+	it("#given a Cloudflare challenge response #when fetching #then does not retry with a bot identity", async () => {
+		// given
+		const attempts: CapturedHeaders[] = [];
+		const server = await createFixtureServer((request, response) => {
+			attempts.push(request.headers);
+			if (attempts.length === 1) {
+				response.writeHead(403, {
+					"cf-mitigated": "challenge",
+					"content-type": "text/html; charset=utf-8",
+				});
+				response.end("<html><body>challenge</body></html>");
+				return;
+			}
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(readerFixtureHtml());
+		});
+
+		// when
+		await executeWebfetch({ url: `${server.baseUrl}/article`, format: "markdown" });
+
+		// then
+		expect(attempts).toHaveLength(1);
+		const challengeHeaders = attempts[0];
+		if (!challengeHeaders) throw new Error("Expected challenge request headers");
+		expect(headerValue(challengeHeaders, "user-agent")).toContain("Mozilla/5.0");
+		expect(headerValue(challengeHeaders, "user-agent")).not.toContain("pi-webfetch");
+		expect(headerValue(challengeHeaders, "sec-fetch-mode")).toBe("navigate");
+		expect(headerValue(challengeHeaders, "sec-fetch-dest")).toBe("document");
+		expect(headerValue(challengeHeaders, "sec-ch-ua-platform")).toBe('"Windows"');
+	});
+
+	it("#given too many redirects #when fetching #then returns the final redirect response body", async () => {
+		// given
+		const server = await createFixtureServer((_request, response) => {
+			response.writeHead(302, {
+				location: "/loop",
+				"content-type": "text/plain; charset=utf-8",
+			});
+			response.end("redirect limit reached");
+		});
+
+		// when
+		const result = await executeWebfetch({ url: `${server.baseUrl}/loop`, format: "text" });
+		const text = textContent(result);
+
+		// then
+		expect(text).toContain("redirect limit reached");
 	});
 });


### PR DESCRIPTION
## Summary

- Send webfetch requests through `undici.request` with browser-shaped navigation headers, including Chrome UA, Accept-Language, client hints, and Sec-Fetch metadata.
- Stop retrying Cloudflare challenge responses with the old `pi-webfetch` bot-specific identity.
- Preserve response-size protections and manual redirect handling, including a regression for redirect-limit response bodies.
- Document the webfetch behavior change in the coding-agent changelog.

## QA Evidence

- Focused regression suite: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/webfetch-reader-mode.test.ts`
  - Evidence: `local-ignore/qa-evidence/20260623-webfetch-human-like/webfetch-header-test-green.txt`
- Real CLI/manual QA: `node local-ignore/qa-evidence/20260623-webfetch-human-like/webfetch-real-cli-qa.mjs`
  - Evidence: `local-ignore/qa-evidence/20260623-webfetch-human-like/webfetch-real-cli.txt`
  - Observed one real webfetch request with Mozilla UA, `Accept-Language: en-US,en;q=0.9`, `Sec-Fetch-Mode: navigate`, `Sec-Fetch-Dest: document`, and unchanged real auth.
- Root quality gate: `npm run check`
  - Evidence: `local-ignore/qa-evidence/20260623-webfetch-human-like/npm-run-check.txt`
- Senpi QA harness self-check: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`
  - Evidence: `local-ignore/qa-evidence/20260623-webfetch-human-like/senpi-qa-common-self-check.txt`
- Final code review: LazyCodex code reviewer approved after the redirect-limit blocker fix.
  - Evidence: `.omo/evidence/webfetch-human-like-code-review.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send webfetch requests with browser-like navigation headers to reduce bot detection and improve page fetch reliability. Switched to `undici.request` while keeping size/time guards and manual redirect handling.

- **Refactors**
  - Use `undici.request` and send Chrome-like headers: `User-Agent`, `Accept-Language`, client hints (`Sec-CH-UA*`), and `Sec-Fetch-*`.
  - Do not retry Cloudflare challenge responses with the old `pi-webfetch` identity.
  - Handle redirects manually (up to 20). Return the body for the final redirect response when the limit is reached.
  - Preserve 5MB response cap, timeouts, and robust abort/stream handling.
  - Added tests for headers, no bot-identity retry, and redirect-limit behavior; updated `CHANGELOG.md`.

<sup>Written for commit 5c4ff93b59ba93cc8e28134f1bca6288673d1689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

