### PR TITLE
test: pin mcp recovery re-exposure contract + widen neo perf budget

### DIFF
--- a/packages/coding-agent/test/mcp/recovery-reregister.test.ts
+++ b/packages/coding-agent/test/mcp/recovery-reregister.test.ts
@@ -1,0 +1,80 @@
+// #147: a server that crashes while the one-shot startup exposure is still in
+// flight used to recover its CONNECTION (reconnect controller) but never its
+// EXPOSURE — the session had zero tools for the rest of its life (first
+// observed on CI via the idle-test diagnostics: state=connected,
+// toolRegistered=false, on a branch that predated W4). The W4 list_changed
+// wiring closed the gap as a side effect: every successful connect fires
+// markToolsChanged -> handleServerToolsChanged -> registerDirectTools. This
+// test pins that recovery-exposure contract so it cannot silently regress.
+
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, type TestRoot, waitForCondition } from "./fixtures/service-lifecycle.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+beforeEach(() => {
+	resetMcpServiceForTests();
+});
+
+afterEach(async () => {
+	await getMcpService().dispose("quit");
+	resetMcpServiceForTests();
+	await cleanupRoots(cleanupTasks);
+});
+
+function mcpRoot(slug: string): TestRoot {
+	return makeMcpRoot(slug, cleanupTasks);
+}
+
+/** Wrapper that crashes while modeFile says "fail", then boots the real fixture. */
+function writeCrashingWrapper(root: TestRoot, modeFile: string): string {
+	const wrapper = join(root.agentDir, "crashy-wrapper.mjs");
+	mkdirSync(dirname(wrapper), { recursive: true });
+	writeFileSync(modeFile, "fail\n");
+	const fixture = pathToFileURL(join(import.meta.dirname, "fixtures", "stdio-server.ts")).href;
+	writeFileSync(
+		wrapper,
+		`
+import { readFileSync } from "node:fs";
+if (readFileSync(${JSON.stringify(modeFile)}, "utf8").trim() === "fail") process.exit(44);
+await import(${JSON.stringify(fixture)});
+`,
+	);
+	chmodSync(wrapper, 0o755);
+	return wrapper;
+}
+
+describe("recovery re-registration (#147)", () => {
+	it("exposes tools after the reconnect controller recovers a crash-at-startup server", async () => {
+		const root = mcpRoot("recovery-reregister");
+		const modeFile = join(root.agentDir, "wrapper-mode.txt");
+		const wrapper = writeCrashingWrapper(root, modeFile);
+		setConfig(root, {
+			fx: {
+				type: "stdio",
+				command: process.execPath,
+				args: [wrapper, "--tools", "2"],
+				connectTimeoutMs: 5000,
+			},
+		});
+		const pi = capturingPi();
+		// Initial attach: every spawn crashes, so the one-shot startup exposure
+		// registers nothing and the connection goes degraded.
+		await attach(root, pi);
+		expect(pi.registeredTools.filter((name) => name.startsWith("mcp_fx_"))).toEqual([]);
+
+		// Heal the server; the reconnect controller's real backoff timers respawn
+		// it. With the fix, recovery re-runs registration and the tools surface.
+		writeFileSync(modeFile, "ok\n");
+		await waitForCondition(
+			() => pi.registeredTools.includes("mcp_fx_tool_1") && pi.activeTools.includes("mcp_fx_tool_1"),
+			15_000,
+		);
+		expect(getMcpService().getConnection("fx")?.state).toBe("connected");
+	});
+});

--- a/packages/neo/internal/app/transcript_test.go
+++ b/packages/neo/internal/app/transcript_test.go
@@ -304,8 +304,13 @@ func TestTranscriptStreamingPerf500Deltas(t *testing.T) {
 		// The race detector multiplies wall-clock ~5-10x; the budget calibrates
 		// uninstrumented builds. Functional + goroutine assertions still run.
 		t.Logf("race build: skipping time budget (took %v)", elapsed)
-	} else if elapsed >= 2*time.Second {
-		t.Fatalf("500 message_update deltas took %v (budget 2s)", elapsed)
+	} else if elapsed >= 8*time.Second {
+		// The budget guards against O(n^2) re-render blowups, where 500 deltas
+		// cost tens of seconds — not against shared-CI scheduling noise. 2s flaked
+		// at 2.13s on a loaded GitHub runner (PR #158 rerun); 8s keeps an
+		// order-of-magnitude margin over the ~0.3s unloaded baseline while staying
+		// far below a genuine regression.
+		t.Fatalf("500 message_update deltas took %v (budget 8s)", elapsed)
 	}
 
 	tr.HandleEvent(eventMsg(t, fmt.Sprintf(


### PR DESCRIPTION
## Summary

Two small test hardenings closing out the loose ends from the three-trains work:

1. **MCP recovery re-exposure contract (fixes #147)** — a server crashing during the one-shot startup exposure used to recover its connection but never its tool exposure (observed on CI as `state=connected, toolRegistered=false` on a pre-W4 branch). W4's list_changed wiring closed the gap as a side effect (`connect → markToolsChanged → registerDirectTools`), verified here by stashing candidate product patches: the path already covers it. This deterministic repro (wrapper crashes until healed, then boots the real stdio fixture) pins the contract so it cannot silently regress. No product change needed.
2. **neo streaming perf budget** — `TestTranscriptStreamingPerf500Deltas` guards against O(n²) re-render blowups (tens of seconds), not scheduler noise; the 2s budget flaked at 2.13s on a loaded runner (blocked PR #158's first rerun). 8s keeps an order-of-magnitude margin over the ~0.3s unloaded baseline while still failing hard on real regressions. Validated `-count=3` locally.

## Verification

- `recovery-reregister.test.ts` green (and red-verified: it exercises the real reconnect-controller path, not a mock)
- `go test ./internal/app/ -run TestTranscriptStreamingPerf500Deltas -count=3` green
- Both changes are test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deterministic test to ensure MCP servers re-register tools after crash recovery, preventing sessions with zero tools (fixes #147). Also raise the `TestTranscriptStreamingPerf500Deltas` budget from 2s to 8s to reduce CI flakiness while still catching real regressions.

<sup>Written for commit d4411c7db54d3b778a5c6a8d33f9bd5e3f1f19b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

