### PR TITLE
fix(coding-agent): hide stderr while tui owns terminal

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/hooks/output-bounds.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/output-bounds.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { redactSensitiveOutput, redactSensitiveTokenValues } from "../../../sensitive-output.ts";
 
 export const DEFAULT_STDOUT_LIMIT_BYTES = 64 * 1024;
 export const DEFAULT_STDERR_LIMIT_BYTES = 64 * 1024;
@@ -60,18 +61,11 @@ export function applyHookOutputSafety(
 }
 
 function redactHookOutput(text: string): string {
-	return redactHookTokenValues(
-		text
-			.replace(/\b([A-Z][A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD|AUTH)[A-Z0-9_]*)=([^\s'"]+)/g, "$1=[REDACTED]")
-			.replace(/\b(Authorization:\s*Bearer\s+)([^\s'"]+)/gi, "$1[REDACTED]")
-			.replace(/\b(Bearer\s+)(sk-[A-Za-z0-9._-]+)/g, "$1[REDACTED]"),
-	);
+	return redactSensitiveOutput(text);
 }
 
 export function redactHookTokenValues(text: string, replacement = "[REDACTED]"): string {
-	return text
-		.replace(/\bghp_[A-Za-z0-9]{20,}\b/g, replacement)
-		.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, replacement);
+	return redactSensitiveTokenValues(text, replacement);
 }
 
 function spillRedactedOutput(stream: "stderr" | "stdout", text: string, policy: HookOutputPolicy | undefined): string {

--- a/packages/coding-agent/src/core/output-guard.ts
+++ b/packages/coding-agent/src/core/output-guard.ts
@@ -4,7 +4,14 @@ interface StdoutTakeoverState {
 	originalStdoutWrite: typeof process.stdout.write;
 }
 
+interface StderrTakeoverState {
+	originalStderrWrite: typeof process.stderr.write;
+	onHiddenDiagnostic: ((text: string) => void) | undefined;
+	formatHiddenDiagnosticFallback: ((text: string) => string) | undefined;
+}
+
 let stdoutTakeoverState: StdoutTakeoverState | undefined;
+let stderrTakeoverState: StderrTakeoverState | undefined;
 
 const RAW_STDOUT_RETRY_DELAY_MS = 10;
 
@@ -76,6 +83,81 @@ export function restoreStdout(): void {
 
 	process.stdout.write = stdoutTakeoverState.originalStdoutWrite;
 	stdoutTakeoverState = undefined;
+}
+
+function stdioChunkToString(chunk: string | Uint8Array, encoding: BufferEncoding | undefined): string {
+	if (typeof chunk === "string") {
+		return chunk;
+	}
+	return Buffer.from(chunk).toString(encoding);
+}
+
+function normalizeThrownError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function writeOriginalStderr(state: StderrTakeoverState, text: string): void {
+	if (text.length === 0) {
+		return;
+	}
+	state.originalStderrWrite.call(process.stderr, text);
+}
+
+export function takeOverStderr(
+	onHiddenDiagnostic?: (text: string) => void,
+	formatHiddenDiagnosticFallback?: (text: string) => string,
+): void {
+	if (stderrTakeoverState) {
+		return;
+	}
+
+	const originalStderrWrite = process.stderr.write;
+
+	process.stderr.write = ((
+		chunk: string | Uint8Array,
+		encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+		callback?: (error?: Error | null) => void,
+	): boolean => {
+		const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
+		const text = stdioChunkToString(chunk, encoding);
+		try {
+			stderrTakeoverState?.onHiddenDiagnostic?.(text);
+		} catch (error) {
+			const state = stderrTakeoverState;
+			if (state) {
+				const fallbackText = state.formatHiddenDiagnosticFallback?.(text) ?? text;
+				writeOriginalStderr(state, fallbackText);
+			}
+			const writeError = normalizeThrownError(error);
+			if (typeof encodingOrCallback === "function") {
+				encodingOrCallback(writeError);
+			} else {
+				callback?.(writeError);
+			}
+			return false;
+		}
+		if (typeof encodingOrCallback === "function") {
+			encodingOrCallback(null);
+		} else {
+			callback?.(null);
+		}
+		return true;
+	}) satisfies typeof process.stderr.write;
+
+	stderrTakeoverState = {
+		formatHiddenDiagnosticFallback,
+		originalStderrWrite,
+		onHiddenDiagnostic,
+	};
+}
+
+export function restoreStderr(): void {
+	if (!stderrTakeoverState) {
+		return;
+	}
+
+	process.stderr.write = stderrTakeoverState.originalStderrWrite;
+	stderrTakeoverState = undefined;
 }
 
 export function isStdoutTakenOver(): boolean {

--- a/packages/coding-agent/src/core/sensitive-output.ts
+++ b/packages/coding-agent/src/core/sensitive-output.ts
@@ -1,0 +1,14 @@
+export function redactSensitiveOutput(text: string): string {
+	return redactSensitiveTokenValues(
+		text
+			.replace(/\b([A-Z][A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD|AUTH)[A-Z0-9_]*)=([^\s'"]+)/g, "$1=[REDACTED]")
+			.replace(/\b(Authorization:\s*Bearer\s+)([^\s'"]+)/gi, "$1[REDACTED]")
+			.replace(/\b(Bearer\s+)(sk-[A-Za-z0-9._-]+)/g, "$1[REDACTED]"),
+	);
+}
+
+export function redactSensitiveTokenValues(text: string, replacement = "[REDACTED]"): string {
+	return text
+		.replace(/\bghp_[A-Za-z0-9]{20,}\b/g, replacement)
+		.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, replacement);
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -140,6 +140,7 @@ import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
 import { UserMessageComponent } from "./components/user-message.ts";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.ts";
+import { restoreInteractiveStderr, takeOverInteractiveStderr } from "./interactive-stderr-guard.ts";
 import { getModelSearchText } from "./model-search.ts";
 import { formatSessionInfo } from "./session-info-format.ts";
 import { resolveStartupToolPaths } from "./startup-tools.ts";
@@ -758,7 +759,13 @@ export class InteractiveMode {
 		this.setupEditorSubmitHandler();
 
 		// Start the UI before initializing extensions so session_start handlers can use interactive dialogs
-		this.ui.start();
+		try {
+			takeOverInteractiveStderr();
+			this.ui.start();
+		} catch (error) {
+			restoreInteractiveStderr();
+			throw error;
+		}
 		this.isInitialized = true;
 
 		await this.themeController.applyFromSettings();
@@ -3821,6 +3828,7 @@ export class InteractiveMode {
 		try {
 			this.ui.stop();
 		} catch {}
+		restoreInteractiveStderr();
 		console.error("pi exiting due to uncaughtException:");
 		console.error(error);
 		process.exit(1);
@@ -3901,12 +3909,14 @@ export class InteractiveMode {
 		process.once("SIGCONT", () => {
 			clearInterval(suspendKeepAlive);
 			process.removeListener("SIGINT", ignoreSigint);
+			takeOverInteractiveStderr();
 			this.ui.start();
 			this.ui.requestRender(true);
 		});
 
 		try {
 			// Stop the TUI (restore terminal to normal mode)
+			restoreInteractiveStderr();
 			this.ui.stop();
 
 			// Send SIGTSTP to process group (pid=0 means all processes in group)
@@ -4058,6 +4068,7 @@ export class InteractiveMode {
 			fs.writeFileSync(tmpFile, currentText, "utf-8");
 
 			// Stop TUI to release terminal
+			restoreInteractiveStderr();
 			this.ui.stop();
 
 			// Split by space to support editor arguments (e.g., "code --wait")
@@ -4092,6 +4103,7 @@ export class InteractiveMode {
 			}
 
 			// Restart TUI
+			takeOverInteractiveStderr();
 			this.ui.start();
 			// Force full re-render since external editor uses alternate screen
 			this.ui.requestRender(true);
@@ -6177,8 +6189,14 @@ export class InteractiveMode {
 			this.unsubscribe();
 		}
 		if (this.isInitialized) {
-			this.ui.stop();
-			this.isInitialized = false;
+			try {
+				this.ui.stop();
+			} finally {
+				this.isInitialized = false;
+				restoreInteractiveStderr();
+			}
+		} else {
+			restoreInteractiveStderr();
 		}
 		this.unregisterSignalHandlers();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-stderr-guard.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-stderr-guard.ts
@@ -1,0 +1,26 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getDebugLogPath } from "../../config.ts";
+import { restoreStderr, takeOverStderr } from "../../core/output-guard.ts";
+import { redactSensitiveOutput } from "../../core/sensitive-output.ts";
+
+function appendHiddenInteractiveStderr(text: string): void {
+	if (text.length === 0) {
+		return;
+	}
+	const debugLogPath = getDebugLogPath();
+	const prefix = `[${new Date().toISOString()}] hidden stderr while TUI active\n`;
+	const redactedText = redactSensitiveOutput(text);
+	const suffix = redactedText.endsWith("\n") ? "" : "\n";
+	fs.mkdirSync(path.dirname(debugLogPath), { recursive: true });
+	fs.appendFileSync(debugLogPath, `${prefix}${redactedText}${suffix}`, { mode: 0o600 });
+	fs.chmodSync(debugLogPath, 0o600);
+}
+
+export function takeOverInteractiveStderr(): void {
+	takeOverStderr(appendHiddenInteractiveStderr, redactSensitiveOutput);
+}
+
+export function restoreInteractiveStderr(): void {
+	restoreStderr();
+}

--- a/packages/coding-agent/test/interactive-stderr-guard.test.ts
+++ b/packages/coding-agent/test/interactive-stderr-guard.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR, getDebugLogPath } from "../src/config.ts";
+import { restoreStderr, takeOverStderr } from "../src/core/output-guard.ts";
+import {
+	restoreInteractiveStderr,
+	takeOverInteractiveStderr,
+} from "../src/modes/interactive/interactive-stderr-guard.ts";
+
+const originalStderrWrite = process.stderr.write;
+const originalAgentDir = process.env[ENV_AGENT_DIR];
+const githubFineGrainedPat = "github_pat_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const tempDirs: string[] = [];
+
+function replaceStderrWrite(write: typeof process.stderr.write): void {
+	Object.defineProperty(process.stderr, "write", {
+		configurable: true,
+		value: write,
+		writable: true,
+	});
+}
+
+function createCapturingStderrWrite(capture: (text: string) => void): typeof process.stderr.write {
+	return ((
+		chunk: string | Uint8Array,
+		encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+		callback?: (error?: Error | null) => void,
+	): boolean => {
+		capture(String(chunk));
+		if (typeof encodingOrCallback === "function") {
+			encodingOrCallback(null);
+		} else {
+			callback?.(null);
+		}
+		return true;
+	}) satisfies typeof process.stderr.write;
+}
+
+afterEach(() => {
+	restoreInteractiveStderr();
+	restoreStderr();
+	replaceStderrWrite(originalStderrWrite);
+	if (originalAgentDir === undefined) {
+		delete process.env[ENV_AGENT_DIR];
+	} else {
+		process.env[ENV_AGENT_DIR] = originalAgentDir;
+	}
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+describe("interactive stderr guard", () => {
+	it("hides direct runtime stderr while the TUI owns the terminal and restores it afterwards", () => {
+		let terminalText = "";
+		const hiddenDiagnostics: string[] = [];
+		replaceStderrWrite(
+			createCapturingStderrWrite((text) => {
+				terminalText += text;
+			}),
+		);
+
+		takeOverStderr((text) => hiddenDiagnostics.push(text));
+		process.stderr.write("omo-senpi ulw-loop status ignored { reason: 'non-zero-exit', code: 1 }\n");
+		process.stderr.write(Buffer.from("omo-senpi ulw-loop continuation skipped { reason: 'inactive' }\n"));
+
+		expect(terminalText).toBe("");
+		expect(hiddenDiagnostics.join("")).toContain("status ignored");
+		expect(hiddenDiagnostics.join("")).toContain("continuation skipped");
+
+		restoreStderr();
+		process.stderr.write("real shutdown error\n");
+		expect(terminalText).toContain("real shutdown error");
+	});
+
+	it("reports hidden diagnostic sink failures to stderr callbacks", () => {
+		let callbackError: Error | null | undefined;
+		let terminalText = "";
+		replaceStderrWrite(
+			createCapturingStderrWrite((text) => {
+				terminalText += text;
+			}),
+		);
+
+		takeOverStderr(() => {
+			throw new Error("debug log unavailable");
+		});
+		const accepted = process.stderr.write("runtime diagnostic\n", (error?: Error | null) => {
+			callbackError = error;
+		});
+
+		expect(accepted).toBe(false);
+		expect(callbackError).toBeInstanceOf(Error);
+		expect(callbackError?.message).toBe("debug log unavailable");
+		expect(terminalText).toBe("runtime diagnostic\n");
+	});
+
+	it("falls back to stderr when hidden diagnostics cannot be saved", () => {
+		let terminalText = "";
+		replaceStderrWrite(
+			createCapturingStderrWrite((text) => {
+				terminalText += text;
+			}),
+		);
+
+		takeOverStderr(
+			() => {
+				throw new Error("debug log unavailable");
+			},
+			(text) => text.replace("stderr-secret", "[REDACTED]"),
+		);
+		const accepted = process.stderr.write("SECRET_TOKEN=stderr-secret\n");
+
+		expect(accepted).toBe(false);
+		expect(terminalText).toBe("SECRET_TOKEN=[REDACTED]\n");
+		expect(terminalText).not.toContain("stderr-secret");
+	});
+
+	it("redacts hidden interactive stderr before writing the debug log", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-hidden-stderr-"));
+		tempDirs.push(agentDir);
+		process.env[ENV_AGENT_DIR] = agentDir;
+
+		takeOverInteractiveStderr();
+		process.stderr.write(
+			[
+				"SECRET_TOKEN=debug-secret",
+				"Authorization: Bearer stderr-secret",
+				`token ${githubFineGrainedPat}`,
+				"github_pat_short",
+			].join("\n"),
+		);
+		restoreInteractiveStderr();
+
+		const debugLogPath = getDebugLogPath();
+		const log = readFileSync(debugLogPath, "utf8");
+		expect(log).toContain("SECRET_TOKEN=[REDACTED]");
+		expect(log).toContain("Authorization: Bearer [REDACTED]");
+		expect(log).toContain("token [REDACTED]");
+		expect(log).toContain("github_pat_short");
+		expect(log).not.toContain("debug-secret");
+		expect(log).not.toContain("stderr-secret");
+		expect(log).not.toContain(githubFineGrainedPat);
+		expect((statSync(debugLogPath).mode & 0o777).toString(8)).toBe("600");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes TUI corruption from runtime stderr writes while the interactive UI owns the terminal. Diagnostics such as `omo-senpi ulw-loop status ignored` and `continuation skipped` are now hidden from the pane and saved to the debug log instead.

Before: background runtime stderr could print across the full-screen UI.
After: interactive mode captures stderr while active, restores it around terminal release paths, and preserves hidden diagnostics in `senpi-debug.log`.

## Changes

- Added stderr takeover/restore support alongside the existing stdout guard.
- Added an interactive stderr guard that appends hidden diagnostics to the debug log with secret redaction and `0600` permissions.
- Restored stderr before crash reporting, Ctrl-Z suspend, external editor launch, and shutdown; retakes it before TUI resume.
- Shared secret redaction between hook output safety and interactive hidden stderr logging.
- Added regression tests for hidden stderr, restore behavior, sink failure fallback, redaction, and debug-log permissions.

## QA / Evidence

- Focused regression: `local-ignore/qa-evidence/20260704-quiet-ulw-status/focused-test-final.txt`
  - `packages/coding-agent/test/interactive-stderr-guard.test.ts`: 4 tests passed.
- Hook redaction regression: `local-ignore/qa-evidence/20260704-quiet-ulw-status/hooks-safety-test-final.txt`
  - `packages/coding-agent/test/suite/hooks-safety.test.ts`: 6 tests passed.
- Full repository check: `local-ignore/qa-evidence/20260704-quiet-ulw-status/npm-run-check-final.txt`
  - `npm run check`: passed with no fixes applied.
- TUI smoke: `local-ignore/qa-evidence/20260704-quiet-ulw-status/tui-smoke-final.txt`
  - tmux-driven TUI boot/render/input/teardown: 5/5 passed; real auth unchanged.
- Mock loop: `local-ignore/qa-evidence/20260704-quiet-ulw-status/mock-loop-final.txt`
  - real CLI loop against localhost fake providers: 5/5 passed; real auth unchanged.
- Targeted manual QA: `local-ignore/qa-evidence/20260704-quiet-ulw-status/tui-stderr-injection-final.txt`
  - injected stderr marker and fake secrets while TUI was active.
  - Pane stayed clean, debug log captured the marker, fake secrets were redacted, debug log mode was `600`, tmux cleaned up, real auth unchanged.

## Risks

- Hidden runtime diagnostics no longer appear in the TUI pane while active. They remain available in the debug log.
- If debug-log writing fails, stderr falls back to the original writer rather than silently dropping diagnostics; interactive fallback redacts sensitive values before writing.

## Secret safety

QA used fake marker values and fake tokens only. The targeted injection artifact verifies redaction and does not require raw real credentials, auth headers, cookies, or environment dumps.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents TUI corruption by capturing runtime stderr while the interactive UI owns the terminal. Hidden diagnostics are redacted and written to the debug log; stderr is restored around suspend, editor, crash, and shutdown paths.

- **Bug Fixes**
  - Implemented stderr takeover/restore in `core/output-guard` and an interactive guard `interactive-stderr-guard` that appends redacted diagnostics to the debug log with 0600 permissions.
  - Restores/takes over stderr when releasing/resuming the terminal: Ctrl-Z suspend/resume, external editor, crash reporting, and shutdown.
  - Added safe fallback: if debug-log writes fail, redacted diagnostics go to the original stderr and errors are surfaced to callbacks.
  - Centralized secret redaction in `core/sensitive-output` and reused it in hook output safety.

<sup>Written for commit eba52925f3e97b2cd08b082ccf926de9c69b7105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

