### PR TITLE
fix(coding-agent): deduplicate todowrite tui output

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts
@@ -1,5 +1,6 @@
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { getTextOutput } from "../../../../tools/render-utils.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../../types.ts";
 import {
 	getTodoResultLines,
@@ -106,14 +107,10 @@ export function registerTodoWriteTool(pi: ExtensionAPI, accessors: TodoAccessors
 			const body = items.length > 0 ? `\n${items.join("\n")}` : "";
 			return new Text(`${theme.fg("toolTitle", theme.bold("todowrite "))}${theme.fg("muted", title)}${body}`, 0, 0);
 		},
-		renderResult(result, _options, theme) {
-			const details = result.details as TodoWriteDetails | undefined;
-			const todos = details?.todos ?? accessors.getCurrentTodos();
-			const lines = getTodoResultLines(todos);
-			const title = lines[0] ?? "0 todos";
-			const items = lines.slice(1);
-			const body = items.length > 0 ? `\n${items.join("\n")}` : "";
-			return new Text(`${theme.fg("muted", title)}${body}`, 0, 0);
+		renderResult(result, _options, theme, context) {
+			if (!context.isError) return new Text("", 0, 0);
+
+			return new Text(theme.fg("toolOutput", getTextOutput(result, context.showImages)), 0, 0);
 		},
 	});
 }

--- a/packages/coding-agent/test/suite/todowrite-render.test.ts
+++ b/packages/coding-agent/test/suite/todowrite-render.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { TUI } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { createEventBus } from "../../src/core/event-bus.ts";
@@ -11,6 +12,7 @@ import { ExtensionRunner } from "../../src/core/extensions/runner.ts";
 import type { ToolRenderContext } from "../../src/core/extensions/types.ts";
 import { ModelRegistry } from "../../src/core/model-registry.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
+import { ToolExecutionComponent } from "../../src/modes/interactive/components/tool-execution.ts";
 import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../../src/utils/ansi.ts";
 
@@ -23,6 +25,12 @@ afterEach(() => {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
+
+function createFakeTui(): TUI {
+	return {
+		requestRender: () => {},
+	} as TUI;
+}
 
 async function renderTodoWriteCall(todos: TodoItem[]): Promise<string> {
 	const root = mkdtempSync(join(tmpdir(), "todowrite-render-"));
@@ -58,6 +66,44 @@ async function renderTodoWriteCall(todos: TodoItem[]): Promise<string> {
 	};
 	const component = tool.definition.renderCall(args, theme, context);
 	return stripAnsi(component.render(100).join("\n"));
+}
+
+async function renderCompletedTodoWrite(todos: TodoItem[], text: string, isError: boolean): Promise<string> {
+	const root = mkdtempSync(join(tmpdir(), "todowrite-completed-render-"));
+	tempRoots.push(root);
+	const runtime = createExtensionRuntime();
+	const extension = await loadExtensionFromFactory(
+		todowriteExtension,
+		root,
+		createEventBus(),
+		runtime,
+		"<builtin:todowrite>",
+	);
+	const sessionManager = SessionManager.inMemory(root);
+	const modelRegistry = ModelRegistry.create(AuthStorage.create(join(root, "auth.json")), root);
+	const runner = new ExtensionRunner([extension], runtime, root, sessionManager, modelRegistry);
+	const tool = runner.getAllRegisteredTools().find((registeredTool) => registeredTool.definition.name === "todowrite");
+	if (!tool) throw new Error("Expected todowrite to be registered");
+
+	const component = new ToolExecutionComponent(
+		"todowrite",
+		"tool-todo",
+		{ todos },
+		{},
+		tool.definition,
+		createFakeTui(),
+		root,
+	);
+	component.updateResult(
+		{
+			content: [{ type: "text", text }],
+			details: { todos },
+			isError,
+		},
+		false,
+	);
+
+	return stripAnsi(component.render(240).join("\n"));
 }
 
 describe("todowrite renderer", () => {
@@ -98,5 +144,29 @@ describe("todowrite renderer", () => {
 		);
 		expect(rendered).not.toContain("\u0000");
 		expect(rendered).not.toContain("\nNormalize");
+	});
+
+	it("renders each completed todo row once after the result arrives", async () => {
+		const target =
+			"packages/coding-agent/src/core/extensions/builtin/todotools/tools/todowrite.ts: Deduplicate completed todo row - expect one rendered row";
+		const todos: TodoItem[] = [{ content: target, status: "completed", priority: "high" }];
+
+		const rendered = await renderCompletedTodoWrite(todos, JSON.stringify(todos), false);
+
+		expect(rendered.split(target)).toHaveLength(2);
+	});
+
+	it("preserves failed todowrite result text", async () => {
+		const todos: TodoItem[] = [
+			{
+				content: "packages/coding-agent/test/suite/todowrite-render.test.ts: Preserve errors - expect visible text",
+				status: "in_progress",
+				priority: "high",
+			},
+		];
+
+		const rendered = await renderCompletedTodoWrite(todos, "todowrite failed: validation exploded", true);
+
+		expect(rendered).toContain("todowrite failed: validation exploded");
 	});
 });


### PR DESCRIPTION
## Summary

TodoWrite output was rendered twice after a tool result completed because both the call renderer and result renderer emitted the same todo rows. This PR keeps the rich call rendering as the single successful-output surface while preserving visible error result text.

Before: a completed TodoWrite call could show the same `0 todos` header and completed rows twice. After: the composed TUI shows one TodoWrite block and each row once.

## Changes

- Return an empty successful result component from the built-in TodoWrite renderer so `ToolExecutionComponent` does not append duplicate rows.
- Continue rendering failed TodoWrite results through the shared text-output path.
- Add regressions through the real `ToolExecutionComponent` composition path for both successful deduplication and visible error text.

## QA / Evidence

- **Focused RED/GREEN regression:** reproduced the duplicate before the implementation, then passed all 4 TodoWrite renderer tests after the fix. Artifacts: `.omo/evidence/task-1-todo-tui-dedup-red.txt`, `.omo/evidence/task-2-todo-tui-dedup-green.txt`, and `.omo/evidence/task-4-todo-tui-dedup-post-sync-focused.txt`. This directly covers the call-plus-result composition contract and error preservation.
- **Repository checks:** `npm run check` passed after synchronizing with the latest `main`, including Biome, pinned-dependency and import checks, TypeScript, browser/web checks, and Neo build/vet/tests. Artifact: `.omo/evidence/task-5-todo-tui-dedup-post-sync-checks.txt`.
- **Real CLI smoke:** the isolated Senpi TUI smoke passed 5/5 and the localhost fake-model loop passed 5/5 without modifying real auth. Artifacts: `local-ignore/qa-evidence/20260710-todo-tui-dedup/tui-smoke-command-output.txt` and `local-ignore/qa-evidence/20260710-todo-tui-dedup/mock-loop-self-test.txt`.
- **Real TodoWrite turn:** drove the source CLI in a tmux PTY against a localhost fake model, captured raw ANSI, rendered the final grid through xterm.js/headless Chrome, and observed exactly one TodoWrite block, one completed target row, one expected active-count title, and one final response. Artifacts: `local-ignore/qa-evidence/20260710-todo-tui-dedup/tui-web-terminal/terminal.png`, `terminal.txt`, `metadata.json`, and `cleanup-receipt.txt`.
- **Independent visual review:** both design/functional and visual/terminal-precision reviewers passed with high confidence and no blockers. Artifacts: `.omo/evidence/task-6a-todo-tui-dedup-visual-review-a.txt` and `.omo/evidence/task-6b-todo-tui-dedup-visual-review-b.txt`.

## Risks

- A tool-specific successful result is now visually empty. The existing call renderer remains the authoritative TodoWrite display, and the integration regression proves the composed TUI still contains the completed row exactly once.
- Error visibility could regress when suppressing successful output. The dedicated error regression verifies the exact failure text remains visible.

## Secret Safety

All QA used isolated sandboxes and localhost fake providers. Evidence redacts authorization data and records that the real auth file was unchanged; no raw credentials, cookies, tokens, or environment dumps are included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate TodoWrite output in the TUI by showing successful results only in the call block and suppressing the duplicate result view. Failed results still display their error text. Each todo row now renders once.

- **Bug Fixes**
  - Successful TodoWrite result now returns an empty result component, so `ToolExecutionComponent` doesn’t append duplicate rows.
  - Failed TodoWrite results flow through the shared text-output path to preserve error text.
  - Added integration tests through `ToolExecutionComponent` to verify deduplication and error visibility.

<sup>Written for commit 6a41e5bc4fffb3104f2000d8d0969594d47720ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

