### PR TITLE
fix(coding-agent): contain invalid renderers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Fixed emergency context pruning to reserve a model-aware output allowance without collapsing the usable prompt budget, preventing oversized tool results from exceeding new-model input limits.
 
+- Fixed invalid extension tool renderers displaying `[render error: Box]` instead of fallback rendering.
+
 ### Removed
 
 ## [2026.7.10-2] - 2026-07-10

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -7,6 +7,7 @@ import { stripAnsi } from "../../../utils/ansi.ts";
 import { convertToPng } from "../../../utils/image-convert.ts";
 import { theme } from "../theme/theme.ts";
 import { createBoundedRenderSignature } from "./render-signature.ts";
+import { isComponent, ToolRendererBoundary } from "./tool-renderer-boundary.ts";
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
@@ -332,9 +333,21 @@ export class ToolExecutionComponent extends Container {
 			} else {
 				try {
 					const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
-					this.callRendererComponent = component;
-					renderContainer.addChild(component);
-					hasContent = true;
+					if (isComponent(component)) {
+						this.callRendererComponent = component;
+						renderContainer.addChild(
+							new ToolRendererBoundary(component, this.createCallFallback(), () => {
+								if (this.callRendererComponent === component) {
+									this.callRendererComponent = undefined;
+								}
+							}),
+						);
+						hasContent = true;
+					} else {
+						this.callRendererComponent = undefined;
+						renderContainer.addChild(this.createCallFallback());
+						hasContent = true;
+					}
 				} catch {
 					this.callRendererComponent = undefined;
 					renderContainer.addChild(this.createCallFallback());
@@ -362,9 +375,24 @@ export class ToolExecutionComponent extends Container {
 							theme,
 							this.getRenderContext(this.resultRendererComponent),
 						);
-						this.resultRendererComponent = component;
-						renderContainer.addChild(component);
-						hasContent = true;
+						if (isComponent(component)) {
+							this.resultRendererComponent = component;
+							renderContainer.addChild(
+								new ToolRendererBoundary(component, this.createResultFallback(), () => {
+									if (this.resultRendererComponent === component) {
+										this.resultRendererComponent = undefined;
+									}
+								}),
+							);
+							hasContent = true;
+						} else {
+							this.resultRendererComponent = undefined;
+							const fallback = this.createResultFallback();
+							if (fallback) {
+								renderContainer.addChild(fallback);
+								hasContent = true;
+							}
+						}
 					} catch {
 						this.resultRendererComponent = undefined;
 						const component = this.createResultFallback();

--- a/packages/coding-agent/src/modes/interactive/components/tool-renderer-boundary.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-renderer-boundary.ts
@@ -1,0 +1,84 @@
+import type { Component } from "@earendil-works/pi-tui";
+
+export function isComponent(value: unknown): value is Component {
+	return (
+		(typeof value === "object" || typeof value === "function") &&
+		value !== null &&
+		typeof Reflect.get(value, "render") === "function" &&
+		typeof Reflect.get(value, "invalidate") === "function"
+	);
+}
+
+export class ToolRendererBoundary implements Component {
+	private component: Component;
+	private componentDisposed = false;
+	private fallback?: Component;
+	private failed = false;
+	private onFailure: () => void;
+
+	constructor(component: Component, fallback: Component | undefined, onFailure: () => void) {
+		this.component = component;
+		this.fallback = fallback;
+		this.onFailure = onFailure;
+	}
+
+	render(width: number): string[] {
+		if (!this.failed) {
+			try {
+				const lines = this.component.render(width);
+				if (Array.isArray(lines)) {
+					const safeLines: string[] = [];
+					for (const line of lines) {
+						if (typeof line !== "string") {
+							throw new TypeError("Tool renderer returned a non-string line");
+						}
+						safeLines.push(line);
+					}
+					return safeLines;
+				}
+			} catch {
+				this.fail();
+				return this.renderFallback(width);
+			}
+			this.fail();
+		}
+		return this.renderFallback(width);
+	}
+
+	invalidate(): void {
+		if (!this.failed) {
+			try {
+				this.component.invalidate();
+			} catch {
+				this.fail();
+			}
+		}
+		this.fallback?.invalidate();
+	}
+
+	dispose(): void {
+		this.disposeComponent();
+		this.fallback?.dispose?.();
+	}
+
+	private fail(): void {
+		if (this.failed) return;
+		this.failed = true;
+		this.onFailure();
+		this.disposeComponent();
+	}
+
+	private disposeComponent(): void {
+		if (this.componentDisposed) return;
+		this.componentDisposed = true;
+		try {
+			this.component.dispose?.();
+		} catch {
+			return;
+		}
+	}
+
+	private renderFallback(width: number): string[] {
+		return this.fallback?.render(width) ?? [];
+	}
+}

--- a/packages/coding-agent/test/tool-execution-invalid-renderer.test.ts
+++ b/packages/coding-agent/test/tool-execution-invalid-renderer.test.ts
@@ -1,0 +1,239 @@
+import { type Component, Text, type TUI } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import type { ToolDefinition } from "../src/core/extensions/types.ts";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { ToolRendererBoundary } from "../src/modes/interactive/components/tool-renderer-boundary.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function createToolDefinition(): ToolDefinition {
+	return {
+		name: "custom_tool",
+		label: "custom_tool",
+		description: "custom tool",
+		parameters: Type.Any(),
+		execute: async () => ({ content: [], details: {} }),
+	};
+}
+
+function createFakeTui(): TUI {
+	return { requestRender: () => {} } as TUI;
+}
+
+function render(component: ToolExecutionComponent): string {
+	return stripAnsi(component.render(120).join("\n"));
+}
+
+describe("ToolExecutionComponent invalid renderers", () => {
+	beforeAll(() => initTheme("dark"));
+
+	test("falls back when a call renderer returns a non-component", () => {
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => ({ toString: () => "invalid component" }));
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-invalid-call-renderer",
+			{ value: "safe" },
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(render(component)).toContain("custom_tool");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("falls back when a call renderer returns a primitive", () => {
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => "invalid component");
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-primitive-call-renderer",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(render(component)).toContain("custom_tool");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("falls back when a result renderer returns a non-component", () => {
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => new Text("custom call", 0, 0));
+		Reflect.set(toolDefinition, "renderResult", () => ({ toString: () => "invalid component" }));
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-invalid-result-renderer",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: "safe result" }], details: {}, isError: false }, false);
+		expect(render(component)).toContain("safe result");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("falls back when a renderer throws before returning a component", () => {
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => {
+			throw new Error("invalid renderer");
+		});
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-throwing-call-renderer",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(render(component)).toContain("custom_tool");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("falls back when a call component throws while rendering", () => {
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => ({
+			render: () => {
+				throw new Error("invalid render");
+			},
+			invalidate: () => {},
+		}));
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-throwing-call-component",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(render(component)).toContain("custom_tool");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("falls back when a result component becomes invalid before rendering", () => {
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => new Text("custom call", 0, 0));
+		Reflect.set(toolDefinition, "renderResult", () => {
+			let renderReads = 0;
+			return {
+				get render() {
+					renderReads += 1;
+					if (renderReads === 1) return () => ["invalid result"];
+					throw new Error("invalid render getter");
+				},
+				invalidate: () => {},
+			};
+		});
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-invalidated-result-component",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: "safe result" }], details: {}, isError: false }, false);
+		expect(render(component)).toContain("safe result");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("accepts callable components", () => {
+		const callableComponent = Object.assign(() => undefined, {
+			render: () => ["callable component"],
+			invalidate: () => {},
+		});
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => callableComponent);
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-callable-component",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(render(component)).toContain("callable component");
+	});
+
+	test("copies renderer lines before adding them to the tool box", () => {
+		let lineReads = 0;
+		const rendererLines = new Proxy(["stable line"], {
+			get(target, property, receiver) {
+				if (property === "0") {
+					lineReads += 1;
+					if (lineReads > 1) throw new Error("line changed after validation");
+				}
+				return Reflect.get(target, property, receiver);
+			},
+		});
+		const toolDefinition = createToolDefinition();
+		Reflect.set(toolDefinition, "renderCall", () => ({ render: () => rendererLines, invalidate: () => {} }));
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-mutable-render-lines",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(render(component)).toContain("stable line");
+		expect(render(component)).not.toContain("[render error: Box]");
+	});
+
+	test("passes the previous component back to the renderer", () => {
+		const firstComponent = new Text("first", 0, 0);
+		const previousComponents: Array<Component | undefined> = [];
+		let renderCount = 0;
+		const toolDefinition = createToolDefinition();
+		Reflect.set(
+			toolDefinition,
+			"renderCall",
+			(_args: unknown, _theme: unknown, context: { lastComponent?: Component }) => {
+				previousComponents.push(context.lastComponent);
+				renderCount += 1;
+				return renderCount === 1 ? firstComponent : new Text("second", 0, 0);
+			},
+		);
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-previous-component",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateArgs({ value: "updated" });
+		expect(previousComponents).toEqual([undefined, firstComponent]);
+		expect(render(component)).toContain("second");
+	});
+
+	test("disposes a failed renderer component exactly once", () => {
+		const dispose = vi.fn();
+		const boundary = new ToolRendererBoundary(
+			{
+				render: () => {
+					throw new Error("invalid render");
+				},
+				invalidate: () => {},
+				dispose,
+			},
+			new Text("fallback", 0, 0),
+			() => {},
+		);
+
+		expect(boundary.render(120).join("\n").trimEnd()).toBe("fallback");
+		boundary.dispose();
+		expect(dispose).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes local interactive sessions that displayed `[render error: Box]` when an extension tool renderer returned a non-`Component` value or failed after returning a component.

Before: malformed extension renderer output was inserted into the tool `Box`, where a later child render failed and the outer TUI reported the Box error marker.

After: extension renderer output is validated and contained at render time. Invalid or failing renderers use the existing tool fallback without exposing the Box error.

## Changes

- Add a `ToolRendererBoundary` that contains renderer, invalidation, and disposal failures.
- Copy validated renderer lines before passing them to `Box` so extension-owned arrays cannot mutate after validation.
- Preserve callable structural components and `lastComponent` reuse behavior.
- Dispose failed extension components exactly once.
- Add focused regressions for invalid object/primitive returns, pre-return throws, render/getter failures, mutable line arrays, callable components, lifecycle reuse, and disposal.
- Add an Unreleased changelog entry.

## QA / Evidence

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/tool-execution-invalid-renderer.test.ts test/tool-execution-component.test.ts test/suite/regressions/tool-renderer-reuse-dispose.test.ts`
  - Surface: invalid renderer containment and renderer lifecycle.
  - Result: 3 files, 41 tests passed.
  - Artifact: `local-ignore/qa-evidence/20260710-box-render-fix-final4/focused-tests.txt`.
- `npm run check`
  - Surface: formatting, dependency gates, TypeScript, browser checks, Neo build/vet/tests.
  - Result: passed.
  - Artifact: `local-ignore/qa-evidence/20260710-box-render-fix-final4/npm-run-check.txt`.
- `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence box-render-fix-final4-tui`
  - Surface: real interactive TUI boot, render, input, teardown, auth isolation.
  - Result: 5/5 passed; no leaked tmux session; real auth unchanged.
  - Artifact: `local-ignore/qa-evidence/20260710-box-render-fix-final4/tui-smoke.txt`.
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence box-render-fix-final4-mock`
  - Surface: deterministic end-to-end loop across OpenAI completions, Anthropic messages, and OpenAI responses.
  - Result: 5/5 passed; localhost-only provider calls; real auth unchanged.
  - Artifact: `local-ignore/qa-evidence/20260710-box-render-fix-final4/mock-loop.txt`.
- Browser-rendered xterm visual QA at 120x34.
  - Result: typed marker present; `[render error: Box]` absent; no overflow, border drift, wide-character drift, or ANSI leakage.
  - Artifacts: `local-ignore/qa-evidence/20260710-box-render-fix/visual/terminal.png` and `tui-check.json`.
- Independent final reviews: goal/constraints PASS, hands-on QA PASS, code quality APPROVE, security PASS, repository context PASS, visual passes A/B PASS.

## Risks

- The boundary intentionally falls back only for extension renderer failures; trusted built-in fallback failures remain visible as normal TUI errors.
- Component reuse and disposal behavior is covered by focused lifecycle regressions, including exact-once disposal after failure.
- The change is limited to interactive tool rendering and does not alter extension APIs or persisted state.

## Secret safety

- QA used isolated sandboxes and localhost fake providers.
- The real `~/.senpi/agent/auth.json` hash remained unchanged.
- No tokens, auth headers, cookies, raw environment dumps, or credential-bearing logs are included in this PR.

## Rebase verification

- Rebased onto the current `origin/main` without force-pushing shared history.
- Resolved the Unreleased changelog overlap by preserving both upstream entries and this fix.
- Re-ran 41 focused tests, `npm run check`, TUI smoke 5/5, mock loop 5/5, and regenerated the xterm visual evidence on the rebased commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes interactive tool rendering to prevent `[render error: Box]` when an extension renderer returns invalid output or throws. Adds a boundary that validates renderer output and falls back cleanly to the existing tool renderer.

- **Bug Fixes**
  - Added `ToolRendererBoundary` to contain render/invalidate/dispose failures and use the fallback.
  - Validates renderer returns a component; supports callable components; preserves `lastComponent` reuse.
  - Copies validated line arrays before passing to `Box` to prevent post-validation mutation.
  - Disposes failed components exactly once.
  - Added focused tests and updated changelog.

<sup>Written for commit 6723feb62372218fe5434cb31f496a609f926fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

