### PR TITLE
Improve TUI rendering reliability and performance

### DIFF
--- a/.github/workflows/perf-trend.yml
+++ b/.github/workflows/perf-trend.yml
@@ -1,0 +1,84 @@
+# advisory-only; may become blocking only after ≥30 runs establish a false-positive rate <5% using ratio gates against a same-runner baseline window
+name: Perf Trend
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  perf-trend:
+    name: Advisory perf trend
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install system dependencies
+        run: |
+          sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
+          sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run advisory benches
+        run: bash scripts/perf-trend-local.sh || echo "bench failed (advisory)"
+
+      - name: Append perf summary
+        if: always()
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          path = Path("perf-trend.json")
+          rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()] if path.exists() else []
+
+          print("| suite | n | p50Ms | p95Ms | bytesPerFrameP50 |")
+          print("| --- | ---: | ---: | ---: | ---: |")
+          for row in rows:
+              bytes_value = row["bytesPerFrameP50"]
+              bytes_text = "-" if bytes_value is None else f"{bytes_value:.3f}"
+              n_value = row["n"]
+              n_text = "-" if n_value is None else str(n_value)
+              print(f"| {row['label']} | {n_text} | {row['p50Ms']:.3f} | {row['p95Ms']:.3f} | {bytes_text} |")
+
+          def p50(label):
+              for row in rows:
+                  if row["label"] == label:
+                      return row["p50Ms"]
+              return None
+
+          baseline_1k = p50("frame-cost-n1000")
+          baseline_10k = p50("frame-cost-n10000")
+          viewport_10k = p50("frame-cost-n10000-viewport")
+          print("")
+          print("| ratio | value |")
+          print("| --- | ---: |")
+          if baseline_10k and viewport_10k:
+              print(f"| flag-on/off p50 | {viewport_10k / baseline_10k:.3f} |")
+          else:
+              print("| flag-on/off p50 | - |")
+          if baseline_1k and baseline_10k:
+              print(f"| 10k/1k scaling p50 | {baseline_10k / baseline_1k:.3f} |")
+          else:
+              print("| 10k/1k scaling p50 | - |")
+          PY
+
+      - name: Upload perf trend artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-trend
+          path: perf-trend.json
+          retention-days: 90

--- a/.github/workflows/perf-trend.yml
+++ b/.github/workflows/perf-trend.yml
@@ -6,10 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   perf-trend:
     name: Advisory perf trend
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     continue-on-error: true
     steps:
       - name: Checkout
@@ -77,7 +81,7 @@ jobs:
 
       - name: Upload perf trend artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: perf-trend
           path: perf-trend.json

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## hook-status ticker unref (2026-07-03)
+
+### What changed
+
+- `interactive-mode.ts`: the hook-status ticker interval is unref'd after creation.
+- `packages/coding-agent/test/hook-status-ticker.test.ts`: verifies the timer exposes and calls `unref()`.
+
+### Why
+
+- The hook-status ticker should not keep the interactive process alive after other work completes.
+
+### Why extension system couldn't handle this
+
+- The timer is internal to `InteractiveMode`'s built-in hook status lifecycle.
+
+### Expected merge conflict zones
+
+- LOW/MED: `interactive-mode.ts` around `startToolHookStatusTimer`, `stopToolHookStatusTimer`, and hook status
+  lifecycle methods.
+
 ## custom entry renderer display order sync (2026-07-02)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1872,6 +1872,7 @@ export class InteractiveMode {
 		this.hookStatusIntervalId = setInterval(() => {
 			this.refreshToolHookStatuses();
 		}, DEFAULT_WORKING_STATUS_MESSAGE_ANIMATION_INTERVAL_MS);
+		this.hookStatusIntervalId.unref();
 	}
 
 	private stopToolHookStatusTimer(): void {

--- a/packages/coding-agent/test/hook-status-ticker.test.ts
+++ b/packages/coding-agent/test/hook-status-ticker.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type HookStatusTickerPrototype = {
+	startToolHookStatusTimer(this: HookStatusTickerThis): void;
+};
+
+type HookStatusTickerThis = {
+	hookStatusIntervalId: ReturnType<typeof setInterval> | undefined;
+	refreshToolHookStatuses(): void;
+};
+
+describe("InteractiveMode hook status ticker", () => {
+	test("unrefs the interval handle when starting the hook status ticker", () => {
+		// Given
+		const prototype = InteractiveMode.prototype as unknown as HookStatusTickerPrototype;
+		const intervalHandle = setInterval(() => {}, 60_000);
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(intervalHandle);
+		const unrefSpy = vi.spyOn(intervalHandle, "unref");
+		const fakeThis: HookStatusTickerThis = {
+			hookStatusIntervalId: undefined,
+			refreshToolHookStatuses: vi.fn(),
+		};
+
+		try {
+			// When
+			prototype.startToolHookStatusTimer.call(fakeThis);
+
+			// Then
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+			expect(unrefSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			clearInterval(intervalHandle);
+			vi.restoreAllMocks();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts
+++ b/packages/coding-agent/test/suite/pi-codex-app-server-harness.test.ts
@@ -28,7 +28,7 @@ describe("pi-codex-app-server runtime harness", () => {
 		try {
 			const failingScript = join(tempRoot, "fail-now.mjs");
 			const cleanupReceipt = join(tempRoot, "cleanup-receipt.txt");
-			writeFileSync(failingScript, "process.exit(42);\n");
+			writeFileSync(failingScript, "setTimeout(() => process.exit(42), 0);\n");
 
 			const result = spawnSync(
 				process.execPath,
@@ -60,7 +60,7 @@ describe("pi-codex-app-server runtime harness", () => {
 		try {
 			const exitingScript = join(tempRoot, "exit-now.mjs");
 			const cleanupReceipt = join(tempRoot, "cleanup-receipt.txt");
-			writeFileSync(exitingScript, "process.exit(0);\n");
+			writeFileSync(exitingScript, "setTimeout(() => process.exit(0), 0);\n");
 
 			const result = spawnSync(
 				process.execPath,

--- a/packages/tui/bench/frame-cost.ts
+++ b/packages/tui/bench/frame-cost.ts
@@ -15,12 +15,18 @@ const DEFAULT_TRANSCRIPT_LINES = 10_000;
 
 export interface FrameCostResult {
 	readonly n: number;
+	readonly stableComponents: boolean;
 	readonly frames: number;
 	readonly p50Ms: number;
 	readonly p95Ms: number;
 	readonly bytesPerFrameP50: number;
 	readonly initialBytes: number;
 	readonly renderCalls: number;
+	readonly transcriptRenderCalls: number;
+}
+
+export interface FrameCostOptions {
+	readonly stableComponents?: boolean;
 }
 
 class LoggingVirtualTerminal extends VirtualTerminal {
@@ -64,9 +70,33 @@ class MeasuredStatusText extends Text {
 }
 
 class MeasuredTranscriptText extends Text {
+	private readonly stableComponents: boolean;
+	private measured = false;
+	private stableLines: string[] | undefined;
+	renderCalls = 0;
+
+	constructor(text: string, paddingX: number, paddingY: number, stableComponents: boolean) {
+		super(text, paddingX, paddingY);
+		this.stableComponents = stableComponents;
+	}
+
+	setMeasured(measured: boolean): void {
+		this.measured = measured;
+	}
+
 	override render(width: number): string[] {
+		if (this.stableComponents && this.stableLines) {
+			return this.stableLines;
+		}
 		this.invalidate();
-		return super.render(width);
+		const lines = super.render(width);
+		if (this.measured) {
+			this.renderCalls += 1;
+		}
+		if (this.stableComponents) {
+			this.stableLines = lines;
+		}
+		return lines;
 	}
 }
 
@@ -76,6 +106,10 @@ function readN(defaultN: number): number {
 	const raw = process.argv[index + 1];
 	const parsed = raw ? Number(raw) : Number.NaN;
 	return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : defaultN;
+}
+
+function readStableComponents(): boolean {
+	return process.argv.includes("--stable-components");
 }
 
 async function runFrame(tui: TUI, status: Text, terminal: LoggingVirtualTerminal, frame: number): Promise<number> {
@@ -91,10 +125,11 @@ async function runFrame(tui: TUI, status: Text, terminal: LoggingVirtualTerminal
 	});
 }
 
-export async function runFrameCost(n: number): Promise<FrameCostResult> {
+export async function runFrameCost(n: number, options: FrameCostOptions = {}): Promise<FrameCostResult> {
+	const stableComponents = options.stableComponents === true;
 	const terminal = new LoggingVirtualTerminal(COLUMNS, ROWS);
 	const tui = new TUI(terminal);
-	const transcript = new MeasuredTranscriptText(makeTranscript(n).join("\n"), 0, 0);
+	const transcript = new MeasuredTranscriptText(makeTranscript(n).join("\n"), 0, 0, stableComponents);
 	const status = new MeasuredStatusText("status frame initial", 0, 0);
 	tui.addChild(transcript);
 	tui.addChild(status);
@@ -111,23 +146,28 @@ export async function runFrameCost(n: number): Promise<FrameCostResult> {
 		const frameTimes: number[] = [];
 		const frameBytes: number[] = [];
 		status.renderCalls = 0;
+		transcript.renderCalls = 0;
 		status.setMeasured(true);
+		transcript.setMeasured(true);
 		for (let frame = 0; frame < MEASURED_FRAMES; frame++) {
 			frameTimes.push(await runFrame(tui, status, terminal, frame));
 			frameBytes.push(terminal.getWriteBytes());
 		}
 		status.setMeasured(false);
+		transcript.setMeasured(false);
 
 		const timeSummary = percentiles(frameTimes);
 		const byteSummary = percentiles(frameBytes);
 		return {
 			n: Math.max(0, Math.floor(n)),
+			stableComponents,
 			frames: MEASURED_FRAMES,
 			p50Ms: timeSummary.p50,
 			p95Ms: timeSummary.p95,
 			bytesPerFrameP50: byteSummary.p50,
 			initialBytes,
 			renderCalls: status.renderCalls,
+			transcriptRenderCalls: transcript.renderCalls,
 		};
 	} finally {
 		tui.stop();
@@ -135,7 +175,7 @@ export async function runFrameCost(n: number): Promise<FrameCostResult> {
 }
 
 async function main(): Promise<void> {
-	const result = await runFrameCost(readN(DEFAULT_TRANSCRIPT_LINES));
+	const result = await runFrameCost(readN(DEFAULT_TRANSCRIPT_LINES), { stableComponents: readStableComponents() });
 	console.log(JSON.stringify(result));
 }
 

--- a/packages/tui/bench/frame-cost.ts
+++ b/packages/tui/bench/frame-cost.ts
@@ -1,0 +1,144 @@
+import { Text } from "../src/components/text.ts";
+import { TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "../test/virtual-terminal.ts";
+import { makeTranscript, percentiles } from "./frame-fixture.ts";
+
+declare const process: {
+	readonly argv: readonly string[];
+};
+
+const COLUMNS = 80;
+const ROWS = 40;
+const WARMUP_FRAMES = 30;
+const MEASURED_FRAMES = 300;
+const DEFAULT_TRANSCRIPT_LINES = 10_000;
+
+export interface FrameCostResult {
+	readonly n: number;
+	readonly frames: number;
+	readonly p50Ms: number;
+	readonly p95Ms: number;
+	readonly bytesPerFrameP50: number;
+	readonly initialBytes: number;
+	readonly renderCalls: number;
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+	private lastWriteAt: number | undefined;
+
+	override write(data: string): void {
+		this.writes.push(data);
+		this.lastWriteAt = performance.now();
+		super.write(data);
+	}
+
+	getWriteBytes(): number {
+		return new TextEncoder().encode(this.writes.join("")).byteLength;
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+		this.lastWriteAt = undefined;
+	}
+
+	getWriteElapsed(start: number): number | undefined {
+		return this.lastWriteAt === undefined ? undefined : this.lastWriteAt - start;
+	}
+}
+
+class MeasuredStatusText extends Text {
+	private measured = false;
+	renderCalls = 0;
+
+	setMeasured(measured: boolean): void {
+		this.measured = measured;
+	}
+
+	override render(width: number): string[] {
+		if (this.measured) {
+			this.renderCalls += 1;
+		}
+		return super.render(width);
+	}
+}
+
+class MeasuredTranscriptText extends Text {
+	override render(width: number): string[] {
+		this.invalidate();
+		return super.render(width);
+	}
+}
+
+function readN(defaultN: number): number {
+	const index = process.argv.indexOf("--n");
+	if (index === -1) return defaultN;
+	const raw = process.argv[index + 1];
+	const parsed = raw ? Number(raw) : Number.NaN;
+	return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : defaultN;
+}
+
+async function runFrame(tui: TUI, status: Text, terminal: LoggingVirtualTerminal, frame: number): Promise<number> {
+	terminal.clearWrites();
+	status.setText(`status frame ${String(frame).padStart(3, "0")}`);
+	const start = performance.now();
+	tui.requestRender();
+	return new Promise<number>((resolve) => {
+		queueMicrotask(async () => {
+			await terminal.waitForRender();
+			resolve(terminal.getWriteElapsed(start) ?? performance.now() - start);
+		});
+	});
+}
+
+export async function runFrameCost(n: number): Promise<FrameCostResult> {
+	const terminal = new LoggingVirtualTerminal(COLUMNS, ROWS);
+	const tui = new TUI(terminal);
+	const transcript = new MeasuredTranscriptText(makeTranscript(n).join("\n"), 0, 0);
+	const status = new MeasuredStatusText("status frame initial", 0, 0);
+	tui.addChild(transcript);
+	tui.addChild(status);
+
+	try {
+		tui.start();
+		await terminal.waitForRender();
+		const initialBytes = terminal.getWriteBytes();
+
+		for (let frame = 0; frame < WARMUP_FRAMES; frame++) {
+			await runFrame(tui, status, terminal, frame);
+		}
+
+		const frameTimes: number[] = [];
+		const frameBytes: number[] = [];
+		status.renderCalls = 0;
+		status.setMeasured(true);
+		for (let frame = 0; frame < MEASURED_FRAMES; frame++) {
+			frameTimes.push(await runFrame(tui, status, terminal, frame));
+			frameBytes.push(terminal.getWriteBytes());
+		}
+		status.setMeasured(false);
+
+		const timeSummary = percentiles(frameTimes);
+		const byteSummary = percentiles(frameBytes);
+		return {
+			n: Math.max(0, Math.floor(n)),
+			frames: MEASURED_FRAMES,
+			p50Ms: timeSummary.p50,
+			p95Ms: timeSummary.p95,
+			bytesPerFrameP50: byteSummary.p50,
+			initialBytes,
+			renderCalls: status.renderCalls,
+		};
+	} finally {
+		tui.stop();
+	}
+}
+
+async function main(): Promise<void> {
+	const result = await runFrameCost(readN(DEFAULT_TRANSCRIPT_LINES));
+	console.log(JSON.stringify(result));
+}
+
+if ((process.argv[1] ?? "").endsWith("/frame-cost.ts")) {
+	await main();
+}

--- a/packages/tui/bench/frame-cost.ts
+++ b/packages/tui/bench/frame-cost.ts
@@ -179,6 +179,6 @@ async function main(): Promise<void> {
 	console.log(JSON.stringify(result));
 }
 
-if ((process.argv[1] ?? "").endsWith("/frame-cost.ts")) {
+if (/(^|[/\\])frame-cost\.(?:ts|js)$/.test(process.argv[1] ?? "")) {
 	await main();
 }

--- a/packages/tui/bench/frame-fixture.ts
+++ b/packages/tui/bench/frame-fixture.ts
@@ -1,0 +1,48 @@
+const ASCII_WORDS = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"] as const;
+const CJK_WORDS = ["漢字", "かな", "測定", "行", "東京", "서울"] as const;
+
+export interface PercentileSummary {
+	readonly p50: number;
+	readonly p95: number;
+}
+
+function pickWord(words: readonly string[], index: number): string {
+	return words[index % words.length] ?? "";
+}
+
+function makePlainLine(index: number): string {
+	const id = String(index).padStart(5, "0");
+	return `${id} plain ${pickWord(ASCII_WORDS, index)} ${pickWord(ASCII_WORDS, index + 2)} ${pickWord(ASCII_WORDS, index + 4)}`;
+}
+
+function makeAnsiLine(index: number): string {
+	const id = String(index).padStart(5, "0");
+	return `${id} color \x1b[36m${pickWord(ASCII_WORDS, index)} span\x1b[39m ${pickWord(ASCII_WORDS, index + 3)}`;
+}
+
+function makeCjkLine(index: number): string {
+	const id = String(index).padStart(5, "0");
+	return `${id} cjk ${pickWord(CJK_WORDS, index)} ${pickWord(CJK_WORDS, index + 2)} ascii tail`;
+}
+
+export function makeTranscript(n: number): string[] {
+	return Array.from({ length: Math.max(0, Math.floor(n)) }, (_, index) => {
+		const bucket = index % 10;
+		if (bucket < 7) return makePlainLine(index);
+		if (bucket < 9) return makeAnsiLine(index);
+		return makeCjkLine(index);
+	});
+}
+
+function percentile(samples: readonly number[], p: number): number {
+	const sorted = [...samples].sort((a, b) => a - b);
+	const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+	return sorted[index] ?? 0;
+}
+
+export function percentiles(samples: readonly number[]): PercentileSummary {
+	return {
+		p50: percentile(samples, 50),
+		p95: percentile(samples, 95),
+	};
+}

--- a/packages/tui/bench/sgr-coalesce-report.json
+++ b/packages/tui/bench/sgr-coalesce-report.json
@@ -1,0 +1,39 @@
+{
+  "bytesBefore": 1296281,
+  "bytesAfter": 1291425,
+  "reductionPct": 0.3746101346853036,
+  "adopted": false,
+  "corpora": [
+    {
+      "name": "frame-cost-n10000-virtual-terminal",
+      "source": "packages/tui/bench/frame-cost.ts pattern",
+      "capture": "virtual terminal writes",
+      "n": 10000,
+      "frames": 50,
+      "writeCount": 51,
+      "bytesBefore": 950014,
+      "bytesAfter": 950014,
+      "reductionPct": 0,
+      "evidence": ".omo/evidence/task-12-write-log-corpus.txt"
+    },
+    {
+      "name": "markdown-200-blocks-50-append-frames",
+      "source": "/tmp/task-12-sgr-corpus.mjs",
+      "capture": "one Markdown component mounted on TUI + LoggingVirtualTerminal",
+      "blocks": 200,
+      "appendFrames": 50,
+      "writeCount": 51,
+      "bytesBefore": 346267,
+      "bytesAfter": 341411,
+      "reductionPct": 1.4023860200365614,
+      "evidence": ".omo/evidence/task-12-markdown-corpus.txt"
+    }
+  ],
+  "provenance": {
+    "head": "750b9bda7b3bb800765f4e33436ce065198e74cb",
+    "generatedAt": "2026-07-02T15:42:21.256Z",
+    "command": "env -u TMUX -u TMUX_PANE -u STY -u ZELLIJ node --import tsx /tmp/task-12-sgr-corpus.mjs",
+    "coalescing": "split each captured write on CRLF/LF and run coalesceAdjacentSgr on each line segment",
+    "adoptionGate": "adopted is true iff reductionPct >= 10"
+  }
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"clean": "shx rm -rf dist",
 		"build": "tsgo -p tsconfig.build.json",
+		"bench:frame-cost": "tsx bench/frame-cost.ts",
 		"test": "node --test --import tsx test/*.test.ts",
 		"prepublishOnly": "npm run clean && npm run build"
 	},

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,31 @@
 # TUI delta rendering fork changes
 
+## 2026-07-03: TUI rendering excellence gates
+
+### What changed
+
+- `packages/tui/src/tui.ts`: added multiplexer-aware full-render policy, bounded mux viewport repaint, opt-in
+  viewport-bounded normalize/diff, scroll-then-diff for bounded concurrent mutations, cursor visibility write
+  coalescing, SGR reset-after-clear coverage, and release-mode render-failure containment.
+- `packages/tui/src/utils.ts`: replaced the width cache with a two-generation cache and added the measured
+  SGR coalescing utility/report path; runtime SGR coalescing remains unwired because the measured byte reduction
+  was below the adoption gate.
+
+### Why this cannot be expressed externally
+
+These behaviors depend on `TUI`'s private render state: previous and raw line snapshots, viewport offsets,
+terminal dimensions, cursor bookkeeping, synchronized output framing, mux detection, image-row handling, and
+row-clear invariants. Components and extensions can reduce churn or request renders, but they cannot safely
+replace the renderer's terminal-byte decisions or update its internal cursor/viewport state.
+
+### Expected merge conflict zones
+
+- HIGH: `packages/tui/src/tui.ts` around `doRender()`, `fullRender()`, `renderViewportInsertScroll()`,
+  `renderScrollbackReplay()`, `positionHardwareCursor()`, and render-error diagnostic handling.
+- MEDIUM: `packages/tui/src/utils.ts` around width caching, terminal-output normalization, and ANSI parsing helpers.
+- LOW: `packages/tui/test/tui-render.test.ts` flicker-budget and scrollback assertions when upstream changes
+  renderer byte expectations.
+
 ## 2026-07-02: autowrap disabled during frame writes (ghost-line fix)
 
 ### What changed

--- a/packages/tui/src/mux.ts
+++ b/packages/tui/src/mux.ts
@@ -1,0 +1,11 @@
+export function isMultiplexerSession(): boolean {
+	return Boolean(process.env.TMUX || process.env.TMUX_PANE || process.env.STY || process.env.ZELLIJ);
+}
+
+export function useLegacyMuxRender(): boolean {
+	return process.env.PI_TUI_LEGACY_MUX_RENDER === "1";
+}
+
+export function viewportRenderEnabled(): boolean {
+	return process.env.PI_TUI_VIEWPORT_RENDER === "1";
+}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -352,6 +352,7 @@ export class TUI extends Container {
 	private pendingOsc11BackgroundQueries: PendingOsc11BackgroundQuery[] = [];
 	private terminalColorSchemeListeners = new Set<(scheme: TerminalColorScheme) => void>();
 	private terminalColorSchemeNotificationsEnabled = false;
+	#lastCursorVisibility: boolean | undefined;
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
@@ -378,7 +379,7 @@ export class TUI extends Container {
 		if (this.showHardwareCursor === enabled) return;
 		this.showHardwareCursor = enabled;
 		if (!enabled) {
-			this.terminal.hideCursor();
+			this.#setCursorVisibility(false);
 		}
 		this.requestRender();
 	}
@@ -536,7 +537,7 @@ export class TUI extends Container {
 		if (!options?.nonCapturing && this.isOverlayVisible(entry)) {
 			this.setFocus(component);
 		}
-		this.terminal.hideCursor();
+		this.#setCursorVisibility(false);
 		this.requestRender();
 
 		// Return handle for controlling this overlay
@@ -552,7 +553,7 @@ export class TUI extends Container {
 						const topVisible = this.getTopmostVisibleOverlay();
 						this.setFocus(topVisible?.component ?? entry.preFocus);
 					}
-					if (this.overlayStack.length === 0) this.terminal.hideCursor();
+					if (this.overlayStack.length === 0) this.#setCursorVisibility(false);
 					this.requestRender();
 				}
 			},
@@ -630,7 +631,7 @@ export class TUI extends Container {
 			const topVisible = this.getTopmostVisibleOverlay();
 			this.setFocus(topVisible?.component ?? overlay.preFocus);
 		}
-		if (this.overlayStack.length === 0) this.terminal.hideCursor();
+		if (this.overlayStack.length === 0) this.#setCursorVisibility(false);
 		this.requestRender();
 	}
 
@@ -667,11 +668,12 @@ export class TUI extends Container {
 
 	start(): void {
 		this.stopped = false;
+		this.#lastCursorVisibility = undefined;
 		this.terminal.start(
 			(data) => this.handleInput(data),
 			() => this.requestRender(),
 		);
-		this.terminal.hideCursor();
+		this.#setCursorVisibility(false);
 		if (this.terminalColorSchemeNotificationsEnabled) {
 			this.terminal.write("\x1b[?2031h");
 		}
@@ -738,8 +740,10 @@ export class TUI extends Container {
 			this.terminal.write("\r\n");
 		}
 
-		this.terminal.showCursor();
+		this.#lastCursorVisibility = undefined;
+		this.#setCursorVisibility(true);
 		this.terminal.stop();
+		this.#lastCursorVisibility = undefined;
 		this.previousLines = [];
 		this.previousKittyImageIds.clear();
 		this.previousWidth = 0;
@@ -748,6 +752,16 @@ export class TUI extends Container {
 		this.hardwareCursorRow = 0;
 		this.maxLinesRendered = 0;
 		this.previousViewportTop = 0;
+	}
+
+	#setCursorVisibility(visible: boolean): void {
+		if (this.#lastCursorVisibility === visible) return;
+		if (visible) {
+			this.terminal.showCursor();
+		} else {
+			this.terminal.hideCursor();
+		}
+		this.#lastCursorVisibility = visible;
 	}
 
 	requestRender(force = false, source = "unknown"): void {
@@ -1905,35 +1919,36 @@ export class TUI extends Container {
 	 * @param totalLines Total number of rendered lines
 	 */
 	private positionHardwareCursor(cursorPos: { row: number; col: number } | null, totalLines: number): void {
-		if (!cursorPos || totalLines <= 0) {
-			this.terminal.hideCursor();
-			return;
-		}
-
-		// Clamp cursor position to valid range
-		const targetRow = Math.max(0, Math.min(cursorPos.row, totalLines - 1));
-		const targetCol = Math.max(0, cursorPos.col);
-
-		// Move cursor from current position to target
-		const rowDelta = targetRow - this.hardwareCursorRow;
 		let buffer = "";
-		if (rowDelta > 0) {
-			buffer += `\x1b[${rowDelta}B`; // Move down
-		} else if (rowDelta < 0) {
-			buffer += `\x1b[${-rowDelta}A`; // Move up
+		if (!cursorPos || totalLines <= 0) {
+			if (this.#lastCursorVisibility !== false) {
+				buffer += "\x1b[?25l";
+				this.#lastCursorVisibility = false;
+			}
+		} else {
+			// Clamp cursor position to valid range
+			const targetRow = Math.max(0, Math.min(cursorPos.row, totalLines - 1));
+			const targetCol = Math.max(0, cursorPos.col);
+
+			// Move cursor from current position to target
+			const rowDelta = targetRow - this.hardwareCursorRow;
+			if (rowDelta > 0) {
+				buffer += `\x1b[${rowDelta}B`; // Move down
+			} else if (rowDelta < 0) {
+				buffer += `\x1b[${-rowDelta}A`; // Move up
+			}
+			// Move to absolute column (1-indexed)
+			buffer += `\x1b[${targetCol + 1}G`;
+
+			this.hardwareCursorRow = targetRow;
+			if (this.#lastCursorVisibility !== this.showHardwareCursor) {
+				buffer += this.showHardwareCursor ? "\x1b[?25h" : "\x1b[?25l";
+				this.#lastCursorVisibility = this.showHardwareCursor;
+			}
 		}
-		// Move to absolute column (1-indexed)
-		buffer += `\x1b[${targetCol + 1}G`;
 
 		if (buffer) {
 			this.terminal.write(buffer);
-		}
-
-		this.hardwareCursorRow = targetRow;
-		if (this.showHardwareCursor) {
-			this.terminal.showCursor();
-		} else {
-			this.terminal.hideCursor();
 		}
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1307,7 +1307,7 @@ export class TUI extends Container {
 		const firstInsertedScreenRow = regionBottom - plan.insertedRows.length + 1;
 		for (let index = 0; index < plan.insertedRows.length; index++) {
 			const screenRow = firstInsertedScreenRow + index;
-			buffer += `\x1b[${screenRow + 1};1H\x1b[2K`;
+			buffer += `\x1b[${screenRow + 1};1H\x1b[2K${TUI.SEGMENT_RESET}`;
 			buffer += plan.insertedRows[index] ?? "";
 		}
 
@@ -1345,7 +1345,7 @@ export class TUI extends Container {
 		const bufferLength = Math.max(height, newLines.length);
 		for (let row = 0; row < bufferLength; row++) {
 			if (row > 0) buffer += "\r\n";
-			buffer += "\r\x1b[2K";
+			buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 			buffer += newLines[row] ?? "";
 		}
 
@@ -1627,7 +1627,7 @@ export class TUI extends Container {
 					buffer += `\x1b[${clearStartOffset}B`;
 				}
 				for (let i = 0; i < extraLines; i++) {
-					buffer += "\r\x1b[2K";
+					buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 					if (i < extraLines - 1) buffer += "\x1b[1B";
 				}
 				const moveBack = Math.max(0, extraLines - 1 + clearStartOffset);
@@ -1699,7 +1699,7 @@ export class TUI extends Container {
 
 				for (let row = 0; row < height; row++) {
 					if (row > 0) buffer += "\r\n";
-					buffer += "\r\x1b[2K";
+					buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 					buffer += newLines[viewportTop + row] ?? "";
 				}
 
@@ -1769,9 +1769,9 @@ export class TUI extends Container {
 					return;
 				}
 
-				buffer += "\x1b[2K";
+				buffer += `\x1b[2K${TUI.SEGMENT_RESET}`;
 				for (let row = 1; row < imageReservedRows; row++) {
-					buffer += "\r\n\x1b[2K";
+					buffer += `\r\n\x1b[2K${TUI.SEGMENT_RESET}`;
 				}
 				buffer += `\x1b[${imageReservedRows - 1}A`;
 				buffer += line;
@@ -1780,7 +1780,7 @@ export class TUI extends Container {
 				continue;
 			}
 
-			buffer += "\x1b[2K"; // Clear current line
+			buffer += `\x1b[2K${TUI.SEGMENT_RESET}`; // Clear current line
 			if (!isImage && visibleWidth(line) > width) {
 				// Log all lines to crash file for debugging
 				const crashLogPath = path.join(os.homedir(), ".senpi", "agent", "senpi-crash.log");
@@ -1825,7 +1825,7 @@ export class TUI extends Container {
 			}
 			const extraLines = this.previousLines.length - newLines.length;
 			for (let i = newLines.length; i < this.previousLines.length; i++) {
-				buffer += "\r\n\x1b[2K";
+				buffer += `\r\n\x1b[2K${TUI.SEGMENT_RESET}`;
 			}
 			// Move cursor back to end of new content
 			buffer += `\x1b[${extraLines}A`;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -224,6 +224,19 @@ function appendRenderErrorLogBestEffort(logPath: string, msg: string): void {
 	}
 }
 
+function writeRenderDiagnosticBestEffort(logPath: string, data: string): boolean {
+	try {
+		fs.mkdirSync(path.dirname(logPath), { recursive: true });
+		fs.writeFileSync(logPath, data);
+		return true;
+	} catch (error) {
+		if (error instanceof Error) {
+			return false;
+		}
+		throw error;
+	}
+}
+
 /**
  * Anchor position for overlays
  */
@@ -2142,8 +2155,7 @@ export class TUI extends Container {
 					"",
 				].join("\n");
 				if (process.env.PI_TUI_STRICT_RENDER === "1") {
-					fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-					fs.writeFileSync(crashLogPath, crashData);
+					const crashDumpWritten = writeRenderDiagnosticBestEffort(crashLogPath, crashData);
 
 					// Clean up terminal state before throwing
 					this.stop();
@@ -2154,14 +2166,15 @@ export class TUI extends Container {
 						"This is likely caused by a custom TUI component not truncating its output.",
 						"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
 						"",
-						`Debug log written to: ${crashLogPath}`,
+						crashDumpWritten
+							? `Debug log written to: ${crashLogPath}`
+							: `Debug log could not be written to: ${crashLogPath}`,
 					].join("\n");
 					throw new Error(errorMsg);
 				}
 
 				if (!this.overWideCrashDumpWritten) {
-					fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-					fs.writeFileSync(crashLogPath, crashData);
+					writeRenderDiagnosticBestEffort(crashLogPath, crashData);
 					this.overWideCrashDumpWritten = true;
 				}
 				const truncatedLine = sliceByColumn(line, 0, width, true) + TUI.SEGMENT_RESET;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1493,7 +1493,7 @@ export class TUI extends Container {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
 			} else {
-				buffer += "\r\x1b[2K";
+				buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -7,7 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.ts";
-import { isMultiplexerSession, useLegacyMuxRender } from "./mux.ts";
+import { isMultiplexerSession, useLegacyMuxRender, viewportRenderEnabled } from "./mux.ts";
 import type { Terminal } from "./terminal.ts";
 import {
 	isOsc11BackgroundColorResponse,
@@ -104,6 +104,23 @@ interface ViewportInsertScrollPlan {
 	insertedRows: string[];
 }
 
+interface ViewportRenderStats {
+	readonly lastNormalizedLines: number;
+	readonly lastKittyImageScannedLines: number;
+	readonly totalNormalizedLines: number;
+	readonly totalKittyImageScannedLines: number;
+	readonly boundedFrames: number;
+	readonly escapedFrames: number;
+	readonly fullFrames: number;
+}
+
+interface NormalizedLinesResult {
+	readonly lines: string[];
+	readonly firstRawChanged: number;
+	readonly compareEndExclusive: number;
+	readonly bounded: boolean;
+}
+
 /**
  * Interface for components that can receive focus and display a hardware cursor.
  * When focused, the component should emit CURSOR_MARKER at the cursor position
@@ -132,12 +149,46 @@ export { visibleWidth };
 
 const renderErrorLoggedClasses = new Set<string>();
 let renderErrorLogWrites = 0;
+const VIEWPORT_RENDER_OVERSCAN = 16;
+const viewportRenderStats = {
+	lastNormalizedLines: 0,
+	lastKittyImageScannedLines: 0,
+	totalNormalizedLines: 0,
+	totalKittyImageScannedLines: 0,
+	boundedFrames: 0,
+	escapedFrames: 0,
+	fullFrames: 0,
+};
 
 export function __renderErrorLogStats(): { writes: number } | undefined {
 	if (process.env.PI_TUI_TEST_SEAMS !== "1") {
 		return undefined;
 	}
 	return { writes: renderErrorLogWrites };
+}
+
+export function __viewportRenderStats(): ViewportRenderStats | undefined {
+	if (process.env.PI_TUI_TEST_SEAMS !== "1") {
+		return undefined;
+	}
+	return { ...viewportRenderStats };
+}
+
+function recordViewportRenderStats(normalizedLines: number, mode: "bounded" | "escaped" | "full"): void {
+	viewportRenderStats.lastNormalizedLines = normalizedLines;
+	viewportRenderStats.totalNormalizedLines += normalizedLines;
+	if (mode === "bounded") {
+		viewportRenderStats.boundedFrames += 1;
+	} else if (mode === "escaped") {
+		viewportRenderStats.escapedFrames += 1;
+	} else {
+		viewportRenderStats.fullFrames += 1;
+	}
+}
+
+function recordKittyImageScanStats(scannedLines: number): void {
+	viewportRenderStats.lastKittyImageScannedLines = scannedLines;
+	viewportRenderStats.totalKittyImageScannedLines += scannedLines;
 }
 
 function componentRenderErrorName(component: Component): string {
@@ -380,6 +431,7 @@ export class Container implements Component {
 export class TUI extends Container {
 	public terminal: Terminal;
 	private previousLines: string[] = [];
+	private previousRawLines: string[] = [];
 	private previousKittyImageIds = new Set<number>();
 	private previousWidth = 0;
 	private previousHeight = 0;
@@ -808,6 +860,7 @@ export class TUI extends Container {
 		this.terminal.stop();
 		this.#lastCursorVisibility = undefined;
 		this.previousLines = [];
+		this.previousRawLines = [];
 		this.previousKittyImageIds.clear();
 		this.previousWidth = 0;
 		this.previousHeight = 0;
@@ -831,6 +884,7 @@ export class TUI extends Container {
 		if (force) {
 			this.inputRenderPending = false;
 			this.previousLines = [];
+			this.previousRawLines = [];
 			this.previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
 			this.previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
 			this.cursorRow = 0;
@@ -1248,18 +1302,96 @@ export class TUI extends Container {
 	private static readonly FRAME_BEGIN = "\x1b[?2026h\x1b[?7l";
 	private static readonly FRAME_END = "\x1b[?7h\x1b[?2026l";
 
-	private applyLineResets(lines: string[]): string[] {
-		const reset = TUI.SEGMENT_RESET;
+	private setPreviousLines(lines: string[], rawLines: string[]): void {
+		this.previousLines = lines;
+		this.previousRawLines = rawLines;
+	}
+
+	private normalizeLine(line: string): { line: string; normalized: boolean } {
+		if (isImageLine(line)) {
+			return { line, normalized: false };
+		}
+		return { line: normalizeTerminalOutput(line) + TUI.SEGMENT_RESET, normalized: true };
+	}
+
+	private applyLineResets(lines: string[], mode: "escaped" | "full" = "full"): NormalizedLinesResult {
+		const normalizedLines: string[] = [];
+		let normalizedCount = 0;
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
-			if (!isImageLine(line)) {
-				lines[i] = normalizeTerminalOutput(line) + reset;
+			if (isImageLine(line)) {
+				normalizedLines.push(line);
+			} else {
+				normalizedLines.push(normalizeTerminalOutput(line) + TUI.SEGMENT_RESET);
+				normalizedCount += 1;
 			}
 		}
-		return lines;
+		recordViewportRenderStats(normalizedCount, mode);
+		return {
+			lines: normalizedLines,
+			firstRawChanged: 0,
+			compareEndExclusive: normalizedLines.length,
+			bounded: false,
+		};
+	}
+
+	private applyViewportLineResets(
+		rawLines: string[],
+		viewportTop: number,
+		height: number,
+		stableDimensions: boolean,
+	): NormalizedLinesResult {
+		if (
+			!viewportRenderEnabled() ||
+			!stableDimensions ||
+			this.previousLines.length === 0 ||
+			this.previousLines.length !== rawLines.length ||
+			this.previousRawLines.length !== rawLines.length
+		) {
+			return this.applyLineResets(rawLines);
+		}
+
+		const windowStart = Math.max(0, viewportTop - VIEWPORT_RENDER_OVERSCAN);
+		const windowEnd = Math.min(rawLines.length, viewportTop + height + VIEWPORT_RENDER_OVERSCAN);
+		let firstRawChanged = -1;
+		for (let i = 0; i < rawLines.length; i++) {
+			if (rawLines[i] === this.previousRawLines[i]) {
+				continue;
+			}
+			if (firstRawChanged === -1) {
+				firstRawChanged = i;
+			}
+			if (i < windowStart || i >= windowEnd) {
+				return this.applyLineResets(rawLines, "escaped");
+			}
+		}
+
+		const lines = this.previousLines.slice();
+		let normalizedCount = 0;
+		if (firstRawChanged !== -1) {
+			for (let i = windowStart; i < windowEnd; i++) {
+				if (rawLines[i] === this.previousRawLines[i]) {
+					continue;
+				}
+				const normalized = this.normalizeLine(rawLines[i] ?? "");
+				lines[i] = normalized.line;
+				if (normalized.normalized) {
+					normalizedCount += 1;
+				}
+			}
+		}
+
+		recordViewportRenderStats(normalizedCount, "bounded");
+		return {
+			lines,
+			firstRawChanged,
+			compareEndExclusive: windowEnd,
+			bounded: true,
+		};
 	}
 
 	private collectKittyImageIds(lines: string[]): Set<number> {
+		recordKittyImageScanStats(lines.length);
 		const ids = new Set<number>();
 		for (const line of lines) {
 			for (const id of extractKittyImageIds(line)) {
@@ -1312,6 +1444,26 @@ export class TUI extends Container {
 		expandForLines(this.previousLines);
 		expandForLines(newLines);
 		return { firstChanged: expandedFirstChanged, lastChanged: expandedLastChanged };
+	}
+
+	private changedRangeNeedsKittyImageExpansion(lines: string[], firstChanged: number, lastChanged: number): boolean {
+		if (this.previousKittyImageIds.size > 0) {
+			return true;
+		}
+
+		const start = Math.max(0, firstChanged);
+		const end = Math.min(lines.length - 1, lastChanged);
+		let scannedLines = 0;
+		for (let i = start; i <= end; i++) {
+			scannedLines += 1;
+			const line = lines[i] ?? "";
+			if (isImageLine(line) || extractKittyImageIds(line).length > 0) {
+				recordKittyImageScanStats(scannedLines);
+				return true;
+			}
+		}
+		recordKittyImageScanStats(scannedLines);
+		return false;
 	}
 
 	private deleteChangedKittyImages(firstChanged: number, lastChanged: number): string {
@@ -1387,6 +1539,7 @@ export class TUI extends Container {
 	private renderViewportInsertScroll(
 		plan: ViewportInsertScrollPlan,
 		newLines: string[],
+		rawLines: string[],
 		cursorPos: { row: number; col: number } | null,
 		width: number,
 		height: number,
@@ -1414,7 +1567,7 @@ export class TUI extends Container {
 		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
 		this.previousViewportTop = plan.viewportTop;
 		this.positionHardwareCursor(cursorPos, newLines.length);
-		this.previousLines = newLines;
+		this.setPreviousLines(newLines, rawLines);
 		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 		this.previousWidth = width;
 		this.previousHeight = height;
@@ -1422,6 +1575,7 @@ export class TUI extends Container {
 
 	private renderScrollbackReplay(
 		newLines: string[],
+		rawLines: string[],
 		cursorPos: { row: number; col: number } | null,
 		width: number,
 		height: number,
@@ -1454,7 +1608,7 @@ export class TUI extends Container {
 		this.maxLinesRendered = newLines.length;
 		this.previousViewportTop = Math.max(0, bufferLength - height);
 		this.positionHardwareCursor(cursorPos, newLines.length);
-		this.previousLines = newLines;
+		this.setPreviousLines(newLines, rawLines);
 		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 		this.previousWidth = width;
 		this.previousHeight = height;
@@ -1462,6 +1616,7 @@ export class TUI extends Container {
 
 	private renderMuxViewportRepaint(
 		newLines: string[],
+		rawLines: string[],
 		cursorPos: { row: number; col: number } | null,
 		width: number,
 		height: number,
@@ -1494,7 +1649,7 @@ export class TUI extends Container {
 		this.maxLinesRendered = newLines.length;
 		this.previousViewportTop = viewportTop;
 		this.positionHardwareCursor(cursorPos, newLines.length);
-		this.previousLines = newLines;
+		this.setPreviousLines(newLines, rawLines);
 		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 		this.previousWidth = width;
 		this.previousHeight = height;
@@ -1607,7 +1762,14 @@ export class TUI extends Container {
 		// Extract cursor position before applying line resets (marker must be found first)
 		const cursorPos = this.extractCursorPosition(newLines, height);
 
-		newLines = this.applyLineResets(newLines);
+		const rawLines = newLines;
+		const normalizedLines = this.applyViewportLineResets(
+			rawLines,
+			prevViewportTop,
+			height,
+			!widthChanged && !heightChanged,
+		);
+		newLines = normalizedLines.lines;
 		const preserveMuxScrollback = this.shouldPreserveMuxScrollback();
 
 		// Helper to clear scrollback and viewport and render all new lines
@@ -1653,7 +1815,7 @@ export class TUI extends Container {
 			const bufferLength = Math.max(height, newLines.length);
 			this.previousViewportTop = Math.max(0, bufferLength - height);
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousLines = newLines;
+			this.setPreviousLines(newLines, rawLines);
 			this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
@@ -1688,7 +1850,7 @@ export class TUI extends Container {
 		if (heightChanged && !isTermuxSession()) {
 			logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
 			if (preserveMuxScrollback) {
-				if (!this.renderMuxViewportRepaint(newLines, cursorPos, width, height)) {
+				if (!this.renderMuxViewportRepaint(newLines, rawLines, cursorPos, width, height)) {
 					fullRender(true, false);
 				}
 			} else {
@@ -1710,7 +1872,10 @@ export class TUI extends Container {
 		let firstChanged = -1;
 		let lastChanged = -1;
 		const maxLines = Math.max(newLines.length, this.previousLines.length);
-		for (let i = 0; i < maxLines; i++) {
+		const diffScanStart =
+			normalizedLines.bounded && normalizedLines.firstRawChanged !== -1 ? normalizedLines.firstRawChanged : 0;
+		const diffScanEndExclusive = normalizedLines.bounded ? normalizedLines.compareEndExclusive : maxLines;
+		for (let i = diffScanStart; i < diffScanEndExclusive; i++) {
 			const oldLine = i < this.previousLines.length ? this.previousLines[i] : "";
 			const newLine = i < newLines.length ? newLines[i] : "";
 
@@ -1729,7 +1894,9 @@ export class TUI extends Container {
 			}
 			lastChanged = newLines.length - 1;
 		}
-		if (firstChanged !== -1) {
+		const needsKittyImageExpansion =
+			firstChanged !== -1 && this.changedRangeNeedsKittyImageExpansion(newLines, firstChanged, lastChanged);
+		if (needsKittyImageExpansion) {
 			const expandedRange = this.expandChangedRangeForKittyImages(firstChanged, lastChanged, newLines);
 			firstChanged = expandedRange.firstChanged;
 			lastChanged = expandedRange.lastChanged;
@@ -1746,7 +1913,7 @@ export class TUI extends Container {
 		}
 
 		if (insertScrollPlan) {
-			this.renderViewportInsertScroll(insertScrollPlan, newLines, cursorPos, width, height);
+			this.renderViewportInsertScroll(insertScrollPlan, newLines, rawLines, cursorPos, width, height);
 			return;
 		}
 
@@ -1791,7 +1958,7 @@ export class TUI extends Container {
 				this.hardwareCursorRow = targetRow;
 			}
 			this.positionHardwareCursor(cursorPos, newLines.length);
-			this.previousLines = newLines;
+			this.setPreviousLines(newLines, rawLines);
 			this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
@@ -1827,18 +1994,26 @@ export class TUI extends Container {
 				if (lineCountDelta !== 0) {
 					if (preserveMuxScrollback) {
 						// Above-viewport scrollback may stay stale in mux panes; only the visible viewport is repainted.
-						if (!this.renderMuxViewportRepaint(newLines, cursorPos, width, height, viewportTop)) {
+						if (!this.renderMuxViewportRepaint(newLines, rawLines, cursorPos, width, height, viewportTop)) {
 							fullRender(true, false);
 						}
 					} else {
-						this.renderScrollbackReplay(newLines, cursorPos, width, height, prevViewportTop, hardwareCursorRow);
+						this.renderScrollbackReplay(
+							newLines,
+							rawLines,
+							cursorPos,
+							width,
+							height,
+							prevViewportTop,
+							hardwareCursorRow,
+						);
 					}
 					return;
 				}
 
 				this.cursorRow = Math.max(0, newLines.length - 1);
 				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
-				this.previousLines = newLines;
+				this.setPreviousLines(newLines, rawLines);
 				this.previousWidth = width;
 				this.previousHeight = height;
 				this.previousViewportTop = viewportTop;
@@ -1869,7 +2044,7 @@ export class TUI extends Container {
 				this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
 				this.previousViewportTop = viewportTop;
 				this.positionHardwareCursor(cursorPos, newLines.length);
-				this.previousLines = newLines;
+				this.setPreviousLines(newLines, rawLines);
 				this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 				this.previousWidth = width;
 				this.previousHeight = height;
@@ -2048,8 +2223,10 @@ export class TUI extends Container {
 		// Position hardware cursor for IME
 		this.positionHardwareCursor(cursorPos, newLines.length);
 
-		this.previousLines = newLines;
-		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+		this.setPreviousLines(newLines, rawLines);
+		if (needsKittyImageExpansion) {
+			this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+		}
 		this.previousWidth = width;
 		this.previousHeight = height;
 	}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -150,6 +150,7 @@ export { visibleWidth };
 
 const renderErrorLoggedClasses = new Set<string>();
 let renderErrorLogWrites = 0;
+const DIAGNOSTIC_LOG_MODE = 0o600;
 const VIEWPORT_RENDER_OVERSCAN = 16;
 // Keep scroll-region wins cheap when a few visible rows mutate during append streaming.
 const MAX_SCROLL_DIFF_ROWS = 4;
@@ -215,7 +216,8 @@ function logRenderErrorOnce(component: Component, error: unknown): void {
 function appendRenderErrorLogBestEffort(logPath: string, msg: string): void {
 	try {
 		fs.mkdirSync(path.dirname(logPath), { recursive: true });
-		fs.appendFileSync(logPath, msg, { encoding: "utf8", mode: 0o600 });
+		fs.appendFileSync(logPath, msg, { encoding: "utf8", mode: DIAGNOSTIC_LOG_MODE });
+		chmodDiagnosticLogBestEffort(logPath);
 	} catch (error) {
 		if (error instanceof Error) {
 			return;
@@ -227,11 +229,23 @@ function appendRenderErrorLogBestEffort(logPath: string, msg: string): void {
 function writeRenderDiagnosticBestEffort(logPath: string, data: string): boolean {
 	try {
 		fs.mkdirSync(path.dirname(logPath), { recursive: true });
-		fs.writeFileSync(logPath, data, { encoding: "utf8", mode: 0o600 });
+		fs.writeFileSync(logPath, data, { encoding: "utf8", mode: DIAGNOSTIC_LOG_MODE });
+		chmodDiagnosticLogBestEffort(logPath);
 		return true;
 	} catch (error) {
 		if (error instanceof Error) {
 			return false;
+		}
+		throw error;
+	}
+}
+
+function chmodDiagnosticLogBestEffort(logPath: string): void {
+	try {
+		fs.chmodSync(logPath, DIAGNOSTIC_LOG_MODE);
+	} catch (error) {
+		if (error instanceof Error) {
+			return;
 		}
 		throw error;
 	}
@@ -1853,7 +1867,8 @@ export class TUI extends Container {
 			if (!debugRedraw) return;
 			const logPath = path.join(os.homedir(), ".senpi", "agent", "senpi-debug.log");
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.previousLines.length}, new=${newLines.length}, height=${height})\n`;
-			fs.appendFileSync(logPath, msg, { encoding: "utf8", mode: 0o600 });
+			fs.appendFileSync(logPath, msg, { encoding: "utf8", mode: DIAGNOSTIC_LOG_MODE });
+			chmodDiagnosticLogBestEffort(logPath);
 		};
 
 		// First render - just output everything without clearing (assumes clean screen)
@@ -2232,7 +2247,8 @@ export class TUI extends Container {
 				"=== buffer ===",
 				JSON.stringify(buffer),
 			].join("\n");
-			fs.writeFileSync(debugPath, debugData, { encoding: "utf8", mode: 0o600 });
+			fs.writeFileSync(debugPath, debugData, { encoding: "utf8", mode: DIAGNOSTIC_LOG_MODE });
+			chmodDiagnosticLogBestEffort(debugPath);
 		}
 
 		// Write entire buffer at once

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -215,7 +215,7 @@ function logRenderErrorOnce(component: Component, error: unknown): void {
 function appendRenderErrorLogBestEffort(logPath: string, msg: string): void {
 	try {
 		fs.mkdirSync(path.dirname(logPath), { recursive: true });
-		fs.appendFileSync(logPath, msg);
+		fs.appendFileSync(logPath, msg, { encoding: "utf8", mode: 0o600 });
 	} catch (error) {
 		if (error instanceof Error) {
 			return;
@@ -227,7 +227,7 @@ function appendRenderErrorLogBestEffort(logPath: string, msg: string): void {
 function writeRenderDiagnosticBestEffort(logPath: string, data: string): boolean {
 	try {
 		fs.mkdirSync(path.dirname(logPath), { recursive: true });
-		fs.writeFileSync(logPath, data);
+		fs.writeFileSync(logPath, data, { encoding: "utf8", mode: 0o600 });
 		return true;
 	} catch (error) {
 		if (error instanceof Error) {
@@ -1853,7 +1853,7 @@ export class TUI extends Container {
 			if (!debugRedraw) return;
 			const logPath = path.join(os.homedir(), ".senpi", "agent", "senpi-debug.log");
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.previousLines.length}, new=${newLines.length}, height=${height})\n`;
-			fs.appendFileSync(logPath, msg);
+			fs.appendFileSync(logPath, msg, { encoding: "utf8", mode: 0o600 });
 		};
 
 		// First render - just output everything without clearing (assumes clean screen)
@@ -2232,7 +2232,7 @@ export class TUI extends Container {
 				"=== buffer ===",
 				JSON.stringify(buffer),
 			].join("\n");
-			fs.writeFileSync(debugPath, debugData);
+			fs.writeFileSync(debugPath, debugData, { encoding: "utf8", mode: 0o600 });
 		}
 
 		// Write entire buffer at once

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -130,6 +130,46 @@ export const CURSOR_MARKER = "\x1b_pi:c\x07";
 
 export { visibleWidth };
 
+const renderErrorLoggedClasses = new Set<string>();
+let renderErrorLogWrites = 0;
+
+export function __renderErrorLogStats(): { writes: number } | undefined {
+	if (process.env.PI_TUI_TEST_SEAMS !== "1") {
+		return undefined;
+	}
+	return { writes: renderErrorLogWrites };
+}
+
+function componentRenderErrorName(component: Component): string {
+	return component.constructor.name || "AnonymousComponent";
+}
+
+function logRenderErrorOnce(component: Component, error: unknown): void {
+	const componentName = componentRenderErrorName(component);
+	if (renderErrorLoggedClasses.has(componentName)) {
+		return;
+	}
+	renderErrorLoggedClasses.add(componentName);
+	renderErrorLogWrites += 1;
+
+	const errorText = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+	const logPath = path.join(os.homedir(), ".senpi", "agent", "senpi-debug.log");
+	const msg = `[${new Date().toISOString()}] render error: ${componentName}: ${errorText}\n`;
+	appendRenderErrorLogBestEffort(logPath, msg);
+}
+
+function appendRenderErrorLogBestEffort(logPath: string, msg: string): void {
+	try {
+		fs.mkdirSync(path.dirname(logPath), { recursive: true });
+		fs.appendFileSync(logPath, msg);
+	} catch (error) {
+		if (error instanceof Error) {
+			return;
+		}
+		throw error;
+	}
+}
+
 /**
  * Anchor position for overlays
  */
@@ -317,7 +357,15 @@ export class Container implements Component {
 	render(width: number): string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
-			const childLines = child.render(width);
+			let childLines: string[];
+			try {
+				childLines = child.render(width);
+			} catch (error) {
+				logRenderErrorOnce(child, error);
+				const componentName = componentRenderErrorName(child);
+				// Focus ownership stays unchanged; render containment must not steal or clear focus implicitly.
+				childLines = [`[render error: ${componentName}]`];
+			}
 			for (const line of childLines) {
 				lines.push(line);
 			}
@@ -353,6 +401,7 @@ export class TUI extends Container {
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
 	private muxViewportRepaintCount = 0;
+	private overWideCrashDumpWritten = false;
 	private stopped = false;
 	private pendingOsc11BackgroundReplies = 0;
 	private pendingOsc11BackgroundQueries: PendingOsc11BackgroundQuery[] = [];
@@ -1890,33 +1939,46 @@ export class TUI extends Container {
 			}
 
 			buffer += `\x1b[2K${TUI.SEGMENT_RESET}`; // Clear current line
-			if (!isImage && visibleWidth(line) > width) {
+			const lineWidth = visibleWidth(line);
+			if (!isImage && lineWidth > width) {
 				// Log all lines to crash file for debugging
 				const crashLogPath = path.join(os.homedir(), ".senpi", "agent", "senpi-crash.log");
 				const crashData = [
 					`Crash at ${new Date().toISOString()}`,
 					`Terminal width: ${width}`,
-					`Line ${i} visible width: ${visibleWidth(line)}`,
+					`Line ${i} visible width: ${lineWidth}`,
 					"",
 					"=== All rendered lines ===",
 					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
 					"",
 				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
+				if (process.env.PI_TUI_STRICT_RENDER === "1") {
+					fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
+					fs.writeFileSync(crashLogPath, crashData);
 
-				// Clean up terminal state before throwing
-				this.stop();
+					// Clean up terminal state before throwing
+					this.stop();
 
-				const errorMsg = [
-					`Rendered line ${i} exceeds terminal width (${visibleWidth(line)} > ${width}).`,
-					"",
-					"This is likely caused by a custom TUI component not truncating its output.",
-					"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
-					"",
-					`Debug log written to: ${crashLogPath}`,
-				].join("\n");
-				throw new Error(errorMsg);
+					const errorMsg = [
+						`Rendered line ${i} exceeds terminal width (${lineWidth} > ${width}).`,
+						"",
+						"This is likely caused by a custom TUI component not truncating its output.",
+						"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
+						"",
+						`Debug log written to: ${crashLogPath}`,
+					].join("\n");
+					throw new Error(errorMsg);
+				}
+
+				if (!this.overWideCrashDumpWritten) {
+					fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
+					fs.writeFileSync(crashLogPath, crashData);
+					this.overWideCrashDumpWritten = true;
+				}
+				const truncatedLine = sliceByColumn(line, 0, width, true) + TUI.SEGMENT_RESET;
+				newLines[i] = truncatedLine;
+				buffer += truncatedLine;
+				continue;
 			}
 			buffer += line;
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -7,6 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.ts";
+import { isMultiplexerSession, useLegacyMuxRender } from "./mux.ts";
 import type { Terminal } from "./terminal.ts";
 import {
 	isOsc11BackgroundColorResponse,
@@ -257,6 +258,10 @@ type BlockedOverlayFocusRestoreState = {
 type ActiveOverlayFocusRestoreState = EligibleOverlayFocusRestoreState | BlockedOverlayFocusRestoreState;
 type OverlayFocusRestoreState = { status: "inactive" } | ActiveOverlayFocusRestoreState;
 type OverlayFocusRestorePolicy = "clear" | "preserve";
+type TuiConstructorOptions = {
+	showHardwareCursor?: boolean;
+	muxDetector?: () => boolean;
+};
 
 /**
  * Container - a component that contains other components
@@ -347,6 +352,7 @@ export class TUI extends Container {
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
+	private muxViewportRepaintCount = 0;
 	private stopped = false;
 	private pendingOsc11BackgroundReplies = 0;
 	private pendingOsc11BackgroundQueries: PendingOsc11BackgroundQuery[] = [];
@@ -358,17 +364,25 @@ export class TUI extends Container {
 	private focusOrderCounter = 0;
 	private overlayStack: OverlayStackEntry[] = [];
 	private overlayFocusRestore: OverlayFocusRestoreState = { status: "inactive" };
+	#muxDetector: () => boolean;
 
-	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
+	constructor(terminal: Terminal, options?: boolean | TuiConstructorOptions) {
 		super();
 		this.terminal = terminal;
-		if (showHardwareCursor !== undefined) {
-			this.showHardwareCursor = showHardwareCursor;
+		// Preserve existing positional boolean callers while allowing explicit render-policy overrides.
+		const normalizedOptions = typeof options === "boolean" ? { showHardwareCursor: options } : (options ?? {});
+		this.#muxDetector = normalizedOptions.muxDetector ?? isMultiplexerSession;
+		if (normalizedOptions.showHardwareCursor !== undefined) {
+			this.showHardwareCursor = normalizedOptions.showHardwareCursor;
 		}
 	}
 
 	get fullRedraws(): number {
 		return this.fullRedrawCount;
+	}
+
+	get muxViewportRepaints(): number {
+		return this.muxViewportRepaintCount;
 	}
 
 	getShowHardwareCursor(): boolean {
@@ -1269,6 +1283,10 @@ export class TUI extends Container {
 		return Array.from({ length: height }, (_, row) => lines[viewportTop + row] ?? "");
 	}
 
+	private shouldPreserveMuxScrollback(): boolean {
+		return this.#muxDetector() && !useLegacyMuxRender();
+	}
+
 	private createViewportInsertScrollPlan(
 		newLines: string[],
 		prevViewportTop: number,
@@ -1363,7 +1381,9 @@ export class TUI extends Container {
 	): void {
 		let buffer = TUI.FRAME_BEGIN;
 		buffer += this.deleteKittyImages(this.previousKittyImageIds);
-		buffer += "\x1b[3J";
+		if (!this.shouldPreserveMuxScrollback()) {
+			buffer += "\x1b[3J";
+		}
 
 		const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
 		if (currentScreenRow > 0) {
@@ -1389,6 +1409,47 @@ export class TUI extends Container {
 		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 		this.previousWidth = width;
 		this.previousHeight = height;
+	}
+
+	private renderMuxViewportRepaint(
+		newLines: string[],
+		cursorPos: { row: number; col: number } | null,
+		width: number,
+		height: number,
+		viewportTop = Math.max(0, newLines.length - height),
+	): boolean {
+		const previousVisible = this.getViewportRows(this.previousLines, this.previousViewportTop, height);
+		const nextVisible = this.getViewportRows(newLines, viewportTop, height);
+		if (previousVisible.some(isImageLine) || nextVisible.some(isImageLine)) {
+			return false;
+		}
+
+		let buffer = TUI.FRAME_BEGIN;
+		const currentScreenRow = Math.max(0, Math.min(height - 1, this.hardwareCursorRow - this.previousViewportTop));
+		if (currentScreenRow > 0) {
+			buffer += `\x1b[${currentScreenRow}A`;
+		}
+
+		for (let row = 0; row < height; row++) {
+			if (row > 0) buffer += "\r\n";
+			buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
+			buffer += newLines[viewportTop + row] ?? "";
+		}
+
+		buffer += TUI.FRAME_END;
+		this.terminal.write(buffer);
+
+		this.muxViewportRepaintCount += 1;
+		this.cursorRow = Math.max(0, newLines.length - 1);
+		this.hardwareCursorRow = viewportTop + Math.max(0, height - 1);
+		this.maxLinesRendered = newLines.length;
+		this.previousViewportTop = viewportTop;
+		this.positionHardwareCursor(cursorPos, newLines.length);
+		this.previousLines = newLines;
+		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+		this.previousWidth = width;
+		this.previousHeight = height;
+		return true;
 	}
 
 	/** Splice overlay content into a base line at a specific column. Single-pass optimized. */
@@ -1498,14 +1559,18 @@ export class TUI extends Container {
 		const cursorPos = this.extractCursorPosition(newLines, height);
 
 		newLines = this.applyLineResets(newLines);
+		const preserveMuxScrollback = this.shouldPreserveMuxScrollback();
 
 		// Helper to clear scrollback and viewport and render all new lines
-		const fullRender = (clear: boolean): void => {
+		const fullRender = (clear: boolean, clearScrollback = clear): void => {
 			this.fullRedrawCount += 1;
 			let buffer = TUI.FRAME_BEGIN;
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
-				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+				buffer += "\x1b[2J\x1b[H";
+				if (clearScrollback && !preserveMuxScrollback) {
+					buffer += "\x1b[3J";
+				}
 			} else {
 				buffer += `\r\x1b[2K${TUI.SEGMENT_RESET}`;
 			}
@@ -1563,7 +1628,8 @@ export class TUI extends Container {
 		// Width changes always need a full re-render because wrapping changes.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.previousWidth} -> ${width})`);
-			fullRender(true);
+			// In multiplexers, re-emit the viewport without 3J so pane history survives; an older copy may remain above.
+			fullRender(true, !preserveMuxScrollback);
 			return;
 		}
 
@@ -1572,7 +1638,13 @@ export class TUI extends Container {
 		// In that environment, a full redraw causes the entire history to replay on every toggle.
 		if (heightChanged && !isTermuxSession()) {
 			logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
-			fullRender(true);
+			if (preserveMuxScrollback) {
+				if (!this.renderMuxViewportRepaint(newLines, cursorPos, width, height)) {
+					fullRender(true, false);
+				}
+			} else {
+				fullRender(true);
+			}
 			return;
 		}
 
@@ -1581,7 +1653,7 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.clearOnShrink && newLines.length < this.maxLinesRendered && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (maxLinesRendered=${this.maxLinesRendered})`);
-			fullRender(true);
+			fullRender(true, !preserveMuxScrollback);
 			return;
 		}
 
@@ -1638,7 +1710,7 @@ export class TUI extends Container {
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
 					logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
-					fullRender(true);
+					fullRender(true, !preserveMuxScrollback);
 					return;
 				}
 				const lineDiff = computeLineDiff(targetRow);
@@ -1649,7 +1721,7 @@ export class TUI extends Container {
 				const extraLines = this.previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					fullRender(true, !preserveMuxScrollback);
 					return;
 				}
 				const clearStartOffset = newLines.length === 0 ? 0 : 1;
@@ -1704,7 +1776,14 @@ export class TUI extends Container {
 
 			if (firstVisibleChanged === -1) {
 				if (lineCountDelta !== 0) {
-					this.renderScrollbackReplay(newLines, cursorPos, width, height, prevViewportTop, hardwareCursorRow);
+					if (preserveMuxScrollback) {
+						// Above-viewport scrollback may stay stale in mux panes; only the visible viewport is repainted.
+						if (!this.renderMuxViewportRepaint(newLines, cursorPos, width, height, viewportTop)) {
+							fullRender(true, false);
+						}
+					} else {
+						this.renderScrollbackReplay(newLines, cursorPos, width, height, prevViewportTop, hardwareCursorRow);
+					}
 					return;
 				}
 
@@ -1795,7 +1874,7 @@ export class TUI extends Container {
 					logRedraw(
 						`kitty image pre-clear would scroll (${imageStartScreenRow} + ${imageReservedRows} > ${height})`,
 					);
-					fullRender(true);
+					fullRender(true, !preserveMuxScrollback);
 					return;
 				}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -102,6 +102,7 @@ interface ViewportInsertScrollPlan {
 	viewportTop: number;
 	regionBottom: number;
 	insertedRows: string[];
+	mutatedRows: Array<{ screenRow: number; content: string }>;
 }
 
 interface ViewportRenderStats {
@@ -150,6 +151,8 @@ export { visibleWidth };
 const renderErrorLoggedClasses = new Set<string>();
 let renderErrorLogWrites = 0;
 const VIEWPORT_RENDER_OVERSCAN = 16;
+// Keep scroll-region wins cheap when a few visible rows mutate during append streaming.
+const MAX_SCROLL_DIFF_ROWS = 4;
 const viewportRenderStats = {
 	lastNormalizedLines: 0,
 	lastKittyImageScannedLines: 0,
@@ -1523,9 +1526,13 @@ export class TUI extends Container {
 			return undefined;
 		}
 
+		const mutatedRows: Array<{ screenRow: number; content: string }> = [];
 		for (let row = 0; row < regionHeight - lineCountDelta; row++) {
 			if (previousVisible[row + lineCountDelta] !== nextVisible[row]) {
-				return undefined;
+				mutatedRows.push({ screenRow: row, content: nextVisible[row] });
+				if (mutatedRows.length > MAX_SCROLL_DIFF_ROWS) {
+					return undefined;
+				}
 			}
 		}
 
@@ -1533,6 +1540,7 @@ export class TUI extends Container {
 			viewportTop,
 			regionBottom: regionHeight - 1,
 			insertedRows: nextVisible.slice(regionHeight - lineCountDelta, regionHeight),
+			mutatedRows,
 		};
 	}
 
@@ -1553,17 +1561,23 @@ export class TUI extends Container {
 		buffer += "\x1b[r";
 
 		const firstInsertedScreenRow = regionBottom - plan.insertedRows.length + 1;
+		let finalPaintedScreenRow = firstInsertedScreenRow + plan.insertedRows.length - 1;
 		for (let index = 0; index < plan.insertedRows.length; index++) {
 			const screenRow = firstInsertedScreenRow + index;
 			buffer += `\x1b[${screenRow + 1};1H\x1b[2K${TUI.SEGMENT_RESET}`;
 			buffer += plan.insertedRows[index] ?? "";
+		}
+		for (const row of plan.mutatedRows) {
+			buffer += `\x1b[${row.screenRow + 1};1H\x1b[2K${TUI.SEGMENT_RESET}`;
+			buffer += row.content;
+			finalPaintedScreenRow = row.screenRow;
 		}
 
 		buffer += TUI.FRAME_END;
 		this.terminal.write(buffer);
 
 		this.cursorRow = Math.max(0, newLines.length - 1);
-		this.hardwareCursorRow = plan.viewportTop + firstInsertedScreenRow + plan.insertedRows.length - 1;
+		this.hardwareCursorRow = plan.viewportTop + finalPaintedScreenRow;
 		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
 		this.previousViewportTop = plan.viewportTop;
 		this.positionHardwareCursor(cursorPos, newLines.length);

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -41,9 +41,44 @@ const zeroWidthRegex = /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark
 const leadingNonPrintingRegex = /^[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]+/v;
 const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
 
-// Cache for non-ASCII strings
-const WIDTH_CACHE_SIZE = 512;
-const widthCache = new Map<string, number>();
+const WIDTH_CACHE_GENERATION_SIZE = 2048;
+let widthCacheCurrent = new Map<string, number>();
+let widthCachePrevious = new Map<string, number>();
+let widthCacheHits = 0;
+let widthCacheMisses = 0;
+
+interface WidthCacheStats {
+	readonly hits: number;
+	readonly misses: number;
+	readonly currentSize: number;
+	readonly previousSize: number;
+	readonly totalRetained: number;
+}
+
+function rotateWidthCacheIfNeeded(): void {
+	if (widthCacheCurrent.size >= WIDTH_CACHE_GENERATION_SIZE) {
+		widthCachePrevious = widthCacheCurrent;
+		widthCacheCurrent = new Map<string, number>();
+	}
+}
+
+function setWidthCache(str: string, width: number): void {
+	widthCacheCurrent.set(str, width);
+	rotateWidthCacheIfNeeded();
+}
+
+export function __widthCacheStats(): WidthCacheStats | undefined {
+	if (process.env.PI_TUI_TEST_SEAMS !== "1") {
+		return undefined;
+	}
+	return {
+		hits: widthCacheHits,
+		misses: widthCacheMisses,
+		currentSize: widthCacheCurrent.size,
+		previousSize: widthCachePrevious.size,
+		totalRetained: widthCacheCurrent.size + widthCachePrevious.size,
+	};
+}
 
 export const cjkBreakRegex =
 	/[\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\p{Script_Extensions=Katakana}\p{Script_Extensions=Hangul}\p{Script_Extensions=Bopomofo}]/u;
@@ -224,10 +259,18 @@ export function visibleWidth(str: string): number {
 	}
 
 	// Check cache
-	const cached = widthCache.get(str);
-	if (cached !== undefined) {
-		return cached;
+	const cachedCurrent = widthCacheCurrent.get(str);
+	if (cachedCurrent !== undefined) {
+		widthCacheHits++;
+		return cachedCurrent;
 	}
+	const cachedPrevious = widthCachePrevious.get(str);
+	if (cachedPrevious !== undefined) {
+		widthCacheHits++;
+		setWidthCache(str, cachedPrevious);
+		return cachedPrevious;
+	}
+	widthCacheMisses++;
 
 	// Normalize: tabs to 3 spaces, strip ANSI escape codes
 	let clean = str;
@@ -259,13 +302,7 @@ export function visibleWidth(str: string): number {
 	}
 
 	// Cache result
-	if (widthCache.size >= WIDTH_CACHE_SIZE) {
-		const firstKey = widthCache.keys().next().value;
-		if (firstKey !== undefined) {
-			widthCache.delete(firstKey);
-		}
-	}
-	widthCache.set(str, width);
+	setWidthCache(str, width);
 
 	return width;
 }

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -315,10 +315,26 @@ export function visibleWidth(str: string): number {
  */
 const THAI_LAO_AM_REGEX = /[\u0e33\u0eb3]/;
 const THAI_LAO_AM_GLOBAL_REGEX = /[\u0e33\u0eb3]/g;
+const ADJACENT_SGR_RUN_REGEX = /(?:\x1b\[[0-9;]*m){2,}/g;
+const SGR_IN_RUN_REGEX = /\x1b\[([0-9;]*)m/g;
 
 export function normalizeTerminalOutput(str: string): string {
 	if (!THAI_LAO_AM_REGEX.test(str)) return str;
 	return str.replace(THAI_LAO_AM_GLOBAL_REGEX, (char) => (char === "\u0e33" ? "\u0e4d\u0e32" : "\u0ecd\u0eb2"));
+}
+
+export function coalesceAdjacentSgr(line: string): string {
+	if (!line.includes("\x1b[")) {
+		return line;
+	}
+
+	return line.replace(ADJACENT_SGR_RUN_REGEX, (run) => {
+		const params: string[] = [];
+		for (const match of run.matchAll(SGR_IN_RUN_REGEX)) {
+			params.push(match[1] === "" ? "0" : (match[1] ?? "0"));
+		}
+		return `\x1b[${params.join(";")}m`;
+	});
 }
 
 /**

--- a/packages/tui/test/cursor-write-hygiene.test.ts
+++ b/packages/tui/test/cursor-write-hygiene.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { setCapabilities } from "../src/terminal-image.ts";
+import { type Component, CURSOR_MARKER, type Focusable, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+const FRAME_BEGIN = "\x1b[?2026h";
+const FRAME_END = "\x1b[?2026l";
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
+
+interface OutputChunk {
+	readonly kind: "write" | "hideCursor" | "showCursor";
+	readonly data: string;
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private readonly chunks: OutputChunk[] = [];
+
+	override write(data: string): void {
+		this.chunks.push({ kind: "write", data });
+		super.write(data);
+	}
+
+	override hideCursor(): void {
+		this.chunks.push({ kind: "hideCursor", data: HIDE_CURSOR });
+		super.hideCursor();
+	}
+
+	override showCursor(): void {
+		this.chunks.push({ kind: "showCursor", data: SHOW_CURSOR });
+		super.showCursor();
+	}
+
+	getChunks(): readonly OutputChunk[] {
+		return this.chunks;
+	}
+}
+
+class CursorComponent implements Component, Focusable {
+	focused = false;
+	private frame = 0;
+
+	nextFrame(): void {
+		this.frame += 1;
+	}
+
+	render(_width: number): string[] {
+		const marker = this.focused ? CURSOR_MARKER : "";
+		return [`frame ${this.frame} ${marker}`];
+	}
+
+	invalidate(): void {}
+}
+
+function countOccurrences(text: string, needle: string): number {
+	return text.split(needle).length - 1;
+}
+
+async function renderNextFrame(tui: TUI, terminal: VirtualTerminal, component: CursorComponent): Promise<void> {
+	component.nextFrame();
+	tui.requestRender();
+	await terminal.waitForRender();
+}
+
+function outputText(chunks: readonly OutputChunk[]): string {
+	return chunks.map((chunk) => chunk.data).join("");
+}
+
+function postFrameChunks(chunks: readonly OutputChunk[]): OutputChunk[][] {
+	const result: OutputChunk[][] = [];
+	let active: OutputChunk[] | undefined;
+
+	for (const chunk of chunks) {
+		if (chunk.data.includes(FRAME_BEGIN)) {
+			active = undefined;
+		}
+		if (active) {
+			result[result.length - 1]?.push(chunk);
+		}
+		if (chunk.data.includes(FRAME_END)) {
+			active = [];
+			result.push(active);
+		}
+	}
+
+	return result;
+}
+
+async function startHiddenCursorTui(): Promise<{
+	readonly terminal: LoggingVirtualTerminal;
+	readonly tui: TUI;
+	readonly component: CursorComponent;
+}> {
+	setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+	const terminal = new LoggingVirtualTerminal(40, 6);
+	const tui = new TUI(terminal, false);
+	const component = new CursorComponent();
+	tui.addChild(component);
+	tui.setFocus(component);
+	tui.start();
+	await terminal.waitForRender();
+	return { terminal, tui, component };
+}
+
+describe("cursor write hygiene", () => {
+	it("omits repeated hidden cursor bytes after the first hidden frame", async () => {
+		const { terminal, tui, component } = await startHiddenCursorTui();
+
+		// given
+		await renderNextFrame(tui, terminal, component);
+		const hideBytesAfterFrameOne = countOccurrences(outputText(terminal.getChunks()), HIDE_CURSOR);
+
+		// when
+		await renderNextFrame(tui, terminal, component);
+		await renderNextFrame(tui, terminal, component);
+
+		// then
+		const hideBytesAfterSteadyFrames = countOccurrences(outputText(terminal.getChunks()), HIDE_CURSOR);
+		assert.strictEqual(hideBytesAfterSteadyFrames, hideBytesAfterFrameOne);
+
+		tui.stop();
+	});
+
+	it("emits exactly one post-frame write after each synchronized frame", async () => {
+		const { terminal, tui, component } = await startHiddenCursorTui();
+
+		// given
+		await renderNextFrame(tui, terminal, component);
+
+		// when
+		await renderNextFrame(tui, terminal, component);
+
+		// then
+		for (const chunks of postFrameChunks(terminal.getChunks())) {
+			assert.strictEqual(chunks.length, 1);
+			assert.strictEqual(chunks[0]?.kind, "write");
+		}
+
+		tui.stop();
+	});
+
+	it("emits show cursor bytes exactly once when hardware cursor visibility is enabled", async () => {
+		const { terminal, tui, component } = await startHiddenCursorTui();
+
+		// given
+		await renderNextFrame(tui, terminal, component);
+
+		// when
+		tui.setShowHardwareCursor(true);
+		await terminal.waitForRender();
+		await renderNextFrame(tui, terminal, component);
+
+		// then
+		assert.strictEqual(countOccurrences(outputText(terminal.getChunks()), SHOW_CURSOR), 1);
+
+		tui.stop();
+	});
+
+	it("reasserts hidden cursor visibility on the first frame after restart", async () => {
+		const { terminal, tui, component } = await startHiddenCursorTui();
+
+		// given
+		await renderNextFrame(tui, terminal, component);
+		tui.stop();
+		const hideBytesBeforeRestart = countOccurrences(outputText(terminal.getChunks()), HIDE_CURSOR);
+
+		// when
+		tui.start();
+		await terminal.waitForRender();
+
+		// then
+		const hideBytesAfterRestart = countOccurrences(outputText(terminal.getChunks()), HIDE_CURSOR);
+		assert.strictEqual(hideBytesAfterRestart, hideBytesBeforeRestart + 1);
+
+		tui.stop();
+	});
+});

--- a/packages/tui/test/frame-cost-harness.test.ts
+++ b/packages/tui/test/frame-cost-harness.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { runFrameCost } from "../bench/frame-cost.ts";
+
+function assertFrameCostShape(result: Awaited<ReturnType<typeof runFrameCost>>, expectedN: number): void {
+	assert.strictEqual(result.n, expectedN);
+	assert.strictEqual(result.frames, 300);
+	assert.strictEqual(result.renderCalls, result.frames);
+	assert.strictEqual(typeof result.p50Ms, "number");
+	assert.strictEqual(typeof result.p95Ms, "number");
+	assert.strictEqual(typeof result.bytesPerFrameP50, "number");
+	assert.strictEqual(typeof result.initialBytes, "number");
+}
+
+describe("frame-cost bench harness", () => {
+	it("returns measured frame-cost JSON when transcript has content", async () => {
+		// given
+		const n = 200;
+
+		// when
+		const result = await runFrameCost(n);
+
+		// then
+		assertFrameCostShape(result, n);
+		assert.ok(result.p50Ms > 0, `Expected positive p50Ms, got ${result.p50Ms}`);
+		assert.ok(result.bytesPerFrameP50 > 0, `Expected positive bytesPerFrameP50, got ${result.bytesPerFrameP50}`);
+	});
+
+	it("resolves without throwing when transcript is empty", async () => {
+		// given
+		const n = 0;
+
+		// when
+		const result = await runFrameCost(n);
+
+		// then
+		assertFrameCostShape(result, n);
+	});
+});

--- a/packages/tui/test/frame-cost-harness.test.ts
+++ b/packages/tui/test/frame-cost-harness.test.ts
@@ -36,4 +36,16 @@ describe("frame-cost bench harness", () => {
 		// then
 		assertFrameCostShape(result, n);
 	});
+
+	it("keeps transcript rendering outside measured frames in stable-components mode", async () => {
+		// given
+		const n = 200;
+
+		// when
+		const result = await runFrameCost(n, { stableComponents: true });
+
+		// then
+		assertFrameCostShape(result, n);
+		assert.strictEqual(result.transcriptRenderCalls, 0);
+	});
 });

--- a/packages/tui/test/mux-scrollback-harness.ts
+++ b/packages/tui/test/mux-scrollback-harness.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+export const FRAME_BEGIN = "\x1b[?2026h";
+export const FRAME_END = "\x1b[?2026l";
+export const ROW_CLEAR = "\x1b[2K";
+export const SCREEN_CLEAR = "\x1b[2J";
+export const SCROLLBACK_CLEAR = "\x1b[3J";
+export const HOME = "\x1b[H";
+export const KITTY_IMAGE_LINE = "\x1b_Gi=42,r=1;AAAA\x1b\\";
+
+export class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+export class StaticComponent implements Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+export class ExpandableTranscriptComponent implements Component {
+	private expanded = false;
+	private readonly tail = Array.from({ length: 6 }, (_, index) => `tail row ${index}`);
+
+	setExpanded(expanded: boolean): void {
+		this.expanded = expanded;
+	}
+
+	render(_width: number): string[] {
+		const prefix = ["session title", "tools"];
+		if (!this.expanded) {
+			return [...prefix, ...this.tail];
+		}
+		const inserted = Array.from({ length: 16 }, (_, index) => `expanded tool detail ${index}`);
+		return [...prefix, ...inserted, ...this.tail];
+	}
+
+	invalidate(): void {}
+}
+
+export class OverlayComponent implements Component {
+	render(_width: number): string[] {
+		return ["OVERLAY"];
+	}
+
+	invalidate(): void {}
+}
+
+export type TuiConstructorOptions = ConstructorParameters<typeof TUI>[1];
+
+export function muxOptions(): TuiConstructorOptions {
+	return { muxDetector: () => true };
+}
+
+export function nonMuxOptions(): TuiConstructorOptions {
+	return { muxDetector: () => false };
+}
+
+export function countOccurrences(text: string, needle: string): number {
+	return text.split(needle).length - 1;
+}
+
+export function assertFrameBalanced(writes: string): void {
+	assert.strictEqual(countOccurrences(writes, FRAME_BEGIN), countOccurrences(writes, FRAME_END));
+}
+
+export async function withEnv<T>(updates: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+	const previousValues = new Map<string, string | undefined>();
+	for (const [key, value] of Object.entries(updates)) {
+		previousValues.set(key, process.env[key]);
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of previousValues) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}
+
+export async function renderReplayTrigger(options: TuiConstructorOptions): Promise<{
+	readonly terminal: LoggingVirtualTerminal;
+	readonly tui: TUI;
+	readonly writes: string;
+}> {
+	const terminal = new LoggingVirtualTerminal(72, 6);
+	const tui = new TUI(terminal, options);
+	const component = new ExpandableTranscriptComponent();
+	tui.addChild(component);
+
+	component.setExpanded(true);
+	tui.start();
+	await terminal.waitForRender();
+	terminal.clearWrites();
+
+	component.setExpanded(false);
+	tui.requestRender();
+	await terminal.waitForRender();
+	const writes = terminal.getWrites();
+	return { terminal, tui, writes };
+}

--- a/packages/tui/test/mux-scrollback.test.ts
+++ b/packages/tui/test/mux-scrollback.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { TUI } from "../src/tui.ts";
+import {
+	assertFrameBalanced,
+	countOccurrences,
+	ExpandableTranscriptComponent,
+	HOME,
+	KITTY_IMAGE_LINE,
+	LoggingVirtualTerminal,
+	muxOptions,
+	nonMuxOptions,
+	OverlayComponent,
+	ROW_CLEAR,
+	renderReplayTrigger,
+	SCREEN_CLEAR,
+	SCROLLBACK_CLEAR,
+	StaticComponent,
+	withEnv,
+} from "./mux-scrollback-harness.ts";
+
+describe("TUI multiplexer scrollback preservation", () => {
+	it("emits a screen clear without clearing scrollback when width changes inside a multiplexer", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 6);
+		const tui = new TUI(terminal, muxOptions());
+		const component = new StaticComponent();
+		component.lines = ["alpha", "beta", "gamma"];
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		terminal.resize(50, 6);
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(writes.includes(SCREEN_CLEAR + HOME), "width change should clear and home the visible screen");
+		assert.strictEqual(countOccurrences(writes, SCROLLBACK_CLEAR), 0, "width change must not clear mux pane history");
+		assertFrameBalanced(writes);
+		tui.stop();
+	});
+
+	it("repaints exactly the visible rows for offscreen line-count changes inside a multiplexer", async () => {
+		const { terminal, tui, writes } = await renderReplayTrigger(muxOptions());
+
+		assert.strictEqual(
+			countOccurrences(writes, ROW_CLEAR),
+			terminal.rows,
+			"mux repaint should rewrite one row per viewport row",
+		);
+		assert.strictEqual(countOccurrences(writes, SCROLLBACK_CLEAR), 0, "mux repaint must not clear pane history");
+		assert.strictEqual(countOccurrences(writes, SCREEN_CLEAR), 0, "mux repaint must not clear the screen");
+		assert.strictEqual(tui.muxViewportRepaints, 1, "mux repaint counter should increment");
+		assert.strictEqual(tui.fullRedraws, 1, "mux repaint should not increment full redraws after initial render");
+		assert.deepStrictEqual(terminal.getViewport(), [
+			"tail row 0",
+			"tail row 1",
+			"tail row 2",
+			"tail row 3",
+			"tail row 4",
+			"tail row 5",
+		]);
+		assertFrameBalanced(writes);
+		tui.stop();
+	});
+
+	it("clears stale rows when a short transcript is repainted in a tall mux viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 8);
+		const tui = new TUI(terminal, muxOptions());
+		const component = new StaticComponent();
+		component.lines = Array.from({ length: 12 }, (_, index) => `long row ${index}`);
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		component.lines = ["short row 0", "short row 1", "short row 2"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(terminal.getViewport(), ["short row 0", "short row 1", "short row 2", "", "", "", "", ""]);
+		assert.strictEqual(countOccurrences(terminal.getWrites(), SCROLLBACK_CLEAR), 0);
+		tui.stop();
+	});
+
+	it("repaints height changes inside a multiplexer without screen or scrollback clears", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal, muxOptions());
+		const component = new StaticComponent();
+		component.lines = Array.from({ length: 20 }, (_, index) => `Line ${index}`);
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		terminal.resize(40, 7);
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.strictEqual(
+			countOccurrences(writes, ROW_CLEAR),
+			terminal.rows,
+			"height change should repaint at most the visible rows",
+		);
+		assert.strictEqual(countOccurrences(writes, SCREEN_CLEAR), 0, "height change must not clear the screen in mux");
+		assert.strictEqual(
+			countOccurrences(writes, SCROLLBACK_CLEAR),
+			0,
+			"height change must not clear scrollback in mux",
+		);
+		assertFrameBalanced(writes);
+		tui.stop();
+	});
+
+	it("uses a no-3J full render once for PI_CLEAR_ON_SHRINK inside a multiplexer", async () => {
+		await withEnv({ PI_CLEAR_ON_SHRINK: "1" }, async () => {
+			const terminal = new LoggingVirtualTerminal(40, 6);
+			const tui = new TUI(terminal, muxOptions());
+			const component = new StaticComponent();
+			component.lines = Array.from({ length: 10 }, (_, index) => `row ${index}`);
+			tui.addChild(component);
+
+			tui.start();
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			component.lines = ["row 0", "row 1"];
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			const shrinkWrites = terminal.getWrites();
+			assert.ok(shrinkWrites.includes(SCREEN_CLEAR + HOME), "clear-on-shrink should full-render the viewport");
+			assert.strictEqual(
+				countOccurrences(shrinkWrites, SCROLLBACK_CLEAR),
+				0,
+				"clear-on-shrink must preserve mux history",
+			);
+			const fullRedrawsAfterShrink = tui.fullRedraws;
+
+			terminal.clearWrites();
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			assert.strictEqual(
+				tui.fullRedraws,
+				fullRedrawsAfterShrink,
+				"maxLinesRendered should prevent repeated shrink clears",
+			);
+			assert.strictEqual(terminal.getWrites(), "", "unchanged follow-up frame should not repaint");
+			tui.stop();
+		});
+	});
+
+	it("falls back to a no-3J full render when a kitty image is in the mux viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 6);
+		const tui = new TUI(terminal, muxOptions());
+		const component = new StaticComponent();
+		component.lines = ["before", KITTY_IMAGE_LINE, "after"];
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		terminal.resize(40, 5);
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(writes.includes(SCREEN_CLEAR + HOME), "kitty image rows should bail to full render");
+		assert.strictEqual(
+			countOccurrences(writes, SCROLLBACK_CLEAR),
+			0,
+			"kitty image full render should preserve mux history",
+		);
+		assert.strictEqual(tui.muxViewportRepaints, 0, "kitty image rows should not use raw viewport repaint");
+		tui.stop();
+	});
+
+	it("keeps open overlays composited when a mux replay trigger repaints the viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(72, 6);
+		const tui = new TUI(terminal, muxOptions());
+		const component = new ExpandableTranscriptComponent();
+		tui.addChild(component);
+		component.setExpanded(true);
+		tui.start();
+		await terminal.waitForRender();
+		tui.showOverlay(new OverlayComponent(), { anchor: "top-left", width: 20 });
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		component.setExpanded(false);
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.strictEqual(countOccurrences(writes, SCROLLBACK_CLEAR), 0, "overlay mux repaint must preserve scrollback");
+		assert.strictEqual(tui.muxViewportRepaints, 1, "overlay replay should use the mux repaint path");
+		assert.ok(terminal.getViewport()[0]?.startsWith("OVERLAY"), "overlay row should remain composited after repaint");
+		tui.stop();
+	});
+
+	it("restores legacy scrollback-clearing byte shape when PI_TUI_LEGACY_MUX_RENDER is enabled", async () => {
+		await withEnv({ PI_TUI_LEGACY_MUX_RENDER: "1" }, async () => {
+			const { tui, writes } = await renderReplayTrigger(muxOptions());
+
+			assert.ok(writes.includes(SCROLLBACK_CLEAR), "legacy mux rendering should clear scrollback");
+			assert.strictEqual(tui.muxViewportRepaints, 0, "legacy mux rendering should not use the mux repaint path");
+			tui.stop();
+		});
+	});
+
+	it("keeps muxDetector false byte-identical to the default non-mux path", async () => {
+		const baseline = await renderReplayTrigger(undefined);
+		const injected = await renderReplayTrigger(nonMuxOptions());
+
+		assert.strictEqual(injected.writes, baseline.writes);
+		assert.strictEqual(injected.tui.fullRedraws, baseline.tui.fullRedraws);
+		baseline.tui.stop();
+		injected.tui.stop();
+	});
+});

--- a/packages/tui/test/mux.test.ts
+++ b/packages/tui/test/mux.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import { isMultiplexerSession, useLegacyMuxRender, viewportRenderEnabled } from "../src/mux.ts";
+
+const ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "PI_TUI_LEGACY_MUX_RENDER", "PI_TUI_VIEWPORT_RENDER"] as const;
+
+type EnvKey = (typeof ENV_KEYS)[number];
+
+const originalEnv = new Map<EnvKey, string | undefined>();
+
+for (const key of ENV_KEYS) {
+	originalEnv.set(key, process.env[key]);
+}
+
+function clearEnv(): void {
+	for (const key of ENV_KEYS) {
+		delete process.env[key];
+	}
+}
+
+function restoreEnv(): void {
+	for (const key of ENV_KEYS) {
+		const value = originalEnv.get(key);
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+}
+
+afterEach(() => {
+	restoreEnv();
+});
+
+describe("isMultiplexerSession", () => {
+	it("returns true when each multiplexer environment variable is set alone", () => {
+		for (const key of ["TMUX", "TMUX_PANE", "STY", "ZELLIJ"] as const) {
+			clearEnv();
+
+			process.env[key] = "x";
+
+			assert.equal(isMultiplexerSession(), true, key);
+		}
+	});
+
+	it("returns false when multiplexer environment variables are unset", () => {
+		clearEnv();
+
+		assert.equal(isMultiplexerSession(), false);
+	});
+
+	it("returns false for empty multiplexer environment strings", () => {
+		clearEnv();
+		process.env.TMUX = "";
+		process.env.TMUX_PANE = "";
+		process.env.STY = "";
+		process.env.ZELLIJ = "";
+
+		assert.equal(isMultiplexerSession(), false);
+	});
+
+	it("reads environment variables at call time after import", () => {
+		clearEnv();
+		assert.equal(isMultiplexerSession(), false);
+
+		process.env.ZELLIJ = "0";
+		assert.equal(isMultiplexerSession(), true);
+
+		process.env.ZELLIJ = "";
+		assert.equal(isMultiplexerSession(), false);
+	});
+});
+
+describe("useLegacyMuxRender", () => {
+	it("returns true only when the legacy render switch is exactly 1", () => {
+		clearEnv();
+		process.env.PI_TUI_LEGACY_MUX_RENDER = "1";
+		assert.equal(useLegacyMuxRender(), true);
+
+		for (const value of ["", "0", "true", "yes"] as const) {
+			process.env.PI_TUI_LEGACY_MUX_RENDER = value;
+
+			assert.equal(useLegacyMuxRender(), false, value);
+		}
+	});
+});
+
+describe("viewportRenderEnabled", () => {
+	it("returns true only when the viewport render switch is exactly 1", () => {
+		clearEnv();
+		process.env.PI_TUI_VIEWPORT_RENDER = "1";
+		assert.equal(viewportRenderEnabled(), true);
+
+		for (const value of ["", "0", "true", "yes"] as const) {
+			process.env.PI_TUI_VIEWPORT_RENDER = value;
+
+			assert.equal(viewportRenderEnabled(), false, value);
+		}
+	});
+});

--- a/packages/tui/test/perf-trend-local.test.ts
+++ b/packages/tui/test/perf-trend-local.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const scriptPath = join(repoRoot, "scripts/perf-trend-local.sh");
+
+type TrendEntry = {
+	readonly suite: string;
+	readonly label: string;
+	readonly n: number | null;
+	readonly p50Ms: number;
+	readonly p95Ms: number;
+	readonly bytesPerFrameP50: number | null;
+};
+
+type CommandResult = {
+	readonly status: number | null;
+	readonly stdout: string;
+	readonly stderr: string;
+};
+
+function isTrendEntry(value: unknown): value is TrendEntry {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"suite" in value &&
+		typeof value.suite === "string" &&
+		"label" in value &&
+		typeof value.label === "string" &&
+		"n" in value &&
+		(typeof value.n === "number" || value.n === null) &&
+		"p50Ms" in value &&
+		typeof value.p50Ms === "number" &&
+		"p95Ms" in value &&
+		typeof value.p95Ms === "number" &&
+		"bytesPerFrameP50" in value &&
+		(typeof value.bytesPerFrameP50 === "number" || value.bytesPerFrameP50 === null)
+	);
+}
+
+function runTrend(extraEnv: Record<string, string>): CommandResult {
+	const result = spawnSync("bash", [scriptPath], {
+		cwd: repoRoot,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			PERF_TREND_FRAME_SMALL_N: "3",
+			PERF_TREND_FRAME_LARGE_N: "5",
+			PERF_TREND_ITERATIONS: "1",
+			...extraEnv,
+		},
+	});
+	if (typeof result.stdout !== "string" || typeof result.stderr !== "string") {
+		throw new TypeError("Expected utf8 output from perf trend child process");
+	}
+	return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+function parseTrend(path: string): readonly TrendEntry[] {
+	return readFileSync(path, "utf8")
+		.split("\n")
+		.filter((line: string) => line.trim().length > 0)
+		.map((line: string) => {
+			const parsed: unknown = JSON.parse(line);
+			if (!isTrendEntry(parsed)) {
+				throw new Error(`Invalid trend entry: ${line}`);
+			}
+			return parsed;
+		});
+}
+
+describe("perf trend local mirror", () => {
+	it("writes parseable JSONL entries for the headless bench list", () => {
+		const givenOutputPath = join(mkdtempSync(join(tmpdir(), "senpi-perf-trend-")), "perf-trend.json");
+
+		const whenResult = runTrend({ PERF_TREND_OUTPUT: givenOutputPath });
+
+		assert.strictEqual(whenResult.status, 0, whenResult.stderr || whenResult.stdout);
+		const thenEntries = parseTrend(givenOutputPath);
+		assert.ok(thenEntries.length >= 3);
+		assert.ok(thenEntries.some((entry) => entry.label === "frame-cost-n3"));
+		assert.ok(thenEntries.some((entry) => entry.label === "frame-cost-n5"));
+		assert.ok(thenEntries.some((entry) => entry.label === "frame-cost-n5-viewport"));
+	});
+
+	it("keeps advisory failure injection non-blocking", () => {
+		const givenOutputPath = join(mkdtempSync(join(tmpdir(), "senpi-perf-trend-edge-")), "perf-trend.json");
+
+		const whenResult = runTrend({ PERF_TREND_INJECT_FAIL: "1", PERF_TREND_OUTPUT: givenOutputPath });
+
+		assert.strictEqual(whenResult.status, 0, whenResult.stderr || whenResult.stdout);
+		assert.match(`${whenResult.stdout}\n${whenResult.stderr}`, /bench failed \(advisory\)/);
+		assert.ok(parseTrend(givenOutputPath).length >= 3);
+	});
+});

--- a/packages/tui/test/perf-trend-local.test.ts
+++ b/packages/tui/test/perf-trend-local.test.ts
@@ -1,13 +1,14 @@
 import assert from "node:assert";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const scriptPath = join(repoRoot, "scripts/perf-trend-local.sh");
+const tempDirs: string[] = [];
 
 type TrendEntry = {
 	readonly suite: string;
@@ -74,9 +75,21 @@ function parseTrend(path: string): readonly TrendEntry[] {
 		});
 }
 
+function createTrendOutputPath(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return join(dir, "perf-trend.json");
+}
+
+after(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 describe("perf trend local mirror", () => {
 	it("writes parseable JSONL entries for the headless bench list", () => {
-		const givenOutputPath = join(mkdtempSync(join(tmpdir(), "senpi-perf-trend-")), "perf-trend.json");
+		const givenOutputPath = createTrendOutputPath("senpi-perf-trend-");
 
 		const whenResult = runTrend({ PERF_TREND_OUTPUT: givenOutputPath });
 
@@ -89,7 +102,7 @@ describe("perf trend local mirror", () => {
 	});
 
 	it("keeps advisory failure injection non-blocking", () => {
-		const givenOutputPath = join(mkdtempSync(join(tmpdir(), "senpi-perf-trend-edge-")), "perf-trend.json");
+		const givenOutputPath = createTrendOutputPath("senpi-perf-trend-edge-");
 
 		const whenResult = runTrend({ PERF_TREND_INJECT_FAIL: "1", PERF_TREND_OUTPUT: givenOutputPath });
 

--- a/packages/tui/test/render-contract.test.ts
+++ b/packages/tui/test/render-contract.test.ts
@@ -169,6 +169,23 @@ describe("TUI render contract", () => {
 		});
 	});
 
+	it("truncates an over-wide raw component when crash logging cannot write in release", async () => {
+		await withEnv({ HOME: "/dev/null", [STRICT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+			const terminal = new LoggingVirtualTerminal(12, 4);
+			const tui = new tuiModule.TUI(terminal);
+			const component = new RawOverWideComponent();
+			component.line = "short";
+			tui.addChild(component);
+			await driveRender(tui, terminal);
+
+			component.line = "x".repeat(30);
+			await assert.doesNotReject(() => driveRender(tui, terminal));
+			assert.strictEqual(visibleWidth(terminal.getViewport()[0] ?? ""), 12);
+			assert.ok(terminal.getWrites().includes("x".repeat(12)));
+			tui.stop();
+		});
+	});
+
 	it("strict mode throws for an over-wide raw component", () => {
 		return withTempHome(async () => {
 			await withEnv({ [STRICT_ENV]: "1", PI_TUI_TEST_SEAMS: "1" }, async () => {

--- a/packages/tui/test/render-contract.test.ts
+++ b/packages/tui/test/render-contract.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import * as tuiModule from "../src/tui.ts";
+import { visibleWidth } from "../src/utils.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+process.env.PI_TUI_TEST_SEAMS = "1";
+
+const STRICT_ENV = "PI_TUI_STRICT_RENDER";
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+class MutableComponent implements tuiModule.Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class ThrowingComponent implements tuiModule.Component, tuiModule.Focusable {
+	focused = false;
+
+	render(_width: number): string[] {
+		throw new Error("render exploded");
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {}
+}
+
+class DifferentThrowingComponent extends ThrowingComponent {}
+
+class RawOverWideComponent implements tuiModule.Component {
+	line = "";
+
+	render(_width: number): string[] {
+		return [this.line];
+	}
+
+	invalidate(): void {}
+}
+
+async function driveRender(tui: tuiModule.TUI, terminal: VirtualTerminal): Promise<void> {
+	const render = Reflect.get(tui, "doRender");
+	assert.strictEqual(typeof render, "function");
+	Reflect.apply(render, tui, []);
+	await terminal.flush();
+}
+
+async function withEnv<T>(updates: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+	const previous = new Map<string, string | undefined>();
+	for (const [key, value] of Object.entries(updates)) {
+		previous.set(key, process.env[key]);
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}
+
+async function withTempHome<T>(run: (home: string) => Promise<T>): Promise<T> {
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), "senpi-render-contract-"));
+	try {
+		return await withEnv({ HOME: home }, () => run(home));
+	} finally {
+		fs.rmSync(home, { recursive: true, force: true });
+	}
+}
+
+function renderErrorStats(): { readonly writes: number } {
+	const stats = tuiModule.__renderErrorLogStats?.();
+	if (stats !== undefined) {
+		return stats;
+	}
+	throw new Error("render error log stats seam must be enabled");
+}
+
+describe("TUI render contract", () => {
+	it("renders fallback for a throwing component when debug logging cannot write", async () => {
+		await withEnv({ HOME: "/dev/null", [STRICT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+			const terminal = new LoggingVirtualTerminal(50, 4);
+			const tui = new tuiModule.TUI(terminal);
+			tui.addChild(new ThrowingComponent());
+
+			await assert.doesNotReject(() => driveRender(tui, terminal));
+			assert.ok(terminal.getViewport().join("\n").includes("[render error: ThrowingComponent]"));
+			tui.stop();
+		});
+	});
+
+	it("renders fallback for a throwing component and continues on a subsequent frame", async () => {
+		await withTempHome(async () => {
+			const terminal = new LoggingVirtualTerminal(50, 4);
+			const tui = new tuiModule.TUI(terminal);
+			const component = new ThrowingComponent();
+			const after = new MutableComponent();
+			after.lines = ["after survives"];
+			tui.addChild(component);
+			tui.addChild(after);
+			tui.setFocus(component);
+
+			await driveRender(tui, terminal);
+			assert.strictEqual(component.focused, true);
+			assert.ok(terminal.getViewport().join("\n").includes("[render error: ThrowingComponent]"));
+			assert.ok(terminal.getViewport().join("\n").includes("after survives"));
+
+			terminal.clearWrites();
+			after.lines = ["next frame"];
+			await driveRender(tui, terminal);
+			assert.ok(terminal.getViewport().join("\n").includes("next frame"));
+			tui.stop();
+		});
+	});
+
+	it("truncates an over-wide raw component and continues in release with test seams enabled", async () => {
+		await withTempHome(async () => {
+			await withEnv({ [STRICT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+				const terminal = new LoggingVirtualTerminal(12, 4);
+				const tui = new tuiModule.TUI(terminal);
+				const component = new RawOverWideComponent();
+				component.line = "short";
+				tui.addChild(component);
+				await driveRender(tui, terminal);
+
+				component.line = "x".repeat(30);
+				await driveRender(tui, terminal);
+				assert.strictEqual(visibleWidth(terminal.getViewport()[0] ?? ""), 12);
+				assert.ok(terminal.getWrites().includes("x".repeat(12)));
+
+				component.line = "ok";
+				await driveRender(tui, terminal);
+				assert.strictEqual(terminal.getViewport()[0], "ok");
+				tui.stop();
+			});
+		});
+	});
+
+	it("strict mode throws for an over-wide raw component", () => {
+		return withTempHome(async () => {
+			await withEnv({ [STRICT_ENV]: "1", PI_TUI_TEST_SEAMS: "1" }, async () => {
+				const terminal = new LoggingVirtualTerminal(12, 4);
+				const tui = new tuiModule.TUI(terminal);
+				const component = new RawOverWideComponent();
+				component.line = "short";
+				tui.addChild(component);
+				await driveRender(tui, terminal);
+
+				component.line = "x".repeat(30);
+				const render = Reflect.get(tui, "doRender");
+				assert.strictEqual(typeof render, "function");
+				assert.throws(() => Reflect.apply(render, tui, []), /exceeds terminal width/);
+			});
+		});
+	});
+
+	it("writes a single crash dump across two over-wide release frames", async () => {
+		await withTempHome(async (home) => {
+			await withEnv({ [STRICT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+				const terminal = new LoggingVirtualTerminal(12, 4);
+				const tui = new tuiModule.TUI(terminal);
+				const component = new RawOverWideComponent();
+				component.line = "short";
+				tui.addChild(component);
+				await driveRender(tui, terminal);
+
+				component.line = "x".repeat(30);
+				await driveRender(tui, terminal);
+				const crashLogPath = path.join(home, ".senpi", "agent", "senpi-crash.log");
+				assert.ok(fs.existsSync(crashLogPath));
+				fs.chmodSync(crashLogPath, 0o444);
+
+				component.line = "y".repeat(30);
+				await driveRender(tui, terminal);
+				assert.ok(terminal.getViewport()[0]?.includes("y".repeat(12)));
+				tui.stop();
+			});
+		});
+	});
+
+	it("logs render errors once per component class", async () => {
+		await withTempHome(async () => {
+			const initial = renderErrorStats().writes;
+			const terminal = new LoggingVirtualTerminal(50, 4);
+			const tui = new tuiModule.TUI(terminal);
+			tui.addChild(new ThrowingComponent());
+
+			await driveRender(tui, terminal);
+			await driveRender(tui, terminal);
+			assert.strictEqual(renderErrorStats().writes, Math.max(initial, 1));
+
+			tui.addChild(new DifferentThrowingComponent());
+			await driveRender(tui, terminal);
+			assert.strictEqual(renderErrorStats().writes, Math.max(initial, 1) + 1);
+			tui.stop();
+		});
+	});
+});

--- a/packages/tui/test/render-diagnostic-permissions.test.ts
+++ b/packages/tui/test/render-diagnostic-permissions.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import * as tuiModule from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+process.env.PI_TUI_TEST_SEAMS = "1";
+
+const STRICT_ENV = "PI_TUI_STRICT_RENDER";
+
+class MutableComponent implements tuiModule.Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class ThrowingComponent implements tuiModule.Component, tuiModule.Focusable {
+	focused = false;
+
+	render(_width: number): string[] {
+		throw new Error("render exploded");
+	}
+
+	handleInput(_data: string): void {}
+
+	invalidate(): void {}
+}
+
+class RawOverWideComponent implements tuiModule.Component {
+	line = "";
+
+	render(_width: number): string[] {
+		return [this.line];
+	}
+
+	invalidate(): void {}
+}
+
+async function driveRender(tui: tuiModule.TUI, terminal: VirtualTerminal): Promise<void> {
+	const render = Reflect.get(tui, "doRender");
+	assert.strictEqual(typeof render, "function");
+	Reflect.apply(render, tui, []);
+	await terminal.flush();
+}
+
+async function withEnv<T>(updates: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+	const previous = new Map<string, string | undefined>();
+	for (const [key, value] of Object.entries(updates)) {
+		previous.set(key, process.env[key]);
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}
+
+async function withTempHome<T>(run: (home: string) => Promise<T>): Promise<T> {
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), "senpi-render-diagnostic-permissions-"));
+	try {
+		return await withEnv({ HOME: home }, () => run(home));
+	} finally {
+		fs.rmSync(home, { recursive: true, force: true });
+	}
+}
+
+describe("TUI diagnostic log permissions", () => {
+	it("tightens existing diagnostic log files after debug and crash writes", async () => {
+		await withTempHome(async (home) => {
+			await withEnv({ [STRICT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+				const agentDir = path.join(home, ".senpi", "agent");
+				const debugLogPath = path.join(agentDir, "senpi-debug.log");
+				const crashLogPath = path.join(agentDir, "senpi-crash.log");
+				fs.mkdirSync(agentDir, { recursive: true });
+				fs.writeFileSync(debugLogPath, "existing debug\n", { encoding: "utf8", mode: 0o644 });
+				fs.writeFileSync(crashLogPath, "existing crash\n", { encoding: "utf8", mode: 0o644 });
+				fs.chmodSync(debugLogPath, 0o644);
+				fs.chmodSync(crashLogPath, 0o644);
+
+				const debugTerminal = new VirtualTerminal(50, 4);
+				const debugTui = new tuiModule.TUI(debugTerminal);
+				debugTui.addChild(new ThrowingComponent());
+				await driveRender(debugTui, debugTerminal);
+				debugTui.stop();
+
+				assert.strictEqual(fs.statSync(debugLogPath).mode & 0o777, 0o600);
+
+				const crashTerminal = new VirtualTerminal(12, 4);
+				const crashTui = new tuiModule.TUI(crashTerminal);
+				const component = new RawOverWideComponent();
+				component.line = "short";
+				crashTui.addChild(component);
+				await driveRender(crashTui, crashTerminal);
+				component.line = "x".repeat(30);
+				await driveRender(crashTui, crashTerminal);
+				crashTui.stop();
+
+				assert.strictEqual(fs.statSync(crashLogPath).mode & 0o777, 0o600);
+			});
+		});
+	});
+
+	it("tightens an existing PI_TUI_DEBUG render dump after writing", async () => {
+		const timestamp = 1234567890;
+		const randomValue = 0.123456789;
+		const originalDateNow = Date.now;
+		const originalMathRandom = Math.random;
+		const debugDir = path.join("/tmp", "tui");
+		const debugPath = path.join(debugDir, `render-${timestamp}-${randomValue.toString(36).slice(2)}.log`);
+
+		Date.now = () => timestamp;
+		Math.random = () => randomValue;
+		try {
+			await withEnv({ PI_TUI_DEBUG: "1", PI_TUI_TEST_SEAMS: "1" }, async () => {
+				fs.mkdirSync(debugDir, { recursive: true });
+				fs.writeFileSync(debugPath, "existing debug dump\n", { encoding: "utf8", mode: 0o644 });
+				fs.chmodSync(debugPath, 0o644);
+
+				const terminal = new VirtualTerminal(50, 4);
+				const tui = new tuiModule.TUI(terminal);
+				const component = new MutableComponent();
+				component.lines = ["first frame"];
+				tui.addChild(component);
+				await driveRender(tui, terminal);
+
+				component.lines = ["second frame"];
+				await driveRender(tui, terminal);
+				tui.stop();
+
+				assert.strictEqual(fs.statSync(debugPath).mode & 0o777, 0o600);
+			});
+		} finally {
+			Date.now = originalDateNow;
+			Math.random = originalMathRandom;
+			fs.rmSync(debugPath, { force: true });
+		}
+	});
+});

--- a/packages/tui/test/scroll-then-diff.test.ts
+++ b/packages/tui/test/scroll-then-diff.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert";
+import { Buffer } from "node:buffer";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+const FRAME_BEGIN = "\x1b[?2026h\x1b[?7l";
+const FRAME_END = "\x1b[?7h\x1b[?2026l";
+const REGION_1_TO_5 = "\x1b[1;5r";
+const SCROLL_REGION_PATTERN = /\x1b\[1;\d+r/;
+const ROW_CLEAR = "\x1b[2K";
+const SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
+const STABLE_BOTTOM_ROWS = ["BOTTOM_SENTINEL_A", "BOTTOM_SENTINEL_B", "BOTTOM_SENTINEL_C"] as const;
+const PRE_CHANGE_TAIL_MUTATE_FALLBACK_BYTES = 430;
+const PURE_APPEND_GOLDEN =
+	`${FRAME_BEGIN}\x1b[1;5r\x1b[5;1H\n\x1b[r` +
+	`\x1b[5;1H${ROW_CLEAR}${SEGMENT_RESET}append 1${SEGMENT_RESET}${FRAME_END}`;
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+class LinesComponent implements Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return [...this.lines];
+	}
+
+	invalidate(): void {}
+}
+
+async function driveRender(tui: TUI, terminal: VirtualTerminal): Promise<void> {
+	const render = Reflect.get(tui, "doRender");
+	assert.strictEqual(typeof render, "function");
+	Reflect.apply(render, tui, []);
+	await terminal.flush();
+}
+
+function initialLines(): string[] {
+	return [
+		"history 0",
+		"history 1",
+		"history 2",
+		"history 3",
+		"scroll away",
+		"body 0",
+		"body 1",
+		"mutable 0",
+		"body 3",
+		...STABLE_BOTTOM_ROWS,
+	];
+}
+
+async function renderTick(nextLines: string[]): Promise<{
+	readonly terminal: LoggingVirtualTerminal;
+	readonly tui: TUI;
+	readonly writes: string;
+}> {
+	const terminal = new LoggingVirtualTerminal(72, 8);
+	const tui = new TUI(terminal);
+	const component = new LinesComponent();
+	component.lines = initialLines();
+	tui.addChild(component);
+	await driveRender(tui, terminal);
+	terminal.clearWrites();
+
+	component.lines = nextLines;
+	await driveRender(tui, terminal);
+	return { terminal, tui, writes: terminal.getWrites() };
+}
+
+function pureAppendLines(): string[] {
+	return [
+		"history 0",
+		"history 1",
+		"history 2",
+		"history 3",
+		"scroll away",
+		"body 0",
+		"body 1",
+		"mutable 0",
+		"body 3",
+		"append 1",
+		...STABLE_BOTTOM_ROWS,
+	];
+}
+
+function tailMutateLines(): string[] {
+	const lines = pureAppendLines();
+	lines[7] = "mutable 1";
+	return lines;
+}
+
+function excessMutationLines(): string[] {
+	return [
+		"history 0",
+		"history 1",
+		"history 2",
+		"history 3",
+		"scroll away",
+		"body 0 changed",
+		"body 1 changed",
+		"mutable 1",
+		"body 3 changed",
+		"append 1 changed",
+		"BOTTOM_SENTINEL_A changed",
+		STABLE_BOTTOM_ROWS[1],
+		STABLE_BOTTOM_ROWS[2],
+	];
+}
+
+async function fullRenderViewport(lines: readonly string[]): Promise<string[]> {
+	const terminal = new VirtualTerminal(72, 8);
+	const tui = new TUI(terminal);
+	const component = new LinesComponent();
+	component.lines = [...lines];
+	tui.addChild(component);
+	await driveRender(tui, terminal);
+	const viewport = terminal.getViewport();
+	tui.stop();
+	return viewport;
+}
+
+describe("scroll-then-diff viewport rendering", () => {
+	it("keeps pure append ticks byte-identical to the insert-scroll golden", async () => {
+		const { tui, writes } = await renderTick(pureAppendLines());
+
+		assert.strictEqual(writes, PURE_APPEND_GOLDEN);
+		console.log(`pure-append-golden bytes=${Buffer.byteLength(writes)} region=${writes.includes(REGION_1_TO_5)}`);
+		tui.stop();
+	});
+
+	it("uses one scroll-region frame for append ticks with bounded shifted-row mutations", async () => {
+		const { terminal, tui, writes } = await renderTick(tailMutateLines());
+
+		assert.ok(writes.includes(REGION_1_TO_5), "bounded tail mutation should use the scroll-region fast path");
+		assert.strictEqual(
+			(writes.match(/\x1b\[\?2026h/g) ?? []).length,
+			1,
+			"bounded tail mutation should stay inside one synchronized frame",
+		);
+		for (const sentinel of STABLE_BOTTOM_ROWS) {
+			assert.ok(!writes.includes(sentinel), `stable bottom sentinel should not be repainted: ${sentinel}`);
+		}
+		assert.ok(
+			Buffer.byteLength(writes) < PRE_CHANGE_TAIL_MUTATE_FALLBACK_BYTES,
+			`bounded tail mutation should stay below fallback fixture ${PRE_CHANGE_TAIL_MUTATE_FALLBACK_BYTES}, got ${Buffer.byteLength(writes)}`,
+		);
+		assert.deepStrictEqual(await fullRenderViewport(tailMutateLines()), terminal.getViewport());
+		console.log(
+			`bounded-tail-mutate bytes=${Buffer.byteLength(writes)} fallbackFixture=${PRE_CHANGE_TAIL_MUTATE_FALLBACK_BYTES} region=${writes.includes(REGION_1_TO_5)} bottomSentinelsAbsent=true`,
+		);
+		tui.stop();
+	});
+
+	it("falls back when shifted-row mutations exceed the bounded diff budget", async () => {
+		const { terminal, tui, writes } = await renderTick(excessMutationLines());
+
+		assert.ok(!SCROLL_REGION_PATTERN.test(writes), "excess mutations should not use the scroll-region fast path");
+		assert.deepStrictEqual(terminal.getViewport(), await fullRenderViewport(excessMutationLines()));
+		console.log(`excess-mutation-fallback bytes=${Buffer.byteLength(writes)} region=false`);
+		tui.stop();
+	});
+
+	it("matches full-render screen state after 50 mixed append and bounded-mutation ticks", async () => {
+		const terminal = new LoggingVirtualTerminal(72, 8);
+		const tui = new TUI(terminal);
+		const component = new LinesComponent();
+		let lines = initialLines();
+		component.lines = lines;
+		tui.addChild(component);
+		await driveRender(tui, terminal);
+
+		for (let tick = 1; tick <= 50; tick++) {
+			const next = [...lines];
+			const insertionIndex = next.length - STABLE_BOTTOM_ROWS.length;
+			if (tick % 3 !== 0) {
+				next[insertionIndex - 2] = `mutable ${tick}`;
+			}
+			next.splice(insertionIndex, 0, `append ${tick}`);
+			lines = next;
+			component.lines = lines;
+			await driveRender(tui, terminal);
+		}
+
+		assert.deepStrictEqual(terminal.getViewport(), await fullRenderViewport(lines));
+		console.log("screen-state-equivalence ticks=50 result=match");
+		tui.stop();
+	});
+});

--- a/packages/tui/test/scroll-then-diff.test.ts
+++ b/packages/tui/test/scroll-then-diff.test.ts
@@ -140,7 +140,6 @@ describe("scroll-then-diff viewport rendering", () => {
 		const { tui, writes } = await renderTick(pureAppendLines());
 
 		assert.strictEqual(writes, PURE_APPEND_GOLDEN);
-		console.log(`pure-append-golden bytes=${Buffer.byteLength(writes)} region=${writes.includes(REGION_1_TO_5)}`);
 		tui.stop();
 	});
 
@@ -161,9 +160,6 @@ describe("scroll-then-diff viewport rendering", () => {
 			`bounded tail mutation should stay below fallback fixture ${PRE_CHANGE_TAIL_MUTATE_FALLBACK_BYTES}, got ${Buffer.byteLength(writes)}`,
 		);
 		assert.deepStrictEqual(await fullRenderViewport(tailMutateLines()), terminal.getViewport());
-		console.log(
-			`bounded-tail-mutate bytes=${Buffer.byteLength(writes)} fallbackFixture=${PRE_CHANGE_TAIL_MUTATE_FALLBACK_BYTES} region=${writes.includes(REGION_1_TO_5)} bottomSentinelsAbsent=true`,
-		);
 		tui.stop();
 	});
 
@@ -172,7 +168,6 @@ describe("scroll-then-diff viewport rendering", () => {
 
 		assert.ok(!SCROLL_REGION_PATTERN.test(writes), "excess mutations should not use the scroll-region fast path");
 		assert.deepStrictEqual(terminal.getViewport(), await fullRenderViewport(excessMutationLines()));
-		console.log(`excess-mutation-fallback bytes=${Buffer.byteLength(writes)} region=false`);
 		tui.stop();
 	});
 
@@ -198,7 +193,6 @@ describe("scroll-then-diff viewport rendering", () => {
 		}
 
 		assert.deepStrictEqual(terminal.getViewport(), await fullRenderViewport(lines));
-		console.log("screen-state-equivalence ticks=50 result=match");
 		tui.stop();
 	});
 });

--- a/packages/tui/test/sgr-coalesce.test.ts
+++ b/packages/tui/test/sgr-coalesce.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import type { Terminal as XtermTerminalType } from "@xterm/headless";
+import { type Component, TUI } from "../src/tui.ts";
+import { coalesceAdjacentSgr } from "../src/utils.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+interface CellSnapshot {
+	readonly chars: string;
+	readonly width: number;
+	readonly fgMode: number;
+	readonly fgColor: number;
+	readonly bgMode: number;
+	readonly bgColor: number;
+	readonly bold: number;
+	readonly dim: number;
+	readonly italic: number;
+	readonly underline: number;
+	readonly blink: number;
+	readonly inverse: number;
+	readonly invisible: number;
+	readonly strikethrough: number;
+}
+
+interface Report {
+	readonly adopted: boolean;
+}
+
+class TestComponent implements Component {
+	lines: string[];
+
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+}
+
+function isXtermTerminal(value: unknown): value is XtermTerminalType {
+	return typeof value === "object" && value !== null && "buffer" in value;
+}
+
+function getXterm(terminal: VirtualTerminal): XtermTerminalType {
+	const value: unknown = Reflect.get(terminal, "xterm");
+	if (!isXtermTerminal(value)) {
+		throw new Error("VirtualTerminal should expose an xterm instance in tests");
+	}
+	return value;
+}
+
+async function renderLine(line: string): Promise<readonly CellSnapshot[]> {
+	const terminal = new VirtualTerminal(96, 3);
+	terminal.write(`${line}\x1b[0m`);
+	await terminal.flush();
+	const xterm = getXterm(terminal);
+	const buffer = xterm.buffer.active;
+	const row = buffer.getLine(buffer.viewportY);
+	if (!row) {
+		throw new Error("expected first row");
+	}
+	const cells: CellSnapshot[] = [];
+	for (let col = 0; col < xterm.cols; col++) {
+		const cell = row.getCell(col);
+		if (!cell) {
+			throw new Error(`expected cell ${col}`);
+		}
+		cells.push({
+			chars: cell.getChars(),
+			width: cell.getWidth(),
+			fgMode: cell.getFgColorMode(),
+			fgColor: cell.getFgColor(),
+			bgMode: cell.getBgColorMode(),
+			bgColor: cell.getBgColor(),
+			bold: cell.isBold(),
+			dim: cell.isDim(),
+			italic: cell.isItalic(),
+			underline: cell.isUnderline(),
+			blink: cell.isBlink(),
+			inverse: cell.isInverse(),
+			invisible: cell.isInvisible(),
+			strikethrough: cell.isStrikethrough(),
+		});
+	}
+	return cells;
+}
+
+function readReport(): Report {
+	const raw = readFileSync(new URL("../bench/sgr-coalesce-report.json", import.meta.url), "utf8");
+	const value: unknown = JSON.parse(raw);
+	if (!hasBooleanAdopted(value)) {
+		throw new Error("report should contain adopted boolean");
+	}
+	return value;
+}
+
+function hasBooleanAdopted(value: unknown): value is Report {
+	return typeof value === "object" && value !== null && "adopted" in value && typeof value.adopted === "boolean";
+}
+
+const semanticCorpus = [
+	"\x1b[31m\x1b[1mred bold\x1b[0m plain",
+	"\x1b[1m\x1b[31mred bold reversed order\x1b[22m\x1b[39m",
+	"\x1b[38;5;196m\x1b[48;5;16m256 color\x1b[0m",
+	"\x1b[38;2;10;20;30m\x1b[48;2;240;230;220mtruecolor\x1b[0m",
+	"\x1b[4m\x1b[24munderline reset before text",
+	"\x1b[3mitalic \x1b[23mplain",
+	"\x1b[1;31m\x1b[44mnested colors\x1b[0m",
+	"\x1b[31mred\x1b[39m default \x1b[32mgreen\x1b[0m",
+	"\x1b[48;5;22mbackground\x1b[49m default",
+	"\x1b[2m\x1b[22mdim reset",
+	"\x1b[7m\x1b[27minverse reset",
+	"\x1b[9m\x1b[29mstrike reset",
+	"\x1b[5m\x1b[25mblink reset",
+	"\x1b[8m\x1b[28mhidden reset",
+	"\x1b[0m\x1b[31mreset then red",
+	"\x1b[m\x1b[32mempty reset then green",
+	"\x1b[38;5;240mgray \x1b[38;5;241mgray2\x1b[0m",
+	"\x1b[38;2;1;2;3mfg \x1b[48;2;4;5;6mbg\x1b[0m",
+	"\x1b[1m\x1b[3m\x1b[4mmany attrs\x1b[0m",
+	"plain \x1b[31mred\x1b[0m tail",
+	"\x1b]8;;https://example.com\x07\x1b[34mlink\x1b[0m\x1b]8;;\x07",
+	"\x1b]8;;https://example.com\x1b\\\x1b[34mlink st\x1b[0m\x1b]8;;\x1b\\",
+	"\x1b]8;id=1;https://example.com\x07\x1b[1mparam link\x1b[0m\x1b]8;;\x07",
+	"\x1b[31m\x1b]8;;https://example.com\x07mixed\x1b]8;;\x07\x1b[0m",
+	"terminator \x1b]8;;https://example.com\x07x\x1b]8;;\x07 \x1b[32mgreen\x1b[0m",
+	"\x1b[31mred\x1b[0m\x1b[2K\x1b[0m\x1b]8;;\x07clear guard",
+	"\x1b[31mred\x1b[39m\x1b[0mreset-heavy",
+	"\x1b[1mwide 漢字\x1b[22m tail",
+	"\x1b[38;5;33memoji 😀\x1b[0m tail",
+	"\x1b[31m\x1b[44mcombo \x1b[49mfg-only\x1b[39m",
+] as const;
+
+describe("coalesceAdjacentSgr", () => {
+	it("merges immediately adjacent SGR sequences exactly", () => {
+		const cases = [
+			{ input: "\x1b[31m\x1b[1mred", expected: "\x1b[31;1mred" },
+			{ input: "a\x1b[38;5;196m\x1b[48;5;16mb", expected: "a\x1b[38;5;196;48;5;16mb" },
+			{ input: "\x1b[38;2;1;2;3m\x1b[48;2;4;5;6mtrue", expected: "\x1b[38;2;1;2;3;48;2;4;5;6mtrue" },
+			{ input: "\x1b[m\x1b[31mempty-reset", expected: "\x1b[0;31mempty-reset" },
+			{ input: "\x1b[31mtext\x1b[1m", expected: "\x1b[31mtext\x1b[1m" },
+			{ input: "\x1b[2K\x1b[0m\x1b]8;;\x07", expected: "\x1b[2K\x1b[0m\x1b]8;;\x07" },
+		] as const;
+
+		for (const { input, expected } of cases) {
+			assert.strictEqual(coalesceAdjacentSgr(input), expected);
+		}
+	});
+
+	it("is a virtual-terminal semantic no-op for the SGR/OSC corpus", async () => {
+		assert.strictEqual(semanticCorpus.length, 30);
+		for (const line of semanticCorpus) {
+			const original = await renderLine(line);
+			const coalesced = await renderLine(coalesceAdjacentSgr(line));
+			assert.deepStrictEqual(coalesced, original, JSON.stringify(line));
+		}
+	});
+
+	it("is idempotent", () => {
+		for (const line of semanticCorpus) {
+			const once = coalesceAdjacentSgr(line);
+			assert.strictEqual(coalesceAdjacentSgr(once), once, JSON.stringify(line));
+		}
+	});
+
+	it("emit-path wiring matches report.adopted", async () => {
+		const report = readReport();
+		const original = "\x1b[31m\x1b[1mcoalesce-probe";
+		const coalesced = "\x1b[31;1mcoalesce-probe";
+		const terminal = new LoggingVirtualTerminal(60, 4);
+		const tui = new TUI(terminal);
+		const component = new TestComponent([original]);
+		tui.addChild(component);
+
+		try {
+			tui.start();
+			await terminal.waitForRender();
+			const writes = terminal.getWrites();
+			if (report.adopted) {
+				assert.ok(writes.includes(coalesced), "adopted report should emit coalesced SGR bytes");
+				assert.ok(!writes.includes(original), "adopted report should not emit original adjacent SGR bytes");
+			} else {
+				assert.ok(writes.includes(original), "non-adopted report should emit original adjacent SGR bytes");
+				assert.ok(!writes.includes(coalesced), "non-adopted report should not emit coalesced SGR bytes");
+			}
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/sgr-row-clear.test.ts
+++ b/packages/tui/test/sgr-row-clear.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+const ROW_CLEAR = "\x1b[2K";
+const SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
+
+class TestComponent implements Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class ExpandableTranscriptComponent implements Component {
+	private expanded = false;
+	readonly tail = Array.from({ length: 6 }, (_, index) => `tail row ${index}`);
+
+	setExpanded(expanded: boolean): void {
+		this.expanded = expanded;
+	}
+
+	render(_width: number): string[] {
+		const prefix = ["session title", "tools"];
+		if (!this.expanded) {
+			return [...prefix, ...this.tail];
+		}
+		const inserted = Array.from({ length: 16 }, (_, index) => `expanded tool detail ${index}`);
+		return [...prefix, ...inserted, ...this.tail];
+	}
+
+	invalidate(): void {}
+}
+
+class InsertScrollComponent implements Component {
+	private inserted = false;
+	private readonly prefix = ["p0", "p1", "p2"];
+	private readonly tail = ["tail0", "tail1", "tail2", "tail3", "tail4"];
+
+	insertRow(): void {
+		this.inserted = true;
+	}
+
+	render(_width: number): string[] {
+		if (!this.inserted) {
+			return [...this.prefix, ...this.tail];
+		}
+		return [...this.prefix, "tail0", "tail1", "tail2", "tail3", "inserted", "tail4"];
+	}
+
+	invalidate(): void {}
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+function assertEveryRowClearResets(frame: string, scenario: string): void {
+	let index = frame.indexOf(ROW_CLEAR);
+	assert.notStrictEqual(index, -1, `${scenario} should exercise at least one row clear`);
+	while (index !== -1) {
+		const afterClear = index + ROW_CLEAR.length;
+		const actualSuffix = frame.slice(afterClear, afterClear + SEGMENT_RESET.length);
+		assert.strictEqual(
+			actualSuffix,
+			SEGMENT_RESET,
+			`${scenario} emitted a row clear without an immediate SGR reset at byte ${index}`,
+		);
+		index = frame.indexOf(ROW_CLEAR, afterClear);
+	}
+}
+
+function armStaleSgr(terminal: LoggingVirtualTerminal): void {
+	terminal.write("\x1b[31m");
+	terminal.clearWrites();
+}
+
+describe("TUI row clears reset stale SGR state", () => {
+	it("resets after row clears on full render", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		component.lines = ["full render"];
+		tui.addChild(component);
+
+		armStaleSgr(terminal);
+		try {
+			tui.start();
+			await terminal.waitForRender();
+
+			assertEveryRowClearResets(terminal.getWrites(), "full render");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("resets after row clears on scrollback replay", async () => {
+		const terminal = new LoggingVirtualTerminal(72, 6);
+		const tui = new TUI(terminal);
+		const component = new ExpandableTranscriptComponent();
+		tui.addChild(component);
+
+		component.setExpanded(true);
+		tui.start();
+		await terminal.waitForRender();
+		armStaleSgr(terminal);
+
+		try {
+			component.setExpanded(false);
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes("\x1b[3J"), "scenario should use scrollback replay");
+			assertEveryRowClearResets(writes, "scrollback replay");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("resets after row clears for deleted lines", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 6);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["a", "b", "c", "d"];
+		tui.start();
+		await terminal.waitForRender();
+		armStaleSgr(terminal);
+
+		try {
+			component.lines = ["a", "b"];
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			assertEveryRowClearResets(terminal.getWrites(), "deleted lines");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("resets after row clears for viewport insert-scroll", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const component = new InsertScrollComponent();
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		armStaleSgr(terminal);
+
+		try {
+			component.insertRow();
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes("\x1b[1;4r"), "scenario should use insert-scroll");
+			assertEveryRowClearResets(writes, "viewport insert-scroll");
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/tui-render-sgr-reset.test.ts
+++ b/packages/tui/test/tui-render-sgr-reset.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class TestComponent implements Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+
+	clearWrites(): void {
+		this.writes = [];
+	}
+}
+
+describe("TUI changed-row SGR repaint", () => {
+	it("resets SGR state before clearing and repainting changed rows", async () => {
+		const terminal = new LoggingVirtualTerminal(72, 6);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["header", "\x1b[38;2;9;131;232mWorking\x1b[0m", "footer", "input"];
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		component.lines = ["header", "\x1b[38;2;9;131;232mWorking harder\x1b[0m", "footer", "input"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(
+			writes.includes("\x1b[2K\x1b[0m\x1b]8;;\x07\x1b[38;2;9;131;232mWorking harder"),
+			"changed-row repaint should reset terminal style state immediately after clearing the row",
+		);
+		assert.ok(
+			!writes.includes("\x1b[2K\x1b[38;2;9;131;232m"),
+			"repaint should not write truecolor text directly after CSI 2K",
+		);
+
+		tui.stop();
+	});
+});

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -322,7 +322,7 @@ describe("TUI Kitty image cleanup", () => {
 
 			const writes = terminal.getWrites();
 			assert.ok(
-				writes.includes(`\x1b[2K\r\n\x1b[2K\x1b[1A${imageSequence}\x1b[1B`),
+				writes.includes(`\x1b[2K\x1b[0m\x1b]8;;\x07\r\n\x1b[2K\x1b[0m\x1b]8;;\x07\x1b[1A${imageSequence}\x1b[1B`),
 				"reserved rows should be cleared before the image placement is drawn",
 			);
 			assert.ok(

--- a/packages/tui/test/viewport-render.test.ts
+++ b/packages/tui/test/viewport-render.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import * as tuiModule from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+process.env.PI_TUI_TEST_SEAMS = "1";
+
+const VIEWPORT_ENV = "PI_TUI_VIEWPORT_RENDER";
+const OVERSCAN = 16;
+
+class LoggingVirtualTerminal extends VirtualTerminal {
+	private writes: string[] = [];
+
+	override write(data: string): void {
+		this.writes.push(data);
+		super.write(data);
+	}
+
+	getWrites(): string {
+		return this.writes.join("");
+	}
+}
+
+class MutableLinesComponent implements tuiModule.Component {
+	lines: string[] = [];
+
+	render(_width: number): string[] {
+		return [...this.lines];
+	}
+
+	invalidate(): void {}
+}
+
+class StreamingComponent implements tuiModule.Component {
+	private tokenCount = 0;
+	readonly stableTail = Array.from({ length: 18 }, (_, index) => `stable viewport row ${index}`);
+
+	appendToken(): void {
+		this.tokenCount += 1;
+	}
+
+	render(_width: number): string[] {
+		return [`streamed tokens ${this.tokenCount}`, ...this.stableTail];
+	}
+
+	invalidate(): void {}
+}
+
+class ExpandableComponent implements tuiModule.Component {
+	private expanded = false;
+	readonly tail = Array.from({ length: 6 }, (_, index) => `tail row ${index}`);
+
+	setExpanded(expanded: boolean): void {
+		this.expanded = expanded;
+	}
+
+	render(_width: number): string[] {
+		if (!this.expanded) {
+			return ["session title", "tools", ...this.tail];
+		}
+		const inserted = Array.from({ length: 16 }, (_, index) => `expanded tool detail ${index}`);
+		return ["session title", "tools", ...inserted, ...this.tail];
+	}
+
+	invalidate(): void {}
+}
+
+class LargeStatusComponent implements tuiModule.Component {
+	readonly transcript = Array.from({ length: 5000 }, (_, index) => `transcript line ${index}`);
+	status = "status frame initial";
+
+	render(_width: number): string[] {
+		return [...this.transcript, this.status];
+	}
+
+	invalidate(): void {}
+}
+
+async function driveRender(tui: tuiModule.TUI, terminal: VirtualTerminal): Promise<void> {
+	const render = Reflect.get(tui, "doRender");
+	assert.strictEqual(typeof render, "function");
+	Reflect.apply(render, tui, []);
+	await terminal.flush();
+}
+
+async function withEnv<T>(updates: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+	const previous = new Map<string, string | undefined>();
+	for (const [key, value] of Object.entries(updates)) {
+		previous.set(key, process.env[key]);
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}
+
+async function captureBytes(
+	enabled: boolean,
+	run: (tui: tuiModule.TUI, terminal: LoggingVirtualTerminal) => Promise<void>,
+): Promise<string> {
+	return await withEnv({ [VIEWPORT_ENV]: enabled ? "1" : undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+		const terminal = new LoggingVirtualTerminal(72, 8);
+		const tui = new tuiModule.TUI(terminal);
+		await run(tui, terminal);
+		const writes = terminal.getWrites();
+		tui.stop();
+		return writes;
+	});
+}
+
+function isViewportStats(
+	value: unknown,
+): value is { readonly lastKittyImageScannedLines: number; readonly lastNormalizedLines: number } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"lastNormalizedLines" in value &&
+		typeof value.lastNormalizedLines === "number" &&
+		"lastKittyImageScannedLines" in value &&
+		typeof value.lastKittyImageScannedLines === "number"
+	);
+}
+
+function viewportStats(): { readonly lastKittyImageScannedLines: number; readonly lastNormalizedLines: number } {
+	const getStats = Reflect.get(tuiModule, "__viewportRenderStats");
+	assert.strictEqual(typeof getStats, "function", "viewport render stats seam must be exported");
+	const stats: unknown = Reflect.apply(getStats, undefined, []);
+	assert.ok(stats, "viewport render stats seam must be enabled");
+	if (!isViewportStats(stats)) {
+		throw new Error("viewport render stats should include lastNormalizedLines");
+	}
+	return stats;
+}
+
+describe("viewport-bounded render", () => {
+	it("keeps streaming bytes identical when enabled", async () => {
+		const run = async (tui: tuiModule.TUI, terminal: LoggingVirtualTerminal): Promise<void> => {
+			const component = new StreamingComponent();
+			tui.addChild(component);
+			await driveRender(tui, terminal);
+			for (let index = 0; index < 12; index++) {
+				component.appendToken();
+				await driveRender(tui, terminal);
+			}
+		};
+
+		assert.strictEqual(await captureBytes(true, run), await captureBytes(false, run));
+	});
+
+	it("escapes to byte-identical behavior for offscreen line-count changes", async () => {
+		const run = async (tui: tuiModule.TUI, terminal: LoggingVirtualTerminal): Promise<void> => {
+			const component = new ExpandableComponent();
+			tui.addChild(component);
+			component.setExpanded(true);
+			await driveRender(tui, terminal);
+			component.setExpanded(false);
+			await driveRender(tui, terminal);
+		};
+
+		assert.strictEqual(await captureBytes(true, run), await captureBytes(false, run));
+	});
+
+	it("escapes to byte-identical behavior for offscreen in-place mutations", async () => {
+		const run = async (tui: tuiModule.TUI, terminal: LoggingVirtualTerminal): Promise<void> => {
+			const component = new MutableLinesComponent();
+			component.lines = Array.from({ length: 60 }, (_, index) => `line ${index}`);
+			tui.addChild(component);
+			await driveRender(tui, terminal);
+			component.lines[0] = "line zero changed offscreen";
+			await driveRender(tui, terminal);
+		};
+
+		assert.strictEqual(await captureBytes(true, run), await captureBytes(false, run));
+	});
+
+	it("normalizes only the viewport plus overscan when one status line changes", async () => {
+		await withEnv({ [VIEWPORT_ENV]: "1", PI_TUI_TEST_SEAMS: "1" }, async () => {
+			const terminal = new VirtualTerminal(80, 40);
+			const tui = new tuiModule.TUI(terminal);
+			const component = new LargeStatusComponent();
+			tui.addChild(component);
+
+			await driveRender(tui, terminal);
+			component.status = "status frame changed";
+			await driveRender(tui, terminal);
+
+			assert.ok(viewportStats().lastNormalizedLines <= terminal.rows + 2 * OVERSCAN + 1);
+			assert.ok(viewportStats().lastKittyImageScannedLines <= 1);
+			tui.stop();
+		});
+	});
+
+	it("normalizes every line when the flag is off", async () => {
+		await withEnv({ [VIEWPORT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+			const terminal = new VirtualTerminal(80, 40);
+			const tui = new tuiModule.TUI(terminal);
+			const component = new LargeStatusComponent();
+			tui.addChild(component);
+
+			await driveRender(tui, terminal);
+			component.status = "status frame changed";
+			await driveRender(tui, terminal);
+
+			assert.strictEqual(viewportStats().lastNormalizedLines, component.transcript.length + 1);
+			tui.stop();
+		});
+	});
+});

--- a/packages/tui/test/width-cache.test.ts
+++ b/packages/tui/test/width-cache.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import * as utils from "../src/utils.ts";
+
+process.env.PI_TUI_TEST_SEAMS = "1";
+
+function styledKey(prefix: string, index: number): string {
+	return `\x1b[31m${prefix}-${index}-한글\x1b[0m`;
+}
+
+type WidthCacheStats = NonNullable<ReturnType<typeof utils.__widthCacheStats>>;
+
+function widthCacheStats(): WidthCacheStats {
+	const stats = utils.__widthCacheStats();
+	if (stats === undefined) {
+		assert.fail("width cache stats seam must be enabled");
+	}
+	return stats;
+}
+
+describe("visibleWidth width cache", () => {
+	it("keeps rotated keys retrievable from the previous generation", () => {
+		// given
+		const keys = Array.from({ length: 2049 }, (_, index) => styledKey("generation", index));
+
+		// when
+		for (const key of keys) {
+			utils.visibleWidth(key);
+		}
+		const afterRotation = widthCacheStats();
+		const hitsBeforeProbe = afterRotation.hits;
+		const firstWidth = utils.visibleWidth(keys[0] ?? "");
+		const afterProbe = widthCacheStats();
+
+		// then
+		assert.strictEqual(firstWidth, 17);
+		assert.strictEqual(afterProbe.hits, hitsBeforeProbe + 1);
+		assert.ok(afterRotation.totalRetained <= 4096);
+		assert.ok(afterProbe.totalRetained <= 4096);
+	});
+
+	it("returns identical widths for a 50-case corpus before and after rotation", () => {
+		// given
+		const corpus = [
+			...Array.from({ length: 10 }, (_, index) => `ascii-${index}-plain`),
+			...Array.from({ length: 10 }, (_, index) => `한글-${index}-中文`),
+			...Array.from({ length: 10 }, (_, index) => `emoji-${index}-👨‍💻-🏳️‍🌈`),
+			...Array.from({ length: 10 }, (_, index) => `\x1b[3${index % 8}mansi-${index}-한\x1b[0m`),
+			...Array.from(
+				{ length: 10 },
+				(_, index) => `\x1b]8;;https://example.com/${index}\x1b\\osc-${index}-界\x1b]8;;\x1b\\`,
+			),
+		];
+		assert.strictEqual(corpus.length, 50);
+		const before = corpus.map((entry) => utils.visibleWidth(entry));
+
+		// when
+		for (let index = 0; index < 5000; index++) {
+			utils.visibleWidth(styledKey("rotation-filler", index));
+		}
+		const after = corpus.map((entry) => utils.visibleWidth(entry));
+
+		// then
+		assert.deepStrictEqual(after, before);
+	});
+
+	it("keeps at least half of repeated 3000-key cyclic sweeps on cache hits", () => {
+		// given
+		const keys = Array.from({ length: 3000 }, (_, index) => styledKey("cyclic", index));
+		for (const key of keys) {
+			utils.visibleWidth(key);
+		}
+		const before = widthCacheStats();
+
+		// when
+		for (let repeat = 0; repeat < 10; repeat++) {
+			for (const key of keys) {
+				utils.visibleWidth(key);
+			}
+		}
+		const after = widthCacheStats();
+
+		// then
+		const hits = after.hits - before.hits;
+		const misses = after.misses - before.misses;
+		assert.ok(hits + misses > 0);
+		assert.ok(hits / (hits + misses) >= 0.5, `expected hit rate >= 0.5, got ${hits}/${hits + misses}`);
+		assert.ok(after.totalRetained <= 4096);
+	});
+});

--- a/scripts/perf-trend-local.sh
+++ b/scripts/perf-trend-local.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+output_path="${PERF_TREND_OUTPUT:-"$repo_root/perf-trend.json"}"
+frame_small_n="${PERF_TREND_FRAME_SMALL_N:-1000}"
+frame_large_n="${PERF_TREND_FRAME_LARGE_N:-10000}"
+injected_failure_used=0
+
+: > "$output_path"
+
+append_normalized_entry() {
+	local label="$1"
+	local kind="$2"
+	local source_path="$3"
+
+	python3 -c '
+import json
+import sys
+
+label = sys.argv[1]
+kind = sys.argv[2]
+raw = json.load(sys.stdin)
+
+if kind == "frame-cost":
+    entry = {
+        "suite": "frame-cost",
+        "label": label,
+        "n": raw["n"],
+        "p50Ms": raw["p50Ms"],
+        "p95Ms": raw["p95Ms"],
+        "bytesPerFrameP50": raw["bytesPerFrameP50"],
+        "raw": raw,
+    }
+else:
+    entry = {
+        "suite": raw["suite"],
+        "label": label,
+        "n": raw["iterations"],
+        "p50Ms": raw["medianMs"],
+        "p95Ms": raw["p95Ms"],
+        "bytesPerFrameP50": None,
+        "raw": raw,
+    }
+
+print(json.dumps(entry, separators=(",", ":")))
+' "$label" "$kind" < "$source_path" >> "$output_path"
+}
+
+run_bench() {
+	local label="$1"
+	local kind="$2"
+	shift 2
+
+	if [[ "${PERF_TREND_INJECT_FAIL:-}" == "1" && "$injected_failure_used" == "0" && "$label" == "frame-cost-n${frame_large_n}" ]]; then
+		injected_failure_used=1
+		echo "bench failed (advisory)"
+		return 0
+	fi
+
+	local bench_output
+	bench_output="$(mktemp)"
+	if (cd "$repo_root/packages/tui" && "$@") > "$bench_output"; then
+		if ! append_normalized_entry "$label" "$kind" "$bench_output"; then
+			echo "bench failed (advisory)"
+		fi
+	else
+		echo "bench failed (advisory)"
+	fi
+	rm -f "$bench_output"
+}
+
+run_bench "frame-cost-n${frame_small_n}" frame-cost npx tsx bench/frame-cost.ts --n "$frame_small_n"
+run_bench "frame-cost-n${frame_large_n}" frame-cost npx tsx bench/frame-cost.ts --n "$frame_large_n"
+run_bench "frame-cost-n${frame_large_n}-viewport" frame-cost env PI_TUI_VIEWPORT_RENDER=1 npx tsx bench/frame-cost.ts --n "$frame_large_n"
+if [[ -n "${PERF_TREND_ITERATIONS:-}" ]]; then
+	run_bench "editor-layout" suite npx tsx bench/editor-layout.ts --iterations "$PERF_TREND_ITERATIONS"
+	run_bench "markdown-render" suite npx tsx bench/markdown-render.ts --iterations "$PERF_TREND_ITERATIONS"
+else
+	run_bench "editor-layout" suite npx tsx bench/editor-layout.ts
+	run_bench "markdown-render" suite npx tsx bench/markdown-render.ts
+fi


### PR DESCRIPTION
## Summary

This PR improves the TUI renderer's multiplexer behavior, long-session frame cost, render-failure containment, write hygiene, and regression instrumentation. High-risk rendering changes stay scoped or gated: `PI_TUI_VIEWPORT_RENDER` remains opt-in, mux behavior has `PI_TUI_LEGACY_MUX_RENDER`, and SGR coalescing was measured but not adopted because the corpus reduction was below the 10% gate.

Current verified head is `f7cfc64234782328b4c194b73838cdae4d521cfa`. The branch shape is 20 commits: the approved rendering plan sequence through `66f3de57`, plus `074684997` documenting the hook-status ticker fork change in the nearest `changes.md`, plus `f7cfc642` stabilizing a timing-sensitive app-server harness fixture required by the amended F2 base-parity gate.

## Changes

- Adds a deterministic TUI frame-cost bench harness and a `--stable-components` mode for isolating normalize/diff/paint cost.
- Adds shared multiplexer and render-policy switches, then preserves tmux/screen/zellij scrollback by avoiding `3J` and using bounded viewport repaint where appropriate.
- Adds opt-in viewport-bounded normalize/diff with byte-identity tests and strict full-suite coverage in both flag states.
- Improves render robustness: component render errors show fallback lines, over-wide rows are clipped in release, strict mode still throws, diagnostic writes are best-effort, and diagnostic logs are tightened to restricted permissions.
- Replaces the 512-entry width-cache cliff with a two-generation cache and coalesces redundant cursor visibility writes.
- Unrefs the coding-agent hook-status ticker interval and documents the fork change in `packages/coding-agent/src/modes/interactive/changes.md`.
- Generalizes insert-scroll into scroll-then-diff for bounded concurrent row mutations.
- Lands the SGR row-clear reset fix and evaluates SGR run coalescing with a committed report; adoption skipped because measured reduction was about 0.4%.
- Adds advisory perf trend CI plus a local mirror script.
- Stabilizes the pi-codex app-server harness immediate-exit fixtures so the amended root-suite parity gate is not blocked by event-loop teardown timing.

## QA / Evidence

- `npm run check`: pass at current head. Evidence: `.omo/evidence/final-qa/f2-base-parity-after-harness-fix/branch-npm-run-check.txt`.
- Root `npm test`: non-hermetic by plan-owner ruling; amended base-parity gate passed at current head with branch failures 82, base failures 107, and branch-minus-base 0. Evidence: `.omo/evidence/final-qa/f2-root-suite-base-parity-after-harness-fix.txt`.
- `packages/tui` full suite, flag off: pass at current head. Evidence: `.omo/evidence/final-qa/f2-base-parity-after-harness-fix/branch-tui-npm-test.txt`.
- `packages/tui` full suite, `PI_TUI_VIEWPORT_RENDER=1`: pass at current head. Evidence: `.omo/evidence/final-qa/f2-base-parity-after-harness-fix/branch-tui-npm-test-viewport.txt`.
- F4 scope fidelity: pass at current head, 20 commits, changed paths within allowlist plus the documented `changes.md` compliance extension. Evidence: `.omo/evidence/final-f4-scope-fidelity-after-harness-fix.md`.
- `changes.md` contract fix: `npm run check`, focused hook-status vitest, and senpi-qa TUI smoke passed. Evidence: `.omo/evidence/changes-md-hook-ticker-stop-hook-verify-3/11-third-stop-hook-full-verification.txt`.
- Harness stabilization fix: focused harness test passed, 5-repeat focused run passed, `npm run check` passed, and senpi-qa TUI smoke passed. Evidence: `.omo/evidence/f2-branch-only-pi-codex-harness/final-report.md` and `local-ignore/qa-evidence/20260703-tui-rendering-excellence-f2-harness-test-fix/tui-smoke-tmux.txt`.
- Manual QA reran all todo scenarios under `.omo/evidence/final-qa/`; summary: `.omo/evidence/final-f3-manual-qa.md`.
- Real tmux integration with 10,000-line transcript, `PI_TUI_VIEWPORT_RENDER=1`, `history-limit 30000`, full-history capture `-pS -`, and explicit `requestRender()` after appends preserved all 40 pre-TUI markers. Evidence: `.omo/evidence/final-qa/integration-request-render-proof.md` and `.omo/evidence/final-qa/integration-request-render-markers.txt`.
- Final review-work gate after harness fix passed goal/constraint, QA, context-mining, code-quality, and security lanes. Evidence: `.omo/evidence/global-review/after-harness-fix-*.md`.

## Risks

- The root workspace test suite still exits 1 in a clean/auth-scrubbed environment because live-provider/auth/external tests are non-hermetic; branch introduces zero new root failures by amended base-parity evidence.
- The renderer core remains large and hot; risk is covered with focused byte-level tests, full TUI suite in both flag states, real tmux QA, and `senpi-qa` TUI smoke.
- `PI_TUI_VIEWPORT_RENDER` is default-off; performance benefit is available opt-in and covered by byte-identity tests.
- SGR run coalescing is not wired into runtime because the evidence gate failed; the pure utility and report remain as evaluation artifacts.

## Secret Safety

No raw credentials, auth headers, cookies, API keys, or private env dumps are included in this PR body. QA used isolated senpi sandboxes and the `senpi-qa` harness asserted the real `~/.senpi/agent/auth.json` was unchanged.
