### PR TITLE
fix(release): publish only standalone packages (drop bundled + private)

### DIFF
--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -5,15 +5,19 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { assertSenpiPackedWorkspaceFiles, prepareSenpiBundledWorkspaces } from "./prepare-senpi-bundled-workspaces.mjs";
 
+// Only STANDALONE-published npm packages belong here. Excluded on purpose:
+//  - @code-yeongyu/senpi-orchestrator is `private: true` (never published).
+//  - @code-yeongyu/senpi-codemode ships via senpi's `bundleDependencies` (packed
+//    INTO the @code-yeongyu/senpi tarball), so consumers get it without a registry
+//    entry; publishing it standalone via OIDC trusted publishing fails E404 because
+//    it is a brand-new scoped package name OIDC cannot create.
 const packages = [
 	{ directory: "packages/ai", name: "@earendil-works/pi-ai" },
 	{ directory: "packages/agent", name: "@earendil-works/pi-agent-core" },
 	{ directory: "packages/tui", name: "@earendil-works/pi-tui" },
-	{ directory: "packages/orchestrator", name: "@code-yeongyu/senpi-orchestrator" },
-	{ directory: "packages/senpi-codemode", name: "@code-yeongyu/senpi-codemode" },
 	{ directory: "packages/coding-agent", name: "@code-yeongyu/senpi" },
 ];
-const sourceOnlyPackages = new Set(["@code-yeongyu/senpi-codemode"]);
+const sourceOnlyPackages = new Set([]);
 
 const dryRun = process.argv.includes("--dry-run");
 const unknownArgs = process.argv.slice(2).filter((arg) => arg !== "--dry-run");


### PR DESCRIPTION
## Summary
The `v2026.7.9` publish reached npm and failed E404 creating a new scoped package: `PUT https://registry.npmjs.org/@code-yeongyu/senpi-codemode - Not found`. npm **trusted publishing (OIDC)** cannot CREATE a brand-new package name, and neither new package in the publish list should have been published standalone:

- **`@code-yeongyu/senpi-codemode`** ships via senpi's `bundleDependencies` — it is packed INTO the `@code-yeongyu/senpi` tarball (verified: 36 files incl. `src/index.ts` under `node_modules/@code-yeongyu/senpi-codemode/`). Consumers get it with **no standalone registry entry**.
- **`@code-yeongyu/senpi-orchestrator`** is `"private": true` — never publishable.

## Changes
- `scripts/publish.mjs`: reduce the publish set to the 4 genuinely standalone packages — `@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`, `@earendil-works/pi-tui`, `@code-yeongyu/senpi` — all of which already exist on npm and publish fine via OIDC. Empties the now-unused `sourceOnlyPackages` set. Documents why the two are excluded.

## Why no npm-account action is needed
The remaining 4 packages all have prior published versions (`pi-ai@0.80.3`, `senpi@2026.7.5-2`, etc.), so OIDC publishes new versions normally (it only cannot CREATE new names). codemode reaches consumers bundled; orchestrator is private/unconsumed.

## QA / Evidence
- `node scripts/publish.mjs --dry-run` validates the 4-package set **EXIT=0**.
- Verified via `tar tzf` that the real `@code-yeongyu/senpi` tarball still bundles codemode: **36 files incl. `package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts`** — bundleDependency delivery unaffected by removing it from the standalone list.
- `npm run check` green (pre-commit).

## Risks
- If codemode/orchestrator are ever intended as standalone npm packages, they need a one-time owner bootstrap (token publish or npmjs.com trusted-publisher setup). Not required for this release: codemode is bundled, orchestrator is private.

## Secret safety
No secrets; release-tooling only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish only standalone packages to fix npm E404s and avoid releasing bundled or private packages. The publish script now targets `@earendil-works/pi-ai`, `@earendil-works/pi-agent-core`, `@earendil-works/pi-tui`, and `@code-yeongyu/senpi`.

- **Bug Fixes**
  - Exclude `@code-yeongyu/senpi-codemode` (bundled via `bundleDependencies`) and `@code-yeongyu/senpi-orchestrator` (private) from publish.
  - Remove unused `sourceOnlyPackages` and add inline comments explaining exclusions.
  - Dry run passes; `@code-yeongyu/senpi` tarball still includes `@code-yeongyu/senpi-codemode`.

<sup>Written for commit 90d459de4d83d1988f3fb8a1eaf045bcabc5e8ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

