### PR TITLE
fix(tui): submit prompt on LF enter

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -860,6 +860,23 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
+		// Submit (Enter)
+		if (kb.matches(data, "tui.input.submit")) {
+			if (this.disableSubmit) return;
+
+			// Workaround for terminals without Shift+Enter support:
+			// If char before cursor is \, delete it and insert newline instead of submitting.
+			const currentLine = this.state.lines[this.state.cursorLine] || "";
+			if (this.state.cursorCol > 0 && currentLine[this.state.cursorCol - 1] === "\\") {
+				this.handleBackspace();
+				this.addNewLine();
+				return;
+			}
+
+			this.submitValue();
+			return;
+		}
+
 		// New line
 		if (
 			kb.matches(data, "tui.input.newLine") ||
@@ -875,23 +892,6 @@ export class Editor implements Component, Focusable {
 				return;
 			}
 			this.addNewLine();
-			return;
-		}
-
-		// Submit (Enter)
-		if (kb.matches(data, "tui.input.submit")) {
-			if (this.disableSubmit) return;
-
-			// Workaround for terminals without Shift+Enter support:
-			// If char before cursor is \, delete it and insert newline instead of submitting.
-			const currentLine = this.state.lines[this.state.cursorLine] || "";
-			if (this.state.cursorCol > 0 && currentLine[this.state.cursorCol - 1] === "\\") {
-				this.handleBackspace();
-				this.addNewLine();
-				return;
-			}
-
-			this.submitValue();
 			return;
 		}
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -38,6 +38,8 @@ async function flushAutocomplete(): Promise<void> {
 	await new Promise((resolve) => setImmediate(resolve));
 }
 
+const EXPLICIT_NEWLINE = "\x1b[13;2u";
+
 describe("Editor component", () => {
 	describe("Prompt history navigation", () => {
 		it("does nothing on Up arrow when history is empty", () => {
@@ -313,6 +315,34 @@ describe("Editor component", () => {
 	});
 
 	describe("Backslash+Enter newline workaround", () => {
+		it("submits when the terminal sends LF for plain Enter", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let submitted = "";
+			editor.onSubmit = (text) => {
+				submitted = text;
+			};
+
+			editor.setText("hello from lf enter");
+			editor.handleInput("\n");
+
+			assert.strictEqual(submitted, "hello from lf enter");
+			assert.strictEqual(editor.getText(), "");
+		});
+
+		it("inserts newline for backslash followed by LF Enter", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let submitted = false;
+			editor.onSubmit = () => {
+				submitted = true;
+			};
+
+			editor.handleInput("\\");
+			editor.handleInput("\n");
+
+			assert.strictEqual(editor.getText(), "\n");
+			assert.strictEqual(submitted, false);
+		});
+
 		it("inserts backslash immediately (no buffering)", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 
@@ -503,7 +533,7 @@ describe("Editor component", () => {
 			editor.handleInput("ä");
 			editor.handleInput("ö");
 			editor.handleInput("ü");
-			editor.handleInput("\n"); // new line
+			editor.handleInput(EXPLICIT_NEWLINE);
 			editor.handleInput("Ä");
 			editor.handleInput("Ö");
 			editor.handleInput("Ü");
@@ -1447,7 +1477,7 @@ describe("Editor component", () => {
 			editor.setText("");
 			editor.handleInput("a");
 			editor.handleInput("b");
-			editor.handleInput("\n");
+			editor.handleInput(EXPLICIT_NEWLINE);
 			editor.handleInput("c");
 			editor.handleInput("d");
 			// Move to end of first line
@@ -1631,7 +1661,7 @@ describe("Editor component", () => {
 			editor.handleInput("l");
 			editor.handleInput("l");
 			editor.handleInput("o");
-			editor.handleInput("\n");
+			editor.handleInput(EXPLICIT_NEWLINE);
 			editor.handleInput("w");
 			editor.handleInput("o");
 			editor.handleInput("r");
@@ -3905,11 +3935,11 @@ describe("Editor component", () => {
 			// Line 3: "" (empty)
 			// Line 4: "abcdefghijklmnop" (16 chars)
 			for (const ch of "1234567890123456") editor.handleInput(ch);
-			editor.handleInput("\n");
-			editor.handleInput("\n");
+			editor.handleInput(EXPLICIT_NEWLINE);
+			editor.handleInput(EXPLICIT_NEWLINE);
 			editor.handleInput(`\x1b[200~${"x".repeat(2000)}\x1b[201~`);
-			editor.handleInput("\n");
-			editor.handleInput("\n");
+			editor.handleInput(EXPLICIT_NEWLINE);
+			editor.handleInput(EXPLICIT_NEWLINE);
 			for (const ch of "abcdefghijklmnop") editor.handleInput(ch);
 			editor.render(30);
 
@@ -3958,7 +3988,7 @@ describe("Editor component", () => {
 			const bigContent = "line\n".repeat(100).trimEnd();
 			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
 			for (const ch of "ijklmnopqr") editor.handleInput(ch);
-			editor.handleInput("\n");
+			editor.handleInput(EXPLICIT_NEWLINE);
 			for (const ch of "123456789012345678") editor.handleInput(ch);
 			editor.render(20);
 
@@ -4013,7 +4043,7 @@ describe("Editor component", () => {
 			const bigContent = "line\n".repeat(100).trimEnd();
 			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
 			for (const ch of "ijklmnopqr") editor.handleInput(ch);
-			editor.handleInput("\n");
+			editor.handleInput(EXPLICIT_NEWLINE);
 			for (const ch of "123456789012345678") editor.handleInput(ch);
 			editor.render(20);
 


### PR DESCRIPTION
## Summary
Fixes the interactive TUI path where pressing Enter could clear the composer without sending the prompt when a terminal delivered plain LF. The editor now lets the configured submit binding handle LF before the newline branch, while preserving the trailing-backslash newline workaround.

## Changes
- Moves `tui.input.submit` handling ahead of generic newline handling in the editor.
- Adds regression coverage for bare LF submission and backslash+LF newline insertion.
- Converts intentional multiline test setup from raw LF to explicit Shift+Enter CSI-u so raw LF remains reserved for Enter regression coverage.

## QA / Evidence
- **TDD red:** focused editor test failed before the fix because `handleInput("\n")` did not submit the prompt. Artifact: `local-ignore/qa-evidence/20260708-enter-submit/red-editor-test.txt`.
- **Focused editor suite:** `cd packages/tui && node --test --import tsx --test-reporter=spec test/editor.test.ts` passed, `183` tests. Artifact: `local-ignore/qa-evidence/20260708-enter-submit/focused-editor-test-after-review.txt`.
- **Real TUI LF submit:** drove the source CLI in tmux with an isolated fake model server; literal Enter submitted the typed prompt, the mock server received it, the TUI rendered the mock response, real auth was unchanged, and sandbox cleanup completed. Artifacts: `local-ignore/qa-evidence/20260708-enter-submit/tui-lf-submit-summary.json`, `local-ignore/qa-evidence/20260708-enter-submit/enter-submit-tui-qa-driver.mjs`.
- **senpi QA smoke:** `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence enter-submit-tui-smoke` passed 5/5 after dependency hydration. Artifact: `local-ignore/qa-evidence/20260708-enter-submit/tui-smoke-self-test-after-install.txt`.
- **Mock loop:** `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --run "submit behavior baseline" --evidence enter-submit-mock-loop-after-install` completed through the fake provider. Artifact: `local-ignore/qa-evidence/20260708-enter-submit/mock-loop-run-after-install.txt`.
- **Full check:** `npm run check` passed after review follow-up. Artifact: `local-ignore/qa-evidence/20260708-enter-submit/npm-run-check-after-review.txt`.
- **Review/debug gates:** QA, code-quality, and security reviewers passed with no blockers; debugging audit recorded three hypotheses and runtime evidence. Artifacts: `local-ignore/qa-evidence/20260708-enter-submit/debugging-audit.md`, `local-ignore/qa-evidence/20260708-enter-submit/manual-qa-matrix.md`.

## Risks
- Legacy raw LF is inherently indistinguishable from `Ctrl+J`; this PR preserves explicit CSI-u Shift+Enter/newline behavior and the existing backslash workaround.
- Unbracketed paste in a terminal that sends raw isolated LF remains ambiguous; supported bracketed paste paths are covered by existing handling.

## Secret safety
QA used isolated `SENPI_CODING_AGENT_DIR` / `SENPI_CODING_AGENT_SESSION_DIR` sandboxes and fake model credentials. The PR body summarizes request evidence instead of pasting raw headers or request JSON.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pressing Enter now submits the prompt even when the terminal sends a plain LF, fixing cases where the composer cleared without sending. Shift+Enter/newline behavior remains intact, including the backslash workaround.

- **Bug Fixes**
  - Handle `tui.input.submit` before generic newline to ensure LF Enter submits.
  - Keep the backslash+LF workaround to insert a newline instead of submitting.
  - Add tests for LF submission and backslash+LF newline; switch multiline tests to explicit CSI-u Shift+Enter (`\x1b[13;2u`).

<sup>Written for commit d9b64a05222d9ae685bc63aba7842dcaf9706554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

