### PR TITLE
feat(coding-agent): show live hook identity in tool hook status rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Added
 
+- Added `ctx.updateToolHookStatus()` so `tool_call`/`tool_result` extension handlers can report what they are doing in the live "Running PreToolUse/PostToolUse hook" TUI status row
+
 ### Changed
 
 ### Fixed
+
+- Fixed the live tool hook status row showing a generic `running builtin:hooks` label instead of the running command hook's configured `statusMessage` (falling back to its sanitized command text)
 
 ## [2026.7.3] - 2026-07-03
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -515,7 +515,7 @@ Only command handlers are executable in builtin hooks v1:
 }
 ```
 
-`command` is required and runs through the host shell with the hook input JSON on stdin. `commandWindows` or `command_windows` can override the command on Windows. `timeout` is seconds and defaults to 600. `statusMessage` is display text only.
+`command` is required and runs through the host shell with the hook input JSON on stdin. `commandWindows` or `command_windows` can override the command on Windows. `timeout` is seconds and defaults to 600. `statusMessage` is display text: while the hook command runs during `PreToolUse`/`PostToolUse`, the TUI shows it in the live `Running PreToolUse/PostToolUse hook: ...` status row (hooks without one show their sanitized command text instead).
 
 Hook commands inherit a minimal environment (`PATH`, home/user/shell/temp variables, and Windows shell basics). Hooks loaded through the plugin manifest helper also receive `PLUGIN_ROOT`, `PLUGIN_DATA`, `CLAUDE_PLUGIN_ROOT`, and `CLAUDE_PLUGIN_DATA`. Every command receives `SENPI_HOOK_SOURCE` and `SENPI_HOOK_EVENT`. Do not put API keys or tokens in hook config, command text, status messages, stdout, stderr, or diagnostics. Read secrets inside the command from your own secret store and avoid echoing them.
 
@@ -1448,6 +1448,19 @@ pi.on("tool_call", (event, ctx) => {
   if (isFatal(event.input)) {
     ctx.shutdown();
   }
+});
+```
+
+### ctx.updateToolHookStatus()
+
+Only available on the context passed to `tool_call` and `tool_result` handlers. Replaces the label of that handler's live `Running PreToolUse/PostToolUse hook: ...` status row in the TUI, so long-running hooks can report what they are doing. Messages are truncated to 79 characters; calls after the handler finished are ignored.
+
+```typescript
+pi.on("tool_result", async (event, ctx) => {
+  ctx.updateToolHookStatus?.("Checking comments");
+  await runCommentChecker(event);
+  ctx.updateToolHookStatus?.("Collecting diagnostics");
+  await collectDiagnostics(event);
 });
 ```
 

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/dispatcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/dispatcher.ts
@@ -1,3 +1,4 @@
+import { stripAnsi } from "../../../../utils/ansi.ts";
 import { type CommandHookRunOptions, type CommandHookRunResult, runCommandHook } from "./command-runner.ts";
 import { matchingHookHandlers } from "./matcher.ts";
 import { type ParsedHookOutput, parseHookOutput } from "./output-parser.ts";
@@ -64,6 +65,7 @@ export type HookDispatchOptions = {
 	readonly envPassthrough?: readonly string[];
 	readonly handlers: readonly ExecutableHookHandler[];
 	readonly input: HookInputWire;
+	readonly onRunningHandlersChange?: (running: readonly ExecutableHookHandler[]) => void;
 	readonly outputPolicy?: HookOutputPolicy;
 	readonly runCommand?: HookCommandRunner;
 	readonly signal?: AbortSignal;
@@ -87,25 +89,41 @@ export async function dispatchHookEvent(options: HookDispatchOptions): Promise<H
 	const selected = selectExecutableHandlers(ordered, options.trustState, options.trustOptions);
 	let nextCompletionIndex = 0;
 	const runner = options.runCommand ?? runCommandHook;
+	const notifyRunningChange = options.onRunningHandlersChange;
+	const runningHandlers: ExecutableHookHandler[] = [];
 	const completed = await Promise.all(
 		selected.runnable.map(async ({ handler, declarationIndex }) => {
-			const run = await runner(handler, options.input, {
-				cwd: options.cwd,
-				...(options.envPassthrough === undefined ? {} : { envPassthrough: options.envPassthrough }),
-				...(options.outputPolicy === undefined ? {} : { outputPolicy: options.outputPolicy }),
-				...(options.signal === undefined ? {} : { signal: options.signal }),
-				...(options.sourceEnv === undefined ? {} : { sourceEnv: options.sourceEnv }),
-			});
-			const parsed = parseHookOutput({
-				event: options.input.event,
-				exitCode: run.exitCode ?? 1,
-				source: handler.source,
-				stderr: run.stderr,
-				stdout: run.stdout,
-			});
-			const completionIndex = nextCompletionIndex;
-			nextCompletionIndex += 1;
-			return { completionIndex, declarationIndex, handler, parsed, run };
+			if (notifyRunningChange !== undefined) {
+				runningHandlers.push(handler);
+				notifyRunningChange([...runningHandlers]);
+			}
+			try {
+				const run = await runner(handler, options.input, {
+					cwd: options.cwd,
+					...(options.envPassthrough === undefined ? {} : { envPassthrough: options.envPassthrough }),
+					...(options.outputPolicy === undefined ? {} : { outputPolicy: options.outputPolicy }),
+					...(options.signal === undefined ? {} : { signal: options.signal }),
+					...(options.sourceEnv === undefined ? {} : { sourceEnv: options.sourceEnv }),
+				});
+				const parsed = parseHookOutput({
+					event: options.input.event,
+					exitCode: run.exitCode ?? 1,
+					source: handler.source,
+					stderr: run.stderr,
+					stdout: run.stdout,
+				});
+				const completionIndex = nextCompletionIndex;
+				nextCompletionIndex += 1;
+				return { completionIndex, declarationIndex, handler, parsed, run };
+			} finally {
+				if (notifyRunningChange !== undefined) {
+					const runningIndex = runningHandlers.indexOf(handler);
+					if (runningIndex !== -1) {
+						runningHandlers.splice(runningIndex, 1);
+					}
+					notifyRunningChange([...runningHandlers]);
+				}
+			}
 		}),
 	);
 	const declarationSummaries = completed
@@ -130,6 +148,27 @@ export async function dispatchHookEvent(options: HookDispatchOptions): Promise<H
 		skipped: selected.skipped,
 		summaries: declarationSummaries,
 	};
+}
+
+export function runningHookHandlersStatusLabel(
+	handlers: readonly ExecutableHookHandler[],
+	platform: NodeJS.Platform = process.platform,
+): string {
+	const label = handlers.map((handler) => hookHandlerStatusLabel(handler, platform)).join(" · ");
+	return label.length <= 79 ? label : `${label.slice(0, 76)}...`;
+}
+
+function hookHandlerStatusLabel(handler: ExecutableHookHandler, platform: NodeJS.Platform): string {
+	const raw =
+		handler.config.statusMessage ??
+		(platform === "win32" && handler.config.commandWindows !== undefined
+			? handler.config.commandWindows
+			: handler.config.command);
+	return stripAnsi(raw)
+		.replace(/[\r\n\t]+/g, " ")
+		.replace(/[\u0000-\u001f\u007f]+/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
 }
 
 function declarationOrdered(handlers: readonly ExecutableHookHandler[]): readonly OrderedHandler[] {

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import type { BeforeAgentStartEventResult, ExtensionAPI, ExtensionContext, LoadedHookSources } from "../../types.ts";
 import { registerHooksCommand } from "./command.ts";
 import { loadHookConfigSources } from "./config-loader.ts";
-import { dispatchHookEvent } from "./dispatcher.ts";
+import { dispatchHookEvent, runningHookHandlersStatusLabel } from "./dispatcher.ts";
 import {
 	buildPostCompactHookInput,
 	buildPreCompactHookInput,
@@ -179,6 +179,10 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 			cwd: ctx.cwd,
 			handlers: state.parsed.executableHandlers,
 			input: buildPreToolUseHookInput(event, ctx),
+			onRunningHandlersChange: (running) => {
+				if (running.length === 0) return;
+				ctx.updateToolHookStatus?.(runningHookHandlersStatusLabel(running));
+			},
 			signal: ctx.signal,
 			trustOptions: { platform: process.platform },
 			trustState: state.trust,
@@ -203,6 +207,10 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 			cwd: ctx.cwd,
 			handlers: state.parsed.executableHandlers,
 			input: buildPostToolUseHookInput(event, ctx),
+			onRunningHandlersChange: (running) => {
+				if (running.length === 0) return;
+				ctx.updateToolHookStatus?.(runningHookHandlersStatusLabel(running));
+			},
 			signal: ctx.signal,
 			trustOptions: { platform: process.platform },
 			trustState: state.trust,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -188,6 +188,10 @@ function cloneJsonValue<T>(value: T): T {
 
 export type ExtensionErrorListener = (error: ExtensionError) => void;
 
+function boundedToolHookStatusMessage(message: string): string {
+	return message.length <= 79 ? message : `${message.slice(0, 76)}...`;
+}
+
 export type ExtensionToolHookName = "PreToolUse" | "PostToolUse";
 export type ExtensionToolHookLifecycleStatus = "completed" | "blocked" | "failed";
 
@@ -205,6 +209,9 @@ type ExtensionToolHookLifecycleEventBase = {
 export type ExtensionToolHookLifecycleEvent =
 	| (ExtensionToolHookLifecycleEventBase & {
 			phase: "start";
+	  })
+	| (ExtensionToolHookLifecycleEventBase & {
+			phase: "update";
 	  })
 	| (ExtensionToolHookLifecycleEventBase & {
 			phase: "end";
@@ -659,15 +666,64 @@ export class ExtensionRunner {
 		}
 
 		const extensionName =
-			extensionPath.startsWith("<") && extensionPath.endsWith(">")
+			builtinName ??
+			(extensionPath.startsWith("<") && extensionPath.endsWith(">")
 				? extensionPath.slice(1, -1)
-				: basename(extensionPath).replace(/\.(?:c|m)?[jt]sx?$/, "");
-		const message = `running ${extensionName}`;
-		return message.length <= 79 ? message : `${message.slice(0, 76)}...`;
+				: basename(extensionPath).replace(/\.(?:c|m)?[jt]sx?$/, ""));
+		return boundedToolHookStatusMessage(`running ${extensionName}`);
 	}
 
 	private emitToolHookLifecycleEvent(event: ExtensionToolHookLifecycleEvent): void {
 		this.toolHookLifecycleObserver?.(event);
+	}
+
+	private beginToolHookRun(
+		baseContext: ExtensionContext,
+		run: {
+			hookName: ExtensionToolHookName;
+			toolName: string;
+			toolCallId: string;
+			extensionPath: string;
+		},
+	): {
+		readonly context: ExtensionContext;
+		end(status: ExtensionToolHookLifecycleStatus, errorMessage?: string): void;
+	} {
+		const base = {
+			type: "tool_hook_status" as const,
+			hookRunId: `${run.toolCallId}:${run.hookName}:${this.nextToolHookRunIndex++}`,
+			hookName: run.hookName,
+			toolName: run.toolName,
+			toolCallId: run.toolCallId,
+			extensionPath: run.extensionPath,
+			startedAt: Date.now(),
+		};
+		let statusMessage = this.getToolHookStatusMessage(run.extensionPath, run.hookName);
+		let ended = false;
+		this.emitToolHookLifecycleEvent({ ...base, phase: "start", statusMessage });
+		// Property descriptors keep the guarded getters from createContext() lazy; a
+		// spread would freeze their current values and bypass stale-instance checks.
+		const context = Object.defineProperties({}, Object.getOwnPropertyDescriptors(baseContext)) as ExtensionContext;
+		context.updateToolHookStatus = (update: string) => {
+			if (ended) return;
+			statusMessage = boundedToolHookStatusMessage(update);
+			this.emitToolHookLifecycleEvent({ ...base, phase: "update", statusMessage });
+		};
+		return {
+			context,
+			end: (status, errorMessage) => {
+				if (ended) return;
+				ended = true;
+				this.emitToolHookLifecycleEvent({
+					...base,
+					phase: "end",
+					statusMessage,
+					completedAt: Date.now(),
+					status,
+					...(errorMessage !== undefined ? { errorMessage } : {}),
+				});
+			},
+		};
 	}
 
 	getMessageRenderer(customType: string): MessageRenderer | undefined {
@@ -1033,24 +1089,18 @@ export class ExtensionRunner {
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
-				const hookRunId = `${event.toolCallId}:PostToolUse:${this.nextToolHookRunIndex++}`;
-				const startedAt = Date.now();
-				const statusMessage = this.getToolHookStatusMessage(ext.path, "PostToolUse");
-				let endStatus: ExtensionToolHookLifecycleStatus = "completed";
-				let errorMessage: string | undefined;
-				this.emitToolHookLifecycleEvent({
-					type: "tool_hook_status",
-					phase: "start",
-					hookRunId,
+				const hookRun = this.beginToolHookRun(ctx, {
 					hookName: "PostToolUse",
 					toolName: event.toolName,
 					toolCallId: event.toolCallId,
 					extensionPath: ext.path,
-					statusMessage,
-					startedAt,
 				});
+				let endStatus: ExtensionToolHookLifecycleStatus = "completed";
+				let errorMessage: string | undefined;
 				try {
-					const handlerResult = (await handler(currentEvent, ctx)) as ToolResultEventResult | undefined;
+					const handlerResult = (await handler(currentEvent, hookRun.context)) as
+						| ToolResultEventResult
+						| undefined;
 					if (!handlerResult) continue;
 
 					if (handlerResult.content !== undefined) {
@@ -1077,20 +1127,7 @@ export class ExtensionRunner {
 						stack,
 					});
 				} finally {
-					this.emitToolHookLifecycleEvent({
-						type: "tool_hook_status",
-						phase: "end",
-						hookRunId,
-						hookName: "PostToolUse",
-						toolName: event.toolName,
-						toolCallId: event.toolCallId,
-						extensionPath: ext.path,
-						statusMessage,
-						startedAt,
-						completedAt: Date.now(),
-						status: endStatus,
-						...(errorMessage !== undefined ? { errorMessage } : {}),
-					});
+					hookRun.end(endStatus, errorMessage);
 				}
 			}
 		}
@@ -1115,24 +1152,16 @@ export class ExtensionRunner {
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
-				const hookRunId = `${event.toolCallId}:PreToolUse:${this.nextToolHookRunIndex++}`;
-				const startedAt = Date.now();
-				const statusMessage = this.getToolHookStatusMessage(ext.path, "PreToolUse");
-				let endStatus: ExtensionToolHookLifecycleStatus = "completed";
-				let errorMessage: string | undefined;
-				this.emitToolHookLifecycleEvent({
-					type: "tool_hook_status",
-					phase: "start",
-					hookRunId,
+				const hookRun = this.beginToolHookRun(ctx, {
 					hookName: "PreToolUse",
 					toolName: event.toolName,
 					toolCallId: event.toolCallId,
 					extensionPath: ext.path,
-					statusMessage,
-					startedAt,
 				});
+				let endStatus: ExtensionToolHookLifecycleStatus = "completed";
+				let errorMessage: string | undefined;
 				try {
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await handler(event, hookRun.context);
 
 					if (handlerResult) {
 						result = handlerResult as ToolCallEventResult;
@@ -1146,20 +1175,7 @@ export class ExtensionRunner {
 					errorMessage = err instanceof Error ? err.message : String(err);
 					throw err;
 				} finally {
-					this.emitToolHookLifecycleEvent({
-						type: "tool_hook_status",
-						phase: "end",
-						hookRunId,
-						hookName: "PreToolUse",
-						toolName: event.toolName,
-						toolCallId: event.toolCallId,
-						extensionPath: ext.path,
-						statusMessage,
-						startedAt,
-						completedAt: Date.now(),
-						status: endStatus,
-						...(errorMessage !== undefined ? { errorMessage } : {}),
-					});
+					hookRun.end(endStatus, errorMessage);
 				}
 			}
 		}

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -7,6 +7,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model } from "@earendil-works/pi-ai";
 import type { KeyId } from "@earendil-works/pi-tui";
 import { type Theme, theme } from "../../modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../utils/ansi.ts";
 import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
 import type { ModelRegistry } from "../model-registry.ts";
@@ -190,6 +191,16 @@ export type ExtensionErrorListener = (error: ExtensionError) => void;
 
 function boundedToolHookStatusMessage(message: string): string {
 	return message.length <= 79 ? message : `${message.slice(0, 76)}...`;
+}
+
+function sanitizedToolHookStatusMessage(message: string): string {
+	return boundedToolHookStatusMessage(
+		stripAnsi(message)
+			.replace(/[\r\n\t]+/g, " ")
+			.replace(/[\u0000-\u001f\u007f]+/g, "")
+			.replace(/\s+/g, " ")
+			.trim(),
+	);
 }
 
 export type ExtensionToolHookName = "PreToolUse" | "PostToolUse";
@@ -706,7 +717,7 @@ export class ExtensionRunner {
 		const context = Object.defineProperties({}, Object.getOwnPropertyDescriptors(baseContext)) as ExtensionContext;
 		context.updateToolHookStatus = (update: string) => {
 			if (ended) return;
-			statusMessage = boundedToolHookStatusMessage(update);
+			statusMessage = sanitizedToolHookStatusMessage(update);
 			this.emitToolHookLifecycleEvent({ ...base, phase: "update", statusMessage });
 		};
 		return {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -376,6 +376,13 @@ export interface ExtensionContext {
 	getSystemPrompt(): string;
 	/** Get hook source paths currently visible to the builtin hooks extension. */
 	getLoadedHookSources?(): LoadedHookSources;
+	/**
+	 * Report what the currently running tool_call/tool_result handler is doing.
+	 * Updates the live "Running PreToolUse/PostToolUse hook" status row in the TUI.
+	 * Only available on the context passed to tool_call/tool_result handlers; calls
+	 * after the handler finished are ignored.
+	 */
+	updateToolHookStatus?(statusMessage: string): void;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1929,6 +1929,20 @@ export class InteractiveMode {
 			this.refreshToolHookStatuses();
 			return;
 		}
+		if (event.phase === "update") {
+			const existing = this.activeToolHooks.get(event.hookRunId);
+			if (!existing) {
+				return;
+			}
+			const updated = { ...existing, statusMessage: event.statusMessage };
+			this.activeToolHooks.set(event.hookRunId, updated);
+			this.activeToolTerminalTitle = formatToolHookTerminalTitle(updated);
+			if (this.ui.terminal) {
+				this.applyTerminalTitle();
+			}
+			this.refreshToolHookStatuses();
+			return;
+		}
 		this.activeToolHooks.delete(event.hookRunId);
 		const nextHook = this.activeToolHooks.values().next().value;
 		this.activeToolTerminalTitle = nextHook ? formatToolHookTerminalTitle(nextHook) : undefined;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1200,6 +1200,86 @@ describe("ExtensionRunner", () => {
 			});
 		});
 
+		it("emits update events while a handler reports live tool hook status", async () => {
+			const runtime = createExtensionRuntime();
+			let staleUpdater: ((statusMessage: string) => void) | undefined;
+			const extension = await loadExtensionFromFactory(
+				(pi) => {
+					pi.on("tool_result", async (_event, ctx) => {
+						ctx.updateToolHookStatus?.("(OmO) Checking Comments");
+						staleUpdater = ctx.updateToolHookStatus;
+					});
+				},
+				tempDir,
+				createEventBus(),
+				runtime,
+				"<builtin:hooks>",
+			);
+			const runner = new ExtensionRunner([extension], runtime, tempDir, sessionManager, modelRegistry);
+			const lifecycleEvents: ExtensionToolHookLifecycleEvent[] = [];
+			runner.setToolHookLifecycleObserver((event) => lifecycleEvents.push(event));
+
+			await runner.emitToolResult({
+				type: "tool_result",
+				toolName: "bash",
+				toolCallId: "call-update",
+				input: {},
+				content: [{ type: "text", text: "ok" }],
+				details: {},
+				isError: false,
+			});
+
+			expect(lifecycleEvents.map((event) => event.phase)).toEqual(["start", "update", "end"]);
+			expect(lifecycleEvents[0]).toMatchObject({
+				phase: "start",
+				statusMessage: "running hooks",
+				extensionPath: "<builtin:hooks>",
+			});
+			expect(lifecycleEvents[1]).toMatchObject({
+				phase: "update",
+				hookRunId: lifecycleEvents[0]?.hookRunId,
+				statusMessage: "(OmO) Checking Comments",
+				startedAt: lifecycleEvents[0]?.startedAt,
+			});
+			expect(lifecycleEvents[2]).toMatchObject({
+				phase: "end",
+				status: "completed",
+				statusMessage: "(OmO) Checking Comments",
+			});
+
+			staleUpdater?.("too late");
+			expect(lifecycleEvents).toHaveLength(3);
+		});
+
+		it("bounds live tool hook status updates to the display budget", async () => {
+			const runtime = createExtensionRuntime();
+			const longMessage = "x".repeat(200);
+			const extension = await loadExtensionFromFactory(
+				(pi) => {
+					pi.on("tool_call", async (_event, ctx) => {
+						ctx.updateToolHookStatus?.(longMessage);
+					});
+				},
+				tempDir,
+				createEventBus(),
+				runtime,
+				"<builtin:hooks>",
+			);
+			const runner = new ExtensionRunner([extension], runtime, tempDir, sessionManager, modelRegistry);
+			const lifecycleEvents: ExtensionToolHookLifecycleEvent[] = [];
+			runner.setToolHookLifecycleObserver((event) => lifecycleEvents.push(event));
+
+			await runner.emitToolCall({
+				type: "tool_call",
+				toolName: "bash",
+				toolCallId: "call-bounded",
+				input: {},
+			});
+
+			const update = lifecycleEvents.find((event) => event.phase === "update");
+			expect(update?.statusMessage).toBe(`${"x".repeat(76)}...`);
+		});
+
 		it("uses bounded custom hook status labels", async () => {
 			const runtime = createExtensionRuntime();
 			const extensionPath = path.join(tempDir, ".senpi", "extensions", "check-output.ts");

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1251,12 +1251,14 @@ describe("ExtensionRunner", () => {
 			expect(lifecycleEvents).toHaveLength(3);
 		});
 
-		it("bounds live tool hook status updates to the display budget", async () => {
+		it("sanitizes and bounds live tool hook status updates", async () => {
 			const runtime = createExtensionRuntime();
 			const longMessage = "x".repeat(200);
+			const noisyMessage = "line\u001b[31mone\ntwo\t\u0007 done";
 			const extension = await loadExtensionFromFactory(
 				(pi) => {
 					pi.on("tool_call", async (_event, ctx) => {
+						ctx.updateToolHookStatus?.(noisyMessage);
 						ctx.updateToolHookStatus?.(longMessage);
 					});
 				},
@@ -1276,8 +1278,9 @@ describe("ExtensionRunner", () => {
 				input: {},
 			});
 
-			const update = lifecycleEvents.find((event) => event.phase === "update");
-			expect(update?.statusMessage).toBe(`${"x".repeat(76)}...`);
+			const updates = lifecycleEvents.filter((event) => event.phase === "update");
+			expect(updates[0]?.statusMessage).toBe("lineone two done");
+			expect(updates[1]?.statusMessage).toBe(`${"x".repeat(76)}...`);
 		});
 
 		it("uses bounded custom hook status labels", async () => {

--- a/packages/coding-agent/test/interactive-mode-hook-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-hook-status.test.ts
@@ -92,4 +92,78 @@ describe("InteractiveMode hook status events", () => {
 		expect(hookStatusContainer.children).toHaveLength(0);
 		expect(fakeThis.stopToolHookStatusTimer).toHaveBeenCalledTimes(1);
 	});
+
+	test("replaces the row label on update events without resetting elapsed time", async () => {
+		vi.useFakeTimers({ now });
+		const prototype = InteractiveMode.prototype as unknown as HookStatusPrototype;
+		const hookStatusContainer = new Container();
+		const fakeThis: HookStatusThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			activeToolHooks: new Map(),
+			hookStatusContainer,
+			startToolHookStatusTimer: vi.fn(),
+			stopToolHookStatusTimer: vi.fn(),
+			refreshToolHookStatuses: prototype.refreshToolHookStatuses,
+			handleToolHookStatusEvent: prototype.handleToolHookStatusEvent,
+			ui: { requestRender: vi.fn() },
+		};
+
+		await prototype.handleEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "start",
+			hookRunId: "run-update",
+			hookName: "PostToolUse",
+			toolName: "bash",
+			toolCallId: "call-1",
+			extensionPath: "<builtin:hooks>",
+			statusMessage: "running hooks",
+			startedAt: now - 7_000,
+		});
+		await prototype.handleEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "update",
+			hookRunId: "run-update",
+			hookName: "PostToolUse",
+			toolName: "bash",
+			toolCallId: "call-1",
+			extensionPath: "<builtin:hooks>",
+			statusMessage: "(OmO) Checking Comments",
+			startedAt: now - 7_000,
+		});
+
+		const rendered = renderHookStatus(hookStatusContainer);
+		expect(rendered).toContain("Running PostToolUse hook: (OmO) Checking Comments (7s)");
+		expect(rendered).not.toContain("running hooks");
+		expect(fakeThis.activeToolHooks.size).toBe(1);
+
+		await prototype.handleEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "update",
+			hookRunId: "run-unknown",
+			hookName: "PostToolUse",
+			toolName: "bash",
+			toolCallId: "call-2",
+			extensionPath: "<builtin:hooks>",
+			statusMessage: "ghost",
+			startedAt: now,
+		});
+		expect(fakeThis.activeToolHooks.size).toBe(1);
+		expect(renderHookStatus(hookStatusContainer)).not.toContain("ghost");
+
+		await prototype.handleEvent.call(fakeThis, {
+			type: "tool_hook_status",
+			phase: "end",
+			hookRunId: "run-update",
+			hookName: "PostToolUse",
+			toolName: "bash",
+			toolCallId: "call-1",
+			extensionPath: "<builtin:hooks>",
+			statusMessage: "(OmO) Checking Comments",
+			startedAt: now - 7_000,
+			completedAt: now,
+			status: "completed",
+		});
+		expect(hookStatusContainer.children).toHaveLength(0);
+	});
 });

--- a/packages/coding-agent/test/suite/hooks-dispatcher.test.ts
+++ b/packages/coding-agent/test/suite/hooks-dispatcher.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { CommandHookRunResult } from "../../src/core/extensions/builtin/hooks/command-runner.ts";
-import { dispatchHookEvent, type HookCommandRunner } from "../../src/core/extensions/builtin/hooks/dispatcher.ts";
+import {
+	dispatchHookEvent,
+	type HookCommandRunner,
+	runningHookHandlersStatusLabel,
+} from "../../src/core/extensions/builtin/hooks/dispatcher.ts";
 import { createHookTrustEntry, hookTrustId } from "../../src/core/extensions/builtin/hooks/trust.ts";
 import type {
 	ExecutableHookHandler,
@@ -98,12 +102,19 @@ function preToolOutput(
 function dispatch(
 	handlers: readonly ExecutableHookHandler[],
 	runCommand: HookCommandRunner,
-	options: { readonly input?: HookInputWire; readonly trusted?: readonly ExecutableHookHandler[] } = {},
+	options: {
+		readonly input?: HookInputWire;
+		readonly trusted?: readonly ExecutableHookHandler[];
+		readonly onRunningHandlersChange?: (running: readonly ExecutableHookHandler[]) => void;
+	} = {},
 ) {
 	return dispatchHookEvent({
 		cwd: "/repo",
 		handlers,
 		input: options.input ?? INPUT,
+		...(options.onRunningHandlersChange === undefined
+			? {}
+			: { onRunningHandlersChange: options.onRunningHandlersChange }),
 		runCommand,
 		trustOptions: { platform: "linux" },
 		trustState: trustedState(options.trusted ?? handlers),
@@ -235,6 +246,66 @@ describe("builtin hooks dispatcher", () => {
 			{ command: "untrusted", reason: "untrusted" },
 		]);
 		expect(result.skipped[0]?.record.executable).toBe(false);
+	});
+
+	it("notifies onRunningHandlersChange as hooks start and finish", async () => {
+		// Given
+		const first = commandHook("run-first", { handlerIndex: 0, matcher: "bash" });
+		const second = commandHook("run-second", { handlerIndex: 1, matcher: "bash" });
+		const deferred = new Map<string, DeferredRun>();
+		const runner: HookCommandRunner = (handler) => {
+			const pending = deferredRun();
+			deferred.set(handler.config.command, pending);
+			return pending.promise;
+		};
+		const transitions: string[][] = [];
+
+		// When
+		const dispatching = dispatch([first, second], runner, {
+			onRunningHandlersChange: (running) => transitions.push(running.map((handler) => handler.config.command)),
+		});
+		await Promise.resolve();
+		deferred.get("run-first")?.resolve(runResult(first, ""));
+		await Promise.resolve();
+		await Promise.resolve();
+		deferred.get("run-second")?.resolve(runResult(second, ""));
+		await dispatching;
+
+		// Then
+		expect(transitions).toEqual([["run-first"], ["run-first", "run-second"], ["run-second"], []]);
+	});
+
+	it("builds running-hook status labels from statusMessage with command fallback", () => {
+		// Given
+		const labeled: ExecutableHookHandler = {
+			...commandHook("node run-hook.mjs comment-checker", { matcher: "bash" }),
+			config: {
+				type: "command",
+				command: "node run-hook.mjs comment-checker",
+				statusMessage: "(OmO) Checking Comments",
+			},
+		};
+		const bare = commandHook("sleep 5 # lsp-diagnostics-pass", { handlerIndex: 1, matcher: "bash" });
+		const windowsAware: ExecutableHookHandler = {
+			...commandHook("posix.sh", { handlerIndex: 2 }),
+			config: { type: "command", command: "posix.sh", commandWindows: "windows.cmd" },
+		};
+		const noisy: ExecutableHookHandler = {
+			...commandHook("noisy", { handlerIndex: 3 }),
+			config: { type: "command", command: "noisy", statusMessage: `line\u001b[31mone\ntwo\t ${"y".repeat(200)}` },
+		};
+
+		// When / Then
+		expect(runningHookHandlersStatusLabel([labeled], "linux")).toBe("(OmO) Checking Comments");
+		expect(runningHookHandlersStatusLabel([bare], "linux")).toBe("sleep 5 # lsp-diagnostics-pass");
+		expect(runningHookHandlersStatusLabel([labeled, bare], "linux")).toBe(
+			"(OmO) Checking Comments · sleep 5 # lsp-diagnostics-pass",
+		);
+		expect(runningHookHandlersStatusLabel([windowsAware], "win32")).toBe("windows.cmd");
+		expect(runningHookHandlersStatusLabel([windowsAware], "linux")).toBe("posix.sh");
+		const noisyLabel = runningHookHandlersStatusLabel([noisy], "linux");
+		expect(noisyLabel.startsWith("lineone two y")).toBe(true);
+		expect(noisyLabel.length).toBeLessThanOrEqual(79);
 	});
 
 	it("keeps nonblocking malformed output diagnostics nonfatal but blocks on explicit continue false", async () => {


### PR DESCRIPTION
## Summary

While a hook runs, the TUI's live status row only ever showed a static per-extension guess — `Running PostToolUse hook: running builtin:hooks` for hooks.json command hooks and `running omo` for extension-registered handlers. Users could not tell **which hook** was running or **what it was doing**. The `statusMessage` field on command hook config was parsed, trust-hashed, and listed by `/hooks`, but never rendered live.

After this change, the row shows each running command hook's configured `statusMessage`, falling back to its sanitized command text, e.g.:

Before: `Running PostToolUse hook: running builtin:hooks (4s)`
After: `Running PostToolUse hook: (OmO) Checking Comments · sleep 5 # lsp-diagnostics-pass (4s)`

Extensions that handle `tool_call`/`tool_result` directly (e.g. omo-senpi) can now report their own live status through a new `ctx.updateToolHookStatus()` API.

## Changes

- **Runner** (`core/extensions/runner.ts`): tool hook lifecycle events gain an `update` phase. Each `tool_call`/`tool_result` handler now runs with a derived context exposing `updateToolHookStatus()` (bounded to 79 chars, ignored after the handler ends; the end event carries the last reported status). Builtins without a specific label render as `running <name>` instead of `running builtin:<name>`.
- **Extension API** (`core/extensions/types.ts`): optional `ctx.updateToolHookStatus?(statusMessage)` on `ExtensionContext`, documented in `docs/extensions.md`.
- **Builtin hooks** (`builtin/hooks/dispatcher.ts`, `builtin/hooks/index.ts`): `dispatchHookEvent` accepts `onRunningHandlersChange` and notifies as concurrent command hooks start/finish; the hooks extension forwards a joined label (`statusMessage` ?? platform command, ANSI/control stripped) to the status row.
- **TUI** (`modes/interactive/interactive-mode.ts`): `update` events replace the row label in place without resetting elapsed time; unknown run ids are ignored; terminal title follows the updated label.

## QA / Evidence

All artifacts under `local-ignore/qa-evidence/20260704-hook-status-tui/` (gitignored; sanitized excerpts below).

- **Live TUI repro (RED)** — real interactive TUI in tmux from source, fake local model server driving a bash tool call, two trusted `hooks.json` PostToolUse hooks (one with `statusMessage`, one without) sleeping 5s: row rendered `Running PostToolUse hook: running builtin:hooks (4s)` — hook identity invisible (`red/frames.txt`).
- **Live TUI proof (GREEN)** — same scenario after the fix: `Running PostToolUse hook: (OmO) Checking Comments · sleep 5 # lsp-diagnostics-pass (4s)` (`green/frames.txt`). This exercises the full path: config → dispatcher → ctx API → runner update event → TUI row.
- **Unit (failing-first)** — 5 new tests captured RED then GREEN: runner update phase + stale-updater ignore + 79-char bounding (`test/extensions-runner.test.ts`), dispatcher running-set notifications + label building incl. win32/sanitize/fallback (`test/suite/hooks-dispatcher.test.ts`), TUI update-phase rendering incl. unknown-run ignore (`test/interactive-mode-hook-status.test.ts`).
- **Regression** — 163 tests across all hook/interactive/runner suites pass; `npm run check` clean (exit 0).
- **senpi-qa channels** — `mock-loop.mjs --with-tool` 4/4 (full agent loop with tool still completes; zero real tokens) and `tui-smoke.mjs --self-test` 5/5 (`mock-loop-with-tool.txt`, `tui-smoke.txt`). Every run asserted the real `~/.senpi/agent/auth.json` unchanged and ran in an isolated sandbox.

## Risks

- `update` is a new lifecycle phase forwarded through `AgentSessionEvent`; the only phase-switching consumer is interactive mode, which handles it explicitly (unit-tested). Other consumers receive an additive event type.
- Hook commands can contain arbitrary bytes; the fallback label strips ANSI/OSC and control characters and is length-bounded (unit-tested), so it cannot garble the TUI.
- Stale `updateToolHookStatus` calls after a handler finishes are dropped via a closure guard (unit-tested), so no cross-talk between sequential handler rows.

## Secret safety

No secret-bearing logs. QA sandboxes used inline mock keys against a localhost fake server; provider env keys were stripped by the harness. Hook status labels reuse the existing display path and the fallback text is the same command text `/hooks list` already shows (redaction rules unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the live identity of running hooks in the TUI status row. Each hook now displays its configured `statusMessage` or a sanitized command; extensions can update the label in real time, and all updates are sanitized and length-bounded.

- **New Features**
  - Added an `update` phase to tool hook lifecycle events and `ctx.updateToolHookStatus()` for `tool_call`/`tool_result` handlers.
  - Builtin hooks dispatcher reports currently running command hooks; the TUI replaces the row label in place and keeps the elapsed time. Terminal title follows the live label.
  - Labels use each hook’s `statusMessage` or platform-aware command text, capped at 79 chars.

- **Bug Fixes**
  - Sanitized live updates and command-derived labels: strip ANSI/OSC and control characters, collapse whitespace, and bound to 79 chars to protect the TUI and terminal title.
  - Replaced the generic `running builtin:hooks` label with the actual hook’s `statusMessage` or sanitized command, and render builtin handlers without a specific label as `running <name>`.

<sup>Written for commit 66300736ddfc901415b14cb53325f64975029df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

