### PR TITLE
feat(coding-agent): add app-server QA redaction packets

### DIFF
--- a/.omo/evidence/20260624-pi-codex-app-server-execution/pr-012-qa-redaction/summary.md
+++ b/.omo/evidence/20260624-pi-codex-app-server-execution/pr-012-qa-redaction/summary.md
@@ -1,0 +1,31 @@
+# PR-012 QA Redaction Evidence
+
+This work is using code-yeongyu/lazycodex teammode.
+
+## Scope
+
+PR-012 implements reusable QA/redaction harness pieces only: sanitized transcript writing, assertion result writing, redaction scanning, reviewer packet generation, seeded fake-secret fail-closed behavior, and cleanup receipt evidence. PR-013 final/live compatibility evidence remains gated.
+
+## Verification
+
+- Failing-first: `targeted-qa-redaction-test.txt` first failed before `write-evidence-packet.mjs` existed, then passed after implementation.
+- Targeted PR-012: `targeted-qa-redaction-test.txt` PASS, 1 file / 3 tests.
+- Focused contract/harness: `focused-contract-harness-qa-redaction.txt` PASS, 3 files / 10 tests.
+- Full pi-codex app-server slice: `full-pi-codex-app-server-suite.txt` PASS, 16 files / 63 tests.
+- `npm run check`: `npm-run-check.txt` PASS.
+- senpi QA: `senpi-qa-cli-smoke.txt` PASS and `senpi-qa-mock-loop.txt` PASS; both report real auth unchanged.
+- Packet writer: `packet-writer.txt` PASS and `reviewer-packet/` contains sanitized packet files.
+- Fail-closed scan: `scan-fail-closed.txt` records expected `exitCode=1` for a seeded fake-secret leak.
+- Evidence root scan: `evidence-root-redaction-scan.txt` PASS.
+
+## Cleanup And Project Tracking
+
+- Cleanup receipt: `cleanup-receipt.txt` records zero owned runtime leaks.
+- Local dependency symlink was removed before staging.
+- External codegraph socket was temporarily moved to `/tmp` for `npm run check` and restored; see `codegraph-check-workaround.txt`.
+- GitHub Project tracking: `BLOCKED:missing-gh-project-scope` from missing `read:project` scope; see `project-tracking-status.txt` and `gh-project-list.err`.
+
+## Residual Risks
+
+- PR-012 validates reusable packet/redaction mechanics, not the PR-013 final live scenario matrix.
+- Redaction patterns cover seeded fake secrets plus common token/header shapes; future secret classes should add detector tests before use in reviewer packets.

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/drive-adapter.mjs
@@ -23,8 +23,9 @@ Options:
   --cleanup-receipt <path>       Write teardown evidence for reviewer packets.
 
 Status:
-  PR-004 runtime smoke plus PR-010 reconnect/resume evidence support. Redaction,
-  realtime/filesystem/plugin/config, and final evidence packet generation are deferred.
+  PR-004 runtime smoke plus PR-010 reconnect/resume evidence support. Use
+  write-evidence-packet.mjs for PR-012 redaction packets. Final PR-013
+  compatibility evidence remains deferred.
 `;
 
 const CHILD_HEALTH_WINDOW_MS = 100;

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/evidence-packet.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/evidence-packet.mjs
@@ -1,0 +1,100 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { sanitizeJsonLine, sanitizeText, scanPathsForSecrets, writeRedactionReport } from "./evidence-redaction.mjs";
+import { writeCleanupReceipt } from "./drive-adapter-support.mjs";
+
+export const REQUIRED_PACKET_FILES = [
+	"summary.md",
+	"commands.txt",
+	"sanitized-transcript.jsonl",
+	"assertions.json",
+	"redaction-report.txt",
+	"residual-risks.md",
+	"cleanup-receipt.txt",
+];
+
+export function readPacketInput(path) {
+	return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+export function writeEvidencePacket(input, outputDir) {
+	const seededSecrets = Array.isArray(input.seededSecrets) ? input.seededSecrets : [];
+	mkdirSync(outputDir, { recursive: true });
+	writeFileSync(join(outputDir, "summary.md"), createSummary(input, seededSecrets));
+	writeFileSync(join(outputDir, "commands.txt"), createCommands(input, seededSecrets));
+	writeFileSync(join(outputDir, "sanitized-transcript.jsonl"), createTranscript(input, seededSecrets));
+	const assertionResult = createAssertions(input, seededSecrets);
+	writeFileSync(join(outputDir, "assertions.json"), assertionResult.content);
+	writeFileSync(join(outputDir, "residual-risks.md"), createResidualRisks(input, seededSecrets));
+	writeCleanupReceipt(join(outputDir, "cleanup-receipt.txt"), normalizeCleanup(input.cleanup));
+	const scanResult = scanPathsForSecrets(outputDir, seededSecrets);
+	writeRedactionReport(join(outputDir, "redaction-report.txt"), scanResult);
+	if (scanResult.status === "fail") return scanResult;
+	if (!assertionResult.passed) {
+		return {
+			status: "assertion-fail",
+			findings: [],
+		};
+	}
+	return scanResult;
+}
+
+function createSummary(input, seededSecrets) {
+	const title = sanitizeText(String(input.title ?? "PR-012 QA redaction evidence packet"), seededSecrets);
+	return [
+		`# ${title}`,
+		"",
+		"- Scope: PR-012 reusable manual QA harness and evidence redaction.",
+		"- Packet files: commands, sanitized transcript, assertions, redaction report, residual risks, cleanup receipt.",
+		"- Secret safety: seeded fake secrets and token-shaped values are redacted before scanning.",
+		"",
+	].join("\n");
+}
+
+function createCommands(input, seededSecrets) {
+	const commands = Array.isArray(input.commands) ? input.commands : [];
+	const lines = [];
+	for (const command of commands) {
+		lines.push(`$ ${sanitizeText(String(command.command ?? ""), seededSecrets)}`);
+		lines.push(`exitCode=${Number(command.exitCode ?? 0)}`);
+		if (command.output !== undefined) {
+			lines.push(sanitizeText(String(command.output), seededSecrets));
+		}
+		lines.push("");
+	}
+	return lines.join("\n");
+}
+
+function createTranscript(input, seededSecrets) {
+	const transcript = Array.isArray(input.transcript) ? input.transcript : [];
+	return `${transcript.map((entry) => sanitizeJsonLine(entry, seededSecrets)).join("\n")}\n`;
+}
+
+function createAssertions(input, seededSecrets) {
+	const assertions = Array.isArray(input.assertions) ? input.assertions : [];
+	const normalized = assertions.map((assertion) => ({
+		name: sanitizeText(String(assertion.name ?? "unnamed assertion"), seededSecrets),
+		passed: assertion.passed === true,
+		details: sanitizeText(String(assertion.details ?? ""), seededSecrets),
+	}));
+	const passed = normalized.every((assertion) => assertion.passed);
+	return {
+		content: `${JSON.stringify({ assertions: normalized, passed }, null, 2)}\n`,
+		passed,
+	};
+}
+
+function createResidualRisks(input, seededSecrets) {
+	const risks = Array.isArray(input.residualRisks) ? input.residualRisks : [];
+	if (risks.length === 0) return "No residual risks recorded.\n";
+	return `${risks.map((risk) => `- ${sanitizeText(String(risk), seededSecrets)}`).join("\n")}\n`;
+}
+
+function normalizeCleanup(cleanup) {
+	return {
+		childProcesses: Number(cleanup?.childProcesses ?? 0),
+		websockets: Number(cleanup?.websockets ?? 0),
+		ownedSockets: Number(cleanup?.ownedSockets ?? 0),
+		externalSocketPathsReferenced: Number(cleanup?.externalSocketPathsReferenced ?? 0),
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/evidence-redaction.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/evidence-redaction.mjs
@@ -1,0 +1,107 @@
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+
+export const SEEDED_FAKE_SECRET = "pi_codex_fake_secret_DO_NOT_LEAK_20260624";
+
+const BUILTIN_SECRET_PATTERNS = [
+	{
+		label: "authorization-bearer",
+		pattern: /Authorization:\s*Bearer\s+(?!\[REDACTED\])[^\s"'`]+/giu,
+		replacement: "Authorization: Bearer [REDACTED]",
+	},
+	{
+		label: "codex-access-token",
+		pattern: /CODEX_ACCESS_TOKEN=(?!\[REDACTED\])([^\s"'`]+)/gu,
+		replacement: "CODEX_ACCESS_TOKEN=[REDACTED]",
+	},
+	{
+		label: "cookie-header",
+		pattern: /Cookie:\s*[^\n\r]+/giu,
+		replacement: "Cookie: [REDACTED]",
+	},
+	{
+		label: "openai-key",
+		pattern: /sk-[A-Za-z0-9_-]{16,}/gu,
+		replacement: "[REDACTED_OPENAI_KEY]",
+	},
+	{
+		label: "github-token",
+		pattern: /gh[pousr]_[A-Za-z0-9_]{16,}/gu,
+		replacement: "[REDACTED_GITHUB_TOKEN]",
+	},
+];
+
+export function sanitizeText(text, seededSecrets = [SEEDED_FAKE_SECRET]) {
+	let sanitized = text;
+	for (const secret of seededSecrets) {
+		if (secret.length > 0) {
+			sanitized = sanitized.split(secret).join("[REDACTED_SEEDED_SECRET]");
+		}
+	}
+	for (const detector of BUILTIN_SECRET_PATTERNS) {
+		sanitized = sanitized.replace(detector.pattern, detector.replacement);
+	}
+	return sanitized;
+}
+
+export function sanitizeJsonLine(value, seededSecrets = [SEEDED_FAKE_SECRET]) {
+	return sanitizeText(JSON.stringify(value), seededSecrets);
+}
+
+export function scanPathsForSecrets(rootPath, seededSecrets = [SEEDED_FAKE_SECRET]) {
+	const findings = [];
+	for (const filePath of listFiles(rootPath)) {
+		const content = readFileSync(filePath, "utf-8");
+		for (const finding of detectSecretLabels(content, seededSecrets)) {
+			findings.push({
+				file: relative(rootPath, filePath) || basename(filePath),
+				label: finding,
+			});
+		}
+	}
+	return {
+		status: findings.length === 0 ? "pass" : "fail",
+		findings,
+	};
+}
+
+export function writeRedactionReport(path, scanResult) {
+	const lines = scanResult.status === "pass" ? ["PASS no secret leaks found"] : ["FAIL secret leaks found"];
+	for (const finding of scanResult.findings) {
+		lines.push(`${finding.file}: ${finding.label}`);
+	}
+	writeFileSync(path, `${lines.join("\n")}\n`);
+}
+
+function detectSecretLabels(content, seededSecrets) {
+	const labels = [];
+	for (const secret of seededSecrets) {
+		if (secret.length > 0 && content.includes(secret)) {
+			labels.push("seeded-fake-secret");
+		}
+	}
+	for (const detector of BUILTIN_SECRET_PATTERNS) {
+		detector.pattern.lastIndex = 0;
+		if (detector.pattern.test(content)) {
+			labels.push(detector.label);
+		}
+	}
+	return labels;
+}
+
+function listFiles(rootPath) {
+	const stat = statSync(rootPath);
+	if (stat.isFile()) return [rootPath];
+	const files = [];
+	for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
+		const path = join(rootPath, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...listFiles(path));
+			continue;
+		}
+		if (entry.isFile()) {
+			files.push(path);
+		}
+	}
+	return files;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/write-evidence-packet.mjs
+++ b/packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/write-evidence-packet.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { scanPathsForSecrets, SEEDED_FAKE_SECRET, writeRedactionReport } from "./evidence-redaction.mjs";
+import { readPacketInput, writeEvidencePacket } from "./evidence-packet.mjs";
+
+const HELP_TEXT = `pi-codex-app-server PR-012 evidence packet writer
+
+Usage:
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/write-evidence-packet.mjs --input <packet.json> --out <dir>
+  node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/write-evidence-packet.mjs --scan <dir> [--seeded-secret <value>]
+
+Options:
+  --help                   Show this help text.
+  --input <path>           JSON packet input with commands, transcript, assertions, cleanup, and residualRisks.
+  --out <dir>              Evidence packet output directory.
+  --scan <dir>             Scan an existing packet or artifact directory for raw secrets.
+  --seeded-secret <value>  Additional fake secret that must fail closed if present.
+  --redaction-report <path> Write scan output to this report path.
+`;
+
+async function main(argv) {
+	if (argv.length === 0 || argv.includes("--help")) {
+		process.stdout.write(HELP_TEXT);
+		return 0;
+	}
+	const args = parseArgs(argv);
+	const seededSecrets = args.seededSecrets.length > 0 ? args.seededSecrets : [SEEDED_FAKE_SECRET];
+	if (args.scanPath) {
+		const scanResult = scanPathsForSecrets(args.scanPath, seededSecrets);
+		if (args.redactionReport) {
+			writeRedactionReport(args.redactionReport, scanResult);
+		}
+		process.stdout.write(formatScanResult(scanResult));
+		return scanResult.status === "pass" ? 0 : 1;
+	}
+	if (!args.inputPath || !args.outputDir) {
+		throw new Error("--input and --out are required unless --scan is used.");
+	}
+	const input = readPacketInput(args.inputPath);
+	const scanResult = writeEvidencePacket(input, args.outputDir);
+	process.stdout.write(formatScanResult(scanResult));
+	return scanResult.status === "pass" ? 0 : 1;
+}
+
+function parseArgs(argv) {
+	const parsed = {
+		inputPath: "",
+		outputDir: "",
+		scanPath: "",
+		seededSecrets: [],
+		redactionReport: "",
+	};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--input":
+				parsed.inputPath = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--out":
+				parsed.outputDir = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--scan":
+				parsed.scanPath = readValue(argv, index, arg);
+				index += 1;
+				break;
+			case "--seeded-secret":
+				parsed.seededSecrets.push(readValue(argv, index, arg));
+				index += 1;
+				break;
+			case "--redaction-report":
+				parsed.redactionReport = readValue(argv, index, arg);
+				index += 1;
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	return parsed;
+}
+
+function formatScanResult(scanResult) {
+	if (scanResult.status === "assertion-fail") {
+		return "FAIL assertions failed\n";
+	}
+	const lines = scanResult.status === "pass" ? ["PASS no secret leaks found"] : ["FAIL secret leaks found"];
+	for (const finding of scanResult.findings) {
+		lines.push(`${finding.file}: ${finding.label}`);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function readValue(argv, index, name) {
+	const value = argv[index + 1];
+	if (!value || value.startsWith("--")) {
+		throw new Error(`${name} requires a value.`);
+	}
+	return value;
+}
+
+try {
+	process.exitCode = await main(process.argv.slice(2));
+} catch (error) {
+	process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+	process.exitCode = 1;
+}

--- a/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-contract.test.ts
@@ -68,8 +68,13 @@ describe("pi-codex-app-server contract lock", () => {
 		expect(EXTERNAL_PROTOCOL_METHODS.every((method) => method.errorBehavior.length > 0)).toBe(true);
 	});
 
-	it("classifies required app-server surfaces without later redaction or evidence-packet code", () => {
-		const downstreamFileNames = ["redaction-scanner.ts", "evidence-packet-writer.ts"];
+	it("classifies required app-server surfaces without final compatibility evidence code", () => {
+		const downstreamFileNames = [
+			"final-compatibility-evidence.ts",
+			"manual-qa-matrix.ts",
+			"qa/final-compatibility-evidence.mjs",
+			"qa/manual-qa-matrix.mjs",
+		];
 
 		const inventoryMethods = APP_SERVER_SURFACE_INVENTORY.map((entry) => entry.method);
 		const missingSurfaces = PLAN_REQUIRED_APP_SERVER_SURFACES.filter((method) => !classifyAppServerSurface(method));

--- a/packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts
@@ -19,7 +19,7 @@ describe("pi-codex-app-server runtime harness", () => {
 		expect(result.stdout).toContain("pi-codex-app-server adapter harness");
 		expect(result.stdout).toContain("--external-stdio");
 		expect(result.stdout).toContain("--app-server-url");
-		expect(result.stdout).toContain("PR-004 runtime smoke plus PR-010 reconnect/resume evidence support");
+		expect(result.stdout).toContain("write-evidence-packet.mjs for PR-012 redaction packets");
 		expect(result.stderr).toBe("");
 	});
 

--- a/packages/coding-agent/test/suite/pi-codex-app-server-qa-redaction.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-qa-redaction.test.ts
@@ -1,0 +1,147 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const FAKE_SECRET = "pi_codex_fake_secret_DO_NOT_LEAK_20260624";
+
+function packetScriptPath(): string {
+	return join(
+		process.cwd(),
+		"src",
+		"core",
+		"extensions",
+		"builtin",
+		"pi-codex-app-server",
+		"qa",
+		"write-evidence-packet.mjs",
+	);
+}
+
+describe("pi-codex-app-server QA redaction harness", () => {
+	it("writes a sanitized reviewer packet with assertions and cleanup receipt", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-qa-redaction-test-"));
+		try {
+			const inputPath = join(tempRoot, "packet-input.json");
+			const packetDir = join(tempRoot, "packet");
+			writeFileSync(
+				inputPath,
+				JSON.stringify({
+					title: "PR-012 redaction smoke",
+					commands: [
+						{
+							command: `codex app-server --token ${FAKE_SECRET}`,
+							exitCode: 0,
+							output: `connected with CODEX_ACCESS_TOKEN=${FAKE_SECRET}`,
+						},
+					],
+					transcript: [
+						{
+							stream: "stderr",
+							message: `Authorization: Bearer ${FAKE_SECRET}`,
+						},
+					],
+					assertions: [
+						{
+							name: "cleanup receipt exists",
+							passed: true,
+							details: `assertion observed ${FAKE_SECRET}`,
+						},
+					],
+					residualRisks: ["PR-013 final scenario matrix remains gated."],
+					cleanup: {
+						childProcesses: 0,
+						websockets: 0,
+						ownedSockets: 0,
+						externalSocketPathsReferenced: 0,
+					},
+					seededSecrets: [FAKE_SECRET],
+				}),
+			);
+
+			const result = spawnSync(process.execPath, [packetScriptPath(), "--input", inputPath, "--out", packetDir], {
+				cwd: process.cwd(),
+				encoding: "utf-8",
+			});
+
+			expect(result.status).toBe(0);
+			expect(result.stderr).toBe("");
+			for (const fileName of [
+				"summary.md",
+				"commands.txt",
+				"sanitized-transcript.jsonl",
+				"assertions.json",
+				"redaction-report.txt",
+				"residual-risks.md",
+				"cleanup-receipt.txt",
+			]) {
+				expect(existsSync(join(packetDir, fileName))).toBe(true);
+			}
+			expect(readFileSync(join(packetDir, "commands.txt"), "utf-8")).not.toContain(FAKE_SECRET);
+			expect(readFileSync(join(packetDir, "sanitized-transcript.jsonl"), "utf-8")).not.toContain(FAKE_SECRET);
+			expect(readFileSync(join(packetDir, "assertions.json"), "utf-8")).not.toContain(FAKE_SECRET);
+			expect(readFileSync(join(packetDir, "redaction-report.txt"), "utf-8")).toContain("PASS no secret leaks found");
+			expect(readFileSync(join(packetDir, "cleanup-receipt.txt"), "utf-8")).toContain("childProcesses=0");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when an existing artifact contains a seeded fake secret", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-qa-redaction-test-"));
+		try {
+			const leakPath = join(tempRoot, "leaky.txt");
+			writeFileSync(leakPath, `raw secret ${FAKE_SECRET}\n`);
+
+			const result = spawnSync(
+				process.execPath,
+				[packetScriptPath(), "--scan", tempRoot, "--seeded-secret", FAKE_SECRET],
+				{ cwd: process.cwd(), encoding: "utf-8" },
+			);
+
+			expect(result.status).toBe(1);
+			expect(result.stdout).toContain("FAIL secret leaks found");
+			expect(result.stdout).toContain("leaky.txt");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when a packet assertion fails", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-codex-qa-redaction-test-"));
+		try {
+			const inputPath = join(tempRoot, "packet-input.json");
+			const packetDir = join(tempRoot, "packet");
+			writeFileSync(
+				inputPath,
+				JSON.stringify({
+					title: "PR-012 assertion failure smoke",
+					commands: [{ command: "node qa-smoke.mjs", exitCode: 1, output: "assertion failed" }],
+					transcript: [],
+					assertions: [{ name: "negative harness exits nonzero", passed: false, details: "status was 0" }],
+					residualRisks: [],
+					cleanup: {
+						childProcesses: 0,
+						websockets: 0,
+						ownedSockets: 0,
+						externalSocketPathsReferenced: 0,
+					},
+					seededSecrets: [FAKE_SECRET],
+				}),
+			);
+
+			const result = spawnSync(process.execPath, [packetScriptPath(), "--input", inputPath, "--out", packetDir], {
+				cwd: process.cwd(),
+				encoding: "utf-8",
+			});
+
+			expect(result.status).toBe(1);
+			expect(result.stdout).toContain("FAIL assertions failed");
+			expect(readFileSync(join(packetDir, "assertions.json"), "utf-8")).toContain("negative harness exits nonzero");
+			expect(readFileSync(join(packetDir, "cleanup-receipt.txt"), "utf-8")).toContain("childProcesses=0");
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

This work is using code-yeongyu/lazycodex teammode.

Adds the PR-012 manual QA/redaction harness pieces for the pi-codex app-server lane:

- sanitized reviewer packet generation for commands, transcripts, assertions, residual risks, and cleanup receipts
- redaction scanner with seeded fake-secret fail-closed behavior and common token/header detectors
- assertion runner output that fails packet generation when assertions fail
- contract guard narrowing so PR-012 QA/redaction files are allowed while PR-013 final compatibility evidence remains gated

PR-013 final/live compatibility scenario execution is intentionally not included.

## Changes

- Added `qa/evidence-redaction.mjs` for sanitization and artifact scanning.
- Added `qa/evidence-packet.mjs` for reviewer packet file generation.
- Added `qa/write-evidence-packet.mjs` CLI for packet writing and scan-only fail-closed checks.
- Updated `qa/drive-adapter.mjs` help text to point reviewers at the PR-012 packet writer.
- Updated contract/harness tests and added `pi-codex-app-server-qa-redaction.test.ts`.
- Added `.omo/evidence/20260624-pi-codex-app-server-execution/pr-012-qa-redaction/summary.md`.

## QA / Evidence

Evidence root: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-012-qa-redaction/`

- Failing-first proof: `targeted-qa-redaction-test.txt` initially failed before `write-evidence-packet.mjs` existed, then passed after implementation.
- Targeted PR-012 test: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/pi-codex-app-server-qa-redaction.test.ts` PASS, 1 file / 3 tests.
- Focused contract/harness tests: `focused-contract-harness-qa-redaction.txt` PASS, 3 files / 10 tests.
- Full pi-codex app-server suite: `full-pi-codex-app-server-suite.txt` PASS, 16 files / 63 tests.
- `npm run check`: `npm-run-check.txt` PASS.
- senpi QA CLI smoke: `senpi-qa-cli-smoke.txt` PASS; real auth unchanged.
- senpi QA mock loop: `senpi-qa-mock-loop.txt` PASS; real auth unchanged and only localhost fake model endpoints used.
- Packet writer evidence: `packet-writer.txt` PASS and `reviewer-packet/` contains `summary.md`, `commands.txt`, `sanitized-transcript.jsonl`, `assertions.json`, `redaction-report.txt`, `residual-risks.md`, and `cleanup-receipt.txt`.
- Scan fail-closed evidence: `scan-fail-closed.txt` records expected `exitCode=1` for a seeded fake-secret leak.
- Evidence root secret scan: `evidence-root-redaction-scan.txt` PASS.

Committed evidence summary: `.omo/evidence/20260624-pi-codex-app-server-execution/pr-012-qa-redaction/summary.md`.

## Cleanup Receipt

- Packet cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-012-qa-redaction/reviewer-packet/cleanup-receipt.txt`.
- Overall cleanup receipt: `local-ignore/qa-evidence/20260624-pi-codex-app-server/pr-012-qa-redaction/cleanup-receipt.txt`.
- Owned runtime resources: child processes 0, websockets 0, owned sockets 0, temp resources 0.
- Local `node_modules` symlink was removed before staging and after the commit hook.
- External `/Users/yeongyu/.omo/codegraph/.../daemon.sock` was temporarily moved to `/tmp` for `npm run check` and restored; see `codegraph-check-workaround.txt`.

## Secret Safety

- No raw secret-bearing logs, auth headers, tokens, cookies, launchd environments, or private credentials are included in the PR body or committed files.
- Reviewer packet generation sanitizes command output, transcript entries, assertion names/details, summary text, and residual risks before writing artifacts.
- Seeded fake-secret regression proves sanitized packet generation exits 0 without leaking the seed.
- Separate scan-only regression proves pre-existing seeded leaks fail closed with nonzero status.

## GitHub Project Status

`BLOCKED:missing-gh-project-scope`

Attempted `gh project list --owner code-yeongyu --format json --limit 20`; GitHub CLI returned missing `read:project` scope. Evidence: `gh-project-list.err` and `project-tracking-status.txt`.

## Residual Risks

- PR-012 covers reusable packet/redaction harness mechanics only; PR-013 final/live compatibility matrix remains gated.
- Redaction detectors cover seeded fake secrets and common token/header shapes. New secret classes should add detector tests before being allowed into reviewer packet artifacts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PR-012 QA/redaction tooling for the app-server. It generates a sanitized reviewer packet and fails closed on secret leaks; PR-013 live compatibility stays gated.

- **New Features**
  - `qa/evidence-redaction.mjs`: redacts seeded fake secrets and common token/header shapes; provides scan and report helpers.
  - `qa/evidence-packet.mjs`: builds reviewer packets (summary, commands, sanitized transcript, assertions, redaction report, residual risks, cleanup receipt) and fails if assertions fail.
  - `qa/write-evidence-packet.mjs` CLI: write packets or scan directories; exits nonzero on leaks or assertion failures.
  - `qa/drive-adapter.mjs`: help text points reviewers to the PR-012 packet writer.
  - Tests: added QA redaction suite and adjusted contract/harness tests.

- **Migration**
  - Generate packet: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/write-evidence-packet.mjs --input <packet.json> --out <dir>`
  - Scan only: `node packages/coding-agent/src/core/extensions/builtin/pi-codex-app-server/qa/write-evidence-packet.mjs --scan <dir> [--seeded-secret <value>] [--redaction-report <path>]`

<sup>Written for commit aa9cba0c6f587046193a00352d041c9d0e3bf7bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

