### PR TITLE
fix(examples): use a current model id in full-control SDK example

### DIFF
--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -26,7 +26,7 @@ if (process.env.MY_ANTHROPIC_KEY) {
 // Model registry with no custom models.json
 const modelRegistry = ModelRegistry.inMemory(authStorage);
 
-const model = getModel("anthropic", "claude-sonnet-4-20250514");
+const model = getModel("anthropic", "claude-opus-4-5");
 if (!model) throw new Error("Model not found");
 
 // In-memory settings with overrides


### PR DESCRIPTION
## Problem

The `Release` workflow (`publish-npm.yml`) failed at `npm run check` → `tsgo`:

```
packages/coding-agent/examples/sdk/12-full-control.ts(29,37): error TS2345:
Argument of type '"claude-sonnet-4-20250514"' is not assignable to parameter of type
'"claude-fable-5" | ... | "claude-sonnet-5"'.
```

The example pinned the dated id `claude-sonnet-4-20250514`. The release **regenerates the model catalog from live models.dev before typechecking**, and models.dev has since dropped that id — so the regenerated model-id union no longer contains it and the hardcoded example fails `tsgo`. It passes locally only because the *committed* catalog still lists the id; the failure surfaces exclusively at release-time regeneration.

## Fix

Use `claude-opus-4-5` — already used by the sibling SDK examples and stable in the union — so the example survives catalog regeneration.

## Verification

- Regenerated the catalog locally (`npm --prefix packages/ai run generate-models`, exactly as the release does): the stale id drops out of the union (0 occurrences), and `tsgo --noEmit` then passes on the example with the new id (reproduced the release failure with the old id, confirmed green with the new one).
- Full `npm run check` (incl. `check:neo`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the full-control SDK example to use a current model id so release-time typechecking passes after catalog regeneration. Replace `claude-sonnet-4-20250514` with `claude-opus-4-5` in `packages/coding-agent/examples/sdk/12-full-control.ts`, matching other examples and the current model union.

<sup>Written for commit 655558f330a988a14845ac32793cf75bcdf11471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

