### PR TITLE
feat(coding-agent): gate the neo TUI behind SENPI_ENABLE_NEO (off by default)

### DIFF
--- a/.agents/skills/senpi-qa/scripts/cli-smoke.mjs
+++ b/.agents/skills/senpi-qa/scripts/cli-smoke.mjs
@@ -26,7 +26,18 @@ async function selfTest() {
 		`code=${help.code}`,
 	);
 
-	checks.ok("--help lists the --neo launcher flag", help.code === 0 && help.stdout.includes("--neo"), `code=${help.code}`);
+	checks.ok(
+		"--help omits the gated --neo flag by default",
+		help.code === 0 && !help.stdout.includes("--neo"),
+		`code=${help.code}`,
+	);
+
+	const helpNeo = await runCli(["--help"], { ...opts, env: { ...box.env, SENPI_ENABLE_NEO: "1" } });
+	checks.ok(
+		"--help lists --neo when SENPI_ENABLE_NEO is set",
+		helpNeo.code === 0 && helpNeo.stdout.includes("--neo"),
+		`code=${helpNeo.code}`,
+	);
 
 	const version = await runCli(["--version"], opts);
 	checks.ok("--version prints a version", version.code === 0 && /\d+\.\d+/.test(version.stdout), version.stdout.trim());

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,7 +26,9 @@
   and `logout`, with OAuth completion delivered via `auth_login_url` / `auth_login_end` session events.
 - Added the neo TUI launch handoff (`--neo`, `--neo-isolated`, `--neo-bin`) and the shared neo daemon
   (`--listen <socket>`: supervisor with atomic registry, token+version handshake, per-connection worker processes,
-  and idle shutdown via `neoDaemon.idleShutdownMs`).
+  and idle shutdown via `neoDaemon.idleShutdownMs`). Gated OFF by default behind `SENPI_ENABLE_NEO=1`: until the
+  per-platform neo binary packages ship, the flags are absent from `--help` and parse as unknown flags so a released
+  build never exposes a non-functional `--neo`. The Go daemon supervisor forces the gate on for its own child.
 - Added a convention guard that rejects senpi-defined PascalCase tool names in core and builtin extension tool registrations.
 - Added the persistent-terminal tool suite (built-in `terminal` extension): the `bash` tool is now PTY-backed with `run_in_background`, `cols`, and `rows`, plus companion tools `bash_output` (with `wait_for`/`filter`/`view:"screen"`), `bash_input` (stdin + named keys), `bash_resize`, and `kill_bash`. Backed by `@earendil-works/pi-pty` (native ConPTY on Windows, `child_process` pipe fallback otherwise). Adds `SENPI_GIT_BASH_PATH` + shell-kind resolution (cmd `/c`, PowerShell `-NoProfile -Command`), `terminal.*` settings, idle-guarded async completion wake, and permission-gates `bash_input` in the `bash` class. See `docs/terminal-tools.md`.
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -7,6 +7,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_SESSION_DIR } from "../config.ts";
 import type { ExtensionFlag } from "../core/extensions/types.ts";
+import { isNeoEnabled } from "./neo/gate.ts";
 
 export type Mode = "text" | "json" | "rpc";
 
@@ -75,7 +76,8 @@ export function isValidThinkingLevel(level: string): level is ThinkingLevel {
 	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
 }
 
-export function parseArgs(args: string[]): Args {
+export function parseArgs(args: string[], options: { neoEnabled?: boolean } = {}): Args {
+	const neoEnabled = options.neoEnabled ?? isNeoEnabled();
 	const result: Args = {
 		messages: [],
 		fileArgs: [],
@@ -198,16 +200,16 @@ export function parseArgs(args: string[]): Args {
 			result.projectTrustOverride = false;
 		} else if (arg === "--offline") {
 			result.offline = true;
-		} else if (arg === "--neo") {
+		} else if (neoEnabled && arg === "--neo") {
 			result.neo = true;
-		} else if (arg === "--neo-isolated") {
+		} else if (neoEnabled && arg === "--neo-isolated") {
 			result.neo = true;
 			result.neoIsolated = true;
-		} else if (arg === "--neo-bin" && i + 1 < args.length) {
+		} else if (neoEnabled && arg === "--neo-bin" && i + 1 < args.length) {
 			result.neoBin = args[++i];
-		} else if (arg === "--listen" && i + 1 < args.length) {
+		} else if (neoEnabled && arg === "--listen" && i + 1 < args.length) {
 			result.neoListen = args[++i];
-		} else if (arg === "--register") {
+		} else if (neoEnabled && arg === "--register") {
 			result.neoRegister = true;
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
@@ -235,7 +237,7 @@ export function parseArgs(args: string[]): Args {
 	return result;
 }
 
-export function printHelp(extensionFlags?: ExtensionFlag[]): void {
+export function printHelp(extensionFlags?: ExtensionFlag[], neoEnabled = isNeoEnabled()): void {
 	const extensionFlagsText =
 		extensionFlags && extensionFlags.length > 0
 			? `\n${chalk.bold("Extension CLI Flags:")}\n${extensionFlags
@@ -246,6 +248,12 @@ export function printHelp(extensionFlags?: ExtensionFlag[]): void {
 					})
 					.join("\n")}\n`
 			: "";
+	const neoOptionsText = neoEnabled
+		? `  --neo                          Launch the neo (Go-native) TUI instead of the classic TUI
+                                 (piped stdin falls back to classic print mode)
+  --neo-isolated                 Like --neo, but use a per-instance backend (no shared daemon)
+`
+		: "";
 	console.log(`${chalk.bold(APP_NAME)} - AI coding assistant with read, bash, edit, write tools
 
 ${chalk.bold("Usage:")}
@@ -306,10 +314,7 @@ ${chalk.bold("Options:")}
   --approve, -a                  Trust project-local files for this run
   --no-approve, -na              Ignore project-local files for this run
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
-  --neo                          Launch the neo (Go-native) TUI instead of the classic TUI
-                                 (piped stdin falls back to classic print mode)
-  --neo-isolated                 Like --neo, but use a per-instance backend (no shared daemon)
-  --help, -h                     Show this help
+${neoOptionsText}  --help, -h                     Show this help
   --version, -v                  Show version number
 
 Extensions can register additional flags (e.g., --plan from plan-mode extension).${extensionFlagsText}

--- a/packages/coding-agent/src/cli/neo/gate.ts
+++ b/packages/coding-agent/src/cli/neo/gate.ts
@@ -1,0 +1,20 @@
+/**
+ * Feature gate for the neo (Go-native) TUI.
+ *
+ * The neo TUI ships as a separate Go binary distributed via per-platform npm
+ * packages (`@code-yeongyu/senpi-neo-tui-<platform>-<arch>`). Those packages are
+ * NOT built or published yet, so on a released senpi the `--neo` handoff can only
+ * fail at binary resolution. Until the binary ships, neo stays behind an opt-in
+ * env gate: OFF by default, so `--neo` and its sibling flags are absent from help
+ * and parse as unknown flags (never dispatched), exactly as if the feature did not
+ * exist. Set `SENPI_ENABLE_NEO=1` (or `true`/`yes`) to develop against it.
+ */
+export const ENV_ENABLE_NEO = "SENPI_ENABLE_NEO";
+
+/** Whether the neo (Go TUI) flags and handoff are exposed for this process. */
+export function isNeoEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	const value = env[ENV_ENABLE_NEO];
+	if (value === undefined) return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes";
+}

--- a/packages/coding-agent/test/neo-args-parse.test.ts
+++ b/packages/coding-agent/test/neo-args-parse.test.ts
@@ -47,29 +47,60 @@ describe("classic parser semantics are byte-identical (no --neo present)", () =>
 	});
 });
 
-describe("--neo flag parsing", () => {
-	test("--neo is now a recognized flag, not an 'Unknown option' error", () => {
-		const parsed = parseArgs(["--neo"]);
+describe("--neo flag parsing (gate enabled)", () => {
+	test("--neo is a recognized flag when neo is enabled, not an 'Unknown option' error", () => {
+		const parsed = parseArgs(["--neo"], { neoEnabled: true });
 		expect(parsed.neo).toBe(true);
 		expect(parsed.diagnostics).toEqual([]);
 	});
 
 	test("--neo-isolated implies neo and sets neoIsolated", () => {
-		const parsed = parseArgs(["--neo-isolated"]);
+		const parsed = parseArgs(["--neo-isolated"], { neoEnabled: true });
 		expect(parsed.neo).toBe(true);
 		expect(parsed.neoIsolated).toBe(true);
 		expect(parsed.diagnostics).toEqual([]);
 	});
 
 	test("--neo-bin captures a dev override path", () => {
-		const parsed = parseArgs(["--neo", "--neo-bin", "/tmp/dev-neo"]);
+		const parsed = parseArgs(["--neo", "--neo-bin", "/tmp/dev-neo"], { neoEnabled: true });
 		expect(parsed.neo).toBe(true);
 		expect(parsed.neoBin).toBe("/tmp/dev-neo");
 	});
 
 	test("--neo coexists with runtime flags without swallowing them", () => {
-		const parsed = parseArgs(["--neo", "--model", "gpt-4o", "hello"]);
+		const parsed = parseArgs(["--neo", "--model", "gpt-4o", "hello"], { neoEnabled: true });
 		expect(parsed.neo).toBe(true);
+		expect(parsed.model).toBe("gpt-4o");
+		expect(parsed.messages).toEqual(["hello"]);
+	});
+});
+
+describe("--neo flags are absent when the gate is off (default)", () => {
+	test("--neo falls through to the unknown-flag channel and never dispatches", () => {
+		const parsed = parseArgs(["--neo"], { neoEnabled: false });
+		expect(parsed.neo).toBeUndefined();
+		expect(parsed.unknownFlags.get("neo")).toBe(true);
+		expect(parsed.diagnostics).toEqual([]);
+	});
+
+	test("--neo-isolated / --register are unknown flags and set no neo state", () => {
+		const parsed = parseArgs(["--neo-isolated", "--register"], { neoEnabled: false });
+		expect(parsed.neo).toBeUndefined();
+		expect(parsed.neoIsolated).toBeUndefined();
+		expect(parsed.neoRegister).toBeUndefined();
+		expect(parsed.unknownFlags.get("neo-isolated")).toBe(true);
+		expect(parsed.unknownFlags.get("register")).toBe(true);
+	});
+
+	test("--listen consumes its value as an unknown flag, not neoListen", () => {
+		const parsed = parseArgs(["--listen", "/tmp/s.sock"], { neoEnabled: false });
+		expect(parsed.neoListen).toBeUndefined();
+		expect(parsed.unknownFlags.get("listen")).toBe("/tmp/s.sock");
+	});
+
+	test("classic runtime flags still parse normally alongside a stray --neo", () => {
+		const parsed = parseArgs(["--neo", "--model", "gpt-4o", "hello"], { neoEnabled: false });
+		expect(parsed.neo).toBeUndefined();
 		expect(parsed.model).toBe("gpt-4o");
 		expect(parsed.messages).toEqual(["hello"]);
 	});

--- a/packages/coding-agent/test/neo-argv.test.ts
+++ b/packages/coding-agent/test/neo-argv.test.ts
@@ -48,40 +48,43 @@ describe("buildNeoArgv — flag passthrough", () => {
 			["explain", "@a.md", "@img.png"],
 		],
 	])("%s", (_label, classicArgv, expectedNeoArgv) => {
-		const parsed = parseArgs(["--neo", ...classicArgv]);
+		const parsed = parseArgs(["--neo", ...classicArgv], { neoEnabled: true });
 		expect(buildNeoArgv(parsed, { isolated: false })).toEqual(expectedNeoArgv);
 	});
 
 	test("isolated: true prepends --neo-isolated → --isolated for the Go binary", () => {
-		const parsed = parseArgs(["--neo", "--neo-isolated", "--model", "gpt-4o"]);
+		const parsed = parseArgs(["--neo", "--neo-isolated", "--model", "gpt-4o"], { neoEnabled: true });
 		expect(buildNeoArgv(parsed, { isolated: true })).toEqual(["--isolated", "--model", "gpt-4o"]);
 	});
 
 	test("isolated: false omits --isolated", () => {
-		const parsed = parseArgs(["--neo", "--model", "gpt-4o"]);
+		const parsed = parseArgs(["--neo", "--model", "gpt-4o"], { neoEnabled: true });
 		expect(buildNeoArgv(parsed, { isolated: false })).toEqual(["--model", "gpt-4o"]);
 	});
 
 	test("neo-only launch (no runtime flags) → empty argv", () => {
-		const parsed = parseArgs(["--neo"]);
+		const parsed = parseArgs(["--neo"], { neoEnabled: true });
 		expect(buildNeoArgv(parsed, { isolated: false })).toEqual([]);
 	});
 
 	test("full kitchen-sink invocation is forwarded in a stable order", () => {
-		const parsed = parseArgs([
-			"--neo",
-			"--provider",
-			"anthropic",
-			"--model",
-			"claude-sonnet",
-			"--thinking",
-			"high",
-			"--no-context-files",
-			"-e",
-			"./ext.ts",
-			"@prompt.md",
-			"Do the task",
-		]);
+		const parsed = parseArgs(
+			[
+				"--neo",
+				"--provider",
+				"anthropic",
+				"--model",
+				"claude-sonnet",
+				"--thinking",
+				"high",
+				"--no-context-files",
+				"-e",
+				"./ext.ts",
+				"@prompt.md",
+				"Do the task",
+			],
+			{ neoEnabled: true },
+		);
 		expect(buildNeoArgv(parsed, { isolated: false })).toEqual([
 			"--provider",
 			"anthropic",

--- a/packages/coding-agent/test/neo-gate.test.ts
+++ b/packages/coding-agent/test/neo-gate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { ENV_ENABLE_NEO, isNeoEnabled } from "../src/cli/neo/gate.ts";
+
+/**
+ * Pin the neo feature-gate contract. `isNeoEnabled` reads a single env var
+ * (`ENV_ENABLE_NEO`), trims + lowercases it, and enables only for "1"/"true"/
+ * "yes". Every case injects an explicit env object — the real `process.env` is
+ * never mutated — so these rows fully define truthy set, case/whitespace
+ * normalization, and default-false behavior. Any regression there reddens here.
+ */
+describe("isNeoEnabled — env gate contract", () => {
+	test.each<[string, string]>([
+		["exact 1", "1"],
+		["exact true", "true"],
+		["exact yes", "yes"],
+		["uppercase TRUE", "TRUE"],
+		["mixed-case Yes", "Yes"],
+		["uppercase YES", "YES"],
+		["padded 1", " 1 "],
+		["padded true", "  true  "],
+		["tab-wrapped yes", "\tyes\n"],
+	])("enabled: %s -> true", (_label, value) => {
+		expect(isNeoEnabled({ [ENV_ENABLE_NEO]: value })).toBe(true);
+	});
+
+	test.each<[string, NodeJS.ProcessEnv]>([
+		["absent (empty env)", {}],
+		["explicit undefined", { [ENV_ENABLE_NEO]: undefined }],
+		["zero", { [ENV_ENABLE_NEO]: "0" }],
+		["false", { [ENV_ENABLE_NEO]: "false" }],
+		["no", { [ENV_ENABLE_NEO]: "no" }],
+		["off", { [ENV_ENABLE_NEO]: "off" }],
+		["empty string", { [ENV_ENABLE_NEO]: "" }],
+		["whitespace only", { [ENV_ENABLE_NEO]: "   " }],
+		["nope", { [ENV_ENABLE_NEO]: "nope" }],
+		["two", { [ENV_ENABLE_NEO]: "2" }],
+		["true with garbage suffix", { [ENV_ENABLE_NEO]: "true1" }],
+		["truthy of another gate ignored", { SENPI_ENABLE_OTHER: "1" }],
+	])("not enabled: %s -> false", (_label, env) => {
+		expect(isNeoEnabled(env)).toBe(false);
+	});
+
+	test("defaults to process.env without mutating it, matching the documented rule", () => {
+		const before = process.env[ENV_ENABLE_NEO];
+		const raw = before;
+		const expected = raw !== undefined && ["1", "true", "yes"].includes(raw.trim().toLowerCase());
+		expect(isNeoEnabled()).toBe(expected);
+		// The default-arg path must not set or delete the key.
+		expect(process.env[ENV_ENABLE_NEO]).toBe(before);
+	});
+});

--- a/packages/coding-agent/test/neo-launch-dispatch.test.ts
+++ b/packages/coding-agent/test/neo-launch-dispatch.test.ts
@@ -23,6 +23,7 @@ describe("--neo early dispatch (no runtime, zero extensions)", () => {
 	const tempDirs: string[] = [];
 	let originalAgentDir: string | undefined;
 	let originalNeoBin: string | undefined;
+	let originalEnableNeo: string | undefined;
 	let originalCwd = process.cwd();
 	let originalExitCode: typeof process.exitCode = process.exitCode;
 	const originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -51,6 +52,8 @@ describe("--neo early dispatch (no runtime, zero extensions)", () => {
 		else process.env[ENV_AGENT_DIR] = originalAgentDir;
 		if (originalNeoBin === undefined) delete process.env.SENPI_NEO_BIN;
 		else process.env.SENPI_NEO_BIN = originalNeoBin;
+		if (originalEnableNeo === undefined) delete process.env.SENPI_ENABLE_NEO;
+		else process.env.SENPI_ENABLE_NEO = originalEnableNeo;
 		for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 	});
 
@@ -95,10 +98,12 @@ describe("--neo early dispatch (no runtime, zero extensions)", () => {
 
 		originalAgentDir = process.env[ENV_AGENT_DIR];
 		originalNeoBin = process.env.SENPI_NEO_BIN;
+		originalEnableNeo = process.env.SENPI_ENABLE_NEO;
 		originalCwd = process.cwd();
 		originalExitCode = process.exitCode;
 		process.env[ENV_AGENT_DIR] = agentDir;
 		process.env.SENPI_NEO_BIN = join(tempDir, "stub-neo");
+		process.env.SENPI_ENABLE_NEO = "1";
 		process.exitCode = undefined;
 		process.chdir(projectDir);
 
@@ -137,9 +142,11 @@ describe("--neo early dispatch (no runtime, zero extensions)", () => {
 		mkdirSync(projectDir, { recursive: true });
 		originalAgentDir = process.env[ENV_AGENT_DIR];
 		originalNeoBin = process.env.SENPI_NEO_BIN;
+		originalEnableNeo = process.env.SENPI_ENABLE_NEO;
 		originalCwd = process.cwd();
 		originalExitCode = process.exitCode;
 		process.env[ENV_AGENT_DIR] = agentDir;
+		process.env.SENPI_ENABLE_NEO = "1";
 		process.exitCode = undefined;
 		process.chdir(projectDir);
 

--- a/packages/neo/internal/bridge/attachqa/setup.go
+++ b/packages/neo/internal/bridge/attachqa/setup.go
@@ -91,6 +91,7 @@ func setupHarness() (*harnessEnv, error) {
 	_ = os.Setenv("SENPI_NEO_WORKER_ARGS", string(workerArgs))
 	_ = os.Setenv("SENPI_CODING_AGENT_DIR", agentDir)
 	_ = os.Setenv("PI_OFFLINE", "1")
+	_ = os.Setenv("SENPI_ENABLE_NEO", "1")
 	_ = os.Setenv("PI_TELEMETRY", "0")
 	for _, k := range providerKeyNames() {
 		_ = os.Unsetenv(k)

--- a/packages/neo/internal/bridge/daemon_integration_test.go
+++ b/packages/neo/internal/bridge/daemon_integration_test.go
@@ -67,6 +67,7 @@ func newDaemonSandbox(t *testing.T) daemonSandbox {
 		"SENPI_CODING_AGENT_DIR="+agentDir,
 		"PI_OFFLINE=1", "PI_TELEMETRY=0",
 		"SENPI_NEO_WORKER_ARGS="+string(workerArgs),
+		"SENPI_ENABLE_NEO=1",
 	)
 	for _, k := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "OPENAI_API_KEY", "GEMINI_API_KEY"} {
 		env = filterEnv(env, k)

--- a/packages/neo/internal/bridge/spawn.go
+++ b/packages/neo/internal/bridge/spawn.go
@@ -19,6 +19,13 @@ import (
 // Example (dev):         SENPI_NEO_CLI_PATH="node .../tsx/dist/cli.mjs --tsconfig .../tsconfig.json .../src/cli.ts"
 const EnvNeoCLIPath = "SENPI_NEO_CLI_PATH"
 
+// EnvEnableNeo gates the neo CLI flags. The daemon supervisor is launched with
+// `--listen`/`--register`, which the CLI only parses when this env is truthy.
+// The daemon is only ever spawned as part of an active neo session, so force the
+// gate on for the child regardless of ambient env — otherwise the supervisor
+// would reject its own flags on a build where neo is off by default.
+const EnvEnableNeo = "SENPI_ENABLE_NEO"
+
 // ErrNoCLIPath is returned by SpawnDaemonDetached when SENPI_NEO_CLI_PATH is
 // unset — the client cannot know how to launch the daemon supervisor. The caller
 // should fall back to isolated transport with a clear message.
@@ -50,6 +57,9 @@ func SpawnDaemonDetached(req SpawnRequest) error {
 	args := append(fields[1:], "--listen", req.Socket, "--register")
 	cmd := exec.Command(fields[0], args...)
 	cmd.Dir = req.Cwd
+	// Force the neo gate on for the supervisor: it must parse its own
+	// `--listen`/`--register` flags even when the ambient build defaults neo off.
+	cmd.Env = append(os.Environ(), EnvEnableNeo+"=1")
 
 	// Detach stdio so the daemon never touches the client's terminal.
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)


### PR DESCRIPTION
## Summary
The neo (Go-native) TUI handoff (`--neo`) resolves a per-platform binary package `@code-yeongyu/senpi-neo-tui-<platform>-<arch>` that is **not built or published** (no CI matrix, absent from `scripts/publish.mjs`, not in the release tarball). On a released build, `--neo` can therefore only fail at binary resolution with an install-a-missing-package error. This PR gates the entire neo flag surface behind an opt-in env var so a shipped build behaves as if the feature does not exist.

**Before:** `senpi --help` lists `--neo`; `senpi --neo` (interactive) prints `The neo TUI (--neo) requires the platform package "...", which is not installed.` and exits 1.
**After (default):** `--neo` is absent from `--help` and parses as an unknown flag — `senpi --neo` boots the classic TUI, exactly like any typo flag. Set `SENPI_ENABLE_NEO=1` to develop against neo.

## Changes
- **New `packages/coding-agent/src/cli/neo/gate.ts`**: `isNeoEnabled(env=process.env)` — true iff `SENPI_ENABLE_NEO` is `1`/`true`/`yes` (trim + case-insensitive), default false.
- **`cli/args.ts`**: `parseArgs(args, { neoEnabled })` and `printHelp(flags, neoEnabled)` take the gate (default `isNeoEnabled()`). When off, `--neo` / `--neo-isolated` / `--neo-bin` / `--listen` / `--register` fall through to the unknown-flag channel and the two `--neo*` help lines are omitted. Dispatch in `main.ts` needs no change — it keys off `parsed.neo` / `parsed.neoListen`, which stay unset.
- **`packages/neo/internal/bridge/spawn.go`**: `SpawnDaemonDetached` forces `SENPI_ENABLE_NEO=1` in the daemon child env, so the supervisor always parses its own `--listen`/`--register` regardless of ambient build default (the daemon only spawns inside an active neo session). Test harnesses (`daemon_integration_test.go`, `attachqa/setup.go`) set the same var.
- **`.agents/skills/senpi-qa/scripts/cli-smoke.mjs`** (QA infra-sync): asserts the new contract in both modes — `--help` omits `--neo` by default, lists it under `SENPI_ENABLE_NEO=1`.
- Tests: `neo-gate.test.ts` (new, 22 cases, authored by the Tester agent); `neo-args-parse` / `neo-argv` / `neo-launch-dispatch` updated to opt into the gate.
- Changelog: the unreleased neo `### Added` entry now records the opt-in gate.

## QA / Evidence
Evidence: `local-ignore/qa-evidence/20260709-neo-gate/` (gitignored).
- **`npm run check`**: green — biome, pinned-deps, ts-imports, shrinkwrap, tsgo/tsc, browser smoke, web-ui, and `check:neo` (Go build+vet+test). The neo Go bridge suite went from FAIL (196s, `Unknown options: --listen, --register`) to `ok 11.7s` after the daemon-child env fix.
- **Unit**: `neo-gate.test.ts` 22/22; `neo-args-parse` + `neo-argv` + `neo-launch-dispatch` green (55 across the three).
- **senpi-qa cli-smoke**: 7/7 — includes `--help omits the gated --neo flag by default` and `--help lists --neo when SENPI_ENABLE_NEO is set`. Artifact: `cli-smoke.txt`.
- **senpi-qa mock-loop**: 5/5 — full agent turn still completes (openai-completions/anthropic-messages/openai-responses baseUrl override), zero real provider calls, real auth unchanged. Artifact: `mock-loop.txt`.
- **Real-CLI tmux matrix** (`gate-behavior-matrix.txt`): `--neo` OFF boots the classic TUI (Trust prompt) identically to the `--frobnicate` control; `--neo` + `SENPI_ENABLE_NEO=1` attempts the neo handoff (binary-resolution error). Real `~/.senpi/agent/auth.json` untouched throughout (isolated `SENPI_CODING_AGENT_DIR`).

## Risks
- A user who relied on `--neo` from a source checkout must now export `SENPI_ENABLE_NEO=1`. Intended: on published builds `--neo` was non-functional anyway. Covered by the tmux matrix (gate ON still hands off).
- Daemon child env injection is additive (`append(os.Environ(), ...)`); the Go bridge suite passing confirms spawn/attach/registry paths are unaffected.

## Secret safety
QA used isolated sandboxes and mock keys. Evidence excerpts contain no tokens, headers, or credentials.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated the neo TUI behind the `SENPI_ENABLE_NEO` env var (off by default) so released builds don’t surface a non-functional `--neo`. With the gate off, help text hides neo flags and `--neo` behaves like an unknown flag; with the gate on, developer behavior is unchanged.

- **New Features**
  - Added `isNeoEnabled()` reading `SENPI_ENABLE_NEO` (`1`/`true`/`yes`).
  - CLI respects the gate: `--neo`, `--neo-isolated`, `--neo-bin`, `--listen`, `--register` are omitted from `--help` and parse as unknown when disabled.
  - The Go daemon supervisor forces `SENPI_ENABLE_NEO=1` for its child so `--listen`/`--register` always parse during neo sessions.

- **Migration**
  - To use `--neo`, set `SENPI_ENABLE_NEO=1`.

<sup>Written for commit e840019a5b5d76b6b6876bb48e5d6dac51b91a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

