### PR TITLE
docs(upstream): document detector head output

### DIFF
--- a/scripts/check-upstream-release.mjs
+++ b/scripts/check-upstream-release.mjs
@@ -11,7 +11,8 @@
  *      Otherwise -> proceed.
  *
  * Output: human-readable log on stderr; `key=value` lines appended to $GITHUB_OUTPUT when set
- * (proceed, tag, sha, current_tag). Also prints the same pairs to stdout for local runs.
+ * (proceed, tag, sha, upstream_head_sha, current_tag). Also prints the same pairs to stdout for
+ * local runs.
  *
  * Flags:
  *   --force   Always report proceed=true (manual re-run / recovery).


### PR DESCRIPTION
## Summary
Updates the upstream detector header comment so its documented output contract includes `upstream_head_sha`. This closes the final gate-review note from PR #107 without changing runtime behavior.

## Changes
- Document `upstream_head_sha` alongside `proceed`, `tag`, `sha`, and `current_tag` in `scripts/check-upstream-release.mjs`.

## QA & Evidence
- **What was tested:** `npm run test:scripts`
  **Observed result:** Passed, including the upstream detector regression.
  **Artifact:** `local-ignore/qa-evidence/20260704-upstream-output-doc-test-scripts.txt`

- **What was tested:** `npm run check`
  **Observed result:** Passed; no fixes applied.
  **Artifact:** `local-ignore/qa-evidence/20260704-upstream-output-doc-check.txt`

## Risks & Residuals
- Runtime risk is minimal; this is a comment-only contract documentation update.
- PR #107 already has CI, GitGuardian, Cubic, code review, and QA approval for the behavior change.

## Related Issues
Follow-up to #107.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented `upstream_head_sha` in the output contract of `scripts/check-upstream-release.mjs` so the upstream release detector’s docs match its actual outputs. No runtime behavior changes.

<sup>Written for commit b548566b1d87a4613d5f77fdd72529ce26cedbf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

