### PR TITLE
fix(coding-agent): steer terminal wake notices

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts
@@ -7,7 +7,7 @@ import { describeExit } from "./tools/spawn.ts";
 const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
 
 export interface TerminalNotifierDeps {
-	/** Deliver a user-visible follow-up message that wakes an idle agent. */
+	/** Deliver a user-visible completion message with the requested scheduling mode. */
 	readonly sendUserMessage: (content: string, options?: { deliverAs?: "steer" | "followUp" }) => void;
 	readonly getContext: () => ExtensionContext | undefined;
 	readonly getMode: () => NotifyMode;
@@ -21,11 +21,11 @@ function buildNotice(id: string, runtime: TerminalRuntimeSession): string {
 }
 
 /**
- * Wakes an idle interactive agent once when a background session completes.
+ * Notifies an interactive agent once when a background session completes.
  *
  * Guards (todo 23): never wakes in one-shot `-p`/`--print`/`--mode json` runs; never wakes
  * without an active model (would spin an auth-less turn); `notify:"off"` suppresses entirely;
- * each session id fires at most once. A busy agent's follow-up naturally queues until idle.
+ * each session id fires at most once. `wake` steers immediately; `next-turn` queues a follow-up.
  */
 export class TerminalNotifier {
 	private readonly notified = new Set<string>();
@@ -36,7 +36,8 @@ export class TerminalNotifier {
 	}
 
 	notifyCompletion(id: string, runtime: TerminalRuntimeSession): void {
-		if (this.deps.getMode() === "off") return;
+		const mode = this.deps.getMode();
+		if (mode === "off") return;
 		if (this.notified.has(id)) return;
 
 		const ctx = this.deps.getContext();
@@ -45,6 +46,8 @@ export class TerminalNotifier {
 		if (!ctx.model) return;
 
 		this.notified.add(id);
-		this.deps.sendUserMessage(buildNotice(id, runtime), { deliverAs: "followUp" });
+		this.deps.sendUserMessage(buildNotice(id, runtime), {
+			deliverAs: mode === "wake" ? "steer" : "followUp",
+		});
 	}
 }

--- a/packages/coding-agent/test/suite/terminal-settings-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-settings-notify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { TerminalNotifier } from "../../src/core/extensions/builtin/terminal/notify.ts";
+import { TerminalNotifier, type TerminalNotifierDeps } from "../../src/core/extensions/builtin/terminal/notify.ts";
 import type { TerminalRuntimeSession } from "../../src/core/extensions/builtin/terminal/runtime-session.ts";
 import {
 	resolveTerminalSettings,
@@ -11,14 +11,19 @@ const exitedRuntime = {
 	exitResult: { exitCode: 0, timedOut: false, cancelled: false, signal: null, backend: "native" },
 } as unknown as TerminalRuntimeSession;
 
+type CapturedNotification = {
+	readonly content: string;
+	readonly options: Parameters<TerminalNotifierDeps["sendUserMessage"]>[1];
+};
+
 function makeNotifier(overrides: {
 	mode?: "wake" | "next-turn" | "off";
 	ctxMode?: string;
 	hasModel?: boolean;
-	sink: string[];
+	sink: CapturedNotification[];
 }) {
 	return new TerminalNotifier({
-		sendUserMessage: (content) => overrides.sink.push(content),
+		sendUserMessage: (content, options) => overrides.sink.push({ content, options }),
 		getMode: () => overrides.mode ?? "wake",
 		getContext: () =>
 			({
@@ -57,28 +62,48 @@ describe("terminal settings resolver", () => {
 
 describe("terminal notifier guards", () => {
 	it("wakes an idle interactive agent exactly once per session", () => {
-		const sink: string[] = [];
-		const notifier = makeNotifier({ sink });
+		// Given: wake notifications are enabled for an interactive session with a model.
+		const sink: CapturedNotification[] = [];
+		const notifier = makeNotifier({ sink, mode: "wake" });
+
+		// When: the same terminal completion is reported twice.
 		notifier.notifyCompletion("bash_1", exitedRuntime);
 		notifier.notifyCompletion("bash_1", exitedRuntime);
+
+		// Then: one steering notification carries the completion notice.
 		expect(sink).toHaveLength(1);
-		expect(sink[0]).toContain("bash_1");
-		expect(sink[0]).toContain("<system-reminder>");
+		expect(sink[0]?.content).toContain("bash_1");
+		expect(sink[0]?.content).toContain("<system-reminder>");
+		expect(sink[0]?.options).toEqual({ deliverAs: "steer" });
+	});
+
+	it("queues next-turn completion as a follow-up", () => {
+		// Given: next-turn notifications are enabled for an interactive session with a model.
+		const sink: CapturedNotification[] = [];
+		const notifier = makeNotifier({ sink, mode: "next-turn" });
+
+		// When: the terminal session completes.
+		notifier.notifyCompletion("bash_1", exitedRuntime);
+
+		// Then: the notice is queued as a follow-up message.
+		expect(sink).toHaveLength(1);
+		expect(sink[0]?.content).toContain("bash_1");
+		expect(sink[0]?.options).toEqual({ deliverAs: "followUp" });
 	});
 
 	it("never wakes in one-shot print/json runs", () => {
-		const sink: string[] = [];
+		const sink: CapturedNotification[] = [];
 		makeNotifier({ sink, ctxMode: "print" }).notifyCompletion("bash_1", exitedRuntime);
 		makeNotifier({ sink, ctxMode: "json" }).notifyCompletion("bash_2", exitedRuntime);
 		expect(sink).toHaveLength(0);
 	});
 
 	it("suppresses when notify is off or no model is active", () => {
-		const off: string[] = [];
+		const off: CapturedNotification[] = [];
 		makeNotifier({ sink: off, mode: "off" }).notifyCompletion("bash_1", exitedRuntime);
 		expect(off).toHaveLength(0);
 
-		const noModel: string[] = [];
+		const noModel: CapturedNotification[] = [];
 		makeNotifier({ sink: noModel, hasModel: false }).notifyCompletion("bash_1", exitedRuntime);
 		expect(noModel).toHaveLength(0);
 	});


### PR DESCRIPTION
## Summary

Background terminal completion notices configured with `notify: "wake"` were sent as follow-up messages, so they waited for a later turn instead of steering the active agent turn. This PR routes wake notices through the steer queue while preserving queued follow-up behavior for `notify: "next-turn"` and suppression for `notify: "off"`.

## Changes

- Classify terminal completion delivery from the configured notification mode: `wake` uses `deliverAs: "steer"`; `next-turn` uses `deliverAs: "followUp"`.
- Keep the existing print/json, missing-model, disabled-notification, and duplicate-completion guards unchanged.
- Extend the notifier suite to assert both notification content and scheduling options for wake and next-turn modes.

## QA / Evidence

- **Focused red-to-green regression:** The unchanged implementation failed only because wake delivered `followUp`; the fixed implementation passed all 6 notifier tests. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/focused-test-red-green.txt`.
- **Notifier mode coverage:** Wake steers, next-turn follows up, off suppresses, duplicate completion emits once, and print/json/no-model guards suppress. Result: 6/6 passed. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/review-work-final/focused-terminal-settings-notify-rerun.txt`.
- **AgentSession scheduling boundary:** Extension-origin steer input is present in the immediate next faux-provider context while follow-up ordering remains covered. Result: 16/16 passed. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/post-rebase-queue.txt`.
- **Repository validation:** `npm run check` completed with no errors, warnings, or infos. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/post-rebase-npm-run-check.txt`.
- **Real CLI mock loop:** The isolated source CLI completed the deterministic tool turn through a localhost fake provider. Result: 4/4 checks passed and real auth remained unchanged. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/review-work-final/mock-loop-openai-responses-with-tool.txt`.
- **RPC and native PTY smoke:** Isolated RPC lifecycle checks passed 4/4; background wait/input/resize/teardown checks passed 7/7. Artifacts: `local-ignore/qa-evidence/20260710-bash-info-steer/post-rebase-rpc.txt` and `post-rebase-pty.txt`.
- **Cross-platform CI:** `Check and test`, GitGuardian, and terminal-tool jobs passed on Ubuntu, macOS, and Windows. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/review-work-final/gh-pr-checks-184.txt`.
- **Five-lane review-work:** Goal/constraint, hands-on QA, code quality, security/concurrency, and historical-context reviews all approved the current head with no blockers.
- **Isolation and cleanup:** The real `~/.senpi/agent/auth.json` was unchanged. No task-owned process, server, port, tmux session, temporary driver, or QA temp file remained. Artifact: `local-ignore/qa-evidence/20260710-bash-info-steer/review-work-final/terminal-final-cleanup-receipt.txt`.

## Risks

- Wake notices now enter the immediate steer queue by design. The focused notifier test and AgentSession queue test cover both sides of that scheduling boundary.
- `next-turn`, `off`, non-interactive modes, missing-model behavior, and duplicate suppression retain their prior semantics and have focused regression coverage.
- The implementation changes no terminal output content, runtime lifecycle, provider behavior, persistence format, or platform-specific code.
- Cubic review is skipped under the workflow's quota exception: its check reports the monthly 80,000-line limit exhausted at 83,762 reviewed lines, with reviews resuming August 1, 2026. It emitted no findings.

## Secret Safety

No tokens, credentials, auth headers, cookies, environment dumps, or secret-bearing raw logs are included. QA ran in isolated sandboxes against localhost fake providers and verified the real auth file remained unchanged.
