### PR TITLE
fix(upstream): restore reviewed no-op policy

### DIFF
--- a/.github/agent/merge-driver.md
+++ b/.github/agent/merge-driver.md
@@ -119,9 +119,6 @@ node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --e
 
 ### 6. Finish
 
-Before declaring the branch PR-ready, re-fetch `upstream/main`. If its full SHA changed,
-return to step 1 with the refreshed tip and repeat affected audit and QA.
-
 Leave the bot branch with committed merge, pin, changelog, and focused fix commits in place.
 Write `.github/agent/last-merge-report.md` with the upstream tag, preserved fork commits,
 conflicts resolved and how, changelog entries added, and QA results.

--- a/.github/agent/skills/merge-upstream/SKILL.md
+++ b/.github/agent/skills/merge-upstream/SKILL.md
@@ -26,7 +26,6 @@ Options:
 
 - Do not run `git rebase`.
 - Do not run `git push --force` or `git push --force-with-lease`.
-- Do not run `git stash push -a`.
 - Do not bypass hooks or signing with `--no-verify` or `--no-gpg-sign`.
 - Ask before pushing.
 
@@ -43,15 +42,14 @@ Options:
 
    Abort on detached HEAD or missing `upstream`. If `origin` is missing, continue locally and skip push.
 
-2. If the worktree is dirty, auto-stash tracked and untracked files:
+2. Require a clean worktree:
 
    ```bash
-   git stash push -u -m "merge-upstream auto-stash $(date +%Y%m%d-%H%M%S)"
-   git stash list -n 1 --format='%gd'
-   git status --porcelain
+   worktree_status=$(git status --porcelain) || exit 1
+   test -z "$worktree_status"
    ```
 
-   Track the stash ref. If the worktree is still dirty after stashing, stop and ask the user to clean it manually.
+   If dirty, stop and ask the user to clean or commit the changes, or use a clean task worktree.
 
 3. Detect the upstream target branch:
 
@@ -106,7 +104,7 @@ Options:
      test -z "$upstream_range"
      ```
 
-     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and gates that depend on a new upstream delta. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, continue through steps 9-10; otherwise jump to step 10 to restore any auto-stash, then stop.
+     This completes upstream integration as a successful no-op. Report the exact refs, SHAs, ancestry result, and empty range; skip the merge, release, and other change-dependent gates. Do not create an empty commit or pull request, or publish a branch solely to represent the sync. If an independent request explicitly approves pushing existing local commits, use step 9's non-destructive push semantics.
    - If behind is greater than `0` and `--ff-allow` is set with ahead `0`, run:
 
      ```bash
@@ -156,14 +154,6 @@ Options:
 
    If the remote branch does not exist, use `git push -u origin "${current_branch}"`. If push is rejected as non-fast-forward, re-fetch and offer only non-destructive options: merge `origin/<branch>` into HEAD and retry, or stop.
 
-10. Restore the stash when one was created:
-
-   ```bash
-   git stash pop "$stash_ref"
-   ```
-
-   If pop conflicts, leave the stash entry in place and report the exact ref.
-
 ## Final Report
 
 Include:
@@ -174,5 +164,4 @@ Include:
 - fork commits preserved
 - upstream commits integrated
 - push status
-- stash status
 - any conflicts and how they were resolved

--- a/.github/workflows/upstream-agent-merge.yml
+++ b/.github/workflows/upstream-agent-merge.yml
@@ -544,6 +544,8 @@ jobs:
           follow_up="none"
           if [ "$PROCEED" != "true" ]; then
             follow_up="none: no new upstream release"
+          elif [ "$AGENT_RESULT" = "NO_RELEASE_NEEDED" ]; then
+            follow_up="none: upstream was already integrated; no release needed"
           elif [ "$AGENT_RESULT" != "CLEAN_PR_READY" ]; then
             follow_up="attention issue or failure path: agent result ${AGENT_RESULT}"
           elif [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
## Summary

- restore the reviewed upstream no-op policy after PR #200 merged an unintended final revert
- require clean-worktree operation without `git stash`
- distinguish an unpublished current branch from a fetch failure
- preserve independently approved pushes while avoiding empty sync commits, branches, and PRs
- report `NO_RELEASE_NEEDED` as a successful workflow outcome

## Why this correction exists

PR #200's reviewed tree was correct at `ac9b3fd4`, but an unintended final revert (`ab0e54c5`) became its merged head. This one-commit PR reapplies those three reviewed file blobs exactly on top of the resulting merge commit.

## Verification

- `git diff --check`
- merge-upstream skill frontmatter parses as YAML
- `.github/workflows/upstream-agent-merge.yml` parses as YAML
- `actionlint .github/workflows/upstream-agent-merge.yml`
- exactly the three intended files differ from `origin/main`
- all three corrected blobs match reviewed commit `ac9b3fd4`
- live `upstream/main` SHA equals the fetched remote-tracking SHA
- `upstream/main` is already an ancestor of this branch and `HEAD..upstream/main` is empty

No runtime package files are changed, so the repository's real-CLI runtime QA gate does not apply.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the reviewed upstream no‑op policy to skip empty syncs, requires a clean worktree, and treats `NO_RELEASE_NEEDED` as a successful outcome.

- **Bug Fixes**
  - Reinstate no‑op behavior: no empty commits/branches/PRs when upstream is already integrated; allow non‑destructive push only if explicitly approved.
  - Enforce clean worktree; remove auto‑stash and stash‑restore steps in `merge-upstream` skill docs.
  - Remove redundant re‑fetch step from `merge-driver` guide.
  - CI: handle `NO_RELEASE_NEEDED` as success and set follow_up to “none: upstream was already integrated; no release needed.”

<sup>Written for commit ab42225847a3aec304f69092f0051bf976a9b4f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

