### PR TITLE
fix(coding-agent): resume queued input after compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2781,7 +2781,8 @@ export class AgentSession {
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
 		const finishCompactionWork = this._sessionWorkBarrier.begin();
 		this._emit({ type: "compaction_start", reason });
-		this._autoCompactionAbortController = new AbortController();
+		const autoCompactionController = new AbortController();
+		this._autoCompactionAbortController = autoCompactionController;
 
 		try {
 			if (!this.model) {
@@ -2830,6 +2831,9 @@ export class AgentSession {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
 				return false;
 			}
+			if (this._autoCompactionAbortController === autoCompactionController) {
+				this._autoCompactionAbortController = undefined;
+			}
 
 			if (willRetry) {
 				const messages = this.agent.state.messages;
@@ -2869,7 +2873,9 @@ export class AgentSession {
 			});
 			return false;
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			if (this._autoCompactionAbortController === autoCompactionController) {
+				this._autoCompactionAbortController = undefined;
+			}
 			finishCompactionWork();
 		}
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -162,6 +162,7 @@ export type AgentSessionEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
 	| AgentSessionAgentEndEvent
 	| { type: "agent_settled" }
+	| { type: "continuation_error"; errorMessage: string }
 	| {
 			type: "queue_update";
 			steering: readonly string[];
@@ -281,6 +282,8 @@ export interface ExtensionBindings {
 }
 
 /** Options for AgentSession.prompt() */
+export type PromptDisposition = "handled" | "queued" | "started";
+
 export interface PromptOptions {
 	/** Whether to expand file-based prompt templates (default: true) */
 	expandPromptTemplates?: boolean;
@@ -292,6 +295,10 @@ export interface PromptOptions {
 	source?: InputSource;
 	/** Internal hook used by RPC mode to observe prompt preflight acceptance or rejection. */
 	preflightResult?: (success: boolean) => void;
+	/** Internal hook used by the TUI to distinguish handled input from owned prompt work. */
+	promptDisposition?: (disposition: PromptDisposition) => void;
+	/** Internal cancellation signal for a prompt that has not acquired session-work ownership yet. */
+	signal?: AbortSignal;
 	sessionTitlePrompt?: string | false;
 }
 
@@ -1459,9 +1466,17 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
+		const throwIfCancelled = (): void => {
+			if (!options?.signal?.aborted) return;
+			const error = new Error("Prompt cancelled before acceptance");
+			error.name = "AbortError";
+			throw error;
+		};
+		throwIfCancelled();
 		const userAbortPromise = this._userAbortPromise;
 		if (userAbortPromise) {
 			await userAbortPromise;
+			throwIfCancelled();
 		}
 		const shouldWaitForSessionWork = options?.source !== "extension";
 		if (
@@ -1469,10 +1484,12 @@ export class AgentSession {
 			(!this.isStreaming || this.isCompacting || this._sessionWorkBarrier.hasActiveWork)
 		) {
 			await this._waitForSettledSessionWork();
+			throwIfCancelled();
 		}
 
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
+		const promptDisposition = options?.promptDisposition;
 		let messages: AgentMessage[] | undefined;
 		let titlePrompt: string | undefined;
 
@@ -1481,8 +1498,10 @@ export class AgentSession {
 			// Extension commands manage their own LLM interaction via pi.sendMessage()
 			if (expandPromptTemplates && text.startsWith("/")) {
 				const handled = await this._tryExecuteExtensionCommand(text);
+				throwIfCancelled();
 				if (handled) {
 					// Extension command executed, no prompt to send
+					promptDisposition?.("handled");
 					preflightResult?.(true);
 					return;
 				}
@@ -1498,7 +1517,9 @@ export class AgentSession {
 					options?.source ?? "interactive",
 					this.isStreaming ? options?.streamingBehavior : undefined,
 				);
+				throwIfCancelled();
 				if (inputResult.action === "handled") {
+					promptDisposition?.("handled");
 					preflightResult?.(true);
 					return;
 				}
@@ -1528,6 +1549,7 @@ export class AgentSession {
 				} else {
 					await this._queueSteer(expandedText, currentImages);
 				}
+				promptDisposition?.("queued");
 				preflightResult?.(true);
 				return;
 			}
@@ -1618,6 +1640,8 @@ export class AgentSession {
 			return;
 		}
 
+		throwIfCancelled();
+		promptDisposition?.("started");
 		preflightResult?.(true);
 		await this._promptAgent(messages);
 		await this.waitForRetry();
@@ -2748,14 +2772,9 @@ export class AgentSession {
 		}
 	}
 
-	private async _continueAgentAfterCurrentRun(): Promise<boolean> {
+	private async _continueAgentAfterCurrentRun(): Promise<void> {
 		await this.agent.waitForIdle();
-		try {
-			await this.agent.continue();
-			return true;
-		} catch {
-			return false;
-		}
+		await this.agent.continue();
 	}
 
 	private _scheduleContinuationAfterCurrentEvent(): void {
@@ -2763,8 +2782,14 @@ export class AgentSession {
 		const currentEventQueue = this._agentEventQueue;
 		const finishContinuationWork = this._sessionWorkBarrier.begin();
 		const continueAfterEvent = async (): Promise<void> => {
-			const launched = await this._continueAgentAfterCurrentRun();
-			if (!launched) {
+			try {
+				await this._continueAgentAfterCurrentRun();
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				this._emit({
+					type: "continuation_error",
+					errorMessage: `Failed to continue queued messages: ${message}`,
+				});
 				await this._emitAgentSettled();
 			}
 		};

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## Release accepted auto-compaction ownership before recovery (2026-07-13)
+
+### What changed
+
+- `agent-session.ts`: accepted auto-compaction now releases only its own abort-controller identity before awaiting the recovery continuation, while the session-work barrier remains active until recovery settles.
+- Final cleanup is identity-guarded so an older compaction cannot clear a newer controller installed during recovery.
+
+### Why extension system couldn't handle this
+
+- Interactive input classification reads core-owned `AgentSession.isCompacting`, and fresh-prompt serialization depends on the private session-work barrier. Extensions cannot split those two lifecycle boundaries safely.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` around `_runAutoCompaction()` accepted-result handling and final controller cleanup.
+
 ## Post-compaction continuation deadlock fix (2026-07-12)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -4,8 +4,9 @@
 
 ### What changed
 
-- `compaction-queue-transfer.ts`: transfers one captured interactive batch entry by entry, commits accepted entries, and restores only the undelivered suffix ahead of input that arrived during transfer.
-- `interactive-mode.ts`: post-compaction rollback no longer clears native session queues; the first prompt carries explicit steer/follow-up intent and commits at prompt preflight acceptance.
+- `compaction-queue-transfer.ts`: transfers one captured interactive batch entry by entry, commits exact accepted identities, searches past hook-handled entries until prompt work has an owner, and restores only the still-owned undelivered suffix ahead of later input.
+- `interactive-mode.ts`: post-compaction rollback no longer clears unrelated native session queues. Transferred-but-unaccepted entries remain visible to Alt-Up/Esc, cancellation restores them without a later prompt start, and detached continuation-launch failures surface in the TUI while native work remains retryable. Overlapping flush requests run in call order, stop when exact ownership is cleared, and are invalidated when a session rebind advances the transfer generation.
+- Mixed steer/follow-up batches adopt the native queue contract after the first prompt owns work: steering runs before follow-ups, with FIFO preserved within each mode rather than across modes.
 
 ### Why extension system couldn't handle this
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Transactional post-compaction queue transfer (2026-07-13)
+
+### What changed
+
+- `compaction-queue-transfer.ts`: transfers one captured interactive batch entry by entry, commits accepted entries, and restores only the undelivered suffix ahead of input that arrived during transfer.
+- `interactive-mode.ts`: post-compaction rollback no longer clears native session queues; the first prompt carries explicit steer/follow-up intent and commits at prompt preflight acceptance.
+
+### Why extension system couldn't handle this
+
+- `compactionQueuedMessages` and the first-prompt handoff are private TUI state. Extensions can add native continuations, but cannot transactionally own or restore the host's interactive queue.
+
+### Expected merge conflict zones
+
+- HIGH: `interactive-mode.ts` around `flushCompactionQueue()` and pending-message display updates.
+- LOW: `compaction-queue-transfer.ts` (fork-only helper).
+
 ## eval/tool image renderer lifecycle (2026-07-10)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
+++ b/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
@@ -3,16 +3,19 @@ export type CompactionQueuedMessage = {
 	readonly mode: "steer" | "followUp";
 };
 
+export type PromptDisposition = "handled" | "queued" | "started";
+
 type TransferOptions = {
 	readonly willRetry?: boolean;
 };
 
 type TransferDependencies = {
 	readonly takeBatch: () => CompactionQueuedMessage[];
-	readonly restoreUndelivered: (messages: readonly CompactionQueuedMessage[]) => void;
+	readonly commitAccepted: (message: CompactionQueuedMessage) => boolean;
+	readonly restoreUndelivered: (messages: readonly CompactionQueuedMessage[]) => number;
 	readonly isCommand: (message: CompactionQueuedMessage) => boolean;
 	readonly deliverCommand: (message: CompactionQueuedMessage) => Promise<void>;
-	readonly deliverFirstPrompt: (message: CompactionQueuedMessage) => Promise<void>;
+	readonly deliverFirstPrompt: (message: CompactionQueuedMessage) => Promise<PromptDisposition>;
 	readonly deliverQueued: (message: CompactionQueuedMessage) => Promise<void>;
 	readonly reportFailure: (error: unknown, undeliveredCount: number) => void;
 };
@@ -33,59 +36,63 @@ export async function transferCompactionQueue(
 				} else {
 					await dependencies.deliverQueued(message);
 				}
+				if (!dependencies.commitAccepted(message)) return;
 				acceptedCount += 1;
 			}
 			return;
 		}
 
-		const firstPromptIndex = batch.findIndex((message) => !dependencies.isCommand(message));
-		if (firstPromptIndex === -1) {
-			for (const message of batch) {
-				await dependencies.deliverCommand(message);
-				acceptedCount += 1;
-			}
-			return;
-		}
-
-		for (const message of batch.slice(0, firstPromptIndex)) {
-			await dependencies.deliverCommand(message);
-			acceptedCount += 1;
-		}
-
-		await dependencies.deliverFirstPrompt(batch[firstPromptIndex]);
-		acceptedCount += 1;
-
-		for (const message of batch.slice(firstPromptIndex + 1)) {
+		let promptWorkOwned = false;
+		for (const message of batch) {
 			if (dependencies.isCommand(message)) {
 				await dependencies.deliverCommand(message);
+			} else if (!promptWorkOwned) {
+				const disposition = await dependencies.deliverFirstPrompt(message);
+				promptWorkOwned = disposition !== "handled";
 			} else {
 				await dependencies.deliverQueued(message);
 			}
+			if (!dependencies.commitAccepted(message)) return;
 			acceptedCount += 1;
 		}
 	} catch (error) {
 		const failure = error instanceof Error ? error : new Error(String(error));
 		const undelivered = batch.slice(acceptedCount);
-		dependencies.restoreUndelivered(undelivered);
-		dependencies.reportFailure(failure, undelivered.length);
+		const restoredCount = dependencies.restoreUndelivered(undelivered);
+		if (restoredCount > 0) {
+			dependencies.reportFailure(failure, restoredCount);
+		}
 	}
 }
 
-export function waitForPromptAcceptance(
-	startPrompt: (preflightResult: (success: boolean) => void) => Promise<void>,
+export function waitForPromptDisposition(
+	startPrompt: (
+		preflightResult: (success: boolean) => void,
+		promptDisposition: (disposition: PromptDisposition) => void,
+	) => Promise<void>,
 	reportPostAcceptanceFailure: (error: unknown) => void,
-): Promise<void> {
-	return new Promise<void>((resolve, reject) => {
+): Promise<PromptDisposition> {
+	return new Promise<PromptDisposition>((resolve, reject) => {
 		let accepted = false;
 		let rejectedAtPreflight = false;
-		const prompt = startPrompt((success) => {
-			if (success) {
-				accepted = true;
-				resolve();
-			} else {
-				rejectedAtPreflight = true;
-			}
-		});
+		let disposition: PromptDisposition | undefined;
+		const resolveAcceptedDisposition = (): void => {
+			if (accepted && disposition) resolve(disposition);
+		};
+		const prompt = startPrompt(
+			(success) => {
+				if (success) {
+					accepted = true;
+					resolveAcceptedDisposition();
+				} else {
+					rejectedAtPreflight = true;
+				}
+			},
+			(nextDisposition) => {
+				disposition = nextDisposition;
+				resolveAcceptedDisposition();
+			},
+		);
 
 		void prompt.then(
 			() => {

--- a/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
+++ b/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
@@ -1,0 +1,105 @@
+export type CompactionQueuedMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+type TransferOptions = {
+	readonly willRetry?: boolean;
+};
+
+type TransferDependencies = {
+	readonly takeBatch: () => CompactionQueuedMessage[];
+	readonly restoreUndelivered: (messages: readonly CompactionQueuedMessage[]) => void;
+	readonly isCommand: (message: CompactionQueuedMessage) => boolean;
+	readonly deliverCommand: (message: CompactionQueuedMessage) => Promise<void>;
+	readonly deliverFirstPrompt: (message: CompactionQueuedMessage) => Promise<void>;
+	readonly deliverQueued: (message: CompactionQueuedMessage) => Promise<void>;
+	readonly reportFailure: (error: unknown, undeliveredCount: number) => void;
+};
+
+export async function transferCompactionQueue(
+	dependencies: TransferDependencies,
+	options: TransferOptions = {},
+): Promise<void> {
+	const batch = dependencies.takeBatch();
+	if (batch.length === 0) return;
+
+	let acceptedCount = 0;
+	try {
+		if (options.willRetry) {
+			for (const message of batch) {
+				if (dependencies.isCommand(message)) {
+					await dependencies.deliverCommand(message);
+				} else {
+					await dependencies.deliverQueued(message);
+				}
+				acceptedCount += 1;
+			}
+			return;
+		}
+
+		const firstPromptIndex = batch.findIndex((message) => !dependencies.isCommand(message));
+		if (firstPromptIndex === -1) {
+			for (const message of batch) {
+				await dependencies.deliverCommand(message);
+				acceptedCount += 1;
+			}
+			return;
+		}
+
+		for (const message of batch.slice(0, firstPromptIndex)) {
+			await dependencies.deliverCommand(message);
+			acceptedCount += 1;
+		}
+
+		await dependencies.deliverFirstPrompt(batch[firstPromptIndex]);
+		acceptedCount += 1;
+
+		for (const message of batch.slice(firstPromptIndex + 1)) {
+			if (dependencies.isCommand(message)) {
+				await dependencies.deliverCommand(message);
+			} else {
+				await dependencies.deliverQueued(message);
+			}
+			acceptedCount += 1;
+		}
+	} catch (error) {
+		const failure = error instanceof Error ? error : new Error(String(error));
+		const undelivered = batch.slice(acceptedCount);
+		dependencies.restoreUndelivered(undelivered);
+		dependencies.reportFailure(failure, undelivered.length);
+	}
+}
+
+export function waitForPromptAcceptance(
+	startPrompt: (preflightResult: (success: boolean) => void) => Promise<void>,
+	reportPostAcceptanceFailure: (error: unknown) => void,
+): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		let accepted = false;
+		let rejectedAtPreflight = false;
+		const prompt = startPrompt((success) => {
+			if (success) {
+				accepted = true;
+				resolve();
+			} else {
+				rejectedAtPreflight = true;
+			}
+		});
+
+		void prompt.then(
+			() => {
+				if (rejectedAtPreflight && !accepted) {
+					reject(new Error("Queued prompt was rejected before acceptance"));
+				}
+			},
+			(error: unknown) => {
+				if (accepted) {
+					reportPostAcceptanceFailure(error);
+				} else {
+					reject(error);
+				}
+			},
+		);
+	});
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -40,6 +40,7 @@ import {
 	matchesKey,
 	ProcessTerminal,
 	Spacer,
+	sanitizeTerminalLabel,
 	setKeybindings,
 	Text,
 	TruncatedText,
@@ -1869,6 +1870,7 @@ export class InteractiveMode {
 		this.pendingMessagesContainer.clear();
 		for (const controller of this.compactionTransferAbortControllers.values()) controller.abort();
 		this.compactionQueueGeneration += 1;
+		this.compactionQueueFlushTail = undefined;
 		this.compactionQueuedMessages = [];
 		this.compactionInFlightMessages = [];
 		this.compactionTransferAbortControllers.clear();
@@ -3422,7 +3424,7 @@ export class InteractiveMode {
 				break;
 
 			case "continuation_error":
-				this.showError(event.errorMessage);
+				this.showError(sanitizeTerminalLabel(event.errorMessage));
 				break;
 
 			case "compaction_start": {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -112,7 +112,7 @@ import { abortedErrorLabel } from "./aborted-error-label.ts";
 import {
 	type CompactionQueuedMessage,
 	transferCompactionQueue,
-	waitForPromptAcceptance,
+	waitForPromptDisposition,
 } from "./compaction-queue-transfer.ts";
 import { ArminComponent } from "./components/armin.ts";
 import { AssistantMessageComponent } from "./components/assistant-message.ts";
@@ -498,6 +498,10 @@ export class InteractiveMode {
 
 	// Messages queued while compaction is running
 	private compactionQueuedMessages: CompactionQueuedMessage[] = [];
+	private compactionInFlightMessages: CompactionQueuedMessage[] = [];
+	private compactionTransferAbortControllers = new Map<CompactionQueuedMessage, AbortController>();
+	private compactionQueueFlushTail: Promise<void> | undefined;
+	private compactionQueueGeneration = 0;
 
 	// Shutdown state
 	private shutdownRequested = false;
@@ -1863,7 +1867,11 @@ export class InteractiveMode {
 		this.loadedResourcesContainer.clear();
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
+		for (const controller of this.compactionTransferAbortControllers.values()) controller.abort();
+		this.compactionQueueGeneration += 1;
 		this.compactionQueuedMessages = [];
+		this.compactionInFlightMessages = [];
+		this.compactionTransferAbortControllers.clear();
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.clearPendingTools();
@@ -3413,6 +3421,10 @@ export class InteractiveMode {
 				await this.checkShutdownRequested();
 				break;
 
+			case "continuation_error":
+				this.showError(event.errorMessage);
+				break;
+
 			case "compaction_start": {
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(true);
@@ -4313,10 +4325,12 @@ export class InteractiveMode {
 		return {
 			steering: [
 				...this.session.getSteeringMessages(),
+				...this.compactionInFlightMessages.filter((msg) => msg.mode === "steer").map((msg) => msg.text),
 				...this.compactionQueuedMessages.filter((msg) => msg.mode === "steer").map((msg) => msg.text),
 			],
 			followUp: [
 				...this.session.getFollowUpMessages(),
+				...this.compactionInFlightMessages.filter((msg) => msg.mode === "followUp").map((msg) => msg.text),
 				...this.compactionQueuedMessages.filter((msg) => msg.mode === "followUp").map((msg) => msg.text),
 			],
 		};
@@ -4328,12 +4342,12 @@ export class InteractiveMode {
 	 */
 	private clearAllQueues(): { steering: string[]; followUp: string[] } {
 		const { steering, followUp } = this.session.clearQueue();
-		const compactionSteering = this.compactionQueuedMessages
-			.filter((msg) => msg.mode === "steer")
-			.map((msg) => msg.text);
-		const compactionFollowUp = this.compactionQueuedMessages
-			.filter((msg) => msg.mode === "followUp")
-			.map((msg) => msg.text);
+		const compactionMessages = [...this.compactionInFlightMessages, ...this.compactionQueuedMessages];
+		const compactionSteering = compactionMessages.filter((msg) => msg.mode === "steer").map((msg) => msg.text);
+		const compactionFollowUp = compactionMessages.filter((msg) => msg.mode === "followUp").map((msg) => msg.text);
+		for (const controller of this.compactionTransferAbortControllers.values()) controller.abort();
+		this.compactionInFlightMessages = [];
+		this.compactionTransferAbortControllers.clear();
 		this.compactionQueuedMessages = [];
 		return {
 			steering: [...steering, ...compactionSteering],
@@ -4426,46 +4440,81 @@ export class InteractiveMode {
 	}
 
 	private async flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void> {
-		await transferCompactionQueue(
-			{
-				takeBatch: () => {
-					const batch = this.compactionQueuedMessages;
-					this.compactionQueuedMessages = [];
-					this.updatePendingMessagesDisplay();
-					return batch;
+		const session = this.session;
+		const generation = this.compactionQueueGeneration ?? 0;
+		const previousFlush = this.compactionQueueFlushTail;
+		const runTransfer = async (): Promise<void> => {
+			if ((this.compactionQueueGeneration ?? 0) !== generation || this.session !== session) return;
+			await transferCompactionQueue(
+				{
+					takeBatch: () => {
+						const batch = this.compactionQueuedMessages;
+						this.compactionQueuedMessages = [];
+						this.compactionInFlightMessages.push(...batch);
+						for (const message of batch) {
+							this.compactionTransferAbortControllers.set(message, new AbortController());
+						}
+						this.updatePendingMessagesDisplay();
+						return batch;
+					},
+					commitAccepted: (message) => {
+						const index = this.compactionInFlightMessages.indexOf(message);
+						if (index === -1) return false;
+						this.compactionInFlightMessages.splice(index, 1);
+						this.compactionTransferAbortControllers.delete(message);
+						this.updatePendingMessagesDisplay();
+						return true;
+					},
+					restoreUndelivered: (messages) => {
+						const restorable = messages.filter((message) => this.compactionInFlightMessages.includes(message));
+						const restorableSet = new Set(restorable);
+						this.compactionInFlightMessages = this.compactionInFlightMessages.filter(
+							(message) => !restorableSet.has(message),
+						);
+						for (const message of restorable) this.compactionTransferAbortControllers.delete(message);
+						this.compactionQueuedMessages = [...restorable, ...this.compactionQueuedMessages];
+						this.updatePendingMessagesDisplay();
+						return restorable.length;
+					},
+					isCommand: (message) => this.isExtensionCommand(message.text),
+					deliverCommand: (message) => session.prompt(message.text),
+					deliverFirstPrompt: (message) =>
+						waitForPromptDisposition(
+							(preflightResult, promptDisposition) =>
+								session.prompt(message.text, {
+									streamingBehavior: message.mode,
+									preflightResult,
+									promptDisposition,
+									signal: this.compactionTransferAbortControllers.get(message)?.signal,
+								}),
+							(error) => {
+								this.showError(
+									`Queued prompt failed after acceptance: ${error instanceof Error ? error.message : String(error)}`,
+								);
+							},
+						),
+					deliverQueued: (message) =>
+						message.mode === "followUp" ? session.followUp(message.text) : session.steer(message.text),
+					reportFailure: (error, undeliveredCount) => {
+						this.showError(
+							`Failed to send queued message${undeliveredCount === 1 ? "" : "s"}: ${
+								error instanceof Error ? error.message : String(error)
+							}`,
+						);
+					},
 				},
-				restoreUndelivered: (messages) => {
-					this.compactionQueuedMessages = [...messages, ...this.compactionQueuedMessages];
-					this.updatePendingMessagesDisplay();
-				},
-				isCommand: (message) => this.isExtensionCommand(message.text),
-				deliverCommand: (message) => this.session.prompt(message.text),
-				deliverFirstPrompt: (message) =>
-					waitForPromptAcceptance(
-						(preflightResult) =>
-							this.session.prompt(message.text, {
-								streamingBehavior: message.mode,
-								preflightResult,
-							}),
-						(error) => {
-							this.showError(
-								`Queued prompt failed after acceptance: ${error instanceof Error ? error.message : String(error)}`,
-							);
-						},
-					),
-				deliverQueued: (message) =>
-					message.mode === "followUp" ? this.session.followUp(message.text) : this.session.steer(message.text),
-				reportFailure: (error, undeliveredCount) => {
-					this.showError(
-						`Failed to send queued message${undeliveredCount === 1 ? "" : "s"}: ${
-							error instanceof Error ? error.message : String(error)
-						}`,
-					);
-				},
-			},
-			options,
-		);
-		this.updatePendingMessagesDisplay();
+				options,
+			);
+			this.updatePendingMessagesDisplay();
+		};
+		const currentFlush = previousFlush ? previousFlush.then(runTransfer, runTransfer) : runTransfer();
+		const settledFlush = currentFlush.catch(() => undefined);
+		this.compactionQueueFlushTail = settledFlush;
+		try {
+			await currentFlush;
+		} finally {
+			if (this.compactionQueueFlushTail === settledFlush) this.compactionQueueFlushTail = undefined;
+		}
 	}
 
 	/** Move pending bash components from pending area to chat */

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4490,6 +4490,7 @@ export class InteractiveMode {
 									signal: this.compactionTransferAbortControllers.get(message)?.signal,
 								}),
 							(error) => {
+								if ((this.compactionQueueGeneration ?? 0) !== generation || this.session !== session) return;
 								this.showError(
 									`Queued prompt failed after acceptance: ${error instanceof Error ? error.message : String(error)}`,
 								);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -109,6 +109,11 @@ import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
 import { checkForNewPiVersion, getReleaseChangelogUrl } from "../../utils/version-check.ts";
 import { abortedErrorLabel } from "./aborted-error-label.ts";
+import {
+	type CompactionQueuedMessage,
+	transferCompactionQueue,
+	waitForPromptAcceptance,
+} from "./compaction-queue-transfer.ts";
 import { ArminComponent } from "./components/armin.ts";
 import { AssistantMessageComponent } from "./components/assistant-message.ts";
 import { BashExecutionComponent } from "./components/bash-execution.ts";
@@ -206,11 +211,6 @@ class ExpandableText extends Text implements Expandable {
 		this.setText(expanded ? this.getExpandedText() : this.getCollapsedText());
 	}
 }
-
-type CompactionQueuedMessage = {
-	text: string;
-	mode: "steer" | "followUp";
-};
 
 type ToolExecutionStartEvent = Extract<AgentSessionEvent, { type: "tool_execution_start" }>;
 type ToolExecutionEndEvent = Extract<AgentSessionEvent, { type: "tool_execution_end" }>;
@@ -4426,80 +4426,46 @@ export class InteractiveMode {
 	}
 
 	private async flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void> {
-		if (this.compactionQueuedMessages.length === 0) {
-			return;
-		}
-
-		const queuedMessages = [...this.compactionQueuedMessages];
-		this.compactionQueuedMessages = [];
+		await transferCompactionQueue(
+			{
+				takeBatch: () => {
+					const batch = this.compactionQueuedMessages;
+					this.compactionQueuedMessages = [];
+					this.updatePendingMessagesDisplay();
+					return batch;
+				},
+				restoreUndelivered: (messages) => {
+					this.compactionQueuedMessages = [...messages, ...this.compactionQueuedMessages];
+					this.updatePendingMessagesDisplay();
+				},
+				isCommand: (message) => this.isExtensionCommand(message.text),
+				deliverCommand: (message) => this.session.prompt(message.text),
+				deliverFirstPrompt: (message) =>
+					waitForPromptAcceptance(
+						(preflightResult) =>
+							this.session.prompt(message.text, {
+								streamingBehavior: message.mode,
+								preflightResult,
+							}),
+						(error) => {
+							this.showError(
+								`Queued prompt failed after acceptance: ${error instanceof Error ? error.message : String(error)}`,
+							);
+						},
+					),
+				deliverQueued: (message) =>
+					message.mode === "followUp" ? this.session.followUp(message.text) : this.session.steer(message.text),
+				reportFailure: (error, undeliveredCount) => {
+					this.showError(
+						`Failed to send queued message${undeliveredCount === 1 ? "" : "s"}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+				},
+			},
+			options,
+		);
 		this.updatePendingMessagesDisplay();
-
-		const restoreQueue = (error: unknown) => {
-			this.session.clearQueue();
-			this.compactionQueuedMessages = queuedMessages;
-			this.updatePendingMessagesDisplay();
-			this.showError(
-				`Failed to send queued message${queuedMessages.length > 1 ? "s" : ""}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		};
-
-		try {
-			if (options?.willRetry) {
-				// When retry is pending, queue messages for the retry turn
-				for (const message of queuedMessages) {
-					if (this.isExtensionCommand(message.text)) {
-						await this.session.prompt(message.text);
-					} else if (message.mode === "followUp") {
-						await this.session.followUp(message.text);
-					} else {
-						await this.session.steer(message.text);
-					}
-				}
-				this.updatePendingMessagesDisplay();
-				return;
-			}
-
-			// Find first non-extension-command message to use as prompt
-			const firstPromptIndex = queuedMessages.findIndex((message) => !this.isExtensionCommand(message.text));
-			if (firstPromptIndex === -1) {
-				// All extension commands - execute them all
-				for (const message of queuedMessages) {
-					await this.session.prompt(message.text);
-				}
-				return;
-			}
-
-			// Execute any extension commands before the first prompt
-			const preCommands = queuedMessages.slice(0, firstPromptIndex);
-			const firstPrompt = queuedMessages[firstPromptIndex];
-			const rest = queuedMessages.slice(firstPromptIndex + 1);
-
-			for (const message of preCommands) {
-				await this.session.prompt(message.text);
-			}
-
-			// Send first prompt (starts streaming)
-			const promptPromise = this.session.prompt(firstPrompt.text).catch((error) => {
-				restoreQueue(error);
-			});
-
-			// Queue remaining messages
-			for (const message of rest) {
-				if (this.isExtensionCommand(message.text)) {
-					await this.session.prompt(message.text);
-				} else if (message.mode === "followUp") {
-					await this.session.followUp(message.text);
-				} else {
-					await this.session.steer(message.text);
-				}
-			}
-			this.updatePendingMessagesDisplay();
-			void promptPromise;
-		} catch (error) {
-			restoreQueue(error);
-		}
 	}
 
 	/** Move pending bash components from pending area to chat */

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
@@ -1,3 +1,4 @@
+import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { expect, it, vi } from "vitest";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 
@@ -122,4 +123,71 @@ it("starts a replacement-session flush while an old transfer remains pending", a
 	expect(context.compactionQueueFlushTail).toBeUndefined();
 	expect(context.compactionQueuedMessages).toEqual([]);
 	expect(context.compactionInFlightMessages).toEqual([]);
+});
+
+it("does not render an accepted old-session prompt failure after session rebind", async () => {
+	const oldMessage: QueueMessage = { text: "accepted old-session prompt", mode: "steer" };
+	let rejectOldPrompt: ((error: Error) => void) | undefined;
+	const oldPromptHeld = new Promise<void>((_resolve, reject) => {
+		rejectOldPrompt = reject;
+	});
+	const showError = vi.fn();
+	const replacementSession: SessionLike = {
+		prompt: vi.fn(async () => {}),
+		followUp: vi.fn(async () => {}),
+		steer: vi.fn(async () => {}),
+	};
+	const context: {
+		compactionQueuedMessages: QueueMessage[];
+		compactionInFlightMessages: QueueMessage[];
+		compactionTransferAbortControllers: Map<QueueMessage, AbortController>;
+		compactionQueueFlushTail: Promise<void> | undefined;
+		compactionQueueGeneration: number;
+		session: SessionLike;
+		readonly isExtensionCommand: (text: string) => boolean;
+		readonly showError: ReturnType<typeof vi.fn>;
+		readonly updatePendingMessagesDisplay: ReturnType<typeof vi.fn>;
+		readonly loadedResourcesContainer: { clear(): void };
+		readonly chatContainer: { clear(): void };
+		readonly pendingMessagesContainer: { clear(): void };
+		streamingComponent: undefined;
+		streamingMessage: undefined;
+		readonly clearPendingTools: () => void;
+		readonly clearToolHookStatuses: () => void;
+		readonly renderInitialMessages: () => void;
+	} = {
+		compactionQueuedMessages: [oldMessage],
+		compactionInFlightMessages: [],
+		compactionTransferAbortControllers: new Map(),
+		compactionQueueFlushTail: undefined,
+		compactionQueueGeneration: 0,
+		session: {
+			prompt: vi.fn((_text: string, options?: PromptOptions) => {
+				options?.promptDisposition?.("started");
+				options?.preflightResult?.(true);
+				return oldPromptHeld;
+			}),
+			followUp: vi.fn(async () => {}),
+			steer: vi.fn(async () => {}),
+		},
+		isExtensionCommand: () => false,
+		showError,
+		updatePendingMessagesDisplay: vi.fn(),
+		loadedResourcesContainer: { clear: vi.fn() },
+		chatContainer: { clear: vi.fn() },
+		pendingMessagesContainer: { clear: vi.fn() },
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		clearPendingTools: vi.fn(),
+		clearToolHookStatuses: vi.fn(),
+		renderInitialMessages: vi.fn(),
+	};
+
+	await getFlushCompactionQueue()(context);
+	getRenderCurrentSessionState()(context);
+	context.session = replacementSession;
+	rejectOldPrompt?.(new Error("stale old-session failure"));
+	await waitForImmediate();
+
+	expect(showError).not.toHaveBeenCalled();
 });

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
@@ -1,0 +1,125 @@
+import { expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type QueueMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+type PromptOptions = {
+	readonly preflightResult?: (success: boolean) => void;
+	readonly promptDisposition?: (disposition: "handled" | "queued" | "started") => void;
+};
+
+type SessionLike = {
+	readonly prompt: (text: string, options?: PromptOptions) => Promise<void>;
+	readonly followUp: (text: string) => Promise<void>;
+	readonly steer: (text: string) => Promise<void>;
+};
+
+function getFlushCompactionQueue() {
+	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
+	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
+	return (context: object): Promise<void> => Promise.resolve(flush.call(context));
+}
+
+function getRenderCurrentSessionState() {
+	const render = Reflect.get(InteractiveMode.prototype, "renderCurrentSessionState");
+	if (typeof render !== "function") throw new Error("Expected InteractiveMode.renderCurrentSessionState");
+	return (context: object): void => render.call(context);
+}
+
+it("starts a replacement-session flush while an old transfer remains pending", async () => {
+	const oldMessage: QueueMessage = { text: "old prompt waiting before acceptance", mode: "steer" };
+	const replacementMessage: QueueMessage = { text: "/replacement prompt", mode: "steer" };
+	let markOldPromptStarted: (() => void) | undefined;
+	let rejectOldPrompt: ((error: Error) => void) | undefined;
+	let releaseReplacementPrompt: (() => void) | undefined;
+	const oldPromptStarted = new Promise<void>((resolve) => {
+		markOldPromptStarted = resolve;
+	});
+	const oldPromptHeld = new Promise<void>((_resolve, reject) => {
+		rejectOldPrompt = reject;
+	});
+	const replacementPromptHeld = new Promise<void>((resolve) => {
+		releaseReplacementPrompt = resolve;
+	});
+	const replacementPrompt = vi.fn(() => replacementPromptHeld);
+	const replacementSession: SessionLike = {
+		prompt: replacementPrompt,
+		followUp: vi.fn(async () => {}),
+		steer: vi.fn(async () => {}),
+	};
+	const context: {
+		compactionQueuedMessages: QueueMessage[];
+		compactionInFlightMessages: QueueMessage[];
+		compactionTransferAbortControllers: Map<QueueMessage, AbortController>;
+		compactionQueueFlushTail: Promise<void> | undefined;
+		compactionQueueGeneration: number;
+		session: SessionLike;
+		readonly isExtensionCommand: (text: string) => boolean;
+		readonly showError: ReturnType<typeof vi.fn>;
+		readonly updatePendingMessagesDisplay: ReturnType<typeof vi.fn>;
+		readonly loadedResourcesContainer: { clear(): void };
+		readonly chatContainer: { clear(): void };
+		readonly pendingMessagesContainer: { clear(): void };
+		streamingComponent: undefined;
+		streamingMessage: undefined;
+		readonly clearPendingTools: () => void;
+		readonly clearToolHookStatuses: () => void;
+		readonly renderInitialMessages: () => void;
+	} = {
+		compactionQueuedMessages: [oldMessage],
+		compactionInFlightMessages: [],
+		compactionTransferAbortControllers: new Map(),
+		compactionQueueFlushTail: undefined,
+		compactionQueueGeneration: 0,
+		session: {
+			prompt: vi.fn(() => {
+				markOldPromptStarted?.();
+				return oldPromptHeld;
+			}),
+			followUp: vi.fn(async () => {}),
+			steer: vi.fn(async () => {}),
+		},
+		isExtensionCommand: (text) => text.startsWith("/"),
+		showError: vi.fn(),
+		updatePendingMessagesDisplay: vi.fn(),
+		loadedResourcesContainer: { clear: vi.fn() },
+		chatContainer: { clear: vi.fn() },
+		pendingMessagesContainer: { clear: vi.fn() },
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		clearPendingTools: vi.fn(),
+		clearToolHookStatuses: vi.fn(),
+		renderInitialMessages: vi.fn(),
+	};
+
+	const flushCompactionQueue = getFlushCompactionQueue();
+	const oldFlush = flushCompactionQueue(context);
+	await oldPromptStarted;
+
+	getRenderCurrentSessionState()(context);
+	context.session = replacementSession;
+	context.compactionQueuedMessages = [replacementMessage];
+	const replacementFlush = flushCompactionQueue(context);
+
+	try {
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(replacementPrompt).toHaveBeenCalledWith(replacementMessage.text);
+		const replacementTail = context.compactionQueueFlushTail;
+		expect(replacementTail).toBeDefined();
+
+		rejectOldPrompt?.(new Error("release stale old transfer"));
+		await oldFlush;
+		expect(context.compactionQueueFlushTail).toBe(replacementTail);
+	} finally {
+		rejectOldPrompt?.(new Error("cleanup stale old transfer"));
+		releaseReplacementPrompt?.();
+		await Promise.allSettled([oldFlush, replacementFlush]);
+	}
+
+	expect(context.compactionQueueFlushTail).toBeUndefined();
+	expect(context.compactionQueuedMessages).toEqual([]);
+	expect(context.compactionInFlightMessages).toEqual([]);
+});

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-transfer-concurrency.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-transfer-concurrency.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type QueueMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+type PromptOptions = {
+	readonly streamingBehavior?: "steer" | "followUp";
+	readonly preflightResult?: (success: boolean) => void;
+	readonly promptDisposition?: (disposition: "handled" | "queued" | "started") => void;
+};
+
+function getFlushCompactionQueue() {
+	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
+	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
+	return (context: object, options?: { willRetry?: boolean }): Promise<void> =>
+		Promise.resolve(flush.call(context, options));
+}
+
+function getClearAllQueues() {
+	const clear = Reflect.get(InteractiveMode.prototype, "clearAllQueues");
+	if (typeof clear !== "function") throw new Error("Expected InteractiveMode.clearAllQueues");
+	return (context: object): { steering: string[]; followUp: string[] } => clear.call(context);
+}
+
+describe("InteractiveMode compaction queue ownership and concurrency", () => {
+	it("stops before the suffix when cancellation clears ownership after native acceptance", async () => {
+		const first: QueueMessage = { text: "accepted before cancel", mode: "steer" };
+		const suffix: QueueMessage = { text: "must remain canceled", mode: "followUp" };
+		const delivered: string[] = [];
+		const showError = vi.fn();
+		const context = {
+			compactionQueuedMessages: [first, suffix],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
+			isExtensionCommand: () => false,
+			showError,
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue: vi.fn(() => ({ steering: [first.text], followUp: [] })),
+				prompt: vi.fn(async () => {}),
+				followUp: vi.fn(async (text: string) => {
+					delivered.push(text);
+				}),
+				steer: vi.fn(async (text: string) => {
+					delivered.push(text);
+					getClearAllQueues()(context);
+				}),
+			},
+		};
+
+		await getFlushCompactionQueue()(context, { willRetry: true });
+
+		expect(delivered).toEqual([first.text]);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(showError).not.toHaveBeenCalled();
+	});
+
+	it("does not deliver a suffix into a replacement session after a queued command rebinds", async () => {
+		const command: QueueMessage = { text: "/switch", mode: "steer" };
+		const suffix: QueueMessage = { text: "must stay out of replacement", mode: "followUp" };
+		const replacementPrompt = vi.fn((_text: string, options?: PromptOptions) => {
+			options?.promptDisposition?.("started");
+			options?.preflightResult?.(true);
+			return Promise.resolve();
+		});
+		const replacementSession = {
+			clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+			prompt: replacementPrompt,
+			followUp: vi.fn(async () => {}),
+			steer: vi.fn(async () => {}),
+		};
+		const context = {
+			compactionQueuedMessages: [command, suffix],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
+			isExtensionCommand: (message: string) => message.startsWith("/"),
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+				prompt: vi.fn(async (text: string) => {
+					expect(text).toBe(command.text);
+					context.compactionInFlightMessages = [];
+					context.compactionTransferAbortControllers.clear();
+					context.session = replacementSession;
+				}),
+				followUp: vi.fn(async () => {}),
+				steer: vi.fn(async () => {}),
+			},
+		};
+
+		await getFlushCompactionQueue()(context, { willRetry: false });
+
+		expect(replacementPrompt).not.toHaveBeenCalled();
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("drains a restored earlier batch before a later overlapping flush", async () => {
+		const earlier: QueueMessage = { text: "earlier", mode: "steer" };
+		const later: QueueMessage = { text: "later", mode: "steer" };
+		let rejectEarlier: ((error: Error) => void) | undefined;
+		let markEarlierStarted: (() => void) | undefined;
+		const earlierStarted = new Promise<void>((resolve) => {
+			markEarlierStarted = resolve;
+		});
+		const earlierFailure = new Promise<void>((_resolve, reject) => {
+			rejectEarlier = reject;
+		});
+		const delivered: string[] = [];
+		let earlierAttempts = 0;
+		const context = {
+			compactionQueuedMessages: [earlier],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
+			isExtensionCommand: () => false,
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+				prompt: vi.fn(async () => {}),
+				followUp: vi.fn(async () => {}),
+				steer: vi.fn((text: string) => {
+					delivered.push(text);
+					if (text === earlier.text && earlierAttempts++ === 0) {
+						markEarlierStarted?.();
+						return earlierFailure;
+					}
+					return Promise.resolve();
+				}),
+			},
+		};
+
+		const firstFlush = getFlushCompactionQueue()(context, { willRetry: true });
+		await earlierStarted;
+		context.compactionQueuedMessages.push(later);
+		const secondFlush = getFlushCompactionQueue()(context, { willRetry: true });
+		rejectEarlier?.(new Error("synthetic earlier failure"));
+		await Promise.all([firstFlush, secondFlush]);
+
+		expect(delivered).toEqual([earlier.text, earlier.text, later.text]);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+	});
+
+	it("leaves replacement-session input untouched by a flush queued before rebind", async () => {
+		const earlier: QueueMessage = { text: "old-session in flight", mode: "steer" };
+		const replacement: QueueMessage = { text: "replacement-session input", mode: "steer" };
+		let releaseEarlier: (() => void) | undefined;
+		let markEarlierStarted: (() => void) | undefined;
+		const earlierStarted = new Promise<void>((resolve) => {
+			markEarlierStarted = resolve;
+		});
+		const earlierHeld = new Promise<void>((resolve) => {
+			releaseEarlier = resolve;
+		});
+		const oldSteer = vi.fn((text: string) => {
+			if (text === earlier.text) {
+				markEarlierStarted?.();
+				return earlierHeld;
+			}
+			return Promise.resolve();
+		});
+		const replacementSteer = vi.fn(async () => {});
+		const replacementSession = {
+			clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+			prompt: vi.fn(async () => {}),
+			followUp: vi.fn(async () => {}),
+			steer: replacementSteer,
+		};
+		const context = {
+			compactionQueuedMessages: [earlier],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
+			compactionQueueFlushTail: undefined as Promise<void> | undefined,
+			compactionQueueGeneration: 0,
+			isExtensionCommand: () => false,
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+				prompt: vi.fn(async () => {}),
+				followUp: vi.fn(async () => {}),
+				steer: oldSteer,
+			},
+		};
+
+		const firstFlush = getFlushCompactionQueue()(context, { willRetry: true });
+		await earlierStarted;
+		const staleQueuedFlush = getFlushCompactionQueue()(context, { willRetry: true });
+		context.compactionQueueGeneration += 1;
+		context.compactionQueuedMessages = [replacement];
+		context.compactionInFlightMessages = [];
+		context.compactionTransferAbortControllers.clear();
+		context.session = replacementSession;
+		releaseEarlier?.();
+		await Promise.all([firstFlush, staleQueuedFlush]);
+
+		expect(oldSteer).toHaveBeenCalledTimes(1);
+		expect(replacementSteer).not.toHaveBeenCalled();
+		expect(context.compactionQueuedMessages).toEqual([replacement]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-transfer.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-transfer.test.ts
@@ -10,6 +10,7 @@ type QueueMessage = {
 type PromptOptions = {
 	readonly streamingBehavior?: "steer" | "followUp";
 	readonly preflightResult?: (success: boolean) => void;
+	readonly promptDisposition?: (disposition: "handled" | "queued" | "started") => void;
 };
 
 function getFlushCompactionQueue() {
@@ -30,6 +31,8 @@ describe("InteractiveMode transactional compaction queue transfer", () => {
 		const showError = vi.fn();
 		const context = {
 			compactionQueuedMessages: [first, failed, suffix],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
 			isExtensionCommand: () => false,
 			showError,
 			updatePendingMessagesDisplay: vi.fn(),
@@ -67,6 +70,8 @@ describe("InteractiveMode transactional compaction queue transfer", () => {
 		const showError = vi.fn();
 		const context = {
 			compactionQueuedMessages: [first, rest],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
 			isExtensionCommand: () => false,
 			showError,
 			updatePendingMessagesDisplay: vi.fn(),
@@ -77,6 +82,7 @@ describe("InteractiveMode transactional compaction queue transfer", () => {
 				prompt: vi.fn((text: string, options?: PromptOptions) => {
 					expect(text).toBe(first.text);
 					observedOptions = options;
+					options?.promptDisposition?.("started");
 					options?.preflightResult?.(true);
 					return Promise.reject(new Error("post-accept turn failure"));
 				}),
@@ -102,6 +108,8 @@ describe("InteractiveMode transactional compaction queue transfer", () => {
 		const showError = vi.fn();
 		const context = {
 			compactionQueuedMessages: [first, suffix],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
 			isExtensionCommand: () => false,
 			showError,
 			updatePendingMessagesDisplay: vi.fn(),

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-transfer.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-transfer.test.ts
@@ -1,0 +1,126 @@
+import { setImmediate as waitForImmediate } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type QueueMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+type PromptOptions = {
+	readonly streamingBehavior?: "steer" | "followUp";
+	readonly preflightResult?: (success: boolean) => void;
+};
+
+function getFlushCompactionQueue() {
+	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
+	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
+	return (context: object, options?: { willRetry?: boolean }): Promise<void> =>
+		Promise.resolve(flush.call(context, options));
+}
+
+describe("InteractiveMode transactional compaction queue transfer", () => {
+	it("restores only the undelivered suffix before late arrivals without clearing native queues", async () => {
+		const first: QueueMessage = { text: "duplicate", mode: "steer" };
+		const failed: QueueMessage = { text: "duplicate", mode: "steer" };
+		const suffix: QueueMessage = { text: "after failure", mode: "followUp" };
+		const late: QueueMessage = { text: "late arrival", mode: "steer" };
+		const clearQueue = vi.fn(() => ({ steering: ["native steer"], followUp: ["goal follow-up"] }));
+		const delivered: QueueMessage[] = [];
+		const showError = vi.fn();
+		const context = {
+			compactionQueuedMessages: [first, failed, suffix],
+			isExtensionCommand: () => false,
+			showError,
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue,
+				prompt: vi.fn(async () => {}),
+				followUp: vi.fn(async () => {}),
+				steer: vi.fn(async (text: string) => {
+					const current = [first, failed].find((message) => message.text === text && !delivered.includes(message));
+					if (!current) throw new Error(`Unexpected transfer: ${text}`);
+					delivered.push(current);
+					if (current === failed) {
+						context.compactionQueuedMessages.push(late);
+						throw new Error("synthetic transfer failure");
+					}
+				}),
+			},
+		};
+
+		await getFlushCompactionQueue()(context, { willRetry: true });
+
+		expect(delivered).toEqual([first, failed]);
+		expect(context.compactionQueuedMessages).toEqual([failed, suffix, late]);
+		expect(context.compactionQueuedMessages[0]).toBe(failed);
+		expect(context.compactionQueuedMessages).not.toContain(first);
+		expect(showError).toHaveBeenCalledWith("Failed to send queued messages: synthetic transfer failure");
+		expect(clearQueue).not.toHaveBeenCalled();
+	});
+
+	it("commits the first prompt at explicit preflight acceptance and never restores it after turn failure", async () => {
+		const first: QueueMessage = { text: "first prompt", mode: "followUp" };
+		const rest: QueueMessage = { text: "queued steer", mode: "steer" };
+		const clearQueue = vi.fn(() => ({ steering: [], followUp: [] }));
+		let observedOptions: PromptOptions | undefined;
+		const showError = vi.fn();
+		const context = {
+			compactionQueuedMessages: [first, rest],
+			isExtensionCommand: () => false,
+			showError,
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue,
+				followUp: vi.fn(async () => {}),
+				steer: vi.fn(async () => {}),
+				prompt: vi.fn((text: string, options?: PromptOptions) => {
+					expect(text).toBe(first.text);
+					observedOptions = options;
+					options?.preflightResult?.(true);
+					return Promise.reject(new Error("post-accept turn failure"));
+				}),
+			},
+		};
+
+		await getFlushCompactionQueue()(context, { willRetry: false });
+		await waitForImmediate();
+
+		expect(observedOptions?.streamingBehavior).toBe("followUp");
+		expect(typeof observedOptions?.preflightResult).toBe("function");
+		expect(context.session.steer).toHaveBeenCalledWith(rest.text);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(showError).toHaveBeenCalledWith("Queued prompt failed after acceptance: post-accept turn failure");
+		expect(clearQueue).not.toHaveBeenCalled();
+	});
+
+	it("restores a preflight-rejected batch ahead of input that arrives during rejection", async () => {
+		const first: QueueMessage = { text: "rejected prompt", mode: "steer" };
+		const suffix: QueueMessage = { text: "suffix", mode: "followUp" };
+		const late: QueueMessage = { text: "late", mode: "steer" };
+		const clearQueue = vi.fn(() => ({ steering: [], followUp: [] }));
+		const showError = vi.fn();
+		const context = {
+			compactionQueuedMessages: [first, suffix],
+			isExtensionCommand: () => false,
+			showError,
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue,
+				followUp: vi.fn(async () => {}),
+				steer: vi.fn(async () => {}),
+				prompt: vi.fn((_text: string, options?: PromptOptions) => {
+					context.compactionQueuedMessages.push(late);
+					options?.preflightResult?.(false);
+					return Promise.reject(new Error("preflight rejected"));
+				}),
+			},
+		};
+
+		await getFlushCompactionQueue()(context, { willRetry: false });
+
+		expect(context.compactionQueuedMessages).toEqual([first, suffix, late]);
+		expect(showError).toHaveBeenCalledWith("Failed to send queued messages: preflight rejected");
+		expect(clearQueue).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -148,6 +148,27 @@ describe("InteractiveMode compaction events", () => {
 		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
 	});
 
+	test("shows a detached continuation launch failure", async () => {
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			showError: vi.fn(),
+		};
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: { type: "continuation_error"; errorMessage: string },
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, {
+			type: "continuation_error",
+			errorMessage: "Failed to continue queued messages: synthetic continuation launch failure",
+		});
+
+		expect(fakeThis.showError).toHaveBeenCalledWith(
+			"Failed to continue queued messages: synthetic continuation launch failure",
+		);
+	});
+
 	test("renders OpenAI remote compaction details in the summary card", () => {
 		const component = new CompactionSummaryMessageComponent({
 			role: "compactionSummary",

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -148,12 +148,16 @@ describe("InteractiveMode compaction events", () => {
 		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
 	});
 
-	test("shows a detached continuation launch failure", async () => {
+	test("sanitizes a detached continuation launch failure before rendering", async () => {
 		const fakeThis = {
 			isInitialized: true,
 			footer: { invalidate: vi.fn() },
 			showError: vi.fn(),
 		};
+		const hostileMessage =
+			"Failed\u001b]52;c;c2VjcmV0\u0007 to\u001b]0;stolen title\u0007 continue" +
+			"\u001b]8;;https://attacker.invalid\u0007 queued\u001b]8;;\u0007\u0000 messages:\u007f" +
+			"\u0085 \u009b31mprovider\u009b0m unavailable";
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
 			event: { type: "continuation_error"; errorMessage: string },
@@ -161,12 +165,15 @@ describe("InteractiveMode compaction events", () => {
 
 		await handleEvent.call(fakeThis, {
 			type: "continuation_error",
-			errorMessage: "Failed to continue queued messages: synthetic continuation launch failure",
+			errorMessage: hostileMessage,
 		});
 
-		expect(fakeThis.showError).toHaveBeenCalledWith(
-			"Failed to continue queued messages: synthetic continuation launch failure",
-		);
+		expect(fakeThis.showError).toHaveBeenCalledWith("Failed to continue queued messages: provider unavailable");
+		const rendered = fakeThis.showError.mock.calls[0]?.[0];
+		expect(rendered).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+		expect(rendered).not.toContain("]52;");
+		expect(rendered).not.toContain("attacker.invalid");
+		expect(rendered).not.toContain("stolen title");
 	});
 
 	test("renders OpenAI remote compaction details in the summary card", () => {

--- a/packages/coding-agent/test/suite/post-compaction-controller-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/post-compaction-controller-lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { setImmediate as waitForImmediate } from "node:timers/promises";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "../../src/core/extensions/index.ts";
+import { SessionWorkBarrier } from "../../src/core/session-work-barrier.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function createAcceptedCompactionExtension(onCompactionAccepted?: () => void) {
+	return (pi: ExtensionAPI): void => {
+		pi.on("session_before_compact", (event) => ({
+			compaction: {
+				summary: "accepted lifecycle summary",
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+			},
+		}));
+		pi.on("session_compact", () => {
+			onCompactionAccepted?.();
+		});
+	};
+}
+
+async function createLifecycleHarness(onCompactionAccepted?: () => void): Promise<Harness> {
+	const harness = await createHarness({
+		models: [{ id: "lifecycle-context", contextWindow: 128_000, maxTokens: 64 }],
+		settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+		extensionFactories: [createAcceptedCompactionExtension(onCompactionAccepted)],
+	});
+	harness.setResponses([fauxAssistantMessage("initial assistant"), fauxAssistantMessage("fresh assistant")]);
+	await harness.session.prompt("initial prompt ".repeat(40));
+	return harness;
+}
+
+function getRunAutoCompaction(harness: Harness) {
+	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof runAutoCompaction !== "function") {
+		throw new Error("Expected AgentSession._runAutoCompaction");
+	}
+	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
+		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
+function getSessionWorkBarrier(harness: Harness): SessionWorkBarrier {
+	const barrier = Reflect.get(harness.session, "_sessionWorkBarrier");
+	if (!(barrier instanceof SessionWorkBarrier)) {
+		throw new Error("Expected AgentSession._sessionWorkBarrier");
+	}
+	return barrier;
+}
+
+describe("post-compaction controller lifecycle", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it("releases compaction classification before held recovery while retaining the session barrier", async () => {
+		const harness = await createLifecycleHarness();
+		harnesses.push(harness);
+		const recoveryStarted = createDeferred();
+		const releaseRecovery = createDeferred();
+		vi.spyOn(harness.session.agent, "continue").mockImplementation(async () => {
+			recoveryStarted.resolve();
+			await releaseRecovery.promise;
+		});
+
+		const recovery = getRunAutoCompaction(harness)("overflow", true);
+		await recoveryStarted.promise;
+		const barrier = getSessionWorkBarrier(harness);
+		let freshPrompt: Promise<void> | undefined;
+		try {
+			expect(harness.session.isCompacting).toBe(false);
+			expect(barrier.hasActiveWork).toBe(true);
+			freshPrompt = harness.session.prompt("fresh prompt during held recovery");
+			await waitForImmediate();
+			expect(harness.faux.state.callCount).toBe(1);
+		} finally {
+			releaseRecovery.resolve();
+			await Promise.allSettled([recovery, ...(freshPrompt ? [freshPrompt] : [])]);
+		}
+
+		expect(barrier.hasActiveWork).toBe(false);
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it("does not let stale cleanup clear a newer auto-compaction controller", async () => {
+		let activeHarness: Harness | undefined;
+		const replacementController = new AbortController();
+		const harness = await createLifecycleHarness(() => {
+			if (!activeHarness) throw new Error("Expected active lifecycle harness");
+			Reflect.set(activeHarness.session, "_autoCompactionAbortController", replacementController);
+		});
+		activeHarness = harness;
+		harnesses.push(harness);
+
+		try {
+			await getRunAutoCompaction(harness)("threshold", false);
+			expect(Reflect.get(harness.session, "_autoCompactionAbortController")).toBe(replacementController);
+			expect(harness.session.isCompacting).toBe(true);
+		} finally {
+			Reflect.set(harness.session, "_autoCompactionAbortController", undefined);
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queue-ownership.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queue-ownership.test.ts
@@ -1,0 +1,252 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+
+type QueuedMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+function createAcceptedCompactionExtension() {
+	return (pi: ExtensionAPI): void => {
+		pi.on("session_before_compact", (event) => ({
+			compaction: {
+				summary: "accepted post-compaction regression summary",
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+			},
+		}));
+	};
+}
+
+function getFlushCompactionQueue() {
+	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
+	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
+	return (context: object, options: { willRetry: boolean }): Promise<void> =>
+		Promise.resolve(flush.call(context, options));
+}
+
+function getRunAutoCompaction(harness: Harness) {
+	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof runAutoCompaction !== "function") throw new Error("Expected AgentSession._runAutoCompaction");
+	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
+		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
+function getAbortAndFireQueuedMessages() {
+	const abortAndFire = Reflect.get(InteractiveMode.prototype, "abortAndFireQueuedMessages");
+	if (typeof abortAndFire !== "function") {
+		throw new Error("Expected InteractiveMode.abortAndFireQueuedMessages");
+	}
+	return (context: object): Promise<number> => Promise.resolve(abortAndFire.call(context));
+}
+
+function getClearAllQueues() {
+	const clearAllQueues = Reflect.get(InteractiveMode.prototype, "clearAllQueues");
+	if (typeof clearAllQueues !== "function") throw new Error("Expected InteractiveMode.clearAllQueues");
+	return (context: object): { steering: string[]; followUp: string[] } => clearAllQueues.call(context);
+}
+
+function getRestoreQueuedMessagesToEditor() {
+	const restoreQueuedMessages = Reflect.get(InteractiveMode.prototype, "restoreQueuedMessagesToEditor");
+	if (typeof restoreQueuedMessages !== "function") {
+		throw new Error("Expected InteractiveMode.restoreQueuedMessagesToEditor");
+	}
+	return (context: object): number => restoreQueuedMessages.call(context);
+}
+
+function createTuiQueueContext(harness: Harness) {
+	return {
+		compactionQueuedMessages: [] as QueuedMessage[],
+		compactionInFlightMessages: [] as QueuedMessage[],
+		compactionTransferAbortControllers: new Map<QueuedMessage, AbortController>(),
+		isExtensionCommand: () => false,
+		showError: (message: string) => {
+			throw new Error(message);
+		},
+		updatePendingMessagesDisplay: () => {},
+		session: harness.session,
+	};
+}
+
+describe("post-compaction queue ownership", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("starts the next transferred prompt when an input hook handles the first entry", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("input", (event) =>
+						event.text === "blocked-first" ? { action: "handled" } : { action: "continue" },
+					);
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("suffix handled")]);
+		const context = createTuiQueueContext(harness);
+		context.compactionQueuedMessages.push(
+			{ text: "blocked-first", mode: "steer" },
+			{ text: "must-not-hang", mode: "followUp" },
+		);
+
+		await getFlushCompactionQueue()(context, { willRetry: false });
+		await harness.session.waitForIdle();
+
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(harness.session.pendingMessageCount).toBe(0);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+		expect(getUserTexts(harness)).toEqual(["must-not-hang"]);
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
+	it("surfaces a failed retry continuation while preserving transferred native work", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [createAcceptedCompactionExtension()],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed context handled")]);
+		await harness.session.prompt("seed continuation context ".repeat(40));
+		const context = createTuiQueueContext(harness);
+		context.compactionQueuedMessages.push({ text: "must-remain-retryable", mode: "steer" });
+		const flushes: Promise<void>[] = [];
+		const continuationErrors: string[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end") {
+				flushes.push(getFlushCompactionQueue()(context, { willRetry: true }));
+			}
+			const possibleFailure = event as { type: string; errorMessage?: string };
+			if (possibleFailure.type === "continuation_error" && possibleFailure.errorMessage) {
+				continuationErrors.push(possibleFailure.errorMessage);
+			}
+		});
+		const continueSpy = vi
+			.spyOn(harness.session.agent, "continue")
+			.mockRejectedValueOnce(new Error("synthetic continuation launch failure"));
+
+		const launched = await getRunAutoCompaction(harness)("threshold", true);
+		await Promise.all(flushes);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(launched).toBe(true);
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(harness.session.pendingMessageCount).toBe(1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(continuationErrors).toEqual(["Failed to continue queued messages: synthetic continuation launch failure"]);
+	});
+
+	it("cancels and restores a first transfer prompt that is waiting for session work", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("must not execute")]);
+		const marker = "queued TUI prompt";
+		const setText = vi.fn<(text: string) => void>();
+		const errors: string[] = [];
+		const context = {
+			compactionQueuedMessages: [{ text: marker, mode: "steer" }] as QueuedMessage[],
+			compactionInFlightMessages: [] as QueuedMessage[],
+			compactionTransferAbortControllers: new Map<QueuedMessage, AbortController>(),
+			isExtensionCommand: () => false,
+			showError: (message: string) => errors.push(message),
+			updatePendingMessagesDisplay: () => {},
+			editor: {
+				getText: () => "",
+				setText,
+			},
+			session: harness.session,
+			clearAllQueues: () => getClearAllQueues()(context),
+		};
+		const sessionWorkBarrier = Reflect.get(harness.session, "_sessionWorkBarrier") as {
+			begin: () => () => void;
+			hasActiveWork: boolean;
+		};
+		const finishHeldWork = sessionWorkBarrier.begin();
+
+		const flush = getFlushCompactionQueue()(context, { willRetry: false });
+		expect(context.compactionQueuedMessages).toEqual([]);
+		const restored = await getAbortAndFireQueuedMessages()(context);
+		finishHeldWork();
+		await flush;
+		await harness.session.waitForIdle();
+
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(restored).toBe(1);
+		expect(setText).toHaveBeenCalledWith(marker);
+		expect(errors).toEqual([]);
+	});
+
+	it("dequeues a first transfer prompt without starting it after session work settles", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("must not execute")]);
+		const marker = "Alt-Up queued TUI prompt";
+		const setText = vi.fn<(text: string) => void>();
+		const errors: string[] = [];
+		const context = {
+			compactionQueuedMessages: [{ text: marker, mode: "steer" }] as QueuedMessage[],
+			compactionInFlightMessages: [] as QueuedMessage[],
+			compactionTransferAbortControllers: new Map<QueuedMessage, AbortController>(),
+			isExtensionCommand: () => false,
+			showError: (message: string) => errors.push(message),
+			updatePendingMessagesDisplay: () => {},
+			editor: {
+				getText: () => "",
+				setText,
+			},
+			session: harness.session,
+			clearAllQueues: () => getClearAllQueues()(context),
+		};
+		const sessionWorkBarrier = Reflect.get(harness.session, "_sessionWorkBarrier") as {
+			begin: () => () => void;
+		};
+		const finishHeldWork = sessionWorkBarrier.begin();
+
+		const flush = getFlushCompactionQueue()(context, { willRetry: false });
+		const restored = getRestoreQueuedMessagesToEditor()(context);
+		finishHeldWork();
+		await flush;
+		await harness.session.waitForIdle();
+
+		expect(restored).toBe(1);
+		expect(setText).toHaveBeenCalledWith(marker);
+		expect(getUserTexts(harness)).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(errors).toEqual([]);
+	});
+
+	it("adopts native steer priority while preserving FIFO within each captured mode", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("first handled"),
+			fauxAssistantMessage("steer handled"),
+			fauxAssistantMessage("follow-up handled"),
+		]);
+		const context = createTuiQueueContext(harness);
+		context.compactionQueuedMessages.push(
+			{ text: "first", mode: "followUp" },
+			{ text: "second-followup", mode: "followUp" },
+			{ text: "third-steer", mode: "steer" },
+		);
+
+		await getFlushCompactionQueue()(context, { willRetry: false });
+		await harness.session.agent.waitForIdle();
+		await harness.session.waitForSettledSessionWork();
+
+		expect(getUserTexts(harness)).toEqual(["first", "third-steer", "second-followup"]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -52,6 +52,8 @@ function getFlushCompactionQueue() {
 function createTuiQueueContext(harness: Harness) {
 	return {
 		compactionQueuedMessages: [] as QueuedMessage[],
+		compactionInFlightMessages: [] as QueuedMessage[],
+		compactionTransferAbortControllers: new Map<QueuedMessage, AbortController>(),
 		isExtensionCommand: () => false,
 		showError: (message: string) => {
 			throw new Error(message);

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync } from "node:fs";
+import { type AssistantMessage, type FauxResponseFactory, fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+
+type Deferred<T> = {
+	readonly promise: Promise<T>;
+	readonly resolve: (value: T) => void;
+};
+
+type QueuedMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+const USER_MARKER = ". [TUI_QUEUED_DOT]";
+const OMO_MARKER = "[OMO_MICROTASK_STEER]";
+const GOAL_MARKER = "[GOAL_FOLLOW_UP]";
+const OVERFLOW_ERROR =
+	"Error Code context_too_large: Your input exceeds the context window of this model. Please adjust your input and try again.";
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve: ((value: T) => void) | undefined;
+	const promise = new Promise<T>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function createAcceptedCompactionExtension() {
+	return (pi: ExtensionAPI): void => {
+		pi.on("session_before_compact", (event) => ({
+			compaction: {
+				summary: "accepted post-compaction regression summary",
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+			},
+		}));
+	};
+}
+
+function getFlushCompactionQueue() {
+	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
+	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
+	return (context: object, options: { willRetry: boolean }): Promise<void> =>
+		Promise.resolve(flush.call(context, options));
+}
+
+function createTuiQueueContext(harness: Harness) {
+	return {
+		compactionQueuedMessages: [] as QueuedMessage[],
+		isExtensionCommand: () => false,
+		showError: (message: string) => {
+			throw new Error(message);
+		},
+		updatePendingMessagesDisplay: () => {},
+		session: harness.session,
+	};
+}
+
+async function submitLikeTui(harness: Harness, context: ReturnType<typeof createTuiQueueContext>, text: string) {
+	if (harness.session.isCompacting) {
+		context.compactionQueuedMessages.push({ text, mode: "steer" });
+		return;
+	}
+	await harness.session.prompt(text, {
+		streamingBehavior: harness.session.isStreaming ? "steer" : undefined,
+	});
+}
+
+function countInPersistedSession(harness: Harness, marker: string): number {
+	const sessionFile = harness.sessionManager.getSessionFile();
+	if (!sessionFile) throw new Error("Expected persisted session file");
+	return readFileSync(sessionFile, "utf8").split(marker).length - 1;
+}
+
+function createOverflowResponse(harness: Harness): AssistantMessage {
+	const model = harness.getModel();
+	return {
+		...fauxAssistantMessage("", { stopReason: "error", errorMessage: OVERFLOW_ERROR }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+	};
+}
+
+describe("post-compaction queued input recovery", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("persists one late TUI marker submitted after the sole compaction flush", async () => {
+		const recoveryStarted = createDeferred<void>();
+		const releaseRecovery = createDeferred<AssistantMessage>();
+		const harness = await createHarness({
+			persistSession: true,
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [createAcceptedCompactionExtension()],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed context handled")]);
+		await harness.session.prompt("seed persisted context ".repeat(40));
+		const context = createTuiQueueContext(harness);
+		const flushes: Promise<void>[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type !== "compaction_end") return;
+			flushes.push(getFlushCompactionQueue()(context, { willRetry: event.willRetry }));
+		});
+		const recoveryResponse: FauxResponseFactory = () => {
+			recoveryStarted.resolve();
+			return releaseRecovery.promise;
+		};
+		harness.setResponses([createOverflowResponse(harness), recoveryResponse, fauxAssistantMessage("marker handled")]);
+
+		const prompt = harness.session.prompt("initial overflow prompt ".repeat(40));
+		await recoveryStarted.promise;
+		await Promise.all(flushes);
+		const markerSubmission = submitLikeTui(harness, context, USER_MARKER);
+		releaseRecovery.resolve(fauxAssistantMessage("overflow recovery handled"));
+		await Promise.all([prompt, markerSubmission]);
+
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(getUserTexts(harness)).toEqual(["initial overflow prompt ".repeat(40), USER_MARKER]);
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(countInPersistedSession(harness, USER_MARKER)).toBe(1);
+	});
+
+	it("does not synthesize a post-compaction turn when no input was queued", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [createAcceptedCompactionExtension()],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed context handled")]);
+		await harness.session.prompt("seed persisted context ".repeat(40));
+		const context = createTuiQueueContext(harness);
+		const flushes: Promise<void>[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type !== "compaction_end") return;
+			flushes.push(getFlushCompactionQueue()(context, { willRetry: event.willRetry }));
+		});
+		harness.setResponses([createOverflowResponse(harness), fauxAssistantMessage("overflow recovery handled")]);
+
+		await harness.session.prompt("initial no-input overflow prompt ".repeat(40));
+		await Promise.all(flushes);
+
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(getUserTexts(harness)).toEqual(["initial no-input overflow prompt ".repeat(40)]);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(countInPersistedSession(harness, USER_MARKER)).toBe(0);
+	});
+
+	it("preserves a late TUI marker beside OMO steer and goal follow-up continuations", async () => {
+		const recoveryStarted = createDeferred<void>();
+		const releaseRecovery = createDeferred<AssistantMessage>();
+		let continuationsArmed = false;
+		let continuationsInjected = false;
+		const harness = await createHarness({
+			persistSession: true,
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [
+				createAcceptedCompactionExtension(),
+				(pi: ExtensionAPI) => {
+					pi.on("agent_end", () => {
+						if (!continuationsArmed || continuationsInjected) return;
+						continuationsInjected = true;
+						pi.sendUserMessage(GOAL_MARKER, { deliverAs: "followUp" });
+						queueMicrotask(() => {
+							pi.sendUserMessage(OMO_MARKER, { deliverAs: "steer" });
+						});
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed context handled")]);
+		await harness.session.prompt("seed persisted context ".repeat(40));
+		continuationsArmed = true;
+		const context = createTuiQueueContext(harness);
+		const flushes: Promise<void>[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type !== "compaction_end") return;
+			flushes.push(getFlushCompactionQueue()(context, { willRetry: event.willRetry }));
+		});
+		const recoveryResponse: FauxResponseFactory = () => {
+			recoveryStarted.resolve();
+			return releaseRecovery.promise;
+		};
+		harness.setResponses([
+			createOverflowResponse(harness),
+			recoveryResponse,
+			fauxAssistantMessage("OMO continuation handled"),
+			fauxAssistantMessage("goal continuation handled"),
+			fauxAssistantMessage("marker handled"),
+		]);
+
+		const prompt = harness.session.prompt("initial competing overflow prompt ".repeat(40));
+		await recoveryStarted.promise;
+		await Promise.all(flushes);
+		const markerSubmission = submitLikeTui(harness, context, USER_MARKER);
+		releaseRecovery.resolve(fauxAssistantMessage("overflow recovery handled"));
+		await Promise.all([prompt, markerSubmission]);
+		await harness.session.agent.waitForIdle();
+
+		const userTexts = getUserTexts(harness);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(userTexts.filter((text) => text === USER_MARKER)).toHaveLength(1);
+		expect(userTexts.filter((text) => text === OMO_MARKER)).toHaveLength(1);
+		expect(userTexts.filter((text) => text === GOAL_MARKER)).toHaveLength(1);
+		expect(countInPersistedSession(harness, USER_MARKER)).toBe(1);
+		expect(countInPersistedSession(harness, OMO_MARKER)).toBe(1);
+		expect(countInPersistedSession(harness, GOAL_MARKER)).toBe(1);
+	});
+});

--- a/packages/neo/internal/app/transcript.go
+++ b/packages/neo/internal/app/transcript.go
@@ -45,7 +45,7 @@ const (
 // feed entry, with the surface that owns it instead. The exhaustiveness test
 // asserts handled ∪ ignored ∪ deferred covers the whole mirror.
 var transcriptIgnoredEvents = map[string]string{
-	"agent_settled":         "RPC completion marker; transcript state is finalized by agent_end/message_end",
+	"agent_settled":          "RPC completion marker; transcript state is finalized by agent_end/message_end",
 	"turn_start":             "turn boundaries render nothing; content arrives via message_* events",
 	"turn_end":               "turn boundaries render nothing; tool results arrive via tool_execution_end",
 	"compaction_start":       "status-indicator surface (shell status line, todo 7)",
@@ -155,6 +155,9 @@ func (t *Transcript) HandleEvent(msg EventMsg) EventDisposition {
 	case "compaction_end":
 		return t.applyCompactionEnd(ev.Payload)
 
+	case "continuation_error":
+		return t.applyContinuationError(ev.Payload)
+
 	case "queue_update":
 		// Hand-off to todo 4: the queue/pending-messages area (shell.Queue) owns
 		// steering/follow-up display; the transcript renders nothing for it.
@@ -166,6 +169,22 @@ func (t *Transcript) HandleEvent(msg EventMsg) EventDisposition {
 	}
 	t.logUnknown(ev.Type)
 	return EventUnknown
+}
+
+func (t *Transcript) applyContinuationError(payload []byte) EventDisposition {
+	var body struct {
+		ErrorMessage string `json:"errorMessage"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil || body.ErrorMessage == "" {
+		t.logMalformed("continuation_error", err)
+		return EventApplied
+	}
+	t.feed.Apply(transcript.FeedEvent{Type: "message_end", Message: &transcript.FeedMessage{
+		Role:         "assistant",
+		StopReason:   "error",
+		ErrorMessage: body.ErrorMessage,
+	}})
+	return EventApplied
 }
 
 // applyMessageEvent decodes the wire message envelope and forwards it to the

--- a/packages/neo/internal/app/transcript_continuation_error_test.go
+++ b/packages/neo/internal/app/transcript_continuation_error_test.go
@@ -1,25 +1,73 @@
 package app_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
 )
 
-func TestTranscriptContinuationErrorRendersExactMessage(t *testing.T) {
+func TestTranscriptContinuationErrorSanitizesTerminalControls(t *testing.T) {
 	// Given: a detached continuation failure emitted by AgentSession.
 	feed, tr := newTranscriptFixture(t)
-	msg := eventMsg(t, `{"type":"continuation_error","errorMessage":"Failed to continue queued messages: provider unavailable"}`)
+	hostileMessage := "Failed\x1b]52;c;c2VjcmV0\x07 to\x1b]0;stolen title\x07 continue" +
+		"\x1b]8;;https://attacker.invalid\x07 queued\x1b]8;;\x07\x00 messages:\x7f" +
+		"\u0085 \x1b[999mprovider\x1b[0m unavailable"
+	line, err := json.Marshal(struct {
+		Type         string `json:"type"`
+		ErrorMessage string `json:"errorMessage"`
+	}{Type: "continuation_error", ErrorMessage: hostileMessage})
+	if err != nil {
+		t.Fatalf("marshal continuation_error: %v", err)
+	}
+	msg := eventMsg(t, string(line))
 
 	// When: Neo translates the session event into its transcript.
 	disposition := tr.HandleEvent(msg)
 
-	// Then: the event is applied and the exact user-visible failure is rendered.
+	// Then: readable text remains while hostile terminal controls are absent.
 	if disposition != app.EventApplied {
 		t.Fatalf("continuation_error disposition = %v, want EventApplied", disposition)
 	}
-	if joined := feedText(feed); !strings.Contains(joined, "Failed to continue queued messages: provider unavailable") {
+	joined := feedText(feed)
+	if !strings.Contains(joined, "Failed to continue queued messages: provider unavailable") {
 		t.Fatalf("continuation_error message missing from transcript: %q", joined)
+	}
+	for _, forbidden := range []string{
+		"\x1b]52;", "\x1b]0;", "\x1b]8;", "\x1b[999m", "\x00", "\x7f", "\u0085",
+		"attacker.invalid", "stolen title", "c2VjcmV0",
+	} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("continuation_error render contains hostile payload %q: %q", forbidden, joined)
+		}
+	}
+	if bells := strings.Count(joined, "\x07"); bells != 3 {
+		t.Fatalf("continuation_error render bell count = %d, want 3 production OSC 133 terminators: %q", bells, joined)
+	}
+}
+
+func TestTranscriptContinuationErrorMalformedPayloadsFailClosed(t *testing.T) {
+	feed, tr := newTranscriptFixture(t)
+	before := feedText(feed)
+
+	for _, line := range []string{
+		`{"type":"continuation_error"}`,
+		`{"type":"continuation_error","errorMessage":42}`,
+	} {
+		if disposition := tr.HandleEvent(eventMsg(t, line)); disposition != app.EventApplied {
+			t.Fatalf("malformed continuation_error disposition = %v, want EventApplied", disposition)
+		}
+	}
+	if after := feedText(feed); after != before {
+		t.Fatalf("malformed continuation_error changed transcript: before=%q after=%q", before, after)
+	}
+
+	valid := eventMsg(t, `{"type":"continuation_error","errorMessage":"subsequent valid failure"}`)
+	if disposition := tr.HandleEvent(valid); disposition != app.EventApplied {
+		t.Fatalf("valid continuation_error disposition = %v, want EventApplied", disposition)
+	}
+	if joined := feedText(feed); !strings.Contains(joined, "subsequent valid failure") {
+		t.Fatalf("valid event after malformed payloads did not render: %q", joined)
 	}
 }

--- a/packages/neo/internal/app/transcript_continuation_error_test.go
+++ b/packages/neo/internal/app/transcript_continuation_error_test.go
@@ -1,0 +1,25 @@
+package app_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/code-yeongyu/senpi/packages/neo/internal/app"
+)
+
+func TestTranscriptContinuationErrorRendersExactMessage(t *testing.T) {
+	// Given: a detached continuation failure emitted by AgentSession.
+	feed, tr := newTranscriptFixture(t)
+	msg := eventMsg(t, `{"type":"continuation_error","errorMessage":"Failed to continue queued messages: provider unavailable"}`)
+
+	// When: Neo translates the session event into its transcript.
+	disposition := tr.HandleEvent(msg)
+
+	// Then: the event is applied and the exact user-visible failure is rendered.
+	if disposition != app.EventApplied {
+		t.Fatalf("continuation_error disposition = %v, want EventApplied", disposition)
+	}
+	if joined := feedText(feed); !strings.Contains(joined, "Failed to continue queued messages: provider unavailable") {
+		t.Fatalf("continuation_error message missing from transcript: %q", joined)
+	}
+}

--- a/packages/neo/internal/bridge/types.go
+++ b/packages/neo/internal/bridge/types.go
@@ -209,7 +209,7 @@ var eventTypes = []string{
 	"message_start", "message_update", "message_end",
 	"tool_execution_start", "tool_execution_update", "tool_execution_end",
 	// --- AgentSessionEvent extensions (agent-session.ts:145-172) ---
-	"agent_settled", "queue_update",
+	"agent_settled", "continuation_error", "queue_update",
 	"compaction_start", "compaction_progress", "compaction_end",
 	"entry_appended", "session_info_changed",
 	"tool_hook_status",     // ExtensionToolHookLifecycleEvent

--- a/packages/neo/internal/ui/transcript/messages.go
+++ b/packages/neo/internal/ui/transcript/messages.go
@@ -131,7 +131,7 @@ func (a *AssistantMessageComponent) Render(width int) []string {
 		out = append(out, "")
 		out = append(out, a.theme.Error(abortMsg))
 	case !hasToolCalls && a.msg.StopReason == "error":
-		errMsg := a.msg.ErrorMessage
+		errMsg := sanitizeInline(a.msg.ErrorMessage)
 		if errMsg == "" {
 			errMsg = "Unknown error"
 		}


### PR DESCRIPTION
## Summary

Fixes the post-compaction hang where terminal input accepted after an overflow compaction could remain stranded, be delivered after cancellation, or cross into a replacement session. The final implementation treats compaction input transfer as an identity-owned transaction: it releases only the accepted compaction controller, preserves the session-work barrier, and commits or restores exact TUI entries without clearing Senpi's native queues.

The post-review corrections distinguish handled prompts from queued/started model work, surface detached continuation failures in both terminal clients, make transferred-but-unaccepted prompts cancelable, serialize overlapping flushes, and generation-guard queued work across session replacement. The final security correction detaches replacement-session flushes from unresolved stale tails and sanitizes continuation errors at both terminal rendering boundaries.

Remote head reviewed and tested locally: `0dc499c1b0eee1d76c71ffdfc58f532cf5e6d822`.

## Changes

- **Compaction lifecycle:** release only the accepted compaction controller before recovery; retain `_sessionWorkBarrier`; preserve a newer controller from stale cleanup.
- **Transactional queue ownership:** transfer exact message identities, commit only accepted entries, restore only the still-owned undelivered suffix before late arrivals, and stop immediately if ownership is lost.
- **Prompt disposition:** add an internal `handled | queued | started` result without changing the existing `preflightResult(true)` acceptance contract. A handled command/input hook no longer strands later TUI input in a native queue.
- **Cancellation:** track transferred-but-unaccepted entries with prompt abort signals so Esc and Alt-Up can restore them without allowing a delayed provider turn after the session-work barrier releases.
- **Continuation errors:** emit typed `continuation_error` events when detached `agent.continue()` launch fails, preserve retryable native work, settle the barrier, and render the exact failure in both the classic TypeScript TUI and Neo.
- **Concurrent flushes and session replacement:** serialize overlapping fire-and-forget flushes in invocation order; capture session plus queue generation so stale queued flushes cannot drain replacement-session input.
- **Replacement-session liveness:** detach the replacement generation from an unresolved old-session flush tail while preserving same-generation serialization and stale-finally identity safety.
- **Terminal safety:** sanitize continuation failures only at the classic and Neo terminal rendering boundaries, preserving raw typed event/RPC diagnostics for non-terminal consumers.
- **Stale accepted-prompt rendering:** suppress a detached old-session prompt rejection after queue-generation/session rebind while preserving same-session post-acceptance error reporting.
- **Ordering contract:** retain Senpi's established native steer-before-follow-up priority with FIFO inside each mode.
- **Regression coverage and notes:** add lifecycle, queue transfer, ownership, concurrency, incident, cancellation, native-priority, RPC/app-server compatibility, classic TUI, and Neo transcript coverage; document the behavior in coding-agent change notes.

## QA & Evidence

Canonical sanitized artifacts are under:
`local-ignore/qa-evidence/20260712-post-compaction-queued-input/`

### RED to GREEN

- **Lifecycle:** pristine base retained stale `isCompacting` ownership through recovery; GREEN releases only the owned controller while the barrier remains active. Artifacts: `task-7-lifecycle-{red,green}.txt`.
- **Transactional transfer:** pristine behavior destructively rolled back shared queues and mishandled late/duplicate input; GREEN commits accepted identities and restores only the undelivered suffix. Artifacts: `task-8-queue-transfer-{red,green}.txt`.
- **Original incident:** pristine base stranded the late dot after accepted overflow compaction; GREEN persists and executes it exactly once. Artifacts: `task-9-incident-{red,green}.txt`.
- **R1 handled entry:** handled first input left a suffix pending with zero provider calls; GREEN searches until work is actually queued or started. Artifacts: `task-17-r1-handled-first-{red,green}.txt`.
- **R2 continuation failure:** detached launch rejection reached no user-visible channel; GREEN emits and renders the exact error while preserving native work. Artifacts: `task-18-r2-*-{red,green}.txt`.
- **R3 cancellation:** Esc/Alt-Up could not cancel a transferred prompt waiting behind session work; GREEN restores it and proves zero provider/user messages. Artifacts: `task-19-r3-*.txt`.
- **R5 ownership loss:** transfer continued after cancellation or session replacement; GREEN terminates immediately when exact identity ownership is gone. Artifacts: `task-22-r5-lost-ownership-{red,green}.txt`.
- **R6 overlap:** a newer flush could overtake a failing older flush; GREEN serializes invocation order. Artifacts: `task-24-r6-overlapping-flush-{red,green}.txt`.
- **R7 stale session:** a queued old-session flush could drain replacement-session input; GREEN generation-guards the flush. Artifacts: `task-25-r7-stale-session-flush-{red,green}.txt`.
- **Neo event parity:** refreshed CI run `29206122438` failed `TestExhaustiveEvents` because TypeScript's new `continuation_error` had no Go variant. Focused RED observed `continuation_error disposition = 3, want EventApplied`; GREEN adds the bridge variant, typed payload decode, visible transcript item, and exact-message regression. Artifacts: `task-44-neo-continuation-error-red.txt`, `task-44-neo-continuation-error-green.txt`.
- **B1 replacement liveness:** an unresolved old-session transfer blocked every replacement flush behind its stale promise tail; GREEN clears only the tail reference during session invalidation, lets replacement input start independently, and proves stale completion cannot clear the newer tail. Artifacts: `task-47-b1-hung-old-tail-red.txt`, `task-50-b1-hung-old-tail-green.txt`.
- **B2 terminal controls:** hostile OSC clipboard/title/hyperlink, CSI, BEL, NUL, DEL, and C1 bytes reached classic and Neo terminal renderers; GREEN preserves exact readable text while removing attacker controls and payload fragments. Malformed Neo payloads fail closed and the stream remains usable. Artifacts: `task-48-b2-classic-terminal-control-red.txt`, `task-49-b2-neo-terminal-control-red.txt`, `task-51-b2-classic-terminal-control-green.txt`, `task-52-b2-neo-terminal-control-green.txt`.
- **R8 stale post-acceptance render:** an accepted old-session prompt rejected after `renderCurrentSessionState()` and wrote `Queued prompt failed after acceptance: stale old-session failure` into the replacement TUI. GREEN requires the captured session and queue generation before rendering the detached rejection. Artifacts: `task-66-r8-stale-post-acceptance-render-red.txt`, `task-67-r8-stale-post-acceptance-render-green.txt`.

### Real Surface

- **Incident TUI:** real source CLI through `node-pty`, rendered by `@xterm/headless`; prior bash tool result reached the next model request, a filesystem receipt independently proved tool execution, and the late dot reached request/session state exactly once. Artifact: `task-34-final-tui-incident.txt`.
- **No-input control:** exactly five requests and no marker request or synthetic dot. Artifact: `task-35-final-tui-no-input.txt`.
- **Competing continuations:** OMO-shaped steer, goal-shaped follow-up, and late terminal dot executed in native-priority order exactly once. Artifact: `task-36-final-tui-competing.txt`.
- **Neo continuation error:** an actual JSON event was decoded through `bridge.DecodeMessage`, routed through `app.NewTranscript`, rendered with the production Grok theme in a real PTY, and replayed through xterm. The exact text `Failed to continue queued messages: provider unavailable` appeared, with 56 nonblank cells using Grok error red `#f7768e`. Artifacts: `task-45-neo-continuation-error.{ans,grid.json,html,txt}` and `task-45-neo-continuation-error-summary.txt`.
- **Classic hostile-error PTY:** production `handleEvent` -> `showError` -> theme/Text rendering ran in a real PTY and xterm replay. Exact readable error remained, attacker controls/payloads were absent, and the grid was nonblank. Artifacts: `task-54-classic-continuation-security.{ans,grid.json,html}` and `task-54-classic-continuation-security-summary.txt`.
- **Neo hostile-error PTY:** production bridge/app/feed rendering ran in a real PTY and xterm replay. Exact readable error remained, attacker controls/payloads were absent, and the BEL count stayed at the three legitimate OSC 133 terminators. Artifacts: `task-55-neo-continuation-security.{ans,grid.json,html}`, `task-55-neo-continuation-security-summary.txt`, and cleanup receipt.
- **R8 replacement-render PTY:** real `flushCompactionQueue`, `renderCurrentSessionState`, and `showError` boundaries rendered the replacement baseline with the stale old-session error absent and a nonblank xterm grid. Artifact: `task-69-r8-stale-render-summary.txt`.
- **R8 incident replay:** fresh source CLI runs repeated incident, no-input, and competing OMO/goal/TUI scenarios through `tmux-pipe-pane+xterm-headless`. The incident persisted one dot across six requests, no-input persisted zero across five, and competing input preserved all three continuations in order across eight. Artifacts: `task-83-r8-tui-incident-*`, `task-84-r8-tui-no-input-*`, `task-85-r8-tui-competing-*`.
- Every TUI/PTY run exited cleanly, stopped its server, removed its sandbox or temporary source, and left real Senpi auth unchanged.

### Automated and Isolation Gates

- Focused R1-R7 matrix: 13 files / 66 tests passed. Artifact: `task-38-final-focused-r1-r7.txt`.
- Final full coding-agent lane: 403 files / 3,571 tests passed with existing skips only; root `npm test` exited 0. Artifact: `task-61-final-npm-test-rerun-2.txt`.
- `npm run check`, `npm run build`, and `npm test` passed before the Neo correction. Artifacts: `task-39-final-npm-check.txt`, `task-40-final-npm-build.txt`, `task-41-final-npm-test.txt`.
- After the Neo correction, `go test -race -shuffle=on -count=1 ./...`, `npm run check:neo`, clean-tree `npm run check:neo`, and the exact root `npm run check` all passed. Artifacts: `task-45-neo-race-test.txt`, `task-45-neo-check.txt`, `task-46-neo-clean-tree-check.txt`, `task-46-final-npm-check-with-neo.txt`.
- After the B1/B2 correction, focused TypeScript passed 14 files / 67 tests; full Neo race passed; `npm run check`, `npm run build`, final `npm test`, Biome/tsgo/gofmt/go vet diagnostics, and scope/LOC/no-excuse/generated/secret/runtime audits all passed. Summary: `task-65-b1-b2-security-correction-summary.md`; supporting artifacts: `task-53` through `task-64`.
- After R8, the affected matrix passed 14 files / 67 tests; `npm run check`, `npm run build`, `npm test`, independent Neo race/shuffle/count-one, and fresh `npm run check:neo` all passed. Coding-agent now reports 403 files / 3,572 tests. Mandatory source QA again passed common/fake/RPC/mock/TUI/CLI/native-PTY channels. Summary: `task-88-r8-final-gate-summary.md`; supporting artifacts: `task-66` through `task-87`.
- Mandatory Senpi QA passed: common isolation 9/9, fake model 3/3, RPC 4/4, mock loop 5/5, tool loops 4/4 on each of three APIs, TUI smoke 5/5, CLI smoke 7/7, and PTY runtime 7/7. Summary: `task-37-senpi-qa-summary.md`.
- Repository-native diagnostics are clean on all five final correction paths: Biome and `tsgo --noEmit` pass for TypeScript; gofmt and targeted go vet pass for Neo. `git diff --check` is clean; no generated/manifest/package/shrinkwrap/lock drift; no added skip/only/todo markers; high-confidence secret scan clean.
- Real auth SHA-256 remained unchanged; no task-owned process, tmux session, server, port, source package, or sandbox remained.
- TypeScript no-excuse comparison: base legacy files contain 19 findings, the final changed set contains 18, and the seven new TypeScript files contain zero. The PR removes one inherited finding and introduces none.
- Go formatting, vet, build, test, and full race gates pass. Pure LOC is 118 for the bridge mirror, 245 for the transcript translator, 155 for the transcript renderer, and 62 for the continuation-error regression.
- Parent diff review verdict before the Neo correction: PASS with no blocker. Artifact: `task-43-final-diff-review.md`. Neo correction review summary: `task-46-neo-ci-correction-summary.md`.

## Risks & Residuals

- **Concurrent identity and duplicate delivery:** mitigated by exact object ownership, per-entry commit, suffix-only restoration, loss-of-ownership termination, and deterministic duplicate/late-arrival tests.
- **Cancellation races:** mitigated by in-flight visibility plus abort checks before and after every pre-ownership wait/interception boundary.
- **Session replacement:** mitigated by captured session identity and a monotonically advanced compaction queue generation.
- **Native queue interference:** mitigated by removing destructive queue clearing and preserving the existing steer-before-follow-up policy.
- **Continuation launch failure:** made visible and retryable in both terminal clients; no automatic retry loop was introduced.
- **Cross-language event parity:** guarded by the existing TypeScript/Go exhaustiveness test plus the focused Neo transcript regression.
- **Terminal-control injection:** mitigated at both terminal boundaries with existing shared sanitizers, hostile-byte unit coverage, and real PTY+xterm proof; raw non-terminal diagnostics remain unchanged.
- **Residual maintenance risk:** `agent-session.ts` and `interactive-mode.ts` are inherited large modules. New owned transfer/concurrency/regression files remain bounded; final exact-head review is rerun after CI.

## Commit Structure

1. `93277a3c3` release compaction ownership before retry.
2. `f195a42ae` transfer compaction queue transactionally.
3. `531fdeedf` cover queued input after compaction.
4. `434ed2abb` preserve queued input ownership across handled input, cancellation, continuation failure, overlapping flushes, and session replacement.
5. `228ca3b5e` render typed continuation failures in Neo and restore cross-language event exhaustiveness.
6. `9b59f5075` detach replacement-session flushes from stale tails and harden both terminal renderers.
7. `0dc499c1b` ignore stale accepted-prompt failures after session rebind.
