### PR TITLE
test(neo): widen daemon race test timeout to de-flake release publish

### DIFF
--- a/packages/neo/internal/bridge/daemonclient_test.go
+++ b/packages/neo/internal/bridge/daemonclient_test.go
@@ -368,7 +368,10 @@ func TestAttachOrSpawn_RaceExactlyOneDaemon(t *testing.T) {
 				AgentDir: agentDir,
 				Cwd:      cwd,
 				Spawn:    sp.spawn,
-				Timeout:  4 * time.Second,
+				// Generous headroom: 4 concurrent racers spawn + poll the registry under
+				// heavily loaded CI (the publish job runs the full suite). Production default
+				// is 10s; the tight 4s here flaked as a cancel/timeout during release publish.
+				Timeout:  30 * time.Second,
 			})
 			results[idx], errs[idx] = res, err
 		}(i)


### PR DESCRIPTION
## Summary
`TestAttachOrSpawn_RaceExactlyOneDaemon` raced 4 concurrent `AttachOrSpawn` clients with a 4s per-client timeout. Under heavily loaded CI — specifically the release `publish-npm` job, which runs the full `npm test` suite — the concurrent daemon spawn + registry poll exceeded 4s, so the job was cancelled/failed on a spurious `bridge: attach-or-spawn timed out`. This blocked the `v2026.7.9` npm publish **twice** with no product defect (the `build` job and all native prebuilds passed every time).

## Changes
- `packages/neo/internal/bridge/daemonclient_test.go`: widen the race test's per-client `Timeout` from `4s` to `30s`. Production default is `10s`; the integration tests already use `45–90s`. Only the 4-client race case is touched; single-client mock-spawner cases keep their tight timeouts.

## QA / Evidence
- `npm run check` green (pre-commit hook, incl. `check:neo` go build/vet/test).
- `go test ./internal/bridge/ -run TestAttachOrSpawn -count=1` → `ok`.
- Root cause corroborated by two consecutive `publish-npm` cancellations at ~15m on the `v2026.7.9` tag, each with `build` succeeding — i.e. the ABI/prebuild fixes are sound and the only remaining blocker was this timing-sensitive test.

## Risks
- Test-only change. A genuine hang still fails, just after 30s instead of 4s — acceptable for a release-gating suite.

## Secret safety
No secrets; test-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the per-client timeout in `TestAttachOrSpawn_RaceExactlyOneDaemon` from 4s to 30s to eliminate flaky timeouts in the release `publish-npm` job under heavy CI load. Test-only change; only the 4-client race case is updated, single-client cases keep their tight timeouts.

<sup>Written for commit 0124ef3210f5c342c003a5ab3ee30a93651fb194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

