### PR TITLE
fix(ai): replay Anthropic server-side fallback blocks on same-model requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed Anthropic same-model replay dropping server-side fallback (`server-side-fallback-2026-06-01` beta) `fallback` content blocks, which mutated the latest assistant message and caused 400 "`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified" on the next request after a mid-response model fallback.
+
 ### Removed
 
 ## [2026.7.2] - 2026-07-02

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -331,6 +331,12 @@ const REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES: ReadonlySet<string> = new Set(
 	"text_editor_code_execution_tool_result",
 	"tool_search_tool_result",
 	"container_upload",
+	// Server-side fallback beta (server-side-fallback-2026-06-01) emits a
+	// `fallback` block mid-response, interleaved with thinking blocks. The API
+	// requires the latest assistant message to be replayed with its block
+	// sequence unmodified; dropping the block yields a 400
+	// ("thinking ... blocks in the latest assistant message cannot be modified").
+	"fallback",
 ]);
 
 function isReplayableAnthropicProviderNativeBlock(raw: unknown): raw is ContentBlockParam {

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -138,6 +138,95 @@ describe("Anthropic provider-native replay", () => {
 		]);
 	});
 
+	it("preserves same-model fallback blocks interleaved with signed thinking", async () => {
+		// Server-side fallback (server-side-fallback-2026-06-01 beta) emits a
+		// `fallback` content block mid-response. Dropping it on replay mutates the
+		// latest assistant message and the API rejects the request with
+		// "`thinking` or `redacted_thinking` blocks in the latest assistant
+		// message cannot be modified".
+		const model = getModel("anthropic", "claude-fable-5");
+		const fallbackBlock = {
+			type: "fallback",
+			from: { model: "claude-fable-5" },
+			to: { model: "claude-opus-4-8" },
+			trigger: { type: "refusal", category: null },
+		};
+		const assistant = assistantMessage(
+			[
+				{ type: "thinking", thinking: "before fallback", thinkingSignature: "sig_1" },
+				{ type: "providerNative", subtype: "fallback", raw: fallbackBlock },
+				{ type: "thinking", thinking: "after fallback", thinkingSignature: "sig_2" },
+				{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "README.md" } },
+			],
+			{ stopReason: "toolUse", model: "claude-fable-5" },
+		);
+
+		const payload = await capturePayload(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{
+				role: "toolResult",
+				toolCallId: "toolu_1",
+				toolName: "read",
+				content: [{ type: "text", text: "tool output" }],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+
+		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([
+			{ type: "thinking", thinking: "before fallback", signature: "sig_1" },
+			fallbackBlock,
+			{ type: "thinking", thinking: "after fallback", signature: "sig_2" },
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
+		]);
+	});
+
+	it("drops same-model provider-native blocks with unknown subtypes", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const assistant = assistantMessage(
+			[
+				{ type: "providerNative", subtype: "mystery_block", raw: { type: "mystery_block", data: "x" } },
+				{ type: "text", text: "kept" },
+			],
+			{ stopReason: "stop" },
+		);
+
+		const payload = await capturePayload(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{ role: "user", content: "follow up", timestamp: 2 },
+		]);
+
+		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([{ type: "text", text: "kept" }]);
+	});
+
+	it("drops fallback blocks from a different model's assistant message", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const assistant = assistantMessage(
+			[
+				{
+					type: "providerNative",
+					subtype: "fallback",
+					raw: { type: "fallback", from: { model: "claude-fable-5" }, to: { model: "claude-opus-4-8" } },
+				},
+				{ type: "text", text: "kept" },
+			],
+			{ stopReason: "stop", model: "claude-fable-5" },
+		);
+
+		const payload = await capturePayload(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{ role: "user", content: "follow up", timestamp: 2 },
+		]);
+
+		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([{ type: "text", text: "kept" }]);
+	});
+
 	it("drops cross-provider provider-native blocks", async () => {
 		const model = getModel("anthropic", "claude-haiku-4-5");
 		const assistant = assistantMessage(


### PR DESCRIPTION
## Summary

Sessions on models using the server-side fallback beta (`server-side-fallback-2026-06-01`, e.g. `claude-fable-5` behind a proxy that sets `fallbacks`) wedged with a 400 as soon as a mid-response fallback occurred:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant
message cannot be modified. These blocks must remain as they were in the original response.
```

The beta emits a `fallback` content block mid-response, interleaved with thinking blocks. senpi stored it as `providerNative` but `REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES` did not include `fallback`, so same-model replay silently dropped the block. The latest assistant message then no longer matched the original response block sequence and the API rejected every subsequent request of that turn — the session could not continue on that model (observed in a real session; both retries failed identically).

**Before:** turn with fallback block -> next request 400, session wedged on that model.
**After:** fallback block replayed verbatim -> turn continues normally.

## Changes

- `packages/ai/src/api/anthropic-messages.ts`: add `fallback` to `REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES` (same-model replay only, matching the existing provider-native replay rules).
- `packages/ai/test/anthropic-provider-native-replay.test.ts`: regression test that a same-model assistant message replays `thinking + fallback + thinking + tool_use` unmodified (fails without the fix), plus pins that unknown same-model provider-native subtypes and cross-model fallback blocks are still dropped.
- `packages/ai/CHANGELOG.md`: unreleased Fixed entry.

## QA / Evidence

Artifacts under `local-ignore/qa-evidence/20260702-fallback-replay/` (gitignored, on the dev machine).

1. **Live API isolation (root cause):** rebuilt the exact failing request from the real session with senpi's own payload builder. Variant A (fallback dropped, current behavior) -> real API 400 with the exact error. Variant B (identical except fallback blocks preserved) -> 200. Isolates the dropped block as the cause. Sanitized results: `replay-A-result.txt`, `replay-B-result.txt`.
2. **Real-CLI mock loop (senpi-qa Channel 3 pattern):** isolated sandbox, provider env stripped, real CLI from source against a local validating fake Anthropic server that streams `thinking + fallback + thinking + tool_use` then validates the replay and answers with the real 400 on mutation.
   - Before fix (src stashed): server saw `[thinking, thinking, tool_use]` (fallback dropped), CLI surfaced the 400 — reproduces the incident end to end (3/3 checks).
   - After fix: server saw `[thinking, fallback, thinking, tool_use]` intact, turn completed with the final text (4/4 checks).
   - Real `~/.senpi/agent/auth.json` sha256 asserted unchanged in both runs.
3. **Tests/checks:** new test RED before / GREEN after; `packages/ai` suite 93 files passed (25 skipped, 667 tests); repo-root `npm run check` exit 0.

This is sufficient because the failing contract (byte-identical latest-assistant replay) is asserted both against the real API and on the real CLI surface, and the drop-paths that must NOT change (cross-model, cross-provider, unknown subtype) are pinned by tests.

## Risks

- Replaying `fallback` against an endpoint without the beta could be rejected as an unknown block type. Mitigated: the block only exists in history if the original response was produced with the beta enabled on the same route, and same-model replay already assumes matching provider config for every other replayable native block (e.g. `server_tool_use`).
- Cross-model/cross-provider handoff unchanged — pinned by the new drop tests and the existing provider-native replay tests.

## Secret safety

No tokens, auth headers, or raw key material in the diff or this PR; evidence excerpts are sanitized (request ids only). QA runs used a mock key against localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400s after Anthropic server-side model fallbacks by replaying `fallback` blocks on same-model requests. This keeps the assistant message block sequence intact so sessions continue normally.

- **Bug Fixes**
  - Allowlisted `fallback` in `REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES` so same-model replays preserve `thinking + fallback + thinking + tool_use` and avoid the “thinking blocks cannot be modified” 400.
  - Tests pin the preserved sequence; unknown same-model provider-native subtypes and cross-model/cross-provider `fallback` blocks remain dropped. Updated `packages/ai` changelog.

<sup>Written for commit 84aa87c0aa2796bbb5e7229f9c7761cca1bdee3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

