### PR TITLE
test(coding-agent): fix ctx.ui.custom characterization path after daemon refactor

### DIFF
--- a/packages/coding-agent/test/suite/rpc-mode-custom-behavior.test.ts
+++ b/packages/coding-agent/test/suite/rpc-mode-custom-behavior.test.ts
@@ -20,13 +20,16 @@ import { describe, expect, it } from "vitest";
 // output() call).
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
-const rpcModePath = join(thisDir, "..", "..", "src", "modes", "rpc", "rpc-mode.ts");
+// The ctx.ui.custom handler was extracted from rpc-mode.ts into
+// connection-handler.ts by the neo daemon refactor (per-connection handler),
+// so the characterization reads it from its current home.
+const rpcModePath = join(thisDir, "..", "..", "src", "modes", "rpc", "connection-handler.ts");
 
-/** Extract the body of the `async custom() { ... }` method from rpc-mode.ts. */
+/** Extract the body of the `async custom() { ... }` method from connection-handler.ts. */
 function extractCustomBody(source: string): string {
 	const marker = "async custom() {";
 	const start = source.indexOf(marker);
-	if (start === -1) throw new Error("async custom() not found in rpc-mode.ts");
+	if (start === -1) throw new Error("async custom() not found in connection-handler.ts");
 	const bodyStart = start + marker.length;
 	let depth = 1;
 	let index = bodyStart;


### PR DESCRIPTION
## Summary
Main went red on the full test suite after two independently-green PRs landed together: task 14 (#131) added `rpc-mode-custom-behavior.test.ts` which greps `rpc-mode.ts` for `async custom()`, and the neo daemon refactor (task 15, #132) **moved** that handler into `connection-handler.ts`. Each PR passed alone; the combination fails.

## Fix
Point the characterization's source read at `connection-handler.ts` where `custom()` now lives. The asserted behavior is unchanged (returns `undefined`, emits no wire message). One-file, test-only.

## QA
`npx vitest --run test/suite/rpc-mode-custom-behavior.test.ts` → 2/2 pass (was 1 failed). Unblocks the attach PR (#133) and every other PR against main.

## Risks
Test-only; no production change. Task 13 (in progress) will further evolve this test when it adds the custom_unsupported capability flag.

## Secret safety
None involved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing characterization test by reading `async custom()` from `src/modes/rpc/connection-handler.ts` instead of `src/modes/rpc/rpc-mode.ts` after the daemon refactor. Test-only change; behavior assertions remain the same.

<sup>Written for commit 09dc5f5887bd8e111355898dc8864ed12e1bd7ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

