### PR TITLE
feat(coding-agent): rewrite Claude Opus 4.5-4.8 prompt preset tuning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Rewrote the Claude Opus 4.5–4.8 system prompt preset tuning against Anthropic's Opus prompting guidance: removed lines restating native model behavior, extended tools-over-reasoning guidance to Opus 4.7, compensated literal instruction following with evident-intent scoping, overrode the default frontend house style on 4.7/4.8, reduced post-user-turn re-reasoning on 4.8, and told all Opus presets not to wrap up early since senpi auto-compacts context.
+
 ### Fixed
 
 ## [2026.7.2] - 2026-07-02

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -11,6 +11,23 @@ Per-model prompt preset extension. Selects a tuned system prompt based on the ac
 - `claude-opus-4-{5,6,7}.ts` / `kimi-k2-{6,7}.ts` - Other family presets.
 - `file-operations.ts` - Shared codex-style "File operations" tuning block consumed by every GPT-5.x preset.
 
+## Claude Opus 4.5-4.8 tuning rewrite against Anthropic overlay docs (2026-07-02)
+
+### What changed
+- Rewrote the `tuningSection` of all four Opus presets (`claude-opus-4-{5,6,7,8}.ts`) from first principles against Anthropic's published Opus 4.7/4.8 prompting guidance.
+- Deleted dead weight: "maintain coherent state" (a documented native strength — zero information), "do not re-anchor with reminder paragraphs" (redundant with the shared Style no-announcement rules), "do X then Y, follow that exact sequence" (literal models do this natively), the 4.5 caveat-closer ban (redundant with the shared Style permission-begging ban), and the 4.6 "constrain with 'one sentence'" line (prompt-author guidance misframed as a model instruction).
+- Added documented deltas the shared prompt does not carry: tools-over-reasoning extended to 4.7 (the tendency is documented starting at 4.7; previously only 4.8 had it), literalism compensation phrased as evident-intent scope with a mandatory scope statement, the persistent cream/serif/terracotta frontend house-style override (4.7/4.8), post-user-turn reasoning economy (4.8 reasons more after user turns in interactive settings), and one harness fact on every Opus preset: senpi auto-compacts context, so never wrap up early (context-aware 4.5+ models otherwise wind down near the limit; mirrors the Fable 5 preset line).
+- Kept the family-signal phrases pinned by `prompt-presets-extension.test.ts` ("ordered steps", "full set rather than the first item", "tool calls over reasoning") so existing coverage still locks preset identity.
+
+### Why
+- The old tunings restated behaviors Opus 4.7/4.8 exhibit natively while omitting the behaviors Anthropic documents as needing prompt-level overrides in a coding harness. Every remaining line now either overrides a documented model prior or states a harness fact the model cannot derive.
+
+### Why extension system couldn't handle this differently
+- The change lives entirely inside the builtin `prompt-preset` extension's Opus tuning strings; no core prompt code changed.
+
+### Expected merge conflict zones on next upstream sync
+- LOW: `claude-opus-4-{5,6,7,8}.ts` tuning template literals if upstream revises its own Opus tuning.
+
 ## Kimi K2.7 catalog coverage + colon-tag boundary (2026-06-15)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-5.ts
@@ -1,7 +1,9 @@
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
 
 function buildClaudeOpus45Tuning(): string {
-	return `Break complex tasks into ordered steps with clear dependencies rather than stating only the outcome. When a task must apply to ALL items in a set, state "apply to every item" explicitly. Do not add caveats, qualifications, or "let me know if..." closers.`;
+	return `Break complex tasks into ordered steps with clear dependencies before executing. When a request covers a set of items, apply it to every item rather than only the first, and state the scope you applied.
+
+Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
 }
 
 export function buildClaudeOpus45Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-6.ts
@@ -1,7 +1,9 @@
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
 
 function buildClaudeOpus46Tuning(): string {
-	return `When a task applies to multiple items, state the full scope explicitly rather than relying on implication. Default output is thorough — constrain with "one sentence", "bullets only", "no preamble" when concise output is needed.`;
+	return `Choose an approach and commit to it; revisit only when new information directly contradicts your reasoning. When a request covers a set of items, apply it to every item and state the scope you applied.
+
+Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
 }
 
 export function buildClaudeOpus46Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-7.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-7.ts
@@ -1,9 +1,13 @@
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
 
 function buildClaudeOpus47Tuning(): string {
-	return `When an instruction names a scope like "every", "all", or "for each", apply it to the full set rather than the first item. When told "do X then Y", follow that exact sequence.
+	return `Apply instructions at the scope the user evidently intends: "every", "all", and "each" mean the full set rather than the first item, and a fix that plainly recurs covers every occurrence. State the scope you applied.
 
-Maintain coherent state across extended multi-tool workflows without drifting from the original goal. Do not re-anchor with reminder paragraphs mid-task.`;
+Prefer tool calls over reasoning when a tool can resolve the question directly; do not reason past a fact you can look up.
+
+For frontend design with no specified visual direction, derive one from the project's context or propose distinct options before building; do not fall back to your default cream/serif/terracotta house style or generic AI aesthetics.
+
+Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
 }
 
 export function buildClaudeOpus47Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-8.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-8.ts
@@ -1,11 +1,13 @@
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
 
 function buildClaudeOpus48Tuning(): string {
-	return `When an instruction names a scope like "every", "all", or "for each", apply it to the full set rather than the first item. When told "do X then Y", follow that exact sequence. State the scope explicitly when applying a rule broadly.
+	return `Apply instructions at the scope the user evidently intends: "every", "all", and "each" mean the full set rather than the first item, and a fix that plainly recurs covers every occurrence. State the scope you applied.
 
-Maintain coherent state across extended multi-tool workflows without drifting from the original goal. Do not re-anchor with reminder paragraphs mid-task.
+Prefer tool calls over reasoning when a tool can resolve the question directly; do not reason past a fact you can look up. After a user turn, reason over what changed; do not re-derive facts already established in the conversation.
 
-Prefer tool calls over reasoning when a tool can resolve the question directly. Do not reason past a fact you can look up.`;
+For frontend design with no specified visual direction, derive one from the project's context or propose distinct options before building; do not fall back to your default cream/serif/terracotta house style or generic AI aesthetics.
+
+Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
 }
 
 export function buildClaudeOpus48Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/test/suite/prompt-presets-model-switch.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-model-switch.test.ts
@@ -46,7 +46,7 @@ describe("prompt preset model switching", () => {
 
 		// then
 		expect(promptChange?.systemPromptName).toBe("claude-opus-4-7");
-		expect(harness.session.systemPrompt).toContain("Maintain coherent state");
+		expect(harness.session.systemPrompt).toContain("full set rather than the first item");
 		expect(extensionEvents).toEqual(["gpt-5.5->claude-opus-4-7:claude-opus-4-7"]);
 		expect(harness.eventsOfType("system_prompt_change").map((event) => event.systemPromptName)).toEqual([
 			"claude-opus-4-7",
@@ -73,7 +73,7 @@ describe("prompt preset model switching", () => {
 		// then
 		expect(promptChange?.systemPromptName).toBe("fallback (senpi-current)");
 		expect(harness.session.systemPrompt).toContain("## Available Tools");
-		expect(harness.session.systemPrompt).not.toContain("Maintain coherent state");
+		expect(harness.session.systemPrompt).not.toContain("full set rather than the first item");
 		expect(harness.eventsOfType("system_prompt_change").map((event) => event.systemPromptName)).toEqual([
 			"fallback (senpi-current)",
 		]);
@@ -98,7 +98,7 @@ describe("prompt preset model switching", () => {
 
 		// then
 		expect(promptChange?.systemPromptName).toBe("claude-opus-4-6");
-		expect(harness.session.systemPrompt).toContain("Default output is thorough");
+		expect(harness.session.systemPrompt).toContain("Choose an approach and commit to it");
 		expect(harness.eventsOfType("system_prompt_change").map((event) => event.systemPromptName)).toEqual([
 			"claude-opus-4-6",
 		]);


### PR DESCRIPTION
## Summary

Rewrites the system prompt tuning for the Claude Opus series presets (`claude-opus-4-{5,6,7,8}`) from first principles against Anthropic's published Opus 4.7/4.8 prompting guidance. The presets remain thin wrappers over `buildDynamicSystemPrompt()`; only the model-specific `tuningSection` strings change.

**Before:** the Opus tunings restated behaviors these models exhibit natively ("maintain coherent state", "follow that exact sequence") while omitting the behaviors Anthropic documents as needing prompt-level overrides in a coding harness.

**After:** every remaining line either overrides a documented Opus prior or states a harness fact the model cannot derive:

- **Removed dead weight:** state-coherence line (documented native strength), "do not re-anchor" (shared Style already bans announcement/filler), "do X then Y exact sequence" (literalism does this natively), 4.5's caveat-closer ban (shared Style permission-begging ban covers it), 4.6's "constrain with 'one sentence'" (prompt-author guidance misframed as a model instruction).
- **Added documented deltas:** tools-over-reasoning extended to 4.7 (the tendency is documented starting at 4.7; previously only 4.8 had it); literalism compensation phrased as evident-intent scoping with a mandatory scope statement (4.7/4.8); the persistent cream/serif/terracotta frontend house-style override (4.7/4.8); post-user-turn reasoning economy (4.8 reasons more after user turns in interactive settings); and one harness fact on all four presets: senpi auto-compacts context, so never wrap up early (context-aware 4.5+ models otherwise wind down near the limit; mirrors the existing Fable 5 preset line).

## Changes

- `claude-opus-4-{5,6,7,8}.ts`: rewritten `tuningSection` strings (4.7/4.8 share scope + tool-triggering + frontend + compaction; 4.8 adds post-turn reasoning economy; 4.5/4.6 keep their version-specific lines plus the compaction fact).
- `prompt-presets-model-switch.test.ts`: updated the three family-signal marker strings that pinned deleted sentences ("Maintain coherent state", "Default output is thorough") to markers from the new tuning. The pins in `prompt-presets-extension.test.ts` ("ordered steps", "full set rather than the first item", "tool calls over reasoning") were preserved verbatim in the new text, so that file is unchanged.
- `prompt-preset/changes.md`: fork tracker entry with the full diagnosis.
- `packages/coding-agent/CHANGELOG.md`: entry under `[Unreleased]` / `### Changed`.

## QA / Evidence

Artifacts: `local-ignore/qa-evidence/20260702-opus-preset-rewrite/` (gitignored; `commands.md`, `wire-qa.txt`, `mock-loop-selftest.txt`, QA script copy).

1. **Wire-level end-to-end proof** (`wire-qa.txt`, 35/35 PASS): a QA script drives the REAL CLI from source (`--print`, extensions enabled) once per Opus model id, with a sandboxed `models.json` registering an anthropic provider whose baseUrl points at a local fake `/v1/messages` endpoint that captures the full request body. Per model it asserts: exit 0, only the localhost fake was hit with the inline mock x-api-key, the wire `system` prompt contains every new tuning line, every deleted line is absent, and shared scaffolding (`## Intent Gate`, `## Verification`) is intact. This exercises the real preset resolution path (model id -> prompt-preset extension -> dynamic prompt builder -> anthropic-messages serializer), so it proves the rewrite ships end to end for all four model families.
2. **Preset test suites** (62/62 PASS): `prompt-presets-extension`, `prompt-presets-model-switch`, `prompt-presets-startup-header`, `prompt-presets-claude-fable-5` via vitest.
3. **Baseline agent-loop regression** (`mock-loop-selftest.txt`, 5/5 PASS): `senpi-qa` mock loop across all three wire formats.
4. `npm run check` — clean, no errors or warnings.

Isolation receipt: all QA runs used temp `SENPI_CODING_AGENT_DIR` sandboxes with provider key env vars stripped; `~/.senpi/agent/auth.json` sha256 asserted unchanged in both channels; zero real provider calls.

## Risks

- **Prompt-behavior risk:** the tuning text changes model behavior, which no offline test can fully prove. Mitigated by grounding every added line in Anthropic's published Opus 4.7/4.8 guidance and every deletion in either documented native behavior or an existing shared-prompt rule; the wire QA proves the intended text (and only that text) reaches the model.
- **Scope-creep risk from evident-intent scoping (4.7/4.8):** bounded by anchoring to explicit scope words and plainly recurring fixes, plus a mandatory "state the scope you applied", which keeps the shared Intent Gate's "no extra scope" rule authoritative.
- **Test coupling:** family-signal pins were kept or updated in the same change; the full preset suite passes.

## Secret safety

No secrets, tokens, auth headers, or env dumps in the diff, PR body, or evidence excerpts. QA used inline mock keys against localhost only; the real auth store was hash-verified untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the Claude Opus 4.5–4.8 prompt preset tuning to align with Anthropic’s 4.7/4.8 guidance, removing redundant rules and adding model-specific overrides. This improves scope handling, tool use, frontend defaults, and prevents early wrap-ups.

- **Refactors**
  - Updated `tuningSection` for `claude-opus-4-{5,6,7,8}`; core `buildDynamicSystemPrompt()` unchanged.
  - Added: tools-over-reasoning (4.7), evident-intent scoping with a required scope statement (4.7/4.8), frontend house-style override (4.7/4.8), post-user-turn reasoning economy (4.8), and “do not wrap up early; context is auto-compacted” (all).
  - Removed redundant lines that restate native behavior or shared rules (e.g., “maintain coherent state”, re-anchoring, literal sequence, 4.5 caveat-closer, 4.6 “one sentence”).
  - Updated markers in `prompt-presets-model-switch.test.ts` to match new pins; other preset tests unchanged.

<sup>Written for commit 48bf4a6c71e05212f2a5a62b5f1de2f5b76a27a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

