### PR TITLE
fix(ai): drop declined pre-fallback blocks when replaying Anthropic turns

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed Anthropic same-model replay of server-side fallback (`server-side-fallback-2026-06-01` beta) turns keeping the declined pre-fallback attempt's `thinking`/`tool_use` blocks, which left the pre-fallback `tool_use` without an adjacent `tool_result` after API-side normalization and caused 400 "`tool_use` ids were found without `tool_result` blocks immediately after" on the next request. Blocks before the final `fallback` marker and their now-orphaned `tool_result`s are dropped per the fallback replay contract; the marker onward replays verbatim.
+
 ### Removed
 
 ## [2026.7.4] - 2026-07-04

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -332,15 +332,64 @@ const REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES: ReadonlySet<string> = new Set(
 	"tool_search_tool_result",
 	"container_upload",
 	// Server-side fallback beta (server-side-fallback-2026-06-01) emits a
-	// `fallback` block mid-response, interleaved with thinking blocks. The API
-	// requires the latest assistant message to be replayed with its block
-	// sequence unmodified; dropping the block yields a 400
-	// ("thinking ... blocks in the latest assistant message cannot be modified").
+	// `fallback` marker mid-response. The marker itself is replayed as a kept
+	// audit block. Blocks emitted *before* the final marker are the declined
+	// attempt and are pruned in convertMessages (see lastAnthropicFallbackBoundary
+	// and collectDiscardedFallbackToolCallIds); the marker onward replays verbatim.
 	"fallback",
 ]);
 
 function isReplayableAnthropicProviderNativeBlock(raw: unknown): raw is ContentBlockParam {
 	return isRecord(raw) && typeof raw.type === "string" && REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES.has(raw.type);
+}
+
+function isSameAnthropicModel(message: AssistantMessage, model: Model<"anthropic-messages">): boolean {
+	return message.provider === model.provider && message.api === model.api && message.model === model.id;
+}
+
+function isAnthropicFallbackMarkerBlock(block: AssistantMessage["content"][number]): boolean {
+	return (
+		block.type === "providerNative" &&
+		block.subtype === "fallback" &&
+		isRecord(block.raw) &&
+		block.raw.type === "fallback"
+	);
+}
+
+// The server-side fallback beta (server-side-fallback-2026-06-01) can emit a
+// `fallback` marker mid-message after a declined attempt is replaced. Blocks
+// before the final marker belong to the discarded attempt: replaying its
+// thinking/tool_use makes the API reject the turn (a discarded tool_use has no
+// matching tool_result after normalization). Returns the index of the last
+// fallback marker, or -1 when the message has none.
+function lastAnthropicFallbackBoundary(content: AssistantMessage["content"]): number {
+	let boundary = -1;
+	for (let index = 0; index < content.length; index++) {
+		if (isAnthropicFallbackMarkerBlock(content[index])) {
+			boundary = index;
+		}
+	}
+	return boundary;
+}
+
+// Tool-call ids emitted by a discarded pre-fallback attempt on a same-model
+// assistant turn. These tool_use blocks are dropped from the assistant turn, so
+// their tool_result blocks must be dropped from the following user turn too — an
+// orphaned tool_result triggers its own 400.
+function collectDiscardedFallbackToolCallIds(messages: Message[], model: Model<"anthropic-messages">): Set<string> {
+	const discarded = new Set<string>();
+	for (const message of messages) {
+		if (message.role !== "assistant" || !isSameAnthropicModel(message, model)) continue;
+		const boundary = lastAnthropicFallbackBoundary(message.content);
+		if (boundary < 0) continue;
+		for (let index = 0; index < boundary; index++) {
+			const block = message.content[index];
+			if (block.type === "toolCall") {
+				discarded.add(block.id);
+			}
+		}
+	}
+	return discarded;
 }
 
 function stringRecord(value: unknown): Record<string, string> | undefined {
@@ -1454,6 +1503,10 @@ function convertMessages(
 		preserveUnsignedThinking: true,
 	});
 
+	// Tool calls from a declined pre-fallback attempt are dropped from their
+	// assistant turn below; drop their tool_results in lockstep so none dangle.
+	const discardedFallbackToolCallIds = collectDiscardedFallbackToolCallIds(transformedMessages, model);
+
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];
 
@@ -1497,9 +1550,21 @@ function convertMessages(
 			}
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];
-			const isSameModel = msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
+			const isSameModel = isSameAnthropicModel(msg, model);
+			// Drop the declined attempt's model-internal blocks (thinking, tool_use)
+			// that precede the final fallback marker; the marker onward is the
+			// serving model's output and replays verbatim.
+			const fallbackBoundary = isSameModel ? lastAnthropicFallbackBoundary(msg.content) : -1;
 
-			for (const block of msg.content) {
+			for (let blockIndex = 0; blockIndex < msg.content.length; blockIndex++) {
+				const block = msg.content[blockIndex];
+				if (
+					fallbackBoundary >= 0 &&
+					blockIndex < fallbackBoundary &&
+					(block.type === "thinking" || block.type === "toolCall")
+				) {
+					continue;
+				}
 				if (block.type === "text") {
 					if (block.text.trim().length === 0) continue;
 					blocks.push({
@@ -1561,29 +1626,37 @@ function convertMessages(
 			// Collect all consecutive toolResult messages, needed for z.ai Anthropic endpoint
 			const toolResults: ContentBlockParam[] = [];
 
-			// Add the current tool result
-			toolResults.push({
-				type: "tool_result",
-				tool_use_id: msg.toolCallId,
-				content: convertContentBlocks(msg.content),
-				is_error: msg.isError,
-			});
+			// Add the current tool result, unless its tool_use was dropped as a
+			// declined pre-fallback attempt (its result would otherwise dangle).
+			if (!discardedFallbackToolCallIds.has(msg.toolCallId)) {
+				toolResults.push({
+					type: "tool_result",
+					tool_use_id: msg.toolCallId,
+					content: convertContentBlocks(msg.content),
+					is_error: msg.isError,
+				});
+			}
 
 			// Look ahead for consecutive toolResult messages
 			let j = i + 1;
 			while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
 				const nextMsg = transformedMessages[j] as ToolResultMessage; // We know it's a toolResult
-				toolResults.push({
-					type: "tool_result",
-					tool_use_id: nextMsg.toolCallId,
-					content: convertContentBlocks(nextMsg.content),
-					is_error: nextMsg.isError,
-				});
+				if (!discardedFallbackToolCallIds.has(nextMsg.toolCallId)) {
+					toolResults.push({
+						type: "tool_result",
+						tool_use_id: nextMsg.toolCallId,
+						content: convertContentBlocks(nextMsg.content),
+						is_error: nextMsg.isError,
+					});
+				}
 				j++;
 			}
 
 			// Skip the messages we've already processed
 			i = j - 1;
+
+			// Every result in this run may have been dropped; don't emit an empty turn.
+			if (toolResults.length === 0) continue;
 
 			// Add a single user message with all tool results
 			params.push({

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -138,12 +138,12 @@ describe("Anthropic provider-native replay", () => {
 		]);
 	});
 
-	it("preserves same-model fallback blocks interleaved with signed thinking", async () => {
+	it("keeps the served attempt and the fallback marker, dropping the discarded thinking before it", async () => {
 		// Server-side fallback (server-side-fallback-2026-06-01 beta) emits a
-		// `fallback` content block mid-response. Dropping it on replay mutates the
-		// latest assistant message and the API rejects the request with
-		// "`thinking` or `redacted_thinking` blocks in the latest assistant
-		// message cannot be modified".
+		// `fallback` content block mid-response. Blocks *before* the marker belong
+		// to the declined attempt; per the replay contract they must be omitted
+		// (the marker onward is the serving model's output and replays verbatim).
+		// The marker itself is kept as an audit block.
 		const model = getModel("anthropic", "claude-fable-5");
 		const fallbackBlock = {
 			type: "fallback",
@@ -176,11 +176,78 @@ describe("Anthropic provider-native replay", () => {
 
 		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
 		expect(assistantPayload?.content).toEqual([
-			{ type: "thinking", thinking: "before fallback", signature: "sig_1" },
 			fallbackBlock,
 			{ type: "thinking", thinking: "after fallback", signature: "sig_2" },
 			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
 		]);
+	});
+
+	it("drops the discarded attempt's tool_use before a fallback boundary and its orphaned tool_result", async () => {
+		// Production 400 (req_011CciJpfp2AxQUwVdt8YhmH): the ccapi server-side-fallback
+		// beta emitted a `fallback` block AFTER a tool_use. Replaying the pre-boundary
+		// tool_use (from the declined Fable attempt) made the API reject the turn:
+		// "tool_use ids were found without tool_result blocks immediately after:
+		// toolu_pre". Per server-side-fallback-2026-06-01, blocks before the final
+		// fallback marker are the declined attempt and must be dropped — and a dropped
+		// tool_use's tool_result must be dropped with it, or it dangles as an orphan.
+		const model = getModel("anthropic", "claude-fable-5");
+		const fallbackBlock = {
+			type: "fallback",
+			from: { model: "claude-fable-5" },
+			to: { model: "claude-opus-4-8" },
+			trigger: { type: "refusal", category: "cyber" },
+		};
+		const assistant = assistantMessage(
+			[
+				{ type: "thinking", thinking: "discarded", thinkingSignature: "sig_pre" },
+				{ type: "toolCall", id: "toolu_pre", name: "bash", arguments: { command: "echo hi" } },
+				{ type: "providerNative", subtype: "fallback", raw: fallbackBlock },
+				{ type: "thinking", thinking: "served", thinkingSignature: "sig_post" },
+				{ type: "toolCall", id: "toolu_post", name: "read", arguments: { path: "README.md" } },
+			],
+			{ stopReason: "toolUse", model: "claude-fable-5" },
+		);
+
+		const payload = await capturePayload(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{
+				role: "toolResult",
+				toolCallId: "toolu_pre",
+				toolName: "bash",
+				content: [{ type: "text", text: "hi" }],
+				isError: false,
+				timestamp: 2,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "toolu_post",
+				toolName: "read",
+				content: [{ type: "text", text: "out" }],
+				isError: false,
+				timestamp: 3,
+			},
+		]);
+
+		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([
+			fallbackBlock,
+			{ type: "thinking", thinking: "served", signature: "sig_post" },
+			{ type: "tool_use", id: "toolu_post", name: "read", input: { path: "README.md" } },
+		]);
+
+		// The discarded tool_use's tool_result must be gone; the served one stays.
+		const toolResultIds: unknown[] = [];
+		for (const message of payload.messages ?? []) {
+			if (message.role !== "user" || !Array.isArray(message.content)) continue;
+			for (const block of message.content) {
+				if (isRecord(block) && block.type === "tool_result") {
+					toolResultIds.push(block.tool_use_id);
+				}
+			}
+		}
+		expect(toolResultIds).not.toContain("toolu_pre");
+		expect(toolResultIds).toContain("toolu_post");
 	});
 
 	it("drops same-model provider-native blocks with unknown subtypes", async () => {


### PR DESCRIPTION
## Problem

The user's Anthropic provider routes through a Cloudflare proxy (`ccapi`) that enables the **server-side fallback beta** (`server-side-fallback-2026-06-01`) for `claude-fable-5`. When Fable declines mid-output, the API emits a `fallback` marker and the Opus fallback model continues the turn. A resulting assistant turn can look like:

```
[thinking, tool_use_pre, FALLBACK, thinking, tool_use_post]
```

When senpi replayed this turn verbatim on the next request, the Anthropic API rejected it with **HTTP 400**:

```
messages.N: `tool_use` ids were found without `tool_result` blocks
immediately after: <id>
```

Observed in production (pi session `019f3094-…`, request `req_011CciJpfp2AxQUwVdt8YhmH`): the request stopped with `stopReason: error` and the session could not continue.

## Root cause

Per the `server-side-fallback-2026-06-01` replay contract, blocks **before** the final `fallback` marker belong to the *declined* attempt and must be omitted on replay; only the marker onward (the serving model's output) replays verbatim. senpi kept every block, so the pre-boundary `tool_use` had no matching `tool_result` after the API normalizes the turn → 400. This is a fork-only concern: the fallback beta is injected by the proxy, and upstream `pi-mono` has no fallback-replay path.

## Fix

In `convertMessages` (`packages/ai/src/api/anthropic-messages.ts`):

- Drop the declined attempt's `thinking` / `tool_use` blocks that precede the final `fallback` marker on a **same-model** assistant turn. The marker (a kept audit block) and everything after it are preserved.
- Drop the dropped `tool_use`'s `tool_result` from the following user turn in lockstep — otherwise it dangles as an orphan and triggers a *different* 400. Empty tool-result turns are no longer emitted.

Non-fallback turns, cross-model/cross-provider fallback blocks, and the fallback-at-index-0 shape are unchanged.

## Testing

- **Unit** (`anthropic-provider-native-replay.test.ts`): added a production-repro case (pre-boundary `thinking` + `tool_use` dropped, orphaned `tool_result` dropped, served attempt kept) and corrected the earlier fallback-replay test, which asserted an unvalidated contract (keeping pre-boundary thinking) that the live API in fact rejects. RED before the fix, GREEN after.
- **Full `packages/ai` suite**: 669 passed, 0 failed.
- **Live API** (via the real ccapi endpoint, `claude-fable-5`): the pre-fix wire shape returns **HTTP 400** with the exact production error; the fixed wire shape returns **HTTP 200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors when replaying Anthropic server-side fallback turns by dropping declined pre-fallback `thinking`/`tool_use` blocks and removing their orphaned `tool_result`s. Restores successful turns for sessions behind Cloudflare `ccapi` using the `server-side-fallback-2026-06-01` beta.

- **Bug Fixes**
  - In `convertMessages`, for same-model assistant turns with a `fallback` marker, drop blocks before the final marker; keep the marker and everything after it.
  - Remove `tool_result`s whose `tool_use` ids were dropped pre-fallback; skip emitting empty tool-result turns.
  - Non-fallback, cross-model, and boundary-at-index-0 cases are unchanged.

- **Docs**
  - Added CHANGELOG entry describing this fallback replay fix.

<sup>Written for commit 99cf0e767c2437dfb87d8d7451aef3b47c01e9b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
## Re-verification (2026-07-06)

Independently re-verified this fix end-to-end before merge:

- **Contract source**: The Anthropic `server-side-fallback-2026-06-01` echo contract requires the declined pre-fallback `thinking`/`tool_use` blocks to be omitted on replay (marker onward verbatim). This single contract reconciles both production 400s in this fork — the "thinking cannot be modified" 400 (PR #99, session `019f2110`) and this adjacency 400 (session `019f3094`). Upstream `badlogic/pi-mono` has no fallback path (`git log HEAD..upstream/main` = 0 commits), so this is a fork-only fix.
- **RED/GREEN**: A working-tree revert to verbatim replay was found uncommitted; restoring this branch's implementation flips the contract tests RED→GREEN. `npm run check` exit 0; `packages/ai` suite 672 passed / 0 failed.
- **Real-CLI QA**: The senpi CLI from source, in an isolated sandbox against a fake validating Anthropic server, completes the turn on the fixed shape and reproduces the exact production 400 on the verbatim shape.
- **Live ccapi A/B**: Replaying session `019f3094`'s genuine signed blocks through the real endpoint — verbatim shape returns HTTP **400** (`messages.21: tool_use ids were found without tool_result blocks immediately after: toolu_01HTN3…`, matching the production error), fixed conversion returns HTTP **200**.