### PR TITLE
fix(coding-agent): preserve queued prompt steer intent

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## preserve steer intent when draining queued input (2026-07-10)
+
+### What changed
+
+- `interactive-mode.ts`: the classic TUI main loop dispatches drained user input with explicit `steer` behavior so an
+  automatic continuation that starts between input capture and dispatch queues the message instead of rejecting it as
+  an unspecified concurrent prompt.
+
+### Why
+
+- Input can be accepted while the session is idle and remain pending until the main loop resumes. If processing becomes
+  active during that interval, dropping the interactive queue intent surfaces a false `Agent is already processing`
+  error even though the user submitted through the TUI's steer path.
+
+### Why extension system couldn't handle this
+
+- The race occurs in `InteractiveMode.run()` after the built-in editor/input queue hands control back to the main loop;
+  extensions cannot replace that host-owned dispatch boundary.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-mode.ts` around the main `getUserInput()` / `session.prompt()` loop.
+
 ## live hook identity in tool hook status rows (2026-07-04)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1025,7 +1025,7 @@ export class InteractiveMode {
 		while (true) {
 			const userInput = await this.getUserInput();
 			try {
-				await this.session.prompt(userInput);
+				await this.session.prompt(userInput, { streamingBehavior: "steer" });
 			} catch (error: unknown) {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 				this.showError(errorMessage);

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 
+vi.mock("../src/utils/version-check.ts", () => ({
+	checkForNewPiVersion: vi.fn(async () => undefined),
+	getReleaseChangelogUrl: vi.fn((version: string) => `https://example.invalid/releases/${version}`),
+}));
+
 type SubmitContext = {
-	defaultEditor: { onSubmit?: (text: string) => void };
+	defaultEditor: { onSubmit?: (text: string) => void | Promise<void> };
 	editor: {
 		addToHistory?: (text: string) => void;
 		setText: (text: string) => void;
@@ -24,9 +29,28 @@ type InputContext = {
 	pendingUserInputs: string[];
 };
 
+type RunContext = {
+	init: () => Promise<void>;
+	version: string;
+	options: Record<string, never>;
+	session: {
+		modelRegistry: { getError: () => string | undefined };
+		prompt: (text: string, options?: unknown) => Promise<void>;
+	};
+	checkForPackageUpdates: () => Promise<string[]>;
+	checkTmuxKeyboardSetup: () => Promise<string | undefined>;
+	maybeWarnAboutAnthropicSubscriptionAuth: () => Promise<void>;
+	getUserInput: () => Promise<string>;
+	showNewVersionNotification: (version: string) => void;
+	showPackageUpdateNotification: (packages: string[]) => void;
+	showWarning: (message: string) => void;
+	showError: (message: string) => void;
+};
+
 type InteractiveModePrivate = {
 	setupEditorSubmitHandler(this: SubmitContext): void;
 	getUserInput(this: InputContext): Promise<string>;
+	run(this: RunContext): Promise<void>;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
@@ -70,5 +94,39 @@ describe("InteractiveMode startup input", () => {
 		await expect(interactiveModePrototype.getUserInput.call(context)).resolves.toBe("queued prompt");
 		expect(context.onInputCallback).toBeUndefined();
 		expect(context.pendingUserInputs).toEqual([]);
+	});
+
+	it("preserves steer intent when the main loop drains queued input", async () => {
+		// Given a queued prompt followed by a sentinel that stops the infinite loop.
+		const stopMainLoop = new Error("stop interactive loop");
+		const prompt = vi.fn(async (_text: string, _options?: unknown) => {});
+		const getUserInput = vi
+			.fn<() => Promise<string>>()
+			.mockResolvedValueOnce("queued prompt")
+			.mockRejectedValueOnce(stopMainLoop);
+		const context: RunContext = {
+			init: vi.fn(async () => {}),
+			version: "test",
+			options: {},
+			session: {
+				modelRegistry: { getError: vi.fn(() => undefined) },
+				prompt,
+			},
+			checkForPackageUpdates: vi.fn(async (): Promise<string[]> => []),
+			checkTmuxKeyboardSetup: vi.fn(async () => undefined),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(async () => {}),
+			getUserInput,
+			showNewVersionNotification: vi.fn(),
+			showPackageUpdateNotification: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		// When the real run loop drains that prompt.
+		await expect(interactiveModePrototype.run.call(context)).rejects.toBe(stopMainLoop);
+
+		// Then dispatch retains steer intent in case a continuation became active.
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(prompt).toHaveBeenCalledWith("queued prompt", { streamingBehavior: "steer" });
 	});
 });


### PR DESCRIPTION
## Summary

Fix a classic-TUI lifecycle race where interactive input could be classified while idle, buffered, and then dispatched after an automatic continuation made the session active again. The main loop previously lost the user's queue intent and triggered the generic `Agent is already processing` guard; it now preserves `steer` intent at that dispatch boundary.

The generic `AgentSession.prompt()` concurrency guard remains unchanged. Unspecified concurrent prompts still reject, while explicit steer and follow-up delivery remain distinct and ordered.

## Changes

- Dispatch classic-TUI main-loop input with `streamingBehavior: "steer"`; the option is inert while idle and queues safely if processing resumed before dispatch.
- Add a deterministic `InteractiveMode.run()` regression that fails when queued input loses steer intent.
- Document the host-owned dispatch-boundary fix and expected conflict zone in the nearest `changes.md`.
- Keep direct active-turn submission, extension commands, notification delivery, generic app-server callers, and the AgentSession guard unchanged.

## QA / Evidence

- **Failing-first regression:** Before the production change, the new focused test failed because `prompt()` received no delivery option. Artifact: `local-ignore/qa-evidence/20260710-processing-queue-race/red-interactive-main-loop.txt`.
- **Current-head focused regression:** `interactive-mode-startup-input.test.ts` passes 3/3 at `51806ed61f2817ec7c84e94aceba24c859e73ca8`. Artifact: `local-ignore/qa-evidence/20260710-processing-queue-race-final-review/focused-regression-current-head.txt`.
- **Active-turn classic TUI:** A 5.75-second localhost stream accepted a second Enter while active, rendered the completion marker, recorded the second prompt exactly once in request 2, and contained zero false processing-error occurrences (`21/21`). Artifacts: `local-ignore/qa-evidence/20260710-processing-queue-race/tui-active-steer.txt`, `tui-active-steer-requests.sanitized.json`, and final structural validation under `...-final-review/validate-active-tui-artifacts.txt`.
- **RPC concurrency contract:** An unspecified concurrent prompt rejected with the exact documented error and never reached the model; explicit steer and follow-up were accepted and observed in `initial -> steer -> follow-up` order. Artifacts: `local-ignore/qa-evidence/20260710-processing-queue-race/rpc-queue-contract.txt`, `rpc-queue-contract.json`, and final structural validation under `...-final-review/validate-rpc-artifacts.txt`.
- **Idle and regression surfaces:** Current-head mock-loop passed 5/5, classic TUI smoke passed 5/5, and CLI smoke passed 7/7 using source CLI and localhost-only fake providers. Artifacts: `local-ignore/qa-evidence/20260710-processing-queue-race-final-review/mock-loop-current-head.txt`, `tui-smoke-current-head.txt`, and `cli-smoke-current-head.txt`.
- **Repository validation:** `npm run check` passed with no formatter changes or reported errors. Artifact: `local-ignore/qa-evidence/20260710-processing-queue-race-final-head/npm-check.txt`.
- **Cross-platform CI:** The successful rerun at the current head passed `Check and test`, GitGuardian, and terminal-tool jobs on Ubuntu, macOS, and Windows. Artifacts: `local-ignore/qa-evidence/20260710-processing-queue-race-final-review/ci-pr-checks-current.txt` and `ci-run-29072720199-jobs.json`.
- **Five-lane review-work:** Goal/constraint, hands-on QA, code quality, security/concurrency, and historical-context reviews all approved the current head with no blockers.
- **Isolation and cleanup:** Real auth remained unchanged. No task-owned process, TCP `18999` listener, tmux session, sandbox, or temporary driver remained. Artifact: `local-ignore/qa-evidence/20260710-processing-queue-race-final-review/final-cleanup-auth-receipt-postrun.txt`.

## Risks

- The main-loop path now defaults drained interactive input to steering if a continuation became active. Source review and focused tests confirm the option is ignored while idle and extension commands are handled before this path.
- The focused unit regression verifies the dispatch boundary directly; the real active-turn TUI and RPC scenarios provide the end-to-end exactly-once, no-error, and ordering proof.
- The first CI attempt at this head failed only in the unrelated Neo `TestIntegrationConcurrentSpawnRaceExactlyOneDaemon` temp-directory cleanup race. The same-head rerun passed the complete `Check and test` job and all platform jobs.
- Cubic review is skipped under the workflow's quota exception: its check reports the monthly 80,000-line limit exhausted at 83,762 reviewed lines, with reviews resuming August 1, 2026. It emitted no findings.

## Secret Safety

All model traffic used localhost fake providers. The real Senpi auth file remained unchanged. Evidence was sanitized; no tokens, auth headers, cookies, credentials, or raw secret-bearing logs are included in this PR.
