### PR TITLE
ci(upstream): auto-merge sync PRs

### DIFF
--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -356,7 +356,18 @@ jobs:
           done
           gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --watch --fail-fast --interval 30
           HEAD_SHA="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --merge --delete-branch --match-head-commit "$HEAD_SHA"
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --merge --auto --delete-branch --match-head-commit "$HEAD_SHA"
+          for attempt in {1..40}; do
+            PR_STATE="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state)"
+            if [ "$PR_STATE" = "MERGED" ]; then
+              break
+            fi
+            if [ "$attempt" = "40" ]; then
+              echo "::error::PR ${PR_NUMBER} did not merge after auto-merge was enabled."
+              exit 1
+            fi
+            sleep 15
+          done
           echo "merged=true" >> "$GITHUB_OUTPUT"
 
       - name: Fresh /cl release audit


### PR DESCRIPTION
## Summary
Fixes the upstream automation merge step after run 28701542801 reached PR #110 but failed because branch policy requires GitHub auto-merge instead of a direct merge.

## Changes
- Uses `gh pr merge --auto --merge` for upstream sync PRs.
- Waits until the PR state is `MERGED` before continuing to the release audit and release steps.

## QA / Evidence
- Focused workflow proof: `local-ignore/qa-evidence/20260704-upstream-pr-automerge/workflow-automerge-proof.txt` confirms the workflow uses `--auto` and waits for `MERGED`.
- Required repo check: `local-ignore/qa-evidence/20260704-upstream-pr-automerge/npm-check-after-install.txt` passed after hydrating dependencies in the isolated worktree.
- Failure evidence motivating this fix: `local-ignore/qa-evidence/20260704-upstream-force-main-sha/github-actions-run-failed-log.txt` shows GitHub returned “base branch policy prohibits the merge” and instructed adding `--auto`.

## Risks
Low. The change keeps merge commits and the existing `--match-head-commit` guard, but lets branch protection complete the merge through auto-merge.

## Secret safety
Evidence paths contain sanitized command output only; no auth headers, tokens, or raw secret material are included in this PR body.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the upstream sync workflow by enabling GitHub auto-merge and waiting for completion, so branch protection can complete the merge. Prevents failures when direct merges are blocked by policy.

- **Bug Fixes**
  - Use `gh pr merge --auto --merge` for upstream sync PRs.
  - Poll until PR state is `MERGED` before release audit and release steps.
  - Keep `--match-head-commit`, merge commits, and branch deletion intact.

<sup>Written for commit 2d4b23d704a0c9c2a01148136de289ea137767e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

