### PR TITLE
fix(coding-agent): match unread buffered bash output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Fixed `bash_output` waits ignoring turn cancellation and accepting unbounded model-supplied timeouts; waits now release without killing the background terminal and individual polls are capped at five minutes.
 
+- Fixed `bash_output` waiting on `wait_for` even when the pattern had already arrived in unread output before the waiter was registered.
+
 - Fixed emergency context pruning to reserve a model-aware output allowance without collapsing the usable prompt budget, preventing oversized tool results from exceeding new-model input limits.
 
 - Fixed invalid extension tool renderers displaying `[render error: Box]` instead of fallback rendering.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
@@ -111,7 +111,7 @@ export class TerminalRuntimeSession {
 	}
 
 	/**
-	 * Wait until `pattern` matches newly produced output, the session exits, the
+	 * Wait until `pattern` matches unread or newly produced output, the session exits, the
 	 * timeout elapses, or the wait is aborted.
 	 */
 	waitFor(pattern: string, timeoutMs: number, signal?: AbortSignal): Promise<OutputWaitOutcome> {
@@ -119,10 +119,13 @@ export class TerminalRuntimeSession {
 		if (regex === null) return Promise.resolve("invalid_pattern");
 		if (this.exited) return Promise.resolve("exited");
 		if (signal?.aborted) return Promise.resolve("aborted");
+		const unreadStart = Math.max(this.consumed, this.droppedChars);
+		const unreadOutput = this.buffer.slice(unreadStart - this.droppedChars);
+		if (regex.test(unreadOutput)) return Promise.resolve("matched");
 		return new Promise((resolve) => {
 			const waiter: OutputWaiter = {
 				regex,
-				buffer: "",
+				buffer: unreadOutput,
 				timer: null,
 				signal,
 				onAbort: () => this.resolveWaiter(waiter, "aborted"),

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBuiltinParserRegistry } from "../../src/core/extensions/builtin/permission-system/parsers.ts";
 import registerTerminalExtension from "../../src/core/extensions/builtin/terminal/index.ts";
 import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import { TerminalRuntimeSession } from "../../src/core/extensions/builtin/terminal/runtime-session.ts";
 import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/tools/bash.ts";
 import { createBashInputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-input.ts";
 import {
@@ -220,6 +221,24 @@ describe("terminal builtin extension — bash_output robustness", () => {
 		const statusCheck = await output.execute("call-status-check", { bash_id: bashId });
 		expect(firstText(statusCheck)).toContain("status: running");
 		await manager.stop(bashId);
+	});
+
+	it("matches unread output that arrived before waiter registration", async () => {
+		const runtime = new TerminalRuntimeSession("buffered-output-fixture", {});
+		const ingestValue: unknown = Reflect.get(runtime, "ingest");
+		if (typeof ingestValue !== "function") throw new Error("Runtime ingest method missing");
+		Reflect.apply(ingestValue, runtime, [new TextEncoder().encode("CODEX_EXIT=0")]);
+		vi.useFakeTimers();
+
+		try {
+			const outcome = runtime.waitFor("CODEX_EXIT=", 1000);
+			await vi.advanceTimersByTimeAsync(1000);
+			await expect(outcome).resolves.toBe("matched");
+		} finally {
+			runtime.session.kill();
+			runtime.dispose();
+			vi.useRealTimers();
+		}
 	});
 
 	it("bounds an oversized timeout at the 300-second schema and runtime ceiling", async () => {


### PR DESCRIPTION
## Summary

`bash_output wait_for` only tested output produced after waiter registration. If the requested marker had already arrived but was still unread, the tool could wait until timeout even though the terminal buffer already contained the match.

This change checks unread retained output before registering the waiter and seeds subsequent matching with that unread prefix, so patterns that are already buffered or split across registration resolve promptly. The inspected session `019f4a05-c31f-7935-8cac-d71b80907128` started before PR #179 merged; PR #179 plus restarting that stale process remains the direct fix for its unbounded cancellation/timeout behavior. This PR is the verified follow-up for the separate unread-buffer case.

## Changes

- Match `wait_for` against the same unread cursor range used by `readDelta()`.
- Seed new waiters with unread retained output so a regex may span buffered and future chunks.
- Add a deterministic regression that times out on the prior implementation and resolves as `matched` after the fix.
- Record the behavior under the coding-agent `[Unreleased]` changelog.

## QA / Evidence

- **Focused TDD regression**
  - Tested: unread output arrives before `waitFor()` starts.
  - Observed: unchanged code returned `timeout`; fixed code returned `matched`.
  - Artifacts: `local-ignore/qa-evidence/20260710-bash-output-completion/red-focused-test.txt`, `green-focused-test.txt`.
  - Why sufficient: directly proves the production behavior change and fails for the original reason.

- **Retained-buffer and boundary stress**
  - Tested: 100 repeated real tool calls, fully buffered matches, unread/future split matches, consumed markers, abort, exit, invalid regex, teardown, and a buffer rollover beyond 1,000,000 retained characters.
  - Observed: 100/100 iterations passed; slowest immediate call was 0.1 ms; rollover retained/future matching completed in 253.3 ms; teardown left no session or scenario process.
  - Artifacts: `local-ignore/qa-evidence/20260710-bash-output-completion/completion-stress.txt`, `codex-reviewer-unread-buffer-qa.txt`, `dropped-prefix-qa.txt`, `cleanup-receipt.txt`.
  - Why sufficient: covers cursor boundaries, split chunks, buffer truncation, cancellation, and cleanup on the real terminal runtime/tool surface.

- **Senpi terminal QA**
  - Tested: `node .agents/skills/senpi-qa/scripts/pty-drive.mjs --self-test --evidence bash-output-completion-post-rebase` after rebasing onto current `main`.
  - Observed: 7/7 passed, including `wait_for`, stdin steering, resize, registry teardown/no orphans, and unchanged real auth hash.
  - Artifact: `local-ignore/qa-evidence/20260710-bash-output-completion/post-rebase-pty-drive.txt`.
  - Why sufficient: drives the real persistent-terminal harness in an isolated sandbox without provider tokens.

- **Regression and workspace checks**
  - Tested: full `terminal-extension.test.ts`, production TypeScript no-excuse audit, and `npm run check` after rebase.
  - Observed: 11/11 tests passed; production file had no strict-style violations; workspace check completed without errors or warnings.
  - Artifacts: `local-ignore/qa-evidence/20260710-bash-output-completion/post-rebase-terminal-extension-tests.txt`, `post-rebase-no-excuse-production.txt`, `post-rebase-check.txt`.
  - Why sufficient: covers the affected suite plus repository-wide format, type, generated-file, browser, web UI, and Neo checks.

## Risks

- User-supplied regex complexity is pre-existing. This change adds one immediate test over at most the retained one-million-character buffer; security review found no new blocking boundary.
- A waiter may retain the unread prefix while active. That prefix is bounded by the existing retained-buffer cap, and the five-minute wait ceiling from PR #179 remains in force.
- The committed regression uses the runtime ingestion seam for determinism. Independent real-tool QA covers the same behavior through `bash_output`.

## Secret Safety

Evidence is sanitized. No tokens, auth headers, cookies, credentials, raw environment dumps, or private transcript content are included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `coding-agent` terminal behavior where `bash_output.wait_for` could time out even when the match was already in the unread buffer. Now it checks retained output first and seeds the waiter buffer so regexes can span buffered and future chunks.

- **Bug Fixes**
  - Check unread retained output before registering a waiter, using the same unread cursor as `readDelta()`.
  - Seed new waiters with the unread prefix to enable cross-chunk regex matches.
  - Add a deterministic regression test and update the `[Unreleased]` changelog.

<sup>Written for commit 05b573002fd6276801a4df23f62c565817a2a542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

