### PR TITLE
docs(upstream): define verified no-op syncs

### DIFF
--- a/.github/agent/merge-driver.md
+++ b/.github/agent/merge-driver.md
@@ -6,8 +6,8 @@ You are Codex running headless inside GitHub Actions on the `senpi` fork
 the current repository checkout. Do not contact external services other than git remotes and
 GitHub through `gh`.
 
-The remotes `origin` (this fork) and `upstream` (`badlogic/pi-mono`) are already configured,
-and `upstream` has been fetched. The current branch is a bot branch created from `main`.
+The remotes `origin` (this fork) and `upstream` (`badlogic/pi-mono`) are already configured.
+The current branch is a bot branch created from `main`.
 
 ## Procedure
 
@@ -17,6 +17,12 @@ Use the **merge-upstream** skill semantics to sync the current bot branch with
 `upstream/main` via a history-preserving merge (`git merge --no-ff`). Honor every skill
 invariant: no rebase, no force-push, no `--no-verify`, and no history rewrite. Do not push,
 open pull requests, merge pull requests, create tags, or run the release.
+
+Fetch live `upstream/main` and apply the skill's verified-no-op terminal condition before
+change-dependent work. For a no-op, report exact refs and full SHAs plus the confirmed
+ancestry and empty `HEAD..upstream/main` range, then finish with
+`MERGE_RESULT: NO_RELEASE_NEEDED`. Do not update the pin, audit changelogs, run QA, create or
+publish a pull request, push, or release.
 
 If the upstream release does not require any source, package, changelog, or pin change after
 inspection, write a short report and finish with `MERGE_RESULT: NO_RELEASE_NEEDED`.
@@ -112,6 +118,9 @@ node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --e
 ```
 
 ### 6. Finish
+
+Before declaring the branch PR-ready, re-fetch `upstream/main`. If its full SHA changed,
+return to step 1 with the refreshed tip and repeat affected audit and QA.
 
 Leave the bot branch with committed merge, pin, changelog, and focused fix commits in place.
 Write `.github/agent/last-merge-report.md` with the upstream tag, preserved fork commits,

--- a/.github/agent/merge-driver.md
+++ b/.github/agent/merge-driver.md
@@ -119,9 +119,6 @@ node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --e
 
 ### 6. Finish
 
-Before declaring the branch PR-ready, re-fetch `upstream/main`. If its full SHA changed,
-return to step 1 with the refreshed tip and repeat affected audit and QA.
-
 Leave the bot branch with committed merge, pin, changelog, and focused fix commits in place.
 Write `.github/agent/last-merge-report.md` with the upstream tag, preserved fork commits,
 conflicts resolved and how, changelog entries added, and QA results.

--- a/.github/agent/merge-driver.md
+++ b/.github/agent/merge-driver.md
@@ -119,6 +119,9 @@ node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --e
 
 ### 6. Finish
 
+Before declaring the branch PR-ready, re-fetch `upstream/main`. If its full SHA changed,
+return to step 1 with the refreshed tip and repeat affected audit and QA.
+
 Leave the bot branch with committed merge, pin, changelog, and focused fix commits in place.
 Write `.github/agent/last-merge-report.md` with the upstream tag, preserved fork commits,
 conflicts resolved and how, changelog entries added, and QA results.

--- a/.github/agent/skills/merge-upstream/SKILL.md
+++ b/.github/agent/skills/merge-upstream/SKILL.md
@@ -26,7 +26,6 @@ Options:
 
 - Do not run `git rebase`.
 - Do not run `git push --force` or `git push --force-with-lease`.
-- Do not run `git stash push -a`.
 - Do not bypass hooks or signing with `--no-verify` or `--no-gpg-sign`.
 - Ask before pushing.
 
@@ -43,15 +42,14 @@ Options:
 
    Abort on detached HEAD or missing `upstream`. If `origin` is missing, continue locally and skip push.
 
-2. If the worktree is dirty, auto-stash tracked and untracked files:
+2. Require a clean worktree:
 
    ```bash
-   git stash push -u -m "merge-upstream auto-stash $(date +%Y%m%d-%H%M%S)"
-   git stash list -n 1 --format='%gd'
-   git status --porcelain
+   worktree_status=$(git status --porcelain) || exit 1
+   test -z "$worktree_status"
    ```
 
-   Track the stash ref. If the worktree is still dirty after stashing, stop and ask the user to clean it manually.
+   If dirty, stop and ask the user to clean or commit the changes, or use a clean task worktree.
 
 3. Detect the upstream target branch:
 
@@ -64,7 +62,18 @@ Options:
    ```bash
    git rev-parse --is-shallow-repository
    git fetch --tags upstream "+refs/heads/${upstream_branch}:refs/remotes/upstream/${upstream_branch}"
-   git fetch origin "+refs/heads/${current_branch}:refs/remotes/origin/${current_branch}"
+   origin_branch_exists=false
+   if git remote get-url origin >/dev/null 2>&1; then
+     if ! origin_branch=$(git ls-remote --heads origin "refs/heads/${current_branch}"); then
+       echo "failed to inspect origin/${current_branch}" >&2
+       exit 1
+     elif [ -n "$origin_branch" ]; then
+       git fetch origin "+refs/heads/${current_branch}:refs/remotes/origin/${current_branch}" || exit 1
+       origin_branch_exists=true
+     else
+       echo "origin/${current_branch} does not exist; current branch is unpublished"
+     fi
+   fi
    git merge-base HEAD "upstream/${upstream_branch}"
    ```
 
@@ -91,10 +100,11 @@ Options:
 
      ```bash
      git merge-base --is-ancestor "$upstream_tip" "$current_head"
-     test -z "$(git rev-list "$current_head..$upstream_tip")"
+     upstream_range=$(git rev-list "$current_head..$upstream_tip") || exit 1
+     test -z "$upstream_range"
      ```
 
-     This is a successful terminal no-op. Restore any auto-stash, report the exact refs, SHAs, ancestry result, and empty commit range, then stop. Even when the request expects publication, do not create an empty commit, branch, pull request, push, release, or run QA/review gates that depend on a change.
+     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and other change-dependent gates. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, use step 9's non-destructive push semantics.
    - If behind is greater than `0` and `--ff-allow` is set with ahead `0`, run:
 
      ```bash
@@ -128,7 +138,9 @@ Options:
    git rev-parse --git-path rebase-apply
    git show -s --format=%P HEAD
    git rev-list --left-right --count "upstream/${upstream_branch}...HEAD"
-   git merge-base --is-ancestor "origin/${current_branch}" HEAD
+   if [ "$origin_branch_exists" = true ]; then
+     git merge-base --is-ancestor "origin/${current_branch}" HEAD
+   fi
    ```
 
    In default mode, verify HEAD has two parents: `previous_head` as first parent and `upstream_tip` as second parent. In `--ff-allow` fast-forward mode, verify HEAD equals `upstream_tip`.
@@ -142,14 +154,6 @@ Options:
 
    If the remote branch does not exist, use `git push -u origin "${current_branch}"`. If push is rejected as non-fast-forward, re-fetch and offer only non-destructive options: merge `origin/<branch>` into HEAD and retry, or stop.
 
-10. Restore the stash when one was created:
-
-   ```bash
-   git stash pop "$stash_ref"
-   ```
-
-   If pop conflicts, leave the stash entry in place and report the exact ref.
-
 ## Final Report
 
 Include:
@@ -160,5 +164,4 @@ Include:
 - fork commits preserved
 - upstream commits integrated
 - push status
-- stash status
 - any conflicts and how they were resolved

--- a/.github/agent/skills/merge-upstream/SKILL.md
+++ b/.github/agent/skills/merge-upstream/SKILL.md
@@ -26,7 +26,6 @@ Options:
 
 - Do not run `git rebase`.
 - Do not run `git push --force` or `git push --force-with-lease`.
-- Do not run `git stash push -a`.
 - Do not bypass hooks or signing with `--no-verify` or `--no-gpg-sign`.
 - Ask before pushing.
 
@@ -43,15 +42,14 @@ Options:
 
    Abort on detached HEAD or missing `upstream`. If `origin` is missing, continue locally and skip push.
 
-2. If the worktree is dirty, auto-stash tracked and untracked files:
+2. Require a clean worktree:
 
    ```bash
-   git stash push -u -m "merge-upstream auto-stash $(date +%Y%m%d-%H%M%S)"
-   git stash list -n 1 --format='%gd'
-   git status --porcelain
+   worktree_status=$(git status --porcelain) || exit 1
+   test -z "$worktree_status"
    ```
 
-   Track the stash ref. If the worktree is still dirty after stashing, stop and ask the user to clean it manually.
+   If dirty, stop and ask the user to clean or commit the changes, or use a clean task worktree.
 
 3. Detect the upstream target branch:
 
@@ -106,7 +104,7 @@ Options:
      test -z "$upstream_range"
      ```
 
-     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and gates that depend on a new upstream delta. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, continue through steps 9-10; otherwise jump to step 10 to restore any auto-stash, then stop.
+     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and other change-dependent gates. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, use step 9's non-destructive push semantics.
    - If behind is greater than `0` and `--ff-allow` is set with ahead `0`, run:
 
      ```bash
@@ -156,14 +154,6 @@ Options:
 
    If the remote branch does not exist, use `git push -u origin "${current_branch}"`. If push is rejected as non-fast-forward, re-fetch and offer only non-destructive options: merge `origin/<branch>` into HEAD and retry, or stop.
 
-10. Restore the stash when one was created:
-
-   ```bash
-   git stash pop "$stash_ref"
-   ```
-
-   If pop conflicts, leave the stash entry in place and report the exact ref.
-
 ## Final Report
 
 Include:
@@ -174,5 +164,4 @@ Include:
 - fork commits preserved
 - upstream commits integrated
 - push status
-- stash status
 - any conflicts and how they were resolved

--- a/.github/agent/skills/merge-upstream/SKILL.md
+++ b/.github/agent/skills/merge-upstream/SKILL.md
@@ -70,18 +70,31 @@ Options:
 
    If the repository is shallow, unshallow `origin` first when available, then `upstream` only if still shallow.
 
-5. Report divergence:
+   Always use the fetched remote-tracking ref as the target; do not decide from a previously cached `upstream/<branch>` tip.
+
+5. Record the exact refs and report divergence:
 
    ```bash
+   current_head=$(git rev-parse HEAD)
+   upstream_tip=$(git rev-parse "upstream/${upstream_branch}")
    git rev-list --count "upstream/${upstream_branch}..HEAD"
    git rev-list --count "HEAD..upstream/${upstream_branch}"
    GIT_PAGER=cat git log --oneline "HEAD..upstream/${upstream_branch}"
    GIT_PAGER=cat git log --first-parent --oneline "upstream/${upstream_branch}..HEAD"
    ```
 
+   Report `HEAD` and `upstream/${upstream_branch}` with their full SHAs.
+
 6. Merge:
 
-   - If behind is `0`, skip merge.
+   - Behind `0` means the fetched `upstream_tip` is already an ancestor of `current_head`. Confirm that state with both checks:
+
+     ```bash
+     git merge-base --is-ancestor "$upstream_tip" "$current_head"
+     test -z "$(git rev-list "$current_head..$upstream_tip")"
+     ```
+
+     This is a successful terminal no-op. Restore any auto-stash, report the exact refs, SHAs, ancestry result, and empty commit range, then stop. Even when the request expects publication, do not create an empty commit, branch, pull request, push, release, or run QA/review gates that depend on a change.
    - If behind is greater than `0` and `--ff-allow` is set with ahead `0`, run:
 
      ```bash
@@ -141,11 +154,11 @@ Options:
 
 Include:
 
-- branch and upstream target
+- branch and upstream target, including their full SHAs
 - whether merge, fast-forward, or no-op happened
+- for a no-op, confirmed ancestry and the empty `HEAD..upstream/<branch>` range
 - fork commits preserved
 - upstream commits integrated
 - push status
 - stash status
 - any conflicts and how they were resolved
-

--- a/.github/agent/skills/merge-upstream/SKILL.md
+++ b/.github/agent/skills/merge-upstream/SKILL.md
@@ -26,6 +26,7 @@ Options:
 
 - Do not run `git rebase`.
 - Do not run `git push --force` or `git push --force-with-lease`.
+- Do not run `git stash push -a`.
 - Do not bypass hooks or signing with `--no-verify` or `--no-gpg-sign`.
 - Ask before pushing.
 
@@ -42,14 +43,15 @@ Options:
 
    Abort on detached HEAD or missing `upstream`. If `origin` is missing, continue locally and skip push.
 
-2. Require a clean worktree:
+2. If the worktree is dirty, auto-stash tracked and untracked files:
 
    ```bash
-   worktree_status=$(git status --porcelain) || exit 1
-   test -z "$worktree_status"
+   git stash push -u -m "merge-upstream auto-stash $(date +%Y%m%d-%H%M%S)"
+   git stash list -n 1 --format='%gd'
+   git status --porcelain
    ```
 
-   If dirty, stop and ask the user to clean or commit the changes, or use a clean task worktree.
+   Track the stash ref. If the worktree is still dirty after stashing, stop and ask the user to clean it manually.
 
 3. Detect the upstream target branch:
 
@@ -104,7 +106,7 @@ Options:
      test -z "$upstream_range"
      ```
 
-     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and other change-dependent gates. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, use step 9's non-destructive push semantics.
+     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and gates that depend on a new upstream delta. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, continue through steps 9-10; otherwise jump to step 10 to restore any auto-stash, then stop.
    - If behind is greater than `0` and `--ff-allow` is set with ahead `0`, run:
 
      ```bash
@@ -154,6 +156,14 @@ Options:
 
    If the remote branch does not exist, use `git push -u origin "${current_branch}"`. If push is rejected as non-fast-forward, re-fetch and offer only non-destructive options: merge `origin/<branch>` into HEAD and retry, or stop.
 
+10. Restore the stash when one was created:
+
+   ```bash
+   git stash pop "$stash_ref"
+   ```
+
+   If pop conflicts, leave the stash entry in place and report the exact ref.
+
 ## Final Report
 
 Include:
@@ -164,4 +174,5 @@ Include:
 - fork commits preserved
 - upstream commits integrated
 - push status
+- stash status
 - any conflicts and how they were resolved

--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -544,6 +544,8 @@ jobs:
           follow_up="none"
           if [ "$PROCEED" != "true" ]; then
             follow_up="none: no new upstream release"
+          elif [ "$AGENT_RESULT" = "NO_RELEASE_NEEDED" ]; then
+            follow_up="none: upstream was already integrated; no release needed"
           elif [ "$AGENT_RESULT" != "CLEAN_PR_READY" ]; then
             follow_up="attention issue or failure path: agent result ${AGENT_RESULT}"
           elif [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -544,8 +544,6 @@ jobs:
           follow_up="none"
           if [ "$PROCEED" != "true" ]; then
             follow_up="none: no new upstream release"
-          elif [ "$AGENT_RESULT" = "NO_RELEASE_NEEDED" ]; then
-            follow_up="none: upstream was already integrated; no release needed"
           elif [ "$AGENT_RESULT" != "CLEAN_PR_READY" ]; then
             follow_up="attention issue or failure path: agent result ${AGENT_RESULT}"
           elif [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
## Summary

- define an already-integrated upstream tip as a verified successful no-op
- require live SHA, ancestry, and empty-range evidence before stopping
- prevent empty commits, pull requests, or published branches created only to represent a no-op
- preserve separately approved non-destructive pushes of existing local commits
- classify `NO_RELEASE_NEEDED` as a successful workflow outcome

## Why

The upstream-sync guidance previously said only to skip the merge when the fork was not behind. That left PR-oriented runs without an explicit terminal policy and could encourage an empty publication artifact. The canonical skill and headless merge driver now agree on the evidence and stopping conditions, and the workflow summary reports that terminal state as success.

## Validation

- `git diff --check origin/main...HEAD`
- parsed the `merge-upstream` skill frontmatter with Ruby YAML
- parsed and linted `.github/workflows/upstream-agent-merge.yml` with Ruby YAML and `actionlint`
- fetched live `upstream/main` and confirmed it matches the remote SHA
- confirmed `upstream/main` is an ancestor of this branch and `HEAD..upstream/main` is empty

This changes agent guidance and one workflow summary branch; package runtime tests and Senpi CLI QA are not applicable.
