### PR TITLE
fix(coding-agent): prevent post-compaction continuation deadlock

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -923,7 +923,8 @@ export class AgentSession {
 		if (event.type === "agent_end") {
 			this._flushPendingBashMessages();
 			if (!launchedContinuation && allowsQueuedContinuation && this.agent.hasQueuedMessages()) {
-				launchedContinuation = await this._continueAgentAfterCurrentRun();
+				this._scheduleContinuationAfterCurrentEvent();
+				launchedContinuation = true;
 			}
 			if (!launchedContinuation) {
 				await this._emitAgentSettled();
@@ -2752,12 +2753,26 @@ export class AgentSession {
 		try {
 			await this.agent.continue();
 			return true;
-		} catch (error) {
-			if (error instanceof Error) {
-				return false;
-			}
-			throw error;
+		} catch {
+			return false;
 		}
+	}
+
+	private _scheduleContinuationAfterCurrentEvent(): void {
+		// Tool hooks wait for queued message persistence, so continue() cannot run inside this event promise.
+		const currentEventQueue = this._agentEventQueue;
+		const finishContinuationWork = this._sessionWorkBarrier.begin();
+		const continueAfterEvent = async (): Promise<void> => {
+			const launched = await this._continueAgentAfterCurrentRun();
+			if (!launched) {
+				await this._emitAgentSettled();
+			}
+		};
+
+		void currentEventQueue
+			.then(continueAfterEvent, continueAfterEvent)
+			.finally(finishContinuationWork)
+			.catch(() => undefined);
 	}
 
 	/**
@@ -2824,11 +2839,14 @@ export class AgentSession {
 					this._incrementMessageRevision();
 				}
 
-				return await this._continueAgentAfterCurrentRun();
+				this._scheduleContinuationAfterCurrentEvent();
+				return true;
 			} else if (this.pendingMessageCount > 0) {
-				return await this._continueAgentAfterCurrentRun();
+				this._scheduleContinuationAfterCurrentEvent();
+				return true;
 			} else if (this.agent.hasQueuedMessages()) {
-				return await this._continueAgentAfterCurrentRun();
+				this._scheduleContinuationAfterCurrentEvent();
+				return true;
 			}
 
 			return false;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Post-compaction continuation deadlock fix (2026-07-12)
+
+### What changed
+
+- `agent-session.ts`: deferred post-compaction and queued-message continuations until the current serialized
+  `agent_end` event promise resolves, while registering the detached continuation in `SessionWorkBarrier`.
+- Overflow retry, threshold/pending-message delivery, and normal queued `agent_end` continuation use the same scheduler.
+
+### Why
+
+- Awaiting `agent.continue()` inside the active `agent_end` queue item deadlocked tool-bearing continuations because
+  pre-tool hooks wait for the current agent-event queue to finish persisting.
+
+### Why extension system couldn't handle this
+
+- `AgentSession` owns the event queue, tool-hook barrier, settlement state, and continuation launch boundary.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` around `agent_end` queued continuation handling and `_runAutoCompaction()` recovery.
+- LOW: `_continueAgentAfterCurrentRun()` and the session-work barrier integration.
+
 ## Upstream model context overflow recovery (2026-07-08)
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/post-compaction-tool-continuation-deadlock.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-tool-continuation-deadlock.test.ts
@@ -178,26 +178,50 @@ describe("post-compaction tool continuation regression", () => {
 		expect(getPersistedAssistantTexts(harness)).toContain("automatic continuation complete");
 	});
 
-	it("settles once when a deferred continuation cannot start", async () => {
-		const toolRuns: string[] = [];
-		const harness = await createOverflowHarness(toolRuns);
+	it("settles and releases session work when a deferred queued continuation cannot start", async () => {
+		let queuedContinuation = false;
+		let activeHarness: Harness | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_end", async () => {
+						if (queuedContinuation) return;
+						queuedContinuation = true;
+						const currentHarness = activeHarness;
+						if (!currentHarness) throw new Error("Harness was not initialized");
+						await currentHarness.session.agent.waitForIdle();
+						currentHarness.session.agent.followUp({
+							role: "user",
+							content: [{ type: "text", text: "rejected continuation" }],
+							timestamp: Date.now(),
+						});
+					});
+				},
+			],
+		});
+		activeHarness = harness;
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("seed response"), createOverflowResponse(harness)]);
-		await harness.session.prompt("seed prompt");
+		harness.setResponses([fauxAssistantMessage("initial answer"), fauxAssistantMessage("next prompt answer")]);
 		const continueSpy = vi
 			.spyOn(harness.session.agent, "continue")
 			.mockRejectedValueOnce("deferred continuation failed");
 
-		const settledBeforeOverflow = harness.eventsOfType("agent_settled").length;
-		const prompt = harness.session.prompt("overflow prompt");
+		const settledBeforePrompt = harness.eventsOfType("agent_settled").length;
+		const firstPrompt = harness.session.prompt("initial prompt");
 
-		expect(await settleWithin(prompt, 500)).toBe("settled");
+		expect(await settleWithin(firstPrompt, 500)).toBe("settled");
 		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(settledBeforePrompt + 1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		harness.session.clearQueue();
+
+		const nextPrompt = harness.session.prompt("next prompt");
+
+		expect(await settleWithin(nextPrompt, 500)).toBe("settled");
 		expect(harness.faux.state.callCount).toBe(2);
-		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
-		expect(harness.eventsOfType("agent_settled")).toHaveLength(settledBeforeOverflow + 1);
-		expect(toolRuns).toEqual([]);
-		expect(getPersistedAssistantTexts(harness)).not.toContain("recovered after tool");
+		expect(getUserTexts(harness)).toEqual(["initial prompt", "next prompt"]);
+		expect(getPersistedAssistantTexts(harness)).toContain("next prompt answer");
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(settledBeforePrompt + 2);
 	});
 
 	it("caps a repeated overflow after one compact-and-retry attempt", async () => {

--- a/packages/coding-agent/test/suite/regressions/post-compaction-tool-continuation-deadlock.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-tool-continuation-deadlock.test.ts
@@ -1,0 +1,241 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getMessageText, getUserTexts, type Harness, type HarnessOptions } from "../harness.ts";
+
+function createEchoTool(toolRuns: string[]): AgentTool {
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo text back",
+		parameters: Type.Object({ text: Type.String() }),
+		execute: async (_toolCallId, params) => {
+			const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+			toolRuns.push(text);
+			return { content: [{ type: "text", text: `echo:${text}` }], details: { text } };
+		},
+	};
+}
+
+async function settleWithin(promise: Promise<void>, timeoutMs: number): Promise<"settled" | "timed-out"> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(() => "settled" as const),
+			new Promise<"timed-out">((resolve) => {
+				timeout = setTimeout(() => resolve("timed-out"), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+	}
+}
+
+async function createOverflowHarness(
+	toolRuns: string[],
+	extensionFactories: NonNullable<HarnessOptions["extensionFactories"]> = [],
+): Promise<Harness> {
+	return createHarness({
+		models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 16 }],
+		settings: {
+			compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 },
+			retry: { enabled: false },
+		},
+		tools: [createEchoTool(toolRuns)],
+		extensionFactories: [
+			(pi) => {
+				pi.on("session_before_compact", async (event) => ({
+					compaction: {
+						summary: "overflow recovery summary",
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+						details: {},
+					},
+				}));
+			},
+			...extensionFactories,
+		],
+	});
+}
+
+function createOverflowResponse(harness: Harness, options: { timestamp?: number } = {}) {
+	const model = harness.getModel();
+	return {
+		...fauxAssistantMessage("", {
+			stopReason: "error" as const,
+			errorMessage:
+				"Error Code context_too_large: Your input exceeds the context window of this model. Please adjust your input and try again.",
+			timestamp: options.timestamp,
+		}),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+	};
+}
+
+function getPersistedAssistantTexts(harness: Harness): string[] {
+	return harness.sessionManager.getEntries().flatMap((entry) => {
+		if (entry.type !== "message" || entry.message.role !== "assistant") {
+			return [];
+		}
+		return [getMessageText(entry.message)];
+	});
+}
+
+function getPersistedAssistantErrorMessages(harness: Harness): string[] {
+	return harness.sessionManager.getEntries().flatMap((entry) => {
+		if (entry.type !== "message" || entry.message.role !== "assistant" || !entry.message.errorMessage) {
+			return [];
+		}
+		return [entry.message.errorMessage];
+	});
+}
+
+describe("post-compaction tool continuation regression", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("resumes a post-compaction overflow retry through a tool without queued input", async () => {
+		const toolRuns: string[] = [];
+		const harness = await createOverflowHarness(toolRuns);
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("seed response"),
+			createOverflowResponse(harness),
+			fauxAssistantMessage([fauxToolCall("echo", { text: "after-compaction" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage("recovered after tool"),
+		]);
+
+		await harness.session.prompt("seed prompt");
+		const settledBeforeRecovery = harness.eventsOfType("agent_settled").length;
+		const prompt = harness.session.prompt("initial overflow prompt");
+
+		expect({
+			promptResult: await settleWithin(prompt, 500),
+			toolExecutions: toolRuns.length,
+		}).toEqual({
+			promptResult: "settled",
+			toolExecutions: 1,
+		});
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(toolRuns).toEqual(["after-compaction"]);
+		expect(getUserTexts(harness)).toEqual(["initial overflow prompt"]);
+		const compactionEntries = harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction");
+		expect(compactionEntries).toHaveLength(1);
+		expect(compactionEntries.map((entry) => entry.summary)).toEqual(["overflow recovery summary"]);
+		expect(
+			harness.eventsOfType("compaction_end").map((event) => ({
+				reason: event.reason,
+				aborted: event.aborted,
+				willRetry: event.willRetry,
+			})),
+		).toEqual([{ reason: "overflow", aborted: false, willRetry: true }]);
+		expect(getPersistedAssistantTexts(harness)).toContain("recovered after tool");
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(settledBeforeRecovery + 1);
+	});
+
+	it("runs a queued follow-up tool after the current turn settles", async () => {
+		const toolRuns: string[] = [];
+		let queuedContinuation = false;
+		const harness = await createHarness({
+			tools: [createEchoTool(toolRuns)],
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_end", () => {
+						if (queuedContinuation) return;
+						queuedContinuation = true;
+						pi.sendUserMessage("automatic continuation", { deliverAs: "followUp" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("initial answer"),
+			fauxAssistantMessage([fauxToolCall("echo", { text: "automatic-follow-up" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage("automatic continuation complete"),
+		]);
+
+		const prompt = harness.session.prompt("initial prompt");
+
+		expect(await settleWithin(prompt, 500)).toBe("settled");
+		expect(toolRuns).toEqual(["automatic-follow-up"]);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(getUserTexts(harness)).toEqual(["initial prompt", "automatic continuation"]);
+		expect(getPersistedAssistantTexts(harness)).toContain("automatic continuation complete");
+	});
+
+	it("settles once when a deferred continuation cannot start", async () => {
+		const toolRuns: string[] = [];
+		const harness = await createOverflowHarness(toolRuns);
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response"), createOverflowResponse(harness)]);
+		await harness.session.prompt("seed prompt");
+		const continueSpy = vi
+			.spyOn(harness.session.agent, "continue")
+			.mockRejectedValueOnce("deferred continuation failed");
+
+		const settledBeforeOverflow = harness.eventsOfType("agent_settled").length;
+		const prompt = harness.session.prompt("overflow prompt");
+
+		expect(await settleWithin(prompt, 500)).toBe("settled");
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(settledBeforeOverflow + 1);
+		expect(toolRuns).toEqual([]);
+		expect(getPersistedAssistantTexts(harness)).not.toContain("recovered after tool");
+	});
+
+	it("caps a repeated overflow after one compact-and-retry attempt", async () => {
+		const toolRuns: string[] = [];
+		const harness = await createOverflowHarness(toolRuns);
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("seed response"),
+			createOverflowResponse(harness),
+			() => createOverflowResponse(harness, { timestamp: Date.now() + 60_000 }),
+		]);
+
+		await harness.session.prompt("seed prompt");
+		const settledBeforeRecovery = harness.eventsOfType("agent_settled").length;
+		const prompt = harness.session.prompt("overflow twice");
+
+		expect(await settleWithin(prompt, 500)).toBe("settled");
+		expect(toolRuns).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(
+			harness.eventsOfType("compaction_end").map((event) => ({
+				accepted: event.accepted,
+				errorMessage: event.errorMessage,
+				willRetry: event.willRetry,
+			})),
+		).toEqual([
+			{ accepted: true, errorMessage: undefined, willRetry: true },
+			{
+				accepted: undefined,
+				errorMessage: expect.stringMatching(
+					/^Context overflow recovery failed after one compact-and-retry attempt/,
+				),
+				willRetry: false,
+			},
+		]);
+		expect(getPersistedAssistantErrorMessages(harness)).toHaveLength(2);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(settledBeforeRecovery + 1);
+	});
+});


### PR DESCRIPTION
## Summary

Fix a permanent AgentSession deadlock that could occur after context-overflow compaction succeeded and the automatic continuation produced a tool call. The continuation is now started only after the serialized `agent_end` event promise unwinds, while `SessionWorkBarrier` keeps the initiating request open until the detached continuation settles.

The failure was reproduced from session `019f55fb-f827-76d8-90e9-c759c5efb240`. Upstream lifecycle handling informed the continuation boundary; recent `oh-my-pi` compaction-thrash changes address a separate no-headroom loop and were intentionally not ported.

## Changes

- Defer overflow retries, post-compaction queued delivery, and ordinary queued `agent_end` continuations through one scheduler outside the active agent-event queue.
- Track deferred continuation work in `SessionWorkBarrier` and emit settlement when a continuation cannot launch, including non-`Error` rejections.
- Add a regression suite covering a tool-bearing overflow retry, an exactly-once queued follow-up, continuation launch rejection, and the one-attempt repeated-overflow cap.
- Record the fork-specific lifecycle change and expected merge-conflict zones in `packages/coding-agent/src/core/changes.md`.

## QA & Evidence

- **Focused lifecycle tests:** 5 files, 47 tests passed. Covers compaction, queueing, settlement, and compaction races.
- **Repeated regression:** the new 4-test file passed 10 consecutive runs.
- **Failing-first proof:** the detached queued-continuation rejection case passes on the PR and times out on the base commit, proving the test exercises the fixed barrier path instead of a pre-existing compaction catch.
- **Full coding-agent suite:** 397 files passed; 3,552 runnable tests passed and 31 skipped with `--maxWorkers=4`.
- **Static validation:** `npm run check` passed, including Biome, dependency/lock checks, tsgo, browser smoke, web UI checks, and Neo build/vet/tests.
- **Real CLI QA:** normal mock provider loop passed 5/5, tool-bearing Responses loop passed 4/4, RPC self-test passed 4/4, and CLI smoke passed 7/7.
- **Real TUI overflow flow:** 22/22 assertions passed across `seed -> context_too_large -> compaction -> queued input -> retry tool call -> final assistant`. Exactly one queued message, compaction entry, tool result, and final marker were persisted; the sandbox, local port, and tmux session were cleaned up and real auth was unchanged.
- **Sanitization:** the final QA evidence directory and PR diff contain no detected secret-shaped content.

Sanitized local receipts are under `local-ignore/qa-evidence/20260712-compaction-continuation-deadlock/`; they are intentionally not committed.

## Risks & Residuals

- The lifecycle risk is bounded by focused queue/compaction tests, repeated runs, the complete coding-agent suite, and the real TUI reproduction.
- Two ordinary root `npm test` attempts encountered existing concurrency flakes outside this change: fixed QA-port exhaustion in the app-server daemon suite and a reftable watcher timeout under load. The daemon suite passed alone, all other workspaces passed, and the complete coding-agent suite passed with four workers. This PR does not change those unrelated tests.
- The deferred scheduler intentionally preserves the existing pre-tool queue barrier rather than weakening message-persistence ordering.
