### PR TITLE
feat(coding-agent): add builtin hooks extension

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added builtin hooks documentation covering supported events, command hook JSON, plugin manifest sources, trust commands, runtime hook paths, migration notes, and current unsupported Claude-only hook shapes.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -409,6 +409,7 @@ The default export can also be `async`. pi waits for async extension factories b
 - Custom tools (or replace built-in tools entirely)
 - Sub-agents and plan mode
 - Custom compaction and summarization
+- Builtin command hooks for local guardrails
 - Permission gates and path protection
 - Custom editors and UI components
 - Status lines, headers, footers
@@ -419,7 +420,7 @@ The default export can also be `async`. pi waits for async extension factories b
 - Games while waiting (yes, Doom runs)
 - ...anything you can dream up
 
-Place in `~/.pi/agent/extensions/`, `.pi/extensions/`, or a [pi package](#pi-packages) to share with others. See [docs/extensions.md](docs/extensions.md) and [examples/extensions/](examples/extensions/).
+Place in `~/.pi/agent/extensions/`, `.pi/extensions/`, or a [pi package](#pi-packages) to share with others. See [docs/extensions.md](docs/extensions.md), [Builtin Hooks](docs/extensions.md#builtin-hooks), and [examples/extensions/](examples/extensions/).
 
 ### Themes
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -39,6 +39,10 @@ See [examples/extensions/](../examples/extensions/) for working implementations.
   - [Lifecycle Overview](#lifecycle-overview)
   - [Resource Events](#resource-events)
   - [Builtin Hooks](#builtin-hooks)
+    - [Hook setup workflow](#hook-setup-workflow)
+    - [Hook input and output](#hook-input-and-output)
+    - [Common hook recipes](#common-hook-recipes)
+    - [Hook troubleshooting](#hook-troubleshooting)
   - [Session Events](#session-events)
   - [Agent Events](#agent-events)
   - [Model Events](#model-events)
@@ -395,6 +399,32 @@ Default senpi hook files are discovered from:
 | Temporary package sources and SDK/host-provided `new DefaultResourceLoader({ additionalHookPaths })` | pre-session | Package/plugin hook JSON files resolved before `session_start`. |
 | `resources_discover` `hookPaths` | runtime | Late sources. They can affect later hook events in the current runtime and `SessionStart` on `/reload` or the next session. |
 
+#### Hook setup workflow
+
+Use builtin hooks when you already have Claude/Codex-style JSON hook configs or when you want a small shell-script guardrail. Use a TypeScript extension instead when the behavior needs rich senpi APIs, UI prompts, custom tools, long-lived state, or non-command handlers.
+
+For a project-local hook:
+
+1. Create `.senpi/hooks.json`.
+2. Put command scripts under `.senpi/hooks/` or another project path.
+3. Start `senpi` in that project.
+4. Run `/hooks list` and copy the real hook id.
+5. Run `/hooks trust <id>` once for each command hook you want to execute.
+6. Trigger the event, then use `/hooks diagnostics` if it did not run.
+
+For a global hook, use `~/.senpi/agent/hooks.json` and a stable global script path. For team-shared hooks, prefer a senpi package or plugin manifest so the scripts and hook JSON move together.
+
+Trust is tied to the command hook's canonical hash. Changing the command text, `commandWindows`, timeout, matcher, or status message makes the hook untrusted again until you review and trust the new hash. Disabling a hook with `/hooks disable <id>` keeps the trust entry but skips execution; `/hooks enable <id>` re-enables it.
+
+Recommended first check after adding a hook:
+
+```text
+/hooks list
+/hooks diagnostics
+```
+
+`/hooks list` should show the source, matcher, trust state, disabled state, and redacted command preview. `/hooks diagnostics` should be empty or contain only diagnostics you intentionally accept.
+
 #### Minimal project hook
 
 Create `.senpi/hooks.json`:
@@ -429,7 +459,8 @@ process.stdin.on("data", (chunk) => {
 });
 process.stdin.on("end", () => {
   const input = JSON.parse(stdin);
-  const command = String(input.tool_input?.command ?? "");
+  const toolInput = input.toolInput ?? input.tool_input ?? {};
+  const command = String(toolInput.command ?? "");
   if (command.includes("rm -rf")) {
     process.stdout.write(JSON.stringify({
       hookSpecificOutput: {
@@ -500,6 +531,194 @@ Hook commands inherit a minimal environment (`PATH`, home/user/shell/temp variab
 Matchers are strings. For tool events, matchers match tool names. For lifecycle events, `*`, event names, reasons such as `startup`, `reload`, `manual`, or `overflow`, comma/pipe-separated literals, and JavaScript regular expressions are supported.
 
 Command stdout may be empty or JSON. Universal JSON fields include `decision`, `reason`, `additionalContext`, `continue`, `stopReason`, `suppressOutput`, `systemMessage`, and `hookSpecificOutput`. `hookSpecificOutput.hookEventName` must match the current event when present. Exit code `2` is treated as a block decision with stderr as the reason.
+
+#### Hook input and output
+
+Every command receives one JSON object on stdin. The object always includes `event` and `cwd`, and includes session/transcript fields when senpi has them:
+
+| Field | Meaning |
+|-------|---------|
+| `event` | Hook event name, such as `PreToolUse` or `UserPromptSubmit`. |
+| `cwd` | Current project working directory. |
+| `session_id` | Session id when available. |
+| `transcript_path` | Session transcript path when available. |
+
+Tool events include both senpi-style camelCase and Claude-compatible snake_case fields:
+
+```json
+{
+  "event": "PreToolUse",
+  "toolName": "bash",
+  "toolInput": { "command": "npm test" },
+  "tool_name": "bash",
+  "tool_input": { "command": "npm test" },
+  "cwd": "/repo"
+}
+```
+
+Prompt hooks receive the raw prompt:
+
+```json
+{
+  "event": "UserPromptSubmit",
+  "prompt": "summarize this repo",
+  "cwd": "/repo"
+}
+```
+
+Output must be valid JSON if you want senpi to apply a decision. Empty stdout means no decision. Prefer event-specific output inside `hookSpecificOutput`:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Do not run destructive commands"
+  }
+}
+```
+
+`PreToolUse` supports `permissionDecision: "allow" | "deny" | "ask"`. `updatedInput` is applied only when `permissionDecision` is `"allow"`. `additionalContext` is saved as hidden context for the active tool result.
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": { "command": "npm test -- --runInBand" },
+    "additionalContext": "The hook serialized this test command."
+  }
+}
+```
+
+`UserPromptSubmit` can block or add context, but it cannot replace the prompt through Claude/Codex-compatible fields:
+
+```json
+{
+  "decision": "block",
+  "reason": "Please include an issue number before starting release work."
+}
+```
+
+`PostToolUse` can replace visible tool output with `updatedToolOutput` and can add `additionalContext`:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "updatedToolOutput": "Output redacted by local hook.",
+    "additionalContext": "The raw tool output was replaced because it matched the secret scanner."
+  }
+}
+```
+
+`Stop` can ask senpi to continue with a follow-up prompt by returning `decision: "block"` plus `additionalContext` or `reason`. senpi caps repeated Stop follow-ups at eight per turn to prevent loops.
+
+#### Common hook recipes
+
+Block dangerous shell commands:
+
+```javascript
+let stdin = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  stdin += chunk;
+});
+process.stdin.on("end", () => {
+  const input = JSON.parse(stdin);
+  const toolInput = input.toolInput ?? input.tool_input ?? {};
+  const command = String(toolInput.command ?? "");
+
+  if (/\brm\s+-rf\b/.test(command)) {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Blocked rm -rf"
+      }
+    }));
+  }
+});
+```
+
+Add per-prompt project context:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .senpi/hooks/prompt-context.mjs",
+            "statusMessage": "Loading prompt context"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+```javascript
+process.stdin.resume();
+process.stdin.on("end", () => {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: "Prefer the repository's AGENTS.md rules over generic defaults."
+    }
+  }));
+});
+```
+
+Stop when a final answer needs a required follow-up:
+
+```javascript
+process.stdin.resume();
+process.stdin.on("end", () => {
+  process.stdout.write(JSON.stringify({
+    decision: "block",
+    hookSpecificOutput: {
+      hookEventName: "Stop",
+      additionalContext: "Before finishing, run the focused regression test and summarize the result."
+    }
+  }));
+});
+```
+
+Distribute hooks from a package:
+
+```json
+{
+  "name": "team-senpi-hooks",
+  "pi": {
+    "hooks": ["./hooks/pretool.json"]
+  }
+}
+```
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "bash|edit|write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ./hooks/check.mjs",
+            "statusMessage": "Running team hook"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Package hook paths are resolved relative to the package root. If you need plugin-root environment variables, use a `.codex-plugin/plugin.json` manifest and `${PLUGIN_ROOT}` in the command.
 
 #### Plugin hooks
 
@@ -594,6 +813,21 @@ For omo-codex or Claude-style hook configs, migrate the lowest-risk checks first
 - Replace `if` conditions with logic inside the command script or with matcher strings for tool/lifecycle selection.
 - Treat `Notification`, subagent/task/teammate/worktree events, and prompt replacement as deferred; document them in plugin README files instead of assuming execution.
 - When the host uses the plugin manifest helper, use `PLUGIN_ROOT` and `PLUGIN_DATA` for plugin-relative scripts and state. Keep secrets out of manifests and hook JSON.
+
+#### Hook troubleshooting
+
+If a hook does not run:
+
+1. Run `/hooks list` and confirm the hook is present, enabled, and trusted.
+2. Run `/hooks diagnostics` and check for malformed JSON, unsupported fields, untrusted hashes, skipped runtime `SessionStart`, or plugin containment errors.
+3. Confirm the matcher matches the event. Tool events match tool names such as `bash`, `edit`, `write`, `Bash`, `Edit`, and `Write`; lifecycle events match reasons such as `startup`, `reload`, `manual`, and `overflow`.
+4. Confirm the command path works from the project cwd. For plugin commands using `${PLUGIN_ROOT}`, the resolved file must exist inside the plugin root.
+5. Keep stdout as valid JSON or empty. Human-readable logs should go to stderr, and secret-bearing logs should be avoided entirely.
+6. After editing hook JSON or scripts, run `/hooks reload`, then `/hooks list` again. If the trusted hash changed, trust the hook again.
+
+If a hook runs but has no effect, check the event support table. Some fields are diagnostic-only by design, such as `PreCompact` `additionalContext` and `customInstructions`, `PostCompact` output fields, and unsupported prompt replacement fields for `UserPromptSubmit`.
+
+If a hook times out, increase `timeout` in seconds or make the script observe stdin and exit quickly. The default timeout is 600 seconds. Invalid timeout values such as `0`, negative numbers, `NaN`, or infinity are rejected and the command is not started.
 
 ### Session Events
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -38,6 +38,7 @@ See [examples/extensions/](../examples/extensions/) for working implementations.
 - [Events](#events)
   - [Lifecycle Overview](#lifecycle-overview)
   - [Resource Events](#resource-events)
+  - [Builtin Hooks](#builtin-hooks)
   - [Session Events](#session-events)
   - [Agent Events](#agent-events)
   - [Model Events](#model-events)
@@ -378,6 +379,219 @@ pi.on("resources_discover", async (event, _ctx) => {
   };
 });
 ```
+
+### Builtin Hooks
+
+The builtin `hooks` extension runs trusted command hooks from JSON config files. It is intended for local guardrails and migration from Claude-style command hooks, while keeping the extension API as the primary senpi customization surface.
+
+Default senpi hook files are discovered from:
+
+| Source | Timing | Notes |
+|--------|--------|-------|
+| `~/.senpi/agent/hooks.json` | pre-session | Global hook config. |
+| `.senpi/hooks.json` | pre-session | Project hook config, loaded after project trust. |
+| SDK or host-provided `new DefaultResourceLoader({ additionalHookPaths })` | pre-session | Package/plugin hosts can inject resolved hook JSON files before `session_start`. |
+| `resources_discover` `hookPaths` | runtime | Late sources. They can affect later hook events in the current runtime and `SessionStart` on `/reload` or the next session. |
+
+#### Minimal project hook
+
+Create `.senpi/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .senpi/hooks/log-pretool.mjs",
+            "timeout": 10,
+            "statusMessage": "Checking bash command"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Create `.senpi/hooks/log-pretool.mjs`:
+
+```javascript
+let stdin = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  stdin += chunk;
+});
+process.stdin.on("end", () => {
+  const input = JSON.parse(stdin);
+  const command = String(input.tool_input?.command ?? "");
+  if (command.includes("rm -rf")) {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Refusing destructive shell command"
+      }
+    }));
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow"
+    }
+  }));
+});
+```
+
+Start senpi in the project and inspect hooks:
+
+```bash
+senpi
+/hooks list
+/hooks trust hk_example_PreToolUse_0_0
+```
+
+The real hook id is shown by `/hooks list`. A command hook must be trusted before it runs. Project hook trust is writable only when the project is trusted.
+
+Exact command grammar:
+
+```text
+Usage: /hooks [list|diagnostics|trust <id>|disable <id>|enable <id>|reload]
+```
+
+`/hooks list` shows executable hooks, ids, trust state, disabled state, matcher, status message, and a redacted command preview. `/hooks diagnostics` shows malformed, unsupported, untrusted, and skipped hook details. `/hooks reload` runs the normal extension/resource reload flow.
+
+#### Command handler JSON
+
+Only command handlers are executable in builtin hooks v1:
+
+```json
+{
+  "type": "command",
+  "command": "node ./hooks/check.mjs",
+  "commandWindows": "node .\\hooks\\check.mjs",
+  "timeout": 30,
+  "statusMessage": "Running hook"
+}
+```
+
+`command` is required and runs through the host shell with the hook input JSON on stdin. `commandWindows` or `command_windows` can override the command on Windows. `timeout` is seconds and defaults to 600. `statusMessage` is display text only.
+
+Hook commands inherit a minimal environment (`PATH`, home/user/shell/temp variables, and Windows shell basics). Hooks loaded through the plugin manifest helper also receive `PLUGIN_ROOT`, `PLUGIN_DATA`, `CLAUDE_PLUGIN_ROOT`, and `CLAUDE_PLUGIN_DATA`. Every command receives `SENPI_HOOK_SOURCE` and `SENPI_HOOK_EVENT`. Do not put API keys or tokens in hook config, command text, status messages, stdout, stderr, or diagnostics. Read secrets inside the command from your own secret store and avoid echoing them.
+
+#### Event map
+
+| Event | senpi source | Supported behavior |
+|-------|--------------|--------------------|
+| `SessionStart` | `session_start` | Runs on startup/reload/new/resume/fork. `additionalContext` is recorded as hidden hook context. Decisions are diagnostics only. |
+| `UserPromptSubmit` | `input` plus `before_agent_start` | Can block the prompt. `additionalContext` is injected as hidden context for the turn. `systemMessage` appends to the turn system prompt. |
+| `PreToolUse` | `tool_call` | Can deny/block, ask (represented as block), allow/approve, mutate `updatedInput` only with `permissionDecision: "allow"`, and add context for the matching tool result. |
+| `PostToolUse` | `tool_result` | Can block by replacing the tool result with an error, replace tool output with `updatedToolOutput`, and append `additionalContext`. |
+| `PreCompact` | `session_before_compact` | Can block/cancel compaction with `decision: "block"` or exit code 2. `additionalContext` and `customInstructions` are diagnostic-only. |
+| `PostCompact` | `session_compact` | Runs after accepted compactions. Output fields are currently diagnostic-only. |
+| `Stop` | `agent_end` | Can block by sending a follow-up prompt from `additionalContext` or `reason`. Reentry is capped at eight blocks per turn. |
+
+Matchers are strings. For tool events, matchers match tool names. For lifecycle events, `*`, event names, reasons such as `startup`, `reload`, `manual`, or `overflow`, comma/pipe-separated literals, and JavaScript regular expressions are supported.
+
+Command stdout may be empty or JSON. Universal JSON fields include `decision`, `reason`, `additionalContext`, `continue`, `stopReason`, `suppressOutput`, `systemMessage`, and `hookSpecificOutput`. `hookSpecificOutput.hookEventName` must match the current event when present. Exit code `2` is treated as a block decision with stderr as the reason.
+
+#### Plugin hooks
+
+Plugin hook manifests are host/package integration inputs, not automatic default senpi discovery. A host can call senpi's plugin hook manifest helper for a plugin root and feed its parsed result into its own hook integration, or resolve hook JSON files and pass those file paths through `additionalHookPaths` before startup.
+
+Plugin hook manifests live at `.codex-plugin/plugin.json` under the plugin root. A manifest can point to hook JSON files:
+
+```json
+{
+  "name": "example-hooks-plugin",
+  "hooks": "./hooks/pretool.json"
+}
+```
+
+It can also inline hook config directly:
+
+```json
+{
+  "name": "inline-hooks-plugin",
+  "hooks": {
+    "hooks": {
+      "SessionStart": [
+        {
+          "matcher": "startup|reload",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node ${PLUGIN_ROOT}/hooks/session-start.mjs"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+`hooks` may also be an array mixing paths, nested arrays, and inline hook objects. Hook paths must stay inside the plugin root. The manifest helper also understands a plugin default hook file at `hooks/hooks.json` unless the host disables default plugin hooks. Plugin commands that reference `${PLUGIN_ROOT}`, `$PLUGIN_ROOT`, or `%PLUGIN_ROOT%` must resolve to existing files inside the plugin root.
+
+Package/plugin hook sources resolved by a host before the session starts are pre-session sources when the host passes them to senpi as additional hook paths. SDK hosts can provide that timing explicitly:
+
+```typescript
+const loader = new DefaultResourceLoader({
+  cwd,
+  agentDir,
+  additionalHookPaths: ["/absolute/path/to/package-hooks.json"],
+});
+```
+
+Pre-session sources are visible to `SessionStart` on initial startup.
+
+#### Runtime hook sources
+
+Extensions can return late hook paths from `resources_discover`:
+
+```typescript
+import { join } from "node:path";
+import type { ExtensionAPI } from "@code-yeongyu/senpi";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("resources_discover", (event, ctx) => {
+    if (event.reason !== "reload") return {};
+    return {
+      hookPaths: [join(ctx.cwd, ".senpi", "generated-hooks.json")],
+    };
+  });
+}
+```
+
+These paths are runtime sources. They can affect later hook events in the current runtime, but their `SessionStart` hooks do not run for the already-started initial session. On `/hooks reload` or `/reload`, runtime `SessionStart` hooks are visible to the reloaded session. If a runtime source contains `SessionStart`, senpi records a diagnostic: `Runtime SessionStart hooks are loaded for reload or the next session only.`
+
+#### Not yet supported
+
+The builtin hooks implementation intentionally does not claim full Claude hook coverage. Unsupported shapes produce warnings or diagnostics and are not executed.
+
+| Area | Not yet supported |
+|------|-------------------|
+| Events | `PermissionRequest`, `PermissionDenied`, `SubagentStart`, `SubagentStop`, `Notification`, `Setup`, `UserPromptExpansion`, `PostToolUseFailure`, `PostToolBatch`, `TaskCreated`, `TaskCompleted`, `StopFailure`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `MessageDisplay`, `SessionEnd`, `Elicitation`, `ElicitationResult`. |
+| Handler types | `prompt`, `agent`, `http`, and `mcp_tool`. |
+| Command forms | Exec-form commands, object-valued `command`, separate `args`, `shell`, and command handlers with `async: true`. |
+| Command fields | `if`, `asyncRewake`, `terminalSequence`, and `continueOnBlock`. |
+| Prompt mutation | UserPromptSubmit prompt replacement fields such as `prompt`, `updatedPrompt`, and `replacementPrompt`. |
+| Async behavior | Claude-style async hooks and `asyncRewake`. |
+| PreCompact mutation | `customInstructions` does not change compaction in builtin hooks v1. |
+
+#### omo-codex migration notes
+
+For omo-codex or Claude-style hook configs, migrate the lowest-risk checks first:
+
+- Keep existing `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `PreCompact`, `PostCompact`, and `Stop` command hooks if they use shell command strings.
+- Move `http`, `mcp_tool`, `prompt`, and `agent` hooks to senpi extensions or tools.
+- Replace `if` conditions with logic inside the command script or with matcher strings for tool/lifecycle selection.
+- Treat `Notification`, subagent/task/teammate/worktree events, and prompt replacement as deferred; document them in plugin README files instead of assuming execution.
+- When the host uses the plugin manifest helper, use `PLUGIN_ROOT` and `PLUGIN_DATA` for plugin-relative scripts and state. Keep secrets out of manifests and hook JSON.
 
 ### Session Events
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -389,8 +389,10 @@ Default senpi hook files are discovered from:
 | Source | Timing | Notes |
 |--------|--------|-------|
 | `~/.senpi/agent/hooks.json` | pre-session | Global hook config. |
+| Global package `pi.hooks` or `hooks/*.json` | pre-session | Package hook config loaded after the global hook file. |
 | `.senpi/hooks.json` | pre-session | Project hook config, loaded after project trust. |
-| SDK or host-provided `new DefaultResourceLoader({ additionalHookPaths })` | pre-session | Package/plugin hosts can inject resolved hook JSON files before `session_start`. |
+| Project package `pi.hooks` or `hooks/*.json` | pre-session | Package hook config loaded after the project hook file. |
+| Temporary package sources and SDK/host-provided `new DefaultResourceLoader({ additionalHookPaths })` | pre-session | Package/plugin hook JSON files resolved before `session_start`. |
 | `resources_discover` `hookPaths` | runtime | Late sources. They can affect later hook events in the current runtime and `SessionStart` on `/reload` or the next session. |
 
 #### Minimal project hook
@@ -501,7 +503,7 @@ Command stdout may be empty or JSON. Universal JSON fields include `decision`, `
 
 #### Plugin hooks
 
-Plugin hook manifests are host/package integration inputs, not automatic default senpi discovery. A host can call senpi's plugin hook manifest helper for a plugin root and feed its parsed result into its own hook integration, or resolve hook JSON files and pass those file paths through `additionalHookPaths` before startup.
+Plugin hook manifests are package integration inputs. Installed senpi packages can expose hook JSON files through `package.json` under `pi.hooks` or by placing JSON files under `hooks/`; those sources are discovered before `session_start` in global, project, or temporary package scope.
 
 Plugin hook manifests live at `.codex-plugin/plugin.json` under the plugin root. A manifest can point to hook JSON files:
 
@@ -537,7 +539,7 @@ It can also inline hook config directly:
 
 `hooks` may also be an array mixing paths, nested arrays, and inline hook objects. Hook paths must stay inside the plugin root. The manifest helper also understands a plugin default hook file at `hooks/hooks.json` unless the host disables default plugin hooks. Plugin commands that reference `${PLUGIN_ROOT}`, `$PLUGIN_ROOT`, or `%PLUGIN_ROOT%` must resolve to existing files inside the plugin root.
 
-Package/plugin hook sources resolved by a host before the session starts are pre-session sources when the host passes them to senpi as additional hook paths. SDK hosts can provide that timing explicitly:
+SDK hosts can still provide explicit pre-session hook sources:
 
 ```typescript
 const loader = new DefaultResourceLoader({

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -43,7 +43,7 @@ For the full first-run flow, see [Quickstart](quickstart.md).
 
 ## Customization
 
-- [Extensions](extensions.md) - TypeScript modules for tools, commands, events, and custom UI.
+- [Extensions](extensions.md) - TypeScript modules for tools, commands, events, custom UI, and builtin command hooks.
 - [Skills](skills.md) - Agent Skills for reusable on-demand capabilities.
 - [Prompt templates](prompt-templates.md) - reusable prompts that expand from slash commands.
 - [Themes](themes.md) - built-in and custom terminal themes.

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -1,8 +1,8 @@
-> pi can help you create pi packages. Ask it to bundle your extensions, skills, prompt templates, or themes.
+> pi can help you create pi packages. Ask it to bundle your extensions, skills, prompt templates, themes, or hook configs.
 
 # Pi Packages
 
-Pi packages bundle extensions, skills, prompt templates, and themes so you can share them through npm or git. A package can declare resources in `package.json` under the `pi` key, or use conventional directories.
+Pi packages bundle extensions, skills, prompt templates, themes, and hook configs so you can share them through npm or git. A package can declare resources in `package.json` under the `pi` key, or use conventional directories.
 
 ## Table of Contents
 
@@ -124,7 +124,8 @@ Add a `pi` manifest to `package.json` or use conventional directories. Include t
     "extensions": ["./extensions"],
     "skills": ["./skills"],
     "prompts": ["./prompts"],
-    "themes": ["./themes"]
+    "themes": ["./themes"],
+    "hooks": ["./hooks"]
   }
 }
 ```
@@ -162,10 +163,11 @@ If no `pi` manifest is present, pi auto-discovers resources from these directori
 - `skills/` recursively finds `SKILL.md` folders and loads top-level `.md` files as skills
 - `prompts/` loads `.md` files
 - `themes/` loads `.json` files
+- `hooks/` loads `.json` files
 
 ## Dependencies
 
-Third party runtime dependencies belong in `dependencies` in `package.json`. Dependencies that do not register extensions, skills, prompt templates, or themes also belong in `dependencies`. When pi installs a package from npm or git, it runs `npm install`, so those dependencies are installed automatically.
+Third party runtime dependencies belong in `dependencies` in `package.json`. Dependencies that do not register extensions, skills, prompt templates, themes, or hook configs also belong in `dependencies`. When pi installs a package from npm or git, it runs `npm install`, so those dependencies are installed automatically.
 
 Pi bundles core packages for extensions and skills. If you import any of these, list them in `peerDependencies` with a `"*"` range and do not bundle them: `@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`, `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `typebox`.
 
@@ -199,7 +201,8 @@ Filter what a package loads using the object form in settings:
       "extensions": ["extensions/*.ts", "!extensions/legacy.ts"],
       "skills": [],
       "prompts": ["prompts/review.md"],
-      "themes": ["+themes/legacy.json"]
+      "themes": ["+themes/legacy.json"],
+      "hooks": ["hooks/pretool.json"]
     }
   ]
 }
@@ -216,7 +219,7 @@ Filter what a package loads using the object form in settings:
 
 ## Enable and Disable Resources
 
-Use `pi config` to enable or disable extensions, skills, prompt templates, and themes from installed packages and local directories. Works for both global (`~/.pi/agent`) and project (`.pi/`) scopes.
+Use `pi config` to enable or disable extensions, skills, prompt templates, themes, and hook configs from installed packages and local directories. Works for both global (`~/.pi/agent`) and project (`.pi/`) scopes.
 
 ## Scope and Deduplication
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -105,6 +105,7 @@ cp permission-gate.ts ~/.senpi/agent/extensions/
 | Extension | Description |
 |-----------|-------------|
 | `dynamic-resources/` | Loads skills, prompts, and themes using `resources_discover` |
+| Builtin hooks | See [docs/extensions.md#builtin-hooks](../../docs/extensions.md#builtin-hooks) for project hook files, plugin manifests, and runtime `hookPaths` examples |
 
 ### Messages & Communication
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2542,12 +2542,12 @@ export class AgentSession {
 			return;
 		}
 
-		const { skillPaths, promptPaths, themePaths } = await this._extensionRunner.emitResourcesDiscover(
+		const { skillPaths, promptPaths, themePaths, hookPaths } = await this._extensionRunner.emitResourcesDiscover(
 			this._cwd,
 			reason,
 		);
 
-		if (skillPaths.length === 0 && promptPaths.length === 0 && themePaths.length === 0) {
+		if (skillPaths.length === 0 && promptPaths.length === 0 && themePaths.length === 0 && hookPaths.length === 0) {
 			return;
 		}
 
@@ -2555,11 +2555,14 @@ export class AgentSession {
 			skillPaths: this.buildExtensionResourcePaths(skillPaths),
 			promptPaths: this.buildExtensionResourcePaths(promptPaths),
 			themePaths: this.buildExtensionResourcePaths(themePaths),
+			hookPaths: this.buildExtensionResourcePaths(hookPaths),
 		};
 
 		this._resourceLoader.extendResources(extensionPaths);
-		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-		this.agent.state.systemPrompt = this._baseSystemPrompt;
+		if (skillPaths.length > 0 || promptPaths.length > 0 || themePaths.length > 0) {
+			this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+			this.agent.state.systemPrompt = this._baseSystemPrompt;
+		}
 	}
 
 	private buildExtensionResourcePaths(entries: Array<{ path: string; extensionPath: string }>): Array<{
@@ -2751,6 +2754,17 @@ export class AgentSession {
 				getMessageRevision: () => this.getMessageRevision(),
 				applyCompaction: (precomputed, options) => this.applyCompaction(precomputed, options),
 				getSystemPrompt: () => this.systemPrompt,
+				getLoadedHookSources: () =>
+					this._resourceLoader.getLoadedHookSources?.() ?? {
+						agentDir: this._cwd,
+						cwd: this._cwd,
+						globalHookSourcePaths: [],
+						globalHooksPath: `${this._cwd}/hooks.json`,
+						preSessionHookSourcePaths: [],
+						projectHookSourcePaths: [],
+						projectHooksPath: `${this._cwd}/.senpi/hooks.json`,
+						runtimeHookSourcePaths: [],
+					},
 				getSystemPromptOptions: () => this._baseSystemPromptOptions,
 			},
 			{

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/command-runner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/command-runner.ts
@@ -1,0 +1,148 @@
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { waitForChildProcess } from "../../../../utils/child-process.ts";
+import {
+	getShellEnv,
+	killProcessTree,
+	trackDetachedChildPid,
+	untrackDetachedChildPid,
+} from "../../../../utils/shell.ts";
+import type { ExecutableHookHandler, HookInputWire } from "./types.ts";
+
+export type CommandHookRunOptions = {
+	readonly cwd: string;
+	readonly signal?: AbortSignal;
+};
+
+export type CommandHookRunResult = {
+	readonly command: string;
+	readonly cwd: string;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number | null;
+	readonly signal: NodeJS.Signals | null;
+	readonly timedOut: boolean;
+	readonly aborted: boolean;
+	readonly durationMs: number;
+	readonly timeoutSeconds?: number;
+};
+
+export async function runCommandHook(
+	handler: ExecutableHookHandler,
+	input: HookInputWire,
+	options: CommandHookRunOptions,
+): Promise<CommandHookRunResult> {
+	const command = selectCommandForPlatform(handler);
+	const startedAt = performance.now();
+	if (options.signal?.aborted) {
+		return buildResult({
+			aborted: true,
+			command,
+			cwd: options.cwd,
+			exitCode: null,
+			signal: null,
+			startedAt,
+			stderr: "",
+			stdout: "",
+			timedOut: false,
+			timeoutSeconds: handler.config.timeout,
+		});
+	}
+
+	const child = spawn(command, {
+		cwd: options.cwd,
+		detached: process.platform !== "win32",
+		env: getShellEnv(),
+		shell: true,
+		stdio: ["pipe", "pipe", "pipe"],
+		windowsHide: true,
+	});
+	if (child.pid !== undefined) trackDetachedChildPid(child.pid);
+
+	const stdout: Buffer[] = [];
+	const stderr: Buffer[] = [];
+	let exitSignal: NodeJS.Signals | null = null;
+	let timedOut = false;
+	let timeoutHandle: NodeJS.Timeout | undefined;
+
+	const killChild = (): void => {
+		if (child.pid !== undefined) killProcessTree(child.pid);
+	};
+	const onAbort = (): void => killChild();
+
+	try {
+		child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
+		child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.once("exit", (_code, signal) => {
+			exitSignal = signal;
+		});
+
+		const timeoutSeconds = handler.config.timeout;
+		if (timeoutSeconds !== undefined && timeoutSeconds > 0) {
+			timeoutHandle = setTimeout(() => {
+				timedOut = true;
+				killChild();
+			}, timeoutSeconds * 1000);
+		}
+
+		if (options.signal !== undefined) {
+			if (options.signal.aborted) onAbort();
+			else options.signal.addEventListener("abort", onAbort, { once: true });
+		}
+
+		child.stdin?.end(JSON.stringify(input));
+		const exitCode = await waitForChildProcess(child);
+		return buildResult({
+			aborted: options.signal?.aborted === true,
+			command,
+			cwd: options.cwd,
+			exitCode: timedOut || options.signal?.aborted === true ? null : exitCode,
+			signal: exitSignal,
+			startedAt,
+			stderr: Buffer.concat(stderr).toString("utf8"),
+			stdout: Buffer.concat(stdout).toString("utf8"),
+			timedOut,
+			timeoutSeconds,
+		});
+	} finally {
+		if (child.pid !== undefined) untrackDetachedChildPid(child.pid);
+		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		if (options.signal !== undefined) options.signal.removeEventListener("abort", onAbort);
+	}
+}
+
+export function selectCommandForPlatform(
+	handler: ExecutableHookHandler,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (platform === "win32" && handler.config.commandWindows !== undefined) {
+		return handler.config.commandWindows;
+	}
+	return handler.config.command;
+}
+
+function buildResult(input: {
+	readonly command: string;
+	readonly cwd: string;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number | null;
+	readonly signal: NodeJS.Signals | null;
+	readonly timedOut: boolean;
+	readonly aborted: boolean;
+	readonly startedAt: number;
+	readonly timeoutSeconds?: number;
+}): CommandHookRunResult {
+	return {
+		aborted: input.aborted,
+		command: input.command,
+		cwd: input.cwd,
+		durationMs: Math.max(0, performance.now() - input.startedAt),
+		exitCode: input.exitCode,
+		signal: input.signal,
+		stderr: input.stderr,
+		stdout: input.stdout,
+		timedOut: input.timedOut,
+		...(input.timeoutSeconds === undefined ? {} : { timeoutSeconds: input.timeoutSeconds }),
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/command-runner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/command-runner.ts
@@ -1,17 +1,24 @@
 import { spawn } from "node:child_process";
 import { performance } from "node:perf_hooks";
 import { waitForChildProcess } from "../../../../utils/child-process.ts";
+import { killProcessTree, trackDetachedChildPid, untrackDetachedChildPid } from "../../../../utils/shell.ts";
 import {
-	getShellEnv,
-	killProcessTree,
-	trackDetachedChildPid,
-	untrackDetachedChildPid,
-} from "../../../../utils/shell.ts";
+	applyHookOutputSafety,
+	buildHookEnvironment,
+	DEFAULT_STDERR_LIMIT_BYTES,
+	DEFAULT_STDOUT_LIMIT_BYTES,
+	type HookOutputPolicy,
+	type HookOutputSafetyMetadata,
+	resolveHookTimeoutSeconds,
+} from "./safety.ts";
 import type { ExecutableHookHandler, HookInputWire } from "./types.ts";
 
 export type CommandHookRunOptions = {
 	readonly cwd: string;
+	readonly envPassthrough?: readonly string[];
+	readonly outputPolicy?: HookOutputPolicy;
 	readonly signal?: AbortSignal;
+	readonly sourceEnv?: NodeJS.ProcessEnv;
 };
 
 export type CommandHookRunResult = {
@@ -24,7 +31,8 @@ export type CommandHookRunResult = {
 	readonly timedOut: boolean;
 	readonly aborted: boolean;
 	readonly durationMs: number;
-	readonly timeoutSeconds?: number;
+	readonly outputSafety: HookOutputSafetyMetadata;
+	readonly timeoutSeconds: number;
 };
 
 export async function runCommandHook(
@@ -34,6 +42,7 @@ export async function runCommandHook(
 ): Promise<CommandHookRunResult> {
 	const command = selectCommandForPlatform(handler);
 	const startedAt = performance.now();
+	const timeoutSeconds = resolveHookTimeoutSeconds(handler);
 	if (options.signal?.aborted) {
 		return buildResult({
 			aborted: true,
@@ -42,25 +51,31 @@ export async function runCommandHook(
 			exitCode: null,
 			signal: null,
 			startedAt,
-			stderr: "",
-			stdout: "",
+			stderr: createEmptyStreamCapture("stderr"),
+			stdout: createEmptyStreamCapture("stdout"),
 			timedOut: false,
-			timeoutSeconds: handler.config.timeout,
+			timeoutSeconds,
+			outputPolicy: options.outputPolicy,
 		});
 	}
 
 	const child = spawn(command, {
 		cwd: options.cwd,
 		detached: process.platform !== "win32",
-		env: getShellEnv(),
+		env: buildHookEnvironment({
+			envPassthrough: options.envPassthrough,
+			handler,
+			input,
+			sourceEnv: options.sourceEnv ?? process.env,
+		}),
 		shell: true,
 		stdio: ["pipe", "pipe", "pipe"],
 		windowsHide: true,
 	});
 	if (child.pid !== undefined) trackDetachedChildPid(child.pid);
 
-	const stdout: Buffer[] = [];
-	const stderr: Buffer[] = [];
+	const stdout = createBoundedStreamCapture("stdout", options.outputPolicy);
+	const stderr = createBoundedStreamCapture("stderr", options.outputPolicy);
 	let exitSignal: NodeJS.Signals | null = null;
 	let timedOut = false;
 	let timeoutHandle: NodeJS.Timeout | undefined;
@@ -71,14 +86,13 @@ export async function runCommandHook(
 	const onAbort = (): void => killChild();
 
 	try {
-		child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
-		child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.stdout?.on("data", (chunk: Buffer) => stdout.append(chunk));
+		child.stderr?.on("data", (chunk: Buffer) => stderr.append(chunk));
 		child.once("exit", (_code, signal) => {
 			exitSignal = signal;
 		});
 
-		const timeoutSeconds = handler.config.timeout;
-		if (timeoutSeconds !== undefined && timeoutSeconds > 0) {
+		if (timeoutSeconds > 0) {
 			timeoutHandle = setTimeout(() => {
 				timedOut = true;
 				killChild();
@@ -99,10 +113,11 @@ export async function runCommandHook(
 			exitCode: timedOut || options.signal?.aborted === true ? null : exitCode,
 			signal: exitSignal,
 			startedAt,
-			stderr: Buffer.concat(stderr).toString("utf8"),
-			stdout: Buffer.concat(stdout).toString("utf8"),
+			stderr,
+			stdout,
 			timedOut,
 			timeoutSeconds,
+			outputPolicy: options.outputPolicy,
 		});
 	} finally {
 		if (child.pid !== undefined) untrackDetachedChildPid(child.pid);
@@ -124,25 +139,76 @@ export function selectCommandForPlatform(
 function buildResult(input: {
 	readonly command: string;
 	readonly cwd: string;
-	readonly stdout: string;
-	readonly stderr: string;
 	readonly exitCode: number | null;
 	readonly signal: NodeJS.Signals | null;
 	readonly timedOut: boolean;
 	readonly aborted: boolean;
 	readonly startedAt: number;
-	readonly timeoutSeconds?: number;
+	readonly stderr: BoundedStreamCapture;
+	readonly stdout: BoundedStreamCapture;
+	readonly timeoutSeconds: number;
+	readonly outputPolicy?: HookOutputPolicy;
 }): CommandHookRunResult {
+	const stdout = input.stdout.finalize(input.outputPolicy);
+	const stderr = input.stderr.finalize(input.outputPolicy);
 	return {
 		aborted: input.aborted,
 		command: input.command,
 		cwd: input.cwd,
 		durationMs: Math.max(0, performance.now() - input.startedAt),
 		exitCode: input.exitCode,
+		outputSafety: { stderr: stderr.safety, stdout: stdout.safety },
 		signal: input.signal,
-		stderr: input.stderr,
-		stdout: input.stdout,
+		stderr: stderr.text,
+		stdout: stdout.text,
 		timedOut: input.timedOut,
-		...(input.timeoutSeconds === undefined ? {} : { timeoutSeconds: input.timeoutSeconds }),
+		timeoutSeconds: input.timeoutSeconds,
+	};
+}
+
+type BoundedStreamCapture = {
+	readonly append: (chunk: Buffer) => void;
+	readonly finalize: (policy: HookOutputPolicy | undefined) => ReturnType<typeof applyHookOutputSafety>;
+};
+
+function createBoundedStreamCapture(
+	stream: "stderr" | "stdout",
+	policy: HookOutputPolicy | undefined,
+): BoundedStreamCapture {
+	const limit =
+		stream === "stdout"
+			? (policy?.maxStdoutBytes ?? DEFAULT_STDOUT_LIMIT_BYTES)
+			: (policy?.maxStderrBytes ?? DEFAULT_STDERR_LIMIT_BYTES);
+	const chunks: Buffer[] = [];
+	let keptBytes = 0;
+	let totalBytes = 0;
+
+	return {
+		append(chunk: Buffer): void {
+			totalBytes += chunk.length;
+			if (keptBytes >= limit) return;
+			const bytesToKeep = Math.min(limit - keptBytes, chunk.length);
+			chunks.push(Buffer.from(chunk.subarray(0, bytesToKeep)));
+			keptBytes += bytesToKeep;
+		},
+		finalize(finalPolicy: HookOutputPolicy | undefined): ReturnType<typeof applyHookOutputSafety> {
+			let text = "";
+			for (const chunk of chunks) {
+				text += chunk.toString("utf8");
+			}
+			return applyHookOutputSafety(stream, text, finalPolicy, {
+				originalBytes: totalBytes,
+				truncated: totalBytes > keptBytes,
+			});
+		},
+	};
+}
+
+function createEmptyStreamCapture(stream: "stderr" | "stdout"): BoundedStreamCapture {
+	return {
+		append(_chunk: Buffer): void {},
+		finalize(policy: HookOutputPolicy | undefined): ReturnType<typeof applyHookOutputSafety> {
+			return applyHookOutputSafety(stream, "", policy, { originalBytes: 0, truncated: false });
+		},
 	};
 }

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/command.ts
@@ -1,0 +1,241 @@
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../types.ts";
+import { createHookTrustEntry, type HookTrustRecord, hookTrustStorageScope, listHookTrustRecords } from "./trust.ts";
+import type { HookStateStorage } from "./trust-storage.ts";
+import type {
+	ExecutableHookHandler,
+	HookDiagnostic,
+	HookRuntimeState,
+	HookTrustEntry,
+	ParsedHookConfig,
+	SupportedHookEvent,
+} from "./types.ts";
+
+const HOOKS_USAGE = "Usage: /hooks [list|diagnostics|trust <id>|disable <id>|enable <id>|reload]";
+const HOOK_SUBCOMMANDS = ["list", "diagnostics", "trust", "disable", "enable", "reload"] as const;
+const DIAGNOSTIC_DISPLAY_LIMIT = 50;
+
+type HookCommandRuntimeState = HookRuntimeState & {
+	readonly storage: HookStateStorage;
+};
+
+type HookRecordPair = {
+	readonly handler: ExecutableHookHandler;
+	readonly record: HookTrustRecord;
+};
+
+type HookCommand =
+	| { readonly kind: "list" }
+	| { readonly kind: "diagnostics" }
+	| { readonly kind: "reload" }
+	| { readonly kind: "trust" | "disable" | "enable"; readonly id: string }
+	| { readonly kind: "usage" };
+
+export function registerHooksCommand(
+	pi: ExtensionAPI,
+	refreshState: (ctx: ExtensionContext) => HookCommandRuntimeState,
+): void {
+	pi.registerCommand("hooks", {
+		description: "Inspect loaded builtin hook sources and diagnostics.",
+		getArgumentCompletions: async (prefix) => hookArgumentCompletions(prefix),
+		handler: async (args, ctx) => {
+			const command = parseHooksCommand(args);
+			if (command.kind === "usage") {
+				ctx.ui.notify(HOOKS_USAGE, "error");
+				return;
+			}
+
+			if (command.kind === "reload") {
+				await ctx.reload();
+				ctx.ui.notify(`Reloaded hooks.\n${formatHookStatus(refreshState(ctx))}`);
+				return;
+			}
+
+			const state = refreshState(ctx);
+			switch (command.kind) {
+				case "list":
+					ctx.ui.notify(formatHookStatus(state));
+					return;
+				case "diagnostics":
+					ctx.ui.notify(
+						formatHookDiagnostics(state.parsed.diagnostics),
+						state.parsed.diagnostics.length > 0 ? "warning" : "info",
+					);
+					return;
+				case "trust":
+				case "disable":
+				case "enable":
+					mutateHookTrust(command.kind, command.id, state, ctx);
+					return;
+			}
+		},
+	});
+}
+
+function hookArgumentCompletions(prefix: string): Array<{ value: string; label: string }> | null {
+	if (/\s/.test(prefix)) {
+		return [];
+	}
+	const completions = HOOK_SUBCOMMANDS.filter((subcommand) => subcommand.startsWith(prefix)).map((subcommand) => ({
+		value: subcommand,
+		label: subcommand,
+	}));
+	return completions.length > 0 ? completions : null;
+}
+
+function parseHooksCommand(args: string): HookCommand {
+	const tokens = args.trim().length === 0 ? [] : args.trim().split(/\s+/);
+	const subcommand = tokens[0] ?? "";
+	if (subcommand === "" || subcommand === "list") {
+		return tokens.length <= 1 ? { kind: "list" } : { kind: "usage" };
+	}
+	if (subcommand === "diagnostics" || subcommand === "reload") {
+		return tokens.length === 1 ? { kind: subcommand } : { kind: "usage" };
+	}
+	if (subcommand === "trust" || subcommand === "disable" || subcommand === "enable") {
+		const id = tokens[1];
+		return tokens.length === 2 && id !== undefined ? { kind: subcommand, id } : { kind: "usage" };
+	}
+	return { kind: "usage" };
+}
+
+function mutateHookTrust(
+	action: "trust" | "disable" | "enable",
+	id: string,
+	state: HookCommandRuntimeState,
+	ctx: ExtensionCommandContext,
+): void {
+	const pair = findHookRecordPair(state, id);
+	if (pair === undefined) {
+		ctx.ui.notify(`Hook not found: ${id}`, "error");
+		return;
+	}
+
+	const scope = hookTrustStorageScope(pair.handler, { projectTrusted: ctx.isProjectTrusted() });
+	if (scope === undefined) {
+		ctx.ui.notify(`Hook not found: ${id}`, "error");
+		return;
+	}
+
+	const entry = entryForAction(action, pair);
+	state.storage.update(scope, (current) => ({
+		version: 1,
+		hooks: {
+			...current.hooks,
+			[id]: entry,
+		},
+	}));
+	ctx.ui.notify(`${pastTenseAction(action)} hook: ${id}`);
+}
+
+function findHookRecordPair(state: HookCommandRuntimeState, id: string): HookRecordPair | undefined {
+	const records = listHookTrustRecords(state.parsed.executableHandlers, state.trust, { platform: process.platform });
+	const index = records.findIndex((record) => record.id === id);
+	if (index < 0) return undefined;
+	const handler = state.parsed.executableHandlers[index];
+	const record = records[index];
+	if (handler === undefined || record === undefined) return undefined;
+	return { handler, record };
+}
+
+function entryForAction(action: "trust" | "disable" | "enable", pair: HookRecordPair): HookTrustEntry {
+	if (action === "trust") {
+		return createHookTrustEntry(pair.handler, { platform: process.platform });
+	}
+	return {
+		enabled: action === "enable",
+		...(pair.record.entry?.trustedHash === undefined ? {} : { trustedHash: pair.record.entry.trustedHash }),
+		scope: pair.record.scope,
+		sourcePath: pair.record.sourcePath,
+		...(pair.record.matcher === undefined ? {} : { matcher: pair.record.matcher }),
+		commandPreview: pair.record.commandPreview,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+function pastTenseAction(action: "trust" | "disable" | "enable"): string {
+	switch (action) {
+		case "trust":
+			return "Trusted";
+		case "disable":
+			return "Disabled";
+		case "enable":
+			return "Enabled";
+	}
+}
+
+export function formatHookStatus(state: HookCommandRuntimeState): string {
+	const parsed = state.parsed;
+	const counts = eventCounts(parsed);
+	const summary =
+		counts.size === 0
+			? "hooks: no executable hooks"
+			: `hooks: ${parsed.executableHandlers.length} executable hooks (${Array.from(counts.entries())
+					.map(([event, count]) => `${event}:${count}`)
+					.join(", ")})`;
+	const records = listHookTrustRecords(parsed.executableHandlers, state.trust, { platform: process.platform });
+	if (records.length === 0) {
+		return summary;
+	}
+	return [summary, ...records.map((record, index) => formatHookRecord(parsed.executableHandlers[index], record))]
+		.filter((line) => line.length > 0)
+		.join("\n");
+}
+
+function eventCounts(parsed: ParsedHookConfig): Map<SupportedHookEvent, number> {
+	const counts = new Map<SupportedHookEvent, number>();
+	for (const handler of parsed.executableHandlers) {
+		counts.set(handler.event, (counts.get(handler.event) ?? 0) + 1);
+	}
+	return counts;
+}
+
+function formatHookRecord(handler: ExecutableHookHandler | undefined, record: HookTrustRecord): string {
+	if (handler === undefined) return "";
+	const parts = [
+		`- ${record.id}`,
+		handler.event,
+		`source:${record.scope}`,
+		`status:${record.trusted ? "trusted" : "untrusted"}`,
+		`disabled:${record.enabled ? "false" : "true"}`,
+	];
+	if (record.matcher !== undefined) {
+		parts.push(`matcher:${sanitizeDisplayText(record.matcher)}`);
+	}
+	if (handler.config.statusMessage !== undefined) {
+		parts.push(`statusMessage:${sanitizeDisplayText(handler.config.statusMessage)}`);
+	}
+	parts.push(`command:${sanitizeDisplayText(record.commandPreview)}`);
+	return parts.join(" ");
+}
+
+export function formatHookDiagnostics(diagnostics: readonly HookDiagnostic[]): string {
+	if (diagnostics.length === 0) {
+		return "hooks diagnostics: none";
+	}
+	const visible = diagnostics.slice(0, DIAGNOSTIC_DISPLAY_LIMIT);
+	const lines = visible.map(
+		(diagnostic) =>
+			`${diagnostic.severity}: ${diagnostic.code} ${sanitizeDisplayText(diagnostic.source.sourcePath)} ${sanitizeDisplayText(
+				diagnostic.path,
+			)} ${sanitizeDisplayText(diagnostic.message)}`,
+	);
+	const remaining = diagnostics.length - visible.length;
+	if (remaining > 0) {
+		lines.push(`... ${remaining} more diagnostics`);
+	}
+	return [`hooks diagnostics: ${diagnostics.length} diagnostics`, ...lines].join("\n");
+}
+
+function sanitizeDisplayText(value: string): string {
+	return value
+		.replace(
+			/(--(?:api-key|apikey|auth|authorization|password|secret|token)=)(?:"[^"]*"|'[^']*'|\S+)/gi,
+			"$1[redacted]",
+		)
+		.replace(
+			/(--(?:api-key|apikey|auth|authorization|password|secret|token)\s+)(?:"[^"]*"|'[^']*'|\S+)/gi,
+			"$1[redacted]",
+		)
+		.replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+		.replace(/\b(?:sk|pk|rk|ghp|github_pat|glpat)-[A-Za-z0-9._-]+/g, "[redacted]");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/command.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../types.ts";
+import { redactHookTokenValues } from "./output-bounds.ts";
 import { createHookTrustEntry, type HookTrustRecord, hookTrustStorageScope, listHookTrustRecords } from "./trust.ts";
 import type { HookStateStorage } from "./trust-storage.ts";
 import type {
@@ -227,15 +228,18 @@ export function formatHookDiagnostics(diagnostics: readonly HookDiagnostic[]): s
 }
 
 function sanitizeDisplayText(value: string): string {
-	return value
-		.replace(
-			/(--(?:api-key|apikey|auth|authorization|password|secret|token)=)(?:"[^"]*"|'[^']*'|\S+)/gi,
-			"$1[redacted]",
-		)
-		.replace(
-			/(--(?:api-key|apikey|auth|authorization|password|secret|token)\s+)(?:"[^"]*"|'[^']*'|\S+)/gi,
-			"$1[redacted]",
-		)
-		.replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
-		.replace(/\b(?:sk|pk|rk|ghp|github_pat|glpat)-[A-Za-z0-9._-]+/g, "[redacted]");
+	return redactHookTokenValues(
+		value
+			.replace(
+				/(--(?:api-key|apikey|auth|authorization|password|secret|token)=)(?:"[^"]*"|'[^']*'|\S+)/gi,
+				"$1[redacted]",
+			)
+			.replace(
+				/(--(?:api-key|apikey|auth|authorization|password|secret|token)\s+)(?:"[^"]*"|'[^']*'|\S+)/gi,
+				"$1[redacted]",
+			)
+			.replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+			.replace(/\b(?:sk|pk|rk|glpat)-[A-Za-z0-9._-]+/g, "[redacted]"),
+		"[redacted]",
+	);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/config-loader.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/config-loader.ts
@@ -1,0 +1,198 @@
+import { diagnostic } from "./diagnostics.ts";
+import { parseHookConfig } from "./schema.ts";
+import type { HookDiagnostic, HookSourceMetadata, ParsedHookConfig } from "./types.ts";
+
+export type HookConfigFileSystem = {
+	readonly readTextFile: (path: string) => string | undefined;
+};
+
+export type HookConfigLoaderOptions = {
+	readonly cwd: string;
+	readonly agentDir: string;
+	readonly fileSystem: HookConfigFileSystem;
+	readonly globalSettingsHooks?: unknown;
+	readonly projectSettingsHooks?: unknown;
+	readonly globalHooksPath?: string;
+	readonly projectHooksPath?: string;
+	readonly globalHookSourcePaths?: readonly string[];
+	readonly projectHookSourcePaths?: readonly string[];
+	readonly preSessionHookSourcePaths?: readonly string[];
+	readonly runtimeHookSourcePaths?: readonly string[];
+};
+
+type SourceScope = HookSourceMetadata["scope"];
+type SourceTiming = HookSourceMetadata["discoveredAt"];
+
+type InlineSource = {
+	readonly kind: "inline";
+	readonly hooks: unknown;
+	readonly scope: SourceScope;
+	readonly sourcePath: string;
+	readonly discoveredAt: SourceTiming;
+};
+
+type FileSource = {
+	readonly kind: "file";
+	readonly scope: SourceScope;
+	readonly sourcePath: string;
+	readonly discoveredAt: SourceTiming;
+};
+
+type SourceCandidate = InlineSource | FileSource;
+
+export function loadHookConfigSources(options: HookConfigLoaderOptions): ParsedHookConfig {
+	const executableHandlers: ParsedHookConfig["executableHandlers"][number][] = [];
+	const diagnostics: HookDiagnostic[] = [];
+	let displayOrder = 0;
+
+	for (const candidate of createSourceCandidates(options)) {
+		const source: HookSourceMetadata = {
+			discoveredAt: candidate.discoveredAt,
+			displayOrder,
+			scope: candidate.scope,
+			sourcePath: candidate.sourcePath,
+		};
+		const loaded = loadCandidate(candidate, source, options.fileSystem);
+		if (!loaded) {
+			continue;
+		}
+		displayOrder += 1;
+		executableHandlers.push(...loaded.executableHandlers);
+		diagnostics.push(...loaded.diagnostics);
+		if (source.discoveredAt === "runtime") {
+			diagnostics.push(...runtimeSessionStartDiagnostics(loaded.executableHandlers, source));
+		}
+	}
+
+	return { executableHandlers, diagnostics };
+}
+
+function createSourceCandidates(options: HookConfigLoaderOptions): SourceCandidate[] {
+	const candidates: SourceCandidate[] = [];
+	if (options.globalSettingsHooks !== undefined) {
+		candidates.push({
+			discoveredAt: "pre-session",
+			hooks: options.globalSettingsHooks,
+			kind: "inline",
+			scope: "global",
+			sourcePath: "<global-settings-hooks>",
+		});
+	}
+	candidates.push(fileSource("global", options.globalHooksPath ?? `${options.agentDir}/hooks.json`, "pre-session"));
+	candidates.push(...fileSources("global", options.globalHookSourcePaths, "pre-session"));
+	if (options.projectSettingsHooks !== undefined) {
+		candidates.push({
+			discoveredAt: "pre-session",
+			hooks: options.projectSettingsHooks,
+			kind: "inline",
+			scope: "project",
+			sourcePath: "<project-settings-hooks>",
+		});
+	}
+	candidates.push(
+		fileSource("project", options.projectHooksPath ?? `${options.cwd}/.senpi/hooks.json`, "pre-session"),
+	);
+	candidates.push(...fileSources("project", options.projectHookSourcePaths, "pre-session"));
+	candidates.push(...fileSources("plugin", options.preSessionHookSourcePaths, "pre-session"));
+	candidates.push(...fileSources("runtime", options.runtimeHookSourcePaths, "runtime"));
+	return candidates;
+}
+
+function fileSources(
+	scope: SourceScope,
+	paths: readonly string[] | undefined,
+	discoveredAt: SourceTiming,
+): SourceCandidate[] {
+	if (!paths) {
+		return [];
+	}
+	return paths.map((path) => fileSource(scope, path, discoveredAt));
+}
+
+function fileSource(scope: SourceScope, sourcePath: string, discoveredAt: SourceTiming): FileSource {
+	return { discoveredAt, kind: "file", scope, sourcePath };
+}
+
+function loadCandidate(
+	candidate: SourceCandidate,
+	source: HookSourceMetadata,
+	fileSystem: HookConfigFileSystem,
+): ParsedHookConfig | undefined {
+	if (candidate.kind === "inline") {
+		return parseHookConfig({ hooks: candidate.hooks }, source);
+	}
+
+	const text = readSourceText(candidate.sourcePath, source, fileSystem);
+	if (text === undefined) {
+		return undefined;
+	}
+	if (typeof text !== "string") {
+		return text;
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(text);
+		return parseHookConfig(parsed, source);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown JSON parse failure.";
+		return {
+			diagnostics: [
+				diagnostic(
+					{
+						code: "invalid_root",
+						message: `Hook source JSON is malformed: ${message}`,
+						path: "$",
+					},
+					source,
+				),
+			],
+			executableHandlers: [],
+		};
+	}
+}
+
+function readSourceText(
+	sourcePath: string,
+	source: HookSourceMetadata,
+	fileSystem: HookConfigFileSystem,
+): string | undefined | ParsedHookConfig {
+	try {
+		return fileSystem.readTextFile(sourcePath);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown file read failure.";
+		return {
+			diagnostics: [
+				diagnostic(
+					{
+						code: "invalid_root",
+						message: `Hook source could not be read: ${message}`,
+						path: "$",
+					},
+					source,
+				),
+			],
+			executableHandlers: [],
+		};
+	}
+}
+
+function runtimeSessionStartDiagnostics(
+	handlers: ParsedHookConfig["executableHandlers"],
+	source: HookSourceMetadata,
+): HookDiagnostic[] {
+	if (!handlers.some((handler) => handler.event === "SessionStart")) {
+		return [];
+	}
+	return [
+		diagnostic(
+			{
+				code: "unsupported_event",
+				event: "SessionStart",
+				message: "Runtime SessionStart hooks are loaded for reload or the next session only.",
+				path: "hooks.SessionStart",
+				severity: "warning",
+			},
+			source,
+		),
+	];
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/diagnostics.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/diagnostics.ts
@@ -1,0 +1,23 @@
+import type { HookDiagnostic, HookDiagnosticCode, HookSourceMetadata } from "./types.ts";
+
+export type DiagnosticDraft = {
+	readonly code: HookDiagnosticCode;
+	readonly message: string;
+	readonly path: string;
+	readonly event?: string;
+	readonly severity?: "error" | "warning";
+};
+
+export function diagnostic(draft: DiagnosticDraft, source: HookSourceMetadata): HookDiagnostic {
+	const base = {
+		code: draft.code,
+		message: draft.message,
+		path: draft.path,
+		severity: draft.severity ?? "error",
+		source,
+	};
+	if (draft.event === undefined) {
+		return base;
+	}
+	return { ...base, event: draft.event };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/dispatcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/dispatcher.ts
@@ -1,0 +1,269 @@
+import { type CommandHookRunOptions, type CommandHookRunResult, runCommandHook } from "./command-runner.ts";
+import { matchingHookHandlers } from "./matcher.ts";
+import { type ParsedHookOutput, parseHookOutput } from "./output-parser.ts";
+import { type HookOutputPolicy, validateHookHandlerSafety } from "./safety.ts";
+import { type HookTrustOptions, type HookTrustRecord, listHookTrustRecords } from "./trust.ts";
+import type {
+	ExecutableHookHandler,
+	HookDiagnostic,
+	HookInputWire,
+	HookSourceMetadata,
+	HookTrustState,
+} from "./types.ts";
+
+export type HookCommandRunner = (
+	handler: ExecutableHookHandler,
+	input: HookInputWire,
+	options: CommandHookRunOptions,
+) => Promise<CommandHookRunResult>;
+
+export type HookDispatchDecision =
+	| { readonly kind: "none" }
+	| {
+			readonly kind: "allow" | "block";
+			readonly reason?: string;
+			readonly source: HookSourceMetadata;
+			readonly sourceCommand: string;
+			readonly updatedInput?: unknown;
+	  }
+	| {
+			readonly fallback: { readonly kind: "block"; readonly reason: string };
+			readonly kind: "ask";
+			readonly nativeRepresentable: false;
+			readonly reason?: string;
+			readonly source: HookSourceMetadata;
+			readonly sourceCommand: string;
+	  };
+
+export type HookDispatchSkipped = {
+	readonly diagnostics: readonly HookDiagnostic[];
+	readonly handler: ExecutableHookHandler;
+	readonly reason: "disabled" | "untrusted" | "unsafe";
+	readonly record: HookTrustRecord;
+};
+
+export type HookDispatchSummary = {
+	readonly completionIndex: number;
+	readonly diagnostics: readonly HookDiagnostic[];
+	readonly handler: ExecutableHookHandler;
+	readonly output: ParsedHookOutput["output"];
+	readonly run: CommandHookRunResult;
+};
+
+export type HookDispatchResult = {
+	readonly decision: HookDispatchDecision;
+	readonly diagnostics: readonly HookDiagnostic[];
+	readonly executableHandlers: readonly ExecutableHookHandler[];
+	readonly matchedHandlers: readonly ExecutableHookHandler[];
+	readonly skipped: readonly HookDispatchSkipped[];
+	readonly summaries: readonly HookDispatchSummary[];
+};
+
+export type HookDispatchOptions = {
+	readonly cwd: string;
+	readonly envPassthrough?: readonly string[];
+	readonly handlers: readonly ExecutableHookHandler[];
+	readonly input: HookInputWire;
+	readonly outputPolicy?: HookOutputPolicy;
+	readonly runCommand?: HookCommandRunner;
+	readonly signal?: AbortSignal;
+	readonly sourceEnv?: NodeJS.ProcessEnv;
+	readonly trustOptions?: HookTrustOptions;
+	readonly trustState: HookTrustState;
+};
+
+type OrderedHandler = {
+	readonly declarationIndex: number;
+	readonly handler: ExecutableHookHandler;
+};
+
+type RunnableHandler = OrderedHandler & {
+	readonly record: HookTrustRecord;
+};
+
+export async function dispatchHookEvent(options: HookDispatchOptions): Promise<HookDispatchResult> {
+	const match = matchingHookHandlers(options.input, options.handlers);
+	const ordered = declarationOrdered(match.handlers);
+	const selected = selectExecutableHandlers(ordered, options.trustState, options.trustOptions);
+	let nextCompletionIndex = 0;
+	const runner = options.runCommand ?? runCommandHook;
+	const completed = await Promise.all(
+		selected.runnable.map(async ({ handler, declarationIndex }) => {
+			const run = await runner(handler, options.input, {
+				cwd: options.cwd,
+				...(options.envPassthrough === undefined ? {} : { envPassthrough: options.envPassthrough }),
+				...(options.outputPolicy === undefined ? {} : { outputPolicy: options.outputPolicy }),
+				...(options.signal === undefined ? {} : { signal: options.signal }),
+				...(options.sourceEnv === undefined ? {} : { sourceEnv: options.sourceEnv }),
+			});
+			const parsed = parseHookOutput({
+				event: options.input.event,
+				exitCode: run.exitCode ?? 1,
+				source: handler.source,
+				stderr: run.stderr,
+				stdout: run.stdout,
+			});
+			const completionIndex = nextCompletionIndex;
+			nextCompletionIndex += 1;
+			return { completionIndex, declarationIndex, handler, parsed, run };
+		}),
+	);
+	const declarationSummaries = completed
+		.toSorted((left, right) => left.declarationIndex - right.declarationIndex)
+		.map((run) => ({
+			completionIndex: run.completionIndex,
+			diagnostics: run.parsed.diagnostics,
+			handler: run.handler,
+			output: run.parsed.output,
+			run: run.run,
+		}));
+	const diagnostics = [
+		...match.diagnostics,
+		...selected.skipped.flatMap((skip) => skip.diagnostics),
+		...declarationSummaries.flatMap((summary) => summary.diagnostics),
+	];
+	return {
+		decision: aggregateDecision(options.input.event, declarationSummaries),
+		diagnostics,
+		executableHandlers: selected.runnable.map((item) => item.handler),
+		matchedHandlers: ordered.map((item) => item.handler),
+		skipped: selected.skipped,
+		summaries: declarationSummaries,
+	};
+}
+
+function declarationOrdered(handlers: readonly ExecutableHookHandler[]): readonly OrderedHandler[] {
+	return handlers
+		.map((handler, index) => ({ declarationIndex: index, handler }))
+		.toSorted(
+			(left, right) =>
+				compareHandlers(left.handler, right.handler) || left.declarationIndex - right.declarationIndex,
+		);
+}
+
+function compareHandlers(left: ExecutableHookHandler, right: ExecutableHookHandler): number {
+	return (
+		left.source.displayOrder - right.source.displayOrder ||
+		left.groupIndex - right.groupIndex ||
+		left.handlerIndex - right.handlerIndex
+	);
+}
+
+function selectExecutableHandlers(
+	handlers: readonly OrderedHandler[],
+	trustState: HookTrustState,
+	trustOptions: HookTrustOptions | undefined,
+): { readonly runnable: readonly RunnableHandler[]; readonly skipped: readonly HookDispatchSkipped[] } {
+	const records = listHookTrustRecords(
+		handlers.map((item) => item.handler),
+		trustState,
+		trustOptions,
+	);
+	const runnable: RunnableHandler[] = [];
+	const skipped: HookDispatchSkipped[] = [];
+	for (const [index, item] of handlers.entries()) {
+		const record = records[index];
+		if (record === undefined) continue;
+		const safetyDiagnostics = validateHookHandlerSafety(item.handler);
+		const unsafe = safetyDiagnostics.some((diagnostic) => diagnostic.severity === "error");
+		if (unsafe) {
+			skipped.push({ diagnostics: safetyDiagnostics, handler: item.handler, reason: "unsafe", record });
+			continue;
+		}
+		if (!record.enabled) {
+			skipped.push({ diagnostics: [], handler: item.handler, reason: "disabled", record });
+			continue;
+		}
+		if (!record.trusted) {
+			skipped.push({ diagnostics: [], handler: item.handler, reason: "untrusted", record });
+			continue;
+		}
+		runnable.push({ ...item, record });
+	}
+	return { runnable, skipped };
+}
+
+function aggregateDecision(
+	event: HookInputWire["event"],
+	summaries: readonly HookDispatchSummary[],
+): HookDispatchDecision {
+	switch (event) {
+		case "PreToolUse":
+			return aggregatePreToolUseDecision(summaries);
+		case "PostToolUse":
+		case "UserPromptSubmit":
+		case "SessionStart":
+		case "PreCompact":
+		case "PostCompact":
+		case "Stop":
+			return aggregateBlockingDecision(summaries);
+	}
+}
+
+function aggregatePreToolUseDecision(summaries: readonly HookDispatchSummary[]): HookDispatchDecision {
+	const blocker = summaries.find(hasBlockingDecision);
+	if (blocker !== undefined) {
+		return decisionWithSource("block", blocker, blocker.output.reason);
+	}
+	const ask = summaries.find((summary) => summary.output.decision === "ask");
+	if (ask !== undefined) {
+		const reason = ask.output.reason ?? "Hook requested manual approval.";
+		return {
+			fallback: { kind: "block", reason },
+			kind: "ask",
+			nativeRepresentable: false,
+			...reasonField(ask.output.reason),
+			source: ask.handler.source,
+			sourceCommand: ask.handler.config.command,
+		};
+	}
+	let allowSummary: HookDispatchSummary | undefined;
+	for (const summary of summaries) {
+		if (summary.output.decision === "allow" || summary.output.decision === "approve") allowSummary = summary;
+	}
+	if (allowSummary !== undefined) {
+		return decisionWithSource("allow", allowSummary, undefined, allowSummary.output.updatedInput);
+	}
+	return { kind: "none" };
+}
+
+function aggregateBlockingDecision(summaries: readonly HookDispatchSummary[]): HookDispatchDecision {
+	const blocker = summaries.find(hasBlockingDecision);
+	if (blocker !== undefined) {
+		return decisionWithSource("block", blocker, blocker.output.reason ?? blocker.output.stopReason);
+	}
+	return { kind: "none" };
+}
+
+function hasBlockingDecision(summary: HookDispatchSummary): boolean {
+	return summary.output.decision === "block" || summary.output.decision === "deny";
+}
+
+function decisionWithSource(
+	kind: "allow" | "block",
+	summary: HookDispatchSummary,
+	reason: string | undefined,
+	updatedInput?: unknown,
+): HookDispatchDecision {
+	return {
+		kind,
+		...reasonField(reason),
+		source: summary.handler.source,
+		sourceCommand: summary.handler.config.command,
+		...updatedInputField(updatedInput),
+	};
+}
+
+function reasonField(reason: string | undefined): { readonly reason?: string } {
+	if (reason === undefined) {
+		return {};
+	}
+	return { reason };
+}
+
+function updatedInputField(updatedInput: unknown): { readonly updatedInput?: unknown } {
+	if (updatedInput === undefined) {
+		return {};
+	}
+	return { updatedInput };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/handler.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/handler.ts
@@ -1,4 +1,5 @@
 import { diagnostic } from "./diagnostics.ts";
+import { isValidHookTimeoutSeconds } from "./safety.ts";
 import type {
 	CommandHookConfig,
 	ExecutableHookHandler,
@@ -166,13 +167,13 @@ function normalizeCommandConfig(
 	}
 
 	const timeout = handler.timeout;
-	if (timeout !== undefined && typeof timeout !== "number") {
+	if (timeout !== undefined && (typeof timeout !== "number" || !isValidHookTimeoutSeconds(timeout))) {
 		context.diagnostics.push(
 			diagnostic(
 				{
 					code: "invalid_timeout",
 					event: context.event,
-					message: "Command hook timeout must be a number.",
+					message: "Command hook timeout must be a finite number greater than 0.",
 					path: `${path}.timeout`,
 				},
 				context.source,

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/handler.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/handler.ts
@@ -1,0 +1,211 @@
+import { diagnostic } from "./diagnostics.ts";
+import type {
+	CommandHookConfig,
+	ExecutableHookHandler,
+	HookDiagnostic,
+	HookSourceMetadata,
+	SupportedHookEvent,
+} from "./types.ts";
+
+const UNSUPPORTED_COMMAND_FIELDS = ["if", "shell", "asyncRewake", "terminalSequence", "continueOnBlock"] as const;
+
+type HandlerParseContext = {
+	readonly event: SupportedHookEvent;
+	readonly matcher?: string;
+	readonly groupIndex: number;
+	readonly handlerIndex: number;
+	readonly source: HookSourceMetadata;
+	readonly diagnostics: HookDiagnostic[];
+};
+
+export function parseHandler(handler: unknown, context: HandlerParseContext): ExecutableHookHandler | undefined {
+	const path = `hooks.${context.event}[${context.groupIndex}].hooks[${context.handlerIndex}]`;
+	if (!isRecord(handler)) {
+		context.diagnostics.push(
+			diagnostic(
+				{ code: "invalid_handler", event: context.event, message: "Hook handler must be an object.", path },
+				context.source,
+			),
+		);
+		return undefined;
+	}
+
+	const type = handler.type;
+	if (type !== "command") {
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "unsupported_handler_type",
+					event: context.event,
+					message: 'Only type: "command" hook handlers are executable in builtin hooks v1.',
+					path: `${path}.type`,
+					severity: "warning",
+				},
+				context.source,
+			),
+		);
+		return undefined;
+	}
+
+	if (hasUnsupportedCommandShape(handler, path, context)) {
+		return undefined;
+	}
+
+	const command = handler.command;
+	if (typeof command !== "string") {
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "invalid_command",
+					event: context.event,
+					message: "Command hook command must be a string.",
+					path: `${path}.command`,
+				},
+				context.source,
+			),
+		);
+		return undefined;
+	}
+
+	const normalized = normalizeCommandConfig(handler, command, path, context);
+	if (!normalized) {
+		return undefined;
+	}
+
+	const base = {
+		config: normalized,
+		event: context.event,
+		groupIndex: context.groupIndex,
+		handlerIndex: context.handlerIndex,
+		source: context.source,
+	};
+	if (context.matcher === undefined) {
+		return base;
+	}
+	return { ...base, matcher: context.matcher };
+}
+
+function hasUnsupportedCommandShape(
+	handler: Record<string, unknown>,
+	path: string,
+	context: HandlerParseContext,
+): boolean {
+	let unsupported = false;
+	for (const field of UNSUPPORTED_COMMAND_FIELDS) {
+		if (field in handler) {
+			unsupported = true;
+			context.diagnostics.push(
+				diagnostic(
+					{
+						code: "unsupported_field",
+						event: context.event,
+						message: `Command hook field ${field} is not executable in builtin hooks v1.`,
+						path: `${path}.${field}`,
+						severity: "warning",
+					},
+					context.source,
+				),
+			);
+		}
+	}
+
+	if (handler.async === true) {
+		unsupported = true;
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "unsupported_async_handler",
+					event: context.event,
+					message: "Async hook handlers are not executable in builtin hooks v1.",
+					path: `${path}.async`,
+					severity: "warning",
+				},
+				context.source,
+			),
+		);
+	}
+
+	if ("args" in handler || isRecord(handler.command)) {
+		unsupported = true;
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "unsupported_command_variant",
+					event: context.event,
+					message: "Exec-form command hooks are not executable in builtin hooks v1.",
+					path: `${path}.command`,
+					severity: "warning",
+				},
+				context.source,
+			),
+		);
+	}
+	return unsupported;
+}
+
+function normalizeCommandConfig(
+	handler: Record<string, unknown>,
+	command: string,
+	path: string,
+	context: HandlerParseContext,
+): CommandHookConfig | undefined {
+	const commandWindowsValue = handler.commandWindows ?? handler.command_windows;
+	if (commandWindowsValue !== undefined && typeof commandWindowsValue !== "string") {
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "invalid_command_windows",
+					event: context.event,
+					message: "commandWindows must be a string.",
+					path: `${path}.commandWindows`,
+				},
+				context.source,
+			),
+		);
+		return undefined;
+	}
+
+	const timeout = handler.timeout;
+	if (timeout !== undefined && typeof timeout !== "number") {
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "invalid_timeout",
+					event: context.event,
+					message: "Command hook timeout must be a number.",
+					path: `${path}.timeout`,
+				},
+				context.source,
+			),
+		);
+		return undefined;
+	}
+
+	const statusMessage = handler.statusMessage;
+	if (statusMessage !== undefined && typeof statusMessage !== "string") {
+		context.diagnostics.push(
+			diagnostic(
+				{
+					code: "invalid_status_message",
+					event: context.event,
+					message: "Command hook statusMessage must be a string.",
+					path: `${path}.statusMessage`,
+				},
+				context.source,
+			),
+		);
+		return undefined;
+	}
+
+	return {
+		type: "command",
+		command,
+		...(typeof commandWindowsValue === "string" ? { commandWindows: commandWindowsValue } : {}),
+		...(typeof timeout === "number" ? { timeout } : {}),
+		...(typeof statusMessage === "string" ? { statusMessage } : {}),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { BeforeAgentStartEventResult, ExtensionAPI, ExtensionContext, LoadedHookSources } from "../../types.ts";
+import { registerHooksCommand } from "./command.ts";
 import { loadHookConfigSources } from "./config-loader.ts";
 import { dispatchHookEvent } from "./dispatcher.ts";
 import {
@@ -33,13 +34,7 @@ import {
 } from "./tool-adapter.ts";
 import { emptyHookTrustState } from "./trust.ts";
 import { FileHookStateStorage } from "./trust-storage.ts";
-import type {
-	HookDiagnostic,
-	HookRuntimeState,
-	HookTrustState,
-	ParsedHookConfig,
-	SupportedHookEvent,
-} from "./types.ts";
+import type { HookTrustState } from "./types.ts";
 
 export { parseHookConfig } from "./schema.ts";
 export type {
@@ -63,7 +58,7 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 	const pendingPreToolContexts = new Map<string, readonly string[]>();
 	const stopTurnTracker = createStopTurnTracker();
 
-	const refreshState = (ctx: ExtensionContext): HookRuntimeState => {
+	const refreshState = (ctx: ExtensionContext) => {
 		const sources = ctx.getLoadedHookSources?.() ?? fallbackHookSources(ctx.cwd);
 		const parsed = loadHookConfigSources({
 			agentDir: sources.agentDir,
@@ -87,7 +82,7 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 			storage.read("global"),
 			ctx.isProjectTrusted() ? storage.read("project") : emptyHookTrustState(),
 		);
-		return { parsed, trust };
+		return { parsed, trust, storage };
 	};
 
 	pi.on("session_start", async (event, ctx) => {
@@ -258,13 +253,7 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 		await applyStopHookResult(pi, ctx, result, stopTurnTracker.turnKey(ctx));
 	});
 
-	pi.registerCommand("hooks", {
-		description: "Inspect loaded builtin hook sources and diagnostics.",
-		handler: async (_args, ctx) => {
-			const state = refreshState(ctx);
-			ctx.ui.notify(formatHookStatus(state.parsed));
-		},
-	});
+	registerHooksCommand(pi, refreshState);
 }
 
 function mergeTrustStates(globalState: HookTrustState, projectState: HookTrustState): HookTrustState {
@@ -282,31 +271,6 @@ function fallbackHookSources(cwd: string): LoadedHookSources {
 		projectHooksPath: `${cwd}/.senpi/hooks.json`,
 		runtimeHookSourcePaths: [],
 	};
-}
-
-function formatHookStatus(parsed: ParsedHookConfig): string {
-	const counts = new Map<SupportedHookEvent, number>();
-	for (const handler of parsed.executableHandlers) {
-		counts.set(handler.event, (counts.get(handler.event) ?? 0) + 1);
-	}
-	const summary =
-		counts.size === 0
-			? "hooks: no executable hooks"
-			: `hooks: ${parsed.executableHandlers.length} executable hooks (${Array.from(counts.entries())
-					.map(([event, count]) => `${event}:${count}`)
-					.join(", ")})`;
-	return appendHookDiagnostics(summary, parsed.diagnostics);
-}
-
-function appendHookDiagnostics(summary: string, diagnostics: readonly HookDiagnostic[]): string {
-	if (diagnostics.length === 0) {
-		return summary;
-	}
-	const lines = diagnostics.map(
-		(diagnostic) =>
-			`${diagnostic.severity}: ${diagnostic.code} ${diagnostic.source.sourcePath} ${diagnostic.path} ${diagnostic.message}`,
-	);
-	return [summary, ...lines].join("\n");
 }
 
 export {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -3,6 +3,17 @@ import type { BeforeAgentStartEventResult, ExtensionAPI, ExtensionContext, Loade
 import { loadHookConfigSources } from "./config-loader.ts";
 import { dispatchHookEvent } from "./dispatcher.ts";
 import {
+	buildPostCompactHookInput,
+	buildPreCompactHookInput,
+	buildSessionStartHookInput,
+	dispatchLifecycleHookEvent,
+	postCompactResultDetails,
+	preCompactResultDetails,
+	recordLifecycleHookResult,
+	sessionBeforeCompactResult,
+	sessionStartResultDetails,
+} from "./lifecycle-adapter.ts";
+import {
 	appendSystemMessages,
 	buildUserPromptHookInput,
 	formatPromptContextMessage,
@@ -76,6 +87,20 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 		);
 		return { parsed, trust };
 	};
+
+	pi.on("session_start", async (event, ctx) => {
+		const state = refreshState(ctx);
+		const input = buildSessionStartHookInput(event, ctx);
+		const result = await dispatchLifecycleHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input,
+			matcherInputs: ["SessionStart", event.reason],
+			...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
+			trustState: state.trust,
+		});
+		recordLifecycleHookResult(pi, "SessionStart", sessionStartResultDetails(result));
+	});
 
 	pi.on("input", async (event, ctx) => {
 		if (event.source === "extension") return undefined;
@@ -185,6 +210,36 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 			trustState: state.trust,
 		});
 		return applyPostToolUseResult(event, result, preToolContexts);
+	});
+
+	pi.on("session_before_compact", async (event, ctx) => {
+		const state = refreshState(ctx);
+		const result = await dispatchLifecycleHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input: buildPreCompactHookInput(event, ctx),
+			matcherInputs: ["PreCompact", event.reason],
+			signal: event.signal,
+			trustState: state.trust,
+		});
+		const details = preCompactResultDetails(result);
+		recordLifecycleHookResult(pi, "PreCompact", details);
+		return sessionBeforeCompactResult(details);
+	});
+
+	pi.on("session_compact", async (event, ctx) => {
+		if (!event.accepted) return undefined;
+		const state = refreshState(ctx);
+		const result = await dispatchLifecycleHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input: buildPostCompactHookInput(event, ctx),
+			matcherInputs: ["PostCompact", event.reason],
+			...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
+			trustState: state.trust,
+		});
+		recordLifecycleHookResult(pi, "PostCompact", postCompactResultDetails(result));
+		return undefined;
 	});
 
 	pi.registerCommand("hooks", {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -23,6 +23,7 @@ import {
 	promptContextFromResult,
 	safeDiagnosticDetails,
 } from "./prompt-adapter.ts";
+import { applyStopHookResult, buildStopHookInput, createStopTurnTracker } from "./stop-adapter.ts";
 import {
 	applyPostToolUseResult,
 	applyPreToolUseResult,
@@ -60,6 +61,7 @@ export type {
 export default function hooksExtension(pi: ExtensionAPI): void {
 	const pendingPromptContexts: PendingPromptHookContext[] = [];
 	const pendingPreToolContexts = new Map<string, readonly string[]>();
+	const stopTurnTracker = createStopTurnTracker();
 
 	const refreshState = (ctx: ExtensionContext): HookRuntimeState => {
 		const sources = ctx.getLoadedHookSources?.() ?? fallbackHookSources(ctx.cwd);
@@ -104,6 +106,7 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 
 	pi.on("input", async (event, ctx) => {
 		if (event.source === "extension") return undefined;
+		stopTurnTracker.reset();
 		pendingPromptContexts.splice(0);
 		const state = refreshState(ctx);
 		const input = buildUserPromptHookInput({
@@ -240,6 +243,19 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 		});
 		recordLifecycleHookResult(pi, "PostCompact", postCompactResultDetails(result));
 		return undefined;
+	});
+
+	pi.on("agent_end", async (event, ctx) => {
+		const state = refreshState(ctx);
+		const result = await dispatchHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input: buildStopHookInput(event, ctx),
+			signal: ctx.signal,
+			trustOptions: { platform: process.platform },
+			trustState: state.trust,
+		});
+		await applyStopHookResult(pi, ctx, result, stopTurnTracker.turnKey(ctx));
 	});
 
 	pi.registerCommand("hooks", {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -12,6 +12,13 @@ import {
 	promptContextFromResult,
 	safeDiagnosticDetails,
 } from "./prompt-adapter.ts";
+import {
+	applyPostToolUseResult,
+	applyPreToolUseResult,
+	buildPostToolUseHookInput,
+	buildPreToolUseHookInput,
+	toolContextsFromResult,
+} from "./tool-adapter.ts";
 import { emptyHookTrustState } from "./trust.ts";
 import { FileHookStateStorage } from "./trust-storage.ts";
 import type {
@@ -41,6 +48,7 @@ export type {
 
 export default function hooksExtension(pi: ExtensionAPI): void {
 	const pendingPromptContexts: PendingPromptHookContext[] = [];
+	const pendingPreToolContexts = new Map<string, readonly string[]>();
 
 	const refreshState = (ctx: ExtensionContext): HookRuntimeState => {
 		const sources = ctx.getLoadedHookSources?.() ?? fallbackHookSources(ctx.cwd);
@@ -139,6 +147,44 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 			result.systemPrompt = systemPrompt;
 		}
 		return result;
+	});
+
+	pi.on("tool_call", async (event, ctx) => {
+		pendingPreToolContexts.delete(event.toolCallId);
+		const state = refreshState(ctx);
+		const result = await dispatchHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input: buildPreToolUseHookInput(event, ctx),
+			signal: ctx.signal,
+			trustOptions: { platform: process.platform },
+			trustState: state.trust,
+		});
+		const toolResult = applyPreToolUseResult(event, result);
+		if (toolResult?.block) {
+			pendingPreToolContexts.delete(event.toolCallId);
+			return toolResult;
+		}
+		const contexts = toolContextsFromResult(result);
+		if (contexts.length > 0) {
+			pendingPreToolContexts.set(event.toolCallId, contexts);
+		}
+		return toolResult;
+	});
+
+	pi.on("tool_result", async (event, ctx) => {
+		const preToolContexts = pendingPreToolContexts.get(event.toolCallId) ?? [];
+		pendingPreToolContexts.delete(event.toolCallId);
+		const state = refreshState(ctx);
+		const result = await dispatchHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input: buildPostToolUseHookInput(event, ctx),
+			signal: ctx.signal,
+			trustOptions: { platform: process.platform },
+			trustState: state.trust,
+		});
+		return applyPostToolUseResult(event, result, preToolContexts);
 	});
 
 	pi.registerCommand("hooks", {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -1,6 +1,17 @@
 import { existsSync, readFileSync } from "node:fs";
-import type { ExtensionAPI, ExtensionContext, LoadedHookSources } from "../../types.ts";
+import type { BeforeAgentStartEventResult, ExtensionAPI, ExtensionContext, LoadedHookSources } from "../../types.ts";
 import { loadHookConfigSources } from "./config-loader.ts";
+import { dispatchHookEvent } from "./dispatcher.ts";
+import {
+	appendSystemMessages,
+	buildUserPromptHookInput,
+	formatPromptContextMessage,
+	HOOK_CUSTOM_MESSAGE_TYPE,
+	type PendingPromptHookContext,
+	promptBlockReasonFromResult,
+	promptContextFromResult,
+	safeDiagnosticDetails,
+} from "./prompt-adapter.ts";
 import { emptyHookTrustState } from "./trust.ts";
 import { FileHookStateStorage } from "./trust-storage.ts";
 import type {
@@ -29,6 +40,8 @@ export type {
 } from "./types.ts";
 
 export default function hooksExtension(pi: ExtensionAPI): void {
+	const pendingPromptContexts: PendingPromptHookContext[] = [];
+
 	const refreshState = (ctx: ExtensionContext): HookRuntimeState => {
 		const sources = ctx.getLoadedHookSources?.() ?? fallbackHookSources(ctx.cwd);
 		const parsed = loadHookConfigSources({
@@ -55,6 +68,78 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 		);
 		return { parsed, trust };
 	};
+
+	pi.on("input", async (event, ctx) => {
+		if (event.source === "extension") return undefined;
+		pendingPromptContexts.splice(0);
+		const state = refreshState(ctx);
+		const input = buildUserPromptHookInput({
+			cwd: ctx.cwd,
+			permissionMode: "default",
+			prompt: event.text,
+			sessionId: ctx.sessionManager.getSessionId(),
+			transcriptPath: ctx.sessionManager.getSessionFile(),
+		});
+		const result = await dispatchHookEvent({
+			cwd: ctx.cwd,
+			handlers: state.parsed.executableHandlers,
+			input,
+			signal: ctx.signal,
+			trustOptions: { platform: process.platform },
+			trustState: state.trust,
+		});
+		if (result.decision.kind === "block") {
+			const reason = promptBlockReasonFromResult(result);
+			ctx.ui.notify(reason, "warning");
+			pi.sendMessage(
+				{
+					customType: HOOK_CUSTOM_MESSAGE_TYPE,
+					content: reason,
+					display: false,
+					details: {
+						decision: "block",
+						event: "UserPromptSubmit",
+						sourcePath: result.decision.source.sourcePath,
+					},
+				},
+				{ triggerTurn: false },
+			);
+			return { action: "handled" };
+		}
+		if (ctx.isIdle()) {
+			const pending = promptContextFromResult(result);
+			if (pending !== undefined) {
+				pendingPromptContexts.push(pending);
+			}
+		}
+		return { action: "continue" };
+	});
+
+	pi.on("before_agent_start", async (event) => {
+		const pending = pendingPromptContexts.shift();
+		if (pending === undefined) return undefined;
+
+		const messageContent = formatPromptContextMessage(pending);
+		const systemPrompt = appendSystemMessages(event.systemPrompt, pending.systemMessages);
+		if (messageContent === undefined && systemPrompt === event.systemPrompt) return undefined;
+
+		const result: BeforeAgentStartEventResult = {};
+		if (messageContent !== undefined) {
+			result.message = {
+				customType: HOOK_CUSTOM_MESSAGE_TYPE,
+				content: messageContent,
+				display: false,
+				details: {
+					event: "UserPromptSubmit",
+					diagnostics: pending.diagnostics.map(safeDiagnosticDetails),
+				},
+			};
+		}
+		if (systemPrompt !== event.systemPrompt) {
+			result.systemPrompt = systemPrompt;
+		}
+		return result;
+	});
 
 	pi.registerCommand("hooks", {
 		description: "Inspect loaded builtin hook sources and diagnostics.",

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -1,0 +1,21 @@
+export { parseHookConfig } from "./schema.ts";
+export type {
+	CommandHookConfig,
+	ExecutableHookHandler,
+	HookDiagnostic,
+	HookDiagnosticCode,
+	HookInputWire,
+	HookOutputWire,
+	HookRuntimeState,
+	HookSourceMetadata,
+	HookTrustEntry,
+	HookTrustState,
+	ParsedHookConfig,
+	SupportedHookEvent,
+	UnsupportedKnownHookEvent,
+} from "./types.ts";
+export {
+	SUPPORTED_HOOK_EVENTS,
+	UNSUPPORTED_HANDLER_TYPES,
+	UNSUPPORTED_KNOWN_HOOK_EVENTS,
+} from "./types.ts";

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -1,3 +1,16 @@
+import { existsSync, readFileSync } from "node:fs";
+import type { ExtensionAPI, ExtensionContext, LoadedHookSources } from "../../types.ts";
+import { loadHookConfigSources } from "./config-loader.ts";
+import { emptyHookTrustState } from "./trust.ts";
+import { FileHookStateStorage } from "./trust-storage.ts";
+import type {
+	HookDiagnostic,
+	HookRuntimeState,
+	HookTrustState,
+	ParsedHookConfig,
+	SupportedHookEvent,
+} from "./types.ts";
+
 export { parseHookConfig } from "./schema.ts";
 export type {
 	CommandHookConfig,
@@ -14,6 +27,86 @@ export type {
 	SupportedHookEvent,
 	UnsupportedKnownHookEvent,
 } from "./types.ts";
+
+export default function hooksExtension(pi: ExtensionAPI): void {
+	const refreshState = (ctx: ExtensionContext): HookRuntimeState => {
+		const sources = ctx.getLoadedHookSources?.() ?? fallbackHookSources(ctx.cwd);
+		const parsed = loadHookConfigSources({
+			agentDir: sources.agentDir,
+			cwd: sources.cwd,
+			fileSystem: {
+				readTextFile(path) {
+					return existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+				},
+			},
+			globalHookSourcePaths: sources.globalHookSourcePaths,
+			globalHooksPath: sources.globalHooksPath,
+			globalSettingsHooks: sources.globalSettingsHooks,
+			preSessionHookSourcePaths: sources.preSessionHookSourcePaths,
+			projectHookSourcePaths: sources.projectHookSourcePaths,
+			projectHooksPath: sources.projectHooksPath,
+			projectSettingsHooks: sources.projectSettingsHooks,
+			runtimeHookSourcePaths: sources.runtimeHookSourcePaths,
+		});
+		const storage = new FileHookStateStorage({ agentDir: sources.agentDir, cwd: sources.cwd });
+		const trust = mergeTrustStates(
+			storage.read("global"),
+			ctx.isProjectTrusted() ? storage.read("project") : emptyHookTrustState(),
+		);
+		return { parsed, trust };
+	};
+
+	pi.registerCommand("hooks", {
+		description: "Inspect loaded builtin hook sources and diagnostics.",
+		handler: async (_args, ctx) => {
+			const state = refreshState(ctx);
+			ctx.ui.notify(formatHookStatus(state.parsed));
+		},
+	});
+}
+
+function mergeTrustStates(globalState: HookTrustState, projectState: HookTrustState): HookTrustState {
+	return { version: 1, hooks: { ...globalState.hooks, ...projectState.hooks } };
+}
+
+function fallbackHookSources(cwd: string): LoadedHookSources {
+	return {
+		agentDir: cwd,
+		cwd,
+		globalHookSourcePaths: [],
+		globalHooksPath: `${cwd}/hooks.json`,
+		preSessionHookSourcePaths: [],
+		projectHookSourcePaths: [],
+		projectHooksPath: `${cwd}/.senpi/hooks.json`,
+		runtimeHookSourcePaths: [],
+	};
+}
+
+function formatHookStatus(parsed: ParsedHookConfig): string {
+	const counts = new Map<SupportedHookEvent, number>();
+	for (const handler of parsed.executableHandlers) {
+		counts.set(handler.event, (counts.get(handler.event) ?? 0) + 1);
+	}
+	const summary =
+		counts.size === 0
+			? "hooks: no executable hooks"
+			: `hooks: ${parsed.executableHandlers.length} executable hooks (${Array.from(counts.entries())
+					.map(([event, count]) => `${event}:${count}`)
+					.join(", ")})`;
+	return appendHookDiagnostics(summary, parsed.diagnostics);
+}
+
+function appendHookDiagnostics(summary: string, diagnostics: readonly HookDiagnostic[]): string {
+	if (diagnostics.length === 0) {
+		return summary;
+	}
+	const lines = diagnostics.map(
+		(diagnostic) =>
+			`${diagnostic.severity}: ${diagnostic.code} ${diagnostic.source.sourcePath} ${diagnostic.path} ${diagnostic.message}`,
+	);
+	return [summary, ...lines].join("\n");
+}
+
 export {
 	SUPPORTED_HOOK_EVENTS,
 	UNSUPPORTED_HANDLER_TYPES,

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
@@ -1,0 +1,361 @@
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	SessionBeforeCompactEvent,
+	SessionBeforeCompactResult,
+	SessionCompactEvent,
+	SessionStartEvent,
+} from "../../types.ts";
+import { diagnostic } from "./diagnostics.ts";
+import { dispatchHookEvent, type HookDispatchResult } from "./dispatcher.ts";
+import { HOOK_CUSTOM_MESSAGE_TYPE, safeDiagnosticDetails } from "./prompt-adapter.ts";
+import { createHookTrustEntry, hookTrustId, listHookTrustRecords } from "./trust.ts";
+import type { ExecutableHookHandler, HookDiagnostic, HookInputWire, HookTrustState } from "./types.ts";
+
+type LifecycleHookEvent = "SessionStart" | "PreCompact" | "PostCompact";
+
+type LifecycleDispatchOptions = {
+	readonly cwd: string;
+	readonly handlers: readonly ExecutableHookHandler[];
+	readonly input: HookInputWire;
+	readonly matcherInputs: readonly string[];
+	readonly signal?: AbortSignal;
+	readonly trustState: HookTrustState;
+};
+
+type LifecycleDispatchSelection = {
+	readonly diagnostics: readonly HookDiagnostic[];
+	readonly handlers: readonly ExecutableHookHandler[];
+};
+
+type LifecycleHookOutput = {
+	readonly additionalContext?: string;
+	readonly customInstructions?: string;
+	readonly decision?: string;
+	readonly reason?: string;
+};
+
+type LifecycleResultDetails = {
+	readonly cancel: boolean;
+	readonly contexts: readonly string[];
+	readonly diagnostics: readonly HookDiagnostic[];
+	readonly reason?: string;
+};
+
+export function buildSessionStartHookInput(event: SessionStartEvent, ctx: ExtensionContext): HookInputWire {
+	const transcriptPath = ctx.sessionManager.getSessionFile();
+	return {
+		cwd: ctx.cwd,
+		event: "SessionStart",
+		hook_event_name: "SessionStart",
+		reason: event.reason,
+		sessionId: ctx.sessionManager.getSessionId(),
+		session_id: ctx.sessionManager.getSessionId(),
+		...(transcriptPath === undefined ? {} : { transcript_path: transcriptPath }),
+	};
+}
+
+export function buildPreCompactHookInput(event: SessionBeforeCompactEvent, ctx: ExtensionContext): HookInputWire {
+	const transcriptPath = ctx.sessionManager.getSessionFile();
+	return {
+		cwd: ctx.cwd,
+		event: "PreCompact",
+		hook_event_name: "PreCompact",
+		reason: event.reason,
+		request_id: event.requestId,
+		session_id: ctx.sessionManager.getSessionId(),
+		will_retry: event.willRetry,
+		...(event.customInstructions === undefined ? {} : { custom_instructions: event.customInstructions }),
+		...(transcriptPath === undefined ? {} : { transcript_path: transcriptPath }),
+	};
+}
+
+export function buildPostCompactHookInput(event: SessionCompactEvent, ctx: ExtensionContext): HookInputWire {
+	const transcriptPath = ctx.sessionManager.getSessionFile();
+	return {
+		accepted: event.accepted,
+		cwd: ctx.cwd,
+		event: "PostCompact",
+		hook_event_name: "PostCompact",
+		reason: event.reason,
+		request_id: event.requestId,
+		session_id: ctx.sessionManager.getSessionId(),
+		will_retry: event.willRetry,
+		...(transcriptPath === undefined ? {} : { transcript_path: transcriptPath }),
+	};
+}
+
+export async function dispatchLifecycleHookEvent(
+	options: LifecycleDispatchOptions,
+): Promise<HookDispatchResult | undefined> {
+	const selection = selectLifecycleHandlers(options);
+	if (selection.handlers.length === 0 && selection.diagnostics.length === 0) return undefined;
+	const trustedHandlers = selection.handlers.map((handler) => stripLifecycleMatcher(handler));
+	const hooks: Record<string, ReturnType<typeof createHookTrustEntry>> = {};
+	for (const handler of trustedHandlers) {
+		hooks[hookTrustId(handler)] = createHookTrustEntry(handler, {
+			platform: process.platform,
+			updatedAt: "2026-06-29T00:00:00.000Z",
+		});
+	}
+	const result = await dispatchHookEvent({
+		cwd: options.cwd,
+		handlers: trustedHandlers,
+		input: options.input,
+		...(options.signal === undefined ? {} : { signal: options.signal }),
+		trustOptions: { platform: process.platform },
+		trustState: { hooks, version: 1 },
+	});
+	return {
+		...result,
+		diagnostics: [...selection.diagnostics, ...result.diagnostics],
+	};
+}
+
+export function sessionStartResultDetails(result: HookDispatchResult | undefined): LifecycleResultDetails {
+	return lifecycleResultDetails("SessionStart", result);
+}
+
+export function preCompactResultDetails(result: HookDispatchResult | undefined): LifecycleResultDetails {
+	const details = lifecycleResultDetails("PreCompact", result);
+	if (details.cancel) return details;
+	const blocker = result?.summaries.find((summary) => {
+		const output = readLifecycleHookOutput("PreCompact", summary.run.stdout);
+		return output?.decision === "block" || output?.decision === "deny";
+	});
+	if (blocker === undefined) return details;
+	const output = readLifecycleHookOutput("PreCompact", blocker.run.stdout);
+	return {
+		...details,
+		cancel: true,
+		...(output?.reason === undefined ? {} : { reason: output.reason }),
+	};
+}
+
+export function postCompactResultDetails(result: HookDispatchResult | undefined): LifecycleResultDetails {
+	return lifecycleResultDetails("PostCompact", result);
+}
+
+export function sessionBeforeCompactResult(details: LifecycleResultDetails): SessionBeforeCompactResult | undefined {
+	return details.cancel ? { cancel: true } : undefined;
+}
+
+export function recordLifecycleHookResult(
+	pi: Pick<ExtensionAPI, "sendMessage">,
+	event: LifecycleHookEvent,
+	details: LifecycleResultDetails,
+): void {
+	if (details.contexts.length === 0 && details.diagnostics.length === 0 && details.reason === undefined) return;
+	const content =
+		details.contexts.length > 0 ? details.contexts.join("\n\n") : (details.reason ?? `${event} hook diagnostics.`);
+	pi.sendMessage(
+		{
+			customType: HOOK_CUSTOM_MESSAGE_TYPE,
+			content,
+			display: false,
+			details: {
+				event,
+				diagnostics: details.diagnostics.map(safeDiagnosticDetails),
+			},
+		},
+		{ triggerTurn: false },
+	);
+}
+
+function selectLifecycleHandlers(options: LifecycleDispatchOptions): LifecycleDispatchSelection {
+	const matched: ExecutableHookHandler[] = [];
+	const diagnostics: HookDiagnostic[] = [];
+	for (const handler of options.handlers) {
+		if (handler.event !== options.input.event) continue;
+		if (isInitialRuntimeSessionStart(handler, options.input)) {
+			diagnostics.push(
+				diagnostic(
+					{
+						code: "unsupported_event",
+						event: "SessionStart",
+						message: "Runtime SessionStart hooks are loaded for reload or the next session only.",
+						path: "hooks.SessionStart",
+						severity: "warning",
+					},
+					handler.source,
+				),
+			);
+			continue;
+		}
+		const match = matchesLifecycleMatcher(handler, options.matcherInputs);
+		diagnostics.push(...match.diagnostics);
+		if (match.matched) matched.push(handler);
+	}
+	const trustRecords = listHookTrustRecords(matched, options.trustState, { platform: process.platform });
+	const trusted = matched.filter((_handler, index) => trustRecords[index]?.executable === true);
+	return { diagnostics, handlers: trusted };
+}
+
+function isInitialRuntimeSessionStart(handler: ExecutableHookHandler, input: HookInputWire): boolean {
+	return input.event === "SessionStart" && input.reason === "startup" && handler.source.discoveredAt === "runtime";
+}
+
+function matchesLifecycleMatcher(
+	handler: ExecutableHookHandler,
+	inputs: readonly string[],
+): { readonly diagnostics: readonly HookDiagnostic[]; readonly matched: boolean } {
+	const matcher = handler.matcher?.trim();
+	if (matcher === undefined || matcher.length === 0 || matcher === "*") {
+		return { diagnostics: [], matched: true };
+	}
+	const literalMatched = matcher
+		.split(/[|,]/)
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0)
+		.some((part) => inputs.includes(part));
+	try {
+		const regex = new RegExp(matcher);
+		return { diagnostics: [], matched: literalMatched || inputs.some((input) => regex.test(input)) };
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			return {
+				diagnostics: [
+					diagnostic(
+						{
+							code: "invalid_matcher",
+							event: handler.event,
+							message: `Hook matcher is not a valid JavaScript regular expression: ${error.message}`,
+							path: `hooks.${handler.event}[${handler.groupIndex}].matcher`,
+							severity: "warning",
+						},
+						handler.source,
+					),
+				],
+				matched: literalMatched,
+			};
+		}
+		throw error;
+	}
+}
+
+function stripLifecycleMatcher(handler: ExecutableHookHandler): ExecutableHookHandler {
+	return {
+		config: handler.config,
+		event: handler.event,
+		groupIndex: handler.groupIndex,
+		handlerIndex: handler.handlerIndex,
+		source: handler.source,
+	};
+}
+
+function lifecycleResultDetails(
+	event: LifecycleHookEvent,
+	result: HookDispatchResult | undefined,
+): LifecycleResultDetails {
+	if (result === undefined) {
+		return { cancel: false, contexts: [], diagnostics: [] };
+	}
+	const diagnostics = [...result.diagnostics, ...commandFailureDiagnostics(event, result)];
+	const contexts: string[] = [];
+	for (const summary of result.summaries) {
+		const output = readLifecycleHookOutput(event, summary.run.stdout);
+		if (output?.additionalContext !== undefined && event !== "PreCompact") {
+			contexts.push(output.additionalContext);
+		}
+		if (event === "PreCompact") {
+			diagnostics.push(...preCompactUnsupportedDiagnostics(summary.handler, output));
+		}
+	}
+	const reason = event === "PreCompact" && result.decision.kind === "block" ? result.decision.reason : undefined;
+	return {
+		cancel: event === "PreCompact" && result.decision.kind === "block",
+		contexts,
+		diagnostics,
+		...(reason === undefined ? {} : { reason }),
+	};
+}
+
+function commandFailureDiagnostics(event: LifecycleHookEvent, result: HookDispatchResult): readonly HookDiagnostic[] {
+	return result.summaries.flatMap((summary) => {
+		if (summary.run.exitCode === 0 || (summary.run.exitCode === 2 && event === "PreCompact")) return [];
+		const status = summary.run.exitCode === null ? "without an exit code" : `with exit code ${summary.run.exitCode}`;
+		return [
+			diagnostic(
+				{
+					code: "invalid_root",
+					event,
+					message: `Hook command failed ${status}.`,
+					path: "process.exitCode",
+					severity: "warning",
+				},
+				summary.handler.source,
+			),
+		];
+	});
+}
+
+function preCompactUnsupportedDiagnostics(
+	handler: ExecutableHookHandler,
+	output: LifecycleHookOutput | undefined,
+): readonly HookDiagnostic[] {
+	if (output === undefined) return [];
+	const diagnostics: HookDiagnostic[] = [];
+	if (output.additionalContext !== undefined) {
+		diagnostics.push(
+			diagnostic(
+				{
+					code: "unsupported_field",
+					event: "PreCompact",
+					message: "PreCompact additionalContext is diagnostic-only in builtin hooks v1.",
+					path: "stdout.hookSpecificOutput.additionalContext",
+					severity: "warning",
+				},
+				handler.source,
+			),
+		);
+	}
+	if (output.customInstructions !== undefined) {
+		diagnostics.push(
+			diagnostic(
+				{
+					code: "unsupported_field",
+					event: "PreCompact",
+					message: "PreCompact customInstructions cannot mutate compaction in builtin hooks v1.",
+					path: "stdout.hookSpecificOutput.customInstructions",
+					severity: "warning",
+				},
+				handler.source,
+			),
+		);
+	}
+	return diagnostics;
+}
+
+function readLifecycleHookOutput(event: LifecycleHookEvent, stdout: string): LifecycleHookOutput | undefined {
+	const trimmed = stdout.trim();
+	if (trimmed.length === 0) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch (error) {
+		if (error instanceof SyntaxError) return undefined;
+		throw error;
+	}
+	if (!isRecord(parsed)) return undefined;
+	const specific = isRecord(parsed.hookSpecificOutput) ? parsed.hookSpecificOutput : undefined;
+	if (specific?.hookEventName !== undefined && specific.hookEventName !== event) return undefined;
+	return {
+		...textField(specific?.additionalContext ?? parsed.additionalContext, "additionalContext"),
+		...textField(specific?.customInstructions ?? parsed.customInstructions, "customInstructions"),
+		...textField(parsed.decision, "decision"),
+		...textField(specific?.permissionDecisionReason ?? parsed.reason, "reason"),
+	};
+}
+
+function textField<K extends keyof LifecycleHookOutput>(
+	value: unknown,
+	key: K,
+): Pick<LifecycleHookOutput, K> | Record<string, never> {
+	if (typeof value !== "string") return {};
+	const trimmed = value.trim();
+	return trimmed.length === 0 ? {} : ({ [key]: trimmed } as Pick<LifecycleHookOutput, K>);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/matcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/matcher.ts
@@ -1,0 +1,139 @@
+import { diagnostic } from "./diagnostics.ts";
+import type { ExecutableHookHandler, HookDiagnostic, HookInputWire } from "./types.ts";
+
+export type HookMatcherResult = {
+	readonly handlers: readonly ExecutableHookHandler[];
+	readonly diagnostics: readonly HookDiagnostic[];
+};
+
+type MatcherSubject = { readonly kind: "ignored" } | { readonly kind: "inputs"; readonly inputs: readonly string[] };
+
+const TOOL_MATCHER_ALIASES: Readonly<Record<string, readonly string[]>> = {
+	apply_patch: ["ApplyPatch", "functions.apply_patch"],
+	bash: ["Bash", "Shell", "shell", "exec_command", "functions.exec_command"],
+	create_goal: ["CreateGoal"],
+	edit: ["Edit", "MultiEdit", "multi_edit"],
+	find: ["Find", "Glob", "glob", "file_search"],
+	get_goal: ["GetGoal"],
+	grep: ["Grep", "Search", "grep_app"],
+	ls: ["LS", "List", "list"],
+	read: ["Read", "open", "read_file"],
+	todoread: ["TodoRead"],
+	todowrite: ["TodoWrite"],
+	update_goal: ["UpdateGoal"],
+	web_search: ["WebSearch", "web-search"],
+	webfetch: ["WebFetch", "web_fetch", "web-fetch"],
+	write: ["Write", "write_file"],
+} as const;
+
+export function matchingHookHandlers(
+	input: HookInputWire,
+	handlers: readonly ExecutableHookHandler[],
+): HookMatcherResult {
+	const subject = matcherSubject(input);
+	const selected: ExecutableHookHandler[] = [];
+	const diagnostics: HookDiagnostic[] = [];
+
+	for (const handler of handlers) {
+		if (handler.event !== input.event) {
+			continue;
+		}
+		if (subject.kind === "ignored") {
+			selected.push(handler);
+			continue;
+		}
+
+		const match = matchesMatcher(handler, subject.inputs);
+		diagnostics.push(...match.diagnostics);
+		if (match.matched) {
+			selected.push(handler);
+		}
+	}
+
+	return { handlers: selected, diagnostics };
+}
+
+function matcherSubject(input: HookInputWire): MatcherSubject {
+	switch (input.event) {
+		case "UserPromptSubmit":
+		case "Stop":
+			return { kind: "ignored" };
+		case "PreToolUse":
+		case "PostToolUse":
+			return { kind: "inputs", inputs: toolMatcherInputs(input.toolName) };
+		case "SessionStart":
+		case "PreCompact":
+		case "PostCompact":
+			return { kind: "inputs", inputs: [input.event] };
+	}
+}
+
+function toolMatcherInputs(toolName: string): readonly string[] {
+	const values = new Set<string>();
+	addMatcherInput(values, toolName);
+
+	const lowerToolName = toolName.toLowerCase();
+	addMatcherInput(values, lowerToolName);
+	addMatcherInput(values, toClaudeToolName(lowerToolName));
+
+	for (const alias of TOOL_MATCHER_ALIASES[lowerToolName] ?? []) {
+		addMatcherInput(values, alias);
+	}
+
+	return [...values];
+}
+
+function addMatcherInput(values: Set<string>, value: string): void {
+	const trimmed = value.trim();
+	if (trimmed.length > 0) {
+		values.add(trimmed);
+	}
+}
+
+function toClaudeToolName(toolName: string): string {
+	return toolName
+		.split(/[-_]/)
+		.filter((part) => part.length > 0)
+		.map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+		.join("");
+}
+
+function matchesMatcher(
+	handler: ExecutableHookHandler,
+	inputs: readonly string[],
+): { readonly matched: boolean; readonly diagnostics: readonly HookDiagnostic[] } {
+	const matcher = handler.matcher?.trim();
+	if (matcher === undefined || matcher.length === 0 || matcher === "*") {
+		return { matched: true, diagnostics: [] };
+	}
+
+	const literalMatched = matcher
+		.split(/[|,]/)
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0)
+		.some((part) => inputs.includes(part));
+
+	try {
+		const regex = new RegExp(matcher);
+		return { matched: literalMatched || inputs.some((input) => regex.test(input)), diagnostics: [] };
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			return {
+				matched: literalMatched,
+				diagnostics: [
+					diagnostic(
+						{
+							code: "invalid_matcher",
+							event: handler.event,
+							message: `Hook matcher is not a valid JavaScript regular expression: ${error.message}`,
+							path: `hooks.${handler.event}[${handler.groupIndex}].matcher`,
+							severity: "warning",
+						},
+						handler.source,
+					),
+				],
+			};
+		}
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/output-bounds.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/output-bounds.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const DEFAULT_STDOUT_LIMIT_BYTES = 64 * 1024;
+export const DEFAULT_STDERR_LIMIT_BYTES = 64 * 1024;
+
+export type HookOutputPolicy = {
+	readonly maxStdoutBytes?: number;
+	readonly maxStderrBytes?: number;
+	readonly spillDir?: string;
+};
+
+export type HookStreamSafetyMetadata = {
+	readonly originalBytes: number;
+	readonly returnedBytes: number;
+	readonly redacted: boolean;
+	readonly spilled: boolean;
+	readonly truncated: boolean;
+	readonly spillPath?: string;
+};
+
+export type HookOutputSafetyMetadata = {
+	readonly stdout: HookStreamSafetyMetadata;
+	readonly stderr: HookStreamSafetyMetadata;
+};
+
+export type HookSafeOutput = {
+	readonly text: string;
+	readonly safety: HookStreamSafetyMetadata;
+};
+
+export function applyHookOutputSafety(
+	stream: "stderr" | "stdout",
+	text: string,
+	policy: HookOutputPolicy | undefined,
+	capture?: { readonly originalBytes: number; readonly truncated: boolean },
+): HookSafeOutput {
+	const originalBytes = capture?.originalBytes ?? Buffer.byteLength(text);
+	const redactedText = redactHookOutput(text);
+	const redacted = redactedText !== text;
+	const limit = stream === "stdout" ? policy?.maxStdoutBytes : policy?.maxStderrBytes;
+	const maxBytes = limit ?? (stream === "stdout" ? DEFAULT_STDOUT_LIMIT_BYTES : DEFAULT_STDERR_LIMIT_BYTES);
+	const redactedBytes = Buffer.byteLength(redactedText);
+	const truncated = capture?.truncated === true || redactedBytes > maxBytes;
+	const spillPath = truncated ? spillRedactedOutput(stream, redactedText, policy) : undefined;
+	const returnedText = truncated ? Buffer.from(redactedText).subarray(0, maxBytes).toString("utf8") : redactedText;
+	return {
+		safety: {
+			originalBytes,
+			redacted,
+			returnedBytes: Buffer.byteLength(returnedText),
+			spilled: spillPath !== undefined,
+			...(spillPath === undefined ? {} : { spillPath }),
+			truncated,
+		},
+		text: returnedText,
+	};
+}
+
+function redactHookOutput(text: string): string {
+	return text
+		.replace(/\b([A-Z][A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD|AUTH)[A-Z0-9_]*)=([^\s'"]+)/g, "$1=[REDACTED]")
+		.replace(/\b(Authorization:\s*Bearer\s+)([^\s'"]+)/gi, "$1[REDACTED]")
+		.replace(/\b(Bearer\s+)(sk-[A-Za-z0-9._-]+)/g, "$1[REDACTED]");
+}
+
+function spillRedactedOutput(stream: "stderr" | "stdout", text: string, policy: HookOutputPolicy | undefined): string {
+	const spillDir = policy?.spillDir ?? join(tmpdir(), "senpi-hook-output");
+	mkdirSync(spillDir, { recursive: true });
+	const path = join(spillDir, `hook-${stream}-${process.pid}-${randomUUID()}.txt`);
+	writeFileSync(path, text);
+	return path;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/output-bounds.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/output-bounds.ts
@@ -60,10 +60,18 @@ export function applyHookOutputSafety(
 }
 
 function redactHookOutput(text: string): string {
+	return redactHookTokenValues(
+		text
+			.replace(/\b([A-Z][A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD|AUTH)[A-Z0-9_]*)=([^\s'"]+)/g, "$1=[REDACTED]")
+			.replace(/\b(Authorization:\s*Bearer\s+)([^\s'"]+)/gi, "$1[REDACTED]")
+			.replace(/\b(Bearer\s+)(sk-[A-Za-z0-9._-]+)/g, "$1[REDACTED]"),
+	);
+}
+
+export function redactHookTokenValues(text: string, replacement = "[REDACTED]"): string {
 	return text
-		.replace(/\b([A-Z][A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD|AUTH)[A-Z0-9_]*)=([^\s'"]+)/g, "$1=[REDACTED]")
-		.replace(/\b(Authorization:\s*Bearer\s+)([^\s'"]+)/gi, "$1[REDACTED]")
-		.replace(/\b(Bearer\s+)(sk-[A-Za-z0-9._-]+)/g, "$1[REDACTED]");
+		.replace(/\bghp_[A-Za-z0-9]{20,}\b/g, replacement)
+		.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, replacement);
 }
 
 function spillRedactedOutput(stream: "stderr" | "stdout", text: string, policy: HookOutputPolicy | undefined): string {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/output-parser.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/output-parser.ts
@@ -1,0 +1,256 @@
+import { diagnostic } from "./diagnostics.ts";
+import type { HookDiagnostic, HookSourceMetadata, SupportedHookEvent } from "./types.ts";
+
+export type HookOutputParseInput = {
+	readonly event: SupportedHookEvent;
+	readonly exitCode: number;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly source: HookSourceMetadata;
+};
+
+type HookDecision = "allow" | "approve" | "ask" | "block" | "deny";
+type MutableHookOutput = {
+	decision?: HookDecision;
+	reason?: string;
+	additionalContext?: string;
+	updatedInput?: unknown;
+	updatedToolOutput?: unknown;
+	continue?: boolean;
+	stopReason?: string;
+	suppressOutput?: boolean;
+	systemMessage?: string;
+};
+
+export type ParsedHookOutput = {
+	readonly output: Readonly<MutableHookOutput>;
+	readonly diagnostics: readonly HookDiagnostic[];
+};
+
+type ParseState = {
+	readonly input: HookOutputParseInput;
+	readonly output: MutableHookOutput;
+	readonly diagnostics: HookDiagnostic[];
+};
+
+const SYSTEM_MESSAGE_EVENTS = new Set<SupportedHookEvent>([
+	"PreToolUse",
+	"PostToolUse",
+	"UserPromptSubmit",
+	"SessionStart",
+	"Stop",
+]);
+
+export function parseHookOutput(input: HookOutputParseInput): ParsedHookOutput {
+	const state: ParseState = { input, output: {}, diagnostics: [] };
+	const stderr = text(input.stderr);
+	if (input.exitCode === 2) {
+		return { output: { decision: "block", ...(stderr === undefined ? {} : { reason: stderr }) }, diagnostics: [] };
+	}
+	const stdout = input.stdout.trim();
+	if (stdout.length === 0) return parsedOutput(state);
+	const parsed = parseStdoutJson(stdout, state);
+	if (!isRecord(parsed)) return parsedOutput(state);
+	parseUniversal(parsed, state);
+	const specific = parseSpecific(parsed.hookSpecificOutput, state);
+	if (specific === "mismatched" || specific === "invalid") return parsedOutput(state);
+	parseEvent(parsed, specific, state);
+	return parsedOutput(state);
+}
+
+function parseStdoutJson(stdout: string, state: ParseState): unknown {
+	try {
+		const parsed: unknown = JSON.parse(stdout);
+		if (isRecord(parsed)) return parsed;
+		add(state, "invalid_root", "stdout", "Hook stdout JSON must be an object.");
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+		add(state, "invalid_root", "stdout", "Hook stdout must be valid JSON.");
+	}
+	return undefined;
+}
+
+function parseUniversal(parsed: Record<string, unknown>, state: ParseState): void {
+	if (typeof parsed.continue === "boolean") {
+		state.output.continue = parsed.continue;
+		if (state.input.event === "Stop" && parsed.continue === false) state.output.decision = "block";
+	}
+	copyText(parsed.stopReason, "stopReason", state);
+	if (typeof parsed.suppressOutput === "boolean") state.output.suppressOutput = parsed.suppressOutput;
+	if (parsed.systemMessage === undefined) return;
+	if (SYSTEM_MESSAGE_EVENTS.has(state.input.event)) {
+		copyText(parsed.systemMessage, "systemMessage", state);
+		return;
+	}
+	add(
+		state,
+		"unsupported_field",
+		"stdout.systemMessage",
+		"Hook systemMessage is not supported for this event.",
+		"warning",
+	);
+}
+
+function parseSpecific(
+	value: unknown,
+	state: ParseState,
+): Record<string, unknown> | "invalid" | "mismatched" | undefined {
+	if (value === undefined) return undefined;
+	if (!isRecord(value)) {
+		add(
+			state,
+			"invalid_event_config",
+			"stdout.hookSpecificOutput",
+			"Hook hookSpecificOutput field must be an object.",
+		);
+		return "invalid";
+	}
+	const eventName = value.hookEventName;
+	if (eventName === undefined || eventName === state.input.event) return value;
+	add(
+		state,
+		"invalid_event_config",
+		"stdout.hookSpecificOutput.hookEventName",
+		`Hook output event ${String(eventName)} does not match ${state.input.event}.`,
+	);
+	return "mismatched";
+}
+
+function parseEvent(
+	parsed: Record<string, unknown>,
+	specific: Record<string, unknown> | undefined,
+	state: ParseState,
+): void {
+	switch (state.input.event) {
+		case "PreToolUse":
+			parsePreToolUse(parsed, specific, state);
+			return;
+		case "PostToolUse":
+			blockOnlyDecision(parsed.decision, "PostToolUse", state);
+			copyText(parsed.reason, "reason", state);
+			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
+			copyUnknown(specific?.updatedToolOutput ?? parsed.updatedToolOutput, "updatedToolOutput", state);
+			return;
+		case "UserPromptSubmit":
+			blockOnlyDecision(parsed.decision, "UserPromptSubmit", state);
+			copyText(parsed.reason, "reason", state);
+			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
+			rejectPromptReplacement(specific, state);
+			return;
+		case "Stop":
+			if (parsed.decision === "block") state.output.decision = "block";
+			else if (parsed.decision !== undefined && parsed.decision !== "continue") {
+				add(
+					state,
+					"unsupported_field",
+					"stdout.decision",
+					"Stop only supports decision block or continue.",
+					"warning",
+				);
+			}
+			copyText(parsed.reason, "reason", state);
+			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
+			return;
+		case "SessionStart":
+			copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
+			if (parsed.decision !== undefined) {
+				add(state, "unsupported_field", "stdout.decision", "SessionStart does not support decisions.", "warning");
+			}
+			return;
+		case "PreCompact":
+		case "PostCompact":
+			return;
+	}
+}
+
+function parsePreToolUse(
+	parsed: Record<string, unknown>,
+	specific: Record<string, unknown> | undefined,
+	state: ParseState,
+): void {
+	const decision = preToolUseDecision(specific?.permissionDecision ?? parsed.decision);
+	if (decision !== undefined) state.output.decision = decision;
+	copyText(specific?.permissionDecisionReason ?? parsed.reason, "reason", state);
+	copyText(specific?.additionalContext ?? parsed.additionalContext, "additionalContext", state);
+	const updatedInput = specific?.updatedInput ?? parsed.updatedInput;
+	if (updatedInput === undefined) return;
+	if (specific?.permissionDecision === "allow") {
+		state.output.updatedInput = updatedInput;
+		return;
+	}
+	add(
+		state,
+		"unsupported_field",
+		"stdout.hookSpecificOutput.updatedInput",
+		"PreToolUse updatedInput is only applied when permissionDecision is allow.",
+		"warning",
+	);
+}
+
+function blockOnlyDecision(value: unknown, event: string, state: ParseState): void {
+	if (value === "block") state.output.decision = "block";
+	else if (value !== undefined)
+		add(state, "unsupported_field", "stdout.decision", `${event} only supports decision block.`, "warning");
+}
+
+function rejectPromptReplacement(specific: Record<string, unknown> | undefined, state: ParseState): void {
+	for (const field of ["prompt", "updatedPrompt", "replacementPrompt"]) {
+		if (specific !== undefined && Object.hasOwn(specific, field)) {
+			add(
+				state,
+				"unsupported_field",
+				`stdout.hookSpecificOutput.${field}`,
+				"UserPromptSubmit prompt replacement is not supported.",
+				"warning",
+			);
+		}
+	}
+}
+
+function preToolUseDecision(value: unknown): HookDecision | undefined {
+	if (value === "allow" || value === "approve" || value === "ask") return value;
+	if (value === "deny" || value === "block") return "deny";
+	return undefined;
+}
+
+function copyText(
+	value: unknown,
+	field: "additionalContext" | "reason" | "stopReason" | "systemMessage",
+	state: ParseState,
+): void {
+	const normalized = text(value);
+	if (normalized !== undefined) state.output[field] = normalized;
+}
+
+function copyUnknown(value: unknown, field: "updatedToolOutput", state: ParseState): void {
+	if (value !== undefined) state.output[field] = value;
+}
+
+function add(
+	state: ParseState,
+	code: "invalid_event_config" | "invalid_root" | "unsupported_field",
+	path: string,
+	message: string,
+	severity?: "error" | "warning",
+): void {
+	state.diagnostics.push(
+		diagnostic(
+			{ code, event: state.input.event, message, path, ...(severity === undefined ? {} : { severity }) },
+			state.input.source,
+		),
+	);
+}
+
+function text(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length === 0 ? undefined : trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsedOutput(state: ParseState): ParsedHookOutput {
+	return { output: state.output, diagnostics: state.diagnostics };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-loader.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-loader.ts
@@ -15,6 +15,7 @@ import {
 	resolveContainedPath,
 	sourceForPath,
 } from "./plugin-manifest.ts";
+import { validateHookHandlerSafety } from "./safety.ts";
 import { parseHookConfig } from "./schema.ts";
 import type { ExecutableHookHandler, HookDiagnostic, ParsedHookConfig } from "./types.ts";
 
@@ -194,7 +195,14 @@ function parseDrafts(
 		});
 		sources.push(source);
 		const parsed = parseHookConfig(draft.config, source);
-		executableHandlers.push(...parsed.executableHandlers);
+		for (const handler of parsed.executableHandlers) {
+			const safetyDiagnostics = validateHookHandlerSafety(handler);
+			if (safetyDiagnostics.length === 0) {
+				executableHandlers.push(handler);
+			} else {
+				parseDiagnostics.push(...safetyDiagnostics);
+			}
+		}
 		parseDiagnostics.push(...parsed.diagnostics);
 	}
 

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-loader.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-loader.ts
@@ -1,0 +1,218 @@
+import { join, resolve } from "node:path";
+import { diagnostic } from "./diagnostics.ts";
+import {
+	buildPluginEnv,
+	DEFAULT_HOOK_PATH,
+	directoryExists,
+	fileExists,
+	isRecord,
+	type LoadPluginHookManifestOptions,
+	MANIFEST_PATH,
+	type PluginHookEnv,
+	type PluginHookSourceMetadata,
+	pluginSource,
+	readJsonFile,
+	resolveContainedPath,
+	sourceForPath,
+} from "./plugin-manifest.ts";
+import { parseHookConfig } from "./schema.ts";
+import type { ExecutableHookHandler, HookDiagnostic, ParsedHookConfig } from "./types.ts";
+
+export type { LoadPluginHookManifestOptions, PluginHookEnv, PluginHookSourceMetadata } from "./plugin-manifest.ts";
+
+export type PluginHookManifestLoadResult = {
+	readonly sources: readonly PluginHookSourceMetadata[];
+	readonly parsed: ParsedHookConfig;
+	readonly diagnostics: readonly HookDiagnostic[];
+};
+
+type HookSourceDraft = {
+	readonly key: string;
+	readonly config: unknown;
+};
+
+export function loadPluginHookManifest(options: LoadPluginHookManifestOptions): PluginHookManifestLoadResult {
+	const pluginRoot = resolve(options.pluginRoot);
+	const manifestPath = join(pluginRoot, MANIFEST_PATH);
+	const env = buildPluginEnv(pluginRoot, options.dataRoot);
+	const discoveredAt = options.discoveredAt ?? "pre-session";
+	const diagnostics: HookDiagnostic[] = [];
+	const drafts: HookSourceDraft[] = [];
+
+	if (!directoryExists(pluginRoot)) {
+		const source = pluginSource({
+			discoveredAt,
+			displayOrder: options.displayOrder,
+			env,
+			manifestPath,
+			pluginRoot,
+			sourcePath: manifestPath,
+		});
+		diagnostics.push(
+			diagnostic(
+				{ code: "invalid_root", message: `Plugin root does not exist: ${pluginRoot}`, path: "$.pluginRoot" },
+				source,
+			),
+		);
+		return emptyResult(diagnostics);
+	}
+
+	if (fileExists(manifestPath)) {
+		const manifest = readJsonFile(manifestPath, manifestPath, sourceForPath(options, env, manifestPath));
+		if (manifest.ok) {
+			drafts.push(...readManifestHookDrafts(manifest.value, options, env, manifestPath, diagnostics));
+		} else {
+			diagnostics.push(manifest.diagnostic);
+		}
+	}
+
+	const defaultPath = resolveContainedPath(pluginRoot, DEFAULT_HOOK_PATH);
+	if (options.includeDefaultHooks !== false && defaultPath.ok && fileExists(defaultPath.path)) {
+		const source = sourceForPath(options, env, defaultPath.path);
+		const config = readJsonFile(defaultPath.path, manifestPath, source);
+		if (config.ok) {
+			drafts.push({ config: config.value, key: defaultPath.path });
+		} else {
+			diagnostics.push(config.diagnostic);
+		}
+	}
+
+	return parseDrafts(drafts, options, env, manifestPath, diagnostics);
+}
+
+export function selectHookCommandForPlatform(
+	handler: ExecutableHookHandler,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (platform === "win32" && handler.config.commandWindows !== undefined) {
+		return handler.config.commandWindows;
+	}
+	return handler.config.command;
+}
+
+function readManifestHookDrafts(
+	manifest: unknown,
+	options: LoadPluginHookManifestOptions,
+	env: PluginHookEnv,
+	manifestPath: string,
+	diagnostics: HookDiagnostic[],
+): HookSourceDraft[] {
+	if (!isRecord(manifest)) {
+		diagnostics.push(
+			diagnostic(
+				{ code: "invalid_root", message: "Plugin manifest must be an object.", path: "$" },
+				sourceForPath(options, env, manifestPath),
+			),
+		);
+		return [];
+	}
+
+	const hooks = manifest.hooks;
+	if (hooks === undefined) {
+		return [];
+	}
+	return normalizeHookDrafts(hooks, "$.hooks", options, env, manifestPath, diagnostics);
+}
+
+function normalizeHookDrafts(
+	value: unknown,
+	path: string,
+	options: LoadPluginHookManifestOptions,
+	env: PluginHookEnv,
+	manifestPath: string,
+	diagnostics: HookDiagnostic[],
+): HookSourceDraft[] {
+	if (typeof value === "string") {
+		const resolved = resolveContainedPath(options.pluginRoot, value);
+		if (!resolved.ok) {
+			diagnostics.push(
+				diagnostic(
+					{ code: "invalid_root", message: resolved.message, path },
+					sourceForPath(options, env, manifestPath),
+				),
+			);
+			return [];
+		}
+		if (!fileExists(resolved.path)) {
+			diagnostics.push(
+				diagnostic(
+					{ code: "invalid_root", message: `Plugin hook file does not exist: ${resolved.path}`, path },
+					sourceForPath(options, env, resolved.path),
+				),
+			);
+			return [];
+		}
+		const source = sourceForPath(options, env, resolved.path);
+		const parsed = readJsonFile(resolved.path, manifestPath, source);
+		if (parsed.ok) {
+			return [{ config: parsed.value, key: resolved.path }];
+		}
+		diagnostics.push(parsed.diagnostic);
+		return [];
+	}
+
+	if (Array.isArray(value)) {
+		const drafts: HookSourceDraft[] = [];
+		for (const [index, item] of value.entries()) {
+			drafts.push(...normalizeHookDrafts(item, `${path}[${index}]`, options, env, manifestPath, diagnostics));
+		}
+		return drafts;
+	}
+
+	if (isRecord(value)) {
+		return [{ config: value, key: `${manifestPath}#${inlineKeyPath(path)}` }];
+	}
+
+	diagnostics.push(
+		diagnostic(
+			{ code: "invalid_root", message: "Plugin manifest hooks must be a path or hook object.", path },
+			sourceForPath(options, env, manifestPath),
+		),
+	);
+	return [];
+}
+
+function parseDrafts(
+	drafts: readonly HookSourceDraft[],
+	options: LoadPluginHookManifestOptions,
+	env: PluginHookEnv,
+	manifestPath: string,
+	diagnostics: HookDiagnostic[],
+): PluginHookManifestLoadResult {
+	const sources: PluginHookSourceMetadata[] = [];
+	const executableHandlers: ExecutableHookHandler[] = [];
+	const parseDiagnostics: HookDiagnostic[] = [];
+
+	for (const [index, draft] of drafts.entries()) {
+		const source = pluginSource({
+			discoveredAt: options.discoveredAt ?? "pre-session",
+			displayOrder: options.displayOrder + index,
+			env,
+			manifestPath,
+			pluginRoot: resolve(options.pluginRoot),
+			sourcePath: draft.key,
+		});
+		sources.push(source);
+		const parsed = parseHookConfig(draft.config, source);
+		executableHandlers.push(...parsed.executableHandlers);
+		parseDiagnostics.push(...parsed.diagnostics);
+	}
+
+	return {
+		diagnostics: [...diagnostics, ...parseDiagnostics],
+		parsed: { diagnostics: parseDiagnostics, executableHandlers },
+		sources,
+	};
+}
+
+function emptyResult(diagnostics: readonly HookDiagnostic[]): PluginHookManifestLoadResult {
+	return {
+		diagnostics,
+		parsed: { diagnostics, executableHandlers: [] },
+		sources: [],
+	};
+}
+
+function inlineKeyPath(path: string): string {
+	return path.replace(/^\$\.?/, "");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-manifest.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/plugin-manifest.ts
@@ -1,0 +1,135 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { diagnostic } from "./diagnostics.ts";
+import type { HookDiagnostic, HookDiscoveryTiming, HookSourceMetadata } from "./types.ts";
+
+export const MANIFEST_PATH = ".codex-plugin/plugin.json";
+export const DEFAULT_HOOK_PATH = "hooks/hooks.json";
+
+export type PluginHookEnv = {
+	readonly PLUGIN_ROOT: string;
+	readonly PLUGIN_DATA: string;
+	readonly CLAUDE_PLUGIN_ROOT: string;
+	readonly CLAUDE_PLUGIN_DATA: string;
+};
+
+export type PluginHookSourceMetadata = HookSourceMetadata & {
+	readonly pluginEnv: PluginHookEnv;
+};
+
+export type LoadPluginHookManifestOptions = {
+	readonly pluginRoot: string;
+	readonly displayOrder: number;
+	readonly discoveredAt?: HookDiscoveryTiming;
+	readonly dataRoot?: string;
+	readonly includeDefaultHooks?: boolean;
+};
+
+export function buildPluginEnv(pluginRoot: string, dataRoot: string | undefined): PluginHookEnv {
+	const pluginData = dataRoot === undefined ? join(pluginRoot, ".plugin-data") : resolve(dataRoot);
+	return {
+		CLAUDE_PLUGIN_DATA: pluginData,
+		CLAUDE_PLUGIN_ROOT: pluginRoot,
+		PLUGIN_DATA: pluginData,
+		PLUGIN_ROOT: pluginRoot,
+	};
+}
+
+export function pluginSource(input: {
+	readonly discoveredAt: HookDiscoveryTiming;
+	readonly displayOrder: number;
+	readonly env: PluginHookEnv;
+	readonly manifestPath: string;
+	readonly pluginRoot: string;
+	readonly sourcePath: string;
+}): PluginHookSourceMetadata {
+	return {
+		discoveredAt: input.discoveredAt,
+		displayOrder: input.displayOrder,
+		manifestPath: input.manifestPath,
+		pluginEnv: input.env,
+		pluginRoot: input.pluginRoot,
+		scope: "plugin",
+		sourcePath: input.sourcePath,
+	};
+}
+
+export function sourceForPath(
+	options: LoadPluginHookManifestOptions,
+	env: PluginHookEnv,
+	sourcePath: string,
+): PluginHookSourceMetadata {
+	const pluginRoot = resolve(options.pluginRoot);
+	return pluginSource({
+		discoveredAt: options.discoveredAt ?? "pre-session",
+		displayOrder: options.displayOrder,
+		env,
+		manifestPath: join(pluginRoot, MANIFEST_PATH),
+		pluginRoot,
+		sourcePath,
+	});
+}
+
+export function resolveContainedPath(
+	pluginRootInput: string,
+	manifestPathInput: string,
+): { readonly ok: true; readonly path: string } | { readonly ok: false; readonly message: string } {
+	const pluginRoot = resolve(pluginRootInput);
+	const normalizedInput = manifestPathInput.replaceAll("\\", "/").replace(/^\.\//, "");
+	const resolvedPath = isAbsolute(normalizedInput) ? resolve(normalizedInput) : resolve(pluginRoot, normalizedInput);
+	if (!isContained(pluginRoot, resolvedPath)) {
+		return {
+			message: `Plugin hook path is outside plugin root: ${manifestPathInput}`,
+			ok: false,
+		};
+	}
+	if (fileExists(resolvedPath)) {
+		const realPath = realpathSync(resolvedPath);
+		if (!isContained(realpathSync(pluginRoot), realPath)) {
+			return {
+				message: `Plugin hook path is outside plugin root: ${manifestPathInput}`,
+				ok: false,
+			};
+		}
+	}
+	return { ok: true, path: resolvedPath };
+}
+
+export function readJsonFile(
+	path: string,
+	manifestPath: string,
+	source: PluginHookSourceMetadata,
+): { readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly diagnostic: HookDiagnostic } {
+	try {
+		const value: unknown = JSON.parse(readFileSync(path, "utf-8"));
+		return { ok: true, value };
+	} catch (error) {
+		if (error instanceof Error) {
+			return {
+				diagnostic: diagnostic(
+					{ code: "invalid_root", message: `Could not read plugin hook JSON: ${error.message}`, path: "$" },
+					{ ...source, manifestPath },
+				),
+				ok: false,
+			};
+		}
+		throw error;
+	}
+}
+
+export function fileExists(path: string): boolean {
+	return existsSync(path) && statSync(path).isFile();
+}
+
+export function directoryExists(path: string): boolean {
+	return existsSync(path) && statSync(path).isDirectory();
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isContained(root: string, target: string): boolean {
+	const rel = relative(root, target);
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/prompt-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/prompt-adapter.ts
@@ -1,0 +1,85 @@
+import type { HookDispatchResult } from "./dispatcher.ts";
+import type { HookDiagnostic, HookInputWire } from "./types.ts";
+
+export const HOOK_CUSTOM_MESSAGE_TYPE = "senpi.hook";
+export const USER_PROMPT_BLOCK_REASON = "UserPromptSubmit hook blocked the prompt.";
+
+export type UserPromptHookInputOptions = {
+	readonly cwd: string;
+	readonly permissionMode: string;
+	readonly prompt: string;
+	readonly sessionId: string;
+	readonly transcriptPath?: string;
+};
+
+export type PendingPromptHookContext = {
+	readonly additionalContext: readonly string[];
+	readonly diagnostics: readonly HookDiagnostic[];
+	readonly systemMessages: readonly string[];
+};
+
+export function buildUserPromptHookInput(options: UserPromptHookInputOptions): HookInputWire {
+	return {
+		cwd: options.cwd,
+		event: "UserPromptSubmit",
+		permission_mode: options.permissionMode,
+		prompt: options.prompt,
+		session_id: options.sessionId,
+		...(options.transcriptPath === undefined ? {} : { transcript_path: options.transcriptPath }),
+	};
+}
+
+export function promptContextFromResult(result: HookDispatchResult): PendingPromptHookContext | undefined {
+	const additionalContext: string[] = [];
+	const systemMessages: string[] = [];
+	for (const summary of result.summaries) {
+		const context = summary.output.additionalContext;
+		if (context !== undefined) additionalContext.push(context);
+		const systemMessage = summary.output.systemMessage;
+		if (systemMessage !== undefined) systemMessages.push(systemMessage);
+	}
+	if (additionalContext.length === 0 && systemMessages.length === 0 && result.diagnostics.length === 0) {
+		return undefined;
+	}
+	return { additionalContext, diagnostics: result.diagnostics, systemMessages };
+}
+
+export function promptBlockReasonFromResult(result: HookDispatchResult): string {
+	if (result.decision.kind !== "block") return USER_PROMPT_BLOCK_REASON;
+	const sourcePath = result.decision.source.sourcePath;
+	const blocker = result.summaries.find(
+		(summary) =>
+			(summary.output.decision === "block" || summary.output.decision === "deny") &&
+			summary.handler.source.sourcePath === sourcePath,
+	);
+	if (blocker?.run.exitCode === 2) return USER_PROMPT_BLOCK_REASON;
+	return result.decision.reason ?? USER_PROMPT_BLOCK_REASON;
+}
+
+export function formatPromptContextMessage(pending: PendingPromptHookContext): string | undefined {
+	if (pending.additionalContext.length === 0) return undefined;
+	return pending.additionalContext.join("\n\n");
+}
+
+export function appendSystemMessages(systemPrompt: string, messages: readonly string[]): string {
+	if (messages.length === 0) return systemPrompt;
+	return `${systemPrompt}\n\n${messages.join("\n\n")}`;
+}
+
+export function safeDiagnosticDetails(diagnostic: HookDiagnostic): {
+	readonly code: HookDiagnostic["code"];
+	readonly event?: string;
+	readonly message: string;
+	readonly path: string;
+	readonly severity: HookDiagnostic["severity"];
+	readonly sourcePath: string;
+} {
+	return {
+		code: diagnostic.code,
+		...(diagnostic.event === undefined ? {} : { event: diagnostic.event }),
+		message: diagnostic.message,
+		path: diagnostic.path,
+		severity: diagnostic.severity,
+		sourcePath: diagnostic.source.sourcePath,
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts
@@ -46,7 +46,18 @@ type PluginRootTarget = {
 };
 
 export function resolveHookTimeoutSeconds(handler: ExecutableHookHandler): number {
-	return handler.config.timeout ?? DEFAULT_HOOK_TIMEOUT_SECONDS;
+	const timeout = handler.config.timeout;
+	if (timeout === undefined) {
+		return DEFAULT_HOOK_TIMEOUT_SECONDS;
+	}
+	if (!isValidHookTimeoutSeconds(timeout)) {
+		throw new Error("Invalid command hook timeout reached runtime execution.");
+	}
+	return timeout;
+}
+
+export function isValidHookTimeoutSeconds(timeout: number): boolean {
+	return Number.isFinite(timeout) && timeout > 0;
 }
 
 export function buildHookEnvironment(options: HookEnvironmentOptions): NodeJS.ProcessEnv {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/safety.ts
@@ -1,0 +1,219 @@
+import { existsSync, realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { diagnostic } from "./diagnostics.ts";
+import type { PluginHookEnv } from "./plugin-manifest.ts";
+import type { ExecutableHookHandler, HookDiagnostic, HookInputWire, HookSourceMetadata } from "./types.ts";
+
+export {
+	applyHookOutputSafety,
+	DEFAULT_STDERR_LIMIT_BYTES,
+	DEFAULT_STDOUT_LIMIT_BYTES,
+	type HookOutputPolicy,
+	type HookOutputSafetyMetadata,
+	type HookSafeOutput,
+	type HookStreamSafetyMetadata,
+} from "./output-bounds.ts";
+
+export const DEFAULT_HOOK_TIMEOUT_SECONDS = 600;
+
+const MINIMAL_INHERITED_ENV = [
+	"PATH",
+	"HOME",
+	"USER",
+	"USERNAME",
+	"LOGNAME",
+	"SHELL",
+	"TMPDIR",
+	"TMP",
+	"TEMP",
+	"SystemRoot",
+	"ComSpec",
+	"PATHEXT",
+] as const;
+const PLUGIN_ROOT_TEMPLATE_TOKEN = "$" + "{PLUGIN_ROOT}";
+const PLUGIN_ROOT_TOKENS = [PLUGIN_ROOT_TEMPLATE_TOKEN, "$PLUGIN_ROOT", "%PLUGIN_ROOT%"] as const;
+
+type HookEnvironmentOptions = {
+	readonly handler: ExecutableHookHandler;
+	readonly input: HookInputWire;
+	readonly sourceEnv: NodeJS.ProcessEnv;
+	readonly envPassthrough?: readonly string[];
+};
+
+type PluginRootTarget = {
+	readonly raw: string;
+	readonly resolvedPath: string;
+};
+
+export function resolveHookTimeoutSeconds(handler: ExecutableHookHandler): number {
+	return handler.config.timeout ?? DEFAULT_HOOK_TIMEOUT_SECONDS;
+}
+
+export function buildHookEnvironment(options: HookEnvironmentOptions): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const key of MINIMAL_INHERITED_ENV) {
+		const value = options.sourceEnv[key];
+		if (value !== undefined) env[key] = value;
+	}
+	for (const key of options.envPassthrough ?? []) {
+		const value = options.sourceEnv[key];
+		if (value !== undefined) env[key] = value;
+	}
+	const pluginEnv = pluginEnvForSource(options.handler.source);
+	if (pluginEnv !== undefined) {
+		env.PLUGIN_ROOT = pluginEnv.PLUGIN_ROOT;
+		env.PLUGIN_DATA = pluginEnv.PLUGIN_DATA;
+		env.CLAUDE_PLUGIN_ROOT = pluginEnv.CLAUDE_PLUGIN_ROOT;
+		env.CLAUDE_PLUGIN_DATA = pluginEnv.CLAUDE_PLUGIN_DATA;
+	}
+	env.SENPI_HOOK_SOURCE = options.handler.source.sourcePath;
+	env.SENPI_HOOK_EVENT = options.input.event;
+	return env;
+}
+
+export function validateHookHandlerSafety(handler: ExecutableHookHandler): readonly HookDiagnostic[] {
+	if (handler.source.scope !== "plugin" || handler.source.pluginRoot === undefined) return [];
+	return [
+		...validateCommandField(handler, "command", handler.config.command),
+		...(handler.config.commandWindows === undefined
+			? []
+			: validateCommandField(handler, "commandWindows", handler.config.commandWindows)),
+	];
+}
+
+function validateCommandField(
+	handler: ExecutableHookHandler,
+	field: "command" | "commandWindows",
+	command: string,
+): readonly HookDiagnostic[] {
+	const diagnostics: HookDiagnostic[] = [];
+	for (const target of extractPluginRootTargets(command, handler.source.pluginRoot ?? "")) {
+		const path = `hooks.${handler.event}[${handler.groupIndex}].hooks[${handler.handlerIndex}].${field}`;
+		if (!isContained(resolve(handler.source.pluginRoot ?? ""), target.resolvedPath)) {
+			diagnostics.push(
+				diagnostic(
+					{
+						code: "invalid_command_target",
+						event: handler.event,
+						message: `Plugin command target is outside plugin root: ${target.raw}`,
+						path,
+					},
+					handler.source,
+				),
+			);
+			continue;
+		}
+		if (!existsSync(target.resolvedPath)) {
+			diagnostics.push(
+				diagnostic(
+					{
+						code: "missing_command_target",
+						event: handler.event,
+						message: `Plugin command target does not exist: ${target.raw}`,
+						path,
+					},
+					handler.source,
+				),
+			);
+			continue;
+		}
+		const realTarget = realpathSync(target.resolvedPath);
+		const realRoot = realpathSync(resolve(handler.source.pluginRoot ?? ""));
+		if (!isContained(realRoot, realTarget)) {
+			diagnostics.push(
+				diagnostic(
+					{
+						code: "invalid_command_target",
+						event: handler.event,
+						message: `Plugin command target resolves outside plugin root: ${target.raw}`,
+						path,
+					},
+					handler.source,
+				),
+			);
+		}
+	}
+	return diagnostics;
+}
+
+function extractPluginRootTargets(command: string, pluginRoot: string): readonly PluginRootTarget[] {
+	const targets: PluginRootTarget[] = [];
+	for (const word of readCommandWords(command)) {
+		for (const token of PLUGIN_ROOT_TOKENS) {
+			if (!word.expanded.includes(token)) continue;
+			const expanded = word.expanded.replaceAll(token, pluginRoot).replaceAll("\\", "/");
+			targets.push({ raw: word.raw, resolvedPath: resolve(expanded) });
+		}
+	}
+	return targets;
+}
+
+function readCommandWords(command: string): readonly { readonly expanded: string; readonly raw: string }[] {
+	const words: { readonly expanded: string; readonly raw: string }[] = [];
+	let index = 0;
+	while (index < command.length) {
+		while (index < command.length && isCommandWordTerminator(command[index])) index += 1;
+		if (index >= command.length) break;
+
+		const start = index;
+		let expanded = "";
+		while (index < command.length && !isCommandWordTerminator(command[index])) {
+			const char = command[index];
+			if (char === "'" || char === '"' || char === "`") {
+				const quote = char;
+				index += 1;
+				while (index < command.length && command[index] !== quote) {
+					expanded += command[index];
+					index += 1;
+				}
+				if (command[index] === quote) index += 1;
+				continue;
+			}
+			expanded += char;
+			index += 1;
+		}
+		words.push({ expanded, raw: command.slice(start, index) });
+	}
+	return words;
+}
+
+function isCommandWordTerminator(char: string | undefined): boolean {
+	return (
+		char === undefined ||
+		char === " " ||
+		char === "\t" ||
+		char === "\n" ||
+		char === ";" ||
+		char === "&" ||
+		char === "|" ||
+		char === "<" ||
+		char === ">" ||
+		char === ")"
+	);
+}
+
+function isContained(root: string, target: string): boolean {
+	const rel = relative(root, target);
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function pluginEnvForSource(source: HookSourceMetadata): PluginHookEnv | undefined {
+	if (!("pluginEnv" in source)) return undefined;
+	const pluginEnv = source.pluginEnv;
+	if (!isPluginHookEnv(pluginEnv)) return undefined;
+	return pluginEnv;
+}
+
+function isPluginHookEnv(value: unknown): value is PluginHookEnv {
+	return (
+		isRecord(value) &&
+		typeof value.PLUGIN_ROOT === "string" &&
+		typeof value.PLUGIN_DATA === "string" &&
+		typeof value.CLAUDE_PLUGIN_ROOT === "string" &&
+		typeof value.CLAUDE_PLUGIN_DATA === "string"
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/schema.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/schema.ts
@@ -1,0 +1,157 @@
+import { diagnostic } from "./diagnostics.ts";
+import { parseHandler } from "./handler.ts";
+import type {
+	ExecutableHookHandler,
+	HookDiagnostic,
+	HookSourceMetadata,
+	ParsedHookConfig,
+	SupportedHookEvent,
+} from "./types.ts";
+import { SUPPORTED_HOOK_EVENTS, UNSUPPORTED_KNOWN_HOOK_EVENTS } from "./types.ts";
+
+const SUPPORTED_EVENT_SET = new Set<string>(SUPPORTED_HOOK_EVENTS);
+const UNSUPPORTED_EVENT_SET = new Set<string>(UNSUPPORTED_KNOWN_HOOK_EVENTS);
+
+export function parseHookConfig(input: unknown, source: HookSourceMetadata): ParsedHookConfig {
+	const diagnostics: HookDiagnostic[] = [];
+	const executableHandlers: ExecutableHookHandler[] = [];
+
+	if (!isRecord(input)) {
+		diagnostics.push(
+			diagnostic({ code: "invalid_root", message: "Hook config must be an object.", path: "$" }, source),
+		);
+		return { executableHandlers, diagnostics };
+	}
+
+	const hooks = input.hooks;
+	if (!isRecord(hooks)) {
+		diagnostics.push(
+			diagnostic(
+				{ code: "invalid_hooks", message: "Hook config must contain an object hooks field.", path: "hooks" },
+				source,
+			),
+		);
+		return { executableHandlers, diagnostics };
+	}
+
+	for (const [eventName, groups] of Object.entries(hooks)) {
+		if (isSupportedHookEvent(eventName)) {
+			executableHandlers.push(...parseSupportedEvent(eventName, groups, source, diagnostics));
+			continue;
+		}
+		diagnostics.push(
+			diagnostic(
+				{
+					code: isUnsupportedKnownHookEvent(eventName) ? "unsupported_event" : "unknown_event",
+					event: eventName,
+					message: `Hook event ${eventName} is not executable in builtin hooks v1.`,
+					path: `hooks.${eventName}`,
+					severity: "warning",
+				},
+				source,
+			),
+		);
+	}
+
+	return { executableHandlers, diagnostics };
+}
+
+function parseSupportedEvent(
+	event: SupportedHookEvent,
+	groups: unknown,
+	source: HookSourceMetadata,
+	diagnostics: HookDiagnostic[],
+): ExecutableHookHandler[] {
+	if (!Array.isArray(groups)) {
+		diagnostics.push(
+			diagnostic(
+				{
+					code: "invalid_event_config",
+					event,
+					message: "Hook event entries must be an array.",
+					path: `hooks.${event}`,
+				},
+				source,
+			),
+		);
+		return [];
+	}
+
+	const handlers: ExecutableHookHandler[] = [];
+	for (const [groupIndex, group] of groups.entries()) {
+		const groupPath = `hooks.${event}[${groupIndex}]`;
+		if (!isRecord(group)) {
+			diagnostics.push(
+				diagnostic(
+					{
+						code: "invalid_handler_group",
+						event,
+						message: "Hook matcher group must be an object.",
+						path: groupPath,
+					},
+					source,
+				),
+			);
+			continue;
+		}
+
+		const matcher = parseMatcher(group.matcher, groupPath, event, source, diagnostics);
+		const hookList = group.hooks;
+		if (!Array.isArray(hookList)) {
+			diagnostics.push(
+				diagnostic(
+					{
+						code: "invalid_handler_list",
+						event,
+						message: "Hook matcher group hooks must be an array.",
+						path: `${groupPath}.hooks`,
+					},
+					source,
+				),
+			);
+			continue;
+		}
+
+		for (const [handlerIndex, handler] of hookList.entries()) {
+			const parsed = parseHandler(handler, { event, matcher, groupIndex, handlerIndex, source, diagnostics });
+			if (parsed) {
+				handlers.push(parsed);
+			}
+		}
+	}
+	return handlers;
+}
+
+function parseMatcher(
+	value: unknown,
+	groupPath: string,
+	event: SupportedHookEvent,
+	source: HookSourceMetadata,
+	diagnostics: HookDiagnostic[],
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value === "string") {
+		return value;
+	}
+	diagnostics.push(
+		diagnostic(
+			{ code: "invalid_matcher", event, message: "Hook matcher must be a string.", path: `${groupPath}.matcher` },
+			source,
+		),
+	);
+	return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSupportedHookEvent(value: string): value is SupportedHookEvent {
+	return SUPPORTED_EVENT_SET.has(value);
+}
+
+function isUnsupportedKnownHookEvent(value: string): boolean {
+	return UNSUPPORTED_EVENT_SET.has(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/stop-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/stop-adapter.ts
@@ -1,0 +1,342 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { diagnostic } from "./diagnostics.ts";
+import type { HookDispatchResult, HookDispatchSummary } from "./dispatcher.ts";
+import { safeDiagnosticDetails } from "./prompt-adapter.ts";
+import type { HookDiagnostic, HookInputWire } from "./types.ts";
+
+export const STOP_STATE_CUSTOM_TYPE = "senpi.hooks.stop-state";
+export const STOP_DIAGNOSTICS_CUSTOM_TYPE = "senpi.hooks.stop-diagnostics";
+export const STOP_OUTPUT_CUSTOM_TYPE = "senpi.hooks.stop-output";
+
+const STOP_REENTRY_LIMIT = 8;
+
+type StopState = {
+	readonly sessionId: string;
+	readonly turnKey: string;
+	readonly count: number;
+};
+
+type StopOutputRecord = {
+	readonly event: "Stop";
+	readonly exitCode: number | null;
+	readonly fields: readonly string[];
+	readonly sourcePath: string;
+};
+
+type StopRuntime = Pick<ExtensionAPI, "appendEntry" | "sendUserMessage">;
+
+export function buildStopHookInput(
+	event: { readonly messages: readonly AgentMessage[] },
+	ctx: ExtensionContext,
+): HookInputWire {
+	const transcriptPath = ctx.sessionManager.getSessionFile();
+	const stopReason = findLastAssistantStopReason(event.messages);
+	return {
+		cwd: ctx.cwd,
+		event: "Stop",
+		hook_event_name: "Stop",
+		session_id: ctx.sessionManager.getSessionId(),
+		...(stopReason === undefined ? {} : { stopReason }),
+		...(transcriptPath === undefined ? {} : { transcript_path: transcriptPath }),
+	};
+}
+
+export function createStopTurnTracker(): {
+	readonly reset: () => void;
+	readonly turnKey: (ctx: ExtensionContext) => string;
+} {
+	let activeTurnKey: string | undefined;
+	let turnIndex = 0;
+	return {
+		reset() {
+			turnIndex += 1;
+			activeTurnKey = undefined;
+		},
+		turnKey(ctx) {
+			if (activeTurnKey !== undefined) return activeTurnKey;
+			const leafId = ctx.sessionManager.getLeafId() ?? ctx.sessionManager.getSessionId();
+			activeTurnKey = `${turnIndex}:${leafId}`;
+			return activeTurnKey;
+		},
+	};
+}
+
+export function applyStopHookResult(
+	pi: StopRuntime,
+	ctx: ExtensionContext,
+	result: HookDispatchResult,
+	turnKey: string,
+): Promise<void> {
+	const sessionId = ctx.sessionManager.getSessionId();
+	const previous = latestStopState(ctx, sessionId, turnKey);
+	if (previous.count >= STOP_REENTRY_LIMIT) {
+		appendStopState(pi, { count: previous.count, sessionId, turnKey });
+		appendStopDiagnostics(pi, [
+			diagnostic(
+				{
+					code: "unsupported_event",
+					event: "Stop",
+					message: "Stop hook reentry limit reached.",
+					path: "hooks.Stop",
+					severity: "warning",
+				},
+				limitDiagnosticSource(result),
+			),
+		]);
+		return Promise.resolve();
+	}
+
+	const unsupportedDiagnostics = unsupportedStopOutputDiagnostics(result);
+	if (unsupportedDiagnostics.length > 0 || result.diagnostics.length > 0) {
+		appendStopDiagnostics(pi, [...result.diagnostics, ...unsupportedDiagnostics]);
+	}
+	appendStopOutputs(pi, stopOutputRecords(result));
+
+	if (result.decision.kind !== "block") {
+		appendStopState(pi, { count: previous.count, sessionId, turnKey });
+		return Promise.resolve();
+	}
+
+	const count = previous.count + 1;
+	appendStopState(pi, { count, sessionId, turnKey });
+	const followUp = stopFollowUpText(result);
+	if (followUp === undefined) {
+		appendStopDiagnostics(pi, [
+			diagnostic(
+				{
+					code: "unsupported_field",
+					event: "Stop",
+					message: "Stop hook blocked without follow-up context.",
+					path: "stdout.reason",
+					severity: "warning",
+				},
+				result.decision.source,
+			),
+		]);
+		return Promise.resolve();
+	}
+	pi.sendUserMessage(followUp, { deliverAs: "followUp" });
+	return waitForFollowUpQueue(ctx);
+}
+
+async function waitForFollowUpQueue(ctx: ExtensionContext): Promise<void> {
+	for (let attempt = 0; attempt < 64; attempt += 1) {
+		await Promise.resolve();
+		if (ctx.hasPendingMessages()) return;
+	}
+}
+
+function latestStopState(ctx: ExtensionContext, sessionId: string, turnKey: string): StopState {
+	const entries = ctx.sessionManager.getEntries();
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (entry?.type !== "custom" || entry.customType !== STOP_STATE_CUSTOM_TYPE) continue;
+		if (!isStopState(entry.data)) continue;
+		if (entry.data.sessionId === sessionId && entry.data.turnKey === turnKey) return entry.data;
+	}
+	return { count: 0, sessionId, turnKey };
+}
+
+function appendStopState(pi: StopRuntime, state: StopState): void {
+	pi.appendEntry(STOP_STATE_CUSTOM_TYPE, state);
+}
+
+function appendStopDiagnostics(pi: StopRuntime, diagnostics: readonly HookDiagnostic[]): void {
+	if (diagnostics.length === 0) return;
+	pi.appendEntry(STOP_DIAGNOSTICS_CUSTOM_TYPE, diagnostics.map(safeStopDiagnosticDetails));
+}
+
+function safeStopDiagnosticDetails(diagnostic: HookDiagnostic): ReturnType<typeof safeDiagnosticDetails> {
+	if (
+		diagnostic.code === "invalid_event_config" &&
+		diagnostic.event === "Stop" &&
+		diagnostic.path === "stdout.hookSpecificOutput.hookEventName"
+	) {
+		return {
+			...safeDiagnosticDetails(diagnostic),
+			message: "Hook output event does not match Stop.",
+		};
+	}
+	return safeDiagnosticDetails(diagnostic);
+}
+
+function appendStopOutputs(pi: StopRuntime, records: readonly StopOutputRecord[]): void {
+	if (records.length === 0) return;
+	pi.appendEntry(STOP_OUTPUT_CUSTOM_TYPE, records);
+}
+
+function stopOutputRecords(result: HookDispatchResult): readonly StopOutputRecord[] {
+	return result.summaries.flatMap((summary) => {
+		const fields = stopOutputFieldPaths(summary);
+		if (fields.length === 0) return [];
+		return [
+			{
+				event: "Stop",
+				exitCode: summary.run.exitCode,
+				fields,
+				sourcePath: summary.handler.source.sourcePath,
+			},
+		];
+	});
+}
+
+function unsupportedStopOutputDiagnostics(result: HookDispatchResult): readonly HookDiagnostic[] {
+	const diagnostics: HookDiagnostic[] = [];
+	for (const summary of result.summaries) {
+		diagnostics.push(...unsupportedSummaryDiagnostics(summary));
+	}
+	return diagnostics;
+}
+
+function unsupportedSummaryDiagnostics(summary: HookDispatchSummary): readonly HookDiagnostic[] {
+	const diagnostics: HookDiagnostic[] = [];
+	if (summary.output.systemMessage !== undefined) {
+		diagnostics.push(unsupportedField(summary, "stdout.systemMessage", "Stop does not support systemMessage."));
+	}
+	if (summary.output.suppressOutput !== undefined) {
+		diagnostics.push(unsupportedField(summary, "stdout.suppressOutput", "Stop does not support suppressOutput."));
+	}
+	if (summary.output.stopReason !== undefined) {
+		diagnostics.push(unsupportedField(summary, "stdout.stopReason", "Stop output stopReason is diagnostic-only."));
+	}
+	if (summary.output.updatedInput !== undefined) {
+		diagnostics.push(unsupportedField(summary, "stdout.updatedInput", "Stop does not support updatedInput."));
+	}
+	if (summary.output.updatedToolOutput !== undefined) {
+		diagnostics.push(
+			unsupportedField(summary, "stdout.updatedToolOutput", "Stop does not support updatedToolOutput."),
+		);
+	}
+	for (const path of rawUnsupportedStopFieldPaths(summary)) {
+		diagnostics.push(unsupportedField(summary, path, `Stop does not support ${path.replace("stdout.", "")}.`));
+	}
+	return diagnostics;
+}
+
+function stopOutputFieldPaths(summary: HookDispatchSummary): readonly string[] {
+	const fields: string[] = [];
+	if (summary.output.decision !== undefined) fields.push("stdout.decision");
+	if (summary.output.reason !== undefined) fields.push("stdout.reason");
+	if (summary.output.additionalContext !== undefined) {
+		const raw = rawStdoutObject(summary.run.stdout);
+		const specific = raw === undefined ? undefined : rawHookSpecificOutput(raw);
+		fields.push(
+			specific !== undefined && Object.hasOwn(specific, "additionalContext")
+				? "stdout.hookSpecificOutput.additionalContext"
+				: "stdout.additionalContext",
+		);
+	}
+	if (summary.output.continue !== undefined) fields.push("stdout.continue");
+	if (summary.output.stopReason !== undefined) fields.push("stdout.stopReason");
+	if (summary.output.suppressOutput !== undefined) fields.push("stdout.suppressOutput");
+	if (summary.output.systemMessage !== undefined) fields.push("stdout.systemMessage");
+	fields.push(...rawUnsupportedStopFieldPaths(summary));
+	return fields;
+}
+
+function rawUnsupportedStopFieldPaths(summary: HookDispatchSummary): readonly string[] {
+	const raw = rawStdoutObject(summary.run.stdout);
+	if (raw === undefined) return [];
+	const fields: string[] = [];
+	pushFieldIfPresent(fields, raw, "updatedInput", "stdout.updatedInput");
+	pushFieldIfPresent(fields, raw, "updatedToolOutput", "stdout.updatedToolOutput");
+	const specific = rawHookSpecificOutput(raw);
+	if (specific !== undefined) {
+		pushFieldIfPresent(fields, specific, "updatedInput", "stdout.hookSpecificOutput.updatedInput");
+		pushFieldIfPresent(fields, specific, "updatedToolOutput", "stdout.hookSpecificOutput.updatedToolOutput");
+	}
+	return fields;
+}
+
+function pushFieldIfPresent(
+	fields: string[],
+	record: Readonly<Record<string, unknown>>,
+	key: string,
+	path: string,
+): void {
+	if (Object.hasOwn(record, key)) fields.push(path);
+}
+
+function rawStdoutObject(stdout: string): Readonly<Record<string, unknown>> | undefined {
+	const trimmed = stdout.trim();
+	if (trimmed.length === 0) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		return isRecord(parsed) ? parsed : undefined;
+	} catch (error) {
+		if (error instanceof SyntaxError) return undefined;
+		throw error;
+	}
+}
+
+function rawHookSpecificOutput(raw: Readonly<Record<string, unknown>>): Readonly<Record<string, unknown>> | undefined {
+	const value = raw.hookSpecificOutput;
+	return isRecord(value) ? value : undefined;
+}
+
+function unsupportedField(summary: HookDispatchSummary, path: string, message: string): HookDiagnostic {
+	return diagnostic(
+		{
+			code: "unsupported_field",
+			event: "Stop",
+			message,
+			path,
+			severity: "warning",
+		},
+		summary.handler.source,
+	);
+}
+
+function stopFollowUpText(result: HookDispatchResult): string | undefined {
+	if (result.decision.kind !== "block") return undefined;
+	const blocker = blockingSummary(result);
+	if (blocker === undefined || blocker.run.exitCode === 2) return undefined;
+	return blocker.output.additionalContext ?? result.decision.reason;
+}
+
+function blockingSummary(result: HookDispatchResult): HookDispatchSummary | undefined {
+	if (result.decision.kind !== "block") return undefined;
+	const sourcePath = result.decision.source.sourcePath;
+	return result.summaries.find(
+		(summary) =>
+			summary.handler.source.sourcePath === sourcePath &&
+			(summary.output.decision === "block" || summary.output.decision === "deny"),
+	);
+}
+
+function limitDiagnosticSource(result: HookDispatchResult): HookDiagnostic["source"] {
+	return (
+		result.matchedHandlers[0]?.source ??
+		result.executableHandlers[0]?.source ?? {
+			discoveredAt: "runtime",
+			displayOrder: 0,
+			scope: "managed",
+			sourcePath: "<builtin:hooks>",
+		}
+	);
+}
+
+function isStopState(value: unknown): value is StopState {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	if (!("sessionId" in value) || !("turnKey" in value) || !("count" in value)) return false;
+	return (
+		typeof value.sessionId === "string" &&
+		typeof value.turnKey === "string" &&
+		typeof value.count === "number" &&
+		Number.isInteger(value.count) &&
+		value.count >= 0
+	);
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function findLastAssistantStopReason(messages: readonly AgentMessage[]): string | undefined {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (message?.role === "assistant") return message.stopReason;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/tool-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/tool-adapter.ts
@@ -1,0 +1,195 @@
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
+import type {
+	ExtensionContext,
+	ToolCallEvent,
+	ToolCallEventResult,
+	ToolResultEvent,
+	ToolResultEventResult,
+} from "../../types.ts";
+import type { HookDispatchResult } from "./dispatcher.ts";
+import type { HookInputWire } from "./types.ts";
+
+export const PRE_TOOL_BLOCK_REASON = "PreToolUse hook blocked the tool call.";
+export const POST_TOOL_BLOCK_REASON = "PostToolUse hook flagged the tool result.";
+
+export function buildPreToolUseHookInput(event: ToolCallEvent, ctx: ExtensionContext): HookInputWire {
+	return {
+		event: "PreToolUse",
+		toolName: event.toolName,
+		toolInput: event.input,
+		cwd: ctx.cwd,
+		session_id: ctx.sessionManager.getSessionId(),
+		hook_event_name: "PreToolUse",
+		tool_name: event.toolName,
+		tool_input: event.input,
+		tool_use_id: event.toolCallId,
+	};
+}
+
+export function buildPostToolUseHookInput(event: ToolResultEvent, ctx: ExtensionContext): HookInputWire {
+	return {
+		event: "PostToolUse",
+		toolName: event.toolName,
+		toolInput: event.input,
+		toolOutput: {
+			content: event.content,
+			details: event.details,
+			is_error: event.isError,
+		},
+		cwd: ctx.cwd,
+		session_id: ctx.sessionManager.getSessionId(),
+		hook_event_name: "PostToolUse",
+		tool_name: event.toolName,
+		tool_input: event.input,
+		tool_response: {
+			content: event.content,
+			details: event.details,
+			is_error: event.isError,
+		},
+		tool_use_id: event.toolCallId,
+	};
+}
+
+export function applyPreToolUseResult(
+	event: ToolCallEvent,
+	result: HookDispatchResult,
+): ToolCallEventResult | undefined {
+	if (result.decision.kind === "block") {
+		return { block: true, reason: preToolBlockReasonFromResult(result) };
+	}
+	if (result.decision.kind === "ask") {
+		return { block: true, reason: result.decision.fallback.reason };
+	}
+	if (result.decision.kind === "allow" && isRecord(result.decision.updatedInput)) {
+		replaceToolInput(event.input, result.decision.updatedInput);
+	}
+	return undefined;
+}
+
+export function applyPostToolUseResult(
+	event: ToolResultEvent,
+	result: HookDispatchResult,
+	preToolContexts: readonly string[] = [],
+): ToolResultEventResult | undefined {
+	if (result.decision.kind === "block") {
+		return {
+			content: [
+				{ type: "text", text: postToolBlockReasonFromResult(result) },
+				...preToolContexts.map(contextTextPart),
+				...toolContextsFromResult(result).map(contextTextPart),
+			],
+			details: event.details,
+			isError: true,
+		};
+	}
+	const replacement = collectPostToolUseReplacement(event, result, preToolContexts);
+	return replacement;
+}
+
+export function toolContextsFromResult(result: HookDispatchResult): readonly string[] {
+	return result.summaries.flatMap((summary) =>
+		summary.output.additionalContext === undefined ? [] : [summary.output.additionalContext],
+	);
+}
+
+function preToolBlockReasonFromResult(result: HookDispatchResult): string {
+	if (result.decision.kind !== "block") return PRE_TOOL_BLOCK_REASON;
+	const sourcePath = result.decision.source.sourcePath;
+	const blocker = result.summaries.find(
+		(summary) =>
+			(summary.handler.source.sourcePath === sourcePath &&
+				(summary.output.decision === "block" || summary.output.decision === "deny")) ||
+			false,
+	);
+	if (blocker?.run.exitCode === 2) return PRE_TOOL_BLOCK_REASON;
+	return result.decision.reason ?? PRE_TOOL_BLOCK_REASON;
+}
+
+function postToolBlockReasonFromResult(result: HookDispatchResult): string {
+	if (result.decision.kind !== "block") return POST_TOOL_BLOCK_REASON;
+	const sourcePath = result.decision.source.sourcePath;
+	const blocker = result.summaries.find(
+		(summary) =>
+			(summary.handler.source.sourcePath === sourcePath &&
+				(summary.output.decision === "block" || summary.output.decision === "deny")) ||
+			false,
+	);
+	if (blocker?.run.exitCode === 2) return POST_TOOL_BLOCK_REASON;
+	return result.decision.reason ?? POST_TOOL_BLOCK_REASON;
+}
+
+function collectPostToolUseReplacement(
+	event: ToolResultEvent,
+	result: HookDispatchResult,
+	preToolContexts: readonly string[],
+): { readonly content: (TextContent | ImageContent)[]; readonly details?: unknown } | undefined {
+	let content: (TextContent | ImageContent)[] = [...event.content];
+	let details: unknown = event.details;
+	let replaced = false;
+	const postToolContexts: string[] = [];
+	for (const summary of result.summaries) {
+		const updated = normalizeUpdatedToolOutput(summary.output.updatedToolOutput);
+		if (updated !== undefined) {
+			content = [...updated.content];
+			details = updated.details;
+			replaced = true;
+		}
+		const context = summary.output.additionalContext;
+		if (context !== undefined) {
+			postToolContexts.push(context);
+		}
+	}
+	for (const context of postToolContexts) {
+		content.push(contextTextPart(context));
+	}
+	for (const context of preToolContexts) {
+		content.push(contextTextPart(context));
+	}
+	if (!replaced && postToolContexts.length === 0 && preToolContexts.length === 0) return undefined;
+	return { content, ...(details === undefined ? {} : { details }) };
+}
+
+function normalizeUpdatedToolOutput(
+	value: unknown,
+): { readonly content: (TextContent | ImageContent)[]; readonly details?: unknown } | undefined {
+	if (typeof value === "string") {
+		return { content: [{ type: "text", text: value }] };
+	}
+	if (isContentArray(value)) {
+		return { content: value };
+	}
+	if (!isRecord(value)) return undefined;
+	const content = value.content;
+	if (typeof content === "string") {
+		return { content: [{ type: "text", text: content }], details: value.details };
+	}
+	if (isContentArray(content)) {
+		return { content, details: value.details };
+	}
+	return undefined;
+}
+
+function replaceToolInput(target: Record<string, unknown>, replacement: Record<string, unknown>): void {
+	for (const key of Object.keys(target)) {
+		delete target[key];
+	}
+	Object.assign(target, replacement);
+}
+
+function contextTextPart(text: string): TextContent {
+	return { type: "text", text };
+}
+
+function isContentArray(value: unknown): value is (TextContent | ImageContent)[] {
+	return Array.isArray(value) && value.every(isContentPart);
+}
+
+function isContentPart(value: unknown): value is TextContent | ImageContent {
+	if (!isRecord(value)) return false;
+	if (value.type === "text") return typeof value.text === "string";
+	return value.type === "image" && typeof value.mimeType === "string" && typeof value.data === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts
@@ -1,0 +1,126 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import lockfile from "proper-lockfile";
+import { CONFIG_DIR_NAME, getAgentDir } from "../../../../config.ts";
+import { emptyHookTrustState, type HookTrustStorageScope, readHookTrustStateJson } from "./trust.ts";
+import type { HookTrustEntry, HookTrustState } from "./types.ts";
+
+export interface HookStateStorage {
+	read(scope: HookTrustStorageScope): HookTrustState;
+	update(scope: HookTrustStorageScope, updater: (current: HookTrustState) => HookTrustState): HookTrustState;
+}
+
+export type FileHookStateStorageOptions = {
+	readonly agentDir?: string;
+	readonly cwd: string;
+};
+
+export class FileHookStateStorage implements HookStateStorage {
+	private readonly globalStatePath: string;
+	private readonly projectStatePath: string;
+
+	constructor(options: FileHookStateStorageOptions) {
+		const agentDir = options.agentDir ?? getAgentDir();
+		this.globalStatePath = join(agentDir, "hooks-state.json");
+		this.projectStatePath = join(options.cwd, CONFIG_DIR_NAME, "hooks-state.json");
+	}
+
+	read(scope: HookTrustStorageScope): HookTrustState {
+		return withHookStateFileLock(statePathForScope(scope, this.globalStatePath, this.projectStatePath), (path) =>
+			readHookTrustStateJson(existsSync(path) ? readFileSync(path, "utf-8") : undefined),
+		);
+	}
+
+	update(scope: HookTrustStorageScope, updater: (current: HookTrustState) => HookTrustState): HookTrustState {
+		return withHookStateFileLock(statePathForScope(scope, this.globalStatePath, this.projectStatePath), (path) => {
+			const current = readHookTrustStateJson(existsSync(path) ? readFileSync(path, "utf-8") : undefined);
+			const next = updater(current);
+			writeFileSync(path, serializeHookTrustState(next), "utf-8");
+			return next;
+		});
+	}
+}
+
+export class InMemoryHookStateStorage implements HookStateStorage {
+	private globalState: HookTrustState = emptyHookTrustState();
+	private projectState: HookTrustState = emptyHookTrustState();
+
+	read(scope: HookTrustStorageScope): HookTrustState {
+		return scope === "global" ? this.globalState : this.projectState;
+	}
+
+	update(scope: HookTrustStorageScope, updater: (current: HookTrustState) => HookTrustState): HookTrustState {
+		const next = updater(this.read(scope));
+		if (scope === "global") {
+			this.globalState = next;
+		} else {
+			this.projectState = next;
+		}
+		return next;
+	}
+}
+
+function statePathForScope(scope: HookTrustStorageScope, globalStatePath: string, projectStatePath: string): string {
+	return scope === "global" ? globalStatePath : projectStatePath;
+}
+
+function serializeHookTrustState(state: HookTrustState): string {
+	const sortedHooks: Record<string, HookTrustEntry> = {};
+	for (const key of Object.keys(state.hooks).sort()) {
+		const entry = state.hooks[key];
+		if (entry !== undefined) {
+			sortedHooks[key] = entry;
+		}
+	}
+	return `${JSON.stringify({ version: 1, hooks: sortedHooks }, null, 2)}\n`;
+}
+
+function acquireHookStateLockSync(path: string): () => void {
+	const stateDir = dirname(path);
+	mkdirSync(stateDir, { recursive: true });
+	const maxAttempts = 10;
+	const delayMs = 20;
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return lockfile.lockSync(stateDir, { realpath: false, lockfilePath: `${path}.lock` });
+		} catch (error) {
+			const code = errorCode(error);
+			if (code !== "ELOCKED" || attempt === maxAttempts) {
+				throw error;
+			}
+			lastError = error;
+			const start = Date.now();
+			while (Date.now() - start < delayMs) {
+				Date.now();
+			}
+		}
+	}
+
+	if (lastError instanceof Error) {
+		throw lastError;
+	}
+	throw new Error("Failed to acquire hook state lock");
+}
+
+function errorCode(error: unknown): string | undefined {
+	if (!isRecord(error)) {
+		return undefined;
+	}
+	const code = error.code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function withHookStateFileLock<T>(path: string, fn: (path: string) => T): T {
+	const release = acquireHookStateLockSync(path);
+	try {
+		return fn(path);
+	} finally {
+		release();
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/trust.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/trust.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { DEFAULT_HOOK_TIMEOUT_SECONDS, isValidHookTimeoutSeconds } from "./safety.ts";
 import type {
 	ExecutableHookHandler,
 	HookSourceMetadata,
@@ -39,7 +40,6 @@ type JsonValue =
 	| readonly JsonValue[]
 	| { readonly [key: string]: JsonValue | undefined };
 
-const DEFAULT_TIMEOUT_SECONDS = 600;
 const HOOK_STATE_VERSION = 1;
 
 export function emptyHookTrustState(): HookTrustState {
@@ -226,7 +226,13 @@ function selectedCommand(handler: ExecutableHookHandler, platform: HookTrustPlat
 }
 
 function normalizedTimeout(timeout: number | undefined): number {
-	return Math.max(timeout ?? DEFAULT_TIMEOUT_SECONDS, 1);
+	if (timeout === undefined) {
+		return DEFAULT_HOOK_TIMEOUT_SECONDS;
+	}
+	if (!isValidHookTimeoutSeconds(timeout)) {
+		throw new Error("Invalid command hook timeout reached trust hashing.");
+	}
+	return timeout;
 }
 
 function sourceKeyHash(source: HookSourceMetadata): string {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/trust.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/trust.ts
@@ -1,0 +1,276 @@
+import { createHash } from "node:crypto";
+import type {
+	ExecutableHookHandler,
+	HookSourceMetadata,
+	HookSourceScope,
+	HookTrustEntry,
+	HookTrustState,
+} from "./types.ts";
+
+export type HookTrustPlatform = NodeJS.Platform;
+export type HookTrustStorageScope = "global" | "project";
+
+export type HookTrustOptions = {
+	readonly platform?: HookTrustPlatform;
+};
+
+export type HookTrustStorageOptions = {
+	readonly projectTrusted: boolean;
+};
+
+export type HookTrustRecord = {
+	readonly id: string;
+	readonly currentHash: string;
+	readonly enabled: boolean;
+	readonly trusted: boolean;
+	readonly executable: boolean;
+	readonly scope: HookSourceScope;
+	readonly sourcePath: string;
+	readonly matcher?: string;
+	readonly commandPreview: string;
+	readonly entry?: HookTrustEntry;
+};
+
+type JsonValue =
+	| null
+	| boolean
+	| number
+	| string
+	| readonly JsonValue[]
+	| { readonly [key: string]: JsonValue | undefined };
+
+const DEFAULT_TIMEOUT_SECONDS = 600;
+const HOOK_STATE_VERSION = 1;
+
+export function emptyHookTrustState(): HookTrustState {
+	return { version: HOOK_STATE_VERSION, hooks: {} };
+}
+
+export function hookTrustId(handler: ExecutableHookHandler): string {
+	return `hk_${sourceKeyHash(handler.source)}_${handler.event}_${handler.groupIndex}_${handler.handlerIndex}`;
+}
+
+export function buildHookTrustRecord(handler: ExecutableHookHandler, options: HookTrustOptions = {}): HookTrustRecord {
+	const id = hookTrustId(handler);
+	const currentHash = hashCommandHook(handler, options);
+	const commandPreview = selectedCommand(handler, options.platform ?? process.platform);
+	return {
+		id,
+		currentHash,
+		enabled: true,
+		trusted: false,
+		executable: false,
+		scope: handler.source.scope,
+		sourcePath: handler.source.sourcePath,
+		...(handler.matcher === undefined ? {} : { matcher: handler.matcher }),
+		commandPreview,
+	};
+}
+
+export function createHookTrustEntry(
+	handler: ExecutableHookHandler,
+	options: HookTrustOptions & { readonly updatedAt?: string } = {},
+): HookTrustEntry {
+	const commandPreview = selectedCommand(handler, options.platform ?? process.platform);
+	return {
+		enabled: true,
+		trustedHash: hashCommandHook(handler, options),
+		scope: handler.source.scope,
+		sourcePath: handler.source.sourcePath,
+		...(handler.matcher === undefined ? {} : { matcher: handler.matcher }),
+		commandPreview,
+		updatedAt: options.updatedAt ?? new Date().toISOString(),
+	};
+}
+
+export function hashCommandHook(handler: ExecutableHookHandler, options: HookTrustOptions = {}): string {
+	const platform = options.platform ?? process.platform;
+	const hook: { [key: string]: JsonValue | undefined } = {
+		async: false,
+		command: handler.config.command,
+		commandWindows: handler.config.commandWindows,
+		platformCommand: selectedCommand(handler, platform),
+		statusMessage: handler.config.statusMessage,
+		timeout: normalizedTimeout(handler.config.timeout),
+		type: "command",
+	};
+	const identity: { [key: string]: JsonValue | undefined } = {
+		event: handler.event,
+		hook,
+		matcher: handler.matcher,
+		sourceKeyHash: sourceKeyHash(handler.source),
+	};
+	return `sha256:${sha256Hex(JSON.stringify(canonicalJson(identity)))}`;
+}
+
+export function isCommandHookTrusted(
+	handler: ExecutableHookHandler,
+	state: HookTrustState,
+	options: HookTrustOptions = {},
+): boolean {
+	const record = buildStatefulHookTrustRecord(handler, state, options);
+	return record.executable;
+}
+
+export function listHookTrustRecords(
+	handlers: readonly ExecutableHookHandler[],
+	state: HookTrustState,
+	options: HookTrustOptions = {},
+): readonly HookTrustRecord[] {
+	return handlers.map((handler) => buildStatefulHookTrustRecord(handler, state, options));
+}
+
+export function filterExecutableTrustedHooks(
+	handlers: readonly ExecutableHookHandler[],
+	state: HookTrustState,
+	options: HookTrustOptions = {},
+): readonly ExecutableHookHandler[] {
+	return handlers.filter((handler) => buildStatefulHookTrustRecord(handler, state, options).executable);
+}
+
+export function readHookTrustStateJson(input: string | undefined): HookTrustState {
+	if (input === undefined || input.trim() === "") {
+		return emptyHookTrustState();
+	}
+	try {
+		return parseHookTrustState(JSON.parse(input));
+	} catch (error) {
+		if (error instanceof Error) {
+			return emptyHookTrustState();
+		}
+		return emptyHookTrustState();
+	}
+}
+
+export function hookTrustStorageScope(
+	handler: ExecutableHookHandler,
+	options: HookTrustStorageOptions,
+): HookTrustStorageScope | undefined {
+	if (handler.source.scope === "project") {
+		return options.projectTrusted ? "project" : undefined;
+	}
+	return "global";
+}
+
+function buildStatefulHookTrustRecord(
+	handler: ExecutableHookHandler,
+	state: HookTrustState,
+	options: HookTrustOptions,
+): HookTrustRecord {
+	const base = buildHookTrustRecord(handler, options);
+	const entry = state.hooks[base.id];
+	const enabled = entry?.enabled ?? true;
+	const trusted = entry?.trustedHash === base.currentHash;
+	return {
+		...base,
+		enabled,
+		trusted,
+		executable: enabled && trusted,
+		...(entry === undefined ? {} : { entry }),
+	};
+}
+
+function parseHookTrustState(input: unknown): HookTrustState {
+	if (!isRecord(input) || input.version !== HOOK_STATE_VERSION || !isRecord(input.hooks)) {
+		return emptyHookTrustState();
+	}
+
+	const hooks: Record<string, HookTrustEntry> = {};
+	for (const [id, entry] of Object.entries(input.hooks)) {
+		const parsed = parseHookTrustEntry(entry);
+		if (parsed !== undefined) {
+			hooks[id] = parsed;
+		}
+	}
+	return { version: HOOK_STATE_VERSION, hooks };
+}
+
+function parseHookTrustEntry(input: unknown): HookTrustEntry | undefined {
+	if (!isRecord(input)) {
+		return undefined;
+	}
+	const enabled = input.enabled;
+	const trustedHash = input.trustedHash;
+	const scope = input.scope;
+	const sourcePath = input.sourcePath;
+	const matcher = input.matcher;
+	const commandPreview = input.commandPreview;
+	const updatedAt = input.updatedAt;
+	if (
+		typeof enabled !== "boolean" ||
+		(trustedHash !== undefined && typeof trustedHash !== "string") ||
+		!isHookSourceScope(scope) ||
+		typeof sourcePath !== "string" ||
+		(matcher !== undefined && typeof matcher !== "string") ||
+		typeof commandPreview !== "string" ||
+		typeof updatedAt !== "string"
+	) {
+		return undefined;
+	}
+	return {
+		enabled,
+		...(trustedHash === undefined ? {} : { trustedHash }),
+		scope,
+		sourcePath,
+		...(matcher === undefined ? {} : { matcher }),
+		commandPreview,
+		updatedAt,
+	};
+}
+
+function selectedCommand(handler: ExecutableHookHandler, platform: HookTrustPlatform): string {
+	if (platform === "win32" && handler.config.commandWindows !== undefined) {
+		return handler.config.commandWindows;
+	}
+	return handler.config.command;
+}
+
+function normalizedTimeout(timeout: number | undefined): number {
+	return Math.max(timeout ?? DEFAULT_TIMEOUT_SECONDS, 1);
+}
+
+function sourceKeyHash(source: HookSourceMetadata): string {
+	return sha256Hex(
+		[source.scope, source.sourcePath, source.pluginRoot ?? "", source.manifestPath ?? ""].join("\0"),
+	).slice(0, 12);
+}
+
+function sha256Hex(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalJson(value: JsonValue): JsonValue {
+	if (Array.isArray(value)) {
+		return value.map(canonicalJson);
+	}
+	if (!isJsonRecord(value)) {
+		return value;
+	}
+	const result: { [key: string]: JsonValue } = {};
+	for (const key of Object.keys(value).sort()) {
+		const child = value[key];
+		if (child !== undefined) {
+			result[key] = canonicalJson(child);
+		}
+	}
+	return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonRecord(value: JsonValue): value is { readonly [key: string]: JsonValue | undefined } {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isHookSourceScope(value: unknown): value is HookSourceScope {
+	return (
+		value === "global" ||
+		value === "project" ||
+		value === "plugin" ||
+		value === "runtime" ||
+		value === "cli" ||
+		value === "managed"
+	);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -123,7 +123,15 @@ export type HookRuntimeState = {
 };
 
 export type HookInputWire =
-	| { readonly event: "SessionStart"; readonly sessionId: string; readonly cwd: string }
+	| {
+			readonly event: "SessionStart";
+			readonly sessionId: string;
+			readonly cwd: string;
+			readonly hook_event_name?: "SessionStart";
+			readonly reason?: string;
+			readonly session_id?: string;
+			readonly transcript_path?: string;
+	  }
 	| {
 			readonly event: "UserPromptSubmit";
 			readonly prompt: string;
@@ -156,8 +164,28 @@ export type HookInputWire =
 			readonly tool_response?: unknown;
 			readonly tool_use_id?: string;
 	  }
-	| { readonly event: "PreCompact"; readonly reason: string; readonly cwd: string }
-	| { readonly event: "PostCompact"; readonly reason: string; readonly cwd: string }
+	| {
+			readonly event: "PreCompact";
+			readonly reason: string;
+			readonly cwd: string;
+			readonly custom_instructions?: string;
+			readonly hook_event_name?: "PreCompact";
+			readonly request_id?: string;
+			readonly session_id?: string;
+			readonly transcript_path?: string;
+			readonly will_retry?: boolean;
+	  }
+	| {
+			readonly event: "PostCompact";
+			readonly reason: string;
+			readonly cwd: string;
+			readonly accepted?: boolean;
+			readonly hook_event_name?: "PostCompact";
+			readonly request_id?: string;
+			readonly session_id?: string;
+			readonly transcript_path?: string;
+			readonly will_retry?: boolean;
+	  }
 	| { readonly event: "Stop"; readonly stopReason?: string; readonly cwd: string };
 
 export type HookOutputWire = {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -186,7 +186,14 @@ export type HookInputWire =
 			readonly transcript_path?: string;
 			readonly will_retry?: boolean;
 	  }
-	| { readonly event: "Stop"; readonly stopReason?: string; readonly cwd: string };
+	| {
+			readonly event: "Stop";
+			readonly stopReason?: string;
+			readonly cwd: string;
+			readonly hook_event_name?: "Stop";
+			readonly session_id?: string;
+			readonly transcript_path?: string;
+	  };
 
 export type HookOutputWire = {
 	readonly decision?: "approve" | "block" | "deny" | "ask";

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -77,6 +77,8 @@ export type HookDiagnosticCode =
 	| "invalid_handler"
 	| "invalid_command"
 	| "invalid_command_windows"
+	| "invalid_command_target"
+	| "missing_command_target"
 	| "invalid_timeout"
 	| "invalid_status_message"
 	| "unknown_event"

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -1,0 +1,150 @@
+export const SUPPORTED_HOOK_EVENTS = [
+	"PreToolUse",
+	"PostToolUse",
+	"UserPromptSubmit",
+	"SessionStart",
+	"PreCompact",
+	"PostCompact",
+	"Stop",
+] as const;
+
+export const UNSUPPORTED_KNOWN_HOOK_EVENTS = [
+	"PermissionRequest",
+	"PermissionDenied",
+	"SubagentStart",
+	"SubagentStop",
+	"Notification",
+	"Setup",
+	"UserPromptExpansion",
+	"PostToolUseFailure",
+	"PostToolBatch",
+	"TaskCreated",
+	"TaskCompleted",
+	"StopFailure",
+	"TeammateIdle",
+	"InstructionsLoaded",
+	"ConfigChange",
+	"CwdChanged",
+	"FileChanged",
+	"WorktreeCreate",
+	"WorktreeRemove",
+	"MessageDisplay",
+	"SessionEnd",
+	"Elicitation",
+	"ElicitationResult",
+] as const;
+
+export const UNSUPPORTED_HANDLER_TYPES = ["prompt", "agent", "http", "mcp_tool"] as const;
+
+export type SupportedHookEvent = (typeof SUPPORTED_HOOK_EVENTS)[number];
+export type UnsupportedKnownHookEvent = (typeof UNSUPPORTED_KNOWN_HOOK_EVENTS)[number];
+export type HookSourceScope = "global" | "project" | "plugin" | "runtime" | "cli" | "managed";
+export type HookDiscoveryTiming = "pre-session" | "runtime";
+
+export type HookSourceMetadata = {
+	readonly scope: HookSourceScope;
+	readonly sourcePath: string;
+	readonly displayOrder: number;
+	readonly discoveredAt: HookDiscoveryTiming;
+	readonly pluginRoot?: string;
+	readonly manifestPath?: string;
+};
+
+export type CommandHookConfig = {
+	readonly type: "command";
+	readonly command: string;
+	readonly commandWindows?: string;
+	readonly timeout?: number;
+	readonly statusMessage?: string;
+};
+
+export type ExecutableHookHandler = {
+	readonly event: SupportedHookEvent;
+	readonly matcher?: string;
+	readonly groupIndex: number;
+	readonly handlerIndex: number;
+	readonly config: CommandHookConfig;
+	readonly source: HookSourceMetadata;
+};
+
+export type HookDiagnosticCode =
+	| "invalid_root"
+	| "invalid_hooks"
+	| "invalid_event_config"
+	| "invalid_matcher"
+	| "invalid_handler_group"
+	| "invalid_handler_list"
+	| "invalid_handler"
+	| "invalid_command"
+	| "invalid_command_windows"
+	| "invalid_timeout"
+	| "invalid_status_message"
+	| "unknown_event"
+	| "unsupported_event"
+	| "unsupported_field"
+	| "unsupported_handler_type"
+	| "unsupported_async_handler"
+	| "unsupported_command_variant";
+
+export type HookDiagnostic = {
+	readonly code: HookDiagnosticCode;
+	readonly severity: "error" | "warning";
+	readonly message: string;
+	readonly path: string;
+	readonly source: HookSourceMetadata;
+	readonly event?: string;
+};
+
+export type ParsedHookConfig = {
+	readonly executableHandlers: readonly ExecutableHookHandler[];
+	readonly diagnostics: readonly HookDiagnostic[];
+};
+
+export type HookTrustEntry = {
+	readonly enabled: boolean;
+	readonly trustedHash?: string;
+	readonly scope: HookSourceScope;
+	readonly sourcePath: string;
+	readonly matcher?: string;
+	readonly commandPreview: string;
+	readonly updatedAt: string;
+};
+
+export type HookTrustState = {
+	readonly version: 1;
+	readonly hooks: Readonly<Record<string, HookTrustEntry>>;
+};
+
+export type HookRuntimeState = {
+	readonly parsed: ParsedHookConfig;
+	readonly trust: HookTrustState;
+};
+
+export type HookInputWire =
+	| { readonly event: "SessionStart"; readonly sessionId: string; readonly cwd: string }
+	| { readonly event: "UserPromptSubmit"; readonly prompt: string; readonly cwd: string }
+	| {
+			readonly event: "PreToolUse";
+			readonly toolName: string;
+			readonly toolInput: unknown;
+			readonly cwd: string;
+	  }
+	| {
+			readonly event: "PostToolUse";
+			readonly toolName: string;
+			readonly toolInput: unknown;
+			readonly toolOutput: unknown;
+			readonly cwd: string;
+	  }
+	| { readonly event: "PreCompact"; readonly reason: string; readonly cwd: string }
+	| { readonly event: "PostCompact"; readonly reason: string; readonly cwd: string }
+	| { readonly event: "Stop"; readonly stopReason?: string; readonly cwd: string };
+
+export type HookOutputWire = {
+	readonly decision?: "approve" | "block" | "deny" | "ask";
+	readonly reason?: string;
+	readonly additionalContext?: string;
+	readonly updatedInput?: unknown;
+	readonly updatedToolOutput?: unknown;
+	readonly continue?: boolean;
+};

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -124,7 +124,14 @@ export type HookRuntimeState = {
 
 export type HookInputWire =
 	| { readonly event: "SessionStart"; readonly sessionId: string; readonly cwd: string }
-	| { readonly event: "UserPromptSubmit"; readonly prompt: string; readonly cwd: string }
+	| {
+			readonly event: "UserPromptSubmit";
+			readonly prompt: string;
+			readonly cwd: string;
+			readonly session_id?: string;
+			readonly permission_mode?: string;
+			readonly transcript_path?: string;
+	  }
 	| {
 			readonly event: "PreToolUse";
 			readonly toolName: string;

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/types.ts
@@ -137,6 +137,11 @@ export type HookInputWire =
 			readonly toolName: string;
 			readonly toolInput: unknown;
 			readonly cwd: string;
+			readonly session_id?: string;
+			readonly hook_event_name?: "PreToolUse";
+			readonly tool_name?: string;
+			readonly tool_input?: unknown;
+			readonly tool_use_id?: string;
 	  }
 	| {
 			readonly event: "PostToolUse";
@@ -144,6 +149,12 @@ export type HookInputWire =
 			readonly toolInput: unknown;
 			readonly toolOutput: unknown;
 			readonly cwd: string;
+			readonly session_id?: string;
+			readonly hook_event_name?: "PostToolUse";
+			readonly tool_name?: string;
+			readonly tool_input?: unknown;
+			readonly tool_response?: unknown;
+			readonly tool_use_id?: string;
 	  }
 	| { readonly event: "PreCompact"; readonly reason: string; readonly cwd: string }
 	| { readonly event: "PostCompact"; readonly reason: string; readonly cwd: string }

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -8,6 +8,7 @@ import filesExtension from "./files.ts";
 import goalExtension from "./goal/index.ts";
 import gptApplyPatchExtension from "./gpt-apply-patch/index.ts";
 import historySearchExtension from "./history-search/index.ts";
+import hooksExtension from "./hooks/index.ts";
 import nestedAgentsMdExtension from "./nested-agents-md/index.ts";
 import openaiWebSearchExtension from "./openai-web-search/index.ts";
 import permissionSystemExtension from "./permission-system/index.ts";
@@ -39,6 +40,7 @@ export const globalDefaultExtensionFactories = {
 } satisfies Record<(typeof globalDefaultExtensionIds)[number], ExtensionFactory>;
 
 export const builtinExtensions: BuiltinExtensionFactory[] = [
+	{ id: "hooks", factory: hooksExtension },
 	{ id: "permission-system", factory: permissionSystemExtension },
 	{ id: "gpt-apply-patch", factory: gptApplyPatchExtension },
 	{ id: "prompt-preset", factory: promptPresetExtension },

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,29 @@
 # Core Extensions Changes
 
+## 2026-06-29 - Builtin hooks extension runtime resource plumbing
+
+### What changed
+
+- Added builtin extension id `hooks` before `permission-system` so builtin command hooks can inspect tool calls before permission prompts.
+- Added `ResourcesDiscoverResult.hookPaths`, `ResourceExtensionPaths.hookPaths`, `DefaultResourceLoader.getLoadedHookSources()`, and `ExtensionContext.getLoadedHookSources()` for hook config source injection.
+- `ExtensionRunner.emitResourcesDiscover()` now collects hook paths, and `AgentSession.extendResourcesFromExtensions()` passes them to the resource loader as runtime hook sources.
+- `builtin/hooks/index.ts` now loads settings/default files, pre-session hook paths, and runtime hook paths lazily; malformed hook sources become diagnostics instead of startup failures.
+- Registered `/hooks` for command-output diagnostics and basic loaded-hook status.
+
+### Semantics
+
+- Initial `SessionStart` only sees pre-session sources: settings/default hook files and `DefaultResourceLoaderOptions.additionalHookPaths`.
+- Runtime `hookPaths` returned from `resources_discover` are late sources. They are visible to later hook events in the current runtime and to reload/next-session `SessionStart`, where `SessionStart` hooks from runtime sources emit the existing caveat diagnostic.
+- Malformed user/runtime hook JSON is nonfatal. Managed or builtin hook safety invariant failures remain hard failures at the dispatch layer rather than being trusted silently.
+
+### Expected merge conflict zones
+
+- MEDIUM: `types.ts` public API additions around `ExtensionContext`, `ResourcesDiscoverResult`, and `ExtensionContextActions`.
+- MEDIUM: `runner.ts` resource discovery aggregation and context construction.
+- MEDIUM: `resource-loader.ts` extension resource plumbing.
+- LOW: `agent-session.ts` `extendResourcesFromExtensions()` resource handoff.
+- LOW: `builtin/index.ts` registration order near `permission-system`.
+
 ## 2026-06-15 - Remove kimi-web-search builtin; fold Kimi search into pi-websearch
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -333,6 +333,16 @@ export class ExtensionRunner {
 		reason: "rejected",
 	});
 	private getSystemPromptFn: () => string = () => "";
+	private getLoadedHookSourcesFn: ExtensionContextActions["getLoadedHookSources"] = () => ({
+		agentDir: "",
+		cwd: this.cwd,
+		globalHookSourcePaths: [],
+		globalHooksPath: "",
+		preSessionHookSourcePaths: [],
+		projectHookSourcePaths: [],
+		projectHooksPath: "",
+		runtimeHookSourcePaths: [],
+	});
 	private getSystemPromptOptionsFn: () => BuildSystemPromptOptions = () => ({ cwd: this.cwd });
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
@@ -403,6 +413,7 @@ export class ExtensionRunner {
 		this.getMessageRevisionFn = contextActions.getMessageRevision;
 		this.applyCompactionFn = contextActions.applyCompaction;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
+		this.getLoadedHookSourcesFn = contextActions.getLoadedHookSources;
 		this.getSystemPromptOptionsFn = contextActions.getSystemPromptOptions ?? (() => ({ cwd: this.cwd }));
 
 		// Flush provider registrations queued during extension loading
@@ -806,6 +817,10 @@ export class ExtensionRunner {
 			getSystemPrompt: () => {
 				runner.assertActive();
 				return runner.getSystemPromptFn();
+			},
+			getLoadedHookSources: () => {
+				runner.assertActive();
+				return runner.getLoadedHookSourcesFn();
 			},
 		};
 	}
@@ -1290,11 +1305,13 @@ export class ExtensionRunner {
 		skillPaths: Array<{ path: string; extensionPath: string }>;
 		promptPaths: Array<{ path: string; extensionPath: string }>;
 		themePaths: Array<{ path: string; extensionPath: string }>;
+		hookPaths: Array<{ path: string; extensionPath: string }>;
 	}> {
 		const ctx = this.createContext();
 		const skillPaths: Array<{ path: string; extensionPath: string }> = [];
 		const promptPaths: Array<{ path: string; extensionPath: string }> = [];
 		const themePaths: Array<{ path: string; extensionPath: string }> = [];
+		const hookPaths: Array<{ path: string; extensionPath: string }> = [];
 
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get("resources_discover");
@@ -1315,6 +1332,9 @@ export class ExtensionRunner {
 					if (result?.themePaths?.length) {
 						themePaths.push(...result.themePaths.map((path) => ({ path, extensionPath: ext.path })));
 					}
+					if (result?.hookPaths?.length) {
+						hookPaths.push(...result.hookPaths.map((path) => ({ path, extensionPath: ext.path })));
+					}
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					const stack = err instanceof Error ? err.stack : undefined;
@@ -1328,7 +1348,7 @@ export class ExtensionRunner {
 			}
 		}
 
-		return { skillPaths, promptPaths, themePaths };
+		return { skillPaths, promptPaths, themePaths, hookPaths };
 	}
 
 	/** Emit input event. Transforms chain, "handled" short-circuits. */

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -373,6 +373,8 @@ export interface ExtensionContext {
 	applyCompaction(precomputed: CompactionResult, options: ApplyCompactionOptions): Promise<ApplyCompactionResult>;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/** Get hook source paths currently visible to the builtin hooks extension. */
+	getLoadedHookSources?(): LoadedHookSources;
 }
 
 /**
@@ -582,6 +584,8 @@ export interface ResourcesDiscoverResult {
 	skillPaths?: string[];
 	promptPaths?: string[];
 	themePaths?: string[];
+	/** Hook config paths discovered after initial session_start; visible to later hooks and reloads. */
+	hookPaths?: string[];
 }
 
 // ============================================================================
@@ -1635,7 +1639,21 @@ export interface ExtensionContextActions {
 	getMessageRevision: () => number;
 	applyCompaction: (precomputed: CompactionResult, options: ApplyCompactionOptions) => Promise<ApplyCompactionResult>;
 	getSystemPrompt: () => string;
+	getLoadedHookSources: () => LoadedHookSources;
 	getSystemPromptOptions?: () => BuildSystemPromptOptions;
+}
+
+export interface LoadedHookSources {
+	readonly cwd: string;
+	readonly agentDir: string;
+	readonly globalHooksPath: string;
+	readonly projectHooksPath: string;
+	readonly globalSettingsHooks?: unknown;
+	readonly projectSettingsHooks?: unknown;
+	readonly globalHookSourcePaths: readonly string[];
+	readonly projectHookSourcePaths: readonly string[];
+	readonly preSessionHookSourcePaths: readonly string[];
+	readonly runtimeHookSourcePaths: readonly string[];
 }
 
 /**

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -71,6 +71,7 @@ export interface ResolvedPaths {
 	skills: ResolvedResource[];
 	prompts: ResolvedResource[];
 	themes: ResolvedResource[];
+	hooks: ResolvedResource[];
 }
 
 export type MissingSourceAction = "install" | "skip" | "error";
@@ -160,6 +161,7 @@ interface PiManifest {
 	skills?: string[];
 	prompts?: string[];
 	themes?: string[];
+	hooks?: string[];
 }
 
 interface ResourceAccumulator {
@@ -167,6 +169,7 @@ interface ResourceAccumulator {
 	skills: Map<string, { metadata: PathMetadata; enabled: boolean }>;
 	prompts: Map<string, { metadata: PathMetadata; enabled: boolean }>;
 	themes: Map<string, { metadata: PathMetadata; enabled: boolean }>;
+	hooks: Map<string, { metadata: PathMetadata; enabled: boolean }>;
 }
 
 /**
@@ -192,17 +195,19 @@ interface PackageFilter {
 	skills?: string[];
 	prompts?: string[];
 	themes?: string[];
+	hooks?: string[];
 }
 
-type ResourceType = "extensions" | "skills" | "prompts" | "themes";
+type ResourceType = "extensions" | "skills" | "prompts" | "themes" | "hooks";
 
-const RESOURCE_TYPES: ResourceType[] = ["extensions", "skills", "prompts", "themes"];
+const RESOURCE_TYPES: ResourceType[] = ["extensions", "skills", "prompts", "themes", "hooks"];
 
 const FILE_PATTERNS: Record<ResourceType, RegExp> = {
 	extensions: /\.(ts|js)$/,
 	skills: /\.md$/,
 	prompts: /\.md$/,
 	themes: /\.json$/,
+	hooks: /\.json$/,
 };
 
 const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
@@ -2266,12 +2271,14 @@ export class DefaultPackageManager implements PackageManager {
 			skills: (globalSettings.skills ?? []) as string[],
 			prompts: (globalSettings.prompts ?? []) as string[],
 			themes: (globalSettings.themes ?? []) as string[],
+			hooks: (globalSettings.hooks ?? []) as string[],
 		};
 		const projectOverrides = {
 			extensions: (projectSettings.extensions ?? []) as string[],
 			skills: (projectSettings.skills ?? []) as string[],
 			prompts: (projectSettings.prompts ?? []) as string[],
 			themes: (projectSettings.themes ?? []) as string[],
+			hooks: (projectSettings.hooks ?? []) as string[],
 		};
 
 		const userDirs = {
@@ -2279,12 +2286,14 @@ export class DefaultPackageManager implements PackageManager {
 			skills: join(globalBaseDir, "skills"),
 			prompts: join(globalBaseDir, "prompts"),
 			themes: join(globalBaseDir, "themes"),
+			hooks: join(globalBaseDir, "hooks"),
 		};
 		const projectDirs = {
 			extensions: join(projectBaseDir, "extensions"),
 			skills: join(projectBaseDir, "skills"),
 			prompts: join(projectBaseDir, "prompts"),
 			themes: join(projectBaseDir, "themes"),
+			hooks: join(projectBaseDir, "hooks"),
 		};
 		const legacyProjectBaseDir = join(this.cwd, ".pi");
 		const legacyProjectDirs = {
@@ -2292,6 +2301,7 @@ export class DefaultPackageManager implements PackageManager {
 			skills: join(legacyProjectBaseDir, "skills"),
 			prompts: join(legacyProjectBaseDir, "prompts"),
 			themes: join(legacyProjectBaseDir, "themes"),
+			hooks: join(legacyProjectBaseDir, "hooks"),
 		};
 		const userAgentsSkillsDir = join(getHomeDir(), ".agents", "skills");
 		const projectTrusted = this.settingsManager.isProjectTrusted();
@@ -2364,6 +2374,13 @@ export class DefaultPackageManager implements PackageManager {
 				projectOverrides.themes,
 				projectBaseDir,
 			);
+			addResources(
+				"hooks",
+				collectFiles(projectDirs.hooks, FILE_PATTERNS.hooks),
+				projectMetadata,
+				projectOverrides.hooks,
+				projectBaseDir,
+			);
 		}
 
 		if (resolve(legacyProjectBaseDir) !== resolve(projectBaseDir)) {
@@ -2398,6 +2415,13 @@ export class DefaultPackageManager implements PackageManager {
 				collectAutoThemeEntries(legacyProjectDirs.themes),
 				legacyProjectMetadata,
 				projectOverrides.themes,
+				legacyProjectBaseDir,
+			);
+			addResources(
+				"hooks",
+				collectFiles(legacyProjectDirs.hooks, FILE_PATTERNS.hooks),
+				legacyProjectMetadata,
+				projectOverrides.hooks,
 				legacyProjectBaseDir,
 			);
 		}
@@ -2448,6 +2472,13 @@ export class DefaultPackageManager implements PackageManager {
 			userOverrides.themes,
 			globalBaseDir,
 		);
+		addResources(
+			"hooks",
+			collectFiles(userDirs.hooks, FILE_PATTERNS.hooks),
+			userMetadata,
+			userOverrides.hooks,
+			globalBaseDir,
+		);
 	}
 
 	private collectFilesFromPaths(paths: string[], resourceType: ResourceType): string[] {
@@ -2482,6 +2513,8 @@ export class DefaultPackageManager implements PackageManager {
 				return accumulator.prompts;
 			case "themes":
 				return accumulator.themes;
+			case "hooks":
+				return accumulator.hooks;
 			default:
 				throw new Error(`Unknown resource type: ${resourceType}`);
 		}
@@ -2505,6 +2538,7 @@ export class DefaultPackageManager implements PackageManager {
 			skills: new Map(),
 			prompts: new Map(),
 			themes: new Map(),
+			hooks: new Map(),
 		};
 	}
 
@@ -2533,6 +2567,7 @@ export class DefaultPackageManager implements PackageManager {
 			skills: mapToResolved(accumulator.skills),
 			prompts: mapToResolved(accumulator.prompts),
 			themes: mapToResolved(accumulator.themes),
+			hooks: mapToResolved(accumulator.hooks),
 		};
 	}
 

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -281,6 +281,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private extensionThemeSourceInfos: Map<string, SourceInfo>;
 	private lastPromptPaths: string[];
 	private lastThemePaths: string[];
+	private globalHookSourcePaths: string[];
+	private projectHookSourcePaths: string[];
+	private preSessionHookSourcePaths: string[];
 	private loadedHookSources: LoadedHookSources;
 	private loaded: boolean;
 
@@ -326,6 +329,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.extensionThemeSourceInfos = new Map();
 		this.lastPromptPaths = [];
 		this.lastThemePaths = [];
+		this.globalHookSourcePaths = [];
+		this.projectHookSourcePaths = [];
+		this.preSessionHookSourcePaths = [];
 		this.loadedHookSources = this.buildLoadedHookSources([]);
 		this.loaded = false;
 	}
@@ -444,7 +450,6 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.extensionSkillSourceInfos = new Map();
 		this.extensionPromptSourceInfos = new Map();
 		this.extensionThemeSourceInfos = new Map();
-		this.loadedHookSources = this.buildLoadedHookSources([...this.loadedHookSources.runtimeHookSourcePaths]);
 
 		// Helper to extract enabled paths and store metadata
 		const getEnabledResources = (resources: ResolvedResource[]): ResolvedResource[] => {
@@ -462,6 +467,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const enabledSkillResources = getEnabledResources(resolvedPaths.skills);
 		const enabledPrompts = getEnabledPaths(resolvedPaths.prompts);
 		const enabledThemes = getEnabledPaths(resolvedPaths.themes);
+		const enabledHookResources = getEnabledResources(resolvedPaths.hooks);
 
 		const enabledSkills = enabledSkillResources.map((resource) => this.mapSkillPath(resource, metadataByPath));
 
@@ -479,11 +485,24 @@ export class DefaultResourceLoader implements ResourceLoader {
 		for (const r of cliExtensionPaths.themes) {
 			metadataByPath.set(r.path, { source: "cli", scope: "temporary", origin: "top-level" });
 		}
+		for (const r of cliExtensionPaths.hooks) {
+			metadataByPath.set(r.path, { source: "cli", scope: "temporary", origin: "top-level" });
+		}
 
 		const cliEnabledExtensions = getEnabledPaths(cliExtensionPaths.extensions);
 		const cliEnabledSkills = getEnabledPaths(cliExtensionPaths.skills);
 		const cliEnabledPrompts = getEnabledPaths(cliExtensionPaths.prompts);
 		const cliEnabledThemes = getEnabledPaths(cliExtensionPaths.themes);
+		const cliEnabledHooks = getEnabledPaths(cliExtensionPaths.hooks);
+
+		this.globalHookSourcePaths = enabledHookResources
+			.filter((resource) => resource.metadata.scope === "user")
+			.map((resource) => resource.path);
+		this.projectHookSourcePaths = enabledHookResources
+			.filter((resource) => resource.metadata.scope === "project")
+			.map((resource) => resource.path);
+		this.preSessionHookSourcePaths = this.mergePaths(cliEnabledHooks, this.additionalHookPaths);
+		this.loadedHookSources = this.buildLoadedHookSources([...this.loadedHookSources.runtimeHookSourcePaths]);
 
 		const extensionPaths = this.noExtensions
 			? cliEnabledExtensions
@@ -743,10 +762,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 		return {
 			agentDir: this.agentDir,
 			cwd: this.cwd,
-			globalHookSourcePaths: [],
+			globalHookSourcePaths: this.globalHookSourcePaths.map((path) => this.resolveResourcePath(path)),
 			globalHooksPath: this.resolveResourcePath(join(this.agentDir, "hooks.json")),
-			preSessionHookSourcePaths: this.additionalHookPaths.map((path) => this.resolveResourcePath(path)),
-			projectHookSourcePaths: [],
+			preSessionHookSourcePaths: this.preSessionHookSourcePaths.map((path) => this.resolveResourcePath(path)),
+			projectHookSourcePaths: this.projectHookSourcePaths.map((path) => this.resolveResourcePath(path)),
 			projectHooksPath: this.resolveResourcePath(join(this.cwd, CONFIG_DIR_NAME, "hooks.json")),
 			runtimeHookSourcePaths: runtimeHookSourcePaths.map((path) => this.resolveResourcePath(path)),
 		};

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -23,7 +23,13 @@ import {
 	loadExtensionFromFactory,
 	loadExtensions,
 } from "./extensions/loader.ts";
-import type { Extension, ExtensionFactory, ExtensionRuntime, LoadExtensionsResult } from "./extensions/types.ts";
+import type {
+	Extension,
+	ExtensionFactory,
+	ExtensionRuntime,
+	LoadExtensionsResult,
+	LoadedHookSources,
+} from "./extensions/types.ts";
 import { DefaultPackageManager, type PathMetadata, type ResolvedResource } from "./package-manager.ts";
 import type { PromptTemplate } from "./prompt-templates.ts";
 import { loadPromptTemplates } from "./prompt-templates.ts";
@@ -37,6 +43,7 @@ export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
 	promptPaths?: Array<{ path: string; metadata: PathMetadata }>;
 	themePaths?: Array<{ path: string; metadata: PathMetadata }>;
+	hookPaths?: Array<{ path: string; metadata: PathMetadata }>;
 }
 
 export interface ResourceLoaderReloadOptions {
@@ -51,6 +58,7 @@ export interface ResourceLoader {
 	getAgentsFiles(): { agentsFiles: Array<{ path: string; content: string }> };
 	getSystemPrompt(): string | undefined;
 	getAppendSystemPrompt(): string[];
+	getLoadedHookSources?(): LoadedHookSources;
 	extendResources(paths: ResourceExtensionPaths): void;
 	reload(options?: ResourceLoaderReloadOptions): Promise<void>;
 }
@@ -199,6 +207,7 @@ export interface DefaultResourceLoaderOptions {
 	additionalSkillPaths?: string[];
 	additionalPromptTemplatePaths?: string[];
 	additionalThemePaths?: string[];
+	additionalHookPaths?: string[];
 	extensionFactories?: ExtensionFactory[];
 	noExtensions?: boolean;
 	noSkills?: boolean;
@@ -233,6 +242,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private additionalSkillPaths: string[];
 	private additionalPromptTemplatePaths: string[];
 	private additionalThemePaths: string[];
+	private additionalHookPaths: string[];
 	private builtinExtensionFactories: BuiltinExtensionFactory[];
 	private extensionFactories: ExtensionFactory[];
 	private noExtensions: boolean;
@@ -271,6 +281,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private extensionThemeSourceInfos: Map<string, SourceInfo>;
 	private lastPromptPaths: string[];
 	private lastThemePaths: string[];
+	private loadedHookSources: LoadedHookSources;
 	private loaded: boolean;
 
 	constructor(options: DefaultResourceLoaderOptions) {
@@ -287,6 +298,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.additionalSkillPaths = options.additionalSkillPaths ?? [];
 		this.additionalPromptTemplatePaths = options.additionalPromptTemplatePaths ?? [];
 		this.additionalThemePaths = options.additionalThemePaths ?? [];
+		this.additionalHookPaths = options.additionalHookPaths ?? [];
 		this.builtinExtensionFactories = builtinExtensions;
 		this.extensionFactories = options.extensionFactories ?? [];
 		this.noExtensions = options.noExtensions ?? false;
@@ -314,6 +326,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.extensionThemeSourceInfos = new Map();
 		this.lastPromptPaths = [];
 		this.lastThemePaths = [];
+		this.loadedHookSources = this.buildLoadedHookSources([]);
 		this.loaded = false;
 	}
 
@@ -345,10 +358,15 @@ export class DefaultResourceLoader implements ResourceLoader {
 		return [];
 	}
 
+	getLoadedHookSources(): LoadedHookSources {
+		return this.loadedHookSources;
+	}
+
 	extendResources(paths: ResourceExtensionPaths): void {
 		const skillPaths = this.normalizeExtensionPaths(paths.skillPaths ?? []);
 		const promptPaths = this.normalizeExtensionPaths(paths.promptPaths ?? []);
 		const themePaths = this.normalizeExtensionPaths(paths.themePaths ?? []);
+		const hookPaths = this.normalizeExtensionPaths(paths.hookPaths ?? []);
 
 		for (const entry of skillPaths) {
 			this.extensionSkillSourceInfos.set(entry.path, createSourceInfo(entry.path, entry.metadata));
@@ -382,6 +400,14 @@ export class DefaultResourceLoader implements ResourceLoader {
 				themePaths.map((entry) => entry.path),
 			);
 			this.updateThemesFromPaths(this.lastThemePaths);
+		}
+
+		if (hookPaths.length > 0) {
+			const runtimeHookSourcePaths = this.mergePaths(
+				[...this.loadedHookSources.runtimeHookSourcePaths],
+				hookPaths.map((entry) => entry.path),
+			);
+			this.loadedHookSources = this.buildLoadedHookSources(runtimeHookSourcePaths);
 		}
 	}
 
@@ -418,6 +444,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.extensionSkillSourceInfos = new Map();
 		this.extensionPromptSourceInfos = new Map();
 		this.extensionThemeSourceInfos = new Map();
+		this.loadedHookSources = this.buildLoadedHookSources([...this.loadedHookSources.runtimeHookSourcePaths]);
 
 		// Helper to extract enabled paths and store metadata
 		const getEnabledResources = (resources: ResolvedResource[]): ResolvedResource[] => {
@@ -710,6 +737,19 @@ export class DefaultResourceLoader implements ResourceLoader {
 				metadata,
 			};
 		});
+	}
+
+	private buildLoadedHookSources(runtimeHookSourcePaths: readonly string[]): LoadedHookSources {
+		return {
+			agentDir: this.agentDir,
+			cwd: this.cwd,
+			globalHookSourcePaths: [],
+			globalHooksPath: this.resolveResourcePath(join(this.agentDir, "hooks.json")),
+			preSessionHookSourcePaths: this.additionalHookPaths.map((path) => this.resolveResourcePath(path)),
+			projectHookSourcePaths: [],
+			projectHooksPath: this.resolveResourcePath(join(this.cwd, CONFIG_DIR_NAME, "hooks.json")),
+			runtimeHookSourcePaths: runtimeHookSourcePaths.map((path) => this.resolveResourcePath(path)),
+		};
 	}
 
 	private updateSkillsFromPaths(skillPaths: string[], metadataByPath?: Map<string, PathMetadata>): void {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -87,6 +87,7 @@ export type PackageSource =
 			skills?: string[];
 			prompts?: string[];
 			themes?: string[];
+			hooks?: string[];
 	  };
 
 export interface Settings {
@@ -119,6 +120,7 @@ export interface Settings {
 	skills?: string[]; // Array of local skill file paths or directories
 	prompts?: string[]; // Array of local prompt template paths or directories
 	themes?: string[]; // Array of local theme file paths or directories
+	hooks?: string[];
 	enableSkillCommands?: boolean; // default: true - register skills as /skill:name commands
 	terminal?: TerminalSettings;
 	images?: ImageSettings;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -100,6 +100,16 @@ describe("ExtensionRunner", () => {
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
 		getSystemPrompt: () => "",
+		getLoadedHookSources: () => ({
+			agentDir: tempDir,
+			cwd: tempDir,
+			globalHookSourcePaths: [],
+			globalHooksPath: path.join(tempDir, "hooks.json"),
+			preSessionHookSourcePaths: [],
+			projectHookSourcePaths: [],
+			projectHooksPath: path.join(tempDir, ".senpi", "hooks.json"),
+			runtimeHookSourcePaths: [],
+		}),
 	};
 
 	type JsonContextFixture = {

--- a/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
@@ -12,8 +12,6 @@ import { SessionManager } from "../../src/core/session-manager.ts";
 import { createTestExtensionsResult } from "../utilities.ts";
 
 const createdDirs: string[] = [];
-const T13_FORBIDDEN_ADAPTER_EVENTS = ["agent_end"] as const;
-
 afterEach(() => {
 	for (const dir of createdDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
@@ -50,7 +48,7 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(hooksIndex).toBeLessThan(permissionIndex);
 	});
 
-	it("registers the T11 prompt, T12 tool, and T13 lifecycle adapter runtime handlers only", async () => {
+	it("registers the T11 prompt, T12 tool, T13 lifecycle, and T14 Stop runtime handlers only", async () => {
 		// Given
 		const cwd = createTempDir("senpi-hooks-t10-registration-cwd");
 		const hooksExtension = getBuiltinExtension("hooks");
@@ -77,10 +75,9 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(registeredEvents.has("session_start")).toBe(true);
 		expect(registeredEvents.has("session_before_compact")).toBe(true);
 		expect(registeredEvents.has("session_compact")).toBe(true);
-		for (const event of T13_FORBIDDEN_ADAPTER_EVENTS) {
-			expect(registeredEvents.has(event)).toBe(false);
-		}
+		expect(registeredEvents.has("agent_end")).toBe(true);
 		expect(Array.from(registeredEvents).sort()).toEqual([
+			"agent_end",
 			"before_agent_start",
 			"input",
 			"session_before_compact",

--- a/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
@@ -12,12 +12,7 @@ import { SessionManager } from "../../src/core/session-manager.ts";
 import { createTestExtensionsResult } from "../utilities.ts";
 
 const createdDirs: string[] = [];
-const T10_FORBIDDEN_ADAPTER_EVENTS = [
-	"session_start",
-	"session_before_compact",
-	"session_compact",
-	"agent_end",
-] as const;
+const T13_FORBIDDEN_ADAPTER_EVENTS = ["agent_end"] as const;
 
 afterEach(() => {
 	for (const dir of createdDirs.splice(0)) {
@@ -55,7 +50,7 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(hooksIndex).toBeLessThan(permissionIndex);
 	});
 
-	it("registers the T11 prompt and T12 tool adapter runtime handlers only", async () => {
+	it("registers the T11 prompt, T12 tool, and T13 lifecycle adapter runtime handlers only", async () => {
 		// Given
 		const cwd = createTempDir("senpi-hooks-t10-registration-cwd");
 		const hooksExtension = getBuiltinExtension("hooks");
@@ -79,10 +74,21 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(registeredEvents.has("before_agent_start")).toBe(true);
 		expect(registeredEvents.has("tool_call")).toBe(true);
 		expect(registeredEvents.has("tool_result")).toBe(true);
-		for (const event of T10_FORBIDDEN_ADAPTER_EVENTS) {
+		expect(registeredEvents.has("session_start")).toBe(true);
+		expect(registeredEvents.has("session_before_compact")).toBe(true);
+		expect(registeredEvents.has("session_compact")).toBe(true);
+		for (const event of T13_FORBIDDEN_ADAPTER_EVENTS) {
 			expect(registeredEvents.has(event)).toBe(false);
 		}
-		expect(Array.from(registeredEvents).sort()).toEqual(["before_agent_start", "input", "tool_call", "tool_result"]);
+		expect(Array.from(registeredEvents).sort()).toEqual([
+			"before_agent_start",
+			"input",
+			"session_before_compact",
+			"session_compact",
+			"session_start",
+			"tool_call",
+			"tool_result",
+		]);
 	});
 
 	it("collects resource-discovered hook paths as runtime hook sources", async () => {

--- a/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
@@ -33,6 +33,32 @@ function getBuiltinExtension(id: string): BuiltinExtensionFactory {
 	return extension;
 }
 
+function hookConfig(command: string): unknown {
+	return {
+		hooks: {
+			PreToolUse: [
+				{
+					hooks: [{ type: "command", command }],
+				},
+			],
+		},
+	};
+}
+
+function packageManifest(name: string, hooks: string[]): unknown {
+	return {
+		name,
+		pi: {
+			hooks,
+		},
+	};
+}
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
 describe("builtin hooks extension registration and resource plumbing", () => {
 	it("registers hooks before the permission system builtin", () => {
 		// Given
@@ -151,6 +177,89 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 			preSessionHookSourcePaths: [resolve(preSessionHookPath)],
 			runtimeHookSourcePaths: [resolve(runtimeHookPath)],
 		});
+	});
+
+	it("discovers package hook resources before session start in canonical scope buckets", async () => {
+		// Given
+		const cwd = createTempDir("senpi-hooks-package-sources-cwd");
+		const agentDir = join(cwd, "agent");
+		const globalPackage = join(cwd, "global-package");
+		const projectPackage = join(cwd, "project-package");
+		const temporaryPackage = join(cwd, "temporary-package");
+		const additionalHookPath = join(cwd, "additional-hooks.json");
+		const globalHookPath = join(globalPackage, "hooks", "global-hooks.json");
+		const projectHookPath = join(projectPackage, "hooks", "project-hooks.json");
+		const temporaryHookPath = join(temporaryPackage, "hooks", "temporary-hooks.json");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(cwd, ".senpi"), { recursive: true });
+		writeJson(globalHookPath, hookConfig("node hooks/global.mjs"));
+		writeJson(projectHookPath, hookConfig("node hooks/project.mjs"));
+		writeJson(temporaryHookPath, hookConfig("node hooks/temporary.mjs"));
+		writeJson(additionalHookPath, hookConfig("node hooks/additional.mjs"));
+		writeJson(join(globalPackage, "package.json"), packageManifest("global-package", ["hooks/global-hooks.json"]));
+		writeJson(join(projectPackage, "package.json"), packageManifest("project-package", ["hooks/project-hooks.json"]));
+		writeJson(
+			join(temporaryPackage, "package.json"),
+			packageManifest("temporary-package", ["hooks/temporary-hooks.json"]),
+		);
+		writeJson(join(agentDir, "settings.json"), { packages: [globalPackage] });
+		writeJson(join(cwd, ".senpi", "settings.json"), { packages: [projectPackage] });
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalExtensionPaths: [temporaryPackage],
+			additionalHookPaths: [additionalHookPath],
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+		});
+
+		// When
+		await loader.reload();
+
+		// Then
+		expect(loader.getLoadedHookSources()).toMatchObject({
+			globalHookSourcePaths: [resolve(globalHookPath)],
+			projectHookSourcePaths: [resolve(projectHookPath)],
+			preSessionHookSourcePaths: [resolve(temporaryHookPath), resolve(additionalHookPath)],
+			runtimeHookSourcePaths: [],
+		});
+	});
+
+	it("refreshes package hook resources on reload after manifest changes", async () => {
+		// Given
+		const cwd = createTempDir("senpi-hooks-package-reload-cwd");
+		const agentDir = join(cwd, "agent");
+		const globalPackage = join(cwd, "global-package");
+		const firstHookPath = join(globalPackage, "hooks", "first.json");
+		const secondHookPath = join(globalPackage, "hooks", "second.json");
+		mkdirSync(agentDir, { recursive: true });
+		writeJson(firstHookPath, hookConfig("node hooks/first.mjs"));
+		writeJson(secondHookPath, hookConfig("node hooks/second.mjs"));
+		writeJson(join(globalPackage, "package.json"), packageManifest("reload-package", ["hooks/first.json"]));
+		writeJson(join(agentDir, "settings.json"), { packages: [globalPackage] });
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+		});
+		await loader.reload();
+		expect(loader.getLoadedHookSources().globalHookSourcePaths).toEqual([resolve(firstHookPath)]);
+
+		// When
+		writeJson(join(globalPackage, "package.json"), packageManifest("reload-package", ["hooks/second.json"]));
+		await loader.reload();
+		const afterAdd = loader.getLoadedHookSources().globalHookSourcePaths;
+		writeJson(join(globalPackage, "package.json"), packageManifest("reload-package", []));
+		await loader.reload();
+
+		// Then
+		expect(afterAdd).toEqual([resolve(secondHookPath)]);
+		expect(loader.getLoadedHookSources().globalHookSourcePaths).toEqual([]);
 	});
 
 	it("keeps malformed hook source diagnostics nonfatal during no-op startup", async () => {

--- a/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
@@ -14,8 +14,6 @@ import { createTestExtensionsResult } from "../utilities.ts";
 const createdDirs: string[] = [];
 const T10_FORBIDDEN_ADAPTER_EVENTS = [
 	"session_start",
-	"tool_call",
-	"tool_result",
 	"session_before_compact",
 	"session_compact",
 	"agent_end",
@@ -57,7 +55,7 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(hooksIndex).toBeLessThan(permissionIndex);
 	});
 
-	it("registers only the T11 prompt adapter runtime handlers", async () => {
+	it("registers the T11 prompt and T12 tool adapter runtime handlers only", async () => {
 		// Given
 		const cwd = createTempDir("senpi-hooks-t10-registration-cwd");
 		const hooksExtension = getBuiltinExtension("hooks");
@@ -79,10 +77,12 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(loadedHooksExtension.commands.has("hooks")).toBe(true);
 		expect(registeredEvents.has("input")).toBe(true);
 		expect(registeredEvents.has("before_agent_start")).toBe(true);
+		expect(registeredEvents.has("tool_call")).toBe(true);
+		expect(registeredEvents.has("tool_result")).toBe(true);
 		for (const event of T10_FORBIDDEN_ADAPTER_EVENTS) {
 			expect(registeredEvents.has(event)).toBe(false);
 		}
-		expect(Array.from(registeredEvents).sort()).toEqual(["before_agent_start", "input"]);
+		expect(Array.from(registeredEvents).sort()).toEqual(["before_agent_start", "input", "tool_call", "tool_result"]);
 	});
 
 	it("collects resource-discovered hook paths as runtime hook sources", async () => {

--- a/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
@@ -1,0 +1,176 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { type BuiltinExtensionFactory, builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import { ExtensionRunner } from "../../src/core/extensions/runner.ts";
+import type { ExtensionFactory } from "../../src/core/extensions/types.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { createTestExtensionsResult } from "../utilities.ts";
+
+const createdDirs: string[] = [];
+const T10_FORBIDDEN_ADAPTER_EVENTS = [
+	"session_start",
+	"tool_call",
+	"tool_result",
+	"input",
+	"session_before_compact",
+	"session_compact",
+	"agent_end",
+] as const;
+
+afterEach(() => {
+	for (const dir of createdDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function createTempDir(prefix: string): string {
+	const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	createdDirs.push(dir);
+	return dir;
+}
+
+function getBuiltinExtension(id: string): BuiltinExtensionFactory {
+	const extension = builtinExtensions.find((entry) => entry.id === id);
+	if (extension === undefined) {
+		throw new Error(`missing builtin extension: ${id}`);
+	}
+	return extension;
+}
+
+describe("builtin hooks extension registration and resource plumbing", () => {
+	it("registers hooks before the permission system builtin", () => {
+		// Given
+		const ids = builtinExtensions.map((extension) => extension.id);
+
+		// When
+		const hooksIndex = ids.indexOf("hooks");
+		const permissionIndex = ids.indexOf("permission-system");
+
+		// Then
+		expect(hooksIndex).toBeGreaterThanOrEqual(0);
+		expect(permissionIndex).toBeGreaterThanOrEqual(0);
+		expect(hooksIndex).toBeLessThan(permissionIndex);
+	});
+
+	it("does not register runtime hook adapter handlers during T10", async () => {
+		// Given
+		const cwd = createTempDir("senpi-hooks-t10-registration-cwd");
+		const hooksExtension = getBuiltinExtension("hooks");
+
+		// When
+		const extensionsResult = await createTestExtensionsResult(
+			[{ factory: hooksExtension.factory, path: "<builtin:hooks>" }],
+			cwd,
+		);
+		const loadedHooksExtension = extensionsResult.extensions.find(
+			(extension) => extension.path === "<builtin:hooks>",
+		);
+		if (loadedHooksExtension === undefined) {
+			throw new Error("builtin hooks extension did not load");
+		}
+		const registeredEvents = new Set(loadedHooksExtension.handlers.keys());
+
+		// Then
+		expect(loadedHooksExtension.commands.has("hooks")).toBe(true);
+		for (const event of T10_FORBIDDEN_ADAPTER_EVENTS) {
+			expect(registeredEvents.has(event)).toBe(false);
+		}
+		expect(Array.from(registeredEvents)).toEqual([]);
+	});
+
+	it("collects resource-discovered hook paths as runtime hook sources", async () => {
+		// Given
+		const cwd = createTempDir("senpi-hooks-runtime-cwd");
+		const hookPath = join(cwd, "runtime-hooks.json");
+		const extensionFactory: ExtensionFactory = (pi) => {
+			pi.on("resources_discover", () => ({ hookPaths: [hookPath] }));
+		};
+		const extensionsResult = await createTestExtensionsResult(
+			[{ factory: extensionFactory, path: "/tmp/hooks-ext.ts" }],
+			cwd,
+		);
+		const runner = new ExtensionRunner(
+			extensionsResult.extensions,
+			extensionsResult.runtime,
+			cwd,
+			SessionManager.inMemory(),
+			ModelRegistry.inMemory(AuthStorage.inMemory()),
+		);
+
+		// When
+		const result = await runner.emitResourcesDiscover(cwd, "reload");
+
+		// Then
+		expect(result.hookPaths).toEqual([{ path: hookPath, extensionPath: "/tmp/hooks-ext.ts" }]);
+	});
+
+	it("stores pre-session and runtime hook sources for extension context reads", async () => {
+		// Given
+		const cwd = createTempDir("senpi-hooks-loader-cwd");
+		const agentDir = join(cwd, "agent");
+		const preSessionHookPath = join(cwd, "pre-session-hooks.json");
+		const runtimeHookPath = join(cwd, "runtime-hooks.json");
+		mkdirSync(agentDir, { recursive: true });
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalHookPaths: [preSessionHookPath],
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+		});
+		await loader.reload();
+
+		// When
+		loader.extendResources({
+			hookPaths: [
+				{
+					path: runtimeHookPath,
+					metadata: { source: "extension:test", scope: "temporary", origin: "top-level" },
+				},
+			],
+		});
+
+		// Then
+		expect(loader.getLoadedHookSources()).toMatchObject({
+			agentDir: resolve(agentDir),
+			cwd: resolve(cwd),
+			globalHooksPath: join(resolve(agentDir), "hooks.json"),
+			projectHooksPath: join(resolve(cwd), ".senpi", "hooks.json"),
+			preSessionHookSourcePaths: [resolve(preSessionHookPath)],
+			runtimeHookSourcePaths: [resolve(runtimeHookPath)],
+		});
+	});
+
+	it("keeps malformed hook source diagnostics nonfatal during no-op startup", async () => {
+		// Given
+		const cwd = createTempDir("senpi-hooks-malformed-cwd");
+		const agentDir = join(cwd, "agent");
+		const malformedPath = join(cwd, "bad-hooks.json");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(malformedPath, "{ bad json", "utf-8");
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalHookPaths: [malformedPath],
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+		});
+
+		// When
+		await expect(loader.reload()).resolves.toBeUndefined();
+		const extensionsResult = loader.getExtensions();
+
+		// Then
+		expect(extensionsResult.errors).not.toContainEqual(expect.objectContaining({ path: "<builtin:hooks>" }));
+		expect(extensionsResult.extensions.some((extension) => extension.path === "<builtin:hooks>")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/hooks-builtin-extension.test.ts
@@ -16,7 +16,6 @@ const T10_FORBIDDEN_ADAPTER_EVENTS = [
 	"session_start",
 	"tool_call",
 	"tool_result",
-	"input",
 	"session_before_compact",
 	"session_compact",
 	"agent_end",
@@ -58,7 +57,7 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 		expect(hooksIndex).toBeLessThan(permissionIndex);
 	});
 
-	it("does not register runtime hook adapter handlers during T10", async () => {
+	it("registers only the T11 prompt adapter runtime handlers", async () => {
 		// Given
 		const cwd = createTempDir("senpi-hooks-t10-registration-cwd");
 		const hooksExtension = getBuiltinExtension("hooks");
@@ -78,10 +77,12 @@ describe("builtin hooks extension registration and resource plumbing", () => {
 
 		// Then
 		expect(loadedHooksExtension.commands.has("hooks")).toBe(true);
+		expect(registeredEvents.has("input")).toBe(true);
+		expect(registeredEvents.has("before_agent_start")).toBe(true);
 		for (const event of T10_FORBIDDEN_ADAPTER_EVENTS) {
 			expect(registeredEvents.has(event)).toBe(false);
 		}
-		expect(Array.from(registeredEvents)).toEqual([]);
+		expect(Array.from(registeredEvents).sort()).toEqual(["before_agent_start", "input"]);
 	});
 
 	it("collects resource-discovered hook paths as runtime hook sources", async () => {

--- a/packages/coding-agent/test/suite/hooks-command-harness.ts
+++ b/packages/coding-agent/test/suite/hooks-command-harness.ts
@@ -1,0 +1,178 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import hooksExtension from "../../src/core/extensions/builtin/hooks/index.ts";
+import type { ExtensionUIContext } from "../../src/core/extensions/index.ts";
+import type { LoadedHookSources } from "../../src/core/extensions/types.ts";
+import type { ResourceLoader } from "../../src/core/resource-loader.ts";
+import { theme } from "../../src/modes/interactive/theme/theme.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+export type Notification = {
+	readonly message: string;
+	readonly type: "info" | "warning" | "error" | undefined;
+};
+
+type HooksState = {
+	readonly hooks: Record<string, HookStateEntry>;
+};
+
+type HookStateEntry = {
+	readonly enabled: boolean;
+	readonly trustedHash?: string;
+};
+
+const harnesses: Harness[] = [];
+
+export function cleanupHooksCommandHarnesses(): void {
+	while (harnesses.length > 0) {
+		harnesses.pop()?.cleanup();
+	}
+}
+
+export async function createHooksCommandHarness(options: { readonly projectHooks: unknown }) {
+	const notifications: Notification[] = [];
+	const payloads: unknown[] = [];
+	const extensionsResult = await createTestExtensionsResult([{ factory: hooksExtension, path: "<builtin:hooks>" }]);
+	const baseResourceLoader = createTestResourceLoader({ extensionsResult });
+	let reloadCalls = 0;
+	let hookSources: LoadedHookSources | undefined;
+	const resourceLoader: ResourceLoader = {
+		...baseResourceLoader,
+		getLoadedHookSources: () => {
+			if (hookSources === undefined) {
+				throw new Error("hook sources not initialized");
+			}
+			return hookSources;
+		},
+		reload: async () => {
+			reloadCalls += 1;
+		},
+	};
+	const harness = await createHarness({
+		resourceLoader,
+		withConfiguredAuth: false,
+		onPayload: (payload) => payloads.push(payload),
+	});
+	harnesses.push(harness);
+	const agentDir = join(harness.tempDir, "agent");
+	const projectHooksPath = join(harness.tempDir, ".senpi", "hooks.json");
+	const projectStatePath = join(harness.tempDir, ".senpi", "hooks-state.json");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(join(harness.tempDir, ".senpi"), { recursive: true });
+	writeFileSync(projectHooksPath, JSON.stringify(options.projectHooks), "utf-8");
+	hookSources = {
+		agentDir,
+		cwd: harness.tempDir,
+		globalHookSourcePaths: [],
+		globalHooksPath: join(agentDir, "hooks.json"),
+		preSessionHookSourcePaths: [],
+		projectHookSourcePaths: [],
+		projectHooksPath,
+		runtimeHookSourcePaths: [],
+	};
+	await harness.session.bindExtensions({
+		uiContext: createUiContext((message, type) => notifications.push({ message, type })),
+		commandContextActions: {
+			waitForIdle: async () => {},
+			newSession: async () => ({ cancelled: false }),
+			fork: async () => ({ cancelled: false }),
+			navigateTree: async () => ({ cancelled: false }),
+			switchSession: async () => ({ cancelled: false }),
+			reload: async () => {
+				await resourceLoader.reload();
+			},
+		},
+	});
+	return {
+		harness,
+		notifications,
+		payloads,
+		projectHooksPath,
+		projectStatePath,
+		get reloadCalls() {
+			return reloadCalls;
+		},
+	};
+}
+
+function createUiContext(
+	onNotify: (message: string, type: "info" | "warning" | "error" | undefined) => void,
+): ExtensionUIContext {
+	return {
+		select: async () => undefined,
+		confirm: async () => false,
+		input: async () => undefined,
+		notify: onNotify,
+		onTerminalInput: () => () => {},
+		setStatus: () => {},
+		setWorkingMessage: () => {},
+		setWorkingVisible: () => {},
+		setWorkingIndicator: () => {},
+		setHiddenThinkingLabel: () => {},
+		setWidget: () => {},
+		setFooter: () => {},
+		setHeader: () => {},
+		setTitle: () => {},
+		custom: async <T>(): Promise<T> => {
+			throw new Error("custom UI is not implemented in /hooks command tests");
+		},
+		pasteToEditor: () => {},
+		setEditorText: () => {},
+		getEditorText: () => "",
+		editor: async () => undefined,
+		addAutocompleteProvider: () => {},
+		setEditorComponent: () => {},
+		getEditorComponent: () => undefined,
+		get theme() {
+			return theme;
+		},
+		getAllThemes: () => [],
+		getTheme: () => undefined,
+		setTheme: () => ({ success: false, error: "themes are not used by /hooks tests" }),
+		getToolsExpanded: () => false,
+		setToolsExpanded: () => {},
+	};
+}
+
+export function lastNotification(notifications: readonly Notification[]): Notification {
+	const notification = notifications.at(-1);
+	if (notification === undefined) {
+		throw new Error("expected notification");
+	}
+	return notification;
+}
+
+export function firstHookId(message: string): string {
+	const match = /^- (hk_[^ ]+)/m.exec(message);
+	if (match === null) {
+		throw new Error(`expected hook ID in message:\n${message}`);
+	}
+	return match[1];
+}
+
+export function readState(path: string): HooksState {
+	const parsed: unknown = JSON.parse(readFileSync(resolve(path), "utf-8"));
+	if (!isRecord(parsed) || !isRecord(parsed.hooks)) {
+		throw new Error("invalid hooks state");
+	}
+	const hooks: Record<string, HookStateEntry> = {};
+	for (const [id, hook] of Object.entries(parsed.hooks)) {
+		if (!isHookStateEntry(hook)) {
+			throw new Error("invalid hooks state");
+		}
+		hooks[id] = hook;
+	}
+	return { hooks };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isHookStateEntry(value: unknown): value is HookStateEntry {
+	if (!isRecord(value) || typeof value.enabled !== "boolean") {
+		return false;
+	}
+	return value.trustedHash === undefined || typeof value.trustedHash === "string";
+}

--- a/packages/coding-agent/test/suite/hooks-command-redaction.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command-redaction.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { formatHookDiagnostics } from "../../src/core/extensions/builtin/hooks/command.ts";
+import { cleanupHooksCommandHarnesses, createHooksCommandHarness, lastNotification } from "./hooks-command-harness.ts";
+
+const GITHUB_CLASSIC_PAT = "ghp_0123456789abcdef0123456789abcdef0123";
+const GITHUB_FINE_GRAINED_PAT = "github_pat_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+afterEach(() => {
+	cleanupHooksCommandHarnesses();
+});
+
+describe("builtin hooks command redaction", () => {
+	it("redacts GitHub PATs in hook list output without over-redacting short fragments", async () => {
+		const setup = await createHooksCommandHarness({
+			projectHooks: {
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: `Bash ${GITHUB_CLASSIC_PAT} ghp_short`,
+							hooks: [
+								{
+									type: "command",
+									command: `node hooks/pre-tool.mjs ${GITHUB_CLASSIC_PAT} ${GITHUB_FINE_GRAINED_PAT} ghp_short github_pat_short`,
+									statusMessage: `checking ${GITHUB_FINE_GRAINED_PAT} github_pat_short`,
+								},
+							],
+						},
+					],
+				},
+			},
+		});
+
+		await setup.harness.session.prompt("/hooks list");
+
+		const message = lastNotification(setup.notifications).message;
+		expect(message).toContain("command:node hooks/pre-tool.mjs [redacted] [redacted] ghp_short github_pat_short");
+		expect(message).toContain("matcher:Bash [redacted] ghp_short");
+		expect(message).toContain("statusMessage:checking [redacted] github_pat_short");
+		expect(message).not.toContain(GITHUB_CLASSIC_PAT);
+		expect(message).not.toContain(GITHUB_FINE_GRAINED_PAT);
+		expect(setup.payloads).toEqual([]);
+	});
+
+	it("redacts GitHub PATs in hook diagnostics without changing short fragments", () => {
+		const message = formatHookDiagnostics([
+			{
+				code: "invalid_command_target",
+				event: "PreToolUse",
+				message: `target ${GITHUB_CLASSIC_PAT} ${GITHUB_FINE_GRAINED_PAT} ghp_short github_pat_short`,
+				path: "hooks.PreToolUse[0].hooks[0].command",
+				severity: "error",
+				source: {
+					discoveredAt: "pre-session",
+					displayOrder: 0,
+					scope: "project",
+					sourcePath: `/repo/${GITHUB_CLASSIC_PAT}/hooks.json`,
+				},
+			},
+		]);
+
+		expect(message).toContain("target [redacted] [redacted] ghp_short github_pat_short");
+		expect(message).toContain("/repo/[redacted]/hooks.json");
+		expect(message).not.toContain(GITHUB_CLASSIC_PAT);
+		expect(message).not.toContain(GITHUB_FINE_GRAINED_PAT);
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-command-runner.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command-runner.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCommandHook, selectCommandForPlatform } from "../../src/core/extensions/builtin/hooks/command-runner.ts";
 import type {
 	ExecutableHookHandler,
@@ -182,5 +182,48 @@ describe("builtin hooks command runner", () => {
 		expect(result.timedOut).toBe(false);
 		expect(result.exitCode).toBeNull();
 		assertProcessExited(Number(readFileSync(pidPath, "utf8")));
+	});
+
+	it("caps stdout and stderr in memory before concatenation", async () => {
+		// Given
+		const cwd = createTempDir("output-cap");
+		mkdirSync(cwd, { recursive: true });
+		const spillDir = join(cwd, "spill");
+		const scriptPath = join(cwd, "large-output.mjs");
+		writeFileSync(
+			scriptPath,
+			["process.stdout.write('o'.repeat(4096));", "process.stderr.write('e'.repeat(4096));"].join("\n"),
+		);
+		const originalConcat = Buffer.concat;
+		const concatSpy = vi.spyOn(Buffer, "concat").mockImplementation((list, totalLength) => {
+			const observedBytes = totalLength ?? list.reduce((sum, chunk) => sum + chunk.length, 0);
+			if (observedBytes > 128) {
+				throw new Error(`unbounded Buffer.concat observed ${observedBytes} bytes`);
+			}
+			return originalConcat(list, totalLength);
+		});
+		const input: HookInputWire = { cwd, event: "SessionStart", sessionId: "s1" };
+
+		try {
+			// When
+			const result = await runCommandHook(createHandler(`${process.execPath} ${scriptPath}`), input, {
+				cwd,
+				outputPolicy: { maxStderrBytes: 128, maxStdoutBytes: 128, spillDir },
+			});
+
+			// Then
+			expect(Buffer.byteLength(result.stdout)).toBeLessThanOrEqual(128);
+			expect(Buffer.byteLength(result.stderr)).toBeLessThanOrEqual(128);
+			expect(result.outputSafety.stdout).toEqual(
+				expect.objectContaining({ originalBytes: 4096, returnedBytes: 128, spilled: true, truncated: true }),
+			);
+			expect(result.outputSafety.stderr).toEqual(
+				expect.objectContaining({ originalBytes: 4096, returnedBytes: 128, spilled: true, truncated: true }),
+			);
+			expect(result.outputSafety.stdout.spillPath).toEqual(expect.any(String));
+			expect(result.outputSafety.stderr.spillPath).toEqual(expect.any(String));
+		} finally {
+			concatSpy.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/suite/hooks-command-runner.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command-runner.test.ts
@@ -145,8 +145,21 @@ describe("builtin hooks command runner", () => {
 		expect(result.timedOut).toBe(true);
 		expect(result.aborted).toBe(false);
 		expect(result.exitCode).toBeNull();
+		expect(result.timeoutSeconds).toBe(0.1);
 		expect(existsSync(pidPath)).toBe(true);
 		assertProcessExited(Number(readFileSync(pidPath, "utf8")));
+	});
+
+	it("rejects invalid timeout values before starting a command", async () => {
+		// Given
+		const cwd = createTempDir("invalid-timeout");
+		mkdirSync(cwd, { recursive: true });
+		const input: HookInputWire = { cwd, event: "SessionStart", sessionId: "s1" };
+
+		// Then
+		await expect(
+			runCommandHook(createHandler('node -e "process.exit(0)"', { timeout: 0 }), input, { cwd }),
+		).rejects.toThrow("Invalid command hook timeout reached runtime execution.");
 	});
 
 	it("kills a running command when the abort signal fires", async () => {

--- a/packages/coding-agent/test/suite/hooks-command-runner.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command-runner.test.ts
@@ -1,0 +1,186 @@
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCommandHook, selectCommandForPlatform } from "../../src/core/extensions/builtin/hooks/command-runner.ts";
+import type {
+	ExecutableHookHandler,
+	HookInputWire,
+	HookSourceMetadata,
+} from "../../src/core/extensions/builtin/hooks/types.ts";
+
+const SOURCE: HookSourceMetadata = {
+	discoveredAt: "pre-session",
+	displayOrder: 1,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+const tempDirs: string[] = [];
+
+function createHandler(command: string, options?: { readonly timeout?: number }): ExecutableHookHandler {
+	return {
+		config: {
+			type: "command",
+			command,
+			...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
+		},
+		event: "PreToolUse",
+		groupIndex: 0,
+		handlerIndex: 0,
+		source: SOURCE,
+	};
+}
+
+function createWindowsHandler(command: string, commandWindows: string): ExecutableHookHandler {
+	return {
+		...createHandler(command),
+		config: {
+			type: "command",
+			command,
+			commandWindows,
+		},
+	};
+}
+
+function createTempDir(name: string): string {
+	const dir = join(realpathSync(tmpdir()), `senpi-hooks-${name}-${process.pid}-${Date.now()}`);
+	tempDirs.push(dir);
+	return dir;
+}
+
+function assertProcessExited(pid: number): void {
+	try {
+		process.kill(pid, 0);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ESRCH") return;
+		throw error;
+	}
+	throw new Error(`process ${pid} is still running`);
+}
+
+describe("builtin hooks command runner", () => {
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("writes JSON stdin, runs in cwd, and captures stdout stderr and exit metadata", async () => {
+		// Given
+		const cwd = createTempDir("json-stdin");
+		mkdirSync(cwd, { recursive: true });
+		const scriptPath = join(cwd, "echo-hook.mjs");
+		writeFileSync(
+			scriptPath,
+			[
+				"let input = '';",
+				"process.stdin.setEncoding('utf8');",
+				"process.stdin.on('data', (chunk) => { input += chunk; });",
+				"process.stdin.on('end', () => {",
+				"  const parsed = JSON.parse(input);",
+				"  process.stdout.write(JSON.stringify({ cwd: process.cwd(), event: parsed.event, tool: parsed.toolName }));",
+				"  process.stderr.write('stderr-marker');",
+				"  process.exit(7);",
+				"});",
+			].join("\n"),
+		);
+		const input: HookInputWire = {
+			cwd,
+			event: "PreToolUse",
+			toolInput: { command: "pwd" },
+			toolName: "Bash",
+		};
+
+		// When
+		const result = await runCommandHook(createHandler(`${process.execPath} ${scriptPath}`), input, { cwd });
+
+		// Then
+		expect(JSON.parse(result.stdout)).toEqual({ cwd, event: "PreToolUse", tool: "Bash" });
+		expect(result.stderr).toBe("stderr-marker");
+		expect(result.exitCode).toBe(7);
+		expect(result.signal).toBeNull();
+		expect(result.timedOut).toBe(false);
+		expect(result.aborted).toBe(false);
+		expect(result.command).toBe(`${process.execPath} ${scriptPath}`);
+		expect(result.cwd).toBe(cwd);
+		expect(result.durationMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("selects commandWindows when the platform is Windows", () => {
+		// Given
+		const handler = createWindowsHandler("node hooks/posix.mjs", "node hooks/windows.mjs");
+
+		// When
+		const windowsCommand = selectCommandForPlatform(handler, "win32");
+		const posixCommand = selectCommandForPlatform(handler, "darwin");
+
+		// Then
+		expect(windowsCommand).toBe("node hooks/windows.mjs");
+		expect(posixCommand).toBe("node hooks/posix.mjs");
+	});
+
+	it("kills a long-running command on timeout and leaves no child process", async () => {
+		// Given
+		const cwd = createTempDir("timeout");
+		mkdirSync(cwd, { recursive: true });
+		const pidPath = join(cwd, "child.pid");
+		const scriptPath = join(cwd, "hang.mjs");
+		writeFileSync(
+			scriptPath,
+			[
+				"import { writeFileSync } from 'node:fs';",
+				`writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+				"setInterval(() => {}, 1000);",
+			].join("\n"),
+		);
+		const input: HookInputWire = { cwd, event: "SessionStart", sessionId: "s1" };
+
+		// When
+		const result = await runCommandHook(createHandler(`${process.execPath} ${scriptPath}`, { timeout: 0.1 }), input, {
+			cwd,
+		});
+
+		// Then
+		expect(result.timedOut).toBe(true);
+		expect(result.aborted).toBe(false);
+		expect(result.exitCode).toBeNull();
+		expect(existsSync(pidPath)).toBe(true);
+		assertProcessExited(Number(readFileSync(pidPath, "utf8")));
+	});
+
+	it("kills a running command when the abort signal fires", async () => {
+		// Given
+		const cwd = createTempDir("abort");
+		mkdirSync(cwd, { recursive: true });
+		const pidPath = join(cwd, "child.pid");
+		const scriptPath = join(cwd, "abortable.mjs");
+		writeFileSync(
+			scriptPath,
+			[
+				"import { writeFileSync } from 'node:fs';",
+				`writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+				"setInterval(() => {}, 1000);",
+			].join("\n"),
+		);
+		const controller = new AbortController();
+		const input: HookInputWire = { cwd, event: "UserPromptSubmit", prompt: "hello" };
+		const running = runCommandHook(createHandler(`${process.execPath} ${scriptPath}`), input, {
+			cwd,
+			signal: controller.signal,
+		});
+
+		// When
+		while (!existsSync(pidPath)) {
+			await delay(10);
+		}
+		controller.abort();
+		const result = await running;
+
+		// Then
+		expect(result.aborted).toBe(true);
+		expect(result.timedOut).toBe(false);
+		expect(result.exitCode).toBeNull();
+		assertProcessExited(Number(readFileSync(pidPath, "utf8")));
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-command-runner.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command-runner.test.ts
@@ -49,12 +49,16 @@ function createTempDir(name: string): string {
 	return dir;
 }
 
-function assertProcessExited(pid: number): void {
-	try {
-		process.kill(pid, 0);
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ESRCH") return;
-		throw error;
+async function waitForProcessExit(pid: number): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+		} catch (error) {
+			if (error instanceof Error && "code" in error && error.code === "ESRCH") return;
+			throw error;
+		}
+		await delay(10);
 	}
 	throw new Error(`process ${pid} is still running`);
 }
@@ -147,7 +151,7 @@ describe("builtin hooks command runner", () => {
 		expect(result.exitCode).toBeNull();
 		expect(result.timeoutSeconds).toBe(0.1);
 		expect(existsSync(pidPath)).toBe(true);
-		assertProcessExited(Number(readFileSync(pidPath, "utf8")));
+		await waitForProcessExit(Number(readFileSync(pidPath, "utf8")));
 	});
 
 	it("rejects invalid timeout values before starting a command", async () => {
@@ -194,7 +198,7 @@ describe("builtin hooks command runner", () => {
 		expect(result.aborted).toBe(true);
 		expect(result.timedOut).toBe(false);
 		expect(result.exitCode).toBeNull();
-		assertProcessExited(Number(readFileSync(pidPath, "utf8")));
+		await waitForProcessExit(Number(readFileSync(pidPath, "utf8")));
 	});
 
 	it("caps stdout and stderr in memory before concatenation", async () => {

--- a/packages/coding-agent/test/suite/hooks-command.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command.test.ts
@@ -1,0 +1,379 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import hooksExtension from "../../src/core/extensions/builtin/hooks/index.ts";
+import type { ExtensionUIContext } from "../../src/core/extensions/index.ts";
+import type { LoadedHookSources } from "../../src/core/extensions/types.ts";
+import type { ResourceLoader } from "../../src/core/resource-loader.ts";
+import { theme } from "../../src/modes/interactive/theme/theme.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+type Notification = {
+	readonly message: string;
+	readonly type: "info" | "warning" | "error" | undefined;
+};
+
+const USAGE = "Usage: /hooks [list|diagnostics|trust <id>|disable <id>|enable <id>|reload]";
+const SECRET = "sk-test-secret-should-not-render";
+const API_KEY_SECRET = "plain-api-key-value-should-not-render";
+const PASSWORD_SECRET = "plain-password-value-should-not-render";
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+	while (harnesses.length > 0) {
+		harnesses.pop()?.cleanup();
+	}
+});
+
+describe("builtin hooks /hooks command", () => {
+	it("lists hook trust status without calling the provider", async () => {
+		const setup = await createHooksCommandHarness({
+			projectHooks: {
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Bash",
+							hooks: [
+								{
+									type: "command",
+									command: `node hooks/pre-tool.mjs --token ${SECRET}`,
+									statusMessage: "checking command",
+								},
+							],
+						},
+					],
+					PostToolUse: [
+						{
+							matcher: "Bash",
+							hooks: [{ type: "command", command: "node hooks/post-tool.mjs" }],
+						},
+					],
+					SessionStart: [
+						{
+							matcher: "startup",
+							hooks: [{ type: "command", command: "node hooks/session-start.mjs" }],
+						},
+					],
+				},
+			},
+		});
+
+		await setup.harness.session.prompt("/hooks");
+
+		const message = lastNotification(setup.notifications).message;
+		expect(message).toContain("hooks: 3 executable hooks");
+		expect(message).toContain("PreToolUse:1");
+		expect(message).toContain("PostToolUse:1");
+		expect(message).toContain("SessionStart:1");
+		expect(message).toContain("untrusted");
+		expect(message).toContain("disabled:false");
+		expect(message).toContain("node hooks/pre-tool.mjs --token [redacted]");
+		expect(message).not.toContain(SECRET);
+		expect(setup.harness.getPendingResponseCount()).toBe(0);
+		expect(setup.payloads).toEqual([]);
+	});
+
+	it("redacts secret assignment flags and quoted values without over-redacting ordinary text", async () => {
+		const setup = await createHooksCommandHarness({
+			projectHooks: {
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Bash",
+							hooks: [
+								{
+									type: "command",
+									command: `node hooks/pre-tool.mjs --api-key=${API_KEY_SECRET} --password="${PASSWORD_SECRET}" --label=keep-visible password-report`,
+								},
+							],
+						},
+					],
+				},
+			},
+		});
+
+		await setup.harness.session.prompt("/hooks");
+
+		const message = lastNotification(setup.notifications).message;
+		expect(message).toContain("command:node hooks/pre-tool.mjs");
+		expect(message).toContain("--api-key=[redacted]");
+		expect(message).toContain("--password=[redacted]");
+		expect(message).toContain("--label=keep-visible password-report");
+		expect(message).not.toContain(API_KEY_SECRET);
+		expect(message).not.toContain(PASSWORD_SECRET);
+		expect(setup.payloads).toEqual([]);
+	});
+
+	it("prints diagnostics separately without raw hook command output", async () => {
+		const setup = await createHooksCommandHarness({
+			projectHooks: {
+				hooks: {
+					PreToolUse: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "node hooks/ok.mjs",
+									shell: SECRET,
+								},
+							],
+						},
+					],
+					UnsupportedFutureEvent: [{ hooks: [{ type: "command", command: `echo ${SECRET}` }] }],
+				},
+			},
+		});
+
+		await setup.harness.session.prompt("/hooks diagnostics");
+
+		const message = lastNotification(setup.notifications).message;
+		expect(message).toContain("hooks diagnostics: 2 diagnostics");
+		expect(message).toContain("warning: unsupported_field");
+		expect(message).toContain("warning: unknown_event");
+		expect(message).not.toContain(SECRET);
+		expect(message).not.toContain("echo ");
+	});
+
+	it("trusts, disables, and enables current hook IDs", async () => {
+		const setup = await createHooksCommandHarness({
+			projectHooks: {
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Bash",
+							hooks: [{ type: "command", command: "node hooks/pre-tool.mjs" }],
+						},
+					],
+				},
+			},
+		});
+		await setup.harness.session.prompt("/hooks list");
+		const id = firstHookId(lastNotification(setup.notifications).message);
+
+		await setup.harness.session.prompt(`/hooks trust ${id}`);
+		expect(lastNotification(setup.notifications).message).toBe(`Trusted hook: ${id}`);
+		expect(readState(setup.projectStatePath).hooks[id]?.trustedHash).toMatch(/^sha256:/);
+		expect(readState(setup.projectStatePath).hooks[id]?.enabled).toBe(true);
+		await setup.harness.session.prompt("/hooks list");
+		expect(lastNotification(setup.notifications).message).toContain(
+			`- ${id} PreToolUse source:project status:trusted`,
+		);
+		expect(lastNotification(setup.notifications).message).toContain("disabled:false");
+
+		await setup.harness.session.prompt(`/hooks disable ${id}`);
+		expect(lastNotification(setup.notifications).message).toBe(`Disabled hook: ${id}`);
+		expect(readState(setup.projectStatePath).hooks[id]?.enabled).toBe(false);
+		await setup.harness.session.prompt("/hooks list");
+		expect(lastNotification(setup.notifications).message).toContain(
+			`- ${id} PreToolUse source:project status:trusted`,
+		);
+		expect(lastNotification(setup.notifications).message).toContain("disabled:true");
+
+		await setup.harness.session.prompt(`/hooks enable ${id}`);
+		expect(lastNotification(setup.notifications).message).toBe(`Enabled hook: ${id}`);
+		expect(readState(setup.projectStatePath).hooks[id]?.enabled).toBe(true);
+		await setup.harness.session.prompt("/hooks list");
+		expect(lastNotification(setup.notifications).message).toContain(
+			`- ${id} PreToolUse source:project status:trusted`,
+		);
+		expect(lastNotification(setup.notifications).message).toContain("disabled:false");
+	});
+
+	it("does not mutate state for unknown hook IDs", async () => {
+		const setup = await createHooksCommandHarness({
+			projectHooks: {
+				hooks: {
+					PreToolUse: [{ hooks: [{ type: "command", command: "node hooks/pre-tool.mjs" }] }],
+				},
+			},
+		});
+		await setup.harness.session.prompt("/hooks list");
+		const before = existsSync(setup.projectStatePath) ? readFileSync(setup.projectStatePath, "utf-8") : "";
+
+		await setup.harness.session.prompt("/hooks trust missing-hook-id");
+
+		const after = existsSync(setup.projectStatePath) ? readFileSync(setup.projectStatePath, "utf-8") : "";
+		const notification = lastNotification(setup.notifications);
+		expect(notification).toEqual({ message: "Hook not found: missing-hook-id", type: "error" });
+		expect(after).toBe(before);
+	});
+
+	it("prints exact usage for malformed input", async () => {
+		const setup = await createHooksCommandHarness({ projectHooks: { hooks: {} } });
+
+		for (const command of [
+			"/hooks wat",
+			"/hooks trust",
+			"/hooks disable",
+			"/hooks enable",
+			"/hooks diagnostics extra",
+			"/hooks reload extra",
+		]) {
+			await setup.harness.session.prompt(command);
+			expect(lastNotification(setup.notifications)).toEqual({ message: USAGE, type: "error" });
+		}
+	});
+
+	it("reloads hook sources before reporting status", async () => {
+		const setup = await createHooksCommandHarness({ projectHooks: { hooks: {} } });
+
+		writeFileSync(
+			setup.projectHooksPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [{ hooks: [{ type: "command", command: "node hooks/reloaded.mjs" }] }],
+				},
+			}),
+			"utf-8",
+		);
+		await setup.harness.session.prompt("/hooks reload");
+
+		expect(setup.reloadCalls).toBe(1);
+		const message = lastNotification(setup.notifications).message;
+		expect(message).toContain("Reloaded hooks.");
+		expect(message).toContain("hooks: 1 executable hooks");
+		expect(message).toContain("node hooks/reloaded.mjs");
+	});
+
+	it("exposes subcommand argument completions", async () => {
+		const setup = await createHooksCommandHarness({ projectHooks: { hooks: {} } });
+		const command = setup.harness.session.extensionRunner.getCommand("hooks");
+
+		await expect(command?.getArgumentCompletions?.("d")).resolves.toEqual([
+			{ value: "diagnostics", label: "diagnostics" },
+			{ value: "disable", label: "disable" },
+		]);
+		await expect(command?.getArgumentCompletions?.("trust ")).resolves.toEqual([]);
+	});
+});
+
+async function createHooksCommandHarness(options: { readonly projectHooks: unknown }) {
+	const notifications: Notification[] = [];
+	const payloads: unknown[] = [];
+	const extensionsResult = await createTestExtensionsResult([{ factory: hooksExtension, path: "<builtin:hooks>" }]);
+	const baseResourceLoader = createTestResourceLoader({ extensionsResult });
+	let reloadCalls = 0;
+	let hookSources: LoadedHookSources | undefined;
+	const resourceLoader: ResourceLoader = {
+		...baseResourceLoader,
+		getLoadedHookSources: () => {
+			if (hookSources === undefined) {
+				throw new Error("hook sources not initialized");
+			}
+			return hookSources;
+		},
+		reload: async () => {
+			reloadCalls += 1;
+		},
+	};
+	const harness = await createHarness({
+		resourceLoader,
+		withConfiguredAuth: false,
+		onPayload: (payload) => payloads.push(payload),
+	});
+	harnesses.push(harness);
+	const agentDir = join(harness.tempDir, "agent");
+	const projectHooksPath = join(harness.tempDir, ".senpi", "hooks.json");
+	const projectStatePath = join(harness.tempDir, ".senpi", "hooks-state.json");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(join(harness.tempDir, ".senpi"), { recursive: true });
+	writeFileSync(projectHooksPath, JSON.stringify(options.projectHooks), "utf-8");
+	hookSources = {
+		agentDir,
+		cwd: harness.tempDir,
+		globalHookSourcePaths: [],
+		globalHooksPath: join(agentDir, "hooks.json"),
+		preSessionHookSourcePaths: [],
+		projectHookSourcePaths: [],
+		projectHooksPath,
+		runtimeHookSourcePaths: [],
+	};
+	await harness.session.bindExtensions({
+		uiContext: createUiContext((message, type) => notifications.push({ message, type })),
+		commandContextActions: {
+			waitForIdle: async () => {},
+			newSession: async () => ({ cancelled: false }),
+			fork: async () => ({ cancelled: false }),
+			navigateTree: async () => ({ cancelled: false }),
+			switchSession: async () => ({ cancelled: false }),
+			reload: async () => {
+				await resourceLoader.reload();
+			},
+		},
+	});
+	return {
+		harness,
+		notifications,
+		payloads,
+		projectHooksPath,
+		projectStatePath,
+		get reloadCalls() {
+			return reloadCalls;
+		},
+	};
+}
+
+function createUiContext(
+	onNotify: (message: string, type: "info" | "warning" | "error" | undefined) => void,
+): ExtensionUIContext {
+	return {
+		select: async () => undefined,
+		confirm: async () => false,
+		input: async () => undefined,
+		notify: onNotify,
+		onTerminalInput: () => () => {},
+		setStatus: () => {},
+		setWorkingMessage: () => {},
+		setWorkingVisible: () => {},
+		setWorkingIndicator: () => {},
+		setHiddenThinkingLabel: () => {},
+		setWidget: () => {},
+		setFooter: () => {},
+		setHeader: () => {},
+		setTitle: () => {},
+		custom: async <T>() => undefined as T,
+		pasteToEditor: () => {},
+		setEditorText: () => {},
+		getEditorText: () => "",
+		editor: async () => undefined,
+		addAutocompleteProvider: () => {},
+		setEditorComponent: () => {},
+		getEditorComponent: () => undefined,
+		get theme() {
+			return theme;
+		},
+		getAllThemes: () => [],
+		getTheme: () => undefined,
+		setTheme: () => ({ success: false, error: "themes are not used by /hooks tests" }),
+		getToolsExpanded: () => false,
+		setToolsExpanded: () => {},
+	};
+}
+
+function lastNotification(notifications: readonly Notification[]): Notification {
+	const notification = notifications.at(-1);
+	if (notification === undefined) {
+		throw new Error("expected notification");
+	}
+	return notification;
+}
+
+function firstHookId(message: string): string {
+	const match = /^- (hk_[^ ]+)/m.exec(message);
+	if (match === null) {
+		throw new Error(`expected hook ID in message:\n${message}`);
+	}
+	return match[1];
+}
+
+function readState(path: string): {
+	readonly hooks: Record<string, { readonly enabled: boolean; readonly trustedHash?: string }>;
+} {
+	const parsed = JSON.parse(readFileSync(resolve(path), "utf-8"));
+	if (typeof parsed !== "object" || parsed === null || !("hooks" in parsed)) {
+		throw new Error("invalid hooks state");
+	}
+	return parsed as { readonly hooks: Record<string, { readonly enabled: boolean; readonly trustedHash?: string }> };
+}

--- a/packages/coding-agent/test/suite/hooks-command.test.ts
+++ b/packages/coding-agent/test/suite/hooks-command.test.ts
@@ -1,30 +1,20 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
-import hooksExtension from "../../src/core/extensions/builtin/hooks/index.ts";
-import type { ExtensionUIContext } from "../../src/core/extensions/index.ts";
-import type { LoadedHookSources } from "../../src/core/extensions/types.ts";
-import type { ResourceLoader } from "../../src/core/resource-loader.ts";
-import { theme } from "../../src/modes/interactive/theme/theme.ts";
-import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
-import { createHarness, type Harness } from "./harness.ts";
-
-type Notification = {
-	readonly message: string;
-	readonly type: "info" | "warning" | "error" | undefined;
-};
+import {
+	cleanupHooksCommandHarnesses,
+	createHooksCommandHarness,
+	firstHookId,
+	lastNotification,
+	readState,
+} from "./hooks-command-harness.ts";
 
 const USAGE = "Usage: /hooks [list|diagnostics|trust <id>|disable <id>|enable <id>|reload]";
 const SECRET = "sk-test-secret-should-not-render";
 const API_KEY_SECRET = "plain-api-key-value-should-not-render";
 const PASSWORD_SECRET = "plain-password-value-should-not-render";
 
-const harnesses: Harness[] = [];
-
 afterEach(() => {
-	while (harnesses.length > 0) {
-		harnesses.pop()?.cleanup();
-	}
+	cleanupHooksCommandHarnesses();
 });
 
 describe("builtin hooks /hooks command", () => {
@@ -248,132 +238,3 @@ describe("builtin hooks /hooks command", () => {
 		await expect(command?.getArgumentCompletions?.("trust ")).resolves.toEqual([]);
 	});
 });
-
-async function createHooksCommandHarness(options: { readonly projectHooks: unknown }) {
-	const notifications: Notification[] = [];
-	const payloads: unknown[] = [];
-	const extensionsResult = await createTestExtensionsResult([{ factory: hooksExtension, path: "<builtin:hooks>" }]);
-	const baseResourceLoader = createTestResourceLoader({ extensionsResult });
-	let reloadCalls = 0;
-	let hookSources: LoadedHookSources | undefined;
-	const resourceLoader: ResourceLoader = {
-		...baseResourceLoader,
-		getLoadedHookSources: () => {
-			if (hookSources === undefined) {
-				throw new Error("hook sources not initialized");
-			}
-			return hookSources;
-		},
-		reload: async () => {
-			reloadCalls += 1;
-		},
-	};
-	const harness = await createHarness({
-		resourceLoader,
-		withConfiguredAuth: false,
-		onPayload: (payload) => payloads.push(payload),
-	});
-	harnesses.push(harness);
-	const agentDir = join(harness.tempDir, "agent");
-	const projectHooksPath = join(harness.tempDir, ".senpi", "hooks.json");
-	const projectStatePath = join(harness.tempDir, ".senpi", "hooks-state.json");
-	mkdirSync(agentDir, { recursive: true });
-	mkdirSync(join(harness.tempDir, ".senpi"), { recursive: true });
-	writeFileSync(projectHooksPath, JSON.stringify(options.projectHooks), "utf-8");
-	hookSources = {
-		agentDir,
-		cwd: harness.tempDir,
-		globalHookSourcePaths: [],
-		globalHooksPath: join(agentDir, "hooks.json"),
-		preSessionHookSourcePaths: [],
-		projectHookSourcePaths: [],
-		projectHooksPath,
-		runtimeHookSourcePaths: [],
-	};
-	await harness.session.bindExtensions({
-		uiContext: createUiContext((message, type) => notifications.push({ message, type })),
-		commandContextActions: {
-			waitForIdle: async () => {},
-			newSession: async () => ({ cancelled: false }),
-			fork: async () => ({ cancelled: false }),
-			navigateTree: async () => ({ cancelled: false }),
-			switchSession: async () => ({ cancelled: false }),
-			reload: async () => {
-				await resourceLoader.reload();
-			},
-		},
-	});
-	return {
-		harness,
-		notifications,
-		payloads,
-		projectHooksPath,
-		projectStatePath,
-		get reloadCalls() {
-			return reloadCalls;
-		},
-	};
-}
-
-function createUiContext(
-	onNotify: (message: string, type: "info" | "warning" | "error" | undefined) => void,
-): ExtensionUIContext {
-	return {
-		select: async () => undefined,
-		confirm: async () => false,
-		input: async () => undefined,
-		notify: onNotify,
-		onTerminalInput: () => () => {},
-		setStatus: () => {},
-		setWorkingMessage: () => {},
-		setWorkingVisible: () => {},
-		setWorkingIndicator: () => {},
-		setHiddenThinkingLabel: () => {},
-		setWidget: () => {},
-		setFooter: () => {},
-		setHeader: () => {},
-		setTitle: () => {},
-		custom: async <T>() => undefined as T,
-		pasteToEditor: () => {},
-		setEditorText: () => {},
-		getEditorText: () => "",
-		editor: async () => undefined,
-		addAutocompleteProvider: () => {},
-		setEditorComponent: () => {},
-		getEditorComponent: () => undefined,
-		get theme() {
-			return theme;
-		},
-		getAllThemes: () => [],
-		getTheme: () => undefined,
-		setTheme: () => ({ success: false, error: "themes are not used by /hooks tests" }),
-		getToolsExpanded: () => false,
-		setToolsExpanded: () => {},
-	};
-}
-
-function lastNotification(notifications: readonly Notification[]): Notification {
-	const notification = notifications.at(-1);
-	if (notification === undefined) {
-		throw new Error("expected notification");
-	}
-	return notification;
-}
-
-function firstHookId(message: string): string {
-	const match = /^- (hk_[^ ]+)/m.exec(message);
-	if (match === null) {
-		throw new Error(`expected hook ID in message:\n${message}`);
-	}
-	return match[1];
-}
-
-function readState(path: string): {
-	readonly hooks: Record<string, { readonly enabled: boolean; readonly trustedHash?: string }>;
-} {
-	const parsed = JSON.parse(readFileSync(resolve(path), "utf-8"));
-	if (typeof parsed !== "object" || parsed === null || !("hooks" in parsed)) {
-		throw new Error("invalid hooks state");
-	}
-	return parsed as { readonly hooks: Record<string, { readonly enabled: boolean; readonly trustedHash?: string }> };
-}

--- a/packages/coding-agent/test/suite/hooks-dispatcher.test.ts
+++ b/packages/coding-agent/test/suite/hooks-dispatcher.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import type { CommandHookRunResult } from "../../src/core/extensions/builtin/hooks/command-runner.ts";
+import { dispatchHookEvent, type HookCommandRunner } from "../../src/core/extensions/builtin/hooks/dispatcher.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import type {
+	ExecutableHookHandler,
+	HookInputWire,
+	HookSourceMetadata,
+	HookTrustEntry,
+	HookTrustState,
+} from "../../src/core/extensions/builtin/hooks/types.ts";
+
+const SOURCE: HookSourceMetadata = {
+	discoveredAt: "pre-session",
+	displayOrder: 7,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+
+const INPUT: HookInputWire = {
+	cwd: "/repo",
+	event: "PreToolUse",
+	toolInput: { command: "rm -rf build" },
+	toolName: "bash",
+};
+
+type DeferredRun = {
+	readonly promise: Promise<CommandHookRunResult>;
+	readonly resolve: (result: CommandHookRunResult) => void;
+};
+
+function commandHook(
+	command: string,
+	overrides: {
+		readonly event?: ExecutableHookHandler["event"];
+		readonly matcher?: string;
+		readonly groupIndex?: number;
+		readonly handlerIndex?: number;
+		readonly source?: HookSourceMetadata;
+	} = {},
+): ExecutableHookHandler {
+	const base = {
+		config: { type: "command", command },
+		event: overrides.event ?? "PreToolUse",
+		groupIndex: overrides.groupIndex ?? 0,
+		handlerIndex: overrides.handlerIndex ?? 0,
+		source: overrides.source ?? SOURCE,
+	} satisfies Omit<ExecutableHookHandler, "matcher">;
+	if (overrides.matcher === undefined) {
+		return base;
+	}
+	return { ...base, matcher: overrides.matcher };
+}
+
+function trustedState(handlers: readonly ExecutableHookHandler[]): HookTrustState {
+	const hooks: Record<string, HookTrustEntry> = {};
+	for (const handler of handlers) {
+		hooks[hookTrustId(handler)] = createHookTrustEntry(handler, {
+			platform: "linux",
+			updatedAt: "2026-06-29T00:00:00.000Z",
+		});
+	}
+	return { hooks, version: 1 };
+}
+
+function runResult(handler: ExecutableHookHandler, stdout: string, stderr = ""): CommandHookRunResult {
+	const streamSafety = (text: string) => ({
+		originalBytes: Buffer.byteLength(text),
+		redacted: false,
+		returnedBytes: Buffer.byteLength(text),
+		spilled: false,
+		truncated: false,
+	});
+	return {
+		aborted: false,
+		command: handler.config.command,
+		cwd: "/repo",
+		durationMs: 1,
+		exitCode: 0,
+		outputSafety: { stderr: streamSafety(stderr), stdout: streamSafety(stdout) },
+		signal: null,
+		stderr,
+		stdout,
+		timedOut: false,
+		timeoutSeconds: 30,
+	};
+}
+
+function preToolOutput(
+	permissionDecision: "allow" | "ask" | "deny",
+	fields: Readonly<Record<string, unknown>> = {},
+): string {
+	return JSON.stringify({
+		hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision, ...fields },
+	});
+}
+
+function dispatch(
+	handlers: readonly ExecutableHookHandler[],
+	runCommand: HookCommandRunner,
+	options: { readonly input?: HookInputWire; readonly trusted?: readonly ExecutableHookHandler[] } = {},
+) {
+	return dispatchHookEvent({
+		cwd: "/repo",
+		handlers,
+		input: options.input ?? INPUT,
+		runCommand,
+		trustOptions: { platform: "linux" },
+		trustState: trustedState(options.trusted ?? handlers),
+	});
+}
+
+function deferredRun(): DeferredRun {
+	let resolveRun: ((result: CommandHookRunResult) => void) | undefined;
+	const promise = new Promise<CommandHookRunResult>((resolve) => {
+		resolveRun = resolve;
+	});
+	if (resolveRun === undefined) {
+		throw new Error("deferred run resolver was not initialized");
+	}
+	return { promise, resolve: resolveRun };
+}
+
+describe("builtin hooks dispatcher", () => {
+	it("starts all matching trusted hooks before aggregating and keeps summaries in declaration order", async () => {
+		// Given
+		const allowSlow = commandHook("allow-slow", { handlerIndex: 0, matcher: "Bash" });
+		const denyFast = commandHook("deny-fast", { handlerIndex: 1, matcher: "bash" });
+		const miss = commandHook("miss", { handlerIndex: 2, matcher: "Read" });
+		const deferred = new Map<string, DeferredRun>();
+		const startedCommands: string[] = [];
+		const runner: HookCommandRunner = (handler) => {
+			startedCommands.push(handler.config.command);
+			const pending = deferredRun();
+			deferred.set(handler.config.command, pending);
+			return pending.promise;
+		};
+
+		// When
+		const dispatching = dispatch([allowSlow, denyFast, miss], runner);
+		await Promise.resolve();
+
+		// Then
+		expect(startedCommands).toEqual(["allow-slow", "deny-fast"]);
+
+		deferred
+			.get("deny-fast")
+			?.resolve(runResult(denyFast, preToolOutput("deny", { permissionDecisionReason: "dangerous command" })));
+		deferred
+			.get("allow-slow")
+			?.resolve(runResult(allowSlow, preToolOutput("allow", { updatedInput: { command: "printf safe" } })));
+		const result = await dispatching;
+
+		expect(result.summaries.map((summary) => summary.handler.config.command)).toEqual(["allow-slow", "deny-fast"]);
+		expect(result.summaries.map((summary) => summary.completionIndex)).toEqual([1, 0]);
+		expect(result.decision).toEqual({
+			kind: "block",
+			reason: "dangerous command",
+			source: denyFast.source,
+			sourceCommand: "deny-fast",
+		});
+		expect(result.diagnostics).toEqual([]);
+	});
+
+	it("aggregates PreToolUse ask above allow and returns explicit blocking fallback data", async () => {
+		// Given
+		const allow = commandHook("allow", { handlerIndex: 0 });
+		const ask = commandHook("ask", { handlerIndex: 1 });
+		const runner: HookCommandRunner = (handler) => {
+			if (handler.config.command === "ask") {
+				return Promise.resolve(
+					runResult(handler, preToolOutput("ask", { permissionDecisionReason: "needs human approval" })),
+				);
+			}
+			return Promise.resolve(
+				runResult(handler, preToolOutput("allow", { updatedInput: { command: "printf safe" } })),
+			);
+		};
+
+		// When
+		const result = await dispatch([allow, ask], runner);
+
+		// Then
+		expect(result.decision.kind).toBe("ask");
+		expect(result.decision).toEqual({
+			fallback: { kind: "block", reason: "needs human approval" },
+			kind: "ask",
+			nativeRepresentable: false,
+			reason: "needs human approval",
+			source: ask.source,
+			sourceCommand: "ask",
+		});
+	});
+
+	it("returns updated input when PreToolUse has only allow decisions", async () => {
+		// Given
+		const first = commandHook("first", { handlerIndex: 0 });
+		const second = commandHook("second", { handlerIndex: 1 });
+		const runner: HookCommandRunner = (handler) =>
+			Promise.resolve(
+				runResult(
+					handler,
+					preToolOutput("allow", { updatedInput: { command: `${handler.config.command}-input` } }),
+				),
+			);
+
+		// When
+		const result = await dispatch([first, second], runner);
+
+		// Then
+		expect(result.decision).toEqual({
+			kind: "allow",
+			source: second.source,
+			sourceCommand: "second",
+			updatedInput: { command: "second-input" },
+		});
+	});
+
+	it("skips matched untrusted hooks while listing them", async () => {
+		// Given
+		const trusted = commandHook("trusted", { handlerIndex: 0 });
+		const untrusted = commandHook("untrusted", { handlerIndex: 1 });
+		const startedCommands: string[] = [];
+		const runner: HookCommandRunner = (handler) => {
+			startedCommands.push(handler.config.command);
+			return Promise.resolve(runResult(handler, ""));
+		};
+
+		// When
+		const result = await dispatch([trusted, untrusted], runner, { trusted: [trusted] });
+
+		// Then
+		expect(startedCommands).toEqual(["trusted"]);
+		expect(result.skipped.map((skip) => ({ command: skip.handler.config.command, reason: skip.reason }))).toEqual([
+			{ command: "untrusted", reason: "untrusted" },
+		]);
+		expect(result.skipped[0]?.record.executable).toBe(false);
+	});
+
+	it("keeps nonblocking malformed output diagnostics nonfatal but blocks on explicit continue false", async () => {
+		// Given
+		const malformed = commandHook("malformed", { event: "PostToolUse", handlerIndex: 0 });
+		const stop = commandHook("stop", { event: "Stop", handlerIndex: 0 });
+		const runner: HookCommandRunner = (handler) => {
+			if (handler.event === "Stop") {
+				return Promise.resolve(runResult(handler, JSON.stringify({ continue: false, stopReason: "not done" })));
+			}
+			return Promise.resolve(runResult(handler, "{not json"));
+		};
+
+		// When
+		const postTool = await dispatch([malformed], runner, {
+			input: {
+				cwd: "/repo",
+				event: "PostToolUse",
+				toolInput: {},
+				toolName: "bash",
+				toolOutput: "ok",
+			},
+			trusted: [malformed, stop],
+		});
+		const stopResult = await dispatch([stop], runner, {
+			input: { cwd: "/repo", event: "Stop", stopReason: "natural" },
+			trusted: [malformed, stop],
+		});
+
+		// Then
+		expect(postTool.decision).toEqual({ kind: "none" });
+		expect(postTool.diagnostics).toContainEqual(expect.objectContaining({ code: "invalid_root", path: "stdout" }));
+		expect(stopResult.decision).toEqual({
+			kind: "block",
+			reason: "not done",
+			source: stop.source,
+			sourceCommand: "stop",
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/hooks-lifecycle.test.ts
@@ -1,0 +1,408 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseHookConfig } from "../../src/core/extensions/builtin/hooks/index.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import type {
+	HookSourceMetadata,
+	HookSourceScope,
+	HookTrustEntry,
+	SupportedHookEvent,
+} from "../../src/core/extensions/builtin/hooks/types.ts";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import type { ExtensionFactory, ResourceLoader } from "../../src/index.ts";
+import { assistantMsg, createTestExtensionsResult, createTestResourceLoader, userMsg } from "../utilities.ts";
+import { createHarness, getMessageText } from "./harness.ts";
+
+const createdDirs: string[] = [];
+
+type HookGroup = {
+	readonly matcher?: string;
+	readonly commands: readonly string[];
+};
+
+type HookProject = Partial<Record<SupportedHookEvent, readonly HookGroup[]>>;
+
+function hooksExtensionFactory(): ExtensionFactory {
+	const extension = builtinExtensions.find((entry) => entry.id === "hooks");
+	if (extension === undefined) {
+		throw new Error("builtin hooks extension is not registered");
+	}
+	return extension.factory;
+}
+
+function createTempDir(prefix: string): string {
+	const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	createdDirs.push(dir);
+	return dir;
+}
+
+function writeHookSource(cwd: string, sourcePath: string, scope: HookSourceScope, project: HookProject): void {
+	mkdirSync(join(cwd, ".senpi"), { recursive: true });
+	mkdirSync(join(cwd, "agent"), { recursive: true });
+	mkdirSync(join(sourcePath, ".."), { recursive: true });
+
+	const hooks = Object.fromEntries(
+		Object.entries(project).map(([event, groups]) => [
+			event,
+			groups.map((group) => ({
+				...(group.matcher === undefined ? {} : { matcher: group.matcher }),
+				hooks: group.commands.map((command) => ({ type: "command", command })),
+			})),
+		]),
+	);
+	const hookConfig = { hooks };
+	writeFileSync(sourcePath, `${JSON.stringify(hookConfig, null, 2)}\n`, "utf-8");
+
+	const source = {
+		discoveredAt: scope === "runtime" ? "runtime" : "pre-session",
+		displayOrder: 0,
+		scope,
+		sourcePath,
+	} satisfies HookSourceMetadata;
+	const parsed = parseHookConfig(hookConfig, source);
+	const hooksState: Record<string, HookTrustEntry> = {};
+	for (const handler of parsed.executableHandlers) {
+		hooksState[hookTrustId(handler)] = createHookTrustEntry(handler, {
+			platform: process.platform,
+			updatedAt: "2026-06-29T00:00:00.000Z",
+		});
+	}
+	const statePath =
+		scope === "project" ? join(cwd, ".senpi", "hooks-state.json") : join(cwd, "agent", "hooks-state.json");
+	writeFileSync(statePath, `${JSON.stringify({ version: 1, hooks: hooksState }, null, 2)}\n`, "utf-8");
+}
+
+function writeProjectHooks(cwd: string, project: HookProject): string {
+	const sourcePath = join(cwd, ".senpi", "hooks.json");
+	writeHookSource(cwd, sourcePath, "project", project);
+	return sourcePath;
+}
+
+function writeRuntimeHooks(cwd: string, sourcePath: string, project: HookProject): void {
+	writeHookSource(cwd, sourcePath, "runtime", project);
+}
+
+function createNodeScript(dir: string, name: string, body: string): string {
+	const scriptPath = join(dir, name);
+	writeFileSync(scriptPath, body, "utf-8");
+	return scriptPath;
+}
+
+function seedCompactableSession(harness: Awaited<ReturnType<typeof createHarness>>): void {
+	harness.settingsManager.applyOverrides({ compaction: { keepRecentTokens: 1 } });
+	harness.sessionManager.appendMessage(userMsg("message to compact"));
+	harness.sessionManager.appendMessage(assistantMsg("assistant response to compact"));
+	harness.sessionManager.appendMessage(userMsg("message to keep"));
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
+function extensionProvidedCompaction(): ExtensionFactory {
+	return (pi) => {
+		pi.on("session_before_compact", (event) => ({
+			compaction: {
+				summary: "summary from extension",
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+			},
+		}));
+	};
+}
+
+function extensionEchoesCompactionInstructions(): ExtensionFactory {
+	return (pi) => {
+		pi.on("session_before_compact", (event) => ({
+			compaction: {
+				summary: `instructions:${event.customInstructions ?? ""}`,
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+			},
+		}));
+	};
+}
+
+afterEach(() => {
+	for (const dir of createdDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("builtin hooks lifecycle adapters", () => {
+	it("dispatches initial SessionStart only from pre-session hook sources with startup reason", async () => {
+		// Given
+		const loaderCwd = createTempDir("senpi-hooks-session-start-loader");
+		const preSessionInputPath = join(loaderCwd, "pre-session-input.json");
+		const runtimeInputPath = join(loaderCwd, "runtime-input.json");
+		const preSessionScript = createNodeScript(
+			loaderCwd,
+			"session-start-pre.mjs",
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(preSessionInputPath)}, stdin); });`,
+		);
+		const runtimeScript = createNodeScript(
+			loaderCwd,
+			"session-start-runtime.mjs",
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(runtimeInputPath)}, stdin); });`,
+		);
+		const runtimeHookPath = join(loaderCwd, "runtime-hooks.json");
+		let activeCwd = "";
+		let runtimeHookPaths: string[] = [];
+		const discoverRuntimeHooks: ExtensionFactory = (pi) => {
+			pi.on("resources_discover", () => ({ hookPaths: [runtimeHookPath] }));
+		};
+		const extensionsResult = await createTestExtensionsResult(
+			[
+				{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" },
+				{ factory: discoverRuntimeHooks, path: "<test:runtime-hooks>" },
+			],
+			loaderCwd,
+		);
+		const baseLoader = createTestResourceLoader({ extensionsResult });
+		const resourceLoader: ResourceLoader = {
+			...baseLoader,
+			extendResources(resources) {
+				runtimeHookPaths = (resources.hookPaths ?? []).map((entry) => resolve(entry.path));
+			},
+			getLoadedHookSources: () => ({
+				agentDir: join(activeCwd, "agent"),
+				cwd: activeCwd,
+				globalHookSourcePaths: [],
+				globalHooksPath: join(activeCwd, "agent", "hooks.json"),
+				globalSettingsHooks: undefined,
+				preSessionHookSourcePaths: [],
+				projectHookSourcePaths: [],
+				projectHooksPath: join(activeCwd, ".senpi", "hooks.json"),
+				projectSettingsHooks: undefined,
+				runtimeHookSourcePaths: runtimeHookPaths,
+			}),
+		};
+		const harness = await createHarness({ resourceLoader });
+		activeCwd = harness.tempDir;
+		writeProjectHooks(harness.tempDir, {
+			SessionStart: [{ matcher: "startup", commands: [`${process.execPath} ${preSessionScript}`] }],
+		});
+		writeRuntimeHooks(harness.tempDir, runtimeHookPath, {
+			SessionStart: [{ matcher: "startup", commands: [`${process.execPath} ${runtimeScript}`] }],
+		});
+		runtimeHookPaths = [resolve(runtimeHookPath)];
+
+		try {
+			// When
+			await harness.session.bindExtensions({ shutdownHandler: () => {} });
+
+			// Then
+			const stdin: unknown = JSON.parse(readFileSync(preSessionInputPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "SessionStart",
+				hook_event_name: "SessionStart",
+				reason: "startup",
+				session_id: harness.session.sessionId,
+			});
+			expect(runtimeHookPaths).toEqual([resolve(runtimeHookPath)]);
+			expect(() => readFileSync(runtimeInputPath, "utf-8")).toThrow();
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("cancels manual PreCompact through a reason matcher without running auto matchers", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-hooks-precompact-cancel");
+		const manualInputPath = join(hookDir, "manual-input.json");
+		const autoInputPath = join(hookDir, "auto-input.json");
+		const cancelledPostInputPath = join(hookDir, "cancelled-post-input.json");
+		const manualScript = createNodeScript(
+			hookDir,
+			"precompact-manual.mjs",
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(manualInputPath)}, stdin); process.stdout.write(JSON.stringify({ decision: 'block', reason: 'manual compaction paused by hook', hookSpecificOutput: { hookEventName: 'PreCompact', additionalContext: 'diagnostic only', customInstructions: 'must not apply' } })); });`,
+		);
+		const autoScript = createNodeScript(
+			hookDir,
+			"precompact-auto.mjs",
+			`import { writeFileSync } from 'node:fs'; process.stdin.on('data', (chunk) => writeFileSync(${JSON.stringify(autoInputPath)}, chunk));`,
+		);
+		const cancelledPostScript = createNodeScript(
+			hookDir,
+			"postcompact-cancelled.mjs",
+			`import { writeFileSync } from 'node:fs'; process.stdin.on('data', (chunk) => writeFileSync(${JSON.stringify(cancelledPostInputPath)}, chunk));`,
+		);
+		const harness = await createHarness({
+			extensionFactories: [
+				{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" },
+				{ factory: extensionProvidedCompaction(), path: "<test:compaction>" },
+			],
+		});
+		writeProjectHooks(harness.tempDir, {
+			PreCompact: [
+				{ matcher: "manual", commands: [`${process.execPath} ${manualScript}`] },
+				{ matcher: "threshold", commands: [`${process.execPath} ${autoScript}`] },
+			],
+			PostCompact: [{ matcher: "manual", commands: [`${process.execPath} ${cancelledPostScript}`] }],
+		});
+		seedCompactableSession(harness);
+
+		try {
+			// When / Then
+			await expect(harness.session.compact("original instructions")).rejects.toThrow("Compaction cancelled");
+			const stdin: unknown = JSON.parse(readFileSync(manualInputPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "PreCompact",
+				hook_event_name: "PreCompact",
+				reason: "manual",
+				session_id: harness.session.sessionId,
+				custom_instructions: "original instructions",
+			});
+			expect(() => readFileSync(autoInputPath, "utf-8")).toThrow();
+			expect(() => readFileSync(cancelledPostInputPath, "utf-8")).toThrow();
+			const customPayload = JSON.stringify(harness.session.messages.filter((message) => message.role === "custom"));
+			expect(customPayload).toContain("manual compaction paused by hook");
+			expect(customPayload).toContain("unsupported_field");
+			expect(customPayload).toContain("additionalContext");
+			expect(customPayload).toContain("customInstructions");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("treats PreCompact additionalContext and customInstructions as diagnostic-only without mutating compaction", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-hooks-precompact-diagnostic");
+		const inputPath = join(hookDir, "input.json");
+		const script = createNodeScript(
+			hookDir,
+			"precompact-diagnostic.mjs",
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(inputPath)}, stdin); process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreCompact', additionalContext: 'diagnostic context', customInstructions: 'mutated instructions' } })); });`,
+		);
+		const harness = await createHarness({
+			extensionFactories: [
+				{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" },
+				{ factory: extensionEchoesCompactionInstructions(), path: "<test:compaction>" },
+			],
+		});
+		writeProjectHooks(harness.tempDir, {
+			PreCompact: [{ matcher: "manual", commands: [`${process.execPath} ${script}`] }],
+		});
+		seedCompactableSession(harness);
+
+		try {
+			// When
+			const result = await harness.session.compact("original instructions");
+
+			// Then
+			expect(result.summary).toBe("instructions:original instructions");
+			const stdin: unknown = JSON.parse(readFileSync(inputPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "PreCompact",
+				hook_event_name: "PreCompact",
+				reason: "manual",
+				session_id: harness.session.sessionId,
+			});
+			const customPayload = JSON.stringify(harness.session.messages.filter((message) => message.role === "custom"));
+			expect(customPayload).toContain("PreCompact hook diagnostics.");
+			expect(customPayload).toContain("additionalContext");
+			expect(customPayload).toContain("customInstructions");
+			expect(customPayload).not.toContain("mutated instructions");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("runs PostCompact only after accepted compaction and records sanitized failure diagnostics", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-hooks-postcompact");
+		const postInputPath = join(hookDir, "post-input.json");
+		const postScript = createNodeScript(
+			hookDir,
+			"postcompact.mjs",
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(postInputPath)}, stdin); process.stderr.write('SECRET_TOKEN=postcompact-secret'); process.exit(1); });`,
+		);
+		const harness = await createHarness({
+			extensionFactories: [
+				{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" },
+				{ factory: extensionProvidedCompaction(), path: "<test:compaction>" },
+			],
+		});
+		writeProjectHooks(harness.tempDir, {
+			PostCompact: [{ matcher: "manual", commands: [`${process.execPath} ${postScript}`] }],
+		});
+		seedCompactableSession(harness);
+
+		try {
+			// When
+			const result = await harness.session.compact();
+
+			// Then
+			expect(result.summary).toBe("summary from extension");
+			const stdin: unknown = JSON.parse(readFileSync(postInputPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "PostCompact",
+				hook_event_name: "PostCompact",
+				reason: "manual",
+				session_id: harness.session.sessionId,
+			});
+			const customText = harness.session.messages
+				.filter((message) => message.role === "custom")
+				.map((message) => getMessageText(message))
+				.join("\n");
+			const customPayload = JSON.stringify(harness.session.messages.filter((message) => message.role === "custom"));
+			expect(customText).toContain("PostCompact hook diagnostics.");
+			expect(customPayload).toContain("Hook command failed with exit code 1.");
+			expect(customPayload).not.toContain("postcompact-secret");
+			expect(customPayload).not.toContain("SECRET_TOKEN");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("sanitizes PostCompact exit code 2 stderr without exposing it as context", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-hooks-postcompact-exit-2");
+		const postInputPath = join(hookDir, "post-exit-2-input.json");
+		const postScript = createNodeScript(
+			hookDir,
+			"postcompact-exit-2.mjs",
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(postInputPath)}, stdin); process.stderr.write('SECRET_TOKEN=exit-two-secret'); process.exit(2); });`,
+		);
+		const harness = await createHarness({
+			extensionFactories: [
+				{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" },
+				{ factory: extensionProvidedCompaction(), path: "<test:compaction>" },
+			],
+		});
+		writeProjectHooks(harness.tempDir, {
+			PostCompact: [{ matcher: "manual", commands: [`${process.execPath} ${postScript}`] }],
+		});
+		seedCompactableSession(harness);
+
+		try {
+			// When
+			const result = await harness.session.compact();
+
+			// Then
+			expect(result.summary).toBe("summary from extension");
+			const stdin: unknown = JSON.parse(readFileSync(postInputPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "PostCompact",
+				hook_event_name: "PostCompact",
+				reason: "manual",
+				session_id: harness.session.sessionId,
+			});
+			const customText = harness.session.messages
+				.filter((message) => message.role === "custom")
+				.map((message) => getMessageText(message))
+				.join("\n");
+			const customPayload = JSON.stringify(harness.session.messages.filter((message) => message.role === "custom"));
+			expect(customText).toContain("PostCompact hook diagnostics.");
+			expect(customPayload).not.toContain("exit-two-secret");
+			expect(customPayload).not.toContain("SECRET_TOKEN");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-loader.test.ts
+++ b/packages/coding-agent/test/suite/hooks-loader.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { loadHookConfigSources } from "../../src/core/extensions/builtin/hooks/config-loader.ts";
+
+function commandHook(command: string, event = "PreToolUse"): string {
+	return JSON.stringify({
+		hooks: {
+			[event]: [
+				{
+					matcher: "*",
+					hooks: [{ type: "command", command }],
+				},
+			],
+		},
+	});
+}
+
+describe("builtin hooks config loader", () => {
+	it("merges explicit hook sources in canonical deterministic order", () => {
+		// Given
+		const files: Readonly<Record<string, string>> = {
+			"/home/agent/hooks.json": commandHook("global-file"),
+			"/repo/.senpi/hooks.json": commandHook("project-file"),
+			"/repo/plugin-a/hooks.json": commandHook("pre-session-a"),
+			"/repo/plugin-b/hooks.json": commandHook("pre-session-b"),
+			"/repo/runtime/hooks.json": commandHook("runtime"),
+		};
+
+		// When
+		const parsed = loadHookConfigSources({
+			agentDir: "/home/agent",
+			cwd: "/repo",
+			fileSystem: {
+				readTextFile: (path) => files[path],
+			},
+			globalHooksPath: "/home/agent/hooks.json",
+			globalSettingsHooks: {
+				PreToolUse: [{ matcher: "*", hooks: [{ type: "command", command: "global-inline" }] }],
+			},
+			preSessionHookSourcePaths: ["/repo/plugin-a/hooks.json", "/repo/plugin-b/hooks.json"],
+			projectHooksPath: "/repo/.senpi/hooks.json",
+			projectSettingsHooks: {
+				PreToolUse: [{ matcher: "*", hooks: [{ type: "command", command: "project-inline" }] }],
+			},
+			runtimeHookSourcePaths: ["/repo/runtime/hooks.json"],
+		});
+
+		// Then
+		expect(parsed.diagnostics).toEqual([]);
+		expect(parsed.executableHandlers.map((handler) => handler.config.command)).toEqual([
+			"global-inline",
+			"global-file",
+			"project-inline",
+			"project-file",
+			"pre-session-a",
+			"pre-session-b",
+			"runtime",
+		]);
+		expect(parsed.executableHandlers.map((handler) => handler.source)).toEqual([
+			{
+				discoveredAt: "pre-session",
+				displayOrder: 0,
+				scope: "global",
+				sourcePath: "<global-settings-hooks>",
+			},
+			{
+				discoveredAt: "pre-session",
+				displayOrder: 1,
+				scope: "global",
+				sourcePath: "/home/agent/hooks.json",
+			},
+			{
+				discoveredAt: "pre-session",
+				displayOrder: 2,
+				scope: "project",
+				sourcePath: "<project-settings-hooks>",
+			},
+			{
+				discoveredAt: "pre-session",
+				displayOrder: 3,
+				scope: "project",
+				sourcePath: "/repo/.senpi/hooks.json",
+			},
+			{
+				discoveredAt: "pre-session",
+				displayOrder: 4,
+				scope: "plugin",
+				sourcePath: "/repo/plugin-a/hooks.json",
+			},
+			{
+				discoveredAt: "pre-session",
+				displayOrder: 5,
+				scope: "plugin",
+				sourcePath: "/repo/plugin-b/hooks.json",
+			},
+			{
+				discoveredAt: "runtime",
+				displayOrder: 6,
+				scope: "runtime",
+				sourcePath: "/repo/runtime/hooks.json",
+			},
+		]);
+	});
+
+	it("accumulates diagnostics without dropping earlier or later valid sources", () => {
+		// Given
+		const files: Readonly<Record<string, string>> = {
+			"/home/agent/hooks.json": "{",
+			"/repo/.senpi/hooks.json": JSON.stringify({ hooks: "bad" }),
+			"/repo/plugin/hooks.json": commandHook("plugin-valid"),
+			"/repo/runtime/hooks.json": commandHook("runtime-session-start", "SessionStart"),
+		};
+
+		// When
+		const parsed = loadHookConfigSources({
+			agentDir: "/home/agent",
+			cwd: "/repo",
+			fileSystem: {
+				readTextFile: (path) => files[path],
+			},
+			globalHooksPath: "/home/agent/hooks.json",
+			globalSettingsHooks: {
+				PreToolUse: [{ hooks: [{ type: "command", command: "global-valid" }] }],
+			},
+			preSessionHookSourcePaths: ["/repo/plugin/hooks.json"],
+			projectHooksPath: "/repo/.senpi/hooks.json",
+			runtimeHookSourcePaths: ["/repo/runtime/hooks.json"],
+		});
+
+		// Then
+		expect(parsed.executableHandlers.map((handler) => handler.config.command)).toEqual([
+			"global-valid",
+			"plugin-valid",
+			"runtime-session-start",
+		]);
+		expect(parsed.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_root",
+					path: "$",
+					source: expect.objectContaining({ sourcePath: "/home/agent/hooks.json" }),
+				}),
+				expect.objectContaining({
+					code: "invalid_hooks",
+					path: "hooks",
+					source: expect.objectContaining({ sourcePath: "/repo/.senpi/hooks.json" }),
+				}),
+				expect.objectContaining({
+					code: "unsupported_event",
+					event: "SessionStart",
+					path: "hooks.SessionStart",
+					severity: "warning",
+					source: expect.objectContaining({
+						discoveredAt: "runtime",
+						sourcePath: "/repo/runtime/hooks.json",
+					}),
+				}),
+			]),
+		);
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-matcher.test.ts
+++ b/packages/coding-agent/test/suite/hooks-matcher.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { matchingHookHandlers } from "../../src/core/extensions/builtin/hooks/matcher.ts";
+import type {
+	ExecutableHookHandler,
+	HookInputWire,
+	HookSourceMetadata,
+	SupportedHookEvent,
+} from "../../src/core/extensions/builtin/hooks/types.ts";
+
+const SOURCE: HookSourceMetadata = {
+	discoveredAt: "pre-session",
+	displayOrder: 11,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+
+function handler(event: SupportedHookEvent, matcher: string | undefined, command: string): ExecutableHookHandler {
+	const base = {
+		config: { type: "command", command },
+		event,
+		groupIndex: 0,
+		handlerIndex: 0,
+		source: SOURCE,
+	} satisfies Omit<ExecutableHookHandler, "matcher">;
+	if (matcher === undefined) {
+		return base;
+	}
+	return { ...base, matcher };
+}
+
+function preToolUse(toolName: string): HookInputWire {
+	return { cwd: "/repo", event: "PreToolUse", toolInput: {}, toolName };
+}
+
+describe("builtin hooks matcher", () => {
+	it("selects tool handlers across match-all, exact, lists, regex, and aliases once", () => {
+		// Given
+		const handlers = [
+			handler("PreToolUse", undefined, "omitted"),
+			handler("PreToolUse", "", "empty"),
+			handler("PreToolUse", "*", "star"),
+			handler("PreToolUse", "bash", "senpi"),
+			handler("PreToolUse", "Bash", "claude"),
+			handler("PreToolUse", "shell", "codex-shell"),
+			handler("PreToolUse", "exec_command", "codex-exec"),
+			handler("PreToolUse", "Read|Edit|Bash", "pipe-list"),
+			handler("PreToolUse", "Read, Edit, Bash", "comma-list"),
+			handler("PreToolUse", "^(Read|Bash)$", "regex"),
+			handler("PreToolUse", "bash|Bash|shell|exec_command", "multi-alias-once"),
+			handler("PreToolUse", "Read", "miss"),
+		];
+
+		// When
+		const result = matchingHookHandlers(preToolUse("bash"), handlers);
+
+		// Then
+		expect(result.diagnostics).toEqual([]);
+		expect(result.handlers.map((hook) => hook.config.command)).toEqual([
+			"omitted",
+			"empty",
+			"star",
+			"senpi",
+			"claude",
+			"codex-shell",
+			"codex-exec",
+			"pipe-list",
+			"comma-list",
+			"regex",
+			"multi-alias-once",
+		]);
+	});
+
+	it("diagnoses invalid regex matchers and falls back to literal list matching", () => {
+		// Given
+		const handlers = [
+			handler("PreToolUse", "Bash, malformed_input(", "fallback-hit"),
+			handler("PreToolUse", "malformed_input(", "fallback-miss"),
+		];
+
+		// When
+		const result = matchingHookHandlers(preToolUse("bash"), handlers);
+
+		// Then
+		expect(result.handlers.map((hook) => hook.config.command)).toEqual(["fallback-hit"]);
+		expect(result.diagnostics).toEqual([
+			expect.objectContaining({
+				code: "invalid_matcher",
+				event: "PreToolUse",
+				path: "hooks.PreToolUse[0].matcher",
+				source: SOURCE,
+			}),
+			expect.objectContaining({
+				code: "invalid_matcher",
+				event: "PreToolUse",
+				path: "hooks.PreToolUse[0].matcher",
+				source: SOURCE,
+			}),
+		]);
+	});
+
+	it("ignores matcher filtering for user prompt and stop events", () => {
+		// Given
+		const handlers = [handler("UserPromptSubmit", "malformed_input(", "prompt"), handler("Stop", "Read", "stop")];
+		const promptInput: HookInputWire = { cwd: "/repo", event: "UserPromptSubmit", prompt: "hello" };
+		const stopInput: HookInputWire = { cwd: "/repo", event: "Stop", stopReason: "stop" };
+
+		// When
+		const promptResult = matchingHookHandlers(promptInput, handlers);
+		const stopResult = matchingHookHandlers(stopInput, handlers);
+
+		// Then
+		expect(promptResult.diagnostics).toEqual([]);
+		expect(promptResult.handlers.map((hook) => hook.config.command)).toEqual(["prompt"]);
+		expect(stopResult.diagnostics).toEqual([]);
+		expect(stopResult.handlers.map((hook) => hook.config.command)).toEqual(["stop"]);
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-output-parser.test.ts
+++ b/packages/coding-agent/test/suite/hooks-output-parser.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import type { HookSourceMetadata, SupportedHookEvent } from "../../src/core/extensions/builtin/hooks/index.ts";
+import { parseHookOutput } from "../../src/core/extensions/builtin/hooks/output-parser.ts";
+
+const SOURCE: HookSourceMetadata = {
+	discoveredAt: "runtime",
+	displayOrder: 3,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+
+function parse(
+	event: SupportedHookEvent,
+	stdout: string,
+	options?: { readonly exitCode?: number; readonly stderr?: string },
+) {
+	return parseHookOutput({
+		event,
+		exitCode: options?.exitCode ?? 0,
+		source: SOURCE,
+		stderr: options?.stderr ?? "",
+		stdout,
+	});
+}
+
+describe("builtin hooks output parser", () => {
+	it("returns no decision when a successful hook writes empty stdout", () => {
+		// Given / When
+		const parsed = parse("PreToolUse", "");
+
+		// Then
+		expect(Object.keys(parsed).sort()).toEqual(["diagnostics", "output"]);
+		expect(parsed.output).toEqual({});
+		expect(parsed.diagnostics).toEqual([]);
+	});
+
+	it("diagnoses malformed stdout JSON unless exit code 2 blocks from stderr", () => {
+		// Given / When
+		const malformedInput = parse("PostToolUse", "{not json");
+		const blocking = parse("PostToolUse", "{not json", { exitCode: 2, stderr: "policy blocked" });
+
+		// Then
+		expect(malformedInput.output).toEqual({});
+		expect(malformedInput.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "invalid_root", path: "stdout" }),
+		);
+		expect(blocking.output).toEqual({ decision: "block", reason: "policy blocked" });
+		expect(blocking.diagnostics).toEqual([]);
+	});
+
+	it("parses PreToolUse allow updated input, deny, and mismatched event diagnostics", () => {
+		// Given / When
+		const allow = parse(
+			"PreToolUse",
+			JSON.stringify({
+				continue: true,
+				hookSpecificOutput: {
+					hookEventName: "PreToolUse",
+					permissionDecision: "allow",
+					permissionDecisionReason: "safe",
+					updatedInput: { command: "printf ok" },
+					additionalContext: "lint gate passed",
+				},
+			}),
+		);
+		const deny = parse(
+			"PreToolUse",
+			JSON.stringify({
+				hookSpecificOutput: {
+					hookEventName: "PreToolUse",
+					permissionDecision: "deny",
+					permissionDecisionReason: "dangerous command",
+					updatedInput: { command: "ignored" },
+				},
+			}),
+		);
+		const staleState = parse(
+			"PreToolUse",
+			JSON.stringify({ hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: "wrong event" } }),
+		);
+		const approveWithUpdatedInput = parse(
+			"PreToolUse",
+			JSON.stringify({
+				hookSpecificOutput: {
+					hookEventName: "PreToolUse",
+					permissionDecision: "approve",
+					updatedInput: { command: "ignored" },
+				},
+			}),
+		);
+
+		// Then
+		expect(allow.output).toEqual({
+			additionalContext: "lint gate passed",
+			continue: true,
+			decision: "allow",
+			reason: "safe",
+			updatedInput: { command: "printf ok" },
+		});
+		expect(allow.diagnostics).toEqual([]);
+		expect(deny.output).toEqual({ decision: "deny", reason: "dangerous command" });
+		expect(deny.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "unsupported_field", path: "stdout.hookSpecificOutput.updatedInput" }),
+		);
+		expect(staleState.output).toEqual({});
+		expect(staleState.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "invalid_event_config", path: "stdout.hookSpecificOutput.hookEventName" }),
+		);
+		expect(approveWithUpdatedInput.output).toEqual({ decision: "approve" });
+		expect(approveWithUpdatedInput.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "unsupported_field", path: "stdout.hookSpecificOutput.updatedInput" }),
+		);
+	});
+
+	it("parses PostToolUse context, block, and updated tool output where representable", () => {
+		// Given / When
+		const context = parse(
+			"PostToolUse",
+			JSON.stringify({
+				decision: "block",
+				reason: "redacted output",
+				hookSpecificOutput: {
+					hookEventName: "PostToolUse",
+					additionalContext: "tool result contained secrets",
+					updatedToolOutput: "redacted",
+				},
+			}),
+		);
+
+		// Then
+		expect(context.output).toEqual({
+			additionalContext: "tool result contained secrets",
+			decision: "block",
+			reason: "redacted output",
+			updatedToolOutput: "redacted",
+		});
+		expect(context.diagnostics).toEqual([]);
+	});
+
+	it("parses UserPromptSubmit block/additionalContext and rejects prompt replacement", () => {
+		// Given / When
+		const parsed = parse(
+			"UserPromptSubmit",
+			JSON.stringify({
+				decision: "block",
+				reason: "missing ticket",
+				hookSpecificOutput: {
+					hookEventName: "UserPromptSubmit",
+					additionalContext: "Use ticket SION-123",
+					prompt: "replacement should not be applied",
+				},
+			}),
+		);
+
+		// Then
+		expect(parsed.output).toEqual({
+			additionalContext: "Use ticket SION-123",
+			decision: "block",
+			reason: "missing ticket",
+		});
+		expect(parsed.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "unsupported_field", path: "stdout.hookSpecificOutput.prompt" }),
+		);
+	});
+
+	it("parses Stop and SessionStart context plus intended universal fields", () => {
+		// Given / When
+		const stop = parse(
+			"Stop",
+			JSON.stringify({
+				continue: false,
+				stopReason: "quality gate failed",
+				suppressOutput: true,
+				systemMessage: "Tell the user the gate failed",
+				hookSpecificOutput: { hookEventName: "Stop", additionalContext: "rerun npm run check" },
+			}),
+		);
+		const sessionStart = parse(
+			"SessionStart",
+			JSON.stringify({
+				systemMessage: "Project instructions loaded",
+				hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: "Prefer strict hooks." },
+			}),
+		);
+		const unsupportedUniversal = parse("PreCompact", JSON.stringify({ systemMessage: "not representable here" }));
+
+		// Then
+		expect(stop.output).toEqual({
+			additionalContext: "rerun npm run check",
+			continue: false,
+			decision: "block",
+			stopReason: "quality gate failed",
+			suppressOutput: true,
+			systemMessage: "Tell the user the gate failed",
+		});
+		expect(stop.diagnostics).toEqual([]);
+		expect(sessionStart.output).toEqual({
+			additionalContext: "Prefer strict hooks.",
+			systemMessage: "Project instructions loaded",
+		});
+		expect(sessionStart.diagnostics).toEqual([]);
+		expect(unsupportedUniversal.output).toEqual({});
+		expect(unsupportedUniversal.diagnostics).toContainEqual(
+			expect.objectContaining({ code: "unsupported_field", path: "stdout.systemMessage" }),
+		);
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-plugin-loader.test.ts
+++ b/packages/coding-agent/test/suite/hooks-plugin-loader.test.ts
@@ -22,6 +22,7 @@ describe("plugin hook manifest loader", () => {
 		const manifestPath = join(pluginRoot, ".codex-plugin", "plugin.json");
 		const pluginRootCommand = ["node $", "{PLUGIN_ROOT}/hooks/one.mjs"].join("");
 		writeJson(join(pluginRoot, "hooks", "one.json"), hookConfig(pluginRootCommand));
+		writeFileSync(join(pluginRoot, "hooks", "one.mjs"), "process.exit(0);\n");
 		writeJson(join(pluginRoot, "hooks", "two.json"), hookConfig("node hooks/two.mjs"));
 		writeJson(join(pluginRoot, "hooks", "hooks.json"), hookConfig("node hooks/default.mjs"));
 		writeJson(manifestPath, {

--- a/packages/coding-agent/test/suite/hooks-plugin-loader.test.ts
+++ b/packages/coding-agent/test/suite/hooks-plugin-loader.test.ts
@@ -1,0 +1,175 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	loadPluginHookManifest,
+	selectHookCommandForPlatform,
+} from "../../src/core/extensions/builtin/hooks/plugin-loader.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { force: true, recursive: true });
+	}
+});
+
+describe("plugin hook manifest loader", () => {
+	it("loads plugin path hooks, inline hooks, default hooks, and root metadata", () => {
+		// Given
+		const pluginRoot = makePluginRoot();
+		const manifestPath = join(pluginRoot, ".codex-plugin", "plugin.json");
+		const pluginRootCommand = ["node $", "{PLUGIN_ROOT}/hooks/one.mjs"].join("");
+		writeJson(join(pluginRoot, "hooks", "one.json"), hookConfig(pluginRootCommand));
+		writeJson(join(pluginRoot, "hooks", "two.json"), hookConfig("node hooks/two.mjs"));
+		writeJson(join(pluginRoot, "hooks", "hooks.json"), hookConfig("node hooks/default.mjs"));
+		writeJson(manifestPath, {
+			hooks: [
+				"./hooks/one.json",
+				["hooks/two.json"],
+				hookConfig("node inline-one.mjs"),
+				[hookConfig("node inline-two.mjs")],
+			],
+		});
+
+		// When
+		const fromManifest = loadPluginHookManifest({ displayOrder: 3, pluginRoot });
+		const fromDefault = loadPluginHookManifest({
+			displayOrder: 9,
+			includeDefaultHooks: true,
+			pluginRoot: makePluginRootWithDefaultHook(),
+		});
+
+		// Then
+		expect(fromManifest.diagnostics).toEqual([]);
+		expect(fromManifest.parsed.executableHandlers.map((handler) => handler.config.command)).toEqual([
+			pluginRootCommand,
+			"node hooks/two.mjs",
+			"node inline-one.mjs",
+			"node inline-two.mjs",
+			"node hooks/default.mjs",
+		]);
+		expect(fromManifest.sources.map((source) => source.sourcePath)).toEqual([
+			join(pluginRoot, "hooks", "one.json"),
+			join(pluginRoot, "hooks", "two.json"),
+			`${manifestPath}#hooks[2]`,
+			`${manifestPath}#hooks[3][0]`,
+			join(pluginRoot, "hooks", "hooks.json"),
+		]);
+		for (const source of fromManifest.sources) {
+			expect(source.scope).toBe("plugin");
+			expect(source.pluginRoot).toBe(pluginRoot);
+			expect(source.manifestPath).toBe(manifestPath);
+			expect(source.pluginEnv).toEqual({
+				CLAUDE_PLUGIN_DATA: join(pluginRoot, ".plugin-data"),
+				CLAUDE_PLUGIN_ROOT: pluginRoot,
+				PLUGIN_DATA: join(pluginRoot, ".plugin-data"),
+				PLUGIN_ROOT: pluginRoot,
+			});
+		}
+		expect(fromDefault.parsed.executableHandlers.map((handler) => handler.config.command)).toEqual([
+			"node hooks/default-only.mjs",
+		]);
+	});
+
+	it("rejects malformed manifest paths, missing files, and plugin root escapes", () => {
+		// Given
+		const missingRoot = makePluginRoot({ hooks: "./hooks/missing.json" });
+		const escapeRoot = makePluginRoot({ hooks: "../escape.json" });
+		const malformedRoot = makePluginRoot({ hooks: [123] });
+
+		// When
+		const missing = loadPluginHookManifest({ displayOrder: 0, pluginRoot: missingRoot });
+		const escapedPath = loadPluginHookManifest({ displayOrder: 0, pluginRoot: escapeRoot });
+		const malformed = loadPluginHookManifest({ displayOrder: 0, pluginRoot: malformedRoot });
+
+		// Then
+		expect(missing.parsed.executableHandlers).toEqual([]);
+		expect(missing.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "invalid_root",
+				path: "$.hooks",
+			}),
+		);
+		expect(escapedPath.parsed.executableHandlers).toEqual([]);
+		expect(escapedPath.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "invalid_root",
+				message: expect.stringContaining("outside plugin root"),
+				path: "$.hooks",
+			}),
+		);
+		expect(malformed.parsed.executableHandlers).toEqual([]);
+		expect(malformed.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "invalid_root",
+				path: "$.hooks[0]",
+			}),
+		);
+	});
+
+	it("normalizes Windows separators and selects platform-specific commands", () => {
+		// Given
+		const pluginRoot = makePluginRoot({
+			hooks: ".\\hooks\\windows.json",
+		});
+		writeJson(join(pluginRoot, "hooks", "windows.json"), {
+			hooks: {
+				PreToolUse: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: "node hooks/posix.mjs",
+								commandWindows: "node hooks/windows.mjs",
+							},
+						],
+					},
+				],
+			},
+		});
+
+		// When
+		const loaded = loadPluginHookManifest({ displayOrder: 0, pluginRoot });
+		const handler = loaded.parsed.executableHandlers[0];
+
+		// Then
+		expect(loaded.diagnostics).toEqual([]);
+		expect(handler?.source.sourcePath).toBe(join(pluginRoot, "hooks", "windows.json"));
+		expect(handler ? selectHookCommandForPlatform(handler, "win32") : undefined).toBe("node hooks/windows.mjs");
+		expect(handler ? selectHookCommandForPlatform(handler, "darwin") : undefined).toBe("node hooks/posix.mjs");
+	});
+});
+
+function makePluginRoot(manifest?: unknown): string {
+	const root = mkdtempSync(join(tmpdir(), "senpi-hooks-plugin-"));
+	tempRoots.push(root);
+	mkdirSync(join(root, ".codex-plugin"), { recursive: true });
+	writeJson(join(root, ".codex-plugin", "plugin.json"), manifest ?? {});
+	return root;
+}
+
+function makePluginRootWithDefaultHook(): string {
+	const root = makePluginRoot();
+	mkdirSync(join(root, "hooks"), { recursive: true });
+	writeJson(join(root, "hooks", "hooks.json"), hookConfig("node hooks/default-only.mjs"));
+	return root;
+}
+
+function hookConfig(command: string): unknown {
+	return {
+		hooks: {
+			PreToolUse: [
+				{
+					hooks: [{ type: "command", command }],
+				},
+			],
+		},
+	};
+}
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/packages/coding-agent/test/suite/hooks-safety.test.ts
+++ b/packages/coding-agent/test/suite/hooks-safety.test.ts
@@ -1,0 +1,266 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCommandHook } from "../../src/core/extensions/builtin/hooks/command-runner.ts";
+import type { PluginHookSourceMetadata } from "../../src/core/extensions/builtin/hooks/plugin-loader.ts";
+import { loadPluginHookManifest } from "../../src/core/extensions/builtin/hooks/plugin-loader.ts";
+import type { ExecutableHookHandler, HookInputWire } from "../../src/core/extensions/builtin/hooks/types.ts";
+
+const tempRoots: string[] = [];
+const PLUGIN_ROOT_TOKEN = "$" + "{PLUGIN_ROOT}";
+
+afterEach(() => {
+	delete process.env.SENPI_TEST_ALLOWED;
+	delete process.env.SENPI_TEST_DENIED;
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { force: true, recursive: true });
+	}
+});
+
+describe("builtin hooks safety policy", () => {
+	it("rejects PLUGIN_ROOT escape targets in command and commandWindows", () => {
+		// Given
+		const pluginRoot = makePluginRoot({
+			hooks: hookConfig(`node ${PLUGIN_ROOT_TOKEN}/../escape.mjs`, `node ${PLUGIN_ROOT_TOKEN}\\..\\escape.ps1`),
+		});
+
+		// When
+		const loaded = loadPluginHookManifest({ displayOrder: 0, pluginRoot });
+
+		// Then
+		expect(loaded.parsed.executableHandlers).toEqual([]);
+		expect(loaded.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_command_target",
+					message: expect.stringContaining("outside plugin root"),
+					path: "hooks.PreToolUse[0].hooks[0].command",
+				}),
+				expect.objectContaining({
+					code: "invalid_command_target",
+					message: expect.stringContaining("outside plugin root"),
+					path: "hooks.PreToolUse[0].hooks[0].commandWindows",
+				}),
+			]),
+		);
+	});
+
+	it("rejects quoted PLUGIN_ROOT escape suffixes with no executable handler", () => {
+		// Given
+		const pluginRoot = makePluginRoot({
+			hooks: hookConfig(`node "${PLUGIN_ROOT_TOKEN}"/../escape.mjs`, `node "%PLUGIN_ROOT%"/../escape.cmd`),
+		});
+
+		// When
+		const loaded = loadPluginHookManifest({ displayOrder: 0, pluginRoot });
+
+		// Then
+		expect(loaded.parsed.executableHandlers).toEqual([]);
+		expect(loaded.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_command_target",
+					message: expect.stringContaining("outside plugin root"),
+					path: "hooks.PreToolUse[0].hooks[0].command",
+				}),
+				expect.objectContaining({
+					code: "invalid_command_target",
+					message: expect.stringContaining("outside plugin root"),
+					path: "hooks.PreToolUse[0].hooks[0].commandWindows",
+				}),
+			]),
+		);
+	});
+
+	it("rejects missing PLUGIN_ROOT command targets with diagnostics", () => {
+		// Given
+		const pluginRoot = makePluginRoot({
+			hooks: hookConfig(`node ${PLUGIN_ROOT_TOKEN}/hooks/missing.mjs`),
+		});
+
+		// When
+		const loaded = loadPluginHookManifest({ displayOrder: 0, pluginRoot });
+
+		// Then
+		expect(loaded.parsed.executableHandlers).toEqual([]);
+		expect(loaded.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "missing_command_target",
+				message: expect.stringContaining("does not exist"),
+				path: "hooks.PreToolUse[0].hooks[0].command",
+			}),
+		);
+	});
+
+	it("passes only minimal env, plugin vars, hook vars, and explicit allowlisted env", async () => {
+		// Given
+		const pluginRoot = makePluginRoot({});
+		const source = pluginSource(pluginRoot, join(pluginRoot, "hooks", "hooks.json"));
+		const scriptPath = join(pluginRoot, "hooks", "env.mjs");
+		mkdirSync(join(pluginRoot, "hooks"), { recursive: true });
+		writeFileSync(
+			scriptPath,
+			[
+				"const selected = {",
+				"  PLUGIN_ROOT: process.env.PLUGIN_ROOT,",
+				"  PLUGIN_DATA: process.env.PLUGIN_DATA,",
+				"  CLAUDE_PLUGIN_ROOT: process.env.CLAUDE_PLUGIN_ROOT,",
+				"  CLAUDE_PLUGIN_DATA: process.env.CLAUDE_PLUGIN_DATA,",
+				"  SENPI_HOOK_SOURCE: process.env.SENPI_HOOK_SOURCE,",
+				"  SENPI_HOOK_EVENT: process.env.SENPI_HOOK_EVENT,",
+				"  SENPI_TEST_ALLOWED: process.env.SENPI_TEST_ALLOWED,",
+				"  SENPI_TEST_DENIED: process.env.SENPI_TEST_DENIED,",
+				"  PATH: process.env.PATH,",
+				"};",
+				"process.stdout.write(JSON.stringify(selected));",
+			].join("\n"),
+		);
+		process.env.SENPI_TEST_ALLOWED = "allowed-value";
+		process.env.SENPI_TEST_DENIED = "denied-value";
+		const input: HookInputWire = { cwd: pluginRoot, event: "SessionStart", sessionId: "s1" };
+
+		// When
+		const result = await runCommandHook(createHandler(`${process.execPath} ${scriptPath}`, source), input, {
+			cwd: pluginRoot,
+			envPassthrough: ["SENPI_TEST_ALLOWED"],
+		});
+
+		// Then
+		expect(JSON.parse(result.stdout)).toEqual({
+			CLAUDE_PLUGIN_DATA: join(pluginRoot, ".plugin-data"),
+			CLAUDE_PLUGIN_ROOT: pluginRoot,
+			PATH: expect.any(String),
+			PLUGIN_DATA: join(pluginRoot, ".plugin-data"),
+			PLUGIN_ROOT: pluginRoot,
+			SENPI_HOOK_EVENT: "SessionStart",
+			SENPI_HOOK_SOURCE: source.sourcePath,
+			SENPI_TEST_ALLOWED: "allowed-value",
+		});
+	});
+
+	it("bounds, redacts, and spills large stdout and stderr", async () => {
+		// Given
+		const pluginRoot = makePluginRoot({});
+		const spillDir = join(pluginRoot, "spill");
+		const scriptPath = join(pluginRoot, "hooks", "large.mjs");
+		mkdirSync(join(pluginRoot, "hooks"), { recursive: true });
+		writeFileSync(
+			scriptPath,
+			[
+				"process.stdout.write('SECRET_TOKEN=stdout-secret\\n' + 'o'.repeat(200));",
+				"process.stderr.write('Authorization: Bearer stderr-secret\\n' + 'e'.repeat(200));",
+			].join("\n"),
+		);
+		const input: HookInputWire = { cwd: pluginRoot, event: "SessionStart", sessionId: "s1" };
+
+		// When
+		const result = await runCommandHook(
+			createHandler(`${process.execPath} ${scriptPath}`, pluginSource(pluginRoot)),
+			input,
+			{
+				cwd: pluginRoot,
+				outputPolicy: { maxStderrBytes: 64, maxStdoutBytes: 64, spillDir },
+			},
+		);
+
+		// Then
+		expect(result.stdout).toContain("[REDACTED]");
+		expect(result.stderr).toContain("[REDACTED]");
+		expect(result.stdout).not.toContain("stdout-secret");
+		expect(result.stderr).not.toContain("stderr-secret");
+		expect(result.outputSafety.stdout).toEqual(
+			expect.objectContaining({ redacted: true, spilled: true, truncated: true }),
+		);
+		expect(result.outputSafety.stderr).toEqual(
+			expect.objectContaining({ redacted: true, spilled: true, truncated: true }),
+		);
+		expect(result.outputSafety.stdout.spillPath).toEqual(expect.any(String));
+		expect(result.outputSafety.stderr.spillPath).toEqual(expect.any(String));
+		expect(readFileSync(result.outputSafety.stdout.spillPath ?? "", "utf8")).not.toContain("stdout-secret");
+		expect(readFileSync(result.outputSafety.stderr.spillPath ?? "", "utf8")).not.toContain("stderr-secret");
+	});
+
+	it("uses the Codex-compatible 600 second timeout by default", async () => {
+		// Given
+		const pluginRoot = makePluginRoot({});
+		const scriptPath = join(pluginRoot, "hooks", "quick.mjs");
+		mkdirSync(join(pluginRoot, "hooks"), { recursive: true });
+		writeFileSync(scriptPath, "process.stdout.write('ok');\n");
+		const input: HookInputWire = { cwd: pluginRoot, event: "SessionStart", sessionId: "s1" };
+
+		// When
+		const result = await runCommandHook(
+			createHandler(`${process.execPath} ${scriptPath}`, pluginSource(pluginRoot)),
+			input,
+			{
+				cwd: pluginRoot,
+			},
+		);
+
+		// Then
+		expect(result.timeoutSeconds).toBe(600);
+		expect(result.timedOut).toBe(false);
+	});
+});
+
+function createHandler(command: string, source: PluginHookSourceMetadata): ExecutableHookHandler {
+	return {
+		config: { command, type: "command" },
+		event: "SessionStart",
+		groupIndex: 0,
+		handlerIndex: 0,
+		source,
+	};
+}
+
+function hookConfig(command: string, commandWindows?: string): unknown {
+	return {
+		hooks: {
+			PreToolUse: [
+				{
+					hooks: [
+						{
+							command,
+							...(commandWindows === undefined ? {} : { commandWindows }),
+							type: "command",
+						},
+					],
+				},
+			],
+		},
+	};
+}
+
+function makePluginRoot(manifest: unknown): string {
+	const root = mkdtempSync(join(tmpdir(), "senpi-hooks-safety-"));
+	tempRoots.push(root);
+	mkdirSync(join(root, ".codex-plugin"), { recursive: true });
+	writeJson(join(root, ".codex-plugin", "plugin.json"), manifest);
+	return root;
+}
+
+function pluginSource(
+	pluginRoot: string,
+	sourcePath = join(pluginRoot, "hooks", "hooks.json"),
+): PluginHookSourceMetadata {
+	return {
+		discoveredAt: "pre-session",
+		displayOrder: 0,
+		manifestPath: join(pluginRoot, ".codex-plugin", "plugin.json"),
+		pluginEnv: {
+			CLAUDE_PLUGIN_DATA: join(pluginRoot, ".plugin-data"),
+			CLAUDE_PLUGIN_ROOT: pluginRoot,
+			PLUGIN_DATA: join(pluginRoot, ".plugin-data"),
+			PLUGIN_ROOT: pluginRoot,
+		},
+		pluginRoot,
+		scope: "plugin",
+		sourcePath,
+	};
+}
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/packages/coding-agent/test/suite/hooks-safety.test.ts
+++ b/packages/coding-agent/test/suite/hooks-safety.test.ts
@@ -9,6 +9,8 @@ import type { ExecutableHookHandler, HookInputWire } from "../../src/core/extens
 
 const tempRoots: string[] = [];
 const PLUGIN_ROOT_TOKEN = "$" + "{PLUGIN_ROOT}";
+const GITHUB_CLASSIC_PAT = "ghp_0123456789abcdef0123456789abcdef0123";
+const GITHUB_FINE_GRAINED_PAT = "github_pat_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 afterEach(() => {
 	delete process.env.SENPI_TEST_ALLOWED;
@@ -148,8 +150,8 @@ describe("builtin hooks safety policy", () => {
 		writeFileSync(
 			scriptPath,
 			[
-				"process.stdout.write('SECRET_TOKEN=stdout-secret\\n' + 'o'.repeat(200));",
-				"process.stderr.write('Authorization: Bearer stderr-secret\\n' + 'e'.repeat(200));",
+				`process.stdout.write('SECRET_TOKEN=stdout-secret\\n${GITHUB_CLASSIC_PAT}\\nghp_short\\n' + 'o'.repeat(200));`,
+				`process.stderr.write('Authorization: Bearer stderr-secret\\n${GITHUB_FINE_GRAINED_PAT}\\ngithub_pat_short\\n' + 'e'.repeat(200));`,
 			].join("\n"),
 		);
 		const input: HookInputWire = { cwd: pluginRoot, event: "SessionStart", sessionId: "s1" };
@@ -160,15 +162,19 @@ describe("builtin hooks safety policy", () => {
 			input,
 			{
 				cwd: pluginRoot,
-				outputPolicy: { maxStderrBytes: 64, maxStdoutBytes: 64, spillDir },
+				outputPolicy: { maxStderrBytes: 192, maxStdoutBytes: 192, spillDir },
 			},
 		);
 
 		// Then
 		expect(result.stdout).toContain("[REDACTED]");
 		expect(result.stderr).toContain("[REDACTED]");
+		expect(result.stdout).toContain("ghp_short");
+		expect(result.stderr).toContain("github_pat_short");
 		expect(result.stdout).not.toContain("stdout-secret");
 		expect(result.stderr).not.toContain("stderr-secret");
+		expect(result.stdout).not.toContain(GITHUB_CLASSIC_PAT);
+		expect(result.stderr).not.toContain(GITHUB_FINE_GRAINED_PAT);
 		expect(result.outputSafety.stdout).toEqual(
 			expect.objectContaining({ redacted: true, spilled: true, truncated: true }),
 		);
@@ -177,8 +183,14 @@ describe("builtin hooks safety policy", () => {
 		);
 		expect(result.outputSafety.stdout.spillPath).toEqual(expect.any(String));
 		expect(result.outputSafety.stderr.spillPath).toEqual(expect.any(String));
-		expect(readFileSync(result.outputSafety.stdout.spillPath ?? "", "utf8")).not.toContain("stdout-secret");
-		expect(readFileSync(result.outputSafety.stderr.spillPath ?? "", "utf8")).not.toContain("stderr-secret");
+		const stdoutSpill = readFileSync(result.outputSafety.stdout.spillPath ?? "", "utf8");
+		const stderrSpill = readFileSync(result.outputSafety.stderr.spillPath ?? "", "utf8");
+		expect(stdoutSpill).toContain("ghp_short");
+		expect(stderrSpill).toContain("github_pat_short");
+		expect(stdoutSpill).not.toContain("stdout-secret");
+		expect(stderrSpill).not.toContain("stderr-secret");
+		expect(stdoutSpill).not.toContain(GITHUB_CLASSIC_PAT);
+		expect(stderrSpill).not.toContain(GITHUB_FINE_GRAINED_PAT);
 	});
 
 	it("uses the Codex-compatible 600 second timeout by default", async () => {

--- a/packages/coding-agent/test/suite/hooks-schema.test.ts
+++ b/packages/coding-agent/test/suite/hooks-schema.test.ts
@@ -161,4 +161,46 @@ describe("builtin hooks schema", () => {
 			}),
 		);
 	});
+
+	it("rejects invalid command hook timeouts without making handlers executable", () => {
+		// Given
+		const invalidTimeouts = [
+			{ label: "zero", value: 0 },
+			{ label: "negative", value: -1 },
+			{ label: "nan", value: Number.NaN },
+			{ label: "positive-infinity", value: Number.POSITIVE_INFINITY },
+			{ label: "negative-infinity", value: Number.NEGATIVE_INFINITY },
+		] as const;
+
+		// When
+		const parsed = parseHookConfig(
+			{
+				hooks: {
+					PreToolUse: [
+						{
+							hooks: invalidTimeouts.map((timeout) => ({
+								type: "command",
+								command: `node hooks/${timeout.label}.mjs`,
+								timeout: timeout.value,
+							})),
+						},
+					],
+				},
+			},
+			SOURCE,
+		);
+
+		// Then
+		expect(parsed.executableHandlers).toEqual([]);
+		expect(parsed.diagnostics).toHaveLength(invalidTimeouts.length);
+		for (const [index] of invalidTimeouts.entries()) {
+			expect(parsed.diagnostics).toContainEqual(
+				expect.objectContaining({
+					code: "invalid_timeout",
+					event: "PreToolUse",
+					path: `hooks.PreToolUse[0].hooks[${index}].timeout`,
+				}),
+			);
+		}
+	});
 });

--- a/packages/coding-agent/test/suite/hooks-schema.test.ts
+++ b/packages/coding-agent/test/suite/hooks-schema.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { HookSourceMetadata, SupportedHookEvent } from "../../src/core/extensions/builtin/hooks/index.ts";
+import {
+	parseHookConfig,
+	SUPPORTED_HOOK_EVENTS,
+	UNSUPPORTED_KNOWN_HOOK_EVENTS,
+} from "../../src/core/extensions/builtin/hooks/index.ts";
+
+const SOURCE: HookSourceMetadata = {
+	discoveredAt: "pre-session",
+	displayOrder: 7,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+
+describe("builtin hooks schema", () => {
+	it("normalizes supported Claude and Codex command hook envelopes", () => {
+		// Given
+		const hooks = Object.fromEntries(
+			SUPPORTED_HOOK_EVENTS.map((event) => [
+				event,
+				[
+					{
+						matcher: "Bash|Edit",
+						hooks: [
+							{
+								type: "command",
+								command: `node hooks/${event}.mjs`,
+								timeout: 30,
+								statusMessage: `Running ${event}`,
+							},
+						],
+					},
+				],
+			]),
+		);
+
+		// When
+		const parsed = parseHookConfig({ hooks }, SOURCE);
+
+		// Then
+		expect(parsed.diagnostics).toEqual([]);
+		expect(parsed.executableHandlers.map((handler) => handler.event)).toEqual(SUPPORTED_HOOK_EVENTS);
+		for (const handler of parsed.executableHandlers) {
+			expect(handler.matcher).toBe("Bash|Edit");
+			expect(handler.config.type).toBe("command");
+			expect(handler.config.command).toBe(`node hooks/${handler.event}.mjs`);
+			expect(handler.config.timeout).toBe(30);
+			expect(handler.config.statusMessage).toBe(`Running ${handler.event}`);
+			expect(handler.source).toEqual(SOURCE);
+		}
+	});
+
+	it("normalizes commandWindows and command_windows aliases", () => {
+		// Given
+		const config = {
+			hooks: {
+				PreToolUse: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: "node hooks/posix.mjs",
+								commandWindows: "node hooks/windows-camel.mjs",
+							},
+							{
+								type: "command",
+								command: "node hooks/posix-two.mjs",
+								command_windows: "node hooks/windows-snake.mjs",
+							},
+						],
+					},
+				],
+			},
+		};
+
+		// When
+		const parsed = parseHookConfig(config, SOURCE);
+
+		// Then
+		expect(parsed.diagnostics).toEqual([]);
+		expect(parsed.executableHandlers.map((handler) => handler.config.commandWindows)).toEqual([
+			"node hooks/windows-camel.mjs",
+			"node hooks/windows-snake.mjs",
+		]);
+	});
+
+	it("keeps unsupported fields, events, and handlers diagnostic-only", () => {
+		// Given
+		const unsupportedHandlers = [
+			{ type: "command", command: "node hooks/condition.mjs", if: "tool.name == 'Bash'" },
+			{ type: "command", command: "node hooks/shell.mjs", shell: "bash" },
+			{ type: "command", command: { program: "node" }, args: ["hooks/exec-form.mjs"] },
+			{ type: "prompt", prompt: "Explain" },
+			{ type: "agent", agent: "reviewer" },
+			{ type: "http", url: "https://example.test/hook" },
+			{ type: "mcp_tool", name: "hook_tool" },
+			{ type: "command", command: "node hooks/async.mjs", async: true },
+			{ type: "command", command: "node hooks/rewake.mjs", asyncRewake: true },
+			{ type: "command", command: "node hooks/terminal.mjs", terminalSequence: "\u001b[31m" },
+			{ type: "command", command: "node hooks/continue.mjs", continueOnBlock: true },
+		];
+		const hooks = Object.fromEntries(
+			UNSUPPORTED_KNOWN_HOOK_EVENTS.map((event) => [
+				event,
+				[{ hooks: [{ type: "command", command: `node hooks/${event}.mjs` }] }],
+			]),
+		);
+
+		// When
+		const parsed = parseHookConfig(
+			{
+				hooks: {
+					...hooks,
+					FutureEvent: [{ hooks: [{ type: "command", command: "node hooks/future.mjs" }] }],
+					PreToolUse: [{ matcher: "*", hooks: unsupportedHandlers }],
+				},
+			},
+			SOURCE,
+		);
+
+		// Then
+		expect(parsed.executableHandlers).toEqual([]);
+		expect(parsed.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
+			expect.arrayContaining([
+				"unsupported_event",
+				"unknown_event",
+				"unsupported_field",
+				"unsupported_command_variant",
+				"unsupported_handler_type",
+				"unsupported_async_handler",
+			]),
+		);
+		expect(parsed.diagnostics.some((diagnostic) => diagnostic.path === "hooks.FutureEvent")).toBe(true);
+		for (const event of UNSUPPORTED_KNOWN_HOOK_EVENTS) {
+			expect(parsed.diagnostics.some((diagnostic) => diagnostic.path === `hooks.${event}`)).toBe(true);
+		}
+	});
+
+	it("rejects malformed command handlers without making them executable", () => {
+		// Given
+		const event: SupportedHookEvent = "PreToolUse";
+
+		// When
+		const parsed = parseHookConfig(
+			{
+				hooks: {
+					[event]: [{ hooks: [{ type: "command", command: 123 }] }],
+				},
+			},
+			SOURCE,
+		);
+
+		// Then
+		expect(parsed.executableHandlers).toEqual([]);
+		expect(parsed.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "invalid_command",
+				event,
+				path: "hooks.PreToolUse[0].hooks[0].command",
+			}),
+		);
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-stop.test.ts
+++ b/packages/coding-agent/test/suite/hooks-stop.test.ts
@@ -1,0 +1,306 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseHookConfig } from "../../src/core/extensions/builtin/hooks/index.ts";
+import {
+	STOP_DIAGNOSTICS_CUSTOM_TYPE,
+	STOP_STATE_CUSTOM_TYPE,
+} from "../../src/core/extensions/builtin/hooks/stop-adapter.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import type { HookSourceMetadata, HookTrustEntry } from "../../src/core/extensions/builtin/hooks/types.ts";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import type { CustomEntry, SessionEntry } from "../../src/core/session-manager.ts";
+import { createHarness, getMessageText, getUserTexts } from "./harness.ts";
+
+const createdDirs: string[] = [];
+
+function hooksExtensionFactory() {
+	const extension = builtinExtensions.find((entry) => entry.id === "hooks");
+	if (extension === undefined) {
+		throw new Error("builtin hooks extension is not registered");
+	}
+	return extension.factory;
+}
+
+function createTempDir(prefix: string): string {
+	const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	createdDirs.push(dir);
+	return dir;
+}
+
+function writeStopHookProject(cwd: string, command: string): void {
+	const senpiDir = join(cwd, ".senpi");
+	mkdirSync(senpiDir, { recursive: true });
+	const sourcePath = join(senpiDir, "hooks.json");
+	const hookConfig = {
+		hooks: {
+			Stop: [
+				{
+					hooks: [{ type: "command", command }],
+				},
+			],
+		},
+	};
+	writeFileSync(sourcePath, `${JSON.stringify(hookConfig, null, 2)}\n`, "utf-8");
+
+	const source = {
+		discoveredAt: "pre-session",
+		displayOrder: 0,
+		scope: "project",
+		sourcePath,
+	} satisfies HookSourceMetadata;
+	const parsed = parseHookConfig(hookConfig, source);
+	const hooks: Record<string, HookTrustEntry> = {};
+	for (const handler of parsed.executableHandlers) {
+		hooks[hookTrustId(handler)] = createHookTrustEntry(handler, {
+			platform: process.platform,
+			updatedAt: "2026-06-29T00:00:00.000Z",
+		});
+	}
+	writeFileSync(join(senpiDir, "hooks-state.json"), `${JSON.stringify({ version: 1, hooks }, null, 2)}\n`, "utf-8");
+}
+
+function createNodeScript(dir: string, name: string, body: string): string {
+	const scriptPath = join(dir, name);
+	writeFileSync(scriptPath, body, "utf-8");
+	return scriptPath;
+}
+
+function isCustomEntryOfType(entry: SessionEntry, customType: string): entry is CustomEntry {
+	return entry.type === "custom" && entry.customType === customType;
+}
+
+function readStopStates(harness: Awaited<ReturnType<typeof createHarness>>): unknown[] {
+	return harness.sessionManager
+		.getEntries()
+		.filter((entry) => isCustomEntryOfType(entry, STOP_STATE_CUSTOM_TYPE))
+		.map((entry) => entry.data);
+}
+
+function readStopDiagnostics(harness: Awaited<ReturnType<typeof createHarness>>): unknown[] {
+	return harness.sessionManager
+		.getEntries()
+		.filter((entry) => isCustomEntryOfType(entry, STOP_DIAGNOSTICS_CUSTOM_TYPE))
+		.map((entry) => entry.data);
+}
+
+function readStopOutputs(harness: Awaited<ReturnType<typeof createHarness>>): unknown[] {
+	return harness.sessionManager
+		.getEntries()
+		.filter((entry) => isCustomEntryOfType(entry, "senpi.hooks.stop-output"))
+		.map((entry) => entry.data);
+}
+
+afterEach(() => {
+	for (const dir of createdDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("builtin hooks Stop adapter", () => {
+	it("queues a follow-up and records session stop state when a Stop hook blocks with context", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-stop-followup-hook");
+		const counterPath = join(hookDir, "counter.txt");
+		const stdinPath = join(hookDir, "stdin.json");
+		const scriptPath = createNodeScript(
+			hookDir,
+			"stop-context.mjs",
+			`import { existsSync, readFileSync, writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); const previous = existsSync(${JSON.stringify(counterPath)}) ? Number(readFileSync(${JSON.stringify(counterPath)}, 'utf-8')) : 0; const next = previous + 1; writeFileSync(${JSON.stringify(counterPath)}, String(next)); if (next === 1) process.stdout.write(JSON.stringify({ decision: 'block', hookSpecificOutput: { hookEventName: 'Stop', additionalContext: 'Please inspect the final answer.' } })); });`,
+		);
+		const harness = await createHarness({
+			extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+		});
+		writeStopHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("draft"), fauxAssistantMessage("revised")]);
+
+		try {
+			// When
+			await harness.session.prompt("ship it");
+
+			// Then
+			expect(getUserTexts(harness)).toEqual(["ship it", "Please inspect the final answer."]);
+			expect(harness.session.messages.filter((message) => message.role === "assistant").map(getMessageText)).toEqual(
+				["draft", "revised"],
+			);
+			const stdin: unknown = JSON.parse(readFileSync(stdinPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "Stop",
+				hook_event_name: "Stop",
+				session_id: harness.session.sessionId,
+			});
+			expect(readStopStates(harness)).toContainEqual(
+				expect.objectContaining({
+					count: 1,
+					sessionId: harness.session.sessionId,
+				}),
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("records nonblocking Stop output without queuing a follow-up", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-stop-nonblocking-hook");
+		const scriptPath = createNodeScript(
+			hookDir,
+			"stop-nonblocking.mjs",
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ reason: 'SECRET_REASON', hookSpecificOutput: { hookEventName: 'Stop', additionalContext: 'SECRET_CONTEXT' } })); });",
+		);
+		const harness = await createHarness({
+			extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+		});
+		writeStopHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("done")]);
+
+		try {
+			// When
+			await harness.session.prompt("finish normally");
+
+			// Then
+			expect(getUserTexts(harness)).toEqual(["finish normally"]);
+			expect(harness.getPendingResponseCount()).toBe(0);
+			const outputPayload = JSON.stringify(readStopOutputs(harness));
+			expect(outputPayload).toContain("stdout.reason");
+			expect(outputPayload).toContain("stdout.hookSpecificOutput.additionalContext");
+			expect(outputPayload).not.toContain("SECRET_REASON");
+			expect(outputPayload).not.toContain("SECRET_CONTEXT");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("records unsupported Stop output fields as diagnostics without triggering a follow-up", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-stop-unsupported-hook");
+		const scriptPath = createNodeScript(
+			hookDir,
+			"stop-unsupported.mjs",
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ decision: 'approve', systemMessage: 'SECRET_SYSTEM_MESSAGE', suppressOutput: true, stopReason: 'SECRET_STOP_REASON', updatedInput: 'SECRET_INPUT', updatedToolOutput: 'SECRET_TOOL_OUTPUT' })); });",
+		);
+		const harness = await createHarness({
+			extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+		});
+		writeStopHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("done")]);
+
+		try {
+			// When
+			await harness.session.prompt("finish once");
+
+			// Then
+			expect(getUserTexts(harness)).toEqual(["finish once"]);
+			expect(harness.getPendingResponseCount()).toBe(0);
+			expect(readStopStates(harness)).toContainEqual(
+				expect.objectContaining({
+					count: 0,
+					sessionId: harness.session.sessionId,
+				}),
+			);
+			const customPayload = JSON.stringify(readStopDiagnostics(harness));
+			expect(customPayload).toContain("unsupported_field");
+			expect(customPayload).toContain("stdout.systemMessage");
+			expect(customPayload).toContain("stdout.suppressOutput");
+			expect(customPayload).toContain("stdout.stopReason");
+			expect(customPayload).toContain("stdout.updatedInput");
+			expect(customPayload).toContain("stdout.updatedToolOutput");
+			expect(customPayload).not.toContain("SECRET_SYSTEM_MESSAGE");
+			expect(customPayload).not.toContain("SECRET_STOP_REASON");
+			expect(customPayload).not.toContain("SECRET_INPUT");
+			expect(customPayload).not.toContain("SECRET_TOOL_OUTPUT");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("sanitizes mismatched hookSpecificOutput hookEventName diagnostics", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-stop-mismatched-hook-event");
+		const scriptPath = createNodeScript(
+			hookDir,
+			"stop-mismatched-event.mjs",
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'TOP_SECRET_STOP_VALUE', additionalContext: 'SECRET_CONTEXT' } })); });",
+		);
+		const harness = await createHarness({
+			extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+		});
+		writeStopHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("done")]);
+
+		try {
+			// When
+			await harness.session.prompt("finish with mismatched stop output");
+
+			// Then
+			expect(getUserTexts(harness)).toEqual(["finish with mismatched stop output"]);
+			expect(harness.getPendingResponseCount()).toBe(0);
+			const diagnosticsPayload = JSON.stringify(readStopDiagnostics(harness));
+			expect(diagnosticsPayload).toContain("invalid_event_config");
+			expect(diagnosticsPayload).toContain("stdout.hookSpecificOutput.hookEventName");
+			expect(diagnosticsPayload).toContain("does not match Stop");
+			expect(diagnosticsPayload).not.toContain("TOP_SECRET_STOP_VALUE");
+			expect(diagnosticsPayload).not.toContain("SECRET_CONTEXT");
+			expect(JSON.stringify(readStopOutputs(harness))).not.toContain("TOP_SECRET_STOP_VALUE");
+			expect(JSON.stringify(readStopOutputs(harness))).not.toContain("SECRET_CONTEXT");
+			expect(getUserTexts(harness).join("\n")).not.toContain("TOP_SECRET_STOP_VALUE");
+			expect(getUserTexts(harness).join("\n")).not.toContain("SECRET_CONTEXT");
+			expect(harness.session.messages.map(getMessageText).join("\n")).not.toContain("TOP_SECRET_STOP_VALUE");
+			expect(harness.session.messages.map(getMessageText).join("\n")).not.toContain("SECRET_CONTEXT");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("caps repeated Stop hook reentry at eight blocks and resets for a new user turn", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-stop-cap-hook");
+		const counterPath = join(hookDir, "counter.txt");
+		const scriptPath = createNodeScript(
+			hookDir,
+			"stop-loop.mjs",
+			`import { existsSync, readFileSync, writeFileSync } from 'node:fs'; process.stdin.resume(); process.stdin.on('end', () => { const previous = existsSync(${JSON.stringify(counterPath)}) ? Number(readFileSync(${JSON.stringify(counterPath)}, 'utf-8')) : 0; const next = previous + 1; writeFileSync(${JSON.stringify(counterPath)}, String(next)); if (next <= 10) { process.stdout.write(JSON.stringify({ decision: 'block', reason: 'loop follow-up' })); } });`,
+		);
+		const harness = await createHarness({
+			extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+		});
+		writeStopHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([
+			fauxAssistantMessage("first-0"),
+			fauxAssistantMessage("first-1"),
+			fauxAssistantMessage("first-2"),
+			fauxAssistantMessage("first-3"),
+			fauxAssistantMessage("first-4"),
+			fauxAssistantMessage("first-5"),
+			fauxAssistantMessage("first-6"),
+			fauxAssistantMessage("first-7"),
+			fauxAssistantMessage("first-8"),
+			fauxAssistantMessage("second-0"),
+			fauxAssistantMessage("second-1"),
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("first user turn");
+			await harness.session.agent.waitForIdle();
+			await harness.session.prompt("second user turn");
+
+			// Then
+			expect(readFileSync(counterPath, "utf-8")).toBe("11");
+			const userTexts = getUserTexts(harness);
+			expect(userTexts.filter((text) => text === "loop follow-up")).toHaveLength(9);
+			expect(userTexts).toContain("second user turn");
+			const stopStates = readStopStates(harness);
+			expect(stopStates).toContainEqual(expect.objectContaining({ count: 8, sessionId: harness.session.sessionId }));
+			expect(stopStates.at(-1)).toEqual(expect.objectContaining({ count: 1 }));
+			const customPayload = JSON.stringify(readStopDiagnostics(harness));
+			expect(customPayload).toContain("Stop hook reentry limit reached.");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-tool-events.test.ts
+++ b/packages/coding-agent/test/suite/hooks-tool-events.test.ts
@@ -1,0 +1,385 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseHookConfig } from "../../src/core/extensions/builtin/hooks/index.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import type {
+	HookSourceMetadata,
+	HookTrustEntry,
+	SupportedHookEvent,
+} from "../../src/core/extensions/builtin/hooks/types.ts";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import type { ExtensionFactory } from "../../src/index.ts";
+import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
+
+const createdDirs: string[] = [];
+type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
+
+function hooksExtensionFactory() {
+	const extension = builtinExtensions.find((entry) => entry.id === "hooks");
+	if (extension === undefined) {
+		throw new Error("builtin hooks extension is not registered");
+	}
+	return extension.factory;
+}
+
+function createTempDir(prefix: string): string {
+	const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	createdDirs.push(dir);
+	return dir;
+}
+
+function createEchoTool(seenInputs: string[]): AgentTool {
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo text back",
+		parameters: Type.Object({ text: Type.String() }),
+		execute: async (_toolCallId, params) => {
+			const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+			seenInputs.push(text);
+			return { content: [{ type: "text", text: `tool:${text}` }], details: { text } };
+		},
+	};
+}
+
+function findToolResult(messages: readonly AgentMessage[]): ToolResultMessage | undefined {
+	const message = messages.find((item) => item.role === "toolResult");
+	return message?.role === "toolResult" ? message : undefined;
+}
+
+function findLatestToolResult(messages: readonly AgentMessage[]): ToolResultMessage | undefined {
+	return messages.findLast((item): item is ToolResultMessage => item.role === "toolResult");
+}
+
+function toolResultText(message: ToolResultMessage | undefined): string {
+	if (message === undefined) return "";
+	return message.content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function writeHookProject(
+	cwd: string,
+	event: SupportedHookEvent,
+	commandOrCommands: string | readonly string[],
+	matcher = "echo",
+): void {
+	const senpiDir = join(cwd, ".senpi");
+	mkdirSync(senpiDir, { recursive: true });
+	const sourcePath = join(senpiDir, "hooks.json");
+	const commands = typeof commandOrCommands === "string" ? [commandOrCommands] : commandOrCommands;
+	const hookConfig = {
+		hooks: {
+			[event]: [
+				{
+					matcher,
+					hooks: commands.map((command) => ({
+						type: "command",
+						command,
+					})),
+				},
+			],
+		},
+	};
+	writeFileSync(sourcePath, `${JSON.stringify(hookConfig, null, 2)}\n`, "utf-8");
+
+	const source = {
+		discoveredAt: "pre-session",
+		displayOrder: 0,
+		scope: "project",
+		sourcePath,
+	} satisfies HookSourceMetadata;
+	const parsed = parseHookConfig(hookConfig, source);
+	const hooks: Record<string, HookTrustEntry> = {};
+	for (const handler of parsed.executableHandlers) {
+		hooks[hookTrustId(handler)] = createHookTrustEntry(handler, {
+			platform: process.platform,
+			updatedAt: "2026-06-29T00:00:00.000Z",
+		});
+	}
+	writeFileSync(join(senpiDir, "hooks-state.json"), `${JSON.stringify({ version: 1, hooks }, null, 2)}\n`, "utf-8");
+}
+
+async function createHooksHarness(
+	seenInputs: string[] = [],
+	extensionFactories: readonly ExtensionFactory[] = [],
+): Promise<Harness> {
+	return createHarness({
+		tools: [createEchoTool(seenInputs)],
+		extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }, ...extensionFactories],
+	});
+}
+
+afterEach(() => {
+	for (const dir of createdDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("builtin hooks tool event adapters", () => {
+	it("blocks PreToolUse deny before execution and sends Claude/Codex tool stdin fields", async () => {
+		// Given
+		const seenInputs: string[] = [];
+		const hookDir = createTempDir("senpi-pre-tool-deny-hook");
+		const stdinPath = join(hookDir, "stdin.json");
+		const scriptPath = join(hookDir, "deny.mjs");
+		writeFileSync(
+			scriptPath,
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: 'destructive command denied' } })); });`,
+			"utf-8",
+		);
+		const harness = await createHooksHarness(seenInputs);
+		writeHookProject(harness.tempDir, "PreToolUse", `${process.execPath} ${scriptPath}`);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "delete everything" }, { id: "tool-deny" })], {
+				stopReason: "toolUse",
+			}),
+			(context) => {
+				return fauxAssistantMessage(toolResultText(findToolResult(context.messages)));
+			},
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("run tool");
+
+			// Then
+			expect(seenInputs).toEqual([]);
+			expect(getAssistantTexts(harness)).toContain("destructive command denied");
+			const stdin: unknown = JSON.parse(readFileSync(stdinPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				session_id: harness.session.sessionId,
+				cwd: harness.tempDir,
+				hook_event_name: "PreToolUse",
+				tool_name: "echo",
+				tool_input: { text: "delete everything" },
+				tool_use_id: "tool-deny",
+			});
+			expect(stdin).not.toHaveProperty("tool_response");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("applies PreToolUse allow updatedInput and exposes additionalContext to the active turn", async () => {
+		// Given
+		const seenInputs: string[] = [];
+		const hookDir = createTempDir("senpi-pre-tool-allow-hook");
+		const scriptPath = join(hookDir, "allow.mjs");
+		writeFileSync(
+			scriptPath,
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow', updatedInput: { text: 'patched input' }, additionalContext: 'Pre hook saw and approved the patched input.' } })); });",
+			"utf-8",
+		);
+		const harness = await createHooksHarness(seenInputs);
+		writeHookProject(harness.tempDir, "PreToolUse", `${process.execPath} ${scriptPath}`);
+		let sawPreContext = false;
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "original input" })], { stopReason: "toolUse" }),
+			(context) => {
+				const toolResult = findToolResult(context.messages);
+				sawPreContext =
+					toolResult?.content.some(
+						(part) => part.type === "text" && part.text.includes("Pre hook saw and approved"),
+					) === true;
+				return fauxAssistantMessage(toolResultText(toolResult));
+			},
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("run tool");
+
+			// Then
+			expect(seenInputs).toEqual(["patched input"]);
+			expect(getAssistantTexts(harness).join("\n")).toContain("tool:patched input");
+			expect(sawPreContext).toBe(true);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("applies PostToolUse updatedToolOutput with additionalContext as model-visible result content", async () => {
+		// Given
+		const seenInputs: string[] = [];
+		const hookDir = createTempDir("senpi-post-tool-hook");
+		const stdinPath = join(hookDir, "stdin.json");
+		const scriptPath = join(hookDir, "post.mjs");
+		writeFileSync(
+			scriptPath,
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PostToolUse', updatedToolOutput: 'redacted replacement', additionalContext: 'Post hook context for the model.' } })); });`,
+			"utf-8",
+		);
+		const harness = await createHooksHarness(seenInputs);
+		writeHookProject(harness.tempDir, "PostToolUse", `${process.execPath} ${scriptPath}`);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "secret output" }, { id: "tool-post" })], {
+				stopReason: "toolUse",
+			}),
+			(context) => {
+				return fauxAssistantMessage(toolResultText(findToolResult(context.messages)));
+			},
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("run tool");
+
+			// Then
+			expect(seenInputs).toEqual(["secret output"]);
+			const assistantText = getAssistantTexts(harness).join("\n");
+			expect(assistantText).toContain("redacted replacement");
+			expect(assistantText).toContain("Post hook context for the model.");
+			expect(assistantText).not.toContain("tool:secret output");
+			const stdin: unknown = JSON.parse(readFileSync(stdinPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				session_id: harness.session.sessionId,
+				cwd: harness.tempDir,
+				hook_event_name: "PostToolUse",
+				tool_name: "echo",
+				tool_input: { text: "secret output" },
+				tool_response: {
+					content: [{ type: "text", text: "tool:secret output" }],
+					details: { text: "secret output" },
+				},
+				tool_use_id: "tool-post",
+			});
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("preserves earlier PostToolUse additionalContext when a later hook replaces tool output", async () => {
+		// Given
+		const seenInputs: string[] = [];
+		const hookDir = createTempDir("senpi-post-tool-multi-hook");
+		const contextScriptPath = join(hookDir, "context.mjs");
+		const replacementScriptPath = join(hookDir, "replacement.mjs");
+		writeFileSync(
+			contextScriptPath,
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: 'Earlier post hook context.' } })); });",
+			"utf-8",
+		);
+		writeFileSync(
+			replacementScriptPath,
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PostToolUse', updatedToolOutput: 'later replacement' } })); });",
+			"utf-8",
+		);
+		const harness = await createHooksHarness(seenInputs);
+		writeHookProject(harness.tempDir, "PostToolUse", [
+			`${process.execPath} ${contextScriptPath}`,
+			`${process.execPath} ${replacementScriptPath}`,
+		]);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "secret output" }, { id: "tool-post-multi" })], {
+				stopReason: "toolUse",
+			}),
+			(context) => fauxAssistantMessage(toolResultText(findToolResult(context.messages))),
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("run tool");
+
+			// Then
+			expect(seenInputs).toEqual(["secret output"]);
+			const assistantText = getAssistantTexts(harness).join("\n");
+			expect(assistantText).toContain("later replacement");
+			expect(assistantText).toContain("Earlier post hook context.");
+			expect(assistantText).not.toContain("tool:secret output");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not reuse PreToolUse additionalContext after a later tool_call handler blocks the same id", async () => {
+		// Given
+		const seenInputs: string[] = [];
+		const hookDir = createTempDir("senpi-pre-tool-stale-context");
+		const scriptPath = join(hookDir, "allow-context.mjs");
+		writeFileSync(
+			scriptPath,
+			"let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { const input = JSON.parse(stdin); const text = input.tool_input?.text; const output = text === 'blocked first' ? { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow', additionalContext: 'Context from blocked first call.' } } : { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } }; process.stdout.write(JSON.stringify(output)); });",
+			"utf-8",
+		);
+		const laterBlocker: ExtensionFactory = (pi) => {
+			pi.on("tool_call", async (event) => {
+				if (event.toolName === "echo" && event.input.text === "blocked first") {
+					return { block: true, reason: "Blocked after builtin hooks queued context." };
+				}
+				return undefined;
+			});
+		};
+		const harness = await createHooksHarness(seenInputs, [laterBlocker]);
+		writeHookProject(harness.tempDir, "PreToolUse", `${process.execPath} ${scriptPath}`);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "blocked first" }, { id: "reused-pre-id" })], {
+				stopReason: "toolUse",
+			}),
+			(context) => fauxAssistantMessage(toolResultText(findLatestToolResult(context.messages))),
+			fauxAssistantMessage([fauxToolCall("echo", { text: "later input" }, { id: "reused-pre-id" })], {
+				stopReason: "toolUse",
+			}),
+			(context) => fauxAssistantMessage(toolResultText(findLatestToolResult(context.messages))),
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("run blocked tool");
+			await harness.session.prompt("run later tool");
+
+			// Then
+			expect(seenInputs).toEqual(["later input"]);
+			const assistantText = getAssistantTexts(harness).join("\n");
+			expect(assistantText).toContain("Blocked after builtin hooks queued context.");
+			expect(assistantText).toContain("tool:later input");
+			expect(assistantText).not.toContain("Context from blocked first call.");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("represents PostToolUse block decisions as model-visible error context after execution", async () => {
+		// Given
+		const seenInputs: string[] = [];
+		const hookDir = createTempDir("senpi-post-tool-block-hook");
+		const scriptPath = join(hookDir, "block.mjs");
+		writeFileSync(
+			scriptPath,
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ decision: 'block', reason: 'Post hook flagged the already executed result.' })); });",
+			"utf-8",
+		);
+		const harness = await createHooksHarness(seenInputs);
+		writeHookProject(harness.tempDir, "PostToolUse", `${process.execPath} ${scriptPath}`);
+		let sawErrorResult = false;
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "unsafe output" })], { stopReason: "toolUse" }),
+			(context) => {
+				const toolResult = findToolResult(context.messages);
+				sawErrorResult = toolResult?.isError === true;
+				return fauxAssistantMessage(toolResultText(toolResult));
+			},
+		]);
+
+		try {
+			// When
+			await harness.session.prompt("run tool");
+
+			// Then
+			expect(seenInputs).toEqual(["unsafe output"]);
+			const assistantText = getAssistantTexts(harness).join("\n");
+			expect(assistantText).toContain("Post hook flagged the already executed result.");
+			expect(assistantText).not.toContain("tool:unsafe output");
+			expect(sawErrorResult).toBe(true);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/hooks-trust.test.ts
+++ b/packages/coding-agent/test/suite/hooks-trust.test.ts
@@ -1,0 +1,228 @@
+import { mkdirSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import lockfile from "proper-lockfile";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	buildHookTrustRecord,
+	createHookTrustEntry,
+	filterExecutableTrustedHooks,
+	hookTrustId,
+	hookTrustStorageScope,
+	isCommandHookTrusted,
+	listHookTrustRecords,
+	readHookTrustStateJson,
+} from "../../src/core/extensions/builtin/hooks/trust.ts";
+import {
+	FileHookStateStorage,
+	InMemoryHookStateStorage,
+} from "../../src/core/extensions/builtin/hooks/trust-storage.ts";
+import type { ExecutableHookHandler, HookSourceMetadata } from "../../src/core/extensions/builtin/hooks/types.ts";
+
+const PROJECT_SOURCE: HookSourceMetadata = {
+	discoveredAt: "pre-session",
+	displayOrder: 1,
+	scope: "project",
+	sourcePath: "/repo/.senpi/hooks.json",
+};
+
+const UPDATED_AT = "2026-06-29T00:00:00.000Z";
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of createdDirs.splice(0)) {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("builtin hooks trust", () => {
+	it("builds stable hook ids and canonical command hashes", () => {
+		// Given
+		const hook = commandHook({ groupIndex: 2, handlerIndex: 3 });
+		const reorderedEquivalent = {
+			source: PROJECT_SOURCE,
+			matcher: "Bash",
+			handlerIndex: 3,
+			groupIndex: 2,
+			event: "PreToolUse",
+			config: {
+				statusMessage: "Checking tool call",
+				timeout: 30,
+				commandWindows: "node hooks/check.ps1",
+				command: "node hooks/check.mjs",
+				type: "command",
+			},
+		} satisfies ExecutableHookHandler;
+
+		// When
+		const record = buildHookTrustRecord(hook, { platform: "linux" });
+		const equivalentRecord = buildHookTrustRecord(reorderedEquivalent, { platform: "linux" });
+
+		// Then
+		expect(record.id).toBe("hk_f426e074193a_PreToolUse_2_3");
+		expect(hookTrustId(hook)).toBe(record.id);
+		expect(record.currentHash).toBe("sha256:83901748237ea5ed4ec8741e50e7fc233770daf0e7f804f4300013ffa44d0406");
+		expect(equivalentRecord).toEqual(record);
+		expect(record.commandPreview).toBe("node hooks/check.mjs");
+	});
+
+	it("invalidates trust when command identity fields change", () => {
+		// Given
+		const hook = commandHook();
+		const trusted = {
+			version: 1,
+			hooks: {
+				[hookTrustId(hook)]: createHookTrustEntry(hook, { platform: "linux", updatedAt: UPDATED_AT }),
+			},
+		} as const;
+
+		// When
+		const commandChanged = commandHook({ command: "node hooks/changed.mjs" });
+		const commandWindowsChanged = commandHook({ commandWindows: "node hooks/changed.ps1" });
+		const timeoutChanged = commandHook({ timeout: 31 });
+		const statusMessageChanged = commandHook({ statusMessage: "Different status" });
+
+		// Then
+		expect(isCommandHookTrusted(hook, trusted, { platform: "linux" })).toBe(true);
+		expect(isCommandHookTrusted(commandChanged, trusted, { platform: "linux" })).toBe(false);
+		expect(isCommandHookTrusted(commandWindowsChanged, trusted, { platform: "linux" })).toBe(false);
+		expect(isCommandHookTrusted(timeoutChanged, trusted, { platform: "linux" })).toBe(false);
+		expect(isCommandHookTrusted(statusMessageChanged, trusted, { platform: "linux" })).toBe(false);
+	});
+
+	it("lists disabled and untrusted hooks while skipping execution", () => {
+		// Given
+		const trustedHook = commandHook({ groupIndex: 0, handlerIndex: 0 });
+		const disabledHook = commandHook({ groupIndex: 0, handlerIndex: 1 });
+		const untrustedHook = commandHook({ groupIndex: 0, handlerIndex: 2 });
+		const state = {
+			version: 1,
+			hooks: {
+				[hookTrustId(trustedHook)]: createHookTrustEntry(trustedHook, {
+					platform: "linux",
+					updatedAt: UPDATED_AT,
+				}),
+				[hookTrustId(disabledHook)]: {
+					...createHookTrustEntry(disabledHook, { platform: "linux", updatedAt: UPDATED_AT }),
+					enabled: false,
+				},
+			},
+		} as const;
+
+		// When
+		const records = listHookTrustRecords([trustedHook, disabledHook, untrustedHook], state, { platform: "linux" });
+		const executable = filterExecutableTrustedHooks([trustedHook, disabledHook, untrustedHook], state, {
+			platform: "linux",
+		});
+
+		// Then
+		expect(
+			records.map((record) => ({ enabled: record.enabled, executable: record.executable, trusted: record.trusted })),
+		).toEqual([
+			{ enabled: true, executable: true, trusted: true },
+			{ enabled: false, executable: false, trusted: true },
+			{ enabled: true, executable: false, trusted: false },
+		]);
+		expect(executable).toEqual([trustedHook]);
+	});
+
+	it("keeps malformed or stale state untrusted", () => {
+		// Given
+		const hook = commandHook();
+
+		// When
+		const malformed = readHookTrustStateJson("{ bad json");
+		const stale = readHookTrustStateJson(JSON.stringify({ version: 0, hooks: { [hookTrustId(hook)]: {} } }));
+
+		// Then
+		expect(isCommandHookTrusted(hook, malformed, { platform: "linux" })).toBe(false);
+		expect(isCommandHookTrusted(hook, stale, { platform: "linux" })).toBe(false);
+	});
+
+	it("persists state through storage without trusting project hooks by default", async () => {
+		// Given
+		const hook = commandHook();
+		const storage = new InMemoryHookStateStorage();
+		const globalHook = commandHook({
+			source: { ...PROJECT_SOURCE, scope: "global", sourcePath: "/home/user/hooks.json" },
+		});
+
+		// When
+		const initial = storage.read("global");
+		storage.update("global", (current) => ({
+			version: 1,
+			hooks: {
+				...current.hooks,
+				[hookTrustId(globalHook)]: createHookTrustEntry(globalHook, { updatedAt: UPDATED_AT }),
+			},
+		}));
+		const persisted = storage.read("global");
+
+		// Then
+		expect(initial).toEqual({ version: 1, hooks: {} });
+		expect(hookTrustStorageScope(hook, { projectTrusted: false })).toBeUndefined();
+		expect(hookTrustStorageScope(hook, { projectTrusted: true })).toBe("project");
+		expect(hookTrustStorageScope(globalHook, { projectTrusted: false })).toBe("global");
+		expect(isCommandHookTrusted(hook, persisted)).toBe(false);
+		expect(isCommandHookTrusted(globalHook, persisted)).toBe(true);
+	});
+
+	it("uses a bounded proper-lockfile-compatible file lock for writes", async () => {
+		// Given
+		const root = await mkdtemp(join(tmpdir(), "senpi-hooks-trust-"));
+		createdDirs.push(root);
+		const agentDir = join(root, "agent");
+		const cwd = join(root, "repo");
+		mkdirSync(dirname(join(agentDir, "hooks-state.json")), { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		const storage = new FileHookStateStorage({ agentDir, cwd });
+		const statePath = join(agentDir, "hooks-state.json");
+		const release = lockfile.lockSync(dirname(statePath), { realpath: false, lockfilePath: `${statePath}.lock` });
+
+		try {
+			expect(() => storage.update("global", (current) => current)).toThrow();
+		} finally {
+			release();
+		}
+
+		// When
+		storage.update("global", (current) => ({
+			version: 1,
+			hooks: {
+				...current.hooks,
+				[hookTrustId(commandHook())]: createHookTrustEntry(commandHook(), { updatedAt: UPDATED_AT }),
+			},
+		}));
+
+		// Then
+		expect(await readFile(statePath, "utf-8")).toContain('"version": 1');
+	});
+});
+
+function commandHook(
+	overrides: {
+		readonly command?: string;
+		readonly commandWindows?: string;
+		readonly timeout?: number;
+		readonly statusMessage?: string;
+		readonly groupIndex?: number;
+		readonly handlerIndex?: number;
+		readonly source?: HookSourceMetadata;
+	} = {},
+): ExecutableHookHandler {
+	return {
+		event: "PreToolUse",
+		matcher: "Bash",
+		groupIndex: overrides.groupIndex ?? 0,
+		handlerIndex: overrides.handlerIndex ?? 0,
+		config: {
+			type: "command",
+			command: overrides.command ?? "node hooks/check.mjs",
+			commandWindows: overrides.commandWindows ?? "node hooks/check.ps1",
+			timeout: overrides.timeout ?? 30,
+			statusMessage: overrides.statusMessage ?? "Checking tool call",
+		},
+		source: overrides.source ?? PROJECT_SOURCE,
+	};
+}

--- a/packages/coding-agent/test/suite/hooks-trust.test.ts
+++ b/packages/coding-agent/test/suite/hooks-trust.test.ts
@@ -91,6 +91,21 @@ describe("builtin hooks trust", () => {
 		expect(isCommandHookTrusted(statusMessageChanged, trusted, { platform: "linux" })).toBe(false);
 	});
 
+	it("rejects invalid timeout values before trust can normalize them", () => {
+		// Given
+		const invalidTimeouts = [0, -1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY] as const;
+
+		// Then
+		expect(buildHookTrustRecord(commandHook({ timeout: 1 }), { platform: "linux" }).commandPreview).toBe(
+			"node hooks/check.mjs",
+		);
+		for (const timeout of invalidTimeouts) {
+			expect(() => buildHookTrustRecord(commandHook({ timeout }), { platform: "linux" })).toThrow(
+				"Invalid command hook timeout reached trust hashing.",
+			);
+		}
+	});
+
 	it("lists disabled and untrusted hooks while skipping execution", () => {
 		// Given
 		const trustedHook = commandHook({ groupIndex: 0, handlerIndex: 0 });

--- a/packages/coding-agent/test/suite/hooks-user-prompt-submit.test.ts
+++ b/packages/coding-agent/test/suite/hooks-user-prompt-submit.test.ts
@@ -1,0 +1,285 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseHookConfig } from "../../src/core/extensions/builtin/hooks/index.ts";
+import { buildUserPromptHookInput } from "../../src/core/extensions/builtin/hooks/prompt-adapter.ts";
+import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
+import type { HookSourceMetadata, HookTrustEntry } from "../../src/core/extensions/builtin/hooks/types.ts";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import { createSyntheticSourceInfo } from "../../src/core/source-info.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
+import { createHarness, getMessageText } from "./harness.ts";
+
+const createdDirs: string[] = [];
+
+function hooksExtensionFactory() {
+	const extension = builtinExtensions.find((entry) => entry.id === "hooks");
+	if (extension === undefined) {
+		throw new Error("builtin hooks extension is not registered");
+	}
+	return extension.factory;
+}
+
+function createTempDir(prefix: string): string {
+	const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	createdDirs.push(dir);
+	return dir;
+}
+
+function writeHookProject(cwd: string, command: string): void {
+	const senpiDir = join(cwd, ".senpi");
+	mkdirSync(senpiDir, { recursive: true });
+	const sourcePath = join(senpiDir, "hooks.json");
+	const hookConfig = {
+		hooks: {
+			UserPromptSubmit: [
+				{
+					hooks: [
+						{
+							type: "command",
+							command,
+						},
+					],
+				},
+			],
+		},
+	};
+	writeFileSync(sourcePath, `${JSON.stringify(hookConfig, null, 2)}\n`, "utf-8");
+
+	const source = {
+		discoveredAt: "pre-session",
+		displayOrder: 0,
+		scope: "project",
+		sourcePath,
+	} satisfies HookSourceMetadata;
+	const parsed = parseHookConfig(hookConfig, source);
+	const hooks: Record<string, HookTrustEntry> = {};
+	for (const handler of parsed.executableHandlers) {
+		hooks[hookTrustId(handler)] = createHookTrustEntry(handler, {
+			platform: process.platform,
+			updatedAt: "2026-06-29T00:00:00.000Z",
+		});
+	}
+	writeFileSync(join(senpiDir, "hooks-state.json"), `${JSON.stringify({ version: 1, hooks }, null, 2)}\n`, "utf-8");
+}
+
+function createHooksHarness(options: Parameters<typeof createHarness>[0] = {}) {
+	return createHarness({
+		extensionFactories: [{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+		...options,
+	});
+}
+
+afterEach(() => {
+	for (const dir of createdDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("builtin hooks UserPromptSubmit adapter", () => {
+	it("adds transcript_path only when a stable session file is available", () => {
+		// Given / When
+		const withoutTranscript = buildUserPromptHookInput({
+			cwd: "/repo",
+			permissionMode: "default",
+			prompt: "hello",
+			sessionId: "session-1",
+		});
+		const withTranscript = buildUserPromptHookInput({
+			cwd: "/repo",
+			permissionMode: "workspace",
+			prompt: "hello",
+			sessionId: "session-1",
+			transcriptPath: "/repo/.senpi/session.jsonl",
+		});
+
+		// Then
+		expect(withoutTranscript).not.toHaveProperty("transcript_path");
+		expect(withTranscript).toMatchObject({
+			permission_mode: "workspace",
+			session_id: "session-1",
+			transcript_path: "/repo/.senpi/session.jsonl",
+		});
+	});
+
+	it("handles blocked prompts with a warning/custom message and no model turn", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-user-prompt-block-hook");
+		const stdinPath = join(hookDir, "stdin.json");
+		const scriptPath = join(hookDir, "block.mjs");
+		writeFileSync(
+			scriptPath,
+			`import { writeFileSync } from 'node:fs'; let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { writeFileSync(${JSON.stringify(stdinPath)}, stdin); process.stdout.write(JSON.stringify({ decision: 'block', reason: 'ticket required' })); });`,
+			"utf-8",
+		);
+		const harness = await createHooksHarness();
+		writeHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("model should not run")]);
+
+		try {
+			// When
+			await harness.session.prompt("ship it");
+
+			// Then
+			expect(harness.getPendingResponseCount()).toBe(1);
+			expect(harness.session.messages.filter((message) => message.role === "user")).toEqual([]);
+			const customMessages = harness.session.messages.filter((message) => message.role === "custom");
+			expect(customMessages).toHaveLength(1);
+			expect(customMessages[0]).toMatchObject({
+				customType: "senpi.hook",
+				display: false,
+			});
+			expect(getMessageText(customMessages[0])).toContain("ticket required");
+			const stdin: unknown = JSON.parse(readFileSync(stdinPath, "utf-8"));
+			expect(stdin).toMatchObject({
+				cwd: harness.tempDir,
+				event: "UserPromptSubmit",
+				permission_mode: "default",
+				prompt: "ship it",
+				session_id: harness.session.sessionId,
+			});
+			expect(stdin).not.toHaveProperty("transcript_path");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("injects hook context after real skill expansion changes the prompt", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-user-prompt-context-hook");
+		const scriptPath = join(hookDir, "context.mjs");
+		const skillPath = join(hookDir, "test-skill.md");
+		writeFileSync(skillPath, "# Test Skill\n\nUse the real expanded skill body.", "utf-8");
+		writeFileSync(
+			scriptPath,
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({ systemMessage: 'Use the project diagnostic.', hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: 'Context from hook only.', prompt: 'REPLACED PROMPT MUST NOT APPEAR' } })); });",
+			"utf-8",
+		);
+		const extensionsResult = await createTestExtensionsResult(
+			[{ factory: hooksExtensionFactory(), path: "<builtin:hooks>" }],
+			hookDir,
+		);
+		const resourceLoader = {
+			...createTestResourceLoader({ extensionsResult }),
+			getSkills: () => ({
+				skills: [
+					{
+						name: "test",
+						description: "Test skill",
+						filePath: skillPath,
+						disableModelInvocation: false,
+						baseDir: hookDir,
+						sourceInfo: createSyntheticSourceInfo(skillPath, {
+							source: "local",
+							scope: "project",
+							origin: "top-level",
+							baseDir: hookDir,
+						}),
+					},
+				],
+				diagnostics: [],
+			}),
+		};
+		const harness = await createHarness({ resourceLoader });
+		writeHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		try {
+			// When
+			await harness.session.prompt("/skill:test original prompt");
+
+			// Then
+			const userMessages = harness.session.messages.filter((message) => message.role === "user");
+			expect(userMessages).toHaveLength(1);
+			expect(getMessageText(userMessages[0])).toContain('<skill name="test" location="');
+			expect(getMessageText(userMessages[0])).toContain("Use the real expanded skill body.");
+			expect(getMessageText(userMessages[0])).toContain("original prompt");
+			expect(getMessageText(userMessages[0])).not.toContain("REPLACED PROMPT");
+			const customMessageText = harness.session.messages
+				.filter((message) => message.role === "custom")
+				.map((message) => getMessageText(message))
+				.join("\n");
+			expect(customMessageText).toContain("Context from hook only.");
+			expect(customMessageText).not.toContain("REPLACED PROMPT");
+			expect(harness.session.systemPrompt).toContain("Use the project diagnostic.");
+			expect(harness.session.systemPrompt).not.toContain("REPLACED PROMPT");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not replay queued context after an unrelated preflight failure", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-user-prompt-stale-context-hook");
+		const scriptPath = join(hookDir, "context-on-first.mjs");
+		writeFileSync(
+			scriptPath,
+			"let stdin = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (chunk) => { stdin += chunk; }); process.stdin.on('end', () => { const input = JSON.parse(stdin); const output = input.prompt === 'first prompt' ? { hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: 'FIRST PROMPT CONTEXT' } } : {}; process.stdout.write(JSON.stringify(output)); });",
+			"utf-8",
+		);
+		const harness = await createHooksHarness({
+			withConfiguredAuth: false,
+		});
+		writeHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+
+		try {
+			// When
+			await expect(harness.session.prompt("first prompt")).rejects.toThrow("No API key found");
+			const model = harness.getModel();
+			harness.authStorage.setRuntimeApiKey(model.provider, "faux-key");
+			harness.session.modelRegistry.registerProvider(model.provider, {
+				api: harness.faux.api,
+				apiKey: "faux-key",
+				baseUrl: model.baseUrl,
+				models: harness.faux.models,
+			});
+			harness.setResponses([fauxAssistantMessage("ok")]);
+			await harness.session.prompt("second prompt");
+
+			// Then
+			const modelVisibleMessages = harness.session.messages.filter(
+				(message) => message.role === "user" || message.role === "custom",
+			);
+			expect(modelVisibleMessages.map((message) => getMessageText(message)).join("\n")).not.toContain(
+				"FIRST PROMPT CONTEXT",
+			);
+			expect(harness.getPendingResponseCount()).toBe(0);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not expose raw command failure stderr as a prompt block message", async () => {
+		// Given
+		const hookDir = createTempDir("senpi-user-prompt-secret-stderr-hook");
+		const scriptPath = join(hookDir, "stderr-secret.mjs");
+		writeFileSync(
+			scriptPath,
+			"process.stdin.resume(); process.stdin.on('end', () => { process.stderr.write('SECRET_TOKEN=abc123'); process.exit(2); });",
+			"utf-8",
+		);
+		const harness = await createHooksHarness();
+		writeHookProject(harness.tempDir, `${process.execPath} ${scriptPath}`);
+		harness.setResponses([fauxAssistantMessage("model should not run")]);
+
+		try {
+			// When
+			await harness.session.prompt("ship it");
+
+			// Then
+			expect(harness.getPendingResponseCount()).toBe(1);
+			const modelVisiblePayload = JSON.stringify(
+				harness.session.messages.filter((message) => message.role === "user" || message.role === "custom"),
+			);
+			expect(modelVisiblePayload).not.toContain("SECRET_TOKEN=abc123");
+			const customMessages = harness.session.messages.filter((message) => message.role === "custom");
+			expect(customMessages).toHaveLength(1);
+			expect(getMessageText(customMessages[0])).toBe("UserPromptSubmit hook blocked the prompt.");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds the built-in hooks extension for senpi so Claude/Codex-style hook definitions can be loaded, trusted, inspected, and dispatched through the real coding-agent runtime.

Before this branch, hook configuration, trust state, manifest loading, command execution, lifecycle adapters, and `/hooks` inspection were not available. After this branch, trusted command hooks can handle prompt, tool, lifecycle, compaction, and stop events with sanitized diagnostics and bounded follow-up behavior.

## Changes

- Adds hook config schema/loading, plugin manifest hook sources, trust-state hashing, command execution safety, output parsing, and dispatcher matching.
- Registers the builtin `hooks` extension and `/hooks` command for listing diagnostics and managing trust/enablement.
- Adapts `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `SessionStart`, `PreCompact`, `PostCompact`, and `Stop` events into senpi runtime behavior.
- Documents extension hooks and adds focused regression coverage for schema, loader, trust, command, tool, prompt, lifecycle, stop, and builtin registration behavior.

## QA / Evidence

- RPC self-test: `node .agents/skills/senpi-qa/scripts/rpc-drive.mjs --self-test` passed; artifact `local-ignore/qa-evidence/20260629-senpi-builtin-hooks/rpc-self-test.txt`.
- Mock loop self-test: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` passed across OpenAI completions, Anthropic messages, and OpenAI responses baseUrl override paths; artifact `local-ignore/qa-evidence/20260629-senpi-builtin-hooks/mock-loop-self-test.txt`.
- Mock loop with tool: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool --api openai-responses` passed, proving a real multi-turn tool loop; artifact `local-ignore/qa-evidence/20260629-senpi-builtin-hooks/mock-loop-with-tool.txt`.
- CLI smoke self-test: `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` passed for help, version, offline model listing, unknown option handling, and auth integrity; artifact `local-ignore/qa-evidence/20260629-senpi-builtin-hooks/cli-smoke-self-test.txt`.
- Hook-specific sandbox QA: `node node_modules/tsx/dist/cli.mjs --tsconfig tsconfig.json local-ignore/qa-evidence/20260629-senpi-builtin-hooks/hooks-real-sandbox-driver.ts` passed 9/9 scenario groups, covering hook load, untrusted skip/listing, `/hooks trust <id>`, trusted PreToolUse block/mutate/context, PostToolUse replacement/context, UserPromptSubmit block/context without prompt replacement, plugin manifest path/inline hooks, pre-session SessionStart vs runtime timing caveat, PreCompact cancel, PostCompact run, Stop follow-up/cap, and unchanged real auth. Artifact `local-ignore/qa-evidence/20260629-senpi-builtin-hooks/hooks-real-sandbox.txt`.

## Risks

- Hook command execution is a sensitive surface. Covered by trust hashing, untrusted skip, command safety, output parsing, redaction, and real sandbox QA evidence above.
- Stop hooks can create repeated follow-up turns. Covered by the Stop loop cap scenario in `hooks-real-sandbox.txt` and committed stop regression tests.
- Runtime hook source timing around `SessionStart` can be surprising. Covered and documented by the pre-session/runtime SessionStart sandbox assertion.

## Secret safety

No raw credentials, auth headers, cookies, launchd environments, or secret-bearing logs are included in this PR body. The senpi-qa channels and hook sandbox assert the real `~/.senpi/agent/auth.json` remained unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a builtin hooks extension to run trusted command hooks for local guardrails across prompts, tools, lifecycle, compaction, and stop events. Adds usage docs and examples, discovers hook configs from `pi` packages, and redacts GitHub tokens in `/hooks` output.

- **New Features**
  - Builtin `hooks` extension: loads `hooks.json` from `~/.senpi/agent`, `.senpi/`, runtime `hookPaths` (including `pi` packages via `package.json#pi.hooks` and conventional `hooks/`), and plugin manifests (`.codex-plugin/plugin.json` + `hooks/hooks.json`).
  - Safe execution: trust-state hashing, env allowlist, path containment, stdout/stderr caps, timeouts.
  - Supported events: `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `SessionStart`, `PreCompact`, `PostCompact`, `Stop`, with tool-name matcher aliases.
  - Parsing and dispatch: decisions (allow/block/ask), input/output updates, extra context, system messages; `/hooks` command for list, diagnostics, trust/enable/disable, reload.
  - Runtime plumbing: `hookPaths` added to resources; hooks load from pre-session and runtime sources; ordered before `permission-system`.
  - Docs: Added Builtin Hooks guide (setup workflow, input/output, recipes, troubleshooting) and linked from README, packages, and examples.

- **Bug Fixes**
  - Redacts GitHub PATs in `/hooks` list and diagnostics output.
  - Validates hook `timeout` values and rejects invalid settings.
  - Stabilizes hook command abort test to reduce flakiness.

<sup>Written for commit e6e060453d0b9ebb766261539b67bb785268cf8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

