### PR TITLE
ci(upstream): clean up auto-merge polling

### DIFF
--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -355,12 +355,18 @@ jobs:
             sleep 5
           done
           gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --watch --fail-fast --interval 30
-          HEAD_SHA="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --merge --auto --delete-branch --match-head-commit "$HEAD_SHA"
+          PR_INFO="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName,headRefOid)"
+          HEAD_BRANCH="$(printf '%s' "$PR_INFO" | jq -r .headRefName)"
+          HEAD_SHA="$(printf '%s' "$PR_INFO" | jq -r .headRefOid)"
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --merge --auto --match-head-commit "$HEAD_SHA"
           for attempt in {1..40}; do
             PR_STATE="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state)"
             if [ "$PR_STATE" = "MERGED" ]; then
               break
+            fi
+            if [ "$PR_STATE" = "CLOSED" ]; then
+              echo "::error::PR ${PR_NUMBER} closed without merging after auto-merge was enabled."
+              exit 1
             fi
             if [ "$attempt" = "40" ]; then
               echo "::error::PR ${PR_NUMBER} did not merge after auto-merge was enabled."
@@ -368,6 +374,9 @@ jobs:
             fi
             sleep 15
           done
+          if [ -n "$HEAD_BRANCH" ] && [ "$HEAD_BRANCH" != "main" ]; then
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --delete "$HEAD_BRANCH"
+          fi
           echo "merged=true" >> "$GITHUB_OUTPUT"
 
       - name: Fresh /cl release audit

--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -374,10 +374,11 @@ jobs:
             fi
             sleep 15
           done
-          if [ -n "$HEAD_BRANCH" ] && [ "$HEAD_BRANCH" != "main" ]; then
-            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --delete "$HEAD_BRANCH"
-          fi
           echo "merged=true" >> "$GITHUB_OUTPUT"
+          if [ -n "$HEAD_BRANCH" ] && [ "$HEAD_BRANCH" != "main" ]; then
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --delete "$HEAD_BRANCH" \
+              || echo "::warning::Could not delete merged branch ${HEAD_BRANCH}; continuing release."
+          fi
 
       - name: Fresh /cl release audit
         id: release_audit


### PR DESCRIPTION
## Summary
Fixes the upstream sync workflow's auto-merge cleanup path after Cubic flagged that `gh pr merge --auto --delete-branch` does not schedule future branch deletion.

The workflow now records the PR head branch, arms auto-merge without the misleading delete flag, fails fast if the PR closes without merging, and deletes the upstream sync branch after the PR reaches `MERGED`.

## Changes
- Capture `headRefName` and `headRefOid` together before arming auto-merge.
- Remove `--delete-branch` from the `--auto` merge command.
- Add a `CLOSED` state check to the merge polling loop.
- Delete the automation branch explicitly after the PR is merged.

## QA / Evidence
- **Workflow proof:** Parsed `.github/workflows/upstream-agent-merge.yml` as YAML, confirmed no `--auto --delete-branch` pairing remains, and confirmed the new `headRefName`, `CLOSED`, and explicit branch deletion paths are present.
  - Artifact: `local-ignore/qa-evidence/20260704-upstream-automerge-cleanup/workflow-automerge-cleanup-proof.txt`
- **Repository check:** `npm run check` passed after dependency hydration.
  - Artifact: `local-ignore/qa-evidence/20260704-upstream-automerge-cleanup/npm-check-after-install.txt`

## Risks
- The explicit branch deletion runs only after `MERGED` and skips `main`, so it is scoped to the automation branch captured from the PR.
- Repository auto-merge is now enabled so the workflow can use `gh pr merge --auto`.

## Secret safety
No secret-bearing logs, auth headers, cookies, tokens, or raw workflow secret values are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the upstream sync workflow’s auto-merge so branches are cleaned up reliably and the job fails fast if the PR closes without merging. Branch deletion is attempted after merge but is non-fatal if it fails.

- Bug Fixes
  - Capture `headRefName` and `headRefOid` before enabling auto-merge.
  - Remove `--delete-branch` from `gh pr merge --auto`.
  - Poll for `MERGED`; fail if state becomes `CLOSED` or times out.
  - Delete the PR head branch after `MERGED` (skips `main`); treat deletion errors as non-fatal.

<sup>Written for commit 9f97a40b9a6e1d61524662428e2ab9dcde9e0bf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

