### PR TITLE
docs: clarify PR evidence requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,13 @@ Unless the user explicitly says otherwise (or it is an urgent must-fix-now hotfi
 
 1. **Branch.** Cut a feature branch (or a git worktree) off `main`. Do not develop on `main`.
 2. **Implement + QA with evidence.** Run the scoped `senpi-qa` channel(s) for what you touched and write the artifacts to `local-ignore/qa-evidence/<YYYYMMDD>-<slug>/`. That evidence is the gate, and it is what the PR must carry.
-3. **Open an English PR** with `gh pr create`. The body states what changed, why there is no regression, and quotes/links the QA evidence (commands + observed real-harness behavior). A PR without QA evidence is not ready to merge.
+3. **Open an English, reviewer-readable PR** with `gh pr create`. The body must include:
+   - **Summary**: user-facing change, reason, and before/after behavior.
+   - **Changes**: reviewer-relevant groups, not a file dump.
+   - **QA / Evidence**: for each command or manual action, the tested surface, observed result, saved artifact/log path, and why it is sufficient.
+   - **Risks**: residual risks mapped to covering evidence and conclusion.
+   - **Secret safety**: no raw secret-bearing logs, env dumps, tokens, auth headers, cookies, or private credentials; use sanitized excerpts or summaries.
+   A PR without reviewer-readable QA/evidence is not ready to merge.
 4. **Verify.** Wait for CI/checks, fix every finding, then re-run the scoped QA and refresh the evidence.
 5. **Merge with a merge commit, ALWAYS.** Land it via `gh pr merge <number> --merge --delete-branch`, then push `main`. NEVER squash-merge or rebase-merge, even if a tool or GitHub default suggests it.
 6. **Conflicts → the `smart-rebase` skill**, then re-run the scoped QA. Never force-push shared history.


### PR DESCRIPTION
## Summary
This PR makes the repository's PR workflow instruction more reviewer-readable. The previous instruction required QA evidence in the PR body, but it left agents to infer what "good evidence" meant; the new instruction requires a plain summary, reviewer-grouped changes, explicit QA/evidence entries, risk mapping, and secret-safe evidence handling.

Before this change, future PRs could satisfy the rule with terse command names or opaque artifact links. After this change, future PRs must explain what changed, why it changed, how behavior differs, what was actually driven, where the evidence lives, why it is sufficient, and what residual risks remain.

## Changes

### PR workflow guidance
- Replaced the terse `Open an English PR` instruction in `AGENTS.md` with an `English, reviewer-readable PR` contract.
- Added required body sections for Summary, Changes, QA / Evidence, Risks, and Secret safety.

### Evidence readability
- Made each QA/evidence entry carry four facts: tested surface, observed result, saved artifact/log path, and sufficiency rationale.
- Required residual risks to map back to evidence and conclusion instead of standing alone.

### Secret safety
- Added explicit guidance to avoid raw secret-bearing logs, env dumps, tokens, auth headers, cookies, or private credentials in PR bodies.

## QA / Evidence

### Instruction-surface QA
- What was tested: the root `AGENTS.md` PR workflow section was inspected as the surface future agents read.
- Observed result: `local-ignore/qa-evidence/20260623-qa-evidence-pr-readable/pr-workflow-excerpt.txt` shows the PR contract now includes Summary, grouped Changes, QA / Evidence, Risks, and Secret safety.
- Artifact/log path: `local-ignore/qa-evidence/20260623-qa-evidence-pr-readable/pr-workflow-excerpt.txt` and `local-ignore/qa-evidence/20260623-qa-evidence-pr-readable/instruction-grep.txt`.
- Why sufficient: this is a docs-only prompt/instruction change, so the relevant behavior is the exact instruction text future agents will read.

### Diff integrity
- What was tested: Git whitespace validation for the changed Markdown.
- Observed result: `git-diff-check.txt` records `exit_code=0`.
- Artifact/log path: `local-ignore/qa-evidence/20260623-qa-evidence-pr-readable/git-diff-check.txt`.
- Why sufficient: it proves the edited Markdown diff has no Git whitespace errors.

### Repository check
- What was tested: the repo pre-commit hook ran the full `npm run check` path during commit.
- Observed result: the hook reported `All pre-commit checks passed!` after `biome check`, pinned dependency check, import check, shrinkwrap check, `tsgo --noEmit`, browser smoke, and web-ui check.
- Artifact/log path: terminal output from commit `fad78be26`; local QA summary is saved at `local-ignore/qa-evidence/20260623-qa-evidence-pr-readable/qa-summary.md`.
- Why sufficient: no code changed, and the repository's required validation path completed successfully for the committed docs change.

## Risks
- Risk: The instruction grows `AGENTS.md` and could dilute the workflow. Evidence: `word-count-before.txt` records 3090 words and `word-count-after.txt` records 3145 words after tightening from the first draft. Conclusion: the 55-word net increase is justified because it replaces ambiguous evidence guidance with the missing reviewer-readable contract.
- Risk: Agents may paste sensitive logs while trying to be explicit. Evidence: the new Secret safety bullet directly forbids raw secret-bearing logs, env dumps, tokens, auth headers, cookies, and private credentials. Conclusion: the instruction now makes evidence explicit without encouraging secret exposure.
- Risk: Runtime behavior could regress. Evidence: only `AGENTS.md` changed, no runtime files or package metadata changed, and the full commit hook check passed. Conclusion: runtime risk is negligible for this docs-only change.

## Notes
- Initial commit attempt failed before checks because this fresh worktree had no dependencies hydrated (`biome: command not found`). I ran `npm ci --ignore-scripts`; it added dependencies from the existing lockfile and found 0 vulnerabilities.
- A later check attempt failed because ignored `.codegraph` pointed at a CodeGraph directory containing `daemon.sock`, which Biome treated as an unknown file type. I temporarily removed only the ignored `.codegraph` symlink, reran the commit hook successfully, and restored the symlink afterward.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the PR workflow in `AGENTS.md` to require reviewer‑readable QA evidence. Adds clear sections and secret‑safety rules so PRs explain what changed and prove it safely.

- **Documentation**
  - Replace “Open an English PR” with an “English, reviewer‑readable PR” contract.
  - Require PR body sections: Summary, Changes, QA/Evidence, Risks, Secret safety.
  - For each evidence item, include tested surface, observed result, artifact path, and why it’s sufficient.
  - Forbid raw secret‑bearing logs, env dumps, tokens, headers, cookies, or private credentials.

<sup>Written for commit fad78be26d805cc8cf30c73b921cf99e2bfa818d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

