### PR TITLE
docs(tui): record LF enter submit fix in changelog

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed the editor swallowing Enter when the terminal delivers it as a bare LF (`\n`): the submit binding now runs before the newline branch, so LF Enter submits the prompt instead of silently inserting a newline. Explicit Shift+Enter/Ctrl+J newline insertion and the trailing-backslash newline workaround are unchanged. ([#156](https://github.com/code-yeongyu/senpi/pull/156))
+
 ## [2026.7.5-2] - 2026-07-05
 
 ### Added


### PR DESCRIPTION
## Summary
PR #156 (`fix(tui): submit prompt on LF enter`, d9b64a052, merged 2026-07-08) fixed the interactive editor swallowing Enter when the terminal delivers it as a bare LF — but its `packages/tui/CHANGELOG.md` entry was never added. This PR records the fix under `[Unreleased]` so the next release notes carry it.

Documentation-only change; no code touched.

## Changes
- `packages/tui/CHANGELOG.md`: one `### Fixed` entry under `[Unreleased]` describing the LF Enter submit fix and its preserved newline behaviors, linking PR #156.

## QA / Evidence
Doc-only, so no code QA channel applies. The described behavior was re-verified today while investigating a user-stuck session (session `019f40ed-ab9a-778e-b672-9b4d050f7759` whose composer "swallowed" Enter):

- 4-way matrix driving the real TUI in tmux against a sandboxed copy of that exact session (fake anthropic-messages server, isolated `SENPI_CODING_AGENT_DIR`, real `~/.senpi/agent/auth.json` sha256 asserted unchanged):
  - installed `2026.7.5-2` + CR Enter → submits
  - installed `2026.7.5-2` + bare LF → **swallowed** (bug reproduced)
  - source `main` + CR Enter → submits
  - source `main` + bare LF → **submits** (fix confirmed)
  - Artifact: `local-ignore/qa-evidence/20260709-session-resume-submit/results.json` (gitignored, local)
- `packages/tui` editor suite on main: 183/183 pass, including the PR #156 LF regressions.

## Risks
None beyond a changelog merge conflict if another entry lands in the same section first.

## Secret safety
No secrets. QA sandboxes used mock keys; evidence excerpts contain no tokens or headers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `packages/tui/CHANGELOG.md` entry under [Unreleased] for the TUI fix that makes bare LF Enter submit instead of inserting a newline, so it appears in the next release notes. Docs-only; Shift+Enter/Ctrl+J newline behaviors remain unchanged.

<sup>Written for commit 8da991545689f725bfb23e303f18f6dbfd527b13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

