### PR TITLE
feat(coding-agent): add app-server stream projection

### DIFF
--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/sanitized-evidence-addendum.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/sanitized-evidence-addendum.md
@@ -1,0 +1,231 @@
+# PR-006 Sanitized Evidence Addendum
+
+This work is using code-yeongyu/lazycodex teammode.
+
+This addendum makes the PR-006 evidence reviewable from a detached PR checkout.
+Full raw artifacts remain under `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/`,
+which is intentionally gitignored. The excerpts below are sanitized: no raw
+secret-bearing logs, env dumps, tokens, auth headers, cookies, or private
+credentials are included.
+
+## Scope
+
+- PR: https://github.com/code-yeongyu/senpi/pull/78
+- Branch: `code-yeongyu/pi-codex-app-server-stream-callback`
+- Initial implementation commit: `18cea8f46b83e2caace347ac42b7c00e6a4ad28b`
+- CamelCase follow-up commit: `dc956dc46e387a14cdd6178e41987f133392d2b5`
+
+PR-006 remains limited to item and notification projection. PR-007
+backpressure/lag, PR-008 callbacks, PR-009 MCP/dynamic tools, PR-010 reconnect,
+redaction QA, and the final evidence packet are intentionally out of scope.
+
+## Command Log
+
+Commands were run from `/Users/yeongyu/local-workspaces/senpi` unless noted.
+
+```bash
+cd packages/coding-agent &&
+  npx tsx ../../node_modules/vitest/dist/cli.js --run \
+    test/suite/pi-codex-app-server-streaming.test.ts
+```
+
+```bash
+cd packages/coding-agent &&
+  npx tsx ../../node_modules/vitest/dist/cli.js --run \
+    test/suite/pi-codex-app-server-streaming.test.ts \
+    test/suite/pi-codex-app-server-contract.test.ts \
+    test/suite/pi-codex-app-server-routing.test.ts
+```
+
+```bash
+npm run check
+node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check
+node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test
+node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test
+node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help
+gh project list --owner code-yeongyu --format json --limit 20
+```
+
+CamelCase blocker follow-up additionally ran:
+
+```bash
+NODE_PATH=/Users/yeongyu/local-workspaces/senpi/node_modules \
+  bun run /Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.13.0/skills/programming/scripts/typescript/check-no-excuse-rules.ts \
+    packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts \
+    packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/item-stream-projector.ts \
+    packages/coding-agent/test/suite/pi-codex-app-server-streaming.test.ts
+```
+
+## Failing-First Evidence
+
+Initial PR-006 failing-first proof showed the streaming suite could not import
+the projector before implementation:
+
+```text
+FAIL test/suite/pi-codex-app-server-streaming.test.ts
+Error: Cannot find module '../../src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts'
+Test Files 1 failed (1)
+Tests no tests
+```
+
+CamelCase blocker failing-first proof showed the actual generated schema shape
+lost correlation before the follow-up fix:
+
+```text
+FAIL test/suite/pi-codex-app-server-streaming.test.ts > projects generated camelCase notification ids without losing session correlation
+-   "appThreadId": "app-thread-1",
+-   "appTurnId": "app-turn-1",
++   "appThreadId": undefined,
++   "appTurnId": undefined,
+-   "externalSessionId": "external-session-1",
++   "externalSessionId": undefined,
+Test Files 1 failed (1)
+Tests 1 failed | 4 passed (5)
+```
+
+## Targeted And Adjacent Tests
+
+Original PR-006 targeted adjacent suite after implementation:
+
+```text
+RUN v4.1.9 /Users/yeongyu/local-workspaces/senpi/packages/coding-agent
+Test Files 3 passed (3)
+Tests 13 passed (13)
+```
+
+CamelCase follow-up final adjacent suite:
+
+```text
+RUN v4.1.9 /Users/yeongyu/local-workspaces/senpi/packages/coding-agent
+Test Files 3 passed (3)
+Tests 14 passed (14)
+```
+
+The added regression covers generated camelCase payload fields:
+`threadId`, `turnId`, `itemId`, `requestId`, and nested `item.id`. The assertion
+also verifies that `item/started` registers the app-server item in `IdMapper`.
+
+## Full Check
+
+Final `npm run check` after the camelCase follow-up:
+
+```text
+> check
+> biome check --write --error-on-warnings . && npm run check:pinned-deps && npm run check:ts-imports && npm run check:shrinkwrap && tsgo --noEmit && node scripts/check-browser-smoke.mjs && node scripts/run-web-ui-check.mjs
+
+Checked 1168 files in 677ms. No fixes applied.
+packages/coding-agent/npm-shrinkwrap.json is up to date.
+Checked 67 files in 37ms. No fixes applied.
+```
+
+The commit hook also reran `npm run check` successfully before accepting
+`dc956dc46e387a14cdd6178e41987f133392d2b5`.
+
+## senpi QA
+
+`common.mjs --self-check`:
+
+```text
+[PASS] repo root resolves
+[PASS] tsx entry present
+[PASS] sandbox isolates agent + session dirs
+[PASS] real auth snapshot taken
+[PASS] free port allocatable
+[PASS] evidence dir creatable under local-ignore
+[PASS] ansi stripping
+[PASS] sandbox removed on cleanup
+[PASS] real auth unchanged
+common.mjs --self-check: 9/9 passed
+```
+
+`cli-smoke.mjs --self-test`:
+
+```text
+[PASS] --help prints usage with flags
+[PASS] --version prints a version
+[PASS] --list-models lists built-in models offline (no API)
+[PASS] unknown option is reported, not silently ignored
+[PASS] real auth unchanged
+cli-smoke.mjs --self-test: 5/5 passed
+```
+
+`mock-loop.mjs --self-test`:
+
+```text
+[PASS] openai-completions: baseUrl override round-trips through the real loop
+[PASS] anthropic-messages: baseUrl override round-trips through the real loop
+[PASS] openai-responses: baseUrl override round-trips through the real loop
+[PASS] zero real provider calls (only localhost fake hit)
+[PASS] real auth unchanged
+mock-loop.mjs --self-test: 5/5 passed
+```
+
+## Adapter Harness Smoke
+
+The PR-004 adapter harness help surface was smoke-tested to verify the checked-in
+manual QA helper remains invokable:
+
+```text
+pi-codex-app-server adapter harness
+Usage:
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --external-stdio --app-server-command <path> [--app-server-args <args>]
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --external-websocket <url>
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --external-unix <sock> --app-server-command <path>
+Status:
+  PR-004 runtime smoke only. Protocol routing, streaming, callbacks, reconnect,
+  redaction, and final evidence packet generation are intentionally deferred.
+```
+
+## Static Audit And File Size
+
+The TypeScript no-excuse audit passed on the camelCase follow-up files:
+
+```text
+No violations in 3 file(s).
+```
+
+Pure non-comment LOC after the follow-up:
+
+```text
+notification-projector.ts: 150
+item-stream-projector.ts: 155
+pi-codex-app-server-streaming.test.ts: 248
+```
+
+## Project Tracking
+
+GitHub Project tracking remains blocked by token scope, which does not block code
+PR creation:
+
+```text
+error: your authentication token is missing required scopes [read:project]
+To request it, run: gh auth refresh -s read:project
+```
+
+Recorded status: `BLOCKED:missing-gh-project-scope`.
+
+## Cleanup Receipt
+
+Cleanup evidence was regenerated with process arguments omitted for secret
+safety:
+
+```text
+Cleanup receipt for PR-006 camelCase projection follow-up
+QA/test commands completed with no intentionally retained senpi adapter processes, sockets, or tmux sessions.
+Relevant process-name check, command arguments omitted for secret safety:
+tmux sessions:
+```
+
+The senpi QA scripts also reported the real auth file unchanged.
+
+## Current Residual Risks
+
+- Live Codex app-server streaming scenarios `07` and `13` are not fully driven
+  through a protocol route in PR-006; this PR proves projection behavior and
+  keeps harness health green.
+- Backpressure, lag markers, overload drop accounting, and terminal flush
+  guarantees remain PR-007.
+- Server-request callbacks, callback cleanup, and no-auto-approval behavior
+  remain PR-008.
+- MCP/dynamic tool callback compatibility remains PR-009.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/summary.md
@@ -1,0 +1,53 @@
+# PR-006 Item and Notification Streaming
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Summary
+
+PR-006 adds the first app-server-to-external projection layer for item and notification streams. It preserves app-server IDs, projects first-class item stream events for text, plan, reasoning, command/process/file/MCP progress, raw response, and terminal turn surfaces, and falls back to lossless opaque `appServer/event` envelopes where no semantic projection exists.
+
+Scope is intentionally limited to PR-006. It does not implement PR-007 backpressure/lag queues, PR-008 server-request callbacks, PR-009 MCP/dynamic tool callback compatibility, PR-010 reconnect, redaction QA, or the final compatibility evidence packet.
+
+## Changed Files
+
+- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/item-stream-projector.ts`
+- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts`
+- `packages/coding-agent/test/suite/pi-codex-app-server-streaming.test.ts`
+- `packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts`
+
+## Evidence
+
+- Failing-first proof: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/failing-first.txt`
+- Focused streaming test: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/targeted-streaming.txt`
+- Adjacent contract/routing/streaming suite: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/targeted-adjacent-suite-final.txt`
+- Full check: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/npm-run-check-final.txt`
+- senpi QA common self-check: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/senpi-qa-common-self-check.txt`
+- senpi QA CLI smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/senpi-qa-cli-smoke.txt`
+- senpi QA mock loop: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/senpi-qa-mock-loop.txt`
+- Adapter harness help smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/drive-adapter-help.txt`
+- Cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/cleanup-receipt.txt`
+- Commands: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/commands.txt`
+
+## Assertions Covered
+
+- Text, plan, and reasoning deltas are separate semantic channels.
+- `item/started` registers authoritative app-server item IDs in the PR-005 `IdMapper`.
+- `item/completed` projects the completed item as authoritative payload.
+- Notifications without a first-class projection emit opaque envelopes with original method, original params, app-server IDs, sequence, stream class, and capability flags.
+- Negotiated notification opt-outs skip projection before sequence allocation.
+- Command, process, file, and MCP progress are classified as best-effort semantic progress without implementing PR-007 drop/lag behavior.
+
+## Project Tracking
+
+`BLOCKED:missing-gh-project-scope` remains. `gh project list --owner code-yeongyu --format json --limit 20` still fails because the token lacks `read:project`.
+
+## Cleanup
+
+No runtime sockets, tmux sessions, browser contexts, containers, or PR-006 temp dirs were left running. The mock loop and fake model server self-tests report real auth unchanged.
+
+## Residual Risks
+
+- Live Codex app-server streaming scenarios `07` and `13` are not fully driven through a protocol route in this PR; PR-006 proves the projection units and keeps harness health green. End-to-end streaming through the adapter remains a later integration/evidence task once the runtime/router surfaces are wired for full event flow.
+- Backpressure, lag markers, overload drop accounting, and terminal flush guarantees remain PR-007.
+- Server-request callbacks, callback cleanup, and no-auto-approval behavior remain PR-008.
+- MCP/dynamic tool callback compatibility remains PR-009.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/summary.md
@@ -17,6 +17,11 @@ Scope is intentionally limited to PR-006. It does not implement PR-007 backpress
 
 ## Evidence
 
+Committed sanitized evidence for detached PR review:
+`.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/sanitized-evidence-addendum.md`.
+
+Full raw artifacts remain under the gitignored paths below for local audit:
+
 - Failing-first proof: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/failing-first.txt`
 - Focused streaming test: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/targeted-streaming.txt`
 - Adjacent contract/routing/streaming suite: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/targeted-adjacent-suite-final.txt`
@@ -27,6 +32,7 @@ Scope is intentionally limited to PR-006. It does not implement PR-007 backpress
 - Adapter harness help smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/drive-adapter-help.txt`
 - Cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/cleanup-receipt.txt`
 - Commands: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/commands.txt`
+- CamelCase follow-up artifacts: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/camelcase-*.txt`
 
 ## Assertions Covered
 

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/item-stream-projector.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/item-stream-projector.ts
@@ -89,8 +89,8 @@ export function projectItemStreamNotification(input: ProjectItemStreamInput): Se
 	if (!shape) return undefined;
 
 	const params = isRecord(input.params) ? input.params : {};
-	const appThreadId = readString(params, "thread_id");
-	const appTurnId = readString(params, "turn_id");
+	const appThreadId = readAppThreadId(params);
+	const appTurnId = readAppTurnId(params);
 	const completedItem = readCompletedItem(input.method, params);
 	const appItemId = readItemId(params, completedItem);
 	const delta = readString(params, "delta");
@@ -140,8 +140,16 @@ function readCompletedItem(method: string, params: Readonly<Record<string, unkno
 	return params.item;
 }
 
+function readAppThreadId(params: Readonly<Record<string, unknown>>): string | undefined {
+	return readString(params, "threadId") ?? readString(params, "thread_id");
+}
+
+function readAppTurnId(params: Readonly<Record<string, unknown>>): string | undefined {
+	return readString(params, "turnId") ?? readString(params, "turn_id");
+}
+
 function readItemId(params: Readonly<Record<string, unknown>>, completedItem: unknown): string | undefined {
-	const itemId = readString(params, "item_id");
+	const itemId = readString(params, "itemId") ?? readString(params, "item_id");
 	if (itemId) return itemId;
 	if (!isRecord(completedItem)) return undefined;
 	return readString(completedItem, "id");

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/item-stream-projector.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/item-stream-projector.ts
@@ -1,0 +1,167 @@
+import type { IdMapper } from "./id-mapper.ts";
+import type { StreamClass } from "./protocol-core.ts";
+
+export type SemanticProjectionChannel =
+	| "command"
+	| "file"
+	| "item"
+	| "mcp"
+	| "plan"
+	| "process"
+	| "raw-response"
+	| "reasoning"
+	| "reasoning-summary"
+	| "text"
+	| "turn";
+
+export type SemanticProjectionType =
+	| "completed"
+	| "delta"
+	| "item-completed"
+	| "item-started"
+	| "part-added"
+	| "progress"
+	| "turn-completed"
+	| "turn-started";
+
+export interface ProjectItemStreamInput {
+	readonly method: string;
+	readonly params: unknown;
+	readonly sequence: number;
+	readonly externalSessionId: string | undefined;
+	readonly idMapper: IdMapper;
+}
+
+export interface SemanticItemStreamProjection {
+	readonly kind: "semantic";
+	readonly method: string;
+	readonly sequence: number;
+	readonly channel: SemanticProjectionChannel;
+	readonly semanticType: SemanticProjectionType;
+	readonly streamClass: StreamClass;
+	readonly externalSessionId: string | undefined;
+	readonly appThreadId: string | undefined;
+	readonly appTurnId: string | undefined;
+	readonly appItemId: string | undefined;
+	readonly delta: string | undefined;
+	readonly index: number | undefined;
+	readonly completedItem: unknown;
+	readonly originalParams: unknown;
+}
+
+interface ItemProjectionShape {
+	readonly channel: SemanticProjectionChannel;
+	readonly semanticType: SemanticProjectionType;
+	readonly streamClass: StreamClass;
+}
+
+const itemProjectionShapes: Readonly<Record<string, ItemProjectionShape>> = {
+	"item/started": { channel: "item", semanticType: "item-started", streamClass: "lossless" },
+	"item/completed": { channel: "item", semanticType: "item-completed", streamClass: "lossless" },
+	"rawResponseItem/completed": { channel: "raw-response", semanticType: "completed", streamClass: "lossless" },
+	"item/agentMessage/delta": { channel: "text", semanticType: "delta", streamClass: "lossless" },
+	"item/plan/delta": { channel: "plan", semanticType: "delta", streamClass: "lossless" },
+	"item/reasoning/summaryTextDelta": { channel: "reasoning-summary", semanticType: "delta", streamClass: "lossless" },
+	"item/reasoning/summaryPartAdded": {
+		channel: "reasoning-summary",
+		semanticType: "part-added",
+		streamClass: "lossless",
+	},
+	"item/reasoning/textDelta": { channel: "reasoning", semanticType: "delta", streamClass: "lossless" },
+	"command/exec/outputDelta": { channel: "command", semanticType: "progress", streamClass: "best-effort" },
+	"item/commandExecution/outputDelta": { channel: "command", semanticType: "progress", streamClass: "best-effort" },
+	"item/commandExecution/terminalInteraction": {
+		channel: "command",
+		semanticType: "progress",
+		streamClass: "best-effort",
+	},
+	"process/outputDelta": { channel: "process", semanticType: "progress", streamClass: "best-effort" },
+	"process/exited": { channel: "process", semanticType: "completed", streamClass: "lossless" },
+	"item/fileChange/outputDelta": { channel: "file", semanticType: "progress", streamClass: "best-effort" },
+	"item/fileChange/patchUpdated": { channel: "file", semanticType: "progress", streamClass: "best-effort" },
+	"item/mcpToolCall/progress": { channel: "mcp", semanticType: "progress", streamClass: "best-effort" },
+	"turn/started": { channel: "turn", semanticType: "turn-started", streamClass: "lossless" },
+	"turn/completed": { channel: "turn", semanticType: "turn-completed", streamClass: "lossless" },
+};
+
+export function projectItemStreamNotification(input: ProjectItemStreamInput): SemanticItemStreamProjection | undefined {
+	const shape = itemProjectionShapes[input.method];
+	if (!shape) return undefined;
+
+	const params = isRecord(input.params) ? input.params : {};
+	const appThreadId = readString(params, "thread_id");
+	const appTurnId = readString(params, "turn_id");
+	const completedItem = readCompletedItem(input.method, params);
+	const appItemId = readItemId(params, completedItem);
+	const delta = readString(params, "delta");
+	const index = readNumber(params, "index");
+
+	if (input.method === "item/started" && appThreadId && appTurnId && appItemId) {
+		registerItemIfNeeded(input.idMapper, {
+			appThreadId,
+			appTurnId,
+			appItemId,
+			itemKind: readItemKind(completedItem),
+		});
+	}
+
+	return {
+		kind: "semantic",
+		method: input.method,
+		sequence: input.sequence,
+		channel: shape.channel,
+		semanticType: shape.semanticType,
+		streamClass: shape.streamClass,
+		externalSessionId: input.externalSessionId,
+		appThreadId,
+		appTurnId,
+		appItemId,
+		delta,
+		index,
+		completedItem,
+		originalParams: input.params,
+	};
+}
+
+interface RegisterItemInput {
+	readonly appThreadId: string;
+	readonly appTurnId: string;
+	readonly appItemId: string;
+	readonly itemKind: string;
+}
+
+function registerItemIfNeeded(idMapper: IdMapper, input: RegisterItemInput): void {
+	if (idMapper.getItem(input.appItemId)) return;
+	idMapper.registerItem(input);
+}
+
+function readCompletedItem(method: string, params: Readonly<Record<string, unknown>>): unknown {
+	if (method !== "item/started" && method !== "item/completed") return undefined;
+	return params.item;
+}
+
+function readItemId(params: Readonly<Record<string, unknown>>, completedItem: unknown): string | undefined {
+	const itemId = readString(params, "item_id");
+	if (itemId) return itemId;
+	if (!isRecord(completedItem)) return undefined;
+	return readString(completedItem, "id");
+}
+
+function readItemKind(item: unknown): string {
+	if (!isRecord(item)) return "unknown";
+	return readString(item, "type") ?? readString(item, "kind") ?? "unknown";
+}
+
+function readString(input: Readonly<Record<string, unknown>>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(input: Readonly<Record<string, unknown>>, key: string): number | undefined {
+	const value = input[key];
+	return typeof value === "number" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts
@@ -127,7 +127,7 @@ class DefaultNotificationProjector implements NotificationProjector {
 			externalCallbackId: undefined,
 			appThreadId,
 			appSessionId: binding?.appSessionId,
-			appTurnId: readString(params, "turn_id"),
+			appTurnId: readAppTurnId(params),
 			appItemId: readAppItemId(input.params),
 			appRequestId: readAppRequestId(params),
 			sequence,
@@ -142,12 +142,16 @@ class DefaultNotificationProjector implements NotificationProjector {
 
 function readAppThreadId(params: unknown): string | undefined {
 	if (!isRecord(params)) return undefined;
-	return readString(params, "thread_id");
+	return readString(params, "threadId") ?? readString(params, "thread_id");
+}
+
+function readAppTurnId(params: Readonly<Record<string, unknown>>): string | undefined {
+	return readString(params, "turnId") ?? readString(params, "turn_id");
 }
 
 function readAppItemId(params: unknown): string | undefined {
 	if (!isRecord(params)) return undefined;
-	const itemId = readString(params, "item_id");
+	const itemId = readString(params, "itemId") ?? readString(params, "item_id");
 	if (itemId) return itemId;
 	const item = params.item;
 	if (!isRecord(item)) return undefined;
@@ -155,7 +159,7 @@ function readAppItemId(params: unknown): string | undefined {
 }
 
 function readAppRequestId(params: Readonly<Record<string, unknown>>): string | undefined {
-	return readString(params, "request_id") ?? readString(params, "id");
+	return readString(params, "requestId") ?? readString(params, "request_id") ?? readString(params, "id");
 }
 
 function readString(input: Readonly<Record<string, unknown>>, key: string): string | undefined {

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts
@@ -1,0 +1,168 @@
+import type { IdMapper } from "./id-mapper.ts";
+import { projectItemStreamNotification, type SemanticItemStreamProjection } from "./item-stream-projector.ts";
+import { classifyAppServerSurface, PI_CODEX_APP_SERVER_PROTOCOL_VERSION, type StreamClass } from "./protocol-core.ts";
+import type { SessionRegistry } from "./session-registry.ts";
+
+export interface NotificationProjectorOptions {
+	readonly connectionId: string;
+	readonly capabilityFlags: readonly string[];
+	readonly notificationOptOuts: readonly string[];
+	readonly idMapper: IdMapper;
+	readonly sessionRegistry: SessionRegistry;
+}
+
+export interface AppServerNotificationInput {
+	readonly method: string;
+	readonly params: unknown;
+}
+
+export interface OpaqueAppServerEnvelope {
+	readonly protocolVersion: typeof PI_CODEX_APP_SERVER_PROTOCOL_VERSION;
+	readonly connectionId: string;
+	readonly externalSessionId: string | undefined;
+	readonly externalRequestId: string | undefined;
+	readonly externalMessageId: string | undefined;
+	readonly externalCallbackId: string | undefined;
+	readonly appThreadId: string | undefined;
+	readonly appSessionId: string | undefined;
+	readonly appTurnId: string | undefined;
+	readonly appItemId: string | undefined;
+	readonly appRequestId: string | undefined;
+	readonly sequence: number;
+	readonly streamClass: StreamClass;
+	readonly capabilityFlags: readonly string[];
+	readonly originalMethod: string;
+	readonly originalParams: unknown;
+	readonly redactionClass: "public-contract" | "secret-bearing";
+}
+
+export interface OpaqueNotificationProjection {
+	readonly kind: "opaque";
+	readonly method: "appServer/event";
+	readonly envelope: OpaqueAppServerEnvelope;
+}
+
+export interface SkippedNotificationProjection {
+	readonly kind: "skipped";
+	readonly reason: "notification-opt-out";
+}
+
+export type NotificationProjection =
+	| OpaqueNotificationProjection
+	| SemanticItemStreamProjection
+	| SkippedNotificationProjection;
+
+export interface NotificationProjector {
+	project(input: AppServerNotificationInput): NotificationProjection;
+}
+
+export function createNotificationProjector(options: NotificationProjectorOptions): NotificationProjector {
+	return new DefaultNotificationProjector(options);
+}
+
+class DefaultNotificationProjector implements NotificationProjector {
+	private readonly connectionId: string;
+	private readonly capabilityFlags: readonly string[];
+	private readonly notificationOptOuts: ReadonlySet<string>;
+	private readonly idMapper: IdMapper;
+	private readonly sessionRegistry: SessionRegistry;
+	private sequence = 0;
+
+	constructor(options: NotificationProjectorOptions) {
+		this.connectionId = options.connectionId;
+		this.capabilityFlags = options.capabilityFlags;
+		this.notificationOptOuts = new Set(options.notificationOptOuts);
+		this.idMapper = options.idMapper;
+		this.sessionRegistry = options.sessionRegistry;
+	}
+
+	project(input: AppServerNotificationInput): NotificationProjection {
+		if (this.notificationOptOuts.has(input.method)) {
+			return { kind: "skipped", reason: "notification-opt-out" };
+		}
+
+		const sequence = this.nextSequence();
+		const appThreadId = readAppThreadId(input.params);
+		const externalSessionId = this.readExternalSessionId(appThreadId);
+		const semantic = projectItemStreamNotification({
+			method: input.method,
+			params: input.params,
+			sequence,
+			externalSessionId,
+			idMapper: this.idMapper,
+		});
+		if (semantic) return semantic;
+
+		return {
+			kind: "opaque",
+			method: "appServer/event",
+			envelope: this.createOpaqueEnvelope(input, sequence, appThreadId, externalSessionId),
+		};
+	}
+
+	private nextSequence(): number {
+		this.sequence += 1;
+		return this.sequence;
+	}
+
+	private readExternalSessionId(appThreadId: string | undefined): string | undefined {
+		if (!appThreadId) return undefined;
+		return this.sessionRegistry.getByAppThreadId(appThreadId)?.externalSessionId;
+	}
+
+	private createOpaqueEnvelope(
+		input: AppServerNotificationInput,
+		sequence: number,
+		appThreadId: string | undefined,
+		externalSessionId: string | undefined,
+	): OpaqueAppServerEnvelope {
+		const params = isRecord(input.params) ? input.params : {};
+		const binding = appThreadId ? this.sessionRegistry.getByAppThreadId(appThreadId) : undefined;
+		return {
+			protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+			connectionId: this.connectionId,
+			externalSessionId,
+			externalRequestId: undefined,
+			externalMessageId: undefined,
+			externalCallbackId: undefined,
+			appThreadId,
+			appSessionId: binding?.appSessionId,
+			appTurnId: readString(params, "turn_id"),
+			appItemId: readAppItemId(input.params),
+			appRequestId: readAppRequestId(params),
+			sequence,
+			streamClass: classifyAppServerSurface(input.method)?.streamClass ?? "lossless",
+			capabilityFlags: this.capabilityFlags,
+			originalMethod: input.method,
+			originalParams: input.params,
+			redactionClass: "public-contract",
+		};
+	}
+}
+
+function readAppThreadId(params: unknown): string | undefined {
+	if (!isRecord(params)) return undefined;
+	return readString(params, "thread_id");
+}
+
+function readAppItemId(params: unknown): string | undefined {
+	if (!isRecord(params)) return undefined;
+	const itemId = readString(params, "item_id");
+	if (itemId) return itemId;
+	const item = params.item;
+	if (!isRecord(item)) return undefined;
+	return readString(item, "id");
+}
+
+function readAppRequestId(params: Readonly<Record<string, unknown>>): string | undefined {
+	return readString(params, "request_id") ?? readString(params, "id");
+}
+
+function readString(input: Readonly<Record<string, unknown>>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
@@ -68,9 +68,8 @@ describe("pi-codex-app-server contract lock", () => {
 		expect(EXTERNAL_PROTOCOL_METHODS.every((method) => method.errorBehavior.length > 0)).toBe(true);
 	});
 
-	it("classifies required app-server surfaces without downstream projection or bridge code", () => {
+	it("classifies required app-server surfaces without callback, reconnect, or evidence-packet code", () => {
 		const downstreamFileNames = [
-			"notification-projector.ts",
 			"server-request-bridge.ts",
 			"reconnect-resume.ts",
 			"redaction-scanner.ts",

--- a/packages/coding-agent/test/suite/pi-codex-app-server-streaming.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-streaming.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { createIdMapper } from "../../src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts";
+import { createNotificationProjector } from "../../src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts";
+import { createSessionRegistry } from "../../src/core/extensions/builtin/pi-codex-app-server/session-registry.ts";
+
+function createBoundProjector() {
+	const sessionRegistry = createSessionRegistry();
+	const idMapper = createIdMapper();
+	const bindResult = sessionRegistry.bindSession({
+		externalSessionId: "external-session-1",
+		appThreadId: "app-thread-1",
+		appSessionId: "app-session-1",
+	});
+	expect(bindResult.kind).toBe("bound");
+	const projector = createNotificationProjector({
+		connectionId: "connection-1",
+		capabilityFlags: ["semantic-events", "opaque-notifications"],
+		notificationOptOuts: [],
+		idMapper,
+		sessionRegistry,
+	});
+	return { idMapper, projector };
+}
+
+describe("pi-codex-app-server notification and item stream projection", () => {
+	it("projects text, plan, reasoning, and completed item streams as separate lossless channels", () => {
+		const { idMapper, projector } = createBoundProjector();
+
+		const started = projector.project({
+			method: "item/started",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item: { id: "app-item-1", type: "agentMessage" },
+			},
+		});
+		const text = projector.project({
+			method: "item/agentMessage/delta",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-item-1",
+				delta: "Hello",
+			},
+		});
+		const plan = projector.project({
+			method: "item/plan/delta",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-item-1",
+				delta: "- inspect routing",
+			},
+		});
+		const reasoning = projector.project({
+			method: "item/reasoning/summaryTextDelta",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-item-1",
+				delta: "Need IDs",
+				index: 0,
+			},
+		});
+		const completed = projector.project({
+			method: "item/completed",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item: { id: "app-item-1", type: "agentMessage", text: "Hello" },
+			},
+		});
+
+		expect([started, text, plan, reasoning, completed]).toMatchObject([
+			{
+				kind: "semantic",
+				sequence: 1,
+				channel: "item",
+				semanticType: "item-started",
+				streamClass: "lossless",
+				externalSessionId: "external-session-1",
+				appThreadId: "app-thread-1",
+				appTurnId: "app-turn-1",
+				appItemId: "app-item-1",
+			},
+			{
+				kind: "semantic",
+				sequence: 2,
+				channel: "text",
+				semanticType: "delta",
+				streamClass: "lossless",
+				delta: "Hello",
+			},
+			{
+				kind: "semantic",
+				sequence: 3,
+				channel: "plan",
+				semanticType: "delta",
+				streamClass: "lossless",
+				delta: "- inspect routing",
+			},
+			{
+				kind: "semantic",
+				sequence: 4,
+				channel: "reasoning-summary",
+				semanticType: "delta",
+				streamClass: "lossless",
+				delta: "Need IDs",
+				index: 0,
+			},
+			{
+				kind: "semantic",
+				sequence: 5,
+				channel: "item",
+				semanticType: "item-completed",
+				streamClass: "lossless",
+				completedItem: { id: "app-item-1", type: "agentMessage", text: "Hello" },
+			},
+		]);
+		expect(idMapper.getItem("app-item-1")).toMatchObject({
+			appThreadId: "app-thread-1",
+			appTurnId: "app-turn-1",
+			appItemId: "app-item-1",
+			itemKind: "agentMessage",
+		});
+	});
+
+	it("emits lossless opaque envelopes for notifications without a first-class projection", () => {
+		const { projector } = createBoundProjector();
+
+		const projected = projector.project({
+			method: "warning",
+			params: {
+				thread_id: "app-thread-1",
+				message: "model warning",
+			},
+		});
+
+		expect(projected).toMatchObject({
+			kind: "opaque",
+			method: "appServer/event",
+			envelope: {
+				protocolVersion: "2026-06-24.pr-001",
+				connectionId: "connection-1",
+				externalSessionId: "external-session-1",
+				appThreadId: "app-thread-1",
+				sequence: 1,
+				streamClass: "lossless",
+				capabilityFlags: ["semantic-events", "opaque-notifications"],
+				originalMethod: "warning",
+				originalParams: {
+					thread_id: "app-thread-1",
+					message: "model warning",
+				},
+				redactionClass: "public-contract",
+			},
+		});
+	});
+
+	it("skips negotiated notification opt-outs before projection", () => {
+		const sessionRegistry = createSessionRegistry();
+		const idMapper = createIdMapper();
+		const projector = createNotificationProjector({
+			connectionId: "connection-1",
+			capabilityFlags: ["opaque-notifications"],
+			notificationOptOuts: ["thread/tokenUsage/updated"],
+			idMapper,
+			sessionRegistry,
+		});
+
+		const projected = projector.project({
+			method: "thread/tokenUsage/updated",
+			params: {
+				thread_id: "app-thread-1",
+				total_tokens: 42,
+			},
+		});
+
+		expect(projected).toEqual({ kind: "skipped", reason: "notification-opt-out" });
+	});
+
+	it("classifies command, process, file, and MCP progress as best-effort semantic progress", () => {
+		const { projector } = createBoundProjector();
+
+		const command = projector.project({
+			method: "item/commandExecution/outputDelta",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-command-1",
+				stream: "stdout",
+				delta: "line",
+			},
+		});
+		const process = projector.project({
+			method: "process/outputDelta",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-process-1",
+				delta: "chunk",
+			},
+		});
+		const file = projector.project({
+			method: "item/fileChange/patchUpdated",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-file-1",
+				patch: "*** Begin Patch",
+			},
+		});
+		const mcp = projector.project({
+			method: "item/mcpToolCall/progress",
+			params: {
+				thread_id: "app-thread-1",
+				turn_id: "app-turn-1",
+				item_id: "app-mcp-1",
+				message: "running",
+			},
+		});
+
+		expect([command, process, file, mcp]).toMatchObject([
+			{ kind: "semantic", channel: "command", semanticType: "progress", streamClass: "best-effort" },
+			{ kind: "semantic", channel: "process", semanticType: "progress", streamClass: "best-effort" },
+			{ kind: "semantic", channel: "file", semanticType: "progress", streamClass: "best-effort" },
+			{ kind: "semantic", channel: "mcp", semanticType: "progress", streamClass: "best-effort" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-streaming.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-streaming.test.ts
@@ -157,6 +157,40 @@ describe("pi-codex-app-server notification and item stream projection", () => {
 		});
 	});
 
+	it("projects generated camelCase notification ids without losing session correlation", () => {
+		const { idMapper, projector } = createBoundProjector();
+		const camelCaseItem = { appThreadId: "app-thread-1", appTurnId: "app-turn-1", appItemId: "app-item-camel-1" };
+
+		const started = projector.project({
+			method: "item/started",
+			params: {
+				threadId: "app-thread-1",
+				turnId: "app-turn-1",
+				item: { id: "app-item-camel-1", type: "agentMessage" },
+			},
+		});
+		const opaque = projector.project({
+			method: "warning",
+			params: {
+				threadId: "app-thread-1",
+				turnId: "app-turn-1",
+				itemId: "app-item-camel-1",
+				requestId: "app-request-1",
+			},
+		});
+
+		expect(started).toMatchObject({
+			kind: "semantic",
+			externalSessionId: "external-session-1",
+			...camelCaseItem,
+		});
+		expect(idMapper.getItem("app-item-camel-1")).toMatchObject({ ...camelCaseItem, itemKind: "agentMessage" });
+		expect(opaque).toMatchObject({
+			kind: "opaque",
+			envelope: { externalSessionId: "external-session-1", ...camelCaseItem, appRequestId: "app-request-1" },
+		});
+	});
+
 	it("skips negotiated notification opt-outs before projection", () => {
 		const sessionRegistry = createSessionRegistry();
 		const idMapper = createIdMapper();


### PR DESCRIPTION
This work is using code-yeongyu/lazycodex teammode.

## Summary

Adds PR-006 item and notification streaming projection for the pi-codex-app-server builtin. The new projection layer consumes the PR-005 session/id maps, preserves authoritative app-server IDs, emits semantic events for item/text/plan/reasoning/progress/turn surfaces, and falls back to lossless opaque `appServer/event` envelopes when no first-class projection exists.

This intentionally does not implement PR-007 backpressure/lag, PR-008 callbacks, PR-009 MCP/dynamic tool callback compatibility, PR-010 reconnect, redaction QA, or the final evidence packet.

## Changes

- Added `item-stream-projector.ts` for text, plan, reasoning, item lifecycle, command/process/file/MCP progress, raw response, and turn terminal projections.
- Added `notification-projector.ts` to sequence app-server notifications, resolve external session correlation from app-thread IDs, apply notification opt-outs, and build opaque envelopes.
- Added focused PR-006 regression coverage for lossless semantic channels, opaque fallback, opt-outs, and best-effort progress classification.
- Updated the PR-001 contract guard so PR-006 projectors are allowed while callback/reconnect/redaction/final-evidence files remain blocked.

## QA / Evidence

- Failing-first proof: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/failing-first.txt`
  - Initial PR-006 test failed because `notification-projector.ts` did not exist yet.
- Focused streaming test: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/targeted-streaming.txt`
  - `test/suite/pi-codex-app-server-streaming.test.ts`: 4 tests passed.
- Adjacent suite: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/targeted-adjacent-suite-final.txt`
  - Contract + routing + streaming suite: 3 files / 13 tests passed.
- Full check: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/npm-run-check-final.txt`
  - `npm run check` passed with no fixes applied on final run.
- Pre-commit gate: commit hook reran `npm run check` and passed.
- senpi QA common self-check: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/senpi-qa-common-self-check.txt`
  - 9/9 passed; real auth unchanged.
- senpi QA CLI smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/senpi-qa-cli-smoke.txt`
  - 5/5 passed; real auth unchanged.
- senpi QA mock loop: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/senpi-qa-mock-loop.txt`
  - 5/5 passed; zero real provider calls; real auth unchanged.
- Adapter harness help smoke: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/drive-adapter-help.txt`
  - Harness help still reports PR-004 runtime-only status and deferred routing/streaming/callback evidence generation.
- Commands: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/commands.txt`
- Cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-006-streaming/cleanup-receipt.txt`

Tracked reviewer summary: `.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/summary.md`

## Project Tracking

`BLOCKED:missing-gh-project-scope` remains. `gh project list --owner code-yeongyu --format json --limit 20` still fails because the token lacks `read:project`.

## Risks

- Live Codex app-server streaming scenarios `07` and `13` are not fully driven through a protocol route in this PR. This PR proves the projection units and keeps CLI/harness health green; end-to-end event-flow evidence remains for the later integrated adapter pass.
- PR-007 still owns lossless queues, lag markers, overload/drop accounting, and terminal flush semantics.
- PR-008 still owns command/file/permission/user-input callback bridging and no-auto-approval behavior.
- PR-009 still owns MCP/dynamic tool callback compatibility.

## Secret Safety

No raw service logs, auth headers, tokens, cookies, launchd environments, or private credentials are included. Evidence is under `local-ignore/`; senpi QA scripts verified real `~/.senpi/agent/auth.json` was unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first streaming projection for `pi-codex-app-server`, emitting semantic item events and sequencing notifications while preserving app-server IDs. Adds a sanitized evidence addendum to help reviewers verify behavior without local artifacts.

- **New Features**
  - `item-stream-projector.ts`: Maps item stream methods to semantic channels (text, plan, reasoning, raw-response, command/process/file/MCP progress, turn start/complete) and registers items in `IdMapper` on `item/started`.
  - `notification-projector.ts`: Sequences notifications, resolves external session via `threadId`/`thread_id`, applies negotiated opt-outs, and builds opaque `appServer/event` envelopes with capability flags.
  - Tests: Streaming suite covers semantic channels, opaque fallback, opt-outs, and best-effort progress classification; contract guard adjusted to allow these projectors. Committed sanitized evidence and a summary under `.omo/evidence/20260624-pi-codex-app-server-execution/pr-006-streaming/`.

- **Bug Fixes**
  - Correctly reads app-server IDs in camelCase and snake_case (`threadId`/`thread_id`, `turnId`/`turn_id`, `itemId`/`item_id`, `requestId`/`request_id`/`id`) to preserve session correlation and item registration.

<sup>Written for commit f8df9df8f24baa8201d14f6e8f8c2bcbbb7bd7f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

