### PR TITLE
fix(release): treat pty native prebuild as optional at pack time

### DIFF
--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -120,6 +120,7 @@ export function copyPublishDependencies(repoRoot) {
 
 export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
 	const nativeTargets = options.nativePrebuildTargets ?? [nativePrebuildTarget()];
+	const prebuildFiles = new Set(nativeTargets.map(nativePrebuildFile));
 	const filePaths = new Set((packed.files ?? []).map((file) => file.path));
 	const missing = [];
 
@@ -129,9 +130,15 @@ export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
 		for (const requiredFile of requiredFiles) {
 			const path = `${packageRoot}/${requiredFile}`;
 			const dryRunPath = `${dryRunPackageRoot}/${requiredFile}`;
-			if (!filePaths.has(path) && !filePaths.has(dryRunPath)) {
-				missing.push(`${path} or ${dryRunPath}`);
+			if (filePaths.has(path) || filePaths.has(dryRunPath)) continue;
+			// The platform native prebuild (.node) is optional — the pty loader falls back
+			// to a child_process pipe when it is absent, so a host without a committed/built
+			// prebuild (e.g. linux-x64 in the npm-publish job) must not fail the pack check.
+			if (prebuildFiles.has(requiredFile)) {
+				console.warn(`Warning: packed ${packageName} has no native prebuild ${requiredFile} (pipe fallback at runtime).`);
+				continue;
 			}
+			missing.push(`${path} or ${dryRunPath}`);
 		}
 	}
 
@@ -151,14 +158,26 @@ export function prepareSenpiBundledWorkspaces(repoRoot = root) {
 			throw new Error(`Missing ${distPath}. Run npm run build before preparing bundled workspaces.`);
 		}
 
+		// Loader files (package.json, dist/index.js, native/index.js) are hard-required.
+		// The platform-specific native prebuild (.node) is NOT: when it is absent the pty
+		// loader uses its child_process pipe fallback (same tolerance as build-binaries.sh,
+		// and the published package historically shipped with no prebuilds at all). So a
+		// missing host prebuild must warn, not fail the publish on a runner whose platform
+		// has no committed or built prebuild (e.g. linux-x64 in the npm-publish job).
+		const prebuildFiles = new Set(workspace.nativePrebuild ? [nativePrebuildFile(nativePrebuildTarget())] : []);
 		const requiredFiles = requiredFilesForWorkspace(workspace, [nativePrebuildTarget()]);
 		for (const requiredFile of requiredFiles) {
 			const requiredPath = join(sourceRoot, requiredFile);
-			if (!existsSync(requiredPath)) {
-				throw new Error(
-					`Missing ${requiredPath}. ${workspace.packageName} cannot be bundled without loader-visible package files.`,
+			if (existsSync(requiredPath)) continue;
+			if (prebuildFiles.has(requiredFile)) {
+				console.warn(
+					`Warning: ${workspace.packageName} has no native prebuild at ${requiredFile}; bundling without it (pipe fallback at runtime).`,
 				);
+				continue;
 			}
+			throw new Error(
+				`Missing ${requiredPath}. ${workspace.packageName} cannot be bundled without loader-visible package files.`,
+			);
 		}
 
 		const targetRoot = join(codingAgentNodeModules, ...workspace.targetParts);

--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -88,20 +88,56 @@ describe("prepareSenpiBundledWorkspaces", () => {
 		);
 	});
 
-	it("fails before bundling pty when the host prebuild is missing", () => {
-		// Given
+	it("bundles pty with a pipe-fallback warning when the host prebuild is missing", () => {
+		// Given: every loader-visible file present, but the host native prebuild absent.
 		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-pty-prebuild-"));
 		writeShrinkwrap(tempDir, { "": { dependencies: {} } });
-		for (const workspace of ["agent", "ai", "tui"]) {
+		for (const workspace of ["agent", "ai", "tui", "senpi-codemode"]) {
 			writeBundledWorkspace(tempDir, workspace);
 		}
 		writeBundledWorkspace(tempDir, "pty");
 		rmSync(join(tempDir, "packages", "pty", nativePrebuildFile(nativePrebuildTarget())));
 
-		// When / Then
+		const warnings = [];
+		const originalWarn = console.warn;
+		console.warn = (message) => warnings.push(String(message));
+
+		// When / Then: the prebuild is optional (pipe fallback), so bundling must not throw.
+		try {
+			assert.doesNotThrow(() => prepareSenpiBundledWorkspaces(tempDir));
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		// And: pty is still copied into coding-agent node_modules (loader files present).
+		assert.equal(
+			readFileSync(
+				join(tempDir, "packages", "coding-agent", "node_modules", "@earendil-works", "pi-pty", "native", "index.js"),
+				"utf8",
+			),
+			"",
+		);
+		// And: a warning names the missing prebuild.
+		assert.ok(
+			warnings.some((message) => /no native prebuild/.test(message)),
+			`expected a pipe-fallback warning, got: ${JSON.stringify(warnings)}`,
+		);
+	});
+
+	it("fails before bundling pty when a loader-visible file is missing", () => {
+		// Given: the hard-required loader file native/index.js is absent.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-pty-loader-"));
+		writeShrinkwrap(tempDir, { "": { dependencies: {} } });
+		for (const workspace of ["agent", "ai", "tui"]) {
+			writeBundledWorkspace(tempDir, workspace);
+		}
+		writeBundledWorkspace(tempDir, "pty");
+		rmSync(join(tempDir, "packages", "pty", "native", "index.js"));
+
+		// When / Then: a missing loader file is still fatal.
 		assert.throws(
 			() => prepareSenpiBundledWorkspaces(tempDir),
-			/Missing .*native\/prebuilds\/.*senpi_pty\..*\.node.*cannot be bundled/,
+			/Missing .*native\/index\.js.*cannot be bundled/,
 		);
 	});
 });

--- a/scripts/prepare-senpi-bundled-workspaces.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.test.mjs
@@ -209,9 +209,8 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 		);
 	});
 
-	it("rejects senpi package metadata that omits the bundled host pty prebuild", () => {
-		// Given
-		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+	it("accepts senpi package metadata that omits the host pty prebuild (pipe fallback)", () => {
+		// Given: all loader files present, but no host native prebuild.
 		const packed = {
 			files: [
 				{ path: "package/dist/cli.js" },
@@ -224,18 +223,24 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
 				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
 				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
 			],
 		};
 
-		// When / Then
-		assert.throws(
-			() => assertSenpiPackedWorkspaceFiles(packed),
-			new RegExp(`@earendil-works/pi-pty/${hostPrebuild.replaceAll("/", "\\/").replaceAll(".", "\\.")}`),
-		);
+		// When / Then: the native prebuild is optional (pipe fallback), so this must not throw.
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
+		} finally {
+			console.warn = originalWarn;
+		}
 	});
 
-	it("defines the all-OS native artifact ingestion contract without requiring fake local binaries", () => {
-		// Given
+	it("accepts an all-OS check when a target's prebuild is absent (pipe fallback)", () => {
+		// Given: the darwin-arm64 prebuild is present but linux-x64 is not.
 		const missingTarget = "linux-x64";
 		const packed = {
 			files: [
@@ -250,15 +255,23 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 				{ path: `package/node_modules/@earendil-works/pi-pty/${nativePrebuildFile("darwin-arm64")}` },
 				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
 				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
 			],
 		};
 
-		// When / Then
+		// When / Then: a missing per-target prebuild is optional, so the check must not throw.
 		assert.ok(SUPPORTED_NATIVE_PREBUILD_TARGETS.includes(missingTarget));
-		assert.throws(
-			() => assertSenpiPackedWorkspaceFiles(packed, { nativePrebuildTargets: ["darwin-arm64", missingTarget] }),
-			/package tarball is missing bundled workspace files: .*native\/prebuilds\/linux-x64\/senpi_pty\.linux-x64\.node/,
-		);
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			assert.doesNotThrow(() =>
+				assertSenpiPackedWorkspaceFiles(packed, { nativePrebuildTargets: ["darwin-arm64", missingTarget] }),
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
 	});
 
 	it("publishes the supported native target list through package checks", () => {


### PR DESCRIPTION
## Summary
With the publish-npm test hang resolved, the `v2026.7.9` publish reached the actual publish step and failed: `Missing packages/pty/native/prebuilds/linux-x64/senpi_pty.linux-x64.node`. `publish-npm` runs on ubuntu (linux-x64), but only the darwin-arm64 prebuild is committed, so `prepareSenpiBundledWorkspaces` / `assertSenpiPackedWorkspaceFiles` hard-threw on the missing host prebuild.

That requirement was wrong. `scripts/build-binaries.sh` already treats a missing pty prebuild as **non-fatal** (the loader uses a `child_process` pipe fallback), and the published package historically shipped with **no prebuilds at all** (verified: `@code-yeongyu/senpi@2026.7.5-2` contains zero `.node` prebuilds). The loader files (`package.json`, `dist/index.js`, `native/index.js`) are what the runtime needs; the platform `.node` is a native fast-path, not a requirement.

## Changes
- `scripts/prepare-senpi-bundled-workspaces.mjs`: both `prepareSenpiBundledWorkspaces` (bundle step) and `assertSenpiPackedWorkspaceFiles` (packed-tarball validator, called from `publish.mjs`) now treat the native prebuild `.node` as **optional** — warn + continue (pipe fallback) when a host's prebuild is absent, while keeping the loader files hard-required (still throw).
- `scripts/prepare-senpi-bundled-workspaces.test.mjs` + `.prepare.test.mjs`: realigned to pin the new contract — missing prebuild → no throw + warning; missing loader file → still throws.

## QA / Evidence
- `npm run check` green (pre-commit, incl. `check:neo`).
- The two prepare/assert test files pass **13/13**.
- Directly verified: a packed set representing the linux-x64 publish runner (all loader files, no linux-x64 `.node`) no longer throws (`assertSenpiPackedWorkspaceFiles`); a set missing `native/index.js` still throws.

## Risks
- If a genuinely required loader file were missing it would still fail (kept fatal). The only relaxation is the platform `.node`, whose absence is already handled at runtime by the pipe fallback.

## Secret safety
No secrets; build-tooling + tests only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat the pty native prebuild as optional during bundling and publish checks to unblock npm publish on Linux. Missing `.node` files now warn and use the pipe-based fallback; loader files remain required.

- **Bug Fixes**
  - Updated `prepareSenpiBundledWorkspaces` and `assertSenpiPackedWorkspaceFiles` to warn and continue when the platform `.node` prebuild is absent; `package.json`, `dist/index.js`, and `native/index.js` are still required.
  - Adjusted tests to assert no-throw with a warning when the prebuild is missing, and to still throw when a loader file is missing.
  - Mirrors `scripts/build-binaries.sh` behavior and matches prior publishes that shipped without prebuilds.

<sup>Written for commit 63f795886e2d17d948903740c69db3c5f49dc7d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

