### PR TITLE
fix(coding-agent): recover corrupted goal stores

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Fixed goal persistence to use atomic file replacement and narrowly recover the observed stale closing-brace
+  corruption, preventing session resume crashes without accepting other malformed JSON.
+
 - Fixed `bash_output` waits ignoring turn cancellation and accepting unbounded model-supplied timeouts; waits now release without killing the background terminal and individual polls are capped at five minutes.
 
 - Fixed `bash_output` waiting on `wait_for` even when the pattern had already arrived in unread output before the waiter was registered.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -5,6 +5,26 @@ Persistent per-thread goal tracking as an in-tree builtin. Ports the standalone
 `pi-goal` extension into senpi with no dependency on it, file-based persistence,
 codex-aligned tool naming, and the budget concept removed.
 
+## Atomic goal store and narrow stale-brace recovery (2026-07-10)
+
+### What changed
+- Fork-specific divergence from standalone `pi-goal`: `store.ts` writes complete JSON to a unique sibling temporary
+  file with mode `0600`, then atomically renames it over the destination and cleans up the temporary file on failure.
+- Goal reads recover only the observed corruption shape: one complete root JSON object followed solely by whitespace
+  and one or more stale closing braces. Truncated JSON, arbitrary trailing bytes, unsupported versions, and invalid
+  goal shapes still fail normally.
+
+### Why this belongs in the builtin
+- The persistence path, file format, and recovery boundary are private to the vendored goal builtin. Keeping this
+  fork-specific behavior in `goal/store.ts` protects session resume without broadening shared session storage or the
+  public extension API.
+
+### Expected merge conflict zones on next upstream sync
+- HIGH in `store.ts` for standalone `pi-goal` changes to imports, temporary-file handling, `writeGoal`,
+  `parseGoalFile`, or malformed JSON recovery.
+- MEDIUM in goal store tests covering persistence and malformed JSON behavior.
+- NONE in shared core session storage and `extensions/types.ts`, which this divergence does not touch.
+
 ## Continuation halts on aborts and terminal turns (2026-06-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
 	GoalAlreadyExistsError,
@@ -32,7 +32,25 @@ export async function writeGoal(ref: GoalStoreRef, goal: Goal | null): Promise<v
 	const filePath = goalFilePath(ref);
 	await mkdir(dirname(filePath), { recursive: true });
 	const file: GoalFile = { version: STORE_VERSION, goal };
-	await writeFile(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf8");
+	await writeGoalFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`);
+}
+
+async function writeGoalFileAtomic(filePath: string, contents: string): Promise<void> {
+	const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await writeFile(tempPath, contents, "utf8");
+		await rename(tempPath, filePath);
+	} catch (error) {
+		try {
+			await rm(tempPath, { force: true });
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"goal store write failed and its temporary file could not be removed",
+			);
+		}
+		throw error;
+	}
 }
 
 export async function createGoal(ref: GoalStoreRef, objective: string): Promise<Goal> {
@@ -152,7 +170,15 @@ function goalTokenDeltaForUsage(usage: TokenUsageSnapshot): number {
 }
 
 function parseGoalFile(raw: string): GoalFile {
-	const parsed: unknown = JSON.parse(raw);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+		const recovered = recoverGoalFileWithStaleClosingBraces(raw);
+		if (recovered === undefined) throw error;
+		parsed = JSON.parse(recovered);
+	}
 	if (!isRecord(parsed)) throw new InvalidGoalStoreError("goal store must be a JSON object");
 	if (parsed.version !== STORE_VERSION) throw new UnsupportedGoalStoreVersionError("unsupported goal store version");
 	const goal = parsed.goal;
@@ -161,6 +187,57 @@ function parseGoalFile(raw: string): GoalFile {
 		version: STORE_VERSION,
 		goal,
 	};
+}
+
+function recoverGoalFileWithStaleClosingBraces(raw: string): string | undefined {
+	let rootStart = 0;
+	while (rootStart < raw.length && /[\t\n\r ]/.test(raw[rootStart] ?? "")) rootStart += 1;
+	if (raw[rootStart] !== "{") return undefined;
+
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let index = rootStart; index < raw.length; index += 1) {
+		const character = raw[index];
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+			} else if (character === "\\") {
+				escaped = true;
+			} else if (character === '"') {
+				inString = false;
+			}
+			continue;
+		}
+
+		if (character === '"') {
+			inString = true;
+		} else if (character === "{" || character === "[") {
+			depth += 1;
+		} else if (character === "}" || character === "]") {
+			depth -= 1;
+			if (depth < 0) return undefined;
+			if (depth === 0) {
+				let hasStaleClosingBrace = false;
+				for (let suffixIndex = index + 1; suffixIndex < raw.length; suffixIndex += 1) {
+					const suffixCharacter = raw[suffixIndex];
+					if (suffixCharacter === "}") {
+						hasStaleClosingBrace = true;
+					} else if (
+						suffixCharacter !== " " &&
+						suffixCharacter !== "\t" &&
+						suffixCharacter !== "\n" &&
+						suffixCharacter !== "\r"
+					) {
+						return undefined;
+					}
+				}
+				return hasStaleClosingBrace ? raw.slice(0, index + 1) : undefined;
+			}
+		}
+	}
+
+	return undefined;
 }
 
 function isMissingFile(error: unknown): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
@@ -36,9 +36,9 @@ export async function writeGoal(ref: GoalStoreRef, goal: Goal | null): Promise<v
 }
 
 async function writeGoalFileAtomic(filePath: string, contents: string): Promise<void> {
-	const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	const tempPath = join(dirname(filePath), `.goal-${randomUUID()}.tmp`);
 	try {
-		await writeFile(tempPath, contents, "utf8");
+		await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600 });
 		await rename(tempPath, filePath);
 	} catch (error) {
 		try {
@@ -177,7 +177,11 @@ function parseGoalFile(raw: string): GoalFile {
 		if (!(error instanceof SyntaxError)) throw error;
 		const recovered = recoverGoalFileWithStaleClosingBraces(raw);
 		if (recovered === undefined) throw error;
-		parsed = JSON.parse(recovered);
+		try {
+			parsed = JSON.parse(recovered);
+		} catch {
+			throw error;
+		}
 	}
 	if (!isRecord(parsed)) throw new InvalidGoalStoreError("goal store must be a JSON object");
 	if (parsed.version !== STORE_VERSION) throw new UnsupportedGoalStoreVersionError("unsupported goal store version");

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	accountGoalUsage,
@@ -9,6 +9,7 @@ import {
 	goalFilePath,
 	readGoal,
 	updateGoal,
+	writeGoal,
 } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { GoalStoreRef } from "../../src/core/extensions/builtin/goal/types.ts";
 
@@ -20,11 +21,114 @@ async function tempStore(threadId = "thread-test"): Promise<GoalStoreRef> {
 	return { baseDir: join(dir, "extensions", "goal"), threadId };
 }
 
-describe("goal store (budget-free)", () => {
-	afterEach(async () => {
-		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+async function writeRawGoalFile(ref: GoalStoreRef, contents: string): Promise<void> {
+	await mkdir(ref.baseDir, { recursive: true });
+	await writeFile(goalFilePath(ref), contents, "utf8");
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("goal store JSON recovery", () => {
+	it("reads an unchanged valid goal file", async () => {
+		// Given
+		const ref = await tempStore("thread-valid-json");
+		const goal = await createGoal(ref, "Keep reading valid goals");
+
+		// When
+		const persisted = await readGoal(ref);
+
+		// Then
+		expect(persisted).toEqual(goal);
 	});
 
+	it("recovers a complete goal file followed by stale closing braces", async () => {
+		// Given
+		const ref = await tempStore("thread-stale-braces");
+		const goal = await createGoal(ref, 'Resume } the "named" session \\ safely');
+		const validContents = await readFile(goalFilePath(ref), "utf8");
+		await writeRawGoalFile(ref, `${validContents}}\n}\n`);
+
+		// When
+		const recovered = await readGoal(ref);
+
+		// Then
+		expect(recovered).toEqual(goal);
+	});
+
+	it("rejects truncated JSON", async () => {
+		// Given
+		const ref = await tempStore("thread-truncated-json");
+		await writeRawGoalFile(ref, '{"version":1,"goal":');
+
+		// When / Then
+		await expect(readGoal(ref)).rejects.toBeInstanceOf(SyntaxError);
+	});
+
+	it("rejects arbitrary trailing text", async () => {
+		// Given
+		const ref = await tempStore("thread-trailing-text");
+		await createGoal(ref, "Reject arbitrary suffixes");
+		const validContents = await readFile(goalFilePath(ref), "utf8");
+		await writeRawGoalFile(ref, `${validContents}not-stale-write-bytes`);
+
+		// When / Then
+		await expect(readGoal(ref)).rejects.toBeInstanceOf(SyntaxError);
+	});
+
+	it("rejects adversarial stale-brace suffixes without blocking", async () => {
+		// Given
+		const ref = await tempStore("thread-adversarial-stale-braces");
+		await createGoal(ref, "Reject adversarial stale-brace suffixes");
+		const validContents = await readFile(goalFilePath(ref), "utf8");
+		await writeRawGoalFile(ref, `${validContents}${"} ".repeat(24)}X`);
+
+		// When / Then
+		const startedAt = performance.now();
+		await expect(readGoal(ref)).rejects.toBeInstanceOf(SyntaxError);
+		const elapsedMs = performance.now() - startedAt;
+		expect(elapsedMs).toBeLessThan(500);
+	});
+
+	it("rejects unsupported versions even with stale closing braces", async () => {
+		// Given
+		const ref = await tempStore("thread-unsupported-version");
+		await writeRawGoalFile(ref, '{"version":2,"goal":null}\n}\n');
+
+		// When / Then
+		await expect(readGoal(ref)).rejects.toThrow("unsupported goal store version");
+	});
+
+	it("rejects invalid goal shapes even with stale closing braces", async () => {
+		// Given
+		const ref = await tempStore("thread-invalid-goal");
+		await writeRawGoalFile(ref, '{"version":1,"goal":{"id":1}}\n}\n');
+
+		// When / Then
+		await expect(readGoal(ref)).rejects.toThrow("goal store contains an invalid goal");
+	});
+});
+
+describe("goal store atomic writes", () => {
+	it("leaves complete JSON after overlapping long and short writes", async () => {
+		// Given
+		const ref = await tempStore("thread-overlapping-writes");
+		const goal = await createGoal(ref, "Initial goal");
+		const longGoal = { ...goal, objective: "x".repeat(4_000_000), updatedAt: goal.updatedAt + 1 };
+		const shortGoal = { ...goal, objective: "short", updatedAt: goal.updatedAt + 2 };
+
+		// When / Then
+		for (let iteration = 0; iteration < 50; iteration += 1) {
+			await Promise.all([writeGoal(ref, longGoal), writeGoal(ref, shortGoal)]);
+			const parsed: unknown = JSON.parse(await readFile(goalFilePath(ref), "utf8"));
+			expect(parsed).toMatchObject({ version: 1 });
+		}
+		expect(await readdir(ref.baseDir)).toEqual([basename(goalFilePath(ref))]);
+	});
+});
+
+describe("goal store (budget-free)", () => {
 	it("creates a persisted active goal with no budget field", async () => {
 		const ref = await tempStore("thread-create");
 		const goal = await createGoal(ref, "  Ship the extension  ");

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -77,6 +77,26 @@ describe("goal store JSON recovery", () => {
 		await expect(readGoal(ref)).rejects.toBeInstanceOf(SyntaxError);
 	});
 
+	it("preserves the original parse error for mismatched container corruption", async () => {
+		// Given
+		const ref = await tempStore("thread-mismatched-container");
+		const raw = '{"version":1,"goal":[}}}';
+		let originalMessage = "";
+		try {
+			JSON.parse(raw);
+		} catch (error) {
+			if (!(error instanceof SyntaxError)) throw error;
+			originalMessage = error.message;
+		}
+		await writeRawGoalFile(ref, raw);
+
+		// When
+		const read = readGoal(ref);
+
+		// Then
+		await expect(read).rejects.toThrow(originalMessage);
+	});
+
 	it("rejects adversarial stale-brace suffixes without blocking", async () => {
 		// Given
 		const ref = await tempStore("thread-adversarial-stale-braces");
@@ -111,20 +131,71 @@ describe("goal store JSON recovery", () => {
 });
 
 describe("goal store atomic writes", () => {
-	it("leaves complete JSON after overlapping long and short writes", async () => {
+	it("writes a goal whose valid basename leaves no room for an appended temp suffix", async () => {
+		// Given
+		const ref = await tempStore("x".repeat(250));
+		expect(Buffer.byteLength(basename(goalFilePath(ref)))).toBe(255);
+
+		// When
+		const goal = await createGoal(ref, "Persist at the component limit");
+
+		// Then
+		expect(await readGoal(ref)).toEqual(goal);
+	});
+
+	it.skipIf(process.platform === "win32")("preserves mode 0600 across atomic replacement", async () => {
+		// Given
+		const ref = await tempStore("thread-private-mode");
+		const goal = await createGoal(ref, "Keep this private");
+		await chmod(goalFilePath(ref), 0o600);
+		const previousUmask = process.umask(0o022);
+
+		// When
+		try {
+			await writeGoal(ref, { ...goal, objective: "Still private" });
+		} finally {
+			process.umask(previousUmask);
+		}
+
+		// Then
+		const fileStat = await stat(goalFilePath(ref));
+		expect(fileStat.mode & 0o777).toBe(0o600);
+	});
+
+	it("leaves a parsed file exactly equal to one overlapping submitted goal", async () => {
 		// Given
 		const ref = await tempStore("thread-overlapping-writes");
 		const goal = await createGoal(ref, "Initial goal");
 		const longGoal = { ...goal, objective: "x".repeat(4_000_000), updatedAt: goal.updatedAt + 1 };
 		const shortGoal = { ...goal, objective: "short", updatedAt: goal.updatedAt + 2 };
+		const submittedFiles = [
+			{ version: 1, goal: longGoal },
+			{ version: 1, goal: shortGoal },
+		];
 
-		// When / Then
+		// When
 		for (let iteration = 0; iteration < 50; iteration += 1) {
 			await Promise.all([writeGoal(ref, longGoal), writeGoal(ref, shortGoal)]);
 			const parsed: unknown = JSON.parse(await readFile(goalFilePath(ref), "utf8"));
-			expect(parsed).toMatchObject({ version: 1 });
+
+			// Then
+			expect(submittedFiles).toContainEqual(parsed);
 		}
 		expect(await readdir(ref.baseDir)).toEqual([basename(goalFilePath(ref))]);
+	});
+
+	it("cleans its temp sibling after a deterministic rename failure", async () => {
+		// Given
+		const ref = await tempStore("thread-rename-failure");
+		await mkdir(goalFilePath(ref), { recursive: true });
+
+		// When
+		const write = writeGoal(ref, null);
+
+		// Then
+		await expect(write).rejects.toBeInstanceOf(Error);
+		expect(await readdir(ref.baseDir)).toEqual([basename(goalFilePath(ref))]);
+		expect((await stat(goalFilePath(ref))).isDirectory()).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -162,24 +162,24 @@ describe("goal store atomic writes", () => {
 		expect(fileStat.mode & 0o777).toBe(0o600);
 	});
 
-	it("leaves a parsed file exactly equal to one overlapping submitted goal", async () => {
+	it("leaves exact bytes from one overlapping submitted goal", async () => {
 		// Given
 		const ref = await tempStore("thread-overlapping-writes");
 		const goal = await createGoal(ref, "Initial goal");
 		const longGoal = { ...goal, objective: "x".repeat(4_000_000), updatedAt: goal.updatedAt + 1 };
 		const shortGoal = { ...goal, objective: "short", updatedAt: goal.updatedAt + 2 };
 		const submittedFiles = [
-			{ version: 1, goal: longGoal },
-			{ version: 1, goal: shortGoal },
+			Buffer.from(`${JSON.stringify({ version: 1, goal: longGoal }, null, 2)}\n`),
+			Buffer.from(`${JSON.stringify({ version: 1, goal: shortGoal }, null, 2)}\n`),
 		];
 
 		// When
 		for (let iteration = 0; iteration < 50; iteration += 1) {
 			await Promise.all([writeGoal(ref, longGoal), writeGoal(ref, shortGoal)]);
-			const parsed: unknown = JSON.parse(await readFile(goalFilePath(ref), "utf8"));
+			const persisted = await readFile(goalFilePath(ref));
 
 			// Then
-			expect(submittedFiles).toContainEqual(parsed);
+			expect(submittedFiles.some((submittedFile) => submittedFile.equals(persisted))).toBe(true);
 		}
 		expect(await readdir(ref.baseDir)).toEqual([basename(goalFilePath(ref))]);
 	});


### PR DESCRIPTION
## Summary

Concurrent goal-store writes could overlap after truncating the same file, leaving a valid JSON object followed by stale closing-brace bytes. Resuming the affected session then crashed the builtin goal extension during `JSON.parse`.

This PR makes goal-store writes atomic and narrowly recovers the already-observed stale-closing-brace corruption. It also hardens the atomic replacement for maximum-length destination names and private file permissions. Valid files behave unchanged; truncated JSON, arbitrary suffixes, unsupported versions, invalid goal shapes, and mismatched corruption still fail with their original error policy.

## Changes

- Write versioned goal files through short, unique same-directory temporary files with mode `0600`, followed by atomic rename and failed-temp cleanup.
- On a `SyntaxError`, locate one complete root object while respecting JSON strings and escapes, and recover only when the remaining bytes are closing braces plus JSON whitespace.
- Preserve the original parse error when a recovery candidate is itself invalid.
- Add regressions for valid reads, observed corruption recovery, malformed controls, adversarial suffix performance, 255-byte destination basenames, private mode preservation, rename-failure cleanup, and exact overlapping-writer serialization bytes.
- Document the user-visible fix and the maintained divergence from standalone `pi-goal`.

## QA / Evidence

- **Root-cause toggle:** concurrent direct writes reproduced malformed files in 38/50 iterations; the same writes awaited sequentially reproduced 0/50. Artifacts: `local-ignore/qa-evidence/20260710-goal-file-json-recovery/task-3-red.txt` and the debug ledger summary.
- **Failing-first review remediation:** before the hardening fix, the focused suite failed on original-error replacement, a valid 255-byte destination basename with `ENAMETOOLONG`, and mode widening from `0600` to `0644`. After the fix, the focused suite passes 21/21. Artifacts: `review-fix-red.txt`, `review-fix-green.txt`, and `post-review-parent-goal-store-verbose.txt`.
- **GPT-5.6 exact-byte blocker:** the final external review found that semantic JSON comparison did not prove the atomic writer's byte-level contract. A temporary compact serializer remained semantically equivalent but made the new exact-`Buffer` assertion fail (`1 failed, 20 skipped`); restoring the unchanged production serializer made it pass (`1 passed, 20 skipped`), and the full goal-store suite passes 21/21. Artifacts: `gpt56-byte-red.txt`, `gpt56-byte-green.txt`, `gpt56-byte-focused.txt`, and `final-byte-parent-goal-store.txt`.
- **Adjacent goal behavior:** goal modules, extension, and E2E suites pass 20/20. Artifact: `final-byte-parent-goal-adjacent.txt`.
- **Repository gate:** `npm run check` passed Biome with no fixes, dependency/import/lock checks, `tsgo --noEmit`, browser/web checks, and Neo build/vet/test. Artifact: `final-byte-parent-npm-run-check.txt`.
- **Real source CLI resume:** a fresh isolated copied-session fixture preserved the exact malformed suffix, resumed through the source CLI, completed `get_goal`, propagated the recovered objective, returned the final marker, and showed no original parse crash. All 15 assertions passed; real session, goal, and auth hashes remained unchanged. The final commit changes only the test assertion; the production `store.ts` SHA-256 remains `7ff8ed1fb4d065ae60b7573c93c4db3c8d24c7940fe97e29502f3999da51b546`. Artifacts: `post-review-C002-source-cli-resume.txt`, `post-review-C002-resume-summary.json`, and `post-review-C002-cleanup-receipt.txt`.
- **Mandatory Senpi QA:** parent and independent GPT-5.6 QA runs each passed RPC 4/4, mock loop 5/5, CLI smoke 7/7, and common harness 9/9 with real auth unchanged. Artifacts: `final-byte-parent-rpc-drive.txt`, `final-byte-parent-mock-loop.txt`, `final-byte-parent-cli-smoke.txt`, `final-byte-qa/summary.json`, and `final-byte-qa/cleanup-receipt.txt`.
- **Programming and cleanup audit:** `git diff --check`, secret/debug scans, temp-file checks, process cleanup, and sandbox cleanup passed; no `.goal-*.tmp` files remain. Artifact: `final-byte-parent-cleanup-audit.txt`.

## Risks

- Concurrent writes remain last-writer-wins, but each visible file is now byte-for-byte one complete submitted canonical serialization; the overlapping-writer regression covers that contract directly.
- Atomic replacement deliberately creates goal files with mode `0600`. The private-file regression verifies replacement cannot widen an existing `0600` file under umask `022`.
- Recovery remains limited to extra `}` bytes and JSON whitespace after one complete root object. Malformed and unsupported content remains rejected by direct tests.
- `store.ts` is at 248 pure LOC, below the 250-line defect threshold but in the warning band. Future substantive growth should split parsing and persistence responsibilities.

## Secret Safety

Evidence contains boolean outcomes, pass counts, sanitized commands, and integrity hashes only. No credentials, auth headers, raw private session contents, provider payloads, or tokens are included in this PR.
