### PR TITLE
feat(senpi-codemode): teach eval batching via instruction and reuse-chain examples

### DIFF
--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -25,37 +25,28 @@ type EvalPromptExample = {
 	readonly code: string;
 };
 
-// senpi ToolDefinition has no examples field, so description embeds parity examples.
+// senpi ToolDefinition has no examples field, so description embeds the examples.
+// ADAPTATION: payloads diverge from omp's json-config chain to teach batch read,
+// comprehension filtering, and parallel tool.<name> fan-out while keeping the
+// three-cell reuse narrative.
 const REUSE_CHAIN_EXAMPLES = [
 	{
 		caption: "First call — set up once",
 		language: "py",
-		title: "imports",
-		code: "import json\nfrom pathlib import Path",
+		title: "collect targets",
+		code: "from pathlib import Path\nfrom collections import Counter\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\nprint(len(files))",
 	},
 	{
-		caption: "Second call — reuse, do NOT re-import",
+		caption: "Second call — reuse `files`, batch-read in one cell",
 		language: "py",
-		title: "load config",
-		code: "data = json.loads(read('package.json'))\ndisplay(data)",
+		title: "scan usages",
+		code: "hits = Counter()\nfor p in files:\n    hits[p.name] = read(p).count('legacyClient')\ndisplay({k: v for k, v in hits.items() if v})",
 	},
 	{
-		caption: "Third call — reuse the loaded config",
+		caption: "Third call — reuse results, fan out session tools in parallel",
 		language: "py",
-		title: "scan deps",
-		code: "display(sorted(data['dependencies']))",
-	},
-	{
-		caption: "Ruby first call — set up once",
-		language: "rb",
-		title: "setup",
-		code: "require 'json'\npkg_path = 'package.json'",
-	},
-	{
-		caption: "Ruby second call — reuse, do NOT re-require",
-		language: "rb",
-		title: "load config",
-		code: "pkg = JSON.parse(read(pkg_path))\ndisplay(pkg.keys.sort)",
+		title: "confirm callsites",
+		code: "dirs = ['src/core', 'src/tools']\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))",
 	},
 ] as const satisfies readonly EvalPromptExample[];
 
@@ -64,7 +55,9 @@ const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 <instruction>
 **One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls{{#if spawns}}, and \`task\` subagents{{/if}} — define helpers, datasets, and clients in one call, then later calls reuse them directly.
 
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone. Parallelize work *within* a cell with the \`parallel(thunks)\` helper, not by batching steps.
+Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+
+**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
 
 Fields:
 
@@ -125,7 +118,7 @@ Pipe handles through stage helpers to build a dependency graph — acyclic waves
 {{/if}}
 
 <critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read. Re-run setup only after \`reset\`, a crash, or a \`NameError\`/\`ReferenceError\`.
+Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
 </critical>`;
 
 export function buildEvalPrompt(

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -7,7 +7,9 @@ exports[`buildEvalPrompt > renders the all with spawns prompt 1`] = `
 <instruction>
 **One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls, and \`task\` subagents — define helpers, datasets, and clients in one call, then later calls reuse them directly.
 
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone. Parallelize work *within* a cell with the \`parallel(thunks)\` helper, not by batching steps.
+Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+
+**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
 
 Fields:
 
@@ -67,7 +69,7 @@ Pipe handles through stage helpers to build a dependency graph — acyclic waves
 </dag>
 
 <critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read. Re-run setup only after \`reset\`, a crash, or a \`NameError\`/\`ReferenceError\`.
+Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
 </critical>
 
 <examples>
@@ -75,44 +77,26 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "imports",
-  "code": "import json\\nfrom pathlib import Path"
+  "title": "collect targets",
+  "code": "from pathlib import Path\\nfrom collections import Counter\\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\\nprint(len(files))"
 }
 \`\`\`
 
-### Second call — reuse, do NOT re-import
+### Second call — reuse \`files\`, batch-read in one cell
 \`\`\`json
 {
   "language": "py",
-  "title": "load config",
-  "code": "data = json.loads(read('package.json'))\\ndisplay(data)"
+  "title": "scan usages",
+  "code": "hits = Counter()\\nfor p in files:\\n    hits[p.name] = read(p).count('legacyClient')\\ndisplay({k: v for k, v in hits.items() if v})"
 }
 \`\`\`
 
-### Third call — reuse the loaded config
+### Third call — reuse results, fan out session tools in parallel
 \`\`\`json
 {
   "language": "py",
-  "title": "scan deps",
-  "code": "display(sorted(data['dependencies']))"
-}
-\`\`\`
-
-### Ruby first call — set up once
-\`\`\`json
-{
-  "language": "rb",
-  "title": "setup",
-  "code": "require 'json'\\npkg_path = 'package.json'"
-}
-\`\`\`
-
-### Ruby second call — reuse, do NOT re-require
-\`\`\`json
-{
-  "language": "rb",
-  "title": "load config",
-  "code": "pkg = JSON.parse(read(pkg_path))\\ndisplay(pkg.keys.sort)"
+  "title": "confirm callsites",
+  "code": "dirs = ['src/core', 'src/tools']\\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))"
 }
 \`\`\`
 </examples>",
@@ -131,7 +115,9 @@ exports[`buildEvalPrompt > renders the js without spawns prompt 1`] = `
 <instruction>
 **One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls — define helpers, datasets, and clients in one call, then later calls reuse them directly.
 
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone. Parallelize work *within* a cell with the \`parallel(thunks)\` helper, not by batching steps.
+Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+
+**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
 
 Fields:
 
@@ -175,7 +161,7 @@ phase(title) → None
 </prelude>
 
 <critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read. Re-run setup only after \`reset\`, a crash, or a \`NameError\`/\`ReferenceError\`.
+Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
 </critical>",
   "promptGuidelines": [
     "Use eval for incremental code execution when a persistent JS, Python, Ruby, or Julia kernel is available.",
@@ -192,7 +178,9 @@ exports[`buildEvalPrompt > renders the js-py without spawns prompt 1`] = `
 <instruction>
 **One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls — define helpers, datasets, and clients in one call, then later calls reuse them directly.
 
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone. Parallelize work *within* a cell with the \`parallel(thunks)\` helper, not by batching steps.
+Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+
+**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
 
 Fields:
 
@@ -237,7 +225,7 @@ phase(title) → None
 </prelude>
 
 <critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read. Re-run setup only after \`reset\`, a crash, or a \`NameError\`/\`ReferenceError\`.
+Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
 </critical>
 
 <examples>
@@ -245,26 +233,26 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "imports",
-  "code": "import json\\nfrom pathlib import Path"
+  "title": "collect targets",
+  "code": "from pathlib import Path\\nfrom collections import Counter\\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\\nprint(len(files))"
 }
 \`\`\`
 
-### Second call — reuse, do NOT re-import
+### Second call — reuse \`files\`, batch-read in one cell
 \`\`\`json
 {
   "language": "py",
-  "title": "load config",
-  "code": "data = json.loads(read('package.json'))\\ndisplay(data)"
+  "title": "scan usages",
+  "code": "hits = Counter()\\nfor p in files:\\n    hits[p.name] = read(p).count('legacyClient')\\ndisplay({k: v for k, v in hits.items() if v})"
 }
 \`\`\`
 
-### Third call — reuse the loaded config
+### Third call — reuse results, fan out session tools in parallel
 \`\`\`json
 {
   "language": "py",
-  "title": "scan deps",
-  "code": "display(sorted(data['dependencies']))"
+  "title": "confirm callsites",
+  "code": "dirs = ['src/core', 'src/tools']\\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))"
 }
 \`\`\`
 </examples>",

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -83,19 +83,18 @@ describe("buildEvalPrompt", () => {
 	});
 
 	it("filters reuse-chain examples by enabled language", () => {
-		// Given: prompts that each expose one language from the upstream example set.
+		// Given: prompts exposing the Python example set and kernels without one.
 		const python = buildEvalPrompt({ py: true, js: false, rb: false, jl: false }, { spawns: false }).description;
 		const ruby = buildEvalPrompt({ py: false, js: false, rb: true, jl: false }, { spawns: false }).description;
 		const node = buildEvalPrompt({ py: false, js: true, rb: false, jl: false }, { spawns: false }).description;
 
 		// When: their embedded reuse-chain examples are rendered.
-		// Then: each prompt contains only examples its kernels can execute.
-		expect(python).toContain("import json");
-		expect(python).not.toContain("require ");
-		expect(ruby).toContain("require ");
-		expect(ruby).not.toContain("import json");
-		expect(node).not.toContain("require ");
-		expect(node).not.toContain("import json");
+		// Then: only Python kernels carry examples, and those teach batch + tool bridging.
+		expect(python).toContain("collect targets");
+		expect(python).toContain("tool.grep");
+		expect(python).toContain("parallel([");
+		expect(ruby).not.toContain("<examples>");
+		expect(node).not.toContain("<examples>");
 	});
 
 	it("documents core helpers with Node wording and no excluded surface", () => {


### PR DESCRIPTION
## What

Rework the eval tool prompt so batch-through-eval usage surfaces on its own instead of relying on operator steering.

- **Instruction**: new `**Batch through eval.**` paragraph — one cell replaces many one-shot tool calls: loop/comprehend over file sets with `read()`/stdlib, post-process `tool.<name>()` results programmatically, fan independent calls through `parallel(thunks)`. Absorbs the old "Parallelize work within a cell" sentence (replacement, not addition).
- **Examples**: the three py reuse-chain slots now demonstrate comprehension+`rglob` collection → batch `read()` loop with `Counter` → `parallel()` fan-out of `tool.grep` calls, while keeping the cell-to-cell state-reuse narrative intact. The two rb slots are dropped — rb defaults off, so the default profile never rendered them.
- **Dedup**: the `<critical>` sentence duplicated verbatim from the instruction ("Re-run setup only after reset/crash/NameError") is deleted.

Net: prompt teaches harness-specific, non-derivable patterns (thunk shape with `d=d` binding, `tool.<name>` args dict, batch-read idiom) in the same slot count; file-mutation and bash payloads intentionally excluded to avoid steering around the edit tool or double-bridging shell.

## QA

- `npx tsx vitest --run test/` in `packages/senpi-codemode`: 350 passed / 6 skipped (snapshots updated deliberately, reviewed line-by-line).
- `npm run check` at repo root: passed (biome, docs, types, neo build+vet+test).
- Prompt-only change to the eval tool description string; no runtime code path touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teaches eval batching in `senpi-codemode` with a new instruction and Python reuse-chain examples showing batch reads and parallel tool calls. Removes Ruby examples and duplicate guidance; prompt-only change with updated tests.

- New Features
  - Added "Batch through eval." instruction, replacing the old "parallelize within a cell" line.
  - Reworked three Python reuse-chain examples to show: file collection with `rglob`, batch `read()` + `Counter`, and parallel `tool.grep` fan-out using thunks.
  - Removed Ruby example slots and a duplicated critical sentence about re-running setup.

<sup>Written for commit 31936d87f54ebac5b9114b55e0a0258d247f2402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

