### PR TITLE
fix(tui): reset SGR state after row clears

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1307,7 +1307,7 @@ export class TUI extends Container {
 		const firstInsertedScreenRow = regionBottom - plan.insertedRows.length + 1;
 		for (let index = 0; index < plan.insertedRows.length; index++) {
 			const screenRow = firstInsertedScreenRow + index;
-			buffer += `\x1b[${screenRow + 1};1H\x1b[2K`;
+			buffer += `\x1b[${screenRow + 1};1H\x1b[2K${TUI.SEGMENT_RESET}`;
 			buffer += plan.insertedRows[index] ?? "";
 		}
 
@@ -1345,7 +1345,7 @@ export class TUI extends Container {
 		const bufferLength = Math.max(height, newLines.length);
 		for (let row = 0; row < bufferLength; row++) {
 			if (row > 0) buffer += "\r\n";
-			buffer += "\r\x1b[2K";
+			buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 			buffer += newLines[row] ?? "";
 		}
 
@@ -1627,7 +1627,7 @@ export class TUI extends Container {
 					buffer += `\x1b[${clearStartOffset}B`;
 				}
 				for (let i = 0; i < extraLines; i++) {
-					buffer += "\r\x1b[2K";
+					buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 					if (i < extraLines - 1) buffer += "\x1b[1B";
 				}
 				const moveBack = Math.max(0, extraLines - 1 + clearStartOffset);
@@ -1699,7 +1699,7 @@ export class TUI extends Container {
 
 				for (let row = 0; row < height; row++) {
 					if (row > 0) buffer += "\r\n";
-					buffer += "\r\x1b[2K";
+					buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 					buffer += newLines[viewportTop + row] ?? "";
 				}
 
@@ -1769,9 +1769,9 @@ export class TUI extends Container {
 					return;
 				}
 
-				buffer += "\x1b[2K";
+				buffer += `\x1b[2K${TUI.SEGMENT_RESET}`;
 				for (let row = 1; row < imageReservedRows; row++) {
-					buffer += "\r\n\x1b[2K";
+					buffer += `\r\n\x1b[2K${TUI.SEGMENT_RESET}`;
 				}
 				buffer += `\x1b[${imageReservedRows - 1}A`;
 				buffer += line;
@@ -1780,7 +1780,7 @@ export class TUI extends Container {
 				continue;
 			}
 
-			buffer += "\x1b[2K"; // Clear current line
+			buffer += `\x1b[2K${TUI.SEGMENT_RESET}`; // Clear current line
 			if (!isImage && visibleWidth(line) > width) {
 				// Log all lines to crash file for debugging
 				const crashLogPath = path.join(os.homedir(), ".senpi", "agent", "senpi-crash.log");
@@ -1825,7 +1825,7 @@ export class TUI extends Container {
 			}
 			const extraLines = this.previousLines.length - newLines.length;
 			for (let i = newLines.length; i < this.previousLines.length; i++) {
-				buffer += "\r\n\x1b[2K";
+				buffer += `\r\n\x1b[2K${TUI.SEGMENT_RESET}`;
 			}
 			// Move cursor back to end of new content
 			buffer += `\x1b[${extraLines}A`;

--- a/packages/tui/test/tui-render-sgr-reset.test.ts
+++ b/packages/tui/test/tui-render-sgr-reset.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class TestComponent implements Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+describe("TUI changed-row SGR repaint", () => {
+	it("resets SGR state before clearing and repainting changed rows", async () => {
+		const terminal = new LoggingVirtualTerminal(72, 6);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["header", "\x1b[38;2;9;131;232mWorking\x1b[0m", "footer", "input"];
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		component.lines = ["header", "\x1b[38;2;9;131;232mWorking harder\x1b[0m", "footer", "input"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(
+			writes.includes("\x1b[2K\x1b[0m\x1b]8;;\x07\x1b[38;2;9;131;232mWorking harder"),
+			"changed-row repaint should reset terminal style state immediately after clearing the row",
+		);
+		assert.ok(
+			!writes.includes("\x1b[2K\x1b[38;2;9;131;232m"),
+			"repaint should not write truecolor text directly after CSI 2K",
+		);
+
+		tui.stop();
+	});
+});

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -322,7 +322,7 @@ describe("TUI Kitty image cleanup", () => {
 
 			const writes = terminal.getWrites();
 			assert.ok(
-				writes.includes(`\x1b[2K\r\n\x1b[2K\x1b[1A${imageSequence}\x1b[1B`),
+				writes.includes(`\x1b[2K\x1b[0m\x1b]8;;\x07\r\n\x1b[2K\x1b[0m\x1b]8;;\x07\x1b[1A${imageSequence}\x1b[1B`),
 				"reserved rows should be cleared before the image placement is drawn",
 			);
 			assert.ok(


### PR DESCRIPTION
## Summary

Fixes TUI rendering corruption where raw ANSI SGR fragments such as `9;131;232m` could appear after differential row clears. The local fork has row-clear/repaint optimization paths that are not present upstream; those paths now reset terminal style state immediately after `CSI 2K` before writing colored content.

Before: changed-row repaint could clear a row and continue in the terminal's previous style state, allowing truecolor SGR tails or colored artifacts to leak into the display.

After: every repaint/replay row clear emits the existing `TUI.SEGMENT_RESET` before row content, preserving the low-flicker path while avoiding stale style state.

## Changes

- Add reset-aware row clears in TUI repaint, viewport replay, scrollback replay, deleted-line clearing, inserted-row repaint, extra-line clearing, and Kitty image reserved-row pre-clear paths.
- Add a focused failing-first regression for truecolor changed-row repaint.
- Update the existing Kitty image cleanup assertion for the reset-aware clear sequence.

## QA / Evidence

- Focused regression RED: `packages/tui` command `node --test --import tsx test/tui-render-sgr-reset.test.ts`; captured the missing reset failure in `local-ignore/qa-evidence/20260626-tui-render-sgr/tui-render-red.txt`.
- Focused regression GREEN: same command passed after the fix; artifact `local-ignore/qa-evidence/20260626-tui-render-sgr/tui-render-green.txt`.
- Existing TUI render suite: `node --test --import tsx test/tui-render.test.ts` passed 36/36; artifact `local-ignore/qa-evidence/20260626-tui-render-sgr/tui-render-suite-green.txt`.
- Required project check: `npm run check` passed; artifact `local-ignore/qa-evidence/20260626-tui-render-sgr/npm-check.txt`.
- Mandatory TUI QA: `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence tui-render-sgr` passed 5/5, confirmed auth unchanged and no raw SGR fragments in the captured TUI transcript; artifacts `local-ignore/qa-evidence/20260626-tui-render-sgr/senpi-tui-smoke.txt` and `local-ignore/qa-evidence/20260626-tui-render-sgr/tui-smoke-tmux.txt`.
- Commit hook reran `npm run check` successfully before commit.

## Risks

The main risk is extra reset bytes in repaint paths affecting terminal styling or Kitty image cleanup. This is covered by the focused SGR repaint regression, the existing TUI render suite including Kitty cleanup, and the tmux smoke test against the real TUI harness.

## Secret safety

No raw secret-bearing logs, env dumps, tokens, auth headers, cookies, or credentials are included. The senpi QA script verified the real auth file was unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset terminal style after each row clear in the TUI to prevent leaked ANSI SGR state and color artifacts. Keeps low-flicker repaints while ensuring cleared rows start from a neutral style.

- **Bug Fixes**
  - Emit a reset immediately after `CSI 2K` across repaint paths: viewport/scrollback replay, inserted/deleted/extra line clears, and Kitty image reserved-row clears.
  - Added a focused regression test for truecolor changed-row repaint and updated the Kitty image cleanup test to assert the clear+reset sequence.

<sup>Written for commit 58339e272f0453ac3e6c43605ee61f8e4577772b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

