### PR TITLE
feat(neo): assembly components wave 3 — transcript/input/extui/shellwire/recovery

### DIFF
--- a/.omo/evidence/task-3-neo-completion-red.txt
+++ b/.omo/evidence/task-3-neo-completion-red.txt
@@ -1,0 +1,46 @@
+=== RED run (todo 3) ===
+$ date -u: 2026-07-08T04:24:10Z
+$ cd packages/neo && go test ./internal/app/... -run TestTranscript && go test ./internal/ui/transcript/...
+# github.com/code-yeongyu/senpi/packages/neo/internal/app_test [github.com/code-yeongyu/senpi/packages/neo/internal/app.test]
+internal/app/transcript_test.go:26:65: undefined: app.Transcript
+internal/app/transcript_test.go:29:19: undefined: app.NewTranscript
+internal/app/transcript_test.go:74:55: undefined: app.EventApplied
+internal/app/transcript_test.go:162:86: undefined: app.EventApplied
+internal/app/transcript_test.go:199:12: undefined: app.NewTranscript
+internal/app/transcript_test.go:253:16: undefined: app.EventUnknown
+internal/app/transcript_test.go:269:18: undefined: app.EventUnknown
+internal/app/transcript_test.go:294:55: undefined: app.EventApplied
+FAIL	github.com/code-yeongyu/senpi/packages/neo/internal/app [build failed]
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+FAIL
+exit: 1
+
+=== RED run (second half standalone; the && above short-circuited) ===
+$ cd packages/neo && go test ./internal/ui/transcript/...
+# github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript [github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript.test]
+internal/ui/transcript/feed_streaming_test.go:113:3: unknown field Partial in struct literal of type FeedEvent
+internal/ui/transcript/feed_streaming_test.go:195:3: unknown field CustomType in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:196:3: unknown field Display in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:201:3: unknown field CustomType in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:202:3: unknown field Display in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:207:3: unknown field Summary in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:211:3: unknown field Summary in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:212:3: unknown field TokensBefore in struct literal of type FeedMessage
+internal/ui/transcript/feed_streaming_test.go:267:7: feed.SetToolsExpanded undefined (type *Feed has no field or method SetToolsExpanded)
+internal/ui/transcript/feed_streaming_test.go:282:7: feed.SetHideThinking undefined (type *Feed has no field or method SetHideThinking)
+internal/ui/transcript/feed_streaming_test.go:282:7: too many errors
+FAIL	github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript [build failed]
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript/qaharness	[no test files]
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript/terminalimage	0.444s
+FAIL
+exit: 1
+
+=== GREEN run ===
+$ date -u: 2026-07-08T04:28:09Z
+$ cd packages/neo && go test ./internal/app/... -run TestTranscript && go test ./internal/ui/transcript/...
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/app	0.708s
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript	(cached)
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript/qaharness	[no test files]
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript/terminalimage	(cached)
+exit: 0

--- a/.omo/evidence/task-4-neo-completion-red.txt
+++ b/.omo/evidence/task-4-neo-completion-red.txt
@@ -1,0 +1,131 @@
+=== RED 2026-07-08T04:25:52Z ===
+$ cd packages/neo && go test ./internal/app/... -run TestInput
+# github.com/code-yeongyu/senpi/packages/neo/internal/app_test [github.com/code-yeongyu/senpi/packages/neo/internal/app.test]
+internal/app/input_test.go:91:17: undefined: app.Router
+internal/app/input_test.go:106:11: undefined: app.NewRouter
+internal/app/input_test.go:148:17: undefined: app.RouteKind
+internal/app/input_test.go:155:18: undefined: app.RouteNone
+internal/app/input_test.go:160:18: undefined: app.RouteOverlay
+internal/app/input_test.go:166:19: undefined: app.RouteOverlay
+internal/app/input_test.go:171:19: undefined: app.RouteRPC
+internal/app/input_test.go:177:18: undefined: app.RouteNative
+internal/app/input_test.go:184:19: undefined: app.RoutePrompt
+internal/app/input_test.go:191:18: undefined: app.RouteUnknown
+internal/app/input_test.go:191:18: too many errors
+FAIL	github.com/code-yeongyu/senpi/packages/neo/internal/app [build failed]
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+FAIL
+exit: 1
+
+=== GREEN 2026-07-08T04:28:04Z ===
+$ cd packages/neo && go test ./internal/app/... -run TestInput -v
+=== RUN   TestInputSubmitRoutingTable
+=== RUN   TestInputSubmitRoutingTable/empty_input_is_ignored
+=== RUN   TestInputSubmitRoutingTable/builtin_overlay_slash_command_idle
+=== RUN   TestInputSubmitRoutingTable/builtin_overlay_slash_command_during_streaming
+=== RUN   TestInputSubmitRoutingTable/builtin_rpc_slash_command
+=== RUN   TestInputSubmitRoutingTable/builtin_native_slash_command
+=== RUN   TestInputSubmitRoutingTable/known_dynamic_command_routes_to_prompt_even_while_streaming
+=== RUN   TestInputSubmitRoutingTable/unknown_slash_command_with_known_set_surfaces_inline_error
+=== RUN   TestInputSubmitRoutingTable/unknown_slash_command_without_dynamic_knowledge_falls_through_to_prompt
+=== RUN   TestInputSubmitRoutingTable/bang_runs_bash
+=== RUN   TestInputSubmitRoutingTable/double_bang_runs_bash_excluded_from_context
+=== RUN   TestInputSubmitRoutingTable/bare_bang_is_a_prompt
+=== RUN   TestInputSubmitRoutingTable/plain_text_idle_prompts
+=== RUN   TestInputSubmitRoutingTable/plain_text_during_streaming_enqueues_steer
+--- PASS: TestInputSubmitRoutingTable (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/empty_input_is_ignored (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/builtin_overlay_slash_command_idle (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/builtin_overlay_slash_command_during_streaming (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/builtin_rpc_slash_command (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/builtin_native_slash_command (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/known_dynamic_command_routes_to_prompt_even_while_streaming (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/unknown_slash_command_with_known_set_surfaces_inline_error (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/unknown_slash_command_without_dynamic_knowledge_falls_through_to_prompt (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/bang_runs_bash (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/double_bang_runs_bash_excluded_from_context (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/bare_bang_is_a_prompt (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/plain_text_idle_prompts (0.00s)
+    --- PASS: TestInputSubmitRoutingTable/plain_text_during_streaming_enqueues_steer (0.00s)
+=== RUN   TestInputUnknownCommandNotice
+--- PASS: TestInputUnknownCommandNotice (0.00s)
+=== RUN   TestInputBuiltinAcceptance
+=== RUN   TestInputBuiltinAcceptance/settings
+=== RUN   TestInputBuiltinAcceptance/model
+=== RUN   TestInputBuiltinAcceptance/favorite-models
+=== RUN   TestInputBuiltinAcceptance/export
+=== RUN   TestInputBuiltinAcceptance/import
+=== RUN   TestInputBuiltinAcceptance/share
+=== RUN   TestInputBuiltinAcceptance/copy
+=== RUN   TestInputBuiltinAcceptance/name
+=== RUN   TestInputBuiltinAcceptance/session
+=== RUN   TestInputBuiltinAcceptance/changelog
+=== RUN   TestInputBuiltinAcceptance/hotkeys
+=== RUN   TestInputBuiltinAcceptance/fork
+=== RUN   TestInputBuiltinAcceptance/clone
+=== RUN   TestInputBuiltinAcceptance/tree
+=== RUN   TestInputBuiltinAcceptance/trust
+=== RUN   TestInputBuiltinAcceptance/login
+=== RUN   TestInputBuiltinAcceptance/logout
+=== RUN   TestInputBuiltinAcceptance/new
+=== RUN   TestInputBuiltinAcceptance/compact
+=== RUN   TestInputBuiltinAcceptance/resume
+=== RUN   TestInputBuiltinAcceptance/reload
+=== RUN   TestInputBuiltinAcceptance/quit
+--- PASS: TestInputBuiltinAcceptance (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/settings (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/model (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/favorite-models (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/export (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/import (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/share (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/copy (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/name (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/session (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/changelog (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/hotkeys (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/fork (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/clone (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/tree (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/trust (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/login (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/logout (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/new (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/compact (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/resume (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/reload (0.00s)
+    --- PASS: TestInputBuiltinAcceptance/quit (0.00s)
+=== RUN   TestInputFollowUpActionQueuesDuringStreaming
+--- PASS: TestInputFollowUpActionQueuesDuringStreaming (0.00s)
+=== RUN   TestInputFollowUpActionIdleActsAsSubmit
+--- PASS: TestInputFollowUpActionIdleActsAsSubmit (0.00s)
+=== RUN   TestInputDequeueRestoresAllQueuedMessages
+--- PASS: TestInputDequeueRestoresAllQueuedMessages (0.00s)
+=== RUN   TestInputDequeueEmptyQueueNotice
+--- PASS: TestInputDequeueEmptyQueueNotice (0.00s)
+=== RUN   TestInputQueueFlushOnAgentEndOnly
+--- PASS: TestInputQueueFlushOnAgentEndOnly (0.00s)
+=== RUN   TestInputAgentEndDropsConsumedSteering
+--- PASS: TestInputAgentEndDropsConsumedSteering (0.00s)
+=== RUN   TestInputAgentEndEmptyQueueIsNil
+--- PASS: TestInputAgentEndEmptyQueueIsNil (0.00s)
+=== RUN   TestInputSyncSteeringPreservesLocalFollowUps
+--- PASS: TestInputSyncSteeringPreservesLocalFollowUps (0.00s)
+=== RUN   TestInputBashLifecycle
+--- PASS: TestInputBashLifecycle (0.00s)
+=== RUN   TestInputBashFailureAndCancelStatus
+--- PASS: TestInputBashFailureAndCancelStatus (0.00s)
+=== RUN   TestInputBashBusyRejectsSecondCommand
+--- PASS: TestInputBashBusyRejectsSecondCommand (0.00s)
+=== RUN   TestInputInterruptAbortsRunningBash
+--- PASS: TestInputInterruptAbortsRunningBash (0.00s)
+=== RUN   TestInputBashResultIgnoresOtherCommands
+--- PASS: TestInputBashResultIgnoresOtherCommands (0.00s)
+=== RUN   TestInputAutocompleteProviderWiring
+--- PASS: TestInputAutocompleteProviderWiring (0.00s)
+=== RUN   TestInputHistoryRecording
+--- PASS: TestInputHistoryRecording (0.00s)
+PASS
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/app	0.210s
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+exit: 0

--- a/.omo/evidence/task-6-neo-completion-red.txt
+++ b/.omo/evidence/task-6-neo-completion-red.txt
@@ -1,0 +1,62 @@
+=== RED 2026-07-08T04:27:14Z ===
+$ cd packages/neo && go test ./internal/app/... -run TestExtUI
+# github.com/code-yeongyu/senpi/packages/neo/internal/app_test [github.com/code-yeongyu/senpi/packages/neo/internal/app.test]
+internal/app/extui_test.go:82:17: undefined: app.ExtUI
+internal/app/extui_test.go:100:13: undefined: app.NewExtUI
+internal/app/extui_test.go:336:25: undefined: app.ExtUIDialogTimeoutMsg
+internal/app/extui_test.go:360:42: undefined: app.ExtUIDialogTimeoutMsg
+internal/app/extui_test.go:394:25: undefined: app.LoginProvidersMsg
+internal/app/extui_test.go:549:25: undefined: app.LoginProvidersMsg
+FAIL	github.com/code-yeongyu/senpi/packages/neo/internal/app [build failed]
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+FAIL
+exit=1
+
+=== GREEN 2026-07-08T04:28:57Z ===
+$ cd packages/neo && go test ./internal/app/... -run TestExtUI -v
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/select
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/confirm
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/input
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/editor
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/notify
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/setStatus
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/setWidget
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/setTitle
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/set_editor_text
+=== RUN   TestExtUIRoundTripCoversAllMirroredMethods/custom_unsupported
+--- PASS: TestExtUIRoundTripCoversAllMirroredMethods (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/select (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/confirm (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/input (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/editor (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/notify (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/setStatus (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/setWidget (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/setTitle (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/set_editor_text (0.00s)
+    --- PASS: TestExtUIRoundTripCoversAllMirroredMethods/custom_unsupported (0.00s)
+=== RUN   TestExtUIRenderShowsCustomUnsupportedName
+--- PASS: TestExtUIRenderShowsCustomUnsupportedName (0.00s)
+=== RUN   TestExtUIDialogEscSendsCancelled
+--- PASS: TestExtUIDialogEscSendsCancelled (0.00s)
+=== RUN   TestExtUIDialogTimeoutSendsDefaultCancel
+--- PASS: TestExtUIDialogTimeoutSendsDefaultCancel (0.01s)
+=== RUN   TestExtUIDialogTimeoutAfterAnswerIsNoop
+--- PASS: TestExtUIDialogTimeoutAfterAnswerIsNoop (0.01s)
+=== RUN   TestExtUILoginFlowURLPanelAndSuccessClose
+--- PASS: TestExtUILoginFlowURLPanelAndSuccessClose (0.00s)
+=== RUN   TestExtUILoginEndFailureKeepsDialogWithError
+--- PASS: TestExtUILoginEndFailureKeepsDialogWithError (0.00s)
+=== RUN   TestExtUILoginEscMidFlowEmitsLoginCancel
+--- PASS: TestExtUILoginEscMidFlowEmitsLoginCancel (0.00s)
+=== RUN   TestExtUILogoutEmitsLogout
+--- PASS: TestExtUILogoutEmitsLogout (0.00s)
+=== RUN   TestExtUILoginAPIKeyPromptEmitsLoginAPIKey
+--- PASS: TestExtUILoginAPIKeyPromptEmitsLoginAPIKey (0.00s)
+=== RUN   TestExtUILoginProviderFetchErrorSurfacesNotice
+--- PASS: TestExtUILoginProviderFetchErrorSurfacesNotice (0.00s)
+PASS
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/app	0.220s
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+exit=0

--- a/.omo/evidence/task-7-neo-completion-red.txt
+++ b/.omo/evidence/task-7-neo-completion-red.txt
@@ -1,0 +1,67 @@
+# RED — 2026-07-08T04:22:44Z
+$ cd packages/neo && go test ./internal/app/... -run TestShellWire
+# github.com/code-yeongyu/senpi/packages/neo/internal/app_test [github.com/code-yeongyu/senpi/packages/neo/internal/app.test]
+internal/app/shellwire_test.go:35:13: undefined: app.ShellWire
+internal/app/shellwire_test.go:49:14: undefined: app.NewShellWire
+internal/app/shellwire_test.go:49:35: undefined: app.ShellWireConfig
+internal/app/shellwire_test.go:359:14: undefined: app.NewShellWire
+internal/app/shellwire_test.go:359:35: undefined: app.ShellWireConfig
+internal/app/shellwire_test.go:396:11: undefined: app.ExtensionShellSink
+internal/app/shellwire_test.go:396:38: undefined: app.ShellWire
+internal/app/shellwire_test.go:427:69: undefined: app.WidgetAboveEditor
+internal/app/shellwire_test.go:434:69: undefined: app.WidgetBelowEditor
+internal/app/shellwire_test.go:445:43: undefined: app.WidgetBelowEditor
+internal/app/shellwire_test.go:445:43: too many errors
+FAIL	github.com/code-yeongyu/senpi/packages/neo/internal/app [build failed]
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+FAIL
+exit=1
+
+# GREEN — 2026-07-08T04:24:18Z
+$ cd packages/neo && go test ./internal/app/... -run TestShellWire -v
+=== RUN   TestShellWireEventRegionTable
+=== RUN   TestShellWireEventRegionTable/auto_retry_start_renders_digit-bearing_countdown
+=== RUN   TestShellWireEventRegionTable/auto_retry_end_clears_the_retry_status
+=== RUN   TestShellWireEventRegionTable/compaction_start_threshold_renders_auto-compacting
+=== RUN   TestShellWireEventRegionTable/compaction_start_overflow_renders_overflow_message
+=== RUN   TestShellWireEventRegionTable/compaction_progress_recovers_a_missed_start
+=== RUN   TestShellWireEventRegionTable/compaction_end_clears_the_compaction_status
+=== RUN   TestShellWireEventRegionTable/compaction_end_does_not_clear_an_active_retry
+=== RUN   TestShellWireEventRegionTable/welcome_stays_before_the_first_turn
+=== RUN   TestShellWireEventRegionTable/agent_start_dismisses_the_welcome
+=== RUN   TestShellWireEventRegionTable/session_info_changed_updates_footer_session_segment
+=== RUN   TestShellWireEventRegionTable/thinking_level_changed_refreshes_footer_right_side
+--- PASS: TestShellWireEventRegionTable (0.00s)
+    --- PASS: TestShellWireEventRegionTable/auto_retry_start_renders_digit-bearing_countdown (0.00s)
+    --- PASS: TestShellWireEventRegionTable/auto_retry_end_clears_the_retry_status (0.00s)
+    --- PASS: TestShellWireEventRegionTable/compaction_start_threshold_renders_auto-compacting (0.00s)
+    --- PASS: TestShellWireEventRegionTable/compaction_start_overflow_renders_overflow_message (0.00s)
+    --- PASS: TestShellWireEventRegionTable/compaction_progress_recovers_a_missed_start (0.00s)
+    --- PASS: TestShellWireEventRegionTable/compaction_end_clears_the_compaction_status (0.00s)
+    --- PASS: TestShellWireEventRegionTable/compaction_end_does_not_clear_an_active_retry (0.00s)
+    --- PASS: TestShellWireEventRegionTable/welcome_stays_before_the_first_turn (0.00s)
+    --- PASS: TestShellWireEventRegionTable/agent_start_dismisses_the_welcome (0.00s)
+    --- PASS: TestShellWireEventRegionTable/session_info_changed_updates_footer_session_segment (0.00s)
+    --- PASS: TestShellWireEventRegionTable/thinking_level_changed_refreshes_footer_right_side (0.00s)
+=== RUN   TestShellWireBootstrapResumeDismissesWelcome
+--- PASS: TestShellWireBootstrapResumeDismissesWelcome (0.00s)
+=== RUN   TestShellWireFooterFormattingGolden
+--- PASS: TestShellWireFooterFormattingGolden (0.00s)
+=== RUN   TestShellWireFooterUnknownContextGolden
+--- PASS: TestShellWireFooterUnknownContextGolden (0.00s)
+=== RUN   TestShellWireTitleStateEmission
+--- PASS: TestShellWireTitleStateEmission (0.00s)
+=== RUN   TestShellWireAgentEndRequestsStatsOnDemand
+--- PASS: TestShellWireAgentEndRequestsStatsOnDemand (0.00s)
+=== RUN   TestShellWireNilStatsRequester
+--- PASS: TestShellWireNilStatsRequester (0.00s)
+=== RUN   TestShellWireRetryCountdownAdvance
+--- PASS: TestShellWireRetryCountdownAdvance (0.00s)
+=== RUN   TestShellWireExtensionStatusSegments
+--- PASS: TestShellWireExtensionStatusSegments (0.00s)
+=== RUN   TestShellWireExtensionWidgetSegments
+--- PASS: TestShellWireExtensionWidgetSegments (0.00s)
+PASS
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/app	0.389s
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+exit=0

--- a/.omo/evidence/task-8-neo-completion-red.txt
+++ b/.omo/evidence/task-8-neo-completion-red.txt
@@ -1,0 +1,36 @@
+$ cd packages/neo && go test ./internal/app/... -run TestRecovery
+# github.com/code-yeongyu/senpi/packages/neo/internal/app_test [github.com/code-yeongyu/senpi/packages/neo/internal/app.test]
+internal/app/recovery_test.go:102:19: undefined: app.ResumedEntry
+internal/app/recovery_test.go:111:50: undefined: app.ResumedEntry
+internal/app/recovery_test.go:123:48: undefined: app.ResumedEntry
+internal/app/recovery_test.go:126:24: undefined: app.ResumedEntry
+internal/app/recovery_test.go:161:13: undefined: app.NewRecovery
+internal/app/recovery_test.go:161:29: undefined: app.RecoveryConfig
+internal/app/recovery_test.go:225:23: undefined: app.RecoveryConnected
+internal/app/recovery_test.go:252:13: undefined: app.NewRecovery
+internal/app/recovery_test.go:252:29: undefined: app.RecoveryConfig
+internal/app/recovery_test.go:305:13: undefined: app.NewRecovery
+internal/app/recovery_test.go:305:13: too many errors
+FAIL	github.com/code-yeongyu/senpi/packages/neo/internal/app [build failed]
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+FAIL
+exit=1
+
+--- GREEN (after implementing internal/app/recovery.go) ---
+$ cd packages/neo && go test ./internal/app/... -run TestRecovery
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/app	(cached)
+?   	github.com/code-yeongyu/senpi/packages/neo/internal/app/qaharness	[no test files]
+exit=0
+
+$ cd packages/neo && go test ./internal/app/ -run TestRecovery -v -count=1
+=== RUN   TestRecoveryDaemonResumesSameSession
+--- PASS: TestRecoveryDaemonResumesSameSession (0.00s)
+=== RUN   TestRecoveryDaemonDropMidResumeRetries
+--- PASS: TestRecoveryDaemonDropMidResumeRetries (0.00s)
+=== RUN   TestRecoveryDaemonRetriesAreCapped
+--- PASS: TestRecoveryDaemonRetriesAreCapped (0.00s)
+=== RUN   TestRecoveryIsolatedExitIsFatalQuitSignal
+--- PASS: TestRecoveryIsolatedExitIsFatalQuitSignal (0.00s)
+PASS
+ok  	github.com/code-yeongyu/senpi/packages/neo/internal/app	0.227s
+exit=0

--- a/packages/neo/internal/app/extui.go
+++ b/packages/neo/internal/app/extui.go
@@ -1,0 +1,542 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/builtinext"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/extui"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/overlays"
+)
+
+// extui.go wires the extension-UI bridge into the app layer (plan todo 6). An
+// ExtensionUIRequestMsg routes through extui.DialogForRequest / ApplyRequest:
+// the interactive dialogs (select/confirm/input/editor) are pushed onto the
+// todo-5 overlay Manager as app.Overlay entries, the fire-and-forget directives
+// (notify/setStatus/setWidget/setTitle/set_editor_text) land on the narrow
+// DirectiveSink (their shell/editor application is todo-9 wiring), and the
+// additive custom_unsupported method renders the builtinext notice. A finished
+// dialog answers with an extension_ui_response carrying the ORIGINAL request id
+// — never a req_N command id — so the ExtensionUIResponder seam writes the line
+// directly instead of going through Client.Request. Timeout semantics mirror
+// connection-handler.ts: a timeout-bearing request arms a timer whose expiry
+// sends the default cancel response and dismisses the dialog.
+//
+// It also owns the /login /logout flows: get_auth_providers → extui.NewLoginDialog
+// → login_start issued with NO timeout (the event-completed exemption,
+// bridge/client.go) → the auth_login_url event renders the URL panel → a
+// successful auth_login_end closes the dialog with a status notice, a failed one
+// keeps it open showing the error; esc mid-flow fires login_cancel.
+//
+// ExtUI implements the Model's OverlayStack by decorating the Manager: the
+// wiring (todo 9) must install the ExtUI — not the bare Manager — as the
+// Model's overlay stack so completed dialogs can attach their response send to
+// the key's tea.Cmd. Every command leaves as a tea.Cmd; nothing blocks the
+// Update goroutine.
+
+// Overlay kinds owned by the extension-UI layer, allocated after the manager's
+// ten built-in kinds so they never collide.
+const (
+	// OverlayExtUI hosts an extension dialog (select/confirm/input/editor) or
+	// the custom_unsupported notice.
+	OverlayExtUI OverlayKind = OverlayStats + 1 + iota
+	// OverlayLogin hosts the /login /logout dialog and its api-key prompt.
+	OverlayLogin
+)
+
+// extUIExpireSignal is the non-key control string cycled through the Manager to
+// pop an overlay the controller finished from the outside (dialog timeout,
+// successful auth_login_end). It is never matched against a binding: the
+// flagged adapter returns on its own done/close flag before any key
+// resolution, and every live dialog treats the unmatched NUL-prefixed string as
+// a no-op (not printable, no chord).
+const extUIExpireSignal = "\x00extui.expire"
+
+// ExtUIRequestDoer issues one RPC command with a per-call timeout. It is the
+// narrow slice of *bridge.Client the extension-UI layer needs; a zero timeout
+// waits indefinitely (reserved for login_start, the event-completed exemption).
+type ExtUIRequestDoer interface {
+	Request(cmd bridge.Command, timeout time.Duration) (bridge.Response, error)
+}
+
+var _ ExtUIRequestDoer = (*bridge.Client)(nil)
+
+// ExtensionUIResponder writes one extension_ui_response line to the bridge
+// stdin, preserving the originating request id. The todo-9 wiring implements it
+// over the transport's line writer; tests inject a recorder.
+type ExtensionUIResponder interface {
+	RespondExtensionUI(resp bridge.ExtensionUIResponse) error
+}
+
+// DirectiveSink receives the fire-and-forget extension directives. The shell
+// (setStatus/setWidget/notify → todo 7 regions), terminal title, and editor
+// (set_editor_text) application is todo-9 wiring; tests inject a recorder.
+type DirectiveSink interface {
+	ApplyDirective(d extui.Directive)
+}
+
+// ExtUIDialogTimeoutMsg fires when a timeout-bearing dialog request's deadline
+// elapsed. Route it to ExtUI.HandleTimeout.
+type ExtUIDialogTimeoutMsg struct{ ID string }
+
+// ExtUIRespondedMsg reports the outcome of an extension_ui_response write. It
+// is advisory: the TS host resolves its default on its own timer regardless.
+type ExtUIRespondedMsg struct {
+	Err error
+	ID  string
+}
+
+// LoginProvidersMsg carries the get_auth_providers result back to the update
+// loop, where HandleLoginProviders builds and pushes the login dialog.
+type LoginProvidersMsg struct {
+	Err       error
+	Mode      string
+	SavedText string
+	Providers []bridge.AuthProvider
+}
+
+// ExtUI is the extension-UI + login controller. It decorates the todo-5 overlay
+// Manager as the Model's OverlayStack, tracking the live extension dialogs (by
+// request id) and the login flow so out-of-band completions (timeouts, auth
+// events) can close them and attach their sends as tea.Cmds.
+type ExtUI struct {
+	deps      extui.Deps
+	mgr       *Manager
+	client    ExtUIRequestDoer
+	responder ExtensionUIResponder
+	sink      DirectiveSink
+	dialogs   map[string]*extDialogOverlay
+	login     *loginOverlay
+	pending   []tea.Cmd
+}
+
+// NewExtUI builds the controller over the overlay manager and the three seams.
+func NewExtUI(deps extui.Deps, mgr *Manager, client ExtUIRequestDoer, responder ExtensionUIResponder, sink DirectiveSink) *ExtUI {
+	return &ExtUI{
+		deps:      deps,
+		mgr:       mgr,
+		client:    client,
+		responder: responder,
+		sink:      sink,
+		dialogs:   map[string]*extDialogOverlay{},
+	}
+}
+
+var _ OverlayStack = (*ExtUI)(nil)
+
+// Active reports whether a modal overlay is open (delegates to the Manager).
+func (c *ExtUI) Active() bool { return c.mgr.Active() }
+
+// Render draws the active overlay frame (delegates to the Manager).
+func (c *ExtUI) Render(width, height int) []string { return c.mgr.Render(width, height) }
+
+// HandleKey routes a raw key through the Manager and attaches any sends the
+// adapters queued while handling it (extension_ui_response writes, auth
+// commands) to the result's tea.Cmd.
+func (c *ExtUI) HandleKey(raw string) OverlayKeyResult {
+	res := c.mgr.HandleKey(raw)
+	res.Cmd = joinCmds(res.Cmd, c.drain())
+	return res
+}
+
+// HandleRequest routes one extension_ui_request. Interactive methods open a
+// dialog overlay (savedEditorText is the editor text live at open, restored on
+// close — master task-12 semantics) and return the timeout timer command when
+// the request carries one; directives apply to the sink; custom_unsupported
+// opens the builtinext notice. Fire-and-forget methods send no response line.
+func (c *ExtUI) HandleRequest(req bridge.ExtensionUIRequest, savedEditorText string) tea.Cmd {
+	if req.Method == builtinext.CustomUnsupportedMethod {
+		ov := &extNoticeOverlay{}
+		notice, ok := builtinext.NoticeForRequest(req, builtinext.NoticeDeps{
+			Theme:       c.deps.Theme,
+			Keybindings: c.deps.Keybindings,
+			Done:        func() { ov.done = true },
+		})
+		if !ok {
+			return nil
+		}
+		ov.notice = notice
+		c.mgr.Push(OverlayExtUI, ov, savedEditorText)
+		return nil
+	}
+	if dir, ok := extui.ApplyRequest(req); ok {
+		c.sink.ApplyDirective(dir)
+		return nil
+	}
+	dialog, ok := extui.DialogForRequest(req, c.deps)
+	if !ok {
+		return nil // not a mirrored method; the bridge exhaustiveness gate keeps this dead
+	}
+	ov := &extDialogOverlay{ctrl: c, dialog: dialog}
+	c.dialogs[req.ID] = ov
+	c.mgr.Push(OverlayExtUI, ov, savedEditorText)
+	return dialogTimeoutCmd(req)
+}
+
+// dialogTimeoutCmd arms the per-request timer when the request carries a
+// timeout (milliseconds, mirroring connection-handler.ts setTimeout).
+func dialogTimeoutCmd(req bridge.ExtensionUIRequest) tea.Cmd {
+	ms, ok := req.Fields["timeout"].(float64)
+	if !ok || ms <= 0 {
+		return nil
+	}
+	id := req.ID
+	d := time.Duration(ms) * time.Millisecond
+	return func() tea.Msg {
+		time.Sleep(d)
+		return ExtUIDialogTimeoutMsg{ID: id}
+	}
+}
+
+// HandleTimeout resolves an elapsed dialog deadline: the default cancel
+// response is sent with the original request id and the dialog is popped when
+// it is the active overlay (restoring the saved editor text). A stale timeout
+// for an already-answered dialog is a no-op.
+func (c *ExtUI) HandleTimeout(msg ExtUIDialogTimeoutMsg) OverlayKeyResult {
+	ov, ok := c.dialogs[msg.ID]
+	if !ok || ov.done {
+		return OverlayKeyResult{}
+	}
+	ov.done = true
+	delete(c.dialogs, msg.ID)
+	c.queue(c.respondCmd(extui.Response{ID: msg.ID, Cancelled: true}))
+	return c.popFlagged(OverlayExtUI)
+}
+
+// HandleEvent routes the auth login events to the live login dialog. Handled is
+// false for every other event (or when no login flow is open) so the caller
+// keeps routing it to the transcript/shell layers.
+func (c *ExtUI) HandleEvent(ev bridge.Event) OverlayKeyResult {
+	if c.login == nil {
+		return OverlayKeyResult{}
+	}
+	switch ev.Type {
+	case "auth_login_url":
+		var p struct {
+			Provider string `json:"provider"`
+			URL      string `json:"url"`
+		}
+		if err := json.Unmarshal(ev.Payload, &p); err != nil {
+			return OverlayKeyResult{}
+		}
+		c.login.dialog.OnAuthURL(p.Provider, p.URL)
+		return OverlayKeyResult{Handled: true}
+	case "auth_login_end":
+		var p struct {
+			Provider string `json:"provider"`
+			Error    string `json:"error"`
+			Success  bool   `json:"success"`
+		}
+		if err := json.Unmarshal(ev.Payload, &p); err != nil {
+			return OverlayKeyResult{}
+		}
+		if !c.login.dialog.OnAuthEnd(p.Provider, p.Success, p.Error) {
+			return OverlayKeyResult{Handled: true} // failure: stays open showing the error
+		}
+		c.login.closeRequested = true
+		res := c.popFlagged(OverlayLogin)
+		res.Cmd = joinCmds(res.Cmd, notice("Logged in to "+p.Provider))
+		return res
+	}
+	return OverlayKeyResult{}
+}
+
+// popFlagged cycles the expire signal through the Manager when the given kind
+// is on top, so the flagged adapter pops itself (restoring the saved editor
+// text), then attaches the queued sends. When another overlay is stacked on top
+// the flagged one closes on its next key instead.
+func (c *ExtUI) popFlagged(kind OverlayKind) OverlayKeyResult {
+	res := OverlayKeyResult{Handled: true}
+	if c.mgr.ActiveKind() == kind {
+		res = c.mgr.HandleKey(extUIExpireSignal)
+		res.Handled = true
+	}
+	res.Cmd = joinCmds(res.Cmd, c.drain())
+	return res
+}
+
+// OpenLogin fetches the provider list for the /login selector. savedEditorText
+// travels through the fetch so the dialog push can save/restore it.
+func (c *ExtUI) OpenLogin(savedEditorText string) tea.Cmd {
+	return c.fetchProviders("login", savedEditorText)
+}
+
+// OpenLogout fetches the provider list for the /logout selector.
+func (c *ExtUI) OpenLogout(savedEditorText string) tea.Cmd {
+	return c.fetchProviders("logout", savedEditorText)
+}
+
+func (c *ExtUI) fetchProviders(mode, savedText string) tea.Cmd {
+	client := c.client
+	return func() tea.Msg {
+		msg := LoginProvidersMsg{Mode: mode, SavedText: savedText}
+		resp, err := client.Request(bridge.Command{Type: "get_auth_providers"}, bridge.DefaultRequestTimeout)
+		if err != nil {
+			msg.Err = err
+			return msg
+		}
+		if !resp.Success {
+			msg.Err = errors.New(resp.Error)
+			return msg
+		}
+		var data struct {
+			Providers []bridge.AuthProvider `json:"providers"`
+		}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			msg.Err = err
+			return msg
+		}
+		msg.Providers = data.Providers
+		return msg
+	}
+}
+
+// HandleLoginProviders builds and pushes the login dialog once the provider
+// fetch resolves (on the Update goroutine — the Manager is not safe off it). A
+// fetch error surfaces as a one-line notice instead.
+func (c *ExtUI) HandleLoginProviders(msg LoginProvidersMsg) tea.Cmd {
+	if msg.Err != nil {
+		return notice("login: " + msg.Err.Error())
+	}
+	dialog := extui.NewLoginDialog(extui.LoginOptions{
+		Mode:        msg.Mode,
+		Theme:       c.deps.Theme,
+		Keybindings: c.deps.Keybindings,
+		Providers:   msg.Providers,
+	})
+	ov := &loginOverlay{ctrl: c, dialog: dialog}
+	c.login = ov
+	c.mgr.Push(OverlayLogin, ov, msg.SavedText)
+	return nil
+}
+
+// openAPIKeyPrompt pushes the key input for an api_key provider; its submit
+// fires login_api_key (a login step, never an extension_ui_response).
+func (c *ExtUI) openAPIKeyPrompt(provider, savedText string) {
+	dialog, ok := extui.DialogForRequest(bridge.ExtensionUIRequest{
+		Type:   "extension_ui_request",
+		ID:     "login_api_key:" + provider,
+		Method: "input",
+		Fields: map[string]any{"title": "Enter API key for " + provider, "placeholder": "API key"},
+	}, c.deps)
+	if !ok {
+		return
+	}
+	c.mgr.Push(OverlayLogin, &apiKeyOverlay{ctrl: c, dialog: dialog, provider: provider}, savedText)
+}
+
+// --- command plumbing ---------------------------------------------------------
+
+// queue defers a command to the next drain, so adapters running inside
+// Manager.HandleKey can attach sends to the key's result.
+func (c *ExtUI) queue(cmd tea.Cmd) {
+	if cmd != nil {
+		c.pending = append(c.pending, cmd)
+	}
+}
+
+func (c *ExtUI) drain() tea.Cmd {
+	if len(c.pending) == 0 {
+		return nil
+	}
+	cmds := c.pending
+	c.pending = nil
+	return joinCmds(cmds...)
+}
+
+// respondCmd builds the tea.Cmd that writes the extension_ui_response line,
+// mapping the dialog outcome onto the three TS response variants (cancelled /
+// confirmed / value).
+func (c *ExtUI) respondCmd(resp extui.Response) tea.Cmd {
+	wire := bridge.ExtensionUIResponse{Type: "extension_ui_response", ID: resp.ID}
+	switch {
+	case resp.Cancelled:
+		wire.Cancelled = true
+	case resp.Confirmed != nil:
+		wire.Confirmed = resp.Confirmed
+	default:
+		wire.Value = resp.Value
+	}
+	responder := c.responder
+	return func() tea.Msg {
+		return ExtUIRespondedMsg{ID: wire.ID, Err: responder.RespondExtensionUI(wire)}
+	}
+}
+
+// requestCmd issues an auth command off the Update goroutine at the given
+// timeout (0 = wait indefinitely — reserved for login_start).
+func (c *ExtUI) requestCmd(cmd bridge.Command, timeout time.Duration) tea.Cmd {
+	client := c.client
+	return func() tea.Msg {
+		resp, err := client.Request(cmd, timeout)
+		return CommandResultMsg{Command: cmd.Type, Response: resp, Err: err}
+	}
+}
+
+func (c *ExtUI) clearLogin(o *loginOverlay) {
+	if c.login == o {
+		c.login = nil
+	}
+}
+
+// joinCmds batches the non-nil commands (nil when none, unwrapped when one).
+func joinCmds(cmds ...tea.Cmd) tea.Cmd {
+	var live []tea.Cmd
+	for _, cmd := range cmds {
+		if cmd != nil {
+			live = append(live, cmd)
+		}
+	}
+	switch len(live) {
+	case 0:
+		return nil
+	case 1:
+		return live[0]
+	default:
+		return tea.Batch(live...)
+	}
+}
+
+func stripLines(lines []string) []string {
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = ui.StripANSI(l)
+	}
+	return out
+}
+
+// --- overlay adapters -----------------------------------------------------------
+
+// extDialogOverlay adapts an extui.Dialog to the Manager's Overlay contract.
+// The dialog resolves its keys through its own keybinding manager (injected via
+// extui.Deps), so the kb parameter is unused here.
+type extDialogOverlay struct {
+	ctrl   *ExtUI
+	dialog extui.Dialog
+	done   bool
+}
+
+func (o *extDialogOverlay) HandleKey(data string, _ *keybindings.Manager, savedText string) overlays.Outcome {
+	if o.done {
+		// Timed out from the outside (response already sent): any key dismisses.
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	}
+	resp, finished := o.dialog.HandleInput(data)
+	if !finished {
+		return overlays.Outcome{Kind: overlays.OutcomeNone}
+	}
+	o.done = true
+	delete(o.ctrl.dialogs, o.dialog.RequestID())
+	o.ctrl.queue(o.ctrl.respondCmd(resp))
+	if resp.Cancelled {
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	}
+	return overlays.Outcome{Kind: overlays.OutcomeSelect}
+}
+
+func (o *extDialogOverlay) RenderPlain(width int) []string {
+	return stripLines(o.dialog.Render(width))
+}
+func (o *extDialogOverlay) RenderStyled(width int) []string { return o.dialog.Render(width) }
+
+// extNoticeOverlay hosts the custom_unsupported notice. No response line is
+// sent: the TS host resolves ctx.ui.custom to undefined on its own.
+type extNoticeOverlay struct {
+	notice *builtinext.CustomUnsupportedNotice
+	done   bool
+}
+
+func (o *extNoticeOverlay) HandleKey(data string, _ *keybindings.Manager, savedText string) overlays.Outcome {
+	o.notice.HandleInput(data) // flips done via the Done callback on confirm/cancel
+	if o.done {
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	}
+	return overlays.Outcome{Kind: overlays.OutcomeNone}
+}
+
+func (o *extNoticeOverlay) RenderPlain(width int) []string {
+	return stripLines(o.notice.Render(width))
+}
+func (o *extNoticeOverlay) RenderStyled(width int) []string { return o.notice.Render(width) }
+
+// loginOverlay adapts extui.LoginDialog: provider selection fires login_start
+// (oauth, NO timeout) / logout / the api-key prompt; esc mid-flow fires
+// login_cancel; a successful auth_login_end sets closeRequested so the next
+// signal pops it.
+type loginOverlay struct {
+	ctrl           *ExtUI
+	dialog         *extui.LoginDialog
+	closeRequested bool
+}
+
+func (o *loginOverlay) HandleKey(data string, _ *keybindings.Manager, savedText string) overlays.Outcome {
+	if o.closeRequested {
+		o.ctrl.clearLogin(o)
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	}
+	cmd := o.dialog.HandleInput(data)
+	if cmd.Done {
+		o.ctrl.clearLogin(o)
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	}
+	switch cmd.Command {
+	case "login_start":
+		// Fire-then-subscribe: NO request timeout (the bridge event-completed
+		// exemption) — completion arrives as auth_login_url / auth_login_end.
+		o.ctrl.queue(o.ctrl.requestCmd(bridge.Command{Type: cmd.Command, Fields: cmd.Fields}, 0))
+		return overlays.Outcome{Kind: overlays.OutcomeNone} // the flow view stays open
+	case "login_cancel":
+		o.ctrl.queue(o.ctrl.requestCmd(bridge.Command{Type: cmd.Command, Fields: cmd.Fields}, bridge.DefaultRequestTimeout))
+		o.ctrl.clearLogin(o)
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	case "logout":
+		o.ctrl.queue(o.ctrl.requestCmd(bridge.Command{Type: cmd.Command, Fields: cmd.Fields}, bridge.DefaultRequestTimeout))
+		o.ctrl.clearLogin(o)
+		return overlays.Outcome{Kind: overlays.OutcomeSelect}
+	case "login_api_key_prompt":
+		provider, _ := cmd.Fields["provider"].(string)
+		o.ctrl.openAPIKeyPrompt(provider, savedText)
+		return overlays.Outcome{Kind: overlays.OutcomeNone}
+	}
+	return overlays.Outcome{Kind: overlays.OutcomeNone}
+}
+
+func (o *loginOverlay) RenderPlain(width int) []string {
+	return stripLines(o.dialog.Render(width))
+}
+func (o *loginOverlay) RenderStyled(width int) []string { return o.dialog.Render(width) }
+
+// apiKeyOverlay maps the key input's outcome onto a login_api_key command. The
+// typed key only crosses the requestCmd seam — it is never echoed to a notice
+// or an extension_ui_response.
+type apiKeyOverlay struct {
+	ctrl     *ExtUI
+	dialog   extui.Dialog
+	provider string
+}
+
+func (o *apiKeyOverlay) HandleKey(data string, _ *keybindings.Manager, savedText string) overlays.Outcome {
+	resp, finished := o.dialog.HandleInput(data)
+	if !finished {
+		return overlays.Outcome{Kind: overlays.OutcomeNone}
+	}
+	if resp.Cancelled || resp.Value == "" {
+		return overlays.Outcome{Kind: overlays.OutcomeCancel, RestoreText: savedText}
+	}
+	o.ctrl.queue(o.ctrl.requestCmd(bridge.Command{
+		Type:   "login_api_key",
+		Fields: map[string]any{"provider": o.provider, "key": resp.Value},
+	}, bridge.DefaultRequestTimeout))
+	return overlays.Outcome{Kind: overlays.OutcomeSelect}
+}
+
+func (o *apiKeyOverlay) RenderPlain(width int) []string {
+	return stripLines(o.dialog.Render(width))
+}
+func (o *apiKeyOverlay) RenderStyled(width int) []string { return o.dialog.Render(width) }

--- a/packages/neo/internal/app/extui_test.go
+++ b/packages/neo/internal/app/extui_test.go
@@ -1,0 +1,566 @@
+package app_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/extui"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+)
+
+// extui_test.go is the todo-6 contract: an ExtensionUIRequestMsg routes through
+// extui.DialogForRequest / ApplyRequest — interactive dialogs enter the todo-5
+// overlay Manager and answer with an extension_ui_response carrying the ORIGINAL
+// request id, directives land on the narrow DirectiveSink, custom_unsupported
+// renders the builtinext notice — and the /login /logout flows run
+// get_auth_providers → login_start (NO timeout) → auth_login_url → auth_login_end
+// with login_cancel on esc. Every one of the 10 mirrored methods
+// (bridge.KnownExtensionUIMethods) round-trips through the table test.
+
+// --- fakes -------------------------------------------------------------------
+
+// authCall records one RPC command issued through the ExtUIRequestDoer seam,
+// including the per-call timeout (the login_start exemption is asserted on it).
+type authCall struct {
+	cmd     bridge.Command
+	timeout time.Duration
+}
+
+type fakeAuthClient struct {
+	responses map[string]bridge.Response
+	err       error
+	calls     []authCall
+}
+
+func (f *fakeAuthClient) Request(cmd bridge.Command, timeout time.Duration) (bridge.Response, error) {
+	f.calls = append(f.calls, authCall{cmd: cmd, timeout: timeout})
+	if f.err != nil {
+		return bridge.Response{}, f.err
+	}
+	if resp, ok := f.responses[cmd.Type]; ok {
+		return resp, nil
+	}
+	return bridge.Response{Type: "response", Command: cmd.Type, Success: true}, nil
+}
+
+func (f *fakeAuthClient) call(cmdType string) (authCall, bool) {
+	for _, c := range f.calls {
+		if c.cmd.Type == cmdType {
+			return c, true
+		}
+	}
+	return authCall{}, false
+}
+
+type fakeResponder struct {
+	sent []bridge.ExtensionUIResponse
+}
+
+func (f *fakeResponder) RespondExtensionUI(resp bridge.ExtensionUIResponse) error {
+	f.sent = append(f.sent, resp)
+	return nil
+}
+
+type fakeSink struct {
+	directives []extui.Directive
+}
+
+func (f *fakeSink) ApplyDirective(d extui.Directive) { f.directives = append(f.directives, d) }
+
+// --- harness -----------------------------------------------------------------
+
+type extUIHarness struct {
+	ext       *app.ExtUI
+	mgr       *app.Manager
+	client    *fakeAuthClient
+	responder *fakeResponder
+	sink      *fakeSink
+}
+
+func newExtUIHarness(t *testing.T) *extUIHarness {
+	t.Helper()
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName, AgentDir: "\x00nonexistent"})
+	if err != nil {
+		t.Fatalf("theme.Load: %v", err)
+	}
+	keys := keybindings.NewManager(nil)
+	client := &fakeAuthClient{responses: map[string]bridge.Response{}}
+	responder := &fakeResponder{}
+	sink := &fakeSink{}
+	mgr := app.NewManager(keys, &fakeRequester{})
+	ext := app.NewExtUI(extui.Deps{Theme: th, Keybindings: keys}, mgr, client, responder, sink)
+	return &extUIHarness{ext: ext, mgr: mgr, client: client, responder: responder, sink: sink}
+}
+
+// press feeds raw keys through the composite ExtUI (the Model's overlay path)
+// and executes any attached commands, returning the last key's result.
+func (h *extUIHarness) press(keys ...string) app.OverlayKeyResult {
+	var last app.OverlayKeyResult
+	for _, k := range keys {
+		last = h.ext.HandleKey(k)
+		runTeaCmd(last.Cmd)
+	}
+	return last
+}
+
+// runTeaCmd executes a tea.Cmd synchronously (recursing into batches) and
+// returns every message it produced.
+func runTeaCmd(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, sub := range batch {
+			out = append(out, runTeaCmd(sub)...)
+		}
+		return out
+	}
+	if msg == nil {
+		return nil
+	}
+	return []tea.Msg{msg}
+}
+
+func extReq(id, method string, fields map[string]any) bridge.ExtensionUIRequest {
+	return bridge.ExtensionUIRequest{Type: "extension_ui_request", ID: id, Method: method, Fields: fields}
+}
+
+func plainFrame(lines []string) string { return ui.StripANSI(strings.Join(lines, "\n")) }
+
+func authEvent(t *testing.T, evType string, fields map[string]any) bridge.Event {
+	t.Helper()
+	payload := map[string]any{"type": evType}
+	for k, v := range fields {
+		payload[k] = v
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal %s payload: %v", evType, err)
+	}
+	return bridge.Event{Type: evType, Payload: raw}
+}
+
+// --- request → dialog → response round-trips (all 10 mirrored methods) --------
+
+// TestExtUIRoundTripCoversAllMirroredMethods drives every mirrored
+// extension_ui_request method through the app layer: the four interactive
+// dialogs answer with an extension_ui_response carrying the original request
+// id, the five directives land on the DirectiveSink without a response, and
+// custom_unsupported renders the builtinext notice (dismissed, no response).
+// The coverage set is asserted against bridge.KnownExtensionUIMethods().
+func TestExtUIRoundTripCoversAllMirroredMethods(t *testing.T) {
+	yes := true
+	type wantResp struct {
+		confirmed *bool
+		value     string
+		cancelled bool
+	}
+	cases := []struct {
+		method    string
+		fields    map[string]any
+		keys      []string
+		want      *wantResp
+		directive bool
+		sinkKind  extui.DirectiveKind
+		notice    bool
+	}{
+		{
+			method: "select",
+			fields: map[string]any{"title": "Pick one", "options": []any{"option-1", "option-2"}},
+			keys:   []string{"\x1b[B", "\r"},
+			want:   &wantResp{value: "option-2"},
+		},
+		{
+			method: "confirm",
+			fields: map[string]any{"title": "Proceed?", "message": "apply the change"},
+			keys:   []string{"\r"},
+			want:   &wantResp{confirmed: &yes},
+		},
+		{
+			method: "input",
+			fields: map[string]any{"title": "Name", "placeholder": "your name"},
+			keys:   []string{"n", "e", "o", "\r"},
+			want:   &wantResp{value: "neo"},
+		},
+		{
+			method: "editor",
+			fields: map[string]any{"title": "Edit note", "prefill": "line1"},
+			keys:   []string{"\n"}, // ctrl+j submits the multiline editor
+			want:   &wantResp{value: "line1"},
+		},
+		{method: "notify", fields: map[string]any{"message": "hi", "notifyType": "warning"}, directive: true, sinkKind: extui.DirectiveNotify},
+		{method: "setStatus", fields: map[string]any{"statusKey": "k", "statusText": "busy"}, directive: true, sinkKind: extui.DirectiveSetStatus},
+		{method: "setWidget", fields: map[string]any{"widgetKey": "w", "widgetLines": []any{"l1"}}, directive: true, sinkKind: extui.DirectiveSetWidget},
+		{method: "setTitle", fields: map[string]any{"title": "My Title"}, directive: true, sinkKind: extui.DirectiveSetTitle},
+		{method: "set_editor_text", fields: map[string]any{"text": "prefill"}, directive: true, sinkKind: extui.DirectiveSetEditorText},
+		{
+			method: "custom_unsupported",
+			fields: map[string]any{"extensionName": "doom-overlay"},
+			keys:   []string{"\r"},
+			notice: true,
+		},
+	}
+
+	if want := len(bridge.KnownExtensionUIMethods()); len(cases) != want {
+		t.Fatalf("round-trip table has %d cases, want all %d mirrored methods", len(cases), want)
+	}
+
+	covered := map[string]bool{}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			h := newExtUIHarness(t)
+			cmd := h.ext.HandleRequest(extReq("req-ext-1", tc.method, tc.fields), "saved draft")
+			if cmd != nil {
+				t.Fatalf("%s: request without a timeout field must not arm a timer", tc.method)
+			}
+
+			if tc.directive {
+				if h.ext.Active() {
+					t.Fatalf("%s: a fire-and-forget directive must not open an overlay", tc.method)
+				}
+				if len(h.sink.directives) != 1 || h.sink.directives[0].Kind != tc.sinkKind {
+					t.Fatalf("%s: expected one %v directive on the sink, got %+v", tc.method, tc.sinkKind, h.sink.directives)
+				}
+				if len(h.responder.sent) != 0 {
+					t.Fatalf("%s: directives must not send an extension_ui_response, got %+v", tc.method, h.responder.sent)
+				}
+				covered[tc.method] = true
+				return
+			}
+
+			if !h.ext.Active() {
+				t.Fatalf("%s: dialog request must open an overlay", tc.method)
+			}
+			if frame := plainFrame(h.ext.Render(80, 24)); strings.TrimSpace(frame) == "" {
+				t.Fatalf("%s: active dialog rendered an empty frame", tc.method)
+			}
+			res := h.press(tc.keys...)
+			if h.ext.Active() {
+				t.Fatalf("%s: dialog must close after its terminal key", tc.method)
+			}
+			if !res.Restore || res.RestoreText != "saved draft" {
+				t.Fatalf("%s: closing must restore the saved editor text, got %+v", tc.method, res)
+			}
+
+			if tc.notice {
+				if len(h.responder.sent) != 0 {
+					t.Fatalf("custom_unsupported must not send a response, got %+v", h.responder.sent)
+				}
+				covered[tc.method] = true
+				return
+			}
+
+			if len(h.responder.sent) != 1 {
+				t.Fatalf("%s: expected exactly one extension_ui_response, got %+v", tc.method, h.responder.sent)
+			}
+			sent := h.responder.sent[0]
+			if sent.Type != "extension_ui_response" || sent.ID != "req-ext-1" {
+				t.Fatalf("%s: response must carry the original request id, got %+v", tc.method, sent)
+			}
+			if sent.Cancelled != tc.want.cancelled || sent.Value != tc.want.value {
+				t.Fatalf("%s: response = %+v, want value=%q cancelled=%v", tc.method, sent, tc.want.value, tc.want.cancelled)
+			}
+			if (sent.Confirmed == nil) != (tc.want.confirmed == nil) {
+				t.Fatalf("%s: confirmed presence mismatch: %+v", tc.method, sent)
+			}
+			if sent.Confirmed != nil && *sent.Confirmed != *tc.want.confirmed {
+				t.Fatalf("%s: confirmed = %v, want %v", tc.method, *sent.Confirmed, *tc.want.confirmed)
+			}
+			covered[tc.method] = true
+		})
+	}
+
+	for method := range bridge.KnownExtensionUIMethods() {
+		if !covered[method] {
+			t.Errorf("mirrored extension-UI method %q has no passing round-trip case", method)
+		}
+	}
+}
+
+// TestExtUIRenderShowsCustomUnsupportedName pins the notice copy: the dialog
+// names the extension and the classic-TUI fallback.
+func TestExtUIRenderShowsCustomUnsupportedName(t *testing.T) {
+	h := newExtUIHarness(t)
+	h.ext.HandleRequest(extReq("req-cu", "custom_unsupported", map[string]any{"extensionName": "doom-overlay"}), "")
+	frame := plainFrame(h.ext.Render(100, 24))
+	if !strings.Contains(frame, "doom-overlay") || !strings.Contains(frame, "classic TUI") {
+		t.Fatalf("notice must name the extension and the classic TUI fallback, got:\n%s", frame)
+	}
+}
+
+// TestExtUIDialogEscSendsCancelled proves esc answers the request with a
+// cancellation (the TS pending map resolves its default) and restores the
+// editor text.
+func TestExtUIDialogEscSendsCancelled(t *testing.T) {
+	h := newExtUIHarness(t)
+	h.ext.HandleRequest(extReq("req-esc", "select", map[string]any{"title": "Pick", "options": []any{"a", "b"}}), "draft")
+	res := h.press("\x1b")
+	if h.ext.Active() {
+		t.Fatal("esc must close the dialog")
+	}
+	if !res.Restore || res.RestoreText != "draft" {
+		t.Fatalf("esc must restore the saved editor text, got %+v", res)
+	}
+	if len(h.responder.sent) != 1 || !h.responder.sent[0].Cancelled || h.responder.sent[0].ID != "req-esc" {
+		t.Fatalf("esc must send a cancelled response with the request id, got %+v", h.responder.sent)
+	}
+}
+
+// --- timeout semantics ---------------------------------------------------------
+
+// TestExtUIDialogTimeoutSendsDefaultCancel proves a timeout-bearing request arms
+// a timer whose expiry sends the default cancel response (connection-handler.ts
+// resolves the default at the same deadline) and closes the dialog, restoring
+// the editor text.
+func TestExtUIDialogTimeoutSendsDefaultCancel(t *testing.T) {
+	h := newExtUIHarness(t)
+	cmd := h.ext.HandleRequest(extReq("req-to", "confirm", map[string]any{"title": "Sure?", "message": "m", "timeout": float64(5)}), "kept")
+	if cmd == nil {
+		t.Fatal("a timeout-bearing request must arm a timer command")
+	}
+	msgs := runTeaCmd(cmd) // sleeps ~5ms then emits the timeout message
+	if len(msgs) != 1 {
+		t.Fatalf("timer command must emit one message, got %+v", msgs)
+	}
+	tm, ok := msgs[0].(app.ExtUIDialogTimeoutMsg)
+	if !ok || tm.ID != "req-to" {
+		t.Fatalf("expected ExtUIDialogTimeoutMsg{req-to}, got %#v", msgs[0])
+	}
+	res := h.ext.HandleTimeout(tm)
+	runTeaCmd(res.Cmd)
+	if h.ext.Active() {
+		t.Fatal("timeout must close the dialog")
+	}
+	if !res.Restore || res.RestoreText != "kept" {
+		t.Fatalf("timeout close must restore the saved editor text, got %+v", res)
+	}
+	if len(h.responder.sent) != 1 || !h.responder.sent[0].Cancelled || h.responder.sent[0].ID != "req-to" {
+		t.Fatalf("timeout must send the default cancel response, got %+v", h.responder.sent)
+	}
+}
+
+// TestExtUIDialogTimeoutAfterAnswerIsNoop proves a stale timeout for an
+// already-answered dialog sends nothing (no duplicate response).
+func TestExtUIDialogTimeoutAfterAnswerIsNoop(t *testing.T) {
+	h := newExtUIHarness(t)
+	cmd := h.ext.HandleRequest(extReq("req-late", "confirm", map[string]any{"title": "Sure?", "message": "m", "timeout": float64(5)}), "")
+	h.press("\r") // answer before the timer fires
+	msgs := runTeaCmd(cmd)
+	res := h.ext.HandleTimeout(msgs[0].(app.ExtUIDialogTimeoutMsg))
+	runTeaCmd(res.Cmd)
+	if len(h.responder.sent) != 1 {
+		t.Fatalf("stale timeout must not send a second response, got %+v", h.responder.sent)
+	}
+}
+
+// --- login / logout flows -------------------------------------------------------
+
+func stubProvidersResponse() bridge.Response {
+	return bridge.Response{
+		Type:    "response",
+		Command: "get_auth_providers",
+		Success: true,
+		Data: json.RawMessage(`{"providers":[` +
+			`{"id":"stub","name":"Stub Provider","authType":"oauth","status":{"configured":false}},` +
+			`{"id":"keyprov","name":"Key Provider","authType":"api_key","status":{"configured":false}}]}`),
+	}
+}
+
+// openLogin drives the provider fetch → dialog push for the given mode.
+func openLogin(t *testing.T, h *extUIHarness, mode string) {
+	t.Helper()
+	h.client.responses["get_auth_providers"] = stubProvidersResponse()
+	var cmd tea.Cmd
+	if mode == "logout" {
+		cmd = h.ext.OpenLogout("login draft")
+	} else {
+		cmd = h.ext.OpenLogin("login draft")
+	}
+	msgs := runTeaCmd(cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("provider fetch must emit one message, got %+v", msgs)
+	}
+	pm, ok := msgs[0].(app.LoginProvidersMsg)
+	if !ok {
+		t.Fatalf("expected LoginProvidersMsg, got %#v", msgs[0])
+	}
+	if pm.Err != nil {
+		t.Fatalf("provider fetch failed: %v", pm.Err)
+	}
+	runTeaCmd(h.ext.HandleLoginProviders(pm))
+	if !h.ext.Active() {
+		t.Fatal("the login dialog must be open after the provider fetch resolves")
+	}
+}
+
+// TestExtUILoginFlowURLPanelAndSuccessClose is the full happy path: /login →
+// get_auth_providers → provider select fires login_start with NO timeout (the
+// event-completed exemption) → auth_login_url renders the URL panel →
+// a successful auth_login_end closes the dialog with a status notice.
+func TestExtUILoginFlowURLPanelAndSuccessClose(t *testing.T) {
+	h := newExtUIHarness(t)
+	openLogin(t, h, "login")
+
+	if frame := plainFrame(h.ext.Render(90, 30)); !strings.Contains(frame, "Stub Provider") {
+		t.Fatalf("login dialog must list the fetched providers, got:\n%s", frame)
+	}
+
+	h.press("\r") // select the oauth provider
+	call, ok := h.client.call("login_start")
+	if !ok {
+		t.Fatalf("selecting an oauth provider must fire login_start, calls=%+v", h.client.calls)
+	}
+	if call.timeout != 0 {
+		t.Fatalf("login_start must be issued with NO timeout (event-completed exemption), got %s", call.timeout)
+	}
+	if call.cmd.Fields["provider"] != "stub" {
+		t.Fatalf("login_start must target the selected provider, got %+v", call.cmd.Fields)
+	}
+	if !h.ext.Active() {
+		t.Fatal("the flow view must stay open awaiting auth events")
+	}
+
+	res := h.ext.HandleEvent(authEvent(t, "auth_login_url", map[string]any{"provider": "stub", "url": "https://stub.example/oauth?code=FAKE"}))
+	if !res.Handled {
+		t.Fatal("auth_login_url must be consumed by the live login dialog")
+	}
+	if frame := plainFrame(h.ext.Render(90, 30)); !strings.Contains(frame, "stub.example/oauth") {
+		t.Fatalf("the flow view must render the auth URL, got:\n%s", frame)
+	}
+
+	res = h.ext.HandleEvent(authEvent(t, "auth_login_end", map[string]any{"provider": "stub", "success": true}))
+	if !res.Handled {
+		t.Fatal("auth_login_end must be consumed by the live login dialog")
+	}
+	msgs := runTeaCmd(res.Cmd)
+	if h.ext.Active() {
+		t.Fatal("a successful auth_login_end must close the login dialog")
+	}
+	if !res.Restore || res.RestoreText != "login draft" {
+		t.Fatalf("closing the login dialog must restore the saved editor text, got %+v", res)
+	}
+	statusSeen := false
+	for _, m := range msgs {
+		if n, ok := m.(app.NoticeMsg); ok && strings.Contains(n.Text, "stub") {
+			statusSeen = true
+		}
+	}
+	if !statusSeen {
+		t.Fatalf("login completion must surface a status notice, got %+v", msgs)
+	}
+}
+
+// TestExtUILoginEndFailureKeepsDialogWithError proves a failed auth_login_end
+// keeps the flow view open and renders the error.
+func TestExtUILoginEndFailureKeepsDialogWithError(t *testing.T) {
+	h := newExtUIHarness(t)
+	openLogin(t, h, "login")
+	h.press("\r")
+	h.ext.HandleEvent(authEvent(t, "auth_login_url", map[string]any{"provider": "stub", "url": "https://stub.example/oauth"}))
+	res := h.ext.HandleEvent(authEvent(t, "auth_login_end", map[string]any{"provider": "stub", "success": false, "error": "oauth port busy"}))
+	if !res.Handled {
+		t.Fatal("the failed auth_login_end must still be consumed")
+	}
+	if !h.ext.Active() {
+		t.Fatal("a failed login must keep the dialog open to show the error")
+	}
+	if frame := plainFrame(h.ext.Render(90, 30)); !strings.Contains(frame, "oauth port busy") {
+		t.Fatalf("the flow view must render the login error, got:\n%s", frame)
+	}
+}
+
+// TestExtUILoginEscMidFlowEmitsLoginCancel proves esc during the URL wait fires
+// login_cancel for the in-flight provider and closes the dialog.
+func TestExtUILoginEscMidFlowEmitsLoginCancel(t *testing.T) {
+	h := newExtUIHarness(t)
+	openLogin(t, h, "login")
+	h.press("\r")
+	h.ext.HandleEvent(authEvent(t, "auth_login_url", map[string]any{"provider": "stub", "url": "https://stub.example/oauth"}))
+
+	res := h.press("\x1b")
+	call, ok := h.client.call("login_cancel")
+	if !ok || call.cmd.Fields["provider"] != "stub" {
+		t.Fatalf("esc mid-flow must fire login_cancel for the provider, calls=%+v", h.client.calls)
+	}
+	if h.ext.Active() {
+		t.Fatal("esc mid-flow must close the login dialog")
+	}
+	if !res.Restore || res.RestoreText != "login draft" {
+		t.Fatalf("cancelling the login must restore the saved editor text, got %+v", res)
+	}
+}
+
+// TestExtUILogoutEmitsLogout proves the logout mode fires the logout command for
+// the selected provider and closes.
+func TestExtUILogoutEmitsLogout(t *testing.T) {
+	h := newExtUIHarness(t)
+	openLogin(t, h, "logout")
+	h.press("\r")
+	call, ok := h.client.call("logout")
+	if !ok || call.cmd.Fields["provider"] != "stub" {
+		t.Fatalf("logout selection must fire logout for the provider, calls=%+v", h.client.calls)
+	}
+	if h.ext.Active() {
+		t.Fatal("logout must close the dialog")
+	}
+}
+
+// TestExtUILoginAPIKeyPromptEmitsLoginAPIKey proves selecting an api_key
+// provider opens the key input and submit fires login_api_key (never an
+// extension_ui_response — it is a login step, not an extension request).
+func TestExtUILoginAPIKeyPromptEmitsLoginAPIKey(t *testing.T) {
+	h := newExtUIHarness(t)
+	openLogin(t, h, "login")
+	h.press("\x1b[B") // move to the api_key provider
+	h.press("\r")     // open the key prompt
+	if !h.ext.Active() {
+		t.Fatal("selecting an api_key provider must open the key input")
+	}
+	h.press("k", "1", "\r")
+	call, ok := h.client.call("login_api_key")
+	if !ok {
+		t.Fatalf("submitting the key must fire login_api_key, calls=%+v", h.client.calls)
+	}
+	if call.cmd.Fields["provider"] != "keyprov" || call.cmd.Fields["key"] != "k1" {
+		t.Fatalf("login_api_key must carry provider+key, got %+v", call.cmd.Fields)
+	}
+	if len(h.responder.sent) != 0 {
+		t.Fatalf("the login key prompt must not send an extension_ui_response, got %+v", h.responder.sent)
+	}
+}
+
+// TestExtUILoginProviderFetchErrorSurfacesNotice proves a failed
+// get_auth_providers surfaces a one-line notice instead of opening a dialog.
+func TestExtUILoginProviderFetchErrorSurfacesNotice(t *testing.T) {
+	h := newExtUIHarness(t)
+	h.client.err = errors.New("bridge unavailable")
+	msgs := runTeaCmd(h.ext.OpenLogin(""))
+	pm, ok := msgs[0].(app.LoginProvidersMsg)
+	if !ok || pm.Err == nil {
+		t.Fatalf("expected an errored LoginProvidersMsg, got %#v", msgs[0])
+	}
+	noticeMsgs := runTeaCmd(h.ext.HandleLoginProviders(pm))
+	if h.ext.Active() {
+		t.Fatal("a failed provider fetch must not open a dialog")
+	}
+	found := false
+	for _, m := range noticeMsgs {
+		if n, ok := m.(app.NoticeMsg); ok && strings.Contains(n.Text, "bridge unavailable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the fetch error must surface as a notice, got %+v", noticeMsgs)
+	}
+}

--- a/packages/neo/internal/app/input.go
+++ b/packages/neo/internal/app/input.go
@@ -1,0 +1,465 @@
+package app
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/editor"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/slash"
+)
+
+// input.go is the todo-4 editor + queue wiring: the Router classifies every
+// editor submission through the slash Dispatcher and routes it to the right
+// surface — builtin slash actions (overlay intents / direct RPC / native ops),
+// `!` bash mode with a streaming BashBlock + abort_bash on interrupt, and plain
+// prompts that queue as steering / follow-up while a turn is streaming. The
+// queue holder is the shared shell.Queue (the pending-messages display renders
+// it), and classic parity is preserved: NOTHING flushes before agent_end —
+// steering is delivered to the running turn immediately (steer RPC, the local
+// entry mirrors it for the pending display), follow-ups stay local until
+// AgentEnd fires them into the next turn.
+//
+// Key-triggered behavior (follow-up queueing, dequeue, bash interrupt) resolves
+// through keybinding Manager ACTION names: the Model matches raw keys via the
+// Manager and hands the resolved registry id to HandleAction — no key string is
+// ever compared here. Todo 9 wires the Router into the Model: editor.OnSubmit →
+// Submit, EventMsg(agent_start/agent_end) → SetStreaming/AgentEnd,
+// EventMsg(queue_update) → SyncSteering, CommandResultMsg → HandleBashResult.
+
+// actionFollowUp is the registry id for the queue-follow-up chord (alt+enter by
+// default). actionDequeue and actionInterrupt live in model.go.
+const actionFollowUp = "app.message.followUp"
+
+// bashBusyNotice mirrors interactive-mode.ts:3058 verbatim (the warning shown
+// when a second `!` command is submitted while one is still running).
+const bashBusyNotice = "A bash command is already running. Press Esc to cancel it first."
+
+// noQueuedNotice / restore notices mirror interactive-mode.ts handleDequeue.
+const noQueuedNotice = "No queued messages to restore"
+
+// Commander is the narrow command seam the Router issues RPC through, matching
+// the todo-2 Session helpers so tests inject fakes. Every method returns a
+// tea.Cmd — the blocking bridge Request runs on the runtime's goroutine, never
+// on the Update goroutine.
+type Commander interface {
+	// Prompt sends a fresh user turn (rpc-types.ts prompt).
+	Prompt(message string) tea.Cmd
+	// Steer injects a mid-turn steer message into the running turn.
+	Steer(message string) tea.Cmd
+	// FollowUp queues a follow-up daemon-side behind a just-started turn (used
+	// by the agent_end flush for everything after the first fired message).
+	FollowUp(message string) tea.Cmd
+	// Bash runs a `!` shell command through the daemon executor (rpc-types.ts:53).
+	Bash(command string, excludeFromContext bool) tea.Cmd
+	// AbortBash cancels the in-flight bash command (rpc-types.ts:54).
+	AbortBash() tea.Cmd
+	// Request issues an arbitrary RPC command — the generic seam builtin slash
+	// actions (/compact, /name, /copy, ...) resolve through.
+	Request(cmd bridge.Command) tea.Cmd
+}
+
+// Session satisfies Commander; Bash and Request are the todo-4 additions below.
+var _ Commander = (*Session)(nil)
+
+// Bash builds the RPC `bash` command for a `!`/`!!` submission. The response
+// carries the full BashResult; there is no chunk streaming over the wire, so
+// the BashBlock renders `$ cmd` immediately and fills on completion.
+func (s *Session) Bash(command string, excludeFromContext bool) tea.Cmd {
+	return s.request(slash.BashCommand(command, excludeFromContext))
+}
+
+// Request exposes the generic command seam over the adapter's default-timeout
+// request path — the Router's builtin RPC actions and the overlay Requester
+// (todo 5) both issue through it.
+func (s *Session) Request(cmd bridge.Command) tea.Cmd {
+	return s.request(cmd)
+}
+
+// EditorBuffer is the narrow editor seam the Router mutates: draft text
+// save/restore (bash-busy, dequeue), in-editor prompt history, and the
+// autocomplete provider hook. *editor.Editor satisfies it.
+type EditorBuffer interface {
+	GetText() string
+	SetText(text string)
+	AddToHistory(text string)
+	SetAutocompleteProvider(p editor.AutocompleteProvider)
+}
+
+var _ EditorBuffer = (*editor.Editor)(nil)
+
+// PromptHistory is the prompt-history PERSISTENCE seam. internal/store exposes
+// no prompt-history API today, so this stays a narrow interface rather than an
+// invented store schema: todo 9 wires the store-backed implementation (and the
+// startup preload into editor.AddToHistory) once the daemon-side history file
+// contract is settled. A nil history keeps the in-editor (session-local)
+// history only.
+type PromptHistory interface {
+	// Append records one submitted line (prompt, steer, follow-up, bash, or
+	// slash command), newest last.
+	Append(text string)
+}
+
+// RouteKind classifies what the Router did with a submission or action.
+type RouteKind int
+
+const (
+	// RouteNone: empty input (or an empty follow-up chord) — nothing happened.
+	RouteNone RouteKind = iota
+	// RoutePrompt: sent to the agent as a fresh turn (plain text while idle,
+	// extension/prompt commands, unknown `/name` fallthrough pre-bootstrap).
+	RoutePrompt
+	// RouteSteerQueued: streaming plain enter — queued as steering AND delivered
+	// to the running turn via the steer RPC.
+	RouteSteerQueued
+	// RouteFollowUpQueued: streaming follow-up chord — queued locally; fires on
+	// agent_end (never earlier).
+	RouteFollowUpQueued
+	// RouteBash: a `!`/`!!` command started with a live BashBlock.
+	RouteBash
+	// RouteBashBusy: `!` rejected because one is already running; the submitted
+	// text was restored to the editor and Notice carries the classic warning.
+	RouteBashBusy
+	// RouteOverlay: a builtin resolved to an overlay intent (todo-5 stack opens
+	// Overlay, e.g. /model → model selector). Arg carries the command tail.
+	RouteOverlay
+	// RouteRPC: a builtin resolved to a direct RPC (Cmd is live). Follow/Arg
+	// carry the composite post-step (/copy → clipboard, /share → gist, /import
+	// → confirm) for todo 9 to run on the CommandResultMsg.
+	RouteRPC
+	// RouteNative: a builtin resolved to a neo-local action (quit/reload/
+	// changelog/jsonl export) that todo 9 executes.
+	RouteNative
+	// RouteUnknown: `/name` matching nothing — Notice carries the grok-style
+	// inline error.
+	RouteUnknown
+	// RouteDequeued: the dequeue action ran; queued messages (if any) were
+	// restored into the editor and Notice carries the status line.
+	RouteDequeued
+	// RouteAbortBash: the interrupt action was claimed by a running bash
+	// command and abort_bash was issued.
+	RouteAbortBash
+)
+
+// RouteResult is the typed outcome of Submit / HandleAction. Cmd is the RPC
+// leaving as a tea.Cmd (nil when the route is purely local); the remaining
+// fields carry the intent payload for the routes todo 9 interprets.
+type RouteResult struct {
+	Kind    RouteKind
+	Cmd     tea.Cmd
+	Overlay slash.OverlayKind // RouteOverlay target
+	Native  slash.NativeKind  // RouteNative target
+	Follow  slash.NativeKind  // RouteRPC composite post-step
+	Arg     string            // parsed command argument (overlay search, paths)
+	Notice  string            // one-line status/warning/inline-error text
+}
+
+// Router owns editor-submission routing and the message queue lifecycle.
+type Router struct {
+	dispatcher *slash.Dispatcher
+	queue      *shell.Queue
+	commander  Commander
+	th         *theme.Theme
+
+	editor  EditorBuffer
+	history PromptHistory
+
+	// known is the dynamic command set from get_commands (nil until
+	// WireAutocomplete): with it, unknown `/name` surfaces an inline error;
+	// without it, classic forwards the line to prompt.
+	known map[string]bool
+
+	streaming   bool
+	bash        *slash.BashBlock
+	bashRunning bool
+}
+
+// NewRouter builds the input router over the slash Dispatcher, the shared
+// shell queue (the same instance the pending-messages display renders), the
+// command seam, and the theme (for BashBlock styling).
+func NewRouter(d *slash.Dispatcher, q *shell.Queue, c Commander, th *theme.Theme) *Router {
+	return &Router{dispatcher: d, queue: q, commander: c, th: th}
+}
+
+// AttachEditor installs the editor seam (draft restore, history, autocomplete).
+func (r *Router) AttachEditor(ed EditorBuffer) { r.editor = ed }
+
+// SetHistory installs the prompt-history persistence sink (todo 9 wiring).
+func (r *Router) SetHistory(h PromptHistory) { r.history = h }
+
+// SetStreaming records whether a turn is in flight (agent_start / bootstrap
+// isStreaming). It selects the prompt-vs-queue path for plain submissions.
+func (r *Router) SetStreaming(v bool) { r.streaming = v }
+
+// Streaming reports the recorded streaming state.
+func (r *Router) Streaming() bool { return r.streaming }
+
+// IsBashRunning reports whether a `!` command is awaiting its response.
+func (r *Router) IsBashRunning() bool { return r.bashRunning }
+
+// BashBlock returns the most recent bash render block (nil before the first
+// `!` command). Todo 9 places it: pending area while streaming, chat when idle.
+func (r *Router) BashBlock() *slash.BashBlock { return r.bash }
+
+// WireAutocomplete builds the CombinedProvider over the merged command list
+// (builtins → prompts → extensions → skills), installs it on the attached
+// editor, and records the dynamic names as dispatch knowledge. Call it with
+// the get_commands response at bootstrap (and again on reload). fdPath ""
+// disables fuzzy @file search, matching the classic fdPath:null handling.
+func (r *Router) WireAutocomplete(dynamic []bridge.RPCSlashCommand, basePath, fdPath string) *slash.CombinedProvider {
+	merged := slash.MergeCommands(dynamic)
+	provider := slash.NewCombinedProvider(slash.AsCommands(merged), basePath, fdPath)
+	if r.editor != nil {
+		r.editor.SetAutocompleteProvider(provider)
+	}
+	known := make(map[string]bool, len(dynamic))
+	for _, c := range dynamic {
+		known[c.Name] = true
+	}
+	r.known = known
+	return provider
+}
+
+// Submit routes one submitted editor line, mirroring the classic onSubmit
+// ordering: builtins → bash mode → dynamic commands / prompt, with the
+// streaming state selecting prompt vs steer-queue for plain text.
+func (r *Router) Submit(text string) RouteResult {
+	res := r.dispatcher.ClassifyWithKnown(text, r.known)
+
+	switch res.Kind {
+	case slash.DispatchIgnore:
+		return RouteResult{Kind: RouteNone}
+
+	case slash.DispatchBuiltin:
+		r.recordHistory(res.Text)
+		return r.routeBuiltin(res.Action)
+
+	case slash.DispatchBash:
+		return r.startBash(res)
+
+	case slash.DispatchExtensionCommand:
+		// Extension/prompt/skill commands execute immediately via prompt, even
+		// while streaming (interactive-mode.ts:3045-3049).
+		r.recordHistory(res.Text)
+		return RouteResult{Kind: RoutePrompt, Cmd: r.commander.Prompt(res.Text)}
+
+	case slash.DispatchUnknownCommand:
+		return RouteResult{Kind: RouteUnknown, Arg: res.UnknownName, Notice: slash.UnknownCommandError(res.UnknownName)}
+
+	default: // slash.DispatchPrompt
+		r.recordHistory(res.Text)
+		if r.streaming {
+			// Plain enter during streaming steers: the local queue entry feeds
+			// the pending display; the steer RPC delivers it to the running turn
+			// (classic session.prompt(text, {streamingBehavior:"steer"})).
+			r.queue.Enqueue(res.Text, shell.QueueSteering)
+			return RouteResult{Kind: RouteSteerQueued, Cmd: r.commander.Steer(res.Text)}
+		}
+		return RouteResult{Kind: RoutePrompt, Cmd: r.commander.Prompt(res.Text)}
+	}
+}
+
+// routeBuiltin translates a resolved builtin Action into its route. Every
+// builtin lands on exactly one of overlay/RPC/native (the acceptance test
+// rejects ActionNone stubs).
+func (r *Router) routeBuiltin(a slash.Action) RouteResult {
+	switch a.Kind {
+	case slash.ActionOpenOverlay:
+		return RouteResult{Kind: RouteOverlay, Overlay: a.Overlay, Arg: a.Arg}
+	case slash.ActionRPC:
+		return RouteResult{Kind: RouteRPC, Cmd: r.commander.Request(a.Command), Follow: a.Follow, Arg: a.Arg}
+	case slash.ActionNative:
+		return RouteResult{Kind: RouteNative, Native: a.Native, Arg: a.Arg}
+	default:
+		// Unreachable while NewBuiltins keeps every handler concrete; surface it
+		// as an inline error rather than dropping the line silently.
+		return RouteResult{Kind: RouteUnknown, Notice: slash.UnknownCommandError(strings.TrimPrefix(a.Arg, "/"))}
+	}
+}
+
+// startBash begins a `!`/`!!` execution: one command at a time (classic
+// warning + draft restore otherwise), a live BashBlock, and the bash RPC.
+func (r *Router) startBash(res slash.Result) RouteResult {
+	if r.bashRunning {
+		if r.editor != nil {
+			r.editor.SetText(res.Text)
+		}
+		return RouteResult{Kind: RouteBashBusy, Notice: bashBusyNotice}
+	}
+	r.recordHistory(res.Text)
+	r.bash = slash.NewBashBlock(res.BashCommand, res.BashExcluded, r.th)
+	r.bashRunning = true
+	return RouteResult{Kind: RouteBash, Cmd: r.commander.Bash(res.BashCommand, res.BashExcluded)}
+}
+
+// HandleAction routes a RESOLVED keybinding action name (the Model matches raw
+// keys through the Manager first — no key strings here). It reports false for
+// actions the Router does not claim, letting the Model's own handlers run.
+func (r *Router) HandleAction(action string) (RouteResult, bool) {
+	switch action {
+	case actionFollowUp:
+		return r.followUpAction(), true
+	case actionDequeue:
+		return r.dequeueAction(), true
+	case actionInterrupt:
+		// The interrupt chord is claimed only while a bash command runs; the
+		// Model's abort path (AbortRequested → session.Abort) owns it otherwise.
+		if r.bashRunning {
+			return RouteResult{Kind: RouteAbortBash, Cmd: r.commander.AbortBash()}, true
+		}
+		return RouteResult{}, false
+	}
+	return RouteResult{}, false
+}
+
+// followUpAction queues the current editor draft as a follow-up while
+// streaming (local until agent_end); when idle it acts like plain enter
+// (interactive-mode.ts:3975-3978).
+func (r *Router) followUpAction() RouteResult {
+	text := strings.TrimSpace(r.editorText())
+	if text == "" {
+		return RouteResult{Kind: RouteNone}
+	}
+	if r.editor != nil {
+		r.editor.SetText("")
+	}
+	if !r.streaming {
+		return r.Submit(text)
+	}
+	r.recordHistory(text)
+	r.queue.Enqueue(text, shell.QueueFollowUp)
+	return RouteResult{Kind: RouteFollowUpQueued}
+}
+
+// dequeueAction drains ALL queued messages back into the editor —
+// [...steering, ...followUp] ahead of the current draft, joined with blank
+// lines (restoreQueuedMessagesToEditor). Steering already consumed by the
+// running turn is daemon-side history and cannot be recalled over RPC; only
+// what the queue still holds is restored.
+func (r *Router) dequeueAction() RouteResult {
+	restored := r.queue.Dequeue()
+	if len(restored) == 0 {
+		return RouteResult{Kind: RouteDequeued, Notice: noQueuedNotice}
+	}
+	parts := []string{strings.Join(restored, "\n\n")}
+	if current := strings.TrimSpace(r.editorText()); current != "" {
+		parts = append(parts, current)
+	}
+	if r.editor != nil {
+		r.editor.SetText(strings.Join(parts, "\n\n"))
+	}
+	notice := "Restored " + strconv.Itoa(len(restored)) + " queued message"
+	if len(restored) > 1 {
+		notice += "s"
+	}
+	notice += " to editor"
+	return RouteResult{Kind: RouteDequeued, Notice: notice}
+}
+
+// AgentEnd flushes the queue — the ONLY flush point (classic parity). Steering
+// consumed during the turn is dropped; the remaining follow-ups fire in FIFO
+// order: the first as a prompt starting the next turn, the rest queued behind
+// it via follow_up (the flushCompactionQueue delivery pattern). Returns nil
+// when nothing was queued.
+func (r *Router) AgentEnd() tea.Cmd {
+	r.streaming = false
+	fired := r.queue.FlushOnAgentEnd()
+	if len(fired) == 0 {
+		return nil
+	}
+	cmds := make([]tea.Cmd, 0, len(fired))
+	cmds = append(cmds, r.commander.Prompt(fired[0]))
+	for _, m := range fired[1:] {
+		cmds = append(cmds, r.commander.FollowUp(m))
+	}
+	return tea.Batch(cmds...)
+}
+
+// SyncSteering reconciles the local steering mirror with a queue_update
+// event's steering list (the daemon consumes steering mid-turn). Local
+// follow-ups are preserved untouched: they exist only here until AgentEnd
+// fires them, so the daemon's view never overwrites them.
+func (r *Router) SyncSteering(steering []string) {
+	_, followUp := r.queue.Messages()
+	r.queue.Dequeue() // drain + clear; contents already captured
+	for _, m := range steering {
+		r.queue.Enqueue(m, shell.QueueSteering)
+	}
+	for _, m := range followUp {
+		r.queue.Enqueue(m, shell.QueueFollowUp)
+	}
+}
+
+// bashResultData is the BashResult subset the block needs (bash-executor.ts:29
+// — output, exitCode undefined when killed, cancelled).
+type bashResultData struct {
+	Output    string `json:"output"`
+	ExitCode  *int   `json:"exitCode"`
+	Cancelled bool   `json:"cancelled"`
+}
+
+// HandleBashResult consumes the bash command's CommandResultMsg: it appends
+// the (single, non-chunked) output to the live block and records the terminal
+// status. Returns false for anything that is not the awaited bash response.
+func (r *Router) HandleBashResult(msg CommandResultMsg) bool {
+	if msg.Command != "bash" || r.bash == nil || !r.bashRunning {
+		return false
+	}
+	r.bashRunning = false
+
+	if msg.Err != nil {
+		r.bash.AppendOutput(msg.Err.Error() + "\n")
+		r.bash.SetComplete(1, false)
+		return true
+	}
+	if !msg.Response.Success {
+		if msg.Response.Error != "" {
+			r.bash.AppendOutput(msg.Response.Error + "\n")
+		}
+		r.bash.SetComplete(1, false)
+		return true
+	}
+
+	var data bashResultData
+	if err := json.Unmarshal(msg.Response.Data, &data); err != nil {
+		r.bash.AppendOutput(err.Error() + "\n")
+		r.bash.SetComplete(1, false)
+		return true
+	}
+	if data.Output != "" {
+		r.bash.AppendOutput(data.Output)
+	}
+	// exitCode is undefined when the process was killed/cancelled; cancelled
+	// wins inside SetComplete, and a missing code on a non-cancelled result is
+	// reported as a failure.
+	exit := 1
+	if data.ExitCode != nil {
+		exit = *data.ExitCode
+	}
+	r.bash.SetComplete(exit, data.Cancelled)
+	return true
+}
+
+// recordHistory adds one submitted line to the in-editor history and the
+// persistence sink (both nil-safe).
+func (r *Router) recordHistory(text string) {
+	if r.editor != nil {
+		r.editor.AddToHistory(text)
+	}
+	if r.history != nil {
+		r.history.Append(text)
+	}
+}
+
+// editorText reads the current draft (empty without an attached editor).
+func (r *Router) editorText() string {
+	if r.editor == nil {
+		return ""
+	}
+	return r.editor.GetText()
+}

--- a/packages/neo/internal/app/input_test.go
+++ b/packages/neo/internal/app/input_test.go
@@ -1,0 +1,682 @@
+package app_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/editor"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/slash"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+// nopMsg is what fake commander tea.Cmds yield when run.
+type nopMsg struct{}
+
+// fakeCommander implements app.Commander, recording each call at tea.Cmd BUILD
+// time as "kind:payload". Build-time recording is what the no-flush-before-
+// agent_end assertions key on: the Router must not even construct a delivery
+// command for a queued follow-up until AgentEnd.
+type fakeCommander struct {
+	calls []string
+}
+
+func (f *fakeCommander) record(entry string) tea.Cmd {
+	f.calls = append(f.calls, entry)
+	return func() tea.Msg { return nopMsg{} }
+}
+
+func (f *fakeCommander) Prompt(message string) tea.Cmd   { return f.record("prompt:" + message) }
+func (f *fakeCommander) Steer(message string) tea.Cmd    { return f.record("steer:" + message) }
+func (f *fakeCommander) FollowUp(message string) tea.Cmd { return f.record("follow_up:" + message) }
+func (f *fakeCommander) AbortBash() tea.Cmd              { return f.record("abort_bash") }
+
+func (f *fakeCommander) Bash(command string, excludeFromContext bool) tea.Cmd {
+	entry := "bash:" + command
+	if excludeFromContext {
+		entry = "bash!!:" + command
+	}
+	return f.record(entry)
+}
+
+func (f *fakeCommander) Request(cmd bridge.Command) tea.Cmd {
+	return f.record("request:" + cmd.Type)
+}
+
+// callsOfKind returns the recorded calls whose kind prefix matches.
+func (f *fakeCommander) callsOfKind(kinds ...string) []string {
+	var out []string
+	for _, c := range f.calls {
+		for _, k := range kinds {
+			if strings.HasPrefix(c, k+":") || c == k {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+// fakeEditor implements app.EditorBuffer.
+type fakeEditor struct {
+	text     string
+	history  []string
+	provider editor.AutocompleteProvider
+}
+
+func (f *fakeEditor) GetText() string          { return f.text }
+func (f *fakeEditor) SetText(text string)      { f.text = text }
+func (f *fakeEditor) AddToHistory(text string) { f.history = append(f.history, text) }
+func (f *fakeEditor) SetAutocompleteProvider(p editor.AutocompleteProvider) {
+	f.provider = p
+}
+
+// fakeHistory implements app.PromptHistory (the persistence seam).
+type fakeHistory struct {
+	entries []string
+}
+
+func (f *fakeHistory) Append(text string) { f.entries = append(f.entries, text) }
+
+// routerFixture bundles a Router with its injected fakes.
+type routerFixture struct {
+	router    *app.Router
+	queue     *shell.Queue
+	commander *fakeCommander
+	editor    *fakeEditor
+	history   *fakeHistory
+}
+
+func newRouterFixture(t *testing.T) *routerFixture {
+	t.Helper()
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName, AgentDir: "\x00nonexistent"})
+	if err != nil {
+		t.Fatalf("theme.Load: %v", err)
+	}
+	q := shell.NewQueue()
+	c := &fakeCommander{}
+	r := app.NewRouter(slash.NewDispatcher(slash.NewBuiltins()), q, c, th)
+	fx := &routerFixture{router: r, queue: q, commander: c, editor: &fakeEditor{}, history: &fakeHistory{}}
+	r.AttachEditor(fx.editor)
+	r.SetHistory(fx.history)
+	return fx
+}
+
+// queueContents flattens the queue as ["S:<msg>"... , "F:<msg>"...].
+func queueContents(q *shell.Queue) []string {
+	steering, followUp := q.Messages()
+	var out []string
+	for _, m := range steering {
+		out = append(out, "S:"+m)
+	}
+	for _, m := range followUp {
+		out = append(out, "F:"+m)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Submit routing table (slash / bang / plain × idle / streaming)
+// ---------------------------------------------------------------------------
+
+func TestInputSubmitRoutingTable(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		streaming bool
+		known     []bridge.RPCSlashCommand
+		wantKind  app.RouteKind
+		wantCalls []string // exact expected commander calls
+		wantQueue []string // queueContents after submit
+	}{
+		{
+			name:     "empty input is ignored",
+			input:    "   ",
+			wantKind: app.RouteNone,
+		},
+		{
+			name:     "builtin overlay slash command idle",
+			input:    "/hotkeys",
+			wantKind: app.RouteOverlay,
+		},
+		{
+			name:      "builtin overlay slash command during streaming",
+			input:     "/hotkeys",
+			streaming: true,
+			wantKind:  app.RouteOverlay,
+		},
+		{
+			name:      "builtin rpc slash command",
+			input:     "/compact",
+			wantKind:  app.RouteRPC,
+			wantCalls: []string{"request:compact"},
+		},
+		{
+			name:     "builtin native slash command",
+			input:    "/quit",
+			wantKind: app.RouteNative,
+		},
+		{
+			name:      "known dynamic command routes to prompt even while streaming",
+			input:     "/mycmd run it",
+			streaming: true,
+			known:     []bridge.RPCSlashCommand{{Name: "mycmd", Source: "extension"}},
+			wantKind:  app.RoutePrompt,
+			wantCalls: []string{"prompt:/mycmd run it"},
+		},
+		{
+			name:     "unknown slash command with known set surfaces inline error",
+			input:    "/definitely-not-a-command",
+			known:    []bridge.RPCSlashCommand{{Name: "mycmd", Source: "extension"}},
+			wantKind: app.RouteUnknown,
+		},
+		{
+			name:     "unknown slash command without dynamic knowledge falls through to prompt",
+			input:    "/maybe-extension",
+			wantKind: app.RoutePrompt,
+			wantCalls: []string{
+				"prompt:/maybe-extension",
+			},
+		},
+		{
+			name:      "bang runs bash",
+			input:     "!ls -la",
+			wantKind:  app.RouteBash,
+			wantCalls: []string{"bash:ls -la"},
+		},
+		{
+			name:      "double bang runs bash excluded from context",
+			input:     "!!ls",
+			wantKind:  app.RouteBash,
+			wantCalls: []string{"bash!!:ls"},
+		},
+		{
+			name:      "bare bang is a prompt",
+			input:     "!",
+			wantKind:  app.RoutePrompt,
+			wantCalls: []string{"prompt:!"},
+		},
+		{
+			name:      "plain text idle prompts",
+			input:     "hello there",
+			wantKind:  app.RoutePrompt,
+			wantCalls: []string{"prompt:hello there"},
+		},
+		{
+			name:      "plain text during streaming enqueues steer",
+			input:     "second thought",
+			streaming: true,
+			wantKind:  app.RouteSteerQueued,
+			wantCalls: []string{"steer:second thought"},
+			wantQueue: []string{"S:second thought"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRouterFixture(t)
+			if tc.known != nil {
+				fx.router.WireAutocomplete(tc.known, t.TempDir(), "")
+			}
+			fx.router.SetStreaming(tc.streaming)
+
+			res := fx.router.Submit(tc.input)
+
+			if res.Kind != tc.wantKind {
+				t.Fatalf("Submit(%q) kind = %v, want %v", tc.input, res.Kind, tc.wantKind)
+			}
+			if !equalStrings(fx.commander.calls, tc.wantCalls) {
+				t.Fatalf("commander calls = %v, want %v", fx.commander.calls, tc.wantCalls)
+			}
+			if !equalStrings(queueContents(fx.queue), tc.wantQueue) {
+				t.Fatalf("queue = %v, want %v", queueContents(fx.queue), tc.wantQueue)
+			}
+			if len(tc.wantCalls) > 0 && res.Kind != app.RouteNative && res.Cmd == nil {
+				t.Fatal("expected a non-nil tea.Cmd carrying the RPC")
+			}
+		})
+	}
+}
+
+func TestInputUnknownCommandNotice(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.WireAutocomplete(nil, t.TempDir(), "")
+
+	res := fx.router.Submit("/nope")
+	if res.Kind != app.RouteUnknown {
+		t.Fatalf("kind = %v, want RouteUnknown", res.Kind)
+	}
+	if want := slash.UnknownCommandError("nope"); res.Notice != want {
+		t.Fatalf("notice = %q, want %q", res.Notice, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: every builtin resolves to a handler or documented overlay route
+// ---------------------------------------------------------------------------
+
+func TestInputBuiltinAcceptance(t *testing.T) {
+	names := slash.BuiltinNames()
+	if len(names) != 22 {
+		t.Fatalf("expected 22 builtin slash commands, got %d", len(names))
+	}
+
+	// The documented route per builtin: overlay | rpc | native. No stubs.
+	wantRoute := map[string]app.RouteKind{
+		"settings":        app.RouteOverlay,
+		"model":           app.RouteOverlay,
+		"favorite-models": app.RouteOverlay,
+		"export":          app.RouteRPC,
+		"import":          app.RouteRPC,
+		"share":           app.RouteRPC,
+		"copy":            app.RouteRPC,
+		"name":            app.RouteRPC,
+		"session":         app.RouteRPC,
+		"changelog":       app.RouteNative,
+		"hotkeys":         app.RouteOverlay,
+		"fork":            app.RouteOverlay,
+		"clone":           app.RouteRPC,
+		"tree":            app.RouteOverlay,
+		"trust":           app.RouteOverlay,
+		"login":           app.RouteOverlay,
+		"logout":          app.RouteOverlay,
+		"new":             app.RouteRPC,
+		"compact":         app.RouteRPC,
+		"resume":          app.RouteOverlay,
+		"reload":          app.RouteNative,
+		"quit":            app.RouteNative,
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			want, ok := wantRoute[name]
+			if !ok {
+				t.Fatalf("builtin %q has no documented route in this acceptance table", name)
+			}
+			fx := newRouterFixture(t)
+			res := fx.router.Submit("/" + name)
+			if res.Kind != want {
+				t.Fatalf("Submit(/%s) kind = %v, want %v", name, res.Kind, want)
+			}
+			switch res.Kind {
+			case app.RouteOverlay:
+				if res.Overlay == slash.OverlayNone {
+					t.Fatalf("/%s resolved to RouteOverlay with OverlayNone (stub)", name)
+				}
+			case app.RouteRPC:
+				if res.Cmd == nil {
+					t.Fatalf("/%s resolved to RouteRPC with nil Cmd (stub)", name)
+				}
+			case app.RouteNative:
+				if res.Native == slash.NativeNone {
+					t.Fatalf("/%s resolved to RouteNative with NativeNone (stub)", name)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Follow-up + dequeue actions (resolved keybinding action names, never keys)
+// ---------------------------------------------------------------------------
+
+func TestInputFollowUpActionQueuesDuringStreaming(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.SetStreaming(true)
+	fx.editor.SetText("do this after")
+
+	res, handled := fx.router.HandleAction("app.message.followUp")
+	if !handled {
+		t.Fatal("app.message.followUp was not handled")
+	}
+	if res.Kind != app.RouteFollowUpQueued {
+		t.Fatalf("kind = %v, want RouteFollowUpQueued", res.Kind)
+	}
+	if got := queueContents(fx.queue); !equalStrings(got, []string{"F:do this after"}) {
+		t.Fatalf("queue = %v, want the queued follow-up", got)
+	}
+	if fx.editor.GetText() != "" {
+		t.Fatalf("editor not cleared after queueing, text = %q", fx.editor.GetText())
+	}
+	// Local until agent_end: no delivery command may have been built.
+	if calls := fx.commander.callsOfKind("prompt", "follow_up", "steer"); len(calls) != 0 {
+		t.Fatalf("follow-up must stay local until agent_end, commander saw %v", calls)
+	}
+}
+
+func TestInputFollowUpActionIdleActsAsSubmit(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.editor.SetText("just send it")
+
+	res, handled := fx.router.HandleAction("app.message.followUp")
+	if !handled {
+		t.Fatal("app.message.followUp was not handled")
+	}
+	if res.Kind != app.RoutePrompt {
+		t.Fatalf("kind = %v, want RoutePrompt (idle alt+enter acts as plain enter)", res.Kind)
+	}
+	if !equalStrings(fx.commander.calls, []string{"prompt:just send it"}) {
+		t.Fatalf("commander calls = %v", fx.commander.calls)
+	}
+	if fx.editor.GetText() != "" {
+		t.Fatalf("editor not cleared, text = %q", fx.editor.GetText())
+	}
+}
+
+func TestInputDequeueRestoresAllQueuedMessages(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.SetStreaming(true)
+
+	fx.router.Submit("steer one") // steering
+	fx.editor.SetText("follow one")
+	fx.router.HandleAction("app.message.followUp")
+	fx.editor.SetText("draft in progress")
+
+	res, handled := fx.router.HandleAction("app.message.dequeue")
+	if !handled {
+		t.Fatal("app.message.dequeue was not handled")
+	}
+	if res.Kind != app.RouteDequeued {
+		t.Fatalf("kind = %v, want RouteDequeued", res.Kind)
+	}
+	// restoreQueuedMessagesToEditor order: [...steering, ...followUp], then the
+	// current draft, joined with blank lines.
+	want := "steer one\n\nfollow one\n\ndraft in progress"
+	if fx.editor.GetText() != want {
+		t.Fatalf("editor text = %q, want %q", fx.editor.GetText(), want)
+	}
+	if !fx.queue.IsEmpty() {
+		t.Fatalf("queue not emptied by dequeue: %v", queueContents(fx.queue))
+	}
+}
+
+func TestInputDequeueEmptyQueueNotice(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	res, handled := fx.router.HandleAction("app.message.dequeue")
+	if !handled {
+		t.Fatal("app.message.dequeue was not handled")
+	}
+	if res.Kind != app.RouteDequeued {
+		t.Fatalf("kind = %v, want RouteDequeued", res.Kind)
+	}
+	if res.Notice != "No queued messages to restore" {
+		t.Fatalf("notice = %q", res.Notice)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Queue flush: agent_end only (classic parity)
+// ---------------------------------------------------------------------------
+
+func TestInputQueueFlushOnAgentEndOnly(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.SetStreaming(true)
+
+	fx.editor.SetText("first follow-up")
+	fx.router.HandleAction("app.message.followUp")
+	fx.editor.SetText("second follow-up")
+	fx.router.HandleAction("app.message.followUp")
+
+	// NO flush before agent_end: nothing delivered yet.
+	if calls := fx.commander.callsOfKind("prompt", "follow_up"); len(calls) != 0 {
+		t.Fatalf("queue flushed before agent_end: %v", calls)
+	}
+
+	cmd := fx.router.AgentEnd()
+	if cmd == nil {
+		t.Fatal("AgentEnd with queued follow-ups returned nil Cmd")
+	}
+	// Classic flush pattern: the first queued message starts the next turn as a
+	// prompt; the rest queue behind it as follow-ups (FIFO).
+	want := []string{"prompt:first follow-up", "follow_up:second follow-up"}
+	if got := fx.commander.callsOfKind("prompt", "follow_up"); !equalStrings(got, want) {
+		t.Fatalf("flush calls = %v, want %v", got, want)
+	}
+	if !fx.queue.IsEmpty() {
+		t.Fatalf("queue not emptied by agent_end flush: %v", queueContents(fx.queue))
+	}
+	if fx.router.Streaming() {
+		t.Fatal("AgentEnd must mark the router idle")
+	}
+}
+
+func TestInputAgentEndDropsConsumedSteering(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.SetStreaming(true)
+	fx.router.Submit("steer it")
+
+	steerCalls := fx.commander.callsOfKind("steer")
+	if cmd := fx.router.AgentEnd(); cmd != nil {
+		t.Fatal("AgentEnd with only steering must return nil (nothing to fire)")
+	}
+	if !fx.queue.IsEmpty() {
+		t.Fatalf("steering not dropped on agent_end: %v", queueContents(fx.queue))
+	}
+	if got := fx.commander.callsOfKind("steer", "prompt", "follow_up"); !equalStrings(got, steerCalls) {
+		t.Fatalf("agent_end re-delivered steering: %v", got)
+	}
+}
+
+func TestInputAgentEndEmptyQueueIsNil(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.SetStreaming(true)
+	if cmd := fx.router.AgentEnd(); cmd != nil {
+		t.Fatal("AgentEnd with an empty queue must return nil")
+	}
+}
+
+func TestInputSyncSteeringPreservesLocalFollowUps(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.SetStreaming(true)
+
+	fx.router.Submit("steer a")
+	fx.router.Submit("steer b")
+	fx.editor.SetText("local follow-up")
+	fx.router.HandleAction("app.message.followUp")
+
+	// The daemon consumed "steer a" mid-turn: queue_update now reports only b.
+	fx.router.SyncSteering([]string{"steer b"})
+
+	want := []string{"S:steer b", "F:local follow-up"}
+	if got := queueContents(fx.queue); !equalStrings(got, want) {
+		t.Fatalf("queue after SyncSteering = %v, want %v", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bash block lifecycle
+// ---------------------------------------------------------------------------
+
+func bashResultMsg(t *testing.T, output string, exitCode any, cancelled bool) app.CommandResultMsg {
+	t.Helper()
+	payload := map[string]any{"output": output, "cancelled": cancelled}
+	if exitCode != nil {
+		payload["exitCode"] = exitCode
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal bash result: %v", err)
+	}
+	return app.CommandResultMsg{
+		Command:  "bash",
+		Response: bridge.Response{Type: "response", Command: "bash", Success: true, Data: data},
+	}
+}
+
+func TestInputBashLifecycle(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	res := fx.router.Submit("!echo hi")
+	if res.Kind != app.RouteBash {
+		t.Fatalf("kind = %v, want RouteBash", res.Kind)
+	}
+	if !fx.router.IsBashRunning() {
+		t.Fatal("bash not marked running after submit")
+	}
+	block := fx.router.BashBlock()
+	if block == nil {
+		t.Fatal("no live bash block after submit")
+	}
+	if block.HeaderPlain() != "$ echo hi" {
+		t.Fatalf("block header = %q", block.HeaderPlain())
+	}
+
+	if !fx.router.HandleBashResult(bashResultMsg(t, "hi\n", 0, false)) {
+		t.Fatal("HandleBashResult did not consume the bash response")
+	}
+	if fx.router.IsBashRunning() {
+		t.Fatal("bash still marked running after completion")
+	}
+	if got := block.OutputLines(); len(got) == 0 || got[0] != "hi" {
+		t.Fatalf("block output = %v, want streamed 'hi'", got)
+	}
+	if block.StatusPlain() != "" {
+		t.Fatalf("clean exit should have empty status, got %q", block.StatusPlain())
+	}
+}
+
+func TestInputBashFailureAndCancelStatus(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	fx.router.Submit("!false")
+	fx.router.HandleBashResult(bashResultMsg(t, "", 2, false))
+	if got := fx.router.BashBlock().StatusPlain(); got != "(exit 2)" {
+		t.Fatalf("failure status = %q, want (exit 2)", got)
+	}
+
+	fx.router.Submit("!sleep 987")
+	if !fx.router.IsBashRunning() {
+		t.Fatal("second bash not running")
+	}
+	fx.router.HandleBashResult(bashResultMsg(t, "", nil, true))
+	if got := fx.router.BashBlock().StatusPlain(); got != "(cancelled)" {
+		t.Fatalf("cancel status = %q, want (cancelled)", got)
+	}
+}
+
+func TestInputBashBusyRejectsSecondCommand(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	fx.router.Submit("!sleep 987")
+	res := fx.router.Submit("!echo blocked")
+	if res.Kind != app.RouteBashBusy {
+		t.Fatalf("kind = %v, want RouteBashBusy", res.Kind)
+	}
+	if res.Notice == "" {
+		t.Fatal("busy rejection must carry the classic warning notice")
+	}
+	// Classic restores the submitted text so the user does not lose it.
+	if fx.editor.GetText() != "!echo blocked" {
+		t.Fatalf("editor text = %q, want the restored command", fx.editor.GetText())
+	}
+	if got := fx.commander.callsOfKind("bash", "bash!!"); !equalStrings(got, []string{"bash:sleep 987"}) {
+		t.Fatalf("second bash must not reach the wire, calls = %v", got)
+	}
+}
+
+func TestInputInterruptAbortsRunningBash(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	// No bash running: interrupt is NOT claimed (the model's abort path owns it).
+	if _, handled := fx.router.HandleAction("app.interrupt"); handled {
+		t.Fatal("interrupt claimed with no bash running")
+	}
+
+	fx.router.Submit("!sleep 987")
+	res, handled := fx.router.HandleAction("app.interrupt")
+	if !handled {
+		t.Fatal("interrupt not claimed while bash is running")
+	}
+	if res.Kind != app.RouteAbortBash {
+		t.Fatalf("kind = %v, want RouteAbortBash", res.Kind)
+	}
+	if got := fx.commander.callsOfKind("abort_bash"); !equalStrings(got, []string{"abort_bash"}) {
+		t.Fatalf("abort_bash not issued, calls = %v", fx.commander.calls)
+	}
+}
+
+func TestInputBashResultIgnoresOtherCommands(t *testing.T) {
+	fx := newRouterFixture(t)
+	fx.router.Submit("!sleep 1")
+	msg := app.CommandResultMsg{Command: "compact", Response: bridge.Response{Type: "response", Command: "compact", Success: true}}
+	if fx.router.HandleBashResult(msg) {
+		t.Fatal("HandleBashResult consumed a non-bash response")
+	}
+	if !fx.router.IsBashRunning() {
+		t.Fatal("bash state clobbered by unrelated response")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete provider wiring + prompt history
+// ---------------------------------------------------------------------------
+
+func TestInputAutocompleteProviderWiring(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	provider := fx.router.WireAutocomplete(
+		[]bridge.RPCSlashCommand{{Name: "mycmd", Description: "demo", Source: "extension"}},
+		t.TempDir(), "",
+	)
+	if provider == nil {
+		t.Fatal("WireAutocomplete returned no provider")
+	}
+	if fx.editor.provider == nil {
+		t.Fatal("provider not installed on the editor seam")
+	}
+	if _, ok := fx.editor.provider.(*slash.CombinedProvider); !ok {
+		t.Fatalf("editor provider is %T, want *slash.CombinedProvider", fx.editor.provider)
+	}
+
+	// The same get_commands payload feeds dispatch knowledge: known dynamic
+	// commands prompt, unknown names surface the inline error.
+	if res := fx.router.Submit("/mycmd"); res.Kind != app.RoutePrompt {
+		t.Fatalf("known dynamic command kind = %v, want RoutePrompt", res.Kind)
+	}
+	if res := fx.router.Submit("/nope"); res.Kind != app.RouteUnknown {
+		t.Fatalf("unknown command kind = %v, want RouteUnknown", res.Kind)
+	}
+}
+
+func TestInputHistoryRecording(t *testing.T) {
+	fx := newRouterFixture(t)
+
+	fx.router.Submit("plain prompt")
+	fx.router.Submit("!echo hi")
+	fx.router.Submit("/compact")
+	fx.router.Submit("   ") // ignored: never recorded
+
+	fx.router.SetStreaming(true)
+	fx.router.Submit("steer msg")
+	fx.editor.SetText("follow msg")
+	fx.router.HandleAction("app.message.followUp")
+
+	want := []string{"plain prompt", "!echo hi", "/compact", "steer msg", "follow msg"}
+	if !equalStrings(fx.editor.history, want) {
+		t.Fatalf("editor history = %v, want %v", fx.editor.history, want)
+	}
+	if !equalStrings(fx.history.entries, want) {
+		t.Fatalf("persisted history = %v, want %v", fx.history.entries, want)
+	}
+}

--- a/packages/neo/internal/app/qaharness/main.go
+++ b/packages/neo/internal/app/qaharness/main.go
@@ -54,7 +54,7 @@ var isolatedArgv = []string{
 }
 
 func main() {
-	scene := flag.String("scene", "welcome", "scene: welcome | session-turn | session-kill | login-flow | status-retry")
+	scene := flag.String("scene", "welcome", "scene: welcome | session-turn | session-kill | login-flow | status-retry | isolated-crash")
 	flag.Parse()
 
 	switch *scene {
@@ -68,6 +68,8 @@ func main() {
 		os.Exit(runLoginFlow())
 	case "status-retry":
 		runStatusRetry()
+	case "isolated-crash":
+		os.Exit(runIsolatedCrash())
 	default:
 		fmt.Fprintln(os.Stderr, "unknown scene:", *scene)
 		os.Exit(2)
@@ -415,4 +417,43 @@ func runStatusRetry() {
 	if len(sh.AboveEditor(width)) == 0 {
 		fmt.Println("retry-status-cleared")
 	}
+}
+
+// runIsolatedCrash (plan task 8) exercises the isolated child-exit → fatal path
+// against the REAL recovery handler: it connects an isolated child, prints
+// RPCCHILD=<pid> at spawn (best-effort via pgrep, the session-kill pattern) so
+// the QA driver can kill -9 it, waits for the adapter's client-closed signal,
+// routes it through app.Recovery, prints the rendered fatal notice, and exits
+// with the recovery's exit code (1 — the launcher re-raises it).
+func runIsolatedCrash() int {
+	sess, result, err := connectIsolated()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "connect:", err)
+		return 1
+	}
+	defer result.Close()
+
+	fmt.Printf("RPCCHILD=%d\n", childPid())
+
+	rec := app.NewRecovery(app.RecoveryConfig{Mode: bridge.TransportIsolated})
+
+	select {
+	case <-sess.sender.closed:
+	case <-time.After(120 * time.Second):
+		fmt.Fprintln(os.Stderr, "timed out waiting for the child to exit")
+		return 1
+	}
+
+	cmd := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed})
+	if cmd == nil {
+		fmt.Fprintln(os.Stderr, "recovery ignored the client-closed signal")
+		return 1
+	}
+	fatal, ok := cmd().(app.RecoveryFatalMsg)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "recovery did not return the fatal quit signal")
+		return 1
+	}
+	fmt.Println("FATAL", fatal.Notice)
+	return fatal.ExitCode
 }

--- a/packages/neo/internal/app/qaharness/main.go
+++ b/packages/neo/internal/app/qaharness/main.go
@@ -54,7 +54,7 @@ var isolatedArgv = []string{
 }
 
 func main() {
-	scene := flag.String("scene", "welcome", "scene: welcome | session-turn | session-kill | login-flow")
+	scene := flag.String("scene", "welcome", "scene: welcome | session-turn | session-kill | login-flow | status-retry")
 	flag.Parse()
 
 	switch *scene {
@@ -66,6 +66,8 @@ func main() {
 		os.Exit(runSessionKill())
 	case "login-flow":
 		os.Exit(runLoginFlow())
+	case "status-retry":
+		runStatusRetry()
 	default:
 		fmt.Fprintln(os.Stderr, "unknown scene:", *scene)
 		os.Exit(2)
@@ -369,3 +371,48 @@ func (stubResponder) RespondExtensionUI(bridge.ExtensionUIResponse) error { retu
 type stubSink struct{}
 
 func (stubSink) ApplyDirective(extui.Directive) {}
+
+// runStatusRetry drives the todo-7 shell wiring with synthetic retry events
+// (plan task 7 QA): it injects an auto_retry_start EventMsg through the
+// ShellWire, prints the digit-bearing countdown status line, then injects
+// auto_retry_end and prints the cleared confirmation. Machine-checkable stdout
+// like the session scenes — the surface under test is the event→status-stack
+// wiring, not a live program.
+func runStatusRetry() {
+	const width = 120
+
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "theme.Load:", err)
+		os.Exit(1)
+	}
+	keys := keybindings.NewManager(nil)
+	cwd, _ := os.Getwd()
+
+	sh := shell.New(th, firstKey(keys, "app.message.dequeue"), appName)
+	wire := app.NewShellWire(sh, app.ShellWireConfig{
+		Theme:   th,
+		Keys:    keys,
+		AppName: appName,
+		Cwd:     cwd,
+		Home:    os.Getenv("HOME"),
+	})
+
+	start := app.EventMsg{Event: bridge.Event{
+		Type:    "auto_retry_start",
+		Payload: json.RawMessage(`{"type":"auto_retry_start","attempt":2,"maxAttempts":5,"delayMs":5000,"errorMessage":"synthetic overload"}`),
+	}}
+	_ = wire.HandleEvent(start)
+	for _, line := range sh.AboveEditor(width) {
+		fmt.Println(line)
+	}
+
+	end := app.EventMsg{Event: bridge.Event{
+		Type:    "auto_retry_end",
+		Payload: json.RawMessage(`{"type":"auto_retry_end","success":true,"attempt":2}`),
+	}}
+	_ = wire.HandleEvent(end)
+	if len(sh.AboveEditor(width)) == 0 {
+		fmt.Println("retry-status-cleared")
+	}
+}

--- a/packages/neo/internal/app/qaharness/main.go
+++ b/packages/neo/internal/app/qaharness/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
 	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
 	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/extui"
 	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
 	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
 )
@@ -52,7 +54,7 @@ var isolatedArgv = []string{
 }
 
 func main() {
-	scene := flag.String("scene", "welcome", "scene: welcome | session-turn | session-kill")
+	scene := flag.String("scene", "welcome", "scene: welcome | session-turn | session-kill | login-flow")
 	flag.Parse()
 
 	switch *scene {
@@ -62,6 +64,8 @@ func main() {
 		os.Exit(runSessionTurn())
 	case "session-kill":
 		os.Exit(runSessionKill())
+	case "login-flow":
+		os.Exit(runLoginFlow())
 	default:
 		fmt.Fprintln(os.Stderr, "unknown scene:", *scene)
 		os.Exit(2)
@@ -262,3 +266,106 @@ func firstKey(keys *keybindings.Manager, action string) string {
 	}
 	return ""
 }
+
+// ---------------------------------------------------------------------------
+// login-flow scene (plan todo 6)
+// ---------------------------------------------------------------------------
+
+// runLoginFlow drives the REAL login dialog through the app extension-UI layer
+// with synthetic auth events: get_auth_providers answers with a stub oauth
+// provider, selecting it fires login_start against a stub client (NO timeout),
+// then an auth_login_url and a successful auth_login_end EventMsg are injected
+// in order. The URL-panel frame renders first (with a capture window), then the
+// post-login state prints as machine-checkable lines.
+func runLoginFlow() int {
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "theme.Load:", err)
+		return 1
+	}
+	keys := keybindings.NewManager(nil)
+	mgr := app.NewManager(keys, stubOverlayRequester{})
+	ext := app.NewExtUI(extui.Deps{Theme: th, Keybindings: keys}, mgr, stubAuthClient{}, stubResponder{}, stubSink{})
+
+	// get_auth_providers → provider list.
+	providersMsg, ok := ext.OpenLogin("")().(app.LoginProvidersMsg)
+	if !ok || providersMsg.Err != nil {
+		fmt.Fprintln(os.Stderr, "login-flow: provider fetch failed:", providersMsg.Err)
+		return 1
+	}
+	drainLoginCmds(ext.HandleLoginProviders(providersMsg))
+	drainLoginCmds(ext.HandleKey("\r").Cmd) // select the stub provider → login_start (flow view)
+
+	// auth_login_url EventMsg → the URL panel frame.
+	urlMsg := app.EventMsg{Event: bridge.Event{
+		Type:    "auth_login_url",
+		Payload: []byte(`{"type":"auth_login_url","provider":"stub","url":"https://stub.example/oauth?code=FAKE"}`),
+	}}
+	ext.HandleEvent(urlMsg.Event)
+	fmt.Println("=== login-flow: auth_login_url ===")
+	for _, line := range ext.Render(100, 30) {
+		fmt.Println(line)
+	}
+	time.Sleep(2 * time.Second) // capture window for the URL panel
+
+	// auth_login_end EventMsg → the dialog closes with status.
+	endMsg := app.EventMsg{Event: bridge.Event{
+		Type:    "auth_login_end",
+		Payload: []byte(`{"type":"auth_login_end","provider":"stub","success":true}`),
+	}}
+	res := ext.HandleEvent(endMsg.Event)
+	fmt.Println("=== login-flow: auth_login_end ===")
+	drainLoginCmds(res.Cmd)
+	fmt.Printf("LOGIN-FLOW provider=stub success=true dialogActive=%v\n", ext.Active())
+	return 0
+}
+
+// drainLoginCmds executes queued tea.Cmds synchronously, printing NoticeMsg
+// lines so the capture shows the login status notice.
+func drainLoginCmds(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	switch m := cmd().(type) {
+	case tea.BatchMsg:
+		for _, sub := range m {
+			drainLoginCmds(sub)
+		}
+	case app.NoticeMsg:
+		fmt.Println("NOTICE " + m.Text)
+	}
+}
+
+// stubOverlayRequester satisfies app.Requester for the overlay manager; the
+// login-flow scene never routes an overlay outcome through it.
+type stubOverlayRequester struct{}
+
+func (stubOverlayRequester) Request(bridge.Command) tea.Cmd        { return nil }
+func (stubOverlayRequester) FileOp(string, map[string]any) tea.Cmd { return nil }
+
+// stubAuthClient answers get_auth_providers with one stub oauth provider and
+// acknowledges every other auth command (login_start succeeds immediately; the
+// flow completes via the injected events).
+type stubAuthClient struct{}
+
+func (stubAuthClient) Request(cmd bridge.Command, _ time.Duration) (bridge.Response, error) {
+	if cmd.Type == "get_auth_providers" {
+		return bridge.Response{
+			Type:    "response",
+			Command: cmd.Type,
+			Success: true,
+			Data:    json.RawMessage(`{"providers":[{"id":"stub","name":"Stub Provider","authType":"oauth","status":{"configured":false}}]}`),
+		}, nil
+	}
+	return bridge.Response{Type: "response", Command: cmd.Type, Success: true}, nil
+}
+
+// stubResponder and stubSink are inert seams: the login flow sends no
+// extension_ui_response and applies no directives.
+type stubResponder struct{}
+
+func (stubResponder) RespondExtensionUI(bridge.ExtensionUIResponse) error { return nil }
+
+type stubSink struct{}
+
+func (stubSink) ApplyDirective(extui.Directive) {}

--- a/packages/neo/internal/app/race_disabled_test.go
+++ b/packages/neo/internal/app/race_disabled_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package app_test
+
+// raceDetectorEnabled reports whether this test binary was built with -race,
+// so timing-budget assertions can skip under instrumentation overhead.
+const raceDetectorEnabled = false

--- a/packages/neo/internal/app/race_enabled_test.go
+++ b/packages/neo/internal/app/race_enabled_test.go
@@ -1,0 +1,7 @@
+//go:build race
+
+package app_test
+
+// raceDetectorEnabled reports whether this test binary was built with -race,
+// so timing-budget assertions can skip under instrumentation overhead.
+const raceDetectorEnabled = true

--- a/packages/neo/internal/app/recovery.go
+++ b/packages/neo/internal/app/recovery.go
@@ -1,0 +1,426 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+)
+
+// Bounded-recovery defaults: the reconnect loop NEVER retries forever — after
+// MaxAttempts it surfaces a fatal quit signal instead.
+const (
+	defaultRecoveryMaxAttempts = 5
+	defaultRecoveryBackoffMin  = 250 * time.Millisecond
+	defaultRecoveryBackoffMax  = 2 * time.Second
+)
+
+// One-line notices the recovery loop exposes for rendering. abortedTurnNotice
+// follows the master task-17 semantics: a turn in flight when the connection
+// dropped is shown ABORTED — there is no live-reattach lease, so its streaming
+// output is gone even though the daemon may have finished it.
+const (
+	abortedTurnNotice   = "connection lost; the in-flight turn was aborted"
+	isolatedFatalNotice = "senpi backend exited unexpectedly; restart senpi --neo to continue"
+	daemonFatalNotice   = "could not reconnect to the senpi daemon; restart senpi --neo to continue"
+)
+
+// RecoveryPhase is the connection state the UI renders.
+type RecoveryPhase int
+
+const (
+	// RecoveryConnected: attached to a live client (also the initial state).
+	RecoveryConnected RecoveryPhase = iota
+	// RecoveryReconnecting: the connection dropped; the bounded loop is running.
+	RecoveryReconnecting
+	// RecoveryFatal: the loop gave up (retry cap) or the isolated child exited.
+	RecoveryFatal
+)
+
+func (p RecoveryPhase) String() string {
+	switch p {
+	case RecoveryConnected:
+		return "connected"
+	case RecoveryReconnecting:
+		return "reconnecting"
+	case RecoveryFatal:
+		return "fatal"
+	default:
+		return "unknown"
+	}
+}
+
+// ResumedEntry is one persisted session entry from get_entries, delivered raw:
+// recovery does not interpret entries — the transcript layer owns decoding.
+type ResumedEntry struct {
+	ID   string
+	Type string
+	Raw  json.RawMessage
+}
+
+// TranscriptReplayer is the narrow replay contract the recovery loop drives; the
+// transcript wiring implements it. MarkTurnAborted is invoked on the update loop
+// (inside HandleClientClosed); ReplayEntries runs on the recovery command's
+// goroutine, so implementations must be safe to call from any goroutine (hand
+// off via program.Send or internal locking).
+type TranscriptReplayer interface {
+	// MarkTurnAborted renders the in-flight turn as aborted with a one-line notice.
+	MarkTurnAborted(notice string)
+	// ReplayEntries replays resumed entries (oldest first) into the transcript.
+	ReplayEntries(entries []ResumedEntry)
+}
+
+// ReattachFunc re-establishes the daemon transport after a drop. Production uses
+// DaemonReattach; tests inject scripted transports.
+type ReattachFunc func() (bridge.Transport, error)
+
+// RecoveryResumedMsg is emitted after a successful reconnect + resume. The old
+// client is dead: the consumer must adopt Client (rewire the session adapter).
+type RecoveryResumedMsg struct {
+	// Client is the fresh RPC client over the reattached transport.
+	Client *bridge.Client
+	// LeafID is the entry id the resume reloaded up to (next resume's `since`).
+	LeafID string
+	// Attempts is how many reattach attempts this recovery consumed.
+	Attempts int
+	// Aborted reports whether a turn was in flight when the drop happened.
+	Aborted bool
+}
+
+// RecoveryFatalMsg is the quit signal: the recovery loop gave up (retry cap) or
+// the isolated child exited. Todo 9 maps it to tea.Quit + os.Exit(ExitCode); the
+// launcher re-raises the code.
+type RecoveryFatalMsg struct {
+	// Err is the recorded exit/reconnect error (wraps bridge.ErrClientClosed for
+	// an isolated child exit).
+	Err error
+	// Notice is the one-line fatal notice to render before exiting.
+	Notice string
+	// ExitCode is the process exit code (always 1).
+	ExitCode int
+}
+
+// RecoverySnapshot is an immutable view of the recovery state for the UI.
+type RecoverySnapshot struct {
+	Phase RecoveryPhase
+	// InFlightTurnAborted is set when a disconnect happened while a turn was in
+	// flight — that turn is rendered as aborted (no live-reattach lease).
+	InFlightTurnAborted bool
+	// LastEntryID is the id the next resume passes as get_entries{since}.
+	LastEntryID string
+	// Reconnects counts successful recoveries.
+	Reconnects int
+	// Notice is the current aborted/fatal one-line notice ("" when none).
+	Notice string
+	// ExitCode is non-zero only in the fatal phase (always 1 there).
+	ExitCode int
+}
+
+// RecoveryConfig configures the app-layer recovery loop.
+type RecoveryConfig struct {
+	// Mode selects the drop semantics: TransportDaemon (the zero value) drops
+	// reconnect + resume; a TransportIsolated child exit is fatal.
+	Mode bridge.TransportMode
+	// Replay is the transcript sink for aborted notices + resumed entries. A nil
+	// Replay is valid (headless): state is still tracked via Snapshot.
+	Replay TranscriptReplayer
+	// Reattach re-establishes the daemon transport; required in daemon mode
+	// (production: DaemonReattach). Ignored in isolated mode.
+	Reattach ReattachFunc
+	// MaxAttempts caps reattach attempts per recovery (default 5); never infinite.
+	MaxAttempts int
+	// BackoffMin/BackoffMax bound the doubling pause between attempts
+	// (defaults 250ms / 2s).
+	BackoffMin time.Duration
+	BackoffMax time.Duration
+	// ResumeTimeout bounds each resume RPC (default bridge.DefaultRequestTimeout).
+	ResumeTimeout time.Duration
+	// Sleep pauses between attempts. Defaults to time.Sleep; tests inject a
+	// recorder so the capped schedule is asserted without real waiting.
+	Sleep func(time.Duration)
+}
+
+// Recovery owns the app-layer reconnect/resume/respawn loop (plan todo 8). On a
+// ClientClosedMsg it either runs the bounded daemon recovery (reconnect — or
+// respawn via the existing bridge attach-or-spawn path — then resume the SAME
+// session) or, in isolated mode, surfaces the fatal exit-1 quit signal. It never
+// kills the daemon: the idle timer owns that lifecycle.
+type Recovery struct {
+	mode          bridge.TransportMode
+	replay        TranscriptReplayer
+	reattach      ReattachFunc
+	maxAttempts   int
+	backoffMin    time.Duration
+	backoffMax    time.Duration
+	resumeTimeout time.Duration
+	sleep         func(time.Duration)
+
+	mu          sync.Mutex
+	phase       RecoveryPhase
+	turnLive    bool
+	abortedTurn bool
+	lastEntryID string
+	reconnects  int
+	notice      string
+	exitCode    int
+}
+
+// NewRecovery builds a Recovery in the connected phase, applying the bounded
+// defaults for any zero config value.
+func NewRecovery(cfg RecoveryConfig) *Recovery {
+	r := &Recovery{
+		mode:          cfg.Mode,
+		replay:        cfg.Replay,
+		reattach:      cfg.Reattach,
+		maxAttempts:   cfg.MaxAttempts,
+		backoffMin:    cfg.BackoffMin,
+		backoffMax:    cfg.BackoffMax,
+		resumeTimeout: cfg.ResumeTimeout,
+		sleep:         cfg.Sleep,
+		phase:         RecoveryConnected,
+	}
+	if r.replay == nil {
+		r.replay = noopReplayer{}
+	}
+	if r.maxAttempts <= 0 {
+		r.maxAttempts = defaultRecoveryMaxAttempts
+	}
+	if r.backoffMin <= 0 {
+		r.backoffMin = defaultRecoveryBackoffMin
+	}
+	if r.backoffMax <= 0 {
+		r.backoffMax = defaultRecoveryBackoffMax
+	}
+	if r.backoffMax < r.backoffMin {
+		r.backoffMax = r.backoffMin
+	}
+	if r.resumeTimeout <= 0 {
+		r.resumeTimeout = bridge.DefaultRequestTimeout
+	}
+	if r.sleep == nil {
+		r.sleep = time.Sleep
+	}
+	return r
+}
+
+// DaemonReattach builds the production ReattachFunc from the original
+// attachment's metadata (bridge.ConnectResult.Daemon). bridge.AttachOrSpawn is
+// the existing transport-level recovery — reconnect when the daemon is alive
+// (including the lost-record self-heal) and respawn via the daemon spawn path
+// when it is dead — so the app layer wraps it rather than duplicating any of it.
+func DaemonReattach(conn *bridge.DaemonConn, capabilities []string, options bridge.NeoRuntimeOptions, timeout time.Duration) ReattachFunc {
+	return func() (bridge.Transport, error) {
+		fresh, err := bridge.AttachOrSpawn(bridge.AttachConfig{
+			AgentDir:       conn.AgentDir,
+			Cwd:            conn.Cwd,
+			Capabilities:   capabilities,
+			RuntimeOptions: options,
+			Timeout:        timeout,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return fresh.Transport, nil
+	}
+}
+
+// MarkTurnInFlight records that a turn is running: a disconnect before it
+// completes is rendered as an aborted turn (never silently reattached).
+func (r *Recovery) MarkTurnInFlight() {
+	r.mu.Lock()
+	r.turnLive = true
+	r.mu.Unlock()
+}
+
+// MarkTurnComplete clears the in-flight marker (a turn that finished normally is
+// not aborted by a later disconnect).
+func (r *Recovery) MarkTurnComplete() {
+	r.mu.Lock()
+	r.turnLive = false
+	r.mu.Unlock()
+}
+
+// NoteEntryID records the newest persisted entry id observed on the event
+// stream; the next resume passes it as get_entries{since} (efficient reload).
+func (r *Recovery) NoteEntryID(id string) {
+	if id == "" {
+		return
+	}
+	r.mu.Lock()
+	r.lastEntryID = id
+	r.mu.Unlock()
+}
+
+// Snapshot returns the current recovery state.
+func (r *Recovery) Snapshot() RecoverySnapshot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return RecoverySnapshot{
+		Phase:               r.phase,
+		InFlightTurnAborted: r.abortedTurn,
+		LastEntryID:         r.lastEntryID,
+		Reconnects:          r.reconnects,
+		Notice:              r.notice,
+		ExitCode:            r.exitCode,
+	}
+}
+
+// HandleClientClosed reacts to a dropped client. Daemon mode marks the in-flight
+// turn aborted immediately and returns the bounded reconnect+resume command;
+// isolated mode returns the fatal exit-1 quit signal. Duplicate drop reports
+// (already recovering, or already fatal) return nil.
+func (r *Recovery) HandleClientClosed(msg ClientClosedMsg) tea.Cmd {
+	closeErr := msg.Err
+	if closeErr == nil {
+		closeErr = bridge.ErrClientClosed
+	}
+
+	r.mu.Lock()
+	if r.phase != RecoveryConnected {
+		r.mu.Unlock()
+		return nil
+	}
+	aborted := r.turnLive
+	r.turnLive = false
+
+	if r.mode == bridge.TransportIsolated {
+		r.phase = RecoveryFatal
+		r.abortedTurn = r.abortedTurn || aborted
+		r.notice = isolatedFatalNotice
+		r.exitCode = 1
+		r.mu.Unlock()
+		fatal := RecoveryFatalMsg{
+			Err:      fmt.Errorf("isolated backend exited: %w", closeErr),
+			Notice:   isolatedFatalNotice,
+			ExitCode: 1,
+		}
+		return func() tea.Msg { return fatal }
+	}
+
+	r.phase = RecoveryReconnecting
+	if aborted {
+		r.abortedTurn = true
+		r.notice = abortedTurnNotice
+	}
+	lastEntry := r.lastEntryID
+	r.mu.Unlock()
+
+	if aborted {
+		r.replay.MarkTurnAborted(abortedTurnNotice)
+	}
+	return func() tea.Msg { return r.reconnectAndResume(lastEntry, aborted) }
+}
+
+// reconnectAndResume runs the bounded daemon recovery: reattach (the bridge path
+// reconnects or respawns), then resume the SAME session and replay its entries.
+// A failed attempt backs off (doubling, capped at backoffMax) until maxAttempts,
+// then the failure surfaces as the fatal quit signal.
+func (r *Recovery) reconnectAndResume(lastEntry string, aborted bool) tea.Msg {
+	if r.reattach == nil {
+		return r.fail(errors.New("recovery: daemon mode requires a Reattach func"))
+	}
+
+	backoff := r.backoffMin
+	var lastErr error
+	for attempt := 1; attempt <= r.maxAttempts; attempt++ {
+		if attempt > 1 {
+			r.sleep(backoff)
+			backoff *= 2
+			if backoff > r.backoffMax {
+				backoff = r.backoffMax
+			}
+		}
+
+		transport, err := r.reattach()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		client := bridge.NewClient(transport)
+		leafID, entries, rerr := resumeSession(client, lastEntry, r.resumeTimeout)
+		if rerr != nil {
+			lastErr = rerr
+			// Close only this half-dead attachment — never the daemon itself
+			// (the idle timer owns the daemon's lifecycle).
+			_ = client.Close()
+			continue
+		}
+
+		r.replay.ReplayEntries(entries)
+		r.mu.Lock()
+		r.phase = RecoveryConnected
+		r.reconnects++
+		if leafID != "" {
+			r.lastEntryID = leafID
+		}
+		r.mu.Unlock()
+		return RecoveryResumedMsg{Client: client, LeafID: leafID, Attempts: attempt, Aborted: aborted}
+	}
+	return r.fail(fmt.Errorf("recovery: gave up after %d attempts: %w", r.maxAttempts, lastErr))
+}
+
+// fail records the fatal state and builds the quit signal.
+func (r *Recovery) fail(err error) tea.Msg {
+	r.mu.Lock()
+	r.phase = RecoveryFatal
+	r.notice = daemonFatalNotice
+	r.exitCode = 1
+	r.mu.Unlock()
+	return RecoveryFatalMsg{Err: err, Notice: daemonFatalNotice, ExitCode: 1}
+}
+
+// resumeSession replays the resume contract onto a fresh client: get_state FIRST
+// (confirms the runtime serves the same session), then get_entries{since:
+// <lastEntry>} (rpc-types.ts) for the efficient reload. It returns the reloaded
+// leaf id and the raw entries for the transcript replay.
+func resumeSession(client *bridge.Client, since string, timeout time.Duration) (string, []ResumedEntry, error) {
+	state, err := client.Request(bridge.Command{Type: "get_state"}, timeout)
+	if err != nil {
+		return "", nil, fmt.Errorf("resume get_state: %w", err)
+	}
+	if !state.Success {
+		return "", nil, fmt.Errorf("resume get_state failed: %s", state.Error)
+	}
+
+	fields := map[string]any{}
+	if since != "" {
+		fields["since"] = since
+	}
+	resp, err := client.Request(bridge.Command{Type: "get_entries", Fields: fields}, timeout)
+	if err != nil {
+		return "", nil, fmt.Errorf("resume get_entries: %w", err)
+	}
+	if !resp.Success {
+		return "", nil, fmt.Errorf("resume get_entries failed: %s", resp.Error)
+	}
+
+	var data struct {
+		Entries []json.RawMessage `json:"entries"`
+		LeafID  string            `json:"leafId"`
+	}
+	if uerr := json.Unmarshal(resp.Data, &data); uerr != nil {
+		return "", nil, fmt.Errorf("resume get_entries decode: %w", uerr)
+	}
+	entries := make([]ResumedEntry, 0, len(data.Entries))
+	for _, raw := range data.Entries {
+		var head struct {
+			ID   string `json:"id"`
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(raw, &head) // best-effort: Raw is preserved either way
+		entries = append(entries, ResumedEntry{ID: head.ID, Type: head.Type, Raw: raw})
+	}
+	return data.LeafID, entries, nil
+}
+
+// noopReplayer is installed when no transcript sink is configured (headless
+// harness); recovery state is still tracked and surfaced via Snapshot.
+type noopReplayer struct{}
+
+func (noopReplayer) MarkTurnAborted(string)       {}
+func (noopReplayer) ReplayEntries([]ResumedEntry) {}

--- a/packages/neo/internal/app/recovery_test.go
+++ b/packages/neo/internal/app/recovery_test.go
@@ -1,0 +1,392 @@
+package app_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles (fakeTransport is shared with session_test.go — same package)
+// ---------------------------------------------------------------------------
+
+// resumeScript is a scripted fake RPC server for the recovery loop: it answers
+// get_state / get_entries over a fakeTransport, records the request order and
+// the get_entries `since` value, and can DROP the transport after a fixed number
+// of answered lines (a mid-resume disconnect — the "drops after N lines" case).
+type resumeScript struct {
+	ft        *fakeTransport
+	leafID    string
+	entries   string // raw JSON array for the get_entries data
+	dropAfter int    // close the transport after this many responses (0 = never)
+	mu        sync.Mutex
+	order     []string
+	since     []string
+}
+
+func newResumeScript(leafID, entries string, dropAfter int) *resumeScript {
+	s := &resumeScript{ft: newFakeTransport(), leafID: leafID, entries: entries, dropAfter: dropAfter}
+	go s.serve()
+	return s
+}
+
+func (s *resumeScript) serve() {
+	answered := 0
+	for {
+		var raw []byte
+		select {
+		case raw = <-s.ft.fromCli:
+		case <-s.ft.closed:
+			return
+		}
+		var cmd struct {
+			ID    string `json:"id"`
+			Type  string `json:"type"`
+			Since string `json:"since"`
+		}
+		if json.Unmarshal(raw, &cmd) != nil {
+			continue
+		}
+		s.mu.Lock()
+		s.order = append(s.order, cmd.Type)
+		if cmd.Type == "get_entries" {
+			s.since = append(s.since, cmd.Since)
+		}
+		s.mu.Unlock()
+
+		var resp string
+		switch cmd.Type {
+		case "get_state":
+			resp = fmt.Sprintf(`{"id":%q,"type":"response","command":"get_state","success":true,"data":{"sessionId":"sess-1","thinkingLevel":"off","isStreaming":false,"isCompacting":false,"steeringMode":"all","followUpMode":"all","autoCompactionEnabled":true,"messageCount":2,"pendingMessageCount":0}}`, cmd.ID)
+		case "get_entries":
+			resp = fmt.Sprintf(`{"id":%q,"type":"response","command":"get_entries","success":true,"data":{"entries":%s,"leafId":%q}}`, cmd.ID, s.entries, s.leafID)
+		default:
+			resp = fmt.Sprintf(`{"id":%q,"type":"response","command":%q,"success":true}`, cmd.ID, cmd.Type)
+		}
+		select {
+		case s.ft.toClient <- []byte(resp):
+		case <-s.ft.closed:
+			return
+		}
+		answered++
+		if s.dropAfter > 0 && answered >= s.dropAfter {
+			_ = s.ft.Close()
+			return
+		}
+	}
+}
+
+func (s *resumeScript) requestOrder() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.order...)
+}
+
+func (s *resumeScript) sinceValues() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.since...)
+}
+
+// fakeReplay records the narrow transcript-replay calls the recovery loop makes.
+type fakeReplay struct {
+	mu       sync.Mutex
+	aborted  []string
+	replayed [][]app.ResumedEntry
+}
+
+func (f *fakeReplay) MarkTurnAborted(notice string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.aborted = append(f.aborted, notice)
+}
+
+func (f *fakeReplay) ReplayEntries(entries []app.ResumedEntry) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.replayed = append(f.replayed, entries)
+}
+
+func (f *fakeReplay) abortedNotices() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.aborted...)
+}
+
+func (f *fakeReplay) replayedBatches() [][]app.ResumedEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([][]app.ResumedEntry(nil), f.replayed...)
+}
+
+// sleepRecorder captures the backoff schedule without real waiting.
+type sleepRecorder struct {
+	mu    sync.Mutex
+	slept []time.Duration
+}
+
+func (s *sleepRecorder) sleep(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.slept = append(s.slept, d)
+}
+
+func (s *sleepRecorder) durations() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]time.Duration(nil), s.slept...)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestRecoveryDaemonResumesSameSession asserts a daemon-mode drop reconnects and
+// resumes the SAME session: get_state is issued BEFORE get_entries, get_entries
+// carries since=<last entry id>, the resumed entries are replayed through the
+// narrow replay interface, and the in-flight turn is rendered aborted at drop
+// time (no live-reattach lease).
+func TestRecoveryDaemonResumesSameSession(t *testing.T) {
+	script := newResumeScript("e9", `[{"id":"e2","type":"message"},{"id":"e3","type":"message"}]`, 0)
+	replay := &fakeReplay{}
+	slept := &sleepRecorder{}
+
+	rec := app.NewRecovery(app.RecoveryConfig{
+		Mode:        bridge.TransportDaemon,
+		Replay:      replay,
+		Reattach:    func() (bridge.Transport, error) { return script.ft, nil },
+		MaxAttempts: 3,
+		BackoffMin:  time.Millisecond,
+		BackoffMax:  4 * time.Millisecond,
+		Sleep:       slept.sleep,
+	})
+	rec.NoteEntryID("e1")
+	rec.MarkTurnInFlight()
+
+	cmd := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed})
+	if cmd == nil {
+		t.Fatalf("daemon drop must start a recovery command")
+	}
+
+	// The aborted notice renders immediately at drop time, before reconnecting.
+	if notices := replay.abortedNotices(); len(notices) != 1 || notices[0] == "" {
+		t.Fatalf("in-flight turn must be marked aborted at drop time, got %#v", notices)
+	}
+	// A duplicate drop report mid-recovery must not start a second loop.
+	if dup := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed}); dup != nil {
+		t.Fatalf("duplicate drop report must be ignored while recovering")
+	}
+
+	msg := cmd()
+	resumed, ok := msg.(app.RecoveryResumedMsg)
+	if !ok {
+		t.Fatalf("want RecoveryResumedMsg, got %T (%v)", msg, msg)
+	}
+	if resumed.Client == nil {
+		t.Fatalf("resumed message must carry the fresh client to adopt")
+	}
+	if resumed.LeafID != "e9" {
+		t.Fatalf("resume must reload the leaf id, got %q", resumed.LeafID)
+	}
+	if !resumed.Aborted {
+		t.Fatalf("resumed message must report the aborted in-flight turn")
+	}
+	if resumed.Attempts != 1 {
+		t.Fatalf("clean reconnect should take one attempt, got %d", resumed.Attempts)
+	}
+
+	order := script.requestOrder()
+	if len(order) != 2 || order[0] != "get_state" || order[1] != "get_entries" {
+		t.Fatalf("resume must issue get_state BEFORE get_entries, got %v", order)
+	}
+	if since := script.sinceValues(); len(since) != 1 || since[0] != "e1" {
+		t.Fatalf("get_entries must carry since=<last entry id>, got %v", since)
+	}
+
+	batches := replay.replayedBatches()
+	if len(batches) != 1 || len(batches[0]) != 2 {
+		t.Fatalf("resumed entries must be replayed once, got %#v", batches)
+	}
+	if batches[0][0].ID != "e2" || batches[0][1].ID != "e3" {
+		t.Fatalf("entries replayed out of order: %#v", batches[0])
+	}
+	if batches[0][0].Type != "message" || len(batches[0][0].Raw) == 0 {
+		t.Fatalf("replayed entry must keep type + raw payload: %#v", batches[0][0])
+	}
+
+	snap := rec.Snapshot()
+	if snap.Phase != app.RecoveryConnected {
+		t.Fatalf("recovery must end reconnected, got %v", snap.Phase)
+	}
+	if !snap.InFlightTurnAborted {
+		t.Fatalf("snapshot must record the aborted in-flight turn: %+v", snap)
+	}
+	if snap.LastEntryID != "e9" {
+		t.Fatalf("next resume must use the reloaded leaf id, got %q", snap.LastEntryID)
+	}
+	if snap.Reconnects != 1 {
+		t.Fatalf("snapshot must count the reconnect, got %d", snap.Reconnects)
+	}
+	if len(slept.durations()) != 0 {
+		t.Fatalf("clean first-attempt reconnect must not back off, slept %v", slept.durations())
+	}
+}
+
+// TestRecoveryDaemonDropMidResumeRetries asserts a transport that drops after N
+// answered lines fails that attempt and the loop retries (with one backoff
+// pause) onto a fresh transport that completes the full resume sequence.
+func TestRecoveryDaemonDropMidResumeRetries(t *testing.T) {
+	dropping := newResumeScript("e9", `[]`, 1) // answers one line, then drops
+	healthy := newResumeScript("e9", `[{"id":"e2","type":"message"}]`, 0)
+	replay := &fakeReplay{}
+	slept := &sleepRecorder{}
+
+	attempt := 0
+	rec := app.NewRecovery(app.RecoveryConfig{
+		Mode:   bridge.TransportDaemon,
+		Replay: replay,
+		Reattach: func() (bridge.Transport, error) {
+			attempt++
+			if attempt == 1 {
+				return dropping.ft, nil
+			}
+			return healthy.ft, nil
+		},
+		MaxAttempts: 3,
+		BackoffMin:  time.Millisecond,
+		BackoffMax:  4 * time.Millisecond,
+		Sleep:       slept.sleep,
+	})
+
+	cmd := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed})
+	if cmd == nil {
+		t.Fatalf("daemon drop must start a recovery command")
+	}
+	msg := cmd()
+	resumed, ok := msg.(app.RecoveryResumedMsg)
+	if !ok {
+		t.Fatalf("want RecoveryResumedMsg, got %T (%v)", msg, msg)
+	}
+	if resumed.Attempts != 2 {
+		t.Fatalf("mid-resume drop must consume one attempt then retry, got %d", resumed.Attempts)
+	}
+	if resumed.Aborted {
+		t.Fatalf("no turn was in flight; resumed must not report an abort")
+	}
+	if got := slept.durations(); !reflect.DeepEqual(got, []time.Duration{time.Millisecond}) {
+		t.Fatalf("one retry must pause once at BackoffMin, slept %v", got)
+	}
+	order := healthy.requestOrder()
+	if len(order) != 2 || order[0] != "get_state" || order[1] != "get_entries" {
+		t.Fatalf("retried resume must issue get_state BEFORE get_entries, got %v", order)
+	}
+	// No entry id was ever observed, so the retried get_entries omits `since`.
+	if since := healthy.sinceValues(); len(since) != 1 || since[0] != "" {
+		t.Fatalf("first-ever resume must omit since, got %v", since)
+	}
+}
+
+// TestRecoveryDaemonRetriesAreCapped asserts the reconnect loop is bounded: the
+// backoff doubles from BackoffMin and is capped at BackoffMax, the attempts stop
+// at MaxAttempts (never infinite), and the failure surfaces as a fatal quit
+// signal with exit code 1.
+func TestRecoveryDaemonRetriesAreCapped(t *testing.T) {
+	replay := &fakeReplay{}
+	slept := &sleepRecorder{}
+
+	attempts := 0
+	rec := app.NewRecovery(app.RecoveryConfig{
+		Mode:   bridge.TransportDaemon,
+		Replay: replay,
+		Reattach: func() (bridge.Transport, error) {
+			attempts++
+			return nil, errors.New("daemon unreachable")
+		},
+		MaxAttempts: 4,
+		BackoffMin:  10 * time.Millisecond,
+		BackoffMax:  20 * time.Millisecond,
+		Sleep:       slept.sleep,
+	})
+
+	cmd := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed})
+	if cmd == nil {
+		t.Fatalf("daemon drop must start a recovery command")
+	}
+	msg := cmd()
+	fatal, ok := msg.(app.RecoveryFatalMsg)
+	if !ok {
+		t.Fatalf("capped retries must surface RecoveryFatalMsg, got %T (%v)", msg, msg)
+	}
+	if fatal.ExitCode != 1 {
+		t.Fatalf("fatal exit code must be 1, got %d", fatal.ExitCode)
+	}
+	if fatal.Err == nil || fatal.Notice == "" {
+		t.Fatalf("fatal must carry the error and a rendered notice: %+v", fatal)
+	}
+	if attempts != 4 {
+		t.Fatalf("retries must stop at MaxAttempts=4, got %d", attempts)
+	}
+	want := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 20 * time.Millisecond}
+	if got := slept.durations(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("backoff must double and cap at BackoffMax: got %v want %v", got, want)
+	}
+	snap := rec.Snapshot()
+	if snap.Phase != app.RecoveryFatal || snap.ExitCode != 1 || snap.Notice == "" {
+		t.Fatalf("snapshot must surface the fatal state: %+v", snap)
+	}
+	// Post-fatal drop reports must never restart the loop.
+	if dup := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed}); dup != nil {
+		t.Fatalf("post-fatal drop report must be ignored")
+	}
+}
+
+// TestRecoveryIsolatedExitIsFatalQuitSignal asserts an isolated child exit is
+// terminal: no reconnect is attempted, the quit signal carries the recorded exit
+// error and exit code 1 (todo 9 maps it to os.Exit; the launcher re-raises),
+// and a fatal notice is exposed for rendering.
+func TestRecoveryIsolatedExitIsFatalQuitSignal(t *testing.T) {
+	rec := app.NewRecovery(app.RecoveryConfig{
+		Mode: bridge.TransportIsolated,
+		Reattach: func() (bridge.Transport, error) {
+			t.Errorf("isolated mode must never reattach")
+			return nil, errors.New("unreachable")
+		},
+	})
+
+	cmd := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed})
+	if cmd == nil {
+		t.Fatalf("isolated child exit must return the quit signal command")
+	}
+	msg := cmd()
+	fatal, ok := msg.(app.RecoveryFatalMsg)
+	if !ok {
+		t.Fatalf("want RecoveryFatalMsg, got %T (%v)", msg, msg)
+	}
+	if fatal.ExitCode != 1 {
+		t.Fatalf("isolated exit must map to exit code 1, got %d", fatal.ExitCode)
+	}
+	if !errors.Is(fatal.Err, bridge.ErrClientClosed) {
+		t.Fatalf("fatal must carry the recorded exit error, got %v", fatal.Err)
+	}
+	if fatal.Notice == "" {
+		t.Fatalf("fatal must expose a rendered notice")
+	}
+
+	snap := rec.Snapshot()
+	if snap.Phase != app.RecoveryFatal {
+		t.Fatalf("isolated exit must land in the fatal phase, got %v", snap.Phase)
+	}
+	if snap.ExitCode != 1 || snap.Notice == "" {
+		t.Fatalf("snapshot must expose the exit-1 fatal state: %+v", snap)
+	}
+	if dup := rec.HandleClientClosed(app.ClientClosedMsg{Err: bridge.ErrClientClosed}); dup != nil {
+		t.Fatalf("post-fatal drop report must be ignored")
+	}
+}

--- a/packages/neo/internal/app/shellwire.go
+++ b/packages/neo/internal/app/shellwire.go
@@ -1,0 +1,434 @@
+package app
+
+import (
+	"encoding/json"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
+)
+
+// shellwire.go is the todo-7 shell-wiring layer: it feeds the presentational
+// shell regions (welcome/status/footer/widgets, internal/ui/shell) from live
+// session state — Bootstrap get_state, on-demand get_session_stats after
+// agent_end, and the event stream. It holds NO rendering logic (the shell
+// components own text + styling; classic reference footer-data-provider.ts +
+// footer.ts) and NO timers: stats refreshes are event-driven + on-demand only,
+// and the retry countdown re-derives from an event-seeded deadline on the app's
+// existing render tick.
+
+// StatsRequester is the narrow on-demand seam the wire pulls fresh session
+// stats through: after agent_end HandleEvent returns the requester's tea.Cmd,
+// whose get_session_stats CommandResultMsg is routed back into
+// HandleCommandResult. Todo 9 adapts the session layer to it; tests inject a
+// counting fake.
+type StatsRequester interface {
+	SessionStats() tea.Cmd
+}
+
+// WidgetPlacement selects which editor side an extension widget renders on,
+// mirroring the rpc setWidget widgetPlacement field ("aboveEditor" default).
+type WidgetPlacement int
+
+const (
+	WidgetAboveEditor WidgetPlacement = iota
+	WidgetBelowEditor
+)
+
+// ExtensionShellSink is the wire's OWN narrow directives seam for the
+// extension-UI shell directives (setStatus/setWidget/setTitle). The todo-6
+// layer produces directives against its own sink contract; todo 9 adapts that
+// producer to this interface — the two halves meet there, deliberately
+// uncoupled here. Empty/nil widget lines clear a key (setWidget(key, undefined)
+// parity); ClearExtensionStatus mirrors setStatus(key, undefined).
+type ExtensionShellSink interface {
+	SetExtensionStatus(key, text string)
+	ClearExtensionStatus(key string)
+	SetExtensionWidget(key string, lines []string, placement WidgetPlacement)
+	SetExtensionTitle(title string)
+	ClearExtensionTitle()
+}
+
+// ShellWireConfig carries the wire's collaborators and environment facts.
+type ShellWireConfig struct {
+	// Theme builds the status indicators (spinner colors); text styling stays
+	// inside the shell components — the wire emits no escape bytes itself.
+	Theme *theme.Theme
+	// Keys resolves the cancel-hint display for retry/compaction statuses
+	// (app.interrupt), never a raw key literal.
+	Keys *keybindings.Manager
+	// Stats is the on-demand get_session_stats seam; nil disables refreshes.
+	Stats StatsRequester
+	// AppName is the terminal-title app label (e.g. "senpi").
+	AppName string
+	// Cwd/Home feed the footer's ~-relativized cwd and the title basename.
+	Cwd  string
+	Home string
+	// GitBranch is the caller-resolved branch label. Watching .git belongs to
+	// the environment layer (classic: footer-data-provider.ts); the wire only
+	// displays what it is handed.
+	GitBranch string
+}
+
+// ShellWire populates a Shell's regions from live session state: welcome until
+// the first turn, footer model/cwd/thinking/token-context stats, the
+// event-driven status stack (retry countdown, compaction), extension
+// status/widget segments, and the terminal title exposed as readable state.
+type ShellWire struct {
+	sh    *shell.Shell
+	th    *theme.Theme
+	keys  *keybindings.Manager
+	stats StatsRequester
+
+	appName     string
+	sessionName string
+	extTitle    string
+	hasExtTitle bool
+
+	footer    shell.FooterData
+	extStatus map[string]string
+
+	turnSeen      bool
+	retryDeadline time.Time
+}
+
+var _ ExtensionShellSink = (*ShellWire)(nil)
+
+// NewShellWire binds the wire to the shell it populates and seeds the static
+// footer facts (cwd/home/branch) so the HUD is meaningful before bootstrap.
+func NewShellWire(sh *shell.Shell, cfg ShellWireConfig) *ShellWire {
+	appName := cfg.AppName
+	if appName == "" {
+		appName = defaultAppName
+	}
+	w := &ShellWire{
+		sh:        sh,
+		th:        cfg.Theme,
+		keys:      cfg.Keys,
+		stats:     cfg.Stats,
+		appName:   appName,
+		extStatus: map[string]string{},
+		footer:    shell.FooterData{Cwd: cfg.Cwd, Home: cfg.Home, GitBranch: cfg.GitBranch},
+	}
+	sh.SetSession("", cfg.Cwd)
+	w.pushFooter()
+	return w
+}
+
+// WindowTitle returns the current terminal title as readable state: the
+// extension override when set, else "<app>[ - <session>] - <cwd base>". Todo 9
+// maps it onto the View's WindowTitle field (charm.land/bubbletea/v2
+// tea.go:141-143) — plain text only; bubbletea owns the OSC escape.
+func (w *ShellWire) WindowTitle() string {
+	if w.hasExtTitle {
+		return w.extTitle
+	}
+	return shell.NormalTitle(w.appName, w.sessionName, w.footer.Cwd)
+}
+
+// HandleEvent applies one session event to the shell regions. It returns a
+// tea.Cmd only for agent_end (the on-demand stats refresh); every other event
+// mutates region state and returns nil.
+func (w *ShellWire) HandleEvent(msg EventMsg) tea.Cmd {
+	ev := msg.Event
+	switch ev.Type {
+	case "agent_start", "turn_start":
+		w.dismissWelcome()
+	case "agent_end":
+		if w.stats != nil {
+			return w.stats.SessionStats()
+		}
+	case "auto_retry_start":
+		var p struct {
+			Attempt     int   `json:"attempt"`
+			MaxAttempts int   `json:"maxAttempts"`
+			DelayMs     int64 `json:"delayMs"`
+		}
+		decodeEventPayload(ev, &p)
+		w.retryDeadline = time.Now().Add(time.Duration(p.DelayMs) * time.Millisecond)
+		w.sh.StatusStack().Set(shell.NewRetryStatus(w.th, p.Attempt, p.MaxAttempts, p.DelayMs, w.cancelHint()))
+	case "auto_retry_end":
+		w.clearStatus(shell.StatusRetry)
+	case "compaction_start":
+		w.setCompaction(ev)
+	case "compaction_progress":
+		if a := w.sh.StatusStack().Active(); a != nil && a.Kind() == shell.StatusCompaction {
+			a.Advance()
+		} else {
+			w.setCompaction(ev) // recover a missed start so progress is visible
+		}
+	case "compaction_end":
+		w.clearStatus(shell.StatusCompaction)
+	case "session_info_changed":
+		var p struct {
+			Name string `json:"name"`
+		}
+		decodeEventPayload(ev, &p)
+		w.applySessionName(p.Name)
+		w.pushFooter()
+	case "thinking_level_changed":
+		var p struct {
+			Level string `json:"level"`
+		}
+		decodeEventPayload(ev, &p)
+		w.footer.ThinkingLevel = p.Level
+		w.pushFooter()
+	}
+	return nil
+}
+
+// HandleBootstrap seeds the footer + title from the get_state /
+// get_available_models fan-in. Failed sub-responses are skipped — the wire
+// keeps whatever state it already has (BootstrapMsg.Err surfacing is the
+// transcript's job, not the footer's).
+func (w *ShellWire) HandleBootstrap(msg BootstrapMsg) {
+	if msg.State.Success {
+		var st bridge.RPCSessionState
+		if json.Unmarshal(msg.State.Data, &st) == nil {
+			w.applyState(st)
+		}
+	}
+	if msg.Models.Success {
+		var data struct {
+			Models []struct {
+				Provider string `json:"provider"`
+			} `json:"models"`
+		}
+		if json.Unmarshal(msg.Models.Data, &data) == nil {
+			seen := map[string]bool{}
+			for _, m := range data.Models {
+				seen[m.Provider] = true
+			}
+			w.footer.ProviderCount = len(seen)
+		}
+	}
+	w.pushFooter()
+}
+
+// applyState folds a get_state snapshot into the footer + title state.
+func (w *ShellWire) applyState(st bridge.RPCSessionState) {
+	w.applySessionName(st.SessionName)
+	w.footer.ThinkingLevel = string(st.ThinkingLevel)
+	w.footer.AutoCompact = st.AutoCompactionEnabled
+	if len(st.Model) > 0 {
+		var m struct {
+			ID            string `json:"id"`
+			Provider      string `json:"provider"`
+			Reasoning     bool   `json:"reasoning"`
+			ContextWindow int    `json:"contextWindow"`
+		}
+		if json.Unmarshal(st.Model, &m) == nil {
+			w.footer.ModelID = m.ID
+			w.footer.Provider = m.Provider
+			w.footer.ModelReasons = m.Reasoning
+			if w.footer.ContextWindow == 0 {
+				w.footer.ContextWindow = m.ContextWindow
+			}
+		}
+	}
+	if st.MessageCount > 0 {
+		w.dismissWelcome() // resumed session: already past its first turn
+	}
+}
+
+// HandleCommandResult consumes a get_session_stats round-trip (the command
+// HandleEvent returned for agent_end) into the footer token/cost/context
+// numbers. Reports whether the message was the wire's to consume.
+func (w *ShellWire) HandleCommandResult(msg CommandResultMsg) bool {
+	if msg.Command != "get_session_stats" {
+		return false
+	}
+	if msg.Err != nil || !msg.Response.Success {
+		return true // a failed refresh keeps the previous numbers
+	}
+	var stats struct {
+		Tokens struct {
+			Input      int `json:"input"`
+			Output     int `json:"output"`
+			CacheRead  int `json:"cacheRead"`
+			CacheWrite int `json:"cacheWrite"`
+		} `json:"tokens"`
+		Cost         float64 `json:"cost"`
+		ContextUsage *struct {
+			Tokens        *int     `json:"tokens"`
+			ContextWindow int      `json:"contextWindow"`
+			Percent       *float64 `json:"percent"`
+		} `json:"contextUsage"`
+	}
+	if json.Unmarshal(msg.Response.Data, &stats) != nil {
+		return true
+	}
+	w.footer.TokensInput = stats.Tokens.Input
+	w.footer.TokensOutput = stats.Tokens.Output
+	w.footer.CacheRead = stats.Tokens.CacheRead
+	w.footer.CacheWrite = stats.Tokens.CacheWrite
+	w.footer.Cost = stats.Cost
+	if cu := stats.ContextUsage; cu != nil {
+		if cu.ContextWindow > 0 {
+			w.footer.ContextWindow = cu.ContextWindow
+		}
+		w.footer.ContextPctKnown = cu.Percent != nil
+		w.footer.ContextPct = 0
+		if cu.Percent != nil {
+			w.footer.ContextPct = *cu.Percent
+		}
+		switch {
+		case cu.Tokens != nil:
+			w.footer.ContextTokens = *cu.Tokens
+		case cu.Percent != nil:
+			// footer.ts estimate: round(window * percent / 100).
+			w.footer.ContextTokens = int(float64(w.footer.ContextWindow)*(*cu.Percent)/100 + 0.5)
+		default:
+			w.footer.ContextTokens = 0 // unknown until the next response
+		}
+	}
+	w.pushFooter()
+	return true
+}
+
+// AdvanceStatus advances the active status spinner one frame and, for the
+// retry countdown, re-derives the remaining seconds (ceil) from the
+// event-seeded deadline. The app's existing render tick drives it — the wire
+// owns no timer of its own.
+func (w *ShellWire) AdvanceStatus(now time.Time) {
+	stack := w.sh.StatusStack()
+	stack.Advance()
+	a := stack.Active()
+	if a == nil || a.Kind() != shell.StatusRetry {
+		return
+	}
+	remaining := w.retryDeadline.Sub(now)
+	if remaining < 0 {
+		remaining = 0
+	}
+	a.SetRemainingSeconds(int((remaining + 999*time.Millisecond) / time.Second))
+}
+
+// SetExtensionStatus installs (or replaces) a keyed footer status segment.
+func (w *ShellWire) SetExtensionStatus(key, text string) {
+	w.extStatus[key] = text
+	w.pushExtStatus()
+}
+
+// ClearExtensionStatus removes a keyed footer status segment.
+func (w *ShellWire) ClearExtensionStatus(key string) {
+	delete(w.extStatus, key)
+	w.pushExtStatus()
+}
+
+// SetExtensionWidget installs a keyed widget block on one editor side. A key
+// lives in exactly one area, so re-placing moves it; empty/nil lines clear it.
+func (w *ShellWire) SetExtensionWidget(key string, lines []string, placement WidgetPlacement) {
+	w.sh.WidgetAbove().Clear(key)
+	w.sh.WidgetBelow().Clear(key)
+	if len(lines) == 0 {
+		return
+	}
+	if placement == WidgetBelowEditor {
+		w.sh.WidgetBelow().Set(key, lines)
+		return
+	}
+	w.sh.WidgetAbove().Set(key, lines)
+}
+
+// SetExtensionTitle overrides the terminal title (interactive-mode
+// extensionTerminalTitle precedence) until ClearExtensionTitle restores the
+// normal title.
+func (w *ShellWire) SetExtensionTitle(title string) {
+	w.extTitle, w.hasExtTitle = title, true
+}
+
+// ClearExtensionTitle drops the extension title override.
+func (w *ShellWire) ClearExtensionTitle() {
+	w.extTitle, w.hasExtTitle = "", false
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+func (w *ShellWire) dismissWelcome() {
+	if w.turnSeen {
+		return
+	}
+	w.turnSeen = true
+	w.sh.DismissWelcome()
+}
+
+func (w *ShellWire) applySessionName(name string) {
+	w.sessionName = name
+	w.footer.SessionName = name
+	w.sh.SetSession(name, w.footer.Cwd)
+}
+
+// cancelHint resolves the app.interrupt key display for status messages.
+func (w *ShellWire) cancelHint() string {
+	if w.keys == nil {
+		return ""
+	}
+	return firstKey(w.keys, actionInterrupt)
+}
+
+// clearStatus clears the stack only when the active indicator matches kind, so
+// an unrelated end event never wipes another surface's status.
+func (w *ShellWire) clearStatus(kind shell.StatusKind) {
+	if a := w.sh.StatusStack().Active(); a != nil && a.Kind() == kind {
+		w.sh.StatusStack().Clear()
+	}
+}
+
+func (w *ShellWire) setCompaction(ev bridge.Event) {
+	var p struct {
+		Reason string `json:"reason"`
+	}
+	decodeEventPayload(ev, &p)
+	w.sh.StatusStack().Set(shell.NewCompactionStatus(w.th, compactionReason(p.Reason), w.cancelHint()))
+}
+
+// compactionReason maps the wire reason strings (extensions/types.ts
+// CompactionReason) onto the shell enum; unknown reasons fall back to manual.
+func compactionReason(reason string) shell.CompactionReason {
+	switch reason {
+	case "threshold":
+		return shell.CompactionThreshold
+	case "overflow":
+		return shell.CompactionOverflow
+	case "pre_prompt":
+		return shell.CompactionPrePrompt
+	case "branch":
+		return shell.CompactionBranch
+	case "extension":
+		return shell.CompactionExtension
+	default:
+		return shell.CompactionManual
+	}
+}
+
+// decodeEventPayload best-effort decodes an event's raw line into dst; a
+// malformed payload leaves dst zero-valued (the UI degrades, never panics).
+func decodeEventPayload(ev bridge.Event, dst any) {
+	if len(ev.Payload) == 0 {
+		return
+	}
+	_ = json.Unmarshal(ev.Payload, dst)
+}
+
+func (w *ShellWire) pushFooter() { w.sh.Footer().SetData(w.footer) }
+
+// pushExtStatus hands the footer a copy so later mutations cannot race a
+// render of the previously-set map.
+func (w *ShellWire) pushExtStatus() {
+	if len(w.extStatus) == 0 {
+		w.sh.Footer().SetExtensionStatuses(nil)
+		return
+	}
+	cp := make(map[string]string, len(w.extStatus))
+	for k, v := range w.extStatus {
+		cp[k] = v
+	}
+	w.sh.Footer().SetExtensionStatuses(cp)
+}

--- a/packages/neo/internal/app/shellwire_test.go
+++ b/packages/neo/internal/app/shellwire_test.go
@@ -1,0 +1,450 @@
+package app_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/theme"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/shell"
+)
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// fakeStatsRequester counts on-demand stats pulls and answers with a canned
+// CommandResultMsg, proving the wire is event-driven + on-demand only.
+type fakeStatsRequester struct{ calls int }
+
+func (f *fakeStatsRequester) SessionStats() tea.Cmd {
+	f.calls++
+	return func() tea.Msg { return app.CommandResultMsg{Command: "get_session_stats"} }
+}
+
+// wireHarness bundles a real shell + the wire under test + the stats fake.
+type wireHarness struct {
+	sh    *shell.Shell
+	wire  *app.ShellWire
+	stats *fakeStatsRequester
+}
+
+func newWireHarness(t *testing.T) *wireHarness {
+	t.Helper()
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName, AgentDir: "\x00nonexistent"})
+	if err != nil {
+		t.Fatalf("theme.Load: %v", err)
+	}
+	keys := keybindings.NewManager(nil)
+	sh := shell.New(th, "alt+up", "senpi")
+	sh.SetWelcome(shell.WelcomeContent{Title: "senpi"})
+	stats := &fakeStatsRequester{}
+	wire := app.NewShellWire(sh, app.ShellWireConfig{
+		Theme:   th,
+		Keys:    keys,
+		Stats:   stats,
+		AppName: "senpi",
+		Cwd:     "/home/u/proj",
+		Home:    "/home/u",
+	})
+	return &wireHarness{sh: sh, wire: wire, stats: stats}
+}
+
+// wireEvent builds an EventMsg from a raw event JSON line, the same shape the
+// bridge codec produces (Payload = full raw object).
+func wireEvent(t *testing.T, raw string) app.EventMsg {
+	t.Helper()
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
+		t.Fatalf("bad event fixture %q: %v", raw, err)
+	}
+	return app.EventMsg{Event: bridge.Event{Type: probe.Type, Payload: json.RawMessage(raw)}}
+}
+
+// okResponse builds a successful RpcResponse with a raw data payload.
+func okResponse(command, data string) bridge.Response {
+	return bridge.Response{Type: "response", Command: command, Success: true, Data: json.RawMessage(data)}
+}
+
+// plainStatus renders the status stack stripped of SGR for text assertions.
+func plainStatus(h *wireHarness) string {
+	return ui.StripANSI(strings.Join(h.sh.StatusStack().Render(120), "\n"))
+}
+
+// bootstrapReasoningModel seeds the wire with a get_state carrying a reasoning
+// model so thinking-level footer assertions have a ":level" suffix to observe.
+func bootstrapReasoningModel(h *wireHarness) {
+	h.wire.HandleBootstrap(app.BootstrapMsg{
+		State: okResponse("get_state", `{"thinkingLevel":"off","steeringMode":"all","followUpMode":"all",`+
+			`"sessionId":"s1","model":{"id":"mock-a","provider":"mock","reasoning":true,"contextWindow":200000},`+
+			`"messageCount":0,"pendingMessageCount":0,"isStreaming":false,"isCompacting":false,"autoCompactionEnabled":true}`),
+		Models: okResponse("get_available_models", `{"models":[{"provider":"mock"},{"provider":"other"},{"provider":"mock"}]}`),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Event → region state table
+// ---------------------------------------------------------------------------
+
+func TestShellWireEventRegionTable(t *testing.T) {
+	cases := []struct {
+		name   string
+		events []string
+		check  func(t *testing.T, h *wireHarness)
+	}{
+		{
+			name:   "auto_retry_start renders digit-bearing countdown",
+			events: []string{`{"type":"auto_retry_start","attempt":2,"maxAttempts":5,"delayMs":3000,"errorMessage":"overloaded"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				got := plainStatus(h)
+				if !strings.Contains(got, "Retrying (2/5) in 3s") {
+					t.Fatalf("expected retry countdown, status was %q", got)
+				}
+			},
+		},
+		{
+			name: "auto_retry_end clears the retry status",
+			events: []string{
+				`{"type":"auto_retry_start","attempt":1,"maxAttempts":3,"delayMs":2000,"errorMessage":"overloaded"}`,
+				`{"type":"auto_retry_end","success":true,"attempt":1}`,
+			},
+			check: func(t *testing.T, h *wireHarness) {
+				if lines := h.sh.StatusStack().Render(120); lines != nil {
+					t.Fatalf("expected idle status after auto_retry_end, got %q", lines)
+				}
+			},
+		},
+		{
+			name:   "compaction_start threshold renders auto-compacting",
+			events: []string{`{"type":"compaction_start","reason":"threshold"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				if got := plainStatus(h); !strings.Contains(got, "Auto-compacting") {
+					t.Fatalf("expected auto-compacting status, got %q", got)
+				}
+			},
+		},
+		{
+			name:   "compaction_start overflow renders overflow message",
+			events: []string{`{"type":"compaction_start","reason":"overflow"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				if got := plainStatus(h); !strings.Contains(got, "Context overflow detected") {
+					t.Fatalf("expected overflow status, got %q", got)
+				}
+			},
+		},
+		{
+			name:   "compaction_progress recovers a missed start",
+			events: []string{`{"type":"compaction_progress","reason":"manual","delta":"x"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				if got := plainStatus(h); !strings.Contains(got, "Compacting context") {
+					t.Fatalf("expected compaction status from progress-only stream, got %q", got)
+				}
+			},
+		},
+		{
+			name: "compaction_end clears the compaction status",
+			events: []string{
+				`{"type":"compaction_start","reason":"manual"}`,
+				`{"type":"compaction_end","reason":"manual","result":null,"aborted":false,"willRetry":false}`,
+			},
+			check: func(t *testing.T, h *wireHarness) {
+				if lines := h.sh.StatusStack().Render(120); lines != nil {
+					t.Fatalf("expected idle status after compaction_end, got %q", lines)
+				}
+			},
+		},
+		{
+			name: "compaction_end does not clear an active retry",
+			events: []string{
+				`{"type":"auto_retry_start","attempt":1,"maxAttempts":3,"delayMs":2000,"errorMessage":"overloaded"}`,
+				`{"type":"compaction_end","reason":"manual","result":null,"aborted":false,"willRetry":false}`,
+			},
+			check: func(t *testing.T, h *wireHarness) {
+				if got := plainStatus(h); !strings.Contains(got, "Retrying") {
+					t.Fatalf("expected retry status to survive compaction_end, got %q", got)
+				}
+			},
+		},
+		{
+			name:   "welcome stays before the first turn",
+			events: nil,
+			check: func(t *testing.T, h *wireHarness) {
+				if h.sh.Header(120) == nil {
+					t.Fatal("expected welcome header before the first turn")
+				}
+			},
+		},
+		{
+			name:   "agent_start dismisses the welcome",
+			events: []string{`{"type":"agent_start"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				if lines := h.sh.Header(120); lines != nil {
+					t.Fatalf("expected welcome dismissed on first turn, got %d lines", len(lines))
+				}
+			},
+		},
+		{
+			name:   "session_info_changed updates footer session segment",
+			events: []string{`{"type":"session_info_changed","name":"alpha"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				got := ui.StripANSI(h.sh.Footer().Render(120)[0])
+				if !strings.Contains(got, "alpha") {
+					t.Fatalf("expected session name in footer, got %q", got)
+				}
+			},
+		},
+		{
+			name:   "thinking_level_changed refreshes footer right side",
+			events: []string{`{"type":"thinking_level_changed","level":"high"}`},
+			check: func(t *testing.T, h *wireHarness) {
+				got := ui.StripANSI(h.sh.Footer().Render(120)[0])
+				if !strings.Contains(got, "mock-a:high") {
+					t.Fatalf("expected model:high on footer right side, got %q", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newWireHarness(t)
+			bootstrapReasoningModel(h)
+			for _, raw := range tc.events {
+				h.wire.HandleEvent(wireEvent(t, raw))
+			}
+			tc.check(t, h)
+		})
+	}
+}
+
+// TestShellWireBootstrapResumeDismissesWelcome proves a resumed session (past
+// its first turn already: messageCount > 0) never shows the welcome card.
+func TestShellWireBootstrapResumeDismissesWelcome(t *testing.T) {
+	h := newWireHarness(t)
+	h.wire.HandleBootstrap(app.BootstrapMsg{
+		State: okResponse("get_state", `{"thinkingLevel":"off","steeringMode":"all","followUpMode":"all",`+
+			`"sessionId":"s1","messageCount":4,"pendingMessageCount":0,"isStreaming":false,"isCompacting":false,`+
+			`"autoCompactionEnabled":true}`),
+	})
+	if lines := h.sh.Header(120); lines != nil {
+		t.Fatalf("expected welcome dismissed for a resumed session, got %d lines", len(lines))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Footer text formatting goldens
+// ---------------------------------------------------------------------------
+
+func TestShellWireFooterFormattingGolden(t *testing.T) {
+	h := newWireHarness(t)
+	bootstrapReasoningModel(h)
+
+	handled := h.wire.HandleCommandResult(app.CommandResultMsg{
+		Command: "get_session_stats",
+		Response: okResponse("get_session_stats", `{"tokens":{"input":12345,"output":678,"cacheRead":200,`+
+			`"cacheWrite":50,"total":13273},"cost":0.042,`+
+			`"contextUsage":{"tokens":8000,"contextWindow":200000,"percent":4.0}}`),
+	})
+	if !handled {
+		t.Fatal("expected the wire to consume the get_session_stats result")
+	}
+
+	const width = 120
+	got := ui.StripANSI(h.sh.Footer().Render(width)[0])
+	left := "~/proj • ↑12,345 • ↓678 • cache 200/50 • $0.042 • 8,000/200,000 (4.0%) (auto)"
+	right := "(mock) mock-a:off"
+	pad := width - ui.VisibleWidth(left) - ui.VisibleWidth(right)
+	want := left + strings.Repeat(" ", pad) + right
+	if got != want {
+		t.Fatalf("footer golden mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestShellWireFooterUnknownContextGolden pins the post-compaction display:
+// contextUsage with null tokens/percent renders the "(?)" marker.
+func TestShellWireFooterUnknownContextGolden(t *testing.T) {
+	h := newWireHarness(t)
+	bootstrapReasoningModel(h)
+
+	h.wire.HandleCommandResult(app.CommandResultMsg{
+		Command: "get_session_stats",
+		Response: okResponse("get_session_stats", `{"tokens":{"input":100,"output":20,"cacheRead":0,`+
+			`"cacheWrite":0,"total":120},"cost":0,`+
+			`"contextUsage":{"tokens":null,"contextWindow":200000,"percent":null}}`),
+	})
+
+	got := ui.StripANSI(h.sh.Footer().Render(120)[0])
+	if !strings.Contains(got, "0/200,000 (?) (auto)") {
+		t.Fatalf("expected unknown-context marker, footer was %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Title state emission
+// ---------------------------------------------------------------------------
+
+func TestShellWireTitleStateEmission(t *testing.T) {
+	h := newWireHarness(t)
+
+	if got := h.wire.WindowTitle(); got != "senpi - proj" {
+		t.Fatalf("initial title = %q, want %q", got, "senpi - proj")
+	}
+
+	h.wire.HandleEvent(wireEvent(t, `{"type":"session_info_changed","name":"alpha"}`))
+	if got := h.wire.WindowTitle(); got != "senpi - alpha - proj" {
+		t.Fatalf("named-session title = %q, want %q", got, "senpi - alpha - proj")
+	}
+
+	h.wire.SetExtensionTitle("custom title")
+	if got := h.wire.WindowTitle(); got != "custom title" {
+		t.Fatalf("extension title = %q, want %q", got, "custom title")
+	}
+
+	h.wire.ClearExtensionTitle()
+	if got := h.wire.WindowTitle(); got != "senpi - alpha - proj" {
+		t.Fatalf("restored title = %q, want %q", got, "senpi - alpha - proj")
+	}
+
+	// name: undefined clears the session label (agent-session.ts contract).
+	h.wire.HandleEvent(wireEvent(t, `{"type":"session_info_changed"}`))
+	if got := h.wire.WindowTitle(); got != "senpi - proj" {
+		t.Fatalf("cleared-session title = %q, want %q", got, "senpi - proj")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// On-demand stats after agent_end (event-driven only, no polling)
+// ---------------------------------------------------------------------------
+
+func TestShellWireAgentEndRequestsStatsOnDemand(t *testing.T) {
+	h := newWireHarness(t)
+
+	if cmd := h.wire.HandleEvent(wireEvent(t, `{"type":"message_update"}`)); cmd != nil {
+		t.Fatal("message_update must not trigger a stats refresh")
+	}
+	if h.stats.calls != 0 {
+		t.Fatalf("stats requested %d times before agent_end", h.stats.calls)
+	}
+
+	cmd := h.wire.HandleEvent(wireEvent(t, `{"type":"agent_end"}`))
+	if cmd == nil {
+		t.Fatal("expected a stats-refresh command from agent_end")
+	}
+	if h.stats.calls != 1 {
+		t.Fatalf("stats requested %d times, want 1", h.stats.calls)
+	}
+	res, ok := cmd().(app.CommandResultMsg)
+	if !ok || res.Command != "get_session_stats" {
+		t.Fatalf("expected a get_session_stats CommandResultMsg, got %#v", res)
+	}
+}
+
+// TestShellWireNilStatsRequester proves agent_end degrades to a no-op command
+// when no requester is wired (constructor contract, not a panic path).
+func TestShellWireNilStatsRequester(t *testing.T) {
+	th, err := theme.Load(theme.Options{Name: theme.DefaultThemeName, AgentDir: "\x00nonexistent"})
+	if err != nil {
+		t.Fatalf("theme.Load: %v", err)
+	}
+	sh := shell.New(th, "alt+up", "senpi")
+	wire := app.NewShellWire(sh, app.ShellWireConfig{
+		Theme: th, Keys: keybindings.NewManager(nil), AppName: "senpi", Cwd: "/tmp", Home: "/tmp",
+	})
+	if cmd := wire.HandleEvent(wireEvent(t, `{"type":"agent_end"}`)); cmd != nil {
+		t.Fatal("expected nil command from agent_end without a stats requester")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Retry countdown advance (tick-driven re-render, deadline seeded by the event)
+// ---------------------------------------------------------------------------
+
+func TestShellWireRetryCountdownAdvance(t *testing.T) {
+	h := newWireHarness(t)
+	h.wire.HandleEvent(wireEvent(t, `{"type":"auto_retry_start","attempt":1,"maxAttempts":3,"delayMs":3000,"errorMessage":"overloaded"}`))
+	start := time.Now()
+
+	if got := plainStatus(h); !strings.Contains(got, "in 3s") {
+		t.Fatalf("expected seeded countdown of 3s, got %q", got)
+	}
+
+	h.wire.AdvanceStatus(start.Add(2 * time.Second))
+	if got := plainStatus(h); !strings.Contains(got, "in 1s") {
+		t.Fatalf("expected countdown at 1s after two elapsed seconds, got %q", got)
+	}
+
+	h.wire.AdvanceStatus(start.Add(10 * time.Second))
+	if got := plainStatus(h); !strings.Contains(got, "in 0s") {
+		t.Fatalf("expected countdown clamped at 0s past the deadline, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Extension setStatus / setWidget keyed segments (the todo-9 adapter seam)
+// ---------------------------------------------------------------------------
+
+// The wire itself is the directives sink todo 9 adapts extension directives to.
+var _ app.ExtensionShellSink = (*app.ShellWire)(nil)
+
+func TestShellWireExtensionStatusSegments(t *testing.T) {
+	h := newWireHarness(t)
+
+	h.wire.SetExtensionStatus("linter", "lint: 3 warnings")
+	lines := h.sh.Footer().Render(120)
+	if len(lines) != 2 {
+		t.Fatalf("expected a second footer line for extension statuses, got %d lines", len(lines))
+	}
+	if got := ui.StripANSI(lines[1]); !strings.Contains(got, "lint: 3 warnings") {
+		t.Fatalf("expected extension status text, got %q", got)
+	}
+
+	// Keys render sorted, mirroring footer.ts map iteration + sort.
+	h.wire.SetExtensionStatus("a-first", "alpha status")
+	got := ui.StripANSI(h.sh.Footer().Render(120)[1])
+	if !strings.Contains(got, "alpha status lint: 3 warnings") {
+		t.Fatalf("expected key-sorted statuses, got %q", got)
+	}
+
+	h.wire.ClearExtensionStatus("linter")
+	h.wire.ClearExtensionStatus("a-first")
+	if lines := h.sh.Footer().Render(120); len(lines) != 1 {
+		t.Fatalf("expected the status line to disappear once cleared, got %d lines", len(lines))
+	}
+}
+
+func TestShellWireExtensionWidgetSegments(t *testing.T) {
+	h := newWireHarness(t)
+
+	h.wire.SetExtensionWidget("w1", []string{"above-widget-line"}, app.WidgetAboveEditor)
+	above := ui.StripANSI(strings.Join(h.sh.AboveEditor(120), "\n"))
+	if !strings.Contains(above, "above-widget-line") {
+		t.Fatalf("expected widget above the editor, got %q", above)
+	}
+
+	// Re-placing the same key moves it: gone above, present below.
+	h.wire.SetExtensionWidget("w1", []string{"below-widget-line"}, app.WidgetBelowEditor)
+	above = ui.StripANSI(strings.Join(h.sh.AboveEditor(120), "\n"))
+	below := ui.StripANSI(strings.Join(h.sh.BelowEditor(120), "\n"))
+	if strings.Contains(above, "widget-line") {
+		t.Fatalf("expected widget removed from above-editor after re-place, got %q", above)
+	}
+	if !strings.Contains(below, "below-widget-line") {
+		t.Fatalf("expected widget below the editor, got %q", below)
+	}
+
+	// nil lines clears (setWidget(key, undefined) parity).
+	h.wire.SetExtensionWidget("w1", nil, app.WidgetBelowEditor)
+	below = ui.StripANSI(strings.Join(h.sh.BelowEditor(120), "\n"))
+	if strings.Contains(below, "widget-line") {
+		t.Fatalf("expected widget cleared, got %q", below)
+	}
+}

--- a/packages/neo/internal/app/transcript.go
+++ b/packages/neo/internal/app/transcript.go
@@ -1,0 +1,323 @@
+package app
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript"
+)
+
+// Transcript-owned keybinding action ids, resolved through the Manager (no raw
+// key string is ever compared here).
+const (
+	actionToolsExpand    = "app.tools.expand"
+	actionThinkingToggle = "app.thinking.toggle"
+)
+
+// maxTrackedUnknownEvents bounds the once-per-type unknown-event log set so a
+// misbehaving stream cannot grow it without limit.
+const maxTrackedUnknownEvents = 64
+
+// EventDisposition reports what the translator did with one EventMsg, so the
+// update loop (todo 9) knows whether the frame changed and tests can prove no
+// event type is dropped silently.
+type EventDisposition int
+
+const (
+	// EventApplied: the event mutated transcript state (Feed.Apply and/or
+	// translator bookkeeping).
+	EventApplied EventDisposition = iota
+	// EventIgnored: the event type is in the explicit ignore-list — it renders on
+	// a non-transcript surface (status line, footer, overlays) owned by another
+	// todo, and produces no feed entry by design.
+	EventIgnored
+	// EventDeferred: the event is owned by a later todo and handed off there
+	// (queue_update → todo 4's queue/pending area).
+	EventDeferred
+	// EventUnknown: the type is not in the bridge event mirror; it is logged once
+	// per type and otherwise skipped.
+	EventUnknown
+)
+
+// transcriptIgnoredEvents is the EXPLICIT ignore-list for the transcript
+// translator: every bridge.KnownEventTypes() key that intentionally produces no
+// feed entry, with the surface that owns it instead. The exhaustiveness test
+// asserts handled ∪ ignored ∪ deferred covers the whole mirror.
+var transcriptIgnoredEvents = map[string]string{
+	"turn_start":             "turn boundaries render nothing; content arrives via message_* events",
+	"turn_end":               "turn boundaries render nothing; tool results arrive via tool_execution_end",
+	"compaction_start":       "status-indicator surface (shell status line, todo 7)",
+	"compaction_progress":    "status-indicator surface (shell status line, todo 7)",
+	"entry_appended":         "custom entry renderers are extension-owned (todo 6); classic renders nothing without one",
+	"session_info_changed":   "terminal title + footer surface (todo 7/9)",
+	"system_prompt_change":   "status-line surface (shell status line, todo 7)",
+	"thinking_level_changed": "footer surface (todo 7)",
+	"auto_retry_start":       "retry status-indicator surface (shell status line, todo 7)",
+	"auto_retry_end":         "retry status-indicator surface (shell status line, todo 7)",
+	"auth_login_url":         "auth login overlay (todo 13)",
+	"auth_login_end":         "auth login overlay (todo 13)",
+	"extension_error":        "delivered as ExtensionErrorMsg by the session adapter demux, never as an EventMsg",
+}
+
+// Transcript translates the session adapter's EventMsg stream into transcript
+// Feed.Apply calls: streaming message deltas, tool-execution lifecycle, hook
+// counts, compaction/branch summaries, and abort fan-out. It owns NO rendering
+// (the Feed does) and never touches the wire codec beyond decoding the typed
+// payload views it maps.
+type Transcript struct {
+	feed *transcript.Feed
+	keys *keybindings.Manager
+
+	// hookCounts tracks active tool hooks per tool-call id (phase start/end),
+	// rendered as the feed's `[hooks: N]` badge. Entries are removed at zero and
+	// the map is reset at turn boundaries, so it stays bounded.
+	hookCounts map[string]int
+
+	// Presentation toggles (classic toolOutputExpanded / hideThinkingBlock).
+	toolsExpanded bool
+	hideThinking  bool
+
+	// unknownLogged holds the event types already logged once (bounded); logf is
+	// the injectable sink (default: standard log, which todo 9 routes to the
+	// bubbletea log file — never the raw terminal).
+	unknownLogged map[string]bool
+	suppressedLog bool
+	logf          func(format string, args ...any)
+}
+
+// NewTranscript wires a translator onto a Feed. Expand/collapse and thinking
+// toggles resolve through the keybinding Manager's app.tools.expand /
+// app.thinking.toggle actions.
+func NewTranscript(feed *transcript.Feed, keys *keybindings.Manager) *Transcript {
+	return &Transcript{
+		feed:          feed,
+		keys:          keys,
+		hookCounts:    map[string]int{},
+		unknownLogged: map[string]bool{},
+		logf:          log.Printf,
+	}
+}
+
+// SetLogf replaces the unknown-event log sink (tests and the program wiring
+// inject theirs; the default is the standard logger).
+func (t *Transcript) SetLogf(logf func(format string, args ...any)) {
+	if logf != nil {
+		t.logf = logf
+	}
+}
+
+// HandleKey routes transcript-level presentation chords through the Manager:
+// app.tools.expand toggles tool/summary expansion and app.thinking.toggle
+// toggles thinking-block visibility. Returns true when the key was consumed.
+func (t *Transcript) HandleKey(raw string) bool {
+	switch {
+	case t.keys.Matches(raw, actionToolsExpand):
+		t.toolsExpanded = !t.toolsExpanded
+		t.feed.SetToolsExpanded(t.toolsExpanded)
+		return true
+	case t.keys.Matches(raw, actionThinkingToggle):
+		t.hideThinking = !t.hideThinking
+		t.feed.SetHideThinking(t.hideThinking)
+		return true
+	}
+	return false
+}
+
+// HandleEvent maps one demuxed session event onto the Feed. Malformed payloads
+// of known types are logged once per type and skipped without panicking; the
+// stream keeps flowing.
+func (t *Transcript) HandleEvent(msg EventMsg) EventDisposition {
+	ev := msg.Event
+	switch ev.Type {
+	case "agent_start":
+		// New turn: per-turn hook bookkeeping resets (classic clearToolHookStatuses).
+		t.hookCounts = map[string]int{}
+		return EventApplied
+
+	case "agent_end":
+		// Turn over: any straggler pending block would spin forever, so abort the
+		// leftovers (no-op after a clean turn) and drop stale hook counts.
+		t.feed.AbortPending()
+		t.hookCounts = map[string]int{}
+		return EventApplied
+
+	case "message_start", "message_update", "message_end":
+		return t.applyMessageEvent(ev.Type, ev.Payload)
+
+	case "tool_execution_start", "tool_execution_update", "tool_execution_end":
+		return t.applyToolEvent(ev.Type, ev.Payload)
+
+	case "tool_hook_status":
+		return t.applyToolHookStatus(ev.Payload)
+
+	case "compaction_end":
+		return t.applyCompactionEnd(ev.Payload)
+
+	case "queue_update":
+		// Hand-off to todo 4: the queue/pending-messages area (shell.Queue) owns
+		// steering/follow-up display; the transcript renders nothing for it.
+		return EventDeferred
+	}
+
+	if _, ok := transcriptIgnoredEvents[ev.Type]; ok {
+		return EventIgnored
+	}
+	t.logUnknown(ev.Type)
+	return EventUnknown
+}
+
+// applyMessageEvent decodes the wire message envelope and forwards it to the
+// Feed; an aborted/errored assistant finalization also aborts pending tool
+// blocks (classic message_end stopReason handling).
+func (t *Transcript) applyMessageEvent(eventType string, payload []byte) EventDisposition {
+	var body struct {
+		Message *transcript.FeedMessage `json:"message"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil || body.Message == nil {
+		t.logMalformed(eventType, err)
+		return EventApplied
+	}
+	t.feed.Apply(transcript.FeedEvent{Type: eventType, Message: body.Message})
+	if eventType == "message_end" && body.Message.Role == "assistant" &&
+		(body.Message.StopReason == "aborted" || body.Message.StopReason == "error") {
+		t.feed.AbortPending()
+	}
+	return EventApplied
+}
+
+// applyToolEvent decodes the tool_execution_* wire shapes (args / partialResult
+// / result + top-level isError) into the Feed's tool lifecycle.
+func (t *Transcript) applyToolEvent(eventType string, payload []byte) EventDisposition {
+	var body struct {
+		ToolCallID string          `json:"toolCallId"`
+		ToolName   string          `json:"toolName"`
+		Args       map[string]any  `json:"args"`
+		Partial    json.RawMessage `json:"partialResult"`
+		Result     json.RawMessage `json:"result"`
+		IsError    bool            `json:"isError"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil || body.ToolCallID == "" {
+		t.logMalformed(eventType, err)
+		return EventApplied
+	}
+	fev := transcript.FeedEvent{
+		Type:       eventType,
+		ToolCallID: body.ToolCallID,
+		ToolName:   body.ToolName,
+		ToolArgs:   body.Args,
+	}
+	switch eventType {
+	case "tool_execution_update":
+		fev.Partial = decodeToolResult(body.Partial, false)
+	case "tool_execution_end":
+		fev.Result = decodeToolResult(body.Result, body.IsError)
+		if fev.Result == nil {
+			// A result-less end still finalizes the block instead of leaving an
+			// eternal spinner.
+			fev.Result = &transcript.FeedToolResult{IsError: body.IsError}
+		}
+	}
+	t.feed.Apply(fev)
+	return EventApplied
+}
+
+// decodeToolResult extracts the content blocks from a wire tool result (the
+// `result`/`partialResult` objects are open-shaped; only `content` renders).
+// Returns nil for an absent or non-object value.
+func decodeToolResult(raw json.RawMessage, isError bool) *transcript.FeedToolResult {
+	if len(raw) == 0 {
+		return nil
+	}
+	var body struct {
+		Content []transcript.ContentBlock `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil
+	}
+	return &transcript.FeedToolResult{Content: body.Content, IsError: isError}
+}
+
+// applyToolHookStatus folds hook lifecycle phases into the per-tool active-hook
+// count the feed renders as `[hooks: N]`.
+func (t *Transcript) applyToolHookStatus(payload []byte) EventDisposition {
+	var body struct {
+		ToolCallID string `json:"toolCallId"`
+		Phase      string `json:"phase"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil || body.ToolCallID == "" {
+		t.logMalformed("tool_hook_status", err)
+		return EventApplied
+	}
+	switch body.Phase {
+	case "start":
+		t.hookCounts[body.ToolCallID]++
+	case "end":
+		if t.hookCounts[body.ToolCallID] > 0 {
+			t.hookCounts[body.ToolCallID]--
+		}
+		if t.hookCounts[body.ToolCallID] == 0 {
+			delete(t.hookCounts, body.ToolCallID)
+		}
+	}
+	t.feed.Apply(transcript.FeedEvent{
+		Type:       "tool_hook_status",
+		ToolCallID: body.ToolCallID,
+		HookCount:  t.hookCounts[body.ToolCallID],
+	})
+	return EventApplied
+}
+
+// applyCompactionEnd renders a successful compaction as a collapsible summary
+// entry. Aborted or failed compactions render nothing here (the status-line
+// surface owns cancellation notices, todo 7).
+func (t *Transcript) applyCompactionEnd(payload []byte) EventDisposition {
+	var body struct {
+		Aborted bool `json:"aborted"`
+		Result  *struct {
+			Summary      string `json:"summary"`
+			TokensBefore int    `json:"tokensBefore"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.logMalformed("compaction_end", err)
+		return EventApplied
+	}
+	if body.Aborted || body.Result == nil {
+		return EventApplied
+	}
+	t.feed.Apply(transcript.FeedEvent{Type: "message_end", Message: &transcript.FeedMessage{
+		Role:         "compactionSummary",
+		Summary:      body.Result.Summary,
+		TokensBefore: body.Result.TokensBefore,
+	}})
+	return EventApplied
+}
+
+// logUnknown logs an unmirrored event type exactly once per type, bounded so a
+// hostile stream cannot grow the set forever (one final suppression notice).
+func (t *Transcript) logUnknown(eventType string) {
+	if t.unknownLogged[eventType] {
+		return
+	}
+	if len(t.unknownLogged) >= maxTrackedUnknownEvents {
+		if !t.suppressedLog {
+			t.suppressedLog = true
+			t.logf("neo transcript: further unknown event types suppressed after %d distinct types", maxTrackedUnknownEvents)
+		}
+		return
+	}
+	t.unknownLogged[eventType] = true
+	t.logf("neo transcript: unknown session event type %q (rendering skipped)", eventType)
+}
+
+// logMalformed reports a known event type whose payload failed to decode; keyed
+// into the same once-per-type set so it cannot spam.
+func (t *Transcript) logMalformed(eventType string, err error) {
+	key := "malformed:" + eventType
+	if t.unknownLogged[key] || len(t.unknownLogged) >= maxTrackedUnknownEvents {
+		return
+	}
+	t.unknownLogged[key] = true
+	t.logf("neo transcript: malformed %s payload skipped (err=%v)", eventType, err)
+}

--- a/packages/neo/internal/app/transcript_test.go
+++ b/packages/neo/internal/app/transcript_test.go
@@ -1,0 +1,317 @@
+package app_test
+
+// Translator contract (todo 3): every EventMsg the session adapter demuxes is
+// mapped into transcript Feed.Apply calls (or explicitly ignored/deferred) —
+// never dropped silently. Includes the bridge.KnownEventTypes exhaustiveness
+// sub-test and the 500-delta streaming perf test.
+//
+// RED first: app.NewTranscript and the disposition constants do not exist
+// until GREEN.
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/bridge"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/keybindings"
+	"github.com/code-yeongyu/senpi/packages/neo/internal/ui/transcript"
+)
+
+// newTranscriptFixture builds a Feed + translator pair on the default theme and
+// pure-default keybindings, with the log sink silenced (tests that assert on
+// logging install their own via SetLogf).
+func newTranscriptFixture(t *testing.T) (*transcript.Feed, *app.Transcript) {
+	t.Helper()
+	feed := transcript.NewFeed(transcript.DefaultRenderTheme())
+	tr := app.NewTranscript(feed, keybindings.NewManager(nil))
+	tr.SetLogf(func(string, ...any) {})
+	return feed, tr
+}
+
+// eventMsg decodes a raw stream line exactly the way the session adapter does
+// (DecodeMessage → AsEvent), so the translator sees real bridge.Event payloads.
+func eventMsg(t *testing.T, line string) app.EventMsg {
+	t.Helper()
+	msg, err := bridge.DecodeMessage([]byte(line))
+	if err != nil {
+		t.Fatalf("decode %q: %v", line, err)
+	}
+	ev, err := msg.AsEvent()
+	if err != nil {
+		t.Fatalf("as event %q: %v", line, err)
+	}
+	return app.EventMsg{Event: ev}
+}
+
+func feedText(feed *transcript.Feed) string {
+	return strings.Join(feed.Render(100), "\n")
+}
+
+// rawForKeyID converts a resolved keybinding id (e.g. "ctrl+o") into the raw
+// terminal bytes the Manager matches on. Only ctrl+<letter> and bare printable
+// ids are needed here; anything else fails the test so the helper never guesses.
+func rawForKeyID(t *testing.T, keyID string) string {
+	t.Helper()
+	if rest, ok := strings.CutPrefix(keyID, "ctrl+"); ok && len(rest) == 1 && rest[0] >= 'a' && rest[0] <= 'z' {
+		return string(rest[0] - 'a' + 1)
+	}
+	if len(keyID) == 1 {
+		return keyID
+	}
+	t.Fatalf("rawForKeyID: unsupported key id %q", keyID)
+	return ""
+}
+
+func TestTranscriptMessageStreamRendersToFeed(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+
+	for _, line := range []string{
+		`{"type":"message_start","message":{"role":"assistant","content":[]}}`,
+		`{"type":"message_update","message":{"role":"assistant","content":[{"type":"text","text":"stream alpha"}]}}`,
+		`{"type":"message_update","message":{"role":"assistant","content":[{"type":"text","text":"stream alpha beta"}]}}`,
+	} {
+		if d := tr.HandleEvent(eventMsg(t, line)); d != app.EventApplied {
+			t.Fatalf("event %q: want EventApplied, got %v", line, d)
+		}
+	}
+	joined := feedText(feed)
+	if !strings.Contains(joined, "stream alpha beta") {
+		t.Fatalf("streamed content missing: %q", joined)
+	}
+	if got := strings.Count(joined, "stream alpha"); got != 1 {
+		t.Fatalf("in-place update duplicated content: %d occurrences in %q", got, joined)
+	}
+
+	tr.HandleEvent(eventMsg(t, `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"stream alpha beta gamma"}]}}`))
+	joined = feedText(feed)
+	if !strings.Contains(joined, "stream alpha beta gamma") {
+		t.Fatalf("finalized content missing: %q", joined)
+	}
+	if got := strings.Count(joined, "stream alpha"); got != 1 {
+		t.Fatalf("message_end appended instead of finalizing: %d occurrences in %q", got, joined)
+	}
+}
+
+func TestTranscriptUserMessageRendersOnce(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+	tr.HandleEvent(eventMsg(t, `{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"please run the suite"}]}}`))
+	tr.HandleEvent(eventMsg(t, `{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"please run the suite"}]}}`))
+	if got := strings.Count(feedText(feed), "please run the suite"); got != 1 {
+		t.Fatalf("user message rendered %d times, want 1", got)
+	}
+}
+
+func TestTranscriptToolLifecycle(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_execution_start","toolCallId":"c1","toolName":"bash","args":{"command":"ls -la"}}`))
+	joined := feedText(feed)
+	if !strings.Contains(joined, "◆") || !strings.Contains(joined, "ls -la") {
+		t.Fatalf("tool start row missing: %q", joined)
+	}
+
+	// Wire shape: args + partialResult on tool_execution_update.
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_execution_update","toolCallId":"c1","toolName":"bash","args":{"command":"ls -la"},"partialResult":{"content":[{"type":"text","text":"partial-line-1"}]}}`))
+	if joined := feedText(feed); !strings.Contains(joined, "partial-line-1") {
+		t.Fatalf("partial output not streamed: %q", joined)
+	}
+
+	// Wire shape: result object + TOP-LEVEL isError on tool_execution_end.
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_execution_end","toolCallId":"c1","toolName":"bash","result":{"content":[{"type":"text","text":"final-output"}]},"isError":false}`))
+	joined = feedText(feed)
+	if !strings.Contains(joined, "final-output") {
+		t.Fatalf("final result missing: %q", joined)
+	}
+	if strings.Contains(joined, "partial-line-1") {
+		t.Fatalf("partial output survived finalization: %q", joined)
+	}
+}
+
+func TestTranscriptToolHookStatusCounts(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_execution_start","toolCallId":"c1","toolName":"bash","args":{"command":"ls"}}`))
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_hook_status","toolCallId":"c1","phase":"start","hookRunId":"h1","hookName":"PreToolUse","toolName":"bash","extensionPath":"/x","statusMessage":"checking","startedAt":1}`))
+	if joined := feedText(feed); !strings.Contains(joined, "[hooks: 1]") {
+		t.Fatalf("active hook count missing: %q", joined)
+	}
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_hook_status","toolCallId":"c1","phase":"end","hookRunId":"h1","hookName":"PreToolUse","toolName":"bash","extensionPath":"/x","statusMessage":"ok","startedAt":1,"completedAt":2,"status":"completed"}`))
+	if joined := feedText(feed); strings.Contains(joined, "[hooks:") {
+		t.Fatalf("hook count not cleared after end phase: %q", joined)
+	}
+}
+
+func TestTranscriptAbortMarksPendingTools(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+	tr.HandleEvent(eventMsg(t, `{"type":"message_start","message":{"role":"assistant","content":[]}}`))
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_execution_start","toolCallId":"c7","toolName":"bash","args":{"command":"sleep 99"}}`))
+
+	// Aborted turn: message_end with stopReason aborted → feed.AbortPending().
+	tr.HandleEvent(eventMsg(t, `{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"aborted","errorMessage":"Request was aborted"}}`))
+	joined := feedText(feed)
+	if !strings.Contains(joined, "Operation aborted") {
+		t.Fatalf("pending tool not aborted on aborted message_end: %q", joined)
+	}
+	for _, frame := range transcript.SpinnerFramesForTest() {
+		if strings.Contains(joined, frame) {
+			t.Fatalf("orphan spinner frame %q after abort", frame)
+		}
+	}
+
+	// agent_end is the safety net for stragglers and must be handled.
+	if d := tr.HandleEvent(eventMsg(t, `{"type":"agent_end","messages":[]}`)); d != app.EventApplied {
+		t.Fatalf("agent_end: want EventApplied, got %v", d)
+	}
+}
+
+func TestTranscriptSummariesAndCustomMessages(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+
+	tr.HandleEvent(eventMsg(t, `{"type":"compaction_end","reason":"manual","aborted":false,"willRetry":false,"result":{"summary":"squeezed the transcript","tokensBefore":12345}}`))
+	tr.HandleEvent(eventMsg(t, `{"type":"message_end","message":{"role":"branchSummary","summary":"took the left fork","fromId":"e1"}}`))
+	tr.HandleEvent(eventMsg(t, `{"type":"message_start","message":{"role":"custom","customType":"memo","display":true,"content":"remember the milk"}}`))
+	tr.HandleEvent(eventMsg(t, `{"type":"message_start","message":{"role":"custom","customType":"hidden","display":false,"content":"invisible-note"}}`))
+
+	joined := feedText(feed)
+	if !strings.Contains(joined, "[compaction]") || !strings.Contains(joined, "12,345") {
+		t.Fatalf("compaction summary missing: %q", joined)
+	}
+	if !strings.Contains(joined, "[branch]") {
+		t.Fatalf("branch summary missing: %q", joined)
+	}
+	if !strings.Contains(joined, "[memo]") || !strings.Contains(joined, "remember the milk") {
+		t.Fatalf("custom message missing: %q", joined)
+	}
+	if strings.Contains(joined, "invisible-note") {
+		t.Fatalf("display=false custom message rendered: %q", joined)
+	}
+
+	// A cancelled compaction adds nothing to the transcript.
+	tr.HandleEvent(eventMsg(t, `{"type":"compaction_end","reason":"manual","aborted":true,"willRetry":false}`))
+	if got := strings.Count(feedText(feed), "[compaction]"); got != 1 {
+		t.Fatalf("aborted compaction_end changed the feed: %d compaction entries", got)
+	}
+}
+
+func TestTranscriptExpandAndThinkingKeysViaManager(t *testing.T) {
+	feed, _ := newTranscriptFixture(t)
+	keys := keybindings.NewManager(nil)
+	tr := app.NewTranscript(feed, keys)
+
+	tr.HandleEvent(eventMsg(t, `{"type":"tool_execution_start","toolCallId":"c1","toolName":"bash","args":{"command":"many"}}`))
+	var lines []string
+	for i := 0; i < 15; i++ {
+		lines = append(lines, fmt.Sprintf("out-line-%d", i))
+	}
+	tr.HandleEvent(eventMsg(t, fmt.Sprintf(
+		`{"type":"tool_execution_end","toolCallId":"c1","toolName":"bash","result":{"content":[{"type":"text","text":%q}]},"isError":false}`,
+		strings.Join(lines, "\n"))))
+	if joined := feedText(feed); !strings.Contains(joined, "out-line-14") {
+		t.Fatalf("tool output missing: %q", joined)
+	}
+
+	expandKeys := keys.Keys("app.tools.expand")
+	if len(expandKeys) == 0 {
+		t.Fatalf("app.tools.expand unbound")
+	}
+	raw := rawForKeyID(t, expandKeys[0])
+	if !tr.HandleKey(raw) {
+		t.Fatalf("expand key %q not consumed", expandKeys[0])
+	}
+	if joined := feedText(feed); !strings.Contains(joined, "out-line-0") {
+		t.Fatalf("expand toggle did not expand tool output: %q", joined)
+	}
+
+	tr.HandleEvent(eventMsg(t, `{"type":"message_end","message":{"role":"assistant","content":[{"type":"thinking","thinking":"pondering deeply"},{"type":"text","text":"answer"}]}}`))
+	thinkKeys := keys.Keys("app.thinking.toggle")
+	if len(thinkKeys) == 0 {
+		t.Fatalf("app.thinking.toggle unbound")
+	}
+	if !tr.HandleKey(rawForKeyID(t, thinkKeys[0])) {
+		t.Fatalf("thinking key %q not consumed", thinkKeys[0])
+	}
+	joined := feedText(feed)
+	if strings.Contains(joined, "pondering deeply") || !strings.Contains(joined, "Thinking...") {
+		t.Fatalf("thinking toggle did not hide the block: %q", joined)
+	}
+
+	// A key bound to neither action is not consumed.
+	if tr.HandleKey("\x00ulw-not-a-key") {
+		t.Fatalf("unrelated key consumed by transcript toggles")
+	}
+}
+
+// TestTranscriptExhaustiveEventCoverage: every bridge.KnownEventTypes() key is
+// either handled (applied/deferred) or in the translator's explicit ignore-list;
+// none falls through to the unknown path.
+func TestTranscriptExhaustiveEventCoverage(t *testing.T) {
+	_, tr := newTranscriptFixture(t)
+	for typ := range bridge.KnownEventTypes() {
+		typ := typ
+		t.Run(typ, func(t *testing.T) {
+			d := tr.HandleEvent(eventMsg(t, fmt.Sprintf(`{"type":%q}`, typ)))
+			if d == app.EventUnknown {
+				t.Fatalf("known event type %q fell through to the unknown path", typ)
+			}
+		})
+	}
+}
+
+func TestTranscriptUnknownEventLoggedOnce(t *testing.T) {
+	_, tr := newTranscriptFixture(t)
+	var logs []string
+	tr.SetLogf(func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	})
+
+	first := tr.HandleEvent(eventMsg(t, `{"type":"ulw_never_heard_of_it"}`))
+	second := tr.HandleEvent(eventMsg(t, `{"type":"ulw_never_heard_of_it"}`))
+	if first != app.EventUnknown || second != app.EventUnknown {
+		t.Fatalf("unknown type dispositions: %v, %v", first, second)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("unknown type must be logged exactly once, got %d logs: %v", len(logs), logs)
+	}
+	if !strings.Contains(logs[0], "ulw_never_heard_of_it") {
+		t.Fatalf("log line does not name the unknown type: %q", logs[0])
+	}
+}
+
+// TestTranscriptStreamingPerf500Deltas drives 500 synthetic message_update
+// deltas through the translator (rendering the frame after every delta) and
+// asserts total processing stays under 2s with no goroutine leak (delta ≤2).
+func TestTranscriptStreamingPerf500Deltas(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+	before := runtime.NumGoroutine()
+
+	tr.HandleEvent(eventMsg(t, `{"type":"message_start","message":{"role":"assistant","content":[]}}`))
+
+	var text strings.Builder
+	start := time.Now()
+	for i := 0; i < 500; i++ {
+		fmt.Fprintf(&text, "delta-%03d ", i)
+		line := fmt.Sprintf(`{"type":"message_update","message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`, text.String())
+		if d := tr.HandleEvent(eventMsg(t, line)); d != app.EventApplied {
+			t.Fatalf("delta %d: want EventApplied, got %v", i, d)
+		}
+		feed.Render(100)
+	}
+	elapsed := time.Since(start)
+	if elapsed >= 2*time.Second {
+		t.Fatalf("500 message_update deltas took %v (budget 2s)", elapsed)
+	}
+
+	tr.HandleEvent(eventMsg(t, fmt.Sprintf(
+		`{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`, text.String())))
+	if joined := feedText(feed); !strings.Contains(joined, "delta-499") {
+		t.Fatalf("final delta missing from render")
+	}
+
+	after := runtime.NumGoroutine()
+	if after-before > 2 {
+		t.Fatalf("goroutine leak: before %d, after %d", before, after)
+	}
+}

--- a/packages/neo/internal/app/transcript_test.go
+++ b/packages/neo/internal/app/transcript_test.go
@@ -300,7 +300,11 @@ func TestTranscriptStreamingPerf500Deltas(t *testing.T) {
 		feed.Render(100)
 	}
 	elapsed := time.Since(start)
-	if elapsed >= 2*time.Second {
+	if raceDetectorEnabled {
+		// The race detector multiplies wall-clock ~5-10x; the budget calibrates
+		// uninstrumented builds. Functional + goroutine assertions still run.
+		t.Logf("race build: skipping time budget (took %v)", elapsed)
+	} else if elapsed >= 2*time.Second {
 		t.Fatalf("500 message_update deltas took %v (budget 2s)", elapsed)
 	}
 

--- a/packages/neo/internal/ui/transcript/feed.go
+++ b/packages/neo/internal/ui/transcript/feed.go
@@ -11,9 +11,12 @@ type entry interface {
 }
 
 // Feed assembles the transcript from the decoded AgentEvent stream. It maps
-// message_end / tool_execution_* events onto the message + tool renderers, keeps
-// pending tool blocks addressable by tool-call id so results and aborts update
-// the right block, and renders the whole feed top-to-bottom.
+// message_start / message_update / message_end / tool_execution_* events onto
+// the message + tool renderers, keeps pending tool blocks addressable by
+// tool-call id so results and aborts update the right block, tracks the live
+// streaming message so updates mutate one entry in place (finalized entries
+// never reflow — their render inputs never change, so re-renders reuse the
+// shared markdown cache), and renders the whole feed top-to-bottom.
 //
 // The event → entry mapping mirrors interactive-mode's session-event handling;
 // the exhaustiveness of the underlying event union is owned + tested by
@@ -26,6 +29,18 @@ type Feed struct {
 	// expandHint is the resolved app.tools.expand key text (from the keybinding
 	// manager at the app layer). Empty falls back to a neutral label.
 	expandHint string
+
+	// Live streaming state (message_start → message_update → message_end).
+	// liveAssistant is set only for assistant streams; other roles are appended
+	// once at message_start and liveRole dedupes their message_end.
+	liveRole      string
+	liveAssistant *AssistantMessageComponent
+
+	// Presentation toggles, applied to existing entries on change and inherited
+	// by entries created afterwards (classic toolOutputExpanded /
+	// hideThinkingBlock semantics).
+	toolsExpanded bool
+	hideThinking  bool
 }
 
 // NewFeed builds an empty transcript feed.
@@ -41,10 +56,16 @@ func (f *Feed) SetExpandHint(hint string) { f.expandHint = hint }
 // Apply folds one decoded event into the feed.
 func (f *Feed) Apply(ev FeedEvent) {
 	switch ev.Type {
+	case "message_start":
+		f.applyMessageStart(ev.Message)
+	case "message_update":
+		f.applyMessageUpdate(ev.Message)
 	case "message_end":
 		f.applyMessage(ev.Message)
 	case "tool_execution_start":
 		f.applyToolStart(ev)
+	case "tool_execution_update":
+		f.applyToolUpdate(ev)
 	case "tool_execution_end":
 		f.applyToolEnd(ev)
 	case "tool_hook_status":
@@ -54,39 +75,174 @@ func (f *Feed) Apply(ev FeedEvent) {
 	}
 }
 
+// applyMessageStart opens a stream: assistant messages get a live component
+// that message_update mutates in place; every other role renders fully at
+// start (classic addMessageToChat on message_start) and liveRole dedupes the
+// matching message_end.
+func (f *Feed) applyMessageStart(m *FeedMessage) {
+	if m == nil {
+		return
+	}
+	if m.Role == "assistant" {
+		comp := NewAssistantMessage(f.assistantMessage(m), AssistantOptions{
+			HideThinking: f.hideThinking,
+			Expanded:     f.toolsExpanded,
+		}, f.theme)
+		f.entries = append(f.entries, comp)
+		f.liveRole, f.liveAssistant = "assistant", comp
+		f.syncToolCalls(m.Content)
+		return
+	}
+	f.appendMessageEntry(m)
+	f.liveRole, f.liveAssistant = m.Role, nil
+}
+
+// applyMessageUpdate replaces the live assistant entry's content in place. The
+// component re-renders through the shared markdown cache, so the unchanged
+// finalized entries above it never reflow. An update with no live stream is
+// dropped (classic parity: streamingComponent guards message_update).
+func (f *Feed) applyMessageUpdate(m *FeedMessage) {
+	if m == nil || m.Role != "assistant" || f.liveAssistant == nil {
+		return
+	}
+	// Same-package in-place mutation: the component owns no content setter and
+	// its render path is stateless, so replacing msg is the update seam.
+	f.liveAssistant.msg = f.assistantMessage(m)
+	f.syncToolCalls(m.Content)
+}
+
+// applyMessage finalizes on message_end: a live stream of the same role is
+// finalized in place (assistant gets its terminal content; other roles were
+// already rendered at message_start); with no matching live stream the message
+// is appended directly (recorded fixtures and non-streamed messages).
 func (f *Feed) applyMessage(m *FeedMessage) {
 	if m == nil {
 		return
 	}
+	if f.liveRole != "" && f.liveRole == m.Role {
+		if m.Role == "assistant" && f.liveAssistant != nil {
+			f.liveAssistant.msg = f.assistantMessage(m)
+			f.syncToolCalls(m.Content)
+		}
+		f.clearLive()
+		return
+	}
+	f.appendMessageEntry(m)
+}
+
+// appendMessageEntry renders one complete message as a new feed entry.
+func (f *Feed) appendMessageEntry(m *FeedMessage) {
 	switch m.Role {
 	case "user":
 		f.entries = append(f.entries, NewUserMessage(messageText(m.Content), f.theme))
 	case "assistant":
-		content := make([]MessageContent, len(m.Content))
-		copy(content, m.Content)
-		f.entries = append(f.entries, NewAssistantMessage(AssistantMessage{
-			Content:      content,
-			StopReason:   m.StopReason,
-			ErrorMessage: m.ErrorMessage,
-		}, AssistantOptions{}, f.theme))
+		comp := NewAssistantMessage(f.assistantMessage(m), AssistantOptions{
+			HideThinking: f.hideThinking,
+			Expanded:     f.toolsExpanded,
+		}, f.theme)
+		f.entries = append(f.entries, comp)
+	case "custom":
+		if !m.Display {
+			return
+		}
+		f.entries = append(f.entries, NewCustomMessage(CustomMessage{
+			CustomType: m.CustomType,
+			Content:    m.Content,
+		}, f.theme))
+	case "branchSummary":
+		comp := NewBranchSummaryMessage(m.Summary, f.expandHint, f.theme)
+		comp.SetExpanded(f.toolsExpanded)
+		f.entries = append(f.entries, comp)
+	case "compactionSummary":
+		comp := NewCompactionSummaryMessage(CompactionSummary{
+			TokensBefore: m.TokensBefore,
+			Summary:      m.Summary,
+		}, f.expandHint, f.theme)
+		comp.SetExpanded(f.toolsExpanded)
+		f.entries = append(f.entries, comp)
 	}
+}
+
+// assistantMessage copies a FeedMessage into the renderer's AssistantMessage
+// (defensive copy so later stream mutations never alias rendered state).
+func (f *Feed) assistantMessage(m *FeedMessage) AssistantMessage {
+	content := make([]MessageContent, len(m.Content))
+	copy(content, m.Content)
+	return AssistantMessage{
+		Content:      content,
+		StopReason:   m.StopReason,
+		ErrorMessage: m.ErrorMessage,
+	}
+}
+
+// syncToolCalls creates/updates pending tool blocks from streamed toolCall
+// content blocks, so tool rows appear while arguments are still streaming
+// (classic message_update pendingTools handling). tool_execution_start later
+// reuses the same block.
+func (f *Feed) syncToolCalls(content []MessageContent) {
+	for _, c := range content {
+		if c.Type != "toolCall" || c.ID == "" {
+			continue
+		}
+		if te, ok := f.tools[c.ID]; ok {
+			te.call.Args = c.Args
+			te.invalidate()
+			continue
+		}
+		te := NewToolExecution(ToolCall{ID: c.ID, Name: c.Name, Args: c.Args}, f.theme)
+		te.SetExpanded(f.toolsExpanded)
+		te.MarkPending()
+		f.tools[c.ID] = te
+		f.entries = append(f.entries, te)
+	}
+}
+
+func (f *Feed) clearLive() {
+	f.liveRole, f.liveAssistant = "", nil
 }
 
 func (f *Feed) applyToolStart(ev FeedEvent) {
 	if ev.ToolCallID == "" {
 		return
 	}
-	te := NewToolExecution(ToolCall{
-		ID:   ev.ToolCallID,
-		Name: ev.ToolName,
-		Args: ev.ToolArgs,
-	}, f.theme)
+	te, ok := f.tools[ev.ToolCallID]
+	if !ok {
+		te = NewToolExecution(ToolCall{
+			ID:   ev.ToolCallID,
+			Name: ev.ToolName,
+			Args: ev.ToolArgs,
+		}, f.theme)
+		te.SetExpanded(f.toolsExpanded)
+		f.tools[ev.ToolCallID] = te
+		f.entries = append(f.entries, te)
+	} else if ev.ToolArgs != nil {
+		// Execution starts with the now-complete arguments.
+		te.call.Args = ev.ToolArgs
+	}
 	te.MarkPending()
 	if ev.HookCount > 0 {
 		te.SetHookCount(ev.HookCount)
 	}
-	f.tools[ev.ToolCallID] = te
-	f.entries = append(f.entries, te)
+}
+
+// applyToolUpdate streams args/partial output into the pending tool block. The
+// block stays pending (the spinner-eligible state) until tool_execution_end
+// replaces the partial with the finalized result. Updates for unknown tool ids
+// are ignored (classic parity).
+func (f *Feed) applyToolUpdate(ev FeedEvent) {
+	te, ok := f.tools[ev.ToolCallID]
+	if !ok {
+		return
+	}
+	if ev.ToolArgs != nil {
+		te.call.Args = ev.ToolArgs
+	}
+	if ev.Partial != nil {
+		// Direct result assignment (not SetResult) keeps the pending state while
+		// the streamed partial body renders under the header row.
+		te.result = &ToolResult{Content: ev.Partial.Content}
+	}
+	te.invalidate()
 }
 
 func (f *Feed) applyToolEnd(ev FeedEvent) {
@@ -107,15 +263,48 @@ func (f *Feed) applyToolEnd(ev FeedEvent) {
 	te.SetResult(ToolResult{Content: ev.Result.Content, IsError: ev.Result.IsError})
 }
 
-// AbortPending marks every still-pending tool block as aborted, so a user abort
-// mid-stream leaves no orphan spinner. Mirrors the interactive-mode abort path.
+// AbortPending marks every still-pending tool block as aborted and closes the
+// live message stream, so a user abort mid-stream leaves no orphan spinner and
+// no resurrectable streaming entry. Mirrors the interactive-mode abort path.
 func (f *Feed) AbortPending() {
 	for _, te := range f.tools {
 		if te.pending {
 			te.Abort()
 		}
 	}
+	f.clearLive()
 }
+
+// SetToolsExpanded toggles collapse/expand across every entry that supports it
+// (tool blocks, summaries) and is inherited by entries created afterwards.
+// Resolved from the app.tools.expand action at the app layer — the Feed never
+// checks keys.
+func (f *Feed) SetToolsExpanded(expanded bool) {
+	f.toolsExpanded = expanded
+	for _, e := range f.entries {
+		if x, ok := e.(interface{ SetExpanded(bool) }); ok {
+			x.SetExpanded(expanded)
+		}
+	}
+}
+
+// ToolsExpanded reports the current expansion state.
+func (f *Feed) ToolsExpanded() bool { return f.toolsExpanded }
+
+// SetHideThinking toggles thinking-block visibility on every assistant entry
+// (including the live one) and is inherited by entries created afterwards.
+// Resolved from the app.thinking.toggle action at the app layer.
+func (f *Feed) SetHideThinking(hide bool) {
+	f.hideThinking = hide
+	for _, e := range f.entries {
+		if a, ok := e.(*AssistantMessageComponent); ok {
+			a.SetHideThinking(hide)
+		}
+	}
+}
+
+// HideThinking reports the current thinking-visibility state.
+func (f *Feed) HideThinking() bool { return f.hideThinking }
 
 // Render lays out the full transcript at width.
 func (f *Feed) Render(width int) []string {

--- a/packages/neo/internal/ui/transcript/feed_streaming_test.go
+++ b/packages/neo/internal/ui/transcript/feed_streaming_test.go
@@ -1,0 +1,290 @@
+package transcript
+
+// Streaming feed contract (todo 3): message_start opens a live assistant entry,
+// message_update mutates it in place (finalized entries never reflow),
+// message_end finalizes, and tool_execution_update streams args/partial output
+// into the pending tool block. Custom/summary message roles render their
+// dedicated components, and the expand/thinking toggles fan out to entries.
+//
+// RED first: the streaming Apply cases and the FeedMessage fields they need do
+// not exist until GREEN.
+
+import (
+	"strings"
+	"testing"
+)
+
+func renderJoined(f *Feed, width int) string {
+	return strings.Join(f.Render(width), "\n")
+}
+
+func TestFeedStreaming_MessageStartUpdateEndInPlace(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+
+	feed.Apply(FeedEvent{Type: "message_start", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: ""}},
+	}})
+	feed.Apply(FeedEvent{Type: "message_update", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "alpha"}},
+	}})
+	feed.Apply(FeedEvent{Type: "message_update", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "alpha beta"}},
+	}})
+
+	joined := renderJoined(feed, 80)
+	if !strings.Contains(joined, "alpha beta") {
+		t.Fatalf("live update not rendered: %q", joined)
+	}
+	if got := strings.Count(joined, "alpha"); got != 1 {
+		t.Fatalf("message_update duplicated the live entry: %d occurrences of %q in %q", got, "alpha", joined)
+	}
+
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "alpha beta gamma"}},
+	}})
+	joined = renderJoined(feed, 80)
+	if !strings.Contains(joined, "alpha beta gamma") {
+		t.Fatalf("message_end did not finalize content: %q", joined)
+	}
+	if got := strings.Count(joined, "alpha"); got != 1 {
+		t.Fatalf("message_end appended instead of finalizing in place: %d occurrences in %q", got, joined)
+	}
+}
+
+func TestFeedStreaming_UserMessageStartThenEndNotDuplicated(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+	user := &FeedMessage{Role: "user", Content: []MessageContent{{Type: "text", Text: "run the tests"}}}
+	feed.Apply(FeedEvent{Type: "message_start", Message: user})
+	feed.Apply(FeedEvent{Type: "message_end", Message: user})
+
+	joined := renderJoined(feed, 80)
+	if got := strings.Count(joined, "run the tests"); got != 1 {
+		t.Fatalf("user message duplicated across start/end: %d occurrences in %q", got, joined)
+	}
+}
+
+func TestFeedStreaming_UpdateWithoutStartIsDropped(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+	feed.Apply(FeedEvent{Type: "message_update", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "stray"}},
+	}})
+	if joined := renderJoined(feed, 80); strings.Contains(joined, "stray") {
+		t.Fatalf("message_update without message_start must be dropped (classic parity): %q", joined)
+	}
+}
+
+func TestFeedStreaming_ToolCallBlocksStreamFromMessageUpdate(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+	feed.Apply(FeedEvent{Type: "message_start", Message: &FeedMessage{Role: "assistant"}})
+	feed.Apply(FeedEvent{Type: "message_update", Message: &FeedMessage{
+		Role: "assistant",
+		Content: []MessageContent{
+			{Type: "toolCall", ID: "t1", Name: "bash", Args: map[string]any{"command": "echo streamed"}},
+		},
+	}})
+
+	joined := renderJoined(feed, 80)
+	if !strings.Contains(joined, "◆") || !strings.Contains(joined, "echo streamed") {
+		t.Fatalf("streamed toolCall block not rendered as pending tool row: %q", joined)
+	}
+
+	// tool_execution_start for the same id must reuse the streamed block, not
+	// append a duplicate (classic pendingTools reuse).
+	feed.Apply(FeedEvent{Type: "tool_execution_start", ToolCallID: "t1", ToolName: "bash",
+		ToolArgs: map[string]any{"command": "echo streamed"}})
+	joined = renderJoined(feed, 80)
+	if got := strings.Count(joined, "◆"); got != 1 {
+		t.Fatalf("tool_execution_start duplicated the streamed tool block: %d markers in %q", got, joined)
+	}
+}
+
+func TestFeedStreaming_ToolExecutionUpdateStreamsPartialAndArgs(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+	feed.Apply(FeedEvent{Type: "tool_execution_start", ToolCallID: "c1", ToolName: "bash",
+		ToolArgs: map[string]any{"command": "sleep 5"}})
+
+	feed.Apply(FeedEvent{Type: "tool_execution_update", ToolCallID: "c1", ToolName: "bash",
+		ToolArgs: map[string]any{"command": "sleep 5 && echo done"},
+		Partial:  &FeedToolResult{Content: []ContentBlock{{Type: "text", Text: "partial-line-1"}}}})
+
+	joined := renderJoined(feed, 80)
+	if !strings.Contains(joined, "partial-line-1") {
+		t.Fatalf("partial result not rendered while pending: %q", joined)
+	}
+	if !strings.Contains(joined, "echo done") {
+		t.Fatalf("streamed args not updated on the pending block: %q", joined)
+	}
+
+	feed.Apply(FeedEvent{Type: "tool_execution_end", ToolCallID: "c1",
+		Result: &FeedToolResult{Content: []ContentBlock{{Type: "text", Text: "final-output"}}}})
+	joined = renderJoined(feed, 80)
+	if !strings.Contains(joined, "final-output") {
+		t.Fatalf("final result missing: %q", joined)
+	}
+	if strings.Contains(joined, "partial-line-1") {
+		t.Fatalf("partial output must be replaced by the final result: %q", joined)
+	}
+}
+
+func TestFeedStreaming_FinalizedLinesNeverReflow(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+	feed.Apply(FeedEvent{Type: "message_start", Message: &FeedMessage{Role: "assistant"}})
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "finalized paragraph one"}},
+	}})
+
+	before := feed.Render(80)
+
+	// A new streaming turn must not reflow the finalized entry's lines.
+	feed.Apply(FeedEvent{Type: "message_start", Message: &FeedMessage{Role: "assistant"}})
+	feed.Apply(FeedEvent{Type: "message_update", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "second turn streaming"}},
+	}})
+
+	after := feed.Render(80)
+	if len(after) < len(before) {
+		t.Fatalf("render shrank: before %d lines, after %d", len(before), len(after))
+	}
+	for i, line := range before {
+		if after[i] != line {
+			t.Fatalf("finalized line %d reflowed:\n before: %q\n after:  %q", i, line, after[i])
+		}
+	}
+}
+
+func TestFeedStreaming_AbortPendingClearsLiveStream(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+	feed.Apply(FeedEvent{Type: "message_start", Message: &FeedMessage{Role: "assistant"}})
+	feed.Apply(FeedEvent{Type: "tool_execution_start", ToolCallID: "c9", ToolName: "bash",
+		ToolArgs: map[string]any{"command": "sleep 99"}})
+
+	feed.AbortPending()
+
+	joined := renderJoined(feed, 80)
+	if !strings.Contains(joined, "Operation aborted") {
+		t.Fatalf("pending tool not aborted: %q", joined)
+	}
+	for _, frame := range SpinnerFramesForTest() {
+		if strings.Contains(joined, frame) {
+			t.Fatalf("orphan spinner frame %q after abort", frame)
+		}
+	}
+
+	// A straggler update after the abort must not resurrect the dead stream.
+	feed.Apply(FeedEvent{Type: "message_update", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "text", Text: "ghost-delta"}},
+	}})
+	if joined := renderJoined(feed, 80); strings.Contains(joined, "ghost-delta") {
+		t.Fatalf("aborted stream resurrected by a straggler update: %q", joined)
+	}
+}
+
+func TestFeedRoles_CustomAndSummaries(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:       "custom",
+		CustomType: "memo",
+		Display:    true,
+		Content:    []MessageContent{{Type: "text", Text: "remember the milk"}},
+	}})
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:       "custom",
+		CustomType: "hidden",
+		Display:    false,
+		Content:    []MessageContent{{Type: "text", Text: "invisible-note"}},
+	}})
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:    "branchSummary",
+		Summary: "took the left fork",
+	}})
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:         "compactionSummary",
+		Summary:      "squeezed the transcript",
+		TokensBefore: 12345,
+	}})
+
+	joined := renderJoined(feed, 80)
+	if !strings.Contains(joined, "[memo]") || !strings.Contains(joined, "remember the milk") {
+		t.Fatalf("displayable custom message not rendered: %q", joined)
+	}
+	if strings.Contains(joined, "invisible-note") {
+		t.Fatalf("display=false custom message must not render: %q", joined)
+	}
+	if !strings.Contains(joined, "[branch]") {
+		t.Fatalf("branch summary not rendered: %q", joined)
+	}
+	if !strings.Contains(joined, "[compaction]") || !strings.Contains(joined, "12,345") {
+		t.Fatalf("compaction summary not rendered: %q", joined)
+	}
+}
+
+func TestFeedRoles_CustomStringContentDecodes(t *testing.T) {
+	events, err := ParseFeedEvents([]byte(
+		`{"type":"message_end","message":{"role":"custom","customType":"memo","display":true,"content":"plain string body"}}` + "\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(events))
+	}
+	feed := NewFeed(DefaultRenderTheme())
+	feed.Apply(events[0])
+	if joined := renderJoined(feed, 80); !strings.Contains(joined, "plain string body") {
+		t.Fatalf("string-content custom message not decoded/rendered: %q", joined)
+	}
+}
+
+func TestFeedToggles_ExpandAndThinking(t *testing.T) {
+	feed := NewFeed(DefaultRenderTheme())
+
+	// 15 output lines: collapsed shows only the trailing 10.
+	var lines []string
+	for i := 0; i < 15; i++ {
+		lines = append(lines, "out-line-"+itoaSigned(i))
+	}
+	feed.Apply(FeedEvent{Type: "tool_execution_start", ToolCallID: "c1", ToolName: "bash",
+		ToolArgs: map[string]any{"command": "many"}})
+	feed.Apply(FeedEvent{Type: "tool_execution_end", ToolCallID: "c1",
+		Result: &FeedToolResult{Content: []ContentBlock{{Type: "text", Text: strings.Join(lines, "\n")}}}})
+
+	joined := renderJoined(feed, 120)
+	if strings.Contains(joined, "out-line-2\x1b") || strings.Contains(joined, "out-line-2\n") {
+		t.Fatalf("collapsed tool output shows head lines: %q", joined)
+	}
+	if !strings.Contains(joined, "out-line-14") {
+		t.Fatalf("collapsed tool output missing tail: %q", joined)
+	}
+
+	feed.SetToolsExpanded(true)
+	joined = renderJoined(feed, 120)
+	if !strings.Contains(joined, "out-line-0") {
+		t.Fatalf("expanded tool output missing head lines: %q", joined)
+	}
+
+	// Thinking toggle: hidden thinking collapses to the label.
+	feed.Apply(FeedEvent{Type: "message_end", Message: &FeedMessage{
+		Role:    "assistant",
+		Content: []MessageContent{{Type: "thinking", Thinking: "pondering deeply"}, {Type: "text", Text: "answer"}},
+	}})
+	joined = renderJoined(feed, 120)
+	if !strings.Contains(joined, "pondering deeply") {
+		t.Fatalf("thinking visible by default: %q", joined)
+	}
+	feed.SetHideThinking(true)
+	joined = renderJoined(feed, 120)
+	if strings.Contains(joined, "pondering deeply") {
+		t.Fatalf("hidden thinking body still rendered: %q", joined)
+	}
+	if !strings.Contains(joined, "Thinking...") {
+		t.Fatalf("hidden thinking label missing: %q", joined)
+	}
+}

--- a/packages/neo/internal/ui/transcript/types.go
+++ b/packages/neo/internal/ui/transcript/types.go
@@ -12,6 +12,11 @@
 // layer, passed in as text).
 package transcript
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // MessageContent is one block of a message's content array. It mirrors the
 // pi-ai content union sufficiently for rendering: text / thinking / toolCall /
 // providerNative / image.
@@ -80,12 +85,52 @@ type SkillBlock struct {
 	Content string
 }
 
-// FeedMessage is a role-tagged message applied to the Feed via message_end.
+// FeedMessage is a role-tagged message applied to the Feed via message_start /
+// message_update / message_end. Beyond user/assistant it carries the fields the
+// custom / branchSummary / compactionSummary roles render (messages.ts shapes).
 type FeedMessage struct {
 	Role         string           `json:"role"`
 	Content      []MessageContent `json:"content"`
 	StopReason   string           `json:"stopReason,omitempty"`
 	ErrorMessage string           `json:"errorMessage,omitempty"`
+
+	// custom role (CustomMessage): extension-authored entries render only when
+	// Display is true, labeled by CustomType.
+	CustomType string `json:"customType,omitempty"`
+	Display    bool   `json:"display,omitempty"`
+
+	// branchSummary / compactionSummary roles.
+	Summary      string `json:"summary,omitempty"`
+	TokensBefore int    `json:"tokensBefore,omitempty"`
+}
+
+// UnmarshalJSON decodes the message content union: custom messages may carry a
+// plain string (`content: string | blocks`, messages.ts CustomMessage) which is
+// normalized into a single text block so every renderer sees []MessageContent.
+func (m *FeedMessage) UnmarshalJSON(data []byte) error {
+	type alias FeedMessage
+	var aux struct {
+		alias
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*m = FeedMessage(aux.alias)
+	m.Content = nil
+	raw := bytes.TrimSpace(aux.Content)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if raw[0] == '"' {
+		var text string
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return err
+		}
+		m.Content = []MessageContent{{Type: "text", Text: text}}
+		return nil
+	}
+	return json.Unmarshal(raw, &m.Content)
 }
 
 // FeedEvent is a decoded stream event the Feed consumes. It carries only the
@@ -103,6 +148,10 @@ type FeedEvent struct {
 	ToolArgs   map[string]any  `json:"toolArgs,omitempty"`
 	Result     *FeedToolResult `json:"result,omitempty"`
 	HookCount  int             `json:"hookCount,omitempty"`
+
+	// tool_execution_update: the streamed partial result shown while the tool is
+	// still pending (replaced by Result on tool_execution_end).
+	Partial *FeedToolResult `json:"partialResult,omitempty"`
 }
 
 // FeedToolResult is a tool result carried on a tool_execution_end event.

--- a/packages/neo/qa/fixtures/stub-select-ext.ts
+++ b/packages/neo/qa/fixtures/stub-select-ext.ts
@@ -1,0 +1,28 @@
+/**
+ * QA fixture: stub select extension (neo plan todo 6).
+ *
+ * Registers a /stubselect slash command that calls ctx.ui.select with two
+ * options and prints the selection to the transcript, so a tmux QA run can
+ * prove the extension-UI select round-trip end to end:
+ *
+ *   senpi --neo ... -e /abs/path/to/packages/neo/qa/fixtures/stub-select-ext.ts
+ *   /stubselect  → dialog → pick "option-2" → transcript shows the choice
+ *
+ * No secrets, no network, no filesystem access — purely the UI bridge.
+ */
+
+import type { ExtensionAPI } from "@code-yeongyu/senpi";
+
+export default function (pi: ExtensionAPI) {
+	pi.registerCommand("stubselect", {
+		description: "QA: pick a stub option via ctx.ui.select",
+		handler: async (_args, ctx) => {
+			const choice = await ctx.ui.select("Pick a stub option", ["option-1", "option-2"]);
+			pi.sendMessage({
+				customType: "stub-select-result",
+				content: `stubselect: ${choice ?? "cancelled"}`,
+				display: true,
+			});
+		},
+	});
+}


### PR DESCRIPTION
## Summary
Wave 3 of the neo Go TUI completion plan (`.omo/plans/neo-go-tui-completion.md`, todos 3/4/6/7/8) — the five remaining assembly components todo 9 will wire into the interactive Model:

- **Streaming transcript** (`internal/app/transcript.go` + `internal/ui/transcript` extension): `Feed.Apply` gains `message_start`/`message_update` (in-place live-entry mutation reusing the markdown cache — finalized lines never reflow) and `tool_execution_update`; app-side translator maps every `EventMsg` with typed dispositions, abort semantics, hook-status folding, and a once-per-type bounded unknown-event log. Exhaustiveness test pins full `bridge.KnownEventTypes()` coverage (explicit 13-entry ignore-list); 500-delta perf gate (0.33s < 2s, goroutine delta 0).
- **Input routing** (`internal/app/input.go`): submit routing table (`/` → slash dispatcher, `!` → streaming bash block with one-at-a-time guard + `abort_bash`, plain → prompt/steer-queue by streaming state), local follow-up queue flushed only on `agent_end` (classic parity), alt+up dequeue, `queue_update` reconciliation, 22/22 slash builtins resolve (no stubs).
- **Extension-UI dialogs + login** (`internal/app/extui.go`): all 10 `bridge.KnownExtensionUIMethods()` round-trip (select/confirm/input/editor as overlay entries; notify/setStatus/setWidget/setTitle/set_editor_text to a directives sink; `custom_unsupported` notice); timeout → default-cancel response; full login flow (`login_start` with the event-completed no-timeout exemption, URL panel, success/failure/cancel/api-key). `/stubselect` QA fixture included.
- **Shell wiring** (`internal/app/shellwire.go`): welcome dismissal, footer data from `get_state`/`get_available_models`/on-demand `get_session_stats` (zero polling), retry-countdown + compaction status stack, WindowTitle state, extension status/widget/title sink. 120-col footer golden.
- **Recovery loop** (`internal/app/recovery.go`): ClientClosedMsg → bounded-backoff reattach via `bridge.AttachOrSpawn` (no transport-recovery duplication), `get_state` strictly before `get_entries{since}` resume replay, aborted-notice for in-flight turns, capped retries → fatal, isolated mode → exit-1 signal.
- qaharness gains `login-flow`, `status-retry`, `isolated-crash` scenes; race-detector guard for the perf budget.

## Process
Five parallel TDD agents in isolated worktrees (each RED→GREEN captured: `.omo/evidence/task-{3,4,6,7,8}-neo-completion-red.txt`), cherry-picked as atomic commits, then integrated verification: full `go test ./... -count=1` green, `-race` green, `go vet`/`build`/`gofmt` clean, full `npm run check` green.

Live tmux QA for these surfaces runs after todo 9 (main wiring) per the recorded sequencing decision — `neo-test.sh` still hits the scaffold until then.

Plan: .omo/plans/neo-go-tui-completion.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements wave 3 of the Neo Go TUI: streaming transcript, input routing/queue, extension‑UI dialogs and login, shell status/footer wiring, and a bounded recovery/resume loop. This improves live UX and resilience under disconnects while bringing the app close to interactive parity.

- **New Features**
  - Streaming transcript: `message_start`/`message_update` in-place updates and `tool_execution_update`; unknown types logged once; coverage pinned against `bridge.KnownEventTypes()`.
  - Input routing: slash dispatcher (22 builtins), `!` bash mode with `abort_bash`, prompt vs steer-queue routing, flush only on `agent_end`, and alt+up dequeue with `queue_update` reconcile.
  - Extension‑UI: select/confirm/input/editor as overlays; directives sink for `notify`/`setStatus`/`setWidget`/`setTitle`/`set_editor_text`; timeouts default-cancel; full login flow with URL panel; `/stubselect` QA fixture.
  - Shell wiring: welcome dismissal; footer from `get_state` and on‑demand `get_session_stats` (no polling); retry countdown and compaction status stack; WindowTitle state; extension status/widget/title sink.
  - Recovery: reattach via `bridge.AttachOrSpawn` with bounded backoff; `get_state` strictly before `get_entries{since}`; aborted notice for in‑flight turns; capped retries to fatal; isolated child exit returns code 1.

<sup>Written for commit d7ca7204d9f3bd07fac08a66a633576fae44ec19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

