### PR TITLE
test(scripts): skip upstream-release test when the remote is unreachable

### DIFF
--- a/scripts/check-upstream-release.test.mjs
+++ b/scripts/check-upstream-release.test.mjs
@@ -19,12 +19,22 @@ function tryGit(args) {
 }
 
 describe("upstream release detector outputs", () => {
+	let upstreamAvailable = false;
+
 	before(() => {
 		if (!tryGit(["remote", "get-url", "upstream"])) {
-			git(["remote", "add", "upstream", UPSTREAM_REMOTE_URL]);
+			if (!tryGit(["remote", "add", "upstream", UPSTREAM_REMOTE_URL])) return;
 			addedUpstreamRemote = true;
 		}
-		git(["fetch", "--quiet", "upstream", "+refs/heads/main:refs/remotes/upstream/main"]);
+		// A real fetch of the upstream GitHub repo. On credential-less/offline
+		// runners (e.g. the release publish job checks out with
+		// persist-credentials:false) this cannot authenticate — skip rather than
+		// hard-fail the whole `test:scripts` suite, since this test inherently
+		// requires the external upstream repo.
+		if (tryGit(["fetch", "--quiet", "upstream", "+refs/heads/main:refs/remotes/upstream/main"]) === "" && !tryGit(["rev-parse", "upstream/main"])) {
+			return;
+		}
+		upstreamAvailable = tryGit(["rev-parse", "upstream/main"]) !== "";
 	});
 
 	after(() => {
@@ -33,7 +43,11 @@ describe("upstream release detector outputs", () => {
 		}
 	});
 
-	it("preserves the release tag sha and emits upstream/main head separately on forced runs", () => {
+	it("preserves the release tag sha and emits upstream/main head separately on forced runs", (t) => {
+		if (!upstreamAvailable) {
+			t.skip("upstream remote unreachable (offline or no git credentials)");
+			return;
+		}
 		const stdout = execFileSync("node", ["scripts/check-upstream-release.mjs", "--force"], { encoding: "utf8" });
 		const output = Object.fromEntries(
 			stdout


### PR DESCRIPTION
## Summary
The `v2026.7.9` `publish-npm` job failed in `npm test` with `fatal: could not read Username for 'https://github.com': terminal prompts disabled`. Root cause: `scripts/check-upstream-release.test.mjs`'s `before()` hook does a **real `git fetch`** of `https://github.com/badlogic/pi-mono.git`. The release publish job checks out with `persist-credentials: false` and disables terminal prompts, so the fetch cannot authenticate and hard-fails the entire `test:scripts` suite — blocking publish with no product defect. It passed locally only because a dev machine has cached git credentials + network.

This was the third and final publish blocker for `v2026.7.9` (after the pty ABI-sentinel decoupling and the daemon-race test timeout). `build` and all native prebuilds succeeded every time.

## Changes
- `scripts/check-upstream-release.test.mjs`: make the upstream `git fetch` non-throwing (`tryGit`) and **skip** the test when `upstream/main` is unreachable. The test inherently requires the external upstream repo, so skipping on a credential-less/offline runner is correct; it still runs fully wherever the remote is reachable.

## QA / Evidence
- `npm run check` green (pre-commit hook, incl. `check:neo`).
- Local run with credentials: `tests 1 / pass 1 / fail 0`.
- Simulated credential-less CI (`GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false`): `tests 1 / pass 0 / fail 0 / skipped 1` — skips cleanly instead of the hard `could not read Username` failure that broke publish.
- Scanned all `scripts/*.test.mjs` and workspace tests: this was the only real-network git test.

## Risks
- The upstream-detector assertion no longer runs on credential-less/offline machines (it skips). Acceptable: the release-gating value is that `npm test` no longer spuriously fails there, and the test still executes wherever the upstream remote is reachable (normal dev + CI with creds).

## Secret safety
No secrets; test-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the upstream-release test when the `upstream/main` remote can’t be fetched (offline or no git credentials), preventing CI publish failures from `fatal: could not read Username`. The test now uses non-throwing git checks and still runs when the remote is reachable.

<sup>Written for commit 318836b29b700f76fa107fd82962605b02c05342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

