### PR TITLE
fix(release): keep orchestrator package private

### DIFF
--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Fixed release publication by keeping the experimental orchestrator workspace private until its npm package scope is configured.
+
 ## [2026.6.28-3] - 2026-06-28
 
 ### Added

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@code-yeongyu/senpi-orchestrator",
 	"version": "2026.6.28-3",
+	"private": true,
 	"description": "experimental orchestrator package for senpi",
 	"type": "module",
 	"main": "./dist/index.js",


### PR DESCRIPTION
## Summary

The `v2026.6.28-3` release workflow reached `Publish npm packages` and failed because npm rejected `@code-yeongyu/senpi-orchestrator` with a 404/not-authorized response. This PR keeps the experimental orchestrator workspace private until its npm package scope is configured, matching the current behavior of the internal workspace packages that are validated but skipped by npm during release publication.

## Changes

- Marks `packages/orchestrator` as private in `package.json`.
- Adds an unreleased changelog entry documenting the release-publish fix.

## QA / Evidence

- Build: `npm run build` passed.
  Evidence: `/Users/yeongyu/.codex-gui-cli-remote/worktrees/da74/senpi/local-ignore/qa-evidence/20260628-orchestrator-private-release-fix/npm-build.txt`
- Check: `npm run check` passed.
  Evidence: `/Users/yeongyu/.codex-gui-cli-remote/worktrees/da74/senpi/local-ignore/qa-evidence/20260628-orchestrator-private-release-fix/npm-check.txt`
- Release publish surface: `npm publish --access public --tag latest --provenance --ignore-scripts --dry-run` from `packages/orchestrator` exited 0 and reported the workspace was skipped because it is private.
  Evidence: `/Users/yeongyu/.codex-gui-cli-remote/worktrees/da74/senpi/local-ignore/qa-evidence/20260628-orchestrator-private-release-fix/orchestrator-npm-publish-dry-run.txt`
- Release validation surface: `node scripts/publish.mjs --dry-run` validated all release packages.
  Evidence: `/Users/yeongyu/.codex-gui-cli-remote/worktrees/da74/senpi/local-ignore/qa-evidence/20260628-orchestrator-private-release-fix/publish-script-dry-run.txt`

## Risks

- This intentionally does not publish `@code-yeongyu/senpi-orchestrator` until npm scope/package permissions are configured. That is consistent with its experimental status and prevents the release workflow from failing before publishing the public `@code-yeongyu/senpi` package.

## Secret safety

No secret-bearing logs, auth headers, npm tokens, cookies, or credentials are included in the PR body or evidence summaries.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the experimental `@code-yeongyu/senpi-orchestrator` package private so the release workflow skips it and doesn’t fail on npm publish. Publishing is deferred until npm scope/permissions are set.

- **Bug Fixes**
  - Set `"private": true` in `packages/orchestrator/package.json`.
  - Added a changelog entry noting the release-publish fix.

<sup>Written for commit 641e9eed973ba6a9fc58b74b6f1f436adb3ac06c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

