### PR TITLE
fix: unblock release — bun binary crash, codemode packing, bun install OOM

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 
+- Fixed the compiled Bun single-file binary crashing on every command (`Cannot find module '../package.json'`): the bundled `@earendil-works/pi-pty` loader read its version eagerly via `require("../package.json")`, which does not exist in the embedded Bun filesystem. It now falls back to the `package.json` shipped beside the executable (lockstep-versioned), so the Bun binary starts.
 - Fixed context-overflow recovery for configured upstream model aliases, so a selected alias such as `gpt-5.5-fast` can auto-compact and retry when the provider reports the wire model `gpt-5.5`.
 - Fixed the built-in `todowrite` tool call row to show the actual todo items instead of only an item count.
 - Fixed sessions going stale forever when the network dropped and reconnected mid-stream: the agent loop's provider stream idle timeout is now enabled by default (follows `httpIdleTimeoutMs`, default 5 min, `0` disables; `retry.provider.timeoutMs` overrides), so a silently dead connection fails with a retryable idle-timeout error and auto-retry recovers the turn. Previously the guard was off unless `retry.provider.timeoutMs` was set, which left the Bun binary (no undici dispatcher protection) hanging indefinitely.

--- a/packages/pty/src/loader.ts
+++ b/packages/pty/src/loader.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -65,11 +66,26 @@ export const NATIVE_PTY_PACKAGE_VERSION = readPackageVersion();
 const SEMVER_CORE_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
 
 function readPackageVersion(): string {
-	const packageMetadata = cjsRequire("../package.json");
-	if (!isRecord(packageMetadata) || typeof packageMetadata.version !== "string") {
-		throw new Error("@earendil-works/pi-pty package.json is missing a string version");
+	// node/tsx/tarball layouts: the sibling `../package.json` resolves normally.
+	try {
+		const packageMetadata = cjsRequire("../package.json");
+		if (isRecord(packageMetadata) && typeof packageMetadata.version === "string") {
+			return packageMetadata.version;
+		}
+	} catch {
+		// Compiled Bun binary: `../package.json` is not in the embedded FS. Fall through.
 	}
-	return packageMetadata.version;
+	// Compiled Bun binary: the release ships package.json beside the executable. All
+	// workspace packages are lockstep-versioned, so the sibling version matches pty's.
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(join(dirname(process.execPath), "package.json"), "utf-8"));
+		if (isRecord(parsed) && typeof parsed.version === "string") {
+			return parsed.version;
+		}
+	} catch {
+		// No readable sibling package.json either.
+	}
+	throw new Error("@earendil-works/pi-pty package.json is missing a string version");
 }
 
 export function getNativePtySentinelExport(packageVersion: string = NATIVE_PTY_PACKAGE_VERSION): string {

--- a/packages/pty/test/loader-version.test.ts
+++ b/packages/pty/test/loader-version.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { getNativePtySentinelExport, NATIVE_PTY_PACKAGE_VERSION } from "../src/loader.ts";
+
+// The compiled Bun single-file binary made `import.meta.url` resolve to `/$bunfs/root/pi`,
+// so the eager `require("../package.json")` threw at module load and crashed every CLI
+// command. These tests pin the resolved-version contract that fix depends on: they cannot
+// even be collected unless `../src/loader.ts` loaded without throwing, and they assert the
+// sentinel export is derived from that resolved version so a regression surfaces here.
+
+const SENTINEL_SHAPE = /^__senpiPtyV\d+_\d+_\d+$/;
+const SEMVER_CORE = /^\d+\.\d+\.\d+(?:-[\w.-]+)?$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+// Independent node/tsx resolution path: read the package's own package.json the way a
+// consumer running under node would, so we cross-check against the module-load result
+// rather than trusting the value the module produced.
+function readOwnPackageVersion(): string {
+	const raw: unknown = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
+	if (!isRecord(raw) || typeof raw.version !== "string") {
+		throw new Error("test fixture: package.json is missing a string version");
+	}
+	return raw.version;
+}
+
+// Recompute the sentinel from major/minor/patch by hand so a bug in either the resolved
+// version or the derivation reddens the cross-check, not just a self-consistent echo.
+function expectedSentinel(version: string): string {
+	const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+	if (match === null) {
+		throw new Error(`test fixture: version is not semver-core: ${version}`);
+	}
+	return `__senpiPtyV${match[1]}_${match[2]}_${match[3]}`;
+}
+
+describe("NATIVE_PTY_PACKAGE_VERSION", () => {
+	it("resolves to the package.json version at module load (proving load did not throw)", () => {
+		expect(typeof NATIVE_PTY_PACKAGE_VERSION).toBe("string");
+		expect(NATIVE_PTY_PACKAGE_VERSION.length).toBeGreaterThan(0);
+		expect(NATIVE_PTY_PACKAGE_VERSION).toMatch(SEMVER_CORE);
+		expect(NATIVE_PTY_PACKAGE_VERSION).toBe(readOwnPackageVersion());
+	});
+});
+
+describe("getNativePtySentinelExport", () => {
+	it("derives the sentinel from the resolved package version", () => {
+		const sentinel = getNativePtySentinelExport(NATIVE_PTY_PACKAGE_VERSION);
+		expect(sentinel).toMatch(SENTINEL_SHAPE);
+		expect(sentinel).toBe(expectedSentinel(NATIVE_PTY_PACKAGE_VERSION));
+	});
+
+	it.each([
+		["2026.7.5-2", "__senpiPtyV2026_7_5"],
+		["1.0.0", "__senpiPtyV1_0_0"],
+		["10.20.30+build.7", "__senpiPtyV10_20_30"],
+	])("maps semver %s to sentinel %s (dropping any suffix)", (version, expected) => {
+		expect(getNativePtySentinelExport(version)).toBe(expected);
+	});
+
+	it.each([["not-semver"], ["2026.7"], ["v1.2.3"], [""]])("throws for the non-semver version %s", (version) => {
+		expect(() => getNativePtySentinelExport(version)).toThrow(/not semver-compatible/);
+	});
+});

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed the bundled `eval` extension failing to load in packaged installs: `completion/handler.ts` imported peer symbols via the monorepo source path `../../../ai/src/*`, which only resolves inside the workspace and threw `Cannot find module` once packed. It now imports from the `@earendil-works/pi-ai/compat` package entry, so `eval` loads in the shipped Node package.
 - Fixed a temporal-dead-zone crash in the `eval` tool: subprocess kernels (py/rb/jl) emit their `ready` frame synchronously during kernel startup, which invoked the message handler before the `kernel` binding initialized and crashed the whole agent process. The self-referential binding is now hoisted so startup frames no longer throw.
 - Fixed cell-output misattribution on reused persistent kernels: `getKernel` now rebinds the per-cell `onMessage` on every call, so a second (and later) cell's streamed `text`/`display`/`log` output is delivered to that cell instead of the previous one.
 - Fixed the Ruby kernel corrupting its JSONL protocol channel: user `puts`/`print` output is now captured via a redirected `$stdout` and emitted as `text` frames instead of being written directly onto the shared stdout stream.

--- a/packages/senpi-codemode/src/completion/handler.ts
+++ b/packages/senpi-codemode/src/completion/handler.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@code-yeongyu/senpi";
-import { completeSimple } from "../../../ai/src/stream.ts";
-import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "../../../ai/src/types.ts";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 
 export interface CompletionRequest {
 	readonly prompt: string;

--- a/scripts/local-release.mjs
+++ b/scripts/local-release.mjs
@@ -242,10 +242,27 @@ function main() {
 				throw new Error("Bun is required for the isolated Bun install. Use --skip-bun-install to skip it.");
 			}
 			mkdirSync(bunInstallDirectory, { recursive: true });
-			const bunDependencies = Object.fromEntries(
-				packages.map((pkg) => [pkg.name, fileSpecifier(bunInstallDirectory, tarballs.get(pkg.name))]),
+			// Bun's resolver enters an unbounded allocating loop (RAM explosion) when a
+			// `file:` tarball that BUNDLES other internal deps is ALSO listed in `overrides`
+			// as a `file:` tarball. Install only the root app as a dependency and pin every
+			// other internal package via `overrides` (never the root itself). npm tolerates
+			// the all-in-overrides shape; bun does not.
+			const bunRootName = "@code-yeongyu/senpi";
+			const bunRootTarball = tarballs.get(bunRootName);
+			if (!bunRootTarball) {
+				throw new Error(`Bun install root package ${bunRootName} was not packed`);
+			}
+			const bunOverrides = Object.fromEntries(
+				packages
+					.filter((pkg) => pkg.name !== bunRootName)
+					.map((pkg) => [pkg.name, fileSpecifier(bunInstallDirectory, tarballs.get(pkg.name))]),
 			);
-			writeFileSync(join(bunInstallDirectory, "package.json"), `${JSON.stringify({ private: true, dependencies: bunDependencies, overrides: bunDependencies }, undefined, "\t")}\n`);
+			const bunPackageJson = {
+				private: true,
+				dependencies: { [bunRootName]: fileSpecifier(bunInstallDirectory, bunRootTarball) },
+				overrides: bunOverrides,
+			};
+			writeFileSync(join(bunInstallDirectory, "package.json"), `${JSON.stringify(bunPackageJson, undefined, "\t")}\n`);
 			run("bun", ["install", "--production", "--ignore-scripts"], { cwd: bunInstallDirectory });
 			createPackageCliShim(bunInstallDirectory);
 		}


### PR DESCRIPTION
## Summary
The local release smoke test (`npm run release:local`) surfaced three release-blocking defects, all introduced after `v2026.7.5-2` (when `@earendil-works/pi-pty` and `@code-yeongyu/senpi-codemode` were first bundled). None shipped in a prior release; together they made the packaged Bun binary unusable and the bundled `eval` extension dead, and made the release build itself exhaust machine RAM.

## Changes
- **`packages/pty/src/loader.ts` — Bun binary crashed on every command.** The loader read its version eagerly via `require("../package.json")`. In the compiled Bun single-file binary `import.meta.url` is `/$bunfs/root/pi`, so `../package.json` is absent and the module throw crashed **every** CLI invocation (`--version`, `--help`, interactive). Now falls back to the `package.json` shipped beside `process.execPath` (all workspace packages are lockstep-versioned, so the sibling version matches). Regression test: `packages/pty/test/loader-version.test.ts`.
- **`packages/senpi-codemode/src/completion/handler.ts` — bundled `eval` extension failed to load when packed.** It imported peer symbols via the monorepo source path `../../../ai/src/stream.ts` / `types.ts`, which only resolves inside the workspace and threw `Cannot find module` in the packed Node install. Now imports from the `@earendil-works/pi-ai/compat` package entry (the same entry `coding-agent` uses), so `eval` loads in the shipped package.
- **`scripts/local-release.mjs` — `bun install` OOM (>10GB RSS).** The isolated Bun package set listed every internal `file:` tarball in both `dependencies` and `overrides`. Overriding an app tarball that itself bundles other internal deps sends Bun's resolver into an unbounded allocating loop. Now installs only the root app (`@code-yeongyu/senpi`) as a dependency and pins the other six internal packages via `overrides` (never the root). npm tolerates the old shape; Bun does not.

## QA / Evidence
Evidence: `local-ignore/qa-evidence/20260709-release-smoke/` (gitignored).
- **`npm run check`**: green (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, tsgo, browser smoke, web-ui, neo go build/vet/test). Pre-commit hook re-ran it green.
- **Root-cause proof (bun OOM)**: isolated A/B matrix — the all-in-overrides shape climbs ~200MB/s to a 10GB kill (stack sample shows the resolver spin); root-only-deps + overrides installs 213 packages in ~6s at 253MB.
- **Local release smoke matrix** (`smoke-matrix.txt`), all three distribution paths: `node/senpi`, `bun-install/senpi`, and the compiled `bun/pi` — each returns `--version` = 2026.7.5-2, **0 neo lines** in `--help`, 1049 `--list-models` lines, and a `Usage:` help. Before this PR the `bun/pi` binary failed all three.
- **Node interactive boot**: codemode now loads with no Extension-issues block; disabling it via `disabledBuiltinExtensions:["codemode"]` removes the extension entry, confirming it was loading (registers `eval`).
- **Unit**: `pty` loader 16/16 (incl. new version test, teeth-verified by the Tester agent); regression suites unaffected.

## Risks
- The compiled Bun binary still cannot resolve codemode's own bundled `package.json` from the embedded FS, so `eval` is unavailable **on the Bun binary only** — this is pre-existing and already documented as accepted graceful degradation (`packages/coding-agent/src/core/changes.md`: "compiled Bun binary package-resolution gaps ... startup continues without eval"). The Node package (the npm/homebrew path) loads `eval` correctly after this PR.
- pty version fallback is additive (try require, then exec-dir sibling, then throw) — node/tsx/tarball paths are unchanged; only the previously-crashing Bun-binary path gains a working branch.

## Secret safety
No secrets. QA used isolated `SENPI_CODING_AGENT_DIR` sandboxes and offline mode; evidence contains no tokens or credentials.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three release blockers: the compiled Bun binary crash, the `eval` extension failing to load when packed, and a Bun install OOM. The Bun CLI now runs, `eval` loads in the Node package, and the local release build finishes.

- **Bug Fixes**
  - `packages/pty/src/loader.ts`: stop eager `require("../package.json")`; add fallback to the sibling `package.json` beside `process.execPath` in the compiled Bun binary to prevent crashes on every command.
  - `packages/senpi-codemode/src/completion/handler.ts`: replace monorepo source imports with `@earendil-works/pi-ai/compat` so the bundled `eval` extension loads in packaged installs.
  - `scripts/local-release.mjs`: prevent Bun resolver OOM by installing only `@code-yeongyu/senpi` as a dependency and pinning other internal packages via `overrides` (do not list the root in both).

<sup>Written for commit 743f25527e87aa9fd16011cf6d4346fcaf7ae23e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

