### PR TITLE
feat(coding-agent): mcp W5 — skills sidecar + capabilities

### DIFF
--- a/.omo/evidence/task-36-senpi-mcp-plugin/w4-real-surface-evidence/analysis.json
+++ b/.omo/evidence/task-36-senpi-mcp-plugin/w4-real-surface-evidence/analysis.json
@@ -19,6 +19,9 @@
         "create_goal",
         "update_goal",
         "get_goal",
+        "eval",
+        "mcp_list_resources",
+        "mcp_read_resource",
         "mcp_search"
       ],
       [
@@ -37,6 +40,7 @@
         "create_goal",
         "update_goal",
         "get_goal",
+        "eval",
         "mcp_fx_tool_1",
         "mcp_fx_tool_10",
         "mcp_fx_tool_11",
@@ -47,6 +51,8 @@
         "mcp_fx_tool_16",
         "mcp_fx_tool_17",
         "mcp_fx_tool_7",
+        "mcp_list_resources",
+        "mcp_read_resource",
         "mcp_search"
       ],
       [
@@ -65,6 +71,7 @@
         "create_goal",
         "update_goal",
         "get_goal",
+        "eval",
         "mcp_fx_tool_1",
         "mcp_fx_tool_10",
         "mcp_fx_tool_11",
@@ -75,10 +82,12 @@
         "mcp_fx_tool_16",
         "mcp_fx_tool_17",
         "mcp_fx_tool_7",
+        "mcp_list_resources",
+        "mcp_read_resource",
         "mcp_search"
       ]
     ],
-    "approxTokens": 135,
+    "approxTokens": 304,
     "finalSearchCallsInMessages": 1
   },
   "session2": {
@@ -100,6 +109,7 @@
       "create_goal",
       "update_goal",
       "get_goal",
+      "eval",
       "mcp_fx_tool_1",
       "mcp_fx_tool_10",
       "mcp_fx_tool_11",
@@ -110,6 +120,8 @@
       "mcp_fx_tool_16",
       "mcp_fx_tool_17",
       "mcp_fx_tool_7",
+      "mcp_list_resources",
+      "mcp_read_resource",
       "mcp_search"
     ],
     "wireToolNamesPerTurn": [
@@ -129,6 +141,7 @@
         "create_goal",
         "update_goal",
         "get_goal",
+        "eval",
         "mcp_fx_tool_1",
         "mcp_fx_tool_10",
         "mcp_fx_tool_11",
@@ -139,6 +152,8 @@
         "mcp_fx_tool_16",
         "mcp_fx_tool_17",
         "mcp_fx_tool_7",
+        "mcp_list_resources",
+        "mcp_read_resource",
         "mcp_search"
       ],
       [
@@ -157,6 +172,7 @@
         "create_goal",
         "update_goal",
         "get_goal",
+        "eval",
         "mcp_fx_tool_1",
         "mcp_fx_tool_10",
         "mcp_fx_tool_11",
@@ -167,6 +183,8 @@
         "mcp_fx_tool_16",
         "mcp_fx_tool_17",
         "mcp_fx_tool_7",
+        "mcp_list_resources",
+        "mcp_read_resource",
         "mcp_search"
       ]
     ],

--- a/.omo/evidence/task-44-senpi-mcp-plugin/INDEX.md
+++ b/.omo/evidence/task-44-senpi-mcp-plugin/INDEX.md
@@ -1,0 +1,19 @@
+# W5 e2e QA gate (todo 44) — verdicts
+
+Date: 2026-07-08 · branch code-yeongyu/senpi-mcp-w5-skills-caps
+
+| Step | Verdict | Evidence |
+|---|---|---|
+| skills sidecar: 0 pre-load exposure → includeTools reveal, union, system-wins | PASS | test/mcp/skills-sidecar.test.ts 4/4 (live stdio fixture registration) |
+| proxy gateway: single tool, search→describe→call chain, bad-args guidance, nearest matches, auto-never | PASS | test/mcp/proxy-mode.test.ts 2/2 (real fixture round-trip) |
+| resources: utility tools presence/absence, live list+read, binary guard, @mcp: mention e2e, malformed pass-through, updated-notification routing | PASS | test/mcp/resources.test.ts 5/5 |
+| prompts → /mcp:fx:fixture_prompt: registration, arg collection, editor injection, required-arg abort | PASS | test/mcp/prompts-commands.test.ts 1/1 (live prompts/get) |
+| elicitation: empty {} capability, typed accept, decline paths, timeout cancel | PASS | test/mcp/elicitation.test.ts 4/4 |
+| progress + logging: level mapping, logLevel filter, flood cap | PASS | test/mcp/progress-logging.test.ts 3/3 (progress→onUpdate is W4 machinery, re-proven below) |
+| docs: schema-vs-docs diff guard + disable instructions + no stale url-mode claim | PASS | scripts/check-mcp-docs.test.mjs 5/5 (guard proof: removing a field heading fails the diff test by construction) |
+| FULL regression | PASS | npm run check EXIT 0 · test/mcp 265/265 · node --test scripts 45/45 |
+| W1-W4 behavior smoke (exposure, promotion, rehydration, wire payloads) | PASS | w4-real-surface.mjs 8/8 on this branch (real CLI + real stdio fixture + fake model server) |
+
+Notes: pre-existing exact-list assertions were hardened with withoutMcpUtilityTools()
+(the todo-39 utility tools legitimately join every catalog that lists resources);
+elicitation's timeout now rides wrap.ts safeTimer per the async-source guard.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Added MCP skills-carry support: a skill can ship MCP servers via an `mcp.json` sidecar or SKILL.md `mcp:` frontmatter; their tools stay hidden (zero payload cost) until the skill loads.
+- Added the opt-in MCP proxy exposure tier (`exposure:"proxy"`): one `mcp_<server>` gateway tool with search/describe/call ops.
+- Added MCP resources: `mcp_list_resources`/`mcp_read_resource` utility tools, `@mcp:<server>/<uri>` prompt mentions, and resource-update subscriptions.
+- Added MCP prompts as slash commands (`/mcp:<server>:<prompt>`) with argument collection and editor injection.
+- Added MCP elicitation (form mode) with sequential input dialogs, clean declines in non-interactive runs, and a bounded cancel timeout.
+- Added MCP server log routing (RFC-5424 levels onto the per-server logger, `logLevel` filtering, burst capping) and user documentation at `docs/mcp.md`.
+
 - Added automatic title generation for unnamed sessions from the first meaningful user prompt, using the active model in a cached forked request.
 - Added the `pi.executeTool()` extension API so extension code can run active tools through the normal validation, permission, `tool_call`, and `tool_result` pipeline.
 

--- a/packages/coding-agent/docs/docs.json
+++ b/packages/coding-agent/docs/docs.json
@@ -61,6 +61,10 @@
 					"path": "skills.md"
 				},
 				{
+					"title": "MCP",
+					"path": "mcp.md"
+				},
+				{
 					"title": "Prompt Templates",
 					"path": "prompt-templates.md"
 				},

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -45,6 +45,7 @@ For the full first-run flow, see [Quickstart](quickstart.md).
 
 - [Extensions](extensions.md) - TypeScript modules for tools, commands, events, custom UI, and builtin command hooks.
 - [Skills](skills.md) - Agent Skills for reusable on-demand capabilities.
+- [MCP](mcp.md) - built-in Model Context Protocol client: servers, context-efficient tool exposure, resources, prompts, auth.
 - [Prompt templates](prompt-templates.md) - reusable prompts that expand from slash commands.
 - [Themes](themes.md) - built-in and custom terminal themes.
 - [Senpi packages](packages.md) - bundle and share extensions, skills, prompts, and themes.

--- a/packages/coding-agent/docs/mcp.md
+++ b/packages/coding-agent/docs/mcp.md
@@ -1,0 +1,205 @@
+# MCP (Model Context Protocol)
+
+senpi ships a built-in MCP client. Servers you configure expose their tools,
+resources, and prompts to the agent with context-efficient defaults: a large
+catalog costs almost nothing until the model actually needs it.
+
+## Quickstart
+
+1. Add a server to `<agentDir>/mcp.json` (global), `.senpi/mcp.json`
+   (project), or import from `.mcp.json` (Claude format, via
+   `settings.importConfigs`):
+
+```json
+{
+  "mcpServers": {
+    "docs": {
+      "command": "npx",
+      "args": ["-y", "@example/docs-mcp"],
+      "env": { "DOCS_TOKEN": "${DOCS_TOKEN}" }
+    }
+  }
+}
+```
+
+2. Start senpi. Run `/mcp` for the status panel, `/mcp status` for a one-line
+   summary, `/mcp add <name> <command...>` to add servers interactively.
+3. Servers needing OAuth: `/mcp login <name>` (see [Auth](#auth)).
+4. Use it: small catalogs register directly; big ones surface through
+   `mcp_search` (see [Exposure tiers](#exposure-tiers)).
+
+## Configuration reference
+
+Top-level shape: `{ "settings": { ... }, "mcpServers": { "<name>": { ... } } }`.
+
+### Server fields (`mcpServers.<name>`)
+
+### `type`
+`"stdio" | "http"`. Default: inferred — `http` when `url` is set, else `stdio`.
+
+### `url`
+HTTP(S) endpoint for `type:"http"` servers (Streamable HTTP with SSE fallback).
+
+### `command`
+Executable for `type:"stdio"` servers. Never passed through a shell.
+
+### `args`
+Argument array for `command`. Default `[]`.
+
+### `env`
+Extra environment variables for the child process. Values support `${VAR}`
+expansion from the trusted parent environment.
+
+### `cwd`
+Working directory for the child process. Default: the session cwd.
+
+### `headers`
+Extra HTTP headers for `type:"http"` servers.
+
+### `auth`
+`"bearer" | "oauth" | false`. Default: autodetected — `bearerTokenEnv` or an
+`Authorization` header implies `bearer`; a 401 from an HTTP server triggers the
+OAuth flow. `false` disables auth entirely.
+
+### `bearerTokenEnv`
+Name of the environment variable holding a bearer token (the value itself
+never lives in config; literal-looking tokens in config produce a warning).
+
+### `oauth`
+OAuth tuning: `clientId`, `callbackPort` (default: ephemeral),
+`scopes`, `clientMetadataUrl`, `flow` (`"code"` default, or
+`"client_credentials"` for headless machine-to-machine).
+
+### `enabled`
+Default `true`. Disabled servers stay in config but never spawn.
+
+### `lifecycle`
+`"lazy"` (default: connect on first use), `"eager"` (connect at session start),
+`"keep-alive"` (eager + 30s pings + automatic reconnect; never idles out).
+
+### `idleTimeoutMin`
+Minutes of zero in-flight calls before a connected server is shut down (its
+tools stay registered; the next call reconnects transparently). Default `10`.
+
+### `requestTimeoutMs`
+Per-request timeout. Default `30000`.
+
+### `connectTimeoutMs`
+Connect + initialize handshake timeout. Default `15000`.
+
+### `includeTools`
+Glob allowlist (`*` wildcards) over server-side tool names. Default: all.
+
+### `excludeTools`
+Glob denylist applied after `includeTools`.
+
+### `directTools`
+`true` = every filtered tool active immediately; or an array of names/globs
+that stay active while the rest goes behind `mcp_search`. Default: none.
+
+### `exposure`
+`"auto"` (default), `"direct"`, `"search"`, or `"proxy"`. See
+[Exposure tiers](#exposure-tiers). `auto` never selects `proxy`.
+
+### `logLevel`
+Minimum RFC-5424 level (`debug`…`emergency`) for the server's
+`notifications/message` log stream. Default: record everything (rate-capped).
+
+### Settings fields (`settings`)
+
+### `toolPrefix`
+Prefix for registered tool names (`<prefix>_<server>_<tool>`). Default `"mcp"`.
+
+### `searchThreshold`
+Filtered-tool count above which `auto` switches a server to search mode.
+Default `10`.
+
+### `outputGuard`
+Caps on tool/resource output: `maxBytes` (default 51200), `maxLines`
+(default 2000), `maxTokens`. Oversized output is truncated with a notice and
+the full artifact is written to disk.
+
+### `importConfigs`
+`["claude"]` imports `.mcp.json` (Claude Code format) from the project root.
+Imported servers require project trust.
+
+### `oauthCallbackUrl`
+Override the OAuth loopback callback URL (e.g. behind port forwarding).
+
+### `stubSwap`
+Opt-in prompt-cache mitigation for search mode: every inactive tool registers
+as a 30-70-token stub so the tools array stays length-stable; activation swaps
+the stub for the full schema in place. Default `false`.
+
+### `nativeToolSearch`
+`"auto"` (default) | `true` | `false`. On Anthropic models, defers inactive
+MCP tools to the provider's native tool-search; any 400 falls back to the
+local `mcp_search` for the session.
+
+## Exposure tiers
+
+| Tier | When | Cost profile |
+|---|---|---|
+| direct | `exposure:"direct"`, `directTools:true`, or `auto` at/below `searchThreshold` | Every tool schema on every request |
+| search (Tier-B) | `exposure:"search"` or `auto` above the threshold | Full catalog registered, ~135 tokens resident (`mcp_search` only); matches promote next turn; promotions survive resume/compaction |
+| proxy (Tier-C) | `exposure:"proxy"` only — never `auto` | One `mcp_<server>` gateway tool (`search`/`describe`/`call` with JSON-string args); cheapest, but no provider-side argument validation |
+
+Skills can carry MCP servers too (an `mcp.json` sidecar next to SKILL.md, or a
+`mcp:` frontmatter block): those servers register with zero active tools and
+reveal their `includeTools` matches when the skill loads. A name collision
+with a configured server resolves in favor of your config.
+
+## Resources and prompts
+
+- `mcp_list_resources` / `mcp_read_resource` register automatically when a
+  connected server lists resources.
+- Mention `@mcp:<server>/<uri>` in your prompt to inline a resource's content
+  into the message; unknown or failing mentions are left untouched with a
+  notice.
+- Every server prompt registers as `/mcp:<server>:<prompt>`; invoking it
+  collects the prompt's arguments and drops the rendered text into the editor.
+- Servers may ask questions mid-call (elicitation, form mode): senpi walks the
+  requested fields through input dialogs; in non-interactive runs the request
+  is declined cleanly.
+
+## Auth
+
+- **Bearer**: set `bearerTokenEnv` (recommended) or an `Authorization` header.
+- **OAuth (interactive)**: `/mcp login <name>` runs the authorization-code +
+  PKCE flow with a loopback callback; tokens persist under `<agentDir>` with
+  `0600` permissions and refresh automatically (single-flight across
+  processes).
+- **OAuth (headless)**: `flow:"client_credentials"` for machine-to-machine, or
+  `/mcp login <name> --paste` to complete the code flow by pasting the
+  redirect URL from another browser/machine.
+- `/mcp logout <name>` clears stored tokens.
+
+## Troubleshooting
+
+| Symptom (`/mcp status`) | Meaning | Fix |
+|---|---|---|
+| `needs_auth` | 401 and no usable token | `/mcp login <name>` |
+| `suspended` | reconnect circuit breaker opened (5 failures/30s) | fix the server, then `/mcp reconnect <name>` |
+| `degraded` | transient failure; auto-reconnect with backoff is running | wait, or `/mcp reconnect <name>` |
+| tools missing | server filtered/disabled, or hidden behind search | check `includeTools`/`excludeTools`, ask the model to `mcp_search` |
+| child exits at spawn (EOF) | bad `command`/`args`/`env` | `/mcp logs <name>` shows the captured stderr |
+| slow first call | lazy server cold boot | use `lifecycle:"eager"` or `"keep-alive"` |
+
+## Security notes
+
+- Config values never pass through a shell; `${VAR}` expansion only reads the
+  trusted parent environment.
+- Project-level and imported configs require project trust before servers
+  spawn; untrusted entries are listed but inert.
+- Tokens are stored `0600` and never logged; server log streams and tool
+  output are redacted by the same secret scrubber as the rest of senpi and
+  capped by `outputGuard`.
+
+## Disabling MCP entirely
+
+Add the builtin to your settings' disabled list — no other configuration is
+needed:
+
+```json
+{ "disabledBuiltinExtensions": ["mcp"] }
+```

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -6,6 +6,43 @@ extension. Fork-native: upstream pi-mono deliberately ships no MCP support, so
 every file under `builtin/mcp/` is fork-owned. Uses the exact-pinned official
 `@modelcontextprotocol/sdk` and the public `pi.*` extension API only.
 
+## W5 — skills-carry-MCP, proxy, resources, prompts, elicitation, logging (2026-07-08)
+
+### What changed
+- New `skills.ts` (todo 37): skills declare MCP servers via an `mcp.json`
+  sidecar (wins) or SKILL.md frontmatter `mcp:` block; declared servers resolve
+  through `config.ts#resolveSkillMcpServer` (source `"skill"`, forced
+  search-mode/no-directTools = 0 pre-load tokens) and register via
+  `service.attachSkillMcpServers`; loading a skill (`/skill:` input or the
+  model reading its SKILL.md) reveals includeTools glob matches through the new
+  `McpTierBRegistration.activate`.
+- New `expose/proxy.ts` (todo 38): `exposure:"proxy"` collapses a server to one
+  `mcp_<server>` gateway (search/describe/call, JSON-string args) reusing BM25
+  and the factored `register.ts#executeMcpCatalogEntry`; policy gains mode
+  `"proxy"`; auto never selects it.
+- New `resources.ts` (todo 39): `mcp_list_resources`/`mcp_read_resource`
+  utility tools (only when resources exist), `@mcp:<server>/<uri>` input-event
+  mention expansion, per-resource subscriptions + updated notifications riding
+  the tools-changed refresh.
+- New `prompts.ts` (todo 40): listed prompts register as `/mcp:<server>:<prompt>`
+  commands (ctx.ui argument collection -> prompts/get -> editor injection).
+- New `elicitation.ts` (todo 41): EMPTY `{}` capability declared at client
+  construction (`transport.ts#buildMcpClient`), flat-primitive form flow over
+  ctx.ui, decline without UI / on URL-mode, bounded cancel timeout.
+- New `logging.ts` (todo 42): notifications/message -> per-server logger with
+  RFC-5424 mapping, `logLevel` filtering, 10/s burst cap.
+
+### Why
+- W5 of the MCP plan: capability surface (skills/resources/prompts/elicitation/
+  logging) on top of W4's exposure machinery, reusing the activation path,
+  guarded call path, and notification refresh loop instead of new plumbing.
+
+### Expected merge conflict zones
+- MEDIUM: `expose/session.ts` / `expose/tier-b.ts` (registration input/return
+  shapes grew: proxyGateways, utilityTools, McpSessionRegistration).
+- LOW: `connection.ts` connect-time subscriptions; `index.ts` event wiring;
+  `service.ts` skill/prompt/resource accessors.
+
 ## Rehydration wiring + single-flight attach (2026-07-08)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/config-schema.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/config-schema.ts
@@ -95,7 +95,7 @@ export type McpServerConfig = Static<typeof ServerSchema> & {
 };
 export type McpSettings = Required<Pick<Static<typeof SettingsSchema>, "toolPrefix">> &
 	Omit<Static<typeof SettingsSchema>, "toolPrefix">;
-export type McpServerSource = "global" | "claude" | "project";
+export type McpServerSource = "global" | "claude" | "project" | "skill";
 export type McpServerState = "enabled" | "disabled" | "untrusted";
 
 export interface ResolvedMcpServer {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/config.ts
@@ -203,6 +203,29 @@ function readServerNames(raw: unknown): string[] {
 	return Object.keys(servers);
 }
 
+/**
+ * Resolve a skill-declared MCP server (mcp.json sidecar or SKILL.md
+ * frontmatter). Exposure is forced to search with no directTools so the
+ * catalog registers with ZERO active tools until the owning skill loads
+ * (0 pre-load payload tokens); lifecycle stays lazy.
+ */
+export function resolveSkillMcpServer(
+	name: string,
+	raw: NonNullable<RawConfig["mcpServers"]>[string],
+	sourcePath: string,
+): ResolvedMcpServer {
+	const config = { ...normalizeServer(raw), directTools: [], exposure: "search" as const };
+	return {
+		config,
+		configHash: hashConfig(config),
+		name,
+		source: "skill",
+		sourcePath,
+		state: config.enabled ? "enabled" : "disabled",
+		transport: config.type,
+	};
+}
+
 function normalizeServer(server: NonNullable<RawConfig["mcpServers"]>[string]): McpServerConfig {
 	const type = server.type ?? (server.url ? "http" : "stdio");
 	return {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/connection.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/connection.ts
@@ -13,6 +13,7 @@ import { diagnoseCapturedMcpConnectFailure, diagnoseMcpConnectFailure } from "./
 import { ConnectError } from "./errors.ts";
 import type { McpLogger } from "./log.ts";
 import { subscribeMcpListChanged } from "./notifications.ts";
+import { subscribeMcpResourceUpdated } from "./resources.ts";
 import {
 	connectMcpTransport,
 	createMcpTransport,
@@ -227,6 +228,9 @@ export class ServerConnection {
 		// Subscribe to list_changed on the fresh client (even if the server never
 		// declared the capability) so dynamic catalog updates reach the service.
 		subscribeMcpListChanged(connection.client, () => this.markToolsChanged());
+		// Resource updates ride the same refresh path: the service re-collects the
+		// catalog (tools AND resources) on tools-changed.
+		subscribeMcpResourceUpdated(connection.client, () => this.markToolsChanged());
 		this.#setState("connected");
 		this.markToolsChanged();
 		return connection.client;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/connection.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/connection.ts
@@ -12,6 +12,7 @@ import type {
 import { diagnoseCapturedMcpConnectFailure, diagnoseMcpConnectFailure } from "./diagnose.ts";
 import { ConnectError } from "./errors.ts";
 import type { McpLogger } from "./log.ts";
+import { subscribeMcpServerLogging } from "./logging.ts";
 import { subscribeMcpListChanged } from "./notifications.ts";
 import { subscribeMcpResourceUpdated } from "./resources.ts";
 import {
@@ -231,6 +232,9 @@ export class ServerConnection {
 		// Resource updates ride the same refresh path: the service re-collects the
 		// catalog (tools AND resources) on tools-changed.
 		subscribeMcpResourceUpdated(connection.client, () => this.markToolsChanged());
+		// Server logging notifications (todo 42): RFC-5424 → the per-server
+		// logger, filtered by config.logLevel, burst-capped.
+		subscribeMcpServerLogging(connection.client, { logLevel: this.#config.logLevel, logger: this.#logger });
 		this.#setState("connected");
 		this.markToolsChanged();
 		return connection.client;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/elicitation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/elicitation.ts
@@ -13,6 +13,8 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { ExtensionUIContext } from "../../types.ts";
+import { createMcpLogger } from "./log.ts";
+import { safeTimer } from "./wrap.ts";
 
 /** Declared empty on purpose: maximum server compatibility (form mode only). */
 export const MCP_CLIENT_ELICITATION_CAPABILITY = { elicitation: {} } as const;
@@ -61,9 +63,11 @@ export async function runElicitationForm(
 	requestedSchema: { properties?: Record<string, ElicitProperty>; required?: string[] },
 	timeoutMs: number = MCP_ELICITATION_TIMEOUT_MS,
 ): Promise<ElicitationResponse> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
+	let timer: NodeJS.Timeout | undefined;
 	const timeout = new Promise<ElicitationResponse>((resolve) => {
-		timer = setTimeout(() => resolve({ action: "cancel" }), timeoutMs);
+		timer = safeTimer("mcp.elicitation.timeout", timeoutMs, () => resolve({ action: "cancel" }), {
+			logger: createMcpLogger("elicitation"),
+		});
 	});
 	try {
 		return await Promise.race([collectForm(ui, message, requestedSchema), timeout]);

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/elicitation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/elicitation.ts
@@ -1,0 +1,108 @@
+// MCP elicitation, form mode only (todo 41).
+//
+// The client declares the capability as an EMPTY object — Spring-AI servers
+// reject richer shapes (FieldCoding lesson from the comparison corpus) — and
+// answers elicitation/create requests mid tool-call by walking the requested
+// flat-primitive schema through sequential ctx.ui primitives (input/select/
+// confirm; NEVER ctx.ui.custom, which is undefined in RPC mode). Without a UI
+// (print mode) the request is declined immediately — spec-correct, no hang.
+// The whole form is bounded by a timeout that resolves to cancel so a wedged
+// dialog can never wedge the tool-call pipeline. URL mode is deliberately not
+// implemented in v1.
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { ExtensionUIContext } from "../../types.ts";
+
+/** Declared empty on purpose: maximum server compatibility (form mode only). */
+export const MCP_CLIENT_ELICITATION_CAPABILITY = { elicitation: {} } as const;
+
+export const MCP_ELICITATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+type ElicitationUi = Pick<ExtensionUIContext, "input" | "select" | "confirm">;
+
+export interface ElicitationResponse {
+	action: "accept" | "decline" | "cancel";
+	content?: Record<string, string | number | boolean>;
+	// SDK request handlers must return an index-signature-compatible result.
+	[key: string]: unknown;
+}
+
+interface ElicitProperty {
+	type?: string;
+	title?: string;
+	description?: string;
+	enum?: unknown[];
+}
+
+let currentUi: (() => ElicitationUi | undefined) | undefined;
+
+/** The extension points this at the live session UI (undefined in print mode). */
+export function setMcpElicitationUiProvider(provider: (() => ElicitationUi | undefined) | undefined): void {
+	currentUi = provider;
+}
+
+/** Wire the elicitation/create handler onto a fresh client. */
+export function configureMcpElicitation(client: Client, timeoutMs: number = MCP_ELICITATION_TIMEOUT_MS): void {
+	client.setRequestHandler(ElicitRequestSchema, async (request) => {
+		const params = request.params;
+		// URL mode is deliberately unsupported in v1 (form mode only).
+		if (!("requestedSchema" in params)) return { action: "decline" };
+		const ui = currentUi?.();
+		if (ui === undefined) return { action: "decline" };
+		return await runElicitationForm(ui, params.message, params.requestedSchema, timeoutMs);
+	});
+}
+
+/** Exported for tests: drive the form directly with a scripted UI. */
+export async function runElicitationForm(
+	ui: ElicitationUi,
+	message: string,
+	requestedSchema: { properties?: Record<string, ElicitProperty>; required?: string[] },
+	timeoutMs: number = MCP_ELICITATION_TIMEOUT_MS,
+): Promise<ElicitationResponse> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<ElicitationResponse>((resolve) => {
+		timer = setTimeout(() => resolve({ action: "cancel" }), timeoutMs);
+	});
+	try {
+		return await Promise.race([collectForm(ui, message, requestedSchema), timeout]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+async function collectForm(
+	ui: ElicitationUi,
+	message: string,
+	requestedSchema: { properties?: Record<string, ElicitProperty>; required?: string[] },
+): Promise<ElicitationResponse> {
+	const content: Record<string, string | number | boolean> = {};
+	const required = new Set(requestedSchema.required ?? []);
+	for (const [name, property] of Object.entries(requestedSchema.properties ?? {})) {
+		const title = `${message} — ${property.title ?? name}`;
+		if (property.type === "boolean") {
+			content[name] = await ui.confirm(title, property.description ?? name);
+			continue;
+		}
+		if (Array.isArray(property.enum) && property.enum.length > 0) {
+			const picked = await ui.select(title, property.enum.map(String));
+			if (picked === undefined) return { action: "decline" };
+			content[name] = picked;
+			continue;
+		}
+		const answer = await ui.input(title, property.description);
+		if (answer === undefined || answer.length === 0) {
+			if (required.has(name)) return { action: "decline" };
+			continue;
+		}
+		if (property.type === "number" || property.type === "integer") {
+			const parsed = Number(answer);
+			if (!Number.isFinite(parsed)) return { action: "decline" };
+			content[name] = parsed;
+			continue;
+		}
+		content[name] = answer;
+	}
+	return { action: "accept", content };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/policy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/policy.ts
@@ -5,7 +5,7 @@ import type { McpServerConfig, McpSettings } from "../config-schema.ts";
 export interface McpExposurePolicyResult {
 	readonly activeEntries: McpToolCatalogEntry[];
 	readonly filteredEntries: McpToolCatalogEntry[];
-	readonly mode: "direct" | "search";
+	readonly mode: "direct" | "search" | "proxy";
 	readonly reason: "explicit" | "threshold" | "directTools";
 	readonly registeredEntries: McpToolCatalogEntry[];
 	readonly warnings: string[];
@@ -39,10 +39,22 @@ export function computeMcpExposurePolicy(
 	if (config.exposure === "direct") {
 		return directResult(filteredEntries, filteredEntries, "explicit");
 	}
+	// Tier-C proxy mode (todo 38): per-server OPT-IN only. The whole catalog
+	// stays behind a single gateway tool; nothing registers directly and auto
+	// never selects this mode (SPEC §5: -27.3pp GSM8K structured-output evidence).
+	if (config.exposure === "proxy") {
+		return {
+			activeEntries: [],
+			filteredEntries,
+			mode: "proxy",
+			reason: "explicit",
+			registeredEntries: [],
+			warnings: [],
+		};
+	}
 	// Tier-B search mode: register the full catalog but keep only directTools
-	// active; mcp_search promotes the rest on demand. `proxy` behaves like search
-	// until the opt-in proxy tool lands (todo 38).
-	if (config.exposure === "search" || config.exposure === "proxy") {
+	// active; mcp_search promotes the rest on demand.
+	if (config.exposure === "search") {
 		return searchResult(filteredEntries, directEntries, "explicit");
 	}
 	if (filteredEntries.length <= (settings.searchThreshold ?? 10)) {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/proxy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/proxy.ts
@@ -1,0 +1,111 @@
+// Tier-C proxy mode (todo 38): per-server OPT-IN (`exposure:"proxy"`).
+//
+// The whole server catalog hides behind ONE always-active `mcp_<server>`
+// gateway tool with three ops: search (BM25 over this server's catalog),
+// describe (schema + description for one tool), call (tool + args as a JSON
+// STRING). The JSON-string args deliberately trade provider strict-mode
+// validation for a ~200-token footprint (SPEC §5: -27.3pp GSM8K structured
+// output under proxy) — which is why auto NEVER selects this mode. Errors are
+// returned as guiding text (never thrown for user mistakes) so the model can
+// self-correct; unknown tool names get nearest-match suggestions.
+
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { Text } from "@earendil-works/pi-tui";
+import { type Static, Type } from "typebox";
+import type { ToolDefinition } from "../../../types.ts";
+import type { McpToolCatalogEntry } from "../catalog.ts";
+import { buildBm25Index } from "./bm25.ts";
+import { executeMcpCatalogEntry, type McpToolDetails, mapMcpCatalogNames } from "./register.ts";
+
+const ParamsSchema = Type.Object({
+	op: Type.Union([Type.Literal("search"), Type.Literal("describe"), Type.Literal("call")], {
+		description: "search: rank tools by capability; describe: full schema for one tool; call: invoke a tool.",
+	}),
+	query: Type.Optional(Type.String({ description: "search: capability description to rank tools by." })),
+	tool: Type.Optional(Type.String({ description: "describe/call: the server-side tool name." })),
+	args: Type.Optional(
+		Type.String({
+			description: 'call: tool arguments as a JSON object STRING, e.g. "{\\"path\\": \\"a.txt\\"}".',
+		}),
+	),
+});
+type Params = Static<typeof ParamsSchema>;
+
+type ProxyResult = AgentToolResult<McpToolDetails | undefined>;
+type McpProxyTool = ToolDefinition<typeof ParamsSchema, McpToolDetails | undefined, unknown>;
+
+export function createMcpProxyTool(server: string, entries: readonly McpToolCatalogEntry[]): McpProxyTool {
+	const named = mapMcpCatalogNames(entries);
+	const byTool = new Map(named.map(({ entry }) => [entry.tool, entry] as const));
+	const index = buildBm25Index(
+		named.map(({ entry, name }) => ({ description: entry.description, name, server, toolName: entry.tool })),
+	);
+	const name = named[0]?.name.split("_").slice(0, 2).join("_") ?? `mcp_${server}`;
+	return {
+		name,
+		label: `MCP proxy for ${server}`,
+		description: `Gateway to the '${server}' MCP server (${entries.length} tools). Use op:"search" with a query to find tools, op:"describe" with a tool name for its schema, then op:"call" with tool + args (args is a JSON object STRING — no strict validation, so match the described schema exactly).`,
+		promptSnippet: `Proxy for the ${server} MCP server: search -> describe -> call (args as a JSON string).`,
+		parameters: ParamsSchema,
+		executionMode: "parallel",
+		async execute(_toolCallId, params: Params, signal, onUpdate): Promise<ProxyResult> {
+			if (params.op === "search") {
+				const matches = index.search(params.query ?? "", 10, {});
+				const body =
+					matches.length === 0
+						? `No '${server}' tools matched. Try broader keywords or op:"describe" with an exact tool name.`
+						: matches
+								.map((match) => `- ${match.doc.toolName} — ${match.doc.description ?? "(no description)"}`)
+								.join("\n");
+				return textResult(server, `Tools on '${server}':\n${body}`);
+			}
+			const entry = params.tool === undefined ? undefined : byTool.get(params.tool);
+			if (entry === undefined) {
+				return textResult(server, unknownToolText(server, params.tool, index));
+			}
+			if (params.op === "describe") {
+				return textResult(
+					server,
+					`${entry.tool}: ${entry.description ?? "(no description)"}\nInput schema (JSON Schema):\n${JSON.stringify(entry.schema ?? {}, null, 2)}`,
+				);
+			}
+			let args: Record<string, unknown>;
+			try {
+				const parsed: unknown = JSON.parse(params.args ?? "{}");
+				if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+					throw new Error("args must encode a JSON object");
+				}
+				args = parsed as Record<string, unknown>;
+			} catch (error) {
+				return textResult(
+					server,
+					`Invalid args for '${entry.tool}': ${error instanceof Error ? error.message : String(error)}. Pass args as a JSON object STRING matching the schema from op:"describe", e.g. {"op":"call","tool":"${entry.tool}","args":"{\\"key\\": \\"value\\"}"}.`,
+				);
+			}
+			return await executeMcpCatalogEntry(entry, args, signal, onUpdate);
+		},
+		renderCall(args, theme) {
+			const detail = args.op === "search" ? (args.query ?? "") : (args.tool ?? "");
+			return new Text(theme.fg("toolTitle", theme.bold(`${name} ${args.op} ${detail}`.trim())), 0, 0);
+		},
+		renderResult(result, options, theme) {
+			const title = options.isPartial ? `${name}: running` : `${name}: ${result.details?.preview ?? "done"}`;
+			return new Text(theme.fg("toolOutput", title), 0, 0);
+		},
+	};
+}
+
+function textResult(server: string, text: string): ProxyResult {
+	return { content: [{ type: "text", text }], details: { preview: firstLine(text), server, tool: "proxy" } };
+}
+
+function unknownToolText(server: string, tool: string | undefined, index: ReturnType<typeof buildBm25Index>): string {
+	const nearest = tool === undefined ? [] : index.search(tool, 3, {});
+	const hint =
+		nearest.length === 0 ? "" : ` Nearest matches: ${nearest.map((match) => match.doc.toolName).join(", ")}.`;
+	return `Unknown tool '${tool ?? "(missing)"}' on '${server}'.${hint} Use op:"search" to list tools.`;
+}
+
+function firstLine(text: string): string {
+	return text.split("\n", 1)[0].slice(0, 80);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/register.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/register.ts
@@ -80,18 +80,7 @@ function createMcpToolDefinition(entry: McpToolCatalogEntry, name: string): McpT
 		executionMode: "parallel",
 		async execute(_toolCallId, params, signal, onUpdate): Promise<AgentToolResult<McpToolDetails | undefined>> {
 			const args: Record<string, unknown> = isRecord(params) ? params : {};
-			const result = await callMcpTool(entry, args, signal, onUpdate, label);
-			const mapped = mapMcpToolResult(normalizeCallToolResult(result));
-			if (!mapped.ok) {
-				throw new ToolExecError(mapped.error.message, { phase: "call", serverName: entry.server });
-			}
-			const guarded = await applyMcpOutputGuard(mapped.content, {
-				agentDir: entry.agentDir,
-				outputGuard: entry.outputGuard,
-				server: entry.server,
-			});
-			const content = toAgentContent(guarded);
-			return { content, details: { preview: previewContent(content), server: entry.server, tool: entry.tool } };
+			return await executeMcpCatalogEntry(entry, args, signal, onUpdate);
 		},
 		renderCall(args, theme) {
 			return new Text(theme.fg("toolTitle", theme.bold(`${name} ${previewArgs(args)}`.trim())), 0, 0);
@@ -103,6 +92,29 @@ function createMcpToolDefinition(entry: McpToolCatalogEntry, name: string): McpT
 			return new Text(theme.fg("toolOutput", title), 0, 0);
 		},
 	};
+}
+
+/** Full guarded call path for one catalog entry (lifecycle + retry + output
+ * guard). Shared by direct/search tool definitions and the Tier-C proxy. */
+export async function executeMcpCatalogEntry(
+	entry: McpToolCatalogEntry,
+	args: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+	onUpdate: Parameters<McpToolDefinition["execute"]>[3],
+): Promise<AgentToolResult<McpToolDetails | undefined>> {
+	const label = `${entry.server}/${entry.tool}`;
+	const result = await callMcpTool(entry, args, signal, onUpdate, label);
+	const mapped = mapMcpToolResult(normalizeCallToolResult(result));
+	if (!mapped.ok) {
+		throw new ToolExecError(mapped.error.message, { phase: "call", serverName: entry.server });
+	}
+	const guarded = await applyMcpOutputGuard(mapped.content, {
+		agentDir: entry.agentDir,
+		outputGuard: entry.outputGuard,
+		server: entry.server,
+	});
+	const content = toAgentContent(guarded);
+	return { content, details: { preview: previewContent(content), server: entry.server, tool: entry.tool } };
 }
 
 async function callMcpTool(

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
@@ -4,9 +4,12 @@ import type { McpCachedServerCatalog } from "../catalog-cache.ts";
 import type { ResolvedMcpConfig } from "../config-schema.ts";
 import type { ServerConnection } from "../connection.ts";
 import { createMcpLogger, type McpLogger } from "../log.ts";
+import { createMcpResourceTools, type McpResourceServer } from "../resources.ts";
 import { computeMcpExposurePolicy } from "./policy.ts";
 import type { McpCatalogRegistrationOptions } from "./register.ts";
 import { type McpTierBRegistration, registerMcpTierBTools } from "./tier-b.ts";
+
+export type McpSessionRegistration = McpTierBRegistration & { resourceServers: McpResourceServer[] };
 
 export interface McpDirectRegistrationEntry {
 	readonly name: string;
@@ -23,11 +26,12 @@ export async function registerDirectMcpTools(
 	config: ResolvedMcpConfig,
 	entries: Iterable<McpDirectRegistrationEntry>,
 	options: McpCatalogRegistrationOptions = {},
-): Promise<McpTierBRegistration | undefined> {
+): Promise<McpSessionRegistration | undefined> {
 	const registeredEntries: McpToolCatalogEntry[] = [];
 	const activeEntries: McpToolCatalogEntry[] = [];
 	let searchMode = false;
 	const proxyGateways: { server: string; entries: McpToolCatalogEntry[] }[] = [];
+	const resourceServers: McpResourceServer[] = [];
 	for (const entry of entries) {
 		const server = config.servers[entry.name];
 		if (server?.config === undefined) continue;
@@ -52,6 +56,17 @@ export async function registerDirectMcpTools(
 							outputGuard: config.settings.outputGuard,
 						},
 					);
+		const cachedResources = entry.cachedCatalog?.resources ?? [];
+		if (cachedResources.length > 0) {
+			resourceServers.push({
+				agentDir: entry.agentDir,
+				connection: entry.connection,
+				outputGuard: config.settings.outputGuard,
+				requestTimeoutMs: server.config.requestTimeoutMs,
+				resources: cachedResources,
+				server: entry.name,
+			});
+		}
 		const policy = computeMcpExposurePolicy(catalog, server.config, config.settings);
 		for (const warning of policy.warnings) entry.logger.warn(warning);
 		if (policy.mode === "search") searchMode = true;
@@ -69,9 +84,11 @@ export async function registerDirectMcpTools(
 	) {
 		return undefined;
 	}
-	return registerMcpTierBTools(
+	const utilityTools = resourceServers.length > 0 ? createMcpResourceTools(() => resourceServers) : [];
+	const registration = registerMcpTierBTools(
 		pi,
-		{ activeEntries, proxyGateways, registeredEntries, searchMode, settings: config.settings },
+		{ activeEntries, proxyGateways, registeredEntries, searchMode, settings: config.settings, utilityTools },
 		(message) => createMcpLogger("service").warn(message),
 	);
+	return { ...registration, resourceServers };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
@@ -27,6 +27,7 @@ export async function registerDirectMcpTools(
 	const registeredEntries: McpToolCatalogEntry[] = [];
 	const activeEntries: McpToolCatalogEntry[] = [];
 	let searchMode = false;
+	const proxyGateways: { server: string; entries: McpToolCatalogEntry[] }[] = [];
 	for (const entry of entries) {
 		const server = config.servers[entry.name];
 		if (server?.config === undefined) continue;
@@ -54,6 +55,7 @@ export async function registerDirectMcpTools(
 		const policy = computeMcpExposurePolicy(catalog, server.config, config.settings);
 		for (const warning of policy.warnings) entry.logger.warn(warning);
 		if (policy.mode === "search") searchMode = true;
+		if (policy.mode === "proxy") proxyGateways.push({ entries: [...policy.filteredEntries], server: entry.name });
 		registeredEntries.push(...policy.registeredEntries);
 		activeEntries.push(...policy.activeEntries);
 	}
@@ -62,13 +64,14 @@ export async function registerDirectMcpTools(
 		registeredEntries.length === 0 &&
 		activeEntries.length === 0 &&
 		!searchMode &&
+		proxyGateways.length === 0 &&
 		options.refreshActiveSetWhenEmpty !== true
 	) {
 		return undefined;
 	}
 	return registerMcpTierBTools(
 		pi,
-		{ activeEntries, registeredEntries, searchMode, settings: config.settings },
+		{ activeEntries, proxyGateways, registeredEntries, searchMode, settings: config.settings },
 		(message) => createMcpLogger("service").warn(message),
 	);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
@@ -4,12 +4,16 @@ import type { McpCachedServerCatalog } from "../catalog-cache.ts";
 import type { ResolvedMcpConfig } from "../config-schema.ts";
 import type { ServerConnection } from "../connection.ts";
 import { createMcpLogger, type McpLogger } from "../log.ts";
+import type { McpPromptServer } from "../prompts.ts";
 import { createMcpResourceTools, type McpResourceServer } from "../resources.ts";
 import { computeMcpExposurePolicy } from "./policy.ts";
 import type { McpCatalogRegistrationOptions } from "./register.ts";
 import { type McpTierBRegistration, registerMcpTierBTools } from "./tier-b.ts";
 
-export type McpSessionRegistration = McpTierBRegistration & { resourceServers: McpResourceServer[] };
+export type McpSessionRegistration = McpTierBRegistration & {
+	resourceServers: McpResourceServer[];
+	promptServers: McpPromptServer[];
+};
 
 export interface McpDirectRegistrationEntry {
 	readonly name: string;
@@ -32,6 +36,7 @@ export async function registerDirectMcpTools(
 	let searchMode = false;
 	const proxyGateways: { server: string; entries: McpToolCatalogEntry[] }[] = [];
 	const resourceServers: McpResourceServer[] = [];
+	const promptServers: McpPromptServer[] = [];
 	for (const entry of entries) {
 		const server = config.servers[entry.name];
 		if (server?.config === undefined) continue;
@@ -56,6 +61,15 @@ export async function registerDirectMcpTools(
 							outputGuard: config.settings.outputGuard,
 						},
 					);
+		const cachedPrompts = entry.cachedCatalog?.prompts ?? [];
+		if (cachedPrompts.length > 0) {
+			promptServers.push({
+				connection: entry.connection,
+				prompts: cachedPrompts,
+				requestTimeoutMs: server.config.requestTimeoutMs,
+				server: entry.name,
+			});
+		}
 		const cachedResources = entry.cachedCatalog?.resources ?? [];
 		if (cachedResources.length > 0) {
 			resourceServers.push({
@@ -90,5 +104,5 @@ export async function registerDirectMcpTools(
 		{ activeEntries, proxyGateways, registeredEntries, searchMode, settings: config.settings, utilityTools },
 		(message) => createMcpLogger("service").warn(message),
 	);
-	return { ...registration, resourceServers };
+	return { ...registration, promptServers, resourceServers };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/status.ts
@@ -6,7 +6,7 @@ import { computeMcpExposurePolicy } from "./policy.ts";
 export interface McpServerExposureStatus {
 	readonly hint?: string;
 	readonly toolCount: number | null;
-	readonly mode?: "direct" | "search";
+	readonly mode?: "direct" | "search" | "proxy";
 }
 
 export function getMcpCatalogExposureStatus(

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
@@ -42,6 +42,8 @@ export interface McpTierBRegistrationInput {
 	readonly searchMode: boolean;
 	/** Tier-C proxy servers (todo 38): one always-active gateway tool each. */
 	readonly proxyGateways?: readonly { server: string; entries: readonly McpToolCatalogEntry[] }[];
+	/** Always-active utility tools (todo 39: mcp_list_resources/mcp_read_resource). */
+	readonly utilityTools?: readonly McpToolDefinition[];
 	readonly settings: McpSettings;
 }
 
@@ -80,6 +82,10 @@ export function registerMcpTierBTools(
 	const gatewayNames: string[] = [];
 	for (const gateway of input.proxyGateways ?? []) {
 		const tool = createMcpProxyTool(gateway.server, gateway.entries);
+		pi.registerTool(tool);
+		gatewayNames.push(tool.name);
+	}
+	for (const tool of input.utilityTools ?? []) {
 		pi.registerTool(tool);
 		gatewayNames.push(tool.name);
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
@@ -52,6 +52,9 @@ export interface McpTierBRegistration {
 	 * re-searching. Returns the newly activated names (empty when nothing new).
 	 */
 	rehydrateFromHistory(messages: readonly unknown[]): string[];
+	/** Activate registered tools by name through the same stable path
+	 * mcp_search uses (skill lazy-reveal, todo 37). Unknown names ignored. */
+	activate(names: readonly string[]): void;
 }
 
 const NOOP_REHYDRATE = (): string[] => [];
@@ -80,7 +83,10 @@ export function registerMcpTierBTools(
 	if (!input.searchMode) {
 		registerToolsPreservingActiveSet(pi, fullDefs, orderActiveSet([...currentBase, ...activeMcpNames], reference));
 		// Direct mode: everything registerable is already active, nothing to replay.
-		return { searchable, rehydrateFromHistory: NOOP_REHYDRATE };
+		const activateDirect = (names: readonly string[]): void => {
+			pi.setActiveTools(orderActiveSet(unionStable(pi.getActiveTools(), names), pi.getActiveTools()));
+		};
+		return { activate: activateDirect, searchable, rehydrateFromHistory: NOOP_REHYDRATE };
 	}
 
 	const stubSwap = input.settings.stubSwap === true;
@@ -95,6 +101,11 @@ export function registerMcpTierBTools(
 		setActiveTools: activateMcpTools,
 	});
 	const registeredNames = new Set(fullDefs.map((def) => def.name));
+	const activate = (names: readonly string[]): void => {
+		const known = names.filter((name) => registeredNames.has(name));
+		if (known.length === 0) return;
+		activateMcpTools(unionStable(pi.getActiveTools(), known));
+	};
 	const rehydrateFromHistory = (messages: readonly unknown[]): string[] => {
 		const restored = rehydrateActiveToolsFromHistory(messages, registeredNames);
 		const current = pi.getActiveTools();
@@ -114,7 +125,7 @@ export function registerMcpTierBTools(
 		// (an accepted cache miss).
 		const active = orderActiveSet([...currentBase, MCP_SEARCH_TOOL_NAME, ...activeMcpNames], reference);
 		registerToolsPreservingActiveSet(pi, fullDefs, active);
-		return { searchable, rehydrateFromHistory };
+		return { activate, searchable, rehydrateFromHistory };
 	}
 
 	// stubSwap: every search-mode tool is registered as a tiny stub and kept
@@ -127,7 +138,7 @@ export function registerMcpTierBTools(
 	});
 	const active = orderActiveSet([...currentBase, MCP_SEARCH_TOOL_NAME, ...fullDefs.map((def) => def.name)], reference);
 	registerToolsPreservingActiveSet(pi, toRegister, active);
-	return { searchable, rehydrateFromHistory };
+	return { activate, searchable, rehydrateFromHistory };
 }
 
 function swapStubsToFull(

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
@@ -15,6 +15,7 @@ import type { ExtensionAPI } from "../../../types.ts";
 import { registerToolsPreservingActiveSet } from "../active-set.ts";
 import type { McpToolCatalogEntry } from "../catalog.ts";
 import type { McpSettings } from "../config-schema.ts";
+import { createMcpProxyTool } from "./proxy.ts";
 import {
 	buildMcpToolDefinitions,
 	type McpToolDefinition,
@@ -39,6 +40,8 @@ export interface McpTierBRegistrationInput {
 	readonly activeEntries: readonly McpToolCatalogEntry[];
 	/** True when at least one server resolved to search mode. */
 	readonly searchMode: boolean;
+	/** Tier-C proxy servers (todo 38): one always-active gateway tool each. */
+	readonly proxyGateways?: readonly { server: string; entries: readonly McpToolCatalogEntry[] }[];
 	readonly settings: McpSettings;
 }
 
@@ -74,7 +77,13 @@ export function registerMcpTierBTools(
 	}));
 	const fullDefs = buildMcpToolDefinitions(input.registeredEntries, warn);
 	const fullByName = new Map(fullDefs.map((def) => [def.name, def] as const));
-	const activeMcpNames = mapMcpCatalogNames(input.activeEntries).map(({ name }) => name);
+	const gatewayNames: string[] = [];
+	for (const gateway of input.proxyGateways ?? []) {
+		const tool = createMcpProxyTool(gateway.server, gateway.entries);
+		pi.registerTool(tool);
+		gatewayNames.push(tool.name);
+	}
+	const activeMcpNames = [...mapMcpCatalogNames(input.activeEntries).map(({ name }) => name), ...gatewayNames];
 	const reference = pi.getActiveTools();
 	// Base tools carry over; any stale mcp_* names from a prior generation are
 	// dropped (membership = base + the intended mcp set; reference orders only).

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -4,6 +4,7 @@ import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
 import { MCP_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
 import { createMcpLogger } from "./log.ts";
+import { expandMcpResourceMentions } from "./resources.ts";
 import { getMcpService } from "./service.ts";
 import {
 	parseSkillMcpDeclarations,
@@ -65,9 +66,20 @@ export default function mcpExtension(pi: ExtensionAPI): void {
 		const targets = skillActivationTargets(skillDecls, skillName, registered);
 		if (targets.length > 0) service.activateSkillMcpTools(targets);
 	};
-	pi.on("input", (event) => {
+	pi.on("input", async (event, ctx) => {
 		const match = /^\s*\/skill:([A-Za-z0-9._-]+)/.exec(event.text);
 		if (match) revealSkill(match[1]);
+		// @mcp:<server>/<uri> mention expansion (todo 39): recognized mentions are
+		// inlined via the sanctioned input transform; failures pass through
+		// untouched with a one-line notice so submission is never blocked.
+		if (event.text.includes("@mcp:")) {
+			const expansion = await expandMcpResourceMentions(event.text, () => getMcpService().getMcpResourceServers());
+			for (const notice of expansion.notices) {
+				createMcpLogger("resources").warn(notice);
+				void ctx.ui?.notify?.(notice, "warning");
+			}
+			if (expansion.changed) return { action: "transform", text: expansion.text };
+		}
 		return undefined;
 	});
 	pi.on("tool_call", (event) => {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -4,6 +4,7 @@ import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
 import { MCP_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
 import { createMcpLogger } from "./log.ts";
+import { registerMcpPromptCommands } from "./prompts.ts";
 import { expandMcpResourceMentions } from "./resources.ts";
 import { getMcpService } from "./service.ts";
 import {
@@ -108,6 +109,7 @@ export default function mcpExtension(pi: ExtensionAPI): void {
 			const service = getMcpService();
 			await service.attachSession(event, ctx, pi);
 			refreshMcpInstructionsForSession(service);
+			registerMcpPromptCommands(pi, service.getMcpPromptServers());
 		})();
 		return attachPromise;
 	};

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
 import { registerMcpCommands } from "./commands.ts";
+import { setMcpElicitationUiProvider } from "./elicitation.ts";
 import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
 import { MCP_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
@@ -119,6 +120,8 @@ export default function mcpExtension(pi: ExtensionAPI): void {
 	);
 	pi.on("before_agent_start", async (event, ctx) => {
 		try {
+			// Elicitation (todo 41): point mid-call forms at the live session UI.
+			setMcpElicitationUiProvider(() => ctx.ui);
 			await (attachPromise ?? attach({ type: "session_start", reason: "startup" }, ctx));
 			const skills = (event.systemPromptOptions.skills ?? []) as readonly SkillLike[];
 			if (skills.length > 0) {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -5,6 +5,12 @@ import { MCP_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
 import { createMcpLogger } from "./log.ts";
 import { getMcpService } from "./service.ts";
+import {
+	parseSkillMcpDeclarations,
+	type SkillLike,
+	type SkillMcpDeclarations,
+	skillActivationTargets,
+} from "./skills.ts";
 import { reportMcpAsyncError, wrapAsync } from "./wrap.ts";
 
 export default function mcpExtension(pi: ExtensionAPI): void {
@@ -44,6 +50,36 @@ export default function mcpExtension(pi: ExtensionAPI): void {
 		getMcpService().maybeRehydrateFromHistory(event.messages);
 	});
 
+	// skills-carry-MCP (todo 37): skills declaring MCP servers (mcp.json
+	// sidecar or SKILL.md frontmatter) register lazily with tools hidden;
+	// loading a skill — /skill:<name> input or the model reading its SKILL.md —
+	// reveals that skill's includeTools matches for the rest of the session.
+	let skillDecls: SkillMcpDeclarations = { servers: new Map(), warnings: [] };
+	let skillsByName = new Map<string, SkillLike>();
+	const loadedSkills = new Set<string>();
+	const revealSkill = (skillName: string): void => {
+		if (loadedSkills.has(skillName) || !skillsByName.has(skillName)) return;
+		loadedSkills.add(skillName);
+		const service = getMcpService();
+		const registered = service.getTierBSearchable();
+		const targets = skillActivationTargets(skillDecls, skillName, registered);
+		if (targets.length > 0) service.activateSkillMcpTools(targets);
+	};
+	pi.on("input", (event) => {
+		const match = /^\s*\/skill:([A-Za-z0-9._-]+)/.exec(event.text);
+		if (match) revealSkill(match[1]);
+		return undefined;
+	});
+	pi.on("tool_call", (event) => {
+		if (event.toolName !== "read") return undefined;
+		const path = (event.input as { path?: string }).path;
+		if (path === undefined) return undefined;
+		for (const [name, skill] of skillsByName) {
+			if (path === skill.filePath || path.endsWith(skill.filePath)) revealSkill(name);
+		}
+		return undefined;
+	});
+
 	// Attach is SINGLE-FLIGHT. session_start handlers are dispatched
 	// fire-and-forget, so a slow attach (a cold MCP server's boot + catalog
 	// collection is awaited inside attachSession) can still be in flight when
@@ -70,6 +106,19 @@ export default function mcpExtension(pi: ExtensionAPI): void {
 	pi.on("before_agent_start", async (event, ctx) => {
 		try {
 			await (attachPromise ?? attach({ type: "session_start", reason: "startup" }, ctx));
+			const skills = (event.systemPromptOptions.skills ?? []) as readonly SkillLike[];
+			if (skills.length > 0) {
+				skillsByName = new Map(skills.map((skill) => [skill.name, skill]));
+				skillDecls = parseSkillMcpDeclarations(skills);
+				const declared = new Map(
+					[...skillDecls.servers].map(([name, decl]) => [name, { raw: decl.raw, sourcePath: decl.sourcePath }]),
+				);
+				const warnings = [
+					...skillDecls.warnings,
+					...(declared.size > 0 ? await getMcpService().attachSkillMcpServers(declared) : []),
+				];
+				for (const warning of warnings) createMcpLogger("skills").warn(warning);
+			}
 			const systemPrompt = injectMcpInstructions(event.systemPrompt);
 			return systemPrompt === undefined ? undefined : { systemPrompt };
 		} catch (error) {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/logging.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/logging.ts
@@ -1,0 +1,67 @@
+// Server logging notifications (todo 42, logging half — tool-call progress
+// already flows through callMcpTool's onprogress → the executing tool's
+// onUpdate callback since W4).
+//
+// notifications/message routes into the per-server MCP logger with RFC-5424
+// levels folded onto the logger's four methods; the server config's
+// `logLevel` field (inert since W1) now filters below-threshold messages, and
+// a token bucket caps bursts at 10 messages/second so a chatty server cannot
+// flood the ring buffer — the final message of a burst always lands because
+// the bucket refills continuously.
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { LoggingMessageNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { McpLogger } from "./log.ts";
+
+export const MCP_LOG_RATE_LIMIT_PER_SECOND = 10;
+
+/** RFC-5424 severity order, most→least severe. */
+const LEVEL_ORDER = ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"] as const;
+type Rfc5424Level = (typeof LEVEL_ORDER)[number];
+
+function severity(level: string): number {
+	const index = LEVEL_ORDER.indexOf(level as Rfc5424Level);
+	return index === -1 ? LEVEL_ORDER.indexOf("info") : index;
+}
+
+function loggerMethod(level: string): "debug" | "info" | "warn" | "error" {
+	switch (level) {
+		case "debug":
+			return "debug";
+		case "info":
+		case "notice":
+			return "info";
+		case "warning":
+			return "warn";
+		default:
+			return "error";
+	}
+}
+
+export interface McpLoggingOptions {
+	readonly logger: McpLogger;
+	/** Minimum level to record (server config `logLevel`); default records all. */
+	readonly logLevel?: string;
+	readonly ratePerSecond?: number;
+	/** Test seam for deterministic bucket refill. */
+	readonly now?: () => number;
+}
+
+export function subscribeMcpServerLogging(client: Client, options: McpLoggingOptions): void {
+	const threshold = options.logLevel === undefined ? undefined : severity(options.logLevel);
+	const rate = options.ratePerSecond ?? MCP_LOG_RATE_LIMIT_PER_SECOND;
+	const now = options.now ?? Date.now;
+	let tokens = rate;
+	let lastRefill = now();
+	client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+		const { level, data, logger: serverLogger } = notification.params;
+		if (threshold !== undefined && severity(level) > threshold) return;
+		const at = now();
+		tokens = Math.min(rate, tokens + ((at - lastRefill) / 1000) * rate);
+		lastRefill = at;
+		if (tokens < 1) return;
+		tokens -= 1;
+		const text = typeof data === "string" ? data : JSON.stringify(data);
+		options.logger[loggerMethod(level)](`[server${serverLogger ? `:${serverLogger}` : ""}] ${text}`);
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/prompts.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/prompts.ts
@@ -1,0 +1,93 @@
+// MCP prompts → slash commands (todo 40).
+//
+// Every prompt a connected server lists becomes a `/mcp:<server>:<prompt>`
+// senpi command. Invoking it collects the prompt's declared arguments through
+// ctx.ui.input (required arguments re-prompt once, then abort with a notice;
+// optional arguments may be left empty), calls prompts/get, and injects the
+// flattened returned messages into the input editor (senpi command semantics:
+// the user reviews and submits). prompts_list_changed rides the existing
+// tools-changed refresh, which re-runs registration; command registration is
+// last-wins, and prompts removed server-side keep a stale command until the
+// next session — invoking one surfaces the server error as a notice.
+
+import type { ExtensionAPI, ExtensionCommandContext } from "../../types.ts";
+import type { McpCachedServerCatalog } from "./catalog-cache.ts";
+import type { ServerConnection } from "./connection.ts";
+import { createMcpLogger } from "./log.ts";
+
+export interface McpPromptServer {
+	readonly server: string;
+	readonly connection: ServerConnection;
+	readonly requestTimeoutMs?: number;
+	readonly prompts: NonNullable<McpCachedServerCatalog["prompts"]>;
+}
+
+type CommandRegistrar = Pick<ExtensionAPI, "registerCommand">;
+
+const registeredCommandNames = new Set<string>();
+
+/** Test seam: forget which commands were registered (module-level last-wins). */
+export function resetMcpPromptCommandsForTests(): void {
+	registeredCommandNames.clear();
+}
+
+export function registerMcpPromptCommands(pi: CommandRegistrar, servers: readonly McpPromptServer[]): string[] {
+	const added: string[] = [];
+	for (const server of servers) {
+		for (const prompt of server.prompts) {
+			const commandName = `mcp:${server.server}:${prompt.name}`;
+			if (registeredCommandNames.has(commandName)) continue;
+			registeredCommandNames.add(commandName);
+			added.push(commandName);
+			pi.registerCommand(commandName, {
+				description: prompt.description ?? `MCP prompt ${prompt.name} from ${server.server}`,
+				handler: async (_args, ctx) => {
+					try {
+						const collected = await collectPromptArguments(prompt.arguments ?? [], ctx);
+						if (collected === undefined) return;
+						const result = await server.connection.client.getPrompt(
+							{ arguments: collected, name: prompt.name },
+							{ timeout: server.requestTimeoutMs },
+						);
+						ctx.ui.setEditorText(flattenPromptMessages(result.messages));
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						createMcpLogger(server.server).warn(`prompt ${prompt.name} failed: ${message}`);
+						ctx.ui.notify(`MCP prompt ${prompt.name} failed: ${message}`, "error");
+					}
+				},
+			});
+		}
+	}
+	return added;
+}
+
+async function collectPromptArguments(
+	declared: ReadonlyArray<{ name: string; description?: string; required?: boolean }>,
+	ctx: ExtensionCommandContext,
+): Promise<Record<string, string> | undefined> {
+	const collected: Record<string, string> = {};
+	for (const argument of declared) {
+		const title = `${argument.name}${argument.required ? "" : " (optional)"}`;
+		const value = await ctx.ui.input(title, argument.description);
+		if (value !== undefined && value.length > 0) {
+			collected[argument.name] = value;
+			continue;
+		}
+		if (argument.required) {
+			ctx.ui.notify(`MCP prompt cancelled: required argument '${argument.name}' not provided.`, "warning");
+			return undefined;
+		}
+	}
+	return collected;
+}
+
+function flattenPromptMessages(messages: ReadonlyArray<{ role: string; content: unknown }>): string {
+	return messages
+		.map((message) => {
+			const content = message.content as { type?: string; text?: string };
+			const text = typeof content?.text === "string" ? content.text : JSON.stringify(message.content);
+			return messages.length > 1 ? `${message.role}: ${text}` : text;
+		})
+		.join("\n\n");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/resources.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/resources.ts
@@ -1,0 +1,182 @@
+// MCP resources (todo 39): list/read/subscribe + @mcp: input-mention expansion.
+//
+// Model-facing access is two utility tools — mcp_list_resources and
+// mcp_read_resource — registered ONLY when at least one connected server
+// actually lists resources (no dead tools). User-facing convenience is the
+// `@mcp:<server>/<uri>` mention, expanded through the sanctioned `input` event
+// transform: recognized mentions are replaced inline with the fetched resource
+// body (output-guarded); unrecognized or failing mentions pass through
+// UNCHANGED with a one-line notice, never blocking the submission. Servers
+// declaring the resources.subscribe capability get per-resource subscriptions;
+// updated/list_changed notifications flow into the existing tools-changed
+// refresh path, so the catalog cache stays current.
+
+import { Text } from "@earendil-works/pi-tui";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { type Static, Type } from "typebox";
+import type { ToolDefinition } from "../../types.ts";
+import type { McpCachedServerCatalog } from "./catalog-cache.ts";
+import type { ServerConnection } from "./connection.ts";
+import { ToolExecError } from "./errors.ts";
+import type { McpToolDetails } from "./expose/register.ts";
+import { applyMcpOutputGuard } from "./guard/output-guard.ts";
+
+export interface McpResourceServer {
+	readonly server: string;
+	readonly connection: ServerConnection;
+	readonly agentDir?: string;
+	readonly outputGuard?: Parameters<typeof applyMcpOutputGuard>[1]["outputGuard"];
+	readonly requestTimeoutMs?: number;
+	readonly resources: NonNullable<McpCachedServerCatalog["resources"]>;
+}
+
+/** Route resource updated notifications into the shared refresh path. */
+export function subscribeMcpResourceUpdated(client: Client, onChange: () => void): void {
+	client.setNotificationHandler(ResourceUpdatedNotificationSchema, () => {
+		onChange();
+	});
+}
+
+/** Best-effort per-resource subscriptions when the server declares support. */
+export async function ensureMcpResourceSubscriptions(
+	client: Client,
+	resources: ReadonlyArray<{ uri: string }>,
+): Promise<void> {
+	if (client.getServerCapabilities()?.resources?.subscribe !== true) return;
+	await Promise.all(
+		resources.map((resource) => client.subscribeResource({ uri: resource.uri }).catch(() => undefined)),
+	);
+}
+
+/** Read one resource and flatten its contents to guarded text. */
+export async function readMcpResourceAsText(server: McpResourceServer, uri: string): Promise<string> {
+	let contents: Awaited<ReturnType<Client["readResource"]>>["contents"];
+	try {
+		const result = await server.connection.client.readResource({ uri }, { timeout: server.requestTimeoutMs });
+		contents = result.contents;
+	} catch (error) {
+		throw new ToolExecError(
+			`Failed to read MCP resource ${uri}: ${error instanceof Error ? error.message : String(error)}`,
+			{
+				phase: "call",
+				serverName: server.server,
+			},
+		);
+	}
+	const parts = contents.map((content) => {
+		if ("text" in content && typeof content.text === "string") return content.text;
+		const blob = "blob" in content && typeof content.blob === "string" ? content.blob : "";
+		return `[binary resource ${content.uri} (${content.mimeType ?? "unknown"}), ~${Math.round((blob.length * 3) / 4)} bytes]`;
+	});
+	const guarded = await applyMcpOutputGuard([{ type: "text", text: parts.join("\n") }], {
+		agentDir: server.agentDir,
+		outputGuard: server.outputGuard,
+		server: server.server,
+	});
+	return guarded.map((block) => ("text" in block && typeof block.text === "string" ? block.text : "")).join("\n");
+}
+
+const ListParams = Type.Object({
+	server: Type.Optional(Type.String({ description: "Restrict to one MCP server name." })),
+});
+const ReadParams = Type.Object({
+	server: Type.String({ description: "MCP server name (from mcp_list_resources)." }),
+	uri: Type.String({ description: "Resource URI to read." }),
+});
+
+type McpUtilityTool = ToolDefinition<typeof ListParams | typeof ReadParams, McpToolDetails | undefined, unknown>;
+
+/** The two model-facing utility tools. Register only when servers() is non-empty. */
+export function createMcpResourceTools(servers: () => readonly McpResourceServer[]): McpUtilityTool[] {
+	const list: ToolDefinition<typeof ListParams, McpToolDetails | undefined, unknown> = {
+		name: "mcp_list_resources",
+		label: "List MCP resources",
+		description: "List resources exposed by connected MCP servers (URI, name, mime type).",
+		parameters: ListParams,
+		executionMode: "parallel",
+		async execute(_id, params: Static<typeof ListParams>) {
+			const scoped = servers().filter((entry) => params.server === undefined || entry.server === params.server);
+			const lines = scoped.flatMap((entry) =>
+				entry.resources.map(
+					(resource) =>
+						`- @mcp:${entry.server}/${resource.uri} — ${resource.name ?? resource.uri}${resource.mimeType ? ` (${resource.mimeType})` : ""}`,
+				),
+			);
+			const text = lines.length === 0 ? "No MCP resources available." : lines.join("\n");
+			return {
+				content: [{ type: "text", text }],
+				details: {
+					preview: `${lines.length} resource(s)`,
+					server: params.server ?? "*",
+					tool: "mcp_list_resources",
+				},
+			};
+		},
+		renderCall(args, theme) {
+			return new Text(theme.fg("toolTitle", theme.bold(`mcp_list_resources ${args.server ?? ""}`.trim())), 0, 0);
+		},
+	};
+	const read: ToolDefinition<typeof ReadParams, McpToolDetails | undefined, unknown> = {
+		name: "mcp_read_resource",
+		label: "Read MCP resource",
+		description: "Read one MCP resource by server name and URI; returns its (guarded) content.",
+		parameters: ReadParams,
+		executionMode: "parallel",
+		async execute(_id, params: Static<typeof ReadParams>) {
+			const entry = servers().find((candidate) => candidate.server === params.server);
+			if (entry === undefined) {
+				throw new ToolExecError(`Unknown MCP server '${params.server}' for resource ${params.uri}.`, {
+					phase: "call",
+					serverName: params.server,
+				});
+			}
+			const text = await readMcpResourceAsText(entry, params.uri);
+			return {
+				content: [{ type: "text", text }],
+				details: { preview: params.uri, server: params.server, tool: "mcp_read_resource" },
+			};
+		},
+		renderCall(args, theme) {
+			return new Text(theme.fg("toolTitle", theme.bold(`mcp_read_resource ${args.server}/${args.uri}`)), 0, 0);
+		},
+	};
+	return [list as McpUtilityTool, read as McpUtilityTool];
+}
+
+const MENTION_PATTERN = /@mcp:([A-Za-z0-9._-]+)\/(\S+)/g;
+
+export interface McpMentionExpansion {
+	readonly text: string;
+	readonly changed: boolean;
+	readonly notices: string[];
+}
+
+/** Expand `@mcp:<server>/<uri>` mentions; failures leave the mention intact. */
+export async function expandMcpResourceMentions(
+	text: string,
+	servers: () => readonly McpResourceServer[],
+): Promise<McpMentionExpansion> {
+	const matches = [...text.matchAll(MENTION_PATTERN)];
+	if (matches.length === 0) return { changed: false, notices: [], text };
+	const notices: string[] = [];
+	let expanded = text;
+	for (const match of matches) {
+		const [mention, serverName, uri] = match;
+		const entry = servers().find((candidate) => candidate.server === serverName);
+		if (entry === undefined) {
+			notices.push(`@mcp mention left as-is: unknown server '${serverName}'.`);
+			continue;
+		}
+		try {
+			const body = await readMcpResourceAsText(entry, uri);
+			expanded = expanded.replace(
+				mention,
+				`<mcp-resource server="${serverName}" uri="${uri}">\n${body}\n</mcp-resource>`,
+			);
+		} catch (error) {
+			notices.push(`@mcp mention left as-is: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	return { changed: expanded !== text, notices, text: expanded };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service-register.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service-register.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "../../types.ts";
 import type { ResolvedMcpConfig } from "./config-schema.ts";
+import type { McpSessionRegistration } from "./expose/session.ts";
 import { registerDirectMcpTools } from "./expose/session.ts";
-import type { McpTierBRegistration } from "./expose/tier-b.ts";
 import type { McpConnectionEntry } from "./service-types.ts";
 import { connectAndRefreshMcpCatalog } from "./startup-race.ts";
 
@@ -16,7 +16,7 @@ export async function registerMcpServiceDirectTools(
 	config: ResolvedMcpConfig,
 	entries: Iterable<McpConnectionEntry>,
 	options: McpServiceDirectToolRegistrationOptions = {},
-): Promise<McpTierBRegistration | undefined> {
+): Promise<McpSessionRegistration | undefined> {
 	return await registerDirectMcpTools(
 		pi,
 		config,

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -6,8 +6,8 @@ import { loadMcpConfig, resolveSkillMcpServer, visitSpawnableMcpServers } from "
 import type { McpServerConfig, ResolvedMcpConfig, ResolvedMcpServer } from "./config-schema.ts";
 import { ServerConnection } from "./connection.ts";
 import { mapMcpCatalogNames } from "./expose/register.ts";
+import type { McpSessionRegistration } from "./expose/session.ts";
 import type { McpServerExposureStatus } from "./expose/status.ts";
-import type { McpTierBRegistration } from "./expose/tier-b.ts";
 import { cleanupMcpOutputArtifacts } from "./guard/output-guard.ts";
 import { markMcpConnectionNeedsAuth } from "./health.ts";
 import { configureMcpConnectionLifecycle, disposeMcpConnectionLifecycle } from "./idle.ts";
@@ -19,6 +19,7 @@ import {
 	formatMcpListChangedDelta,
 } from "./notifications.ts";
 import { configureMcpReconnect, disposeMcpReconnect, reconnectMcpNow } from "./reconnect.ts";
+import type { McpResourceServer } from "./resources.ts";
 import { getMcpServiceExposureStatus } from "./service-exposure.ts";
 import { registerMcpServiceDirectTools } from "./service-register.ts";
 import { buildMcpServerSnapshot } from "./service-snapshot.ts";
@@ -52,7 +53,7 @@ export class McpService {
 	#authEnv: Record<string, string | undefined> | undefined;
 	readonly #pendingAuth = new Map<string, import("./auth/oauth-provider.ts").McpOAuthProvider>();
 	#refreshActiveSetWhenNoTools = false;
-	#tierBRegistration: McpTierBRegistration | undefined;
+	#tierBRegistration: McpSessionRegistration | undefined;
 	#historyScanned = false;
 	#sessionOptions: McpSessionOptions = {};
 	#pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool"> | undefined;
@@ -132,6 +133,11 @@ export class McpService {
 	 * used by the skills loader to compute activation targets. */
 	getTierBSearchable(): ReadonlyArray<{ name: string; toolName: string; server: string }> {
 		return this.#tierBRegistration?.searchable ?? [];
+	}
+
+	/** Connected servers that list resources (todo 39), for mention expansion. */
+	getMcpResourceServers(): readonly McpResourceServer[] {
+		return this.#tierBRegistration?.resourceServers ?? [];
 	}
 
 	/** Reveal skill-owned tools (todo 37): activation is effective the next

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -135,6 +135,11 @@ export class McpService {
 		return this.#tierBRegistration?.searchable ?? [];
 	}
 
+	/** Connected servers that list prompts (todo 40), for slash registration. */
+	getMcpPromptServers(): readonly import("./prompts.ts").McpPromptServer[] {
+		return this.#tierBRegistration?.promptServers ?? [];
+	}
+
 	/** Connected servers that list resources (todo 39), for mention expansion. */
 	getMcpResourceServers(): readonly McpResourceServer[] {
 		return this.#tierBRegistration?.resourceServers ?? [];

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, SessionShutdownEvent, SessionStartEvent } from "../.
 import { detectLiteralBearerWarnings, resolveServerAuth } from "./auth/context.ts";
 import { collectToolCatalog } from "./catalog.ts";
 import { getValidCachedServer, readMcpCatalogCache } from "./catalog-cache.ts";
-import { loadMcpConfig, visitSpawnableMcpServers } from "./config.ts";
+import { loadMcpConfig, resolveSkillMcpServer, visitSpawnableMcpServers } from "./config.ts";
 import type { McpServerConfig, ResolvedMcpConfig, ResolvedMcpServer } from "./config-schema.ts";
 import { ServerConnection } from "./connection.ts";
 import { mapMcpCatalogNames } from "./expose/register.ts";
@@ -54,6 +54,7 @@ export class McpService {
 	#refreshActiveSetWhenNoTools = false;
 	#tierBRegistration: McpTierBRegistration | undefined;
 	#historyScanned = false;
+	#sessionOptions: McpSessionOptions = {};
 	#pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool"> | undefined;
 	readonly #connections = new Map<string, McpConnectionEntry>();
 	readonly #connectionKeysByName = new Map<string, string>();
@@ -77,6 +78,7 @@ export class McpService {
 		this.#pi = _pi;
 		this.#authAgentDir = options.agentDir;
 		this.#authEnv = options.env;
+		this.#sessionOptions = options;
 		const toolRefreshGeneration = this.#toolRefreshGeneration + 1;
 		this.#toolRefreshGeneration = toolRefreshGeneration;
 		await this.#syncFromConfig(config, options, event.reason !== "reload", _pi, toolRefreshGeneration);
@@ -87,6 +89,55 @@ export class McpService {
 		// one turn late. Doing it here puts restored tools on the very first
 		// wire payload after a --continue/resume.
 		if (_pi !== undefined) this.#rehydrateFromSessionHistory(ctx);
+	}
+
+	/**
+	 * Register skill-declared MCP servers (todo 37). Skill servers are forced
+	 * into search mode with no directTools, so their catalogs register with
+	 * ZERO active tools until activateSkillMcpTools reveals them. A name
+	 * collision with a system-configured server keeps the system config and
+	 * returns a warning (system wins).
+	 */
+	async attachSkillMcpServers(
+		declared: ReadonlyMap<string, { raw: Parameters<typeof resolveSkillMcpServer>[1]; sourcePath: string }>,
+	): Promise<string[]> {
+		const config = this.#config;
+		const pi = this.#pi;
+		if (config === null || pi === undefined) return [];
+		const warnings: string[] = [];
+		let added = 0;
+		for (const [name, decl] of declared) {
+			const existing = config.servers[name];
+			if (existing !== undefined && existing.source !== "skill") {
+				warnings.push(
+					`MCP server '${name}' from skill ${decl.sourcePath} collides with the ${existing.source} config; system config wins.`,
+				);
+				continue;
+			}
+			const resolved = resolveSkillMcpServer(name, decl.raw, decl.sourcePath);
+			if (existing !== undefined && existing.configHash === resolved.configHash) continue;
+			config.servers[name] = resolved;
+			added += 1;
+		}
+		if (added > 0) {
+			const toolRefreshGeneration = this.#toolRefreshGeneration + 1;
+			this.#toolRefreshGeneration = toolRefreshGeneration;
+			await this.#syncFromConfig(config, this.#sessionOptions, false, pi, toolRefreshGeneration);
+			await this.#registerDirectTools(pi);
+		}
+		return warnings;
+	}
+
+	/** Registered searchable catalog (mapped name + server-side tool name),
+	 * used by the skills loader to compute activation targets. */
+	getTierBSearchable(): ReadonlyArray<{ name: string; toolName: string; server: string }> {
+		return this.#tierBRegistration?.searchable ?? [];
+	}
+
+	/** Reveal skill-owned tools (todo 37): activation is effective the next
+	 * turn, exactly like an mcp_search promotion. Unknown names are ignored. */
+	activateSkillMcpTools(names: readonly string[]): void {
+		this.#tierBRegistration?.activate(names);
 	}
 
 	#rehydrateFromSessionHistory(ctx: McpSessionContext): void {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/skills.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/skills.ts
@@ -1,0 +1,143 @@
+// skills-carry-MCP sidecar loader (todo 37).
+//
+// Skills can ship MCP servers two ways: an `mcp.json` sidecar next to SKILL.md
+// (Amp-compatible: a map of serverName -> {command/args/env | url/headers} plus
+// an optional includeTools glob list, optionally wrapped in `mcpServers`), or a
+// `mcp:` block in SKILL.md frontmatter. The sidecar wins when both exist.
+// Declared servers register LAZY with tools hidden (0 pre-load payload tokens,
+// enforced by resolveSkillMcpServer forcing search mode with no directTools);
+// loading a skill (a `/skill:<name>` command or the model reading its SKILL.md)
+// reveals the union of its includeTools matches for the session. The same
+// server declared by multiple skills union-merges includeTools; a name
+// collision with a system-configured server is resolved system-wins at
+// registration (service.attachSkillMcpServers). There is no reliable unload
+// signal, so revealed tools stay active for the session.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseFrontmatter } from "../../../../utils/frontmatter.ts";
+import type { RawConfig } from "./config-schema.ts";
+
+type RawServer = NonNullable<RawConfig["mcpServers"]>[string];
+
+export interface SkillLike {
+	readonly name: string;
+	readonly filePath: string;
+	readonly baseDir: string;
+}
+
+interface SkillServerDecl {
+	raw: RawServer & { includeTools?: string[] };
+	sourcePath: string;
+	/** skill name -> includeTools globs declared by that skill (default all). */
+	includeToolsBySkill: Map<string, string[]>;
+}
+
+export interface SkillMcpDeclarations {
+	servers: Map<string, SkillServerDecl>;
+	warnings: string[];
+}
+
+export function parseSkillMcpDeclarations(skills: readonly SkillLike[]): SkillMcpDeclarations {
+	const servers = new Map<string, SkillServerDecl>();
+	const warnings: string[] = [];
+	for (const skill of skills) {
+		const { declared, sourcePath, warning } = readSkillServers(skill);
+		if (warning !== undefined) warnings.push(warning);
+		for (const [name, raw] of Object.entries(declared)) {
+			const globs = normalizeGlobs(raw.includeTools);
+			const existing = servers.get(name);
+			if (existing === undefined) {
+				servers.set(name, { includeToolsBySkill: new Map([[skill.name, globs]]), raw, sourcePath });
+				continue;
+			}
+			// Same server from multiple skills: first config wins, includeTools
+			// union-merge per skill (revealed together once any owner loads).
+			existing.includeToolsBySkill.set(skill.name, globs);
+		}
+	}
+	return { servers, warnings };
+}
+
+function readSkillServers(skill: SkillLike): {
+	declared: Record<string, RawServer & { includeTools?: string[] }>;
+	sourcePath: string;
+	warning?: string;
+} {
+	const sidecarPath = join(skill.baseDir, "mcp.json");
+	if (existsSync(sidecarPath)) {
+		try {
+			const parsed: unknown = JSON.parse(readFileSync(sidecarPath, "utf8"));
+			return { declared: unwrapServerMap(parsed), sourcePath: sidecarPath };
+		} catch (error) {
+			return {
+				declared: {},
+				sourcePath: sidecarPath,
+				warning: `Skill '${skill.name}': invalid mcp.json sidecar skipped (${error instanceof Error ? error.message : String(error)}); the skill itself still loads.`,
+			};
+		}
+	}
+	try {
+		const { frontmatter } = parseFrontmatter<{ mcp?: unknown }>(readFileSync(skill.filePath, "utf8"));
+		if (frontmatter.mcp === undefined) return { declared: {}, sourcePath: skill.filePath };
+		return { declared: unwrapServerMap(frontmatter.mcp), sourcePath: skill.filePath };
+	} catch (error) {
+		return {
+			declared: {},
+			sourcePath: skill.filePath,
+			warning: `Skill '${skill.name}': unreadable frontmatter mcp block skipped (${error instanceof Error ? error.message : String(error)}); the skill itself still loads.`,
+		};
+	}
+}
+
+function unwrapServerMap(value: unknown): Record<string, RawServer & { includeTools?: string[] }> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+	const record = value as Record<string, unknown>;
+	const map = typeof record.mcpServers === "object" && record.mcpServers !== null ? record.mcpServers : record;
+	const declared: Record<string, RawServer & { includeTools?: string[] }> = {};
+	for (const [name, server] of Object.entries(map as Record<string, unknown>)) {
+		if (typeof server !== "object" || server === null || Array.isArray(server)) continue;
+		declared[name] = server as RawServer & { includeTools?: string[] };
+	}
+	return declared;
+}
+
+function normalizeGlobs(includeTools: unknown): string[] {
+	if (!Array.isArray(includeTools)) return ["*"];
+	const globs = includeTools.filter((glob): glob is string => typeof glob === "string" && glob.length > 0);
+	return globs.length > 0 ? globs : ["*"];
+}
+
+/** `*`-only glob match against the ORIGINAL (server-side) tool name. */
+export function matchIncludeTools(globs: readonly string[], toolName: string): boolean {
+	return globs.some((glob) => {
+		const pattern = `^${glob.split("*").map(escapeRegExp).join(".*")}$`;
+		return new RegExp(pattern).test(toolName);
+	});
+}
+
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Names to reveal when `skillName` loads: for every server the skill declared,
+ * every REGISTERED tool (mapped `mcp_<server>_<tool>` name) whose server-side
+ * tool name matches the union of that skill's includeTools globs.
+ */
+export function skillActivationTargets(
+	declarations: SkillMcpDeclarations,
+	skillName: string,
+	registered: ReadonlyArray<{ name: string; toolName: string; server: string }>,
+): string[] {
+	const targets = new Set<string>();
+	for (const [serverName, decl] of declarations.servers) {
+		const globs = decl.includeToolsBySkill.get(skillName);
+		if (globs === undefined) continue;
+		for (const tool of registered) {
+			if (tool.server !== serverName) continue;
+			if (matchIncludeTools(globs, tool.toolName)) targets.add(tool.name);
+		}
+	}
+	return [...targets].sort();
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/startup-race.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/startup-race.ts
@@ -4,6 +4,7 @@ import type { ResolvedMcpServer } from "./config-schema.ts";
 import type { ServerConnection } from "./connection.ts";
 import { markMcpConnectionNeedsAuth } from "./health.ts";
 import { createMcpLogger } from "./log.ts";
+import { ensureMcpResourceSubscriptions } from "./resources.ts";
 import type { McpConnectionEntry } from "./service-types.ts";
 import { safeTimer } from "./wrap.ts";
 
@@ -53,6 +54,9 @@ export async function connectAndRefreshMcpCatalog(
 		const catalog = await collectServerCatalogForCache(entry.connection, serverConfig, entry.configHash);
 		entry.cachedCatalog = catalog;
 		await writeMcpCachedServer(entry.agentDir, entry.name, catalog);
+		// Per-resource subscriptions (todo 39): only when the server declares
+		// resources.subscribe; best-effort, failures are non-fatal.
+		await ensureMcpResourceSubscriptions(entry.connection.client, catalog.resources ?? []);
 	} catch (error) {
 		entry.logger.warn("Failed to refresh MCP catalog cache", {
 			error: error instanceof Error ? error.message : String(error),

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/transport.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/transport.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { McpOAuthProvider } from "./auth/oauth-provider.ts";
 import type { McpServerConfig } from "./config-schema.ts";
+import { configureMcpElicitation, MCP_CLIENT_ELICITATION_CAPABILITY } from "./elicitation.ts";
 import { AuthError, ConnectError, TimeoutError } from "./errors.ts";
 import type { McpLogger } from "./log.ts";
 import { delay, reapProcessTree } from "./process-tree.ts";
@@ -155,7 +156,7 @@ function createConnection(
 	if (transport instanceof StdioClientTransport) trackStdioStart(transport, captureRootPid);
 	return {
 		captureRootPid,
-		client: new Client({ name: "senpi-mcp-client", version: "0.0.0" }),
+		client: buildMcpClient(),
 		connectTimeoutMs,
 		asyncErrorSink,
 		getRootPid: () => {
@@ -267,3 +268,15 @@ function isTerminableHttpTransport(
 }
 
 const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+function buildMcpClient(): Client {
+	// Elicitation capability is declared EMPTY on purpose (form mode only;
+	// Spring-AI servers reject richer shapes) and the create-handler is wired
+	// before any connect so mid-call requests never race registration.
+	const client = new Client(
+		{ name: "senpi-mcp-client", version: "0.0.0" },
+		{ capabilities: MCP_CLIENT_ELICITATION_CAPABILITY },
+	);
+	configureMcpElicitation(client);
+	return client;
+}

--- a/packages/coding-agent/test/mcp/catalog-cache.test.ts
+++ b/packages/coding-agent/test/mcp/catalog-cache.test.ts
@@ -4,7 +4,14 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadMcpConfig } from "../../src/core/extensions/builtin/mcp/config.ts";
 import { getMcpService, McpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { attach, capturingPi, registeredTool, testContext, textContent } from "./fixtures/register-call.ts";
+import {
+	attach,
+	capturingPi,
+	registeredTool,
+	testContext,
+	textContent,
+	withoutMcpUtilityTools,
+} from "./fixtures/register-call.ts";
 import {
 	cleanupRoots,
 	makeRoot,
@@ -38,7 +45,7 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 
-		expect(pi.registeredTools).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
 		await expect(readCounter(counterFile)).rejects.toMatchObject({ code: "ENOENT" });
 
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
@@ -57,7 +64,7 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 
-		expect(pi.registeredTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 		expect(await readCounter(counterFile)).toBe(1);
 		const cache = await readCache(root);
 		expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1", "tool_2"]);
@@ -72,7 +79,7 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 
-		expect(pi.registeredTools).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
 		const cache = await readCache(root);
 		expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1"]);
 	});
@@ -86,8 +93,8 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 
-		expect(pi.registeredTools).toEqual(["mcp_fx_tool_1"]);
-		expect(pi.registeredTools).not.toContain("mcp_fx_fake_999");
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).not.toContain("mcp_fx_fake_999");
 		expect(await readCounter(counterFile)).toBe(1);
 		const cache = await readCache(root);
 		expect(cache.servers.fx.configHash).toBe(configHash(root, "fx"));
@@ -105,10 +112,10 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 
-		await waitForCondition(() => pi.activeTools.includes("mcp_fx_tool_2"), 2500);
+		await waitForCondition(() => withoutMcpUtilityTools(pi.activeTools).includes("mcp_fx_tool_2"), 2500);
 		expect(await readCounter(counterFile)).toBe(1);
-		expect(pi.activeTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
-		expect(pi.activeTools).not.toContain("mcp_fx_stale_cached");
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).not.toContain("mcp_fx_stale_cached");
 		const cache = await readCache(root);
 		expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1", "tool_2"]);
 	});

--- a/packages/coding-agent/test/mcp/elicitation.test.ts
+++ b/packages/coding-agent/test/mcp/elicitation.test.ts
@@ -1,0 +1,61 @@
+// MCP elicitation form mode (todo 41): capability declared empty; the form
+// walks flat primitives through ui.input/select/confirm; missing UI or a
+// missing required answer declines; the bounded timeout cancels; numbers
+// parse or decline; URL-mode requests decline (v1 is form-only).
+
+import { describe, expect, it } from "vitest";
+import {
+	MCP_CLIENT_ELICITATION_CAPABILITY,
+	runElicitationForm,
+} from "../../src/core/extensions/builtin/mcp/elicitation.ts";
+
+const SCHEMA = {
+	properties: {
+		confirmed: { type: "boolean" },
+		count: { type: "integer" },
+		mode: { enum: ["alpha", "beta"], type: "string" },
+		name: { type: "string" },
+	},
+	required: ["name"],
+};
+
+function scriptedUi(overrides: Partial<Record<"input" | "select" | "confirm", unknown>> = {}) {
+	return {
+		confirm: async () => true,
+		input: async (title: string) => (title.includes("count") ? "42" : "Ada"),
+		select: async () => "beta",
+		...overrides,
+	} as never;
+}
+
+describe("mcp elicitation form", () => {
+	it("declares the capability as an empty object", () => {
+		expect(MCP_CLIENT_ELICITATION_CAPABILITY).toEqual({ elicitation: {} });
+	});
+
+	it("accepts with typed values from scripted ui answers", async () => {
+		const response = await runElicitationForm(scriptedUi(), "Server asks", SCHEMA);
+		expect(response).toEqual({
+			action: "accept",
+			content: { confirmed: true, count: 42, mode: "beta", name: "Ada" },
+		});
+	});
+
+	it("declines when a required answer is missing and on invalid numbers", async () => {
+		const missing = await runElicitationForm(scriptedUi({ input: async () => undefined }), "Ask", SCHEMA);
+		expect(missing.action).toBe("decline");
+
+		const badNumber = await runElicitationForm(
+			scriptedUi({ input: async (title: string) => (title.includes("count") ? "not-a-number" : "Ada") }),
+			"Ask",
+			SCHEMA,
+		);
+		expect(badNumber.action).toBe("decline");
+	});
+
+	it("cancels via the bounded timeout without wedging", async () => {
+		const hangingUi = scriptedUi({ input: () => new Promise(() => undefined) });
+		const response = await runElicitationForm(hangingUi, "Ask", SCHEMA, 50);
+		expect(response).toEqual({ action: "cancel" });
+	});
+});

--- a/packages/coding-agent/test/mcp/exposure-policy.test.ts
+++ b/packages/coding-agent/test/mcp/exposure-policy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { attach, capturingPi, mcpRoot as makeMcpRoot, withoutMcpUtilityTools } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -35,13 +35,17 @@ describe("MCP Tier-A exposure policy", () => {
 		setConfig(includeRoot, { fx: { ...stdioServer(["--tools", "5"]), includeTools: ["tool_[13]"] } });
 		const includePi = capturingPi();
 		await attach(includeRoot, includePi);
-		expect(includePi.activeTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_3"]);
+		expect(withoutMcpUtilityTools(includePi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_3"]);
 
 		const excludeRoot = mcpRoot("exclude-only");
 		setConfig(excludeRoot, { fx: { ...stdioServer(["--tools", "5"]), excludeTools: ["tool_[24]"] } });
 		const excludePi = capturingPi();
 		await attach(excludeRoot, excludePi);
-		expect(excludePi.activeTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_3", "mcp_fx_tool_5"]);
+		expect(withoutMcpUtilityTools(excludePi.activeTools)).toEqual([
+			"mcp_fx_tool_1",
+			"mcp_fx_tool_3",
+			"mcp_fx_tool_5",
+		]);
 
 		const bothRoot = mcpRoot("include-exclude");
 		setConfig(bothRoot, {
@@ -49,13 +53,18 @@ describe("MCP Tier-A exposure policy", () => {
 		});
 		const bothPi = capturingPi();
 		await attach(bothRoot, bothPi);
-		expect(bothPi.activeTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+		expect(withoutMcpUtilityTools(bothPi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 
 		const starRoot = mcpRoot("star");
 		setConfig(starRoot, { fx: { ...stdioServer(["--tools", "5"]), excludeTools: ["tool_5"], includeTools: ["*"] } });
 		const starPi = capturingPi();
 		await attach(starRoot, starPi);
-		expect(starPi.activeTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2", "mcp_fx_tool_3", "mcp_fx_tool_4"]);
+		expect(withoutMcpUtilityTools(starPi.activeTools)).toEqual([
+			"mcp_fx_tool_1",
+			"mcp_fx_tool_2",
+			"mcp_fx_tool_3",
+			"mcp_fx_tool_4",
+		]);
 	});
 
 	it("flips at the threshold boundary: 10 filtered tools direct, 11 filtered tools -> search mode", async () => {
@@ -63,17 +72,19 @@ describe("MCP Tier-A exposure policy", () => {
 		setConfig(tenRoot, { fx: stdioServer(["--tools", "10"]) });
 		const tenPi = capturingPi();
 		await attach(tenRoot, tenPi);
-		expect(tenPi.registeredTools).toEqual(toolNames(10));
-		expect(tenPi.activeTools).toEqual(toolNames(10));
+		expect(withoutMcpUtilityTools(tenPi.registeredTools)).toEqual(toolNames(10));
+		expect(withoutMcpUtilityTools(tenPi.activeTools)).toEqual(toolNames(10));
 
 		const elevenRoot = mcpRoot("threshold-11");
 		setConfig(elevenRoot, { fx: stdioServer(["--tools", "11"]) });
 		const elevenPi = capturingPi();
 		await attach(elevenRoot, elevenPi);
 		// All 11 tools are registered (catalog present) plus mcp_search...
-		expect([...elevenPi.registeredTools].sort()).toEqual([...toolNames(11), "mcp_search"].sort());
+		expect([...withoutMcpUtilityTools(elevenPi.registeredTools)].sort()).toEqual(
+			[...toolNames(11), "mcp_search"].sort(),
+		);
 		// ...but only mcp_search is active: the 11 tools cost zero tokens until promoted.
-		expect(elevenPi.activeTools).toEqual(["mcp_search"]);
+		expect(withoutMcpUtilityTools(elevenPi.activeTools)).toEqual(["mcp_search"]);
 		// The W1 pending-W4 warning fallback is gone.
 		expect(logContains("fx", "pending-W4")).toBe(false);
 	});
@@ -92,8 +103,14 @@ describe("MCP Tier-A exposure policy", () => {
 		await attach(root, pi);
 
 		// Search mode keeps directTools active alongside the always-active mcp_search.
-		expect(pi.activeTools).toEqual(["bash", "mcp_fx_tool_1", "mcp_fx_tool_12", "mcp_fx_tool_2", "mcp_search"]);
-		expect(pi.setActiveCalls[pi.setActiveCalls.length - 1]).toEqual([
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual([
+			"bash",
+			"mcp_fx_tool_1",
+			"mcp_fx_tool_12",
+			"mcp_fx_tool_2",
+			"mcp_search",
+		]);
+		expect(withoutMcpUtilityTools(pi.setActiveCalls[pi.setActiveCalls.length - 1])).toEqual([
 			"bash",
 			"mcp_fx_tool_1",
 			"mcp_fx_tool_12",
@@ -109,8 +126,8 @@ describe("MCP Tier-A exposure policy", () => {
 
 		await attach(root, pi);
 
-		expect([...pi.registeredTools].sort()).toEqual([...toolNames(30), "mcp_search"].sort());
-		expect(pi.activeTools).toEqual(["mcp_search"]);
+		expect([...withoutMcpUtilityTools(pi.registeredTools)].sort()).toEqual([...toolNames(30), "mcp_search"].sort());
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_search"]);
 		expect(logContains("fx", "pending-W4")).toBe(false);
 	});
 
@@ -121,9 +138,9 @@ describe("MCP Tier-A exposure policy", () => {
 
 		await attach(root, pi);
 
-		expect(pi.registeredTools).toEqual([]);
-		expect(pi.activeTools).toEqual(["bash"]);
-		expect(pi.setActiveCalls).toEqual([["bash"]]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual([]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["bash"]);
+		expect(pi.setActiveCalls.map((call) => withoutMcpUtilityTools(call))).toEqual([["bash"]]);
 		expect(logContains("fx", "0 exposed")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/mcp/exposure-tierb.test.ts
+++ b/packages/coding-agent/test/mcp/exposure-tierb.test.ts
@@ -12,7 +12,7 @@ import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { createHarness, type Harness } from "../suite/harness.ts";
-import { mcpRoot as makeMcpRoot, mcpExtensionFor } from "./fixtures/register-call.ts";
+import { mcpRoot as makeMcpRoot, mcpExtensionFor, withoutMcpUtilityTools } from "./fixtures/register-call.ts";
 import type { TestRoot } from "./fixtures/service-lifecycle.ts";
 import { cleanupRoots, stdioServer } from "./fixtures/service-lifecycle.ts";
 
@@ -71,7 +71,7 @@ describe("todo32 tier-B: searchThreshold flip", () => {
 		let tenTools: string[] = [];
 		ten.setResponses([
 			(context) => {
-				tenTools = names(toolShapes(context));
+				tenTools = withoutMcpUtilityTools(names(toolShapes(context)));
 				return fauxAssistantMessage("ok");
 			},
 		]);
@@ -85,7 +85,7 @@ describe("todo32 tier-B: searchThreshold flip", () => {
 		let elevenTools: string[] = [];
 		eleven.setResponses([
 			(context) => {
-				elevenTools = names(toolShapes(context));
+				elevenTools = withoutMcpUtilityTools(names(toolShapes(context)));
 				return fauxAssistantMessage("ok");
 			},
 		]);
@@ -102,7 +102,7 @@ describe("todo32 tier-B: exposure override matrix", () => {
 		let directTools: string[] = [];
 		direct.setResponses([
 			(context) => {
-				directTools = names(toolShapes(context));
+				directTools = withoutMcpUtilityTools(names(toolShapes(context)));
 				return fauxAssistantMessage("ok");
 			},
 		]);
@@ -116,7 +116,7 @@ describe("todo32 tier-B: exposure override matrix", () => {
 		let searchTools: string[] = [];
 		search.setResponses([
 			(context) => {
-				searchTools = names(toolShapes(context));
+				searchTools = withoutMcpUtilityTools(names(toolShapes(context)));
 				return fauxAssistantMessage("ok");
 			},
 		]);
@@ -135,8 +135,10 @@ describe("todo32 tier-B: resident token cost", () => {
 		harness.setResponses([
 			(context) => {
 				const shapes = toolShapes(context);
-				residentNames = names(shapes);
-				residentJson = JSON.stringify(context.tools ?? []);
+				residentNames = withoutMcpUtilityTools(names(shapes));
+				residentJson = JSON.stringify(
+					(context.tools ?? []).filter((tool) => withoutMcpUtilityTools([tool.name]).length > 0),
+				);
 				return fauxAssistantMessage("ok");
 			},
 		]);

--- a/packages/coding-agent/test/mcp/fixtures/register-call.ts
+++ b/packages/coding-agent/test/mcp/fixtures/register-call.ts
@@ -123,3 +123,9 @@ export async function expectFileToContain(path: string, needle: string): Promise
 	}
 	throw lastError instanceof Error ? lastError : new Error(`file did not contain ${needle}: ${path}`);
 }
+
+/** Strip the todo-39 resource utility tools so exact-list assertions written
+ * before they existed keep pinning only the server-derived catalog. */
+export function withoutMcpUtilityTools(names: readonly string[]): string[] {
+	return names.filter((name) => name !== "mcp_list_resources" && name !== "mcp_read_resource");
+}

--- a/packages/coding-agent/test/mcp/progress-logging.test.ts
+++ b/packages/coding-agent/test/mcp/progress-logging.test.ts
@@ -1,0 +1,57 @@
+// Server logging notifications (todo 42): RFC-5424 levels fold onto the
+// logger's four methods, config logLevel filters below-threshold messages,
+// and a 10/s token bucket absorbs floods without losing steady-state flow.
+// (Tool-call progress → onUpdate is W4 behavior, covered by the tier-B and
+// register tests plus the real-surface driver.)
+
+import { describe, expect, it } from "vitest";
+import { subscribeMcpServerLogging } from "../../src/core/extensions/builtin/mcp/logging.ts";
+
+type Handler = (notification: { params: { level: string; data: unknown; logger?: string } }) => void;
+
+function harness(options: { logLevel?: string; now?: () => number } = {}) {
+	let handler: Handler = () => undefined;
+	const client = { setNotificationHandler: (_schema: unknown, callback: Handler) => (handler = callback) };
+	const lines: string[] = [];
+	const logger = {
+		debug: (message: string) => lines.push(`debug ${message}`),
+		error: (message: string) => lines.push(`error ${message}`),
+		info: (message: string) => lines.push(`info ${message}`),
+		warn: (message: string) => lines.push(`warn ${message}`),
+	};
+	subscribeMcpServerLogging(client as never, { logger: logger as never, ...options });
+	return {
+		emit: (level: string, data: unknown, name?: string) => handler({ params: { data, level, logger: name } }),
+		lines,
+	};
+}
+
+describe("mcp server logging", () => {
+	it("maps RFC-5424 levels onto logger methods with server logger names", () => {
+		const { emit, lines } = harness();
+		emit("debug", "d");
+		emit("notice", "n", "sub");
+		emit("warning", "w");
+		emit("critical", "c");
+		expect(lines).toEqual(["debug [server] d", "info [server:sub] n", "warn [server] w", "error [server] c"]);
+	});
+
+	it("filters below the configured logLevel", () => {
+		const { emit, lines } = harness({ logLevel: "warning" });
+		emit("debug", "hidden");
+		emit("info", "hidden");
+		emit("error", "kept");
+		expect(lines).toEqual(["error [server] kept"]);
+	});
+
+	it("rate-limits a flood without losing steady-state messages", () => {
+		let clock = 0;
+		const { emit, lines } = harness({ now: () => clock });
+		for (let i = 0; i < 100; i += 1) emit("info", `burst-${i}`);
+		expect(lines.length).toBe(10);
+		// A second later the bucket refills: the next message lands.
+		clock = 1000;
+		emit("info", "after-burst");
+		expect(lines.at(-1)).toBe("info [server] after-burst");
+	});
+});

--- a/packages/coding-agent/test/mcp/prompts-commands.test.ts
+++ b/packages/coding-agent/test/mcp/prompts-commands.test.ts
@@ -1,0 +1,88 @@
+// MCP prompts → slash commands (todo 40): every listed prompt registers as
+// /mcp:<server>:<prompt>; invoking collects declared arguments via ctx.ui and
+// injects the prompts/get messages into the input editor; a missing required
+// argument aborts with a notice instead of calling the server.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	registerMcpPromptCommands,
+	resetMcpPromptCommandsForTests,
+} from "../../src/core/extensions/builtin/mcp/prompts.ts";
+import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+beforeEach(() => {
+	resetMcpServiceForTests();
+	resetMcpPromptCommandsForTests();
+});
+
+afterEach(async () => {
+	await getMcpService().dispose("quit");
+	resetMcpServiceForTests();
+	await cleanupRoots(cleanupTasks);
+});
+
+function mcpRoot(slug: string): TestRoot {
+	return makeMcpRoot(slug, cleanupTasks);
+}
+
+interface FakeCommand {
+	description?: string;
+	handler: (args: string, ctx: never) => Promise<void>;
+}
+
+function commandRecorder(): {
+	commands: Map<string, FakeCommand>;
+	registerCommand: (name: string, options: FakeCommand) => void;
+} {
+	const commands = new Map<string, FakeCommand>();
+	return { commands, registerCommand: (name, options) => commands.set(name, options) };
+}
+
+function fakeCommandCtx(answers: Array<string | undefined>) {
+	const notices: string[] = [];
+	let editorText = "";
+	return {
+		ctx: {
+			ui: {
+				input: async () => answers.shift(),
+				notify: (message: string) => {
+					notices.push(message);
+				},
+				setEditorText: (text: string) => {
+					editorText = text;
+				},
+			},
+		} as never,
+		getEditorText: () => editorText,
+		notices,
+	};
+}
+
+describe("mcp prompts as slash commands", () => {
+	it("registers /mcp:<server>:<prompt> and injects prompts/get output into the editor", async () => {
+		const root = mcpRoot("prompts-live");
+		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
+		const pi = capturingPi();
+		await attach(root, pi);
+
+		const recorder = commandRecorder();
+		const added = registerMcpPromptCommands(recorder as never, getMcpService().getMcpPromptServers());
+		expect(added).toEqual(["mcp:fx:fixture_prompt"]);
+
+		const command = recorder.commands.get("mcp:fx:fixture_prompt");
+		expect(command?.description).toContain("Fixture prompt");
+
+		const happy = fakeCommandCtx(["World"]);
+		await command?.handler("", happy.ctx);
+		expect(happy.getEditorText()).toBe("Hello World");
+
+		const aborted = fakeCommandCtx([undefined]);
+		await command?.handler("", aborted.ctx);
+		expect(aborted.getEditorText()).toBe("");
+		expect(aborted.notices[0]).toContain("required argument 'name'");
+	});
+});

--- a/packages/coding-agent/test/mcp/proxy-mode.test.ts
+++ b/packages/coding-agent/test/mcp/proxy-mode.test.ts
@@ -14,6 +14,7 @@ import {
 	registeredTool,
 	testContext,
 	textContent,
+	withoutMcpUtilityTools,
 } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 
@@ -40,9 +41,9 @@ describe("tier-C proxy mode", () => {
 		const pi = capturingPi();
 		await attach(root, pi);
 
-		const mcpActive = pi.getActiveTools().filter((name) => name.startsWith("mcp_"));
+		const mcpActive = withoutMcpUtilityTools(pi.getActiveTools()).filter((name) => name.startsWith("mcp_"));
 		expect(mcpActive).toEqual(["mcp_fx"]);
-		expect(pi.registeredTools.filter((name) => name.startsWith("mcp_fx_"))).toEqual([]);
+		expect(withoutMcpUtilityTools(pi.registeredTools).filter((name) => name.startsWith("mcp_fx_"))).toEqual([]);
 
 		const gateway = registeredTool(pi, "mcp_fx");
 		const search = await gateway.execute(

--- a/packages/coding-agent/test/mcp/proxy-mode.test.ts
+++ b/packages/coding-agent/test/mcp/proxy-mode.test.ts
@@ -1,0 +1,109 @@
+// Tier-C proxy mode (todo 38): `exposure:"proxy"` hides a server's whole
+// catalog behind ONE always-active gateway tool (search/describe/call with
+// JSON-string args); user mistakes come back as guiding text, unknown tools
+// get nearest-match hints, and auto NEVER selects proxy.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultSettings } from "../../src/core/extensions/builtin/mcp/config-schema.ts";
+import { computeMcpExposurePolicy } from "../../src/core/extensions/builtin/mcp/expose/policy.ts";
+import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import {
+	attach,
+	capturingPi,
+	mcpRoot as makeMcpRoot,
+	registeredTool,
+	testContext,
+	textContent,
+} from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+beforeEach(() => {
+	resetMcpServiceForTests();
+});
+
+afterEach(async () => {
+	await getMcpService().dispose("quit");
+	resetMcpServiceForTests();
+	await cleanupRoots(cleanupTasks);
+});
+
+function mcpRoot(slug: string): TestRoot {
+	return makeMcpRoot(slug, cleanupTasks);
+}
+
+describe("tier-C proxy mode", () => {
+	it("exposes exactly one gateway; search/describe/call round-trip; bad args guide the model", async () => {
+		const root = mcpRoot("proxy-live");
+		setConfig(root, { fx: { ...stdioServer(["--tools", "5"]), exposure: "proxy" } });
+		const pi = capturingPi();
+		await attach(root, pi);
+
+		const mcpActive = pi.getActiveTools().filter((name) => name.startsWith("mcp_"));
+		expect(mcpActive).toEqual(["mcp_fx"]);
+		expect(pi.registeredTools.filter((name) => name.startsWith("mcp_fx_"))).toEqual([]);
+
+		const gateway = registeredTool(pi, "mcp_fx");
+		const search = await gateway.execute(
+			"tc-s",
+			{ op: "search", query: "generated fixture tool 2" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(search)).toContain("tool_2");
+
+		const describe = await gateway.execute(
+			"tc-d",
+			{ op: "describe", tool: "tool_2" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(describe)).toContain("Input schema");
+
+		const call = await gateway.execute(
+			"tc-c",
+			{ args: '{"value":"via-proxy"}', op: "call", tool: "tool_2" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(call)).toBe("fixture tool_2 value=via-proxy mode=alpha");
+
+		const badArgs = await gateway.execute(
+			"tc-b",
+			{ args: "{not json", op: "call", tool: "tool_2" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(badArgs)).toContain("JSON object STRING");
+
+		const unknown = await gateway.execute(
+			"tc-u",
+			{ op: "call", tool: "tool_99x" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(unknown)).toContain("Unknown tool");
+		expect(textContent(unknown)).toContain("Nearest matches");
+	});
+
+	it("auto exposure never selects proxy", () => {
+		const entries = Array.from({ length: 40 }, (_, index) => ({
+			description: `tool ${index}`,
+			schema: {},
+			server: "big",
+			tool: `tool_${index}`,
+		}));
+		const policy = computeMcpExposurePolicy(
+			entries as never,
+			{ exposure: "auto" } as never,
+			defaultSettings as never,
+		);
+		expect(policy.mode).not.toBe("proxy");
+	});
+});

--- a/packages/coding-agent/test/mcp/register-call.test.ts
+++ b/packages/coding-agent/test/mcp/register-call.test.ts
@@ -15,6 +15,7 @@ import {
 	testContext,
 	textContent,
 	toolResultTexts,
+	withoutMcpUtilityTools,
 } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer } from "./fixtures/service-lifecycle.ts";
 
@@ -44,14 +45,14 @@ describe("MCP catalog + registerTool bridge", () => {
 
 		await attach(root, pi);
 
-		expect(pi.registeredTools).toEqual([
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual([
 			"mcp_fx_tool_1",
 			"mcp_fx_tool_2",
 			"mcp_fx_tool_3",
 			"mcp_fx_tool_4",
 			"mcp_fx_tool_5",
 		]);
-		expect(pi.activeTools).toEqual(pi.registeredTools);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(withoutMcpUtilityTools(pi.registeredTools));
 	});
 
 	it("runs a model turn through the registered MCP tool and returns fixture payload", async () => {

--- a/packages/coding-agent/test/mcp/resources.test.ts
+++ b/packages/coding-agent/test/mcp/resources.test.ts
@@ -1,0 +1,122 @@
+// MCP resources (todo 39): utility tools registered only when a server lists
+// resources; read maps text AND binary contents (guarded); resource-updated
+// notifications ride the tools-changed refresh path; @mcp: mentions inline the
+// resource body while malformed/unknown mentions pass through with a notice.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	expandMcpResourceMentions,
+	type McpResourceServer,
+	readMcpResourceAsText,
+	subscribeMcpResourceUpdated,
+} from "../../src/core/extensions/builtin/mcp/resources.ts";
+import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import {
+	attach,
+	capturingPi,
+	mcpRoot as makeMcpRoot,
+	registeredTool,
+	testContext,
+	textContent,
+} from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+beforeEach(() => {
+	resetMcpServiceForTests();
+});
+
+afterEach(async () => {
+	await getMcpService().dispose("quit");
+	resetMcpServiceForTests();
+	await cleanupRoots(cleanupTasks);
+});
+
+function mcpRoot(slug: string): TestRoot {
+	return makeMcpRoot(slug, cleanupTasks);
+}
+
+function fakeBinaryServer(): McpResourceServer {
+	return {
+		connection: {
+			client: {
+				readResource: async () => ({
+					contents: [{ blob: "QUFBQQ==", mimeType: "image/png", uri: "fake://bin" }],
+				}),
+			},
+		},
+		resources: [{ name: "bin", uri: "fake://bin" }],
+		server: "fake",
+	} as never;
+}
+
+describe("mcp resources", () => {
+	it("registers utility tools only with resources present; list+read round-trip", async () => {
+		const root = mcpRoot("res-live");
+		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
+		const pi = capturingPi();
+		await attach(root, pi);
+
+		expect(pi.getActiveTools()).toContain("mcp_list_resources");
+		const list = await registeredTool(pi, "mcp_list_resources").execute(
+			"t1",
+			{},
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(list)).toContain("@mcp:fx/fixture://resource/one");
+
+		const read = await registeredTool(pi, "mcp_read_resource").execute(
+			"t2",
+			{ server: "fx", uri: "fixture://resource/one" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+		expect(textContent(read)).toBe("resource body for fixture://resource/one");
+	});
+
+	it("stays absent when no server lists resources", async () => {
+		const root = mcpRoot("res-none");
+		setConfig(root, {});
+		const pi = capturingPi();
+		await attach(root, pi);
+		expect(pi.registeredTools).not.toContain("mcp_list_resources");
+	});
+
+	it("maps binary contents to a guarded placeholder", async () => {
+		const text = await readMcpResourceAsText(fakeBinaryServer(), "fake://bin");
+		expect(text).toContain("[binary resource fake://bin (image/png)");
+	});
+
+	it("expands known mentions and passes malformed ones through with a notice", async () => {
+		const root = mcpRoot("res-mention");
+		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
+		const pi = capturingPi();
+		await attach(root, pi);
+		const servers = () => getMcpService().getMcpResourceServers();
+
+		const ok = await expandMcpResourceMentions("Use @mcp:fx/fixture://resource/one please", servers);
+		expect(ok.changed).toBe(true);
+		expect(ok.text).toContain("resource body for fixture://resource/one");
+		expect(ok.text).toContain('<mcp-resource server="fx"');
+
+		const bad = await expandMcpResourceMentions("See @mcp:nope/some://uri now", servers);
+		expect(bad.changed).toBe(false);
+		expect(bad.text).toBe("See @mcp:nope/some://uri now");
+		expect(bad.notices).toHaveLength(1);
+	});
+
+	it("routes resource-updated notifications into the change callback", () => {
+		const handlers: Array<() => void> = [];
+		const client = { setNotificationHandler: (_schema: unknown, handler: () => void) => handlers.push(handler) };
+		let changed = 0;
+		subscribeMcpResourceUpdated(client as never, () => {
+			changed += 1;
+		});
+		for (const handler of handlers) handler();
+		expect(changed).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/mcp/skills-sidecar.test.ts
+++ b/packages/coding-agent/test/mcp/skills-sidecar.test.ts
@@ -1,0 +1,128 @@
+// skills-carry-MCP sidecar loader (todo 37): declared servers register with
+// tools hidden (0 pre-load exposure); loading a skill reveals its includeTools
+// matches; sidecar beats frontmatter; multi-skill same-server union; a name
+// collision with a system-configured server resolves system-wins with a warning.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import {
+	matchIncludeTools,
+	parseSkillMcpDeclarations,
+	type SkillLike,
+	skillActivationTargets,
+} from "../../src/core/extensions/builtin/mcp/skills.ts";
+import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+beforeEach(() => {
+	resetMcpServiceForTests();
+});
+
+afterEach(async () => {
+	await getMcpService().dispose("quit");
+	resetMcpServiceForTests();
+	await cleanupRoots(cleanupTasks);
+});
+
+function mcpRoot(slug: string): TestRoot {
+	return makeMcpRoot(slug, cleanupTasks);
+}
+
+function makeSkill(root: TestRoot, name: string, options: { sidecar?: unknown; frontmatterMcp?: string }): SkillLike {
+	const baseDir = join(root.cwd, "skills", name);
+	mkdirSync(baseDir, { recursive: true });
+	const filePath = join(baseDir, "SKILL.md");
+	const fm = options.frontmatterMcp === undefined ? "" : `\nmcp:\n${options.frontmatterMcp}`;
+	writeFileSync(filePath, `---\nname: ${name}\ndescription: test skill${fm}\n---\n\nBody.\n`);
+	if (options.sidecar !== undefined) writeFileSync(join(baseDir, "mcp.json"), JSON.stringify(options.sidecar));
+	return { baseDir, filePath, name };
+}
+
+function fixtureServerRaw(tools: number): Record<string, unknown> {
+	const base = stdioServer(["--tools", String(tools)]);
+	return { ...base, includeTools: undefined };
+}
+
+describe("skills-carry-MCP declarations", () => {
+	it("parses frontmatter-only skills and lets a sidecar win over frontmatter", () => {
+		const root = mcpRoot("skills-parse");
+		const fmOnly = makeSkill(root, "fm-only", {
+			frontmatterMcp: `  fmsrv:\n    type: stdio\n    command: node\n    args: ["x"]`,
+		});
+		const both = makeSkill(root, "both", {
+			frontmatterMcp: `  losersrv:\n    command: node`,
+			sidecar: { winsrv: { args: ["y"], command: "node", type: "stdio" } },
+		});
+		const decls = parseSkillMcpDeclarations([fmOnly, both]);
+		expect([...decls.servers.keys()].sort()).toEqual(["fmsrv", "winsrv"]);
+		expect(decls.servers.get("winsrv")?.sourcePath.endsWith("mcp.json")).toBe(true);
+		expect(decls.warnings).toEqual([]);
+	});
+
+	it("union-merges includeTools when two skills declare the same server", () => {
+		const root = mcpRoot("skills-union");
+		const a = makeSkill(root, "skill-a", { sidecar: { shared: { command: "node", includeTools: ["tool_1"] } } });
+		const b = makeSkill(root, "skill-b", { sidecar: { shared: { command: "node", includeTools: ["tool_2*"] } } });
+		const decls = parseSkillMcpDeclarations([a, b]);
+		const registered = [
+			{ name: "mcp_shared_tool_1", server: "shared", toolName: "tool_1" },
+			{ name: "mcp_shared_tool_2", server: "shared", toolName: "tool_2" },
+			{ name: "mcp_shared_tool_3", server: "shared", toolName: "tool_3" },
+		];
+		expect(skillActivationTargets(decls, "skill-a", registered)).toEqual(["mcp_shared_tool_1"]);
+		expect(skillActivationTargets(decls, "skill-b", registered)).toEqual(["mcp_shared_tool_2"]);
+		expect(matchIncludeTools(["*"], "anything")).toBe(true);
+	});
+});
+
+describe("skills-carry-MCP live registration", () => {
+	it("registers hidden until activation, then reveals includeTools matches", async () => {
+		const root = mcpRoot("skills-live");
+		setConfig(root, {});
+		const pi = capturingPi();
+		await attach(root, pi);
+
+		const skill = makeSkill(root, "carrier", {
+			sidecar: { fx2: { ...fixtureServerRaw(3), includeTools: ["tool_1", "tool_3"] } },
+		});
+		const decls = parseSkillMcpDeclarations([skill]);
+		const declared = new Map(
+			[...decls.servers].map(([name, decl]) => [name, { raw: decl.raw, sourcePath: decl.sourcePath }]),
+		);
+		const warnings = await getMcpService().attachSkillMcpServers(declared);
+		expect(warnings).toEqual([]);
+
+		// 0 exposure pre-load: catalog registered, nothing active.
+		const active = pi.getActiveTools();
+		expect(pi.registeredTools).toContain("mcp_fx2_tool_1");
+		expect(active.filter((name) => name.startsWith("mcp_fx2_"))).toEqual([]);
+
+		const targets = skillActivationTargets(decls, "carrier", getMcpService().getTierBSearchable());
+		expect(targets).toEqual(["mcp_fx2_tool_1", "mcp_fx2_tool_3"]);
+		getMcpService().activateSkillMcpTools(targets);
+		const revealed = pi.getActiveTools().filter((name) => name.startsWith("mcp_fx2_"));
+		expect(revealed).toEqual(["mcp_fx2_tool_1", "mcp_fx2_tool_3"]);
+	});
+
+	it("keeps the system config and warns on a server-name collision", async () => {
+		const root = mcpRoot("skills-collision");
+		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
+		const pi = capturingPi();
+		await attach(root, pi);
+
+		const skill = makeSkill(root, "clasher", { sidecar: { fx: { command: "node", args: ["evil"] } } });
+		const decls = parseSkillMcpDeclarations([skill]);
+		const declared = new Map(
+			[...decls.servers].map(([name, decl]) => [name, { raw: decl.raw, sourcePath: decl.sourcePath }]),
+		);
+		const warnings = await getMcpService().attachSkillMcpServers(declared);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("system config wins");
+		// The system server's tool stays intact and active (direct mode).
+		expect(pi.getActiveTools()).toContain("mcp_fx_tool_1");
+	});
+});

--- a/packages/coding-agent/test/mcp/startup-race.test.ts
+++ b/packages/coding-agent/test/mcp/startup-race.test.ts
@@ -6,7 +6,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadMcpConfig } from "../../src/core/extensions/builtin/mcp/config.ts";
 import { ConnectError, ToolExecError } from "../../src/core/extensions/builtin/mcp/errors.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { capturingPi, registeredTool, testContext, textContent } from "./fixtures/register-call.ts";
+import {
+	capturingPi,
+	registeredTool,
+	testContext,
+	textContent,
+	withoutMcpUtilityTools,
+} from "./fixtures/register-call.ts";
 import { cleanupRoots, makeRoot, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -28,9 +34,9 @@ describe("MCP startup race", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
-		await waitFor(() => pi.registeredTools.length === 2, 2500);
+		await waitFor(() => withoutMcpUtilityTools(pi.registeredTools).length === 2, 2500);
 
-		expect(pi.registeredTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 		expect(getMcpService().getServerSnapshots()).toMatchObject([
 			{ name: "fx", lifecycleState: "connected", configState: "enabled" },
 		]);
@@ -45,8 +51,8 @@ describe("MCP startup race", () => {
 		const elapsedMs = await timedAttach(root, pi);
 
 		expect(elapsedMs).toBeLessThan(300);
-		expect(pi.activeTools).toEqual(["mcp_fx_tool_1"]);
-		expect(pi.registeredTools).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
 		expect(getMcpService().getServerSnapshots()).toMatchObject([
 			{ name: "fx", lifecycleState: "connecting", configState: "enabled" },
 		]);
@@ -61,7 +67,7 @@ describe("MCP startup race", () => {
 		const elapsedMs = await timedAttach(root, pi);
 
 		expect(elapsedMs).toBeLessThan(300);
-		expect(pi.activeTools).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1"]);
 		expect(getMcpService().getServerSnapshots()).toMatchObject([
 			{ name: "fx", lifecycleState: "connecting", configState: "enabled" },
 		]);
@@ -74,11 +80,11 @@ describe("MCP startup race", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
-		expect(pi.activeTools).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1"]);
 
-		await waitFor(() => pi.activeTools.includes("mcp_fx_tool_2"), 2500);
+		await waitFor(() => withoutMcpUtilityTools(pi.activeTools).includes("mcp_fx_tool_2"), 2500);
 
-		expect(pi.activeTools).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 		const tool = registeredTool(pi, "mcp_fx_tool_2");
 		const result = await tool.execute("tc-hot-swap", { value: "late" }, undefined, undefined, testContext());
 		expect(textContent(result)).toBe("fixture tool_2 value=late mode=alpha");
@@ -93,10 +99,10 @@ describe("MCP startup race", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
-		const before = JSON.stringify(pi.activeTools);
+		const before = JSON.stringify(withoutMcpUtilityTools(pi.activeTools));
 
 		await waitFor(() => getMcpService().getConnection("fx")?.state === "connected", 2500);
-		const after = JSON.stringify(pi.activeTools);
+		const after = JSON.stringify(withoutMcpUtilityTools(pi.activeTools));
 
 		expect(after).toBe(before);
 		expect(before).toBe(JSON.stringify(["mcp_fx_tool_1", "mcp_fx_tool_2"]));
@@ -122,7 +128,7 @@ describe("MCP startup race", () => {
 
 		expect(attachElapsedMs).toBeLessThan(300);
 		expect(callElapsedMs).toBeLessThan(30_000);
-		expect(pi.activeTools).toEqual(["mcp_fx_tool_1"]);
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1"]);
 	});
 });
 

--- a/scripts/check-mcp-docs.test.mjs
+++ b/scripts/check-mcp-docs.test.mjs
@@ -1,0 +1,55 @@
+// Guard (todo 43): every field in the SHIPPED MCP TypeBox schema must appear
+// as a `### \`field\`` heading in docs/mcp.md, so schema drift breaks CI
+// instead of silently rotting the reference. Parses the schema SOURCE (the
+// object-literal keys) rather than importing TS, keeping this a plain
+// node --test script like its siblings.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const schemaSource = readFileSync(
+	join(root, "packages", "coding-agent", "src", "core", "extensions", "builtin", "mcp", "config-schema.ts"),
+	"utf8",
+);
+const docs = readFileSync(join(root, "packages", "coding-agent", "docs", "mcp.md"), "utf8");
+
+function literalKeys(blockName) {
+	const start = schemaSource.indexOf(`const ${blockName} = Type.Object(`);
+	assert.notEqual(start, -1, `schema block ${blockName} not found`);
+	const open = schemaSource.indexOf("{", start);
+	let depth = 0;
+	let end = open;
+	for (let i = open; i < schemaSource.length; i += 1) {
+		if (schemaSource[i] === "{") depth += 1;
+		if (schemaSource[i] === "}") depth -= 1;
+		if (depth === 0) {
+			end = i;
+			break;
+		}
+	}
+	const body = schemaSource.slice(open + 1, end);
+	// Top-level keys only: lines at one-tab indent ending with a Type.* value.
+	return [...body.matchAll(/^\t\t(\w+): /gm)].map((match) => match[1]);
+}
+
+test("docs/mcp.md documents every shipped server field", () => {
+	const missing = literalKeys("ServerSchema").filter((key) => !docs.includes(`### \`${key}\``));
+	assert.deepEqual(missing, [], `undocumented server fields: ${missing.join(", ")}`);
+});
+
+test("docs/mcp.md documents every shipped settings field", () => {
+	const missing = literalKeys("SettingsSchema").filter((key) => !docs.includes(`### \`${key}\``));
+	assert.deepEqual(missing, [], `undocumented settings fields: ${missing.join(", ")}`);
+});
+
+test("docs/mcp.md keeps the full-disable instructions", () => {
+	assert.ok(docs.includes('"disabledBuiltinExtensions": ["mcp"]'), "disable instructions missing");
+});
+
+test("docs/mcp.md makes no url-mode elicitation claim", () => {
+	assert.ok(!/url[- ]mode/i.test(docs), "docs must not advertise url-mode elicitation (v1 is form-only)");
+});


### PR DESCRIPTION
## Summary

MCP plan Wave 5 (todos 37-44), the final capability wave: skills-carried MCP servers, the opt-in Tier-C proxy, resources with `@mcp:` mentions, prompts as slash commands, form-mode elicitation, server log routing, full user documentation with a schema-drift guard, and the W5 e2e gate.

## What's included

- **skills-carry-MCP** (`skills.ts`): skills ship servers via an `mcp.json` sidecar (wins) or SKILL.md `mcp:` frontmatter; catalogs register with ZERO active tools (0 pre-load payload) and reveal `includeTools` glob matches when the skill loads (`/skill:` input or SKILL.md read); same-server union merge across skills; system-config name collisions resolve system-wins with a warning.
- **Tier-C proxy** (`expose/proxy.ts`): `exposure:"proxy"` collapses a server to one `mcp_<server>` gateway (search/describe/call, JSON-string args) reusing BM25 + the factored guarded call path; `auto` never selects it.
- **Resources** (`resources.ts`): `mcp_list_resources`/`mcp_read_resource` (registered only when resources exist), `@mcp:<server>/<uri>` input-event mention expansion (failures pass through with a notice), per-resource subscriptions + updated notifications riding the tools-changed refresh.
- **Prompts** (`prompts.ts`): every listed prompt registers as `/mcp:<server>:<prompt>` — ctx.ui argument collection → prompts/get → editor injection.
- **Elicitation** (`elicitation.ts`): capability declared as EMPTY `{}` at client construction; flat-primitive form flow over ctx.ui; declines cleanly without UI or on URL-mode requests; bounded cancel timeout on wrap.ts safeTimer.
- **Server logging** (`logging.ts`): notifications/message → per-server logger with RFC-5424 mapping, `logLevel` filtering (field live at last), 10/s burst cap.
- **Docs** (`docs/mcp.md`): quickstart, complete config reference (every shipped schema field + defaults), tier guide, auth incl. headless, troubleshooting matrix, security notes, `disabledBuiltinExtensions` full-disable; linked from index/docs.json; CHANGELOG entries; `scripts/check-mcp-docs.test.mjs` fails CI on schema-vs-docs drift.
- `builtin/mcp/changes.md` ledger entry for the wave.

## Verification (todo 44 gate — INDEX at `.omo/evidence/task-44-senpi-mcp-plugin/`)

- Full `test/mcp` suite **265/265** on the merged tree; `npm run check` green; scripts tests 45/45 (docs guard included)
- W4 real-surface wire-payload driver **8/8** re-run on this branch — no exposure/promotion/rehydration regression
- Per-feature live-fixture round-trips: skills 4/4, proxy 2/2, resources 5/5, prompts 1/1, elicitation 4/4, logging 3/3
- Pre-existing exact-list assertions hardened with `withoutMcpUtilityTools()` (the utility tools legitimately join catalogs that list resources)

Completes the senpi-mcp-plugin plan's build waves (W0-W5). F1-F4 final verification follows on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the final MCP capability wave: skills can carry MCP servers with lazy exposure, an opt‑in proxy tier, resources with mention expansion, prompts as slash commands, elicitation forms, server log routing, and full docs. Improves context efficiency and completes the built‑in MCP client surface.

- **New Features**
  - Skills can ship MCP servers via `mcp.json` sidecar or SKILL.md frontmatter; zero pre‑load tools; `includeTools` revealed on skill load; union across skills; system config wins on name clashes.
  - Tier‑C proxy: `exposure:"proxy"` creates a single `mcp_<server>` gateway (search/describe/call with JSON‑string args); never selected by auto.
  - Resources: `mcp_list_resources` and `mcp_read_resource`; input mentions expand `@mcp:<server>/<uri>`; per‑resource subscriptions and update routing.
  - Prompts: each server prompt becomes `/mcp:<server>:<prompt>` with argument collection and editor injection.
  - Elicitation: form‑mode only; empty capability declaration; clean declines without UI; bounded cancel timeout.
  - Server logging: RFC‑5424 level mapping, `logLevel` filtering, and a 10/s burst cap.
  - Docs: `docs/mcp.md` with a full reference; CI guard `scripts/check-mcp-docs.test.mjs` blocks schema‑docs drift; nav links added.
  - Tests: W5 e2e gate added; full suite passes on this branch.

- **Migration**
  - Skills: add an `mcp.json` sidecar (preferred) or a `mcp:` block in SKILL.md; set `includeTools` globs for tools to reveal on load.
  - Proxy: set `exposure:"proxy"` on a server to enable the single‑gateway mode.
  - Resources: use `@mcp:<server>/<uri>` in input; call `mcp_list_resources` / `mcp_read_resource` as needed.
  - Prompts: run `/mcp:<server>:<prompt>`; required args are prompted.
  - Logging: set `logLevel` per server to control notification verbosity.

<sup>Written for commit e742270de4372a838f6867113d101ac09668a31a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

