### PR TITLE
chore(builtins): sync vendored pi-* extension versions after dependency migration

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
@@ -16,8 +16,8 @@ function parsePositiveInt(value: string | undefined): number | undefined {
 }
 
 export function resolveBashTimeoutDefaults(env: EnvLike): BashTimeoutDefaults {
-	const defaultSeconds = parsePositiveInt(env.PI_BASH_DEFAULT_TIMEOUT_SECONDS) ?? BASH_DEFAULT_TIMEOUT_SECONDS;
-	const rawMax = parsePositiveInt(env.PI_BASH_MAX_TIMEOUT_SECONDS) ?? BASH_MAX_TIMEOUT_SECONDS;
+	const defaultSeconds = parsePositiveInt(env["PI_BASH_DEFAULT_TIMEOUT_SECONDS"]) ?? BASH_DEFAULT_TIMEOUT_SECONDS;
+	const rawMax = parsePositiveInt(env["PI_BASH_MAX_TIMEOUT_SECONDS"]) ?? BASH_MAX_TIMEOUT_SECONDS;
 	const maxSeconds = Math.max(rawMax, defaultSeconds);
 	return { defaultSeconds, maxSeconds };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/external-versions.json
+++ b/packages/coding-agent/src/core/extensions/builtin/external-versions.json
@@ -2,32 +2,32 @@
 	"extensions": {
 		"bash-timeout": {
 			"packageName": "pi-bash-timeout",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"source": "../pi-extensions/pi-bash-timeout"
 		},
 		"gpt-apply-patch": {
 			"packageName": "pi-apply-patch",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"source": "../pi-extensions/pi-apply-patch"
 		},
 		"todowrite": {
 			"packageName": "pi-todotools",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"source": "../pi-extensions/pi-todotools"
 		},
 		"goal": {
 			"packageName": "pi-goal",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"source": "../pi-extensions/pi-goal"
 		},
 		"websearch": {
 			"packageName": "pi-websearch",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"source": "../pi-extensions/pi-websearch"
 		},
 		"webfetch": {
 			"packageName": "pi-webfetch",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"source": "../pi-extensions/pi-webfetch"
 		},
 		"nested-agents-md": {
@@ -37,7 +37,7 @@
 		},
 		"rules": {
 			"packageName": "@code-yeongyu/pi-rules",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"source": "../pi-extensions/pi-rules"
 		}
 	}

--- a/packages/coding-agent/test/suite/builtin-extension-sync.test.ts
+++ b/packages/coding-agent/test/suite/builtin-extension-sync.test.ts
@@ -14,8 +14,8 @@ describe("synced builtin extensions", () => {
 		};
 
 		expect(manifest.extensions?.["bash-timeout"]?.packageName).toBe("pi-bash-timeout");
-		expect(manifest.extensions?.["bash-timeout"]?.version).toBe("0.1.0");
+		expect(manifest.extensions?.["bash-timeout"]?.version).toBe("0.1.1");
 		expect(manifest.extensions?.todowrite?.packageName).toBe("pi-todotools");
-		expect(manifest.extensions?.todowrite?.version).toBe("0.1.0");
+		expect(manifest.extensions?.todowrite?.version).toBe("0.1.1");
 	});
 });


### PR DESCRIPTION
## What

Reflects a dependency-version migration performed across the sibling `code-yeongyu/pi-*` extension repos that senpi vendors as builtin extensions. Each of the 7 affected repos was migrated off the dead `@mariozechner/pi-*` scope (frozen at npm 0.73.1) onto the current `@earendil-works/pi-*` scope, with toolchains and lockfiles brought current, then re-vendored here.

## Why

The vendored builtin extensions (`bash-timeout`, `gpt-apply-patch`, `todowrite`, `goal`, `websearch`, `webfetch`, `rules`) still declared peer dependencies on `@mariozechner/pi-*`, a package line that no longer receives updates — the project migrated to `@earendil-works/pi-*` (npm `0.80.6`). Four repos were also a full toolchain generation behind.

Peer deps were pinned to `*` rather than a caret range: senpi's workspace pins pi at CalVer `2026.7.10-2` while npm publishes SemVer `0.80.6`, and a caret like `^0.80.0` satisfies neither. `*` is the only range valid across both version lines (this also fixed `pi-apply-patch`, whose `^0.78.1` had already gone stale).

## Sibling repo changes (pushed to their `main`)

| repo | change | version |
|---|---|---|
| pi-bash-timeout | scope + toolchain | 0.1.0 → 0.1.1 |
| pi-goal | scope + toolchain | 0.2.0 → 0.2.1 |
| pi-websearch | scope + toolchain | 0.2.0 → 0.2.1 |
| pi-webfetch | scope + toolchain + biome autofix | 0.1.0 → 0.1.1 |
| pi-todotools | scope | 0.1.0 → 0.1.1 |
| pi-rules | scope + declare pi-tui peer + mock updates | 0.1.0 → 0.1.1 |
| pi-apply-patch | peer version `^0.78.1` → `*` | 0.1.1 → 0.1.2 |

All 7 repos: `npm run check` + tests green (513 tests total).

## This PR (senpi)

Re-ran `scripts/sync-builtin-extensions.mjs`:
- `external-versions.json`: version bumps for all 7 vendored packages
- `bash-timeout/timeout.ts`: picks up upstream index-signature access tightening (DIR_SYNC re-copy)
- `builtin-extension-sync` test: updated pinned `bash-timeout`/`todowrite` expectations to `0.1.1`

Full senpi pre-commit gate (biome, pinned-deps, shrinkwrap, install-lock, tsgo, web-ui, neo Go build+vet+test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs vendored builtin `pi-*` extensions to the latest versions after the migration to the `@earendil-works` scope. Updates `bash-timeout` env var reads to bracket notation and adjusts tests to the new versions.

- **Dependencies**
  - Bumped vendored versions in `external-versions.json`: `pi-bash-timeout` 0.1.1, `pi-apply-patch` 0.1.2, `pi-todotools` 0.1.1, `pi-goal` 0.2.1, `pi-websearch` 0.2.1, `pi-webfetch` 0.1.1, `@code-yeongyu/pi-rules` 0.1.1.

<sup>Written for commit 594070d757dd28826988055d0a1fcccdc269910f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

