### PR TITLE
fix(coding-agent): pin update changelog links

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed update notifications to link to the senpi changelog for the specific advertised release instead of the drifting upstream `main` changelog.
+
 ## [2026.6.28-4] - 2026-06-28
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -100,7 +100,7 @@ import { parseGitUrl } from "../../utils/git.ts";
 import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
-import { checkForNewPiVersion } from "../../utils/version-check.ts";
+import { checkForNewPiVersion, getReleaseChangelogUrl } from "../../utils/version-check.ts";
 import { abortedErrorLabel } from "./aborted-error-label.ts";
 import { ArminComponent } from "./components/armin.ts";
 import { AssistantMessageComponent } from "./components/assistant-message.ts";
@@ -4089,7 +4089,7 @@ export class InteractiveMode {
 	showNewVersionNotification(newVersion: string): void {
 		const action = theme.fg("accent", `${APP_NAME} update`);
 		const updateInstruction = theme.fg("muted", `New version ${newVersion} is available. Run `) + action;
-		const changelogUrl = "https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md";
+		const changelogUrl = getReleaseChangelogUrl(newVersion);
 		const changelogLink = getCapabilities().hyperlinks
 			? hyperlink(theme.fg("accent", changelogUrl), changelogUrl)
 			: theme.fg("accent", changelogUrl);

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -4,6 +4,8 @@ import { getPiUserAgent } from "./pi-user-agent.ts";
 
 const LATEST_VERSION_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}/latest`;
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10000;
+const RELEASE_CHANGELOG_BASE_URL = "https://github.com/code-yeongyu/senpi/blob";
+const RELEASE_CHANGELOG_PATH = "packages/coding-agent/CHANGELOG.md";
 
 export interface LatestPiRelease {
 	version: string;
@@ -26,6 +28,12 @@ export function isNewerPackageVersion(candidateVersion: string, currentVersion: 
 		return comparison > 0;
 	}
 	return candidateVersion.trim() !== currentVersion.trim();
+}
+
+export function getReleaseChangelogUrl(version: string): string {
+	const trimmedVersion = version.trim();
+	const tag = trimmedVersion.startsWith("v") ? trimmedVersion : `v${trimmedVersion}`;
+	return `${RELEASE_CHANGELOG_BASE_URL}/${tag}/${RELEASE_CHANGELOG_PATH}`;
 }
 
 export async function getLatestPiRelease(

--- a/packages/coding-agent/test/version-check.test.ts
+++ b/packages/coding-agent/test/version-check.test.ts
@@ -4,6 +4,7 @@ import {
 	comparePackageVersions,
 	getLatestPiRelease,
 	getLatestPiVersion,
+	getReleaseChangelogUrl,
 	isNewerPackageVersion,
 } from "../src/utils/version-check.ts";
 
@@ -55,6 +56,12 @@ describe("version checks", () => {
 					accept: "application/json",
 				}),
 			}),
+		);
+	});
+
+	it("builds a release-specific senpi changelog URL", () => {
+		expect(getReleaseChangelogUrl("2026.6.28-4")).toBe(
+			"https://github.com/code-yeongyu/senpi/blob/v2026.6.28-4/packages/coding-agent/CHANGELOG.md",
 		);
 	});
 


### PR DESCRIPTION
## Summary
The update-available banner was linking users to the upstream `earendil-works/pi-mono` `main` changelog, so the link could be wrong for senpi users and drift away from the advertised release. This PR changes the banner to build a release-specific `code-yeongyu/senpi` changelog URL from the new version string.

Before: `https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md`
After for `2026.6.28-4`: `https://github.com/code-yeongyu/senpi/blob/v2026.6.28-4/packages/coding-agent/CHANGELOG.md`

## Changes
- Added `getReleaseChangelogUrl(version)` next to the existing version-check helpers so update notification links are derived consistently.
- Updated `InteractiveMode.showNewVersionNotification()` to use the release-specific senpi changelog URL instead of the hardcoded upstream `main` URL.
- Added a focused regression test for the advertised `2026.6.28-4` changelog URL.
- Added an Unreleased changelog entry for the fixed update notification link.

## QA / Evidence
- **What was tested:** Focused red/green regression in `packages/coding-agent/test/version-check.test.ts`.
  **Observed result:** RED failed with `TypeError: getReleaseChangelogUrl is not a function`; GREEN passed 7/7 after the helper and call-site fix.
  **Artifact:** `local-ignore/qa-evidence/20260629-update-banner-changelog/red-green.txt`.
  **Why sufficient:** Proves the old behavior lacked the release-specific URL helper and the new helper returns the exact senpi tag-pinned changelog URL.

- **What was tested:** Required repo validation with `npm run check`.
  **Observed result:** Passed; Biome, pinned-deps, TypeScript import checks, shrinkwrap/install-lock checks, `tsgo --noEmit`, browser smoke, and web UI checks completed.
  **Artifact:** `local-ignore/qa-evidence/20260629-update-banner-changelog/npm-run-check.txt`.
  **Why sufficient:** Covers the required workspace validation for code changes.

- **What was tested:** Required senpi QA harness for the coding-agent/TUI surface.
  **Observed result:** `common.mjs --self-check` passed 9/9, `tui-smoke.mjs --self-test --driver tmux` passed 5/5, and `cli-smoke.mjs --self-test` passed 5/5. Real auth was unchanged.
  **Artifact:** `local-ignore/qa-evidence/20260629-update-banner-changelog/senpi-qa.txt`.
  **Why sufficient:** Exercises the real CLI/TUI harness in isolated sandboxes without real credentials.

- **What was tested:** Rendered update notification surface for mocked version `2026.6.28-4`.
  **Observed result:** Rendered output contains `Update Available`, `senpi update`, and `https://github.com/code-yeongyu/senpi/blob/v2026.6.28-4/packages/coding-agent/CHANGELOG.md`.
  **Artifact:** `local-ignore/qa-evidence/20260629-update-banner-changelog/cli-surface.txt`.
  **Why sufficient:** Directly proves the visible banner text now points to the release-specific senpi changelog. A full startup tmux attempt was preserved in `cli-surface-startup-attempt-failed.txt` but is not counted because the no-model startup path did not reliably emit the async update notice.

## Risks
- The URL assumes release tags are named with a leading `v`, which matches the current release tags such as `v2026.6.28-4`; covered by the focused regression and rendered banner proof.
- This changes only the changelog link target. The version check and update command behavior are unchanged; covered by `npm run check` and senpi CLI/TUI smoke.

## Secret Safety
No raw secrets, tokens, auth headers, cookies, env dumps, or private credentials are included. senpi QA verified the real auth file was unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the update banner to link to the release-specific `code-yeongyu/senpi` changelog instead of the upstream `earendil-works/pi-mono` main branch. The link is now tag-pinned using the new version (e.g., `v2026.6.28-4`) so users see the correct release notes.

- **Bug Fixes**
  - Added `getReleaseChangelogUrl(version)` and updated `InteractiveMode.showNewVersionNotification()` to use it.
  - Added a focused test for the `2026.6.28-4` changelog URL.

<sup>Written for commit 93be74af97ee26335d39b139300e403f6e25f5d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

