### PR TITLE
fix(release): npm-version-agnostic source-only pack content check

### DIFF
--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -64,9 +64,12 @@ function validatePack(directory) {
 	}
 	if (sourceOnlyPackages.has(packageJson.name)) {
 		const filePaths = new Set((packed.files ?? []).map((file) => file.path));
-		for (const requiredPath of ["package/src/index.ts", "package/README.md", "package/CHANGELOG.md", "package/LICENSE"]) {
-			if (!filePaths.has(requiredPath)) {
-				throw new Error(`${packageJson.name} package tarball is missing ${requiredPath}`);
+		// `npm pack --json` file paths vary by npm version: some emit a `package/` prefix,
+		// others emit bare repo-relative paths. Accept either so the source-only content
+		// check is npm-version-agnostic (mirrors assertSenpiPackedWorkspaceFiles).
+		for (const requiredFile of ["src/index.ts", "README.md", "CHANGELOG.md", "LICENSE"]) {
+			if (!filePaths.has(`package/${requiredFile}`) && !filePaths.has(requiredFile)) {
+				throw new Error(`${packageJson.name} package tarball is missing ${requiredFile}`);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
The `v2026.7.9` publish reached the publish step and failed: `@code-yeongyu/senpi-codemode package tarball is missing package/src/index.ts`. `validatePack`'s source-only content check hardcoded the `package/` path prefix, but `npm pack --json` emits **bare repo-relative paths** (`src/index.ts`) on this npm version — so the check never matched, even though the source is genuinely packed. This is the first release with a source-only package (`senpi-codemode`), so the bug had never been exercised.

## Changes
- `scripts/publish.mjs`: the source-only content check now accepts **either** path form (`package/<file>` or bare `<file>`), mirroring the dual-form handling already in `assertSenpiPackedWorkspaceFiles`.

## QA / Evidence
- Reproduced locally with the exact `validatePack` command (`npm pack --dry-run --ignore-scripts --json` in `packages/senpi-codemode`): paths come back as `src/index.ts`, `LICENSE`, etc. (no `package/` prefix) — confirming the mismatch.
- After the fix, the same command's paths satisfy the check.
- `node scripts/publish.mjs --dry-run` now validates **all 6 packages end-to-end with EXIT=0** (this is the exact pre-publish validation the CI publish-npm job runs before `npm publish`).
- `npm run check` green (pre-commit).

## Risks
- The source content is verified present via `npm pack --dry-run`; this only fixes the path-matching of the guard. A genuinely missing source file would still fail (both path forms absent).

## Secret safety
No secrets; release-tooling only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish validation to be npm-version-agnostic by accepting both `package/<file>` and `<file>` paths from `npm pack --json`, unblocking the source-only publish for `@code-yeongyu/senpi-codemode`.

- **Bug Fixes**
  - In `scripts/publish.mjs`, the source-only check now recognizes both path forms for required files.
  - Verified via `npm pack --dry-run --ignore-scripts --json` and `node scripts/publish.mjs --dry-run` across all packages.

<sup>Written for commit 21f66ecebabbd20d682049501bf65f935696234e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

