### PR TITLE
fix(coding-agent): drain delayed child stdout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fixed bash command output collection to keep reading delayed descendant stdout after the parent process exits ([#5303](https://github.com/earendil-works/pi/issues/5303)).
 - Fixed builtin webfetch extraction for Tistory-style articles so the post body and readable line breaks are preserved instead of blog chrome or category blocks.
 - Fixed `--session` and `SessionManager.open()` to reject non-empty invalid session files without overwriting them ([#6002](https://github.com/earendil-works/pi/issues/6002)).
 - Fixed user-message transcript rendering to keep visible backslashes in Markdown escape sequences such as `\"` ([#6105](https://github.com/earendil-works/pi/issues/6105)).

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -13,7 +13,7 @@ import {
 import type { Readable } from "node:stream";
 import crossSpawn from "cross-spawn";
 
-const EXIT_STDIO_GRACE_MS = 100;
+const EXIT_STDIO_GRACE_MS = 250;
 
 export function spawnProcess(
 	command: string,

--- a/packages/coding-agent/test/suite/regressions/5303-bash-output-truncation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5303-bash-output-truncation.test.ts
@@ -33,7 +33,7 @@ describe.skipIf(process.platform === "win32")("issue #5303 bash output truncatio
 
 	it("captures output emitted after exit while a detached child holds stdout open", async () => {
 		// The shell exits immediately, but a backgrounded subshell keeps the stdout
-		// pipe open and emits ticks every 50ms, the last well past the 100ms grace.
+		// pipe open and emits ticks every 50ms, the last well past the original 100ms grace.
 		const command = 'printf "HEAD\\n"; ( for i in 1 2 3 4 5 6; do sleep 0.05; printf "TICK$i\\n"; done ) &';
 		child = spawnProcess("/bin/sh", ["-c", command], {
 			stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

This PR completes the manual upstream-sync check for the current fork tip and fixes the validation blocker found during that workflow. The latest upstream release (`v0.80.2`) is already merged into `origin/main`, so no upstream merge commit is needed.

During validation, the existing #5303 regression failed on this host because the post-exit stdio idle grace could still close a child process pipe before delayed descendant stdout arrived. The fix raises that grace from 100ms to 250ms while keeping the quiet-handle release behavior covered by the existing regression test.

## Changes

- Keeps `waitForChildProcess()` reading delayed inherited stdout for a longer post-exit idle window.
- Updates the #5303 regression wording to distinguish the original 100ms failure threshold from the current implementation.
- Adds a coding-agent changelog entry for the stdout-drain fix.

## QA / Evidence

- Upstream/base assessment: `node scripts/check-upstream-release.mjs` returned `proceed=false`, `tag=v0.80.2`, `current_tag=v0.80.2`; saved at `local-ignore/qa-evidence/20260628-merge-upstream-release/check-upstream-release.txt`.
- RED proof: `npx vitest --run test/suite/regressions/5303-bash-output-truncation.test.ts test/suite/pi-codex-app-server-harness.test.ts` failed before the fix because output stopped before `TICK6`; saved at `local-ignore/qa-evidence/20260628-merge-upstream-release/coding-agent-failed-tests-rerun.txt`.
- GREEN targeted proof: the same targeted command passed after the fix (`2 passed`, `6 passed`); saved at `local-ignore/qa-evidence/20260628-merge-upstream-release/coding-agent-failed-tests-green.txt`.
- Build: `npm run build` passed; saved at `local-ignore/qa-evidence/20260628-merge-upstream-release/npm-build-after-fix.txt`.
- Check: `npm run check` passed; saved at `local-ignore/qa-evidence/20260628-merge-upstream-release/npm-check-after-fix.txt`.
- Tests: full `npm test` passed with provider credential env vars stripped so live-provider suites skip instead of using invalid inherited keys; saved at `local-ignore/qa-evidence/20260628-merge-upstream-release/npm-test-after-fix-provider-env-stripped.txt`.
- Manual QA: `senpi-qa` common, mock-loop, CLI smoke, and tmux TUI smoke all passed with real auth unchanged; saved under `local-ignore/qa-evidence/20260628-merge-upstream-release/` and `local-ignore/qa-evidence/20260628-merge-upstream-release-tui/`.
- Reviewer gate: independent read-only reviewer returned `UNCONDITIONAL APPROVAL`; local report path `.omo/evidence/validate-heavy-merge-upstream-pr-release-workflow-patch-code-review.md`.

## Risks

- The longer grace can make a quiet inherited stdout handle wait up to 250ms instead of 100ms after parent exit. The existing quiet-handle regression still passed in the targeted test pair, so the delay remains bounded well under the test's 2s threshold.
- Provider-backed live API tests were not run because inherited provider credentials on this machine are invalid. The offline/provider-stripped suite and senpi mock-loop QA covered the deterministic non-token paths.

## Secret safety

No raw secrets, auth headers, cookies, or private credentials are included in this PR body. The superseded local `npm-test.txt` artifact contains only provider-masked 401 output and is intentionally not used as public evidence; the accepted test evidence is the provider-stripped green run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bash output truncation in `coding-agent` by continuing to drain delayed child stdout after the parent exits. Raises the post-exit stdio idle grace from 100ms to 250ms; updates the regression test wording and changelog.

<sup>Written for commit 1d308b34f2ebd31930cb4a3a95ac976614229281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

