### PR TITLE
feat(coding-agent): add app-server runtime transport

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/extension.ts
@@ -1,52 +1,138 @@
-import type {
-	ExtensionAPI,
-	ExtensionContext,
-	ExtensionHandler,
-	SessionShutdownEvent,
-	SessionStartEvent,
-} from "../../types.ts";
+import type { ExtensionAPI, ExtensionContext, SessionShutdownEvent, SessionStartEvent } from "../../types.ts";
 import { PI_CODEX_APP_SERVER_PROTOCOL_VERSION } from "./protocol-core.ts";
+import {
+	createPiCodexAppServerRuntime,
+	type PiCodexAppServerRuntimeController,
+	type PiCodexAppServerRuntimeFlags,
+	type PiCodexAppServerTransportMode,
+} from "./transport-runtime.ts";
 
 export const PI_CODEX_APP_SERVER_COMMAND = "pi-codex-app-server";
 export const PI_CODEX_APP_SERVER_FLAG_ENABLED = "pi-codex-app-server";
 export const PI_CODEX_APP_SERVER_FLAG_MODE = "pi-codex-app-server-mode";
+export const PI_CODEX_APP_SERVER_FLAG_APP_SERVER_COMMAND = "pi-codex-app-server-command";
+export const PI_CODEX_APP_SERVER_FLAG_APP_SERVER_ARGS = "pi-codex-app-server-args";
+export const PI_CODEX_APP_SERVER_FLAG_URL = "pi-codex-app-server-url";
+export const PI_CODEX_APP_SERVER_FLAG_UNIX_SOCKET = "pi-codex-app-server-unix-socket";
+export const PI_CODEX_APP_SERVER_FLAG_TIMEOUT_MS = "pi-codex-app-server-timeout-ms";
 
 const DEFAULT_TRANSPORT_MODE = "stdio";
-const SKELETON_NOTICE = [
-	"pi-codex-app-server PR-002 skeleton",
+const DEFAULT_APP_SERVER_COMMAND = "codex";
+const DEFAULT_APP_SERVER_ARGS = "app-server";
+const DEFAULT_TIMEOUT_MS = "5000";
+const RUNTIME_NOTICE_PREFIX = [
+	"pi-codex-app-server PR-004 runtime",
 	`Protocol contract: ${PI_CODEX_APP_SERVER_PROTOCOL_VERSION}`,
-	"Runtime transport is intentionally deferred.",
 ].join("\n");
+
+interface RuntimeExtensionContext {
+	readonly hasUI: boolean;
+	readonly ui: Pick<ExtensionContext["ui"], "notify">;
+}
+type RuntimeLifecycleHandler<E> = (event: E, ctx: RuntimeExtensionContext) => Promise<void> | void;
 
 export interface PiCodexAppServerExtensionApi {
 	readonly registerCommand: ExtensionAPI["registerCommand"];
 	readonly registerFlag: ExtensionAPI["registerFlag"];
-	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
-	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
+	readonly getFlag: ExtensionAPI["getFlag"];
+	on(event: "session_start", handler: RuntimeLifecycleHandler<SessionStartEvent>): void;
+	on(event: "session_shutdown", handler: RuntimeLifecycleHandler<SessionShutdownEvent>): void;
 }
 
-export function registerPiCodexAppServerExtension(pi: PiCodexAppServerExtensionApi): void {
+export function registerPiCodexAppServerExtension(
+	pi: PiCodexAppServerExtensionApi,
+	createRuntime: () => PiCodexAppServerRuntimeController = createPiCodexAppServerRuntime,
+): void {
+	const runtime = createRuntime();
 	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_ENABLED, {
 		type: "boolean",
 		default: false,
-		description: "Enable the pi-codex-app-server skeleton surface without starting runtime transport.",
+		description: "Enable pi-codex-app-server runtime transport during session lifecycle.",
 	});
 	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_MODE, {
 		type: "string",
 		default: DEFAULT_TRANSPORT_MODE,
-		description: "Select the future pi-codex-app-server transport mode: stdio, websocket, or unix.",
+		description: "Select the pi-codex-app-server transport mode: stdio, websocket, or unix.",
+	});
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_APP_SERVER_COMMAND, {
+		type: "string",
+		default: DEFAULT_APP_SERVER_COMMAND,
+		description: "Codex app-server command for stdio or unix proxy transport.",
+	});
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_APP_SERVER_ARGS, {
+		type: "string",
+		default: DEFAULT_APP_SERVER_ARGS,
+		description: "Codex app-server command arguments for stdio transport.",
+	});
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_URL, {
+		type: "string",
+		default: "",
+		description: "Remote websocket URL for websocket transport.",
+	});
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_UNIX_SOCKET, {
+		type: "string",
+		default: "",
+		description: "Unix socket path for app-server proxy transport.",
+	});
+	pi.registerFlag(PI_CODEX_APP_SERVER_FLAG_TIMEOUT_MS, {
+		type: "string",
+		default: DEFAULT_TIMEOUT_MS,
+		description: "Runtime transport setup timeout in milliseconds.",
 	});
 	pi.registerCommand(PI_CODEX_APP_SERVER_COMMAND, {
-		description: "Inspect the Codex app-server adapter skeleton status",
+		description: "Inspect the Codex app-server adapter runtime status",
 		handler: async (_args, ctx) => {
-			notifyIfVisible(ctx, SKELETON_NOTICE);
+			notifyIfVisible(ctx, `${RUNTIME_NOTICE_PREFIX}\nStatus: ${runtime.getStatus().kind}`);
 		},
 	});
-	pi.on("session_start", () => undefined);
-	pi.on("session_shutdown", () => undefined);
+	pi.on("session_start", async (_event, ctx) => {
+		const flags = readRuntimeFlags(pi);
+		const status = await runtime.start(flags);
+		notifyIfVisible(ctx, `${RUNTIME_NOTICE_PREFIX}\nStatus: ${status.kind}`);
+	});
+	pi.on("session_shutdown", async (_event, ctx) => {
+		const status = await runtime.stop();
+		notifyIfVisible(ctx, `${RUNTIME_NOTICE_PREFIX}\nStatus: ${status.kind}`);
+	});
 }
 
-function notifyIfVisible(ctx: ExtensionContext, message: string): void {
+function notifyIfVisible(ctx: RuntimeExtensionContext, message: string): void {
 	if (!ctx.hasUI) return;
 	ctx.ui.notify(message, "info");
+}
+
+function readRuntimeFlags(pi: PiCodexAppServerExtensionApi): PiCodexAppServerRuntimeFlags {
+	return {
+		enabled: pi.getFlag(PI_CODEX_APP_SERVER_FLAG_ENABLED) === true,
+		mode: readTransportMode(pi),
+		appServerCommand: readStringFlag(pi, PI_CODEX_APP_SERVER_FLAG_APP_SERVER_COMMAND, DEFAULT_APP_SERVER_COMMAND),
+		appServerArgs: readArgsFlag(pi, PI_CODEX_APP_SERVER_FLAG_APP_SERVER_ARGS),
+		appServerUrl: readStringFlag(pi, PI_CODEX_APP_SERVER_FLAG_URL, ""),
+		appServerSocketPath: readStringFlag(pi, PI_CODEX_APP_SERVER_FLAG_UNIX_SOCKET, ""),
+		connectTimeoutMs: readPositiveIntegerFlag(pi, PI_CODEX_APP_SERVER_FLAG_TIMEOUT_MS, Number(DEFAULT_TIMEOUT_MS)),
+	};
+}
+
+function readTransportMode(pi: PiCodexAppServerExtensionApi): PiCodexAppServerTransportMode {
+	const mode = pi.getFlag(PI_CODEX_APP_SERVER_FLAG_MODE);
+	if (mode === "websocket" || mode === "unix") return mode;
+	return "stdio";
+}
+
+function readStringFlag(pi: PiCodexAppServerExtensionApi, name: string, fallback: string): string {
+	const value = pi.getFlag(name);
+	return typeof value === "string" ? value : fallback;
+}
+
+function readArgsFlag(pi: PiCodexAppServerExtensionApi, name: string): readonly string[] {
+	return readStringFlag(pi, name, DEFAULT_APP_SERVER_ARGS)
+		.split(" ")
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0);
+}
+
+function readPositiveIntegerFlag(pi: PiCodexAppServerExtensionApi, name: string, fallback: number): number {
+	const value = Number(readStringFlag(pi, name, String(fallback)));
+	if (Number.isInteger(value) && value > 0) return value;
+	return fallback;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter-support.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter-support.mjs
@@ -1,0 +1,90 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export const DEFAULT_TIMEOUT_MS = 5000;
+
+export function parseArgs(argv) {
+	const parsed = {
+		externalStdio: false,
+		externalWebsocket: "",
+		externalUnix: "",
+		appServerCommand: "",
+		appServerArgs: ["app-server"],
+		appServerUrl: "",
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+		cleanupReceipt: "",
+	};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--external-stdio":
+				parsed.externalStdio = true;
+				break;
+			case "--external-websocket":
+				parsed.externalWebsocket = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--external-unix":
+				parsed.externalUnix = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--app-server-command":
+				parsed.appServerCommand = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--app-server-args":
+				parsed.appServerArgs = readValue(argv, index, arg)
+					.split(" ")
+					.map((part) => part.trim())
+					.filter((part) => part.length > 0);
+				index += 1;
+				break;
+			case "--app-server-url":
+				parsed.appServerUrl = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--timeout-ms":
+				parsed.timeoutMs = Number(readValue(argv, index, arg));
+				index += 1;
+				break;
+			case "--cleanup-receipt":
+				parsed.cleanupReceipt = readValue(argv, index, arg);
+				index += 1;
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	if (!Number.isInteger(parsed.timeoutMs) || parsed.timeoutMs <= 0) {
+		throw new Error("--timeout-ms must be a positive integer.");
+	}
+	return parsed;
+}
+
+export function writeCleanupReceipt(path, cleanup) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		[
+			"cleanup-receipt",
+			`childProcesses=${cleanup.childProcesses}`,
+			`websockets=${cleanup.websockets}`,
+			`ownedSockets=${cleanup.ownedSockets}`,
+			`externalSocketPathsReferenced=${cleanup.externalSocketPathsReferenced}`,
+			"tmuxSessions=0",
+			"tempDirs=0",
+			"browserContexts=0",
+			"containers=0",
+			"qaOnlyEnvFiles=0",
+			"",
+		].join("\n"),
+	);
+}
+
+function readValue(argv, index, name) {
+	const value = argv[index + 1];
+	if (!value || value.startsWith("--")) {
+		throw new Error(`${name} requires a value.`);
+	}
+	return value;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs
@@ -1,32 +1,237 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
+import { parseArgs, writeCleanupReceipt } from "./drive-adapter-support.mjs";
+
 const HELP_TEXT = `pi-codex-app-server adapter harness
 
 Usage:
   node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --external-stdio --app-server-command <path> [--app-server-args <args>]
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --external-websocket <url>
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --external-unix <sock> --app-server-command <path>
 
 Options:
   --help                         Show this help text.
-  --external-stdio               Reserved for PR-004 stdio adapter driving.
-  --external-websocket <host>    Reserved for PR-004 websocket adapter driving.
-  --external-unix <path>         Reserved for PR-004 unix-socket adapter driving.
-  --app-server-command <path>    Reserved for the Codex app-server binary path.
-  --app-server-args <args>       Reserved for Codex app-server command arguments.
-  --app-server-url <url>         Reserved for a shared Codex app-server websocket URL.
+  --external-stdio               Smoke child-process stdio runtime setup.
+  --external-websocket <url>     Smoke remote websocket runtime setup.
+  --external-unix <path>         Smoke unix proxy runtime setup for this socket path.
+  --app-server-command <path>    Codex app-server command or test double.
+  --app-server-args <args>       Codex app-server command arguments.
+  --app-server-url <url>         Shared Codex app-server websocket URL.
+  --timeout-ms <ms>              Setup timeout. Default: 5000.
+  --cleanup-receipt <path>       Write teardown evidence for reviewer packets.
 
 Status:
-  PR-002 skeleton only. Runtime transport, protocol routing, streaming,
-  callbacks, reconnect, and redaction are intentionally deferred.
+  PR-004 runtime smoke only. Protocol routing, streaming, callbacks, reconnect,
+  redaction, and final evidence packet generation are intentionally deferred.
 `;
 
-function main(argv) {
+const CHILD_HEALTH_WINDOW_MS = 100;
+
+async function main(argv) {
 	if (argv.length === 0 || argv.includes("--help")) {
 		process.stdout.write(HELP_TEXT);
 		return 0;
 	}
 
-	process.stderr.write("drive-adapter.mjs is a PR-002 harness shell; runtime driving is deferred.\n");
-	return 2;
+	const args = parseArgs(argv);
+	const cleanup = {
+		childProcesses: 0,
+		websockets: 0,
+		ownedSockets: 0,
+		externalSocketPathsReferenced: args.externalUnix ? 1 : 0,
+	};
+	try {
+		if (args.externalStdio) {
+			await smokeChildProcess(args, cleanup, args.appServerArgs);
+			process.stdout.write("PASS stdio runtime smoke\n");
+			return 0;
+		}
+		if (args.externalUnix) {
+			await smokeChildProcess(args, cleanup, ["app-server", "proxy", "--sock", args.externalUnix]);
+			process.stdout.write("PASS unix proxy runtime smoke\n");
+			return 0;
+		}
+		if (args.externalWebsocket || args.appServerUrl) {
+			await smokeWebSocket(args.externalWebsocket || args.appServerUrl, args.timeoutMs, cleanup);
+			process.stdout.write("PASS websocket runtime smoke\n");
+			return 0;
+		}
+		process.stderr.write("No PR-004 runtime smoke mode selected.\n");
+		return 2;
+	} finally {
+		if (args.cleanupReceipt) {
+			writeCleanupReceipt(args.cleanupReceipt, cleanup);
+		}
+	}
 }
 
-process.exitCode = main(process.argv.slice(2));
+async function smokeChildProcess(args, cleanup, commandArgs) {
+	if (!args.appServerCommand) {
+		throw new Error("--app-server-command is required for child-process transport smoke.");
+	}
+	const child = spawn(args.appServerCommand, commandArgs, { stdio: "pipe" });
+	let childStarted = false;
+	let childTracked = false;
+	try {
+		await new Promise((resolve, reject) => {
+			let settled = false;
+			let healthWindow;
+			const timeout = setTimeout(() => {
+				void finish(new Error(`child process health timeout after ${args.timeoutMs}ms`));
+			}, args.timeoutMs);
+			const finish = async (error) => {
+				if (settled) return;
+				settled = true;
+				clear();
+				if (error) {
+					if (childStarted) {
+						await stopChild(child);
+					} else {
+						child.kill("SIGTERM");
+					}
+					if (childTracked) {
+						cleanup.childProcesses -= 1;
+						childTracked = false;
+					}
+					reject(error);
+					return;
+				}
+				resolve();
+			};
+			const onSpawn = () => {
+				childStarted = true;
+				childTracked = true;
+				cleanup.childProcesses += 1;
+				healthWindow = setTimeout(() => {
+					void finish();
+				}, CHILD_HEALTH_WINDOW_MS);
+				healthWindow.unref();
+			};
+			const onError = (error) => {
+				void finish(error);
+			};
+			const onExit = (code, signal) => {
+				if (childTracked) {
+					cleanup.childProcesses -= 1;
+					childTracked = false;
+				}
+				if (code !== null) {
+					void finish(new Error(`child process exited before health window with code ${code}`));
+					return;
+				}
+				void finish(new Error(`child process exited before health window from signal ${signal}`));
+			};
+			const clear = () => {
+				clearTimeout(timeout);
+				clearTimeout(healthWindow);
+				child.off("spawn", onSpawn);
+				child.off("error", onError);
+				child.off("exit", onExit);
+			};
+
+			child.once("spawn", onSpawn);
+			child.once("error", onError);
+			child.once("exit", onExit);
+		});
+	} finally {
+		if (childStarted && child.exitCode === null && child.signalCode === null) {
+			await stopChild(child);
+			if (childTracked) {
+				cleanup.childProcesses -= 1;
+			}
+		}
+	}
+}
+
+function stopChild(child) {
+	return new Promise((resolve) => {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			resolve();
+			return;
+		}
+		const timeout = setTimeout(() => {
+			child.kill("SIGKILL");
+		}, 1000);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolve();
+		});
+		child.kill("SIGTERM");
+	});
+}
+
+function smokeWebSocket(url, timeoutMs, cleanup) {
+	if (!url) {
+		throw new Error("--external-websocket or --app-server-url is required for websocket transport smoke.");
+	}
+	if (!globalThis.WebSocket) {
+		throw new Error("WebSocket is unavailable in this Node runtime.");
+	}
+	return new Promise((resolve, reject) => {
+		const socket = new WebSocket(url);
+		let settled = false;
+		let tracked = true;
+		cleanup.websockets += 1;
+		const timeout = setTimeout(() => {
+			void finish(new Error(`websocket connect timeout after ${timeoutMs}ms`));
+		}, timeoutMs);
+		const clear = () => {
+			clearTimeout(timeout);
+			socket.removeEventListener("open", onOpen);
+			socket.removeEventListener("error", onError);
+			socket.removeEventListener("close", onClose);
+		};
+		const finish = async (error) => {
+			if (settled) return;
+			settled = true;
+			clear();
+			await closeWebSocket(socket, error ? "runtime_smoke_failed" : "runtime_smoke_done");
+			if (tracked) {
+				cleanup.websockets -= 1;
+				tracked = false;
+			}
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		};
+		const onOpen = () => {
+			void finish();
+		};
+		const onError = () => {
+			void finish(new Error("websocket connection failed"));
+		};
+		const onClose = () => {
+			void finish(new Error("websocket closed before opening"));
+		};
+		socket.addEventListener("open", onOpen);
+		socket.addEventListener("error", onError);
+		socket.addEventListener("close", onClose);
+	});
+}
+
+function closeWebSocket(socket, reason) {
+	return new Promise((resolve) => {
+		if (socket.readyState === 3) {
+			resolve();
+			return;
+		}
+		const timeout = setTimeout(resolve, 1000);
+		const onClose = () => {
+			clearTimeout(timeout);
+			resolve();
+		};
+		socket.addEventListener("close", onClose, { once: true });
+		socket.close(1000, reason);
+	});
+}
+
+try {
+	process.exitCode = await main(process.argv.slice(2));
+} catch (error) {
+	process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+	process.exitCode = 1;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/runtime-errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/runtime-errors.ts
@@ -1,0 +1,11 @@
+import type { PiCodexAppServerTransportMode } from "./transport-runtime.ts";
+
+export class PiCodexAppServerRuntimeError extends Error {
+	readonly mode: PiCodexAppServerTransportMode;
+
+	constructor(mode: PiCodexAppServerTransportMode, message: string) {
+		super(message);
+		this.name = "PiCodexAppServerRuntimeError";
+		this.mode = mode;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts
@@ -1,0 +1,260 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { PiCodexAppServerRuntimeError } from "./runtime-errors.ts";
+import { openWebSocketConnection, type PiCodexAppServerWebSocketDependencies } from "./websocket-transport.ts";
+
+export type { PiCodexAppServerWebSocketLike } from "./websocket-transport.ts";
+
+export type PiCodexAppServerTransportMode = "stdio" | "websocket" | "unix";
+
+export interface PiCodexAppServerRuntimeFlags {
+	readonly enabled: boolean;
+	readonly mode: PiCodexAppServerTransportMode;
+	readonly appServerCommand: string;
+	readonly appServerArgs: readonly string[];
+	readonly appServerUrl: string;
+	readonly appServerSocketPath?: string;
+	readonly connectTimeoutMs: number;
+}
+
+export type PiCodexAppServerRuntimeStatus =
+	| { readonly kind: "stopped" }
+	| { readonly kind: "starting"; readonly mode: PiCodexAppServerTransportMode }
+	| { readonly kind: "running"; readonly mode: PiCodexAppServerTransportMode }
+	| { readonly kind: "failed"; readonly mode: PiCodexAppServerTransportMode; readonly message: string };
+
+export interface PiCodexAppServerRuntimeController {
+	start(flags: PiCodexAppServerRuntimeFlags): Promise<PiCodexAppServerRuntimeStatus>;
+	stop(): Promise<PiCodexAppServerRuntimeStatus>;
+	getStatus(): PiCodexAppServerRuntimeStatus;
+}
+
+export type PiCodexAppServerRuntime = PiCodexAppServerRuntimeController;
+
+export type PiCodexAppServerRuntimeDependencies = PiCodexAppServerWebSocketDependencies;
+
+interface RuntimeConnection {
+	readonly mode: PiCodexAppServerTransportMode;
+	close(): Promise<void>;
+	onFailure(handler: (message: string) => void): void;
+}
+
+interface ChildProcessConnectionOptions {
+	readonly mode: PiCodexAppServerTransportMode;
+	readonly command: string;
+	readonly args: readonly string[];
+	readonly connectTimeoutMs: number;
+}
+
+export function createPiCodexAppServerRuntime(
+	dependencies: PiCodexAppServerRuntimeDependencies = {},
+): PiCodexAppServerRuntime {
+	return new DefaultPiCodexAppServerRuntime(dependencies);
+}
+
+class DefaultPiCodexAppServerRuntime implements PiCodexAppServerRuntime {
+	private status: PiCodexAppServerRuntimeStatus = { kind: "stopped" };
+	private connection: RuntimeConnection | undefined;
+	private readonly dependencies: PiCodexAppServerRuntimeDependencies;
+
+	constructor(dependencies: PiCodexAppServerRuntimeDependencies) {
+		this.dependencies = dependencies;
+	}
+
+	async start(flags: PiCodexAppServerRuntimeFlags): Promise<PiCodexAppServerRuntimeStatus> {
+		await this.stop();
+		if (!flags.enabled) {
+			this.status = { kind: "stopped" };
+			return this.status;
+		}
+
+		this.status = { kind: "starting", mode: flags.mode };
+		try {
+			const connection = await openConnection(flags, this.dependencies);
+			connection.onFailure((message) => {
+				if (this.connection !== connection) return;
+				this.connection = undefined;
+				this.status = { kind: "failed", mode: connection.mode, message };
+			});
+			this.connection = connection;
+			this.status = { kind: "running", mode: flags.mode };
+			return this.status;
+		} catch (error) {
+			this.connection = undefined;
+			this.status = { kind: "failed", mode: flags.mode, message: formatError(error) };
+			return this.status;
+		}
+	}
+
+	async stop(): Promise<PiCodexAppServerRuntimeStatus> {
+		const activeConnection = this.connection;
+		this.connection = undefined;
+		if (activeConnection) {
+			await activeConnection.close();
+		}
+		this.status = { kind: "stopped" };
+		return this.status;
+	}
+
+	getStatus(): PiCodexAppServerRuntimeStatus {
+		return this.status;
+	}
+}
+
+async function openConnection(
+	flags: PiCodexAppServerRuntimeFlags,
+	dependencies: PiCodexAppServerRuntimeDependencies,
+): Promise<RuntimeConnection> {
+	switch (flags.mode) {
+		case "stdio":
+			return openChildProcessConnection({
+				mode: flags.mode,
+				command: flags.appServerCommand,
+				args: flags.appServerArgs,
+				connectTimeoutMs: flags.connectTimeoutMs,
+			});
+		case "unix":
+			return openChildProcessConnection({
+				mode: flags.mode,
+				command: flags.appServerCommand,
+				args: resolveUnixProxyArgs(flags),
+				connectTimeoutMs: flags.connectTimeoutMs,
+			});
+		case "websocket": {
+			const webSocketConnection = await openWebSocketConnection(
+				flags.appServerUrl,
+				flags.connectTimeoutMs,
+				dependencies,
+			);
+			return {
+				mode: "websocket",
+				close: webSocketConnection.close,
+				onFailure: webSocketConnection.onUnexpectedClose,
+			};
+		}
+	}
+}
+
+function resolveUnixProxyArgs(flags: PiCodexAppServerRuntimeFlags): readonly string[] {
+	if (flags.appServerArgs.length > 0 && flags.appServerArgs.join(" ") !== "app-server") {
+		return flags.appServerArgs;
+	}
+	const socketPath = flags.appServerSocketPath;
+	if (!socketPath) {
+		throw new PiCodexAppServerRuntimeError("unix", "Unix transport requires an app-server socket path.");
+	}
+	return ["app-server", "proxy", "--sock", socketPath];
+}
+
+async function openChildProcessConnection(options: ChildProcessConnectionOptions): Promise<RuntimeConnection> {
+	if (options.command.trim().length === 0) {
+		throw new PiCodexAppServerRuntimeError(options.mode, "App-server command is required.");
+	}
+	const child = spawn(options.command, [...options.args], { stdio: "pipe" });
+	const connection = new ChildProcessRuntimeConnection(child, options.mode);
+	await waitForChildSpawn(child, options.mode, options.connectTimeoutMs);
+	return connection;
+}
+
+class ChildProcessRuntimeConnection implements RuntimeConnection {
+	readonly mode: PiCodexAppServerTransportMode;
+	private readonly child: ChildProcessWithoutNullStreams;
+	private failureHandler: ((message: string) => void) | undefined;
+	private failureMessage: string | undefined;
+	private closing = false;
+
+	constructor(child: ChildProcessWithoutNullStreams, mode: PiCodexAppServerTransportMode) {
+		this.child = child;
+		this.mode = mode;
+		child.once("exit", (code, signal) => {
+			if (this.closing) return;
+			this.recordFailure(formatChildExit(mode, code, signal));
+		});
+		child.once("error", (error) => {
+			if (this.closing) return;
+			this.recordFailure(error.message);
+		});
+	}
+
+	async close(): Promise<void> {
+		this.closing = true;
+		await stopChild(this.child);
+	}
+
+	onFailure(handler: (message: string) => void): void {
+		this.failureHandler = handler;
+		if (this.failureMessage) {
+			const message = this.failureMessage;
+			queueMicrotask(() => handler(message));
+		}
+	}
+
+	private recordFailure(message: string): void {
+		this.failureMessage = message;
+		this.failureHandler?.(message);
+	}
+}
+
+function waitForChildSpawn(
+	child: ChildProcessWithoutNullStreams,
+	mode: PiCodexAppServerTransportMode,
+	connectTimeoutMs: number,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			cleanup();
+			child.kill("SIGTERM");
+			reject(
+				new PiCodexAppServerRuntimeError(mode, `App-server process did not spawn within ${connectTimeoutMs}ms.`),
+			);
+		}, connectTimeoutMs);
+
+		const cleanup = () => {
+			clearTimeout(timeout);
+			child.off("spawn", onSpawn);
+			child.off("error", onError);
+		};
+		const onSpawn = () => {
+			cleanup();
+			resolve();
+		};
+		const onError = (error: Error) => {
+			cleanup();
+			reject(error);
+		};
+
+		child.once("spawn", onSpawn);
+		child.once("error", onError);
+	});
+}
+
+function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+	return new Promise((resolve) => {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			resolve();
+			return;
+		}
+		const timeout = setTimeout(() => {
+			child.kill("SIGKILL");
+		}, 1000);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolve();
+		});
+		child.kill("SIGTERM");
+	});
+}
+
+function formatError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	return String(error);
+}
+
+function formatChildExit(
+	mode: PiCodexAppServerTransportMode,
+	code: number | null,
+	signal: NodeJS.Signals | null,
+): string {
+	if (code !== null) return `${mode} app-server process exited unexpectedly with code ${code}.`;
+	if (signal !== null) return `${mode} app-server process exited unexpectedly from signal ${signal}.`;
+	return `${mode} app-server process exited unexpectedly.`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts
@@ -127,8 +127,8 @@ async function openConnection(
 			);
 			return {
 				mode: "websocket",
-				close: webSocketConnection.close,
-				onFailure: webSocketConnection.onUnexpectedClose,
+				close: () => webSocketConnection.close(),
+				onFailure: (handler) => webSocketConnection.onUnexpectedClose(handler),
 			};
 		}
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/websocket-transport.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/websocket-transport.ts
@@ -1,0 +1,100 @@
+import { PiCodexAppServerRuntimeError } from "./runtime-errors.ts";
+
+type WebSocketEventType = "open" | "error" | "close";
+type WebSocketListener = () => void;
+
+export interface PiCodexAppServerWebSocketLike {
+	readonly readyState: number;
+	addEventListener(type: WebSocketEventType, listener: WebSocketListener, options?: { readonly once?: boolean }): void;
+	removeEventListener(type: WebSocketEventType, listener: WebSocketListener): void;
+	close(code?: number, reason?: string): void;
+}
+
+export interface PiCodexAppServerWebSocketDependencies {
+	createWebSocket?(url: string): PiCodexAppServerWebSocketLike;
+}
+
+export interface PiCodexAppServerWebSocketConnection {
+	close(): Promise<void>;
+	onUnexpectedClose(handler: (message: string) => void): void;
+}
+
+export function openWebSocketConnection(
+	url: string,
+	connectTimeoutMs: number,
+	dependencies: PiCodexAppServerWebSocketDependencies,
+): Promise<PiCodexAppServerWebSocketConnection> {
+	if (url.trim().length === 0) {
+		throw new PiCodexAppServerRuntimeError("websocket", "Websocket URL is required.");
+	}
+
+	return new Promise((resolve, reject) => {
+		const socket = createRuntimeWebSocket(url, dependencies);
+		const timeout = setTimeout(() => {
+			cleanup();
+			socket.close(1000, "connect_timeout");
+			reject(
+				new PiCodexAppServerRuntimeError("websocket", `WebSocket connect timeout after ${connectTimeoutMs}ms.`),
+			);
+		}, connectTimeoutMs);
+		const cleanup = () => {
+			clearTimeout(timeout);
+			socket.removeEventListener("open", onOpen);
+			socket.removeEventListener("error", onError);
+			socket.removeEventListener("close", onClose);
+		};
+		const onOpen = () => {
+			cleanup();
+			resolve({
+				close: () => closeWebSocket(socket),
+				onUnexpectedClose: (handler) => {
+					socket.addEventListener("close", () => handler("WebSocket closed unexpectedly."));
+					socket.addEventListener("error", () => handler("WebSocket failed after opening."));
+				},
+			});
+		};
+		const onError = () => {
+			cleanup();
+			reject(new PiCodexAppServerRuntimeError("websocket", "WebSocket connection failed."));
+		};
+		const onClose = () => {
+			cleanup();
+			reject(new PiCodexAppServerRuntimeError("websocket", "WebSocket closed before opening."));
+		};
+
+		socket.addEventListener("open", onOpen);
+		socket.addEventListener("error", onError);
+		socket.addEventListener("close", onClose);
+	});
+}
+
+function createRuntimeWebSocket(
+	url: string,
+	dependencies: PiCodexAppServerWebSocketDependencies,
+): PiCodexAppServerWebSocketLike {
+	if (dependencies.createWebSocket) return dependencies.createWebSocket(url);
+	const WebSocketConstructor = globalThis.WebSocket;
+	if (!WebSocketConstructor) {
+		throw new PiCodexAppServerRuntimeError("websocket", "WebSocket transport is unavailable in this runtime.");
+	}
+	return new WebSocketConstructor(url);
+}
+
+function closeWebSocket(socket: PiCodexAppServerWebSocketLike): Promise<void> {
+	return new Promise((resolve) => {
+		if (socket.readyState === 3) {
+			resolve();
+			return;
+		}
+		const timeout = setTimeout(resolve, 1000);
+		socket.addEventListener(
+			"close",
+			() => {
+				clearTimeout(timeout);
+				resolve();
+			},
+			{ once: true },
+		);
+		socket.close(1000, "runtime_shutdown");
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/websocket-transport.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/websocket-transport.ts
@@ -45,13 +45,7 @@ export function openWebSocketConnection(
 		};
 		const onOpen = () => {
 			cleanup();
-			resolve({
-				close: () => closeWebSocket(socket),
-				onUnexpectedClose: (handler) => {
-					socket.addEventListener("close", () => handler("WebSocket closed unexpectedly."));
-					socket.addEventListener("error", () => handler("WebSocket failed after opening."));
-				},
-			});
+			resolve(new RuntimeWebSocketConnection(socket));
 		};
 		const onError = () => {
 			cleanup();
@@ -66,6 +60,43 @@ export function openWebSocketConnection(
 		socket.addEventListener("error", onError);
 		socket.addEventListener("close", onClose);
 	});
+}
+
+class RuntimeWebSocketConnection implements PiCodexAppServerWebSocketConnection {
+	private readonly socket: PiCodexAppServerWebSocketLike;
+	private failureHandler: ((message: string) => void) | undefined;
+	private failureMessage: string | undefined;
+	private closing = false;
+
+	constructor(socket: PiCodexAppServerWebSocketLike) {
+		this.socket = socket;
+		socket.addEventListener("close", () => {
+			if (this.closing) return;
+			this.recordFailure("WebSocket closed unexpectedly.");
+		});
+		socket.addEventListener("error", () => {
+			if (this.closing) return;
+			this.recordFailure("WebSocket failed after opening.");
+		});
+	}
+
+	async close(): Promise<void> {
+		this.closing = true;
+		await closeWebSocket(this.socket);
+	}
+
+	onUnexpectedClose(handler: (message: string) => void): void {
+		this.failureHandler = handler;
+		if (this.failureMessage) {
+			const message = this.failureMessage;
+			queueMicrotask(() => handler(message));
+		}
+	}
+
+	private recordFailure(message: string): void {
+		this.failureMessage = message;
+		this.failureHandler?.(message);
+	}
 }
 
 function createRuntimeWebSocket(

--- a/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
@@ -68,12 +68,16 @@ describe("pi-codex-app-server contract lock", () => {
 		expect(EXTERNAL_PROTOCOL_METHODS.every((method) => method.errorBehavior.length > 0)).toBe(true);
 	});
 
-	it("classifies required app-server surfaces without runtime routing code", () => {
-		const runtimeFileNames = [
-			"transport-runtime.ts",
+	it("classifies required app-server surfaces without routing projection or bridge code", () => {
+		const downstreamFileNames = [
 			"request-router.ts",
 			"notification-projector.ts",
 			"server-request-bridge.ts",
+			"session-registry.ts",
+			"id-mapper.ts",
+			"reconnect-resume.ts",
+			"redaction-scanner.ts",
+			"evidence-packet-writer.ts",
 		];
 
 		const inventoryMethods = APP_SERVER_SURFACE_INVENTORY.map((entry) => entry.method);
@@ -83,7 +87,7 @@ describe("pi-codex-app-server contract lock", () => {
 		expect(inventoryMethods).toEqual(expect.arrayContaining([...PLAN_REQUIRED_APP_SERVER_SURFACES]));
 		expect(missingSurfaces).toEqual([]);
 		expect(classifications.map((classification) => classification?.relayClass)).not.toContain(undefined);
-		for (const fileName of runtimeFileNames) {
+		for (const fileName of downstreamFileNames) {
 			expect(existsSync(join(extensionRoot, fileName))).toBe(false);
 		}
 	});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts
@@ -1,18 +1,25 @@
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import {
 	PI_CODEX_APP_SERVER_COMMAND,
+	PI_CODEX_APP_SERVER_FLAG_APP_SERVER_ARGS,
+	PI_CODEX_APP_SERVER_FLAG_APP_SERVER_COMMAND,
 	PI_CODEX_APP_SERVER_FLAG_ENABLED,
 	PI_CODEX_APP_SERVER_FLAG_MODE,
+	PI_CODEX_APP_SERVER_FLAG_TIMEOUT_MS,
+	PI_CODEX_APP_SERVER_FLAG_UNIX_SOCKET,
+	PI_CODEX_APP_SERVER_FLAG_URL,
 	type PiCodexAppServerExtensionApi,
 	registerPiCodexAppServerExtension,
 } from "../../src/core/extensions/builtin/pi-codex-app-server/extension.ts";
 import piCodexAppServerExtension from "../../src/core/extensions/builtin/pi-codex-app-server/index.ts";
 import type {
+	PiCodexAppServerRuntimeController,
+	PiCodexAppServerRuntimeFlags,
+} from "../../src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts";
+import type {
 	ExtensionAPI,
-	ExtensionHandler,
+	ExtensionContext,
 	RegisteredCommand,
 	SessionShutdownEvent,
 	SessionStartEvent,
@@ -20,18 +27,25 @@ import type {
 
 type CommandRegistration = Omit<RegisteredCommand, "name" | "sourceInfo">;
 type FlagRegistration = Parameters<ExtensionAPI["registerFlag"]>[1];
-type LifecycleHandler = ExtensionHandler<SessionStartEvent> | ExtensionHandler<SessionShutdownEvent>;
+interface RuntimeExtensionContext {
+	readonly hasUI: boolean;
+	readonly ui: Pick<ExtensionContext["ui"], "notify">;
+}
+type RuntimeLifecycleHandler<E> = (event: E, ctx: RuntimeExtensionContext) => Promise<void> | void;
+type LifecycleHandler = RuntimeLifecycleHandler<SessionStartEvent> | RuntimeLifecycleHandler<SessionShutdownEvent>;
 
 interface PiCodexAppServerHarness {
 	readonly commands: Map<string, CommandRegistration>;
 	readonly flags: Map<string, FlagRegistration>;
 	readonly handlers: Map<string, readonly LifecycleHandler[]>;
+	setFlag(name: string, value: boolean | string): void;
 }
 
 class HarnessApi implements PiCodexAppServerExtensionApi {
 	readonly commands = new Map<string, CommandRegistration>();
 	readonly flags = new Map<string, FlagRegistration>();
 	readonly handlers = new Map<string, LifecycleHandler[]>();
+	readonly flagValues = new Map<string, boolean | string>();
 
 	registerCommand(name: string, options: CommandRegistration): void {
 		this.commands.set(name, options);
@@ -39,10 +53,18 @@ class HarnessApi implements PiCodexAppServerExtensionApi {
 
 	registerFlag(name: string, options: FlagRegistration): void {
 		this.flags.set(name, options);
+		if (options.default !== undefined) {
+			this.flagValues.set(name, options.default);
+		}
 	}
 
-	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
-	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
+	getFlag(name: string): boolean | string | undefined {
+		if (!this.flags.has(name)) return undefined;
+		return this.flagValues.get(name);
+	}
+
+	on(event: "session_start", handler: RuntimeLifecycleHandler<SessionStartEvent>): void;
+	on(event: "session_shutdown", handler: RuntimeLifecycleHandler<SessionShutdownEvent>): void;
 	on(event: "session_start" | "session_shutdown", handler: LifecycleHandler): void {
 		const registered = this.handlers.get(event) ?? [];
 		registered.push(handler);
@@ -53,7 +75,23 @@ class HarnessApi implements PiCodexAppServerExtensionApi {
 function createHarness(): PiCodexAppServerHarness {
 	const pi = new HarnessApi();
 	registerPiCodexAppServerExtension(pi);
-	return { commands: pi.commands, flags: pi.flags, handlers: pi.handlers };
+	return {
+		commands: pi.commands,
+		flags: pi.flags,
+		handlers: pi.handlers,
+		setFlag(name: string, value: boolean | string) {
+			pi.flagValues.set(name, value);
+		},
+	};
+}
+
+function createContext(): RuntimeExtensionContext {
+	return {
+		ui: {
+			notify: () => undefined,
+		},
+		hasUI: true,
+	};
 }
 
 describe("pi-codex-app-server extension skeleton", () => {
@@ -70,31 +108,55 @@ describe("pi-codex-app-server extension skeleton", () => {
 		expect(commands.get(PI_CODEX_APP_SERVER_COMMAND)?.description).toContain("Codex app-server");
 		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_ENABLED)).toMatchObject({ type: "boolean", default: false });
 		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_MODE)).toMatchObject({ type: "string", default: "stdio" });
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_APP_SERVER_COMMAND)).toMatchObject({
+			type: "string",
+			default: "codex",
+		});
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_APP_SERVER_ARGS)).toMatchObject({
+			type: "string",
+			default: "app-server",
+		});
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_URL)).toMatchObject({ type: "string", default: "" });
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_UNIX_SOCKET)).toMatchObject({ type: "string", default: "" });
+		expect(flags.get(PI_CODEX_APP_SERVER_FLAG_TIMEOUT_MS)).toMatchObject({ type: "string", default: "5000" });
 		expect(handlers.get("session_start")).toHaveLength(1);
 		expect(handlers.get("session_shutdown")).toHaveLength(1);
 	});
 
-	it("ships a harness shell that exposes help without starting runtime transport", () => {
-		const harnessPath = join(
-			process.cwd(),
-			"src",
-			"core",
-			"extensions",
-			"builtin",
-			"pi-codex-app-server",
-			"qa",
-			"drive-adapter.mjs",
-		);
+	it("starts runtime only when enabled and stops it on session shutdown", async () => {
+		const started: PiCodexAppServerRuntimeFlags[] = [];
+		let stopCount = 0;
+		const runtime: PiCodexAppServerRuntimeController = {
+			getStatus: () => ({ kind: "stopped" }),
+			start: async (flags) => {
+				started.push(flags);
+				return { kind: "running", mode: flags.mode };
+			},
+			stop: async () => {
+				stopCount += 1;
+				return { kind: "stopped" };
+			},
+		};
+		const pi = new HarnessApi();
+		registerPiCodexAppServerExtension(pi, () => runtime);
+		pi.flagValues.set(PI_CODEX_APP_SERVER_FLAG_ENABLED, true);
 
-		const result = spawnSync(process.execPath, [harnessPath, "--help"], {
-			cwd: process.cwd(),
-			encoding: "utf-8",
-		});
+		const startHandler = pi.handlers.get("session_start")?.[0] as RuntimeLifecycleHandler<SessionStartEvent>;
+		const shutdownHandler = pi.handlers.get("session_shutdown")?.[0] as RuntimeLifecycleHandler<SessionShutdownEvent>;
+		await startHandler({ type: "session_start", reason: "startup" }, createContext());
+		await shutdownHandler({ type: "session_shutdown", reason: "quit" }, createContext());
 
-		expect(result.status).toBe(0);
-		expect(result.stdout).toContain("pi-codex-app-server adapter harness");
-		expect(result.stdout).toContain("--external-stdio");
-		expect(result.stdout).toContain("--app-server-url");
-		expect(result.stderr).toBe("");
+		expect(started).toEqual([
+			{
+				enabled: true,
+				mode: "stdio",
+				appServerCommand: "codex",
+				appServerArgs: ["app-server"],
+				appServerUrl: "",
+				appServerSocketPath: "",
+				connectTimeoutMs: 5000,
+			},
+		]);
+		expect(stopCount).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function harnessPath(): string {
+	return join(process.cwd(), "src", "core", "extensions", "builtin", "pi-codex-app-server", "qa", "drive-adapter.mjs");
+}
+
+describe("pi-codex-app-server runtime harness", () => {
+	it("exposes help without starting runtime transport", () => {
+		const result = spawnSync(process.execPath, [harnessPath(), "--help"], {
+			cwd: process.cwd(),
+			encoding: "utf-8",
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("pi-codex-app-server adapter harness");
+		expect(result.stdout).toContain("--external-stdio");
+		expect(result.stdout).toContain("--app-server-url");
+		expect(result.stdout).toContain("PR-004 runtime smoke only");
+		expect(result.stderr).toBe("");
+	});
+
+	it("fails runtime smoke on immediate nonzero child exit and writes a clean receipt", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-harness-test-"));
+		try {
+			const failingScript = join(tempRoot, "fail-now.mjs");
+			const cleanupReceipt = join(tempRoot, "cleanup-receipt.txt");
+			writeFileSync(failingScript, "process.exit(42);\n");
+
+			const result = spawnSync(
+				process.execPath,
+				[
+					harnessPath(),
+					"--external-stdio",
+					"--app-server-command",
+					process.execPath,
+					"--app-server-args",
+					failingScript,
+					"--timeout-ms",
+					"1000",
+					"--cleanup-receipt",
+					cleanupReceipt,
+				],
+				{ cwd: process.cwd(), encoding: "utf-8" },
+			);
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain("exited before health window with code 42");
+			expect(readFileSync(cleanupReceipt, "utf-8")).toContain("childProcesses=0");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("fails runtime smoke on immediate zero child exit and writes a clean receipt", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-harness-test-"));
+		try {
+			const exitingScript = join(tempRoot, "exit-now.mjs");
+			const cleanupReceipt = join(tempRoot, "cleanup-receipt.txt");
+			writeFileSync(exitingScript, "process.exit(0);\n");
+
+			const result = spawnSync(
+				process.execPath,
+				[
+					harnessPath(),
+					"--external-stdio",
+					"--app-server-command",
+					process.execPath,
+					"--app-server-args",
+					exitingScript,
+					"--timeout-ms",
+					"1000",
+					"--cleanup-receipt",
+					cleanupReceipt,
+				],
+				{ cwd: process.cwd(), encoding: "utf-8" },
+			);
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain("exited before health window with code 0");
+			expect(readFileSync(cleanupReceipt, "utf-8")).toContain("childProcesses=0");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("fails runtime smoke when child spawn fails and writes a clean receipt", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-harness-test-"));
+		try {
+			const cleanupReceipt = join(tempRoot, "cleanup-receipt.txt");
+
+			const result = spawnSync(
+				process.execPath,
+				[
+					harnessPath(),
+					"--external-stdio",
+					"--app-server-command",
+					join(tempRoot, "missing-app-server"),
+					"--timeout-ms",
+					"1000",
+					"--cleanup-receipt",
+					cleanupReceipt,
+				],
+				{ cwd: process.cwd(), encoding: "utf-8" },
+			);
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain("ENOENT");
+			expect(readFileSync(cleanupReceipt, "utf-8")).toContain("childProcesses=0");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-runtime-fakes.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-runtime-fakes.ts
@@ -1,0 +1,56 @@
+import type { PiCodexAppServerWebSocketLike } from "../../src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts";
+
+export class FakeWebSocket implements PiCodexAppServerWebSocketLike {
+	readonly url: string;
+	readyState = 0;
+	private readonly listeners = new Map<string, Set<() => void>>();
+
+	constructor(url: string, options: { readonly open: boolean; readonly closeAfterOpen?: boolean } = { open: true }) {
+		this.url = url;
+		if (options.open) {
+			queueMicrotask(() => {
+				this.readyState = 1;
+				this.emit("open");
+				if (options.closeAfterOpen) {
+					this.closeUnexpectedly();
+				}
+			});
+		}
+	}
+
+	addEventListener(
+		type: "open" | "error" | "close",
+		listener: () => void,
+		options?: { readonly once?: boolean },
+	): void {
+		const wrapped = options?.once
+			? () => {
+					this.removeEventListener(type, wrapped);
+					listener();
+				}
+			: listener;
+		const listeners = this.listeners.get(type) ?? new Set<() => void>();
+		listeners.add(wrapped);
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: "open" | "error" | "close", listener: () => void): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	close(): void {
+		this.readyState = 3;
+		this.emit("close");
+	}
+
+	closeUnexpectedly(): void {
+		this.readyState = 3;
+		this.emit("close");
+	}
+
+	private emit(type: "open" | "error" | "close"): void {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener();
+		}
+	}
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts
@@ -69,6 +69,16 @@ async function waitForFile(path: string): Promise<void> {
 	}
 }
 
+async function waitForRuntimeFailure(runtime: PiCodexAppServerRuntime): Promise<void> {
+	const deadline = Date.now() + 1000;
+	while (runtime.getStatus().kind !== "failed") {
+		if (Date.now() > deadline) {
+			throw new Error(`Timed out waiting for failed runtime status; last status: ${runtime.getStatus().kind}`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 describe("pi-codex-app-server runtime transport", () => {
 	it("starts a child-process stdio app-server and stops it cleanly", async () => {
 		const runtime = createPiCodexAppServerRuntime();
@@ -101,7 +111,7 @@ describe("pi-codex-app-server runtime transport", () => {
 			appServerUrl: "",
 			connectTimeoutMs: 1000,
 		});
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await waitForRuntimeFailure(runtime);
 
 		expect(started).toMatchObject({ kind: "running", mode: "stdio" });
 		expect(runtime.getStatus()).toMatchObject({

--- a/packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts
@@ -1,0 +1,267 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createPiCodexAppServerRuntime,
+	type PiCodexAppServerRuntime,
+	type PiCodexAppServerWebSocketLike,
+} from "../../src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	for (const tempRoot of tempRoots.splice(0)) {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+function createTempRoot(): string {
+	const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-runtime-test-"));
+	tempRoots.push(tempRoot);
+	return tempRoot;
+}
+
+function createLongRunningScript(): string {
+	const tempRoot = createTempRoot();
+	const scriptPath = join(tempRoot, "fake-app-server.mjs");
+	writeFileSync(
+		scriptPath,
+		[
+			"process.stdout.write('ready\\n');",
+			"process.on('SIGTERM', () => process.exit(0));",
+			"setInterval(() => undefined, 1000);",
+		].join("\n"),
+	);
+	return scriptPath;
+}
+
+function createArgumentRecorderScript(outputPath: string): string {
+	const tempRoot = createTempRoot();
+	const scriptPath = join(tempRoot, "record-args.sh");
+	writeFileSync(
+		scriptPath,
+		[
+			"#!/bin/sh",
+			`printf '%s\\n' "$@" > ${JSON.stringify(outputPath)}`,
+			"trap 'exit 0' TERM",
+			"while true; do sleep 1; done",
+		].join("\n"),
+	);
+	chmodSync(scriptPath, 0o755);
+	return scriptPath;
+}
+
+function createExitingScript(exitCode: number): string {
+	const tempRoot = createTempRoot();
+	const scriptPath = join(tempRoot, "exit-now.mjs");
+	writeFileSync(scriptPath, `process.exit(${exitCode});\n`);
+	return scriptPath;
+}
+
+class FakeWebSocket implements PiCodexAppServerWebSocketLike {
+	readonly url: string;
+	readyState = 0;
+	private readonly listeners = new Map<string, Set<() => void>>();
+
+	constructor(url: string, options: { readonly open: boolean } = { open: true }) {
+		this.url = url;
+		if (options.open) {
+			queueMicrotask(() => {
+				this.readyState = 1;
+				this.emit("open");
+			});
+		}
+	}
+
+	addEventListener(
+		type: "open" | "error" | "close",
+		listener: () => void,
+		options?: { readonly once?: boolean },
+	): void {
+		const wrapped = options?.once
+			? () => {
+					this.removeEventListener(type, wrapped);
+					listener();
+				}
+			: listener;
+		const listeners = this.listeners.get(type) ?? new Set<() => void>();
+		listeners.add(wrapped);
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: "open" | "error" | "close", listener: () => void): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	close(): void {
+		this.readyState = 3;
+		this.emit("close");
+	}
+
+	closeUnexpectedly(): void {
+		this.readyState = 3;
+		this.emit("close");
+	}
+
+	private emit(type: "open" | "error" | "close"): void {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener();
+		}
+	}
+}
+
+async function waitForFile(path: string): Promise<void> {
+	const deadline = Date.now() + 1000;
+	while (!existsSync(path)) {
+		if (Date.now() > deadline) {
+			throw new Error(`Timed out waiting for ${path}`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+describe("pi-codex-app-server runtime transport", () => {
+	it("starts a child-process stdio app-server and stops it cleanly", async () => {
+		const runtime = createPiCodexAppServerRuntime();
+		const scriptPath = createLongRunningScript();
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "stdio",
+			appServerCommand: process.execPath,
+			appServerArgs: [scriptPath],
+			appServerUrl: "",
+			connectTimeoutMs: 1000,
+		});
+		const stopped = await runtime.stop();
+
+		expect(started).toMatchObject({ kind: "running", mode: "stdio" });
+		expect(stopped).toEqual({ kind: "stopped" });
+		expect(runtime.getStatus()).toEqual({ kind: "stopped" });
+	});
+
+	it.each([42, 0])("marks runtime failed when a stdio child exits with code %s before shutdown", async (exitCode) => {
+		const runtime = createPiCodexAppServerRuntime();
+		const scriptPath = createExitingScript(exitCode);
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "stdio",
+			appServerCommand: process.execPath,
+			appServerArgs: [scriptPath],
+			appServerUrl: "",
+			connectTimeoutMs: 1000,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(started).toMatchObject({ kind: "running", mode: "stdio" });
+		expect(runtime.getStatus()).toMatchObject({
+			kind: "failed",
+			mode: "stdio",
+			message: `stdio app-server process exited unexpectedly with code ${exitCode}.`,
+		});
+	});
+
+	it("opens and closes a websocket app-server transport for health setup", async () => {
+		const openedUrls: string[] = [];
+		const runtime: PiCodexAppServerRuntime = createPiCodexAppServerRuntime({
+			createWebSocket: (url) => {
+				openedUrls.push(url);
+				return new FakeWebSocket(url);
+			},
+		});
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "websocket",
+			appServerCommand: "",
+			appServerArgs: [],
+			appServerUrl: "ws://127.0.0.1:7654",
+			connectTimeoutMs: 1000,
+		});
+		const stopped = await runtime.stop();
+
+		expect(started).toMatchObject({ kind: "running", mode: "websocket" });
+		expect(stopped).toEqual({ kind: "stopped" });
+		expect(openedUrls).toEqual(["ws://127.0.0.1:7654"]);
+	});
+
+	it("marks runtime failed when websocket closes unexpectedly after setup", async () => {
+		let socket: FakeWebSocket | undefined;
+		const runtime = createPiCodexAppServerRuntime({
+			createWebSocket: (url) => {
+				socket = new FakeWebSocket(url);
+				return socket;
+			},
+		});
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "websocket",
+			appServerCommand: "",
+			appServerArgs: [],
+			appServerUrl: "ws://127.0.0.1:7654",
+			connectTimeoutMs: 1000,
+		});
+		socket?.closeUnexpectedly();
+
+		expect(started).toMatchObject({ kind: "running", mode: "websocket" });
+		expect(runtime.getStatus()).toMatchObject({
+			kind: "failed",
+			mode: "websocket",
+			message: "WebSocket closed unexpectedly.",
+		});
+	});
+
+	it("records failed status when websocket setup times out", async () => {
+		const runtime = createPiCodexAppServerRuntime({
+			createWebSocket: (url) => new FakeWebSocket(url, { open: false }),
+		});
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "websocket",
+			appServerCommand: "",
+			appServerArgs: [],
+			appServerUrl: "ws://127.0.0.1:7654",
+			connectTimeoutMs: 10,
+		});
+
+		expect(started).toMatchObject({
+			kind: "failed",
+			mode: "websocket",
+			message: "WebSocket connect timeout after 10ms.",
+		});
+		expect(runtime.getStatus()).toEqual(started);
+	});
+
+	it("uses codex app-server proxy arguments for unix socket transport", async () => {
+		const runtime = createPiCodexAppServerRuntime();
+		const tempRoot = createTempRoot();
+		const outputPath = join(tempRoot, "argv.json");
+		const socketPath = join(tempRoot, "codex.sock");
+		const scriptPath = createArgumentRecorderScript(outputPath);
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "unix",
+			appServerCommand: scriptPath,
+			appServerArgs: [],
+			appServerUrl: "",
+			appServerSocketPath: socketPath,
+			connectTimeoutMs: 1000,
+		});
+		await waitForFile(outputPath);
+		const stopped = await runtime.stop();
+
+		expect(started).toMatchObject({ kind: "running", mode: "unix" });
+		expect(stopped).toEqual({ kind: "stopped" });
+		expect(readFileSync(outputPath, "utf-8").trim().split("\n")).toEqual([
+			"app-server",
+			"proxy",
+			"--sock",
+			socketPath,
+		]);
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts
@@ -5,8 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	createPiCodexAppServerRuntime,
 	type PiCodexAppServerRuntime,
-	type PiCodexAppServerWebSocketLike,
 } from "../../src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts";
+import { FakeWebSocket } from "./pi-codex-app-server-runtime-fakes.ts";
 
 const tempRoots: string[] = [];
 
@@ -57,58 +57,6 @@ function createExitingScript(exitCode: number): string {
 	const scriptPath = join(tempRoot, "exit-now.mjs");
 	writeFileSync(scriptPath, `process.exit(${exitCode});\n`);
 	return scriptPath;
-}
-
-class FakeWebSocket implements PiCodexAppServerWebSocketLike {
-	readonly url: string;
-	readyState = 0;
-	private readonly listeners = new Map<string, Set<() => void>>();
-
-	constructor(url: string, options: { readonly open: boolean } = { open: true }) {
-		this.url = url;
-		if (options.open) {
-			queueMicrotask(() => {
-				this.readyState = 1;
-				this.emit("open");
-			});
-		}
-	}
-
-	addEventListener(
-		type: "open" | "error" | "close",
-		listener: () => void,
-		options?: { readonly once?: boolean },
-	): void {
-		const wrapped = options?.once
-			? () => {
-					this.removeEventListener(type, wrapped);
-					listener();
-				}
-			: listener;
-		const listeners = this.listeners.get(type) ?? new Set<() => void>();
-		listeners.add(wrapped);
-		this.listeners.set(type, listeners);
-	}
-
-	removeEventListener(type: "open" | "error" | "close", listener: () => void): void {
-		this.listeners.get(type)?.delete(listener);
-	}
-
-	close(): void {
-		this.readyState = 3;
-		this.emit("close");
-	}
-
-	closeUnexpectedly(): void {
-		this.readyState = 3;
-		this.emit("close");
-	}
-
-	private emit(type: "open" | "error" | "close"): void {
-		for (const listener of this.listeners.get(type) ?? []) {
-			listener();
-		}
-	}
 }
 
 async function waitForFile(path: string): Promise<void> {
@@ -205,6 +153,31 @@ describe("pi-codex-app-server runtime transport", () => {
 			connectTimeoutMs: 1000,
 		});
 		socket?.closeUnexpectedly();
+
+		expect(started).toMatchObject({ kind: "running", mode: "websocket" });
+		expect(runtime.getStatus()).toMatchObject({
+			kind: "failed",
+			mode: "websocket",
+			message: "WebSocket closed unexpectedly.",
+		});
+	});
+
+	it("marks runtime failed when websocket closes before status handler registration", async () => {
+		const runtime = createPiCodexAppServerRuntime({
+			createWebSocket: (url) => new FakeWebSocket(url, { open: true, closeAfterOpen: true }),
+		});
+
+		const started = await runtime.start({
+			enabled: true,
+			mode: "websocket",
+			appServerCommand: "",
+			appServerArgs: [],
+			appServerUrl: "ws://127.0.0.1:7654",
+			connectTimeoutMs: 1000,
+		});
+		await new Promise<void>((resolve) => {
+			queueMicrotask(resolve);
+		});
 
 		expect(started).toMatchObject({ kind: "running", mode: "websocket" });
 		expect(runtime.getStatus()).toMatchObject({


### PR DESCRIPTION
## Summary

This work is using code-yeongyu/lazycodex teammode.

Adds PR-004 runtime transport/lifecycle integration for `pi-codex-app-server` after PR-003 protocol/capability merge. The extension now starts/stops a scoped runtime from session lifecycle flags and exposes transport status without adding routing/session maps, streaming projection, callbacks, reconnect durability, redaction QA, or final evidence-packet behavior.

Before: the built-in app-server extension registered only the skeleton command/flags and the QA harness was a placeholder.
After: lifecycle can start child-process stdio, remote websocket, or unix proxy-compatible runtime setup, observe setup failures and post-open transport liveness failures, and drive focused PR-004 harness smokes with cleanup receipts.

## Changes

- Add runtime transport controller for stdio, websocket, and unix proxy-compatible setup.
- Wire app-server runtime flags through extension session start/shutdown.
- Track health/status transitions for setup timeout/failure, unexpected child-process exit, and unexpected websocket close/error after open.
- Add typed runtime error and websocket transport boundaries without importing protocol/session routing concerns.
- Expand `qa/drive-adapter.mjs` into a PR-004 harness with stdio, websocket, unix proxy-compatible, negative child-exit, timeout, and cleanup-receipt behavior.
- Add focused extension, harness, and runtime tests, including no parameter properties and cleanup-accounting regressions.

## Changed Files

- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/extension.ts`
- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter-support.mjs`
- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs`
- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/runtime-errors.ts`
- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/transport-runtime.ts`
- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/websocket-transport.ts`
- `packages/coding-agent/test/suite/pi-codex-app-server-extension.test.ts`
- `packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts`
- `packages/coding-agent/test/suite/pi-codex-app-server-runtime.test.ts`

## QA / Evidence

Evidence root: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-004-runtime/`

- Failing-first proof: initial targeted PR-004 run failed before runtime files/lifecycle integration existed; later review blockers were reproduced by tests for early child exit, code-0 early child exit, no-spawn cleanup, websocket timeout, and post-open liveness status.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-extension.test.ts test/suite/pi-codex-app-server-runtime.test.ts test/suite/pi-codex-app-server-harness.test.ts` -> 3 files, 14 tests passed. Artifact: `targeted-tests.txt`.
- `npm run check` -> passed with no fixes applied on final run. Artifact: `npm-run-check.txt`.
- Harness help smoke -> passed. Artifact: `harness-help.txt`.
- Harness stdio smoke -> `PASS stdio runtime smoke`. Artifact: `stdio-smoke.txt`; receipt: `receipts/stdio-cleanup-receipt.txt`.
- Harness unix proxy-compatible smoke -> `PASS unix proxy runtime smoke`. Artifact: `unix-smoke.txt`; receipt: `receipts/unix-cleanup-receipt.txt`.
- Harness websocket smoke -> `PASS websocket runtime smoke`. Artifact: `websocket-smoke.txt`; receipt: `receipts/websocket-cleanup-receipt.txt`.
- Harness negative child-exit path -> expected failure: `child process exited before health window with code 42`. Artifact: `negative-child-exit.txt`; receipt: `receipts/negative-cleanup-receipt.txt`.
- senpi QA CLI smoke: `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` -> 5/5 passed, real auth unchanged. Artifact: `senpi-qa-cli-smoke.txt`.
- senpi QA mock loop: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` -> 5/5 passed, real auth unchanged, only localhost fake base URLs used. Artifact: `senpi-qa-mock-loop.txt`.

## Cleanup Receipts

Aggregate receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-004-runtime/cleanup-receipt.txt`.

All owned leak counts are zero across stdio, websocket, negative, and unix proxy-compatible smokes: `childProcesses=0`, `websockets=0`, `ownedSockets=0`, `tmuxSessions=0`, `tempDirs=0`, `browserContexts=0`, `containers=0`, `qaOnlyEnvFiles=0`.

The unix proxy-compatible receipt records `externalSocketPathsReferenced=1`; this is not an owned socket/resource leak because the harness references but does not create the socket path.

## Secret Safety

No raw tokens, auth headers, cookies, launchd environments, service logs, or real provider credentials are included. senpi QA artifacts explicitly report that `/Users/yeongyu/.senpi/agent/auth.json` was unchanged. Mock loop evidence used localhost fake model endpoints only.

## GitHub Project Status

`gh project list --owner code-yeongyu --format json --limit 20` failed because the local token lacks `read:project`.

Recorded status: `BLOCKED:missing-gh-project-scope`.

## Risks / Downstream Status

- PR-004 intentionally stops at runtime transport/lifecycle/harness. Routing/session maps, streaming projection, callbacks, reconnect durability, redaction QA, and final compatibility evidence remain downstream lanes.
- Runtime liveness is transport-boundary status only. It observes child process exit and websocket close/error after open and transitions out of `running`; it does not reconnect or resume.
- Websocket transport uses the runtime-provided/global `WebSocket`; environments without `globalThis.WebSocket` surface a failed runtime status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime transport to `pi-codex-app-server` with stdio, websocket, and unix proxy modes that start/stop with the session and show clear status. Also tightens input guards, adds a status command/notifications, and stabilizes liveness tests.

- **New Features**
  - Runtime controller with `starting/running/failed/stopped` status and setup timeout; guarded flags (positive timeout, required URL/command/socket by mode) and safe mode parsing (default `stdio`).
  - Lifecycle wiring with UI notifications; `pi-codex-app-server` command reports current status; start on session start, stop on shutdown.
  - Liveness tracking for early child exit and websocket close/error after open; WebSocket uses `globalThis.WebSocket` or injected dep; QA harness `qa/drive-adapter.mjs` drives stdio/websocket/unix smokes, supports timeout, and writes cleanup receipts; tests stabilized.

- **Migration**
  - Enable via `pi-codex-app-server=true`; select mode with `pi-codex-app-server-mode` (`stdio` default).
  - Configure transport:
    - `stdio/unix`: `pi-codex-app-server-command` (default `codex`), `pi-codex-app-server-args` (default `app-server`), `pi-codex-app-server-unix-socket` for unix; if args are default for unix, auto-inject `app-server proxy --sock <path>`.
    - `websocket`: `pi-codex-app-server-url`.
  - Optional: `pi-codex-app-server-timeout-ms` (positive integer, default `5000`).

<sup>Written for commit d78c3e8be81e48953639c5d8628393f37e58e55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

