### PR TITLE
fix(coding-agent): point rpc custom() characterization test at its source

### DIFF
--- a/packages/coding-agent/test/suite/rpc-mode-custom-behavior.test.ts
+++ b/packages/coding-agent/test/suite/rpc-mode-custom-behavior.test.ts
@@ -8,9 +8,13 @@ import { describe, expect, it } from "vitest";
 // Task 14 (neo) reimplements the 5 builtin ctx.ui.custom extensions natively in
 // Go and adds a Go-side "custom_unsupported" notice dialog. The audit asked for
 // an ADDITIVE TS test asserting the CURRENT behavior of ctx.ui.custom in RPC
-// mode (rpc-mode.ts, the `async custom()` method): it returns undefined
-// synchronously with NO wire message emitted — there is nothing for a default
-// RPC client to render a dialog FROM today. This test documents exactly that.
+// mode (the `async custom()` method): it returns undefined synchronously with
+// NO wire message emitted — there is nothing for a default RPC client to render
+// a dialog FROM today. This test documents exactly that.
+//
+// The RPC uiContext (with `async custom()`) was extracted from rpc-mode.ts into
+// connection-handler.ts during the neo daemon refactor, so this test reads the
+// method from its current home.
 //
 // It is intentionally kept off-main and additive: it neither imports the private
 // createExtensionUIContext closure nor changes production code. Instead it (1)
@@ -20,13 +24,13 @@ import { describe, expect, it } from "vitest";
 // output() call).
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
-const rpcModePath = join(thisDir, "..", "..", "src", "modes", "rpc", "rpc-mode.ts");
+const rpcUiContextPath = join(thisDir, "..", "..", "src", "modes", "rpc", "connection-handler.ts");
 
-/** Extract the body of the `async custom() { ... }` method from rpc-mode.ts. */
+/** Extract the body of the `async custom() { ... }` method from the RPC uiContext source. */
 function extractCustomBody(source: string): string {
 	const marker = "async custom() {";
 	const start = source.indexOf(marker);
-	if (start === -1) throw new Error("async custom() not found in rpc-mode.ts");
+	if (start === -1) throw new Error("async custom() not found in connection-handler.ts");
 	const bodyStart = start + marker.length;
 	let depth = 1;
 	let index = bodyStart;
@@ -41,7 +45,7 @@ function extractCustomBody(source: string): string {
 
 describe("rpc-mode ctx.ui.custom characterization", () => {
 	it("source: async custom() returns undefined and emits no wire message", () => {
-		const source = readFileSync(rpcModePath, "utf-8");
+		const source = readFileSync(rpcUiContextPath, "utf-8");
 		const body = extractCustomBody(source);
 
 		// The current body is a comment plus `return undefined as never;`.


### PR DESCRIPTION
## Summary

`main` CI is red: `test/suite/rpc-mode-custom-behavior.test.ts` throws `async custom() not found in rpc-mode.ts`. The neo daemon refactor extracted the RPC `uiContext` (including `async custom()`) out of `rpc-mode.ts` into `connection-handler.ts`, but this characterization test still read `rpc-mode.ts`.

This points the test at `connection-handler.ts` where `custom()` now lives. The asserted behavior is unchanged — the method body still returns `undefined as never` and emits no wire message (no `output(`, no `extension_ui_request`).

## Changes

- `rpc-mode-custom-behavior.test.ts`: read `connection-handler.ts` instead of `rpc-mode.ts`; update the error message and comments to match the method's new home.

## QA / Evidence

- **What was tested:** `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/rpc-mode-custom-behavior.test.ts`
- **Observed result:** 2 passed (was throwing before the fix).
- **Why sufficient:** this is the exact test that fails on main; it now passes against the current source layout, and the assertions (undefined result, no wire output) are unchanged.

## Risks

Test-only change, no production code touched. Restores the intended characterization against the refactored source.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing CI by pointing the RPC `custom()` characterization test at `connection-handler.ts` instead of `rpc-mode.ts`. Behavior is unchanged: it still returns `undefined` and emits no wire message.

<sup>Written for commit 436d4e88d71b2ed66b9d7cba2f2a5645b66dd5ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

