### PR TITLE
test(coding-agent): serialize CI vitest to one fork to fix publish-job hang

### DIFF
--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -17,16 +17,17 @@ export default defineConfig({
 		reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
 		silent: "passed-only",
 		// Cap fork concurrency ON CI ONLY. This suite's subprocess-lifecycle tests
-		// (MCP keep-alive/ping-on-call fixtures, and now the default-on terminal PTY
-		// builtin) each spawn several real child processes. With the default forks
-		// pool (maxWorkers = CPU count) the 4-vCPU GitHub runner is oversubscribed once
-		// every default-on builtin's suite runs in parallel, and those child processes
-		// get starved — surfacing as intermittent "condition timed out" / off-by-one
-		// ping-count / kernel-startup-timeout flakes that no per-test timeout bump can
-		// fix (it is CPU/IO starvation, not tight deadlines). Two workers keep useful
-		// parallelism while bounding peak concurrent subprocesses. Local runs (many
-		// cores, no oversubscription) keep the default pool for speed.
-		...(process.env.GITHUB_ACTIONS ? { pool: "forks" as const, maxWorkers: 2 } : {}),
+		// (MCP keep-alive/ping-on-call fixtures, the default-on terminal PTY builtin,
+		// and the app-server daemon/websocket listeners) each spawn several real child
+		// processes. On the 4-vCPU GitHub runner, running these in parallel oversubscribes
+		// CPU/IO and — worse in the release publish job — leaves child processes unreaped
+		// long enough that the forks pool cannot exit, hanging the whole `npm test` step
+		// (observed: coding-agent RUN never summarizes, orphan senpi/esbuild processes).
+		// A per-test timeout cannot fix a pool-shutdown hang. Serialize to a single fork
+		// on CI: it bounds peak concurrent subprocesses to one suite's worth, trading a
+		// slower run for a deterministic one. Local runs (many cores) keep the default
+		// pool for speed.
+		...(process.env.GITHUB_ACTIONS ? { pool: "forks" as const, maxWorkers: 1, teardownTimeout: 20000 } : {}),
 		server: {
 			deps: {
 				external: [/@silvia-odwyer\/photon-node/],


### PR DESCRIPTION
## Summary
The `v2026.7.9` release `publish-npm` job hung its `npm test` step **four consecutive times**: the coding-agent vitest RUN started but never produced a `Test Files` summary, and the job was killed leaving orphan `senpi`/`esbuild` child processes. The suite passes locally (3457 tests, ~30s) and in the `ci.yml` Check-and-test job — so this is CI subprocess **oversubscription**, not a test-logic defect.

The app-server daemon/websocket listeners, MCP keep-alive fixtures, and the default-on terminal PTY builtin each spawn real child processes. Under the publish runner's load the forks pool could not reap them fast enough, so the pool never exited — a pool-shutdown hang that per-test timeouts cannot catch (they cover test execution, not pool teardown).

## Changes
- `packages/coding-agent/vitest.config.ts`: on CI (`GITHUB_ACTIONS`), serialize to a single fork (`maxWorkers: 1`, was `2`) so peak concurrent subprocesses are bounded to one suite's worth, plus `teardownTimeout: 20000` so a stuck teardown fails fast instead of hanging. Local runs keep the default multi-core pool for speed.

## QA / Evidence
- `npm run check` green (pre-commit, incl. `check:neo`).
- App-server suite under the simulated CI path (`GITHUB_ACTIONS=1`): 4 files / 18 tests pass, ~13s.
- Full coding-agent suite green locally (3457 passed / 31 skipped).
- Root cause corroborated by four publish-npm hangs, each: `agent` + `ai` summaries present, `coding-agent` RUN with no summary, orphan `senpi`/`esbuild` processes in the runner teardown.

## Risks
- CI test runs are slower (single fork). Acceptable trade for a deterministic release gate; the prior `maxWorkers: 2` still hung the publish job.

## Secret safety
No secrets; config-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize `vitest` on CI to a single fork to stop publish job hangs caused by unreaped child processes. Added a 20s teardown timeout to fail fast; local runs keep default concurrency.

- **Bug Fixes**
  - On CI, set `{ pool: "forks", maxWorkers: 1 }` in `packages/coding-agent/vitest.config.ts`.
  - Add `teardownTimeout: 20000` for stuck teardowns.
  - No change to local runs; keep default multi-core pool.

<sup>Written for commit df609bd53fb833317e8eeff3ca82cf7b4efb6f0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

