### PR TITLE
fix(coding-agent): make bash_output waits interruptible

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed `bash_output` waits ignoring turn cancellation and accepting unbounded model-supplied timeouts; waits now release without killing the background terminal and individual polls are capped at five minutes.
+
 ### Removed
 
 ## [2026.7.10-2] - 2026-07-10

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
@@ -17,10 +17,15 @@ export interface DeltaRead {
 	readonly droppedChars: number;
 }
 
+type OutputWaitOutcome = "matched" | "exited" | "timeout" | "aborted" | "invalid_pattern";
+
 interface OutputWaiter {
 	readonly regex: RegExp;
 	buffer: string;
-	resolve: (matched: boolean) => void;
+	timer: ReturnType<typeof setTimeout> | null;
+	readonly signal: AbortSignal | undefined;
+	readonly onAbort: () => void;
+	readonly resolve: (outcome: OutputWaitOutcome) => void;
 }
 
 /**
@@ -47,7 +52,7 @@ export class TerminalRuntimeSession {
 		});
 		this.session = createTerminalSession(options);
 		this.unsubscribeData = this.session.onData((chunk) => this.ingest(chunk));
-		this.session.onExit(() => this.settleWaiters());
+		this.session.onExit(() => this.settleWaiters("exited"));
 	}
 
 	get backend(): string | null {
@@ -79,7 +84,7 @@ export class TerminalRuntimeSession {
 		}
 		for (const waiter of this.waiters) {
 			waiter.buffer += text;
-			if (waiter.regex.test(waiter.buffer)) this.resolveWaiter(waiter, true);
+			if (waiter.regex.test(waiter.buffer)) this.resolveWaiter(waiter, "matched");
 		}
 	}
 
@@ -106,40 +111,50 @@ export class TerminalRuntimeSession {
 	}
 
 	/**
-	 * Wait until `pattern` matches newly produced output, the session exits, or the
-	 * timeout elapses. Returns `"matched" | "exited" | "timeout" | "invalid_pattern"`.
+	 * Wait until `pattern` matches newly produced output, the session exits, the
+	 * timeout elapses, or the wait is aborted.
 	 */
-	waitFor(pattern: string, timeoutMs: number): Promise<"matched" | "exited" | "timeout" | "invalid_pattern"> {
+	waitFor(pattern: string, timeoutMs: number, signal?: AbortSignal): Promise<OutputWaitOutcome> {
 		const regex = safeRegExp(pattern);
 		if (regex === null) return Promise.resolve("invalid_pattern");
 		if (this.exited) return Promise.resolve("exited");
+		if (signal?.aborted) return Promise.resolve("aborted");
 		return new Promise((resolve) => {
 			const waiter: OutputWaiter = {
 				regex,
 				buffer: "",
-				resolve: (matched) => {
-					clearTimeout(timer);
-					resolve(matched ? "matched" : this.exited ? "exited" : "timeout");
-				},
+				timer: null,
+				signal,
+				onAbort: () => this.resolveWaiter(waiter, "aborted"),
+				resolve,
 			};
-			const timer = setTimeout(() => this.resolveWaiter(waiter, false), timeoutMs);
 			this.waiters.add(waiter);
+			waiter.timer = setTimeout(() => this.resolveWaiter(waiter, "timeout"), timeoutMs);
+			if (signal) {
+				signal.addEventListener("abort", waiter.onAbort, { once: true });
+				if (signal.aborted) this.resolveWaiter(waiter, "aborted");
+			}
 		});
 	}
 
 	dispose(): void {
 		this.unsubscribeData?.();
 		this.unsubscribeData = null;
-		this.settleWaiters();
+		this.settleWaiters(this.exited ? "exited" : "timeout");
 		this.screen.dispose();
 	}
 
-	private settleWaiters(): void {
-		for (const waiter of [...this.waiters]) this.resolveWaiter(waiter, false);
+	private settleWaiters(outcome: "exited" | "timeout"): void {
+		for (const waiter of [...this.waiters]) this.resolveWaiter(waiter, outcome);
 	}
 
-	private resolveWaiter(waiter: OutputWaiter, matched: boolean): void {
+	private resolveWaiter(waiter: OutputWaiter, outcome: Exclude<OutputWaitOutcome, "invalid_pattern">): void {
 		if (!this.waiters.delete(waiter)) return;
-		waiter.resolve(matched);
+		if (waiter.timer !== null) {
+			clearTimeout(waiter.timer);
+			waiter.timer = null;
+		}
+		waiter.signal?.removeEventListener("abort", waiter.onAbort);
+		waiter.resolve(outcome);
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
@@ -4,6 +4,8 @@ import { DEFAULT_OUTPUT_WAIT_TIMEOUT_SECONDS, safeRegExp, TERMINAL_OUTPUT_TOOL }
 import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
 import { describeExit } from "./spawn.ts";
 
+const MAX_OUTPUT_WAIT_TIMEOUT_SECONDS = 300;
+
 export const bashOutputSchema = Type.Object({
 	bash_id: Type.String({ description: "Session id returned by a run_in_background bash call." }),
 	filter: Type.Optional(Type.String({ description: "Only return output lines matching this regex." })),
@@ -11,7 +13,13 @@ export const bashOutputSchema = Type.Object({
 		Type.String({ description: "Block until output matches this regex, the session exits, or timeout." }),
 	),
 	block: Type.Optional(Type.Boolean({ description: "When wait_for is set, block (default true)." })),
-	timeout: Type.Optional(Type.Number({ description: "wait_for timeout in seconds (default 30)." })),
+	timeout: Type.Optional(
+		Type.Number({
+			minimum: 0,
+			maximum: MAX_OUTPUT_WAIT_TIMEOUT_SECONDS,
+			description: "wait_for timeout in seconds (default 30, maximum 300).",
+		}),
+	),
 	view: Type.Optional(
 		Type.Union([Type.Literal("log"), Type.Literal("screen")], {
 			description: "'log' returns new raw output (default); 'screen' returns the rendered xterm grid.",
@@ -51,13 +59,17 @@ export function createBashOutputTool(ctx: TerminalToolContext) {
 			"Read new output from a background bash session, or block until wait_for matches / the session exits / timeout. Use view:'screen' for a rendered full-screen snapshot.",
 		promptSnippet: "Read/subscribe to background bash session output (wait_for, filter, screen view)",
 		parameters: bashOutputSchema,
-		async execute(_toolCallId: string, input: BashOutputInput, _signal?: AbortSignal): Promise<TerminalToolResult> {
+		async execute(_toolCallId: string, input: BashOutputInput, signal?: AbortSignal): Promise<TerminalToolResult> {
 			const runtime = ctx.manager.get(input.bash_id);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 
 			if (input.wait_for && input.block !== false) {
-				const timeoutMs = Math.trunc((input.timeout ?? DEFAULT_OUTPUT_WAIT_TIMEOUT_SECONDS) * 1000);
-				const outcome = await runtime.waitFor(input.wait_for, timeoutMs);
+				const timeoutSeconds = Math.min(
+					Math.max(input.timeout ?? DEFAULT_OUTPUT_WAIT_TIMEOUT_SECONDS, 0),
+					MAX_OUTPUT_WAIT_TIMEOUT_SECONDS,
+				);
+				const timeoutMs = Math.trunc(timeoutSeconds * 1000);
+				const outcome = await runtime.waitFor(input.wait_for, timeoutMs, signal);
 				if (outcome === "invalid_pattern") return errorResult(`Invalid wait_for regex: ${input.wait_for}`);
 			}
 

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -4,7 +4,10 @@ import registerTerminalExtension from "../../src/core/extensions/builtin/termina
 import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
 import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/tools/bash.ts";
 import { createBashInputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-input.ts";
-import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
+import {
+	bashOutputSchema,
+	createBashOutputTool,
+} from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
 import { createBashResizeTool } from "../../src/core/extensions/builtin/terminal/tools/bash-resize.ts";
 import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
@@ -219,7 +222,10 @@ describe("terminal builtin extension — bash_output robustness", () => {
 		await manager.stop(bashId);
 	});
 
-	it("an oversized timeout (1800 seconds) is clamped to a 300-second single-poll ceiling", async () => {
+	it("bounds an oversized timeout at the 300-second schema and runtime ceiling", async () => {
+		const timeoutSchema = bashOutputSchema.properties.timeout;
+		expect("maximum" in timeoutSchema ? timeoutSchema.maximum : undefined).toBe(300);
+
 		const bash = createPtyBashTool(ctx);
 		const output = createBashOutputTool(ctx);
 		const started = await bash.execute(

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBuiltinParserRegistry } from "../../src/core/extensions/builtin/permission-system/parsers.ts";
 import registerTerminalExtension from "../../src/core/extensions/builtin/terminal/index.ts";
 import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
@@ -153,5 +153,88 @@ describe("terminal permission gating", () => {
 		const requests = registry.parse("bash_input", { input: "rm -rf /tmp/thing" }, "/tmp");
 		expect(requests[0]?.permission).toBe("bash");
 		expect(requests[0]?.patterns).toContain("rm");
+	});
+});
+
+describe("terminal builtin extension — bash_output robustness", () => {
+	let manager: TerminalManager;
+	let ctx: TerminalToolContext;
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		manager = new TerminalManager({});
+		ctx = {
+			manager,
+			cwd: process.cwd(),
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => process.env,
+		};
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await manager.teardown();
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	it("bash_output wait_for is released by an AbortSignal without killing the live background PTY", async () => {
+		const bash = createPtyBashTool(ctx);
+		const output = createBashOutputTool(ctx);
+		const started = await bash.execute("call-bg-abort", { command: "sleep 30", run_in_background: true }, undefined);
+		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
+		if (!bashId) throw new Error("Background bash did not return an id");
+
+		const controller = new AbortController();
+		const waitPromise = output.execute(
+			"call-wait-abort",
+			{ bash_id: bashId, wait_for: "NEVER_MATCHES_THIS_PATTERN_XYZ", timeout: 10 },
+			controller.signal,
+		);
+		const waitCompleted = new Promise<Awaited<typeof waitPromise>>((resolve, reject) => {
+			const timeout = setTimeout(
+				() => reject(new Error("AbortSignal did not release wait_for within 1 second")),
+				1000,
+			);
+			waitPromise.then(
+				(value) => {
+					clearTimeout(timeout);
+					resolve(value);
+				},
+				(error: unknown) => {
+					clearTimeout(timeout);
+					reject(error);
+				},
+			);
+		});
+
+		controller.abort();
+		const result = await waitCompleted;
+		expect(firstText(result)).toContain("status: running");
+
+		const statusCheck = await output.execute("call-status-check", { bash_id: bashId });
+		expect(firstText(statusCheck)).toContain("status: running");
+		await manager.stop(bashId);
+	});
+
+	it("an oversized timeout (1800 seconds) is clamped to a 300-second single-poll ceiling", async () => {
+		const bash = createPtyBashTool(ctx);
+		const output = createBashOutputTool(ctx);
+		const started = await bash.execute(
+			"call-bg-clamp",
+			{ command: "echo READY", run_in_background: true },
+			undefined,
+		);
+		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
+		if (!bashId) throw new Error("Background bash did not return an id");
+		const runtime = ctx.manager.get(bashId);
+		if (!runtime) throw new Error(`No terminal session found with id: ${bashId}`);
+
+		const waitForSpy = vi.spyOn(runtime, "waitFor").mockResolvedValueOnce("timeout");
+		await output.execute("call-wait-oversized", { bash_id: bashId, wait_for: "READY", timeout: 1800 }, undefined);
+
+		expect(waitForSpy).toHaveBeenCalledWith("READY", 300000, undefined);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes an effectively uninterruptible `bash_output` wait observed in Senpi session `019f49b6-6351-75b8-92a2-595236f9b3d1`. That session issued waits of 600, 900, 1500, and 1800 seconds; the final call only returned when the underlying PTY was killed because `bash_output` discarded the agent loop's `AbortSignal`.

After this change, cancelling a turn releases only the output wait and leaves the persistent terminal alive for later reads or explicit cleanup. Individual `bash_output` waits are also bounded to five minutes.

## Changes

- Thread the tool-call `AbortSignal` into `TerminalRuntimeSession.waitFor`.
- Settle waiters explicitly on match, exit, timeout, abort, or disposal while clearing their timer and abort listener exactly once.
- Bound `bash_output.timeout` to 0-300 seconds in the tool schema and defensively clamp direct callers at runtime.
- Add deterministic regressions for aborting a wait without killing its PTY and for the schema/runtime timeout ceiling.
- Record the user-visible fix in the coding-agent changelog.

## Root cause and comparison

- Senpi accepted arbitrary model-supplied wait durations and ignored the cancellation signal already supplied by the agent loop.
- Codex bounds terminal polling windows and separates poll cancellation from process lifetime.
- oh-my-pi and free-code likewise use bounded, interruptible waits without cancelling the background job itself.

The implementation follows that same separation: abort the wait, not the terminal session.

## QA / Evidence

- **Focused terminal extension regression suite**
  - What was tested: matching output, abort release, PTY survival, and the 300-second schema/runtime ceiling.
  - Observed result: 1 file passed, 10 tests passed.
  - Artifact: `local-ignore/qa-evidence/20260710-bash-output-hang/targeted-test-review-fix.txt`
  - Why sufficient: directly locks both reported failure modes without timing sleeps.

- **Native terminal-tool abort scenario**
  - What was tested: a real native PTY running `sleep 30`, `bash_output(timeout:1800)`, immediate abort, subsequent status read, explicit kill, and teardown.
  - Observed result: 8/8 checks passed; wait returned in 1 ms; terminal remained `status: running`; tracked sessions ended at 0.
  - Artifact: `local-ignore/qa-evidence/20260710-bash-output-hang/abort-wait.txt`
  - Why sufficient: exercises the exact user-visible cancellation boundary on the real terminal backend.

- **Persistent terminal QA channel**
  - What was tested: background `wait_for`, stdin steering, screen snapshot/resize, and registry teardown.
  - Observed result: 7/7 checks passed on the native backend; no orphaned tracked sessions; real auth hash unchanged.
  - Artifact: `local-ignore/qa-evidence/20260710-bash-output-hang/pty-drive.txt`
  - Why sufficient: covers adjacent PTY behavior sharing the changed runtime.

- **Real CLI agent loop**
  - What was tested: source CLI registration and dispatch of `bash` -> `bash_output(wait_for)` -> final model turn through a local fake provider.
  - Observed result: 6/6 checks passed; marker flowed through the third request; auth hash unchanged.
  - Artifact: `local-ignore/qa-evidence/20260710-bash-output-hang/cli-terminal-loop.txt`
  - Why sufficient: proves the fix did not break the actual agent-loop tool surface.

- **Repository gates**
  - Commands: `npm run check`, `npm run build`, and mock-loop with a tool call.
  - Observed result: all passed; mock loop 4/4; no real provider calls.
  - Artifacts: `local-ignore/qa-evidence/20260710-bash-output-hang/npm-run-check-review-fix.txt`, `npm-run-build.txt`, `mock-loop.txt`
  - Why sufficient: covers type/lint/workspace gates, build output, and a deterministic end-to-end turn.

- **Independent review**
  - Observed result: five review lanes approved goal coverage, async correctness, QA evidence, API compatibility, and diff-scoped resource safety.

## Risks

- A cancelled wait returns the current terminal status/output rather than killing the terminal. This is intentional and verified by the native PTY scenario.
- Direct callers that bypass schema validation are still clamped defensively. Normal validated tool calls reject values above 300 seconds.
- Pre-existing JavaScript regex backtracking and waiter-buffer hardening opportunities are unchanged by this focused fix; this branch reduces exposure by bounding and making waits cancellable.

## Secret safety

QA used isolated fake-provider sandboxes where applicable, captured no tokens or auth headers, and verified the real `~/.senpi/agent/auth.json` hash remained unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uninterruptible waits in `bash_output`. Cancelling a turn now stops the wait immediately and keeps the terminal alive; individual waits are capped at 5 minutes.

- **Bug Fixes**
  - Threaded the tool-call `AbortSignal` into `TerminalRuntimeSession.waitFor` and added an "aborted" outcome.
  - Resolved waiters exactly once on match, exit, timeout, abort, or disposal; timers and abort listeners are cleared.
  - Clamped `bash_output.timeout` to 0–300 seconds in the schema and defensively at runtime.
  - Added deterministic tests covering aborting a wait without killing the PTY and enforcing the 300s ceiling.

<sup>Written for commit 3b2d4ca5b34cc0ae6fdaeeccdb8a3fe955797958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

