### PR TITLE
feat(coding-agent): add app-server capability negotiation

### DIFF
--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-003-protocol-capability/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-003-protocol-capability/summary.md
@@ -1,0 +1,32 @@
+# PR-003 protocol/capability evidence
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Summary
+
+PR-003 adds protocol-only capability negotiation for the pi-codex-app-server extension. It parses external initialize capability payloads, requires opaque notification and opaque callback support, maps app-server notification opt-outs, and creates adapter-originated JSON-RPC errors under `data.source = "pi-codex-app-server"`.
+
+No runtime transport, child process, websocket, unix socket, session routing, stream projection, callback execution, reconnect, or final redaction QA is implemented in this PR.
+
+## Commands and evidence
+
+- Failing-first proof: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/failing-first.txt`
+- Targeted capability test: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-capability-green.txt`
+- Contract/skeleton/capability test rerun: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-suite-rerun.txt`
+- Full check: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/npm-run-check-rerun.txt`
+- senpi QA common self-check: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-common-self-check.txt`
+- senpi QA CLI smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-cli-smoke.txt`
+- senpi QA mock loop: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-mock-loop.txt`
+- Adapter harness help smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/drive-adapter-help.txt`
+- Cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/cleanup-receipt.txt`
+
+## Project tracking
+
+BLOCKED:missing-gh-project-scope - `gh project list --owner code-yeongyu --format json --limit 20` failed because the token lacks `read:project`.
+
+## Residual risks
+
+- Negotiation is pure protocol state only; runtime connection handoff remains PR-004.
+- Session/request routing remains PR-005.
+- Item streaming, backpressure, and callbacks remain PR-006 through PR-009.
+- Realtime/filesystem/plugin/config pass-through remains PR-011 and is not unblocked by this PR alone.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-003-protocol-capability/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-003-protocol-capability/summary.md
@@ -20,6 +20,15 @@ No runtime transport, child process, websocket, unix socket, session routing, st
 - Adapter harness help smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/drive-adapter-help.txt`
 - Cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/cleanup-receipt.txt`
 
+Follow-up for PR review comment `4786308592`:
+
+- Updated app-server-side initialize capability field names to match Codex `InitializeCapabilities`: `requestAttestation`, `mcpServerOpenaiFormElicitation`, and `optOutNotificationMethods`.
+- Refreshed targeted PR-003 test: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-capability-followup-after-cleanup.txt`
+- Refreshed contract/skeleton/capability suite: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-suite-followup-after-cleanup.txt`
+- Refreshed full check after ignored `.codegraph` symlink cleanup: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/npm-run-check-followup-after-cleanup.txt`
+- Refreshed senpi QA: `senpi-qa-common-self-check-followup.txt`, `senpi-qa-cli-smoke-followup.txt`, `senpi-qa-mock-loop-followup.txt`, and `drive-adapter-help-followup.txt`
+- Tool-state cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/codegraph-symlink-cleanup.txt`
+
 ## Project tracking
 
 BLOCKED:missing-gh-project-scope - `gh project list --owner code-yeongyu --format json --limit 20` failed because the token lacks `read:project`.

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/capability-negotiator.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/capability-negotiator.ts
@@ -1,0 +1,200 @@
+import { type AdapterJsonRpcError, createAdapterJsonRpcError } from "./error-mapper.ts";
+import { PI_CODEX_APP_SERVER_PROTOCOL_VERSION } from "./protocol-core.ts";
+import { PLAN_REQUIRED_SERVER_NOTIFICATION_SURFACES } from "./protocol-required-surfaces.ts";
+
+export type NegotiatedCapabilityFlag =
+	| "semantic-events"
+	| "opaque-notifications"
+	| "opaque-callbacks"
+	| "realtime"
+	| "filesystem"
+	| "app-plugin-config"
+	| "app-server-experimental-api"
+	| "app-server-attestation"
+	| "app-server-mcp-form-elicitation";
+
+export interface ExternalInitializeCapabilities {
+	readonly protocolVersion: typeof PI_CODEX_APP_SERVER_PROTOCOL_VERSION;
+	readonly semanticEvents: boolean;
+	readonly opaqueNotifications: boolean;
+	readonly opaqueCallbacks: boolean;
+	readonly realtime: boolean;
+	readonly filesystem: boolean;
+	readonly appPluginConfig: boolean;
+	readonly notificationOptOuts: readonly string[];
+}
+
+export interface AppServerInitializeCapabilities {
+	readonly experimentalApi?: boolean;
+	readonly attestationRequests?: boolean;
+	readonly mcpFormElicitation?: boolean;
+	readonly notificationOptOuts?: readonly string[];
+}
+
+export interface CapabilityNegotiationInput {
+	readonly external: ExternalInitializeCapabilities;
+	readonly appServer?: AppServerInitializeCapabilities;
+}
+
+export type CapabilityNegotiationResult = CapabilityNegotiationAccepted | CapabilityNegotiationRejected;
+
+export interface CapabilityNegotiationAccepted {
+	readonly kind: "accepted";
+	readonly protocolVersion: typeof PI_CODEX_APP_SERVER_PROTOCOL_VERSION;
+	readonly capabilityFlags: readonly NegotiatedCapabilityFlag[];
+	readonly notificationOptOuts: readonly string[];
+	readonly error?: undefined;
+}
+
+export interface CapabilityNegotiationRejected {
+	readonly kind: "rejected";
+	readonly error: AdapterJsonRpcError;
+}
+
+const notificationSurfaceNames = new Set<string>(PLAN_REQUIRED_SERVER_NOTIFICATION_SURFACES);
+
+export class ExternalInitializeCapabilitiesError extends Error {
+	readonly adapterCode: "malformed-message" | "unsupported-protocol-version" | "unsupported-notification-opt-out";
+
+	constructor(
+		message: string,
+		adapterCode: "malformed-message" | "unsupported-protocol-version" | "unsupported-notification-opt-out",
+	) {
+		super(message);
+		this.name = "ExternalInitializeCapabilitiesError";
+		this.adapterCode = adapterCode;
+	}
+}
+
+export function parseExternalInitializeCapabilities(input: unknown): ExternalInitializeCapabilities {
+	if (!isRecord(input)) {
+		throw new ExternalInitializeCapabilitiesError("Initialize params must be an object.", "malformed-message");
+	}
+	const protocolVersion = input.protocolVersion;
+	if (protocolVersion !== PI_CODEX_APP_SERVER_PROTOCOL_VERSION) {
+		throw new ExternalInitializeCapabilitiesError(
+			`Unsupported pi-codex-app-server protocol version: ${String(protocolVersion)}`,
+			"unsupported-protocol-version",
+		);
+	}
+
+	const capabilities = input.capabilities;
+	if (!isRecord(capabilities)) {
+		throw new ExternalInitializeCapabilitiesError("Initialize capabilities must be an object.", "malformed-message");
+	}
+
+	const notificationOptOuts = parseNotificationOptOuts(capabilities.notificationOptOuts);
+	return {
+		protocolVersion,
+		semanticEvents: readRequiredBoolean(capabilities, "semanticEvents"),
+		opaqueNotifications: readRequiredBoolean(capabilities, "opaqueNotifications"),
+		opaqueCallbacks: readRequiredBoolean(capabilities, "opaqueCallbacks"),
+		realtime: readOptionalBoolean(capabilities, "realtime"),
+		filesystem: readOptionalBoolean(capabilities, "filesystem"),
+		appPluginConfig: readOptionalBoolean(capabilities, "appPluginConfig"),
+		notificationOptOuts,
+	};
+}
+
+export function negotiatePiCodexAppServerCapabilities(input: CapabilityNegotiationInput): CapabilityNegotiationResult {
+	const missingRequiredCapabilities = findMissingRequiredCapabilities(input.external);
+	if (missingRequiredCapabilities.length > 0) {
+		return {
+			kind: "rejected",
+			error: createAdapterJsonRpcError({
+				adapterCode: "incompatible-capabilities",
+				message: "External client is incompatible with pi-codex-app-server.",
+				details: missingRequiredCapabilities,
+			}),
+		};
+	}
+
+	return {
+		kind: "accepted",
+		protocolVersion: input.external.protocolVersion,
+		capabilityFlags: buildCapabilityFlags(input.external, input.appServer),
+		notificationOptOuts: mapNotificationOptOuts(input.external, input.appServer),
+	};
+}
+
+function findMissingRequiredCapabilities(external: ExternalInitializeCapabilities): readonly string[] {
+	const missing: string[] = [];
+	if (!external.opaqueNotifications) {
+		missing.push("opaqueNotifications is required so app-server notifications are never silently dropped");
+	}
+	if (!external.opaqueCallbacks) {
+		missing.push("opaqueCallbacks is required because app-server server requests are control flow");
+	}
+	return missing;
+}
+
+function buildCapabilityFlags(
+	external: ExternalInitializeCapabilities,
+	appServer: AppServerInitializeCapabilities | undefined,
+): readonly NegotiatedCapabilityFlag[] {
+	const flags: NegotiatedCapabilityFlag[] = [];
+	if (external.semanticEvents) flags.push("semantic-events");
+	if (external.opaqueNotifications) flags.push("opaque-notifications");
+	if (external.opaqueCallbacks) flags.push("opaque-callbacks");
+	if (external.realtime) flags.push("realtime");
+	if (external.filesystem) flags.push("filesystem");
+	if (external.appPluginConfig) flags.push("app-plugin-config");
+	if (appServer?.experimentalApi) flags.push("app-server-experimental-api");
+	if (appServer?.attestationRequests) flags.push("app-server-attestation");
+	if (appServer?.mcpFormElicitation) flags.push("app-server-mcp-form-elicitation");
+	return flags;
+}
+
+function mapNotificationOptOuts(
+	external: ExternalInitializeCapabilities,
+	appServer: AppServerInitializeCapabilities | undefined,
+): readonly string[] {
+	const appServerOptOuts = new Set<string>(appServer?.notificationOptOuts ?? []);
+	if (appServerOptOuts.size === 0) return [];
+	return external.notificationOptOuts.filter((method) => appServerOptOuts.has(method));
+}
+
+function parseNotificationOptOuts(value: unknown): readonly string[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new ExternalInitializeCapabilitiesError("notificationOptOuts must be an array.", "malformed-message");
+	}
+	const optOuts: string[] = [];
+	for (const method of value) {
+		if (typeof method !== "string") {
+			throw new ExternalInitializeCapabilitiesError(
+				"notificationOptOuts entries must be strings.",
+				"malformed-message",
+			);
+		}
+		if (!notificationSurfaceNames.has(method)) {
+			throw new ExternalInitializeCapabilitiesError(
+				`Unknown app-server notification opt-out: ${method}`,
+				"unsupported-notification-opt-out",
+			);
+		}
+		optOuts.push(method);
+	}
+	return optOuts;
+}
+
+function readRequiredBoolean(input: Readonly<Record<string, unknown>>, key: string): boolean {
+	const value = input[key];
+	if (typeof value !== "boolean") {
+		throw new ExternalInitializeCapabilitiesError(`${key} must be a boolean.`, "malformed-message");
+	}
+	return value;
+}
+
+function readOptionalBoolean(input: Readonly<Record<string, unknown>>, key: string): boolean {
+	const value = input[key];
+	if (value === undefined) return false;
+	if (typeof value !== "boolean") {
+		throw new ExternalInitializeCapabilitiesError(`${key} must be a boolean.`, "malformed-message");
+	}
+	return value;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/capability-negotiator.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/capability-negotiator.ts
@@ -26,9 +26,9 @@ export interface ExternalInitializeCapabilities {
 
 export interface AppServerInitializeCapabilities {
 	readonly experimentalApi?: boolean;
-	readonly attestationRequests?: boolean;
-	readonly mcpFormElicitation?: boolean;
-	readonly notificationOptOuts?: readonly string[];
+	readonly requestAttestation?: boolean;
+	readonly mcpServerOpenaiFormElicitation?: boolean;
+	readonly optOutNotificationMethods?: readonly string[] | null;
 }
 
 export interface CapabilityNegotiationInput {
@@ -140,8 +140,8 @@ function buildCapabilityFlags(
 	if (external.filesystem) flags.push("filesystem");
 	if (external.appPluginConfig) flags.push("app-plugin-config");
 	if (appServer?.experimentalApi) flags.push("app-server-experimental-api");
-	if (appServer?.attestationRequests) flags.push("app-server-attestation");
-	if (appServer?.mcpFormElicitation) flags.push("app-server-mcp-form-elicitation");
+	if (appServer?.requestAttestation) flags.push("app-server-attestation");
+	if (appServer?.mcpServerOpenaiFormElicitation) flags.push("app-server-mcp-form-elicitation");
 	return flags;
 }
 
@@ -149,7 +149,7 @@ function mapNotificationOptOuts(
 	external: ExternalInitializeCapabilities,
 	appServer: AppServerInitializeCapabilities | undefined,
 ): readonly string[] {
-	const appServerOptOuts = new Set<string>(appServer?.notificationOptOuts ?? []);
+	const appServerOptOuts = new Set<string>(appServer?.optOutNotificationMethods ?? []);
 	if (appServerOptOuts.size === 0) return [];
 	return external.notificationOptOuts.filter((method) => appServerOptOuts.has(method));
 }

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/error-mapper.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/error-mapper.ts
@@ -1,0 +1,49 @@
+export const ADAPTER_ERROR_SOURCE = "pi-codex-app-server";
+export const ADAPTER_JSON_RPC_ERROR_CODE = -32080;
+
+export type AdapterErrorCode =
+	| "incompatible-capabilities"
+	| "malformed-message"
+	| "unsupported-protocol-version"
+	| "unsupported-notification-opt-out";
+
+export interface AdapterJsonRpcError {
+	readonly code: typeof ADAPTER_JSON_RPC_ERROR_CODE;
+	readonly message: string;
+	readonly data: {
+		readonly source: typeof ADAPTER_ERROR_SOURCE;
+		readonly adapterCode: AdapterErrorCode;
+		readonly details: readonly string[];
+		readonly retryable: boolean;
+	};
+}
+
+export interface AppServerJsonRpcError {
+	readonly code: number;
+	readonly message: string;
+	readonly data?: unknown;
+}
+
+export interface AdapterJsonRpcErrorInput {
+	readonly adapterCode: AdapterErrorCode;
+	readonly message: string;
+	readonly details?: readonly string[];
+	readonly retryable?: boolean;
+}
+
+export function createAdapterJsonRpcError(input: AdapterJsonRpcErrorInput): AdapterJsonRpcError {
+	return {
+		code: ADAPTER_JSON_RPC_ERROR_CODE,
+		message: input.message,
+		data: {
+			source: ADAPTER_ERROR_SOURCE,
+			adapterCode: input.adapterCode,
+			details: input.details ?? [],
+			retryable: input.retryable ?? false,
+		},
+	};
+}
+
+export function preserveAppServerJsonRpcError(error: AppServerJsonRpcError): AppServerJsonRpcError {
+	return error;
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-capability.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-capability.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+	negotiatePiCodexAppServerCapabilities,
+	parseExternalInitializeCapabilities,
+} from "../../src/core/extensions/builtin/pi-codex-app-server/capability-negotiator.ts";
+import {
+	ADAPTER_ERROR_SOURCE,
+	ADAPTER_JSON_RPC_ERROR_CODE,
+	createAdapterJsonRpcError,
+	preserveAppServerJsonRpcError,
+} from "../../src/core/extensions/builtin/pi-codex-app-server/error-mapper.ts";
+import { PI_CODEX_APP_SERVER_PROTOCOL_VERSION } from "../../src/core/extensions/builtin/pi-codex-app-server/protocol-core.ts";
+
+describe("pi-codex-app-server capability negotiation", () => {
+	it("accepts semantic plus opaque relay and maps app-server notification opt-outs", () => {
+		const parsed = parseExternalInitializeCapabilities({
+			protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+			capabilities: {
+				semanticEvents: true,
+				opaqueNotifications: true,
+				opaqueCallbacks: true,
+				realtime: false,
+				filesystem: true,
+				appPluginConfig: true,
+				notificationOptOuts: ["thread/tokenUsage/updated", "warning"],
+			},
+		});
+
+		const negotiated = negotiatePiCodexAppServerCapabilities({
+			external: parsed,
+			appServer: {
+				experimentalApi: true,
+				attestationRequests: true,
+				mcpFormElicitation: true,
+				notificationOptOuts: ["warning", "thread/tokenUsage/updated", "configWarning"],
+			},
+		});
+
+		expect(negotiated).toMatchObject({
+			kind: "accepted",
+			protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+			capabilityFlags: [
+				"semantic-events",
+				"opaque-notifications",
+				"opaque-callbacks",
+				"filesystem",
+				"app-plugin-config",
+				"app-server-experimental-api",
+				"app-server-attestation",
+				"app-server-mcp-form-elicitation",
+			],
+			notificationOptOuts: ["thread/tokenUsage/updated", "warning"],
+		});
+	});
+
+	it("rejects clients that refuse opaque notifications or opaque callbacks", () => {
+		const withoutNotifications = parseExternalInitializeCapabilities({
+			protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+			capabilities: {
+				semanticEvents: true,
+				opaqueNotifications: false,
+				opaqueCallbacks: true,
+			},
+		});
+		const withoutCallbacks = parseExternalInitializeCapabilities({
+			protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+			capabilities: {
+				semanticEvents: true,
+				opaqueNotifications: true,
+				opaqueCallbacks: false,
+			},
+		});
+
+		expect(negotiatePiCodexAppServerCapabilities({ external: withoutNotifications }).error).toMatchObject({
+			code: ADAPTER_JSON_RPC_ERROR_CODE,
+			data: {
+				source: ADAPTER_ERROR_SOURCE,
+				adapterCode: "incompatible-capabilities",
+			},
+		});
+		expect(negotiatePiCodexAppServerCapabilities({ external: withoutCallbacks }).error).toMatchObject({
+			code: ADAPTER_JSON_RPC_ERROR_CODE,
+			data: {
+				source: ADAPTER_ERROR_SOURCE,
+				adapterCode: "incompatible-capabilities",
+			},
+		});
+	});
+
+	it("rejects malformed protocol versions and unknown notification opt-outs at the boundary", () => {
+		expect(() =>
+			parseExternalInitializeCapabilities({
+				protocolVersion: "2026-06-24.pr-000",
+				capabilities: {
+					semanticEvents: true,
+					opaqueNotifications: true,
+					opaqueCallbacks: true,
+				},
+			}),
+		).toThrow("Unsupported pi-codex-app-server protocol version");
+
+		expect(() =>
+			parseExternalInitializeCapabilities({
+				protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+				capabilities: {
+					semanticEvents: true,
+					opaqueNotifications: true,
+					opaqueCallbacks: true,
+					notificationOptOuts: ["not/a-real-notification"],
+				},
+			}),
+		).toThrow("Unknown app-server notification opt-out");
+	});
+});
+
+describe("pi-codex-app-server error namespace", () => {
+	it("marks adapter errors with the pi-codex-app-server source without rewriting app-server errors", () => {
+		const adapterError = createAdapterJsonRpcError({
+			adapterCode: "malformed-message",
+			message: "Malformed initialize params.",
+			details: ["capabilities must be an object"],
+		});
+		const appServerError = preserveAppServerJsonRpcError({
+			code: -32001,
+			message: "app-server overloaded",
+			data: { retryAfterMs: 100 },
+		});
+
+		expect(adapterError).toEqual({
+			code: ADAPTER_JSON_RPC_ERROR_CODE,
+			message: "Malformed initialize params.",
+			data: {
+				source: ADAPTER_ERROR_SOURCE,
+				adapterCode: "malformed-message",
+				details: ["capabilities must be an object"],
+				retryable: false,
+			},
+		});
+		expect(appServerError).toEqual({
+			code: -32001,
+			message: "app-server overloaded",
+			data: { retryAfterMs: 100 },
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-capability.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-capability.test.ts
@@ -30,9 +30,9 @@ describe("pi-codex-app-server capability negotiation", () => {
 			external: parsed,
 			appServer: {
 				experimentalApi: true,
-				attestationRequests: true,
-				mcpFormElicitation: true,
-				notificationOptOuts: ["warning", "thread/tokenUsage/updated", "configWarning"],
+				requestAttestation: true,
+				mcpServerOpenaiFormElicitation: true,
+				optOutNotificationMethods: ["warning", "thread/tokenUsage/updated", "configWarning"],
 			},
 		});
 


### PR DESCRIPTION
## Summary

This work is using code-yeongyu/lazycodex teammode.

Adds PR-003 protocol/capability negotiation for the `pi-codex-app-server` builtin extension after PR-001 contract lock and PR-002 skeleton/lifecycle.

Before: the extension had locked protocol inventory plus a lifecycle-safe skeleton, but no parser for external initialize capabilities, no opaque-relay compatibility check, no notification opt-out mapping, and no adapter-owned JSON-RPC error namespace.

After: the extension has pure protocol helpers that parse external initialize capability payloads, require opaque notifications and opaque callbacks, map app-server notification opt-outs, expose negotiated capability flags, and preserve app-server JSON-RPC errors without rewriting them.

## Changes

- Added `capability-negotiator.ts` for initialize capability parsing, protocol-version checks, opaque relay enforcement, app-server capability flag mapping, and notification opt-out intersection.
- Added `error-mapper.ts` for adapter-originated JSON-RPC errors with `data.source = "pi-codex-app-server"` and pass-through app-server error preservation.
- Added focused negative compatibility and error-namespace tests.
- Added PR-003 evidence summary at `.omo/evidence/20260624-pi-codex-app-server-execution/pr-003-protocol-capability/summary.md`.

## Boundaries

- No runtime transport, child process, websocket, unix socket, routing/session state, streaming/item projection, callbacks, reconnect, or final redaction QA.
- Preserves PR-001 protocol contract surfaces and PR-002 command/flag/lifecycle seams.
- Downstream lanes can consume these pure negotiation/error helpers after PR-003 is accepted; PR-004 runtime and PR-005 routing remain responsible for wiring them into live adapter flow. PR-011 realtime/filesystem/plugin/config pass-through is not unblocked by this PR alone.

## QA / Evidence

- Failing-first proof: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-capability.test.ts`
  - Initial result: failed for missing `error-mapper.ts`, saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/failing-first.txt`.
- Targeted PR-003 test: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-capability.test.ts`
  - Result: 1 file / 4 tests passed, saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-capability-green.txt`.
- Contract/skeleton/capability regression set: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-contract.test.ts test/suite/pi-codex-app-server-extension.test.ts test/suite/pi-codex-app-server-capability.test.ts`
  - Result: 3 files / 10 tests passed, saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-suite-rerun.txt`.
- Full check: `npm run check`
  - Result: passed with no fixes, warnings, or infos on rerun; saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/npm-run-check-rerun.txt`.
- senpi QA common self-check: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`
  - Result: 9/9 passed, real auth unchanged; saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-common-self-check.txt`.
- senpi QA CLI smoke: `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`
  - Result: 5/5 passed, real auth unchanged; saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-cli-smoke.txt`.
- senpi QA mock loop: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`
  - Result: 5/5 passed across OpenAI completions, Anthropic messages, and OpenAI responses mock paths; zero real provider calls; real auth unchanged. Saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-mock-loop.txt`.
- Adapter harness help: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help`
  - Result: help output still reports PR-002 runtime deferral; saved at `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/drive-adapter-help.txt`.

## Cleanup Receipt

- `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/cleanup-receipt.txt`
- No runtime transport, app-server child process, websocket server, unix socket, tmux session, browser, container, or QA-only env file was created by PR-003.
- Process scan found no live `mock-loop.mjs`, fake model server, `drive-adapter.mjs`, or `pi-codex-app-server` process after QA.

## Secret Safety

- Evidence uses `local-ignore/`, which is gitignored.
- senpi QA scripts reported the real `~/.senpi/agent/auth.json` unchanged.
- No raw secret-bearing logs, auth headers, tokens, cookies, launchd environments, or private credentials are included in committed files or PR text.

## GitHub Project Status

- BLOCKED:missing-gh-project-scope
- `gh project list --owner code-yeongyu --format json --limit 20` failed because the current token lacks `read:project`.
- This is recorded in `.omo/evidence/20260624-pi-codex-app-server-execution/pr-003-protocol-capability/summary.md`.

## Risks

- Negotiation is pure protocol state only; live runtime use remains PR-004.
- Session/request routing remains PR-005.
- Item streaming, backpressure, and callbacks remain PR-006 through PR-009.
- PR-011 realtime/filesystem/plugin/config pass-through still depends on earlier runtime/routing/projection seams.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds protocol-level capability negotiation for the `pi-codex-app-server` extension. Parses initialize capabilities, enforces opaque relay compatibility, maps notification opt-outs, and namespaces adapter JSON-RPC errors to prepare for later runtime wiring.

- **New Features**
  - Parse initialize payloads and enforce protocol version.
  - Require opaque notifications and callbacks; reject incompatible clients with adapter-scoped JSON-RPC errors.
  - Intersect client and server notification opt-outs.
  - Expose negotiated flags (semantic events, realtime, filesystem, app-plugin-config, experimental API, attestation, MCP forms).
  - Add error mapper to namespace adapter errors and pass through app-server errors unchanged.
  - Add focused tests for negotiation and error namespace.

- **Bug Fixes**
  - Align app-server capability fields to Codex `InitializeCapabilities`: `requestAttestation`, `mcpServerOpenaiFormElicitation`, `optOutNotificationMethods`.

<sup>Written for commit fab120c0a4d3dc7e3466d3acb9689ea5c949f755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up: InitializeCapabilities field names

Addressed blocking leader comment https://github.com/code-yeongyu/senpi/pull/75#issuecomment-4786308592.

This work is using code-yeongyu/lazycodex teammode.

- Updated app-server-side capability shape to use Codex serialized `InitializeCapabilities` field names: `requestAttestation`, `mcpServerOpenaiFormElicitation`, and `optOutNotificationMethods`.
- Positive capability fixture now uses the same app-server field names.
- Scope remains pure protocol/capability only; no runtime/routing/stream/callback/reconnect code was added.
- Refreshed evidence:
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-capability-followup-after-cleanup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/targeted-suite-followup-after-cleanup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/npm-run-check-followup-after-cleanup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-common-self-check-followup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-cli-smoke-followup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/senpi-qa-mock-loop-followup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/drive-adapter-help-followup.txt`
  - `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-003-protocol-capability/codegraph-symlink-cleanup.txt`
