### PR TITLE
fix: sessions no longer go stale forever when the network drops mid-stream

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed harness session storage short entry ids to use the random tail of the generated uuidv7 instead of the timestamp prefix, which was nearly constant between calls ([#6242](https://github.com/earendil-works/pi/issues/6242)).
+- Fixed the agent loop leaving the provider request dangling when the stream idle timeout fires: the loop now passes a per-request abort signal to the stream function and aborts it on idle timeout, so dead connections (e.g. after a network drop and reconnect) are torn down instead of leaking.
 
 ### Removed
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -303,6 +303,20 @@ async function streamAssistantResponse(
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
 
+	// Dedicated controller for the provider request so the loop can tear the
+	// request down itself (idle timeout), not only when the caller aborts.
+	const requestAbortController = new AbortController();
+	let detachCallerAbort: (() => void) | undefined;
+	if (signal !== undefined) {
+		if (signal.aborted) {
+			requestAbortController.abort(signal.reason);
+		} else {
+			const onCallerAbort = () => requestAbortController.abort(signal.reason);
+			signal.addEventListener("abort", onCallerAbort, { once: true });
+			detachCallerAbort = () => signal.removeEventListener("abort", onCallerAbort);
+		}
+	}
+
 	try {
 		// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 		let messages = context.messages;
@@ -329,11 +343,16 @@ async function streamAssistantResponse(
 		const response = await streamFunction(config.model, llmContext, {
 			...config,
 			apiKey: resolvedApiKey,
-			signal,
+			signal: requestAbortController.signal,
 		});
 
 		const iterator = response[Symbol.asyncIterator]();
-		const eventReader = createAssistantEventReader(iterator, config.timeoutMs, signal);
+		const eventReader = createAssistantEventReader(
+			iterator,
+			config.timeoutMs,
+			requestAbortController.signal,
+			(error) => requestAbortController.abort(error),
+		);
 		try {
 			while (true) {
 				const next = await eventReader.next();
@@ -411,6 +430,8 @@ async function streamAssistantResponse(
 		}
 		await emit({ type: "message_end", message: finalMessage });
 		return finalMessage;
+	} finally {
+		detachCallerAbort?.();
 	}
 }
 
@@ -425,6 +446,7 @@ function createAssistantEventReader(
 	iterator: AsyncIterator<AssistantMessageEvent>,
 	timeoutMs: number | undefined,
 	signal: AbortSignal | undefined,
+	onIdleTimeout?: (error: StreamIdleTimeoutError) => void,
 ): AssistantEventReader {
 	const idleTimeoutMs =
 		typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined;
@@ -449,7 +471,7 @@ function createAssistantEventReader(
 				void iterator.return?.();
 				return Promise.reject(new Error("Request was aborted"));
 			}
-			return readNextAssistantEvent(iterator, idleTimeoutMs, abortPromise);
+			return readNextAssistantEvent(iterator, idleTimeoutMs, abortPromise, onIdleTimeout);
 		},
 		dispose: () => removeAbortListener?.(),
 	};
@@ -459,6 +481,7 @@ async function readNextAssistantEvent(
 	iterator: AsyncIterator<AssistantMessageEvent>,
 	idleTimeoutMs: number | undefined,
 	abortPromise: Promise<typeof ABORTED> | undefined,
+	onIdleTimeout?: (error: StreamIdleTimeoutError) => void,
 ): Promise<IteratorResult<AssistantMessageEvent>> {
 	if (idleTimeoutMs === undefined && abortPromise === undefined) {
 		return iterator.next();
@@ -479,8 +502,12 @@ async function readNextAssistantEvent(
 
 		if (idleTimeoutMs !== undefined) {
 			timeout = setTimeout(() => {
+				const error = new StreamIdleTimeoutError(idleTimeoutMs);
 				void iterator.return?.();
-				settle(() => reject(new StreamIdleTimeoutError(idleTimeoutMs)));
+				settle(() => reject(error));
+				// Abort after settling so the failure surfaces as an idle timeout,
+				// not as a generic abort, while the dead request still gets torn down.
+				onIdleTimeout?.(error);
 			}, idleTimeoutMs);
 		}
 

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -302,6 +302,63 @@ describe("agentLoop with AgentMessage", () => {
 		]);
 	});
 
+	it("should abort the provider request when the stream stays idle past timeoutMs", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [],
+		};
+		const userPrompt: AgentMessage = createUserMessage("Hello");
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			timeoutMs: 20,
+		};
+
+		let requestSignal: AbortSignal | undefined;
+		const stream = agentLoop([userPrompt], context, config, undefined, (_model, _context, options) => {
+			requestSignal = options?.signal;
+			return new HangingAssistantStream();
+		});
+
+		const { messages } = await collectAgentEvents(stream, 500);
+		const assistantMessage = messages.find((message): message is AssistantMessage => message.role === "assistant");
+		expect(assistantMessage?.stopReason).toBe("error");
+		expect(requestSignal?.aborted).toBe(true);
+		expect(String(requestSignal?.reason)).toContain("Idle timeout waiting for provider stream after 20ms");
+	});
+
+	it("should abort the provider request signal when the caller aborts mid-stream", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [],
+			tools: [],
+		};
+		const userPrompt: AgentMessage = createUserMessage("Hello");
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+		const controller = new AbortController();
+
+		let requestSignal: AbortSignal | undefined;
+		const stream = agentLoop([userPrompt], context, config, controller.signal, (_model, _context, options) => {
+			requestSignal = options?.signal;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const partial = createAssistantMessage([{ type: "text", text: "partial answer" }]);
+				mockStream.push({ type: "start", partial });
+				controller.abort();
+			});
+			return mockStream;
+		});
+
+		const { messages } = await collectAgentEvents(stream, 500);
+		const assistantMessage = messages.find((message): message is AssistantMessage => message.role === "assistant");
+		expect(assistantMessage?.stopReason).toBe("aborted");
+		expect(requestSignal?.aborted).toBe(true);
+	});
+
 	it("should register one abort listener while reading a provider stream", async () => {
 		const context: AgentContext = {
 			systemPrompt: "You are helpful.",

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -21,6 +21,20 @@ describe("provider retry classification", () => {
 		).toBe(true);
 	});
 
+	it("classifies agent-loop stream idle timeouts as retryable", () => {
+		// Emitted by @earendil-works/pi-agent-core when a provider stream stops
+		// delivering events (e.g. a connection that died after a network change).
+		// Must stay retryable so sessions recover instead of surfacing a dead end.
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "Idle timeout waiting for provider stream after 300000ms",
+				}),
+			),
+		).toBe(true);
+	});
+
 	it("keeps provider limit errors non-retryable", () => {
 		expect(
 			isRetryableAssistantError(

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed sessions going stale forever when the network dropped and reconnected mid-stream: the agent loop's provider stream idle timeout is now enabled by default (follows `httpIdleTimeoutMs`, default 5 min, `0` disables; `retry.provider.timeoutMs` overrides), so a silently dead connection fails with a retryable idle-timeout error and auto-retry recovers the turn. Previously the guard was off unless `retry.provider.timeoutMs` was set, which left the Bun binary (no undici dispatcher protection) hanging indefinitely.
+
 ### Removed
 
 - Removed the never-functional `pi-codex-app-server` extension and flags; earlier Unreleased entries described unwired scaffolding rather than a usable integration surface.

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -378,7 +378,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		followUpMode: settingsManager.getFollowUpMode(),
 		transport: settingsManager.getTransport(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
-		timeoutMs: providerRetrySettings.timeoutMs,
+		timeoutMs: settingsManager.getAgentStreamIdleTimeoutMs(),
 		maxRetryDelayMs: providerRetrySettings.maxRetryDelayMs,
 	});
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -27,7 +27,7 @@ export interface BranchSummarySettings {
 }
 
 export interface ProviderRetrySettings {
-	timeoutMs?: number;
+	timeoutMs?: number; // SDK request timeout + agent stream idle timeout; defaults to httpIdleTimeoutMs
 	maxRetries?: number; // SDK/provider retry attempts
 	maxRetryDelayMs?: number; // default: 60000 (max server-requested delay before failing)
 }
@@ -900,6 +900,23 @@ export class SettingsManager {
 			maxRetries: this.settings.retry?.provider?.maxRetries,
 			maxRetryDelayMs: this.settings.retry?.provider?.maxRetryDelayMs ?? 60000,
 		};
+	}
+
+	/**
+	 * Idle timeout for the agent loop's provider event reader. Defaults to
+	 * httpIdleTimeoutMs so streams that stop delivering events (e.g. a
+	 * connection that silently died after a network change) fail with a
+	 * retryable idle-timeout error instead of hanging the session forever.
+	 * `retry.provider.timeoutMs` overrides it; an httpIdleTimeoutMs of 0
+	 * ("disabled") disables the reader guard as well.
+	 */
+	getAgentStreamIdleTimeoutMs(): number | undefined {
+		const providerTimeoutMs = this.settings.retry?.provider?.timeoutMs;
+		if (providerTimeoutMs !== undefined) {
+			return providerTimeoutMs;
+		}
+		const httpIdleTimeoutMs = this.getHttpIdleTimeoutMs();
+		return httpIdleTimeoutMs === 0 ? undefined : httpIdleTimeoutMs;
 	}
 
 	getWebSocketConnectTimeoutMs(): number | undefined {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4483,6 +4483,7 @@ export class InteractiveMode {
 					onHttpIdleTimeoutMsChange: (timeoutMs) => {
 						this.settingsManager.setHttpIdleTimeoutMs(timeoutMs);
 						configureHttpDispatcher(timeoutMs);
+						this.session.agent.timeoutMs = this.settingsManager.getAgentStreamIdleTimeoutMs();
 						this.showStatus(`HTTP idle timeout: ${formatHttpIdleTimeoutMs(timeoutMs)}`);
 					},
 					onThinkingLevelChange: (level) => {

--- a/packages/coding-agent/test/sdk-stream-options.test.ts
+++ b/packages/coding-agent/test/sdk-stream-options.test.ts
@@ -113,6 +113,52 @@ describe("createAgentSession stream options", () => {
 		}
 	}
 
+	async function captureAgentIdleTimeout(settings: {
+		httpIdleTimeoutMs?: number;
+		retry?: { provider?: { timeoutMs?: number } };
+	}): Promise<number | undefined> {
+		const model = createModel("openai-completions");
+		const settingsManager = SettingsManager.inMemory(settings);
+		const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+		authStorage.setRuntimeApiKey(model.provider, "test-api-key");
+		const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+		const sessionManager = SessionManager.inMemory(cwd);
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			model,
+			authStorage,
+			modelRegistry,
+			settingsManager,
+			sessionManager,
+		});
+
+		try {
+			return session.agent.timeoutMs;
+		} finally {
+			session.dispose();
+		}
+	}
+
+	it("enables the agent stream idle timeout by default", async () => {
+		expect(await captureAgentIdleTimeout({})).toBe(300_000);
+	});
+
+	it("follows httpIdleTimeoutMs for the agent stream idle timeout", async () => {
+		expect(await captureAgentIdleTimeout({ httpIdleTimeoutMs: 60_000 })).toBe(60_000);
+	});
+
+	it("disables the agent stream idle timeout when httpIdleTimeoutMs is 0", async () => {
+		expect(await captureAgentIdleTimeout({ httpIdleTimeoutMs: 0 })).toBeUndefined();
+	});
+
+	it("prefers retry.provider.timeoutMs for the agent stream idle timeout", async () => {
+		expect(await captureAgentIdleTimeout({ httpIdleTimeoutMs: 0, retry: { provider: { timeoutMs: 5_000 } } })).toBe(
+			5_000,
+		);
+	});
+
 	it("forwards httpIdleTimeoutMs as timeoutMs for OpenAI Codex", async () => {
 		const options = await captureStreamOptions("openai-codex-responses", { httpIdleTimeoutMs: 1234 });
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -263,6 +263,45 @@ describe("SettingsManager", () => {
 
 			expect(thenRetrySettings.timeoutMs).toBe(12_345);
 		});
+
+		it("should default the agent stream idle timeout to httpIdleTimeoutMs", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBe(300_000);
+		});
+
+		it("should follow a custom httpIdleTimeoutMs for the agent stream idle timeout", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ httpIdleTimeoutMs: 60_000 }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBe(60_000);
+		});
+
+		it("should disable the agent stream idle timeout when httpIdleTimeoutMs is 0", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ httpIdleTimeoutMs: 0 }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBeUndefined();
+		});
+
+		it("should prefer retry.provider.timeoutMs for the agent stream idle timeout", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(
+				givenSettingsPath,
+				JSON.stringify({ httpIdleTimeoutMs: 0, retry: { provider: { timeoutMs: 5_000 } } }),
+			);
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBe(5_000);
+		});
 	});
 
 	describe("project trust", () => {


### PR DESCRIPTION
## Summary

When the network drops and reconnects mid-stream, the old TCP connection becomes a black hole: no bytes, no FIN/RST, no error. Before this PR the session stayed **stale forever** on the Bun binary — the provider read never resolves, the agent loop never gets an event, and auto-retry never engages because no error ever surfaces.

Why it was runtime-dependent:

- The SDK `timeout` option (openai/anthropic) only guards until response headers; mid-body stalls are unguarded (`fetchWithTimeout` clears its timer once headers arrive).
- On **Node**, the undici dispatcher configured by `configureHttpDispatcher()` (bodyTimeout = `httpIdleTimeoutMs`, default 5 min) eventually rescued the process.
- On **Bun** (the shipped `pi` binary), the undici dispatcher provides no protection — the hang was literally forever.
- The agent loop already has a stream idle guard (`createAssistantEventReader`, added in 09679869f), but it was only wired when `retry.provider.timeoutMs` was explicitly set, i.e. off for everyone by default. When it did fire, `iterator.return?.()` was a no-op on `EventStream`, so the dead request was never torn down.

After: the loop-level idle guard is on by default (follows `httpIdleTimeoutMs`: default 300 s, `0` disables, `retry.provider.timeoutMs` overrides), fires runtime- and transport-independently, tears the dead request down via a per-request `AbortController`, and produces `Idle timeout waiting for provider stream after <n>ms` — which is classified retryable, so the existing auto-retry restarts the turn and the session self-heals once the network is back.

## Changes

- `packages/agent/src/agent-loop.ts`: per-assistant-request `AbortController` passed to the stream function; caller aborts propagate through a single listener (preserves the one-abort-listener invariant); the idle-timeout watchdog now aborts the request with the `StreamIdleTimeoutError` as reason.
- `packages/coding-agent`: `SettingsManager.getAgentStreamIdleTimeoutMs()` (`retry.provider.timeoutMs` ?? `httpIdleTimeoutMs`, `0` → disabled); `createAgentSession` wires it as the Agent default; the `/settings` HTTP-idle-timeout change updates the live agent too. No SDK-layer behavior change: the value forwarded to provider SDKs is identical to before.
- `packages/ai/test/retry.test.ts`: pins the idle-timeout message as retryable (the recovery chain contract).

## QA / Evidence

TDD: all new tests were captured failing first (`requestSignal` undefined on idle timeout; `getAgentStreamIdleTimeoutMs` missing; `agent.timeoutMs` undefined), then green after the fix.

Real-surface stall harness (sandboxed via senpi-qa `common.mjs`, isolated `SENPI_CODING_AGENT_DIR`, real `~/.senpi/agent/auth.json` sha256-guarded in every run): a local SSE server sends headers + one chunk, then goes silent forever with the socket held open — exactly what a network drop leaves behind. Evidence in `local-ignore/qa-evidence/20260706-stall-qa-*` (gitignored; summary.json / transcript.txt / server-requests.json per run, index in `20260706-stall-qa-regression-channels/README.md`):

| run | repo | runtime | result |
|---|---|---|---|
| main + default settings | main | bun | **HANG — killed at 60 s, no error (the reported bug)** |
| main + retry-on, server heals on 2nd attempt | main | bun | **HANG at 45 s — retry never engages** |
| main + default settings | main | node | exits 8.2 s via undici dispatcher (Node was bounded, Bun was not) |
| fix + default settings | PR | bun | exits 5.7 s, `Idle timeout waiting for provider stream after 5000ms` |
| fix + reader-only (dispatcher pinned 300 s) | PR | node/bun | exits ~6 s via the new reader guard specifically |
| fix + retry-on, server heals on 2nd attempt | PR | bun | **exit 0 in 6.7 s, model answer delivered, 2 requests — auto-heal proven** |

Unit/integration: `packages/agent` suite 179 passed; `packages/coding-agent` suite 3160 passed (31 pre-existing skips); `npm run check` fully green.

senpi-qa regression channels (all with auth-guard receipts): mock-loop `--self-test` 5/5 (all three wire formats), rpc-drive 4/4, cli-smoke 6/6, tui-smoke 5/5.

## Risks

- A provider that legitimately sends no parsed events for >5 min would now fail retryably instead of waiting. Mitigated: 300 s matches the existing `httpIdleTimeoutMs` default already applied as undici bodyTimeout on Node (so Node behavior at defaults is unchanged in practice), the timeout is per-event (any delta resets it), it is configurable, and `httpIdleTimeoutMs = 0` ("disabled" in `/settings`) disables the guard entirely.
- Providers now receive a per-request abort signal instead of the caller signal. Caller-abort propagation is pinned by a characterization test, and the one-listener perf invariant test still passes.

## Secret safety

No tokens, auth headers, or env dumps in the PR or evidence. QA ran against localhost fake servers in isolated sandboxes; every run asserts the real `auth.json` is byte-identical.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sessions hanging forever after a mid‑stream network drop by enabling a default stream idle timeout and actively aborting dead provider requests so auto‑retry can recover.

- **Bug Fixes**
  - Agent loop now uses a per‑request AbortController and aborts on idle with `StreamIdleTimeoutError`, tearing down the provider request across runtimes (incl. Bun).
  - Stream idle timeout is on by default: follows `httpIdleTimeoutMs` (300s default), `0` disables, and `retry.provider.timeoutMs` overrides; the value updates live in interactive mode.
  - Idle‑timeout errors are classified retryable in `packages/ai`, allowing the turn to restart and self‑heal once the network returns.
  - Added tests for idle‑timeout abort, caller‑abort propagation, settings defaults, and precedence.

<sup>Written for commit 0f237c8cc2c1aeea2f24f839f85268d334d13a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

