### PR TITLE
fix(coding-agent): preserve Tistory webfetch bodies

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed builtin webfetch extraction for Tistory-style articles so the post body and readable line breaks are preserved instead of blog chrome or category blocks.
+
 ## [2026.6.23-2] - 2026-06-23
 
 ### Added

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -8,7 +8,8 @@ Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-we
 - `webfetch/fetcher.ts`: `buildHeaders` return type `HeadersInit` -> `Record<string, string>` (senpi's root tsconfig has no DOM lib, so the `HeadersInit` global is unavailable; the value is already a plain string record).
 - Runtime deps `@mozilla/readability`, `jsdom`, and `turndown` (+ `@types/jsdom`, `@types/turndown`) added to `package.json`.
 - HTML markdown/text responses now pass through Readability before conversion so reader-style article content is returned without nav/header/footer/aside/script page chrome. Registers the `webfetch` tool, gated by `PI_WEBFETCH` (default on).
+- Tistory-style article containers are preferred over surrounding blog chrome, noisy related-post/sidebar blocks are stripped from the cloned article, and text conversion uses a DOM pass to preserve readable line breaks.
 
 ## Conflict zones
 
-Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the `HeadersInit` patch after re-running the transform, then re-check `npm run check`.
+Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the `HeadersInit` patch and Tistory article/noise selector behavior after re-running the transform, then re-check `npm run check`.

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.ts
@@ -29,6 +29,7 @@ const EXPLICIT_ARTICLE_SELECTORS = [
 	".content-article",
 	"#content .contents_style",
 ];
+const TITLE_SELECTORS = [".tit_post", ".entry-title", ".post-title", ".article-title", "h1"];
 const ARTICLE_NOISE_SELECTOR = [
 	"script",
 	"style",
@@ -53,8 +54,6 @@ const ARTICLE_NOISE_SELECTOR = [
 	".tagTrail",
 	".sidebar",
 ].join(", ");
-const TITLE_SELECTOR = "h1, .tit_post, .entry-title, .post-title, .article-title";
-
 const ENTITIES: Readonly<Record<string, string>> = {
 	amp: "&",
 	apos: "'",
@@ -159,11 +158,8 @@ function extractReadableArticle(html: string, url: string): ReadableArticle | un
 				}
 				const text = normalizePlainText(clonedNode.textContent ?? "");
 				if (text.length < MIN_EXPLICIT_ARTICLE_TEXT_LENGTH) continue;
-				const title = normalizePlainText(
-					dom.window.document.querySelector(TITLE_SELECTOR)?.textContent ?? dom.window.document.title,
-				);
 				explicitArticle = {
-					title,
+					title: selectPreferredTitle(dom.window.document, dom.window.document.title),
 					content: clonedNode.innerHTML,
 					hasHeading: /<h[1-6]\b/i.test(clonedNode.innerHTML),
 				};
@@ -177,9 +173,7 @@ function extractReadableArticle(html: string, url: string): ReadableArticle | un
 			}).parse();
 			if (!article?.content || !article.textContent) return undefined;
 			return {
-				title: normalizePlainText(
-					dom.window.document.querySelector(TITLE_SELECTOR)?.textContent ?? article.title ?? "",
-				),
+				title: selectPreferredTitle(dom.window.document, article.title ?? ""),
 				content: article.content,
 				hasHeading: /<h[1-6]\b/i.test(article.content),
 			};
@@ -190,6 +184,14 @@ function extractReadableArticle(html: string, url: string): ReadableArticle | un
 		if (error instanceof Error) return undefined;
 		throw error;
 	}
+}
+
+function selectPreferredTitle(document: Document, fallback: string): string {
+	for (const selector of TITLE_SELECTORS) {
+		const title = normalizePlainText(document.querySelector(selector)?.textContent ?? "");
+		if (title) return title;
+	}
+	return normalizePlainText(fallback);
 }
 
 function normalizePlainText(text: string): string {

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.ts
@@ -12,9 +12,48 @@ const TAGS_TO_REMOVE = /<(script|style|noscript|iframe|object|embed|meta|link)\b
 const VOID_TAGS_TO_REMOVE = /<(script|style|noscript|iframe|object|embed|meta|link)\b[^>]*\/?>/gi;
 const BLOCK_BREAK_TAGS =
 	/<\/?(address|article|aside|blockquote|br|dd|div|dl|dt|figcaption|figure|footer|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>/gi;
+const BLOCK_BREAK_SELECTOR =
+	"address, article, aside, blockquote, dd, div, dl, dt, figcaption, figure, footer, h1, h2, h3, h4, h5, h6, header, hr, li, main, nav, ol, p, pre, section, table, tbody, tfoot, thead, tr, ul";
+const CELL_BREAK_SELECTOR = "td, th";
 const TAGS = /<[^>]+>/g;
-const WHITESPACE = /[\t\f\v ]+/g;
+const WHITESPACE = /[\t\f\v \u00a0]+/g;
 const NEWLINE_RUN = /\n{3,}/g;
+const MIN_EXPLICIT_ARTICLE_TEXT_LENGTH = 30;
+const EXPLICIT_ARTICLE_SELECTORS = [
+	".article_view",
+	".tt_article_useless_p_margin",
+	".entry-content",
+	".contents_style",
+	".post-content",
+	".article-content",
+	".content-article",
+	"#content .contents_style",
+];
+const ARTICLE_NOISE_SELECTOR = [
+	"script",
+	"style",
+	"noscript",
+	"iframe",
+	"object",
+	"embed",
+	"meta",
+	"link",
+	"nav",
+	"aside",
+	"footer",
+	".another_category",
+	".area_related",
+	".related",
+	".revenue_unit_wrap",
+	".adsbygoogle",
+	".container_postbtn",
+	".postbtn_like",
+	".comments",
+	".comment",
+	".tagTrail",
+	".sidebar",
+].join(", ");
+const TITLE_SELECTOR = "h1, .tit_post, .entry-title, .post-title, .article-title";
 
 const ENTITIES: Readonly<Record<string, string>> = {
 	amp: "&",
@@ -36,9 +75,9 @@ turndownService.remove(["script", "style", "noscript", "iframe", "object", "embe
 
 export function htmlToMarkdown(html: string, url: string): string {
 	const article = extractReadableArticle(html, url);
-	if (!article) return turndownService.turndown(html).trim();
+	if (!article) return normalizeMarkdown(turndownService.turndown(html));
 
-	const markdown = turndownService.turndown(article.content).trim();
+	const markdown = normalizeMarkdown(turndownService.turndown(article.content));
 	if (!article.title || article.hasHeading || markdown.startsWith(`# ${article.title}`)) return markdown;
 	return `# ${article.title}\n\n${markdown}`.trim();
 }
@@ -56,17 +95,48 @@ export function htmlToText(html: string, url: string): string {
 }
 
 function htmlFragmentToPlainText(html: string): string {
+	try {
+		const dom = new JSDOM(`<body>${html}</body>`, {
+			contentType: "text/html",
+			virtualConsole: new VirtualConsole(),
+		});
+		try {
+			const document = dom.window.document;
+			for (const element of document.querySelectorAll(
+				"script, style, noscript, iframe, object, embed, meta, link",
+			)) {
+				element.remove();
+			}
+			for (const element of document.querySelectorAll("br")) {
+				element.replaceWith(document.createTextNode("\n"));
+			}
+			for (const element of document.querySelectorAll(CELL_BREAK_SELECTOR)) {
+				element.after(document.createTextNode("\n"));
+			}
+			for (const element of document.querySelectorAll(BLOCK_BREAK_SELECTOR)) {
+				element.before(document.createTextNode("\n"));
+				element.after(document.createTextNode("\n"));
+			}
+			return normalizePlainText(document.body.textContent ?? "");
+		} finally {
+			dom.window.close();
+		}
+	} catch (error) {
+		if (!(error instanceof Error)) throw error;
+	}
+
+	return htmlFragmentToPlainTextFallback(html);
+}
+
+function htmlFragmentToPlainTextFallback(html: string): string {
 	return decodeHtmlEntities(
-		html
-			.replace(TAGS_TO_REMOVE, "")
-			.replace(VOID_TAGS_TO_REMOVE, "")
-			.replace(BLOCK_BREAK_TAGS, "\n")
-			.replace(TAGS, "")
-			.replace(WHITESPACE, " ")
-			.replace(/[ \t]+\n/g, "\n")
-			.replace(/\n[ \t]+/g, "\n")
-			.replace(NEWLINE_RUN, "\n\n")
-			.trim(),
+		normalizePlainText(
+			html
+				.replace(TAGS_TO_REMOVE, "")
+				.replace(VOID_TAGS_TO_REMOVE, "")
+				.replace(BLOCK_BREAK_TAGS, "\n")
+				.replace(TAGS, ""),
+		),
 	);
 }
 
@@ -78,13 +148,38 @@ function extractReadableArticle(html: string, url: string): ReadableArticle | un
 			virtualConsole: new VirtualConsole(),
 		});
 		try {
+			let explicitArticle: ReadableArticle | undefined;
+			for (const selector of EXPLICIT_ARTICLE_SELECTORS) {
+				const candidate = dom.window.document.querySelector(selector);
+				if (!candidate) continue;
+				const clonedNode = candidate.cloneNode(true);
+				if (!(clonedNode instanceof dom.window.Element)) continue;
+				for (const noisyElement of clonedNode.querySelectorAll(ARTICLE_NOISE_SELECTOR)) {
+					noisyElement.remove();
+				}
+				const text = normalizePlainText(clonedNode.textContent ?? "");
+				if (text.length < MIN_EXPLICIT_ARTICLE_TEXT_LENGTH) continue;
+				const title = normalizePlainText(
+					dom.window.document.querySelector(TITLE_SELECTOR)?.textContent ?? dom.window.document.title,
+				);
+				explicitArticle = {
+					title,
+					content: clonedNode.innerHTML,
+					hasHeading: /<h[1-6]\b/i.test(clonedNode.innerHTML),
+				};
+				break;
+			}
+			if (explicitArticle) return explicitArticle;
+
 			const article = new Readability(dom.window.document, {
 				charThreshold: 80,
 				keepClasses: false,
 			}).parse();
 			if (!article?.content || !article.textContent) return undefined;
 			return {
-				title: normalizePlainText(article.title ?? ""),
+				title: normalizePlainText(
+					dom.window.document.querySelector(TITLE_SELECTOR)?.textContent ?? article.title ?? "",
+				),
 				content: article.content,
 				hasHeading: /<h[1-6]\b/i.test(article.content),
 			};
@@ -98,14 +193,21 @@ function extractReadableArticle(html: string, url: string): ReadableArticle | un
 }
 
 function normalizePlainText(text: string): string {
-	return decodeHtmlEntities(
-		text
-			.replace(WHITESPACE, " ")
-			.replace(/[ \t]+\n/g, "\n")
-			.replace(/\n[ \t]+/g, "\n")
-			.replace(NEWLINE_RUN, "\n\n")
-			.trim(),
-	);
+	return text
+		.replace(WHITESPACE, " ")
+		.replace(/[ \t]+\n/g, "\n")
+		.replace(/\n[ \t]+/g, "\n")
+		.replace(NEWLINE_RUN, "\n\n")
+		.trim();
+}
+
+function normalizeMarkdown(markdown: string): string {
+	return markdown
+		.replace(/\r\n?/g, "\n")
+		.replace(/[ \t]+\n/g, "\n")
+		.replace(/\n[ \t]+/g, "\n")
+		.replace(NEWLINE_RUN, "\n\n")
+		.trim();
 }
 
 export function decodeHtmlEntities(text: string): string {

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
@@ -211,8 +211,12 @@ function getHeader(headers: IncomingHttpHeaders, name: string): string {
 async function discardBody(body: ResponseBodyStream): Promise<void> {
 	try {
 		await body.dump({ limit: 1024 });
-	} catch {
-		// Preserve the caller's original failure.
+	} catch (error) {
+		if (error instanceof Error) {
+			body.destroy(error);
+			return;
+		}
+		throw error;
 	}
 }
 

--- a/packages/coding-agent/test/suite/pi-codex-app-server-worktree-routing.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-worktree-routing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createIdMapper } from "../../src/core/extensions/builtin/pi-codex-app-server/id-mapper.ts";
+import { createRequestRouter } from "../../src/core/extensions/builtin/pi-codex-app-server/request-router.ts";
+import { createSessionRegistry } from "../../src/core/extensions/builtin/pi-codex-app-server/session-registry.ts";
+import { RecordingAppServerClient } from "./pi-codex-app-server-routing-fakes.ts";
+
+describe("pi-codex-app-server worktree routing", () => {
+	it("preserves external repository and worktree metadata when starting a session", async () => {
+		// given
+		const client = new RecordingAppServerClient([{ thread: { id: "app-thread-1", session_id: "app-session-1" } }]);
+		const router = createRequestRouter({
+			client,
+			idMapper: createIdMapper(),
+			sessionRegistry: createSessionRegistry(),
+		});
+		const appParams = {
+			cwd: "/Users/yeongyu/local-workspaces/pi-webfetch-tistory-worktree",
+			environments: [
+				{
+					id: "external-worktree",
+					cwd: "/Users/yeongyu/local-workspaces/pi-webfetch-tistory-worktree",
+				},
+			],
+			runtime_workspace_roots: ["/Users/yeongyu/local-workspaces/pi-webfetch-tistory-worktree"],
+			runtimeWorkspaceRoots: ["/Users/yeongyu/local-workspaces/pi-webfetch-tistory-worktree"],
+			selectedCapabilityRoots: ["/Users/yeongyu/local-workspaces/pi-webfetch-tistory-worktree"],
+		};
+
+		// when
+		await router.route({
+			method: "session/new",
+			externalRequestId: "external-worktree-request",
+			params: {
+				externalSessionId: "external-worktree-session",
+				appParams,
+			},
+		});
+
+		// then
+		expect(client.calls).toEqual([{ method: "thread/start", params: appParams }]);
+	});
+});

--- a/packages/coding-agent/test/suite/webfetch-explicit-article.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-explicit-article.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readability = vi.hoisted(() => ({
+	parse: vi.fn(() => {
+		throw new Error("Readability should not run for explicit article matches");
+	}),
+}));
+
+vi.mock("@mozilla/readability", () => ({
+	Readability: class {
+		parse(): unknown {
+			return readability.parse();
+		}
+	},
+}));
+
+import { htmlToMarkdown } from "../../src/core/extensions/builtin/webfetch/webfetch/content.ts";
+
+function explicitArticleHtml(): string {
+	return `<!doctype html>
+		<html>
+			<body>
+				<h1 class="tit_post">Explicit Article</h1>
+				<div class="article_view">
+					<p>Explicit article body has enough words to pass the direct article selector threshold.</p>
+				</div>
+			</body>
+		</html>`;
+}
+
+describe("webfetch explicit article extraction", () => {
+	beforeEach(() => {
+		readability.parse.mockClear();
+	});
+
+	it("#given an explicit article container #when converting markdown #then skips Readability fallback parsing", () => {
+		// given / when
+		const markdown = htmlToMarkdown(explicitArticleHtml(), "https://example.test/post");
+
+		// then
+		expect(markdown).toContain("# Explicit Article");
+		expect(markdown).toContain("Explicit article body");
+		expect(readability.parse).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/suite/webfetch-tistory-reader-mode.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-tistory-reader-mode.test.ts
@@ -82,6 +82,47 @@ function tistoryFixtureHtml(): string {
 		</html>`;
 }
 
+function titlePriorityFixtureHtml(): string {
+	return `<!doctype html>
+		<html>
+			<head>
+				<title>관리자 메뉴가 제목을 이기면 안 됨</title>
+				<meta name="description" content="티스토리 블로그 홍보 문구">
+			</head>
+			<body class="tt-body-page">
+				<header>
+					<h1>블로그 이름</h1>
+					<a href="/manage">관리자</a>
+					<a href="/category">분류 전체보기</a>
+				</header>
+				<section class="sidebar">
+					<h2>최근 글</h2>
+					<p>관련 없는 사이드바 설명이 길게 들어가서 리더가 이 영역을 본문으로 착각하면 안 됩니다.</p>
+				</section>
+				<div id="content">
+					<h1 class="tit_post">티스토리 본문을 읽어야 합니다</h1>
+					<div class="entry-content contents_style">
+						<div class="article_view tt_article_useless_p_margin">
+							<p data-ke-size="size16">첫 번째 본문 문장은 짧은 티스토리 글에서도 반드시 남아야 합니다.</p>
+							<p data-ke-size="size16">두 번째 본문 문장은 카테고리나 관련 글보다 우선되어야 합니다.</p>
+							<figure data-ke-type="image">
+								<figcaption>본문 이미지 설명도 보존됩니다.</figcaption>
+							</figure>
+						</div>
+						<div class="another_category">
+							<h4>다른 글 보기</h4>
+							<ul>
+								<li>관련 글 제목 하나</li>
+								<li>관련 글 제목 둘</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+				<footer>구독하기 푸터와 방명록 링크</footer>
+			</body>
+		</html>`;
+}
+
 function newlineFixtureHtml(): string {
 	return `<!doctype html>
 		<html>
@@ -138,6 +179,44 @@ describe("webfetch Tistory reader-mode cleanup", () => {
 		expect(text).not.toContain("관련 글 제목");
 		expect(text).not.toContain("구독하기 푸터");
 		expect(text).not.toContain("tistoryTracker");
+	});
+
+	it("#given Tistory title chrome #when fetching markdown #then prefers the article title over site chrome", async () => {
+		// given
+		const server = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(titlePriorityFixtureHtml());
+		});
+
+		// when
+		const result = await executeWebfetch({ url: `${server.baseUrl}/tistory-title`, format: "markdown" });
+		const text = textContent(result);
+
+		// then
+		expect(text).toContain("# 티스토리 본문을 읽어야 합니다");
+		expect(text).toContain("첫 번째 본문 문장은");
+		expect(text).toContain("두 번째 본문 문장은");
+		expect(text).not.toContain("블로그 이름");
+		expect(text).not.toContain("관련 없는 사이드바 설명");
+	});
+
+	it("#given Tistory title chrome #when fetching text #then prefers the article title over site chrome", async () => {
+		// given
+		const server = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(titlePriorityFixtureHtml());
+		});
+
+		// when
+		const result = await executeWebfetch({ url: `${server.baseUrl}/tistory-title-text`, format: "text" });
+		const text = textContent(result);
+
+		// then
+		expect(text.startsWith("티스토리 본문을 읽어야 합니다")).toBe(true);
+		expect(text).toContain("첫 번째 본문 문장은");
+		expect(text).toContain("두 번째 본문 문장은");
+		expect(text).not.toContain("블로그 이름");
+		expect(text).not.toContain("관련 없는 사이드바 설명");
 	});
 
 	it("#given Tistory text with inline spans and blocks #when fetching text #then preserves readable line breaks", async () => {

--- a/packages/coding-agent/test/suite/webfetch-tistory-reader-mode.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-tistory-reader-mode.test.ts
@@ -1,0 +1,185 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Static } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { webfetch } from "../../src/core/extensions/builtin/webfetch/webfetch/tool.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+
+type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void;
+type WebfetchParams = Static<typeof webfetch.parameters>;
+
+const servers: Server[] = [];
+const context = {} as ExtensionContext;
+
+async function createFixtureServer(handler: RouteHandler): Promise<{ readonly baseUrl: string }> {
+	const server = createServer(handler);
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (typeof address !== "object" || address === null) {
+		throw new Error("Expected TCP server address");
+	}
+	servers.push(server);
+	return { baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function executeWebfetch(params: WebfetchParams) {
+	return webfetch.execute("tool", params, undefined, undefined, context);
+}
+
+function textContent(result: Awaited<ReturnType<typeof executeWebfetch>>): string {
+	const first = result.content[0];
+	if (first?.type !== "text") {
+		throw new Error("Expected text content");
+	}
+	return first.text;
+}
+
+afterEach(async () => {
+	await Promise.all(servers.splice(0).map(closeServer));
+});
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function tistoryFixtureHtml(): string {
+	return `<!doctype html>
+		<html>
+			<head>
+				<title>관리자 메뉴가 제목을 이기면 안 됨</title>
+				<meta name="description" content="티스토리 블로그 홍보 문구">
+			</head>
+			<body class="tt-body-page">
+				<header>
+					<a href="/manage">관리자</a>
+					<a href="/category">분류 전체보기</a>
+				</header>
+				<section class="sidebar">
+					<h2>최근 글</h2>
+					<p>관련 없는 사이드바 설명이 길게 들어가서 리더가 이 영역을 본문으로 착각하면 안 됩니다.</p>
+				</section>
+				<div id="content">
+					<h1 class="tit_post">티스토리 본문을 읽어야 합니다</h1>
+					<div class="entry-content contents_style">
+						<div class="article_view tt_article_useless_p_margin">
+							<p data-ke-size="size16">첫 번째 본문 문장은 짧은 티스토리 글에서도 반드시 남아야 합니다.</p>
+							<p data-ke-size="size16">두 번째 본문 문장은 카테고리나 관련 글보다 우선되어야 합니다.</p>
+							<figure data-ke-type="image">
+								<figcaption>본문 이미지 설명도 보존됩니다.</figcaption>
+							</figure>
+						</div>
+						<div class="another_category">
+							<h4>다른 글 보기</h4>
+							<ul>
+								<li>관련 글 제목 하나</li>
+								<li>관련 글 제목 둘</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+				<footer>구독하기 푸터와 방명록 링크</footer>
+				<script>window.tistoryTracker = true;</script>
+			</body>
+		</html>`;
+}
+
+function newlineFixtureHtml(): string {
+	return `<!doctype html>
+		<html>
+			<body>
+				<div class="article_view">
+					<h1>줄바꿈 보존</h1>
+					<p><span>첫 줄</span><br><span>둘째 줄</span></p>
+					<p><span>새 문단</span> <strong>강조</strong></p>
+					<ul>
+						<li><span>첫 항목</span></li>
+						<li><span>둘째 항목</span></li>
+					</ul>
+					<table>
+						<tr><td>왼쪽 칸</td><td>오른쪽 칸</td></tr>
+					</table>
+				</div>
+			</body>
+		</html>`;
+}
+
+function literalEntityFixtureHtml(): string {
+	return `<!doctype html>
+		<html>
+			<body>
+				<article>
+					<h1>Literal Entity Fixture</h1>
+					<p>Rendered tag example: &amp;lt;custom-element&amp;gt;</p>
+					<p>Escaped ampersand example: AT&amp;amp;T docs</p>
+				</article>
+			</body>
+		</html>`;
+}
+
+describe("webfetch Tistory reader-mode cleanup", () => {
+	it("#given Tistory article wrappers #when fetching markdown #then prefers the article body over category chrome", async () => {
+		// given
+		const server = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(tistoryFixtureHtml());
+		});
+
+		// when
+		const result = await executeWebfetch({ url: `${server.baseUrl}/tistory`, format: "markdown" });
+		const text = textContent(result);
+
+		// then
+		expect(text).toContain("# 티스토리 본문을 읽어야 합니다");
+		expect(text).toContain("첫 번째 본문 문장은");
+		expect(text).toContain("두 번째 본문 문장은");
+		expect(text).toContain("본문 이미지 설명도 보존됩니다");
+		expect(text).not.toContain("관리자 메뉴가 제목을 이기면 안 됨");
+		expect(text).not.toContain("분류 전체보기");
+		expect(text).not.toContain("최근 글");
+		expect(text).not.toContain("관련 글 제목");
+		expect(text).not.toContain("구독하기 푸터");
+		expect(text).not.toContain("tistoryTracker");
+	});
+
+	it("#given Tistory text with inline spans and blocks #when fetching text #then preserves readable line breaks", async () => {
+		// given
+		const server = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(newlineFixtureHtml());
+		});
+
+		// when
+		const result = await executeWebfetch({ url: `${server.baseUrl}/newline`, format: "text" });
+		const text = textContent(result);
+
+		// then
+		expect(text).toContain("줄바꿈 보존\n\n첫 줄\n둘째 줄\n\n새 문단 강조");
+		expect(text).toContain("첫 항목\n\n둘째 항목");
+		expect(text).toContain("왼쪽 칸\n오른쪽 칸");
+		expect(text).not.toContain("\n\n\n");
+		expect(text).not.toContain("첫 줄둘째 줄");
+	});
+
+	it("#given literal HTML entity examples #when fetching markdown and text #then preserves one decoded layer only", async () => {
+		// given
+		const server = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(literalEntityFixtureHtml());
+		});
+
+		// when
+		const markdown = textContent(
+			await executeWebfetch({ url: `${server.baseUrl}/literal-entity`, format: "markdown" }),
+		);
+		const text = textContent(await executeWebfetch({ url: `${server.baseUrl}/literal-entity`, format: "text" }));
+
+		// then
+		expect(markdown).toContain("&lt;custom-element&gt;");
+		expect(markdown).toContain("AT&amp;T docs");
+		expect(markdown).not.toContain("<custom-element>");
+		expect(markdown).not.toContain("AT&T docs");
+		expect(text).toContain("&lt;custom-element&gt;");
+		expect(text).toContain("AT&amp;T docs");
+		expect(text).not.toContain("<custom-element>");
+		expect(text).not.toContain("AT&T docs");
+	});
+});


### PR DESCRIPTION
## Summary

Builtin webfetch now preserves Tistory-style article bodies, readable text line breaks, literal HTML entities, and article titles even when blog chrome appears first in the DOM. This updates Senpi's builtin webfetch implementation to match the external `pi-webfetch` fixes and keeps app-server external repository/worktree metadata pass-through covered.

## Changes

- Prefer explicit article containers such as `.article_view`, `.entry-content`, and `.contents_style` before falling back to Mozilla Readability.
- Strip common Tistory/sidebar/related-post noise from cloned article containers.
- Preserve readable plain-text line breaks through a DOM text conversion pass.
- Preserve only one decoded entity layer so literal HTML examples like `&lt;custom-element&gt;` remain inspectable.
- Prefer article-title selectors such as `.tit_post` before generic `h1`, avoiding blog header titles in Tistory output.
- Add regressions for explicit article extraction, title priority, line breaks, entities, and external app-server session metadata.

## QA / Evidence

- External repo PRs merged:
  - `code-yeongyu/pi-webfetch` PR #2, #3, #4, and #5 merged.
  - PR #4 merge commit: `ce0d63ac3039019c4f3cdf0b2999e70e6aa158b1`.
  - PR #5 merge commit: `e449fdc4f92eb5218fe36ff0bcb1d5bd35d39e7e`.
- External repo validation for PR #5:
  - `npm test`: 4 files / 37 tests passed.
  - `npm run check`: `tsgo --noEmit` and `biome check .` passed.
- Senpi validation after latest title-priority update:
  - `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/webfetch-tistory-reader-mode.test.ts`: 1 file / 5 tests passed.
    - Artifact: `/Users/yeongyu/local-workspaces/senpi-webfetch-tistory-worktree/local-ignore/qa-evidence/20260626-webfetch-title-selector/webfetch-tistory-reader-mode-vitest.txt`
  - `npm run check` passed, including Biome, pinned deps, import checks, shrinkwrap check, `tsgo --noEmit`, browser smoke, and web UI check.
  - Pre-commit hook reran `npm run check` successfully for commit `c12355d0e`.
- Mandatory Senpi QA:
  - Mock-loop self-test for OpenAI completions passed through the real CLI against localhost fake model only; real auth unchanged.
    - Artifact: `/Users/yeongyu/local-workspaces/senpi-webfetch-tistory-worktree/local-ignore/qa-evidence/20260626-webfetch-title-selector/mock-loop-openai-completions.txt`
  - CLI smoke self-test passed; real auth unchanged.
    - Artifact: `/Users/yeongyu/local-workspaces/senpi-webfetch-tistory-worktree/local-ignore/qa-evidence/20260626-webfetch-title-selector-cli-smoke.txt`
  - Earlier PR QA remains available under `/Users/yeongyu/local-workspaces/senpi-webfetch-tistory-worktree/local-ignore/qa-evidence/20260625-webfetch-tistory-worktree-pr/`.

## Risks

The explicit-article and title preferences are selector-based, so there is residual risk on sites that reuse these class names outside articles. The text-length threshold, noise stripping, Readability fallback, external repo validation, and targeted Tistory regressions cover the intended behavior.

## Secret safety

Evidence contains command output and sanitized QA summaries only. No raw tokens, auth headers, cookies, launchd environments, or credential-bearing logs are included.


## Post-merge Audit Addendum

- Failing-first title-priority proof was captured after merge by applying only the new title tests to the previous implementation commit.
  - Senpi RED artifact: `/Users/yeongyu/local-workspaces/senpi-webfetch-tistory-worktree/local-ignore/qa-evidence/20260626-webfetch-title-selector/senpi-webfetch-title-red.txt`
  - Failure proved the old builtin selected `# 블로그 이름` instead of `# 티스토리 본문을 읽어야 합니다`.
- The matching GREEN proof remains:
  - `/Users/yeongyu/local-workspaces/senpi-webfetch-tistory-worktree/local-ignore/qa-evidence/20260626-webfetch-title-selector/webfetch-tistory-reader-mode-vitest.txt`
