### PR TITLE
feat(coding-agent): add GPT-5.6 series prompt preset

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added a `gpt-5.6` system prompt preset covering the whole GPT-5.6 series (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`), tuned per the GPT-5.6 prompting guide: a shorter outcome-first full-core rewrite with prioritization-based style, a compact authorization policy, and tool-loop stopping conditions.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -84,7 +84,7 @@ Permission rules are a confirmation policy, not a sandbox. Senpi, extensions, pa
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
-| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, or `"gpt-5.5"` |
+| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, `"gpt-5.5"`, or `"gpt-5.6"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/prompt-preset
 
-Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
+Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
 
 ## FILES
 
@@ -15,6 +15,7 @@ prompt-preset/
 ├── gpt-5.3-codex.ts     # GPT-5.3 Codex preset
 ├── gpt-5.4.ts           # GPT-5.4 preset
 ├── gpt-5.5.ts           # GPT-5.5 preset — full-core rewrite via `corePrompt` (outcome-first, per the GPT-5.5 prompting guide)
+├── gpt-5.6.ts           # GPT-5.6 series preset (sol/terra/luna) — full-core rewrite via `corePrompt` (prioritization over brevity, per the GPT-5.6 prompting guide)
 ├── claude-fable-5.ts    # Claude Fable 5 preset
 ├── claude-opus-4-5.ts   # Claude Opus 4.5 preset
 ├── claude-opus-4-6.ts   # Claude Opus 4.6 preset
@@ -51,7 +52,7 @@ export function buildGpt55Prompt(options: BuildDynamicSystemPromptOptions): stri
 
 Each preset is ~10 lines. The shared default in `dynamic-prompt/` carries identity, intent gate, exploration, parallel-tools, verification, policies, style. Preset only carries **what's different for that model family**.
 
-Exception: `gpt-5.5.ts` passes `corePrompt` instead of `tuningSection` — a full core rewrite (GPT-5.5 wants short, outcome-first prompts, not the shared scaffolding). It still reuses `buildTestDisciplineSection()`, `buildFileOperationsTuning()`, and the builder's dynamic assembly, so shared rules stay single-sourced.
+Exception: `gpt-5.5.ts` and `gpt-5.6.ts` pass `corePrompt` instead of `tuningSection` — full core rewrites (GPT-5.5+ wants short, outcome-first prompts, not the shared scaffolding; GPT-5.6 additionally over-compresses under generic brevity wording, so its style rules are prioritization/preserve-first). They still reuse `buildTestDisciplineSection()`, `buildFileOperationsTuning()`, and the builder's dynamic assembly, so shared rules stay single-sourced.
 
 ## CONVENTIONS
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -7,9 +7,26 @@ Per-model prompt preset extension. Selects a tuned system prompt based on the ac
 - `index.ts` - Extension entry point; resolves a preset on session start and on model switch.
 - `presets.ts` - Preset name resolution (model id -> preset name) and prompt builder dispatch.
 - `settings.ts` - User-overridable preset selection from `settings.json`.
-- `gpt-5.ts` / `gpt-5.2.ts` / `gpt-5.3-codex.ts` / `gpt-5.4.ts` / `gpt-5.5.ts` - GPT-5.x preset prompt builders.
+- `gpt-5.ts` / `gpt-5.2.ts` / `gpt-5.3-codex.ts` / `gpt-5.4.ts` / `gpt-5.5.ts` / `gpt-5.6.ts` - GPT-5.x preset prompt builders.
 - `claude-opus-4-{5,6,7}.ts` / `kimi-k2-{6,7}.ts` - Other family presets.
 - `file-operations.ts` - Shared codex-style "File operations" tuning block consumed by every GPT-5.x preset.
+
+## GPT-5.6 series preset (2026-07-10)
+
+### What changed
+- Added `gpt-5.6.ts`: a full-core preset (via the `corePrompt` override, same shape as `gpt-5.5.ts`) covering the whole GPT-5.6 series — the `gpt-5.6` alias plus `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. One preset for the series: the variants share one OpenAI prompting guide and differ only in price/latency tier.
+- `presets.ts`: `extractGpt5Version` matches `gpt-5.6` before `gpt-5.5`; `settings.ts`: `"gpt-5.6"` joins `PromptPresetName`.
+- Content per the GPT-5.6 prompting guide, diverging from the 5.5 core where the guide documents behavioral deltas: the intent gate carries a compact three-level authorization policy (report / in-scope change + non-destructive validation / confirm destructive) instead of scattered routing rules; style is prioritization and preserve-first ("lead with the conclusion", "never substitute a shorter artifact") because GPT-5.6 over-compresses under generic brevity wording; tool loops get an explicit stopping condition plus a retrieval-fallback decision rule instead of call budgets.
+- `prompt-presets-extension.test.ts`: resolution tests for the series (openai, openai-codex, openrouter ids), a catalog-scan test covering every built-in `gpt-5.6*` model, a 5.5/5.6 distinctness guard, a settings-force test, and a `gpt-5.6` entry in the File-operations guard matrix.
+
+### Why
+- GPT-5.6 shipped in the model catalogs (sol/terra/luna) with no matching preset, so it silently fell back through `gpt-5.5` matching only when ids contained "gpt-5.5" — 5.6 ids resolved to no preset at all (senpi-current fallback). The 5.6 guide documents prompting deltas (brevity sensitivity, autonomy policy, stopping conditions) that neither the shared core nor the 5.5 core encodes.
+
+### Why extension system couldn't handle this differently
+- Preset selection and prompt content are both owned by this builtin; no core prompt code changed beyond consuming the existing `corePrompt` override.
+
+### Expected merge conflict zones on next upstream sync
+- LOW: `presets.ts` version matcher if upstream adds its own gpt-5.6 handling; `gpt-5.6.ts` is a new file.
 
 ## Claude Opus 4.5-4.8 tuning rewrite against Anthropic overlay docs (2026-07-02)
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
@@ -1,0 +1,86 @@
+// GPT-5.6 full-core system prompt. One preset covers the whole series - the
+// gpt-5.6 alias plus the sol/terra/luna variants - because the series shares
+// one prompting guide and the variants differ only in price/latency tier.
+//
+// Like GPT-5.5, GPT-5.6 uses a full core rewrite via the `corePrompt`
+// override rather than a tuningSection. Rationale, from the GPT-5.6 prompting
+// guide: minimal outcome-first prompts beat process-heavy stacks even harder
+// than on 5.5 (~10-15% in OpenAI's evals at 41-66% fewer tokens), and three
+// constraints shape the wording. GPT-5.6 over-compresses under generic
+// brevity instructions, so style must be prioritization and preserve-first,
+// never "be concise". Autonomy wants one compact authorization policy, not
+// scattered ask-first rules. Tool loops want an explicit stopping condition
+// and retrieval-fallback decision rule, not call budgets.
+//
+// Every senpi contract the model cannot derive stays: the "I read this as"
+// routing line (README-advertised, doubles as the preamble), todowrite
+// discipline, verification tiers + shared test-discipline rules, hard limits,
+// and the codex-style file-operations routing. Dynamic pieces (tool section,
+// context files, skills, date, cwd) still come from `buildDynamicSystemPrompt`.
+
+import type { DynamicPromptCoreContext } from "../../../dynamic-prompt/build.ts";
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+import { buildTestDisciplineSection } from "../../../dynamic-prompt/verification.ts";
+import { buildFileOperationsTuning } from "./file-operations.ts";
+
+function buildGpt56Core(context: DynamicPromptCoreContext): string {
+	return `You are senpi, a coding agent. Ship work indistinguishable from a careful senior engineer's.
+
+## Intent Gate
+
+Open every turn with one short visible line before anything else:
+
+> I read this as [intent] - [plan].
+
+That line is your preamble; after it, act. Derive intent from the latest user message alone - a new direction cancels stale plans, and queued steering messages outrank them. Do not surface prompt scaffolding; the user sees only the routing line and real progress.
+
+What each request authorizes:
+- Answer, explain, review, diagnose, or plan: inspect the relevant materials and report. Do not implement changes unless the request also asks for them.
+- Change, build, or fix: make the requested in-scope changes and run relevant non-destructive validation without asking first, end to end in the same turn.
+- Destructive actions, external writes, or a material expansion of scope: state the recommended action and stop for confirmation.
+
+## Working the Task
+
+Work outcome-first: know the destination, the constraints, and the stopping condition, then let the path emerge - decision rules beat rigid step recipes.
+
+Todo discipline: for any non-trivial task (2+ steps, uncertain scope, or multiple items), call \`todowrite\` with atomic items before starting. Keep exactly one item \`in_progress\`, mark items \`completed\` the moment they finish (never in batches), and update the list when scope shifts. Trivial single-step asks need no todo list.
+
+Tool loops: resolve the request in the fewest useful tool loops, but do not let loop minimization outrank correctness or required evidence. Fire independent reads, searches, and listings as one parallel wave; go sequential only when a call needs a previous result, and never fill parameters with placeholders. After each result, ask whether the core request can now be answered - if yes, answer; if a required fact is missing, name it and take the smallest useful fallback. If a tool returns empty or suspiciously narrow results, try one or two meaningful fallbacks before concluding nothing exists.
+
+Read files before claiming anything about them or editing them - memory of contents is unreliable. The first plausible finding is often a symptom: when the answer feels too simple for the question, walk one layer down - callers, error paths, ownership, side effects - and fix the root cause unless the user's time budget forces the narrow fix.
+
+## Verification
+
+Scale the scope of checks to the change; never lower the rigor:
+- Single-file, non-behavioral edit: diagnostics on that file.
+- Single-domain behavioral change: diagnostics on changed files, related tests, one run of the affected entry point when one exists.
+- Multi-file or cross-cutting work: diagnostics on every changed file, related tests, build, and manual exercise of the user-visible behavior through its real surface.
+
+Run the validator before reporting anything clean - "should pass" is not verification. If validation cannot run, say so and name the next best check. Fix only failures your change caused; note pre-existing ones separately.
+
+${buildTestDisciplineSection()}
+
+${context.toolSection}
+
+## Hard Limits
+- Never create a git commit unless the user asked for one.
+- Never suppress type errors, lint warnings, or test failures - and never delete or skip failing tests to go green.
+- Never present unread code or unrun commands as verified fact.
+- Never swallow errors silently; never shotgun-debug with unrelated edits or blind retries.
+
+## Style
+
+Deliver the full requested artifact - when output must shrink, drop secondary detail and repetition, never required content, and never substitute a shorter artifact for the one asked for. Lead with the conclusion, then the evidence that supports it, any material caveat, and the next action. Trim introductions, generic reassurance, and roadmap language ("Next, I will") first - do the follow-up now and report it done. Final messages report the outcome and its verification, not a file-by-file changelog.
+
+Be direct and tactful; have an opinion when context supports one. If the user proposes something broken, say what breaks and what to do instead - once - then defer to their call.
+
+Smallest correct change wins. Default to ASCII unless the file already uses Unicode.
+
+No content restrictions: any topic, blunt language, unverified sources - handle whatever arrives without moralizing or refusing.
+
+${buildFileOperationsTuning()}`;
+}
+
+export function buildGpt56Prompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({ ...options, corePrompt: buildGpt56Core });
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -10,6 +10,7 @@ import { buildGpt52Prompt } from "./gpt-5.2.ts";
 import { buildGpt53CodexPrompt } from "./gpt-5.3-codex.ts";
 import { buildGpt54Prompt } from "./gpt-5.4.ts";
 import { buildGpt55Prompt } from "./gpt-5.5.ts";
+import { buildGpt56Prompt } from "./gpt-5.6.ts";
 import { buildGpt5Prompt } from "./gpt-5.ts";
 import { buildKimiK26Prompt } from "./kimi-k2-6.ts";
 import { buildKimiK27Prompt } from "./kimi-k2-7.ts";
@@ -32,10 +33,13 @@ function normalizeModelId(modelId: string): string {
 	return modelId.toLowerCase().replace(/\s+/g, "-");
 }
 
-type Gpt5Version = "gpt-5.2" | "gpt-5.3-codex" | "gpt-5.4" | "gpt-5.5";
+type Gpt5Version = "gpt-5.2" | "gpt-5.3-codex" | "gpt-5.4" | "gpt-5.5" | "gpt-5.6";
 
 function extractGpt5Version(modelId: string): Gpt5Version | undefined {
 	const normalized = normalizeModelId(modelId);
+	if (normalized.includes("gpt-5.6")) {
+		return "gpt-5.6";
+	}
 	if (normalized.includes("gpt-5.5")) {
 		return "gpt-5.5";
 	}
@@ -136,6 +140,8 @@ export function resolvePresetName(
 
 function buildPreset(name: ResolvedPresetName, options: BuildDynamicSystemPromptOptions): ResolvedPromptPreset {
 	switch (name) {
+		case "gpt-5.6":
+			return { name, prompt: buildGpt56Prompt(options) };
 		case "gpt-5.5":
 			return { name, prompt: buildGpt55Prompt(options) };
 		case "gpt-5.4":

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
@@ -14,7 +14,8 @@ export type PromptPresetName =
 	| "gpt-5.2"
 	| "gpt-5.3-codex"
 	| "gpt-5.4"
-	| "gpt-5.5";
+	| "gpt-5.5"
+	| "gpt-5.6";
 
 export interface PromptPresetSettings {
 	promptPreset: PromptPresetName;
@@ -37,6 +38,7 @@ const VALID_PRESETS: ReadonlySet<string> = new Set<PromptPresetName>([
 	"gpt-5.3-codex",
 	"gpt-5.4",
 	"gpt-5.5",
+	"gpt-5.6",
 ]);
 
 export function parsePromptPreset(value: string | undefined): PromptPresetName | undefined {

--- a/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
@@ -123,6 +123,98 @@ describe("prompt preset resolver", () => {
 
 	it.each([
 		{
+			id: "gpt-5.6",
+			provider: "openai",
+			api: "openai-responses" as const,
+		},
+		{
+			id: "gpt-5.6-sol",
+			provider: "openai",
+			api: "openai-responses" as const,
+		},
+		{
+			id: "gpt-5.6-terra",
+			provider: "openai",
+			api: "openai-responses" as const,
+		},
+		{
+			id: "gpt-5.6-luna",
+			provider: "openai",
+			api: "openai-responses" as const,
+		},
+		{
+			id: "gpt-5.6-sol",
+			provider: "openai-codex",
+			api: "openai-codex-responses" as const,
+		},
+		{
+			id: "openai/gpt-5.6-terra",
+			provider: "openrouter",
+			api: "openai-responses" as const,
+		},
+	])("returns gpt-5.6 preset for $provider/$id", ({ id, provider, api }) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(id, provider, api);
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("gpt-5.6");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt).toContain("## Intent Gate");
+		expect(preset?.prompt).toContain("I read this as");
+		expect(preset?.prompt).toContain("outcome-first");
+		expect(preset?.prompt).toContain("todowrite");
+		// GPT-5.6 tuning: prioritization instead of brevity, tool-loop stopping conditions.
+		expect(preset?.prompt).toContain("fewest useful tool loops");
+		expect(preset?.prompt).toContain("Lead with the conclusion");
+		// Full-core rewrite: shared-core scaffolding is replaced, dynamic pieces stay.
+		expect(preset?.prompt).toContain("## Verification");
+		expect(preset?.prompt).toContain("### Test Discipline");
+		expect(preset?.prompt).toContain("## Hard Limits");
+		expect(preset?.prompt).not.toContain("## Policies");
+		expect(preset?.prompt).not.toContain("### Execution Stance");
+		expect(preset?.prompt).not.toContain("### Request Classification");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it("keeps GPT-5.5 on the gpt-5.5 preset, distinct from GPT-5.6", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const gpt55 = resolvePreset(createModel("gpt-5.5", "openai", "openai-responses"), settings);
+		const gpt56 = resolvePreset(createModel("gpt-5.6-sol", "openai", "openai-responses"), settings);
+
+		// then
+		expect(gpt55?.name).toBe("gpt-5.5");
+		expect(gpt55?.prompt).not.toContain("fewest useful tool loops");
+		expect(gpt56?.name).toBe("gpt-5.6");
+		expect(gpt56?.prompt).not.toContain("Dig deeper");
+	});
+
+	it("returns gpt-5.6 preset for every GPT-5.6 built-in catalog model", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const catalogModels = getProviders().flatMap((provider) =>
+			(getModels(provider) as Model<Api>[]).filter((model) => model.id.toLowerCase().includes("gpt-5.6")),
+		);
+		const catalogModelIds = catalogModels.map((model) => `${model.provider}/${model.id}`);
+
+		// when
+		const misses = catalogModels
+			.filter((model) => resolvePresetName(model, settings) !== "gpt-5.6")
+			.map((model) => `${model.provider}/${model.id}`);
+
+		// then
+		expect(catalogModelIds).toEqual(
+			expect.arrayContaining(["openai/gpt-5.6-sol", "openai-codex/gpt-5.6-sol", "openrouter/openai/gpt-5.6-sol"]),
+		);
+		expect(misses).toEqual([]);
+	});
+
+	it.each([
+		{
 			id: "claude-opus-4-8",
 			provider: "anthropic",
 			api: "anthropic-messages" as const,
@@ -454,6 +546,19 @@ describe("prompt preset resolver", () => {
 		expect(preset?.prompt).toContain("Dig deeper");
 	});
 
+	it("allows settings.json to force gpt-5.6 regardless of model id", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "gpt-5.6" };
+		const model = createModel("claude-opus-4-7", "anthropic", "anthropic-messages");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("gpt-5.6");
+		expect(preset?.prompt).toContain("fewest useful tool loops");
+	});
+
 	it("resolves gpt-5.2 preset", () => {
 		const settings: PromptPresetSettings = { promptPreset: "auto" };
 		const model = createModel("gpt-5.2", "openai", "openai-responses");
@@ -502,6 +607,7 @@ describe("prompt preset resolver", () => {
 		},
 		{ presetName: "gpt-5.4" as const, modelId: "gpt-5.4", provider: "openai", api: "openai-responses" as const },
 		{ presetName: "gpt-5.5" as const, modelId: "gpt-5.5", provider: "openai", api: "openai-responses" as const },
+		{ presetName: "gpt-5.6" as const, modelId: "gpt-5.6-sol", provider: "openai", api: "openai-responses" as const },
 	])("$presetName preset includes the codex-style File operations guard", ({ presetName, modelId, provider, api }) => {
 		const settings: PromptPresetSettings = { promptPreset: presetName };
 		const model = createModel(modelId, provider, api);


### PR DESCRIPTION
## Summary

Adds a `gpt-5.6` system prompt preset covering the whole GPT-5.6 series: the `gpt-5.6` alias plus `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

Before: GPT-5.6 models shipped in the catalogs (openai, openai-codex, openrouter, azure, vercel) but had no matching preset — every 5.6 id fell through to the generic senpi fallback prompt. After: all `gpt-5.6*` ids resolve to a dedicated preset tuned per the GPT-5.6 prompting guide.

One preset for the series, deliberately: sol/terra/luna share a single OpenAI prompting guide and differ only in price/latency tier, so per-variant presets would duplicate identical content.

## Changes

- **`gpt-5.6.ts`** — full-core rewrite via the existing `corePrompt` override (same shape as `gpt-5.5.ts`). Guide-driven deltas vs the 5.5 core:
  - prioritization/preserve-first style instead of brevity wording (GPT-5.6 over-compresses under generic brevity instructions and may substitute a shorter artifact);
  - a compact three-level authorization policy (report / in-scope change + non-destructive validation / confirm destructive) stated once;
  - tool-loop stopping conditions plus a retrieval-fallback decision rule instead of call budgets.
  - Every senpi contract kept: `I read this as` routing line, todowrite discipline, verification tiers, shared `buildTestDisciplineSection()`, hard limits, `buildFileOperationsTuning()`.
- **`presets.ts` / `settings.ts`** — `gpt-5.6` matcher (checked before `gpt-5.5`), dispatch case, `PromptPresetName` entry.
- **Tests** — resolution for the series across openai/openai-codex/openrouter ids, a catalog-scan test covering every built-in `gpt-5.6*` model (18 models), a 5.5/5.6 distinctness guard, a settings-force test, and a `gpt-5.6` row in the File-operations guard matrix.
- **Docs** — prompt-preset `AGENTS.md` + `changes.md`, `docs/settings.md` enum, coding-agent `CHANGELOG.md`.

## QA / Evidence

Artifacts in `local-ignore/qa-evidence/20260710-gpt56-preset/` (gitignored; sanitized, no credentials).

| Check | Result | Artifact |
|---|---|---|
| TDD: RED before impl (10 new cases fail: preset undefined; 45 existing pass) → GREEN after (55/55) | PASS | vitest runs, summarized in `summary.json` |
| Related suites: all 7 `prompt-*`/`agent-session-prompt` test files | 97/97 PASS | vitest run |
| `npm run check` (biome, tsgo, shrinkwrap, browser smoke, web-ui, neo) | PASS | pre-commit output on the commit |
| Wire proof (senpi-qa Channel-3 pattern): real CLI turn from source, isolated sandbox, fake model server registered as `gpt-5.6-sol` — recorded request's system prompt contains the 5.6 core markers (`fewest useful tool loops`, `What each request authorizes`, `Lead with the conclusion`, `### Test Discipline`, `apply_patch`) and none of the shared-core scaffolding (`## Policies`) | 15/15 PASS | `qa-run-output.txt`, `gpt56-system-prompt.txt`, `gpt56-request.json`, `qa-driver-script.mjs` |
| Control: `mock-model` id does NOT get the 5.6 preset | PASS | `control-system-prompt.txt` |
| Channel-3 regression: `mock-loop.mjs --self-test` (all 3 wire formats) | 5/5 PASS | `mock-loop-self-test.txt` |
| Isolation: sandboxed `SENPI_CODING_AGENT_DIR`, `PI_OFFLINE=1`, provider keys stripped; real `~/.senpi/agent/auth.json` sha256 asserted unchanged | PASS | `qa-run-output.txt` |

This is sufficient because it proves the change end to end on the real surface: preset resolution (unit), the exact system prompt bytes reaching the provider wire on a real CLI turn (integration), and a negative control showing no regression for non-5.6 models.

## Risks

- Matcher is substring-based (`includes("gpt-5.6")`): a hypothetical future id containing `gpt-5.6` that wants different treatment would need a new branch — same accepted tradeoff as every existing GPT version matcher; ordering (5.6 before 5.5) is pinned by the distinctness test.
- Prompt-content drift vs future guide revisions: content is documented in `changes.md` with the guide rationale, and family-signal phrases are pinned by tests.

## Secret safety

No secret-bearing logs. QA request artifacts redact auth headers (`<mock-redacted>`); only a local fake server was ever contacted; the real auth store was hash-verified unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GPT-5.6 series system prompt preset for the coding agent. All `gpt-5.6*` models now resolve to a tuned full-core prompt instead of the generic fallback.

- **New Features**
  - Added `gpt-5.6.ts`: full-core via `corePrompt`; prioritization/preserve-first style, compact 3-level authorization policy, tool-loop stopping rules; keeps routing line, `todowrite`, verification, hard limits, and file-ops tuning.
  - Updated `presets.ts`: `gpt-5.6` matcher evaluated before `gpt-5.5`; covers `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` across `openai`, `openai-codex`, and `openrouter`.
  - Updated `settings.ts` and `docs/settings.md`: allow forcing `"gpt-5.6"`.
  - Tests in `prompt-presets-extension.test.ts`: resolution for all catalog `gpt-5.6*`, 5.5/5.6 distinctness guard, and File-operations guard entry. Docs updated (`AGENTS.md`, `changes.md`, `CHANGELOG.md`).

<sup>Written for commit da8866e8972521db4c810a6f8b23203df7eec0c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

