### PR TITLE
fix(tui): render hygiene — stale scheduling across restart, external stdout dirt, title OSC injection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed TUI screen corruption from external stdout writes: `console.log` from libraries or extensions while a TUI owns the terminal (interactive mode, startup dialogs, config selector) is now hidden from the screen and appended, redacted, to the debug log — matching the existing stderr guard.
+
 ## [2026.7.3] - 2026-07-03
 
 ### Added

--- a/packages/coding-agent/src/cli/config-selector.ts
+++ b/packages/coding-agent/src/cli/config-selector.ts
@@ -3,6 +3,7 @@
  */
 
 import { ProcessTerminal, TUI } from "@earendil-works/pi-tui";
+import { appendHiddenTuiStdout } from "../core/hidden-stdout-log.ts";
 import type { ResolvedPaths } from "../core/package-manager.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
 import { ConfigSelectorComponent } from "../modes/interactive/components/config-selector.ts";
@@ -21,7 +22,7 @@ export async function selectConfig(options: ConfigSelectorOptions): Promise<void
 	initTheme(options.settingsManager.getTheme(), true);
 
 	return new Promise((resolve) => {
-		const ui = new TUI(new ProcessTerminal());
+		const ui = new TUI(new ProcessTerminal({ onExternalStdoutWrite: appendHiddenTuiStdout }));
 		let resolved = false;
 
 		const selector = new ConfigSelectorComponent(

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -2,6 +2,7 @@ import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
 import { existsSync } from "fs";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, getAgentDir, getSettingsPath, PACKAGE_NAME } from "../config.ts";
 import { areExperimentalFeaturesEnabled } from "../core/experimental.ts";
+import { appendHiddenTuiStdout } from "../core/hidden-stdout-log.ts";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import { DefaultPackageManager, type ResolvedResource } from "../core/package-manager.ts";
 import { SettingsManager } from "../core/settings-manager.ts";
@@ -79,7 +80,10 @@ export async function createStartupTui(settingsManager: SettingsManager): Promis
 	const terminalTheme = detectTerminalBackgroundFromEnv().theme;
 	initTheme(resolveThemeSetting(settingsManager.getThemeSetting(), terminalTheme) ?? terminalTheme);
 	setKeybindings(KeybindingsManager.create());
-	const ui = new TUI(new ProcessTerminal(), settingsManager.getShowHardwareCursor());
+	const ui = new TUI(
+		new ProcessTerminal({ onExternalStdoutWrite: appendHiddenTuiStdout }),
+		settingsManager.getShowHardwareCursor(),
+	);
 	ui.setClearOnShrink(settingsManager.getClearOnShrink());
 	return ui;
 }

--- a/packages/coding-agent/src/core/hidden-stdout-log.ts
+++ b/packages/coding-agent/src/core/hidden-stdout-log.ts
@@ -1,0 +1,17 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getDebugLogPath } from "../config.ts";
+import { redactSensitiveOutput } from "./sensitive-output.ts";
+
+export function appendHiddenTuiStdout(text: string): void {
+	if (text.length === 0) {
+		return;
+	}
+	const debugLogPath = getDebugLogPath();
+	const prefix = `[${new Date().toISOString()}] hidden stdout while TUI active\n`;
+	const redactedText = redactSensitiveOutput(text);
+	const suffix = redactedText.endsWith("\n") ? "" : "\n";
+	fs.mkdirSync(path.dirname(debugLogPath), { recursive: true });
+	fs.appendFileSync(debugLogPath, `${prefix}${redactedText}${suffix}`, { mode: 0o600 });
+	fs.chmodSync(debugLogPath, 0o600);
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -75,6 +75,7 @@ import type {
 	WorkingIndicatorOptions,
 } from "../../core/extensions/index.ts";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
+import { appendHiddenTuiStdout } from "../../core/hidden-stdout-log.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
 import { createCompactionSummaryMessage } from "../../core/messages.ts";
@@ -499,7 +500,10 @@ export class InteractiveMode {
 			await this.rebindCurrentSession({ renderBeforeBind: true });
 		});
 		this.version = VERSION;
-		this.ui = new TUI(new ProcessTerminal(), this.settingsManager.getShowHardwareCursor());
+		this.ui = new TUI(
+			new ProcessTerminal({ onExternalStdoutWrite: appendHiddenTuiStdout }),
+			this.settingsManager.getShowHardwareCursor(),
+		);
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.headerContainer = new Container();
 		this.loadedResourcesContainer = new Container();

--- a/packages/coding-agent/test/hidden-stdout-log.test.ts
+++ b/packages/coding-agent/test/hidden-stdout-log.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR, getDebugLogPath } from "../src/config.ts";
+import { appendHiddenTuiStdout } from "../src/core/hidden-stdout-log.ts";
+
+const originalAgentDir = process.env[ENV_AGENT_DIR];
+const githubFineGrainedPat = "github_pat_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	if (originalAgentDir === undefined) {
+		delete process.env[ENV_AGENT_DIR];
+	} else {
+		process.env[ENV_AGENT_DIR] = originalAgentDir;
+	}
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+describe("hidden TUI stdout log", () => {
+	it("redacts hidden interactive stdout before writing the debug log", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-hidden-stdout-"));
+		tempDirs.push(agentDir);
+		process.env[ENV_AGENT_DIR] = agentDir;
+
+		appendHiddenTuiStdout(
+			[
+				"SECRET_TOKEN=debug-secret",
+				"Authorization: Bearer stdout-secret",
+				`token ${githubFineGrainedPat}`,
+				"github_pat_short",
+			].join("\n"),
+		);
+
+		const debugLogPath = getDebugLogPath();
+		const log = readFileSync(debugLogPath, "utf8");
+		expect(log).toContain("hidden stdout while TUI active");
+		expect(log).toContain("SECRET_TOKEN=[REDACTED]");
+		expect(log).toContain("Authorization: Bearer [REDACTED]");
+		expect(log).toContain("token [REDACTED]");
+		expect(log).toContain("github_pat_short");
+		expect(log).not.toContain("debug-secret");
+		expect(log).not.toContain("stdout-secret");
+		expect(log).not.toContain(githubFineGrainedPat);
+		expect((statSync(debugLogPath).mode & 0o777).toString(8)).toBe("600");
+	});
+
+	it("ignores empty chunks", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-hidden-stdout-empty-"));
+		tempDirs.push(agentDir);
+		process.env[ENV_AGENT_DIR] = agentDir;
+
+		appendHiddenTuiStdout("");
+
+		expect(() => statSync(getDebugLogPath())).toThrow();
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added an opt-in `ProcessTerminal` external stdout guard (`onExternalStdoutWrite`): while the terminal is started, stdout writes not issued by the terminal itself (e.g. `console.log` from libraries or extensions) are forwarded to the handler instead of reaching the screen, preventing differential-render desync and visual corruption.
+
 ### Changed
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fixed render scheduling state leaking across TUI `stop()`/`start()`, which could leave a restarted TUI unable to render passive updates (streaming output, timers) until a keypress or forced redraw.
+- Fixed `setTitle` to strip control characters so session, tool, or extension titles containing BEL/ESC cannot terminate the OSC sequence early and dump the remainder onto the screen.
 
 ## [2026.7.3] - 2026-07-03
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed render scheduling state leaking across TUI `stop()`/`start()`, which could leave a restarted TUI unable to render passive updates (streaming output, timers) until a keypress or forced redraw.
+
 ## [2026.7.3] - 2026-07-03
 
 ### Added

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -68,7 +68,7 @@ export {
 // Input buffering for batch splitting
 export { StdinBuffer, type StdinBufferEventMap, type StdinBufferOptions } from "./stdin-buffer.ts";
 // Terminal interface and implementations
-export { ProcessTerminal, type Terminal } from "./terminal.ts";
+export { ProcessTerminal, type ProcessTerminalOptions, type Terminal } from "./terminal.ts";
 // Terminal colors
 export {
 	parseOsc11BackgroundColor,

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -99,11 +99,25 @@ export interface Terminal {
 	setProgress(active: boolean): void;
 }
 
+export interface ProcessTerminalOptions {
+	/**
+	 * When set, stdout writes not issued by this terminal are hidden from the
+	 * screen while the terminal is started and forwarded to this handler
+	 * instead. External writes (console.log, libraries) would otherwise
+	 * interleave with frames and desynchronize differential rendering.
+	 */
+	onExternalStdoutWrite?: (text: string) => void;
+}
+
 /**
  * Real terminal using process.stdin/stdout
  */
 export class ProcessTerminal implements Terminal {
 	private wasRaw = false;
+	private onExternalStdoutWrite?: (text: string) => void;
+	private originalStdoutWrite?: typeof process.stdout.write;
+	private rawStdoutWrite?: (data: string) => void;
+	private forwardingExternalWrite = false;
 	private inputHandler?: (data: string) => void;
 	private resizeHandler?: () => void;
 	private _kittyProtocolActive = false;
@@ -129,8 +143,64 @@ export class ProcessTerminal implements Terminal {
 		return env;
 	})();
 
+	constructor(options?: ProcessTerminalOptions) {
+		this.onExternalStdoutWrite = options?.onExternalStdoutWrite;
+	}
+
 	get kittyProtocolActive(): boolean {
 		return this._kittyProtocolActive;
+	}
+
+	private rawWrite(data: string): void {
+		if (this.rawStdoutWrite) {
+			this.rawStdoutWrite(data);
+			return;
+		}
+		process.stdout.write(data);
+	}
+
+	private installExternalStdoutGuard(): void {
+		const handler = this.onExternalStdoutWrite;
+		if (!handler || this.originalStdoutWrite) {
+			return;
+		}
+		this.originalStdoutWrite = process.stdout.write;
+		const rawWrite = process.stdout.write.bind(process.stdout);
+		this.rawStdoutWrite = rawWrite;
+
+		process.stdout.write = ((
+			chunk: string | Uint8Array,
+			encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+			callback?: (error?: Error | null) => void,
+		): boolean => {
+			const cb = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+			const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
+			const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(encoding);
+			if (this.forwardingExternalWrite) {
+				rawWrite(text);
+				cb?.(null);
+				return true;
+			}
+			this.forwardingExternalWrite = true;
+			try {
+				handler(text);
+			} catch {
+				rawWrite(text);
+			} finally {
+				this.forwardingExternalWrite = false;
+			}
+			cb?.(null);
+			return true;
+		}) as typeof process.stdout.write;
+	}
+
+	private removeExternalStdoutGuard(): void {
+		if (!this.originalStdoutWrite) {
+			return;
+		}
+		process.stdout.write = this.originalStdoutWrite;
+		this.originalStdoutWrite = undefined;
+		this.rawStdoutWrite = undefined;
 	}
 
 	get modifyOtherKeysActive(): boolean {
@@ -138,6 +208,7 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	start(onInput: (data: string) => void, onResize: () => void): void {
+		this.installExternalStdoutGuard();
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
 
@@ -149,7 +220,7 @@ export class ProcessTerminal implements Terminal {
 		process.stdin.resume();
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
-		process.stdout.write("\x1b[?2004h");
+		this.rawWrite("\x1b[?2004h");
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -233,7 +304,7 @@ export class ProcessTerminal implements Terminal {
 		}
 		this.keyboardProtocolPushed = true;
 		this.clearKeyboardProtocolNegotiationBuffer();
-		process.stdout.write(KITTY_KEYBOARD_PROTOCOL_QUERY);
+		this.rawWrite(KITTY_KEYBOARD_PROTOCOL_QUERY);
 	}
 
 	private handleKeyboardProtocolNegotiationSequence(
@@ -330,13 +401,13 @@ export class ProcessTerminal implements Terminal {
 
 	private enableModifyOtherKeys(): void {
 		if (this._kittyProtocolActive || this._modifyOtherKeysActive) return;
-		process.stdout.write("\x1b[>4;2m");
+		this.rawWrite("\x1b[>4;2m");
 		this._modifyOtherKeysActive = true;
 	}
 
 	private disableModifyOtherKeys(): void {
 		if (!this._modifyOtherKeysActive) return;
-		process.stdout.write("\x1b[>4;0m");
+		this.rawWrite("\x1b[>4;0m");
 		this._modifyOtherKeysActive = false;
 	}
 
@@ -382,7 +453,7 @@ export class ProcessTerminal implements Terminal {
 		if (shouldDisableKittyProtocol) {
 			// Disable Kitty keyboard protocol first so any late key releases
 			// do not generate new Kitty escape sequences.
-			process.stdout.write("\x1b[<u");
+			this.rawWrite("\x1b[<u");
 			this.keyboardProtocolPushed = false;
 			this._kittyProtocolActive = false;
 			setKittyProtocolActive(false);
@@ -416,18 +487,18 @@ export class ProcessTerminal implements Terminal {
 
 	stop(): void {
 		if (this.clearProgressInterval()) {
-			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
+			this.rawWrite(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
 		}
 
 		// Disable bracketed paste mode
-		process.stdout.write("\x1b[?2004l");
+		this.rawWrite("\x1b[?2004l");
 
 		const shouldDisableKittyProtocol = this.keyboardProtocolPushed || this._kittyProtocolActive;
 		this.clearKeyboardProtocolNegotiationBuffer();
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (shouldDisableKittyProtocol) {
-			process.stdout.write("\x1b[<u");
+			this.rawWrite("\x1b[<u");
 			this.keyboardProtocolPushed = false;
 			this._kittyProtocolActive = false;
 			setKittyProtocolActive(false);
@@ -460,10 +531,12 @@ export class ProcessTerminal implements Terminal {
 		if (process.stdin.setRawMode) {
 			process.stdin.setRawMode(this.wasRaw);
 		}
+
+		this.removeExternalStdoutGuard();
 	}
 
 	write(data: string): void {
-		process.stdout.write(data);
+		this.rawWrite(data);
 		if (this.writeLogPath) {
 			try {
 				fs.appendFileSync(this.writeLogPath, data, { encoding: "utf8" });
@@ -484,52 +557,52 @@ export class ProcessTerminal implements Terminal {
 	moveBy(lines: number): void {
 		if (lines > 0) {
 			// Move down
-			process.stdout.write(`\x1b[${lines}B`);
+			this.rawWrite(`\x1b[${lines}B`);
 		} else if (lines < 0) {
 			// Move up
-			process.stdout.write(`\x1b[${-lines}A`);
+			this.rawWrite(`\x1b[${-lines}A`);
 		}
 		// lines === 0: no movement
 	}
 
 	hideCursor(): void {
-		process.stdout.write("\x1b[?25l");
+		this.rawWrite("\x1b[?25l");
 	}
 
 	showCursor(): void {
-		process.stdout.write("\x1b[?25h");
+		this.rawWrite("\x1b[?25h");
 	}
 
 	clearLine(): void {
-		process.stdout.write("\x1b[K");
+		this.rawWrite("\x1b[K");
 	}
 
 	clearFromCursor(): void {
-		process.stdout.write("\x1b[J");
+		this.rawWrite("\x1b[J");
 	}
 
 	clearScreen(): void {
-		process.stdout.write("\x1b[2J\x1b[H"); // Clear screen and move to home (1,1)
+		this.rawWrite("\x1b[2J\x1b[H"); // Clear screen and move to home (1,1)
 	}
 
 	setTitle(title: string): void {
 		// OSC 0;title BEL - set terminal window title
-		process.stdout.write(`\x1b]0;${title}\x07`);
+		this.rawWrite(`\x1b]0;${title}\x07`);
 	}
 
 	setProgress(active: boolean): void {
 		if (active) {
 			// OSC 9;4;3 - indeterminate progress
-			process.stdout.write(TERMINAL_PROGRESS_ACTIVE_SEQUENCE);
+			this.rawWrite(TERMINAL_PROGRESS_ACTIVE_SEQUENCE);
 			if (!this.progressInterval) {
 				this.progressInterval = setInterval(() => {
-					process.stdout.write(TERMINAL_PROGRESS_ACTIVE_SEQUENCE);
+					this.rawWrite(TERMINAL_PROGRESS_ACTIVE_SEQUENCE);
 				}, TERMINAL_PROGRESS_KEEPALIVE_MS);
 			}
 		} else {
 			this.clearProgressInterval();
 			// OSC 9;4;0 - clear progress
-			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
+			this.rawWrite(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
 		}
 	}
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -586,8 +586,11 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	setTitle(title: string): void {
-		// OSC 0;title BEL - set terminal window title
-		this.rawWrite(`\x1b]0;${title}\x07`);
+		// OSC 0;title BEL - set terminal window title. Control characters are
+		// stripped so a title cannot terminate the OSC early and leak the rest
+		// onto the screen.
+		const sanitizedTitle = title.replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
+		this.rawWrite(`\x1b]0;${sanitizedTitle}\x07`);
 	}
 
 	setProgress(active: boolean): void {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -813,6 +813,8 @@ export class TUI extends Container {
 
 	start(): void {
 		this.stopped = false;
+		this.renderRequested = false;
+		this.inputRenderPending = false;
 		this.#lastCursorVisibility = undefined;
 		this.terminal.start(
 			(data) => this.handleInput(data),
@@ -866,6 +868,8 @@ export class TUI extends Container {
 
 	stop(): void {
 		this.stopped = true;
+		this.renderRequested = false;
+		this.inputRenderPending = false;
 		if (this.renderTimer) {
 			clearTimeout(this.renderTimer);
 			this.renderTimer = undefined;

--- a/packages/tui/test/external-stdout-guard.test.ts
+++ b/packages/tui/test/external-stdout-guard.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { ProcessTerminal } from "../src/terminal.ts";
+
+interface GuardHarness {
+	terminal: ProcessTerminal;
+	writes: string[];
+	hidden: string[];
+	stubbedWrite: typeof process.stdout.write;
+	cleanup(): void;
+}
+
+function setupGuardHarness(options?: { withHandler?: boolean; handler?: (text: string) => void }): GuardHarness {
+	const writes: string[] = [];
+	const hidden: string[] = [];
+	const previousWrite = process.stdout.write;
+	const previousStdinOn = process.stdin.on;
+	const previousResume = process.stdin.resume;
+	const previousPause = process.stdin.pause;
+	const previousEnv = new Map<string, string | undefined>();
+	for (const name of ["PI_TUI_KEYBOARD_PROTOCOL", "TMUX", "TMUX_PANE", "PI_TUI_WRITE_LOG"]) {
+		previousEnv.set(name, process.env[name]);
+		delete process.env[name];
+	}
+	process.env.PI_TUI_KEYBOARD_PROTOCOL = "0";
+
+	const stubbedWrite = ((chunk: string | Uint8Array) => {
+		writes.push(String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	process.stdout.write = stubbedWrite;
+	process.stdin.on = ((_event: string | symbol, _listener: (...args: unknown[]) => void) =>
+		process.stdin) as typeof process.stdin.on;
+	process.stdin.resume = (() => process.stdin) as typeof process.stdin.resume;
+	process.stdin.pause = (() => process.stdin) as typeof process.stdin.pause;
+
+	const handler = options?.handler ?? ((text: string) => hidden.push(text));
+	const terminal = new ProcessTerminal(
+		options?.withHandler === false ? undefined : { onExternalStdoutWrite: handler },
+	);
+
+	let cleaned = false;
+	return {
+		terminal,
+		writes,
+		hidden,
+		stubbedWrite,
+		cleanup(): void {
+			if (cleaned) return;
+			cleaned = true;
+			try {
+				terminal.stop();
+			} finally {
+				process.stdout.write = previousWrite;
+				process.stdin.on = previousStdinOn;
+				process.stdin.resume = previousResume;
+				process.stdin.pause = previousPause;
+				for (const [name, value] of previousEnv) {
+					if (value === undefined) delete process.env[name];
+					else process.env[name] = value;
+				}
+			}
+		},
+	};
+}
+
+describe("ProcessTerminal external stdout guard", () => {
+	it("hides external stdout writes while started and forwards them to the handler", () => {
+		const harness = setupGuardHarness();
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			harness.writes.length = 0;
+
+			process.stdout.write("external junk\n");
+
+			assert.deepEqual(harness.hidden, ["external junk\n"]);
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("external junk")),
+				false,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("lets the terminal's own writes reach stdout while the guard is active", () => {
+		const harness = setupGuardHarness();
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			harness.writes.length = 0;
+
+			harness.terminal.write("\x1b[?2026hframe\x1b[?2026l");
+			harness.terminal.setProgress(true);
+			harness.terminal.setProgress(false);
+			harness.terminal.hideCursor();
+
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("frame")),
+				true,
+			);
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("\x1b]9;4;3\x07")),
+				true,
+			);
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("\x1b[?25l")),
+				true,
+			);
+			assert.deepEqual(harness.hidden, []);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("captures console.log while started", () => {
+		const harness = setupGuardHarness();
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			harness.writes.length = 0;
+
+			console.log("stray library log");
+
+			assert.equal(
+				harness.hidden.some((text) => text.includes("stray library log")),
+				true,
+			);
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("stray library log")),
+				false,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("decodes Buffer chunks before forwarding", () => {
+		const harness = setupGuardHarness();
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			harness.writes.length = 0;
+
+			process.stdout.write(Buffer.from("binary chunk"));
+
+			assert.deepEqual(harness.hidden, ["binary chunk"]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("restores passthrough after stop()", () => {
+		const harness = setupGuardHarness();
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			harness.terminal.stop();
+			harness.writes.length = 0;
+
+			process.stdout.write("after stop\n");
+
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("after stop")),
+				true,
+			);
+			assert.deepEqual(harness.hidden, []);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not patch stdout when no handler is configured", () => {
+		const harness = setupGuardHarness({ withHandler: false });
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			assert.equal(process.stdout.write, harness.stubbedWrite);
+			harness.writes.length = 0;
+
+			process.stdout.write("plain passthrough\n");
+
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("plain passthrough")),
+				true,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("falls back to raw stdout when the handler throws", () => {
+		const harness = setupGuardHarness({
+			handler: () => {
+				throw new Error("handler exploded");
+			},
+		});
+		try {
+			harness.terminal.start(
+				() => {},
+				() => {},
+			);
+			harness.writes.length = 0;
+
+			process.stdout.write("must not vanish\n");
+
+			assert.equal(
+				harness.writes.some((chunk) => chunk.includes("must not vanish")),
+				true,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/tui/test/render-scheduling-restart.test.ts
+++ b/packages/tui/test/render-scheduling-restart.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class TestComponent implements Component {
+	lines: string[] = [];
+	render(_width: number): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+describe("TUI render scheduling across stop/start", () => {
+	it("renders after restart when a render request was pending at stop()", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		component.lines = ["before"];
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		assert.ok(terminal.getViewport().some((line) => line.includes("before")));
+
+		// Request a render and stop before the scheduled render fires.
+		component.lines = ["pending-at-stop"];
+		tui.requestRender();
+		tui.stop();
+		await terminal.waitForRender();
+
+		terminal.reset();
+		tui.start();
+		component.lines = ["after-restart"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(
+			terminal.getViewport().some((line) => line.includes("after-restart")),
+			`expected "after-restart" in viewport, got: ${JSON.stringify(terminal.getViewport().slice(0, 3))}`,
+		);
+		tui.stop();
+	});
+
+	it("renders after restart when requestRender was called while stopped", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		component.lines = ["initial"];
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		tui.stop();
+
+		// e.g. streaming events arriving while an external editor owns the terminal
+		component.lines = ["stopped-update"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		terminal.reset();
+		tui.start();
+		component.lines = ["resumed"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(
+			terminal.getViewport().some((line) => line.includes("resumed")),
+			`expected "resumed" in viewport, got: ${JSON.stringify(terminal.getViewport().slice(0, 3))}`,
+		);
+		tui.stop();
+	});
+
+	it("renders after restart when an expedited input render was pending at stop()", async () => {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		component.lines = ["input-before"];
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+
+		component.lines = ["input-pending"];
+		tui.requestRender(false, "input");
+		tui.stop();
+		await terminal.waitForRender();
+
+		terminal.reset();
+		tui.start();
+		component.lines = ["input-after-restart"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(
+			terminal.getViewport().some((line) => line.includes("input-after-restart")),
+			`expected "input-after-restart" in viewport, got: ${JSON.stringify(terminal.getViewport().slice(0, 3))}`,
+		);
+		tui.stop();
+	});
+});

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -336,3 +336,32 @@ describe("ProcessTerminal dimensions", () => {
 		}
 	});
 });
+
+describe("ProcessTerminal setTitle", () => {
+	function captureSetTitle(title: string): string[] {
+		const writes: string[] = [];
+		const previousWrite = process.stdout.write;
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			writes.push(String(chunk));
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			new ProcessTerminal().setTitle(title);
+		} finally {
+			process.stdout.write = previousWrite;
+		}
+		return writes;
+	}
+
+	it("strips control characters so titles cannot escape the OSC sequence", () => {
+		const writes = captureSetTitle("evil\x07\x1b[2Jrest\ntitle\x9c!");
+
+		assert.deepEqual(writes, ["\x1b]0;evil[2Jresttitle!\x07"]);
+	});
+
+	it("passes plain titles through unchanged", () => {
+		const writes = captureSetTitle("pi - my-project");
+
+		assert.deepEqual(writes, ["\x1b]0;pi - my-project\x07"]);
+	});
+});


### PR DESCRIPTION
## Summary

Audit of the TUI rendering pipeline for three defect classes: updates that arrive late or never, frames that stack at wrong rows, and screens dirtied by output the renderer does not control. Three concrete routes were found and fixed:

1. **Stale render scheduling across `stop()`/`start()`** — `TUI.stop()` cleared the throttle timer but left `renderRequested`/`inputRenderPending` set. Any render requested inside the pending window (nextTick or the 16ms timer) or while the TUI was stopped (e.g. streaming events during an external editor session) stranded the flag, so after restart every plain `requestRender()` silently no-oped until a keypress or forced redraw.
2. **External stdout writes while a TUI owns the terminal** — stderr was already guarded (`takeOverInteractiveStderr`) but stdout was not. A `console.log` from any library or extension interleaved with frames, scrolled the viewport, and permanently desynchronized differential rendering (subsequent diffs paint at wrong rows). `ProcessTerminal` now supports an opt-in guard that hides external stdout writes and forwards them to a handler; the coding agent wires it on every TUI surface and appends the hidden writes, redacted, to the debug log.
3. **Control characters in terminal titles** — session/tool/extension titles flow into `OSC 0` unsanitized; an embedded BEL/ESC terminated the sequence early and dumped the remainder as raw output onto the screen. Titles are now stripped of C0/C1 control characters.

After this PR, a restarted TUI always resumes passive rendering, and stray stdout output or hostile titles can no longer corrupt the screen; hidden output is preserved (redacted) in the debug log.

## Changes

- **Render scheduling (`packages/tui/src/tui.ts`)**: reset `renderRequested`/`inputRenderPending` in both `stop()` and `start()`. Regression tests in `test/render-scheduling-restart.test.ts` cover the three stranding paths (pending-at-stop, requested-while-stopped, expedited-input-pending).
- **External stdout guard (`packages/tui/src/terminal.ts`)**: new `ProcessTerminalOptions.onExternalStdoutWrite`. While started, `process.stdout.write` is patched; non-terminal writes go to the handler, the terminal's own output routes through the captured raw writer (all direct `process.stdout.write` call sites converted to `rawWrite`). Passthrough restores on `stop()`; a throwing handler falls back to raw stdout so output is never lost. Tests in `test/external-stdout-guard.test.ts`.
- **Title sanitization (`packages/tui/src/terminal.ts`)**: `setTitle` strips `[\u0000-\u001f\u007f-\u009f]`. Tests in `test/terminal.test.ts`.
- **Coding-agent wiring (`packages/coding-agent`)**: new `core/hidden-stdout-log.ts` (`appendHiddenTuiStdout`: redact via `redactSensitiveOutput`, append to debug log, mode 600 — mirrors the stderr guard) wired into all three `ProcessTerminal` constructions: interactive mode, startup dialogs (trust prompt/onboarding/session picker), config selector. Tests in `test/hidden-stdout-log.test.ts`.

## QA & Evidence

All artifacts under `local-ignore/qa-evidence/20260704-tui-render-hygiene/` (gitignored; sanitized excerpts below). Every unit criterion was captured failing (RED) before the production change.

- **What was tested:** end-to-end tmux scenario (`e2e-stdout-guard.sh`): real CLI from source in an isolated sandbox with an extension that `console.log`s once while the trust dialog is up and once while the interactive TUI runs, including a fake `SECRET_TOKEN`.
  - **Observed result:** 10/10 PASS — neither marker appears on either screen; both writes land in the sandbox debug log under `hidden stdout while TUI active`; `SECRET_TOKEN=[REDACTED]`; real `~/.senpi/agent/auth.json` sha unchanged; tmux session torn down. Before the startup-surface wiring, the same scenario showed the marker rendered on top of the trust dialog — a live capture of the bug class.
  - **Artifact:** `e2e-stdout-guard.txt`, `e2e-screen-startup.txt`, `e2e-screen-interactive.txt`, `e2e-debug-log-excerpt.txt`
  - **Why sufficient:** proves the guard end-to-end on both real TUI surfaces, including redaction and isolation.
- **What was tested:** senpi-qa Channel 2 (`tui-smoke.mjs --self-test --driver tmux`) and Channel 3 (`mock-loop.mjs --self-test`, `--with-tool`), plus Channel 4 (`cli-smoke.mjs --self-test`).
  - **Observed result:** 5/5, 5/5, 4/4, 5/5 — TUI boots/renders/accepts input with the guard active; full agent loop completes across all three wire formats; CLI flags unaffected; auth untouched in every run.
  - **Artifact:** `tui-smoke.txt`, `mock-loop.txt`, `mock-loop-with-tool.txt`, `cli-smoke.txt`
  - **Why sufficient:** proves no regression on the primary user-facing surfaces with the patched stdout path in place.
- **What was tested:** unit suites — `packages/tui` full run and targeted coding-agent tests; repo `npm run check`.
  - **Observed result:** tui 818 pass / 0 fail (813 pre-existing + new); `hidden-stdout-log.test.ts` + `interactive-stderr-guard.test.ts` 6/6; `npm run check` fully clean (biome, tsgo, shrinkwrap, install-lock, web-ui).
  - **Why sufficient:** covers the unit contracts and repo-wide type/lint gates.

## Risks & Residuals

- **Patching a global (`process.stdout.write`)**: opt-in only (no handler → no patch, zero behavior change for other pi-tui consumers); self-writes use the captured raw writer; restore on `stop()`; re-entrancy guarded; throwing handlers fall back to raw. Covered by `external-stdout-guard.test.ts` (7 cases) and the e2e run. Mitigated.
- **Child processes with inherited stdio** write directly to the fd and cannot be intercepted (same limitation as the stderr guard). Accepted; tool output in this repo is piped.
- **Hidden output is invisible on screen by design** — preserved redacted in the debug log, identical to the established stderr-guard policy. Accepted.

## Secret safety

No raw secret-bearing logs. The QA secret is a fake marker value; evidence excerpts show only its `[REDACTED]` form. Real auth material was never read or written (sha-verified in every channel).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI render hygiene: renders no longer stall after restart, external stdout can’t dirty the screen, and terminal titles can’t inject control sequences. The coding agent enables the stdout guard on all TUI surfaces and logs hidden output (redacted) to the debug log.

- **Bug Fixes**
  - Reset render scheduling flags on `start()`/`stop()` so passive renders resume after restart.
  - Strip control characters in `setTitle` to prevent OSC 0 injection.

- **New Features**
  - Add opt-in external stdout guard via `ProcessTerminal.onExternalStdoutWrite`; wired in `packages/coding-agent` (interactive, startup dialogs, config selector) and logs hidden writes (redacted).

<sup>Written for commit c994b4258451933c408f687d369be484a1c67d5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

