### PR TITLE
fix(coding-agent): preserve nested legacy config

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## Nested legacy config migration (2026-07-01)
+
+### What changed
+
+- `migrations.ts`: split legacy directory and extension-system migrations into focused modules.
+- `legacy-senpi-dir-migration.ts`: migrates missing files from nested legacy `~/.senpi/.pi/agent` and `~/.senpi/.pi/mom` directories into the current senpi config layout without overwriting existing files.
+
+### Why
+
+- Some pre-rename local configs ended up under nested `~/.senpi/.pi/agent`, so a fresh `~/.senpi/agent` could strand custom `models.json` entries such as ccapi-routed Anthropic models.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: startup migration orchestration in `migrations.ts`.
+
 ## shared provider-native rendering in text output (2026-05-14)
 
 ### What changed

--- a/packages/coding-agent/src/extension-system-migration.ts
+++ b/packages/coding-agent/src/extension-system-migration.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+import { existsSync, readdirSync, renameSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR_NAME, getAgentDir } from "./config.ts";
+
+function migrateCommandsToPrompts(baseDir: string, label: string): boolean {
+	const commandsDir = join(baseDir, "commands");
+	const promptsDir = join(baseDir, "prompts");
+
+	if (existsSync(commandsDir) && !existsSync(promptsDir)) {
+		try {
+			renameSync(commandsDir, promptsDir);
+			console.log(chalk.green(`Migrated ${label} commands/ → prompts/`));
+			return true;
+		} catch (err) {
+			console.log(
+				chalk.yellow(
+					`Warning: Could not migrate ${label} commands/ to prompts/: ${err instanceof Error ? err.message : err}`,
+				),
+			);
+		}
+	}
+	return false;
+}
+
+function checkDeprecatedExtensionDirs(baseDir: string, label: string): string[] {
+	const hooksDir = join(baseDir, "hooks");
+	const toolsDir = join(baseDir, "tools");
+	const warnings: string[] = [];
+
+	if (existsSync(hooksDir)) {
+		warnings.push(`${label} hooks/ directory found. Hooks have been renamed to extensions.`);
+	}
+
+	if (existsSync(toolsDir)) {
+		try {
+			const entries = readdirSync(toolsDir);
+			const customTools = entries.filter((entry) => {
+				const lower = entry.toLowerCase();
+				return (
+					lower !== "fd" && lower !== "rg" && lower !== "fd.exe" && lower !== "rg.exe" && !entry.startsWith(".")
+				);
+			});
+			if (customTools.length > 0) {
+				warnings.push(
+					`${label} tools/ directory contains custom tools. Custom tools have been merged into extensions.`,
+				);
+			}
+		} catch {
+			return warnings;
+		}
+	}
+
+	return warnings;
+}
+
+export function migrateExtensionSystem(cwd: string): string[] {
+	const agentDir = getAgentDir();
+	const projectDir = join(cwd, CONFIG_DIR_NAME);
+
+	migrateCommandsToPrompts(agentDir, "Global");
+	migrateCommandsToPrompts(projectDir, "Project");
+
+	return [...checkDeprecatedExtensionDirs(agentDir, "Global"), ...checkDeprecatedExtensionDirs(projectDir, "Project")];
+}

--- a/packages/coding-agent/src/legacy-senpi-dir-migration.ts
+++ b/packages/coding-agent/src/legacy-senpi-dir-migration.ts
@@ -1,0 +1,84 @@
+import os from "node:os";
+import chalk from "chalk";
+import { existsSync, mkdirSync, readdirSync, realpathSync, renameSync } from "fs";
+import { dirname, isAbsolute, join, relative, resolve } from "path";
+import { CONFIG_DIR_NAME, getAgentDir } from "./config.ts";
+
+function pathsPointToSameLocation(leftPath: string, rightPath: string): boolean {
+	try {
+		return realpathSync(leftPath) === realpathSync(rightPath);
+	} catch {
+		return false;
+	}
+}
+
+function isWithinOrSamePath(childPath: string, parentPath: string): boolean {
+	const relativePath = relative(resolve(parentPath), resolve(childPath));
+	return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function migratePathPreservingExisting(oldPath: string, newPath: string, label: string): void {
+	if (!existsSync(oldPath)) return;
+	if (existsSync(newPath) && pathsPointToSameLocation(oldPath, newPath)) return;
+
+	if (!existsSync(newPath)) {
+		try {
+			mkdirSync(dirname(newPath), { recursive: true });
+			renameSync(oldPath, newPath);
+			console.log(chalk.green(`Migrated ${label} ${oldPath} → ${newPath}`));
+		} catch {
+			return;
+		}
+		return;
+	}
+
+	let entries: string[];
+	try {
+		entries = readdirSync(oldPath);
+	} catch {
+		return;
+	}
+
+	let movedAny = false;
+	for (const entry of entries) {
+		const source = join(oldPath, entry);
+		const target = join(newPath, entry);
+		if (existsSync(target)) continue;
+		try {
+			renameSync(source, target);
+			movedAny = true;
+		} catch {}
+	}
+
+	if (movedAny) {
+		console.log(chalk.green(`Migrated missing ${label} entries ${oldPath} → ${newPath}`));
+	}
+}
+
+export function migrateLegacySenpiDirs(cwd: string): void {
+	if (CONFIG_DIR_NAME === ".pi") return;
+
+	const homeDir = os.homedir();
+	const globalNewAgentDir = getAgentDir();
+	const globalNewMomDir = join(homeDir, CONFIG_DIR_NAME, "mom");
+	const projectNewDir = join(cwd, CONFIG_DIR_NAME);
+	const shouldMigrateHomeConfig = isWithinOrSamePath(globalNewAgentDir, join(homeDir, CONFIG_DIR_NAME));
+
+	const moves: Array<readonly [string, string, string]> = [
+		[join(cwd, ".pi"), projectNewDir, "project config directory"],
+		[join(cwd, CONFIG_DIR_NAME, ".pi"), projectNewDir, "nested project config directory"],
+	];
+
+	if (shouldMigrateHomeConfig) {
+		moves.unshift(
+			[join(homeDir, ".pi", "agent"), globalNewAgentDir, "global agent directory"],
+			[join(homeDir, CONFIG_DIR_NAME, ".pi", "agent"), globalNewAgentDir, "nested global agent directory"],
+			[join(homeDir, ".pi", "mom"), globalNewMomDir, "global mom directory"],
+			[join(homeDir, CONFIG_DIR_NAME, ".pi", "mom"), globalNewMomDir, "nested global mom directory"],
+		);
+	}
+
+	for (const [oldPath, newPath, label] of moves) {
+		migratePathPreservingExisting(oldPath, newPath, label);
+	}
+}

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -2,12 +2,13 @@
  * One-time migrations that run on startup.
  */
 
-import os from "node:os";
 import chalk from "chalk";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { CONFIG_DIR_NAME, getAgentDir, getBinDir } from "./config.ts";
+import { getAgentDir, getBinDir } from "./config.ts";
 import { migrateKeybindingsConfig } from "./core/keybindings.ts";
+import { migrateExtensionSystem } from "./extension-system-migration.ts";
+import { migrateLegacySenpiDirs } from "./legacy-senpi-dir-migration.ts";
 
 const MIGRATION_GUIDE_URL =
 	"https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md#extensions-migration";
@@ -131,30 +132,6 @@ export function migrateSessionsFromAgentRoot(): void {
 	}
 }
 
-/**
- * Migrate commands/ to prompts/ if needed.
- * Works for both regular directories and symlinks.
- */
-function migrateCommandsToPrompts(baseDir: string, label: string): boolean {
-	const commandsDir = join(baseDir, "commands");
-	const promptsDir = join(baseDir, "prompts");
-
-	if (existsSync(commandsDir) && !existsSync(promptsDir)) {
-		try {
-			renameSync(commandsDir, promptsDir);
-			console.log(chalk.green(`Migrated ${label} commands/ → prompts/`));
-			return true;
-		} catch (err) {
-			console.log(
-				chalk.yellow(
-					`Warning: Could not migrate ${label} commands/ to prompts/: ${err instanceof Error ? err.message : err}`,
-				),
-			);
-		}
-	}
-	return false;
-}
-
 function migrateKeybindingsConfigFile(): void {
 	const configPath = join(getAgentDir(), "keybindings.json");
 	if (!existsSync(configPath)) return;
@@ -169,35 +146,6 @@ function migrateKeybindingsConfigFile(): void {
 		writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
 	} catch {
 		// Ignore malformed files during migration
-	}
-}
-
-function migrateLegacySenpiDirs(cwd: string): void {
-	if (CONFIG_DIR_NAME === ".pi") return;
-
-	const homeDir = os.homedir();
-	const globalOldAgentDir = join(homeDir, ".pi", "agent");
-	const globalNewAgentDir = getAgentDir();
-	const globalOldMomDir = join(homeDir, ".pi", "mom");
-	const globalNewMomDir = join(homeDir, CONFIG_DIR_NAME, "mom");
-	const projectOldDir = join(cwd, ".pi");
-	const projectNewDir = join(cwd, CONFIG_DIR_NAME);
-
-	const moves: Array<[string, string, string]> = [
-		[globalOldAgentDir, globalNewAgentDir, "global agent directory"],
-		[globalOldMomDir, globalNewMomDir, "global mom directory"],
-		[projectOldDir, projectNewDir, "project config directory"],
-	];
-
-	for (const [oldPath, newPath, label] of moves) {
-		if (!existsSync(oldPath) || existsSync(newPath)) continue;
-		try {
-			mkdirSync(dirname(newPath), { recursive: true });
-			renameSync(oldPath, newPath);
-			console.log(chalk.green(`Migrated ${label} ${oldPath} → ${newPath}`));
-		} catch {
-			// Ignore migration failures and keep startup working.
-		}
 	}
 }
 
@@ -243,62 +191,6 @@ function migrateToolsToBin(): void {
 	if (movedAny) {
 		console.log(chalk.green(`Migrated managed binaries tools/ → bin/`));
 	}
-}
-
-/**
- * Check for deprecated hooks/ and tools/ directories.
- * Note: tools/ may contain fd/rg binaries extracted by pi, so only warn if it has other files.
- */
-function checkDeprecatedExtensionDirs(baseDir: string, label: string): string[] {
-	const hooksDir = join(baseDir, "hooks");
-	const toolsDir = join(baseDir, "tools");
-	const warnings: string[] = [];
-
-	if (existsSync(hooksDir)) {
-		warnings.push(`${label} hooks/ directory found. Hooks have been renamed to extensions.`);
-	}
-
-	if (existsSync(toolsDir)) {
-		// Check if tools/ contains anything other than fd/rg (which are auto-extracted binaries)
-		try {
-			const entries = readdirSync(toolsDir);
-			const customTools = entries.filter((e) => {
-				const lower = e.toLowerCase();
-				return (
-					lower !== "fd" && lower !== "rg" && lower !== "fd.exe" && lower !== "rg.exe" && !e.startsWith(".") // Ignore .DS_Store and other hidden files
-				);
-			});
-			if (customTools.length > 0) {
-				warnings.push(
-					`${label} tools/ directory contains custom tools. Custom tools have been merged into extensions.`,
-				);
-			}
-		} catch {
-			// Ignore read errors
-		}
-	}
-
-	return warnings;
-}
-
-/**
- * Run extension system migrations (commands→prompts) and collect warnings about deprecated directories.
- */
-function migrateExtensionSystem(cwd: string): string[] {
-	const agentDir = getAgentDir();
-	const projectDir = join(cwd, CONFIG_DIR_NAME);
-
-	// Migrate commands/ to prompts/
-	migrateCommandsToPrompts(agentDir, "Global");
-	migrateCommandsToPrompts(projectDir, "Project");
-
-	// Check for deprecated directories
-	const warnings = [
-		...checkDeprecatedExtensionDirs(agentDir, "Global"),
-		...checkDeprecatedExtensionDirs(projectDir, "Project"),
-	];
-
-	return warnings;
 }
 
 /**

--- a/packages/coding-agent/test/senpi-migration.test.ts
+++ b/packages/coding-agent/test/senpi-migration.test.ts
@@ -60,4 +60,93 @@ describe("senpi migration", () => {
 		expect(fs.existsSync(path.join(fakeHome, ".senpi", "mom", "auth.json"))).toBe(true);
 		expect(fs.existsSync(path.join(cwd, ".senpi", "settings.json"))).toBe(true);
 	});
+
+	it("moves missing nested legacy agent files without overwriting current files", () => {
+		// given
+		const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "senpi-nested-migration-test-"));
+		tempDirs.push(rootDir);
+		const fakeHome = path.join(rootDir, "home");
+		const cwd = path.join(rootDir, "project");
+		const newAgentDir = path.join(fakeHome, ".senpi", "agent");
+		const nestedOldAgentDir = path.join(fakeHome, ".senpi", ".pi", "agent");
+		fs.mkdirSync(newAgentDir, { recursive: true });
+		fs.mkdirSync(nestedOldAgentDir, { recursive: true });
+		fs.writeFileSync(path.join(newAgentDir, "settings.json"), '{"source":"current"}\n', "utf-8");
+		fs.writeFileSync(path.join(newAgentDir, "auth.json"), '{"openai-codex":{"type":"oauth"}}\n', "utf-8");
+		fs.writeFileSync(path.join(nestedOldAgentDir, "settings.json"), '{"source":"legacy"}\n', "utf-8");
+		fs.writeFileSync(
+			path.join(nestedOldAgentDir, "auth.json"),
+			'{"anthropic":{"type":"api_key","key":"legacy"}}\n',
+			"utf-8",
+		);
+		fs.writeFileSync(path.join(nestedOldAgentDir, "models.json"), '{"providers":{}}\n', "utf-8");
+
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		const previousHome = process.env.HOME;
+		process.env[ENV_AGENT_DIR] = newAgentDir;
+		process.env.HOME = fakeHome;
+
+		try {
+			// when
+			runMigrations(cwd);
+		} finally {
+			// then
+			if (previousAgentDir === undefined) {
+				delete process.env[ENV_AGENT_DIR];
+			} else {
+				process.env[ENV_AGENT_DIR] = previousAgentDir;
+			}
+			if (previousHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = previousHome;
+			}
+		}
+
+		expect(fs.readFileSync(path.join(newAgentDir, "settings.json"), "utf-8")).toBe('{"source":"current"}\n');
+		expect(fs.readFileSync(path.join(newAgentDir, "auth.json"), "utf-8")).toBe('{"openai-codex":{"type":"oauth"}}\n');
+		expect(fs.readFileSync(path.join(newAgentDir, "models.json"), "utf-8")).toBe('{"providers":{}}\n');
+		expect(fs.existsSync(path.join(nestedOldAgentDir, "models.json"))).toBe(false);
+		expect(fs.existsSync(path.join(nestedOldAgentDir, "settings.json"))).toBe(true);
+		expect(fs.existsSync(path.join(nestedOldAgentDir, "auth.json"))).toBe(true);
+	});
+
+	it("does not drain home config through .pi symlink when agent dir is an external sandbox", () => {
+		// given
+		const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "senpi-symlink-migration-test-"));
+		tempDirs.push(rootDir);
+		const fakeHome = path.join(rootDir, "home");
+		const cwd = path.join(rootDir, "project");
+		const sandboxAgentDir = path.join(rootDir, "sandbox", "agent");
+		const currentAgentDir = path.join(fakeHome, ".senpi", "agent");
+		fs.mkdirSync(currentAgentDir, { recursive: true });
+		fs.mkdirSync(sandboxAgentDir, { recursive: true });
+		fs.symlinkSync(".senpi", path.join(fakeHome, ".pi"), "dir");
+		fs.writeFileSync(path.join(currentAgentDir, "models.json"), '{"providers":{}}\n', "utf-8");
+
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		const previousHome = process.env.HOME;
+		process.env[ENV_AGENT_DIR] = sandboxAgentDir;
+		process.env.HOME = fakeHome;
+
+		try {
+			// when
+			runMigrations(cwd);
+		} finally {
+			// then
+			if (previousAgentDir === undefined) {
+				delete process.env[ENV_AGENT_DIR];
+			} else {
+				process.env[ENV_AGENT_DIR] = previousAgentDir;
+			}
+			if (previousHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = previousHome;
+			}
+		}
+
+		expect(fs.readFileSync(path.join(currentAgentDir, "models.json"), "utf-8")).toBe('{"providers":{}}\n');
+		expect(fs.existsSync(path.join(sandboxAgentDir, "models.json"))).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes a startup migration gap that stranded custom model config under nested legacy senpi paths such as `~/.senpi/.pi/agent`. The user-facing impact is that custom `models.json` entries and `favoriteModels` can reappear after migration instead of being hidden from the model picker.

Root cause: the previous migration skipped legacy directories whenever the current target directory already existed. That protected existing files, but it also stranded missing files such as `models.json`. While fixing that, the migration also needed to avoid draining `~/.pi -> ~/.senpi` symlinked home config into external sandbox agent dirs.

## Changes

- Split extension-system migration helpers out of `migrations.ts` so startup migration code stays smaller and focused.
- Added `legacy-senpi-dir-migration.ts` to move only missing files from legacy/nested config directories without overwriting current files.
- Guarded global home migration so external `SENPI_CODING_AGENT_DIR` sandboxes do not consume real home config through `.pi` symlinks.
- Added regression coverage for nested legacy file recovery and the symlink/sandbox guard.

## QA / Evidence

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/senpi-migration.test.ts` from `packages/coding-agent`: 3 tests passed.
- `npm run check`: passed; also re-run by the commit hook with no fixes applied.
- `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`: 5/5 passed. Evidence: `local-ignore/qa-evidence/20260701-nested-senpi-pi-migration/cli-smoke-final-after-guard.txt`.
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`: 5/5 passed, including Anthropic Messages baseUrl override through the real loop and zero real provider calls. Evidence: `local-ignore/qa-evidence/20260701-nested-senpi-pi-migration/mock-loop-final-after-guard.txt`.
- Manual local model surface check: `modelsError null`; favorites resolved to `anthropic/claude-opus-4-8`, `anthropic/claude-opus-4-7`, `anthropic/claude-opus-4-6`, and `apitopia/glm-5.2`.

## Risks

- Migration behavior changes are startup-sensitive, but tests cover the two risky edges: preserving existing current files while moving missing nested files, and not draining symlinked home config into external sandboxes.
- External custom model credentials are not committed; local model restoration uses existing local configuration references only.

## Secret safety

No raw tokens, auth headers, OAuth blobs, or private credentials are included in the diff or PR text. QA evidence uses isolated fake-provider runs and only records sanitized paths/results.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes startup migration to recover nested legacy Senpi config under `~/.senpi/.pi/*` without overwriting current files. Restores `models.json` and favorites in the model picker, and prevents draining home config into external sandboxes.

- **Bug Fixes**
  - Move only missing files from `~/.senpi/.pi/agent`/`mom` and project `.pi` into the current `~/.senpi` layout; keep existing files intact.
  - Guard home-config migration so `.pi` symlinks don’t pull config into external sandboxes when `SENPI_CODING_AGENT_DIR` points outside the home dir.

- **Refactors**
  - Extracted extension-system logic to `extension-system-migration.ts` and added `legacy-senpi-dir-migration.ts`; slimmed `migrations.ts`.
  - Added tests covering nested file recovery and the sandbox/symlink guard.

<sup>Written for commit 9a71aae87d1db00fde046c9e1634109ea3179a9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

