### PR TITLE
feat(neo): app model skeleton + frame layout + QA mock-env (completion wave 1)

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs
@@ -18,8 +18,13 @@ import { pathToFileURL } from "node:url";
 const isMain = import.meta.url === pathToFileURL(process.argv[1] || "").href;
 
 /**
- * @param {{ port?: number, turns?: Array<{text?:string, toolCalls?:Array<{id?:string,name:string,args:object}>}> }} opts
+ * @param {{ port?: number, turns?: Array<{text?:string, chunks?:number, chunkDelayMs?:number, toolCalls?:Array<{id?:string,name:string,args:object}>}> }} opts
  * @returns {Promise<{url:string, origin:string, port:number, requests:object[], stop:()=>Promise<void>}>}
+ *
+ * A turn's `text` is emitted as ONE delta by default. Set `chunks` (>1) to split
+ * it into that many text deltas so streaming has an in-flight window (abort/steer
+ * QA); `chunkDelayMs` spaces those deltas apart. Both absent = byte-identical
+ * single-delta behavior.
  */
 export function startFakeModelServer({ port = 0, turns = [{ text: "OK" }] } = {}) {
 	const requests = [];
@@ -85,6 +90,49 @@ function sseHead(res) {
 	res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
 }
 
+/** Split a string into `n` contiguous pieces that concatenate back to the original. */
+function splitIntoChunks(text, n) {
+	const chars = Array.from(text);
+	if (chars.length === 0) return [""];
+	const count = Math.max(1, Math.min(n, chars.length));
+	const base = Math.floor(chars.length / count);
+	let rem = chars.length % count;
+	const pieces = [];
+	let idx = 0;
+	for (let i = 0; i < count; i++) {
+		const take = base + (rem > 0 ? 1 : 0);
+		if (rem > 0) rem--;
+		pieces.push(chars.slice(idx, idx + take).join(""));
+		idx += take;
+	}
+	return pieces;
+}
+
+/**
+ * Emit a turn's text via `emitDelta`, then run `done`. Without `chunks` this is a
+ * single synchronous `emitDelta(turn.text)` (byte-identical to legacy behavior);
+ * with `chunks` > 1 the text is split into that many deltas written `chunkDelayMs`
+ * apart, and `done` runs after the last one so the response closes in order.
+ */
+function emitTextDeltas(turn, emitDelta, done) {
+	if (!turn.text) return done();
+	const n = Number.isInteger(turn.chunks) && turn.chunks > 1 ? turn.chunks : 0;
+	if (!n) {
+		emitDelta(turn.text);
+		return done();
+	}
+	const pieces = splitIntoChunks(turn.text, n);
+	const delay = Number.isFinite(turn.chunkDelayMs) ? turn.chunkDelayMs : 0;
+	let i = 0;
+	const tick = () => {
+		emitDelta(pieces[i]);
+		i++;
+		if (i < pieces.length) setTimeout(tick, delay);
+		else done();
+	};
+	tick();
+}
+
 // --- OpenAI chat completions ---------------------------------------------
 function writeCompletionsSse(res, turn, modelId) {
 	sseHead(res);
@@ -98,12 +146,13 @@ function writeCompletionsSse(res, turn, modelId) {
 		function: { name: tc.name, arguments: JSON.stringify(tc.args ?? {}) },
 	}));
 	send({ role: "assistant", content: "" });
-	if (turn.text) send({ content: turn.text });
-	if (tcs.length) send({ tool_calls: tcs });
-	send({}, tcs.length ? "tool_calls" : "stop");
-	res.write(`data: ${JSON.stringify({ ...base, choices: [], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}\n\n`);
-	res.write("data: [DONE]\n\n");
-	res.end();
+	emitTextDeltas(turn, (t) => send({ content: t }), () => {
+		if (tcs.length) send({ tool_calls: tcs });
+		send({}, tcs.length ? "tool_calls" : "stop");
+		res.write(`data: ${JSON.stringify({ ...base, choices: [], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}\n\n`);
+		res.write("data: [DONE]\n\n");
+		res.end();
+	});
 }
 
 // --- Anthropic Messages ---------------------------------------------------
@@ -114,22 +163,28 @@ function writeAnthropicSse(res, turn, modelId) {
 		message: { id: "msg_mock", type: "message", role: "assistant", model: modelId, content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 1, output_tokens: 0 } },
 	});
 	let index = 0;
+	const afterText = () => {
+		for (const tc of turn.toolCalls || []) {
+			ev("content_block_start", { index, content_block: { type: "tool_use", id: tc.id || `toolu_${index}`, name: tc.name, input: {} } });
+			ev("content_block_delta", { index, delta: { type: "input_json_delta", partial_json: JSON.stringify(tc.args ?? {}) } });
+			ev("content_block_stop", { index });
+			index++;
+		}
+		const stopReason = (turn.toolCalls || []).length ? "tool_use" : "end_turn";
+		ev("message_delta", { delta: { stop_reason: stopReason, stop_sequence: null }, usage: { output_tokens: 1 } });
+		ev("message_stop", {});
+		res.end();
+	};
 	if (turn.text) {
 		ev("content_block_start", { index, content_block: { type: "text", text: "" } });
-		ev("content_block_delta", { index, delta: { type: "text_delta", text: turn.text } });
-		ev("content_block_stop", { index });
-		index++;
+		emitTextDeltas(turn, (t) => ev("content_block_delta", { index, delta: { type: "text_delta", text: t } }), () => {
+			ev("content_block_stop", { index });
+			index++;
+			afterText();
+		});
+	} else {
+		afterText();
 	}
-	for (const tc of turn.toolCalls || []) {
-		ev("content_block_start", { index, content_block: { type: "tool_use", id: tc.id || `toolu_${index}`, name: tc.name, input: {} } });
-		ev("content_block_delta", { index, delta: { type: "input_json_delta", partial_json: JSON.stringify(tc.args ?? {}) } });
-		ev("content_block_stop", { index });
-		index++;
-	}
-	const stopReason = (turn.toolCalls || []).length ? "tool_use" : "end_turn";
-	ev("message_delta", { delta: { stop_reason: stopReason, stop_sequence: null }, usage: { output_tokens: 1 } });
-	ev("message_stop", {});
-	res.end();
 }
 
 // --- OpenAI Responses -----------------------------------------------------
@@ -141,31 +196,41 @@ function writeResponsesSse(res, turn, modelId) {
 	ev("response.created", { response: { id: respId, object: "response", status: "in_progress", model: modelId, output: [] } });
 	let outputIndex = 0;
 	const outputItems = [];
+	const afterText = () => {
+		emitToolCalls();
+		ev("response.completed", {
+			response: { id: respId, object: "response", status: "completed", model: modelId, output: outputItems, usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } },
+		});
+		res.end();
+	};
 	if (turn.text) {
 		const itemId = "msg_mock";
 		ev("response.output_item.added", { output_index: outputIndex, item: { id: itemId, type: "message", status: "in_progress", role: "assistant", content: [] } });
 		ev("response.content_part.added", { item_id: itemId, output_index: outputIndex, content_index: 0, part: { type: "output_text", text: "", annotations: [] } });
-		ev("response.output_text.delta", { item_id: itemId, output_index: outputIndex, content_index: 0, delta: turn.text });
-		const item = { id: itemId, type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text: turn.text, annotations: [] }] };
-		ev("response.output_item.done", { output_index: outputIndex, item });
-		outputItems.push(item);
-		outputIndex++;
+		emitTextDeltas(turn, (t) => ev("response.output_text.delta", { item_id: itemId, output_index: outputIndex, content_index: 0, delta: t }), () => {
+			const item = { id: itemId, type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text: turn.text, annotations: [] }] };
+			ev("response.output_item.done", { output_index: outputIndex, item });
+			outputItems.push(item);
+			outputIndex++;
+			afterText();
+		});
+	} else {
+		afterText();
 	}
-	for (const tc of turn.toolCalls || []) {
-		const itemId = `fc_${outputIndex}`;
-		const callId = tc.id || `call_${outputIndex}`;
-		const argStr = JSON.stringify(tc.args ?? {});
-		ev("response.output_item.added", { output_index: outputIndex, item: { id: itemId, type: "function_call", status: "in_progress", call_id: callId, name: tc.name, arguments: "" } });
-		ev("response.function_call_arguments.delta", { item_id: itemId, output_index: outputIndex, delta: argStr });
-		const item = { id: itemId, type: "function_call", status: "completed", call_id: callId, name: tc.name, arguments: argStr };
-		ev("response.output_item.done", { output_index: outputIndex, item });
-		outputItems.push(item);
-		outputIndex++;
+
+	function emitToolCalls() {
+		for (const tc of turn.toolCalls || []) {
+			const itemId = `fc_${outputIndex}`;
+			const callId = tc.id || `call_${outputIndex}`;
+			const argStr = JSON.stringify(tc.args ?? {});
+			ev("response.output_item.added", { output_index: outputIndex, item: { id: itemId, type: "function_call", status: "in_progress", call_id: callId, name: tc.name, arguments: "" } });
+			ev("response.function_call_arguments.delta", { item_id: itemId, output_index: outputIndex, delta: argStr });
+			const item = { id: itemId, type: "function_call", status: "completed", call_id: callId, name: tc.name, arguments: argStr };
+			ev("response.output_item.done", { output_index: outputIndex, item });
+			outputItems.push(item);
+			outputIndex++;
+		}
 	}
-	ev("response.completed", {
-		response: { id: respId, object: "response", status: "completed", model: modelId, output: outputItems, usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } },
-	});
-	res.end();
 }
 
 // --- self-test ------------------------------------------------------------

--- a/packages/neo/internal/app/deps.go
+++ b/packages/neo/internal/app/deps.go
@@ -1,16 +1,31 @@
 package app
 
-// This file anchors the charm TUI stack and supporting libraries as direct
-// module dependencies so their pinned versions are retained by `go mod tidy`
-// before the packages that use them in earnest land in later tasks. The
-// blank imports are load-bearing: they are the app's real runtime deps
-// (bubbletea program, bubbles widgets, lipgloss styling, glamour markdown,
-// ansi/uniseg text handling) and go-winio for Windows named-pipe transport.
 import (
+	// glamour (transcript markdown, todo 3) and bubbles/spinner (shell status
+	// spinner, todo 7) are pinned charm deps that no wired neo package imports
+	// yet. Keep them blank-imported so `go mod tidy` retains their versions until
+	// those todos consume them for real; every other charm dep is now imported by
+	// live code (bubbletea here, lipgloss/ansi/uniseg in internal/ui + theme).
 	_ "charm.land/bubbles/v2/spinner"
-	_ "charm.land/bubbletea/v2"
 	_ "charm.land/glamour/v2"
-	_ "charm.land/lipgloss/v2"
-	_ "github.com/charmbracelet/x/ansi"
-	_ "github.com/rivo/uniseg"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
 )
+
+// Deps carries the collaborators the app Model composes into its frame. This
+// todo's Deps hold only the presentational + input pieces the skeleton needs;
+// the bridge session adapter, store, and recovery wiring attach in later todos.
+type Deps struct {
+	// Theme is the resolved neo skin every region renders through.
+	Theme *theme.Theme
+	// Keys is the keybinding manager. EVERY app-level chord (exit, interrupt,
+	// hints) resolves through it — the Model never compares raw key bytes itself.
+	Keys *keybindings.Manager
+	// AppName is the welcome-card app label + terminal title (e.g. "senpi").
+	AppName string
+	// Welcome is the startup welcome content. When zero-valued the Model fills in
+	// a default card titled with AppName.
+	Welcome shell.WelcomeContent
+}

--- a/packages/neo/internal/app/model.go
+++ b/packages/neo/internal/app/model.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/editor"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript"
+)
+
+// Action ids the Model resolves through the keybinding Manager. These are
+// registry ids, not key strings — the Manager maps them to the resolved keys, so
+// no raw key byte is ever compared against a literal here.
+const (
+	actionExit      = "app.exit"
+	actionInterrupt = "app.interrupt"
+	actionDequeue   = "app.message.dequeue"
+)
+
+// Frame fallbacks used before the first tea.WindowSizeMsg lands (and as a floor
+// so the pre-turn welcome renders even with no size yet).
+const (
+	defaultWidth   = 80
+	defaultHeight  = 24
+	defaultAppName = "senpi"
+)
+
+// OverlayStack is the overlay-manager contract the frame consults. Todo 5
+// implements it (internal/app/overlaystack.go); the skeleton holds it as an
+// interface so an active modal can capture the frame and key input. A nil stack
+// — this todo's default — means no overlay is ever active.
+type OverlayStack interface {
+	// Active reports whether a modal overlay is currently open and capturing the
+	// frame + key input.
+	Active() bool
+	// Render draws the active overlay's frame lines at the terminal size. Only
+	// called when Active reports true.
+	Render(width, height int) []string
+}
+
+// AbortRequested is emitted when the user triggers app.interrupt. The session
+// adapter (todo 2) consumes it to abort the in-flight turn; the skeleton only
+// emits it, since there is no bridge to abort yet.
+type AbortRequested struct{}
+
+// Model is the neo TUI's root bubbletea model. It owns the theme, the keybinding
+// manager, the shell region set, the editor, and the transcript feed, and
+// composes them into one frame each render. Overlays (todo 5) and the bridge
+// session (todo 2) attach through the fields/interface stubbed here.
+type Model struct {
+	theme    *theme.Theme
+	keys     *keybindings.Manager
+	shell    *shell.Shell
+	editor   *editor.Editor
+	feed     *transcript.Feed
+	overlays OverlayStack
+
+	width  int
+	height int
+}
+
+// NewModel builds the root Model from its dependencies.
+func NewModel(deps Deps) *Model {
+	appName := deps.AppName
+	if appName == "" {
+		appName = defaultAppName
+	}
+
+	sh := shell.New(deps.Theme, firstKey(deps.Keys, actionDequeue), appName)
+	welcome := deps.Welcome
+	if welcome.Title == "" {
+		welcome.Title = appName
+	}
+	if len(welcome.Menu) == 0 {
+		welcome.Menu = []shell.MenuEntry{{Label: "Quit", Key: firstKey(deps.Keys, actionExit)}}
+	}
+	sh.SetWelcome(welcome)
+
+	ed := editor.New(editor.Options{PaddingX: 1})
+	ed.SetFocused(true)
+
+	feed := transcript.NewFeed(transcript.NewRenderTheme(deps.Theme))
+	feed.SetExpandHint(firstKey(deps.Keys, "app.tools.expand"))
+
+	return &Model{
+		theme:  deps.Theme,
+		keys:   deps.Keys,
+		shell:  sh,
+		editor: ed,
+		feed:   feed,
+	}
+}
+
+// Init implements tea.Model. The skeleton needs no startup command; bubbletea
+// delivers the initial tea.WindowSizeMsg on its own.
+func (m *Model) Init() tea.Cmd { return nil }
+
+// Update implements tea.Model.
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch v := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = v.Width, v.Height
+		m.editor.SetViewport(v.Width, v.Height)
+		return m, nil
+	case tea.KeyboardEnhancementsMsg:
+		// The terminal answered the KeyboardEnhancements request declared by the
+		// View. When it supports key disambiguation, flip the matcher onto its
+		// Kitty-protocol path so app chords resolve exactly as classic does.
+		if v.SupportsKeyDisambiguation() {
+			keybindings.SetKittyProtocolActive(true)
+		}
+		return m, nil
+	case tea.KeyPressMsg:
+		return m.handleKey(v)
+	case tea.PasteMsg:
+		m.editor.Update(msg)
+		return m, nil
+	}
+	return m, nil
+}
+
+// handleKey routes a key press. App-level chords (interrupt, exit) resolve
+// through the Manager first; everything else is forwarded to the focused editor.
+func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	raw := editor.KeyToRaw(tea.Key(msg))
+
+	// app.interrupt aborts the in-flight turn (todo 2 consumes AbortRequested).
+	if m.keys.Matches(raw, actionInterrupt) {
+		return m, emitAbort
+	}
+	// app.exit quits, but only when the editor is empty — matching the classic
+	// ctrl+d-on-empty semantics (a non-empty editor keeps ctrl+d for the editor's
+	// own delete-forward binding).
+	if m.keys.Matches(raw, actionExit) && m.editor.GetText() == "" {
+		return m, tea.Quit
+	}
+
+	m.editor.Update(msg)
+	return m, nil
+}
+
+// emitAbort is the tea.Cmd that publishes an AbortRequested message.
+func emitAbort() tea.Msg { return AbortRequested{} }
+
+// View implements tea.Model, composing the frame per the shell region order
+// (shell/shell.go): welcome header, transcript, above-editor regions, the editor
+// itself, below-editor regions, then a hint line. When an overlay is active it
+// captures the whole frame instead.
+func (m *Model) View() tea.View {
+	width, height := m.frameSize()
+
+	if m.overlays != nil && m.overlays.Active() {
+		return m.newView(strings.Join(m.overlays.Render(width, height), "\n"), nil)
+	}
+
+	var lines []string
+	lines = append(lines, m.shell.Header(width)...)      // welcome (pre-first-turn only)
+	lines = append(lines, m.feed.Render(width)...)       // transcript
+	lines = append(lines, m.shell.AboveEditor(width)...) // widgets + status + pending
+
+	editorOriginY := len(lines)
+	editorRows := m.editor.Render(width)
+	for _, row := range editorRows {
+		lines = append(lines, editor.StripCursorMarker(row))
+	}
+
+	lines = append(lines, m.shell.BelowEditor(width)...) // widgets + footer
+	lines = append(lines, m.hintLine(width))             // shortcut hint line
+
+	cursor := m.editor.ViewCursor(editorRows, 0, editorOriginY)
+	return m.newView(strings.Join(lines, "\n"), cursor)
+}
+
+// newView wraps content in a tea.View, requesting keyboard enhancements via the
+// View field (bubbletea v2 has no program option for this) and NOT enabling the
+// alternate screen. Basic key disambiguation is on by default; requesting
+// alternate keys lets chords like shift+enter disambiguate when supported.
+func (m *Model) newView(content string, cursor *tea.Cursor) tea.View {
+	v := tea.NewView(content)
+	v.KeyboardEnhancements.ReportAlternateKeys = true
+	if cursor != nil {
+		v.Cursor = cursor
+	}
+	return v
+}
+
+// hintLine renders the bottom shortcut hint, resolving every key display through
+// the Manager (no literal key strings), and truncates it to the frame width.
+func (m *Model) hintLine(width int) string {
+	var parts []string
+	if k := firstKey(m.keys, actionInterrupt); k != "" {
+		parts = append(parts, k+" interrupt")
+	}
+	if k := firstKey(m.keys, actionExit); k != "" {
+		parts = append(parts, k+" exit")
+	}
+	hint := ui.TruncateToWidth(strings.Join(parts, "  ·  "), width, "")
+	return m.theme.Hint().Render(hint)
+}
+
+// frameSize returns the render size, falling back to the default floor before
+// the first tea.WindowSizeMsg (and guarding against non-positive dimensions).
+func (m *Model) frameSize() (width, height int) {
+	width, height = m.width, m.height
+	if width <= 0 {
+		width = defaultWidth
+	}
+	if height <= 0 {
+		height = defaultHeight
+	}
+	return width, height
+}
+
+// SetOverlays installs the overlay stack (todo 5). Kept as a setter so the
+// skeleton's constructor stays free of the not-yet-built overlay manager.
+func (m *Model) SetOverlays(o OverlayStack) { m.overlays = o }
+
+// firstKey returns the first resolved key display for an action, or "" when the
+// action is unbound.
+func firstKey(m *keybindings.Manager, action string) string {
+	keys := m.Keys(action)
+	if len(keys) == 0 {
+		return ""
+	}
+	return keys[0]
+}

--- a/packages/neo/internal/app/model_test.go
+++ b/packages/neo/internal/app/model_test.go
@@ -1,0 +1,121 @@
+package app_test
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+)
+
+// newTestModel builds a Model bound to the default theme and pure-default
+// keybindings, hermetic (no real ~/.senpi read via the sentinel agent dir).
+func newTestModel(t *testing.T) *app.Model {
+	t.Helper()
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName, AgentDir: "\x00nonexistent"})
+	if err != nil {
+		t.Fatalf("theme.Load: %v", err)
+	}
+	return app.NewModel(app.Deps{
+		Theme:   th,
+		Keys:    keybindings.NewManager(nil),
+		AppName: "senpi",
+	})
+}
+
+// wideCardBorder is the rounded top-left corner the welcome card draws only at
+// wide widths (>= the welcome reflow width). The editor/footer never draw it, so
+// its presence is a reliable proxy for "the frame reflowed to the wide layout".
+const wideCardBorder = "╭"
+
+// TestUpdateWindowSizeReflowsView proves Update(tea.WindowSizeMsg) re-renders the
+// View at the new width: the wide welcome card appears at 120 columns and is gone
+// (compact layout) at 60 columns.
+func TestUpdateWindowSizeReflowsView(t *testing.T) {
+	m := newTestModel(t)
+
+	if _, cmd := m.Update(tea.WindowSizeMsg{Width: 120, Height: 36}); cmd != nil {
+		_ = cmd
+	}
+	wide := m.View().Content
+	if !strings.Contains(wide, wideCardBorder) {
+		t.Fatalf("expected wide welcome card border %q at 120 cols, view was:\n%s", wideCardBorder, wide)
+	}
+
+	m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
+	narrow := m.View().Content
+	if strings.Contains(narrow, wideCardBorder) {
+		t.Fatalf("expected compact layout (no %q) at 60 cols, view was:\n%s", wideCardBorder, narrow)
+	}
+}
+
+// TestExitKeyReturnsQuit proves the app.exit key (ctrl+d by default), resolved
+// through the keybinding Manager, returns tea.Quit when the editor is empty.
+func TestExitKeyReturnsQuit(t *testing.T) {
+	m := newTestModel(t)
+	m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected a command from the app.exit key, got nil")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("expected tea.QuitMsg from app.exit key, got %T", cmd())
+	}
+}
+
+// TestInterruptEmitsAbortRequested proves the app.interrupt key (escape by
+// default) emits an AbortRequested message for the session adapter (todo 2) to
+// consume — not a quit.
+func TestInterruptEmitsAbortRequested(t *testing.T) {
+	m := newTestModel(t)
+	m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected a command from the app.interrupt key, got nil")
+	}
+	if _, ok := cmd().(app.AbortRequested); !ok {
+		t.Fatalf("expected app.AbortRequested from app.interrupt key, got %T", cmd())
+	}
+}
+
+// TestViewSmallTerminalNoPanic proves View degrades gracefully at and below the
+// 40x10 floor without panicking.
+func TestViewSmallTerminalNoPanic(t *testing.T) {
+	sizes := []struct{ w, h int }{{40, 10}, {20, 6}, {1, 1}}
+	for _, s := range sizes {
+		m := newTestModel(t)
+		m.Update(tea.WindowSizeMsg{Width: s.w, Height: s.h})
+		got := m.View().Content // must not panic
+		if got == "" {
+			t.Errorf("empty view at %dx%d", s.w, s.h)
+		}
+	}
+}
+
+// TestViewContainsWelcomePreFirstTurn proves the composed frame shows the welcome
+// card (bearing the app label) before any turn has run, even before the first
+// WindowSizeMsg arrives.
+func TestViewContainsWelcomePreFirstTurn(t *testing.T) {
+	m := newTestModel(t)
+	content := m.View().Content
+	if !strings.Contains(content, "senpi") {
+		t.Fatalf("expected welcome card app label %q pre-first-turn, view was:\n%s", "senpi", content)
+	}
+}
+
+// TestNewProgramConstructs proves the program constructor builds a runnable
+// bubbletea program from Deps without altscreen (constructed, not run).
+func TestNewProgramConstructs(t *testing.T) {
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName, AgentDir: "\x00nonexistent"})
+	if err != nil {
+		t.Fatalf("theme.Load: %v", err)
+	}
+	p := app.NewProgram(app.Deps{Theme: th, Keys: keybindings.NewManager(nil), AppName: "senpi"})
+	if p == nil {
+		t.Fatal("NewProgram returned nil")
+	}
+}

--- a/packages/neo/internal/app/program.go
+++ b/packages/neo/internal/app/program.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// NewProgram builds the root bubbletea program from its dependencies. It uses no
+// alternate screen (neo renders inline, matching the classic TUI); keyboard
+// enhancements are requested through the Model's View, not a program option
+// (bubbletea v2.0.8 exposes no WithKeyboardEnhancements option), and the
+// terminal's reply arrives as tea.KeyboardEnhancementsMsg.
+func NewProgram(deps Deps) *tea.Program {
+	return tea.NewProgram(NewModel(deps))
+}

--- a/packages/neo/internal/app/qaharness/main.go
+++ b/packages/neo/internal/app/qaharness/main.go
@@ -1,0 +1,81 @@
+// Command qaharness is the manual-QA driver for the neo app Model (plan task 1).
+// It runs the REAL root Model inside a live bubbletea v2 program — no alternate
+// screen — so a tmux pane can capture the composed frame:
+//
+//	tmux send-keys 'go run ./internal/app/qaharness --scene welcome' Enter
+//	tmux capture-pane -e -p > frame.ans
+//
+// Unlike the shell qaharness (which prints a single scene and exits), this driver
+// exercises the assembled Model.View through a running program and stays alive
+// until the terminal quits it (app.exit on an empty editor) or it is killed —
+// matching the editor qaharness pattern, since the frame under test is the live
+// program's own output.
+//
+// Scenes:
+//
+//	welcome - the pre-first-turn frame: the composed welcome card (wide bordered
+//	          card at >= 100 cols, compact centered layout below).
+//
+// It is NOT a package test; it is invoked by hand or by the tmux QA script.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
+)
+
+const appName = "senpi"
+
+func main() {
+	scene := flag.String("scene", "welcome", "scene: welcome")
+	flag.Parse()
+
+	if *scene != "welcome" {
+		fmt.Fprintln(os.Stderr, "unknown scene:", *scene)
+		os.Exit(2)
+	}
+
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "theme.Load:", err)
+		os.Exit(1)
+	}
+	keys := keybindings.NewManager(nil)
+
+	p := app.NewProgram(app.Deps{
+		Theme:   th,
+		Keys:    keys,
+		AppName: appName,
+		Welcome: welcomeContent(keys),
+	})
+	if _, err := p.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "qaharness error:", err)
+		os.Exit(1)
+	}
+}
+
+// welcomeContent builds the startup card content, resolving every menu key hint
+// through the keybinding manager (no literal key strings).
+func welcomeContent(keys *keybindings.Manager) shell.WelcomeContent {
+	return shell.WelcomeContent{
+		Title: appName,
+		Menu: []shell.MenuEntry{
+			{Label: "Resume session", Key: firstKey(keys, "app.sessions.observe")},
+			{Label: "Search history", Key: firstKey(keys, "app.history.search")},
+			{Label: "Quit", Key: firstKey(keys, "app.exit")},
+		},
+	}
+}
+
+func firstKey(keys *keybindings.Manager, action string) string {
+	if k := keys.Keys(action); len(k) > 0 {
+		return k[0]
+	}
+	return ""
+}

--- a/packages/neo/qa/mock-env-child.mjs
+++ b/packages/neo/qa/mock-env-child.mjs
@@ -1,0 +1,54 @@
+/**
+ * Detached fake-model-server host for `mock-env.mjs`.
+ *
+ * `startFakeModelServer` is in-process, so the mock-env parent cannot host it and
+ * exit (a plain `eval $(...)` would kill the server). This child runs the server
+ * in a process that OUTLIVES the parent: it prints its bound port on stdout as a
+ * single `READY {json}` line, then stays alive (the listening socket keeps the
+ * event loop running) until `kill $ULW_MOCK_PID`. An interval mirrors each new
+ * request's last user-text line into the request log for QA assertions.
+ *
+ * Contract (all via env, set by the parent):
+ *   MOCK_ENV_TURNS  JSON array of scripted turns for startFakeModelServer
+ *   MOCK_ENV_LOG    absolute path of the requests log to append to
+ */
+
+import { appendFileSync } from "node:fs";
+import { startFakeModelServer } from "../../../.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs";
+
+function lastUserText(messages) {
+	if (!Array.isArray(messages)) return "";
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (!msg || msg.role !== "user") continue;
+		const content = msg.content;
+		if (typeof content === "string") return content;
+		if (Array.isArray(content)) {
+			return content.map((part) => (typeof part === "string" ? part : (part?.text ?? ""))).join("");
+		}
+		return "";
+	}
+	return "";
+}
+
+async function main() {
+	const turns = JSON.parse(process.env.MOCK_ENV_TURNS || "[{}]");
+	const logPath = process.env.MOCK_ENV_LOG;
+
+	const server = await startFakeModelServer({ turns });
+	process.stdout.write(`READY ${JSON.stringify({ port: server.port, origin: server.origin, url: server.url })}\n`);
+
+	let logged = 0;
+	setInterval(() => {
+		for (; logged < server.requests.length; logged++) {
+			try {
+				appendFileSync(logPath, `${lastUserText(server.requests[logged].messages)}\n`);
+			} catch {}
+		}
+	}, 100);
+}
+
+main().catch((error) => {
+	process.stderr.write(`mock-env-child: ${error instanceof Error ? error.stack : String(error)}\n`);
+	process.exit(1);
+});

--- a/packages/neo/qa/mock-env.mjs
+++ b/packages/neo/qa/mock-env.mjs
@@ -1,0 +1,161 @@
+/**
+ * Shared TUI QA environment for the neo (Go) app.
+ *
+ * Boots a deterministic fake-model server in a DETACHED child (so `eval $(...)`
+ * can source the exports and exit while the server keeps running), builds an
+ * isolated ~/.senpi sandbox pointed at that server, and prints the `export`
+ * lines every neo QA scenario sources. The server never touches a real provider
+ * or the real ~/.senpi.
+ *
+ * Usage (from repo root):
+ *   eval $(node packages/neo/qa/mock-env.mjs [--turns <preset>])
+ *   ... run neo against $SENPI_CODING_AGENT_DIR / $SENPI_NEO_CLI_PATH ...
+ *   kill $ULW_MOCK_PID; rm -rf "$ULW_SANDBOX"     # cleanup contract
+ *
+ * Presets (every one embeds a unique on-screen marker so QA polls a real
+ * rendered string, never an internal event). The fake server advances one turn
+ * per model call and reuses the last:
+ *   plain               [{text:"ULWMARK-OK"}]                       (default)
+ *   tool-then-markdown  bash tool call, then "# ULWMARK-OK" heading
+ *   stream-slow         "… ULWMARK" in 6 deltas 300ms apart, then "ULWMARK-2"
+ *
+ * STDOUT carries ONLY the export lines; everything else goes to stderr so
+ * `eval $(...)` stays clean.
+ */
+
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { cliEntry, makeSandbox, repoRoot } from "../../../.agents/skills/senpi-qa/scripts/lib/common.mjs";
+import { writeMockModelsJson } from "../../../.agents/skills/senpi-qa/scripts/lib/mock-loop-support.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Scripted turns per preset. Markers are the strings QA asserts on screen. */
+const TURN_PRESETS = {
+	plain: [{ text: "ULWMARK-OK" }],
+	"tool-then-markdown": [{ toolCalls: [{ name: "bash", args: { command: "ls" } }] }, { text: "# ULWMARK-OK" }],
+	"stream-slow": [{ text: "… ULWMARK", chunks: 6, chunkDelayMs: 300 }, { text: "ULWMARK-2" }],
+};
+
+/** The mock provider/models both scenarios switch between (`mock-a` is default). */
+const MOCK_PROVIDER = "mock";
+const MOCK_API = "openai-completions";
+const MOCK_API_KEY = "sk-mock-qa-7f3a";
+const NEO_FLAGS = "--no-context-files --no-skills --no-extensions --approve";
+const READY_TIMEOUT_MS = 15000;
+
+function flagValue(name) {
+	const argv = process.argv.slice(2);
+	const i = argv.indexOf(name);
+	return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function fail(message) {
+	process.stderr.write(`mock-env: ${message}\n`);
+	process.exit(2);
+}
+
+/** Two models, both aimed at the fake server, so `/model` proves a real switch. */
+function writeTwoModelConfig(agentDir, baseUrl) {
+	const model = (id) => ({
+		id,
+		baseUrl,
+		api: MOCK_API,
+		contextWindow: 128000,
+		maxTokens: 4096,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	});
+	const config = {
+		providers: {
+			[MOCK_PROVIDER]: { baseUrl, apiKey: MOCK_API_KEY, api: MOCK_API, models: [model("mock-a"), model("mock-b")] },
+		},
+	};
+	writeFileSync(join(agentDir, "models.json"), JSON.stringify(config, null, 2));
+}
+
+/** Resolve when the child prints its `READY {json}` line; reject on timeout/exit. */
+function waitForReady(child) {
+	return new Promise((resolve, reject) => {
+		let buffer = "";
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Error(`fake server did not report ready within ${READY_TIMEOUT_MS}ms`));
+		}, READY_TIMEOUT_MS);
+		const onData = (chunk) => {
+			buffer += chunk.toString();
+			const line = buffer.split("\n").find((l) => l.startsWith("READY "));
+			if (!line) return;
+			cleanup();
+			try {
+				resolve(JSON.parse(line.slice("READY ".length)));
+			} catch (error) {
+				reject(error instanceof Error ? error : new Error(String(error)));
+			}
+		};
+		const onExit = (code) => {
+			cleanup();
+			reject(new Error(`fake server child exited early (code ${code})`));
+		};
+		function cleanup() {
+			clearTimeout(timer);
+			child.stdout.off("data", onData);
+			child.off("exit", onExit);
+		}
+		child.stdout.on("data", onData);
+		child.on("exit", onExit);
+	});
+}
+
+async function main() {
+	const preset = flagValue("--turns") ?? "plain";
+	const turns = TURN_PRESETS[preset];
+	if (!turns) fail(`unknown --turns "${preset}". valid: ${Object.keys(TURN_PRESETS).join(", ")}`);
+
+	const box = makeSandbox("neo-mock-env");
+	const logPath = join(box.dir, "requests.log");
+
+	const child = spawn(process.execPath, [join(__dirname, "mock-env-child.mjs")], {
+		detached: true,
+		stdio: ["ignore", "pipe", "inherit"],
+		env: { ...process.env, MOCK_ENV_TURNS: JSON.stringify(turns), MOCK_ENV_LOG: logPath },
+	});
+
+	let ready;
+	try {
+		ready = await waitForReady(child);
+	} catch (error) {
+		try {
+			process.kill(child.pid);
+		} catch {}
+		box.cleanup();
+		fail(error instanceof Error ? error.message : String(error));
+	}
+
+	// writeMockModelsJson writes one model; overwrite with the two-model config.
+	writeMockModelsJson(box.agentDir, { url: ready.url, origin: ready.origin, port: ready.port }, MOCK_API);
+	writeTwoModelConfig(box.agentDir, ready.url);
+
+	const exports = [
+		`export SENPI_CODING_AGENT_DIR=${box.agentDir}`,
+		`export SENPI_CODING_AGENT_SESSION_DIR=${box.sessionDir}`,
+		`export SENPI_NEO_CLI_PATH=${cliEntry(repoRoot())}`,
+		`export ULW_MOCK_PID=${child.pid}`,
+		`export ULW_MOCK_PORT=${ready.port}`,
+		`export ULW_MOCK_LOG=${logPath}`,
+		`export ULW_SANDBOX=${box.dir}`,
+		`export ULW_NEO_FLAGS='${NEO_FLAGS}'`,
+	];
+	process.stdout.write(`${exports.join("\n")}\n`);
+
+	// Detach so the server outlives this parent; drop the pipe so we exit cleanly
+	// WITHOUT cleaning up the sandbox (the QA caller owns cleanup via ULW_*).
+	child.unref();
+	child.stdout.destroy();
+}
+
+main().catch((error) => {
+	process.stderr.write(`mock-env: ${error instanceof Error ? error.stack : String(error)}\n`);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
Wave 1 of the neo Go TUI completion plan (`.omo/plans/neo-go-tui-completion.md`, todo 1):
- Root bubbletea `Model` (`packages/neo/internal/app/model.go`): Init/Update/View composing welcome/feed/editor/footer/hint per the `shell.go` region order; `app.exit`/`app.interrupt` resolved through the keybindings Manager (zero hardcoded keys); no altscreen; keyboard enhancements via `View.KeyboardEnhancements`; graceful degrade at ≤40x10.
- `app.NewProgram(deps)` constructor + app qaharness (`--scene welcome`) that runs the real Model for tmux capture QA.
- QA infra: `packages/neo/qa/mock-env.mjs` — detached fake-model-server env helper (two-model mock-a/mock-b fixture, ULWMARK turn presets, request log, hermetic sandbox via senpi-qa `makeSandbox`) + strictly-additive `chunks`/`chunkDelayMs` streaming extension to `fake-model-server.mjs` (absent fields keep byte-identical single-delta behavior).

## QA evidence (RED→GREEN + real surface)
- TDD RED captured before impl: `.omo/evidence/task-1-neo-completion-red.txt` (undefined app.Model/NewModel/Deps/NewProgram with behavioral tests present) → GREEN `go test ./internal/app/...` ok.
- tmux 120x36: composed welcome frame captured (`╭` card border + `senpi` label) → `.omo/evidence/task-1-neo-completion.{ans,html,json}` triplet.
- tmux 40x10: compact layout, ctrl+d → exit 0, zero panics → `.omo/evidence/task-1-neo-completion-degrade.txt`.
- `mock-loop.mjs --self-test` 5/5 PASS post-extension; chunked streaming functionally proven (6 deltas, 300ms apart); full `npm run check` green in pre-commit (incl. `check:neo` full go suite).

Plan: .omo/plans/neo-go-tui-completion.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the neo Go TUI’s root Bubble Tea model and frame layout, plus a detached mock environment for QA with optional streaming. Sets up the real program, tests, and a harness to capture frames in tmux (wave 1 of the completion plan).

- **New Features**
  - Root app `Model` composing welcome → feed → editor → footer → hint; resolves `app.exit`/`app.interrupt` via `keybindings.Manager` (no hardcoded keys), requests keyboard enhancements, no altscreen, and degrades cleanly at small sizes; overlay hook included.
  - `NewProgram(deps)` constructor and `qaharness` (`packages/neo/internal/app/qaharness`, `--scene welcome`) to run the real model for tmux captures.
  - Additive streaming to `fake-model-server.mjs` via `chunks`/`chunkDelayMs` (defaults keep single-delta behavior byte-identical).
  - QA mock env (`packages/neo/qa/mock-env.mjs` + child) that launches a detached fake server, sets a hermetic sandbox, provides two models (`mock-a`, `mock-b`), ULWMARK turn presets, and a request log.
  - Tests (`model_test.go`) cover resize reflow, `app.exit` quit on empty editor, `app.interrupt` emitting `AbortRequested`, small-terminal safety, and `NewProgram` construction.

<sup>Written for commit 48d884ed5a5a449a4f802e52e07eccf2605806c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

