### PR TITLE
fix(ai): preserve encrypted web search replay

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -359,24 +359,6 @@ function isReplayableAnthropicProviderNativeBlock(raw: unknown): raw is ContentB
 	return isRecord(raw) && typeof raw.type === "string" && REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES.has(raw.type);
 }
 
-function stripEncryptedContentFromWebSearchResult(raw: Record<string, unknown>): Record<string, unknown> {
-	const { encrypted_content: _encryptedContent, ...rest } = raw;
-	return rest;
-}
-
-function sanitizeReplayableAnthropicProviderNativeBlock(raw: unknown): ContentBlockParam | undefined {
-	if (!isReplayableAnthropicProviderNativeBlock(raw)) return undefined;
-	if (!isRecord(raw) || raw.type !== "web_search_tool_result" || !Array.isArray(raw.content)) return raw;
-
-	return {
-		...raw,
-		content: raw.content.map((item) => {
-			if (!isRecord(item) || item.type !== "web_search_result") return item;
-			return stripEncryptedContentFromWebSearchResult(item);
-		}),
-	} as ContentBlockParam;
-}
-
 function isSameAnthropicModel(message: AssistantMessage, model: Model<"anthropic-messages">): boolean {
 	return message.provider === model.provider && message.api === model.api && message.model === model.id;
 }
@@ -1734,10 +1716,7 @@ function convertMessages(
 						input: block.arguments ?? {},
 					});
 				} else if (block.type === "providerNative") {
-					if (isSameModel) {
-						const replayableBlock = sanitizeReplayableAnthropicProviderNativeBlock(block.raw);
-						if (replayableBlock) blocks.push(replayableBlock);
-					}
+					if (isSameModel && isReplayableAnthropicProviderNativeBlock(block.raw)) blocks.push(block.raw);
 				}
 			}
 			if (blocks.length === 0) continue;

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,14 +1,17 @@
 # AI Source Changes
 
-## 2026-07-08 - Anthropic web search replay encrypted content
+## 2026-07-14 - Anthropic web search replay encrypted content correction
 
 ### What changed and why
 
-- `api/anthropic-messages.ts`: same-model provider-native replay now strips `encrypted_content` from nested
-  `web_search_result` items before sending prior server-side web search results back in the next Anthropic request.
-- The raw session `019f3d9f-ddf6-7d87-add8-95a5f703e99b` showed follow-up turns failing with 400
-  `messages.1.content.0: Invalid encrypted_content in search_result block`; the visible result metadata
-  (`type`, `title`, `url`, `page_age`) is preserved.
+- `api/anthropic-messages.ts`: same-model provider-native replay now preserves each nested `web_search_result` item's
+  `encrypted_content` byte-for-byte before sending prior server-side web search results back in the next Anthropic
+  request. The existing same-provider/api/model boundary, fallback pruning, and cross-model dropping behavior remain
+  unchanged.
+- Anthropic's current web-search contract requires `encrypted_content` to be passed back unmodified for multi-turn use.
+  The July 8 stripping workaround was wrong under that contract: it discarded opaque provider-owned replay state after
+  one observed 400, even though the raw session stored all seven encrypted fields and Senpi removed them during
+  conversion.
 
 ### Files modified
 

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -134,7 +134,14 @@ describe("Anthropic provider-native replay", () => {
 			{
 				type: "web_search_tool_result",
 				tool_use_id: "srvu_1",
-				content: [{ type: "web_search_result", title: "Example", url: "https://example.com" }],
+				content: [
+					{
+						type: "web_search_result",
+						title: "Example",
+						url: "https://example.com",
+						encrypted_content: "enc",
+					},
+				],
 			},
 			{ type: "thinking", thinking: "protected thinking", signature: "sig_1" },
 			{ type: "text", text: "kept" },
@@ -307,7 +314,14 @@ describe("Anthropic provider-native replay", () => {
 			{
 				type: "web_search_tool_result",
 				tool_use_id: "srvu_paired",
-				content: [{ type: "web_search_result", title: "A", url: "https://a.example" }],
+				content: [
+					{
+						type: "web_search_result",
+						title: "A",
+						url: "https://a.example",
+						encrypted_content: "enc",
+					},
+				],
 			},
 			fallbackBlock,
 			{ type: "thinking", thinking: "served", signature: "sig_post" },

--- a/packages/ai/test/anthropic-web-search-replay-encryption.test.ts
+++ b/packages/ai/test/anthropic-web-search-replay-encryption.test.ts
@@ -47,7 +47,7 @@ async function captureMessages(
 }
 
 describe("Anthropic web search replay encryption", () => {
-	it("omits encrypted_content from replayed web search results", async () => {
+	it("preserves encrypted_content byte-for-byte in replayed web search results", async () => {
 		const model = getModel("anthropic", "claude-fable-5");
 		const assistant: AssistantMessage = {
 			role: "assistant",
@@ -96,6 +96,7 @@ describe("Anthropic web search replay encryption", () => {
 						title: "Example",
 						url: "https://example.com",
 						page_age: "2026-07-07",
+						encrypted_content: "opaque-ciphertext",
 					},
 				],
 			},


### PR DESCRIPTION
## Summary

Fix Anthropic session replay after server-side web search results. Senpi was deleting Anthropic's opaque `encrypted_content` from persisted `web_search_result` blocks before replay, so the next same-model turn failed with `RequestWebSearchResultBlock.encrypted_content: Field required` even though the session had stored every required field.

This keeps provider-native replay unchanged after the existing same-provider/API/model gate. It does not change external extensions: request-history serialization is owned by `packages/ai`, not `pi-extensions`.

## Changes

- Remove the replay sanitizer that stripped `encrypted_content` from Anthropic `web_search_tool_result` blocks.
- Preserve the complete provider-native block byte-for-byte only within the existing same-provider, same-API, and same-model boundary.
- Retain fallback pruning, unknown-block exclusion, cross-model dropping, and cross-provider dropping.
- Add regression coverage that captures the outbound Anthropic request and requires the opaque encrypted value to remain exact.
- Update the fork change record with the failure mode and ownership boundary.

## QA & Evidence

- **Focused replay tests:** `vitest` passed 2 files and 8 tests, including exact encrypted-content preservation, fallback pruning, same-model replay, cross-model dropping, and cross-provider dropping.
- **Static validation:** `npm run check` passed at commit `dd2ca708c`.
- **Real CLI QA:** the Senpi QA harness passed common isolation 9/9, the Anthropic localhost mock loop 3/3 on `/v1/messages`, and CLI smoke 7/7 including unknown-option failure.
- **Safety checks:** no real provider calls or token spend, real auth remained byte-identical, QA processes and sandboxes were cleaned up, and `git diff --check` passed.
- **Final reviews:** code review `CLEAR / APPROVE`, manual QA `passed`, final quality gate `APPROVE` with no blockers.

## Risks & Residuals

- Risk is limited to Anthropic provider-native history replay. The replayable subtype allowlist and provider/API/model boundary are unchanged.
- Opaque state is still dropped across models and providers, so this does not broaden where encrypted provider state can travel.
- No `pi-extensions` update is required because extensions define/inject the web-search tool, while `packages/ai` owns persisted provider-native response serialization.

## Related Session

- Senpi session `019f5f59-f34e-729f-8577-2005d906d796`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Anthropic web search replay by keeping opaque `encrypted_content` in provider-native `web_search_result` blocks for same-model requests. Fixes follow-up turn failures while keeping cross-model/provider behavior unchanged.

- **Bug Fixes**
  - Removed the sanitizer that stripped `encrypted_content` from replayed `web_search_tool_result` blocks in `packages/ai`.
  - Kept replay gated to the same provider/API/model; existing fallback pruning and cross-boundary dropping remain.
  - Added regression tests to assert byte-for-byte preservation and updated the change log.

<sup>Written for commit dd2ca708ce43c8d69bf33d3a557f307d82850ddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

