### PR TITLE
fix(coding-agent): compact upstream-model overflow retries

### DIFF
--- a/.omo/evidence/auto-compact-context-too-large-code-review.md
+++ b/.omo/evidence/auto-compact-context-too-large-code-review.md
@@ -1,0 +1,70 @@
+# Code Quality Review: auto-compact-context-too-large
+
+## Verdict
+
+- codeQualityStatus: WATCH
+- recommendation: APPROVE
+- verdict: PASS
+- blockers: none
+
+## Scope Reviewed
+
+Requested files only:
+
+- `packages/coding-agent/src/core/agent-session.ts`
+- `packages/coding-agent/src/core/model-registry.ts`
+- `packages/coding-agent/test/model-registry.test.ts`
+- `packages/coding-agent/test/suite/harness.ts`
+- `packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts`
+- `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts`
+- `packages/coding-agent/CHANGELOG.md`
+
+Note: the worktree also has unlisted changes in `packages/coding-agent/src/core/changes.md` and `.omo/evidence/task-5-context-overflow-upstream-model-compaction.txt`. I inspected them only as scope/evidence context; this verdict does not approve those paths.
+
+## Skill-Perspective Check
+
+Ran/consulted:
+
+- `omo:remove-ai-slops` via `/Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.16.0/skills/remove-ai-slops/SKILL.md`
+- `omo:programming` via `/Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.16.0/skills/programming/SKILL.md`
+- TypeScript reference via `/Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.16.0/skills/programming/references/typescript/README.md`
+
+Result: no blocking violation in the requested diff. The new regression file uses private-method reflection, which is implementation-coupled, but that style already exists in nearby compaction tests and this diff also adds a public `prompt()`-path regression. Existing touched files are oversized by the programming skill's 250 pure-LOC lens; the diff itself is narrow and does not add a new responsibility.
+
+## Findings
+
+### CRITICAL
+
+None.
+
+### HIGH
+
+None.
+
+### MEDIUM
+
+None.
+
+### LOW
+
+- Existing file-size risk: `packages/coding-agent/src/core/agent-session.ts` is about 3370 pure LOC and `packages/coding-agent/src/core/model-registry.ts` is about 1086 pure LOC. This change adds a small, localized alias comparison/accessor and does not materially worsen architecture, but future edits in these files should prefer extraction when touching larger behavior.
+- Test coupling note: `packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts:9` reaches private methods with `Reflect`. This is not a blocker because `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts:76` covers the same alias overflow behavior through the public `prompt()` path.
+
+## Review Notes
+
+- `packages/coding-agent/src/core/agent-session.ts:340` adds a small source-match helper that keeps the existing provider guard and extends model equality to the configured upstream model id.
+- `packages/coding-agent/src/core/agent-session.ts:2499` uses the helper only for the overflow source check; unrelated model overflows still require current context pressure before compaction.
+- `packages/coding-agent/src/core/model-registry.ts:795` exposes the same upstream-id map already used by `getApiKeyAndHeaders()`, avoiding credential resolution in the compaction gate.
+- `packages/coding-agent/test/suite/harness.ts:76` and `:144` extend the faux harness just enough to register upstream alias metadata through `ModelRegistry.registerProvider()`.
+- `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts:76` verifies the user-facing dot retry path compacts before sending the prompt and does not call `agent.continue()`.
+- `packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts:87` verifies the negative same-provider/unrelated-model case below threshold does not compact.
+
+## Verification
+
+Commands run from `/Users/yeongyu/local-workspaces/senpi-wt/fix/auto-compact-context-too-large` unless noted:
+
+- `git diff --check` - passed.
+- From `packages/coding-agent`: `npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-registry.test.ts test/suite/regressions/context-overflow-model-alias.test.ts test/suite/regressions/pre-prompt-compaction-no-continue.test.ts` - 3 files passed, 87 tests passed.
+- `npm run check` - passed, including Biome, pinned deps, TS import checks, shrinkwrap/install-lock checks, `tsgo --noEmit`, web UI checks, and neo build/vet/test.
+
+I also spot-checked executor evidence under `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/`, including red failure, focused green runs, QA self-tests, and final check output.

--- a/.omo/evidence/auto-compact-context-too-large-readiness.md
+++ b/.omo/evidence/auto-compact-context-too-large-readiness.md
@@ -1,0 +1,33 @@
+# Auto-compact context-too-large readiness packet
+
+## Changed files in scope
+
+- packages/coding-agent/CHANGELOG.md
+- packages/coding-agent/src/core/agent-session.ts
+- packages/coding-agent/src/core/changes.md
+- packages/coding-agent/src/core/model-registry.ts
+- packages/coding-agent/test/model-registry.test.ts
+- packages/coding-agent/test/suite/harness.ts
+- packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts
+- packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+- .omo/evidence/task-5-context-overflow-upstream-model-compaction.txt
+- .omo/evidence/auto-compact-context-too-large-code-review.md
+- .omo/evidence/upstream-model-overflow-compaction-code-review.md
+
+## Code-quality / slop coverage
+
+- Code quality reviewer PASS: `.omo/evidence/auto-compact-context-too-large-code-review.md`
+- Security reviewer PASS: `.omo/evidence/upstream-model-overflow-compaction-code-review.md`
+- Final gate reviewer rerun PASS: no blockers after remediation.
+
+## Verification artifacts
+
+- RED: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/red-context-overflow-model-alias.txt`
+- GREEN focused: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/focused-tests-after-check-fix.txt`
+- Full check: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/npm-run-check-after-review-remediation.txt`
+- Debugging audit: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/debugging-audit.md`
+- QA matrix: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/review-qa/manualQa-matrix.md`
+
+## Current status receipt
+
+See `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/status-after-review-remediation.txt`.

--- a/.omo/evidence/task-5-context-overflow-upstream-model-compaction.txt
+++ b/.omo/evidence/task-5-context-overflow-upstream-model-compaction.txt
@@ -1,0 +1,15 @@
+# Task 5 QA evidence summary
+
+Real CLI/RPC QA was run from the isolated worktree with senpi-qa scripts. Full raw artifacts are under `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/` and are intentionally not committed.
+
+- RPC self-test: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/senpi-qa-rpc-self-test.txt`
+  - PASS: `get_state` returned documented shape; no real provider API required; real `/Users/yeongyu/.senpi/agent/auth.json` unchanged.
+- OpenAI Responses mock loop: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/senpi-qa-mock-loop-openai-responses.txt`
+  - PASS: baseUrl override round-tripped through the real loop against localhost `/v1/responses`; zero real provider calls; real auth unchanged.
+- CLI smoke: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/senpi-qa-cli-smoke.txt`
+  - PASS: `--help`, `--version`, offline `--list-models`, and unknown flag behavior; real auth unchanged.
+- Bug-specific fixture fallback: focused Vitest integration covers the upstream alias overflow path and pre-prompt dot retry deterministically without real providers.
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/focused-tests-after-check-fix.txt`
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/green-pre-prompt-upstream-overflow.txt`
+
+Cleanup receipt: senpi-qa scripts use isolated temp sandboxes and self-report auth unchanged; this task spawned no persistent server, browser, tmux session, or container.

--- a/.omo/evidence/upstream-model-overflow-compaction-code-review.md
+++ b/.omo/evidence/upstream-model-overflow-compaction-code-review.md
@@ -1,0 +1,75 @@
+# Upstream Model Overflow Compaction Security Review
+
+Verdict: PASS
+
+## Scope Reviewed
+
+- Worktree: `/Users/yeongyu/local-workspaces/senpi-wt/fix/auto-compact-context-too-large`
+- Diff basis: local working-tree patch; `origin/main...HEAD` is empty.
+- Changed production/docs/evidence reviewed:
+  - `packages/coding-agent/src/core/agent-session.ts`
+  - `packages/coding-agent/src/core/model-registry.ts`
+  - `packages/coding-agent/src/core/changes.md`
+  - `packages/coding-agent/CHANGELOG.md`
+  - `packages/coding-agent/test/model-registry.test.ts`
+  - `packages/coding-agent/test/suite/harness.ts`
+  - `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts`
+  - `packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts`
+  - `.omo/evidence/task-5-context-overflow-upstream-model-compaction.txt`
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/*`
+
+## Skill-Perspective Check
+
+- Consulted `omo:remove-ai-slops`: no deletion-only tests, tautological removal tests, unnecessary parsing/normalization, speculative extraction, or production slop found in the reviewed delta.
+- Consulted `omo:programming` and TypeScript reference: no new `any`, dynamic import, type-escape, needless abstraction, brittle prompt test, or production boundary validation violation found.
+- Consulted `codex-security:security-diff-scan` and shared hard rules: review stayed diff-scoped and checked secret exposure, credential/auth access, metadata trust, retry/DoS, provider-call behavior, and evidence leakage.
+
+## Findings
+
+### CRITICAL
+
+None.
+
+### HIGH
+
+None.
+
+### MEDIUM
+
+None.
+
+### LOW
+
+None.
+
+## Security Notes
+
+- Secret/auth exposure: no new credential source is introduced. `ModelRegistry.getUpstreamModelId()` reads the existing in-memory `modelRequestUpstreamIds` map only; it does not call `getApiKeyAndHeaders()` or resolve provider env/secrets. Existing secret-bearing code paths remain in `getApiKeyAndHeaders()` at `packages/coding-agent/src/core/model-registry.ts:901`.
+- Unsafe metadata trust: the new overflow match still requires same provider and either current model id or configured upstream model id in `packages/coding-agent/src/core/agent-session.ts:340` and `packages/coding-agent/src/core/agent-session.ts:2499`. This aligns inbound overflow attribution with existing outbound request rewriting in `packages/coding-agent/src/core/sdk.ts:324`.
+- Retry/DoS: context-overflow messages remain excluded from generic retry at `packages/coding-agent/src/core/agent-session.ts:3221`, and overflow recovery remains latched to one compact-and-retry attempt at `packages/coding-agent/src/core/agent-session.ts:2529`.
+- Real-provider calls: reviewed QA evidence reports localhost-only mock-loop coverage and unchanged real auth. I also reran the focused regression scope locally.
+- Evidence/PR leakage: no PR exists for the branch (`gh pr list --head fix/auto-compact-context-too-large` returned `[]`). Current evidence/body-like files contain artifact paths and synthetic fixture text only. The broad secret scan of current fix evidence matched only synthetic `read /tmp/h2.jpg` fixture text in diff snapshots.
+
+## Verification
+
+- Reran focused scope directly:
+  - `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/context-overflow-model-alias.test.ts test/suite/regressions/pre-prompt-compaction-no-continue.test.ts test/model-registry.test.ts`
+  - Result: 3 files passed, 87 tests passed.
+- Reviewed executor evidence:
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/review-qa/01-focused-vitest.txt`: 3 files passed, 87 tests passed.
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/npm-run-check-final.txt`: recorded full `npm run check` pass.
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/senpi-qa-mock-loop-openai-responses.txt`: localhost-only mock loop, zero real provider calls, real auth unchanged.
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/senpi-qa-rpc-self-test.txt`: offline RPC self-test, real auth unchanged.
+  - `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/senpi-qa-cli-smoke.txt`: CLI smoke, offline model listing, real auth unchanged.
+- Did not rerun `npm run check` directly because its configured command invokes `biome check --write`, which can modify source files and conflicts with this read-only review assignment. The recorded artifact was inspected instead.
+
+## Residual Risks
+
+- The security decision trusts the existing models.json/provider registration boundary for `upstreamModelId`. A malicious local config can already redirect requests through `upstreamModelId`; this patch only mirrors that configured value for overflow attribution.
+- Overflow classification still depends on provider error strings and usage metadata in `packages/ai/src/utils/overflow.ts`; this patch does not broaden or harden that classifier.
+
+## Result
+
+- codeQualityStatus: CLEAR
+- recommendation: APPROVE
+- blockers: none

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed
 
+- Fixed context-overflow recovery for configured upstream model aliases, so a selected alias such as `gpt-5.5-fast` can auto-compact and retry when the provider reports the wire model `gpt-5.5`.
 - Fixed the built-in `todowrite` tool call row to show the actual todo items instead of only an item count.
 - Fixed sessions going stale forever when the network dropped and reconnected mid-stream: the agent loop's provider stream idle timeout is now enabled by default (follows `httpIdleTimeoutMs`, default 5 min, `0` disables; `retry.provider.timeoutMs` overrides), so a silently dead connection fails with a retryable idle-timeout error and auto-retry recovers the turn. Previously the guard was off unless `retry.provider.timeoutMs` was set, which left the Bun binary (no undici dispatcher protection) hanging indefinitely.
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -337,6 +337,16 @@ function estimateMessagesTokens(messages: AgentMessage[]): number {
 	return tokens;
 }
 
+function isSameOverflowSource(
+	message: AssistantMessage,
+	model: Model<Api>,
+	upstreamModelId: string | undefined,
+): boolean {
+	if (message.provider !== model.provider) return false;
+	if (message.model === model.id) return true;
+	return message.model === upstreamModelId;
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -2487,7 +2497,8 @@ export class AgentSession {
 		// to a larger-context model (e.g. codex) - the overflow error from the old model
 		// shouldn't trigger compaction for the new model.
 		const sameModel =
-			this.model && assistantMessage.provider === this.model.provider && assistantMessage.model === this.model.id;
+			this.model &&
+			isSameOverflowSource(assistantMessage, this.model, this._modelRegistry.getUpstreamModelId(this.model));
 
 		// Skip compaction checks if this assistant message is older than the latest
 		// compaction boundary. This prevents a stale pre-compaction usage/error

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Upstream model context overflow recovery (2026-07-08)
+
+### What changed
+
+- `model-registry.ts`: exposed configured `upstreamModelId` metadata synchronously so session-control code can compare selected aliases with provider-reported wire model ids without resolving credentials.
+- `agent-session.ts`: overflow recovery now treats a context-window error from the configured upstream model id as the same current-model source, preserving the existing stale/unrelated model guard.
+
+### Why extension system couldn't handle this
+
+- Provider context-overflow recovery happens inside the core session compaction gate before extensions can safely decide whether to retry the active turn.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` around `_checkCompaction()` overflow eligibility.
+- LOW: `model-registry.ts` around model request metadata accessors.
+
 ## Bundled codemode extension loading (2026-07-06)
 
 ### What changed

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -792,6 +792,10 @@ export class ModelRegistry {
 		return this.models.find((m) => m.provider === provider && m.id === modelId);
 	}
 
+	getUpstreamModelId(model: Model<Api>): string | undefined {
+		return this.modelRequestUpstreamIds.get(this.getModelRequestKey(model.provider, model.id));
+	}
+
 	/**
 	 * Get API key for a model.
 	 */

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -939,9 +939,15 @@ describe("ModelRegistry", () => {
 			expect(normal).toBeDefined();
 			expect(priority).toBeDefined();
 
-			const normalAuth = await registry.getApiKeyAndHeaders(normal!);
-			const priorityAuth = await registry.getApiKeyAndHeaders(priority!);
+			if (!normal || !priority) {
+				throw new Error("Expected custom upstream models to be registered");
+			}
 
+			const normalAuth = await registry.getApiKeyAndHeaders(normal);
+			const priorityAuth = await registry.getApiKeyAndHeaders(priority);
+
+			expect(registry.getUpstreamModelId(normal)).toBeUndefined();
+			expect(registry.getUpstreamModelId(priority)).toBe("gpt-5.5");
 			expect(normalAuth).toMatchObject({ ok: true });
 			expect(priorityAuth).toMatchObject({
 				ok: true,

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -73,6 +73,7 @@ export interface HarnessOptions {
 	resourceLoader?: ResourceLoader;
 	extensionFactories?: Array<ExtensionFactory | CreateTestExtensionsResultInput>;
 	withConfiguredAuth?: boolean;
+	upstreamModelId?: string;
 	onPayload?: (payload: unknown) => void;
 	persistSession?: boolean;
 	autoTitleSessions?: boolean;
@@ -140,6 +141,10 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 				contextWindow: registeredModel.contextWindow,
 				maxTokens: registeredModel.maxTokens,
 				baseUrl: registeredModel.baseUrl,
+				upstreamModelId:
+					registeredModel.id === model.id && options.upstreamModelId !== undefined
+						? options.upstreamModelId
+						: undefined,
 			})),
 		});
 	}

--- a/packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts
+++ b/packages/coding-agent/test/suite/regressions/context-overflow-model-alias.test.ts
@@ -1,0 +1,124 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+type CheckCompaction = (assistantMessage: AssistantMessage) => Promise<void>;
+type RunAutoCompaction = (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+
+function getCheckCompaction(session: Harness["session"]): CheckCompaction {
+	const value: unknown = Reflect.get(session, "_checkCompaction");
+	if (typeof value !== "function") {
+		throw new Error("AgentSession._checkCompaction is not available for regression tests");
+	}
+	return async (assistantMessage) => {
+		await value.call(session, assistantMessage);
+	};
+}
+
+function stubRunAutoCompaction(session: Harness["session"]) {
+	const stub = vi.fn<RunAutoCompaction>(async () => true);
+	Reflect.set(session, "_runAutoCompaction", stub);
+	return stub;
+}
+
+function zeroUsage(): AssistantMessage["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+describe("context overflow recovery", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) {
+			harness.cleanup();
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("auto-compacts when a provider reports the canonical model behind the selected alias", async () => {
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "quotio-openai",
+			upstreamModelId: "gpt-5.5",
+			models: [
+				{
+					id: "gpt-5.5-fast",
+					contextWindow: 272_000,
+				},
+			],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384 } },
+		});
+		harnesses.push(harness);
+		const selectedModel = harness.getModel();
+		const userMessage: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "read /tmp/h2.jpg" }],
+			timestamp: Date.now() - 500,
+		};
+		const overflowMessage: AssistantMessage = {
+			...fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage:
+					"Error Code context_too_large: Your input exceeds the context window of this model. Please adjust your input and try again.",
+				timestamp: Date.now(),
+			}),
+			api: selectedModel.api,
+			provider: selectedModel.provider,
+			model: "gpt-5.5",
+			usage: zeroUsage(),
+		};
+		harness.session.agent.state.messages = [userMessage, overflowMessage];
+
+		const runAutoCompactionSpy = stubRunAutoCompaction(harness.session);
+
+		await getCheckCompaction(harness.session)(overflowMessage);
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledWith("overflow", true);
+	});
+
+	it("does not auto-compact unrelated same-provider model overflow below the threshold", async () => {
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "quotio-openai",
+			models: [
+				{
+					id: "gpt-5.5-fast",
+					contextWindow: 272_000,
+				},
+			],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384 } },
+		});
+		harnesses.push(harness);
+		const selectedModel = harness.getModel();
+		const overflowMessage: AssistantMessage = {
+			...fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage:
+					"Error Code context_too_large: Your input exceeds the context window of this model. Please adjust your input and try again.",
+				timestamp: Date.now(),
+			}),
+			api: selectedModel.api,
+			provider: selectedModel.provider,
+			model: "unrelated-model",
+			usage: zeroUsage(),
+		};
+		harness.session.agent.state.messages = [
+			{ role: "user", content: [{ type: "text", text: "continue" }], timestamp: Date.now() - 500 },
+			overflowMessage,
+		];
+
+		const runAutoCompactionSpy = stubRunAutoCompaction(harness.session);
+
+		await getCheckCompaction(harness.session)(overflowMessage);
+
+		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -72,4 +72,62 @@ describe("pre-prompt compaction regression", () => {
 		expect(getUserTexts(harness)).toContain("next prompt");
 		expect(harness.faux.state.callCount).toBe(1);
 	});
+
+	it("compacts upstream model alias overflow before a dot retry", async () => {
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "quotio-openai",
+			upstreamModelId: "gpt-5.5",
+			models: [{ id: "gpt-5.5-fast", contextWindow: 272_000, maxTokens: 128_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "upstream alias pre-prompt summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "read /tmp/h2.jpg" }],
+			timestamp: now - 1000,
+		});
+		const overflowAssistant: AssistantMessage = {
+			...fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage:
+					"Error Code context_too_large: Your input exceeds the context window of this model. Please adjust your input and try again.",
+				timestamp: now - 500,
+			}),
+			api: model.api,
+			provider: model.provider,
+			model: "gpt-5.5",
+			usage: createUsage(0),
+		};
+		harness.sessionManager.appendMessage(overflowAssistant);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([fauxAssistantMessage("recovered after compaction")]);
+		const continueSpy = vi.spyOn(harness.session.agent, "continue");
+
+		await expect(harness.session.prompt(".")).resolves.toBeUndefined();
+
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "overflow",
+			aborted: false,
+			willRetry: true,
+		});
+		expect(getUserTexts(harness)).toContain(".");
+		expect(harness.faux.state.callCount).toBe(1);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes context-overflow recovery when the selected model is a configured alias but the provider reports the canonical upstream model id in the failed assistant message. In the captured session, `quotio-openai/gpt-5.5-fast` sent through `gpt-5.5`; the old same-model guard treated that overflow as unrelated, so the next `.` retry failed again instead of compacting. After this change, the session compaction gate recognizes configured upstream model ids as the same overflow source and auto-compacts before retrying.

## Changes

- Exposes configured `upstreamModelId` metadata from `ModelRegistry` without resolving credentials or API keys.
- Extends the context-overflow source check to accept same-provider messages from either the selected model id or its configured upstream model id.
- Adds regressions for alias overflow compaction, unrelated same-provider overflow rejection, and the public `.` retry path that must compact before sending the next prompt.
- Records the change in the coding-agent changelog and core changes ledger.

## QA / Evidence

- Red regression: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/red-context-overflow-model-alias.txt` captured the alias-overflow case failing before the fix.
- Focused green tests: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/focused-tests-after-check-fix.txt`, `green-context-overflow-model-alias-upstream.txt`, `green-model-registry-upstream.txt`, and `green-pre-prompt-upstream-overflow.txt` cover the new accessor, alias overflow compaction, negative unrelated-model guard, and public dot retry behavior.
- Full repository check: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/npm-run-check-after-review-remediation.txt` passed `npm run check`.
- Required senpi QA: `senpi-qa-rpc-self-test.txt`, `senpi-qa-mock-loop-openai-responses.txt`, and `senpi-qa-cli-smoke.txt` passed under `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/`; each recorded that real `/Users/yeongyu/.senpi/agent/auth.json` was unchanged.
- Runtime/debug review: `local-ignore/qa-evidence/20260708-auto-compact-context-too-large/debugging-audit.md` plus committed review reports under `.omo/evidence/auto-compact-context-too-large-*.md` and `.omo/evidence/upstream-model-overflow-compaction-code-review.md` record no blocking findings.

## Risks

- The fix intentionally trusts existing configured model metadata. A malicious local model registration could already redirect through `upstreamModelId`; this PR only uses that existing value to attribute overflow errors.
- Over-broad compaction is guarded by provider equality and exact selected/upstream model id matching. The negative regression verifies unrelated same-provider overflows below threshold do not compact.
- Provider error classification still depends on existing overflow detection utilities; this PR does not broaden those classifiers.

## Secret safety

Evidence and PR text contain artifact paths and synthetic fixture prompts only. No raw tokens, auth headers, cookies, launchd environments, or provider credentials are included, and the senpi QA receipts record real auth unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-compaction for context-too-large errors when a selected model is an alias. If the provider reports the upstream model (e.g., `gpt-5.5`) behind an alias (e.g., `gpt-5.5-fast`), the session now compacts before retrying instead of looping.

- **Bug Fixes**
  - Treat overflow from either the selected model id or its `upstreamModelId` (same provider) as the same source in `agent-session.ts`.
  - Expose `ModelRegistry.getUpstreamModelId()` to read configured upstream ids without resolving credentials.
  - Add regressions for alias overflow compaction, negative unrelated-model guard, and the public "." retry path that compacts before sending.

<sup>Written for commit a4cec18ba10a72c6c72c32c60d644ffdd13336fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

