### PR TITLE
refactor: enforce snake_case tool-name convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You do **not** need to install these packages for normal senpi use; their functi
 | [`pi-openai-web-search`](https://github.com/code-yeongyu/pi-openai-web-search) | `openai-web-search` | OpenAI Responses native web search. |
 | [`pi-todotools`](https://github.com/code-yeongyu/pi-todotools) | `todowrite` | `todowrite` / `todoread`, todo sidebar state, workflow prompt guidance, and continuation follow-ups. |
 
-Other builtins such as `permission-system`, `prompt-preset`, `anthropic-bash`, `service-tier`, `tool-pair-guard`, `compaction`, `history-search`, `session-observer`, and `kimi-web-search` are senpi-owned builtin extensions, not installable sibling packages.
+Other builtins such as `permission-system`, `prompt-preset`, `anthropic-bash`, `service-tier`, `tool-pair-guard`, `compaction`, `history-search`, `session-observer`, `websearch`, `webfetch`, `nested-agents-md`, `rules`, and `goal` are senpi-owned builtin extensions, not installable sibling packages.
 
 ## Why "senpi"
 
@@ -194,7 +194,11 @@ In-tree, tightly coupled to senpi internals. Loaded in this exact registration o
 | 12 | [`compaction`](packages/coding-agent/src/core/extensions/builtin/compaction/) | Speculative + emergency compaction policy: degradation monitor, circuit breaker, per-turn cap, todo bridging, checkpoint state, restoration tracker, tool-result truncation | [AGENTS.md](packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md) · [changes.md](packages/coding-agent/src/core/extensions/builtin/compaction/changes.md) |
 | 13 | [`history-search`](packages/coding-agent/src/core/extensions/builtin/history-search/) | `/history` command — searches prompt history across sessions in an overlay | — |
 | 14 | [`session-observer`](packages/coding-agent/src/core/extensions/builtin/session-observer/) | `/sessions` command — peeks at previous session transcripts in a HUD overlay | — |
-| 15 | [`kimi-web-search`](packages/coding-agent/src/core/extensions/builtin/kimi-web-search/) | `SearchWeb` / `FetchURL` tools backed by the Kimi search/fetch API; toggled via `PI_KIMI_WEB_SEARCH` | — |
+| 15 | [`websearch`](packages/coding-agent/src/core/extensions/builtin/websearch/) | Provider-backed `web_search` tool with config-gated activation, TUI status, and source-aware results | — |
+| 16 | [`webfetch`](packages/coding-agent/src/core/extensions/builtin/webfetch/) | `webfetch` tool for URL content as markdown, text, or HTML with bounded time and size | — |
+| 17 | [`nested-agents-md`](packages/coding-agent/src/core/extensions/builtin/nested-agents-md/) | Auto-injects nearby `AGENTS.md` files when the agent reads from nested directories | — |
+| 18 | [`rules`](packages/coding-agent/src/core/extensions/builtin/rules/) | Auto-discovers project rule files and exposes `/rules` / `/reload-rules` commands | — |
+| 19 | [`goal`](packages/coding-agent/src/core/extensions/builtin/goal/) | Persistent goal tracking tools, footer state, and continuation prompts | — |
 
 > The builtin directories above are new vs upstream `pi-mono` — none exist in `badlogic/pi-mono`. Vendored versions are pinned in [`external-versions.json`](packages/coding-agent/src/core/extensions/builtin/external-versions.json) and synced from the sibling `pi-extensions` checkout with [`sync-builtin-extensions.mjs`](packages/coding-agent/scripts/sync-builtin-extensions.mjs).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `senpi app-server` mode for Codex-compatible app-server integrations, including stdio, websocket, and websocket-over-UDS transports, multi-session serving, wire approval requests, daemon subcommands, and protocol documentation.
 - Added the built-in MCP extension skeleton and exact-pinned official MCP SDK dependency groundwork.
+- Added a convention guard that rejects senpi-defined PascalCase tool names in core and builtin extension tool registrations.
 
 ### Changed
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -71,11 +71,11 @@
 - LOW: `agent-session.ts` `extendResourcesFromExtensions()` resource handoff.
 - LOW: `builtin/index.ts` registration order near `permission-system`.
 
-## 2026-06-15 - Remove kimi-web-search builtin; fold Kimi search into pi-websearch
+## 2026-06-15 - Remove legacy Kimi-specific web-search builtin; fold Kimi search into pi-websearch
 
 ### What changed
 
-- Removed `builtin/kimi-web-search/` and its registration in `builtin/index.ts`. The `kimi_search_web` / `kimi_fetch_url` tools no longer exist.
+- Removed the legacy Kimi-specific web-search builtin and its registration in `builtin/index.ts`. Its search/fetch tools no longer exist.
 - Kimi search is now a `pi-websearch` provider (`kimi`, vendored at 0.2.0). On a `kimi-coding` model the native auto-route prepends a `kimi` entry (api.kimi.com/coding/v1/search) using the model API key, so `web_search` works zero-config and falls back to the configured chain. URL fetching is handled by the `webfetch` builtin.
 - `test/suite/regressions/3592-...test.ts`: dropped `kimi_search_web` / `kimi_fetch_url` from the tool-list expectations.
 
@@ -190,38 +190,6 @@
 ### Expected merge conflict zones
 
 - LOW: `builtin/system-messages.ts`, `builtin/todotools/system-messages.ts`, and `builtin/todotools/state.ts` if upstream or vendored builtins rename these helper surfaces.
-## 2026-05-14 - Add kimi-web-search builtin extension
-
-### What changed
-
-- Added `builtin/kimi-web-search/index.ts`: New builtin extension that registers `SearchWeb` and `FetchURL` tools for Kimi Code platform.
-- Registers tools via `pi.registerTool()` (not provider-native injection like anthropic-web-search/openai-web-search).
-- Calls Kimi Code service endpoints:
-  - Search: `POST https://api.kimi.com/coding/v1/search` with `{text_query, limit, enable_page_crawling, timeout_seconds}`
-  - Fetch: `POST https://api.kimi.com/coding/v1/fetch` with `{url}`
-- Passes `Authorization: Bearer <api_key>` and `X-Msh-Tool-Call-Id` headers matching Kimi CLI behavior.
-- Fallback to local HTTP fetch when Kimi fetch service returns error.
-- Configurable via env vars: `PI_KIMI_WEB_SEARCH`, `PI_KIMI_SEARCH_BASE_URL`, `PI_KIMI_FETCH_BASE_URL`.
-- Registered in `builtin/index.ts` as builtin extension id `kimi-web-search`.
-
-### Why
-
-- Kimi Code platform provides official SearchWeb/FetchURL services (`moonshot_search`/`moonshot_fetch`), but senpi had no integration.
-- The existing `anthropic-web-search` extension incorrectly injected Anthropic-native `web_search_20250305` into kimi-coding requests (because both use `api: "anthropic-messages"`), which Kimi API does not support.
-
-### Why extension system couldn't handle this alone
-
-- While this *could* be a user extension, it requires deep integration with:
-  - `ctx.modelRegistry.getApiKeyAndHeaders()` for auth resolution
-  - Knowledge of Kimi Code service URL conventions
-  - Proper `X-Msh-Tool-Call-Id` header passing
-- As a builtin, it stays consistent with anthropic-web-search/openai-web-search and can be maintained alongside provider updates.
-
-### Expected merge conflict zones
-
-- LOW: `builtin/index.ts` extension registration list.
-- LOW: `builtin/kimi-web-search/index.ts` if Kimi Code service API changes.
-
 ## 2026-05-14 - Native Web Tool UI Cleanup Hooks
 
 ### What changed

--- a/packages/coding-agent/test/suite/tool-name-convention.test.ts
+++ b/packages/coding-agent/test/suite/tool-name-convention.test.ts
@@ -1,0 +1,84 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type ToolNameViolation = {
+	readonly file: string;
+	readonly line: number;
+	readonly name: string;
+};
+
+const sourceRoots = [
+	fileURLToPath(new URL("../../src/core/tools/", import.meta.url)),
+	fileURLToPath(new URL("../../src/core/extensions/builtin/", import.meta.url)),
+] as const;
+const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
+const PASCAL_CASE_TOOL_NAME =
+	/(?:^|[^\w])name\s*:\s*["']([A-Z][A-Za-z0-9_]*)["']|registerTool\s*\(\s*["']([A-Z][A-Za-z0-9_]*)["']/g;
+
+function lineNumberAt(source: string, index: number): number {
+	let line = 1;
+	for (let i = 0; i < index; i++) {
+		if (source.charCodeAt(i) === 10) line++;
+	}
+	return line;
+}
+
+function findPascalCaseToolNames(file: string, source: string): ToolNameViolation[] {
+	const violations: ToolNameViolation[] = [];
+	for (const match of source.matchAll(PASCAL_CASE_TOOL_NAME)) {
+		const name = match[1] ?? match[2];
+		if (!name) continue;
+		violations.push({ file, line: lineNumberAt(source, match.index), name });
+	}
+	return violations;
+}
+
+async function collectTypeScriptFiles(root: string): Promise<string[]> {
+	const entries = await readdir(root, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const path = join(root, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...(await collectTypeScriptFiles(path)));
+			continue;
+		}
+		if (entry.isFile() && entry.name.endsWith(".ts")) files.push(path);
+	}
+	return files;
+}
+
+async function findSourceViolations(): Promise<ToolNameViolation[]> {
+	const files = (await Promise.all(sourceRoots.map(collectTypeScriptFiles))).flat();
+	const violations: ToolNameViolation[] = [];
+	for (const file of files) {
+		const source = await readFile(file, "utf-8");
+		violations.push(...findPascalCaseToolNames(relative(packageRoot, file), source));
+	}
+	return violations;
+}
+
+describe("tool name convention", () => {
+	it("keeps senpi-defined tool names snake_case", async () => {
+		const violations = await findSourceViolations();
+		expect(violations).toEqual([]);
+	});
+
+	it("detects PascalCase tool names while ignoring provider-fixed hook event names", () => {
+		const source = `
+pi.registerTool({
+	name: "BadTool",
+	description: "fixture"
+});
+pi.registerTool("AlsoBad");
+const providerFixed = { hook_event_name: "PreToolUse" };
+pi.registerTool({
+	name: "still_open
+`;
+		expect(findPascalCaseToolNames("fixture.ts", source)).toEqual([
+			{ file: "fixture.ts", line: 3, name: "BadTool" },
+			{ file: "fixture.ts", line: 6, name: "AlsoBad" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

PR-A for the persistent-terminal-tool plan C7 snake_case convention. Discovery found no renamable senpi-defined PascalCase tool names, so this lands the convention guard only and removes stale docs for the deleted Kimi-specific web-search builtin.

Before: future builtin/core tool registrations could introduce PascalCase tool names without a focused guard, and README/extension notes still mentioned the removed `kimi-web-search` / `SearchWeb` / `FetchURL` surface.
After: core and builtin extension source roots are guarded against PascalCase tool names, provider-fixed hook event names are left alone, and stale Kimi tool docs are cleaned.

## Changes

- Added `packages/coding-agent/test/suite/tool-name-convention.test.ts` to scan `src/core/tools/` and `src/core/extensions/builtin/` for PascalCase senpi-defined tool names.
- Kept provider-fixed `hook_event_name` values classified as KEEP, not tool renames.
- Updated top-level README builtin tables away from the removed Kimi-specific builtin and toward current `websearch` / `webfetch` / `nested-agents-md` / `rules` / `goal` builtins.
- Removed stale extension-change prose that advertised the deleted Kimi-specific builtin/tool surface.
- Added a coding-agent changelog entry for the convention guard.

## Discovery Table

| Name | File:line | Classification | Notes |
|---|---|---|---|
| Stop | `packages/coding-agent/src/core/extensions/builtin/hooks/stop-adapter.ts:38` | KEEP provider-fixed | Claude-compatible `hook_event_name`, not an LLM tool name |
| PreToolUse | `packages/coding-agent/src/core/extensions/builtin/hooks/tool-adapter.ts:22` | KEEP provider-fixed | Claude-compatible `hook_event_name`, not an LLM tool name |
| PostToolUse | `packages/coding-agent/src/core/extensions/builtin/hooks/tool-adapter.ts:41` | KEEP provider-fixed | Claude-compatible `hook_event_name`, not an LLM tool name |
| SessionStart | `packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts:50` | KEEP provider-fixed | Claude-compatible `hook_event_name`, not an LLM tool name |
| PreCompact | `packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts:63` | KEEP provider-fixed | Claude-compatible `hook_event_name`, not an LLM tool name |
| PostCompact | `packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts:79` | KEEP provider-fixed | Claude-compatible `hook_event_name`, not an LLM tool name |

Renamable senpi-defined PascalCase tool names: none.

## QA / Evidence

- Baseline discovery audit: reproduced PascalCase-like `name:` / `registerTool` grep and stale Kimi doc grep. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/discovery.txt`.
- Classified discovery + final grep-clean: no senpi-defined PascalCase tool names remain in core/builtin tool roots; stale Kimi tool docs clean in README/coding-agent docs/src. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/final-grep-clean.txt`.
- Failing-first guard proof: planted `BadTool` under the scanned builtin source tree; guard failed and reported the planted file/name/line. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/guard-planted-failure.txt`.
- Targeted guard test, rerun twice after cleanup: `cd packages/coding-agent && npx vitest --run test/suite/tool-name-convention.test.ts`. Artifacts: `local-ignore/qa-evidence/20260706-snake-case-tool-names/guard-test-pass-1-after-check-fix.txt`, `local-ignore/qa-evidence/20260706-snake-case-tool-names/guard-test-pass-2-after-check-fix.txt`.
- Full repo check: `npm run check` passed. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/npm-run-check-final.txt`.
- senpi-qa mock loop: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` passed 5/5, including auth unchanged. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/senpi-qa-mock-loop-self-test.txt`.
- senpi-qa CLI smoke: `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` passed 6/6, including auth unchanged. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/senpi-qa-cli-smoke-self-test.txt`.
- Cleanup receipt: planted fixture removed; no task-owned QA processes left running; unrelated `senpi-codemode` vitest processes observed and left untouched. Artifact: `local-ignore/qa-evidence/20260706-snake-case-tool-names/cleanup-receipt.txt`.
- Plan/ledger local state updated: `.omo/plans/persistent-terminal-tool.md` todos 27-29 checked; `.omo/start-work/ledger.jsonl` has task-completed entries for todos 27-29.

## Risks

- No tool invocation migration risk because discovery found no renamable senpi-defined PascalCase tool names.
- The guard is regex/text based rather than AST based. It is intentionally lightweight and scoped to the tool-definition source roots; the planted failure and malformed-snippet test cover the intended boundary.
- Historical plan files may still mention the old Kimi tool names as task context; stale user-facing source/docs were cleaned.

## Secret safety

No secret-bearing logs, env dumps, tokens, auth headers, cookies, or private credentials are included. senpi-qa artifacts report only that the real auth file hash remained unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces snake_case for senpi-defined tool names via a test guard and cleans docs that mentioned the removed Kimi-specific web-search builtin. This prevents new PascalCase tool registrations in core and builtin extensions.

- **Refactors**
  - Added `packages/coding-agent/test/suite/tool-name-convention.test.ts` to scan `src/core/tools/` and `src/core/extensions/builtin/` for PascalCase tool names.
  - Ignored provider-fixed hook event names (e.g., `PreToolUse`).
  - Updated README builtin list to `websearch`, `webfetch`, `nested-agents-md`, `rules`, `goal`; removed `kimi-web-search`.
  - Pruned `src/core/extensions/changes.md` to summarize the Kimi removal.
  - Added a CHANGELOG note for the convention guard.

<sup>Written for commit c81c25d2dd46e9567ebc480220c9ae5e7c8d1bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

