### PR TITLE
fix: bound model context budgets for new metadata

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Prevented invalid model or request `maxTokens` metadata from reaching provider payloads by falling back to the available context budget.
+
 ### Removed
 
 ## [2026.7.10-2] - 2026-07-10

--- a/packages/ai/src/api/simple-options.ts
+++ b/packages/ai/src/api/simple-options.ts
@@ -124,9 +124,15 @@ const CONTEXT_SAFETY_TOKENS = 4096;
 const MIN_MAX_TOKENS = 1;
 
 export function clampMaxTokensToContext(model: Model<Api>, context: Context, maxTokens: number): number {
-	if (model.contextWindow <= 0) return Math.max(MIN_MAX_TOKENS, maxTokens);
+	if (model.contextWindow <= 0) {
+		return Number.isFinite(maxTokens) && maxTokens > 0
+			? Math.max(MIN_MAX_TOKENS, Math.floor(maxTokens))
+			: MIN_MAX_TOKENS;
+	}
 	const available = model.contextWindow - estimateContextTokens(context).tokens - CONTEXT_SAFETY_TOKENS;
-	return Math.min(maxTokens, Math.max(MIN_MAX_TOKENS, available));
+	const safeAvailable = Math.max(MIN_MAX_TOKENS, available);
+	const requested = Number.isFinite(maxTokens) && maxTokens > 0 ? Math.floor(maxTokens) : safeAvailable;
+	return Math.min(requested, safeAvailable);
 }
 
 export function buildBaseOptions(

--- a/packages/ai/test/context-estimate.test.ts
+++ b/packages/ai/test/context-estimate.test.ts
@@ -78,4 +78,28 @@ describe("context token estimation", () => {
 			lastUsageIndex: 3,
 		});
 	});
+
+	it.each([
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		Number.NEGATIVE_INFINITY,
+		0,
+		-1,
+	])("replaces invalid model maxTokens %s with the safe available context", (maxTokens) => {
+		const context: Context = { messages: [] };
+
+		expect(buildBaseOptions({ ...model, maxTokens }, context).maxTokens).toBe(5_904);
+	});
+
+	it.each([
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		Number.NEGATIVE_INFINITY,
+		0,
+		-1,
+	])("replaces invalid requested maxTokens %s with the safe available context", (maxTokens) => {
+		const context: Context = { messages: [] };
+
+		expect(buildBaseOptions(model, context, { maxTokens }).maxTokens).toBe(5_904);
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed `bash_output` waits ignoring turn cancellation and accepting unbounded model-supplied timeouts; waits now release without killing the background terminal and individual polls are capped at five minutes.
 
-- Fixed emergency context pruning to reserve each model's valid separate output-token allowance, preventing oversized tool results from exceeding new-model input budgets.
+- Fixed emergency context pruning to reserve a model-aware output allowance without collapsing the usable prompt budget, preventing oversized tool results from exceeding new-model input limits.
 
 ### Removed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Fixed `bash_output` waits ignoring turn cancellation and accepting unbounded model-supplied timeouts; waits now release without killing the background terminal and individual polls are capped at five minutes.
 
+- Fixed emergency context pruning to reserve each model's valid separate output-token allowance, preventing oversized tool results from exceeding new-model input budgets.
+
 ### Removed
 
 ## [2026.7.10-2] - 2026-07-10

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -45,6 +45,7 @@ const EMERGENCY_COMPACTION_INSTRUCTIONS =
 const PROACTIVE_COMPACTION_INSTRUCTIONS = "Proactively compact before the next agent turn.";
 const MAX_PENDING_METADATA = 8;
 const IMAGE_PROMPT_TOKEN_ESTIMATE = 1_200;
+const MAX_OUTPUT_RESERVE_RATIO = 0.5;
 
 interface PendingCompactionMetadata {
 	checkpoint: checkpointState.AgentCheckpoint;
@@ -61,6 +62,14 @@ function isOpenAiResponsesModel(model: ExtensionContext["model"]): boolean {
 
 function estimatePendingPromptTokens(event: { prompt?: string; images?: readonly unknown[] }): number {
 	return approxTokens(event.prompt ?? "") + (event.images?.length ?? 0) * IMAGE_PROMPT_TOKEN_ESTIMATE;
+}
+
+function getPromptContextWindow(contextWindow: number, maxTokens: number | undefined): number {
+	if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens) || maxTokens <= 0 || contextWindow <= 0) {
+		return contextWindow;
+	}
+	const outputReserve = Math.min(maxTokens, Math.floor(contextWindow * MAX_OUTPUT_RESERVE_RATIO));
+	return contextWindow - outputReserve;
 }
 
 function withAdditionalTokens(usage: ContextUsage, additionalTokens: number): ContextUsage {
@@ -395,11 +404,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	pi.on("context", (event, ctx) => {
 		const usage = ctx.getContextUsage();
 		const contextWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
-		const maxTokens = ctx.model?.maxTokens;
-		const promptContextWindow =
-			typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 && maxTokens < contextWindow
-				? contextWindow - maxTokens
-				: contextWindow;
+		const promptContextWindow = getPromptContextWindow(contextWindow, ctx.model?.maxTokens);
 		const sourceMessages = shouldApplyContextReduction({
 			usageTokens: usage?.tokens ?? null,
 			contextWindow,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -395,6 +395,11 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	pi.on("context", (event, ctx) => {
 		const usage = ctx.getContextUsage();
 		const contextWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+		const maxTokens = ctx.model?.maxTokens;
+		const promptContextWindow =
+			typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0 && maxTokens < contextWindow
+				? contextWindow - maxTokens
+				: contextWindow;
 		const sourceMessages = shouldApplyContextReduction({
 			usageTokens: usage?.tokens ?? null,
 			contextWindow,
@@ -402,7 +407,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 		})
 			? reduceContextMessages(event.messages, BUILTIN_CONTEXT_REDUCTION_OPTIONS).messages
 			: event.messages;
-		const emergency = hardLimitEmergencyPrune(sourceMessages, contextWindow);
+		const emergency = hardLimitEmergencyPrune(sourceMessages, promptContextWindow);
 		return { messages: repairOrphanedToolResults(convertToLlm(emergency.messages)) };
 	});
 

--- a/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
+++ b/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
@@ -288,6 +288,29 @@ describe("compaction hard-limit emergency behavior", () => {
 		});
 	});
 
+	describe("Given model output tokens nearly equal the context window", () => {
+		describe("When context hook runs with a moderate paired tool result", () => {
+			it("Then it keeps a usable prompt budget instead of pruning to the output-cap remainder", async () => {
+				// Given
+				const handler = createContextHandler();
+				const messages: AgentMessage[] = [
+					userMessage("Run a moderate command", 1),
+					assistantWithToolCall("call-moderate", "produce moderate output", 2),
+					toolResult("call-moderate", "A".repeat(20_000), 3),
+					userMessage("Use the moderate result", 4),
+				];
+				const originalBytes = JSON.stringify(messages);
+
+				// When
+				const result = await handler({ type: "context", messages }, createContext(131_072, 129_024));
+				const pruned = result?.messages ?? messages;
+
+				// Then
+				expect(JSON.stringify(pruned)).toBe(originalBytes);
+			});
+		});
+	});
+
 	describe("Given usage is at the hard limit before the next agent turn", () => {
 		describe("When before_agent_start runs", () => {
 			it("Then aggressive extension compaction is applied once before normal threshold compaction", async () => {

--- a/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
+++ b/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
@@ -87,7 +87,7 @@ function createBeforeAgentStartHandler(): ExtensionHandler<BeforeAgentStartEvent
 	return beforeAgentStartHandler as ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>;
 }
 
-function createContext(contextWindow: number, compact = vi.fn()): ExtensionContext {
+function createContext(contextWindow: number, maxTokens = contextWindow, compact = vi.fn()): ExtensionContext {
 	const sessionManager = Object.create(null) as ExtensionContext["sessionManager"];
 	sessionManager.getBranch = vi.fn(() => []);
 	return {
@@ -98,7 +98,7 @@ function createContext(contextWindow: number, compact = vi.fn()): ExtensionConte
 		isProjectTrusted: () => true,
 		sessionManager,
 		modelRegistry: {} as ExtensionContext["modelRegistry"],
-		model: { contextWindow } as ExtensionContext["model"],
+		model: { contextWindow, maxTokens } as ExtensionContext["model"],
 		serviceTier: undefined,
 		isIdle: () => true,
 		signal: undefined,
@@ -192,7 +192,7 @@ describe("compaction hard-limit emergency behavior", () => {
 				];
 
 				// When
-				const result = await handler({ type: "context", messages }, createContext(2_000, compact));
+				const result = await handler({ type: "context", messages }, createContext(2_000, 2_000, compact));
 				const pruned = result?.messages ?? messages;
 
 				// Then
@@ -221,7 +221,7 @@ describe("compaction hard-limit emergency behavior", () => {
 					lastUser,
 				];
 
-				const context = createContext(20, compact);
+				const context = createContext(20, 20, compact);
 
 				// When
 				const result = await handler({ type: "context", messages }, context);
@@ -234,6 +234,56 @@ describe("compaction hard-limit emergency behavior", () => {
 				expect(pruned).not.toContainEqual(messages[2]);
 				const { toolCallIds, toolResultIds } = collectToolPairIds(pruned);
 				expect(toolCallIds).toEqual(toolResultIds);
+			});
+		});
+	});
+
+	describe("Given model output tokens consume part of the context window", () => {
+		describe("When context hook runs with an oversized paired tool result", () => {
+			it("Then it reserves valid model output budget and preserves the latest user and tool pair", async () => {
+				// Given
+				const handler = createContextHandler();
+				const lastUser = userMessage("Keep this latest request", 4);
+				const messages: AgentMessage[] = [
+					userMessage("Run a command", 1),
+					assistantWithToolCall("call-large", "produce large output", 2),
+					toolResult("call-large", "A".repeat(1_000_000), 3),
+					lastUser,
+				];
+				const maximumInputTokens = Math.floor((372_000 - 128_000) * 0.95);
+
+				// When
+				const result = await handler({ type: "context", messages }, createContext(372_000, 128_000));
+				const pruned = result?.messages ?? messages;
+
+				// Then
+				expect(estimateContextTokens(pruned).tokens).toBeLessThanOrEqual(maximumInputTokens);
+				expect(pruned).toContainEqual(lastUser);
+				const { toolCallIds, toolResultIds } = collectToolPairIds(pruned);
+				expect(toolCallIds).toEqual(toolResultIds);
+			});
+		});
+	});
+
+	describe("Given model output tokens equal the context window", () => {
+		describe("When context hook runs with a small paired tool result", () => {
+			it("Then it leaves the paired result byte-for-byte unchanged", async () => {
+				// Given
+				const handler = createContextHandler();
+				const messages: AgentMessage[] = [
+					userMessage("Run a small command", 1),
+					assistantWithToolCall("call-small", "printf small", 2),
+					toolResult("call-small", "small result\n", 3),
+					userMessage("Use the small result", 4),
+				];
+				const originalBytes = JSON.stringify(messages);
+
+				// When
+				const result = await handler({ type: "context", messages }, createContext(372_000, 372_000));
+				const pruned = result?.messages ?? messages;
+
+				// Then
+				expect(JSON.stringify(pruned)).toBe(originalBytes);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Senpi sessions could retain near-megabyte tool results until the next provider request exceeded a newly added model's usable input budget. Session `019f49d2-dc1c-780f-a06b-01331af33419` recorded four tool results around one million characters and two `context_too_large` failures after requests reached roughly 299K-318K input tokens.

This change makes emergency pruning reserve a model-aware output allowance without allowing near-equal model metadata to collapse the prompt budget. It also sanitizes invalid `maxTokens` values at the shared provider-options boundary so future model catalog entries cannot emit NaN, infinite, zero, or negative output limits.

## Changes

- Reserve finite positive model output capacity when deriving the emergency prompt budget.
- Cap that reservation at half the context window so near-equal output caps retain a usable prompt budget.
- Preserve the latest user message and tool call/result pairing during emergency pruning.
- Normalize invalid model and per-request `maxTokens` values to the finite available context budget before provider payload construction.
- Add regressions for the original 372K/128K overflow, equal and near-equal limits, and invalid numeric metadata.

## QA / Evidence

- RED original overflow reproducer: 250,008 estimated prompt tokens exceeded the 231,800-token safe target. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/red.txt`.
- RED near-equal metadata reproducer: a 131,072/129,024 model incorrectly truncated a moderate paired result. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/review-fix/near-equal-red.txt`.
- RED invalid metadata reproducer: NaN, infinities, zero, and negative limits reached base provider options. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/review-fix/invalid-max-tokens-red.txt`.
- Focused coding-agent regression: 6/6 passed. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/final/focused-coding-agent.txt`.
- AI context/options regression: 12/12 passed. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/final/context-estimate.txt`.
- Repository validation: `npm run check` passed, including TypeScript checks and Neo build/vet/tests. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/final/npm-check.txt`.
- Real source CLI mock loop: 5/5 passed across OpenAI completions, Anthropic messages, and OpenAI responses; only localhost was contacted and real auth remained unchanged. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/final/mock-loop.txt`.
- RPC smoke: 4/4 passed with no provider call and real auth unchanged. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/final/rpc.txt`.
- CLI smoke: 7/7 passed for help, version, model listing, feature-gated flags, and invalid option handling; real auth remained unchanged. Artifact: `local-ignore/qa-evidence/20260710-model-overflow/final/cli-smoke.txt`.
- Five review lanes passed: goal/constraint verification, code quality, QA execution, security, and history/context mining.

## Risks

- The 50% reservation ceiling is conservative for models advertising output limits close to their total context. The near-equal regression proves it avoids destructive tiny prompt budgets, while provider request clamping still keeps the combined request within the available context.
- Emergency pruning remains approximate because token estimation is approximate. The original overflow boundary and real provider-format mock loops cover the affected request path.
- Invalid `maxTokens` now falls back to available context rather than failing locally. This favors a finite usable provider request and is covered for both model metadata and explicit request options.

## Secret Safety

- QA used isolated sandboxes and localhost fake providers.
- The real `~/.senpi/agent/auth.json` checksum was verified unchanged by every Senpi QA channel.
- No tokens, auth headers, cookies, environment dumps, or secret-bearing logs are included in this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents context overflows by reserving model-aware output tokens during emergency pruning and sanitizing invalid `maxTokens`, so large tool results no longer push requests past model limits and the latest user + tool pair is preserved.

- **Bug Fixes**
  - Reserve output tokens when pruning; cap reservation at 50% of the context window to keep prompt space usable.
  - Preserve the latest user message and its tool call/result during emergency pruning.
  - Clamp invalid model/request `maxTokens` (NaN, Infinity, zero, negative) to the safe available context before provider payloads.
  - Add tests for the 372K/128K overflow, equal/near-equal caps, and invalid numeric metadata.

<sup>Written for commit dcc09a1997885dcded9a1a5b7457c5066ee062bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

