### PR TITLE
feat(coding-agent): add app-server routing state

### DIFF
--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-005-routing/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-005-routing/summary.md
@@ -12,6 +12,7 @@ Implemented scope:
 - Duplicate binding guards for external session ids and app-server thread ids.
 - Request, turn, item, and server-request correlation maps.
 - External request router for initialize, initialized, session/thread operations, and turn start/steer/interrupt.
+- `session/read` now requires a live external session binding and injects the authoritative app-server `thread_id` before calling `thread/read`.
 - PR-005 fixtures for initialize field names, session lifecycle/tombstones, duplicate binding policy, and turn id routing.
 
 Out of scope:
@@ -31,11 +32,17 @@ Raw logs are under `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-005
 - Focused PR-001 through PR-005 suite after split: `targeted-suite-after-split.txt`.
 - Focused suite after type fix: `targeted-suite-after-type-fix.txt`.
 - Focused suite after duplicate session preflight: `targeted-suite-after-preflight.txt`.
+- Blocking review follow-up focused suite: `targeted-suite-session-read-fix-rerun.txt`.
 - Full check: `npm-run-check-after-preflight.txt`.
+- Blocking review follow-up full check: `npm-run-check-session-read-fix-rerun.txt`.
 - senpi QA common self-check: `senpi-qa-common-self-check.txt`.
+- Blocking review follow-up common self-check: `senpi-qa-common-self-check-session-read-fix.txt`.
 - senpi QA CLI smoke: `senpi-qa-cli-smoke.txt`.
+- Blocking review follow-up CLI smoke: `senpi-qa-cli-smoke-session-read-fix.txt`.
 - senpi QA mock loop: `senpi-qa-mock-loop.txt`.
+- Blocking review follow-up mock loop: `senpi-qa-mock-loop-session-read-fix.txt`.
 - Adapter harness help: `drive-adapter-help.txt`.
+- Blocking review follow-up adapter harness help: `drive-adapter-help-session-read-fix.txt`.
 - Cleanup receipt: `cleanup-receipt.txt`.
 - Secret-safety receipt: `secret-safety.txt`.
 - GitHub Project tracking: `project-tracking.txt`.
@@ -51,3 +58,12 @@ Raw logs are under `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-005
 - PR-005 routes against a pure app-server request-client seam; live JSON-RPC transport wiring remains downstream of PR-004 runtime integration.
 - App-thread collisions are rejected after app-server response unless a future route exposes a reliable incoming app-server `thread_id` preflight.
 - PR-010 still owns resume tokens, snapshot reload, replay cursors, pending callback replay/rejection, tombstones durability, and duplicate terminal protection.
+
+## Blocking Review Follow-up
+
+Comment: https://github.com/code-yeongyu/senpi/pull/77#issuecomment-4787074725
+
+- Split `session/read` away from `session/list`.
+- Routed `session/read` through `requireSession(params)`.
+- Injected the bound app-server `thread_id` into `thread/read` via `withThreadId(appParamsFrom(params), active.binding)`.
+- Added focused regressions in `pi-codex-app-server-session-read-routing.test.ts` for successful `thread_id` injection and unknown/tombstoned session rejection before app-server calls.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-005-routing/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-005-routing/summary.md
@@ -1,0 +1,53 @@
+# PR-005 routing-state evidence summary
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Summary
+
+PR-005 adds pure routing/session-state support for `pi-codex-app-server` after PR-004 runtime transport.
+
+Implemented scope:
+
+- Session registry for external session id to authoritative app-server thread/session id bindings.
+- Duplicate binding guards for external session ids and app-server thread ids.
+- Request, turn, item, and server-request correlation maps.
+- External request router for initialize, initialized, session/thread operations, and turn start/steer/interrupt.
+- PR-005 fixtures for initialize field names, session lifecycle/tombstones, duplicate binding policy, and turn id routing.
+
+Out of scope:
+
+- Streaming projection.
+- Server callback execution.
+- Reconnect durability.
+- Redaction QA.
+- Final compatibility evidence packet.
+
+## Evidence
+
+Raw logs are under `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-005-routing/`.
+
+- Failing-first proof: `failing-first.txt`.
+- Targeted routing initial green: `targeted-routing-initial.txt`.
+- Focused PR-001 through PR-005 suite after split: `targeted-suite-after-split.txt`.
+- Focused suite after type fix: `targeted-suite-after-type-fix.txt`.
+- Focused suite after duplicate session preflight: `targeted-suite-after-preflight.txt`.
+- Full check: `npm-run-check-after-preflight.txt`.
+- senpi QA common self-check: `senpi-qa-common-self-check.txt`.
+- senpi QA CLI smoke: `senpi-qa-cli-smoke.txt`.
+- senpi QA mock loop: `senpi-qa-mock-loop.txt`.
+- Adapter harness help: `drive-adapter-help.txt`.
+- Cleanup receipt: `cleanup-receipt.txt`.
+- Secret-safety receipt: `secret-safety.txt`.
+- GitHub Project tracking: `project-tracking.txt`.
+
+## Project Tracking
+
+`BLOCKED:missing-gh-project-scope`
+
+`gh project list --owner code-yeongyu --format json --limit 20` failed because the current token lacks `read:project`. This is recorded but does not block PR creation.
+
+## Residual Risks
+
+- PR-005 routes against a pure app-server request-client seam; live JSON-RPC transport wiring remains downstream of PR-004 runtime integration.
+- App-thread collisions are rejected after app-server response unless a future route exposes a reliable incoming app-server `thread_id` preflight.
+- PR-010 still owns resume tokens, snapshot reload, replay cursors, pending callback replay/rejection, tombstones durability, and duplicate terminal protection.

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/compatibility-fixtures/external_to_app/initialize.json
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/compatibility-fixtures/external_to_app/initialize.json
@@ -3,5 +3,12 @@
   "externalMethod": "initialize",
   "requiredCapabilities": ["opaqueNotifications", "opaqueCallbacks"],
   "appServerMethods": ["initialize", "initialized"],
-  "idPolicy": "external request ids are correlation only"
+  "idPolicy": "external request ids are correlation only",
+  "appServerCapabilityFields": [
+    "experimentalApi",
+    "requestAttestation",
+    "mcpServerOpenaiFormElicitation",
+    "optOutNotificationMethods"
+  ],
+  "notificationOptOutPolicy": "route only the negotiated intersection of external notificationOptOuts and app-server optOutNotificationMethods"
 }

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/compatibility-fixtures/external_to_app/thread_start_resume_fork.json
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/compatibility-fixtures/external_to_app/thread_start_resume_fork.json
@@ -1,6 +1,34 @@
 {
   "description": "Session lifecycle maps to thread lifecycle while preserving app-server thread and session ids.",
-  "externalMethods": ["session/new", "session/resume", "session/fork"],
-  "appServerMethods": ["thread/start", "thread/resume", "thread/fork"],
-  "authoritativeIds": ["appThreadId", "appSessionId"]
+  "externalMethods": [
+    "session/new",
+    "session/resume",
+    "session/fork",
+    "session/list",
+    "session/read",
+    "session/archive",
+    "session/delete",
+    "session/unsubscribe"
+  ],
+  "appServerMethods": [
+    "thread/start",
+    "thread/resume",
+    "thread/fork",
+    "thread/list",
+    "thread/read",
+    "thread/archive",
+    "thread/delete",
+    "thread/unsubscribe"
+  ],
+  "authoritativeIds": ["appThreadId", "appSessionId"],
+  "duplicateBindingPolicy": {
+    "externalSessionId": "reject without replacing the existing binding",
+    "appThreadId": "reject when already bound to a different external session",
+    "adapterCode": "duplicate-routing-id"
+  },
+  "closePolicy": {
+    "session/archive": "tombstone after app-server success",
+    "session/delete": "tombstone after app-server success",
+    "session/unsubscribe": "unsubscribe without tombstoning"
+  }
 }

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/compatibility-fixtures/external_to_app/turn_start_steer_interrupt.json
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/compatibility-fixtures/external_to_app/turn_start_steer_interrupt.json
@@ -3,5 +3,11 @@
   "externalMethods": ["turn/start", "turn/steer", "turn/interrupt"],
   "appServerMethods": ["turn/start", "turn/steer", "turn/interrupt"],
   "authoritativeIds": ["appThreadId", "appTurnId"],
-  "correlationOnly": ["externalMessageId"]
+  "correlationOnly": ["externalMessageId", "externalTurnId"],
+  "routingPolicy": {
+    "turn/start": "inject bound app-server thread_id and pass externalMessageId as client_user_message_id",
+    "turn/steer": "inject bound app-server thread_id and preserve appTurnId as expected_turn_id",
+    "turn/interrupt": "inject bound app-server thread_id and preserve appTurnId as turn_id"
+  },
+  "tombstonePolicy": "reject turn routing for tombstoned external sessions with invalid-session-state"
 }

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/error-mapper.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/error-mapper.ts
@@ -2,8 +2,11 @@ export const ADAPTER_ERROR_SOURCE = "pi-codex-app-server";
 export const ADAPTER_JSON_RPC_ERROR_CODE = -32080;
 
 export type AdapterErrorCode =
+	| "duplicate-routing-id"
 	| "incompatible-capabilities"
+	| "invalid-session-state"
 	| "malformed-message"
+	| "unsupported-routing-method"
 	| "unsupported-protocol-version"
 	| "unsupported-notification-opt-out";
 

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts
@@ -1,0 +1,137 @@
+import { type AdapterJsonRpcError, createAdapterJsonRpcError } from "./error-mapper.ts";
+
+export interface RoutedRequest {
+	readonly externalRequestId: string;
+	readonly appMethod: string;
+	readonly startedAtMs: number;
+}
+
+export interface RoutedTurn {
+	readonly appTurnId: string;
+	readonly appThreadId: string;
+	readonly externalTurnId?: string;
+	readonly externalMessageId?: string;
+}
+
+export interface RoutedItem {
+	readonly appItemId: string;
+	readonly appTurnId: string;
+	readonly appThreadId: string;
+	readonly externalItemId?: string;
+	readonly itemKind: string;
+}
+
+export interface RoutedServerRequest {
+	readonly appRequestId: string;
+	readonly externalCallbackId: string;
+	readonly appThreadId?: string;
+	readonly appTurnId?: string;
+	readonly appItemId?: string;
+	readonly method: string;
+}
+
+export interface RegistrationResult {
+	readonly kind: "registered" | "resolved";
+}
+
+export type IdMapperResult = RegistrationResult | { readonly kind: "rejected"; readonly error: AdapterJsonRpcError };
+
+export interface IdMapper {
+	registerRequest(input: RoutedRequest): IdMapperResult;
+	resolveRequest(externalRequestId: string): IdMapperResult;
+	getRequest(externalRequestId: string): RoutedRequest | undefined;
+	registerTurn(input: RoutedTurn): IdMapperResult;
+	getTurn(appTurnId: string): RoutedTurn | undefined;
+	registerItem(input: RoutedItem): IdMapperResult;
+	getItem(appItemId: string): RoutedItem | undefined;
+	registerServerRequest(input: RoutedServerRequest): IdMapperResult;
+	resolveServerRequest(appRequestId: string): IdMapperResult;
+	getServerRequest(appRequestId: string): RoutedServerRequest | undefined;
+}
+
+export function createIdMapper(nowMs: () => number = Date.now): IdMapper {
+	return new InMemoryIdMapper(nowMs);
+}
+
+class InMemoryIdMapper implements IdMapper {
+	private readonly requests = new Map<string, RoutedRequest>();
+	private readonly turns = new Map<string, RoutedTurn>();
+	private readonly items = new Map<string, RoutedItem>();
+	private readonly serverRequests = new Map<string, RoutedServerRequest>();
+	private readonly nowMs: () => number;
+
+	constructor(nowMs: () => number) {
+		this.nowMs = nowMs;
+	}
+
+	registerRequest(input: RoutedRequest): IdMapperResult {
+		if (this.requests.has(input.externalRequestId)) {
+			return rejectDuplicate(`Duplicate external request id: ${input.externalRequestId}`);
+		}
+		this.requests.set(input.externalRequestId, {
+			...input,
+			startedAtMs: input.startedAtMs || this.nowMs(),
+		});
+		return { kind: "registered" };
+	}
+
+	resolveRequest(externalRequestId: string): IdMapperResult {
+		this.requests.delete(externalRequestId);
+		return { kind: "resolved" };
+	}
+
+	getRequest(externalRequestId: string): RoutedRequest | undefined {
+		return this.requests.get(externalRequestId);
+	}
+
+	registerTurn(input: RoutedTurn): IdMapperResult {
+		if (this.turns.has(input.appTurnId)) {
+			return rejectDuplicate(`Duplicate app-server turn id: ${input.appTurnId}`);
+		}
+		this.turns.set(input.appTurnId, input);
+		return { kind: "registered" };
+	}
+
+	getTurn(appTurnId: string): RoutedTurn | undefined {
+		return this.turns.get(appTurnId);
+	}
+
+	registerItem(input: RoutedItem): IdMapperResult {
+		if (this.items.has(input.appItemId)) {
+			return rejectDuplicate(`Duplicate app-server item id: ${input.appItemId}`);
+		}
+		this.items.set(input.appItemId, input);
+		return { kind: "registered" };
+	}
+
+	getItem(appItemId: string): RoutedItem | undefined {
+		return this.items.get(appItemId);
+	}
+
+	registerServerRequest(input: RoutedServerRequest): IdMapperResult {
+		if (this.serverRequests.has(input.appRequestId)) {
+			return rejectDuplicate(`Duplicate app-server request id: ${input.appRequestId}`);
+		}
+		this.serverRequests.set(input.appRequestId, input);
+		return { kind: "registered" };
+	}
+
+	resolveServerRequest(appRequestId: string): IdMapperResult {
+		this.serverRequests.delete(appRequestId);
+		return { kind: "resolved" };
+	}
+
+	getServerRequest(appRequestId: string): RoutedServerRequest | undefined {
+		return this.serverRequests.get(appRequestId);
+	}
+}
+
+function rejectDuplicate(message: string): IdMapperResult {
+	return {
+		kind: "rejected",
+		error: createAdapterJsonRpcError({
+			adapterCode: "duplicate-routing-id",
+			message,
+		}),
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router-params.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router-params.ts
@@ -1,0 +1,122 @@
+import { type AdapterJsonRpcError, createAdapterJsonRpcError } from "./error-mapper.ts";
+import type { ExternalProtocolMethodName } from "./protocol-core.ts";
+import type { SessionBinding } from "./session-registry.ts";
+
+export interface RoutingParams {
+	readonly externalSessionId?: string;
+	readonly externalTurnId?: string;
+	readonly appTurnId?: string;
+	readonly appParams?: unknown;
+}
+
+export interface ThreadBinding {
+	readonly appThreadId: string;
+	readonly appSessionId: string;
+}
+
+export interface RouterAdapterErrorResult {
+	readonly kind: "adapter-error";
+	readonly error: AdapterJsonRpcError;
+}
+
+export function parseRoutingParams(params: unknown): RoutingParams {
+	if (!isRecord(params)) return {};
+	return {
+		externalSessionId: readString(params, "externalSessionId"),
+		externalTurnId: readString(params, "externalTurnId"),
+		appTurnId: readString(params, "appTurnId"),
+		appParams: params.appParams,
+	};
+}
+
+export function appParamsFrom(params: unknown): unknown {
+	const routingParams = parseRoutingParams(params);
+	return routingParams.appParams ?? {};
+}
+
+export function withThreadId(params: unknown, binding: SessionBinding): Record<string, unknown> {
+	return withField(params, "thread_id", binding.appThreadId);
+}
+
+export function withOptionalField(params: unknown, key: string, value: string | undefined): Record<string, unknown> {
+	if (!value) return copyRecord(params);
+	return withField(params, key, value);
+}
+
+export function withField(params: unknown, key: string, value: string): Record<string, unknown> {
+	const copied = copyRecord(params);
+	copied[key] = value;
+	return copied;
+}
+
+export function parseThreadBinding(
+	response: unknown,
+):
+	| { readonly kind: "binding"; readonly binding: ThreadBinding }
+	| { readonly kind: "adapter-error"; readonly error: AdapterJsonRpcError } {
+	const thread = isRecord(response) && isRecord(response.thread) ? response.thread : response;
+	if (!isRecord(thread)) return invalidSession("App-server thread response must be an object.");
+	const appThreadId = readString(thread, "id");
+	const appSessionId = readString(thread, "session_id");
+	if (!appThreadId || !appSessionId) {
+		return invalidSession("App-server thread response must include id and session_id.");
+	}
+	return { kind: "binding", binding: { appThreadId, appSessionId } };
+}
+
+export function readTurnId(response: unknown): string | undefined {
+	if (!isRecord(response)) return undefined;
+	if (isRecord(response.turn)) return readString(response.turn, "id");
+	return readString(response, "turn_id") ?? readString(response, "id");
+}
+
+export function mapExternalMethod(method: ExternalProtocolMethodName): string {
+	const mapped = METHOD_MAP[method];
+	return mapped ?? method;
+}
+
+export function invalidSession(message: string): RouterAdapterErrorResult {
+	return {
+		kind: "adapter-error",
+		error: createAdapterJsonRpcError({ adapterCode: "invalid-session-state", message }),
+	};
+}
+
+export function unsupported(method: string): RouterAdapterErrorResult {
+	return {
+		kind: "adapter-error",
+		error: createAdapterJsonRpcError({
+			adapterCode: "unsupported-routing-method",
+			message: `Unsupported PR-005 routing method: ${method}`,
+		}),
+	};
+}
+
+const METHOD_MAP: Partial<Record<ExternalProtocolMethodName, string>> = {
+	"session/new": "thread/start",
+	"session/resume": "thread/resume",
+	"session/fork": "thread/fork",
+	"session/list": "thread/list",
+	"session/read": "thread/read",
+	"session/archive": "thread/archive",
+	"session/delete": "thread/delete",
+	"session/unsubscribe": "thread/unsubscribe",
+};
+
+function copyRecord(params: unknown): Record<string, unknown> {
+	const copied: Record<string, unknown> = {};
+	if (!isRecord(params)) return copied;
+	for (const [key, value] of Object.entries(params)) {
+		copied[key] = value;
+	}
+	return copied;
+}
+
+function readString(input: Readonly<Record<string, unknown>>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router.ts
@@ -104,8 +104,9 @@ class DefaultRequestRouter implements RequestRouter {
 			case "session/fork":
 				return this.routeThreadBinding(input.method, input.params);
 			case "session/list":
-			case "session/read":
 				return this.callAppServer(mapExternalMethod(input.method), appParamsFrom(input.params));
+			case "session/read":
+				return this.routeThreadRead(input.params);
 			case "session/archive":
 			case "session/delete":
 			case "session/unsubscribe":
@@ -168,6 +169,12 @@ class DefaultRequestRouter implements RequestRouter {
 		});
 		if (bindResult.kind === "rejected") return { kind: "adapter-error", error: bindResult.error };
 		return { kind: "app-server-response", appServerResponse: response };
+	}
+
+	private async routeThreadRead(params: unknown): Promise<RouteExternalRequestResult> {
+		const active = this.requireSession(params);
+		if (active.kind === "adapter-error") return active;
+		return this.callAppServer("thread/read", withThreadId(appParamsFrom(params), active.binding));
 	}
 
 	private async routeThreadClose(

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router.ts
@@ -1,0 +1,260 @@
+import {
+	type AppServerInitializeCapabilities,
+	type ExternalInitializeCapabilities,
+	negotiatePiCodexAppServerCapabilities,
+	parseExternalInitializeCapabilities,
+} from "./capability-negotiator.ts";
+import { type AdapterJsonRpcError, createAdapterJsonRpcError } from "./error-mapper.ts";
+import type { IdMapper } from "./id-mapper.ts";
+import type { ExternalProtocolMethodName } from "./protocol-core.ts";
+import {
+	appParamsFrom,
+	invalidSession,
+	mapExternalMethod,
+	parseRoutingParams,
+	parseThreadBinding,
+	readTurnId,
+	unsupported,
+	withField,
+	withOptionalField,
+	withThreadId,
+} from "./request-router-params.ts";
+import type { SessionBinding, SessionRegistry } from "./session-registry.ts";
+
+export interface AppServerRequestClient {
+	request(method: string, params: unknown): Promise<unknown>;
+}
+
+export interface RouteExternalRequestInput {
+	readonly method: ExternalProtocolMethodName;
+	readonly params: unknown;
+	readonly externalRequestId?: string;
+	readonly externalMessageId?: string;
+}
+
+export type RouteExternalRequestResult =
+	| { readonly kind: "app-server-response"; readonly appServerResponse: unknown }
+	| { readonly kind: "adapter-error"; readonly error: AdapterJsonRpcError };
+type ActiveSessionResult =
+	| { readonly kind: "active"; readonly binding: SessionBinding }
+	| { readonly kind: "adapter-error"; readonly error: AdapterJsonRpcError };
+
+export interface RequestRouter {
+	route(input: RouteExternalRequestInput): Promise<RouteExternalRequestResult>;
+}
+
+export interface RequestRouterOptions {
+	readonly client: AppServerRequestClient;
+	readonly idMapper: IdMapper;
+	readonly sessionRegistry: SessionRegistry;
+	readonly appServerCapabilities?: AppServerInitializeCapabilities;
+}
+
+export function createRequestRouter(options: RequestRouterOptions): RequestRouter {
+	return new DefaultRequestRouter(options);
+}
+
+class DefaultRequestRouter implements RequestRouter {
+	private readonly client: AppServerRequestClient;
+	private readonly idMapper: IdMapper;
+	private readonly sessionRegistry: SessionRegistry;
+	private readonly appServerCapabilities: AppServerInitializeCapabilities | undefined;
+
+	constructor(options: RequestRouterOptions) {
+		this.client = options.client;
+		this.idMapper = options.idMapper;
+		this.sessionRegistry = options.sessionRegistry;
+		this.appServerCapabilities = options.appServerCapabilities;
+	}
+
+	async route(input: RouteExternalRequestInput): Promise<RouteExternalRequestResult> {
+		const requestRegistration = this.registerRequest(input);
+		if (requestRegistration) return requestRegistration;
+
+		try {
+			return await this.routeRegistered(input);
+		} finally {
+			if (input.externalRequestId) {
+				this.idMapper.resolveRequest(input.externalRequestId);
+			}
+		}
+	}
+
+	private registerRequest(input: RouteExternalRequestInput): RouteExternalRequestResult | undefined {
+		if (!input.externalRequestId) return undefined;
+		const result = this.idMapper.registerRequest({
+			externalRequestId: input.externalRequestId,
+			appMethod: mapExternalMethod(input.method),
+			startedAtMs: Date.now(),
+		});
+		if (result.kind === "rejected") {
+			return { kind: "adapter-error", error: result.error };
+		}
+		return undefined;
+	}
+
+	private async routeRegistered(input: RouteExternalRequestInput): Promise<RouteExternalRequestResult> {
+		switch (input.method) {
+			case "initialize":
+				return this.routeInitialize(input.params);
+			case "initialized":
+				return this.callAppServer("initialized", {});
+			case "session/new":
+			case "session/resume":
+			case "session/fork":
+				return this.routeThreadBinding(input.method, input.params);
+			case "session/list":
+			case "session/read":
+				return this.callAppServer(mapExternalMethod(input.method), appParamsFrom(input.params));
+			case "session/archive":
+			case "session/delete":
+			case "session/unsubscribe":
+				return this.routeThreadClose(input.method, input.params);
+			case "turn/start":
+				return this.routeTurnStart(input.params, input.externalMessageId);
+			case "turn/steer":
+				return this.routeTurnSteer(input.params);
+			case "turn/interrupt":
+				return this.routeTurnInterrupt(input.params);
+			default:
+				return unsupported(input.method);
+		}
+	}
+
+	private async routeInitialize(params: unknown): Promise<RouteExternalRequestResult> {
+		const parsed = parseInitialize(params);
+		if (parsed.kind === "adapter-error") return parsed;
+		const negotiated = negotiatePiCodexAppServerCapabilities({
+			external: parsed.external,
+			appServer: this.appServerCapabilities,
+		});
+		if (negotiated.kind === "rejected") {
+			return { kind: "adapter-error", error: negotiated.error };
+		}
+		return this.callAppServer("initialize", {
+			capabilities: {
+				experimentalApi: this.appServerCapabilities?.experimentalApi,
+				requestAttestation: this.appServerCapabilities?.requestAttestation,
+				mcpServerOpenaiFormElicitation: this.appServerCapabilities?.mcpServerOpenaiFormElicitation,
+				optOutNotificationMethods: negotiated.notificationOptOuts,
+			},
+		});
+	}
+
+	private async routeThreadBinding(
+		method: ExternalProtocolMethodName,
+		params: unknown,
+	): Promise<RouteExternalRequestResult> {
+		const routingParams = parseRoutingParams(params);
+		if (!routingParams.externalSessionId) {
+			return invalidSession("Session routing requires externalSessionId.");
+		}
+		if (this.sessionRegistry.getByExternalSessionId(routingParams.externalSessionId)) {
+			return {
+				kind: "adapter-error",
+				error: createAdapterJsonRpcError({
+					adapterCode: "duplicate-routing-id",
+					message: `Duplicate external session id: ${routingParams.externalSessionId}`,
+				}),
+			};
+		}
+		const response = await this.client.request(mapExternalMethod(method), appParamsFrom(params));
+		const binding = parseThreadBinding(response);
+		if (binding.kind === "adapter-error") return binding;
+		const bindResult = this.sessionRegistry.bindSession({
+			externalSessionId: routingParams.externalSessionId,
+			appThreadId: binding.binding.appThreadId,
+			appSessionId: binding.binding.appSessionId,
+		});
+		if (bindResult.kind === "rejected") return { kind: "adapter-error", error: bindResult.error };
+		return { kind: "app-server-response", appServerResponse: response };
+	}
+
+	private async routeThreadClose(
+		method: ExternalProtocolMethodName,
+		params: unknown,
+	): Promise<RouteExternalRequestResult> {
+		const active = this.requireSession(params);
+		if (active.kind === "adapter-error") return active;
+		const response = await this.client.request(
+			mapExternalMethod(method),
+			withThreadId(appParamsFrom(params), active.binding),
+		);
+		if (method === "session/archive" || method === "session/delete") {
+			this.sessionRegistry.tombstoneExternalSession(active.binding.externalSessionId);
+		}
+		return { kind: "app-server-response", appServerResponse: response };
+	}
+
+	private async routeTurnStart(
+		params: unknown,
+		externalMessageId: string | undefined,
+	): Promise<RouteExternalRequestResult> {
+		const active = this.requireSession(params);
+		if (active.kind === "adapter-error") return active;
+		const response = await this.client.request(
+			"turn/start",
+			withOptionalField(
+				withThreadId(appParamsFrom(params), active.binding),
+				"client_user_message_id",
+				externalMessageId,
+			),
+		);
+		const appTurnId = readTurnId(response);
+		if (appTurnId) {
+			this.idMapper.registerTurn({
+				appTurnId,
+				appThreadId: active.binding.appThreadId,
+				externalMessageId,
+				externalTurnId: parseRoutingParams(params).externalTurnId,
+			});
+		}
+		return { kind: "app-server-response", appServerResponse: response };
+	}
+
+	private async routeTurnSteer(params: unknown): Promise<RouteExternalRequestResult> {
+		const active = this.requireSession(params);
+		if (active.kind === "adapter-error") return active;
+		const appTurnId = parseRoutingParams(params).appTurnId;
+		if (!appTurnId) return invalidSession("turn/steer requires appTurnId.");
+		return this.callAppServer(
+			"turn/steer",
+			withField(withThreadId(appParamsFrom(params), active.binding), "expected_turn_id", appTurnId),
+		);
+	}
+
+	private async routeTurnInterrupt(params: unknown): Promise<RouteExternalRequestResult> {
+		const active = this.requireSession(params);
+		if (active.kind === "adapter-error") return active;
+		const appTurnId = parseRoutingParams(params).appTurnId;
+		if (!appTurnId) return invalidSession("turn/interrupt requires appTurnId.");
+		return this.callAppServer("turn/interrupt", withField(withThreadId({}, active.binding), "turn_id", appTurnId));
+	}
+
+	private requireSession(params: unknown): ActiveSessionResult {
+		const externalSessionId = parseRoutingParams(params).externalSessionId;
+		if (!externalSessionId) return invalidSession("Routing requires externalSessionId.");
+		const lookup = this.sessionRegistry.requireActiveSession(externalSessionId);
+		if (lookup.kind === "rejected") return { kind: "adapter-error", error: lookup.error };
+		return lookup;
+	}
+
+	private async callAppServer(method: string, params: unknown): Promise<RouteExternalRequestResult> {
+		return { kind: "app-server-response", appServerResponse: await this.client.request(method, params) };
+	}
+}
+
+function parseInitialize(
+	params: unknown,
+):
+	| { readonly kind: "parsed"; readonly external: ExternalInitializeCapabilities }
+	| { readonly kind: "adapter-error"; readonly error: AdapterJsonRpcError } {
+	try {
+		return { kind: "parsed", external: parseExternalInitializeCapabilities(params) };
+	} catch (error) {
+		if (error instanceof Error) {
+			return invalidSession(error.message);
+		}
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/session-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/session-registry.ts
@@ -1,0 +1,130 @@
+import { type AdapterJsonRpcError, createAdapterJsonRpcError } from "./error-mapper.ts";
+
+export interface SessionBindingInput {
+	readonly externalSessionId: string;
+	readonly appThreadId: string;
+	readonly appSessionId: string;
+}
+
+export interface ReplayCursor {
+	readonly lastCompletedTurnId?: string;
+	readonly lastProjectedItemId?: string;
+	readonly lastLosslessSequence?: number;
+}
+
+export interface SessionBinding {
+	readonly externalSessionId: string;
+	readonly appThreadId: string;
+	readonly appSessionId: string;
+	readonly tombstoned: boolean;
+	readonly replayCursor: ReplayCursor;
+}
+
+export type SessionBindResult =
+	| { readonly kind: "bound"; readonly binding: SessionBinding }
+	| { readonly kind: "rejected"; readonly error: AdapterJsonRpcError };
+
+export type SessionLookupResult =
+	| { readonly kind: "active"; readonly binding: SessionBinding }
+	| { readonly kind: "rejected"; readonly error: AdapterJsonRpcError };
+
+export interface SessionRegistry {
+	bindSession(input: SessionBindingInput): SessionBindResult;
+	getByExternalSessionId(externalSessionId: string): SessionBinding | undefined;
+	getByAppThreadId(appThreadId: string): SessionBinding | undefined;
+	requireActiveSession(externalSessionId: string): SessionLookupResult;
+	tombstoneExternalSession(externalSessionId: string): SessionLookupResult;
+	updateReplayCursor(externalSessionId: string, replayCursor: ReplayCursor): SessionLookupResult;
+}
+
+export function createSessionRegistry(): SessionRegistry {
+	return new InMemorySessionRegistry();
+}
+
+class InMemorySessionRegistry implements SessionRegistry {
+	private readonly byExternalSessionId = new Map<string, SessionBinding>();
+	private readonly externalSessionIdByAppThreadId = new Map<string, string>();
+
+	bindSession(input: SessionBindingInput): SessionBindResult {
+		if (this.byExternalSessionId.has(input.externalSessionId)) {
+			return rejectDuplicate(`Duplicate external session id: ${input.externalSessionId}`);
+		}
+		const existingExternalSessionId = this.externalSessionIdByAppThreadId.get(input.appThreadId);
+		if (existingExternalSessionId && existingExternalSessionId !== input.externalSessionId) {
+			return rejectDuplicate(`Duplicate app-server thread id: ${input.appThreadId}`);
+		}
+		const binding: SessionBinding = {
+			externalSessionId: input.externalSessionId,
+			appThreadId: input.appThreadId,
+			appSessionId: input.appSessionId,
+			tombstoned: false,
+			replayCursor: {},
+		};
+		this.byExternalSessionId.set(binding.externalSessionId, binding);
+		this.externalSessionIdByAppThreadId.set(binding.appThreadId, binding.externalSessionId);
+		return { kind: "bound", binding };
+	}
+
+	getByExternalSessionId(externalSessionId: string): SessionBinding | undefined {
+		return this.byExternalSessionId.get(externalSessionId);
+	}
+
+	getByAppThreadId(appThreadId: string): SessionBinding | undefined {
+		const externalSessionId = this.externalSessionIdByAppThreadId.get(appThreadId);
+		if (!externalSessionId) return undefined;
+		return this.byExternalSessionId.get(externalSessionId);
+	}
+
+	requireActiveSession(externalSessionId: string): SessionLookupResult {
+		const binding = this.byExternalSessionId.get(externalSessionId);
+		if (!binding) {
+			return rejectSession(`Unknown external session: ${externalSessionId}`);
+		}
+		if (binding.tombstoned) {
+			return rejectSession(`External session is tombstoned: ${externalSessionId}`);
+		}
+		return { kind: "active", binding };
+	}
+
+	tombstoneExternalSession(externalSessionId: string): SessionLookupResult {
+		const lookup = this.requireActiveSession(externalSessionId);
+		if (lookup.kind === "rejected") return lookup;
+		const tombstoned: SessionBinding = {
+			...lookup.binding,
+			tombstoned: true,
+		};
+		this.byExternalSessionId.set(externalSessionId, tombstoned);
+		return { kind: "active", binding: tombstoned };
+	}
+
+	updateReplayCursor(externalSessionId: string, replayCursor: ReplayCursor): SessionLookupResult {
+		const lookup = this.requireActiveSession(externalSessionId);
+		if (lookup.kind === "rejected") return lookup;
+		const updated: SessionBinding = {
+			...lookup.binding,
+			replayCursor,
+		};
+		this.byExternalSessionId.set(externalSessionId, updated);
+		return { kind: "active", binding: updated };
+	}
+}
+
+function rejectSession(message: string): SessionLookupResult {
+	return {
+		kind: "rejected",
+		error: createAdapterJsonRpcError({
+			adapterCode: "invalid-session-state",
+			message,
+		}),
+	};
+}
+
+function rejectDuplicate(message: string): SessionBindResult {
+	return {
+		kind: "rejected",
+		error: createAdapterJsonRpcError({
+			adapterCode: "duplicate-routing-id",
+			message,
+		}),
+	};
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
@@ -68,13 +68,10 @@ describe("pi-codex-app-server contract lock", () => {
 		expect(EXTERNAL_PROTOCOL_METHODS.every((method) => method.errorBehavior.length > 0)).toBe(true);
 	});
 
-	it("classifies required app-server surfaces without routing projection or bridge code", () => {
+	it("classifies required app-server surfaces without downstream projection or bridge code", () => {
 		const downstreamFileNames = [
-			"request-router.ts",
 			"notification-projector.ts",
 			"server-request-bridge.ts",
-			"session-registry.ts",
-			"id-mapper.ts",
 			"reconnect-resume.ts",
 			"redaction-scanner.ts",
 			"evidence-packet-writer.ts",

--- a/packages/coding-agent/test/suite/pi-codex-app-server-routing-fakes.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-routing-fakes.ts
@@ -1,0 +1,29 @@
+import type { AppServerRequestClient } from "../../src/core/extensions/builtin/pi-codex-app-server/request-router.ts";
+
+export class RecordingAppServerClient implements AppServerRequestClient {
+	readonly calls: { readonly method: string; readonly params: unknown }[] = [];
+	private readonly responses: unknown[];
+
+	constructor(responses: readonly unknown[]) {
+		this.responses = [...responses];
+	}
+
+	async request(method: string, params: unknown): Promise<unknown> {
+		this.calls.push({ method, params });
+		return this.responses.shift() ?? {};
+	}
+}
+
+export class ThrowOnceAppServerClient implements AppServerRequestClient {
+	readonly calls: { readonly method: string; readonly params: unknown }[] = [];
+	private thrown = false;
+
+	async request(method: string, params: unknown): Promise<unknown> {
+		this.calls.push({ method, params });
+		if (!this.thrown) {
+			this.thrown = true;
+			throw new Error("synthetic app-server failure");
+		}
+		return { ok: true };
+	}
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-routing.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-routing.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import { createIdMapper } from "../../src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts";
+import { PI_CODEX_APP_SERVER_PROTOCOL_VERSION } from "../../src/core/extensions/builtin/pi-codex-app-server/protocol-core.ts";
+import { createRequestRouter } from "../../src/core/extensions/builtin/pi-codex-app-server/request-router.ts";
+import { createSessionRegistry } from "../../src/core/extensions/builtin/pi-codex-app-server/session-registry.ts";
+import { RecordingAppServerClient, ThrowOnceAppServerClient } from "./pi-codex-app-server-routing-fakes.ts";
+
+describe("pi-codex-app-server routing state", () => {
+	it("routes initialize through capability negotiation with Codex capability field names", async () => {
+		const client = new RecordingAppServerClient([{ server: "initialized" }]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: createSessionRegistry(),
+			appServerCapabilities: {
+				experimentalApi: true,
+				requestAttestation: true,
+				mcpServerOpenaiFormElicitation: true,
+				optOutNotificationMethods: ["warning", "thread/tokenUsage/updated"],
+			},
+		});
+
+		const result = await router.route({
+			method: "initialize",
+			params: {
+				protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+				capabilities: {
+					semanticEvents: true,
+					opaqueNotifications: true,
+					opaqueCallbacks: true,
+					notificationOptOuts: ["thread/tokenUsage/updated"],
+				},
+			},
+			externalRequestId: "external-request-1",
+		});
+
+		expect(result).toMatchObject({ kind: "app-server-response", appServerResponse: { server: "initialized" } });
+		expect(client.calls).toEqual([
+			{
+				method: "initialize",
+				params: {
+					capabilities: {
+						experimentalApi: true,
+						requestAttestation: true,
+						mcpServerOpenaiFormElicitation: true,
+						optOutNotificationMethods: ["thread/tokenUsage/updated"],
+					},
+				},
+			},
+		]);
+	});
+
+	it("binds external sessions to authoritative app-server thread and session IDs", async () => {
+		const registry = createSessionRegistry();
+		const client = new RecordingAppServerClient([
+			{ thread: { id: "app-thread-1", session_id: "app-session-1" } },
+			{ thread: { id: "app-thread-2", session_id: "app-session-2" } },
+		]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: registry,
+		});
+
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-2",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/project" } },
+		});
+		await router.route({
+			method: "session/resume",
+			externalRequestId: "external-request-3",
+			params: { externalSessionId: "external-session-2", appParams: { thread_id: "app-thread-2" } },
+		});
+
+		expect(registry.getByExternalSessionId("external-session-1")).toMatchObject({
+			externalSessionId: "external-session-1",
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-1",
+			tombstoned: false,
+		});
+		expect(registry.getByAppThreadId("app-thread-2")).toMatchObject({
+			externalSessionId: "external-session-2",
+			appThreadId: "app-thread-2",
+			appSessionId: "app-session-2",
+		});
+		expect(client.calls.map((call) => call.method)).toEqual(["thread/start", "thread/resume"]);
+	});
+
+	it("cleans request correlation when app-server routing throws before a result", async () => {
+		const client = new ThrowOnceAppServerClient();
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: createSessionRegistry(),
+		});
+
+		await expect(
+			router.route({
+				method: "session/list",
+				externalRequestId: "external-request-retry",
+				params: { appParams: { limit: 1 } },
+			}),
+		).rejects.toThrow("synthetic app-server failure");
+		const retry = await router.route({
+			method: "session/list",
+			externalRequestId: "external-request-retry",
+			params: { appParams: { limit: 1 } },
+		});
+
+		expect(retry).toEqual({ kind: "app-server-response", appServerResponse: { ok: true } });
+		expect(client.calls).toEqual([
+			{ method: "thread/list", params: { limit: 1 } },
+			{ method: "thread/list", params: { limit: 1 } },
+		]);
+	});
+
+	it("rejects duplicate external session bindings before calling app-server", async () => {
+		const registry = createSessionRegistry();
+		const client = new RecordingAppServerClient([
+			{ thread: { id: "app-thread-1", session_id: "app-session-1" } },
+			{ thread: { id: "orphan-thread", session_id: "orphan-session" } },
+		]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: registry,
+		});
+
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-first",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/project" } },
+		});
+		const duplicate = await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-duplicate",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/other" } },
+		});
+
+		expect(duplicate).toMatchObject({
+			kind: "adapter-error",
+			error: {
+				data: {
+					source: "pi-codex-app-server",
+					adapterCode: "duplicate-routing-id",
+				},
+			},
+		});
+		expect(client.calls).toEqual([{ method: "thread/start", params: { cwd: "/tmp/project" } }]);
+		expect(registry.getByExternalSessionId("external-session-1")).toMatchObject({
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-1",
+		});
+	});
+
+	it("routes turn start, steer, and interrupt using app-server IDs from session state", async () => {
+		const registry = createSessionRegistry();
+		const idMapper = createIdMapper();
+		const client = new RecordingAppServerClient([
+			{ thread: { id: "app-thread-1", session_id: "app-session-1" } },
+			{ turn: { id: "app-turn-1" } },
+			{ ok: true },
+			{ ok: true },
+		]);
+		const router = createRequestRouter({ client, idMapper, sessionRegistry: registry });
+
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-4",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/project" } },
+		});
+		await router.route({
+			method: "turn/start",
+			externalRequestId: "external-request-5",
+			externalMessageId: "external-message-1",
+			params: { externalSessionId: "external-session-1", appParams: { input: [{ text: "hello" }] } },
+		});
+		await router.route({
+			method: "turn/steer",
+			externalRequestId: "external-request-6",
+			params: {
+				externalSessionId: "external-session-1",
+				appTurnId: "app-turn-1",
+				appParams: { input: [{ text: "steer" }] },
+			},
+		});
+		await router.route({
+			method: "turn/interrupt",
+			externalRequestId: "external-request-7",
+			params: { externalSessionId: "external-session-1", appTurnId: "app-turn-1" },
+		});
+
+		expect(client.calls.slice(1)).toEqual([
+			{
+				method: "turn/start",
+				params: {
+					thread_id: "app-thread-1",
+					client_user_message_id: "external-message-1",
+					input: [{ text: "hello" }],
+				},
+			},
+			{
+				method: "turn/steer",
+				params: {
+					thread_id: "app-thread-1",
+					expected_turn_id: "app-turn-1",
+					input: [{ text: "steer" }],
+				},
+			},
+			{
+				method: "turn/interrupt",
+				params: {
+					thread_id: "app-thread-1",
+					turn_id: "app-turn-1",
+				},
+			},
+		]);
+		expect(idMapper.getTurn("app-turn-1")).toMatchObject({
+			appThreadId: "app-thread-1",
+			appTurnId: "app-turn-1",
+			externalMessageId: "external-message-1",
+		});
+	});
+
+	it("tombstones sessions after archive/delete and rejects later turns", async () => {
+		const registry = createSessionRegistry();
+		const client = new RecordingAppServerClient([
+			{ thread: { id: "app-thread-1", session_id: "app-session-1" } },
+			{ ok: true },
+		]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: registry,
+		});
+
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-8",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/project" } },
+		});
+		await router.route({
+			method: "session/archive",
+			externalRequestId: "external-request-9",
+			params: { externalSessionId: "external-session-1" },
+		});
+		const rejected = await router.route({
+			method: "turn/start",
+			externalRequestId: "external-request-10",
+			params: { externalSessionId: "external-session-1", appParams: { input: [{ text: "too late" }] } },
+		});
+
+		expect(registry.getByExternalSessionId("external-session-1")).toMatchObject({ tombstoned: true });
+		expect(rejected).toMatchObject({
+			kind: "adapter-error",
+			error: {
+				data: {
+					source: "pi-codex-app-server",
+					adapterCode: "invalid-session-state",
+				},
+			},
+		});
+		expect(client.calls.map((call) => call.method)).toEqual(["thread/start", "thread/archive"]);
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-session-read-routing.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-session-read-routing.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createIdMapper } from "../../src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts";
+import { createRequestRouter } from "../../src/core/extensions/builtin/pi-codex-app-server/request-router.ts";
+import { createSessionRegistry } from "../../src/core/extensions/builtin/pi-codex-app-server/session-registry.ts";
+import { RecordingAppServerClient } from "./pi-codex-app-server-routing-fakes.ts";
+
+describe("pi-codex-app-server session read routing", () => {
+	it("routes session read with the bound app-server thread id", async () => {
+		const registry = createSessionRegistry();
+		const client = new RecordingAppServerClient([
+			{ thread: { id: "app-thread-1", session_id: "app-session-1" } },
+			{ thread: { id: "app-thread-1", session_id: "app-session-1", name: "read thread" } },
+		]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: registry,
+		});
+
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-read-start",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/project" } },
+		});
+		const read = await router.route({
+			method: "session/read",
+			externalRequestId: "external-request-read",
+			params: { externalSessionId: "external-session-1" },
+		});
+
+		expect(read).toMatchObject({
+			kind: "app-server-response",
+			appServerResponse: { thread: { id: "app-thread-1", name: "read thread" } },
+		});
+		expect(client.calls).toEqual([
+			{ method: "thread/start", params: { cwd: "/tmp/project" } },
+			{ method: "thread/read", params: { thread_id: "app-thread-1" } },
+		]);
+	});
+
+	it("rejects unknown and tombstoned session reads before calling app-server", async () => {
+		const registry = createSessionRegistry();
+		const client = new RecordingAppServerClient([
+			{ thread: { id: "app-thread-1", session_id: "app-session-1" } },
+			{ ok: true },
+		]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: registry,
+		});
+
+		const unknown = await router.route({
+			method: "session/read",
+			externalRequestId: "external-request-read-unknown",
+			params: { externalSessionId: "missing-session" },
+		});
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-request-read-start-2",
+			params: { externalSessionId: "external-session-1", appParams: { cwd: "/tmp/project" } },
+		});
+		await router.route({
+			method: "session/archive",
+			externalRequestId: "external-request-read-archive",
+			params: { externalSessionId: "external-session-1" },
+		});
+		const tombstoned = await router.route({
+			method: "session/read",
+			externalRequestId: "external-request-read-tombstoned",
+			params: { externalSessionId: "external-session-1" },
+		});
+
+		expect(unknown).toMatchObject({
+			kind: "adapter-error",
+			error: { data: { source: "pi-codex-app-server", adapterCode: "invalid-session-state" } },
+		});
+		expect(tombstoned).toMatchObject({
+			kind: "adapter-error",
+			error: { data: { source: "pi-codex-app-server", adapterCode: "invalid-session-state" } },
+		});
+		expect(client.calls).toEqual([
+			{ method: "thread/start", params: { cwd: "/tmp/project" } },
+			{ method: "thread/archive", params: { thread_id: "app-thread-1" } },
+		]);
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-session-registry.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-session-registry.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createSessionRegistry } from "../../src/core/extensions/builtin/pi-codex-app-server/session-registry.ts";
+
+describe("pi-codex-app-server session registry", () => {
+	it("rejects duplicate external session and app-thread bindings without overwriting existing state", () => {
+		const registry = createSessionRegistry();
+		const firstBinding = registry.bindSession({
+			externalSessionId: "external-session-1",
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-1",
+		});
+		const duplicateExternal = registry.bindSession({
+			externalSessionId: "external-session-1",
+			appThreadId: "app-thread-2",
+			appSessionId: "app-session-2",
+		});
+		const duplicateThread = registry.bindSession({
+			externalSessionId: "external-session-2",
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-3",
+		});
+
+		expect(firstBinding).toMatchObject({
+			kind: "bound",
+			binding: {
+				externalSessionId: "external-session-1",
+				appThreadId: "app-thread-1",
+				appSessionId: "app-session-1",
+			},
+		});
+		expect(duplicateExternal).toMatchObject({
+			kind: "rejected",
+			error: {
+				data: {
+					source: "pi-codex-app-server",
+					adapterCode: "duplicate-routing-id",
+				},
+			},
+		});
+		expect(duplicateThread).toMatchObject({
+			kind: "rejected",
+			error: {
+				data: {
+					source: "pi-codex-app-server",
+					adapterCode: "duplicate-routing-id",
+				},
+			},
+		});
+		expect(registry.getByExternalSessionId("external-session-1")).toMatchObject({
+			externalSessionId: "external-session-1",
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-1",
+		});
+		expect(registry.getByAppThreadId("app-thread-1")).toMatchObject({
+			externalSessionId: "external-session-1",
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-1",
+		});
+		expect(registry.getByExternalSessionId("external-session-2")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
This work is using code-yeongyu/lazycodex teammode.

## Summary

Adds Wave 3 / PR-005 routing-state for `pi-codex-app-server` after PR-004 runtime transport merge `b0c5f32647d8821ee54497956c1fd782093c565d`.

Before: the adapter had contract, skeleton, capability negotiation, and runtime transport health, but no pure state layer for external session ids, app-server thread/session bindings, request correlation, or external-to-app request routing.

After: the adapter has pure routing modules for initialize, initialized, session/thread operations, and turn start/steer/interrupt. App-server ids remain authoritative; external ids are correlation only. Streaming projection, callbacks, reconnect durability, redaction QA, and final evidence packet remain deferred.

## Changes

- Added `session-registry.ts` for external session to app-server thread/session bindings, active lookups, replay cursor anchors, tombstones, and duplicate binding rejection.
- Added `id-mapper.ts` for external request, turn, item, and server-request correlation maps.
- Added `request-router.ts` plus `request-router-params.ts` for pure external-to-app routing against an app-server request-client seam.
- Added explicit adapter error codes for duplicate routing ids, invalid session state, and unsupported PR-005 routing methods.
- Updated external-to-app fixtures for initialize capability field names, duplicate binding policy, session close/tombstone behavior, and turn id mapping.
- Updated the contract test scope guard to allow PR-005 routing files while still blocking downstream projection, callback, reconnect, and evidence-packet files.
- Added focused routing and session-registry regression tests.

## QA / Evidence

Evidence root: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-005-routing/`.

- Failing-first proof: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-routing.test.ts`
  - Initial result: failed for missing `id-mapper.ts`, saved in `failing-first.txt`.
- Targeted routing test: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-routing.test.ts`
  - Result: passed after implementation, saved in `targeted-routing-initial.txt`.
- Focused PR-001 through PR-005 suite: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-contract.test.ts test/suite/pi-codex-app-server-extension.test.ts test/suite/pi-codex-app-server-capability.test.ts test/suite/pi-codex-app-server-runtime.test.ts test/suite/pi-codex-app-server-routing.test.ts test/suite/pi-codex-app-server-session-registry.test.ts`
  - Result after final duplicate-session preflight: 6 files / 25 tests passed, saved in `targeted-suite-after-preflight.txt`.
- Full check: `npm run check`
  - Result: passed, saved in `npm-run-check-after-preflight.txt`.
  - Commit hook reran `npm run check` and passed during commit `f69a0a3d8`.
- senpi QA common self-check: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`
  - Result: 9/9 passed, real auth unchanged, saved in `senpi-qa-common-self-check.txt`.
- senpi QA CLI smoke: `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`
  - Result: 5/5 passed, real auth unchanged, saved in `senpi-qa-cli-smoke.txt`.
- senpi QA mock loop: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`
  - Result: 5/5 passed across OpenAI completions, Anthropic messages, and OpenAI responses mock paths; zero real provider calls; real auth unchanged. Saved in `senpi-qa-mock-loop.txt`.
- Adapter harness help: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help`
  - Result: exited 0 and confirms runtime smoke only; routing, streaming, callbacks, reconnect, redaction, and final evidence remain deferred. Saved in `drive-adapter-help.txt`.
- Cleanup receipt: `cleanup-receipt.txt`.
- Secret-safety receipt: `secret-safety.txt`.
- Tracked evidence summary: `.omo/evidence/20260624-pi-codex-app-server-execution/pr-005-routing/summary.md`.

## Early Review Follow-ups

- Duplicate authoritative bindings: `session-registry.ts` now rejects duplicate `externalSessionId` and duplicate `appThreadId` with `duplicate-routing-id`; regression added in `pi-codex-app-server-session-registry.test.ts`.
- Request-correlation cleanup: `DefaultRequestRouter.route()` now resolves registered external request ids in `finally`; throwing-client retry regression added in `pi-codex-app-server-routing.test.ts`.
- Duplicate external session preflight: `session/new|resume|fork` now rejects an already-bound `externalSessionId` before calling app-server; regression proves the second app-server call is not made.

## Cleanup Receipt

No app-server runtime transport, child process, websocket, unix socket, tmux session, browser context, container, temp dir, or QA-only env file was created by PR-005 routing work. The lane drove pure routing tests, `npm run check`, senpi QA self-tests, and `drive-adapter.mjs --help` only.

## Project Tracking

`BLOCKED:missing-gh-project-scope`

- cwd: `/Users/yeongyu/local-workspaces/senpi`
- command: `gh project list --owner code-yeongyu --format json --limit 20`
- observed: `error: your authentication token is missing required scopes [read:project]`
- artifact: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-005-routing/project-tracking.txt`

This is recorded and does not block PR creation.

## Secret Safety

Evidence is under gitignored `local-ignore/`. No raw auth headers, bearer tokens, cookies, launchd environments, private profile configs, service logs, or credential files were copied into committed files or PR text. senpi QA scripts reported the real auth file unchanged.

## Residual Risks

- PR-005 routes against a pure app-server request-client seam; live JSON-RPC transport wiring remains downstream integration work.
- App-thread collisions are rejected after app-server response unless a future route exposes a reliable incoming app-server `thread_id` preflight.
- PR-006/PR-007/PR-008/PR-009 still own streaming, backpressure, callbacks, MCP, and dynamic tool behavior.
- PR-010 still owns resume tokens, snapshot reload, replay cursors, pending callback replay/rejection, durable tombstones, and duplicate terminal protection.
- The TypeScript no-excuse checker from the external skill could not run from its cache path because it could not resolve `typescript`; `biome`, `tsgo`, `npm run check`, manual LOC review, and debug/suppression grep all passed.

## Downstream Status

PR-005 unblocks item/notification streaming and callback lanes to consume stable session/id/request maps. Reconnect durability is still intentionally blocked until PR-010.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pure routing state layer for `pi-codex-app-server` to bind external sessions to authoritative app-server IDs and route initialize, session, and turn methods. Also fixes session reads by routing them to `thread/read` with the bound `thread_id`.

- **New Features**
  - Session registry maps external session IDs to app `thread_id`/`session_id`; rejects duplicates; tombstones on archive/delete.
  - ID mapper tracks external requests, turns, items, and server requests; cleans up on completion.
  - Request router handles initialize/initialized; session new/resume/fork/list/read/archive/delete/unsubscribe; turn start/steer/interrupt; injects `thread_id`; preserves `appTurnId`; preflights duplicate external sessions; rejects tombstoned sessions.
  - Compatibility fixtures updated for initialize capability fields and notification opt-outs, session lifecycle policies, and turn ID routing.
  - Adapter error codes added: `duplicate-routing-id`, `invalid-session-state`, `unsupported-routing-method`.

- **Bug Fixes**
  - `session/read` is routed via `thread/read` with the bound `thread_id`; requires an active session; rejects unknown or tombstoned sessions before calling the app-server.

<sup>Written for commit bc4fa3d3ca1a36aea49531eb8611f1559e442cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

