### PR TITLE
feat(ai): add Anthropic XML tool-call protocol

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added the `anthropic-xml` text tool-call protocol for OpenAI-compatible models that emit legacy Anthropic `<invoke>` and `<parameter>` XML, including streaming, schema-driven argument coercion, XML escaping, case-insensitive tool resolution, and bounded malformed-fragment recovery.
+
 ### Changed
 
 ### Fixed

--- a/packages/ai/src/tool-call-middleware/TESTING.md
+++ b/packages/ai/src/tool-call-middleware/TESTING.md
@@ -143,6 +143,29 @@ senpi --provider openrouter-gemma --model "google/gemma-4-31b-it" -p "Use bash t
 
 ---
 
+### 4. Anthropic XML Protocol
+
+The Anthropic XML format uses an attribute-bearing `<invoke>` element with nested `<parameter>` elements.
+
+Add an OpenAI-compatible custom model with `"toolCallFormat": "anthropic-xml"`, then run:
+
+```bash
+senpi --provider <provider> --model <model> -p \
+  "Use the Bash tool to run 'printf anthropic-xml-ok' and report the output."
+```
+
+**Expected Behavior:**
+- The model emits `<invoke name="Bash"><parameter name="command">printf anthropic-xml-ok</parameter></invoke>`.
+- The middleware resolves the declared tool name, parses schema-typed parameters, and executes the tool.
+- The tool result or final response contains `anthropic-xml-ok`.
+
+**Protocol Format Details:**
+- Multiple `<parameter>` elements are allowed.
+- An optional `<function_calls>` wrapper is accepted only when it contains a recognized complete invocation.
+- Incomplete retained fragments are bounded and released according to the middleware error policy.
+
+---
+
 ## Troubleshooting
 
 ### Common Issues
@@ -232,6 +255,7 @@ Look for the `toolCallFormat` field in the output. Valid values are:
 - `hermes` - For Qwen and other Hermes-format models
 - `xml` or `morphXml` - For Gemini and XML-based models
 - `gemma4-delimiter` - For Gemma 4 models
+- `anthropic-xml` - For legacy Anthropic invoke/parameter XML
 - `native` - For models with native tool calling (OpenAI, Anthropic)
 
 ## Summary Table
@@ -241,3 +265,4 @@ Look for the `toolCallFormat` field in the output. Valid values are:
 | Hermes | openrouter-qwen | qwen/qwen3.5-27b | `senpi --provider openrouter-qwen --model "qwen/qwen3.5-27b" -p "Read package.json"` |
 | MorphXml | openrouter-gemini | google/gemini-3-flash-preview | `senpi --provider openrouter-gemini --model "google/gemini-3-flash-preview" -p "List TypeScript files"` |
 | Gemma4 | openrouter-gemma | google/gemma-4-31b-it | `senpi --provider openrouter-gemma --model "google/gemma-4-31b-it" -p "Run date command"` |
+| Anthropic XML | custom OpenAI-compatible provider | compatible text-tool model | `senpi --provider <provider> --model <model> -p "Use Bash to run printf anthropic-xml-ok"` |

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -39,3 +39,16 @@
 - `packages/ai/src/tool-call-middleware/protocols/*`
 - `packages/ai/src/tool-call-middleware/types.ts`
 - `packages/ai/test/tool-call-middleware/*`
+
+## 2026-07-14 - Anthropic legacy XML tool-call protocol
+
+### What changed and why
+
+- Added the `anthropic-xml` text-tool protocol for OpenAI-compatible models that emit legacy Anthropic-style
+  `<invoke name="..."><parameter name="...">...</parameter></invoke>` calls.
+- Registered the format in the middleware protocol registry, compatibility whitelist, and coding-agent custom-model schema.
+- Added batch, streaming, resource-bound, formatter, coercion, registration, and faux-provider end-to-end coverage.
+
+### Why the extension system could not handle this
+
+- Text-tool parsing and custom-model format validation happen in shared AI and coding-agent core before extension tool execution.

--- a/packages/ai/src/tool-call-middleware/context-transformer.ts
+++ b/packages/ai/src/tool-call-middleware/context-transformer.ts
@@ -8,6 +8,13 @@ import type {
 	UserMessage,
 } from "../types.ts";
 import {
+	anthropicXmlFormatToolCall,
+	anthropicXmlFormatToolResponse,
+	anthropicXmlFormatToolsSystemPrompt,
+	createAnthropicXmlStreamParser,
+	parseAnthropicXmlGeneratedText,
+} from "./protocols/anthropic-xml/index.ts";
+import {
 	gemma4CreateStreamParser,
 	gemma4FormatToolCall,
 	gemma4FormatToolResponse,
@@ -78,10 +85,19 @@ const gemma4Protocol: ToolCallProtocol = {
 	createStreamParser: gemma4CreateStreamParser,
 };
 
+const anthropicXmlProtocol: ToolCallProtocol = {
+	formatToolsSystemPrompt: anthropicXmlFormatToolsSystemPrompt,
+	formatToolResponse: anthropicXmlFormatToolResponse,
+	formatToolCall: anthropicXmlFormatToolCall,
+	parseGeneratedText: parseAnthropicXmlGeneratedText,
+	createStreamParser: createAnthropicXmlStreamParser,
+};
+
 /**
  * Protocol registry mapping format strings to protocol implementations.
  */
 const protocolRegistry: Record<ToolCallFormat, ToolCallProtocol> = {
+	"anthropic-xml": anthropicXmlProtocol,
 	hermes: hermesProtocol,
 	xml: morphXmlProtocol,
 	"yaml-xml": yamlXmlProtocol,

--- a/packages/ai/src/tool-call-middleware/index.ts
+++ b/packages/ai/src/tool-call-middleware/index.ts
@@ -16,7 +16,7 @@ export type {
  * Extracts the tool call format from a model's compatibility settings.
  * Only applies to models using the "openai-completions" API with compat settings.
  * @param model - The model to check
- * @returns The tool call format ("hermes", "xml", "yaml-xml", or "gemma4-delimiter") or undefined if not set
+ * @returns The configured supported tool call format, or undefined if not set
  */
 export function getToolCallFormat<TApi extends Api>(model: Model<TApi>): ToolCallFormat | undefined {
 	if (model.api !== "openai-completions") {
@@ -27,7 +27,13 @@ export function getToolCallFormat<TApi extends Api>(model: Model<TApi>): ToolCal
 	if (!format) {
 		return undefined;
 	}
-	if (format === "hermes" || format === "xml" || format === "yaml-xml" || format === "gemma4-delimiter") {
+	if (
+		format === "hermes" ||
+		format === "xml" ||
+		format === "yaml-xml" ||
+		format === "gemma4-delimiter" ||
+		format === "anthropic-xml"
+	) {
 		return format;
 	}
 	return undefined;

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/coerce-parameters.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/coerce-parameters.ts
@@ -1,0 +1,117 @@
+import type { TSchema } from "typebox";
+import { IsArray, IsBoolean, IsInteger, IsNumber, IsObject, IsString } from "typebox";
+import { Value } from "typebox/value";
+import type { Tool } from "../../../types.ts";
+import { decodeXmlEntities } from "./xml-entities.ts";
+
+type RawParameter = {
+	readonly name: string;
+	readonly rawValue: string;
+};
+
+type CoercionResult = { readonly ok: true; readonly value: unknown } | { readonly ok: false };
+
+const INVALID: CoercionResult = { ok: false };
+const LEADING_RAW_NEWLINE = /^(?:\r\n|\r|\n)/;
+const TRAILING_RAW_NEWLINE = /(?:\r\n|\r|\n)$/;
+
+function trimRawBoundaryNewlines(value: string): string {
+	return value.replace(LEADING_RAW_NEWLINE, "").replace(TRAILING_RAW_NEWLINE, "");
+}
+
+export function coerceParameters(rawParams: readonly RawParameter[], tool: Tool): Record<string, unknown> | null {
+	if (!IsObject(tool.parameters)) {
+		return null;
+	}
+
+	const argumentsRecord: Record<string, unknown> = {};
+	for (const rawParam of rawParams) {
+		if (Object.hasOwn(argumentsRecord, rawParam.name)) {
+			return null;
+		}
+
+		const propertySchema = tool.parameters.properties[rawParam.name];
+		const rawValue = trimRawBoundaryNewlines(rawParam.rawValue);
+		const result = propertySchema
+			? coerceKnownValue(rawValue, propertySchema)
+			: { ok: true, value: coerceUnknownValue(rawValue) };
+		if (!result.ok) {
+			return null;
+		}
+
+		Object.defineProperty(argumentsRecord, rawParam.name, {
+			configurable: true,
+			enumerable: true,
+			value: result.value,
+			writable: true,
+		});
+	}
+
+	return passesToolValidation(tool, argumentsRecord) ? argumentsRecord : null;
+}
+
+function coerceKnownValue(rawValue: string, schema: TSchema): CoercionResult {
+	const value = decodeXmlEntities(rawValue);
+
+	if (IsString(schema)) {
+		return { ok: true, value };
+	}
+
+	if (IsNumber(schema) || IsInteger(schema)) {
+		if (value.trim().length === 0) {
+			return INVALID;
+		}
+		const parsed = Number(value);
+		if (!Number.isFinite(parsed) || (IsInteger(schema) && !Number.isInteger(parsed))) {
+			return INVALID;
+		}
+		return { ok: true, value: parsed };
+	}
+
+	if (IsBoolean(schema)) {
+		if (value === "true") {
+			return { ok: true, value: true };
+		}
+		if (value === "false") {
+			return { ok: true, value: false };
+		}
+		return INVALID;
+	}
+
+	if (IsArray(schema)) {
+		const parsed = tryParseJson(value);
+		return parsed.ok && Array.isArray(parsed.value) ? parsed : INVALID;
+	}
+
+	if (IsObject(schema)) {
+		const parsed = tryParseJson(value);
+		return parsed.ok && isJsonObject(parsed.value) ? parsed : INVALID;
+	}
+
+	return { ok: true, value: coerceUnknownValue(rawValue) };
+}
+
+function coerceUnknownValue(rawValue: string): unknown {
+	const value = decodeXmlEntities(rawValue);
+	const parsed = tryParseJson(value);
+	return parsed.ok ? parsed.value : value;
+}
+
+function tryParseJson(value: string): CoercionResult {
+	try {
+		return { ok: true, value: JSON.parse(value) };
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			return INVALID;
+		}
+		throw error;
+	}
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function passesToolValidation(tool: Tool, argumentsRecord: Record<string, unknown>): boolean {
+	return Value.Check(tool.parameters, argumentsRecord);
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/format.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/format.ts
@@ -1,0 +1,74 @@
+import type { Tool } from "../../../types.ts";
+import type { ToolResultContent } from "../../types.ts";
+import { encodeXmlAttribute, encodeXmlParameterText, encodeXmlText } from "./xml-entities.ts";
+
+function serializeToolValue(value: unknown): string {
+	if (typeof value === "object" && value !== null) {
+		return JSON.stringify(value) ?? "null";
+	}
+
+	return String(value);
+}
+
+function renderToolDefinitions(tools: Tool[]): string {
+	const json = JSON.stringify(
+		tools.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters,
+		})),
+	);
+
+	return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+}
+
+export function anthropicXmlFormatToolsSystemPrompt(tools: Tool[]): string {
+	if (tools.length === 0) {
+		return "";
+	}
+
+	return `# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures as JSON within <tools></tools> XML tags:
+<tools>${renderToolDefinitions(tools)}</tools>
+
+# Format
+
+For each function call, emit exactly one bare <invoke> element with the tool name in its name attribute.
+Put each argument in one <parameter> element with its name in the name attribute.
+Do not wrap the invoke element in another XML element.
+
+# Example
+<invoke name="get_weather"><parameter name="city">Seoul</parameter></invoke>`;
+}
+
+export function anthropicXmlFormatToolCall(name: string, args: Record<string, unknown>): string {
+	const parameters = Object.entries(args).map(
+		([parameterName, value]) =>
+			`<parameter name="${encodeXmlAttribute(parameterName)}">${encodeXmlParameterText(serializeToolValue(value))}</parameter>`,
+	);
+
+	return [`<invoke name="${encodeXmlAttribute(name)}">`, ...parameters, "</invoke>"].join("\n");
+}
+
+export function anthropicXmlFormatToolResponse(
+	toolName: string,
+	_toolCallId: string,
+	content: ToolResultContent[],
+): string {
+	const textContent = content
+		.filter((entry): entry is Extract<ToolResultContent, { type: "text" }> => entry.type === "text")
+		.map((entry) => entry.text)
+		.join("\n");
+
+	return [
+		"<function_results>",
+		"<result>",
+		`<tool_name>${encodeXmlText(toolName)}</tool_name>`,
+		`<stdout>${encodeXmlText(textContent)}</stdout>`,
+		"</result>",
+		"</function_results>",
+	].join("\n");
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/index.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/index.ts
@@ -1,0 +1,7 @@
+export {
+	anthropicXmlFormatToolCall,
+	anthropicXmlFormatToolResponse,
+	anthropicXmlFormatToolsSystemPrompt,
+} from "./format.ts";
+export { parseAnthropicXmlGeneratedText } from "./parse.ts";
+export { createAnthropicXmlStreamParser } from "./stream.ts";

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/invoke-match.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/invoke-match.ts
@@ -1,0 +1,26 @@
+import type { InvokeBlockMatch, InvokeOpenTagMatch } from "./invoke-tag-scanner.ts";
+import { findInvokeOpenTag, scanInvokeBlock } from "./invoke-tag-scanner.ts";
+
+export type InvokeMatch = {
+	readonly openingTag: InvokeOpenTagMatch;
+	readonly block: InvokeBlockMatch | null;
+};
+
+export function findNextInvokeMatch(
+	text: string,
+	fromIndex: number,
+	matchesToolName: (toolName: string) => boolean,
+): InvokeMatch | null {
+	let cursor = Math.max(0, fromIndex);
+	while (cursor < text.length) {
+		const openingTag = findInvokeOpenTag(text, cursor);
+		if (!openingTag) {
+			return null;
+		}
+		if (matchesToolName(openingTag.toolName)) {
+			return { openingTag, block: scanInvokeBlock(text, openingTag) };
+		}
+		cursor = openingTag.index + openingTag.length;
+	}
+	return null;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/invoke-tag-scanner.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/invoke-tag-scanner.ts
@@ -1,0 +1,289 @@
+import { decodeXmlEntities } from "./xml-entities.ts";
+
+const PROTOCOL_TAG_NAMES = ["invoke", "parameter", "function_calls"] as const;
+
+const INVOKE_OPEN_TAG_BODY = String.raw`<\s*invoke\b\s+name\s*=\s*(?:"([^"]+)"|'([^']+)')`;
+const INVOKE_OPEN_TAG = new RegExp(`${INVOKE_OPEN_TAG_BODY}\\s*>`, "g");
+const INVOKE_CLOSE_TAG = /<\s*\/\s*invoke\s*>/g;
+const NESTED_INVOKE_OPEN_TAG = /<\s*invoke\b[^>]*>/g;
+const PARAMETER_MARKUP = /<\s*\/?\s*parameter\b/g;
+const PARAMETER_OPEN_TAG = /<\s*parameter\b\s+name\s*=\s*(?:"([^"]+)"|'([^']+)')\s*>/g;
+const PARAMETER_CLOSE_TAG = /<\s*\/\s*parameter\s*>/g;
+
+type TagMatch = {
+	readonly index: number;
+	readonly length: number;
+};
+
+type ParameterOpenTagMatch = TagMatch & {
+	readonly name: string;
+};
+
+type ParameterBoundary =
+	| { readonly kind: "parameter-close"; readonly match: TagMatch }
+	| { readonly kind: "invoke-close"; readonly match: TagMatch };
+
+export type InvokeOpenTagMatch = {
+	readonly index: number;
+	readonly length: number;
+	readonly toolName: string;
+};
+
+export type InvokeParameter = {
+	readonly name: string;
+	readonly rawValue: string;
+};
+
+export type InvokeBlockMatch = {
+	readonly contentEnd: number;
+	readonly end: number;
+	readonly parameters: InvokeParameter[] | null;
+};
+
+function findTag(pattern: RegExp, text: string, fromIndex: number): TagMatch | null {
+	pattern.lastIndex = Math.max(0, fromIndex);
+	const match = pattern.exec(text);
+	return match ? { index: match.index, length: match[0].length } : null;
+}
+
+function findParameterOpenTagAt(text: string, index: number): ParameterOpenTagMatch | null {
+	PARAMETER_OPEN_TAG.lastIndex = index;
+	const match = PARAMETER_OPEN_TAG.exec(text);
+	if (!match || match.index !== index) {
+		return null;
+	}
+
+	const name = match[1] ?? match[2];
+	return name ? { index, length: match[0].length, name: decodeXmlEntities(name) } : null;
+}
+
+function findParameterBoundary(text: string, fromIndex: number): ParameterBoundary | null {
+	let cursor = fromIndex;
+	let nestedInvokeDepth = 0;
+
+	while (cursor < text.length) {
+		const parameterClose = findTag(PARAMETER_CLOSE_TAG, text, cursor);
+		const invokeOpen = findTag(NESTED_INVOKE_OPEN_TAG, text, cursor);
+		const invokeClose = findTag(INVOKE_CLOSE_TAG, text, cursor);
+		const nextIndex = Math.min(
+			parameterClose?.index ?? Number.POSITIVE_INFINITY,
+			invokeOpen?.index ?? Number.POSITIVE_INFINITY,
+			invokeClose?.index ?? Number.POSITIVE_INFINITY,
+		);
+
+		if (!Number.isFinite(nextIndex)) {
+			return null;
+		}
+		if (invokeOpen && invokeOpen.index === nextIndex) {
+			const nextParameterClose = findTag(PARAMETER_CLOSE_TAG, text, invokeOpen.index + invokeOpen.length);
+			const nestedParameterOpen = findTag(PARAMETER_OPEN_TAG, text, invokeOpen.index + invokeOpen.length);
+			const nestedInvokeClose = findTag(INVOKE_CLOSE_TAG, text, invokeOpen.index + invokeOpen.length);
+			if (
+				nestedInvokeClose === null ||
+				((nestedParameterOpen === null || nestedParameterOpen.index > nestedInvokeClose.index) &&
+					nextParameterClose !== null &&
+					nestedInvokeClose.index > nextParameterClose.index)
+			) {
+				cursor = invokeOpen.index + invokeOpen.length;
+				continue;
+			}
+			nestedInvokeDepth += 1;
+			cursor = invokeOpen.index + invokeOpen.length;
+			continue;
+		}
+		if (invokeClose && invokeClose.index === nextIndex) {
+			if (nestedInvokeDepth === 0) {
+				return { kind: "invoke-close", match: invokeClose };
+			}
+			nestedInvokeDepth -= 1;
+			cursor = invokeClose.index + invokeClose.length;
+			continue;
+		}
+		if (parameterClose) {
+			if (nestedInvokeDepth === 0) {
+				return { kind: "parameter-close", match: parameterClose };
+			}
+			cursor = parameterClose.index + parameterClose.length;
+		}
+	}
+
+	return null;
+}
+
+export function findInvokeOpenTag(text: string, fromIndex: number): InvokeOpenTagMatch | null {
+	INVOKE_OPEN_TAG.lastIndex = Math.max(0, fromIndex);
+	const match = INVOKE_OPEN_TAG.exec(text);
+	if (!match || match.index === undefined) {
+		return null;
+	}
+
+	const toolName = match[1] ?? match[2];
+	return toolName ? { index: match.index, length: match[0].length, toolName: decodeXmlEntities(toolName) } : null;
+}
+
+export function findIncompleteInvokeOpenTag(text: string, fromIndex: number): InvokeOpenTagMatch | null {
+	const index = Math.max(0, fromIndex);
+	const candidate = text.slice(index);
+	const match = /^<\s*invoke\b\s+name\s*=\s*/.exec(candidate);
+	if (!match) {
+		return null;
+	}
+
+	const quoteIndex = match[0].length;
+	const quote = candidate[quoteIndex];
+	if (quote !== '"' && quote !== "'") {
+		return null;
+	}
+
+	const toolNameStart = quoteIndex + 1;
+	const closingQuoteIndex = candidate.indexOf(quote, toolNameStart);
+	if (closingQuoteIndex === -1) {
+		const toolName = decodeXmlEntities(candidate.slice(toolNameStart));
+		return toolName.length > 0 ? { index, length: candidate.length, toolName } : null;
+	}
+
+	const toolName = decodeXmlEntities(candidate.slice(toolNameStart, closingQuoteIndex));
+	if (toolName.length === 0 || candidate.slice(closingQuoteIndex + 1).trim().length > 0) {
+		return null;
+	}
+
+	return { index, length: candidate.length, toolName };
+}
+
+export function scanInvokeBlock(text: string, openingTag: InvokeOpenTagMatch): InvokeBlockMatch | null {
+	const parameters: InvokeParameter[] = [];
+	let cursor = Math.max(0, openingTag.index + openingTag.length);
+
+	while (cursor <= text.length) {
+		const invokeClose = findTag(INVOKE_CLOSE_TAG, text, cursor);
+		if (!invokeClose) {
+			return null;
+		}
+
+		const parameterMarkup = findTag(PARAMETER_MARKUP, text, cursor);
+		const nestedInvokeOpen = findTag(NESTED_INVOKE_OPEN_TAG, text, cursor);
+		if (
+			nestedInvokeOpen &&
+			nestedInvokeOpen.index < invokeClose.index &&
+			(!parameterMarkup || nestedInvokeOpen.index < parameterMarkup.index)
+		) {
+			return null;
+		}
+		if (!parameterMarkup || invokeClose.index < parameterMarkup.index) {
+			return {
+				contentEnd: invokeClose.index,
+				end: invokeClose.index + invokeClose.length,
+				parameters,
+			};
+		}
+
+		const parameterOpen = findParameterOpenTagAt(text, parameterMarkup.index);
+		if (!parameterOpen) {
+			return {
+				contentEnd: invokeClose.index,
+				end: invokeClose.index + invokeClose.length,
+				parameters: null,
+			};
+		}
+
+		const valueStart = parameterOpen.index + parameterOpen.length;
+		const boundary = findParameterBoundary(text, valueStart);
+		if (!boundary) {
+			return null;
+		}
+
+		switch (boundary.kind) {
+			case "invoke-close":
+				return {
+					contentEnd: boundary.match.index,
+					end: boundary.match.index + boundary.match.length,
+					parameters: null,
+				};
+			case "parameter-close":
+				parameters.push({
+					name: parameterOpen.name,
+					rawValue: text.slice(valueStart, boundary.match.index),
+				});
+				cursor = boundary.match.index + boundary.match.length;
+				break;
+		}
+	}
+
+	return null;
+}
+
+function isAttributePrefix(remainder: string): boolean {
+	const attributeMatch = /^(\s*)([A-Za-z]*)/.exec(remainder);
+	if (!attributeMatch) {
+		return false;
+	}
+
+	const attributeName = attributeMatch[2] ?? "";
+	const afterAttributeName = remainder.slice(attributeMatch[0].length);
+	if (attributeName.length < "name".length) {
+		return "name".startsWith(attributeName) && afterAttributeName.trim().length === 0;
+	}
+	if (attributeName !== "name") {
+		return false;
+	}
+	if (afterAttributeName.trim().length === 0) {
+		return true;
+	}
+
+	const equalsMatch = /^\s*=\s*(.*)$/.exec(afterAttributeName);
+	if (!equalsMatch) {
+		return false;
+	}
+
+	const valuePrefix = equalsMatch[1] ?? "";
+	if (valuePrefix.length === 0) {
+		return true;
+	}
+
+	const quote = valuePrefix[0];
+	if (quote !== '"' && quote !== "'") {
+		return false;
+	}
+
+	const closingQuoteIndex = valuePrefix.indexOf(quote, 1);
+	return closingQuoteIndex === -1 || valuePrefix.slice(closingQuoteIndex + 1).trim().length === 0;
+}
+
+function isPotentialProtocolStart(candidate: string): boolean {
+	if (!candidate.startsWith("<")) {
+		return false;
+	}
+
+	const body = candidate.slice(1);
+	const leadingWhitespace = /^\s*/.exec(body)?.[0] ?? "";
+	const namePart = body.slice(leadingWhitespace.length);
+	if (namePart.length === 0) {
+		return true;
+	}
+
+	const tagName = PROTOCOL_TAG_NAMES.find((name) => name.startsWith(namePart) || namePart.startsWith(name));
+	if (!tagName) {
+		return false;
+	}
+	if (namePart.length < tagName.length) {
+		return true;
+	}
+
+	const remainder = namePart.slice(tagName.length);
+	if (remainder.includes(">")) {
+		return false;
+	}
+	if (tagName === "function_calls") {
+		return /^\s*$/.test(remainder);
+	}
+	return isAttributePrefix(remainder);
+}
+
+export function getSafeInvokeTextLength(text: string): number {
+	const lastTagIndex = text.lastIndexOf("<");
+	if (lastTagIndex === -1) {
+		return text.length;
+	}
+
+	return isPotentialProtocolStart(text.slice(lastTagIndex)) ? lastTagIndex : text.length;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/parse.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/parse.ts
@@ -1,0 +1,62 @@
+import type { Tool } from "../../../types.ts";
+import type { ParsedToolCall, ParserOptions } from "../../types.ts";
+import { coerceParameters } from "./coerce-parameters.ts";
+import { findNextInvokeMatch } from "./invoke-match.ts";
+import { findInvokeOpenTag, scanInvokeBlock } from "./invoke-tag-scanner.ts";
+import { createToolResolver } from "./tool-resolver.ts";
+
+export function parseAnthropicXmlGeneratedText(text: string, tools: Tool[], options?: ParserOptions): ParsedToolCall[] {
+	if (text.length === 0 || tools.length === 0) {
+		return [];
+	}
+
+	const resolveTool = createToolResolver(tools);
+	const parsedToolCalls: ParsedToolCall[] = [];
+	let cursor = 0;
+
+	while (cursor < text.length) {
+		const openingTag = findInvokeOpenTag(text, cursor);
+		if (!openingTag) {
+			break;
+		}
+
+		const tool = resolveTool(openingTag.toolName);
+		const block = scanInvokeBlock(text, openingTag);
+		if (!tool) {
+			const nextKnownInvoke = findNextInvokeMatch(
+				text,
+				openingTag.index + openingTag.length,
+				(toolName) => resolveTool(toolName) !== undefined,
+			);
+			if (
+				nextKnownInvoke &&
+				(block === null || (nextKnownInvoke.block !== null && nextKnownInvoke.block.end === block.end))
+			) {
+				cursor = nextKnownInvoke.openingTag.index;
+				continue;
+			}
+		}
+		if (!block) {
+			break;
+		}
+
+		const originalCallText = text.slice(openingTag.index, block.end);
+		cursor = block.end;
+
+		if (!tool) {
+			continue;
+		}
+
+		const argumentsRecord = block.parameters ? coerceParameters(block.parameters, tool) : null;
+		if (!argumentsRecord) {
+			options?.onError?.("Could not process anthropic-xml tool call, keeping original text.", {
+				toolCall: originalCallText,
+			});
+			continue;
+		}
+
+		parsedToolCalls.push({ name: tool.name, arguments: argumentsRecord });
+	}
+
+	return parsedToolCalls;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/stream-boundary.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/stream-boundary.ts
@@ -1,0 +1,164 @@
+const WHITESPACE = /\s/;
+const INVOKE_OPEN_TAG = /^<\s*invoke\b[^>]*>$/;
+const INVOKE_CLOSE_TAG = /^<\s*\/\s*invoke\s*>$/;
+const PARAMETER_OPEN_TAG = /^<\s*parameter\b[^>]*>$/;
+const PARAMETER_CLOSE_TAG = /^<\s*\/\s*parameter\s*>$/;
+
+/** Incomplete protocol fragments are rejected before retained input can exceed this many UTF-16 code units. */
+export const ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH = 64 * 1024;
+
+export type StreamBoundaryMatcher = {
+	feed(text: string): boolean;
+};
+
+export type PendingFragment = {
+	readonly kind: "invoke" | "function-calls" | "open-tag";
+	readonly matcher: StreamBoundaryMatcher;
+};
+
+type ClosingTagState = "seek" | "after-open" | "after-slash" | "name" | "after-name";
+
+function isWhitespace(character: string): boolean {
+	return WHITESPACE.test(character);
+}
+
+function createInvokeBoundaryMatcher(): StreamBoundaryMatcher {
+	let invokeDepth = 0;
+	const parameterInvokeDepths: number[] = [];
+	let tagCharacters: string[] | null = null;
+
+	return {
+		feed(text: string): boolean {
+			for (const character of text) {
+				if (tagCharacters === null) {
+					if (character === "<") {
+						tagCharacters = [character];
+					}
+					continue;
+				}
+
+				if (character === "<") {
+					tagCharacters = [character];
+					continue;
+				}
+				tagCharacters.push(character);
+				if (character !== ">") {
+					continue;
+				}
+
+				const tag = tagCharacters.join("");
+				tagCharacters = null;
+				if (INVOKE_OPEN_TAG.test(tag)) {
+					invokeDepth += 1;
+					continue;
+				}
+				if (PARAMETER_OPEN_TAG.test(tag)) {
+					parameterInvokeDepths.push(invokeDepth);
+					continue;
+				}
+				if (PARAMETER_CLOSE_TAG.test(tag)) {
+					const parameterInvokeDepth = parameterInvokeDepths.pop();
+					if (parameterInvokeDepth !== undefined && invokeDepth > parameterInvokeDepth) {
+						invokeDepth = parameterInvokeDepth;
+					}
+					continue;
+				}
+				if (!INVOKE_CLOSE_TAG.test(tag) || invokeDepth === 0) {
+					continue;
+				}
+
+				invokeDepth -= 1;
+				while (parameterInvokeDepths.length > 0) {
+					const parameterInvokeDepth = parameterInvokeDepths[parameterInvokeDepths.length - 1];
+					if (parameterInvokeDepth === undefined || parameterInvokeDepth <= invokeDepth) {
+						break;
+					}
+					parameterInvokeDepths.pop();
+				}
+				if (invokeDepth === 0) {
+					return true;
+				}
+			}
+			return false;
+		},
+	};
+}
+
+export function createClosingTagMatcher(tagName: "invoke" | "function_calls"): StreamBoundaryMatcher {
+	let state: ClosingTagState = "seek";
+	let nameIndex = 0;
+
+	function restart(character: string): void {
+		state = character === "<" ? "after-open" : "seek";
+		nameIndex = 0;
+	}
+
+	return {
+		feed(text: string): boolean {
+			let matched = false;
+			for (const character of text) {
+				switch (state) {
+					case "seek":
+						if (character === "<") {
+							state = "after-open";
+						}
+						break;
+					case "after-open":
+						if (character === "/") {
+							state = "after-slash";
+						} else if (!isWhitespace(character)) {
+							restart(character);
+						}
+						break;
+					case "after-slash":
+						if (character === tagName[0]) {
+							nameIndex = 1;
+							state = "name";
+						} else if (!isWhitespace(character)) {
+							restart(character);
+						}
+						break;
+					case "name":
+						if (character !== tagName[nameIndex]) {
+							restart(character);
+							break;
+						}
+						nameIndex += 1;
+						if (nameIndex === tagName.length) {
+							state = "after-name";
+						}
+						break;
+					case "after-name":
+						if (character === ">") {
+							matched = true;
+							state = "seek";
+							nameIndex = 0;
+						} else if (!isWhitespace(character)) {
+							restart(character);
+						}
+						break;
+				}
+			}
+			return matched;
+		},
+	};
+}
+
+export function createTagEndMatcher(): StreamBoundaryMatcher {
+	return {
+		feed(text: string): boolean {
+			return text.includes(">");
+		},
+	};
+}
+
+export function createPendingFragment(kind: PendingFragment["kind"], text: string): PendingFragment {
+	const matcher =
+		kind === "invoke"
+			? createInvokeBoundaryMatcher()
+			: kind === "function-calls"
+				? createClosingTagMatcher("function_calls")
+				: createTagEndMatcher();
+	matcher.feed(text);
+	return { kind, matcher };
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/stream.ts
@@ -1,0 +1,269 @@
+import type { Tool } from "../../../types.ts";
+import type { ParserOptions, StreamParser, StreamParserEvent } from "../../types.ts";
+import { coerceParameters } from "./coerce-parameters.ts";
+import { findNextInvokeMatch } from "./invoke-match.ts";
+import {
+	findIncompleteInvokeOpenTag,
+	findInvokeOpenTag,
+	getSafeInvokeTextLength,
+	scanInvokeBlock,
+} from "./invoke-tag-scanner.ts";
+import { parseAnthropicXmlGeneratedText } from "./parse.ts";
+import {
+	ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH,
+	createPendingFragment,
+	type PendingFragment,
+} from "./stream-boundary.ts";
+import { createToolResolver } from "./tool-resolver.ts";
+
+export { ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH } from "./stream-boundary.ts";
+
+const FUNCTION_CALLS_OPEN_TAG = /<\s*function_calls\s*>/;
+const FUNCTION_CALLS_CLOSE_TAG = /<\s*\/\s*function_calls\s*>/;
+const FUNCTION_CALLS_COMPLETE_TAG = /^<\s*\/?\s*function_calls\s*>/;
+const FUNCTION_CALLS_OPEN_PREFIX = "<function_calls>";
+const FUNCTION_CALLS_CLOSE_PREFIX = "</function_calls>";
+const EAGER_OPEN_TAG_SCAN_LENGTH = 128;
+const RETAINED_FRAGMENT_OVERFLOW_MESSAGE = `Anthropic XML streaming fragment exceeded the ${ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH}-character retained-input limit.`;
+
+type FunctionCallsTag = {
+	readonly index: number;
+	readonly length: number;
+};
+
+function shouldEmitRawToolCallTextOnError(options?: ParserOptions): boolean {
+	return options?.emitRawToolCallTextOnError === true;
+}
+
+function emitText(events: StreamParserEvent[], text: string): void {
+	if (text.length > 0) {
+		events.push({ type: "text", text });
+	}
+}
+
+function findFunctionCallsTag(pattern: RegExp, text: string, fromIndex: number): FunctionCallsTag | null {
+	const match = pattern.exec(text.slice(fromIndex));
+	if (!match || match.index === undefined) {
+		return null;
+	}
+
+	return { index: fromIndex + match.index, length: match[0].length };
+}
+
+function isPotentialFunctionCallsTag(candidate: string): boolean {
+	if (FUNCTION_CALLS_COMPLETE_TAG.test(candidate)) {
+		return false;
+	}
+	const compactCandidate = candidate.replace(/\s/g, "");
+	return (
+		FUNCTION_CALLS_OPEN_PREFIX.startsWith(compactCandidate) ||
+		FUNCTION_CALLS_CLOSE_PREFIX.startsWith(compactCandidate)
+	);
+}
+
+function getSafeStreamTextLength(text: string): number {
+	const scannerSafeLength = getSafeInvokeTextLength(text);
+	const lastTagIndex = text.lastIndexOf("<");
+	if (lastTagIndex === -1) {
+		return scannerSafeLength;
+	}
+
+	return isPotentialFunctionCallsTag(text.slice(lastTagIndex))
+		? Math.min(scannerSafeLength, lastTagIndex)
+		: scannerSafeLength;
+}
+
+function reportError(options: ParserOptions | undefined, message: string, toolCall: string): void {
+	options?.onError?.(message, { toolCall });
+}
+
+export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOptions): StreamParser {
+	const resolveTool = createToolResolver(tools);
+	let buffer = "";
+	let nextToolCallIndex = 0;
+	let pendingFragment: PendingFragment | null = null;
+
+	function retainPendingFragment(kind: PendingFragment["kind"]): void {
+		pendingFragment = createPendingFragment(kind, buffer);
+	}
+
+	function overflowPendingFragment(): StreamParserEvent[] {
+		const retainedFragment = buffer;
+		buffer = "";
+		pendingFragment = null;
+		reportError(options, RETAINED_FRAGMENT_OVERFLOW_MESSAGE, retainedFragment);
+
+		const events: StreamParserEvent[] = [];
+		if (shouldEmitRawToolCallTextOnError(options)) {
+			emitText(events, retainedFragment);
+		}
+		return events;
+	}
+
+	function processBuffer(): StreamParserEvent[] {
+		const events: StreamParserEvent[] = [];
+		pendingFragment = null;
+
+		while (buffer.length > 0) {
+			const invokeOpenTag = findInvokeOpenTag(buffer, 0);
+			const functionCallsOpenTag = findFunctionCallsTag(FUNCTION_CALLS_OPEN_TAG, buffer, 0);
+
+			if (functionCallsOpenTag && (!invokeOpenTag || functionCallsOpenTag.index <= invokeOpenTag.index)) {
+				if (functionCallsOpenTag.index > 0) {
+					emitText(events, buffer.slice(0, functionCallsOpenTag.index));
+					buffer = buffer.slice(functionCallsOpenTag.index);
+					continue;
+				}
+
+				const functionCallsCloseTag = findFunctionCallsTag(
+					FUNCTION_CALLS_CLOSE_TAG,
+					buffer,
+					functionCallsOpenTag.length,
+				);
+				if (!functionCallsCloseTag) {
+					retainPendingFragment("function-calls");
+					break;
+				}
+
+				const wrapperEnd = functionCallsCloseTag.index + functionCallsCloseTag.length;
+				const wrapperContent = buffer.slice(functionCallsOpenTag.length, functionCallsCloseTag.index);
+				if (parseAnthropicXmlGeneratedText(wrapperContent, tools).length > 0) {
+					buffer = wrapperContent + buffer.slice(wrapperEnd);
+				} else {
+					emitText(events, buffer.slice(0, wrapperEnd));
+					buffer = buffer.slice(wrapperEnd);
+				}
+				continue;
+			}
+
+			if (invokeOpenTag) {
+				if (invokeOpenTag.index > 0) {
+					emitText(events, buffer.slice(0, invokeOpenTag.index));
+					buffer = buffer.slice(invokeOpenTag.index);
+					continue;
+				}
+
+				const tool = resolveTool(invokeOpenTag.toolName);
+				const block = scanInvokeBlock(buffer, invokeOpenTag);
+				if (!tool) {
+					const nextKnownInvoke = findNextInvokeMatch(
+						buffer,
+						invokeOpenTag.index + invokeOpenTag.length,
+						(toolName) => resolveTool(toolName) !== undefined,
+					);
+					if (
+						nextKnownInvoke &&
+						(block === null || (nextKnownInvoke.block !== null && nextKnownInvoke.block.end === block.end))
+					) {
+						emitText(events, buffer.slice(0, nextKnownInvoke.openingTag.index));
+						buffer = buffer.slice(nextKnownInvoke.openingTag.index);
+						continue;
+					}
+				}
+				if (!block) {
+					retainPendingFragment("invoke");
+					break;
+				}
+
+				const originalCallText = buffer.slice(0, block.end);
+				buffer = buffer.slice(block.end);
+
+				if (!tool) {
+					emitText(events, originalCallText);
+					continue;
+				}
+
+				const index = nextToolCallIndex;
+				nextToolCallIndex += 1;
+				const id = `anthropic-xml-tool-${index}`;
+				const argumentsRecord = block.parameters ? coerceParameters(block.parameters, tool) : null;
+				if (argumentsRecord === null) {
+					reportError(
+						options,
+						"Could not process streaming Anthropic XML tool call, keeping original text.",
+						originalCallText,
+					);
+					if (shouldEmitRawToolCallTextOnError(options)) {
+						emitText(events, originalCallText);
+					}
+					continue;
+				}
+
+				events.push({ type: "toolcall_start", index, name: tool.name, id });
+				events.push({
+					type: "toolcall_delta",
+					index,
+					argumentsDelta: JSON.stringify(argumentsRecord),
+				});
+				events.push({ type: "toolcall_end", index, name: tool.name, id, arguments: argumentsRecord });
+				continue;
+			}
+
+			const safeLength = getSafeStreamTextLength(buffer);
+			if (safeLength === 0) {
+				if (buffer.length >= EAGER_OPEN_TAG_SCAN_LENGTH) {
+					retainPendingFragment("open-tag");
+				}
+				break;
+			}
+			emitText(events, buffer.slice(0, safeLength));
+			buffer = buffer.slice(safeLength);
+		}
+
+		return events;
+	}
+
+	return {
+		feed(textDelta: string): StreamParserEvent[] {
+			if (textDelta.length === 0) {
+				return [];
+			}
+
+			const events: StreamParserEvent[] = [];
+			let offset = 0;
+			while (offset < textDelta.length) {
+				const capacity = ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH - buffer.length;
+				if (capacity === 0) {
+					events.push(...overflowPendingFragment());
+					continue;
+				}
+
+				const nextOffset = Math.min(textDelta.length, offset + capacity);
+				const chunk = textDelta.slice(offset, nextOffset);
+				offset = nextOffset;
+				buffer += chunk;
+
+				if (pendingFragment) {
+					if (pendingFragment.matcher.feed(chunk)) {
+						events.push(...processBuffer());
+					}
+				} else {
+					events.push(...processBuffer());
+				}
+
+				if (pendingFragment && buffer.length === ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH) {
+					events.push(...overflowPendingFragment());
+				}
+			}
+			return events;
+		},
+		finish(): StreamParserEvent[] {
+			const events = processBuffer();
+			if (buffer.length === 0) {
+				return events;
+			}
+
+			const invokeOpenTag = findInvokeOpenTag(buffer, 0) ?? findIncompleteInvokeOpenTag(buffer, 0);
+			if (invokeOpenTag && invokeOpenTag.index === 0 && resolveTool(invokeOpenTag.toolName)) {
+				reportError(options, "Could not complete streaming Anthropic XML tool call at finish.", buffer);
+				if (shouldEmitRawToolCallTextOnError(options)) {
+					emitText(events, buffer);
+				}
+			} else {
+				emitText(events, buffer);
+			}
+			buffer = "";
+			return events;
+		},
+	};
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/tool-resolver.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/tool-resolver.ts
@@ -1,0 +1,22 @@
+import type { Tool } from "../../../types.ts";
+
+export type ToolResolver = (toolName: string) => Tool | undefined;
+
+export function createToolResolver(tools: readonly Tool[]): ToolResolver {
+	const exactToolMap = new Map(tools.map((tool) => [tool.name, tool]));
+	const insensitiveToolMap = new Map<string, Tool | null>();
+	for (const tool of tools) {
+		const normalizedName = tool.name.toLowerCase();
+		const existing = insensitiveToolMap.get(normalizedName);
+		insensitiveToolMap.set(normalizedName, existing === undefined ? tool : existing === tool ? tool : null);
+	}
+
+	return (toolName: string): Tool | undefined => {
+		const exactTool = exactToolMap.get(toolName);
+		if (exactTool) {
+			return exactTool;
+		}
+
+		return insensitiveToolMap.get(toolName.toLowerCase()) ?? undefined;
+	};
+}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/xml-entities.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/xml-entities.ts
@@ -1,0 +1,41 @@
+export function encodeXmlText(value: string): string {
+	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function encodeXmlLineBreaks(value: string): string {
+	return value.replaceAll("\r", "&#13;").replaceAll("\n", "&#10;");
+}
+
+export function encodeXmlParameterText(value: string): string {
+	const encoded = encodeXmlText(value);
+	let contentStart = 0;
+	while (encoded[contentStart] === "\r" || encoded[contentStart] === "\n") {
+		contentStart += 1;
+	}
+
+	let contentEnd = encoded.length;
+	while (contentEnd > contentStart && (encoded[contentEnd - 1] === "\r" || encoded[contentEnd - 1] === "\n")) {
+		contentEnd -= 1;
+	}
+
+	return (
+		encodeXmlLineBreaks(encoded.slice(0, contentStart)) +
+		encoded.slice(contentStart, contentEnd) +
+		encodeXmlLineBreaks(encoded.slice(contentEnd))
+	);
+}
+
+export function encodeXmlAttribute(value: string): string {
+	return encodeXmlText(value).replaceAll('"', "&quot;").replaceAll("'", "&apos;");
+}
+
+export function decodeXmlEntities(value: string): string {
+	return value
+		.replaceAll("&#13;", "\r")
+		.replaceAll("&#10;", "\n")
+		.replaceAll("&quot;", '"')
+		.replaceAll("&apos;", "'")
+		.replaceAll("&lt;", "<")
+		.replaceAll("&gt;", ">")
+		.replaceAll("&amp;", "&");
+}

--- a/packages/ai/src/tool-call-middleware/types.ts
+++ b/packages/ai/src/tool-call-middleware/types.ts
@@ -4,9 +4,11 @@ import type { ImageContent, TextContent, Tool } from "../types.ts";
  * Supported tool call formats for models that don't natively support tool calling.
  * - "hermes": Hermes 2/3 format with special delimiters
  * - "xml": XML-based tool call format
+ * - "yaml-xml": YAML arguments inside XML tool tags
  * - "gemma4-delimiter": Gemma 4 specific delimiter format
+ * - "anthropic-xml": Legacy Anthropic invoke/parameter XML format
  */
-export type ToolCallFormat = "hermes" | "xml" | "yaml-xml" | "gemma4-delimiter";
+export type ToolCallFormat = "hermes" | "xml" | "yaml-xml" | "gemma4-delimiter" | "anthropic-xml";
 
 /**
  * Content type for tool results (text or image)

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-coerce.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-coerce.test.ts
@@ -1,0 +1,324 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { coerceParameters } from "../../src/tool-call-middleware/protocols/anthropic-xml/coerce-parameters.ts";
+import type { Tool } from "../../src/types.ts";
+
+function createTool(parameters: Tool["parameters"]): Tool {
+	return {
+		name: "probe",
+		description: "Probe tool",
+		parameters,
+	};
+}
+
+describe("coerceParameters", () => {
+	it("coerces typed primitives after trimming one raw boundary newline", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				message: Type.String(),
+				count: Type.Number(),
+				index: Type.Integer(),
+				enabled: Type.Boolean(),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "message", rawValue: "\n  keep  spaces \n" },
+				{ name: "count", rawValue: "\n1.25\n" },
+				{ name: "index", rawValue: "\n-2\n" },
+				{ name: "enabled", rawValue: "\ntrue\n" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({
+			message: "  keep  spaces ",
+			count: 1.25,
+			index: -2,
+			enabled: true,
+		});
+	});
+
+	it("accepts exact true and false boolean literals only", () => {
+		// given
+		const tool = createTool(Type.Object({ enabled: Type.Boolean() }));
+
+		// when
+		const result = coerceParameters([{ name: "enabled", rawValue: "false" }], tool);
+		const invalid = coerceParameters([{ name: "enabled", rawValue: " TRUE " }], tool);
+
+		// then
+		expect(result).toEqual({ enabled: false });
+		expect(invalid).toBeNull();
+	});
+
+	it("trims raw boundary newlines before entity decoding and not after", () => {
+		// given
+		const tool = createTool(Type.Object({ message: Type.String(), enabled: Type.Boolean() }));
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "message", rawValue: "&#10;keep&#10;" },
+				{ name: "enabled", rawValue: "&#10;true&#10;" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+		expect(
+			coerceParameters(
+				[{ name: "message", rawValue: "&#10;keep&#10;" }],
+				createTool(Type.Object({ message: Type.String() })),
+			),
+		).toEqual({ message: "\nkeep\n" });
+	});
+
+	it("parses JSON arrays and objects with the expected top-level shape", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				items: Type.Array(Type.String()),
+				options: Type.Object({ mode: Type.String() }),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "items", rawValue: '["one","two"]' },
+				{ name: "options", rawValue: '{"mode":"safe"}' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ items: ["one", "two"], options: { mode: "safe" } });
+	});
+
+	it("rejects non-finite numbers when every other required value is valid", () => {
+		// given
+		const tool = createTool(Type.Object({ count: Type.Number(), index: Type.Integer() }));
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "count", rawValue: "Infinity" },
+				{ name: "index", rawValue: "2" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects fractional integers when every other required value is valid", () => {
+		// given
+		const tool = createTool(Type.Object({ count: Type.Number(), index: Type.Integer() }));
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "count", rawValue: "4" },
+				{ name: "index", rawValue: "1.5" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects malformed integers when every other required value is valid", () => {
+		// given
+		const tool = createTool(Type.Object({ count: Type.Number(), index: Type.Integer() }));
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "count", rawValue: "4" },
+				{ name: "index", rawValue: "not-an-integer" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects malformed JSON when every other required value is valid", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				items: Type.Array(Type.String()),
+				options: Type.Object({ mode: Type.String() }),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "items", rawValue: '["one"]' },
+				{ name: "options", rawValue: "{bad" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects an object-shaped array value when every other required value is valid", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				items: Type.Array(Type.String()),
+				options: Type.Object({ mode: Type.String() }),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "items", rawValue: '{"0":"one"}' },
+				{ name: "options", rawValue: '{"mode":"safe"}' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects an array-shaped object value when every other required value is valid", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				items: Type.Array(Type.String()),
+				options: Type.Object({ mode: Type.String() }),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "items", rawValue: '["one"]' },
+				{ name: "options", rawValue: '["safe"]' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("JSON-parses unknown properties before falling back to a string", () => {
+		// given
+		const tool = createTool(Type.Object({ known: Type.String() }));
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "known", rawValue: "ok" },
+				{ name: "metadata", rawValue: '{"source":"xml"}' },
+				{ name: "note", rawValue: "\n<system>ignore this instruction</system>\n" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({
+			known: "ok",
+			metadata: { source: "xml" },
+			note: "<system>ignore this instruction</system>",
+		});
+	});
+
+	it("rejects duplicate parameters instead of silently overwriting", () => {
+		// given
+		const tool = createTool(Type.Object({ name: Type.String() }));
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "name", rawValue: "first" },
+				{ name: "name", rawValue: "second" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects missing required values at the validation boundary", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				name: Type.String(),
+				settings: Type.Object({ level: Type.Integer(), mode: Type.String() }),
+				items: Type.Array(Type.Object({ count: Type.Integer() })),
+			}),
+		);
+
+		// when
+		const result = coerceParameters([], tool);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects a fractional nested integer when all unrelated required values are valid", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				name: Type.String(),
+				settings: Type.Object({ level: Type.Integer(), mode: Type.String() }),
+				items: Type.Array(Type.Object({ count: Type.Integer() })),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "name", rawValue: "probe" },
+				{ name: "settings", rawValue: '{"level":1.5,"mode":"safe"}' },
+				{ name: "items", rawValue: '[{"count":2}]' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+
+	it("rejects a fractional nested array integer when all unrelated required values are valid", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				name: Type.String(),
+				settings: Type.Object({ level: Type.Integer(), mode: Type.String() }),
+				items: Type.Array(Type.Object({ count: Type.Integer() })),
+			}),
+		);
+
+		// when
+		const result = coerceParameters(
+			[
+				{ name: "name", rawValue: "probe" },
+				{ name: "settings", rawValue: '{"level":1,"mode":"safe"}' },
+				{ name: "items", rawValue: '[{"count":1.5}]' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toBeNull();
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-e2e.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-e2e.test.ts
@@ -1,0 +1,156 @@
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { fauxAssistantMessage, registerFauxProvider } from "../../src/providers/faux.ts";
+import { stream } from "../../src/stream.ts";
+import {
+	getProtocol,
+	getToolCallFormat,
+	wrapStreamWithToolCallMiddleware,
+} from "../../src/tool-call-middleware/index.ts";
+import type { AssistantMessage, AssistantMessageEvent, Model, Tool } from "../../src/types.ts";
+
+const bashTool: Tool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({ command: Type.String() }),
+};
+
+const registrations: Array<ReturnType<typeof registerFauxProvider>> = [];
+type ToolCallEndEvent = Extract<AssistantMessageEvent, { type: "toolcall_end" }>;
+type E2eResult = { events: AssistantMessageEvent[]; result: AssistantMessage };
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+function createModel(faux: ReturnType<typeof registerFauxProvider>): Model<"openai-completions"> {
+	return {
+		...faux.getModel(),
+		api: "openai-completions",
+		compat: { toolCallFormat: "anthropic-xml" },
+	} satisfies Model<"openai-completions">;
+}
+
+function createFauxStream(
+	faux: ReturnType<typeof registerFauxProvider>,
+	text: string,
+	model: Model<"openai-completions">,
+): ReturnType<typeof stream> {
+	faux.setResponses([fauxAssistantMessage(text, { stopReason: "stop" })]);
+	return stream(model, { messages: [{ role: "user", content: "Run it", timestamp: 0 }] });
+}
+
+async function collectEvents(streamToCollect: ReturnType<typeof stream>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of streamToCollect) {
+		events.push(event);
+	}
+	return events;
+}
+
+function textDeltas(events: readonly AssistantMessageEvent[]): string {
+	return events
+		.filter((event): event is Extract<AssistantMessageEvent, { type: "text_delta" }> => event.type === "text_delta")
+		.map((event) => event.delta)
+		.join("");
+}
+
+function toolCallEnds(events: readonly AssistantMessageEvent[]): ToolCallEndEvent[] {
+	return events.filter((event): event is ToolCallEndEvent => event.type === "toolcall_end");
+}
+
+function expectToolCallLifecycle(events: readonly AssistantMessageEvent[]): void {
+	const types = events.map((event) => event.type);
+	const start = types.indexOf("toolcall_start");
+	const delta = types.indexOf("toolcall_delta");
+	const end = types.indexOf("toolcall_end");
+
+	expect(types[0]).toBe("start");
+	expect(start).toBeGreaterThanOrEqual(0);
+	expect(delta).toBeGreaterThan(start);
+	expect(end).toBeGreaterThan(delta);
+}
+
+async function runFauxResponse(text: string): Promise<E2eResult> {
+	const faux = registerFauxProvider({
+		api: "openai-completions",
+		tokenSize: { min: 1, max: 1 },
+		schedulerHook: () => undefined,
+	});
+	registrations.push(faux);
+	const model = createModel(faux);
+	const format = getToolCallFormat(model);
+	if (format === undefined) {
+		throw new Error("Expected anthropic-xml compatibility format");
+	}
+
+	const innerStream = createFauxStream(faux, text, model);
+	const wrappedStream = wrapStreamWithToolCallMiddleware(innerStream, getProtocol(format), [bashTool]);
+	const events = await collectEvents(wrappedStream);
+	return { events, result: await wrappedStream.result() };
+}
+
+describe("anthropic-xml faux-provider e2e", () => {
+	it("catches the user's Bash invoke as canonical tool-call events", async () => {
+		// Given
+		const response =
+			'Let me run it.\n<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>\nDone.';
+
+		// When
+		const run = await runFauxResponse(response);
+
+		// Then
+		expectToolCallLifecycle(run.events);
+		const [toolCall] = toolCallEnds(run.events);
+		if (toolCall === undefined) {
+			throw new Error("Expected one Bash tool call");
+		}
+		expect(toolCall.toolCall).toMatchObject({
+			name: "Bash",
+			arguments: { command: "echo hi" },
+		});
+		expect(textDeltas(run.events)).toBe("Let me run it.\n\nDone.");
+		expect(run.result.content).toEqual([
+			{ type: "text", text: "Let me run it.\n" },
+			{ type: "toolCall", id: "anthropic-xml-tool-0", name: "Bash", arguments: { command: "echo hi" } },
+			{ type: "text", text: "\nDone." },
+		]);
+		expect(run.result.stopReason).toBe("toolUse");
+	});
+
+	it("preserves prose and catches two Bash invokes in one faux response", async () => {
+		// Given
+		const response =
+			'First.\n<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>\nSecond.\n' +
+			'<invoke name="Bash"><parameter name="command">echo bye</parameter></invoke>\nFinished.';
+
+		// When
+		const run = await runFauxResponse(response);
+
+		// Then
+		const toolCalls = toolCallEnds(run.events);
+		expect(toolCalls).toHaveLength(2);
+		expect(toolCalls.map((event) => event.toolCall.arguments.command)).toEqual(["echo hi", "echo bye"]);
+		expect(textDeltas(run.events)).toBe("First.\n\nSecond.\n\nFinished.");
+		expect(run.result.stopReason).toBe("toolUse");
+		expect(run.result.content).toHaveLength(5);
+	});
+
+	it("accepts the optional function_calls wrapper without emitting wrapper text", async () => {
+		// Given
+		const response =
+			'<function_calls><invoke name="Bash"><parameter name="command">echo hi</parameter></invoke></function_calls>';
+
+		// When
+		const run = await runFauxResponse(response);
+
+		// Then
+		expect(toolCallEnds(run.events)).toHaveLength(1);
+		expect(textDeltas(run.events)).toBe("");
+		expect(run.result.content).toEqual([
+			{ type: "toolCall", id: "anthropic-xml-tool-0", name: "Bash", arguments: { command: "echo hi" } },
+		]);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-format.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-format.test.ts
@@ -1,0 +1,127 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import {
+	anthropicXmlFormatToolCall,
+	anthropicXmlFormatToolResponse,
+	anthropicXmlFormatToolsSystemPrompt,
+} from "../../src/tool-call-middleware/protocols/anthropic-xml/format.ts";
+import type { ToolResultContent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({
+		city: Type.String(),
+		unit: Type.Optional(Type.String()),
+	}),
+};
+
+describe("anthropicXmlFormatToolsSystemPrompt", () => {
+	it("renders JSON tool definitions and a bare invoke example", () => {
+		// given
+		const tools = [weatherTool];
+
+		// when
+		const prompt = anthropicXmlFormatToolsSystemPrompt(tools);
+		const toolsStart = prompt.lastIndexOf("<tools>") + "<tools>".length;
+		const toolsEnd = prompt.lastIndexOf("</tools>");
+
+		// then
+		expect(JSON.parse(prompt.slice(toolsStart, toolsEnd))).toEqual([
+			{
+				name: weatherTool.name,
+				description: weatherTool.description,
+				parameters: weatherTool.parameters,
+			},
+		]);
+		expect(prompt).toContain('<invoke name="get_weather"><parameter name="city">Seoul</parameter></invoke>');
+		expect(prompt).toContain("exactly one");
+		expect(prompt).not.toContain("<function_calls>");
+	});
+});
+
+describe("anthropicXmlFormatToolCall", () => {
+	it("formats scalar values verbatim and nested values as compact JSON", () => {
+		// given
+		const args = {
+			city: "Seoul",
+			includeForecast: true,
+			days: 2,
+			filters: { temperature: "mild" },
+			tags: ["today", "local"],
+		};
+
+		// when
+		const formatted = anthropicXmlFormatToolCall("get_weather", args);
+
+		// then
+		expect(formatted).toBe(
+			'<invoke name="get_weather">\n' +
+				'<parameter name="city">Seoul</parameter>\n' +
+				'<parameter name="includeForecast">true</parameter>\n' +
+				'<parameter name="days">2</parameter>\n' +
+				'<parameter name="filters">{"temperature":"mild"}</parameter>\n' +
+				'<parameter name="tags">["today","local"]</parameter>\n' +
+				"</invoke>",
+		);
+		expect(formatted).not.toContain("<function_calls>");
+	});
+
+	it("escapes XML-sensitive tool, parameter, and scalar values", () => {
+		// given
+		const args = { 'query<&"': '<unsafe> & "value"' };
+
+		// when
+		const formatted = anthropicXmlFormatToolCall('search<&"', args);
+
+		// then
+		expect(formatted).toBe(
+			'<invoke name="search&lt;&amp;&quot;">\n' +
+				'<parameter name="query&lt;&amp;&quot;">&lt;unsafe&gt; &amp; "value"</parameter>\n' +
+				"</invoke>",
+		);
+	});
+});
+
+describe("anthropicXmlFormatToolResponse", () => {
+	it("extracts text content into Anthropic-style function results", () => {
+		// given
+		const content: ToolResultContent[] = [
+			{ type: "text", text: "first line" },
+			{ type: "image", data: "ignored", mimeType: "image/png" },
+			{ type: "text", text: "second line" },
+		];
+
+		// when
+		const formatted = anthropicXmlFormatToolResponse("run_command", "call-1", content);
+
+		// then
+		expect(formatted).toBe(
+			"<function_results>\n" +
+				"<result>\n" +
+				"<tool_name>run_command</tool_name>\n" +
+				"<stdout>first line\nsecond line</stdout>\n" +
+				"</result>\n" +
+				"</function_results>",
+		);
+	});
+
+	it("escapes XML-sensitive tool names and stdout content", () => {
+		// given
+		const content: ToolResultContent[] = [{ type: "text", text: 'line </stdout> & <result> "output"' }];
+
+		// when
+		const formatted = anthropicXmlFormatToolResponse('tool</tool_name>&"', "call-2", content);
+
+		// then
+		expect(formatted).toBe(
+			"<function_results>\n" +
+				"<result>\n" +
+				'<tool_name>tool&lt;/tool_name&gt;&amp;"</tool_name>\n' +
+				'<stdout>line &lt;/stdout&gt; &amp; &lt;result&gt; "output"</stdout>\n' +
+				"</result>\n" +
+				"</function_results>",
+		);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-parser.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-parser.test.ts
@@ -1,0 +1,299 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { anthropicXmlFormatToolCall } from "../../src/tool-call-middleware/protocols/anthropic-xml/format.ts";
+import { parseAnthropicXmlGeneratedText } from "../../src/tool-call-middleware/protocols/anthropic-xml/parse.ts";
+import type { Tool } from "../../src/types.ts";
+
+const bashTool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+} satisfies Tool;
+
+const canonicalBashTool = {
+	name: "bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+} satisfies Tool;
+
+const inspectTool = {
+	name: "inspect",
+	description: "Inspect a value",
+	parameters: Type.Object({
+		label: Type.String(),
+		count: Type.Number(),
+	}),
+} satisfies Tool;
+
+const flagTool = {
+	name: "Flag",
+	description: "Toggle a flag",
+	parameters: Type.Object({ enabled: Type.Boolean() }),
+} satisfies Tool;
+
+const noopTool = {
+	name: "noop",
+	description: "Do nothing",
+	parameters: Type.Object({}),
+} satisfies Tool;
+
+const optionalTool = {
+	name: "optional",
+	description: "Accept an optional note",
+	parameters: Type.Object({
+		note: Type.Optional(Type.String()),
+	}),
+} satisfies Tool;
+
+const xmlSensitiveTool = {
+	name: 'probe<&"',
+	description: "Probe XML-sensitive values",
+	parameters: Type.Object({ message: Type.String() }),
+} satisfies Tool;
+
+describe("parseAnthropicXmlGeneratedText", () => {
+	it("parses one bare invoke with schema-typed parameters", () => {
+		// given
+		const text =
+			'<invoke name="inspect"><parameter name="label">sample</parameter><parameter name="count">3.5</parameter></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [inspectTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "inspect", arguments: { label: "sample", count: 3.5 } }]);
+	});
+
+	it("parses a pretty-printed Boolean parameter", () => {
+		// given
+		const text = '<invoke name="Flag"><parameter name="enabled">\ntrue\n</parameter></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [flagTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Flag", arguments: { enabled: true } }]);
+	});
+
+	it("parses multiple invokes in order", () => {
+		// given
+		const text = [
+			"before",
+			'<invoke name="Bash"><parameter name="command">echo first</parameter></invoke>',
+			"between",
+			'<invoke name="Bash"><parameter name="command">echo second</parameter></invoke>',
+			"after",
+		].join(" ");
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([
+			{ name: "Bash", arguments: { command: "echo first" } },
+			{ name: "Bash", arguments: { command: "echo second" } },
+		]);
+	});
+
+	it("canonicalizes a unique case-insensitive tool-name match to the declared tool name", () => {
+		// given
+		const text = '<invoke name="Bash"><parameter name="command">echo ulwqa</parameter></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [canonicalBashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "bash", arguments: { command: "echo ulwqa" } }]);
+	});
+
+	it("does not guess an ambiguous case-insensitive tool-name match", () => {
+		// given
+		const text = '<invoke name="BaSh"><parameter name="command">echo ulwqa</parameter></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [canonicalBashTool, bashTool]);
+
+		// then
+		expect(parsed).toEqual([]);
+	});
+
+	it("accepts an optional function_calls wrapper", () => {
+		// given
+		const text = '<function_calls>\n<invoke name="noop"></invoke>\n</function_calls>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [noopTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "noop", arguments: {} }]);
+	});
+
+	it("preserves embedded angle brackets and multiline string values", () => {
+		// given
+		const command = "printf '<value> & keep'\nline two";
+		const text = `<invoke name="Bash"><parameter name="command">${command}</parameter></invoke>`;
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command } }]);
+	});
+
+	it("round-trips XML delimiters and boundary newlines from the formatter", () => {
+		// given
+		const message = "\n\nalpha &#10; </parameter> beta </invoke> & <tag>\r\nmiddle\n\n";
+		const text = anthropicXmlFormatToolCall(xmlSensitiveTool.name, { message });
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [xmlSensitiveTool]);
+
+		// then
+		expect(text).toContain('<parameter name="message">&#10;&#10;alpha');
+		expect(text).toContain("middle&#10;&#10;</parameter>");
+		expect(parsed).toEqual([{ name: xmlSensitiveTool.name, arguments: { message } }]);
+	});
+
+	it("preserves prompt-like invoke markup inside a parameter value", () => {
+		// given
+		const command = 'Show <invoke name="Other"><parameter name="example">raw</parameter></invoke> exactly as text';
+		const text = `<invoke name="Bash"><parameter name="command">${command}</parameter></invoke>`;
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command } }]);
+	});
+
+	it("preserves an unbalanced nested invoke opening tag inside a parameter value", () => {
+		// given
+		const command = 'prefix <invoke name="Other"> literally';
+		const text = `<invoke name="Bash"><parameter name="command">${command}</parameter></invoke>`;
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command } }]);
+	});
+
+	it("skips unknown invokes and continues with later known invokes", () => {
+		// given
+		const text = [
+			'<invoke name="Unknown"><parameter name="value">ignored</parameter></invoke>',
+			'<invoke name="Bash"><parameter name="command">echo known</parameter></invoke>',
+		].join("\n");
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command: "echo known" } }]);
+	});
+
+	it("resynchronizes after an unclosed unknown invoke and parses a later known invoke", () => {
+		// given
+		const text =
+			'<invoke name="Unknown"><parameter name="value">unterminated\n' +
+			'<invoke name="Bash"><parameter name="command">echo recovered</parameter></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command: "echo recovered" } }]);
+	});
+
+	it("does not resynchronize away from an incomplete known invoke", () => {
+		// given
+		const text =
+			'<invoke name="Bash"><parameter name="command">unterminated\n' +
+			'<invoke name="Bash"><parameter name="command">echo hidden</parameter></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([]);
+	});
+
+	it("does not complete a known no-parameter invoke with a later nested close tag", () => {
+		// given
+		const text = '<invoke name="noop">unterminated\n<invoke name="noop"></invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [noopTool]);
+
+		// then
+		expect(parsed).toEqual([]);
+	});
+
+	it("reports invalid coercion and skips the malformed call", () => {
+		// given
+		const onError = vi.fn();
+		const text = [
+			'<invoke name="inspect"><parameter name="label">bad</parameter><parameter name="count">not-a-number</parameter></invoke>',
+			'<invoke name="inspect"><parameter name="label">good</parameter><parameter name="count">2</parameter></invoke>',
+		].join("\n");
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [inspectTool], { onError });
+
+		// then
+		expect(parsed).toEqual([{ name: "inspect", arguments: { label: "good", count: 2 } }]);
+		expect(onError).toHaveBeenCalledOnce();
+		expect(onError).toHaveBeenCalledWith(
+			"Could not process anthropic-xml tool call, keeping original text.",
+			expect.objectContaining({
+				toolCall:
+					'<invoke name="inspect"><parameter name="label">bad</parameter><parameter name="count">not-a-number</parameter></invoke>',
+			}),
+		);
+	});
+
+	it("returns an empty argument object for a known invoke without parameters", () => {
+		// given
+		const text = '<invoke name="noop">\n</invoke>';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [noopTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "noop", arguments: {} }]);
+	});
+
+	it.each([
+		["no-parameter", noopTool],
+		["optional-parameter", optionalTool],
+	])("reports malformed parameter markup for a %s tool", (_description, tool) => {
+		// given
+		const onError = vi.fn();
+		const text = `<invoke name="${tool.name}"><parameter name="ignored">unterminated</invoke>`;
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [tool], { onError });
+
+		// then
+		expect(parsed).toEqual([]);
+		expect(onError).toHaveBeenCalledOnce();
+		expect(onError).toHaveBeenCalledWith("Could not process anthropic-xml tool call, keeping original text.", {
+			toolCall: text,
+		});
+	});
+
+	it("stops cleanly at a truncated invoke after returning complete calls", () => {
+		// given
+		const text = '<invoke name="noop"></invoke><invoke name="Bash"><parameter name="command">echo incomplete';
+
+		// when
+		const parsed = parseAnthropicXmlGeneratedText(text, [noopTool, bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "noop", arguments: {} }]);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-scanner.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-scanner.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+	findInvokeOpenTag,
+	getSafeInvokeTextLength,
+	scanInvokeBlock,
+} from "../../src/tool-call-middleware/protocols/anthropic-xml/invoke-tag-scanner.ts";
+
+function findInvokeCloseIndex(text: string, fromIndex: number): number {
+	const block = scanInvokeBlock(text, { index: fromIndex, length: 0, toolName: "" });
+	return block?.contentEnd ?? -1;
+}
+
+function parseParameterTags(inner: string) {
+	const block = scanInvokeBlock(`${inner}</invoke>`, { index: 0, length: 0, toolName: "" });
+	return block?.parameters ?? null;
+}
+
+describe("findInvokeOpenTag", () => {
+	it("finds double-quoted invoke names and ignores a leading function_calls wrapper", () => {
+		// given
+		const text = '<function_calls>\n<invoke name="Bash">';
+
+		// when
+		const match = findInvokeOpenTag(text, 0);
+
+		// then
+		expect(match).toEqual({
+			index: text.indexOf("<invoke"),
+			length: '<invoke name="Bash">'.length,
+			toolName: "Bash",
+		});
+	});
+
+	it("finds single-quoted names with whitespace around the tag syntax", () => {
+		// given
+		const text = "prefix <  invoke  name = 'list_files'  >";
+
+		// when
+		const match = findInvokeOpenTag(text, 0);
+
+		// then
+		expect(match).toEqual({
+			index: text.indexOf("<"),
+			length: text.length - "prefix ".length,
+			toolName: "list_files",
+		});
+	});
+
+	it("starts searching at the requested index", () => {
+		// given
+		const text = '<invoke name="first"></invoke><invoke name="second">';
+
+		// when
+		const match = findInvokeOpenTag(text, text.indexOf("</invoke>") + "</invoke>".length);
+
+		// then
+		expect(match?.toolName).toBe("second");
+	});
+});
+
+describe("findInvokeCloseIndex", () => {
+	it("finds the first closing invoke tag after the content start", () => {
+		// given
+		const text = '<invoke name="Bash">body</invoke> trailing';
+
+		// when
+		const closeIndex = findInvokeCloseIndex(text, '<invoke name="Bash">'.length);
+
+		// then
+		expect(closeIndex).toBe(text.indexOf("</invoke>"));
+	});
+
+	it("ignores prompt-like invoke text inside a parameter value", () => {
+		// given
+		const text =
+			'<invoke name="Bash"><parameter name="command">show <invoke name="Other">example</invoke> literally</parameter></invoke>';
+
+		// when
+		const closeIndex = findInvokeCloseIndex(text, '<invoke name="Bash">'.length);
+
+		// then
+		expect(closeIndex).toBe(text.lastIndexOf("</invoke>"));
+	});
+});
+
+describe("parseParameterTags", () => {
+	it("preserves parameter order and captures multiline values verbatim", () => {
+		// given
+		const inner = [
+			'\n<parameter name="command">echo first</parameter>',
+			"\n< parameter name = 'script' >line 1\n<value>\nline 2 > line 3</parameter>",
+		].join("");
+
+		// when
+		const parameters = parseParameterTags(inner);
+
+		// then
+		expect(parameters).toEqual([
+			{ name: "command", rawValue: "echo first" },
+			{ name: "script", rawValue: "line 1\n<value>\nline 2 > line 3" },
+		]);
+	});
+
+	it("returns an empty list when no parameter tags are present", () => {
+		// given
+		const inner = "plain invoke content";
+
+		// when
+		const parameters = parseParameterTags(inner);
+
+		// then
+		expect(parameters).toEqual([]);
+	});
+
+	it("rejects unclosed parameter markup instead of returning partial parameters", () => {
+		// given
+		const inner = '<parameter name="ignored">unterminated';
+
+		// when
+		const parameters = parseParameterTags(inner);
+
+		// then
+		expect(parameters).toBeNull();
+	});
+});
+
+describe("getSafeInvokeTextLength", () => {
+	it("withholds a partial invoke start from the text prefix", () => {
+		// given
+		const text = "prefix text <inv";
+
+		// when
+		const safeLength = getSafeInvokeTextLength(text);
+
+		// then
+		expect(safeLength).toBe(text.indexOf("<inv"));
+	});
+
+	it.each([
+		"<parameter",
+		"<function_calls",
+		"< invoke name=",
+		'<invoke name="Bash',
+		"<invoke name='Bash'",
+	])("withholds partial %s starts", (partialStart) => {
+		// given
+		const text = `prefix ${partialStart}`;
+
+		// when
+		const safeLength = getSafeInvokeTextLength(text);
+
+		// then
+		expect(safeLength).toBe(text.indexOf("<"));
+	});
+
+	it("emits an already-invalid closed invoke attribute with trailing content", () => {
+		// given
+		const text = 'prefix <invoke name="Bash" prose';
+
+		// when
+		const safeLength = getSafeInvokeTextLength(text);
+
+		// then
+		expect(findInvokeOpenTag(text, 0)).toBeNull();
+		expect(safeLength).toBe(text.length);
+	});
+
+	it("returns the full length when no partial protocol start trails the text", () => {
+		// given
+		const text = "ordinary text with < and > characters";
+
+		// when
+		const safeLength = getSafeInvokeTextLength(text);
+
+		// then
+		expect(safeLength).toBe(text.length);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-stream-edge.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-stream-edge.test.ts
@@ -1,0 +1,199 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { anthropicXmlFormatToolCall } from "../../src/tool-call-middleware/protocols/anthropic-xml/format.ts";
+import { createAnthropicXmlStreamParser } from "../../src/tool-call-middleware/protocols/anthropic-xml/stream.ts";
+import type { StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const bashTool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+} satisfies Tool;
+
+const canonicalBashTool = {
+	name: "bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+} satisfies Tool;
+
+const noopTool = {
+	name: "noop",
+	description: "Do nothing",
+	parameters: Type.Object({}),
+} satisfies Tool;
+
+function textOutput(events: StreamParserEvent[]): string {
+	return events
+		.filter((event): event is Extract<StreamParserEvent, { type: "text" }> => event.type === "text")
+		.map((event) => event.text)
+		.join("");
+}
+
+function toolCallEnds(events: StreamParserEvent[]): Extract<StreamParserEvent, { type: "toolcall_end" }>[] {
+	return events.filter(
+		(event): event is Extract<StreamParserEvent, { type: "toolcall_end" }> => event.type === "toolcall_end",
+	);
+}
+
+describe("createAnthropicXmlStreamParser edge cases", () => {
+	it("round-trips encoded delimiters and boundary newlines from the formatter", () => {
+		// given
+		const command = "\nprintf '</parameter> </invoke> & <tag>'\n";
+		const input = anthropicXmlFormatToolCall("Bash", { command });
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events).map((event) => event.arguments.command)).toEqual([command]);
+		expect(textOutput(events)).toBe("");
+	});
+
+	it("canonicalizes a unique case-insensitive tool-name match to the declared stream tool name", () => {
+		// given
+		const parser = createAnthropicXmlStreamParser([canonicalBashTool]);
+
+		// when
+		const events = [
+			...parser.feed('<invoke name="Bash"><parameter name="command">echo ulwqa</parameter></invoke>'),
+			...parser.finish(),
+		];
+
+		// then
+		expect(events).toEqual([
+			{ type: "toolcall_start", index: 0, name: "bash", id: "anthropic-xml-tool-0" },
+			{ type: "toolcall_delta", index: 0, argumentsDelta: '{"command":"echo ulwqa"}' },
+			{
+				type: "toolcall_end",
+				index: 0,
+				name: "bash",
+				id: "anthropic-xml-tool-0",
+				arguments: { command: "echo ulwqa" },
+			},
+		]);
+	});
+
+	it("preserves an unbalanced nested invoke opening tag inside a parameter value", () => {
+		// given
+		const command = 'prefix <invoke name="Other"> literally';
+		const input = `<invoke name="Bash"><parameter name="command">${command}</parameter></invoke>`;
+
+		// when
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events).map((event) => event.arguments.command)).toEqual([command]);
+		expect(textOutput(events)).toBe("");
+	});
+
+	it("resynchronizes after an unclosed unknown invoke and streams a later known invoke", () => {
+		// given
+		const unknownPrefix = '<invoke name="Unknown"><parameter name="value">unterminated\n';
+		const knownCall = '<invoke name="Bash"><parameter name="command">echo recovered</parameter></invoke>';
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+
+		// when
+		const events = [...parser.feed(unknownPrefix), ...parser.feed(knownCall), ...parser.finish()];
+
+		// then
+		expect(textOutput(events)).toBe(unknownPrefix);
+		expect(toolCallEnds(events).map((event) => event.arguments.command)).toEqual(["echo recovered"]);
+	});
+
+	it("does not resynchronize away from an incomplete known invoke in the stream", () => {
+		// given
+		const onError = vi.fn();
+		const input =
+			'<invoke name="Bash"><parameter name="command">unterminated\n' +
+			'<invoke name="Bash"><parameter name="command">echo hidden</parameter></invoke>';
+		const parser = createAnthropicXmlStreamParser([bashTool], { onError });
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toEqual([]);
+		expect(onError).toHaveBeenCalledWith("Could not complete streaming Anthropic XML tool call at finish.", {
+			toolCall: input,
+		});
+	});
+
+	it("does not stream a known no-parameter invoke closed by a later nested call", () => {
+		// given
+		const onError = vi.fn();
+		const input = '<invoke name="noop">unterminated\n<invoke name="noop"></invoke>';
+		const parser = createAnthropicXmlStreamParser([noopTool], { onError });
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toEqual([]);
+		expect(onError).toHaveBeenCalledWith("Could not complete streaming Anthropic XML tool call at finish.", {
+			toolCall: input,
+		});
+	});
+
+	it("preserves literal function_calls prose when it does not wrap a recognized invoke", () => {
+		// given
+		const input = "Before <function_calls>literal prose</function_calls> after";
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(textOutput(events)).toBe(input);
+		expect(toolCallEnds(events)).toEqual([]);
+	});
+
+	it("preserves a function_calls wrapper when its recognized invoke is incomplete", () => {
+		// given
+		const onError = vi.fn();
+		const input = 'Before <function_calls><invoke name="Bash">literal</function_calls> after';
+		const parser = createAnthropicXmlStreamParser([bashTool], { onError });
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(textOutput(events)).toBe(input);
+		expect(toolCallEnds(events)).toEqual([]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ emitRaw: false, expected: [] },
+		{ emitRaw: true, expected: [{ type: "text", text: '<invoke name="Bash' }] },
+	])("applies the error policy to a recognized opening tag truncated before the closing quote (raw: $emitRaw)", ({
+		emitRaw,
+		expected,
+	}) => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([bashTool], {
+			emitRawToolCallTextOnError: emitRaw,
+			onError,
+		});
+		const incompleteCall = '<invoke name="Bash';
+
+		// when
+		const feedEvents = parser.feed(`Before ${incompleteCall}`);
+		const finishEvents = parser.finish();
+
+		// then
+		expect(feedEvents).toEqual([{ type: "text", text: "Before " }]);
+		expect(finishEvents).toEqual(expected);
+		expect(onError).toHaveBeenCalledOnce();
+		expect(onError).toHaveBeenCalledWith("Could not complete streaming Anthropic XML tool call at finish.", {
+			toolCall: incompleteCall,
+		});
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-stream-resource.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-stream-resource.test.ts
@@ -1,0 +1,139 @@
+import { performance } from "node:perf_hooks";
+import { Type } from "typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH,
+	createAnthropicXmlStreamParser,
+} from "../../src/tool-call-middleware/protocols/anthropic-xml/stream.ts";
+import type { StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const scanWork = vi.hoisted(() => ({ calls: 0, codeUnits: 0 }));
+
+vi.mock("../../src/tool-call-middleware/protocols/anthropic-xml/invoke-tag-scanner.ts", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("../../src/tool-call-middleware/protocols/anthropic-xml/invoke-tag-scanner.ts")
+		>();
+	const scanInvokeBlock = (...parameters: Parameters<typeof actual.scanInvokeBlock>) => {
+		scanWork.calls += 1;
+		scanWork.codeUnits += parameters[0].length;
+		return actual.scanInvokeBlock(...parameters);
+	};
+	return { ...actual, scanInvokeBlock };
+});
+
+const EXPECTED_OVERFLOW_MESSAGE = `Anthropic XML streaming fragment exceeded the ${ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH}-character retained-input limit.`;
+
+const bashTool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+} satisfies Tool;
+
+const recoveryCall = '<invoke name="Bash"><parameter name="command">echo recovered</parameter></invoke>';
+
+function createBoundaryHeavyCall(targetLength: number): { readonly command: string; readonly input: string } {
+	const prefix = '<invoke name="Bash"><parameter name="command">';
+	const suffix = "</parameter></invoke>";
+	const commandLength = targetLength - prefix.length - suffix.length;
+	const nestedPairLength = prefix.length + suffix.length;
+	const candidateCount = Math.floor(commandLength / nestedPairLength);
+	const command =
+		prefix.repeat(candidateCount) +
+		"x".repeat(commandLength - candidateCount * nestedPairLength) +
+		suffix.repeat(candidateCount);
+	return { command, input: prefix + command + suffix };
+}
+
+function textOutput(events: StreamParserEvent[]): string {
+	return events
+		.filter((event): event is Extract<StreamParserEvent, { type: "text" }> => event.type === "text")
+		.map((event) => event.text)
+		.join("");
+}
+
+function toolCallEnds(events: StreamParserEvent[]): Extract<StreamParserEvent, { type: "toolcall_end" }>[] {
+	return events.filter(
+		(event): event is Extract<StreamParserEvent, { type: "toolcall_end" }> => event.type === "toolcall_end",
+	);
+}
+
+beforeEach(() => {
+	scanWork.calls = 0;
+	scanWork.codeUnits = 0;
+});
+
+it("keeps nested candidate-close processing linear in one-character streams", () => {
+	// given
+	const { command, input } = createBoundaryHeavyCall(24 * 1024);
+	const parser = createAnthropicXmlStreamParser([bashTool]);
+	const events: StreamParserEvent[] = [];
+
+	// when
+	const startedAt = performance.now();
+	for (const character of input) {
+		events.push(...parser.feed(character));
+	}
+	events.push(...parser.finish());
+	const elapsedMs = performance.now() - startedAt;
+
+	// then
+	expect(elapsedMs).toBeLessThan(10_000);
+	expect(scanWork.calls, `scan work: ${JSON.stringify(scanWork)}`).toBe(2);
+	expect(scanWork.codeUnits, `scan work: ${JSON.stringify(scanWork)}`).toBeLessThanOrEqual(input.length + 128);
+	expect(toolCallEnds(events).map((event) => event.arguments.command)).toEqual([command]);
+});
+
+describe.each([
+	{
+		kind: "invoke",
+		prefix: '<invoke name="Bash"><parameter name="command">',
+	},
+	{
+		kind: "function_calls wrapper",
+		prefix: "<function_calls>",
+	},
+])("createAnthropicXmlStreamParser resource bounds for an incomplete $kind", ({ prefix }) => {
+	it.each([
+		{ emitRaw: false, expectedRawText: "" },
+		{ emitRaw: true, expectedRawText: "input" },
+	])("bounds one-byte deltas and recovers after overflow (raw: $emitRaw)", ({ emitRaw, expectedRawText }) => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([bashTool], {
+			emitRawToolCallTextOnError: emitRaw,
+			onError,
+		});
+		const input = prefix + "x".repeat(ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH - prefix.length);
+		const overflowEvents: StreamParserEvent[] = [];
+
+		// when
+		const startedAt = performance.now();
+		for (const character of input) {
+			overflowEvents.push(...parser.feed(character));
+		}
+		const elapsedMs = performance.now() - startedAt;
+		const recoveryEvents = [...parser.feed(recoveryCall), ...parser.finish()];
+
+		// then
+		expect(elapsedMs).toBeLessThan(5_000);
+		expect(onError).toHaveBeenCalledOnce();
+		const [message, metadata] = onError.mock.calls[0] ?? [];
+		expect(message).toBe(EXPECTED_OVERFLOW_MESSAGE);
+		expect(metadata).toEqual({ toolCall: input });
+		expect(textOutput(overflowEvents)).toBe(expectedRawText === "input" ? input : expectedRawText);
+		expect(toolCallEnds(recoveryEvents)).toEqual([
+			{
+				type: "toolcall_end",
+				index: 0,
+				name: "Bash",
+				id: "anthropic-xml-tool-0",
+				arguments: { command: "echo recovered" },
+			},
+		]);
+		expect(textOutput(recoveryEvents)).toBe("");
+	});
+});

--- a/packages/ai/test/tool-call-middleware/anthropic-xml-stream.test.ts
+++ b/packages/ai/test/tool-call-middleware/anthropic-xml-stream.test.ts
@@ -1,0 +1,323 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { createAnthropicXmlStreamParser } from "../../src/tool-call-middleware/protocols/anthropic-xml/stream.ts";
+import type { ParserOptions, StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const bashTool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+} satisfies Tool;
+
+const counterTool = {
+	name: "Count",
+	description: "Count a value",
+	parameters: Type.Object({
+		count: Type.Number(),
+	}),
+} satisfies Tool;
+
+const noopTool = {
+	name: "noop",
+	description: "Do nothing",
+	parameters: Type.Object({}),
+} satisfies Tool;
+
+function seededRandom(seed: number): () => number {
+	let current = seed;
+	return () => {
+		current = (current * 9301 + 49_297) % 233_280;
+		return current / 233_280;
+	};
+}
+
+function randomChunkSplit(text: string, seed: number): string[] {
+	const random = seededRandom(seed);
+	const chunks: string[] = [];
+	let index = 0;
+	while (index < text.length) {
+		const size = Math.floor(random() * 8) + 1;
+		chunks.push(text.slice(index, index + size));
+		index += size;
+	}
+	return chunks;
+}
+
+function collectBashEvents(input: string, seed: number, options?: ParserOptions): StreamParserEvent[] {
+	const parser = createAnthropicXmlStreamParser([bashTool], options);
+	const events: StreamParserEvent[] = [];
+	for (const chunk of randomChunkSplit(input, seed)) {
+		events.push(...parser.feed(chunk));
+	}
+	events.push(...parser.finish());
+	return events;
+}
+
+function textOutput(events: StreamParserEvent[]): string {
+	return events
+		.filter((event): event is Extract<StreamParserEvent, { type: "text" }> => event.type === "text")
+		.map((event) => event.text)
+		.join("");
+}
+
+function toolCallEnds(events: StreamParserEvent[]): Extract<StreamParserEvent, { type: "toolcall_end" }>[] {
+	return events.filter(
+		(event): event is Extract<StreamParserEvent, { type: "toolcall_end" }> => event.type === "toolcall_end",
+	);
+}
+
+describe("createAnthropicXmlStreamParser", () => {
+	it("emits a complete invoke as one tool call", () => {
+		// given
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+
+		// when
+		const events = [
+			...parser.feed('<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>'),
+			...parser.finish(),
+		];
+
+		// then
+		expect(events).toEqual([
+			{ type: "toolcall_start", index: 0, name: "Bash", id: "anthropic-xml-tool-0" },
+			{ type: "toolcall_delta", index: 0, argumentsDelta: '{"command":"echo hi"}' },
+			{
+				type: "toolcall_end",
+				index: 0,
+				name: "Bash",
+				id: "anthropic-xml-tool-0",
+				arguments: { command: "echo hi" },
+			},
+		]);
+	});
+
+	it.each([0, 1, 7, 13, 21, 42])("keeps arbitrary chunk splits stable (seed %s)", (seed) => {
+		// given
+		const input =
+			'Before <invoke name="Bash"><parameter name="command">printf \'<ok>\'\nnext</parameter></invoke> after';
+
+		// when
+		const events = collectBashEvents(input, seed);
+
+		// then
+		expect(toolCallEnds(events)).toEqual([
+			{
+				type: "toolcall_end",
+				index: 0,
+				name: "Bash",
+				id: "anthropic-xml-tool-0",
+				arguments: { command: "printf '<ok>'\nnext" },
+			},
+		]);
+		expect(events.filter((event) => event.type === "toolcall_start")).toHaveLength(1);
+		expect(events.filter((event) => event.type === "toolcall_delta")).toEqual([
+			{ type: "toolcall_delta", index: 0, argumentsDelta: '{"command":"printf \'<ok>\'\\nnext"}' },
+		]);
+		expect(textOutput(events)).toBe("Before  after");
+		expect(textOutput(events)).not.toContain("<invoke");
+		expect(textOutput(events)).not.toContain("</invoke>");
+	});
+
+	it("withholds a split invoke start tag from plain text", () => {
+		// given
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+
+		// when
+		const firstEvents = parser.feed("prefix <inv");
+		const remainingEvents = [
+			...parser.feed('oke name="Bash"><parameter name="command">ls</parameter></invoke> suffix'),
+			...parser.finish(),
+		];
+
+		// then
+		expect(firstEvents).toEqual([{ type: "text", text: "prefix " }]);
+		expect(firstEvents.some((event) => event.type === "toolcall_end")).toBe(false);
+		expect(toolCallEnds(remainingEvents)).toHaveLength(1);
+		expect(textOutput([...firstEvents, ...remainingEvents])).toBe("prefix  suffix");
+	});
+
+	it("drops the optional function_calls wrapper while preserving prose", () => {
+		// given
+		const input =
+			'Before <function_calls><invoke name="Bash"><parameter name="command">ls</parameter></invoke></function_calls> after';
+
+		// when
+		const events = collectBashEvents(input, 13);
+
+		// then
+		expect(toolCallEnds(events)).toHaveLength(1);
+		expect(textOutput(events)).toBe("Before  after");
+		expect(textOutput(events)).not.toContain("function_calls");
+	});
+
+	it("assigns deterministic ids to consecutive known invokes", () => {
+		// given
+		const parser = createAnthropicXmlStreamParser([bashTool]);
+		const input =
+			'<invoke name="Bash"><parameter name="command">one</parameter></invoke><invoke name="Bash"><parameter name="command">two</parameter></invoke>';
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(
+			toolCallEnds(events).map((event) => ({ index: event.index, id: event.id, command: event.arguments.command })),
+		).toEqual([
+			{ index: 0, id: "anthropic-xml-tool-0", command: "one" },
+			{ index: 1, id: "anthropic-xml-tool-1", command: "two" },
+		]);
+	});
+
+	it("preserves prompt-like invoke markup inside a parameter value", () => {
+		// given
+		const command = 'Show <invoke name="Other"><parameter name="example">raw</parameter></invoke> exactly as text';
+		const input = `<invoke name="Bash"><parameter name="command">${command}</parameter></invoke>`;
+
+		// when
+		const events = collectBashEvents(input, 21);
+
+		// then
+		expect(toolCallEnds(events).map((event) => event.arguments.command)).toEqual([command]);
+		expect(textOutput(events)).toBe("");
+	});
+
+	it("keeps a complete unknown invoke as text without reporting an error", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([bashTool], { onError });
+		const unknownCall = '<invoke name="Other"><parameter name="command">echo no</parameter></invoke>';
+
+		// when
+		const events = [...parser.feed(`Before ${unknownCall} after`), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toHaveLength(0);
+		expect(textOutput(events)).toBe(`Before ${unknownCall} after`);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("suppresses a malformed known invoke and reports the original text", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([counterTool], { onError });
+		const call = '<invoke name="Count"><parameter name="count">not-a-number</parameter></invoke>';
+
+		// when
+		const events = [...parser.feed(`Before ${call} after`), ...parser.finish()];
+
+		// then
+		expect(events).toEqual([
+			{ type: "text", text: "Before " },
+			{ type: "text", text: " after" },
+		]);
+		expect(onError).toHaveBeenCalledWith(
+			"Could not process streaming Anthropic XML tool call, keeping original text.",
+			{
+				toolCall: call,
+			},
+		);
+	});
+
+	it("emits a malformed complete invoke as raw text when enabled", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([counterTool], {
+			onError,
+			emitRawToolCallTextOnError: true,
+		});
+		const call = '<invoke name="Count"><parameter name="count">not-a-number</parameter></invoke>';
+
+		// when
+		const events = [...parser.feed(`Before ${call} after`), ...parser.finish()];
+
+		// then
+		expect(textOutput(events)).toBe(`Before ${call} after`);
+		expect(toolCallEnds(events)).toHaveLength(0);
+		expect(onError).toHaveBeenCalledOnce();
+	});
+
+	it("rejects malformed parameter markup for a no-parameter tool", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([noopTool], { onError });
+		const call = '<invoke name="noop"><parameter name="ignored">unterminated</invoke>';
+
+		// when
+		const events = [...parser.feed(`Before ${call} after`), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toHaveLength(0);
+		expect(textOutput(events)).toBe("Before  after");
+		expect(onError).toHaveBeenCalledWith(
+			"Could not process streaming Anthropic XML tool call, keeping original text.",
+			{ toolCall: call },
+		);
+	});
+
+	it("reports and suppresses an incomplete known invoke at finish by default", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([bashTool], { onError });
+		const incompleteCall = '<invoke name="Bash"><parameter name="command">ls';
+
+		// when
+		const feedEvents = parser.feed(`Before ${incompleteCall}`);
+		const finishEvents = parser.finish();
+
+		// then
+		expect(feedEvents).toEqual([{ type: "text", text: "Before " }]);
+		expect(finishEvents).toEqual([]);
+		expect(toolCallEnds([...feedEvents, ...finishEvents])).toHaveLength(0);
+		expect(onError).toHaveBeenCalledWith("Could not complete streaming Anthropic XML tool call at finish.", {
+			toolCall: incompleteCall,
+		});
+	});
+
+	it("emits an incomplete known invoke as raw text at finish when enabled", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([bashTool], {
+			onError,
+			emitRawToolCallTextOnError: true,
+		});
+		const incompleteCall = '<invoke name="Bash"><parameter name="command">ls';
+
+		// when
+		const feedEvents = parser.feed(`Before ${incompleteCall}`);
+		const finishEvents = parser.finish();
+
+		// then
+		expect(feedEvents).toEqual([{ type: "text", text: "Before " }]);
+		expect(finishEvents).toEqual([{ type: "text", text: incompleteCall }]);
+		expect(toolCallEnds([...feedEvents, ...finishEvents])).toHaveLength(0);
+		expect(onError).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		{ emitRaw: false, expected: [] },
+		{ emitRaw: true, expected: [{ type: "text", text: '<invoke name="Bash"' }] },
+	])("applies the error policy to an incomplete known opening tag (raw: $emitRaw)", ({ emitRaw, expected }) => {
+		// given
+		const onError = vi.fn();
+		const parser = createAnthropicXmlStreamParser([bashTool], {
+			emitRawToolCallTextOnError: emitRaw,
+			onError,
+		});
+		const incompleteCall = '<invoke name="Bash"';
+
+		// when
+		const feedEvents = parser.feed(`Before ${incompleteCall}`);
+		const finishEvents = parser.finish();
+
+		// then
+		expect(feedEvents).toEqual([{ type: "text", text: "Before " }]);
+		expect(finishEvents).toEqual(expected);
+		expect(onError).toHaveBeenCalledOnce();
+		expect(onError).toHaveBeenCalledWith("Could not complete streaming Anthropic XML tool call at finish.", {
+			toolCall: incompleteCall,
+		});
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `anthropic-xml` as a valid `compat.toolCallFormat` in custom `models.json` provider and model definitions.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -135,6 +135,7 @@ const OpenAICompletionsCompatSchema = Type.Object({
 	supportsStrictMode: Type.Optional(Type.Boolean()),
 	toolCallFormat: Type.Optional(
 		Type.Union([
+			Type.Literal("anthropic-xml"),
 			Type.Literal("hermes"),
 			Type.Literal("gemma4"),
 			Type.Literal("gemma4-delimiter"),

--- a/packages/coding-agent/test/anthropic-xml-registration.test.ts
+++ b/packages/coding-agent/test/anthropic-xml-registration.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { getProtocol, getToolCallFormat } from "../../ai/src/tool-call-middleware/index.ts";
+import type { Api, Model, Tool } from "../../ai/src/types.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRegistry } from "../src/core/model-registry.ts";
+
+const bashTool: Tool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({
+		command: Type.String(),
+	}),
+};
+
+const openAiCompletionsModel = {
+	id: "anthropic-xml-model",
+	name: "Anthropic XML model",
+	api: "openai-completions",
+	provider: "registration-test",
+	baseUrl: "https://example.invalid/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 1024,
+	compat: { toolCallFormat: "anthropic-xml" },
+} satisfies Model<"openai-completions">;
+
+const openAiCompletionsModelWithoutCompat = {
+	...openAiCompletionsModel,
+	compat: undefined,
+} satisfies Model<"openai-completions">;
+
+const nonCompletionsModel: Model<Api> = {
+	...openAiCompletionsModel,
+	api: "anthropic-messages",
+};
+
+describe("anthropic-xml registration", () => {
+	let tempDir: string | undefined;
+
+	afterEach(() => {
+		if (tempDir !== undefined) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
+
+	it("parses a Bash invocation when the anthropic-xml protocol is resolved", () => {
+		// Given
+		const generatedText = '<invoke name="Bash"><parameter name="command">printf registration-ok</parameter></invoke>';
+
+		// When
+		const parsed = getProtocol("anthropic-xml").parseGeneratedText(generatedText, [bashTool]);
+
+		// Then
+		expect(parsed).toEqual([
+			{
+				name: "Bash",
+				arguments: { command: "printf registration-ok" },
+			},
+		]);
+	});
+
+	it("activates anthropic-xml for an openai-completions model with compat", () => {
+		// Given
+		const model = openAiCompletionsModel;
+
+		// When
+		const format = getToolCallFormat(model);
+
+		// Then
+		expect(format).toBe("anthropic-xml");
+	});
+
+	it("does not activate without compatibility settings", () => {
+		// Given
+		const model = openAiCompletionsModelWithoutCompat;
+
+		// When
+		const format = getToolCallFormat(model);
+
+		// Then
+		expect(format).toBeUndefined();
+	});
+
+	it("does not activate for a non-openai-completions API", () => {
+		// Given
+		const model = nonCompletionsModel;
+
+		// When
+		const format = getToolCallFormat(model);
+
+		// Then
+		expect(format).toBeUndefined();
+	});
+
+	it("accepts anthropic-xml in a models.json compatibility block", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-anthropic-xml-registration-"));
+		const modelsJsonPath = join(tempDir, "models.json");
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"registration-test": {
+						api: "openai-completions",
+						baseUrl: "https://example.invalid/v1",
+						compat: { toolCallFormat: "anthropic-xml" },
+						models: [{ id: "anthropic-xml-model" }],
+					},
+				},
+			}),
+		);
+
+		// When
+		const registry = ModelRegistry.create(AuthStorage.create(join(tempDir, "auth.json")), modelsJsonPath);
+
+		// Then
+		expect(registry.getError()).toBeUndefined();
+		expect(registry.find("registration-test", "anthropic-xml-model")?.id).toBe("anthropic-xml-model");
+	});
+});


### PR DESCRIPTION
## Summary

Add an `anthropic-xml` text tool-call protocol for OpenAI-compatible models that emit legacy Anthropic `<invoke>` and `<parameter>` XML.

Before this change, those responses remained plain assistant text and could not execute registered tools. After this change, Senpi parses complete and streamed calls, resolves tool names case-insensitively when unambiguous, coerces arguments against the tool schema, executes the canonical tool, and serializes the call/result back into model context.

## Changes

- Add bounded batch and streaming parsers for bare `<invoke>` calls and genuine `<function_calls>` wrappers.
- Preserve literal wrapper prose and malformed or unknown calls according to the existing middleware error policy.
- Add schema-driven parameter coercion, XML entity handling, canonical formatting, and case-insensitive tool resolution.
- Register `anthropic-xml` in the AI middleware and custom `models.json` schema.
- Add parser, scanner, streaming, resource-bound, formatting, coercion, end-to-end, and registration coverage.
- Document the protocol and add unreleased changelog entries.

## QA / Evidence

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/tool-call-middleware/anthropic-xml-*.test.ts`: 8 files, 92 tests passed. Evidence: `local-ignore/qa-evidence/20260714-anthropic-xml-tool-call-protocol/01-anthropic-xml-tests.txt`.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/anthropic-xml-registration.test.ts`: 1 file, 5 tests passed. Evidence: `02-registration-tests.txt`.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/tool-call-middleware/*.test.ts`: 17 files, 223 tests passed. Evidence: `03-middleware-tests.txt`.
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`: all OpenAI completions, Anthropic messages, and OpenAI Responses isolated real-loop checks passed, 5/5; real auth unchanged. Evidence: `04-mock-loop-self-test.txt`.
- Real source CLI against an isolated localhost faux provider: uppercase `Bash` canonicalized to `bash`, bare and wrapped calls executed, canonical call/result reached the second request, literal wrapper prose remained text, provider credential environment variables were stripped, and real auth was unchanged. Evidence: `05-cli-qa.json` and `06-cli-qa-inspection.txt`.
- `npm run check`: passed, including TypeScript checks, browser/web UI checks, and Neo build/vet/test. Evidence: `09-npm-run-check.txt`.
- No-excuse scan passed for all new and changed TypeScript lines; all new source and test files remain at or below 250 pure LOC. Evidence: `10-no-excuse-check.txt` and `11-pure-loc.txt`.
- Isolation harness self-check passed 9/9; no daemon owned by this worktree survived the root check. Evidence: `07-isolation-self-check.txt` and `14-process-compare.txt`.

All evidence is stored in the gitignored local QA evidence directory above.

## Risks

- XML recovery behavior is intentionally conservative: malformed known calls are reported and retained or dropped according to middleware options. Dedicated malformed-fragment, streaming-boundary, and resource-limit tests cover this behavior.
- Case-insensitive resolution only applies when the normalized name is unambiguous; exact matches continue to win. Registration and CLI evidence cover the intended `Bash` to `bash` path.
- The retained streaming fragment is capped at 64 KiB to prevent unbounded buffering; overflow behavior is covered by resource tests.

## Secret safety

- QA used localhost fake providers with mock credentials and `PI_OFFLINE=1`.
- The isolation harness verified `/Users/yeongyu/.senpi/agent/auth.json` was unchanged.
- No raw provider tokens, auth headers, cookies, environment dumps, or private credentials are included in this PR or its evidence summary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `anthropic-xml` text tool-call protocol to run tools from legacy Anthropic `<invoke>/<parameter>` XML, including streaming support and canonical call/result formatting.

- **New Features**
  - Registered `anthropic-xml` in the AI middleware protocol registry and `getToolCallFormat`; accepted in coding-agent `models.json` schema.
  - Parses bare `<invoke>` and optional `<function_calls>` wrappers; streaming parser with a 64 KiB retained-fragment cap and safe resync.
  - Case-insensitive tool resolution when unambiguous, schema-driven argument coercion, and XML entity encoding/decoding.
  - Preserves surrounding prose; unknown or malformed calls follow the existing error policy (optional `emitRawToolCallTextOnError`).

- **Migration**
  - Set `compat.toolCallFormat` to `anthropic-xml` for OpenAI-compatible custom models in `models.json`.
  - No changes required to tool definitions; existing schemas are used for argument coercion.

<sup>Written for commit 4b1fc1aa089c43ad66e28704502af0fc7e371b4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

