### PR TITLE
feat(coding-agent): add app-server pass-through gates

### DIFF
--- a/.omo/evidence/20260625-pi-codex-app-server-execution/pr-011-realtime-fs-config/summary.md
+++ b/.omo/evidence/20260625-pi-codex-app-server-execution/pr-011-realtime-fs-config/summary.md
@@ -1,0 +1,47 @@
+# PR-011 Realtime/filesystem/plugin/config pass-through evidence
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Scope
+
+- Implemented Wave 5 request pass-through only for PR-011-owned app-server client requests: filesystem `fs/*`, realtime `thread/realtime/*`, app/plugin/skills/hooks/marketplace/config/externalAgentConfig/remoteControl surfaces.
+- Kept command/process/MCP/tool/account/model/review/fuzzy-file/windows/feedback/environment/mock surfaces outside PR-011 rejected as `unsupported-routing-method` unless already handled by prior specific routes.
+- Added opaque notification coverage for fs/realtime/warning/deprecation/config/app/remote-control notifications through the existing app-server event envelope.
+
+## Failing-first proof
+
+- Command: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-pass-through.test.ts`
+- Initial result before implementation: FAIL, 2 failed / 1 passed. New pass-through tests received `unsupported-routing-method` instead of app-server responses or capability-gated errors.
+
+## Verification
+
+- Targeted PR-011 test: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-pass-through.test.ts` -> PASS, 1 file / 4 tests.
+- Full pi-codex adapter suite: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-*.test.ts` -> PASS, 15 files / 60 tests.
+- Required check: `npm run check` -> PASS.
+- senpi QA common harness: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check` -> PASS, 9/9, real auth unchanged.
+- Adapter harness availability: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help` -> PASS.
+
+## Scenario 17
+
+- Scenario 17 live realtime text/audio against a real Codex app-server runtime is NOT-RUN for PR-011 in this isolated senpi worktree because PR-012/PR-013 final manual QA/redaction lanes remain gated and no live Codex realtime app-server endpoint is available here.
+- PR-011 coverage instead proves protocol/router pass-through for `thread/realtime/*` and opaque realtime notifications with hermetic tests. No runtime transport, callback, stream projection, reconnect, redaction, or final evidence scope was added.
+
+## Project tracking
+
+- `gh project list --owner code-yeongyu --format json --limit 20` -> `BLOCKED:missing-gh-project-scope` because token is missing `read:project`.
+
+## Cleanup
+
+- Removed ignored `.codegraph` symlink at `/Users/yeongyu/.codex/worktrees/cd6e/senpi/.codegraph` so Biome would not follow `/Users/yeongyu/.omo/codegraph/projects/senpi-dab18ee9e5d425a8/daemon.sock` and fail `npm run check` with `internalError/fs Unknown file type`.
+- Cleanup receipt: `local-ignore/qa-evidence/20260625-pi-codex-app-server/pr-011-realtime-fs-config/tool-state-cleanup.txt`.
+- `npm install --ignore-scripts` was used only to hydrate the isolated worktree; `node_modules/` remains ignored and no package metadata was changed.
+
+## Secret safety
+
+- Evidence contains no raw tokens, auth headers, cookies, launchd environments, or real credential contents.
+- senpi QA common self-check verified `/Users/yeongyu/.senpi/agent/auth.json` was unchanged.
+
+## Residual risks
+
+- Runtime transport and live realtime audio behavior remain covered by downstream manual QA lanes, not this protocol-only PR.
+- PR-011 intentionally does not pass through command/process/MCP/tool/account/model/review/windows/feedback/environment surfaces.

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/protocol-core.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/protocol-core.ts
@@ -1,10 +1,11 @@
 import { APP_SERVER_SURFACE_INVENTORY } from "./protocol-inventory.ts";
+import type { AppServerClientRequestSurface } from "./protocol-required-surfaces.ts";
 
 export { APP_SERVER_SURFACE_INVENTORY } from "./protocol-inventory.ts";
 
 export const PI_CODEX_APP_SERVER_PROTOCOL_VERSION = "2026-06-24.pr-001";
 
-export type ExternalProtocolMethodName =
+export type CoreExternalProtocolMethodName =
 	| "initialize"
 	| "initialized"
 	| "session/new"
@@ -26,6 +27,7 @@ export type ExternalProtocolMethodName =
 	| "lag"
 	| "disconnect"
 	| "resume";
+export type ExternalProtocolMethodName = CoreExternalProtocolMethodName | AppServerClientRequestSurface;
 
 export type StreamClass = "lossless" | "best-effort" | "snapshot-authoritative" | "control";
 export type RelayClass = "semantic" | "opaque-lossless" | "opaque-best-effort" | "snapshot-authoritative";

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/protocol-required-surfaces.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/protocol-required-surfaces.ts
@@ -122,6 +122,8 @@ export const PLAN_REQUIRED_CLIENT_REQUEST_SURFACES = [
 	"fuzzyFileSearch/sessionStop",
 ] as const;
 
+export type AppServerClientRequestSurface = (typeof PLAN_REQUIRED_CLIENT_REQUEST_SURFACES)[number];
+
 export const PLAN_REQUIRED_SERVER_REQUEST_SURFACES = [
 	"item/commandExecution/requestApproval",
 	"item/fileChange/requestApproval",

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/request-router.ts
@@ -1,6 +1,7 @@
 import {
 	type AppServerInitializeCapabilities,
 	type ExternalInitializeCapabilities,
+	type NegotiatedCapabilityFlag,
 	negotiatePiCodexAppServerCapabilities,
 	parseExternalInitializeCapabilities,
 } from "./capability-negotiator.ts";
@@ -59,6 +60,7 @@ class DefaultRequestRouter implements RequestRouter {
 	private readonly idMapper: IdMapper;
 	private readonly sessionRegistry: SessionRegistry;
 	private readonly appServerCapabilities: AppServerInitializeCapabilities | undefined;
+	private negotiatedCapabilityFlags: ReadonlySet<NegotiatedCapabilityFlag> = new Set();
 
 	constructor(options: RequestRouterOptions) {
 		this.client = options.client;
@@ -118,7 +120,7 @@ class DefaultRequestRouter implements RequestRouter {
 			case "turn/interrupt":
 				return this.routeTurnInterrupt(input.params);
 			default:
-				return unsupported(input.method);
+				return this.routePassThrough(input.method, input.params);
 		}
 	}
 
@@ -132,7 +134,7 @@ class DefaultRequestRouter implements RequestRouter {
 		if (negotiated.kind === "rejected") {
 			return { kind: "adapter-error", error: negotiated.error };
 		}
-		return this.callAppServer("initialize", {
+		const response = await this.callAppServer("initialize", {
 			capabilities: {
 				experimentalApi: this.appServerCapabilities?.experimentalApi,
 				requestAttestation: this.appServerCapabilities?.requestAttestation,
@@ -140,6 +142,10 @@ class DefaultRequestRouter implements RequestRouter {
 				optOutNotificationMethods: negotiated.notificationOptOuts,
 			},
 		});
+		if (response.kind === "app-server-response") {
+			this.negotiatedCapabilityFlags = new Set(negotiated.capabilityFlags);
+		}
+		return response;
 	}
 
 	private async routeThreadBinding(
@@ -238,6 +244,25 @@ class DefaultRequestRouter implements RequestRouter {
 		return this.callAppServer("turn/interrupt", withField(withThreadId({}, active.binding), "turn_id", appTurnId));
 	}
 
+	private async routePassThrough(
+		method: ExternalProtocolMethodName,
+		params: unknown,
+	): Promise<RouteExternalRequestResult> {
+		if (!passThroughClientRequestMethods.has(method)) return unsupported(method);
+		const capabilityGate = capabilityGateForPassThrough(method);
+		if (capabilityGate && !this.negotiatedCapabilityFlags.has(capabilityGate)) {
+			return {
+				kind: "adapter-error",
+				error: createAdapterJsonRpcError({
+					adapterCode: "incompatible-capabilities",
+					message: `External client did not negotiate ${capabilityGate} for ${method}.`,
+					details: [method],
+				}),
+			};
+		}
+		return this.callAppServer(method, appParamsFrom(params));
+	}
+
 	private requireSession(params: unknown): ActiveSessionResult {
 		const externalSessionId = parseRoutingParams(params).externalSessionId;
 		if (!externalSessionId) return invalidSession("Routing requires externalSessionId.");
@@ -249,6 +274,77 @@ class DefaultRequestRouter implements RequestRouter {
 	private async callAppServer(method: string, params: unknown): Promise<RouteExternalRequestResult> {
 		return { kind: "app-server-response", appServerResponse: await this.client.request(method, params) };
 	}
+}
+
+const passThroughClientRequestMethods: ReadonlySet<string> = new Set([
+	"skills/list",
+	"skills/extraRoots/set",
+	"hooks/list",
+	"marketplace/add",
+	"marketplace/remove",
+	"marketplace/upgrade",
+	"plugin/list",
+	"plugin/installed",
+	"plugin/read",
+	"plugin/skill/read",
+	"plugin/share/save",
+	"plugin/share/updateTargets",
+	"plugin/share/list",
+	"plugin/share/checkout",
+	"plugin/share/delete",
+	"app/list",
+	"fs/readFile",
+	"fs/writeFile",
+	"fs/createDirectory",
+	"fs/getMetadata",
+	"fs/readDirectory",
+	"fs/remove",
+	"fs/copy",
+	"fs/watch",
+	"fs/unwatch",
+	"skills/config/write",
+	"plugin/install",
+	"plugin/uninstall",
+	"thread/realtime/start",
+	"thread/realtime/appendAudio",
+	"thread/realtime/appendText",
+	"thread/realtime/appendSpeech",
+	"thread/realtime/stop",
+	"thread/realtime/listVoices",
+	"remoteControl/enable",
+	"remoteControl/disable",
+	"remoteControl/status/read",
+	"remoteControl/pairing/start",
+	"remoteControl/pairing/status",
+	"remoteControl/client/list",
+	"remoteControl/client/revoke",
+	"config/read",
+	"externalAgentConfig/detect",
+	"externalAgentConfig/import",
+	"externalAgentConfig/import/readHistories",
+	"config/value/write",
+	"config/batchWrite",
+	"configRequirements/read",
+] as const);
+
+function capabilityGateForPassThrough(method: string): NegotiatedCapabilityFlag | undefined {
+	if (method.startsWith("fs/")) return "filesystem";
+	if (method.startsWith("thread/realtime/")) return "realtime";
+	if (isAppPluginConfigMethod(method)) return "app-plugin-config";
+	return undefined;
+}
+
+function isAppPluginConfigMethod(method: string): boolean {
+	return (
+		method.startsWith("skills/") ||
+		method.startsWith("hooks/") ||
+		method.startsWith("marketplace/") ||
+		method.startsWith("plugin/") ||
+		method.startsWith("app/") ||
+		method.startsWith("config") ||
+		method.startsWith("externalAgentConfig/") ||
+		method.startsWith("remoteControl/")
+	);
 }
 
 function parseInitialize(

--- a/packages/coding-agent/test/suite/pi-codex-app-server-pass-through.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-pass-through.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { createIdMapper } from "../../src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts";
+import { createNotificationProjector } from "../../src/core/extensions/builtin/pi-codex-app-server/notification-projector.ts";
+import { PI_CODEX_APP_SERVER_PROTOCOL_VERSION } from "../../src/core/extensions/builtin/pi-codex-app-server/protocol-core.ts";
+import { createRequestRouter } from "../../src/core/extensions/builtin/pi-codex-app-server/request-router.ts";
+import { createSessionRegistry } from "../../src/core/extensions/builtin/pi-codex-app-server/session-registry.ts";
+import { RecordingAppServerClient } from "./pi-codex-app-server-routing-fakes.ts";
+
+describe("pi-codex-app-server Wave 5 pass-through", () => {
+	it("passes filesystem, realtime, app, plugin, config, marketplace, and remote-control requests through after trust negotiation", async () => {
+		const client = new RecordingAppServerClient([
+			{ ok: true },
+			{ watch_id: "watch-1" },
+			{ voices: [] },
+			{ apps: [] },
+			{ plugins: [] },
+			{ config: {} },
+			{ installed: true },
+			{ enabled: true },
+		]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: createSessionRegistry(),
+		});
+
+		await router.route({
+			method: "initialize",
+			params: {
+				protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+				capabilities: {
+					semanticEvents: true,
+					opaqueNotifications: true,
+					opaqueCallbacks: true,
+					filesystem: true,
+					realtime: true,
+					appPluginConfig: true,
+				},
+			},
+		});
+
+		const results = [
+			await router.route({ method: "fs/watch", params: { appParams: { path: "/tmp/project/src" } } }),
+			await router.route({ method: "thread/realtime/listVoices", params: { appParams: { locale: "en-US" } } }),
+			await router.route({ method: "app/list", params: { appParams: { include_disabled: true } } }),
+			await router.route({ method: "plugin/list", params: { appParams: { include_builtin: true } } }),
+			await router.route({ method: "config/read", params: { appParams: { section: "app-server" } } }),
+			await router.route({ method: "marketplace/add", params: { appParams: { plugin_id: "plugin-a" } } }),
+			await router.route({ method: "remoteControl/enable", params: { appParams: { bind: "127.0.0.1" } } }),
+		];
+
+		expect(results).toMatchObject([
+			{ kind: "app-server-response", appServerResponse: { watch_id: "watch-1" } },
+			{ kind: "app-server-response", appServerResponse: { voices: [] } },
+			{ kind: "app-server-response", appServerResponse: { apps: [] } },
+			{ kind: "app-server-response", appServerResponse: { plugins: [] } },
+			{ kind: "app-server-response", appServerResponse: { config: {} } },
+			{ kind: "app-server-response", appServerResponse: { installed: true } },
+			{ kind: "app-server-response", appServerResponse: { enabled: true } },
+		]);
+		expect(client.calls).toEqual([
+			{ method: "initialize", params: { capabilities: { optOutNotificationMethods: [] } } },
+			{ method: "fs/watch", params: { path: "/tmp/project/src" } },
+			{ method: "thread/realtime/listVoices", params: { locale: "en-US" } },
+			{ method: "app/list", params: { include_disabled: true } },
+			{ method: "plugin/list", params: { include_builtin: true } },
+			{ method: "config/read", params: { section: "app-server" } },
+			{ method: "marketplace/add", params: { plugin_id: "plugin-a" } },
+			{ method: "remoteControl/enable", params: { bind: "127.0.0.1" } },
+		]);
+	});
+
+	it("rejects filesystem, realtime, and app/plugin/config pass-through without the matching trust capability", async () => {
+		const client = new RecordingAppServerClient([{ ok: true }]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: createSessionRegistry(),
+		});
+
+		await router.route({
+			method: "initialize",
+			params: {
+				protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+				capabilities: {
+					semanticEvents: true,
+					opaqueNotifications: true,
+					opaqueCallbacks: true,
+				},
+			},
+		});
+
+		const fs = await router.route({ method: "fs/watch", params: { appParams: { path: "/tmp/project" } } });
+		const realtime = await router.route({ method: "thread/realtime/start", params: { appParams: {} } });
+		const config = await router.route({ method: "config/read", params: { appParams: {} } });
+
+		expect([fs, realtime, config]).toMatchObject([
+			{ kind: "adapter-error", error: { data: { adapterCode: "incompatible-capabilities" } } },
+			{ kind: "adapter-error", error: { data: { adapterCode: "incompatible-capabilities" } } },
+			{ kind: "adapter-error", error: { data: { adapterCode: "incompatible-capabilities" } } },
+		]);
+		expect(client.calls).toEqual([
+			{ method: "initialize", params: { capabilities: { optOutNotificationMethods: [] } } },
+		]);
+	});
+
+	it("keeps out-of-scope inventory methods unsupported for PR-011", async () => {
+		const client = new RecordingAppServerClient([{ ok: true }]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: createSessionRegistry(),
+		});
+
+		await router.route({
+			method: "initialize",
+			params: {
+				protocolVersion: PI_CODEX_APP_SERVER_PROTOCOL_VERSION,
+				capabilities: {
+					semanticEvents: true,
+					opaqueNotifications: true,
+					opaqueCallbacks: true,
+					filesystem: true,
+					realtime: true,
+					appPluginConfig: true,
+				},
+			},
+		});
+
+		const command = await router.route({ method: "command/exec", params: { appParams: { command: "pwd" } } });
+		const mcp = await router.route({
+			method: "mcpServer/tool/call",
+			params: { appParams: { server: "test", tool: "echo" } },
+		});
+
+		expect([command, mcp]).toMatchObject([
+			{ kind: "adapter-error", error: { data: { adapterCode: "unsupported-routing-method" } } },
+			{ kind: "adapter-error", error: { data: { adapterCode: "unsupported-routing-method" } } },
+		]);
+		expect(client.calls).toEqual([
+			{ method: "initialize", params: { capabilities: { optOutNotificationMethods: [] } } },
+		]);
+	});
+
+	it("relays filesystem, realtime, warning, deprecation, config, app, and remote-control notifications as opaque app-server events", () => {
+		const sessionRegistry = createSessionRegistry();
+		const bindResult = sessionRegistry.bindSession({
+			externalSessionId: "external-session-1",
+			appThreadId: "app-thread-1",
+			appSessionId: "app-session-1",
+		});
+		expect(bindResult.kind).toBe("bound");
+		const projector = createNotificationProjector({
+			connectionId: "connection-1",
+			capabilityFlags: ["opaque-notifications", "filesystem", "realtime", "app-plugin-config"],
+			notificationOptOuts: [],
+			idMapper: createIdMapper(),
+			sessionRegistry,
+		});
+
+		const projections = [
+			projector.project({ method: "fs/changed", params: { thread_id: "app-thread-1", path: "/tmp/project/a.ts" } }),
+			projector.project({
+				method: "thread/realtime/transcript/delta",
+				params: { thread_id: "app-thread-1", turn_id: "app-turn-1", item_id: "app-item-1", delta: "hi" },
+			}),
+			projector.project({ method: "warning", params: { thread_id: "app-thread-1", message: "warning" } }),
+			projector.project({
+				method: "deprecationNotice",
+				params: { thread_id: "app-thread-1", message: "deprecated" },
+			}),
+			projector.project({ method: "configWarning", params: { thread_id: "app-thread-1", key: "sandbox" } }),
+			projector.project({ method: "app/list/updated", params: { thread_id: "app-thread-1" } }),
+			projector.project({ method: "remoteControl/status/changed", params: { thread_id: "app-thread-1" } }),
+		];
+
+		expect(projections).toMatchObject([
+			{ kind: "opaque", method: "appServer/event", envelope: { sequence: 1, originalMethod: "fs/changed" } },
+			{
+				kind: "opaque",
+				method: "appServer/event",
+				envelope: {
+					sequence: 2,
+					originalMethod: "thread/realtime/transcript/delta",
+					appTurnId: "app-turn-1",
+					appItemId: "app-item-1",
+				},
+			},
+			{ kind: "opaque", method: "appServer/event", envelope: { sequence: 3, originalMethod: "warning" } },
+			{ kind: "opaque", method: "appServer/event", envelope: { sequence: 4, originalMethod: "deprecationNotice" } },
+			{ kind: "opaque", method: "appServer/event", envelope: { sequence: 5, originalMethod: "configWarning" } },
+			{ kind: "opaque", method: "appServer/event", envelope: { sequence: 6, originalMethod: "app/list/updated" } },
+			{
+				kind: "opaque",
+				method: "appServer/event",
+				envelope: { sequence: 7, originalMethod: "remoteControl/status/changed" },
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

This work is using code-yeongyu/lazycodex teammode.

Adds Wave 5 PR-011 protocol pass-through for the pi Codex app-server adapter. The router now forwards only PR-011-owned app-server request families after explicit capability negotiation: filesystem, realtime, app/plugin/skills/hooks/marketplace/config/externalAgentConfig, and remote-control surfaces.

Before this PR, those methods were rejected as unsupported. After this PR, negotiated clients can relay them through `appParams`, while out-of-scope inventory-listed methods such as `command/exec` and `mcpServer/tool/call` remain unsupported for PR-011.

## Changes

- Adds a narrow Wave 5 pass-through allowlist in `request-router.ts`.
- Stores negotiated capability flags after successful initialize and requires:
  - `filesystem` for `fs/*`
  - `realtime` for `thread/realtime/*`
  - `app-plugin-config` for app/plugin/skills/hooks/marketplace/config/externalAgentConfig/remoteControl requests
- Extends external request typing to include app-server client request surfaces without making the full inventory routable.
- Adds focused PR-011 regression coverage for successful pass-through, missing trust capabilities, out-of-scope methods, and Wave 5 opaque notification relay.
- Adds reviewer evidence summary at `.omo/evidence/20260625-pi-codex-app-server-execution/pr-011-realtime-fs-config/summary.md`.

## QA / Evidence

- Failing-first proof: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-pass-through.test.ts` initially failed with `unsupported-routing-method` for new pass-through cases.
- Targeted PR-011 test: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-pass-through.test.ts` -> PASS, 1 file / 4 tests.
- Full app-server adapter suite: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-*.test.ts` -> PASS, 15 files / 60 tests.
- Required check: `npm run check` -> PASS.
- Commit hook reran `npm run check` -> PASS.
- senpi QA common harness: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check` -> PASS, 9/9, real auth unchanged.
- Adapter harness availability: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs --help` -> PASS.

Artifacts:

- `.omo/evidence/20260625-pi-codex-app-server-execution/pr-011-realtime-fs-config/summary.md`
- `local-ignore/qa-evidence/20260625-pi-codex-app-server/pr-011-realtime-fs-config/summary.md`
- `local-ignore/qa-evidence/20260625-pi-codex-app-server/pr-011-realtime-fs-config/commands.txt`
- `local-ignore/qa-evidence/20260625-pi-codex-app-server/pr-011-realtime-fs-config/project-tracking.txt`
- `local-ignore/qa-evidence/20260625-pi-codex-app-server/pr-011-realtime-fs-config/tool-state-cleanup.txt`
- `local-ignore/qa-evidence/20260625-pi-codex-app-server/pr-011-realtime-fs-config/secret-safety.txt`

## Scenario 17

NOT-RUN for live realtime text/audio in this isolated senpi worktree. PR-012/PR-013 final manual QA/redaction lanes remain gated, and no live Codex realtime app-server endpoint is available here. PR-011 coverage proves protocol/router pass-through for `thread/realtime/*` and opaque realtime notifications with hermetic tests.

## Cleanup Receipt

- Removed ignored `.codegraph` symlink from the worktree so Biome would not follow `/Users/yeongyu/.omo/codegraph/projects/senpi-dab18ee9e5d425a8/daemon.sock` and fail with `internalError/fs Unknown file type`.
- The symlink was recreated once by background tool-state bootstrap before commit; it was removed again before the commit hook.
- `npm install --ignore-scripts` hydrated the isolated worktree only. `node_modules/` remains ignored and no package metadata changed.

## Project Tracking

`BLOCKED:missing-gh-project-scope`: `gh project list --owner code-yeongyu --format json --limit 20` failed because the token is missing `read:project`.

## Secret Safety

Evidence contains no raw tokens, auth headers, cookies, launchd environments, or credential contents. senpi QA common self-check verified `/Users/yeongyu/.senpi/agent/auth.json` was unchanged.

## Risks

Runtime transport and live realtime audio behavior remain downstream manual QA scope. PR-011 intentionally keeps command/process/MCP/tool/account/model/review/windows/feedback/environment surfaces unsupported unless prior PR-specific routes already handle them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Wave 5 PR-011 pass-through routing to the `packages/coding-agent` pi Codex app-server adapter. After capability negotiation, the router forwards a narrow set of app-server client requests and keeps all others unsupported.

- **New Features**
  - Allowlisted pass-through in `request-router.ts` for `fs/*`, `thread/realtime/*`, and `app|plugin|skills|hooks|marketplace|config|externalAgentConfig|remoteControl` requests via `appParams`.
  - Capability gates: `filesystem` for `fs/*`, `realtime` for `thread/realtime/*`, `app-plugin-config` for the rest; flags are stored after `initialize`.
  - Extends external request typing to include app-server client surfaces without exposing the full inventory.
  - Keeps out-of-scope methods (e.g., `command/exec`, `mcpServer/tool/call`) rejected as `unsupported-routing-method`.

<sup>Written for commit 18472ff6279bdb26ccb4f80beba0389a41a9416e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

