### PR TITLE
fix(tui): clear dirty line before initial render

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1478,6 +1478,8 @@ export class TUI extends Container {
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+			} else {
+				buffer += "\r\x1b[2K";
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -270,6 +270,26 @@ describe("TUI lifecycle memory", () => {
 });
 
 describe("TUI input render scheduling", () => {
+	it("clears a dirty current line before the initial render", async () => {
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		// given
+		terminal.write("12:21 \x1b[2mfrom-shell-prompt");
+		component.lines = ["\x1b[1m•\x1b[22m \x1b[2mWorking\x1b[22m"];
+
+		// when
+		tui.start();
+		await terminal.waitForRender();
+
+		// then
+		assert.strictEqual(terminal.getViewport()[0], "• Working");
+
+		tui.stop();
+	});
+
 	it("echoes focused component input on the next tick while a normal render is pending", async () => {
 		const terminal = new VirtualTerminal(40, 5);
 		const tui = new TUI(terminal);


### PR DESCRIPTION
## Summary

Fixes intermittent TUI first-frame corruption where stale shell prompt/status text can remain on the current terminal line and get joined with the new Senpi status text after commands such as `git fetch` or `git pull`.

Before this change, a first non-clearing render could append `• Working` after whatever was already on the current line. After this change, the initial non-clearing render returns to the start of the current line and clears it before writing the first TUI line.

## Changes

- Clear the current terminal line before non-clearing full renders in `packages/tui/src/tui.ts`.
- Add a regression test that seeds a dirty current line and asserts the rendered viewport starts with exactly `• Working`.

## QA / Evidence

- Focused RED proof: `local-ignore/qa-evidence/20260629-git-status-rendering-focused/red-dirty-current-line.txt`
  - Shows the old behavior failing with actual `12:21 from-shell-prompt• Working` vs expected `• Working`.
- Focused GREEN proof: `local-ignore/qa-evidence/20260629-git-status-rendering-focused/green-tui-render-test.txt`
  - `cd packages/tui && node --test --import tsx test/tui-render.test.ts`
  - Result: 37 tests passed, 0 failed.
  - Includes flicker-budget checks with `fullRenderTrueAfterInit=0` and balanced DECSET markers.
- Package regression: `local-ignore/qa-evidence/20260629-git-status-rendering-focused/packages-tui-npm-test.txt`
  - `cd packages/tui && npm test`
  - Result: 745 tests passed, 0 failed.
- Workspace check: `local-ignore/qa-evidence/20260629-git-status-rendering-focused/npm-run-check.txt`
  - `npm run check`
  - Result: exit status 0.
- Manual TUI QA: `local-ignore/qa-evidence/20260629-git-status-rendering-tui-rerun/tui-smoke-console.txt`
  - `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence git-status-rendering-tui-rerun`
  - Result: 5/5 passed. The TUI booted, rendered, accepted composer input, tore down without leaked session/process, and left real auth unchanged.
- Cleanup receipt: `local-ignore/qa-evidence/20260629-git-status-rendering-tui-rerun/tmux-ls-after.txt`
  - Shows only the pre-existing `ccapi_secret_scan` tmux session after QA.

## Risks

- The added `\r\x1b[2K` sequence is intentionally scoped to non-clearing full renders. The existing full-screen clear path is unchanged.
- Main residual risk is terminal-specific interpretation of erase-line behavior, covered by virtual-terminal regression, TUI smoke through tmux, package tests, and the existing flicker-budget assertions.

## Secret safety

- Evidence artifacts are under `local-ignore/`, which is gitignored.
- QA used the isolated senpi harness and reported real auth unchanged.
- No raw tokens, auth headers, cookies, credentials, or secret-bearing logs are included in the PR body.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the current terminal line before the TUI’s first non-clearing render to prevent stale shell prompt text from merging with the first status line (e.g., after git fetch/pull).

- **Bug Fixes**
  - On non-clearing full renders, send “\r\x1b[2K” to reset to column 0 and erase the line before writing.
  - Added a regression test that seeds a dirty line and asserts the first rendered line is exactly “• Working”.

<sup>Written for commit f4600bc6e83a6473ba9cd23de9cbc02377a0c946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

