### PR TITLE
fix(coding-agent): bound session resume CPU work

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -15,7 +15,7 @@ import { findInitialModel, getModelNarrowingPatterns, resolveModelScope } from "
 import { mergeProviderAttributionHeaders } from "./provider-attribution.ts";
 import type { ResourceLoader } from "./resource-loader.ts";
 import { DefaultResourceLoader } from "./resource-loader.ts";
-import { getDefaultSessionDir, SessionManager } from "./session-manager.ts";
+import { getDefaultSessionDir, type SessionContext, SessionManager } from "./session-manager.ts";
 import { SettingsManager } from "./settings-manager.ts";
 import { getSupportedThinkingLevels } from "./thinking-levels.ts";
 import { time } from "./timings.ts";
@@ -197,22 +197,28 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		time("resourceLoader.reload");
 	}
 
-	// Check if session has existing data to restore
-	const existingSession = sessionManager.buildSessionContext();
-	const hasExistingSession = existingSession.messages.length > 0;
-	const hasThinkingEntry = sessionManager.getBranch().some((entry) => entry.type === "thinking_level_change");
+	const hasExistingSession = sessionManager.hasContextMessages();
+	const hasThinkingEntry = sessionManager.hasThinkingLevelChanges();
+	let existingSession: SessionContext | undefined;
+	const getExistingSession = (): SessionContext => {
+		existingSession ??= sessionManager.buildSessionContext();
+		return existingSession;
+	};
 
 	let model = options.model;
 	let modelFallbackMessage: string | undefined;
 
 	// If session has data, try to restore model from it
-	if (!model && hasExistingSession && existingSession.model) {
-		const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
-		if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
-			model = restoredModel;
-		}
-		if (!model) {
-			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;
+	if (!model && hasExistingSession) {
+		const sessionContext = getExistingSession();
+		if (sessionContext.model) {
+			const restoredModel = modelRegistry.find(sessionContext.model.provider, sessionContext.model.modelId);
+			if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
+				model = restoredModel;
+			}
+			if (!model) {
+				modelFallbackMessage = `Could not restore model ${sessionContext.model.provider}/${sessionContext.model.modelId}`;
+			}
 		}
 	}
 
@@ -239,7 +245,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// If session has data, restore thinking level from it
 	if (thinkingLevel === undefined && hasExistingSession) {
 		thinkingLevel = hasThinkingEntry
-			? (existingSession.thinkingLevel as ThinkingLevel)
+			? (getExistingSession().thinkingLevel as ThinkingLevel)
 			: (settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL);
 	}
 
@@ -378,7 +384,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	// Restore messages if session has existing data
 	if (hasExistingSession) {
-		agent.state.messages = existingSession.messages;
+		agent.state.messages = getExistingSession().messages;
 		if (!hasThinkingEntry) {
 			sessionManager.appendThinkingLevelChange(thinkingLevel);
 		}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -482,6 +482,8 @@ export function getDefaultSessionDir(cwd: string, agentDir: string = getDefaultA
 }
 
 const SESSION_READ_BUFFER_SIZE = 1024 * 1024;
+const SESSION_HEADER_READ_BUFFER_SIZE = 4 * 1024;
+const SESSION_HEADER_MAX_BYTES = SESSION_READ_BUFFER_SIZE;
 
 function parseSessionEntryLine(line: string): FileEntry | null {
 	if (!line.trim()) return null;
@@ -539,20 +541,51 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 }
 
 function readSessionHeader(filePath: string): SessionHeader | null {
+	let fd: number | undefined;
 	try {
-		const fd = openSync(filePath, "r");
-		const buffer = Buffer.alloc(512);
-		const bytesRead = readSync(fd, buffer, 0, 512, 0);
-		closeSync(fd);
-		const firstLine = buffer.toString("utf8", 0, bytesRead).split("\n")[0];
-		if (!firstLine) return null;
+		fd = openSync(filePath, "r");
+		const decoder = new StringDecoder("utf8");
+		const buffer = Buffer.allocUnsafe(SESSION_HEADER_READ_BUFFER_SIZE);
+		let pending = "";
+		let firstLine: string | undefined;
+		let totalBytesRead = 0;
+
+		while (firstLine === undefined) {
+			const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
+			if (bytesRead === 0) {
+				firstLine = pending + decoder.end();
+				break;
+			}
+			totalBytesRead += bytesRead;
+
+			pending += decoder.write(buffer.subarray(0, bytesRead));
+			const newlineIndex = pending.indexOf("\n");
+			if (newlineIndex !== -1) {
+				firstLine = pending.slice(0, newlineIndex);
+			} else if (totalBytesRead >= SESSION_HEADER_MAX_BYTES) {
+				return null;
+			}
+		}
+
+		if (!firstLine.trim()) return null;
 		const header = JSON.parse(firstLine) as Record<string, unknown>;
 		if (header.type !== "session" || typeof header.id !== "string") {
 			return null;
 		}
-		return header as unknown as SessionHeader;
+		return {
+			type: "session",
+			id: header.id,
+			timestamp: typeof header.timestamp === "string" ? header.timestamp : "",
+			cwd: typeof header.cwd === "string" ? header.cwd : "",
+			...(typeof header.version === "number" ? { version: header.version } : {}),
+			...(typeof header.parentSession === "string" ? { parentSession: header.parentSession } : {}),
+		};
 	} catch {
 		return null;
+	} finally {
+		if (fd !== undefined) {
+			closeSync(fd);
+		}
 	}
 }
 
@@ -1211,6 +1244,37 @@ export class SessionManager {
 		return buildSessionContext(this.getEntries(), this.leafId);
 	}
 
+	hasContextMessages(): boolean {
+		return this.hasBranchEntry(
+			(entry) =>
+				entry.type === "message" ||
+				entry.type === "custom_message" ||
+				entry.type === "compaction" ||
+				(entry.type === "branch_summary" && Boolean(entry.summary)),
+		);
+	}
+
+	hasThinkingLevelChanges(): boolean {
+		return this.hasBranchEntry((entry) => entry.type === "thinking_level_change");
+	}
+
+	countCompactions(): number {
+		let count = 0;
+		for (const entry of this.fileEntries) {
+			if (entry.type === "compaction") count++;
+		}
+		return count;
+	}
+
+	private hasBranchEntry(predicate: (entry: SessionEntry) => boolean): boolean {
+		let current = this.leafId ? this.byId.get(this.leafId) : undefined;
+		while (current) {
+			if (predicate(current)) return true;
+			current = current.parentId ? this.byId.get(current.parentId) : undefined;
+		}
+		return false;
+	}
+
 	/**
 	 * Get session header.
 	 */
@@ -1457,8 +1521,7 @@ export class SessionManager {
 	static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
 		const resolvedPath = resolvePath(path);
 		// Extract cwd from session header if possible, otherwise use process.cwd()
-		const entries = loadEntriesFromFile(resolvedPath);
-		const header = entries.find((e) => e.type === "session") as SessionHeader | undefined;
+		const header = readSessionHeader(resolvedPath);
 		const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ? normalizePath(sessionDir) : resolve(resolvedPath, "..");

--- a/packages/coding-agent/src/core/session-resident-store.ts
+++ b/packages/coding-agent/src/core/session-resident-store.ts
@@ -2,6 +2,7 @@ import { Buffer } from "buffer";
 
 const RESIDENT_STRING_MIN_BYTES = 32 * 1024;
 const RESIDENT_STRING_PREFIX = "\u0000senpi-resident-string:v1:";
+const OMIT_JSON_VALUE = Symbol("omit-json-value");
 
 export interface ResidentStoreStats {
 	blobCount: number;
@@ -56,8 +57,77 @@ export class ResidentStringStore {
 }
 
 function transformJson<T>(value: T, transformString: (text: string) => string): T {
-	const serialized = JSON.stringify(value, (_key, item: unknown) =>
-		typeof item === "string" ? transformString(item) : item,
-	);
-	return JSON.parse(serialized) as T;
+	const transformed = transformJsonValue(value, transformString, "", new WeakSet());
+	if (transformed === OMIT_JSON_VALUE) {
+		const serialized = JSON.stringify(value);
+		if (serialized === undefined) {
+			throw new SyntaxError("JSON-compatible value expected");
+		}
+		return JSON.parse(serialized) as T;
+	}
+	return transformed as T;
+}
+
+function transformJsonValue(
+	value: unknown,
+	transformString: (text: string) => string,
+	key: string,
+	seen: WeakSet<object>,
+): unknown | typeof OMIT_JSON_VALUE {
+	if (typeof value === "string") {
+		return transformString(value);
+	}
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : null;
+	}
+	if (value === null || typeof value === "boolean") {
+		return value;
+	}
+	if (typeof value === "bigint") {
+		throw new TypeError("Do not know how to serialize a BigInt");
+	}
+	if (typeof value === "undefined" || typeof value === "function" || typeof value === "symbol") {
+		return OMIT_JSON_VALUE;
+	}
+
+	if (seen.has(value)) {
+		throw new TypeError("Converting circular structure to JSON");
+	}
+	seen.add(value);
+
+	const jsonValue = hasJsonSerializer(value) ? value.toJSON(key) : value;
+	if (jsonValue !== value) {
+		const transformed = transformJsonValue(jsonValue, transformString, key, seen);
+		seen.delete(value);
+		return transformed;
+	}
+
+	if (Array.isArray(value)) {
+		const transformed = Array.from({ length: value.length }, (_item, index) => {
+			const item = value[index];
+			const transformedItem = transformJsonValue(item, transformString, String(index), seen);
+			return transformedItem === OMIT_JSON_VALUE ? null : transformedItem;
+		});
+		seen.delete(value);
+		return transformed;
+	}
+
+	const transformed: Record<string, unknown> = {};
+	for (const [key, item] of Object.entries(value)) {
+		const transformedItem = transformJsonValue(item, transformString, key, seen);
+		if (transformedItem !== OMIT_JSON_VALUE) {
+			Object.defineProperty(transformed, key, {
+				configurable: true,
+				enumerable: true,
+				value: transformedItem,
+				writable: true,
+			});
+		}
+	}
+	seen.delete(value);
+	return transformed;
+}
+
+function hasJsonSerializer(value: object): value is { toJSON: (key: string) => unknown } {
+	return "toJSON" in value && typeof value.toJSON === "function";
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -724,7 +724,7 @@ export async function main(args: string[], options?: MainOptions) {
 		} = buildSessionOptions(
 			parsed,
 			scopedModels,
-			sessionManager.buildSessionContext().messages.length > 0,
+			sessionManager.hasContextMessages(),
 			modelRegistry,
 			settingsManager,
 		);

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import { formatProviderNativeBody, formatProviderNativeSummary } from "../../provider-native-rendering.ts";
 import { getMarkdownTheme, theme } from "../theme/theme.ts";
+import { createBoundedRenderSignature } from "./render-signature.ts";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
@@ -101,9 +102,10 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	updateContent(message: AssistantMessage): void {
+		const previousMessage = this.lastMessage;
 		this.lastMessage = message;
 		const messageSignature = this.createMessageSignature(message);
-		if (this.lastMessageSignature === messageSignature) {
+		if (previousMessage === message && this.lastMessageSignature === messageSignature) {
 			return;
 		}
 		this.lastMessageSignature = messageSignature;
@@ -203,7 +205,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	private createMessageSignature(message: AssistantMessage): string {
-		return JSON.stringify({
+		return createBoundedRenderSignature({
 			content: message.content,
 			hiddenThinkingLabel: this.hiddenThinkingLabel,
 			hideThinkingBlock: this.hideThinkingBlock,

--- a/packages/coding-agent/src/modes/interactive/components/render-signature.ts
+++ b/packages/coding-agent/src/modes/interactive/components/render-signature.ts
@@ -1,0 +1,123 @@
+const SIGNATURE_STRING_MAX_LENGTH = 160;
+const SIGNATURE_STRING_SAMPLE_EDGE_LENGTH = 64;
+const SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH = 64;
+const SIGNATURE_ARRAY_ITEM_LIMIT = 40;
+const SIGNATURE_OBJECT_KEY_LIMIT = 80;
+const SIGNATURE_DEPTH_LIMIT = 8;
+
+type RenderSignatureValue =
+	| string
+	| number
+	| boolean
+	| null
+	| readonly RenderSignatureValue[]
+	| { readonly [key: string]: RenderSignatureValue };
+
+export function createBoundedRenderSignature(value: unknown): string {
+	return JSON.stringify(summarizeSignatureValue(value));
+}
+
+function summarizeSignatureString(text: string): string {
+	if (text.length <= SIGNATURE_STRING_MAX_LENGTH) {
+		return text;
+	}
+	const sample = sampleSignatureString(text);
+	return `[string length=${text.length} hash=${hashSignatureString(sample)}]`;
+}
+
+function sampleSignatureString(text: string): string {
+	const first = text.slice(0, SIGNATURE_STRING_SAMPLE_EDGE_LENGTH);
+	const last = text.slice(-SIGNATURE_STRING_SAMPLE_EDGE_LENGTH);
+	const middleStart = Math.max(0, Math.floor((text.length - SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH) / 2));
+	const quarterStart = Math.max(0, Math.floor((text.length - SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH) / 4));
+	const threeQuarterStart = Math.max(0, Math.floor(((text.length - SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH) * 3) / 4));
+	return [
+		first,
+		text.slice(quarterStart, quarterStart + SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH),
+		text.slice(middleStart, middleStart + SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH),
+		text.slice(threeQuarterStart, threeQuarterStart + SIGNATURE_STRING_SAMPLE_WINDOW_LENGTH),
+		last,
+	].join("\u0000");
+}
+
+function hashSignatureString(source: string): string {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < source.length; index++) {
+		hash ^= source.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(36);
+}
+
+function hashSignatureValue(value: unknown): string {
+	return hashSignatureString(JSON.stringify(summarizeSignatureValue(value)));
+}
+
+function summarizeSignatureValue(
+	value: unknown,
+	key = "",
+	depth = 0,
+	seen: WeakSet<object> = new WeakSet(),
+): RenderSignatureValue {
+	if (typeof value === "string") {
+		return summarizeSignatureString(value);
+	}
+	if (typeof value === "number" || typeof value === "boolean" || value === null) {
+		return value;
+	}
+	if (typeof value === "undefined") {
+		return "[undefined]";
+	}
+	if (typeof value === "bigint") {
+		return `[bigint ${value.toString()}]`;
+	}
+	if (typeof value === "symbol") {
+		return `[symbol ${value.description ?? ""}]`;
+	}
+	if (typeof value === "function") {
+		return `[function ${value.name}]`;
+	}
+	if (seen.has(value)) {
+		return "[circular]";
+	}
+	if (depth >= SIGNATURE_DEPTH_LIMIT) {
+		return Array.isArray(value) ? `[array depth-limit length=${value.length}]` : "[object depth-limit]";
+	}
+	seen.add(value);
+
+	const jsonValue = hasJsonSerializer(value) ? value.toJSON(key) : value;
+	if (jsonValue !== value) {
+		const summarized = summarizeSignatureValue(jsonValue, key, depth, seen);
+		seen.delete(value);
+		return summarized;
+	}
+
+	if (Array.isArray(value)) {
+		const summarized = value
+			.slice(0, SIGNATURE_ARRAY_ITEM_LIMIT)
+			.map((item, index) => summarizeSignatureValue(item, String(index), depth + 1, seen));
+		if (value.length > SIGNATURE_ARRAY_ITEM_LIMIT) {
+			const tailHash = hashSignatureValue(value.slice(SIGNATURE_ARRAY_ITEM_LIMIT));
+			seen.delete(value);
+			return [...summarized, `[+${value.length - SIGNATURE_ARRAY_ITEM_LIMIT} items hash=${tailHash}]`];
+		}
+		seen.delete(value);
+		return summarized;
+	}
+
+	const summarized: Record<string, RenderSignatureValue> = {};
+	const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+	for (const [key, item] of entries.slice(0, SIGNATURE_OBJECT_KEY_LIMIT)) {
+		summarized[key] = summarizeSignatureValue(item, key, depth + 1, seen);
+	}
+	if (entries.length > SIGNATURE_OBJECT_KEY_LIMIT) {
+		const omitted = entries.slice(SIGNATURE_OBJECT_KEY_LIMIT);
+		summarized.__truncatedKeys = `[+${omitted.length} keys hash=${hashSignatureValue(Object.fromEntries(omitted))}]`;
+	}
+	seen.delete(value);
+	return summarized;
+}
+
+function hasJsonSerializer(value: object): value is { toJSON: (key: string) => unknown } {
+	return "toJSON" in value && typeof value.toJSON === "function";
+}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -6,6 +6,7 @@ import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/rend
 import { stripAnsi } from "../../../utils/ansi.ts";
 import { convertToPng } from "../../../utils/image-convert.ts";
 import { theme } from "../theme/theme.ts";
+import { createBoundedRenderSignature } from "./render-signature.ts";
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
@@ -178,6 +179,7 @@ export class ToolExecutionComponent extends Container {
 
 	updateArgs(args: any): void {
 		this.args = args;
+		this.lastDisplaySignature = undefined;
 		this.updateSpinnerAnimation();
 		this.updateDisplay();
 	}
@@ -202,6 +204,7 @@ export class ToolExecutionComponent extends Container {
 		if (!isPartial) {
 			this.argsComplete = true;
 		}
+		this.lastDisplaySignature = undefined;
 		this.updateSpinnerAnimation();
 		this.updateDisplay();
 		this.maybeConvertImagesForKitty();
@@ -440,7 +443,7 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private createRenderSignature(): string {
-		return JSON.stringify({
+		return createBoundedRenderSignature({
 			args: this.args,
 			argsComplete: this.argsComplete,
 			executionStarted: this.executionStarted,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3626,8 +3626,7 @@ export class InteractiveMode {
 		this.renderProjectTrustWarningIfNeeded();
 
 		// Show compaction info if session was compacted
-		const allEntries = this.sessionManager.getEntries();
-		const compactionCount = allEntries.filter((e) => e.type === "compaction").length;
+		const compactionCount = this.sessionManager.countCompactions();
 		if (compactionCount > 0) {
 			const times = compactionCount === 1 ? "1 time" : `${compactionCount} times`;
 			this.showStatus(`Session compacted ${times}`);

--- a/packages/coding-agent/test/assistant-message-render-signature.test.ts
+++ b/packages/coding-agent/test/assistant-message-render-signature.test.ts
@@ -1,0 +1,110 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, test, vi } from "vitest";
+import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+function createAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o-mini",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("AssistantMessageComponent render signatures", () => {
+	test("#given large resumed assistant text #when rendering #then signature does not stringify full content", () => {
+		initTheme("dark");
+		const largeText = `large-assistant-content:${"a".repeat(64 * 1024)}`;
+		const originalStringify = JSON.stringify;
+		const stringifySpy = vi.spyOn(JSON, "stringify").mockImplementation((value, replacer, space) => {
+			const rendered = originalStringify(value, replacer, space);
+			if (rendered?.includes(largeText)) {
+				throw new Error("assistant message signature should not JSON.stringify full content");
+			}
+			return rendered;
+		});
+
+		try {
+			const component = new AssistantMessageComponent(createAssistantMessage([{ type: "text", text: largeText }]));
+			expect(() => component.render(120)).not.toThrow();
+		} finally {
+			stringifySpy.mockRestore();
+		}
+	});
+
+	test("#given equal-length large assistant updates #when rendering #then the latest content is shown", () => {
+		initTheme("dark");
+		const oldText = `OLDMARKER:${"a".repeat(64 * 1024)}`;
+		const newText = `NEWMARKER:${"b".repeat(64 * 1024)}`;
+		const component = new AssistantMessageComponent(createAssistantMessage([{ type: "text", text: oldText }]));
+
+		expect(component.render(120).join("\n")).toContain("OLDMARKER");
+
+		component.updateContent(createAssistantMessage([{ type: "text", text: newText }]));
+		const rendered = component.render(120).join("\n");
+
+		expect(newText).toHaveLength(oldText.length);
+		expect(rendered).toContain("NEWMARKER");
+		expect(rendered).not.toContain("OLDMARKER");
+	});
+
+	test("#given assistant content after the signature item limit changes #when rendering #then the tail update is shown", () => {
+		initTheme("dark");
+		const unchangedPrefix = Array.from({ length: 40 }, (_item, index) => ({
+			type: "text" as const,
+			text: `prefix-${index}`,
+		}));
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([...unchangedPrefix, { type: "text", text: "TAILOLD" }]),
+		);
+
+		expect(component.render(120).join("\n")).toContain("TAILOLD");
+
+		component.updateContent(createAssistantMessage([...unchangedPrefix, { type: "text", text: "TAILNEW" }]));
+		const rendered = component.render(120).join("\n");
+
+		expect(rendered).toContain("TAILNEW");
+		expect(rendered).not.toContain("TAILOLD");
+	});
+
+	test("#given provider native Date changes #when rendering #then JSON-visible body updates", () => {
+		initTheme("dark");
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([
+				{
+					type: "providerNative",
+					subtype: "date_test",
+					raw: { date: new Date("2026-06-26T00:00:00.000Z") },
+				},
+			]),
+		);
+
+		expect(component.render(160).join("\n")).toContain("2026-06-26T00:00:00.000Z");
+
+		component.updateContent(
+			createAssistantMessage([
+				{
+					type: "providerNative",
+					subtype: "date_test",
+					raw: { date: new Date("2027-06-26T00:00:00.000Z") },
+				},
+			]),
+		);
+		const rendered = component.render(160).join("\n");
+
+		expect(rendered).toContain("2027-06-26T00:00:00.000Z");
+		expect(rendered).not.toContain("2026-06-26T00:00:00.000Z");
+	});
+});

--- a/packages/coding-agent/test/render-signature.test.ts
+++ b/packages/coding-agent/test/render-signature.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from "vitest";
+import { createBoundedRenderSignature } from "../src/modes/interactive/components/render-signature.ts";
+
+describe("createBoundedRenderSignature", () => {
+	test("#given large strings #when creating a render signature #then string hashing work is bounded", () => {
+		const largeText = `large-signature:${"a".repeat(64 * 1024)}`;
+		const charCodeSpy = vi.spyOn(String.prototype, "charCodeAt");
+
+		try {
+			const signature = createBoundedRenderSignature({
+				content: largeText,
+				nested: [{ details: `large-details:${"b".repeat(64 * 1024)}` }],
+			});
+
+			expect(signature).toContain("string length=");
+			expect(charCodeSpy.mock.calls.length).toBeLessThan(2_000);
+		} finally {
+			charCodeSpy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/session-manager/resident-retention.test.ts
+++ b/packages/coding-agent/test/session-manager/resident-retention.test.ts
@@ -1,7 +1,8 @@
+import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../src/core/session-manager.ts";
 
 const SENTINEL_PREFIX = "\\u0000senpi-resident-string:v1:";
@@ -30,11 +31,40 @@ function assistantMessage(text: string) {
 	};
 }
 
+function imageToolResultMessage(imageData: string, detailsData: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "tool-image-1",
+		toolName: "computer",
+		content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+		details: {
+			screenshotMetadata: {
+				data: detailsData,
+				width: 1024,
+				height: 768,
+			},
+		},
+		isError: false,
+		timestamp: 3,
+	};
+}
+
+function providerNativeAssistantMessage(raw: unknown): AssistantMessage {
+	return {
+		...assistantMessage("provider native payload"),
+		content: [{ type: "providerNative", subtype: "test", raw }],
+	};
+}
+
 function defined<T>(value: T | undefined, name: string): T {
 	if (value === undefined) {
 		throw new Error(`${name} should be defined`);
 	}
 	return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 describe("SessionManager resident retention", () => {
@@ -128,5 +158,134 @@ describe("SessionManager resident retention", () => {
 		expect(readFileSync(forkedFile, "utf8")).not.toContain(SENTINEL_PREFIX);
 		expect(secondId).toBeTruthy();
 		expect(firstId).toBeTruthy();
+	});
+
+	it("serves public readers without reserializing materialized large resident strings", () => {
+		const imageData = largeText("image-data");
+		const detailsData = largeText("details-data");
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage({ role: "user", content: "capture the screen", timestamp: 1 });
+		session.appendMessage(assistantMessage("using the computer tool"));
+		session.appendMessage(imageToolResultMessage(imageData, detailsData));
+
+		const sessionFile = defined(session.getSessionFile(), "session file");
+		const reloaded = SessionManager.open(sessionFile, tempDir);
+		expect(reloaded.getResidentStoreStats().blobCount).toBeGreaterThanOrEqual(2);
+
+		const originalStringify = JSON.stringify;
+		const stringifySpy = vi.spyOn(JSON, "stringify").mockImplementation((value, replacer, space) => {
+			const rendered = originalStringify(value, replacer, space);
+			if (rendered?.includes(imageData) || rendered?.includes(detailsData)) {
+				throw new Error("public session readers should not JSON.stringify full resident payloads");
+			}
+			return rendered;
+		});
+
+		try {
+			const entries = reloaded.getEntries();
+			const toolResultEntry = entries.find(
+				(entry) => entry.type === "message" && entry.message.role === "toolResult",
+			);
+			if (toolResultEntry?.type !== "message" || toolResultEntry.message.role !== "toolResult") {
+				throw new Error("tool result entry should be present");
+			}
+			expect(toolResultEntry.message.content[0]).toEqual({ type: "image", data: imageData, mimeType: "image/png" });
+			expect(toolResultEntry.message.details).toEqual({
+				screenshotMetadata: {
+					data: detailsData,
+					width: 1024,
+					height: 768,
+				},
+			});
+			expect(reloaded.buildSessionContext().messages).toHaveLength(3);
+		} finally {
+			stringifySpy.mockRestore();
+		}
+	});
+
+	it("preserves JSON toJSON redaction semantics while externalizing large strings", () => {
+		const publicText = largeText("to-json-public");
+		const createdAt = new Date("2026-06-26T00:00:00.000Z");
+		const sparseArray: string[] = [];
+		sparseArray.length = 3;
+		sparseArray[0] = publicText;
+		sparseArray[2] = "tail";
+		const rawPayload = {
+			createdAt,
+			secret: "should not survive toJSON",
+			toJSON: () => ({
+				array: [undefined, Number.NaN, publicText],
+				createdAt,
+				nested: { omitted: undefined, visible: "kept" },
+				publicText,
+				sparseArray,
+			}),
+		};
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage(providerNativeAssistantMessage(rawPayload));
+
+		expect(session.getResidentStoreStats().blobCount).toBeGreaterThanOrEqual(1);
+		const sessionFile = defined(session.getSessionFile(), "session file");
+		const persisted = readFileSync(sessionFile, "utf8");
+		expect(persisted).toContain(publicText);
+		expect(persisted).not.toContain("should not survive toJSON");
+		expect(persisted).not.toContain(SENTINEL_PREFIX);
+
+		const entry = defined(session.getEntries()[0], "provider native entry");
+		if (entry.type !== "message" || entry.message.role !== "assistant") {
+			throw new Error("provider native assistant entry should be present");
+		}
+		const content = defined(entry.message.content[0], "provider native content");
+		if (content.type !== "providerNative" || !isRecord(content.raw)) {
+			throw new Error("provider native raw should be materialized as a record");
+		}
+		expect(content.raw.publicText).toBe(publicText);
+		expect(content.raw.createdAt).toBe("2026-06-26T00:00:00.000Z");
+		expect(content.raw.secret).toBeUndefined();
+		expect(content.raw.array).toEqual([null, null, publicText]);
+		expect(content.raw.nested).toEqual({ visible: "kept" });
+		expect(content.raw.sparseArray).toEqual([publicText, null, "tail"]);
+	});
+
+	it("preserves JSON object data properties named __proto__", () => {
+		const protoText = largeText("proto-data-property");
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendMessage(
+			providerNativeAssistantMessage({
+				["__proto__"]: protoText,
+				visible: "ok",
+			}),
+		);
+
+		const entry = defined(session.getEntries()[0], "provider native entry");
+		if (entry.type !== "message" || entry.message.role !== "assistant") {
+			throw new Error("provider native assistant entry should be present");
+		}
+		const content = defined(entry.message.content[0], "provider native content");
+		if (content.type !== "providerNative" || !isRecord(content.raw)) {
+			throw new Error("provider native raw should be materialized as a record");
+		}
+
+		expect(Object.hasOwn(content.raw, "__proto__")).toBe(true);
+		expect(Reflect.get(content.raw, "__proto__")).toBe(protoText);
+		expect(content.raw.visible).toBe("ok");
+	});
+
+	it("persists custom entry dates using JSON toJSON semantics", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		const date = new Date("2026-06-26T12:34:56.789Z");
+		session.appendMessage(assistantMessage("flush custom entries"));
+		session.appendCustomEntry("date-payload", { date });
+
+		const sessionFile = defined(session.getSessionFile(), "session file");
+		const persisted = readFileSync(sessionFile, "utf8");
+		expect(persisted).toContain('"date":"2026-06-26T12:34:56.789Z"');
+		expect(persisted).not.toContain('"date":{}');
+
+		const customEntry = session.getEntries().find((entry) => entry.type === "custom");
+		if (customEntry?.type !== "custom" || !isRecord(customEntry.data)) {
+			throw new Error("custom date entry should be present");
+		}
+		expect(customEntry.data.date).toBe("2026-06-26T12:34:56.789Z");
 	});
 });

--- a/packages/coding-agent/test/session-manager/session-open-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-open-state.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { findMostRecentSession, SessionManager } from "../../src/core/session-manager.ts";
+
+describe("SessionManager open and lightweight state", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-open-state-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("opens sessions with headers longer than the first read buffer", () => {
+		const file = join(tempDir, "long-header.jsonl");
+		writeFileSync(
+			file,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "long-header",
+				timestamp: "2025-01-01T00:00:00Z",
+				cwd: tempDir,
+				parentSession: "parent-session-".repeat(80),
+			})}\n` +
+				'{"type":"message","id":"1","parentId":null,"timestamp":"2025-01-01T00:00:01Z","message":{"role":"user","content":"hi","timestamp":1}}\n',
+		);
+
+		const sessionManager = SessionManager.open(file, tempDir);
+
+		expect(sessionManager.getSessionId()).toBe("long-header");
+		expect(sessionManager.getCwd()).toBe(tempDir);
+		expect(sessionManager.getEntries()).toHaveLength(1);
+	});
+
+	it("opens sessions without preloading non-header entries", () => {
+		const file = join(tempDir, "open-once.jsonl");
+		const sentinel = "NON_HEADER_SENTINEL_OPEN_ONCE";
+		writeFileSync(
+			file,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "open-once",
+				timestamp: "2025-01-01T00:00:00Z",
+				cwd: tempDir,
+			})}\n` +
+				`${JSON.stringify({
+					type: "message",
+					id: "1",
+					parentId: null,
+					timestamp: "2025-01-01T00:00:01Z",
+					message: { role: "user", content: sentinel, timestamp: 1 },
+				})}\n`,
+		);
+
+		const originalParse = JSON.parse;
+		let sentinelParses = 0;
+		const parseSpy = vi
+			.spyOn(JSON, "parse")
+			.mockImplementation(
+				(text: string, reviver?: (this: unknown, key: string, value: unknown) => unknown): unknown => {
+					if (text.includes(sentinel)) {
+						sentinelParses++;
+					}
+					return originalParse(text, reviver);
+				},
+			);
+
+		try {
+			const sessionManager = SessionManager.open(file, tempDir);
+
+			expect(sessionManager.getSessionId()).toBe("open-once");
+			expect(sessionManager.getEntries()).toHaveLength(1);
+			expect(sentinelParses).toBe(1);
+		} finally {
+			parseSpy.mockRestore();
+		}
+	});
+
+	it("matches cwd for sessions with long headers", () => {
+		const project = join(tempDir, "project-long-header");
+		const file = join(tempDir, "long-header.jsonl");
+		writeFileSync(
+			file,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "long-header",
+				timestamp: "2025-01-01T00:00:00Z",
+				cwd: project,
+				parentSession: "parent-session-".repeat(80),
+			})}\n` +
+				'{"type":"message","id":"1","parentId":null,"timestamp":"2025-01-01T00:00:01Z","message":{"role":"user","content":"hi","timestamp":1}}\n',
+		);
+
+		expect(findMostRecentSession(tempDir, project)).toBe(file);
+	});
+
+	it("reports context and metadata state from the current branch", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+
+		expect(session.hasContextMessages()).toBe(false);
+		expect(session.hasThinkingLevelChanges()).toBe(false);
+		expect(session.countCompactions()).toBe(0);
+
+		session.appendModelChange("openai", "gpt-test");
+		const firstMessageId = session.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+		session.appendThinkingLevelChange("high");
+		session.appendCompaction("summary", firstMessageId, 42);
+
+		expect(session.hasContextMessages()).toBe(true);
+		expect(session.hasThinkingLevelChanges()).toBe(true);
+		expect(session.countCompactions()).toBe(1);
+
+		session.branch(firstMessageId);
+
+		expect(session.hasContextMessages()).toBe(true);
+		expect(session.hasThinkingLevelChanges()).toBe(false);
+	});
+
+	it("treats custom-message-only sessions as existing context", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		session.appendCustomMessageEntry("test-extension", "extension context", false);
+
+		expect(session.buildSessionContext().messages).toHaveLength(1);
+		expect(session.hasContextMessages()).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/tool-execution-render-signature.test.ts
+++ b/packages/coding-agent/test/tool-execution-render-signature.test.ts
@@ -1,0 +1,97 @@
+import type { TUI } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+function createFakeTui(): TUI {
+	return {
+		requestRender: () => {},
+	} as TUI;
+}
+
+describe("ToolExecutionComponent render signatures", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("does not stringify full image results while computing render cache signatures", () => {
+		const imageData = `image-data:${"a".repeat(64 * 1024)}`;
+		const detailsData = `details-data:${"b".repeat(64 * 1024)}`;
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-large-image-result",
+			{},
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+
+		const originalStringify = JSON.stringify;
+		const stringifySpy = vi.spyOn(JSON, "stringify").mockImplementation((value, replacer, space) => {
+			const rendered = originalStringify(value, replacer, space);
+			if (rendered?.includes(imageData) || rendered?.includes(detailsData)) {
+				throw new Error("render signature should not JSON.stringify full image payloads");
+			}
+			return rendered;
+		});
+
+		try {
+			expect(() =>
+				component.updateResult(
+					{
+						content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+						details: {
+							screenshotMetadata: {
+								data: detailsData,
+								width: 1024,
+								height: 768,
+							},
+						},
+						isError: false,
+					},
+					false,
+				),
+			).not.toThrow();
+			expect(() => component.render(120)).not.toThrow();
+		} finally {
+			stringifySpy.mockRestore();
+		}
+	});
+
+	test("bounds large image result signature work across repeated renders", () => {
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-repeated-large-image-result",
+			{},
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		const charCodeSpy = vi.spyOn(String.prototype, "charCodeAt");
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "image", data: `image-data:${"a".repeat(64 * 1024)}`, mimeType: "image/png" }],
+					details: {
+						screenshotMetadata: {
+							data: `details-data:${"b".repeat(64 * 1024)}`,
+							width: 1024,
+							height: 768,
+						},
+					},
+					isError: false,
+				},
+				false,
+			);
+			component.render(120);
+			component.render(120);
+
+			expect(charCodeSpy.mock.calls.length).toBeLessThan(4_000);
+		} finally {
+			charCodeSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes excessive CPU when resuming a large Senpi session with `senpi --session 019f025b-4347-777f-a8fc-e2eaf21bd50e`.

Before this change, startup paths and TUI render caches could force full materialization or full-string hashing of 22 MB resident session payloads. After this PR, resume startup reads only the session header until entries are needed, lightweight state checks avoid building full context, resident string traversal preserves JSON semantics without whole-object stringify, and TUI render signatures sample bounded string windows.

## Changes

- Session resume startup now uses a chunked header reader in `SessionManager.open()` instead of loading every JSONL entry before constructing the manager.
- Added lightweight branch-aware session state helpers for existing context, thinking-level changes, and compaction counts, then switched startup/TUI call sites away from full context materialization where only existence/counts are needed.
- Reworked resident string transformation to traverse JSON-shaped values directly while preserving `toJSON`, Date, sparse array, omitted-property, numeric special-value, circular, BigInt, and own `__proto__` semantics.
- Added bounded render signatures for assistant messages and tool executions so large image/details/provider-native payloads do not get stringified or fully hashed during repeated render checks.
- Added regression coverage for lazy session open, long headers, custom-message context restore, resident traversal semantics, and bounded render signatures.

## QA / Evidence

- **What was tested:** RED-on-main focused regressions for lazy session open, long headers, context-message detection, resident traversal/signatures, and JSON `__proto__` behavior.
  **Observed result:** `origin/main` failed the targeted regressions as expected.
  **Artifact:** `local-ignore/qa-evidence/20260626-session-load-cpu/red-focused-tests-current-complete-3.txt`.
  **Why sufficient:** Proves the tests cover the bug class instead of only passing after the fix.

- **What was tested:** Focused GREEN regression suite after the fix.
  **Observed result:** 8 files / 76 tests passed.
  **Artifact:** `local-ignore/qa-evidence/20260626-session-load-cpu/green-focused-tests-final-complete-3.txt`.
  **Why sufficient:** Covers the changed session-manager, resident-store, assistant-message, and tool-execution behavior directly.

- **What was tested:** Required repo check after code changes.
  **Observed result:** `npm run check` passed cleanly.
  **Artifact:** `local-ignore/qa-evidence/20260626-session-load-cpu/npm-run-check-open-final-4.txt`.
  **Why sufficient:** Covers typecheck/lint/package checks required by the repo.

- **What was tested:** Mandatory senpi-qa harness channels from source.
  **Observed result:** common self-check 9/9, TUI smoke 5/5, mock-loop self-test 5/5, mock-loop with tool 4/4; real auth unchanged.
  **Artifacts:** `common-self-check-open-final.txt`, `tui-smoke-open-final.txt`, `mock-loop-open-final.txt`, `mock-loop-tool-open-final.txt`.
  **Why sufficient:** Exercises real CLI/TUI/agent-loop surfaces in isolated sandboxes.

- **What was tested:** Actual copied 22,061,314-byte / 666-line session load through tmux with `pi-test.sh --session 019f025b-4347-777f-a8fc-e2eaf21bd50e` and isolated session/auth dirs.
  **Observed result:** startup CPU spike max 132.7% at sample 3, then 0.0% by sample 8; TUI rendered a non-empty layout; tmux/temp cleanup completed; real auth unchanged.
  **Artifacts:** `session-load-cpu-summary.txt`, `session-load-cpu-ps.txt`, `session-load-cpu-cpu-summary-open-final-2.txt`, `session-load-cpu-pane.txt`, `session-load-cpu-ui-proof.txt`, `session-load-cpu-qa-open-final-2.txt`.
  **Why sufficient:** Replays the user-reported session path against the real interactive surface without storing raw session content.

- **What was tested:** Evidence privacy checks.
  **Observed result:** secret/sentinel scan and non-ASCII UI-proof scan are both empty.
  **Artifacts:** `privacy-scan-open-final-2.txt`, `ui-proof-nonascii-scan.txt`.
  **Why sufficient:** Confirms the proof artifacts do not contain raw session text, auth headers, token-shaped strings, or unredacted TUI text.

- **What was reviewed:** Final code and QA reviews.
  **Observed result:** code review approved with no blockers; QA review passed with no missing evidence.
  **Artifacts:** `.omo/evidence/session-load-cpu-code-review-final.md`, `.omo/evidence/session-load-cpu-qa-review-final.md`.
  **Why sufficient:** Independent reviewers re-audited the prior blockers and required evidence.

## Risks

- Bounded render signatures intentionally sample large strings rather than hashing every byte. Collision risk is mitigated by re-rendering on new assistant message objects and clearing tool display signatures when args/results update; focused tests cover equal-length changed payloads and bounded `charCodeAt` work.
- Session startup now uses a header-only read before entries are loaded. Long-header and no-preload regression tests cover this boundary, including cwd matching for session discovery.
- Resident traversal now mirrors JSON serialization rules directly. Regression tests cover `toJSON`, Date, sparse arrays, omitted properties, `NaN`, `Infinity`, circular/BigInt behavior by existing semantics, and own `__proto__` data properties.

## Secret Safety

No raw session pane transcript is committed or included in the PR body. QA artifacts live under gitignored `local-ignore/qa-evidence/20260626-session-load-cpu/`; the sanitized UI proof records metrics and a redacted preview only. Privacy scan artifacts are empty.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts CPU spikes when resuming large sessions by avoiding eager reads and expensive hashing. Startup now reads only the session header, keeps resident strings lazy, and bounds TUI render signature work.

- **Bug Fixes**
  - `SessionManager.open()` reads the session header in chunks; no preloading of JSONL entries; supports long headers.
  - Added lightweight state helpers (`hasContextMessages`, `hasThinkingLevelChanges`, `countCompactions`) and updated call sites in `sdk`, `main`, and interactive mode to avoid full context builds.
  - Reworked resident string traversal to mirror JSON rules (respects `toJSON`, Date, sparse arrays, special numbers, circulars, BigInt errors, own `__proto__`); avoids whole-object stringify when materialized.
  - Introduced bounded render signatures for assistant messages and tool executions; large strings are sampled and hashed within limits; re-renders trigger on object changes; repeated renders stay cheap.

<sup>Written for commit b6ea9a446fdd3846b8dd57fff32760cdbb5e1795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

