### PR TITLE
feat(coding-agent): add permission presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ For Slack/chat automation and workflows see [earendil-works/pi-chat](https://git
 
 ## Permissions & Containerization
 
-Pi does not include a built-in permission system for restricting filesystem, process, network, or credential access. By default, it runs with the permissions of the user and process that launched it.
+Pi runs with the permissions of the user and process that launched it. The built-in permission system can ask, allow, or deny tool calls before they run, but it is not a sandbox and does not restrict the host process, installed extensions, package installs, or child processes after they are started.
+
+By default, Pi uses the `full-access` permission preset, so ordinary tool calls do not prompt. Choose a stricter preset with `permissionPreset` in settings or `--permission-preset` on the CLI:
+
+- `full-access`: allow all permission checks
+- `workspace`: allow workspace read, search, edit, and shell tools; ask for external-directory access
+- `read-only`: allow read/search/list tools; ask before edits, shell commands, and external-directory access
+- `ask`: restore prompt-on-unknown behavior
+
+Explicit `permission` rules in settings and `--permission` CLI rules override the selected preset.
 
 If you need stronger boundaries, containerize or sandbox Pi. See [packages/coding-agent/docs/containerization.md](packages/coding-agent/docs/containerization.md) for three patterns:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added built-in permission presets with `full-access` as the default and `workspace`, `read-only`, and `ask` options selectable from settings or `--permission-preset`.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -285,6 +285,37 @@ Use `/settings` to modify common options, or edit JSON files directly:
 
 See [docs/settings.md](docs/settings.md) for all options.
 
+### Permissions
+
+Pi includes a built-in permission system for tool calls. The default preset is `full-access`, which allows tool calls without prompting. Use `permissionPreset` in settings or `--permission-preset` for stricter behavior:
+
+| Preset | Behavior |
+|--------|----------|
+| `full-access` | Allow all permission checks |
+| `workspace` | Allow read, list, grep, edit, and bash; ask for external-directory access |
+| `read-only` | Allow read, list, and grep; ask before edit, bash, and external-directory access |
+| `ask` | Prompt whenever no explicit rule matches |
+
+```json
+{
+  "permissionPreset": "workspace",
+  "permission": {
+    "bash": {
+      "rm *": "deny"
+    }
+  }
+}
+```
+
+Explicit `permission` rules override the selected preset. CLI overrides have the highest precedence:
+
+```bash
+pi --permission-preset read-only
+pi --permission-preset workspace --permission "bash:rm *=deny"
+```
+
+Permissions are confirmation policy, not a sandbox. Pi and its extensions still run with the permissions of the host process. Use containers, VMs, or a policy sandbox for isolation.
+
 ### Project Trust
 
 On interactive startup, pi asks before trusting a project folder that contains project-local settings, resources, or project `.agents/skills` and has no saved decision for the folder or a parent folder in `~/.pi/agent/trust.json`. Trusting a project allows pi to load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
@@ -491,7 +522,7 @@ Pi is aggressively extensible so it doesn't have to dictate your workflow. Featu
 
 **No sub-agents.** There's many ways to do this. Spawn pi instances via tmux, or build your own with [extensions](#extensions), or install a package that does it your way.
 
-**No permission popups.** Run in a container, or build your own confirmation flow with [extensions](#extensions) inline with your environment and security requirements.
+**Permission presets, not a sandbox.** Use the built-in permission presets for tool-call confirmation policy. Run in a container or VM when you need an actual isolation boundary.
 
 **No plan mode.** Write plans to files, or build it with [extensions](#extensions), or install a package.
 
@@ -572,6 +603,8 @@ cat README.md | pi -p "Summarize this text"
 |--------|-------------|
 | `--tools <list>`, `-t <list>` | Allowlist specific tool names across built-in, extension, and custom tools |
 | `--exclude-tools <list>`, `-xt <list>` | Disable specific tool names across built-in, extension, and custom tools |
+| `--permission-preset <preset>` | Set permission preset: `full-access`, `workspace`, `read-only`, or `ask` |
+| `--permission <rules>` | Add permission rules, e.g. `bash:rm *=deny` or `edit=ask` |
 | `--no-builtin-tools`, `-nbt` | Disable built-in tools by default but keep extension/custom tools enabled |
 | `--no-tools`, `-nt` | Disable all tools by default |
 

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -32,6 +32,10 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 senpi does not include a built-in sandbox. Built-in tools can read files, write files, edit files, and run shell commands with the permissions of the senpi process. Extensions are TypeScript modules that run with the same permissions. Package installs, shell commands, language servers, test commands, and other developer tools behave as ordinary local processes.
 
+The built-in permission system is a tool-call confirmation policy. Its default preset is `full-access`, so ordinary tool calls do not prompt. You can choose stricter presets with `permissionPreset` or `--permission-preset`: `workspace`, `read-only`, or `ask`. Explicit `permission` rules and `--permission` CLI rules can allow, ask, or deny matching tool calls.
+
+Permission presets are not an isolation boundary. They do not constrain the host process itself, user-installed extensions, package lifecycle behavior, already-started child processes, or credentials available to the process.
+
 This is intentional. senpi is designed to operate on local source trees, invoke project toolchains, and integrate with the user's existing development environment. A partial in-process sandbox would be easy to misunderstand as a security boundary while still depending on the host shell, filesystem, package managers, credentials, and extension code. Real isolation needs to come from the operating system or a virtualization/container boundary.
 
 Project trust is only an input-loading guard. It prevents a repository from silently changing senpi's settings or extensions before you approve it. It does not make untrusted code, untrusted prompts, or untrusted model output safe. Prompt injection from repository files, comments, documentation, context files, or build output is expected local-agent risk and cannot be reliably prevented by senpi.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -21,6 +21,60 @@ If no extension or saved decision applies, `defaultProjectTrust` controls the fa
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.senpi/agent/trust.json` only; the current session is not reloaded, so restart senpi for changes to take effect.
 
+## Permissions
+
+Senpi includes a built-in permission system for tool calls. It evaluates a preset first, then applies explicit rules from global settings, project settings, and CLI flags. The last matching rule wins.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `permissionPreset` | string | `"full-access"` | Permission preset: `"full-access"`, `"workspace"`, `"read-only"`, or `"ask"` |
+| `permission` | object | - | Explicit permission rules that override the selected preset |
+
+Presets:
+
+| Preset | Behavior |
+|--------|----------|
+| `full-access` | Allow all permission checks without prompting |
+| `workspace` | Allow `read`, `list`, `grep`, `edit`, and `bash`; ask for `external_directory` |
+| `read-only` | Allow `read`, `list`, and `grep`; ask for `edit`, `bash`, and `external_directory` |
+| `ask` | Restore prompt-on-unknown behavior |
+
+Example:
+
+```json
+{
+  "permissionPreset": "workspace",
+  "permission": {
+    "bash": {
+      "rm *": "deny"
+    },
+    "edit": {
+      "secrets/*": "ask"
+    }
+  }
+}
+```
+
+Flat rules apply to all patterns for that permission:
+
+```json
+{
+  "permissionPreset": "read-only",
+  "permission": {
+    "bash": "deny"
+  }
+}
+```
+
+CLI overrides have the highest precedence:
+
+```bash
+senpi --permission-preset ask
+senpi --permission-preset workspace --permission "bash:rm *=deny"
+```
+
+Permission rules are a confirmation policy, not a sandbox. Senpi, extensions, package installs, and child processes still run with the host process permissions.
+
 ## All Settings
 
 ### Model & Thinking

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -303,6 +303,6 @@ pi --exclude-tools ask_question
 
 Pi keeps the core small and pushes workflow-specific behavior into extensions, skills, prompt templates, and packages.
 
-It intentionally does not include built-in MCP, sub-agents, permission popups, plan mode, to-dos, or background bash. You can build or install those workflows as extensions or packages, or use external tools such as containers and tmux.
+It intentionally does not include built-in MCP, sub-agents, plan mode, to-dos, background bash, or an in-process sandbox. Use permission presets for tool-call confirmation policy, and use external tools such as containers, VMs, policy sandboxes, and tmux when you need stronger workflow or isolation behavior.
 
 For the full rationale, read the [blog post](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/).

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/permission-system
 
-Builtin extension #1. Full port of opencode's permission flow. Loads rules from CLI (`--permission tool=action`), settings (`permission` key: tool → action, or tool → { pattern → action }), and per-session approvals. Prompts the user for unknown tool calls, persists "always allow" decisions, blocks denied calls with a structured error, and supports parser-aware patterns (bash command prefixes, file path globs for read/write/edit/apply_patch). **JSONL storage shape is a contract — migration required to change it.**
+Builtin extension #1. Full port of opencode's permission flow. Loads preset/rule policy from CLI (`--permission-preset`, `--permission tool=action`), settings (`permissionPreset`, `permission`), and per-session approvals. Defaults to the `full-access` preset, persists "always allow" decisions, blocks denied calls with a structured error, and supports parser-aware patterns (bash command prefixes, file path globs for read/write/edit/apply_patch). **JSONL storage shape is a contract — migration required to change it.**
 
 ## FILES
 
@@ -10,10 +10,10 @@ permission-system/
 ├── service.ts          # Permission service core (ask/reply/list)
 ├── evaluate.ts         # Rule evaluator with wildcard matching
 ├── wildcard.ts         # Wildcard matcher
-├── types.ts            # Action ("ask"|"allow"|"deny"), Rule, Request, Reply
-├── settings.ts         # Loads `permission` from global/project settings.json + approved JSONL
-├── cli.ts              # `--permission tool=action` flag parser
-├── config.ts           # fromConfig / merge / disabled state transforms
+├── types.ts            # Action ("ask"|"allow"|"deny"), preset names, Rule, Request, Reply
+├── settings.ts         # Loads presets/rules from global/project settings.json + approved JSONL
+├── cli.ts              # `--permission-preset` and `--permission tool=action` flag parsers
+├── config.ts           # preset rules / fromConfig / merge / disabled state transforms
 ├── storage.ts          # JSONL persistence (CONTRACT — don't change line shape)
 ├── arity.ts            # Bash command prefix parser
 ├── parsers.ts          # Tool input parser registry (paths, globs, apply_patch bodies)
@@ -39,11 +39,17 @@ permission-system/
 
 `evaluate.ts` is **last-match-wins** over the concatenated ruleset; later sources override earlier ones:
 
-1. **Global settings** (`~/.senpi/agent/settings.json` `permission`).
-2. **Project settings** (`.senpi/settings.json` `permission`).
-3. **CLI flags** (`--permission`).
-4. **Session approvals** — in-memory "always allow" rules; new ones are appended to `<projectDir>/.senpi/permissions-approved.jsonl` on session shutdown.
-5. **No match** — interactive → ask; non-interactive → block (`non-interactive.ts`).
+1. **Default preset** — `full-access`.
+2. **Global preset** (`~/.senpi/agent/settings.json` `permissionPreset`).
+3. **Global settings** (`~/.senpi/agent/settings.json` `permission`).
+4. **Project preset** (`.senpi/settings.json` `permissionPreset`).
+5. **Project settings** (`.senpi/settings.json` `permission`).
+6. **CLI preset** (`--permission-preset`).
+7. **CLI flags** (`--permission`).
+8. **Session approvals** — in-memory "always allow" rules; new ones are appended to `<projectDir>/.senpi/permissions-approved.jsonl` on session shutdown.
+9. **No match** — interactive → ask; non-interactive → block (`non-interactive.ts`).
+
+Presets other than `full-access` start with `*=ask` so they mask lower-precedence wildcard allows before adding their own allows.
 
 Pattern syntax: tool name + optional arg pattern, e.g. `bash:rm *`, `write:/etc/**`. Wildcard matching in `wildcard.ts`, rule lookup in `evaluate.ts`.
 
@@ -51,17 +57,17 @@ Pattern syntax: tool name + optional arg pattern, e.g. `bash:rm *`, `write:/etc/
 
 - **JSONL storage is the contract**: `storage.ts` writes append-only newline-delimited JSON. Schema changes require a migration. Other tools (audit, replay) parse this format.
 - **Parsers are tool-aware**: `parsers.ts` extracts the *meaningful* arg per tool — file path for read/write/edit, command prefix for bash, file paths for `apply_patch` body (2026-04-13).
-- **`external-dir.ts` forces ask** when target path is outside repo root, regardless of allow-rules — explicit user consent required.
+- **`external-dir.ts` emits an extra permission** when target path is outside repo root. `workspace` and `read-only` ask for that permission unless a later explicit rule allows it.
 
 ## ANTI-PATTERNS
 
 - Changing the JSONL line shape without a migration script — breaks existing approval files.
 - Adding a new tool that mutates files without registering a parser in `parsers.ts` — falls back to wildcard, loses per-path granularity.
 - Bypassing the parser registry from a builtin tool's render path — render and approval must agree on the displayed action.
-- Hardcoding deny-list defaults in `config.ts` — leave defaults empty; ship policy via settings or examples.
+- Adding a preset without a reset rule when it needs to override a lower-precedence wildcard allow.
 
 ## NOTES
 
 - `apply_patch` permission scope (per-file) was added 2026-04-13 once GPT models routed file edits through `apply_patch`. Without it, every patch would fall back to wildcard edit approval.
-- Print / JSON / RPC modes use `non-interactive.ts` — denies any rule not pre-approved, returning a structured error to the model.
+- Print / JSON / RPC modes use `non-interactive.ts` — denies any `ask` result, returning a structured error to the model.
 - `events.ts` emits `permission_asked` / `permission_replied` for telemetry; downstream extensions can subscribe.

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/changes.md
@@ -22,6 +22,25 @@ Full port of opencode's permission system to senpi-mono as a builtin extension.
 ## Why Builtin Extension?
 Following pi-mono's extension-first philosophy. All permission logic is in the extension, zero core tool modifications.
 
+## 2026-06-23 - permission presets
+
+### What changed and why
+- Added `permissionPreset` settings and `--permission-preset` CLI support with `full-access` as the default.
+- Added `workspace`, `read-only`, and `ask` presets that mask lower-precedence wildcard allows before applying their own policy.
+- Kept approved JSONL storage unchanged; session approvals still load separately after static rules.
+
+### Files modified
+- `types.ts`
+- `config.ts`
+- `cli.ts`
+- `settings.ts`
+- `index.ts`
+
+### Expected merge conflict zones
+- `settings.ts` merge order if upstream changes settings precedence.
+- `config.ts` preset rule definitions if upstream adds default permission policy.
+- `index.ts` extension flag registration if upstream moves permission flags into core args.
+
 ## 2026-05-11 - Local wildcard matcher
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/cli.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/cli.ts
@@ -1,4 +1,4 @@
-import type { Action, Rule, Ruleset } from "./types.ts";
+import type { Action, PermissionPresetName, Rule, Ruleset } from "./types.ts";
 
 export function parsePermissionFlag(value: string): Ruleset {
 	const rules: Rule[] = [];
@@ -20,4 +20,20 @@ export function parsePermissionFlag(value: string): Ruleset {
 	}
 
 	return rules;
+}
+
+export function parsePermissionPresetFlag(value: string): PermissionPresetName | undefined {
+	return parsePermissionPresetName(value.trim());
+}
+
+export function parsePermissionPresetName(value: string): PermissionPresetName | undefined {
+	switch (value) {
+		case "full-access":
+		case "workspace":
+		case "read-only":
+		case "ask":
+			return value;
+		default:
+			return undefined;
+	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/config.ts
@@ -1,8 +1,32 @@
 import os from "node:os";
-import type { PermissionConfig, Rule, Ruleset } from "./types.ts";
+import type { PermissionConfig, PermissionPresetName, Rule, Ruleset } from "./types.ts";
 import { Wildcard } from "./wildcard.ts";
 
 export const EDIT_TOOLS = ["edit", "write", "apply_patch", "multiedit"];
+export const DEFAULT_PERMISSION_PRESET: PermissionPresetName = "full-access";
+
+const PERMISSION_PRESET_RULES: Record<PermissionPresetName, Ruleset> = {
+	"full-access": [{ permission: "*", pattern: "*", action: "allow" }],
+	workspace: [
+		{ permission: "*", pattern: "*", action: "ask" },
+		{ permission: "read", pattern: "*", action: "allow" },
+		{ permission: "list", pattern: "*", action: "allow" },
+		{ permission: "grep", pattern: "*", action: "allow" },
+		{ permission: "edit", pattern: "*", action: "allow" },
+		{ permission: "bash", pattern: "*", action: "allow" },
+		{ permission: "external_directory", pattern: "*", action: "ask" },
+	],
+	"read-only": [
+		{ permission: "*", pattern: "*", action: "ask" },
+		{ permission: "read", pattern: "*", action: "allow" },
+		{ permission: "list", pattern: "*", action: "allow" },
+		{ permission: "grep", pattern: "*", action: "allow" },
+		{ permission: "edit", pattern: "*", action: "ask" },
+		{ permission: "bash", pattern: "*", action: "ask" },
+		{ permission: "external_directory", pattern: "*", action: "ask" },
+	],
+	ask: [{ permission: "*", pattern: "*", action: "ask" }],
+};
 
 export function expand(path: string): string {
 	if (path.startsWith("~/")) {
@@ -34,6 +58,10 @@ export function fromConfig(config: PermissionConfig): Ruleset {
 	}
 
 	return rules;
+}
+
+export function rulesForPreset(preset: PermissionPresetName): Ruleset {
+	return PERMISSION_PRESET_RULES[preset].map((rule) => ({ ...rule }));
 }
 
 export function merge(...rulesets: Ruleset[]): Ruleset {

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/index.ts
@@ -1,7 +1,7 @@
 import { SettingsManager } from "../../../settings-manager.ts";
 import type { ExtensionAPI } from "../../types.ts";
 import { extractPatchedPaths } from "../gpt-apply-patch/index.ts";
-import { parsePermissionFlag } from "./cli.ts";
+import { parsePermissionFlag, parsePermissionPresetFlag } from "./cli.ts";
 import { disabled } from "./config.ts";
 import { createEventEmitter } from "./events.ts";
 import { handleNoUI } from "./non-interactive.ts";
@@ -67,13 +67,26 @@ export default function permissionSystemExtension(pi: ExtensionAPI): void {
 		description: "Set permission rules (format: tool=action or tool:pattern=action)",
 		type: "string",
 	});
+	pi.registerFlag("permission-preset", {
+		description: "Set permission preset (full-access, workspace, read-only, or ask)",
+		type: "string",
+	});
 
 	pi.on("session_start", async (_event, ctx) => {
 		const settingsManager = SettingsManager.create(ctx.cwd);
 		const permissionFlag = pi.getFlag("permission");
+		const permissionPresetFlag = pi.getFlag("permission-preset");
 		cliRuleset = typeof permissionFlag === "string" ? parsePermissionFlag(permissionFlag) : [];
+		const cliPreset =
+			typeof permissionPresetFlag === "string" ? parsePermissionPresetFlag(permissionPresetFlag) : undefined;
 
-		const loadedSettings = loadPermissionSettings(settingsManager, cliRuleset, ctx.cwd);
+		if (typeof permissionPresetFlag === "string" && !cliPreset) {
+			throw new Error(
+				`Invalid --permission-preset "${permissionPresetFlag}". Expected one of: full-access, workspace, read-only, ask.`,
+			);
+		}
+
+		const loadedSettings = loadPermissionSettings(settingsManager, cliRuleset, ctx.cwd, cliPreset);
 		staticRuleset = loadedSettings.staticRuleset;
 		const approved = loadedSettings.approved;
 		parserRegistry = createBuiltinParserRegistry();

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/parsers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/parsers.ts
@@ -1,6 +1,6 @@
 import { extractPatchedPaths } from "../gpt-apply-patch/index.ts";
 import { BashArity } from "../permission-system/arity.ts";
-import { extractExternalPaths } from "../permission-system/external-dir.ts";
+import { extractExternalPaths, isExternalPath } from "../permission-system/external-dir.ts";
 import type { Request } from "../permission-system/types.ts";
 
 /** Simplified permission request without ID/session metadata */
@@ -31,20 +31,51 @@ function getString(input: Record<string, unknown>, ...keys: string[]): string | 
 	return undefined;
 }
 
-function toParentDirectoryPattern(inputPath: string): string {
+type AlwaysScope = "file" | "directory";
+
+function toParentDirectoryPattern(inputPath: string, scope: AlwaysScope): string {
 	if (inputPath === "~" || inputPath === "$HOME") {
 		return `${inputPath}/*`;
+	}
+
+	if (scope === "directory") {
+		return inputPath.endsWith("/") || inputPath.endsWith("\\") ? `${inputPath}*` : `${inputPath}/*`;
 	}
 
 	if (inputPath.endsWith("/") || inputPath.endsWith("\\")) {
 		return `${inputPath}*`;
 	}
 
-	return inputPath.replace(/[\\/][^\\/]+$/, "/*");
+	const parentPattern = inputPath.replace(/[\\/][^\\/]+$/, "/*");
+	if (parentPattern === "/*") {
+		return inputPath;
+	}
+	return parentPattern;
 }
 
 function parseFilePath(input: Record<string, unknown>): string | undefined {
 	return getString(input, "path", "file_path");
+}
+
+function withExternalDirectoryRequests(
+	requests: PermissionRequest[],
+	paths: string[],
+	cwd: string,
+	scope: AlwaysScope,
+): PermissionRequest[] {
+	const externalPaths = paths.filter((inputPath) => isExternalPath(inputPath, cwd));
+	if (externalPaths.length === 0) {
+		return requests;
+	}
+
+	return [
+		...requests,
+		{
+			permission: "external_directory",
+			patterns: externalPaths,
+			always: externalPaths.map((externalPath) => toParentDirectoryPattern(externalPath, scope)),
+		},
+	];
 }
 
 /** Registry for tool-specific permission parsers */
@@ -92,7 +123,7 @@ export function createBuiltinParserRegistry(): ParserRegistry {
 			requests.push({
 				permission: "external_directory",
 				patterns: externalPaths,
-				always: externalPaths.map(toParentDirectoryPattern),
+				always: externalPaths.map((externalPath) => toParentDirectoryPattern(externalPath, "file")),
 			});
 		}
 
@@ -103,16 +134,21 @@ export function createBuiltinParserRegistry(): ParserRegistry {
 		return [fallbackPermissionRequest("edit")];
 	};
 
-	const parseEditPermission: ToolPermissionParser = (_toolName, input) => {
+	const parseEditPermission: ToolPermissionParser = (_toolName, input, cwd) => {
 		const filePath = parseFilePath(input);
 		if (filePath) {
-			return [
-				{
-					permission: "edit",
-					patterns: [filePath],
-					always: [filePath],
-				},
-			];
+			return withExternalDirectoryRequests(
+				[
+					{
+						permission: "edit",
+						patterns: [filePath],
+						always: [filePath],
+					},
+				],
+				[filePath],
+				cwd,
+				"file",
+			);
 		}
 
 		const patchText = getString(input, "input", "patchText");
@@ -125,11 +161,13 @@ export function createBuiltinParserRegistry(): ParserRegistry {
 			return editParser("edit", input, "");
 		}
 
-		return patchedPaths.map((patchedPath) => ({
+		const editRequests = patchedPaths.map((patchedPath) => ({
 			permission: "edit",
 			patterns: [patchedPath],
 			always: [patchedPath],
 		}));
+
+		return withExternalDirectoryRequests(editRequests, patchedPaths, cwd, "file");
 	};
 
 	registry.register("edit", parseEditPermission);
@@ -137,22 +175,27 @@ export function createBuiltinParserRegistry(): ParserRegistry {
 	registry.register("apply_patch", parseEditPermission);
 	registry.register("multiedit", parseEditPermission);
 
-	registry.register("read", (_toolName, input) => {
+	registry.register("read", (_toolName, input, cwd) => {
 		const filePath = parseFilePath(input);
 		if (!filePath) {
 			return [fallbackPermissionRequest("read")];
 		}
 
-		return [
-			{
-				permission: "read",
-				patterns: [filePath],
-				always: [filePath],
-			},
-		];
+		return withExternalDirectoryRequests(
+			[
+				{
+					permission: "read",
+					patterns: [filePath],
+					always: [filePath],
+				},
+			],
+			[filePath],
+			cwd,
+			"file",
+		);
 	});
 
-	registry.register("grep", (_toolName, input) => {
+	registry.register("grep", (_toolName, input, cwd) => {
 		const searchPath = getString(input, "path");
 		const pattern = getString(input, "pattern");
 		const permissionPattern = searchPath ?? pattern;
@@ -160,24 +203,30 @@ export function createBuiltinParserRegistry(): ParserRegistry {
 			return [fallbackPermissionRequest("grep")];
 		}
 
-		return [
+		const grepRequests: PermissionRequest[] = [
 			{
 				permission: "grep",
 				patterns: [permissionPattern],
 				always: ["*"],
 			},
 		];
+		return searchPath ? withExternalDirectoryRequests(grepRequests, [searchPath], cwd, "directory") : grepRequests;
 	});
 
-	const listParser: ToolPermissionParser = (_toolName, input) => {
+	const listParser: ToolPermissionParser = (_toolName, input, cwd) => {
 		const searchPath = getString(input, "path") ?? ".";
-		return [
-			{
-				permission: "list",
-				patterns: [searchPath],
-				always: [searchPath],
-			},
-		];
+		return withExternalDirectoryRequests(
+			[
+				{
+					permission: "list",
+					patterns: [searchPath],
+					always: [searchPath],
+				},
+			],
+			[searchPath],
+			cwd,
+			"directory",
+		);
 	};
 
 	registry.register("find", listParser);

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/settings.ts
@@ -1,15 +1,22 @@
 import type { Settings, SettingsManager } from "../../../settings-manager.ts";
-import { fromConfig, merge } from "./config.ts";
+import { parsePermissionPresetName } from "./cli.ts";
+import { DEFAULT_PERMISSION_PRESET, fromConfig, merge, rulesForPreset } from "./config.ts";
 import { loadApproved } from "./storage.ts";
-import type { PermissionConfig, Ruleset } from "./types.ts";
+import type { PermissionConfig, PermissionPresetName, Ruleset } from "./types.ts";
+
+type PermissionSettings = {
+	permission?: PermissionConfig;
+	permissionPreset?: unknown;
+};
 
 /**
  * Load permission settings from global and project settings.json files.
  *
  * Merge order (highest precedence last):
- *   1. Global settings (~/.senpi/agent/settings.json)
- *   2. Project settings (.senpi/settings.json)
- *   3. CLI override (passed directly to this function)
+ *   1. Default preset
+ *   2. Global preset and rules (~/.senpi/agent/settings.json)
+ *   3. Project preset and rules (.senpi/settings.json)
+ *   4. CLI preset and rules
  *
  * Runtime approvals are stored separately in .senpi/permissions-approved.jsonl
  * and loaded via loadApproved() from storage.ts.
@@ -18,15 +25,46 @@ export function loadPermissionSettings(
 	settingsManager: SettingsManager,
 	cliOverride: Ruleset,
 	projectDir: string,
+	cliPresetOverride?: PermissionPresetName,
 ): { staticRuleset: Ruleset; approved: Ruleset } {
-	const globalSettings = settingsManager.getGlobalSettings() as Settings & { permission?: PermissionConfig };
+	const globalSettings = settingsManager.getGlobalSettings() as Settings & PermissionSettings;
+	const globalPreset = parseSettingsPreset(globalSettings.permissionPreset, "global");
+	const globalPresetRuleset = globalPreset ? rulesForPreset(globalPreset) : [];
 	const globalRuleset = globalSettings.permission ? fromConfig(globalSettings.permission) : [];
 
-	const projectSettings = settingsManager.getProjectSettings() as Settings & { permission?: PermissionConfig };
+	const projectSettings = settingsManager.getProjectSettings() as Settings & PermissionSettings;
+	const projectPreset = parseSettingsPreset(projectSettings.permissionPreset, "project");
+	const projectPresetRuleset = projectPreset ? rulesForPreset(projectPreset) : [];
 	const projectRuleset = projectSettings.permission ? fromConfig(projectSettings.permission) : [];
 
-	const staticRuleset = merge(globalRuleset, projectRuleset, cliOverride);
+	const cliPresetRuleset = cliPresetOverride ? rulesForPreset(cliPresetOverride) : [];
+	const staticRuleset = merge(
+		rulesForPreset(DEFAULT_PERMISSION_PRESET),
+		globalPresetRuleset,
+		globalRuleset,
+		projectPresetRuleset,
+		projectRuleset,
+		cliPresetRuleset,
+		cliOverride,
+	);
 	const approved = loadApproved(projectDir);
 
 	return { staticRuleset, approved };
+}
+
+function parseSettingsPreset(value: unknown, scope: "global" | "project"): PermissionPresetName | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error(`Invalid ${scope} permissionPreset ${JSON.stringify(value)}. Expected a string.`);
+	}
+
+	const preset = parsePermissionPresetName(value);
+	if (!preset) {
+		throw new Error(
+			`Invalid ${scope} permissionPreset "${value}". Expected one of: full-access, workspace, read-only, ask.`,
+		);
+	}
+	return preset;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/types.ts
@@ -14,6 +14,8 @@ export type Ruleset = Rule[];
 /** Configuration format for settings.json */
 export type PermissionConfig = Record<string, Action | Record<string, Action>>;
 
+export type PermissionPresetName = "full-access" | "workspace" | "read-only" | "ask";
+
 /** User reply to a permission request */
 export type Reply = "once" | "always" | "reject";
 

--- a/packages/coding-agent/test/permission/cli.test.ts
+++ b/packages/coding-agent/test/permission/cli.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parsePermissionFlag } from "../../src/core/extensions/builtin/permission-system/cli.ts";
+import {
+	parsePermissionFlag,
+	parsePermissionPresetFlag,
+} from "../../src/core/extensions/builtin/permission-system/cli.ts";
 import type { Rule } from "../../src/core/extensions/builtin/permission-system/types.ts";
 
 function createRule(permission: string, pattern: string, action: Rule["action"]): Rule {
@@ -124,6 +127,32 @@ describe("permission-system cli", () => {
 
 			// then
 			expect(result).toEqual([createRule("bash", "rm -rf *", "deny")]);
+		});
+	});
+
+	describe("parsePermissionPresetFlag", () => {
+		it("accepts built-in permission preset names", () => {
+			// when/then
+			expect(parsePermissionPresetFlag("full-access")).toBe("full-access");
+			expect(parsePermissionPresetFlag("workspace")).toBe("workspace");
+			expect(parsePermissionPresetFlag("read-only")).toBe("read-only");
+			expect(parsePermissionPresetFlag("ask")).toBe("ask");
+		});
+
+		it("trims valid preset names", () => {
+			// when
+			const result = parsePermissionPresetFlag(" workspace ");
+
+			// then
+			expect(result).toBe("workspace");
+		});
+
+		it("rejects unknown preset names", () => {
+			// when
+			const result = parsePermissionPresetFlag("dangerous");
+
+			// then
+			expect(result).toBeUndefined();
 		});
 	});
 });

--- a/packages/coding-agent/test/permission/config.test.ts
+++ b/packages/coding-agent/test/permission/config.test.ts
@@ -1,11 +1,13 @@
 import os from "node:os";
 import { describe, expect, it } from "vitest";
 import {
+	DEFAULT_PERMISSION_PRESET,
 	disabled,
 	EDIT_TOOLS,
 	expand,
 	fromConfig,
 	merge,
+	rulesForPreset,
 } from "../../src/core/extensions/builtin/permission-system/config.ts";
 import type { PermissionConfig, Ruleset } from "../../src/core/extensions/builtin/permission-system/types.ts";
 
@@ -14,6 +16,57 @@ describe("permission config transforms", () => {
 		it("contains the expected edit-related tools", () => {
 			// then
 			expect(EDIT_TOOLS).toEqual(["edit", "write", "apply_patch", "multiedit"]);
+		});
+	});
+
+	describe("rulesForPreset", () => {
+		it("defaults to full access so tool calls are not prompted", () => {
+			// when
+			const result = rulesForPreset(DEFAULT_PERMISSION_PRESET);
+
+			// then
+			expect(DEFAULT_PERMISSION_PRESET).toBe("full-access");
+			expect(result).toEqual([{ permission: "*", pattern: "*", action: "allow" }]);
+		});
+
+		it("keeps ask preset as the previous prompt-on-unknown behavior", () => {
+			// when
+			const result = rulesForPreset("ask");
+
+			// then
+			expect(result).toEqual([{ permission: "*", pattern: "*", action: "ask" }]);
+		});
+
+		it("allows workspace tools while asking for external directory access", () => {
+			// when
+			const result = rulesForPreset("workspace");
+
+			// then
+			expect(result).toEqual([
+				{ permission: "*", pattern: "*", action: "ask" },
+				{ permission: "read", pattern: "*", action: "allow" },
+				{ permission: "list", pattern: "*", action: "allow" },
+				{ permission: "grep", pattern: "*", action: "allow" },
+				{ permission: "edit", pattern: "*", action: "allow" },
+				{ permission: "bash", pattern: "*", action: "allow" },
+				{ permission: "external_directory", pattern: "*", action: "ask" },
+			]);
+		});
+
+		it("allows read-only tools while asking before writes and commands", () => {
+			// when
+			const result = rulesForPreset("read-only");
+
+			// then
+			expect(result).toEqual([
+				{ permission: "*", pattern: "*", action: "ask" },
+				{ permission: "read", pattern: "*", action: "allow" },
+				{ permission: "list", pattern: "*", action: "allow" },
+				{ permission: "grep", pattern: "*", action: "allow" },
+				{ permission: "edit", pattern: "*", action: "ask" },
+				{ permission: "bash", pattern: "*", action: "ask" },
+				{ permission: "external_directory", pattern: "*", action: "ask" },
+			]);
 		});
 	});
 

--- a/packages/coding-agent/test/permission/external-path-presets.test.ts
+++ b/packages/coding-agent/test/permission/external-path-presets.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { rulesForPreset } from "../../src/core/extensions/builtin/permission-system/config.ts";
+import { evaluate } from "../../src/core/extensions/builtin/permission-system/evaluate.ts";
+import { createBuiltinParserRegistry } from "../../src/core/extensions/builtin/permission-system/parsers.ts";
+
+describe("permission presets for external paths", () => {
+	const cwd = "/Users/me/project";
+	const registry = createBuiltinParserRegistry();
+
+	it("asks for external paths from direct path-taking tools under workspace preset", () => {
+		// given
+		const cases = [
+			{ toolName: "read", input: { path: "../secret.txt" } },
+			{ toolName: "write", input: { path: "/tmp/outside.txt", content: "hello" } },
+			{ toolName: "grep", input: { pattern: "token", path: "/tmp" } },
+			{ toolName: "ls", input: { path: "/tmp", limit: 20 } },
+		];
+		const ruleset = rulesForPreset("workspace");
+
+		for (const testCase of cases) {
+			// when
+			const requests = registry.parse(testCase.toolName, testCase.input, cwd);
+			const externalRequest = requests.find((request) => request.permission === "external_directory");
+
+			// then
+			expect(externalRequest, testCase.toolName).toBeDefined();
+			expect(evaluate("external_directory", externalRequest?.patterns[0] ?? "", ruleset).action).toBe("ask");
+		}
+	});
+
+	it("does not broaden root-level external path approvals to the filesystem root", () => {
+		// given
+		const cases = [
+			{ toolName: "ls", input: { path: "/tmp" }, always: ["/tmp/*"] },
+			{ toolName: "read", input: { path: "/tmp/file.txt" }, always: ["/tmp/*"] },
+			{ toolName: "read", input: { path: "/secret.txt" }, always: ["/secret.txt"] },
+			{ toolName: "read", input: { path: "/secret" }, always: ["/secret"] },
+		];
+
+		for (const testCase of cases) {
+			// when
+			const requests = registry.parse(testCase.toolName, testCase.input, cwd);
+			const externalRequest = requests.find((request) => request.permission === "external_directory");
+
+			// then
+			expect(externalRequest?.always, testCase.toolName).toEqual(testCase.always);
+		}
+	});
+});

--- a/packages/coding-agent/test/permission/presets.test.ts
+++ b/packages/coding-agent/test/permission/presets.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { rulesForPreset } from "../../src/core/extensions/builtin/permission-system/config.ts";
+import { evaluate } from "../../src/core/extensions/builtin/permission-system/evaluate.ts";
+import { handleNoUI } from "../../src/core/extensions/builtin/permission-system/non-interactive.ts";
+import type { Request, Ruleset } from "../../src/core/extensions/builtin/permission-system/types.ts";
+
+function createRequest(overrides: Partial<Request> = {}): Request {
+	return {
+		id: overrides.id ?? "request-1",
+		sessionID: overrides.sessionID ?? "session-1",
+		permission: overrides.permission ?? "bash",
+		patterns: overrides.patterns ?? ["git status"],
+		always: overrides.always ?? ["*"],
+		metadata: overrides.metadata ?? {},
+		tool: overrides.tool,
+	};
+}
+
+describe("permission presets", () => {
+	it("overrides an earlier full-access preset with workspace ask boundaries", () => {
+		// given
+		const ruleset = [...rulesForPreset("full-access"), ...rulesForPreset("workspace")];
+
+		// when/then
+		expect(evaluate("bash", "git status", ruleset).action).toBe("allow");
+		expect(evaluate("external_directory", "../outside", ruleset).action).toBe("ask");
+		expect(evaluate("unknown_tool", "*", ruleset).action).toBe("ask");
+	});
+
+	it("overrides an earlier full-access preset with read-only ask boundaries", () => {
+		// given
+		const ruleset = [...rulesForPreset("full-access"), ...rulesForPreset("read-only")];
+
+		// when/then
+		expect(evaluate("read", "README.md", ruleset).action).toBe("allow");
+		expect(evaluate("bash", "git status", ruleset).action).toBe("ask");
+		expect(evaluate("edit", "src/index.ts", ruleset).action).toBe("ask");
+		expect(evaluate("unknown_tool", "*", ruleset).action).toBe("ask");
+	});
+
+	it("allows no-UI requests with full-access", () => {
+		// given
+		const events: Array<{ event: string; data: unknown }> = [];
+
+		// when
+		const result = handleNoUI(createRequest(), rulesForPreset("full-access"), [], (event, data) => {
+			events.push({ event, data });
+		});
+
+		// then
+		expect(result).toBeUndefined();
+		expect(events.map((event) => event.event)).toEqual(["permission_asked", "permission_replied"]);
+	});
+
+	it("rejects no-UI requests when a preset still requires confirmation", () => {
+		// given
+		const events: Array<{ event: string; data: unknown }> = [];
+		const staticRuleset: Ruleset = rulesForPreset("read-only");
+
+		// when
+		const result = handleNoUI(createRequest(), staticRuleset, [], (event, data) => {
+			events.push({ event, data });
+		});
+
+		// then
+		expect(result).toEqual({
+			requestID: "request-1",
+			reply: "reject",
+			message: "Permission required for bash (git status). Use --permission bash=allow to override.",
+		});
+		expect(events.map((event) => event.event)).toEqual(["permission_asked"]);
+	});
+});

--- a/packages/coding-agent/test/permission/settings.test.ts
+++ b/packages/coding-agent/test/permission/settings.test.ts
@@ -1,0 +1,136 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { evaluate } from "../../src/core/extensions/builtin/permission-system/evaluate.ts";
+import { loadPermissionSettings } from "../../src/core/extensions/builtin/permission-system/settings.ts";
+import type { Ruleset } from "../../src/core/extensions/builtin/permission-system/types.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+function withTempDir<T>(run: (dir: string) => T): T {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-permission-settings-"));
+	try {
+		return run(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function writeSettings(path: string, settings: Record<string, unknown>): void {
+	writeFileSync(path, JSON.stringify(settings));
+}
+
+describe("permission settings", () => {
+	it("uses full-access as the default preset", () => {
+		return withTempDir((projectDir) => {
+			// given
+			const settingsManager = SettingsManager.inMemory();
+
+			// when
+			const result = loadPermissionSettings(settingsManager, [], projectDir);
+
+			// then
+			expect(evaluate("bash", "rm -rf node_modules", result.staticRuleset).action).toBe("allow");
+			expect(result.approved).toEqual([]);
+		});
+	});
+
+	it("lets an explicit ask preset restore prompt-on-unknown behavior", () => {
+		return withTempDir((projectDir) => {
+			// given
+			const agentDir = join(projectDir, "agent");
+			mkdirSync(agentDir, { recursive: true });
+			writeSettings(join(agentDir, "settings.json"), { permissionPreset: "ask" });
+			const settingsManager = SettingsManager.create(projectDir, agentDir);
+
+			// when
+			const result = loadPermissionSettings(settingsManager, [], projectDir);
+
+			// then
+			expect(evaluate("bash", "ls", result.staticRuleset).action).toBe("ask");
+		});
+	});
+
+	it("lets CLI preset and rules override configured presets", () => {
+		return withTempDir((projectDir) => {
+			// given
+			const agentDir = join(projectDir, "agent");
+			mkdirSync(agentDir, { recursive: true });
+			writeSettings(join(agentDir, "settings.json"), { permissionPreset: "read-only" });
+			const settingsManager = SettingsManager.create(projectDir, agentDir);
+			const cliRuleset: Ruleset = [{ permission: "bash", pattern: "rm *", action: "deny" }];
+
+			// when
+			const result = loadPermissionSettings(settingsManager, cliRuleset, projectDir, "workspace");
+
+			// then
+			expect(evaluate("edit", "src/index.ts", result.staticRuleset).action).toBe("allow");
+			expect(evaluate("bash", "rm -rf node_modules", result.staticRuleset).action).toBe("deny");
+		});
+	});
+
+	it("applies source precedence from global settings through CLI rules", () => {
+		return withTempDir((projectDir) => {
+			// given
+			const agentDir = join(projectDir, "agent");
+			mkdirSync(agentDir, { recursive: true });
+			writeSettings(join(agentDir, "settings.json"), {
+				permissionPreset: "workspace",
+				permission: {
+					bash: "deny",
+					edit: "deny",
+				},
+			});
+			mkdirSync(join(projectDir, ".senpi"), { recursive: true });
+			writeSettings(join(projectDir, ".senpi", "settings.json"), {
+				permissionPreset: "read-only",
+				permission: {
+					edit: "allow",
+				},
+			});
+			const settingsManager = SettingsManager.create(projectDir, agentDir);
+			const cliRuleset: Ruleset = [{ permission: "bash", pattern: "rm *", action: "deny" }];
+
+			// when
+			const result = loadPermissionSettings(settingsManager, cliRuleset, projectDir, "workspace");
+
+			// then
+			expect(evaluate("read", "README.md", result.staticRuleset).action).toBe("allow");
+			expect(evaluate("edit", "src/index.ts", result.staticRuleset).action).toBe("allow");
+			expect(evaluate("bash", "git status", result.staticRuleset).action).toBe("allow");
+			expect(evaluate("bash", "rm -rf node_modules", result.staticRuleset).action).toBe("deny");
+			expect(evaluate("external_directory", "../outside", result.staticRuleset).action).toBe("ask");
+		});
+	});
+
+	it("rejects invalid permission presets from settings with a clear error", () => {
+		return withTempDir((projectDir) => {
+			// given
+			const agentDir = join(projectDir, "agent");
+			mkdirSync(agentDir, { recursive: true });
+			writeSettings(join(agentDir, "settings.json"), { permissionPreset: "dangerous" });
+			const settingsManager = SettingsManager.create(projectDir, agentDir);
+
+			// when/then
+			expect(() => loadPermissionSettings(settingsManager, [], projectDir)).toThrow(
+				'Invalid global permissionPreset "dangerous". Expected one of: full-access, workspace, read-only, ask.',
+			);
+		});
+	});
+
+	it("rejects invalid project permission presets with a clear error", () => {
+		return withTempDir((projectDir) => {
+			// given
+			const agentDir = join(projectDir, "agent");
+			mkdirSync(agentDir, { recursive: true });
+			mkdirSync(join(projectDir, ".senpi"), { recursive: true });
+			writeSettings(join(projectDir, ".senpi", "settings.json"), { permissionPreset: "dangerous" });
+			const settingsManager = SettingsManager.create(projectDir, agentDir);
+
+			// when/then
+			expect(() => loadPermissionSettings(settingsManager, [], projectDir)).toThrow(
+				'Invalid project permissionPreset "dangerous". Expected one of: full-access, workspace, read-only, ask.',
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Add built-in permission presets: `full-access` (default), `workspace`, `read-only`, and `ask`.
- Expose presets through `permissionPreset` settings and `--permission-preset`, while preserving explicit permission rule precedence.
- Keep external-directory confirmation for stricter presets, including direct path-taking tools, and avoid overbroad root-level "allow always" scopes.
- Update README, package docs, security/settings/usage docs, changelog, and permission-system notes.

## QA Evidence

- `local-ignore/qa-evidence/20260623-permission-presets/permission-suite-green-after-no-extension-fix.txt`
  - `npx tsx ../../node_modules/vitest/dist/cli.js --run test/permission`
  - 15 permission test files / 479 tests passed.
- `local-ignore/qa-evidence/20260623-permission-presets/npm-run-check-after-no-extension-fix.txt`
  - `npm run check` passed.
- `local-ignore/qa-evidence/20260623-permission-presets/git-diff-check-after-no-extension-fix.txt`
  - `git diff --check` passed.
- `local-ignore/qa-evidence/20260623-permission-presets/senpi-qa-permission-default-full-access.txt`
  - Real CLI default `full-access` executed a bash tool without `--approve`; cleanup and auth-unchanged receipt included.
- `local-ignore/qa-evidence/20260623-permission-presets/senpi-qa-permission-preset-readonly.txt`
  - Real CLI `read-only` blocked bash marker creation; cleanup and auth-unchanged receipt included.
- `local-ignore/qa-evidence/20260623-permission-presets/senpi-qa-permission-external-path-workspace-after-no-extension-fix.txt`
  - Real CLI `workspace` blocked a direct external read without leaking the external file secret; cleanup and auth-unchanged receipt included.
- `.omo/evidence/permission-presets-code-review.md`
  - Final code review approved.
- `.omo/evidence/G001-update-senpi-built-in-permission-sys-gate-review.md`
  - Final gate review approved.

## Notes

The local `.omo/evidence` and `local-ignore/qa-evidence` artifacts are intentionally not committed; they remain in the worktree as review/QA evidence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds built-in permission presets to the coding agent with `full-access` as the default and new `workspace`, `read-only`, and `ask` options. Exposes `permissionPreset` in settings and `--permission-preset` on the CLI while keeping explicit `permission` rules and CLI overrides in control.

- **New Features**
  - Presets: `full-access` (allow all), `workspace` (allow read/list/grep/edit/bash; ask for external dirs), `read-only` (allow read/list/grep; ask for edit/bash/external dirs), `ask` (prompt on unknown).
  - Settings and CLI: `permissionPreset` and `--permission-preset`; explicit `permission` and `--permission` rules still override the preset.
  - Precedence: default preset → global preset/rules → project preset/rules → CLI preset/rules → session approvals.
  - External directories: adds an `external_directory` check for path-taking tools; stricter presets ask before accessing paths outside the workspace; avoids overbroad root-level “always” scopes.
  - Updated docs and CLI help across README, `packages/coding-agent` docs, and changelog.

<sup>Written for commit 07b15835b729c61eb3fa0229643fd3581850b9c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

