### PR TITLE
feat(coding-agent): add Claude Fable 5 prompt preset

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,8 @@
 			"!**/models.generated.ts",
 			"!**/*.models.ts",
 			"!packages/mom/data/**/*",
-			"!!**/node_modules"
+			"!!**/node_modules",
+			"!!**/.codegraph"
 		]
 	}
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added public SDK exports for CLI-equivalent model and scoped-model resolution ([#6201](https://github.com/earendil-works/pi/issues/6201)).
 - Added extension entry renderers for persisted display-only session entries that are rendered in interactive mode without being sent to the model context.
+- Added a Claude Fable 5 system prompt preset with auto-detection for `claude-fable-5` model IDs across built-in providers, selectable via `promptPreset: "claude-fable-5"`.
 
 ### Changed
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -84,7 +84,7 @@ Permission rules are a confirmation policy, not a sandbox. Senpi, extensions, pa
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
-| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, or `"gpt-5.5"` |
+| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, or `"gpt-5.5"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/prompt-preset
 
-Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x, claude-opus-4-{5,6,7}, kimi-k2-{6,7}) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
+Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
 
 ## FILES
 
@@ -15,9 +15,12 @@ prompt-preset/
 ├── gpt-5.3-codex.ts     # GPT-5.3 Codex preset
 ├── gpt-5.4.ts           # GPT-5.4 preset
 ├── gpt-5.5.ts           # GPT-5.5 preset
+├── claude-fable-5.ts    # Claude Fable 5 preset
 ├── claude-opus-4-5.ts   # Claude Opus 4.5 preset
 ├── claude-opus-4-6.ts   # Claude Opus 4.6 preset
 ├── claude-opus-4-7.ts   # Claude Opus 4.7 preset
+├── claude-opus-4-8.ts   # Claude Opus 4.8 preset
+├── glm-5-2.ts           # GLM 5.2 preset
 ├── kimi-k2-6.ts         # Kimi K2.6 preset
 ├── kimi-k2-7.ts         # Kimi K2.7 preset
 └── changes.md           # Fork tracker (model-family rename 2026-04-30, file-operations 2026-05-07)

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5.ts
@@ -1,0 +1,17 @@
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+
+function buildClaudeFable5Tuning(): string {
+	return `When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has already made, or narrate options you will not pursue. When weighing a choice, give a recommendation, not a survey.
+
+Before reporting progress, audit each claim against a tool result from this session. Only report work you can point to evidence for; if something is not yet verified, say so explicitly. If tests fail, say so with the output.
+
+Pause for the user only when the work genuinely requires them: a destructive or irreversible action, a real scope change, or input only they can provide. If you hit one of these, ask and end the turn rather than ending on a promise. Before ending your turn, check your last paragraph: if it is a plan, a question, or a promise about work you have not done, do that work now with tool calls.
+
+Terse shorthand between tool calls is fine; your final summary is for a reader who did not see it. Lead with the outcome in complete sentences, then supporting detail. Keep output short by dropping detail that does not change what the reader does next, not by compressing into fragments, arrow chains, or labels you made up mid-task.
+
+Do not stop, summarize, or suggest a new session on account of context limits. Continue the work.`;
+}
+
+export function buildClaudeFable5Prompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildClaudeFable5Tuning() });
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -1,5 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import type { BuildDynamicSystemPromptOptions } from "../../../dynamic-prompt/build.ts";
+import { buildClaudeFable5Prompt } from "./claude-fable-5.ts";
 import { buildClaudeOpus45Prompt } from "./claude-opus-4-5.ts";
 import { buildClaudeOpus46Prompt } from "./claude-opus-4-6.ts";
 import { buildClaudeOpus47Prompt } from "./claude-opus-4-7.ts";
@@ -74,6 +75,10 @@ function isGlm52Model(model: ModelWithPromptPresetMetadata): boolean {
 	return hasGlm52Signal(model.id) || (model.name !== undefined && hasGlm52Signal(model.name));
 }
 
+function isClaudeFable5Model(modelId: string): boolean {
+	return normalizeModelId(modelId).includes("fable-5");
+}
+
 type ClaudeOpusVersion = "claude-opus-4-8" | "claude-opus-4-7" | "claude-opus-4-6" | "claude-opus-4-5";
 
 function extractClaudeOpusVersion(modelId: string): ClaudeOpusVersion | undefined {
@@ -116,6 +121,9 @@ export function resolvePresetName(
 	if (isKimiK26Model(model)) {
 		return "kimi-k2-6";
 	}
+	if (isClaudeFable5Model(model.id)) {
+		return "claude-fable-5";
+	}
 	const claudeVersion = extractClaudeOpusVersion(model.id);
 	if (claudeVersion) {
 		return claudeVersion;
@@ -144,6 +152,8 @@ function buildPreset(name: ResolvedPresetName, options: BuildDynamicSystemPrompt
 			return { name, prompt: buildKimiK27Prompt(options) };
 		case "kimi-k2-6":
 			return { name, prompt: buildKimiK26Prompt(options) };
+		case "claude-fable-5":
+			return { name, prompt: buildClaudeFable5Prompt(options) };
 		case "claude-opus-4-8":
 			return { name, prompt: buildClaudeOpus48Prompt(options) };
 		case "claude-opus-4-7":

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
@@ -2,6 +2,7 @@ import type { Settings, SettingsManager } from "../../../settings-manager.ts";
 
 export type PromptPresetName =
 	| "auto"
+	| "claude-fable-5"
 	| "claude-opus-4-8"
 	| "claude-opus-4-7"
 	| "claude-opus-4-6"
@@ -23,6 +24,7 @@ type SettingsWithPromptPreset = Settings & { promptPreset?: string };
 
 const VALID_PRESETS: ReadonlySet<string> = new Set<PromptPresetName>([
 	"auto",
+	"claude-fable-5",
 	"claude-opus-4-8",
 	"claude-opus-4-7",
 	"claude-opus-4-6",

--- a/packages/coding-agent/test/suite/prompt-presets-claude-fable-5.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-claude-fable-5.test.ts
@@ -1,0 +1,125 @@
+import { type Api, getModels, getProviders, type Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	type PromptPresetSettings,
+	resolvePreset,
+	resolvePresetName,
+} from "../../src/core/extensions/builtin/prompt-preset/presets.ts";
+
+function createModel(id: string, provider: string, api: Api = "anthropic-messages"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api,
+		provider,
+		baseUrl: "https://example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	};
+}
+
+function hasFable5CatalogSignal(model: Model<Api>): boolean {
+	const searchable = `${model.id} ${model.name}`.toLowerCase().replace(/\s+/g, "-");
+	return /(?:^|[/@._-])claude-fable-5(?:$|[/@._:-])/.test(searchable);
+}
+
+function getFable5CatalogModels(): Model<Api>[] {
+	return getProviders().flatMap((provider) => (getModels(provider) as Model<Api>[]).filter(hasFable5CatalogSignal));
+}
+
+describe("Claude Fable 5 prompt preset", () => {
+	it.each([
+		"claude-fable-5",
+		"anthropic/claude-fable-5",
+		"us.anthropic.claude-fable-5",
+		"eu.anthropic.claude-fable-5",
+		"global.anthropic.claude-fable-5",
+		"Claude Fable 5",
+	])("resolves %s to the claude-fable-5 preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "anthropic");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("claude-fable-5");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt).toContain("## Intent Gate");
+		expect(preset?.prompt).toContain("a recommendation, not a survey");
+		expect(preset?.prompt).toContain("audit each claim against a tool result");
+		expect(preset?.prompt).toContain("on account of context limits");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it.each([
+		"claude-opus-4-8",
+		"~anthropic/claude-fable-latest",
+		"some-fable-compatible-router",
+	])("does not route %s to the claude-fable-5 preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "anthropic");
+
+		// when
+		const presetName = resolvePresetName(model, settings);
+
+		// then
+		expect(presetName).not.toBe("claude-fable-5");
+	});
+
+	it("allows settings.json to force claude-fable-5 regardless of model id", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "claude-fable-5" };
+		const model = createModel("some-random-model", "custom", "openai-responses");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("claude-fable-5");
+		expect(preset?.prompt).toContain("audit each claim against a tool result");
+	});
+
+	it("does not include GPT or Kimi tuning in the claude-fable-5 preset", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel("claude-fable-5", "anthropic");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("claude-fable-5");
+		expect(preset?.prompt).not.toContain("apply_patch");
+		expect(preset?.prompt).not.toContain("filler verification language");
+	});
+
+	it("returns claude-fable-5 preset for every Claude Fable 5 built-in catalog model", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const catalogModels = getFable5CatalogModels();
+		const catalogModelIds = catalogModels.map((model) => `${model.provider}/${model.id}`);
+
+		// when
+		const misses = catalogModels
+			.filter((model) => resolvePresetName(model, settings) !== "claude-fable-5")
+			.map((model) => `${model.provider}/${model.id}`);
+
+		// then
+		expect(catalogModelIds).toEqual(
+			expect.arrayContaining([
+				"anthropic/claude-fable-5",
+				"github-copilot/claude-fable-5",
+				"openrouter/anthropic/claude-fable-5",
+				"amazon-bedrock/global.anthropic.claude-fable-5",
+				"vercel-ai-gateway/anthropic/claude-fable-5",
+			]),
+		);
+		expect(misses).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `claude-fable-5` system prompt preset to the builtin prompt-preset extension. Before: Claude Fable 5 models (present in the catalog for anthropic, amazon-bedrock regional variants, openrouter, vercel-ai-gateway, github-copilot, cloudflare-ai-gateway, and opencode) fell through to the generic fallback prompt. After: any model id containing `fable-5` auto-resolves to a Fable 5 tuned prompt, and `promptPreset: "claude-fable-5"` forces it.

The tuning follows Anthropic's Fable 5 prompting guidance, kept to the thin-wrapper preset shape (only what differs from the shared dynamic prompt): act once information is sufficient (no re-litigating settled decisions), evidence-audited progress claims, checkpoint discipline against early stopping, readable final summaries instead of working shorthand, and no self-truncation on context-budget concerns. `~anthropic/claude-fable-latest` intentionally stays unrouted, consistent with `~anthropic/claude-opus-latest`.

Also fixes a local-dev breakage found while committing: biome's scanner followed the untracked `.codegraph` symlink (created by local codegraph tooling, listed in `.git/info/exclude`) into a directory containing a live daemon unix socket and failed `npm run check` with `internalError/fs`, blocking every pre-commit on such machines. Excluded at scanner level (`!!**/.codegraph`), same as `node_modules`.

## Changes

- Preset: new `claude-fable-5.ts` tuning section; matcher + dispatch in `presets.ts`; `claude-fable-5` added to `PromptPresetName` and `VALID_PRESETS` in `settings.ts`.
- Tests (TDD): `test/suite/prompt-presets-claude-fable-5.test.ts` — routing for direct/bedrock/gateway id shapes, negative routing (opus, fable-latest, lookalike ids), settings-forced override, no GPT/Kimi tuning leakage, and full catalog coverage across built-in providers.
- Docs: `docs/settings.md` preset list updated (also adds previously missing `claude-opus-4-8`, `glm-5.2`, `kimi-k2-7`); prompt-preset `AGENTS.md` file tree refreshed; CHANGELOG entry under Unreleased.
- Dev env: `biome.json` scanner exclusion for `.codegraph`.

## QA / Evidence

Artifacts: `local-ignore/qa-evidence/20260702-claude-fable-5-preset/` (gitignored; script + outputs + captured wire prompts).

1. Unit (TDD): new suite written first and watched fail 9/12, then pass 12/12 after implementation. Sibling suites `prompt-presets-{extension,glm-5-2,model-switch,startup-header}` pass 60/60. Sufficient for resolver logic, not for the runtime surface, hence:
2. Wire-level QA (real CLI from source, isolated sandbox, hermetic env, zero real API calls): registered model id `claude-fable-5` on a mock provider pointing at a local fake model server and drove a real `--print` turn. 11/11 PASS — the system prompt captured off the wire contains the Fable 5 tuning; a control turn with `mock-model` does not; no `apply_patch` GPT tuning leaked; real `~/.senpi/agent/auth.json` sha256 unchanged (`qa-fable-preset-output.txt`, `fable-system-prompt.txt`, `control-system-prompt.txt`).
3. Regression channels: `mock-loop.mjs --self-test` 5/5 (all three wire formats round-trip, localhost only), `cli-smoke.mjs --self-test` 5/5 (`mock-loop-self-test.txt`, `cli-smoke-self-test.txt`).
4. `npm run check` passes end to end after the biome scanner fix (it was failing before this branch on machines with a `.codegraph` symlink; all non-biome steps passed independently as well).

## Risks

- Over-broad matching: any id containing `fable-5` routes to the preset. Covered by negative tests (`~anthropic/claude-fable-latest`, `some-fable-compatible-router`, opus ids) and by mirroring the existing opus matcher convention.
- Prompt-quality regression for Fable 5 users: tuning is additive to the shared dynamic prompt and mirrors Anthropic's published guidance; the catalog test pins every built-in Fable 5 model to the preset so behavior is at least deliberate and inspectable.
- Biome scanner exclusion hiding real files: `.codegraph` is machine-local tooling state, never source; the exclusion mirrors the existing `node_modules` entry.

## Secret safety

No secret-bearing logs. QA ran with all provider key env vars stripped, an inline mock key, and an isolated sandbox; the auth-file guard asserted the real key store was untouched. Evidence artifacts contain only prompts and mock-server traffic.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Claude Fable 5 system prompt preset with auto-routing for model IDs containing `fable-5` across built-in providers. Also excludes `.codegraph` from the `biome` scanner to prevent local `npm run check` failures.

- **New Features**
  - Added `claude-fable-5` preset in `prompt-preset`; auto-detects any model ID with `fable-5`; force via `promptPreset: "claude-fable-5"`.
  - Tuning: act once info is sufficient, evidence-audited progress, readable final summaries, no context-limit self-truncation.
  - Tests for routing, negative cases, and catalog coverage; docs and preset list updated.

- **Bug Fixes**
  - Excluded `.codegraph` from `biome` scanning to avoid symlink/socket errors and unblock `npm run check`.

<sup>Written for commit 8462cb700425771971b76807dfe4ad6ab218d4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

