### PR TITLE
ci: drop redundant check+test from publish-npm job

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -223,14 +223,13 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # Build only — the tagged commit already passed the required "Check and test"
+      # status gate on main (full `npm run check` + `npm test`). Re-running the whole
+      # workspace test suite here is redundant and, on this contended publish runner,
+      # its subprocess-heavy suites (app-server/daemon, MCP, PTY) leak handles and hang
+      # the job. Build produces the dist artifacts `scripts/publish.mjs` bundles.
       - name: Build
         run: npm run build
-
-      - name: Check
-        run: npm run check
-
-      - name: Test
-        run: npm test
 
       - name: Upgrade npm for trusted publishing
         run: |


### PR DESCRIPTION
## Summary
The `v2026.7.9` `publish-npm` job failed/hung **five times** in its `npm test` step. Root cause: publish-npm re-ran the full workspace `npm run check` + `npm test` on the **same commit that had already passed the REQUIRED `Check and test` status gate** on main. On the contended publish runner, the subprocess-heavy coding-agent suites (app-server/daemon, MCP, PTY) leak handles so the vitest forks pool never exits — hanging the job — while the identical suite passes locally (3457 tests, ~30s) and in the required Check-and-test job.

## Changes
- `.github/workflows/build-binaries.yml`: remove the redundant `Check` and `Test` steps from the `publish-npm` job. It's now the standard build-and-publish shape: Checkout → Setup → Install → **Build** → Upgrade npm → Publish. `Build` stays because `scripts/publish.mjs` bundles its dist artifacts.

## Why this is safe
- `Check and test` is a **required** status check on `main` (verified via branch-protection API). Any commit a release tag points at has already passed the full `npm run check` + `npm test` before it could land on main. Re-running them inside publish-npm added no safety — only a second, contention-flaky execution on a busier runner.
- Tests remain fully enforced on every PR/commit via the required Check-and-test job. This change only stops the *duplicate* run at publish time.

## QA / Evidence
- Workflow YAML validated (js-yaml parse); publish-npm steps confirmed: `Checkout, Setup Node.js, Install system dependencies, Install dependencies, Build, Upgrade npm for trusted publishing, Publish npm packages`.
- `npm run check` green (pre-commit).
- Root cause corroborated by five publish-npm failures, each showing `agent`+`ai` suite summaries then the `coding-agent` RUN hanging with orphan `senpi`/`esbuild` processes — never a test assertion failure.

## Risks
- If a release tag were ever pushed to a commit that bypassed the required gate, publish would no longer re-test it. Mitigation: the release flow tags commits on `main`, which is gate-protected; and `Build` still fails the publish if the tree doesn't compile.

## Secret safety
No secrets; workflow-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant `Check` and `Test` steps from the `publish-npm` job to prevent publish hangs and flakiness, relying on the required `Check and test` gate on `main`. The job now builds artifacts for `scripts/publish.mjs` and then publishes (Build → Publish).

<sup>Written for commit dc181597dfa9098195694c4b5c1ba6ae8224bc12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

