### PR TITLE
feat(coding-agent): add app-server backpressure semantics

### DIFF
--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/16-backpressure-lag.sanitized.jsonl
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/16-backpressure-lag.sanitized.jsonl
@@ -2,6 +2,6 @@
 {"scenario":"16-backpressure-lag","step":"enqueue","method":"item/commandExecution/outputDelta","streamClass":"best-effort","sequence":2,"result":"queued"}
 {"scenario":"16-backpressure-lag","step":"enqueue","method":"process/outputDelta","streamClass":"best-effort","sequence":3,"result":"dropped","droppedProgressEvents":1}
 {"scenario":"16-backpressure-lag","step":"enqueue","method":"item/completed","streamClass":"lossless","sequence":4,"result":"queued"}
-{"scenario":"16-backpressure-lag","step":"drain","methods":["item/agentMessage/delta","item/commandExecution/outputDelta","lag","item/completed"],"lagBeforeNextLossless":true,"droppedProgressEvents":1,"nextLosslessSequence":4}
+{"scenario":"16-backpressure-lag","step":"drain","methods":["item/agentMessage/delta","item/commandExecution/outputDelta","lag","item/completed"],"sequences":[1,2,3,4],"monotonicUniqueSequences":true,"lagBeforeNextLossless":true,"droppedProgressEvents":1,"nextLosslessSequence":4}
 {"scenario":"16-backpressure-lag","step":"terminal-flush","methods":["item/commandExecution/outputDelta","item/agentMessage/delta","turn/completed"],"losslessDropped":false}
 {"scenario":"16-backpressure-lag","step":"overload","code":-32001,"message":"app-server overloaded","retryable":true,"retryAfterMs":250}

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/16-backpressure-lag.sanitized.jsonl
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/16-backpressure-lag.sanitized.jsonl
@@ -1,0 +1,7 @@
+{"scenario":"16-backpressure-lag","step":"enqueue","method":"item/agentMessage/delta","streamClass":"lossless","sequence":1,"result":"queued"}
+{"scenario":"16-backpressure-lag","step":"enqueue","method":"item/commandExecution/outputDelta","streamClass":"best-effort","sequence":2,"result":"queued"}
+{"scenario":"16-backpressure-lag","step":"enqueue","method":"process/outputDelta","streamClass":"best-effort","sequence":3,"result":"dropped","droppedProgressEvents":1}
+{"scenario":"16-backpressure-lag","step":"enqueue","method":"item/completed","streamClass":"lossless","sequence":4,"result":"queued"}
+{"scenario":"16-backpressure-lag","step":"drain","methods":["item/agentMessage/delta","item/commandExecution/outputDelta","lag","item/completed"],"lagBeforeNextLossless":true,"droppedProgressEvents":1,"nextLosslessSequence":4}
+{"scenario":"16-backpressure-lag","step":"terminal-flush","methods":["item/commandExecution/outputDelta","item/agentMessage/delta","turn/completed"],"losslessDropped":false}
+{"scenario":"16-backpressure-lag","step":"overload","code":-32001,"message":"app-server overloaded","retryable":true,"retryAfterMs":250}

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/cleanup-receipt.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/cleanup-receipt.md
@@ -1,0 +1,11 @@
+# PR-007 Cleanup Receipt
+
+This work is using code-yeongyu/lazycodex teammode.
+
+UTC: 2026-06-24T09:57:41Z.
+
+QA/test commands completed with no intentionally retained senpi adapter
+processes, sockets, or tmux sessions. Process command arguments were omitted
+from cleanup evidence for secret safety.
+
+The senpi QA scripts reported the real auth file unchanged.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/cleanup-receipt.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/cleanup-receipt.md
@@ -4,6 +4,8 @@ This work is using code-yeongyu/lazycodex teammode.
 
 UTC: 2026-06-24T09:57:41Z.
 
+Follow-up refresh UTC: 2026-06-24T10:11Z.
+
 QA/test commands completed with no intentionally retained senpi adapter
 processes, sockets, or tmux sessions. Process command arguments were omitted
 from cleanup evidence for secret safety.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/commands.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/commands.md
@@ -40,3 +40,8 @@ NODE_PATH=/Users/yeongyu/local-workspaces/senpi/node_modules \
     packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts \
     packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts
 ```
+
+Review follow-up for lag marker sequence monotonicity reused the same targeted,
+adjacent, check, and senpi QA commands. Refreshed local artifact filenames use
+the `followup-lag-sequence-*` prefix under
+`local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-007-backpressure/`.

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/commands.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/commands.md
@@ -1,0 +1,42 @@
+# PR-007 Commands
+
+This work is using code-yeongyu/lazycodex teammode.
+
+All commands were run from `/Users/yeongyu/local-workspaces/senpi` unless noted.
+
+```bash
+git fetch origin main --prune
+git switch -c code-yeongyu/pi-codex-app-server-backpressure-lag origin/main
+```
+
+```bash
+cd packages/coding-agent &&
+  npx tsx ../../node_modules/vitest/dist/cli.js --run \
+    test/suite/pi-codex-app-server-backpressure.test.ts
+```
+
+```bash
+cd packages/coding-agent &&
+  npx tsx ../../node_modules/vitest/dist/cli.js --run \
+    test/suite/pi-codex-app-server-backpressure.test.ts \
+    test/suite/pi-codex-app-server-streaming.test.ts \
+    test/suite/pi-codex-app-server-contract.test.ts \
+    test/suite/pi-codex-app-server-routing.test.ts \
+    test/suite/pi-codex-app-server-capability.test.ts
+```
+
+```bash
+npm run check
+node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check
+node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test
+node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test
+node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help
+gh project list --owner code-yeongyu --format json --limit 20
+```
+
+```bash
+NODE_PATH=/Users/yeongyu/local-workspaces/senpi/node_modules \
+  bun run /Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.13.0/skills/programming/scripts/typescript/check-no-excuse-rules.ts \
+    packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts \
+    packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts
+```

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/summary.md
@@ -96,8 +96,32 @@ pi-codex-app-server-backpressure.test.ts: 76 pure LOC
 - Lossless events are not dropped under best-effort pressure.
 - Best-effort progress drops increment dropped-progress accounting.
 - A `lag` event appears before the next lossless event after best-effort drops.
+- The `lag` event consumes its own monotonic adapter sequence; `nextLosslessSequence` points to the following lossless event.
 - Terminal flush drains queued progress and lossless turn completion.
 - App-server overload is preserved as retryable JSON-RPC `-32001`.
+
+## Review Follow-Up: Lag Marker Sequence
+
+The review blocker at PR #79 identified that the original lag marker reused the
+following lossless event sequence. The follow-up regression now fails if emitted
+sequences are duplicate or non-monotonic. Red output before the fix showed:
+
+```text
+expected [ 1, 2, 4, 4 ] to deeply equal [ 1, 2, 3, 4 ]
+```
+
+After the fix, the lag marker uses the last dropped progress event's consumed
+adapter sequence, while `nextLosslessSequence` still points to the following
+lossless event. Refreshed artifacts:
+
+- `followup-lag-sequence-failing-first.txt`: failed with duplicate sequence `[1, 2, 4, 4]`.
+- `followup-lag-sequence-targeted-final.txt`: 1 file / 3 tests passed.
+- `followup-lag-sequence-adjacent-final.txt`: 5 files / 21 tests passed.
+- `followup-lag-sequence-npm-run-check-final.txt`: `npm run check` passed.
+- `followup-lag-sequence-senpi-qa-common-self-check.txt`: 9/9 passed.
+- `followup-lag-sequence-senpi-qa-cli-smoke.txt`: 5/5 passed.
+- `followup-lag-sequence-senpi-qa-mock-loop.txt`: 5/5 passed.
+- `followup-lag-sequence-drive-adapter-help.txt`: adapter harness help rendered.
 
 ## Project Tracking
 

--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/summary.md
@@ -1,0 +1,121 @@
+# PR-007 Backpressure And Lag Semantics
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Summary
+
+PR-007 adds a projection-level backpressure controller for the app-server
+adapter. It keeps lossless events queued, drops only best-effort progress when
+the best-effort queue is saturated, emits a `lag` marker before the next
+lossless event after a drop, tracks dropped-progress accounting, flushes
+terminal turns without losing lossless events, and preserves retryable
+app-server overload as JSON-RPC `-32001`.
+
+Scope is intentionally limited to PR-007. It does not implement PR-008
+callbacks, PR-009 MCP/dynamic tools, PR-010 reconnect, redaction QA, or final
+evidence packet generation.
+
+## Changed Files
+
+- `packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts`
+- `packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts`
+- `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/summary.md`
+- `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/commands.md`
+- `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/cleanup-receipt.md`
+- `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/16-backpressure-lag.sanitized.jsonl`
+
+## Evidence
+
+Full raw artifacts remain under
+`local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-007-backpressure/`.
+Committed sanitized evidence is in this directory.
+
+- Failing-first proof: `failing-first.txt` failed because `stream-backpressure.ts` did not exist.
+- Focused backpressure test: `targeted-backpressure-final.txt` passed, 1 file / 3 tests.
+- Adjacent app-server suite: `targeted-adjacent-suite-final.txt` passed, 5 files / 21 tests.
+- Full check: `npm-run-check-final.txt` passed.
+- senpi QA common self-check: `senpi-qa-common-self-check.txt` passed, 9/9.
+- senpi QA CLI smoke: `senpi-qa-cli-smoke.txt` passed, 5/5.
+- senpi QA mock loop: `senpi-qa-mock-loop.txt` passed, 5/5.
+- Adapter harness help smoke: `drive-adapter-help.txt` printed the adapter harness usage.
+- Strict audit: `no-excuse-audit.txt` reported no violations in 2 files.
+- Scenario 16 artifact: `16-backpressure-lag.sanitized.jsonl`.
+- Cleanup receipt: `cleanup-receipt.md`.
+
+## Safe Output Excerpts
+
+Failing-first proof:
+
+```text
+FAIL test/suite/pi-codex-app-server-backpressure.test.ts
+Error: Cannot find module '../../src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts'
+Test Files 1 failed (1)
+Tests no tests
+```
+
+Focused test after implementation:
+
+```text
+Test Files 1 passed (1)
+Tests 3 passed (3)
+```
+
+Adjacent app-server suite:
+
+```text
+Test Files 5 passed (5)
+Tests 21 passed (21)
+```
+
+Full check:
+
+```text
+Checked 1170 files in 858ms. No fixes applied.
+packages/coding-agent/npm-shrinkwrap.json is up to date.
+Checked 67 files in 33ms. No fixes applied.
+```
+
+senpi QA:
+
+```text
+common.mjs --self-check: 9/9 passed
+cli-smoke.mjs --self-test: 5/5 passed
+mock-loop.mjs --self-test: 5/5 passed
+```
+
+Static audit and file size:
+
+```text
+No violations in 2 file(s).
+stream-backpressure.ts: 122 pure LOC
+pi-codex-app-server-backpressure.test.ts: 76 pure LOC
+```
+
+## Assertions Covered
+
+- Lossless events are not dropped under best-effort pressure.
+- Best-effort progress drops increment dropped-progress accounting.
+- A `lag` event appears before the next lossless event after best-effort drops.
+- Terminal flush drains queued progress and lossless turn completion.
+- App-server overload is preserved as retryable JSON-RPC `-32001`.
+
+## Project Tracking
+
+`BLOCKED:missing-gh-project-scope` remains. `gh project list --owner
+code-yeongyu --format json --limit 20` still fails because the token lacks
+`read:project`.
+
+## Secret Safety
+
+Evidence includes sanitized summaries and excerpts only. It does not include raw
+secret-bearing logs, env dumps, tokens, auth headers, cookies, or private
+credentials.
+
+## Residual Risks
+
+- PR-007 is projection-level backpressure. It does not wire a live external
+  transport slow-reader loop yet because PR-010 owns reconnect/resume transport
+  recovery and PR-008 owns callback delivery.
+- Server-request callback delivery failure/rejection remains PR-008.
+- MCP/dynamic tool callback compatibility remains PR-009.
+- Reconnect/resume after disconnect remains PR-010.

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts
@@ -59,6 +59,7 @@ class DefaultStreamBackpressureController implements StreamBackpressureControlle
 	private droppedProgressEvents = 0;
 	private emittedLagMarkers = 0;
 	private pendingDroppedProgressEvents = 0;
+	private pendingLagSequence: number | undefined;
 
 	constructor(options: StreamBackpressureOptions) {
 		this.connectionId = options.connectionId;
@@ -94,6 +95,7 @@ class DefaultStreamBackpressureController implements StreamBackpressureControlle
 		if (this.countQueuedBestEffortEvents() >= this.bestEffortQueueLimit) {
 			this.droppedProgressEvents += 1;
 			this.pendingDroppedProgressEvents += 1;
+			this.pendingLagSequence = readSequence(event);
 			return;
 		}
 		this.queue.push(event);
@@ -101,8 +103,12 @@ class DefaultStreamBackpressureController implements StreamBackpressureControlle
 
 	private enqueueLossless(event: StreamBackpressureEvent): void {
 		if (this.pendingDroppedProgressEvents > 0) {
-			this.queue.push(this.createLagEvent(readSequence(event)));
+			const nextLosslessSequence = readSequence(event);
+			this.queue.push(
+				this.createLagEvent(this.pendingLagSequence ?? nextLosslessSequence - 1, nextLosslessSequence),
+			);
 			this.pendingDroppedProgressEvents = 0;
+			this.pendingLagSequence = undefined;
 			this.emittedLagMarkers += 1;
 		}
 		this.queue.push(event);
@@ -112,12 +118,12 @@ class DefaultStreamBackpressureController implements StreamBackpressureControlle
 		return this.queue.filter((event) => readStreamClass(event) === "best-effort").length;
 	}
 
-	private createLagEvent(nextLosslessSequence: number): LagStreamEvent {
+	private createLagEvent(sequence: number, nextLosslessSequence: number): LagStreamEvent {
 		return {
 			kind: "lag",
 			method: "lag",
 			connectionId: this.connectionId,
-			sequence: nextLosslessSequence,
+			sequence,
 			streamClass: "control",
 			droppedProgressEvents: this.pendingDroppedProgressEvents,
 			nextLosslessSequence,

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts
@@ -1,0 +1,145 @@
+import type { AppServerJsonRpcError } from "./error-mapper.ts";
+import type { NotificationProjection } from "./notification-projector.ts";
+
+export type StreamBackpressureEvent = Exclude<NotificationProjection, { readonly kind: "skipped" }>;
+
+export interface LagStreamEvent {
+	readonly kind: "lag";
+	readonly method: "lag";
+	readonly connectionId: string;
+	readonly sequence: number;
+	readonly streamClass: "control";
+	readonly droppedProgressEvents: number;
+	readonly nextLosslessSequence: number;
+}
+
+export type StreamBackpressureOutput = StreamBackpressureEvent | LagStreamEvent;
+
+export interface StreamBackpressureOptions {
+	readonly connectionId: string;
+	readonly bestEffortQueueLimit: number;
+}
+
+export interface StreamBackpressureStats {
+	readonly droppedProgressEvents: number;
+	readonly emittedLagMarkers: number;
+	readonly queuedEvents: number;
+}
+
+export interface AppServerOverloadOptions {
+	readonly retryAfterMs?: number;
+}
+
+export interface StreamBackpressureController {
+	enqueue(event: StreamBackpressureEvent): void;
+	drainAll(): readonly StreamBackpressureOutput[];
+	flushTerminal(): readonly StreamBackpressureOutput[];
+	stats(): StreamBackpressureStats;
+}
+
+export function createStreamBackpressureController(options: StreamBackpressureOptions): StreamBackpressureController {
+	return new DefaultStreamBackpressureController(options);
+}
+
+export function createAppServerOverloadError(options: AppServerOverloadOptions = {}): AppServerJsonRpcError {
+	return {
+		code: -32001,
+		message: "app-server overloaded",
+		data: {
+			retryable: true,
+			...(options.retryAfterMs === undefined ? {} : { retryAfterMs: options.retryAfterMs }),
+		},
+	};
+}
+
+class DefaultStreamBackpressureController implements StreamBackpressureController {
+	private readonly connectionId: string;
+	private readonly bestEffortQueueLimit: number;
+	private readonly queue: StreamBackpressureOutput[] = [];
+	private droppedProgressEvents = 0;
+	private emittedLagMarkers = 0;
+	private pendingDroppedProgressEvents = 0;
+
+	constructor(options: StreamBackpressureOptions) {
+		this.connectionId = options.connectionId;
+		this.bestEffortQueueLimit = Math.max(0, options.bestEffortQueueLimit);
+	}
+
+	enqueue(event: StreamBackpressureEvent): void {
+		if (readStreamClass(event) === "best-effort") {
+			this.enqueueBestEffort(event);
+			return;
+		}
+
+		this.enqueueLossless(event);
+	}
+
+	drainAll(): readonly StreamBackpressureOutput[] {
+		return this.drainQueuedEvents();
+	}
+
+	flushTerminal(): readonly StreamBackpressureOutput[] {
+		return this.drainQueuedEvents();
+	}
+
+	stats(): StreamBackpressureStats {
+		return {
+			droppedProgressEvents: this.droppedProgressEvents,
+			emittedLagMarkers: this.emittedLagMarkers,
+			queuedEvents: this.queue.length,
+		};
+	}
+
+	private enqueueBestEffort(event: StreamBackpressureEvent): void {
+		if (this.countQueuedBestEffortEvents() >= this.bestEffortQueueLimit) {
+			this.droppedProgressEvents += 1;
+			this.pendingDroppedProgressEvents += 1;
+			return;
+		}
+		this.queue.push(event);
+	}
+
+	private enqueueLossless(event: StreamBackpressureEvent): void {
+		if (this.pendingDroppedProgressEvents > 0) {
+			this.queue.push(this.createLagEvent(readSequence(event)));
+			this.pendingDroppedProgressEvents = 0;
+			this.emittedLagMarkers += 1;
+		}
+		this.queue.push(event);
+	}
+
+	private countQueuedBestEffortEvents(): number {
+		return this.queue.filter((event) => readStreamClass(event) === "best-effort").length;
+	}
+
+	private createLagEvent(nextLosslessSequence: number): LagStreamEvent {
+		return {
+			kind: "lag",
+			method: "lag",
+			connectionId: this.connectionId,
+			sequence: nextLosslessSequence,
+			streamClass: "control",
+			droppedProgressEvents: this.pendingDroppedProgressEvents,
+			nextLosslessSequence,
+		};
+	}
+
+	private drainQueuedEvents(): readonly StreamBackpressureOutput[] {
+		const drained = [...this.queue];
+		this.queue.length = 0;
+		return drained;
+	}
+}
+
+function readStreamClass(
+	event: StreamBackpressureOutput,
+): "lossless" | "best-effort" | "snapshot-authoritative" | "control" {
+	if (event.kind === "lag") return event.streamClass;
+	if (event.kind === "semantic") return event.streamClass;
+	return event.envelope.streamClass;
+}
+
+function readSequence(event: StreamBackpressureEvent): number {
+	if (event.kind === "semantic") return event.sequence;
+	return event.envelope.sequence;
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+	createAppServerOverloadError,
+	createStreamBackpressureController,
+	type StreamBackpressureEvent,
+} from "../../src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts";
+
+function event(method: string, sequence: number, streamClass: "lossless" | "best-effort"): StreamBackpressureEvent {
+	return {
+		kind: "semantic",
+		method,
+		sequence,
+		channel: streamClass === "lossless" ? "text" : "command",
+		semanticType: streamClass === "lossless" ? "delta" : "progress",
+		streamClass,
+		externalSessionId: "external-session-1",
+		appThreadId: "app-thread-1",
+		appTurnId: "app-turn-1",
+		appItemId: "app-item-1",
+		delta: "chunk",
+		index: undefined,
+		completedItem: undefined,
+		originalParams: {},
+	};
+}
+
+describe("pi-codex-app-server stream backpressure", () => {
+	it("keeps lossless events and emits a lag marker before the next lossless event after best-effort drops", () => {
+		const controller = createStreamBackpressureController({
+			connectionId: "connection-1",
+			bestEffortQueueLimit: 1,
+		});
+
+		controller.enqueue(event("item/agentMessage/delta", 1, "lossless"));
+		controller.enqueue(event("item/commandExecution/outputDelta", 2, "best-effort"));
+		controller.enqueue(event("process/outputDelta", 3, "best-effort"));
+		controller.enqueue(event("item/completed", 4, "lossless"));
+		const drained = controller.drainAll();
+
+		expect(drained.map((entry) => entry.method)).toEqual([
+			"item/agentMessage/delta",
+			"item/commandExecution/outputDelta",
+			"lag",
+			"item/completed",
+		]);
+		expect(drained[2]).toMatchObject({
+			kind: "lag",
+			method: "lag",
+			connectionId: "connection-1",
+			droppedProgressEvents: 1,
+			nextLosslessSequence: 4,
+		});
+		expect(controller.stats()).toMatchObject({
+			droppedProgressEvents: 1,
+			emittedLagMarkers: 1,
+			queuedEvents: 0,
+		});
+	});
+
+	it("flushes queued best-effort progress before a terminal turn without dropping lossless events", () => {
+		const controller = createStreamBackpressureController({
+			connectionId: "connection-1",
+			bestEffortQueueLimit: 4,
+		});
+
+		controller.enqueue(event("item/commandExecution/outputDelta", 1, "best-effort"));
+		controller.enqueue(event("item/agentMessage/delta", 2, "lossless"));
+		controller.enqueue(event("turn/completed", 3, "lossless"));
+
+		expect(controller.flushTerminal().map((entry) => entry.method)).toEqual([
+			"item/commandExecution/outputDelta",
+			"item/agentMessage/delta",
+			"turn/completed",
+		]);
+	});
+
+	it("preserves retryable app-server overload as JSON-RPC -32001", () => {
+		expect(createAppServerOverloadError({ retryAfterMs: 250 })).toEqual({
+			code: -32001,
+			message: "app-server overloaded",
+			data: { retryable: true, retryAfterMs: 250 },
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-backpressure.test.ts
@@ -3,6 +3,7 @@ import {
 	createAppServerOverloadError,
 	createStreamBackpressureController,
 	type StreamBackpressureEvent,
+	type StreamBackpressureOutput,
 } from "../../src/core/extensions/builtin/pi-codex-app-server/stream-backpressure.ts";
 
 function event(method: string, sequence: number, streamClass: "lossless" | "best-effort"): StreamBackpressureEvent {
@@ -43,6 +44,7 @@ describe("pi-codex-app-server stream backpressure", () => {
 			"lag",
 			"item/completed",
 		]);
+		expect(drained.map(readOutputSequence)).toEqual([1, 2, 3, 4]);
 		expect(drained[2]).toMatchObject({
 			kind: "lag",
 			method: "lag",
@@ -82,3 +84,8 @@ describe("pi-codex-app-server stream backpressure", () => {
 		});
 	});
 });
+
+function readOutputSequence(event: StreamBackpressureOutput): number {
+	if (event.kind === "semantic" || event.kind === "lag") return event.sequence;
+	return event.envelope.sequence;
+}


### PR DESCRIPTION
This work is using code-yeongyu/lazycodex teammode.

## Summary

PR-007 adds projection-level backpressure semantics for the pi-codex-app-server adapter. It preserves lossless events under pressure, drops only best-effort progress when the best-effort queue is saturated, emits a `lag` marker before the next lossless event after drops, tracks dropped-progress accounting, flushes terminal turns, and preserves retryable app-server overload as JSON-RPC `-32001`.

Scope is intentionally limited to PR-007. PR-008 callbacks, PR-009 MCP/dynamic tool compatibility, PR-010 reconnect, redaction QA, and final evidence packet generation are not implemented here.

## Changes

- Added `stream-backpressure.ts` with:
  - lossless queue preservation
  - best-effort progress drop accounting
  - `lag` projection emitted before the next lossless event
  - terminal flush drain path
  - app-server overload helper returning `-32001`
- Added focused PR-007 regression tests.
- Added committed PR-007 evidence packet and scenario `16` sanitized JSONL.

## QA / Evidence

Raw local artifacts are under `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-007-backpressure/`. Committed sanitized evidence is under `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/`.

Commands and results:

- Failing-first: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-backpressure.test.ts`
  - Artifact: `failing-first.txt`
  - Result: failed before implementation because `stream-backpressure.ts` did not exist.
- Focused test: same command after implementation
  - Artifact: `targeted-backpressure-final.txt`
  - Result: 1 file / 3 tests passed.
- Adjacent app-server suite: `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-backpressure.test.ts test/suite/pi-codex-app-server-streaming.test.ts test/suite/pi-codex-app-server-contract.test.ts test/suite/pi-codex-app-server-routing.test.ts test/suite/pi-codex-app-server-capability.test.ts`
  - Artifacts: `targeted-adjacent-suite-final.txt`, `targeted-adjacent-suite-post-evidence.txt`
  - Result: 5 files / 21 tests passed.
- Full check: `npm run check`
  - Artifacts: `npm-run-check-final.txt`, `npm-run-check-post-evidence.txt`
  - Result: passed; pre-commit hook also reran `npm run check` and passed.
- senpi QA:
  - `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check` -> 9/9 passed.
  - `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` -> 5/5 passed.
  - `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` -> 5/5 passed.
  - `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help` -> adapter harness help rendered.
- Static audit:
  - `NODE_PATH=/Users/yeongyu/local-workspaces/senpi/node_modules bun run /Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.13.0/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...`
  - Artifact: `no-excuse-audit-final.txt`
  - Result: no violations in 2 files; pure LOC 122 and 76.
- Scenario 16:
  - Committed artifact: `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/16-backpressure-lag.sanitized.jsonl`
  - Shows queued lossless text, queued best-effort progress, dropped progress accounting, `lag` before next lossless item completion, terminal flush, and overload `-32001`.
- Cleanup:
  - Artifact: `.omo/evidence/20260624-pi-codex-app-server-execution/pr-007-backpressure/cleanup-receipt.md`
  - Result: no intentionally retained senpi adapter processes, sockets, or tmux sessions; process arguments omitted for secret safety.

## Secret Safety

Evidence includes sanitized summaries and excerpts only. It does not include raw secret-bearing logs, env dumps, tokens, auth headers, cookies, or private credentials. The cleanup receipt omits process command arguments.

## GitHub Project Status

`BLOCKED:missing-gh-project-scope` remains. `gh project list --owner code-yeongyu --format json --limit 20` still fails because the token lacks `read:project`. This is recorded in `project-status.txt` and does not block PR creation.

## Risks

- This is projection-level backpressure. It does not wire a live external transport slow-reader loop; PR-010 owns reconnect/resume transport recovery.
- Server-request callback delivery failure/rejection remains PR-008.
- MCP/dynamic tool callback compatibility remains PR-009.
- Redaction QA and final evidence packet remain later gated work.

## Downstream Unblock Status

PR-008 callbacks, PR-009 MCP/dynamic tools, PR-010 reconnect, redaction QA, and final evidence packet remain gated until PR-007 is accepted/merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds projection-level backpressure to the `pi-codex-app-server` adapter. Lossless events are preserved; best-effort events are dropped under pressure with a `lag` marker, and overload is returned as retryable JSON-RPC `-32001`. Fixes ensure the `lag` marker has its own sequence and keeps sequences monotonic.

- **New Features**
  - Keep lossless events; drop best-effort when the queue is full; track drop counts.
  - Emit a `lag` control event before the next lossless item after any drop (includes dropped count and `nextLosslessSequence`).
  - Flush terminal turns: drain queued progress and complete without losing lossless events.
  - Add `createAppServerOverloadError` that returns retryable `-32001` with optional `retryAfterMs`.
  - Introduce `stream-backpressure.ts` and focused tests under `packages/coding-agent`.

- **Bug Fixes**
  - Assign the `lag` marker its own adapter sequence (from the last dropped progress); sequences are now unique and monotonic, with `nextLosslessSequence` pointing to the following lossless event.

<sup>Written for commit 1d5a253afa841e68bf0ac3d0e9994d2ac9f4a29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

