### PR TITLE
test(coding-agent): fix compaction test broken by model catalog window drift

### DIFF
--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -248,7 +248,13 @@ describe("AgentSession auto-compaction queue resume", () => {
 	it("should trigger threshold compaction for error messages using last successful usage", async () => {
 		const model = session.model!;
 
-		// A successful assistant message with high token usage (near context limit)
+		// Usage near the model's context limit so threshold compaction triggers.
+		// Derived from the model's actual contextWindow rather than a hardcoded 200K, so
+		// the assertion stays correct when the generated model catalog updates the window
+		// (Claude Sonnet 4.5 grew from 200K to 1M). shouldCompact fires when the context
+		// tokens exceed contextWindow - reserveTokens (default 16384), so sit 8K under the
+		// window — above the threshold for any window size.
+		const nearLimitTokens = model.contextWindow - 8_000;
 		const successfulAssistant: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: "large successful response" }],
@@ -256,11 +262,11 @@ describe("AgentSession auto-compaction queue resume", () => {
 			provider: model.provider,
 			model: model.id,
 			usage: {
-				input: 180_000,
-				output: 10_000,
+				input: nearLimitTokens,
+				output: 0,
 				cacheRead: 0,
 				cacheWrite: 0,
-				totalTokens: 190_000,
+				totalTokens: nearLimitTokens,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "stop",


### PR DESCRIPTION
## Problem

The `Release` publish-npm job failed on one test in `packages/coding-agent`:

```
agent-session-auto-compaction-queue.test.ts > should trigger threshold compaction for error messages using last successful usage
AssertionError: expected "_runAutoCompaction" to be called with arguments: [ 'threshold', false ]
Number of calls: 0
```

This blocked publishing `v2026.7.5` (nothing was published). It is **not** a regression in this cycle's code — the test source and all compaction logic are unchanged since `v2026.7.4` (whose publish job passed this test).

## Root cause

The test uses `getModel("anthropic", "claude-sonnet-4-5")` and sets up **190K tokens** of "last successful usage", expecting threshold compaction to fire. `shouldCompact` triggers when `contextTokens > contextWindow - reserveTokens` (default `reserveTokens` = 16384).

The generated model catalog was refreshed from models.dev, growing **Sonnet 4.5's `contextWindow` from 200000 to 1000000**:
- Old: `190000 > 200000 - 16384 = 183616` → **true** → compaction fired → test passed.
- New: `190000 > 1000000 - 16384 = 983616` → **false** → no compaction → test failed.

So the test hardcoded an assumption about a live-catalog value. This is the same drift class as the sibling example-model-id fix (#116).

## Fix

Derive the near-limit usage from the model's actual `contextWindow` (`window - 8000`, comfortably above the 16384 reserve) so the assertion holds for any window size. **Behavior is unchanged** — only the test fixture is made drift-proof.

## Testing

- The failing test now passes; full file 6/6 green (RED before, GREEN after).
- Full `npm run check` (incl. `check:neo`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix publish-blocking compaction test by deriving near-limit token usage from the model’s `contextWindow`, making the test resilient to model catalog window changes.

- **Bug Fixes**
  - Replace hardcoded 190K tokens with `model.contextWindow - 8_000` (above the 16,384 reserve) so threshold compaction reliably triggers regardless of window size.
  - No behavior changes; only the test fixture is updated.

<sup>Written for commit a9609d5960d2d4a7e3f9812c115b1d5ae37b9348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

