### PR TITLE
feat(coding-agent): add pi codex app-server skeleton

### DIFF
--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-002-skeleton/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-002-skeleton/summary.md
@@ -1,0 +1,43 @@
+# PR-002 skeleton-lifecycle summary
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Result
+
+PR-002 adds the senpi builtin extension skeleton for `pi-codex-app-server` after PR-001 contract lock merge `c8da502ae746bcb28f79755e15711679dba4e84e`.
+
+## Changed files
+
+- `packages/coding-agent/src/core/extensions/builtin/index.ts`
+- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/index.ts`
+- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/extension.ts`
+- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs`
+- `packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts`
+
+## Verification
+
+Evidence root: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-002-skeleton/`
+
+- Failing-first proof: targeted test initially failed because `pi-codex-app-server/extension.ts` did not exist.
+- Targeted extension test: `targeted-extension-test.txt` records 3 passing tests covering builtin registry inclusion, extension command/flags/lifecycle hooks, and harness help.
+- Harness help smoke: `drive-adapter-help.txt` records `drive-adapter.mjs --help` output.
+- Required check: `npm-run-check.txt` records `npm run check` passing.
+- senpi QA common self-check: `senpi-qa-common-self-check.txt` passed.
+- senpi QA CLI smoke: `senpi-qa-cli-smoke.txt` passed.
+- senpi QA mock loop: `senpi-qa-mock-loop.txt` passed.
+- Cleanup receipt: `cleanup-receipt.txt`.
+- Secret safety: `secret-safety.txt`.
+
+## Project tracking
+
+BLOCKED:missing-gh-project-scope. `gh project list --owner code-yeongyu --format json --limit 20` failed because the token lacks `read:project`.
+
+## Cleanup
+
+No runtime process, socket, port, tmux session, browser context, container, temp dir, or QA-only env file was created by PR-002 skeleton tests. A generated local CodeGraph daemon socket at `/Users/yeongyu/.omo/codegraph/projects/senpi-9ccd0b01f5030dce/daemon.sock` was removed after Biome reported it as an unknown file type.
+
+## Residual risks
+
+- Runtime transport is intentionally not implemented in PR-002; PR-004 owns child-process stdio, websocket, and unix socket runtime behavior.
+- Protocol routing and capability negotiation remain deferred to PR-003 and later routing PRs.
+- The `/pi-codex-app-server` command currently reports skeleton status only and does not connect to Codex app-server.

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -11,6 +11,7 @@ import historySearchExtension from "./history-search/index.ts";
 import nestedAgentsMdExtension from "./nested-agents-md/index.ts";
 import openaiWebSearchExtension from "./openai-web-search/index.ts";
 import permissionSystemExtension from "./permission-system/index.ts";
+import piCodexAppServerExtension from "./pi-codex-app-server/index.ts";
 import promptPresetExtension from "./prompt-preset/index.ts";
 import promptUrlWidgetExtension from "./prompt-url-widget.ts";
 import redrawsExtension from "./redraws.ts";
@@ -57,4 +58,5 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "nested-agents-md", factory: nestedAgentsMdExtension },
 	{ id: "rules", factory: piRulesExtension },
 	{ id: "goal", factory: goalExtension },
+	{ id: "pi-codex-app-server", factory: piCodexAppServerExtension },
 ];

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/extension.ts
@@ -1,0 +1,52 @@
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionHandler,
+	SessionShutdownEvent,
+	SessionStartEvent,
+} from "../../types.ts";
+import { PI_CODEX_APP_SERVER_PROTOCOL_VERSION } from "./protocol-core.ts";
+
+export const PI_CODEX_APP_SERVER_COMMAND = "pi-codex-app-server";
+export const PI_CODEX_APP_SERVER_FLAG_ENABLED = "pi-codex-app-server";
+export const PI_CODEX_APP_SERVER_FLAG_MODE = "pi-codex-app-server-mode";
+
+const DEFAULT_TRANSPORT_MODE = "stdio";
+const SKELETON_NOTICE = [
+	"pi-codex-app-server PR-002 skeleton",
+	`Protocol contract: ${PI_CODEX_APP_SERVER_PROTOCOL_VERSION}`,
+	"Runtime transport is intentionally deferred.",
+].join("\n");
+
+export interface PiCodexAppServerExtensionApi {
+	readonly registerCommand: ExtensionAPI["registerCommand"];
+	readonly registerFlag: ExtensionAPI["registerFlag"];
+	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
+	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
+}
+
+export function registerPiCodexAppServerExtension(pi: PiCodexAppServerExtensionApi): void {
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_ENABLED, {
+		type: "boolean",
+		default: false,
+		description: "Enable the pi-codex-app-server skeleton surface without starting runtime transport.",
+	});
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_MODE, {
+		type: "string",
+		default: DEFAULT_TRANSPORT_MODE,
+		description: "Select the future pi-codex-app-server transport mode: stdio, websocket, or unix.",
+	});
+	pi.registerCommand(PI_CODEX_APP_SERVER_COMMAND, {
+		description: "Inspect the Codex app-server adapter skeleton status",
+		handler: async (_args, ctx) => {
+			notifyIfVisible(ctx, SKELETON_NOTICE);
+		},
+	});
+	pi.on("session_start", () => undefined);
+	pi.on("session_shutdown", () => undefined);
+}
+
+function notifyIfVisible(ctx: ExtensionContext, message: string): void {
+	if (!ctx.hasUI) return;
+	ctx.ui.notify(message, "info");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/index.ts
@@ -1,0 +1,6 @@
+import type { ExtensionAPI } from "../../types.ts";
+import { registerPiCodexAppServerExtension } from "./extension.ts";
+
+export default function piCodexAppServerExtension(pi: ExtensionAPI): void {
+	registerPiCodexAppServerExtension(pi);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const HELP_TEXT = `pi-codex-app-server adapter harness
+
+Usage:
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help
+
+Options:
+  --help                         Show this help text.
+  --external-stdio               Reserved for PR-004 stdio adapter driving.
+  --external-websocket <host>    Reserved for PR-004 websocket adapter driving.
+  --external-unix <path>         Reserved for PR-004 unix-socket adapter driving.
+  --app-server-command <path>    Reserved for the Codex app-server binary path.
+  --app-server-args <args>       Reserved for Codex app-server command arguments.
+  --app-server-url <url>         Reserved for a shared Codex app-server websocket URL.
+
+Status:
+  PR-002 skeleton only. Runtime transport, protocol routing, streaming,
+  callbacks, reconnect, and redaction are intentionally deferred.
+`;
+
+function main(argv) {
+	if (argv.length === 0 || argv.includes("--help")) {
+		process.stdout.write(HELP_TEXT);
+		return 0;
+	}
+
+	process.stderr.write("drive-adapter.mjs is a PR-002 harness shell; runtime driving is deferred.\n");
+	return 2;
+}
+
+process.exitCode = main(process.argv.slice(2));

--- a/packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import {
+	PI_CODEX_APP_SERVER_COMMAND,
+	PI_CODEX_APP_SERVER_FLAG_ENABLED,
+	PI_CODEX_APP_SERVER_FLAG_MODE,
+	type PiCodexAppServerExtensionApi,
+	registerPiCodexAppServerExtension,
+} from "../../src/core/extensions/builtin/pi-codex-app-server/extension.ts";
+import piCodexAppServerExtension from "../../src/core/extensions/builtin/pi-codex-app-server/index.ts";
+import type {
+	ExtensionAPI,
+	ExtensionHandler,
+	RegisteredCommand,
+	SessionShutdownEvent,
+	SessionStartEvent,
+} from "../../src/core/extensions/types.ts";
+
+type CommandRegistration = Omit<RegisteredCommand, "name" | "sourceInfo">;
+type FlagRegistration = Parameters<ExtensionAPI["registerFlag"]>[1];
+type LifecycleHandler = ExtensionHandler<SessionStartEvent> | ExtensionHandler<SessionShutdownEvent>;
+
+interface PiCodexAppServerHarness {
+	readonly commands: Map<string, CommandRegistration>;
+	readonly flags: Map<string, FlagRegistration>;
+	readonly handlers: Map<string, readonly LifecycleHandler[]>;
+}
+
+class HarnessApi implements PiCodexAppServerExtensionApi {
+	readonly commands = new Map<string, CommandRegistration>();
+	readonly flags = new Map<string, FlagRegistration>();
+	readonly handlers = new Map<string, LifecycleHandler[]>();
+
+	registerCommand(name: string, options: CommandRegistration): void {
+		this.commands.set(name, options);
+	}
+
+	registerFlag(name: string, options: FlagRegistration): void {
+		this.flags.set(name, options);
+	}
+
+	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
+	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
+	on(event: "session_start" | "session_shutdown", handler: LifecycleHandler): void {
+		const registered = this.handlers.get(event) ?? [];
+		registered.push(handler);
+		this.handlers.set(event, registered);
+	}
+}
+
+function createHarness(): PiCodexAppServerHarness {
+	const pi = new HarnessApi();
+	registerPiCodexAppServerExtension(pi);
+	return { commands: pi.commands, flags: pi.flags, handlers: pi.handlers };
+}
+
+describe("pi-codex-app-server extension skeleton", () => {
+	it("registers exactly one builtin factory entry", () => {
+		const entries = builtinExtensions.filter((extension) => extension.id === "pi-codex-app-server");
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.factory).toBe(piCodexAppServerExtension);
+	});
+
+	it("registers the command, flags, and lifecycle no-op handlers", () => {
+		const { commands, flags, handlers } = createHarness();
+
+		expect(commands.get(PI_CODEX_APP_SERVER_COMMAND)?.description).toContain("Codex app-server");
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_ENABLED)).toMatchObject({ type: "boolean", default: false });
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_MODE)).toMatchObject({ type: "string", default: "stdio" });
+		expect(handlers.get("session_start")).toHaveLength(1);
+		expect(handlers.get("session_shutdown")).toHaveLength(1);
+	});
+
+	it("ships a harness shell that exposes help without starting runtime transport", () => {
+		const harnessPath = join(
+			process.cwd(),
+			"src",
+			"core",
+			"extensions",
+			"builtin",
+			"pi-codex-app-server",
+			"qa",
+			"drive-adapter.mjs",
+		);
+
+		const result = spawnSync(process.execPath, [harnessPath, "--help"], {
+			cwd: process.cwd(),
+			encoding: "utf-8",
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("pi-codex-app-server adapter harness");
+		expect(result.stdout).toContain("--external-stdio");
+		expect(result.stdout).toContain("--app-server-url");
+		expect(result.stderr).toBe("");
+	});
+});


### PR DESCRIPTION
This work is using code-yeongyu/lazycodex teammode.

## Summary

Adds the Wave 2 / PR-002 `pi-codex-app-server` builtin extension skeleton after PR-001 contract lock merge `c8da502ae746bcb28f79755e15711679dba4e84e` from #73.

Before: PR-001 contract files existed, but there was no registered builtin extension surface, no `/pi-codex-app-server` command, no extension flags, no lifecycle hooks, and no adapter harness entry point.

After: senpi registers a builtin `pi-codex-app-server` extension with a status command, CLI flags, lifecycle-safe no-op startup/shutdown handlers, and a help-only `qa/drive-adapter.mjs` harness shell. Runtime transport, routing, streaming, callbacks, capability negotiation, reconnect, and redaction behavior remain intentionally deferred to later PRs.

## Changes

- Registers `pi-codex-app-server` in `packages/coding-agent/src/core/extensions/builtin/index.ts` after the existing builtins.
- Adds `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/index.ts` and `extension.ts`.
- Adds `/pi-codex-app-server` skeleton status command.
- Adds extension CLI flags:
  - `--pi-codex-app-server` boolean, default `false`.
  - `--pi-codex-app-server-mode <value>` string, default `stdio`.
- Adds lifecycle-safe no-op `session_start` and `session_shutdown` handlers.
- Adds `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs` with `--help` and reserved PR-004 transport flags only.
- Adds `packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts` covering builtin registry inclusion, extension registration behavior, and harness help.
- Adds tracked summary evidence at `.omo/evidence/20260624-pi-codex-app-server-execution/pr-002-skeleton/summary.md`.

## QA / Evidence

Evidence root: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-002-skeleton/`.

- Failing-first proof: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-extension.test.ts` initially failed with `Cannot find module '../../src/core/extensions/builtin/pi-codex-app-server/extension.ts'` before implementation. Saved in `failing-first-proof.txt`.
- Targeted extension test: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-extension.test.ts` passed with 1 file and 3 tests. Saved in `targeted-extension-test.txt`.
- Harness help smoke: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help` exited 0 and printed the reserved stdio/websocket/unix/app-server options. Saved in `drive-adapter-help.txt`.
- Full check: `npm run check` passed. The commit hook reran the same check and passed. Saved in `npm-run-check.txt`.
- senpi QA common self-check: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check` passed. Saved in `senpi-qa-common-self-check.txt`.
- senpi QA CLI smoke: `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` passed. Saved in `senpi-qa-cli-smoke.txt`.
- senpi QA mock loop: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` passed. Saved in `senpi-qa-mock-loop.txt`.

## Cleanup Receipt

No runtime process, socket, port, tmux session, browser context, container, temp dir, or QA-only env file was created by PR-002 skeleton tests. Cleanup receipt saved in `cleanup-receipt.txt`.

During `npm run check`, Biome initially failed on a generated local CodeGraph daemon socket at `/Users/yeongyu/.omo/codegraph/projects/senpi-9ccd0b01f5030dce/daemon.sock`; I removed that generated socket and reran `npm run check` successfully.

## Project Tracking

BLOCKED:missing-gh-project-scope. `gh project list --owner code-yeongyu --format json --limit 20` failed because the GitHub token lacks `read:project`. This is recorded in the tracked summary and PR evidence. Per coordination, this does not block opening PR-002.

## Secret Safety

No raw secret-bearing logs, auth headers, bearer tokens, cookies, launchd environments, service logs, or real credential files were read or copied into evidence. Secret safety receipt saved in `secret-safety.txt`.

## Residual Risks

- Runtime transport is intentionally not implemented in PR-002; PR-004 owns child-process stdio, websocket, and unix socket runtime behavior.
- Protocol routing and capability negotiation remain deferred to PR-003 and later routing PRs.
- The `/pi-codex-app-server` command currently reports skeleton status only and does not connect to Codex app-server.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `pi-codex-app-server` builtin extension skeleton to the coding agent. It provides a status command, CLI flags, and lifecycle-safe no-op handlers; runtime transport is deferred.

- **New Features**
  - Registers the `pi-codex-app-server` builtin extension.
  - Adds `/pi-codex-app-server` status command and flags: `--pi-codex-app-server` (default false) and `--pi-codex-app-server-mode` (default `stdio`).
  - Adds no-op `session_start` and `session_shutdown` handlers.
  - Ships `qa/drive-adapter.mjs` harness with `--help` and reserved transport options; includes tests for registry inclusion and command/flag/lifecycle behavior.

<sup>Written for commit daa27dbc6d7d94d8bc75255442bffeb9d9c94e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

