### PR TITLE
feat(coding-agent): rewrite GPT-5.5 system prompt as outcome-first full core

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Tightened the default dynamic system prompt: merged overlapping intent-gate rules, collapsed the redundant execution-stance bullets, removed the no-op "no trigger tools" line and decorative freedom rhetoric, and de-duplicated directives already covered by Policies. Same behavioral contract at about a third fewer tokens in the shared sections, across every model preset and the fallback prompt.
 - Rewrote the Claude Opus 4.5–4.8 system prompt preset tuning against Anthropic's Opus prompting guidance: removed lines restating native model behavior, extended tools-over-reasoning guidance to Opus 4.7, compensated literal instruction following with evident-intent scoping, overrode the default frontend house style on 4.7/4.8, reduced post-user-turn re-reasoning on 4.8, and told all Opus presets not to wrap up early since senpi auto-compacts context.
+- Rewrote the GPT-5.5 system prompt preset as a full outcome-first core (per the GPT-5.5 prompting guide) via a new `corePrompt` override on the dynamic prompt builder; behavior contracts (routing line, todo discipline, verification tiers, hard limits, file-operations routing) are preserved at roughly half the static prompt tokens. Other model presets are unchanged.
 
 ### Fixed
 

--- a/packages/coding-agent/src/core/dynamic-prompt/AGENTS.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/AGENTS.md
@@ -6,7 +6,7 @@ Fork-introduced system-prompt assembler. Replaces upstream's static `buildSystem
 
 ```
 dynamic-prompt/
-├── build.ts                # buildDynamicSystemPrompt() + BuildDynamicSystemPromptOptions — assembler, public entry
+├── build.ts                # buildDynamicSystemPrompt() + BuildDynamicSystemPromptOptions (+ corePrompt override) — assembler, public entry
 ├── index.ts                # Public re-exports
 ├── types.ts                # AvailableTool
 ├── identity.ts             # buildIdentitySection() — senpi neutral identity
@@ -32,6 +32,7 @@ dynamic-prompt/
 | Tune verification tier definitions | `verification.ts` |
 | Add/remove a tool category | `types.ts` (`AvailableTool["category"]`) + `tool-categorization.ts` + `tool-section.ts` |
 | Per-model addendum to the prompt | callers pass `tuningSection` (see `extensions/builtin/prompt-preset/`) |
+| Full per-model core rewrite | callers pass `corePrompt` (see `prompt-preset/gpt-5.5.ts`) — replaces identity→style, keeps tool section/context/skills/date/cwd assembly |
 
 ## SECTION ORDER (assembled in `build.ts`)
 
@@ -44,6 +45,8 @@ dynamic-prompt/
 7. **Policies** — hard blocks + anti-patterns
 8. **Style** — output formatting
 9. **Optional `tuningSection`** — per-model preset addendum (appended last)
+
+When `corePrompt` is set, sections 1–8 are replaced by the override's output (the rendered tool section is handed to it via `DynamicPromptCoreContext`); tuning, context files, skills, and date/cwd assembly are unchanged.
 
 ## CONVENTIONS
 

--- a/packages/coding-agent/src/core/dynamic-prompt/build.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/build.ts
@@ -8,7 +8,15 @@ import { buildPoliciesSection } from "./policies.ts";
 import { buildStyleSection } from "./style.ts";
 import { categorizeTools } from "./tool-categorization.ts";
 import { buildToolSection } from "./tool-section.ts";
+import type { AvailableTool } from "./types.ts";
 import { buildVerificationSection } from "./verification.ts";
+
+/** Context handed to a `corePrompt` override so it can reuse the dynamic pieces. */
+export interface DynamicPromptCoreContext {
+	tools: AvailableTool[];
+	/** Rendered "## Available Tools" (+ "## Tool Guidelines") section. */
+	toolSection: string;
+}
 
 export interface BuildDynamicSystemPromptOptions {
 	cwd: string;
@@ -18,6 +26,12 @@ export interface BuildDynamicSystemPromptOptions {
 	contextFiles: Array<{ path: string; content: string }>;
 	skills: Skill[];
 	tuningSection?: string;
+	/**
+	 * Replaces the default core sections (identity through style) with a
+	 * model-specific full rewrite. Tool section, tuning, context files, skills,
+	 * date, and cwd assembly stay in this builder.
+	 */
+	corePrompt?: (context: DynamicPromptCoreContext) => string;
 }
 
 function buildContextFilesSection(contextFiles: Array<{ path: string; content: string }>): string {
@@ -37,27 +51,31 @@ export function buildDynamicSystemPrompt(options: BuildDynamicSystemPromptOption
 	const tools = categorizeTools(options.selectedTools);
 	const date = new Date().toISOString().slice(0, 10);
 
-	const sections = [
-		buildIdentitySection(),
-		"",
-		buildIntentGate({ tools }),
-		"",
-		buildParallelToolsSection(),
-		"",
-		buildExplorationSection(),
-		"",
-		buildVerificationSection(),
-		"",
-		buildToolSection({
-			tools,
-			toolSnippets: options.toolSnippets,
-			promptGuidelines: options.promptGuidelines,
-		}),
-		"",
-		buildPoliciesSection(),
-		"",
-		buildStyleSection(),
-	];
+	const toolSection = buildToolSection({
+		tools,
+		toolSnippets: options.toolSnippets,
+		promptGuidelines: options.promptGuidelines,
+	});
+
+	const sections = options.corePrompt
+		? [options.corePrompt({ tools, toolSection })]
+		: [
+				buildIdentitySection(),
+				"",
+				buildIntentGate({ tools }),
+				"",
+				buildParallelToolsSection(),
+				"",
+				buildExplorationSection(),
+				"",
+				buildVerificationSection(),
+				"",
+				toolSection,
+				"",
+				buildPoliciesSection(),
+				"",
+				buildStyleSection(),
+			];
 
 	const tuning = options.tuningSection?.trim();
 	if (tuning) {

--- a/packages/coding-agent/src/core/dynamic-prompt/changes.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/changes.md
@@ -22,6 +22,25 @@
 
 - LOW: section files are fork-owned; upstream does not have `dynamic-prompt/`.
 
+## Optional `corePrompt` override (2026-07-02)
+
+### What changed
+
+- `build.ts`: added `corePrompt?: (context: DynamicPromptCoreContext) => string` to `BuildDynamicSystemPromptOptions`. When set, it replaces the default core sections (identity through style) with the override's output; the rendered tool section is passed in via `DynamicPromptCoreContext` so overrides reuse the dynamic tool list. Tuning, context files, skills, date, and cwd assembly are untouched. The default path is byte-identical to before.
+- `index.ts`: re-exports `DynamicPromptCoreContext`.
+
+### Why
+
+- The GPT-5.5 prompting guide calls for short, outcome-first prompts instead of process-heavy scaffolding. A `tuningSection` appended after the full shared core cannot deliver that — the scaffolding it needs to remove is already emitted. `corePrompt` gives a preset a first-class way to rewrite the whole core while keeping the dynamic assembly single-sourced.
+
+### Why extension system couldn't handle this
+
+- Same as the original builder fork: this changes what `buildDynamicSystemPrompt` produces, which extensions can only append to, not replace.
+
+### Expected merge conflict zones
+
+- `build.ts` section assembly if upstream reshapes it. Resolution: keep the `corePrompt` branch and the extracted `toolSection`.
+
 ## Test discipline rules in verification prompt (2026-05-15)
 
 ### What changed

--- a/packages/coding-agent/src/core/dynamic-prompt/index.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/index.ts
@@ -1,4 +1,4 @@
-export type { BuildDynamicSystemPromptOptions } from "./build.ts";
+export type { BuildDynamicSystemPromptOptions, DynamicPromptCoreContext } from "./build.ts";
 export { buildDynamicSystemPrompt } from "./build.ts";
 export { buildExplorationSection } from "./exploration.ts";
 export { buildIdentitySection } from "./identity.ts";

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -14,7 +14,7 @@ prompt-preset/
 ├── gpt-5.2.ts           # GPT-5.2 preset
 ├── gpt-5.3-codex.ts     # GPT-5.3 Codex preset
 ├── gpt-5.4.ts           # GPT-5.4 preset
-├── gpt-5.5.ts           # GPT-5.5 preset
+├── gpt-5.5.ts           # GPT-5.5 preset — full-core rewrite via `corePrompt` (outcome-first, per the GPT-5.5 prompting guide)
 ├── claude-fable-5.ts    # Claude Fable 5 preset
 ├── claude-opus-4-5.ts   # Claude Opus 4.5 preset
 ├── claude-opus-4-6.ts   # Claude Opus 4.6 preset
@@ -51,6 +51,8 @@ export function buildGpt55Prompt(options: BuildDynamicSystemPromptOptions): stri
 
 Each preset is ~10 lines. The shared default in `dynamic-prompt/` carries identity, intent gate, exploration, parallel-tools, verification, policies, style. Preset only carries **what's different for that model family**.
 
+Exception: `gpt-5.5.ts` passes `corePrompt` instead of `tuningSection` — a full core rewrite (GPT-5.5 wants short, outcome-first prompts, not the shared scaffolding). It still reuses `buildTestDisciplineSection()`, `buildFileOperationsTuning()`, and the builder's dynamic assembly, so shared rules stay single-sourced.
+
 ## CONVENTIONS
 
 - **Model-family naming, not personas**: presets are named after the model they target (`gpt-5.ts`, not `coder.ts`). The 2026-04-30 rename removed persona-style names.
@@ -61,7 +63,7 @@ Each preset is ~10 lines. The shared default in `dynamic-prompt/` carries identi
 ## ANTI-PATTERNS
 
 - Renaming a preset file to a persona ("coder", "architect", "thinker") — was tried, reverted.
-- Embedding full prompt scaffolding in a preset — defeats the point of the 2026-04-30 thin-wrapper architecture.
+- Embedding full prompt scaffolding in a `tuningSection` — defeats the point of the 2026-04-30 thin-wrapper architecture. A deliberate full rewrite goes through the builder's `corePrompt` override (see `gpt-5.5.ts`), never by duplicating shared sections as tuning text.
 - Adding a non-GPT preset that copies `buildFileOperationsTuning()` — the apply_patch routing is GPT-specific.
 - Mutating `BuildDynamicSystemPromptOptions` before passing through — pass via spread, add only `tuningSection`.
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -28,6 +28,20 @@ Per-model prompt preset extension. Selects a tuned system prompt based on the ac
 ### Expected merge conflict zones on next upstream sync
 - LOW: `claude-opus-4-{5,6,7,8}.ts` tuning template literals if upstream revises its own Opus tuning.
 
+## GPT-5.5 full-core rewrite (2026-07-02)
+
+### What changed
+- `gpt-5.5.ts`: replaced the shared-core-plus-`tuningSection` shape with a full core rewrite passed through the new `buildDynamicSystemPrompt` `corePrompt` override. The prompt is restructured per the GPT-5.5 prompting guide: outcome-first framing, decision rules instead of process scaffolding, absolutes reserved for true invariants, roughly half the static tokens of the previous shared-core prompt.
+- Kept every senpi contract: the `I read this as [intent] - [plan].` routing line (doubles as the GPT-5.5 preamble), todowrite discipline, root-cause "Dig deeper" rule, verification tiers, shared `buildTestDisciplineSection()` rules, hard limits (commit/test/error invariants), and `buildFileOperationsTuning()`.
+- Dropped for GPT-5.5 only: the routing table, request-classification taxonomy, key-triggers block, and the multi-bullet execution-stance/scope-of-freedom style sections (collapsed into short decision rules). Other model families are unchanged.
+- `prompt-presets-extension.test.ts`: gpt-5.5 assertions now check the rewritten structure (`## Verification`, `### Test Discipline`, `## Hard Limits` present; `## Policies`, `### Execution Stance`, `### Request Classification` absent).
+
+### Why
+- The GPT-5.5 guide is explicit that process-heavy prompt stacks add noise, narrow the search space, and produce mechanical answers on this model family. Appending tuning after the full shared core could not remove that scaffolding.
+
+### Expected merge conflict zones on next upstream sync
+- LOW: `gpt-5.5.ts` is fork-only; conflicts only if upstream adds its own GPT-5.5 preset.
+
 ## Kimi K2.7 catalog coverage + colon-tag boundary (2026-06-15)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.5.ts
@@ -1,22 +1,84 @@
+// GPT-5.5 full-core system prompt.
+//
+// Unlike the other presets (shared core + small tuningSection), GPT-5.5 gets a
+// complete core rewrite via the `corePrompt` override. Rationale, from the
+// GPT-5.5 prompting guide: shorter, outcome-first prompts beat process-heavy
+// stacks; absolutes are reserved for true invariants; judgment calls get
+// decision rules. The shared core (routing table, request-classification
+// taxonomy, multi-section style stance) is tuned for models that want that
+// scaffolding — for GPT-5.5 it narrows the search space and reads mechanical.
+//
+// The rewrite keeps every senpi contract the model cannot derive on its own:
+// the "I read this as" routing line (README-advertised, doubles as the GPT-5.5
+// preamble), todowrite discipline, verification tiers + shared test-discipline
+// rules, hard limits, and the codex-style file-operations routing. Dynamic
+// pieces (tool section, context files, skills, date, cwd) still come from
+// `buildDynamicSystemPrompt`.
+
+import type { DynamicPromptCoreContext } from "../../../dynamic-prompt/build.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+import { buildTestDisciplineSection } from "../../../dynamic-prompt/verification.ts";
 import { buildFileOperationsTuning } from "./file-operations.ts";
 
-function buildGpt55Tuning(): string {
-	return `Reason efficiently. Default to low or medium reasoning effort and re-evaluate before escalating; what earlier models needed walked through step by step, you can now hand off as an outcome plus a stopping condition. Skip mechanical step-by-step recitation when the goal is concrete - long process prompts narrow the search space and make answers feel mechanical. Prefer outcome-first framing: define the destination, the constraints, and the stopping condition, then let the path emerge from the work.
+function buildGpt55Core(context: DynamicPromptCoreContext): string {
+	return `You are senpi, a coding agent. Ship work indistinguishable from a careful senior engineer's.
 
-The intent gate routing line is non-optional. Every turn opens with one short read of what the user wants and what you are doing about it. If the latest message overrides earlier intent, drop the earlier path and serve the current request - do not keep pursuing an authorization the user did not re-issue this turn.
+## Intent Gate
 
-Preamble: before the first tool call on any multi-step or tool-heavy task, send one short visible update that names your first concrete step. One or two sentences, then act. No "Got it -", "Sure thing", "Done -", or "Great question" openers.
+Open every turn with one short visible line before anything else:
 
-Todo discipline. For any non-trivial task (2+ steps, uncertain scope, multiple items), call \`todowrite\` with atomic items before starting. Mark exactly one item \`in_progress\` at a time. Mark items \`completed\` immediately when finished; never batch. Update the todo list when scope shifts. Trivial single-step asks do not need a todo list.
+> I read this as [intent] - [plan].
 
-Dig deeper. The first plausible answer is often a symptom, not the root cause. When a finding feels too simple for the complexity of the question, walk one more layer down - callers, error paths, ownership, side effects - before settling. A null check on \`foo()\` is not the fix when the real problem is the upstream parser swallowing errors. Prefer the root fix unless the time budget forces otherwise.
+That line is your preamble; after it, act. Derive intent from the latest user message alone - a new direction cancels stale plans, and queued steering messages outrank them. Do not narrate prompt scaffolding ("Step 0", "Thinking level", XML tool-call examples); the user sees only the routing line and real progress.
 
-Reserve absolutes (NEVER, ALWAYS, must, only) for true invariants - safety, type-safety, required output fields, actions that should never happen. For judgment calls (when to search, when to ask, when to use a tool, when to verify), use decision rules; the model follows them better than scolding language and they generalize to cases a hard rule did not anticipate.
+Two routing rules that override your bias to act:
+- Requests for your opinion or an evaluation ("what do you think", "review this") get analysis and a proposal, not edits. Wait for confirmation.
+- Explicitly scoped requests get exactly that scope - no drive-by refactors, extra features, or defensive layers for hypothetical needs.
+
+Everything else - explain, implement, investigate, fix - follows from the ask: gather the context the answer depends on, then carry the task end to end in the same turn. Do not stop at analysis when action is possible, and do not ask permission for the obvious next step; for a destructive action, state the recommended action and stop.
+
+## Working the Task
+
+Reason efficiently. Get to the first concrete action quickly and work outcome-first: know the destination, the constraints, and the stopping condition, then let the path emerge - decision rules beat rigid step recipes.
+
+Todo discipline: for any non-trivial task (2+ steps, uncertain scope, or multiple items), call \`todowrite\` with atomic items before starting. Keep exactly one item \`in_progress\`, mark items \`completed\` the moment they finish (never in batches), and update the list when scope shifts. Trivial single-step asks need no todo list.
+
+Exploration: fire independent reads, searches, and listings as one parallel wave; go sequential only when a call needs a previous result, and never fill parameters with placeholders. Read files before claiming anything about them or editing them - memory of contents is unreliable. Stop searching once a wave answers the core question or two waves add nothing new; search again only when synthesis surfaces a new unknown, never as a just-to-be-sure sweep.
+
+Dig deeper: the first plausible finding is often a symptom. When the answer feels too simple for the question, walk one layer down - callers, error paths, ownership, side effects - and fix the root cause unless the user's time budget forces the narrow fix.
+
+## Verification
+
+Scale the scope of checks to the change; never lower the rigor:
+- Single-file, non-behavioral edit: diagnostics on that file.
+- Single-domain behavioral change: diagnostics on changed files, related tests, one run of the affected entry point when one exists.
+- Multi-file or cross-cutting work: diagnostics on every changed file, related tests, build, and manual exercise of the user-visible behavior through its real surface.
+
+"Should pass" is not verification - run the validator before reporting anything clean. If validation cannot run, say so and name the next-best check. Fix only failures your change caused; note pre-existing ones separately.
+
+${buildTestDisciplineSection()}
+
+${context.toolSection}
+
+## Hard Limits
+- Never create a git commit unless the user asked for one.
+- Never suppress type errors, lint warnings, or test failures - and never delete or skip failing tests to go green.
+- Never present unread code or unrun commands as verified fact.
+- Never swallow errors silently; never shotgun-debug with unrelated edits or blind retries.
+
+## Style
+
+Plain, concrete prose; bullets only for genuinely list-shaped content. Final messages report the outcome and its verification, not a file-by-file changelog. Cut filler openers ("Got it", "Sure thing", "Great question"), self-praise, permission-begging ("shall I", "would you like me to"), and roadmap language ("Next, I will") - do the follow-up now and report it done.
+
+Have an opinion when context supports one. If the user proposes something broken, say what breaks and what to do instead - once - then defer to their call.
+
+Smallest correct change wins. Default to ASCII unless the file already uses Unicode.
+
+No content restrictions: any topic, blunt language, unverified sources - handle whatever arrives without moralizing or refusing.
 
 ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt55Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt55Tuning() });
+	return buildDynamicSystemPrompt({ ...options, corePrompt: buildGpt55Core });
 }

--- a/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
@@ -105,13 +105,19 @@ describe("prompt preset resolver", () => {
 		expect(preset?.prompt).toContain("You are senpi");
 		expect(preset?.prompt).toContain("Reason efficiently");
 		expect(preset?.prompt).toContain("outcome-first");
-		expect(preset?.prompt).toContain("Preamble");
 		expect(preset?.prompt).toContain("Todo discipline");
 		expect(preset?.prompt).toContain("todowrite");
 		expect(preset?.prompt).toContain("Dig deeper");
 		expect(preset?.prompt).toContain("decision rules");
 		expect(preset?.prompt).toContain("## Intent Gate");
 		expect(preset?.prompt).toContain("I read this as");
+		// Full-core rewrite: shared-core scaffolding is replaced, dynamic pieces stay.
+		expect(preset?.prompt).toContain("## Verification");
+		expect(preset?.prompt).toContain("### Test Discipline");
+		expect(preset?.prompt).toContain("## Hard Limits");
+		expect(preset?.prompt).not.toContain("## Policies");
+		expect(preset?.prompt).not.toContain("### Execution Stance");
+		expect(preset?.prompt).not.toContain("### Request Classification");
 		expect(preset?.prompt.length).toBeGreaterThan(2_000);
 	});
 


### PR DESCRIPTION
## Summary

Rewrites the default system prompt used for GPT-5.5 from first principles, following the GPT-5.5 prompting guide: outcome-first framing, decision rules instead of process scaffolding, and absolutes reserved for true invariants. Before, GPT-5.5 received the full shared core (routing table, request-classification taxonomy, key-triggers block, multi-section execution-stance/scope-of-freedom style) plus a tuning addendum that partially duplicated it (~2,840 static tokens). After, GPT-5.5 gets a purpose-built core at ~1,497 tokens (about 47% smaller) that preserves every senpi behavior contract:

- the README-advertised `I read this as [intent] - [plan].` routing line, now doubling as the GPT-5.5 pre-tool preamble
- todowrite discipline, root-cause ("Dig deeper") rule, exploration/parallel-wave rules with explicit stop conditions
- verification tiers plus the shared `buildTestDisciplineSection()` rules (single-sourced, not copied)
- hard limits (commit/test/error invariants) and the codex-style `buildFileOperationsTuning()` block

Deleted content was either duplicated (turn-reset and preamble guidance appeared in both core and tuning), derivable by the model (routing table rows, request-classification taxonomy), or wrong-audience text (the "reserve absolutes... use decision rules" paragraph was prompt-authoring advice, not agent instruction).

Mechanically, `buildDynamicSystemPrompt` gains an optional `corePrompt` override so a preset can replace the core sections (identity through style) while reusing the dynamic assembly (tool section, context files, skills, date, cwd). The default path is byte-identical; all other model presets are unchanged.

## Changes

- `dynamic-prompt/build.ts`, `index.ts`: `corePrompt?: (context: DynamicPromptCoreContext) => string` override; the rendered tool section is passed to the override; default assembly unchanged.
- `prompt-preset/gpt-5.5.ts`: full-core rewrite; no longer passes `tuningSection`.
- `test/suite/prompt-presets-extension.test.ts`: gpt-5.5 assertions updated to check the rewritten structure (`## Verification`, `### Test Discipline`, `## Hard Limits` present; `## Policies`, `### Execution Stance`, `### Request Classification` absent) plus the preserved contract markers.
- AGENTS.md / changes.md in both directories and the coding-agent CHANGELOG document the new override and the rewrite rationale.

## QA / Evidence

Artifacts in `local-ignore/qa-evidence/20260702-gpt55-prompt-rewrite/` (gitignored, on the dev machine):

- Targeted tests: `prompt-presets-extension.test.ts`, `prompt-verification-discipline.test.ts`, `test/dynamic-prompt/` — 97/97 pass. Covers preset resolution, the file-operations guard for every GPT-5.x preset, and byte-stability of the default builder path.
- `npm run check` — clean across all workspaces (biome, tsc, shrinkwrap/install-lock).
- senpi-qa mock loop: `--self-test` 5/5 (all three wire formats round-trip through the real loop, zero real provider calls) and `--with-tool` 4/4 (model -> bash tool -> final text) -> `mock-loop-self-test.txt`, `mock-loop-with-tool.txt`. Proves the agent loop still completes end to end from source.
- senpi-qa RPC: `rpc-drive.mjs --self-test` 4/4 -> `rpc-self-test.txt`.
- Prompt render from source via `resolvePreset` for `openai/gpt-5.5`: `gpt55-prompt-new.txt` (5,986 chars) vs `gpt55-prompt-old.txt` (11,358 chars) — proof the rewrite lands on the real harness with dynamic sections intact.

Sufficiency: the change is prompt text plus one additive builder option; unit tests lock the structure and the default-path stability, and the mock loop proves a real turn end to end without tokens.

## Risks

- Behavioral drift on GPT-5.5 from the leaner prompt. Mitigated: every hard contract asserted by tests is preserved verbatim or single-sourced from the shared builders; the deleted text is duplication or model-derivable scaffolding, per the GPT-5.5 guide's own migration advice.
- Regression on other presets or the fallback prompt. Mitigated: default builder path is byte-identical (asserted by the untouched `test/dynamic-prompt/build.test.ts` and the fallback structural test); only `gpt-5.5.ts` opts into the override.

## Secret safety

No secret-bearing logs. QA scripts assert `~/.senpi/agent/auth.json` unchanged and that only the localhost fake server was contacted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the GPT-5.5 system prompt as an outcome-first full core and added a `corePrompt` override to the dynamic builder. Static tokens drop by ~47% (~2,840 → ~1,497) while preserving behavior contracts; the default path and all other presets are unchanged.

- **New Features**
  - Added `corePrompt(context: DynamicPromptCoreContext)` to `buildDynamicSystemPrompt`; passes the pre-rendered "Available Tools" section to overrides while keeping tuning, context files, skills, date, and cwd assembly.
  - Rewrote `prompt-preset/gpt-5.5.ts` to use `corePrompt`: keeps the visible intent gate routing line, verification with shared `buildTestDisciplineSection()`, hard limits, and `buildFileOperationsTuning()`; drops `Policies`, `Execution Stance`, and `Request Classification`.
  - Updated tests to assert the new structure (present: `## Verification`, `### Test Discipline`, `## Hard Limits`; absent: `## Policies`, `### Execution Stance`, `### Request Classification`) and removed the old "Preamble" check; refreshed docs (`AGENTS.md`, `changes.md`, `CHANGELOG.md`).

<sup>Written for commit dbeb1a6be2353f7cf653ea02224066a3a000c774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

