### PR TITLE
fix(ai): drop unpaired pre-fallback server_tool_use on Anthropic replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed Anthropic same-model replay of server-side fallback (`server-side-fallback-2026-06-01` beta) turns keeping the declined pre-fallback attempt's `thinking`/`tool_use` blocks, which left the pre-fallback `tool_use` without an adjacent `tool_result` after API-side normalization and caused 400 "`tool_use` ids were found without `tool_result` blocks immediately after" on the next request. Blocks before the final `fallback` marker and their now-orphaned `tool_result`s are dropped per the fallback replay contract; the marker onward replays verbatim.
+- Extended the same server-side fallback replay fix to also drop an unpaired `server_tool_use` block before the `fallback` marker (a declined attempt whose server-tool result never arrived), which would otherwise dangle and trigger its own 400. Paired server-tool blocks (a `server_tool_use` with its result) still replay verbatim.
 
 ### Removed
 

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -372,6 +372,26 @@ function lastAnthropicFallbackBoundary(content: AssistantMessage["content"]): nu
 	return boundary;
 }
 
+function isAnthropicServerToolUseBlock(raw: unknown): raw is { readonly type: "server_tool_use"; readonly id: string } {
+	return isRecord(raw) && raw.type === "server_tool_use" && typeof raw.id === "string";
+}
+
+// tool_use ids referenced by server-tool result blocks in content[0, boundary).
+// A pre-boundary `server_tool_use` whose id is absent here is unpaired — the
+// fallback interrupted the declined attempt before its result arrived — so
+// replaying it would leave a server tool_use with no adjacent result and 400 the
+// turn. Paired server-tool blocks replay verbatim per the fallback contract.
+function pairedServerToolUseIdsBeforeBoundary(content: AssistantMessage["content"], boundary: number): Set<string> {
+	const paired = new Set<string>();
+	for (let index = 0; index < boundary; index++) {
+		const block = content[index];
+		if (block.type !== "providerNative" || !isRecord(block.raw)) continue;
+		const toolUseId = block.raw.tool_use_id;
+		if (typeof toolUseId === "string") paired.add(toolUseId);
+	}
+	return paired;
+}
+
 // Tool-call ids emitted by a discarded pre-fallback attempt on a same-model
 // assistant turn. These tool_use blocks are dropped from the assistant turn, so
 // their tool_result blocks must be dropped from the following user turn too — an
@@ -1551,19 +1571,30 @@ function convertMessages(
 		} else if (msg.role === "assistant") {
 			const blocks: ContentBlockParam[] = [];
 			const isSameModel = isSameAnthropicModel(msg, model);
-			// Drop the declined attempt's model-internal blocks (thinking, tool_use)
-			// that precede the final fallback marker; the marker onward is the
-			// serving model's output and replays verbatim.
+			// Blocks before the final fallback marker are the declined attempt; the
+			// marker onward is the serving model's output and replays verbatim.
 			const fallbackBoundary = isSameModel ? lastAnthropicFallbackBoundary(msg.content) : -1;
+			const preBoundaryPairedServerToolUseIds =
+				fallbackBoundary >= 0
+					? pairedServerToolUseIdsBeforeBoundary(msg.content, fallbackBoundary)
+					: new Set<string>();
 
 			for (let blockIndex = 0; blockIndex < msg.content.length; blockIndex++) {
 				const block = msg.content[blockIndex];
-				if (
-					fallbackBoundary >= 0 &&
-					blockIndex < fallbackBoundary &&
-					(block.type === "thinking" || block.type === "toolCall")
-				) {
-					continue;
+				if (fallbackBoundary >= 0 && blockIndex < fallbackBoundary) {
+					// Drop the declined attempt's model-internal blocks: thinking,
+					// tool_use, and any unpaired server_tool_use. Paired server-tool
+					// blocks and text survive per the fallback replay contract.
+					if (block.type === "thinking" || block.type === "toolCall") {
+						continue;
+					}
+					if (
+						block.type === "providerNative" &&
+						isAnthropicServerToolUseBlock(block.raw) &&
+						!preBoundaryPairedServerToolUseIds.has(block.raw.id)
+					) {
+						continue;
+					}
 				}
 				if (block.type === "text") {
 					if (block.text.trim().length === 0) continue;

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -250,6 +250,63 @@ describe("Anthropic provider-native replay", () => {
 		expect(toolResultIds).toContain("toolu_post");
 	});
 
+	it("drops an unpaired server_tool_use before a fallback boundary but keeps a paired one", async () => {
+		// Per server-side-fallback-2026-06-01, blocks before the final fallback
+		// marker belong to the declined attempt. The replay contract keeps text and
+		// *paired* server-tool blocks but omits an unpaired `server_tool_use` — its
+		// missing result would otherwise leave it dangling and 400 the turn. Here the
+		// declined attempt has one paired search (result present) and one unpaired
+		// search (fallback interrupted before its result); only the paired pair may
+		// replay.
+		const model = getModel("anthropic", "claude-fable-5");
+		const pairedUse = { type: "server_tool_use", id: "srvu_paired", name: "web_search", input: { query: "a" } };
+		const pairedResult = {
+			type: "web_search_tool_result",
+			tool_use_id: "srvu_paired",
+			content: [{ type: "web_search_result", title: "A", url: "https://a.example", encrypted_content: "enc" }],
+		};
+		const unpairedUse = { type: "server_tool_use", id: "srvu_unpaired", name: "web_search", input: { query: "b" } };
+		const fallbackBlock = {
+			type: "fallback",
+			from: { model: "claude-fable-5" },
+			to: { model: "claude-opus-4-8" },
+			trigger: { type: "refusal", category: "cyber" },
+		};
+		const assistant = assistantMessage(
+			[
+				{ type: "providerNative", subtype: "server_tool_use", raw: pairedUse },
+				{ type: "providerNative", subtype: "web_search_tool_result", raw: pairedResult },
+				{ type: "providerNative", subtype: "server_tool_use", raw: unpairedUse },
+				{ type: "providerNative", subtype: "fallback", raw: fallbackBlock },
+				{ type: "thinking", thinking: "served", thinkingSignature: "sig_post" },
+				{ type: "toolCall", id: "toolu_post", name: "read", arguments: { path: "README.md" } },
+			],
+			{ stopReason: "toolUse", model: "claude-fable-5" },
+		);
+
+		const payload = await capturePayload(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{
+				role: "toolResult",
+				toolCallId: "toolu_post",
+				toolName: "read",
+				content: [{ type: "text", text: "out" }],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+
+		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([
+			pairedUse,
+			pairedResult,
+			fallbackBlock,
+			{ type: "thinking", thinking: "served", signature: "sig_post" },
+			{ type: "tool_use", id: "toolu_post", name: "read", input: { path: "README.md" } },
+		]);
+	});
+
 	it("drops same-model provider-native blocks with unknown subtypes", async () => {
 		const model = getModel("anthropic", "claude-haiku-4-5");
 		const assistant = assistantMessage(


### PR DESCRIPTION
## Context

Follow-up hardening to the server-side fallback replay fix (#113). A code-review audit of #113 surfaced a real but narrow gap.

## Problem

#113 drops a declined pre-fallback attempt's `thinking`/`tool_use` blocks before the `fallback` marker, but every *replayable* provider-native block before the marker — including `server_tool_use` — was kept unconditionally. Per the `server-side-fallback-2026-06-01` replay contract, an **unpaired** `server_tool_use` before the marker (the fallback interrupted the declined attempt before its server-tool result arrived) must be omitted; replaying it leaves a server `tool_use` with no adjacent result and can trigger the same class of 400 the original fix addressed.

This is exotic — server tools normally resolve in-turn — so it was not present in the production session #113 fixed, but it is a genuine contract gap.

## Fix

In `convertMessages`, when a same-model assistant turn has a fallback boundary, drop a pre-boundary `server_tool_use` whose id is **not** referenced by any server-tool result block before the marker (unpaired). **Paired** server-tool blocks (a `server_tool_use` with its matching result) and text still replay verbatim.

## Testing

- New unit test `drops an unpaired server_tool_use before a fallback boundary but keeps a paired one` — RED before the change (unpaired block was kept), GREEN after. Asserts the paired pair + marker + served blocks replay while the unpaired `server_tool_use` is dropped.
- Full `packages/ai` suite: 673 passed, 0 failed. `npm run check` green.

## Note

`packages/ai/src/api/anthropic-messages.ts` is 1544 pure LOC (pre-existing; this adds ~22). Splitting this provider adapter is a separate refactor out of scope for a bugfix and is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 400s in Anthropic same-model replay by dropping unpaired pre-fallback `server_tool_use` blocks. Paired server-tool blocks and text still replay; `thinking`/`tool_use` remain dropped per the `server-side-fallback-2026-06-01` contract.

- **Bug Fixes**
  - In `convertMessages`, when a fallback boundary exists, scan pre-boundary blocks for server-tool results and drop any pre-boundary `server_tool_use` whose `id` isn’t referenced; keep paired server-tool blocks.
  - Added unit test to verify unpaired `server_tool_use` is removed and paired blocks are preserved; all tests pass.

<sup>Written for commit fd19a4f834cbd76218625cbbc78b2fa69bc9f925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

