### PR TITLE
fix(ai): sanitize Anthropic web search replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed OpenAI Responses and Azure OpenAI Responses requests to avoid sending `max_output_tokens` values below the provider minimum ([#6265](https://github.com/earendil-works/pi/issues/6265)).
+- Fixed Anthropic same-model replay of server-side web search results so `encrypted_content` is not sent back inside replayed search result blocks, avoiding 400 `Invalid encrypted_content in search_result block` errors on follow-up turns.
 
 ### Removed
 

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -343,6 +343,24 @@ function isReplayableAnthropicProviderNativeBlock(raw: unknown): raw is ContentB
 	return isRecord(raw) && typeof raw.type === "string" && REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES.has(raw.type);
 }
 
+function stripEncryptedContentFromWebSearchResult(raw: Record<string, unknown>): Record<string, unknown> {
+	const { encrypted_content: _encryptedContent, ...rest } = raw;
+	return rest;
+}
+
+function sanitizeReplayableAnthropicProviderNativeBlock(raw: unknown): ContentBlockParam | undefined {
+	if (!isReplayableAnthropicProviderNativeBlock(raw)) return undefined;
+	if (!isRecord(raw) || raw.type !== "web_search_tool_result" || !Array.isArray(raw.content)) return raw;
+
+	return {
+		...raw,
+		content: raw.content.map((item) => {
+			if (!isRecord(item) || item.type !== "web_search_result") return item;
+			return stripEncryptedContentFromWebSearchResult(item);
+		}),
+	} as ContentBlockParam;
+}
+
 function isSameAnthropicModel(message: AssistantMessage, model: Model<"anthropic-messages">): boolean {
 	return message.provider === model.provider && message.api === model.api && message.model === model.id;
 }
@@ -1643,8 +1661,9 @@ function convertMessages(
 						input: block.arguments ?? {},
 					});
 				} else if (block.type === "providerNative") {
-					if (isSameModel && isReplayableAnthropicProviderNativeBlock(block.raw)) {
-						blocks.push(block.raw);
+					if (isSameModel) {
+						const replayableBlock = sanitizeReplayableAnthropicProviderNativeBlock(block.raw);
+						if (replayableBlock) blocks.push(replayableBlock);
 					}
 				}
 			}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,26 @@
 # AI Source Changes
 
+## 2026-07-08 - Anthropic web search replay encrypted content
+
+### What changed and why
+
+- `api/anthropic-messages.ts`: same-model provider-native replay now strips `encrypted_content` from nested
+  `web_search_result` items before sending prior server-side web search results back in the next Anthropic request.
+- The raw session `019f3d9f-ddf6-7d87-add8-95a5f703e99b` showed follow-up turns failing with 400
+  `messages.1.content.0: Invalid encrypted_content in search_result block`; the visible result metadata
+  (`type`, `title`, `url`, `page_age`) is preserved.
+
+### Files modified
+
+- `api/anthropic-messages.ts`
+- `../test/anthropic-provider-native-replay.test.ts`
+- `../test/anthropic-web-search-replay-encryption.test.ts`
+
+### Expected merge conflict zones
+
+- LOW: `api/anthropic-messages.ts` around `sanitizeReplayableAnthropicProviderNativeBlock` and the provider-native
+  replay path.
+
 ## 2026-07-06 - Anthropic server-side fallback replay contract
 
 ### What changed and why

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -131,7 +131,11 @@ describe("Anthropic provider-native replay", () => {
 		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
 		expect(assistantPayload?.content).toEqual([
 			serverToolUse,
-			webSearchToolResult,
+			{
+				type: "web_search_tool_result",
+				tool_use_id: "srvu_1",
+				content: [{ type: "web_search_result", title: "Example", url: "https://example.com" }],
+			},
 			{ type: "thinking", thinking: "protected thinking", signature: "sig_1" },
 			{ type: "text", text: "kept" },
 			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
@@ -300,7 +304,11 @@ describe("Anthropic provider-native replay", () => {
 		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
 		expect(assistantPayload?.content).toEqual([
 			pairedUse,
-			pairedResult,
+			{
+				type: "web_search_tool_result",
+				tool_use_id: "srvu_paired",
+				content: [{ type: "web_search_result", title: "A", url: "https://a.example" }],
+			},
 			fallbackBlock,
 			{ type: "thinking", thinking: "served", signature: "sig_post" },
 			{ type: "tool_use", id: "toolu_post", name: "read", input: { path: "README.md" } },

--- a/packages/ai/test/anthropic-web-search-replay-encryption.test.ts
+++ b/packages/ai/test/anthropic-web-search-replay-encryption.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.ts";
+import "../src/providers/register-builtins.ts";
+import { streamSimple } from "../src/stream.ts";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
+
+type CapturedMessage = { readonly role: string; readonly content: unknown };
+
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+async function captureMessages(
+	model: Model<"anthropic-messages">,
+	messages: Context["messages"],
+): Promise<readonly CapturedMessage[]> {
+	let capturedMessages: readonly CapturedMessage[] | undefined;
+	const stream = streamSimple(
+		{ ...model, baseUrl: "http://127.0.0.1:9" },
+		{ messages },
+		{
+			apiKey: "fake-key",
+			onPayload: (payload) => {
+				if (isRecord(payload) && Array.isArray(payload.messages)) {
+					capturedMessages = payload.messages.flatMap((message) => {
+						if (!isRecord(message) || typeof message.role !== "string") return [];
+						return [{ role: message.role, content: message.content }];
+					});
+				}
+				return payload;
+			},
+		},
+	);
+
+	await stream.result();
+	if (!capturedMessages) throw new Error("Expected payload capture");
+	return capturedMessages;
+}
+
+describe("Anthropic web search replay encryption", () => {
+	it("omits encrypted_content from replayed web search results", async () => {
+		const model = getModel("anthropic", "claude-fable-5");
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-fable-5",
+			content: [
+				{
+					type: "providerNative",
+					subtype: "web_search_tool_result",
+					raw: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvu_1",
+						content: [
+							{
+								type: "web_search_result",
+								title: "Example",
+								url: "https://example.com",
+								page_age: "2026-07-07",
+								encrypted_content: "opaque-ciphertext",
+							},
+						],
+					},
+				},
+				{ type: "text", text: "kept" },
+			],
+			usage,
+			stopReason: "stop",
+			timestamp: 1,
+		};
+
+		const messages = await captureMessages(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{ role: "user", content: "follow up", timestamp: 2 },
+		]);
+
+		const assistantPayload = messages.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([
+			{
+				type: "web_search_tool_result",
+				tool_use_id: "srvu_1",
+				content: [
+					{
+						type: "web_search_result",
+						title: "Example",
+						url: "https://example.com",
+						page_age: "2026-07-07",
+					},
+				],
+			},
+			{ type: "text", text: "kept" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes Anthropic same-model replay for server-side web search results. Prior assistant turns could replay `web_search_tool_result.content[].encrypted_content` into the next request, matching the captured session failure:

`messages.1.content.0: Invalid encrypted_content in search_result block`

After this change, replay keeps the visible search result metadata (`type`, `title`, `url`, `page_age`) and omits only the rejected encrypted payload.

## Changes

- Added an Anthropic replay sanitizer for provider-native `web_search_tool_result` blocks.
- Updated existing provider-native replay expectations to assert encrypted search payloads are not re-sent.
- Added a focused regression for the saved-session failure shape.
- Documented the package change in `packages/ai/CHANGELOG.md` and `packages/ai/src/changes.md`.

## QA / Evidence

- RED proof: `local-ignore/qa-evidence/20260708-search-result-encrypted-content/c1-red.txt`
  - New regression failed before the fix because `encrypted_content` remained in the replay payload.
- Focused green tests: `local-ignore/qa-evidence/20260708-search-result-encrypted-content/c1-c2-green.txt`
  - `anthropic-web-search-replay-encryption.test.ts` and `anthropic-provider-native-replay.test.ts`, 8 tests passed.
- Final pre-rebase full check: `local-ignore/qa-evidence/20260708-search-result-encrypted-content/npm-run-check-final.txt`
  - `npm run check` passed.
- Post-rebase focused tests: `local-ignore/qa-evidence/20260708-search-result-encrypted-content/post-rebase-focused-tests.txt`
  - Same focused Anthropic replay tests passed after rebasing onto latest `origin/main`.
- Post-rebase full check: `local-ignore/qa-evidence/20260708-search-result-encrypted-content/post-rebase-npm-run-check.txt`
  - `npm run check` passed after rebase.
- Mandatory senpi QA:
  - `senpi-qa-common-self-check.txt`: isolation/auth guard passed.
  - `senpi-qa-mock-loop-anthropic.txt`: real CLI mock loop passed for `anthropic-messages`, auth unchanged.
  - `senpi-qa-cli-smoke.txt`: CLI help/version/list-models/unknown flag passed, auth unchanged.
  - `senpi-qa-rpc-self-test.txt`: RPC state boot passed offline, auth unchanged.
  - `post-rebase-senpi-qa-mock-loop-anthropic.txt`: Anthropic mock loop passed again after rebase.

## Risks

- Risk: removing `encrypted_content` could drop provider-private continuity data for replayed web search results.
  - Mitigation: only nested `web_search_result.encrypted_content` is removed; the server tool result block, `tool_use_id`, visible metadata, and non-web-search provider-native replay behavior are preserved. Focused replay tests cover both the new failure shape and existing server-tool replay.

## Secret safety

No raw encrypted payloads, auth headers, cookies, tokens, or credential files are included in the PR body or evidence summary. Evidence files are local and gitignored.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 400 errors from Anthropic follow-up turns by stripping `encrypted_content` from replayed web search results while keeping visible fields (`type`, `title`, `url`, `page_age`). Same-model provider-native replay now sends clean `web_search_tool_result` blocks.

- **Bug Fixes**
  - Strip `encrypted_content` from nested `web_search_result` items during same-model replay in `packages/ai/src/api/anthropic-messages.ts`.
  - Add `anthropic-web-search-replay-encryption.test.ts` and update `anthropic-provider-native-replay.test.ts` to assert sanitized replay.
  - Update `packages/ai/CHANGELOG.md` and `packages/ai/src/changes.md`.

<sup>Written for commit b609c1751551bd81e78c8ec1118e25032e140cd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

