### PR TITLE
fix(coding-agent): show todowrite item details

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Fixed the built-in `todowrite` tool call row to show the actual todo items instead of only an item count.
 - Fixed sessions going stale forever when the network dropped and reconnected mid-stream: the agent loop's provider stream idle timeout is now enabled by default (follows `httpIdleTimeoutMs`, default 5 min, `0` disables; `retry.provider.timeoutMs` overrides), so a silently dead connection fails with a retryable idle-timeout error and auto-retry recovers the turn. Previously the guard was off unless `retry.provider.timeoutMs` was set, which left the Bun binary (no undici dispatcher protection) hanging indefinitely.
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts
@@ -100,11 +100,11 @@ export function registerTodoWriteTool(pi: ExtensionAPI, accessors: TodoAccessors
 			};
 		},
 		renderCall(args, theme) {
-			return new Text(
-				theme.fg("toolTitle", theme.bold("todowrite ")) + theme.fg("muted", `${args.todos.length} item(s)`),
-				0,
-				0,
-			);
+			const lines = getTodoResultLines(args.todos);
+			const title = lines[0] ?? "0 todos";
+			const items = lines.slice(1);
+			const body = items.length > 0 ? `\n${items.join("\n")}` : "";
+			return new Text(`${theme.fg("toolTitle", theme.bold("todowrite "))}${theme.fg("muted", title)}${body}`, 0, 0);
 		},
 		renderResult(result, _options, theme) {
 			const details = result.details as TodoWriteDetails | undefined;

--- a/packages/coding-agent/test/suite/todowrite-render.test.ts
+++ b/packages/coding-agent/test/suite/todowrite-render.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import type { TodoItem } from "../../src/core/extensions/builtin/todotools/index.ts";
+import todowriteExtension from "../../src/core/extensions/builtin/todotools/index.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../../src/core/extensions/runner.ts";
+import type { ToolRenderContext } from "../../src/core/extensions/types.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../src/utils/ansi.ts";
+
+const tempRoots: string[] = [];
+
+beforeAll(() => initTheme("dark"));
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+async function renderTodoWriteCall(todos: TodoItem[]): Promise<string> {
+	const root = mkdtempSync(join(tmpdir(), "todowrite-render-"));
+	tempRoots.push(root);
+	const runtime = createExtensionRuntime();
+	const extension = await loadExtensionFromFactory(
+		todowriteExtension,
+		root,
+		createEventBus(),
+		runtime,
+		"<builtin:todowrite>",
+	);
+	const sessionManager = SessionManager.inMemory(root);
+	const modelRegistry = ModelRegistry.create(AuthStorage.create(join(root, "auth.json")), root);
+	const runner = new ExtensionRunner([extension], runtime, root, sessionManager, modelRegistry);
+	const tool = runner.getAllRegisteredTools().find((registeredTool) => registeredTool.definition.name === "todowrite");
+	if (!tool?.definition.renderCall) throw new Error("Expected todowrite renderCall to be registered");
+
+	const args = { todos };
+	const context: ToolRenderContext<undefined, typeof args> = {
+		args,
+		toolCallId: "tool-todo",
+		invalidate: () => {},
+		lastComponent: undefined,
+		state: undefined,
+		cwd: root,
+		executionStarted: false,
+		argsComplete: true,
+		isPartial: false,
+		expanded: false,
+		showImages: false,
+		isError: false,
+	};
+	const component = tool.definition.renderCall(args, theme, context);
+	return stripAnsi(component.render(100).join("\n"));
+}
+
+describe("todowrite renderer", () => {
+	it("renders todo contents in the call title when todos are updated", async () => {
+		const rendered = await renderTodoWriteCall([
+			{
+				content:
+					"packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts: Show todo contents - expect visible rows",
+				status: "in_progress",
+				priority: "high",
+			},
+			{
+				content: "packages/coding-agent/test/suite/todowrite-render.test.ts: Add regression - expect failure first",
+				status: "pending",
+				priority: "medium",
+			},
+		]);
+
+		expect(rendered).toContain("todowrite");
+		expect(rendered).toContain("[•] packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts");
+		expect(rendered).toContain("Show todo");
+		expect(rendered).toContain("contents - expect visible rows");
+		expect(rendered).toContain("[ ] packages/coding-agent/test/suite/todowrite-render.test.ts: Add regression");
+		expect(rendered).not.toBe("todowrite 2 item(s)");
+	});
+
+	it("sanitizes multiline and control-character todo content in the call title", async () => {
+		const rendered = await renderTodoWriteCall([
+			{
+				content: "packages/coding-agent/src/core/extensions/builtin/todotools/state.ts:\nNormalize\u0000 todo text",
+				status: "pending",
+				priority: "high",
+			},
+		]);
+
+		expect(rendered).toContain(
+			"[ ] packages/coding-agent/src/core/extensions/builtin/todotools/state.ts: Normalize todo text",
+		);
+		expect(rendered).not.toContain("\u0000");
+		expect(rendered).not.toContain("\nNormalize");
+	});
+});

--- a/packages/coding-agent/test/suite/todowrite-render.test.ts
+++ b/packages/coding-agent/test/suite/todowrite-render.test.ts
@@ -81,7 +81,7 @@ describe("todowrite renderer", () => {
 		expect(rendered).toContain("Show todo");
 		expect(rendered).toContain("contents - expect visible rows");
 		expect(rendered).toContain("[ ] packages/coding-agent/test/suite/todowrite-render.test.ts: Add regression");
-		expect(rendered).not.toBe("todowrite 2 item(s)");
+		expect(rendered).not.toContain("item(s)");
 	});
 
 	it("sanitizes multiline and control-character todo content in the call title", async () => {


### PR DESCRIPTION
## Summary
Fixes the `todowrite` tool-call renderer so the visible tool row shows the actual todo list instead of only `todowrite N item(s)`. The renderer now reuses the existing sanitized todo line formatter used by the result/sidebar, so multiline and control-character todo text is normalized consistently.

## Changes
- Updated the `todowrite` call renderer to show the open todo count plus each todo row.
- Added a focused regression that loads the real built-in extension through `ExtensionRunner` and asserts the rendered call includes todo rows and sanitized text.

## QA & Evidence
- **What was tested:** Focused regression, RED before implementation.
  **Observed result:** Failed because renderCall returned only `todowrite N item(s)`.
  **Artifact:** `local-ignore/qa-evidence/20260707-todowrite-render/red-focused-test.txt`
  **Why sufficient:** Proves the bug was reproduced before the fix.

- **What was tested:** Focused regression after implementation.
  **Observed result:** `2 passed`.
  **Artifact:** `local-ignore/qa-evidence/20260707-todowrite-render/green-focused-test-after-typefix.txt`
  **Why sufficient:** Covers visible todo rows and sanitization behavior.

- **What was tested:** Full repo check.
  **Observed result:** `npm run check` passed, including TS, web, and neo checks.
  **Artifact:** `local-ignore/qa-evidence/20260707-todowrite-render/npm-run-check.txt`
  **Why sufficient:** Covers formatting, type checks, generated lock checks, browser smoke, and Go validation.

- **What was tested:** senpi real TUI and deterministic loop QA.
  **Observed result:** TUI smoke 5/5 passed; mock loop 5/5 passed; real auth unchanged.
  **Artifacts:** `local-ignore/qa-evidence/20260707-todowrite-render/senpi-qa-tui.txt`, `local-ignore/qa-evidence/20260707-todowrite-render/senpi-qa-mock-loop.txt`, `local-ignore/qa-evidence/20260708-todowrite-render-tui/`
  **Why sufficient:** Drives the user-facing TUI surface and a zero-token full agent loop after touching `packages/coding-agent`.

- **What was tested:** Manual renderer surface driver.
  **Observed result:** Rendered output contains `todowrite 2 todos`, the in-progress row, the pending sanitized row, and cleanup receipts.
  **Artifact:** `local-ignore/qa-evidence/20260707-todowrite-render/manual-render.txt`
  **Why sufficient:** Directly proves the previously hidden todo contents are visible through the real registered tool renderer.

## Risks & Residuals
- Terminal wrapping can split long todo lines; the renderer still shows all content and tests assert wrapped fragments instead of brittle unwrapped lines.
- The change reuses existing todo sanitization, so no new parsing or display policy was introduced.

## Related Issues
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows actual todo items for `todowrite` tool-call rows instead of only a count, using the same sanitized formatting as the result/sidebar.

- **Bug Fixes**
  - Updated the `todowrite` call renderer to use the formatted summary line plus each sanitized todo row; removes the generic "item(s)" label.
  - Hardened the regression test to load the built-in extension via `ExtensionRunner`, asserting visible rows, multiline/control-char sanitization, and absence of "item(s)".

<sup>Written for commit f7f12794d691e0845ff43b2de1957e04d99af915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Follow-up Verification After Review Gate
- Added the `packages/coding-agent` Unreleased changelog entry and tightened the regression to reject count-only `item(s)` output directly.
- Re-ran focused regression: `local-ignore/qa-evidence/20260707-todowrite-render/green-focused-test-after-review-fix.txt`.
- Re-ran full repo check: `local-ignore/qa-evidence/20260707-todowrite-render/npm-run-check-after-review-fix.txt`.
- Investigated the earlier CI failure: `local-ignore/qa-evidence/20260707-todowrite-render/ci-failed-before-blocker-fix.log`; it failed in unrelated `test/mcp/idle.test.ts` timeout while this PR's focused tests were green.
- Fixed the standalone source package in `pi-todotools` to avoid future vendored-source drift: https://github.com/code-yeongyu/pi-todotools/pull/9.
