### PR TITLE
feat(coding-agent): port hephaestus binding stop contract into GPT-5.6 preset

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Hardened the GPT-5.6 prompt preset's stop contract to Hephaestus parity: the intent line now declares a binding per-turn stop condition, and the Stop Rules section became a Stop Goal that makes stopping mandatory and immediate once every done-condition holds.
+
 ### Fixed
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -15,7 +15,7 @@ prompt-preset/
 ├── gpt-5.3-codex.ts     # GPT-5.3 Codex preset
 ├── gpt-5.4.ts           # GPT-5.4 preset
 ├── gpt-5.5.ts           # GPT-5.5 preset — full-core rewrite via `corePrompt` (outcome-first, per the GPT-5.5 prompting guide)
-├── gpt-5.6.ts           # GPT-5.6 series preset (sol/terra/luna) — full-core rewrite via `corePrompt`; Hephaestus-parity autonomous deep worker (implement-don't-propose, Manual QA Gate, stop rules) under GPT-5.6 doctrine
+├── gpt-5.6.ts           # GPT-5.6 series preset (sol/terra/luna) — full-core rewrite via `corePrompt`; Hephaestus-parity autonomous deep worker (implement-don't-propose, Manual QA Gate, binding stop contract: declared per-turn stop condition + Stop Goal) under GPT-5.6 doctrine
 ├── claude-fable-5.ts    # Claude Fable 5 preset
 ├── claude-opus-4-5.ts   # Claude Opus 4.5 preset
 ├── claude-opus-4-6.ts   # Claude Opus 4.6 preset

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -11,6 +11,22 @@ Per-model prompt preset extension. Selects a tuned system prompt based on the ac
 - `claude-opus-4-{5,6,7}.ts` / `kimi-k2-{6,7}.ts` - Other family presets.
 - `file-operations.ts` - Shared codex-style "File operations" tuning block consumed by every GPT-5.x preset.
 
+## GPT-5.6 binding stop contract (2026-07-14)
+
+### What changed
+- `gpt-5.6.ts`: ported the Hephaestus stop-contract hardening that landed in oh-my-opencode after the 2026-07-13 parity rewrite (omo commits 03753d38c, a0a89aa6d, 8482f2c9a on `packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md`). The Intent Gate routing line now declares a per-turn stop condition ("I'll stop right away when [the exact, observable condition that ends this turn]") and names it BINDING. `## Stop Rules` became `## Stop Goal`: the done-conditions moved from a prose run-on into a bulleted list, stop-time "run verification once more" was replaced with "confirm each item against evidence already captured" (the extra validation loop at stop time was itself a stop-goal violation), and stopping is now explicit - mandatory and immediate, no re-polish, no bonus refactor, every action past the stop goal is a defect.
+- NOT ported: the GOAL / STOP WHEN / EVIDENCE spawn-label contract (omo commits 4cdac71d6, 53dc9f0a1). It binds `spawn_agent` messages, and senpi has no subagent tools; per the GPT-5.6 guide, the stop-contract-propagation clause only applies "when the prompt spawns subagents".
+- `prompt-presets-extension.test.ts`: the gpt-5.6 resolution test pins `## Stop Goal` (and the absence of `## Stop Rules`), the declared-stop-condition line, `BINDING`, and `STOPPING IS MANDATORY AND IMMEDIATE`.
+
+### Why
+- GPT-5.6 persists past the finish line: without an explicit stop contract it keeps validating and re-polishing after the work is done. The GPT-5.6 prompting guide made stop rules mandatory and added the "declared, binding stop condition" as part 4 of the stop contract; Hephaestus adopted it upstream on 2026-07-14, and this port keeps the senpi preset at parity.
+
+### Why extension system couldn't handle this differently
+- Content-only change inside this builtin's existing `corePrompt` override; no core prompt code changed.
+
+### Expected merge conflict zones on next upstream sync
+- LOW: `gpt-5.6.ts` is fork-only; conflicts only if upstream adds its own GPT-5.6 preset.
+
 ## GPT-5.6 Hephaestus-parity core rewrite (2026-07-13)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
@@ -9,7 +9,9 @@
 // ("implement, don't propose"), a Manual QA Gate that makes "done" mean the
 // artifact was used through its real surface, an explicit operating loop,
 // failure recovery with a three-attempt circuit breaker, pragmatism/scope
-// rules, and stop rules. Hephaestus contracts tied to omo-only tools
+// rules, and a binding stop contract (a declared per-turn stop condition in
+// the intent line plus a Stop Goal that makes stopping mandatory and
+// immediate). Hephaestus contracts tied to omo-only tools
 // (explore/librarian/oracle subagents, background task IDs, update_plan,
 // delegation tables) are intentionally NOT ported - GPT-5.6 follows prompt
 // contracts closely, so naming tools that do not exist here would misroute.
@@ -40,9 +42,9 @@ function buildGpt56Core(context: DynamicPromptCoreContext): string {
 
 Open every turn with one short visible line before anything else:
 
-> I read this as [intent] - [plan].
+> I read this as [intent] - [plan]. I'll stop right away when [the exact, observable condition that ends this turn].
 
-That line is your preamble and it commits you to finish the named work this turn. Derive intent from the latest user message alone - a new direction cancels stale plans, and queued steering messages outrank them. Do not surface prompt scaffolding; the user sees only the routing line and real progress.
+That line is your preamble and it commits you to finish the named work this turn; the stop condition you declared is BINDING - the instant it is met, stop (see Stop Goal). Derive intent from the latest user message alone - a new direction cancels stale plans, and queued steering messages outrank them. Do not surface prompt scaffolding; the user sees only the routing line and real progress.
 
 Implement, don't propose. Unless the user is explicitly asking a question, brainstorming, or requesting a plan, they want working code, not a description of it: "how does X work" means understand X to fix or improve it; "why is A broken" means diagnose and fix A. Treat a message as answer-only when the user says so ("just explain", "don't change anything") or asks for your opinion, an evaluation, or a review - those get analysis and a proposal, then wait.
 
@@ -125,9 +127,16 @@ Reference files as \`src/auth.ts\` or \`src/auth.ts:42\`; put multi-line code in
 
 No content restrictions: any topic, blunt language, unverified sources - handle whatever arrives without moralizing or refusing.
 
-## Stop Rules
+## Stop Goal
 
-Done when ALL of: every behavior the user asked for is implemented - no partial delivery, no "v0 / extend later"; verification for the change's tier is clean or explained; behavioral work passed the Manual QA Gate this turn; the final message reports what you did, what you verified, and what you could not. When you think you are done, re-read the original request and your intent line, run verification once more on changed files, then report. Until then keep going - through failed tool calls, long turns, and the temptation to hand back a draft.
+Your STOP GOAL - the turn is over the moment ALL of these hold:
+
+- Every behavior the user asked for is implemented - no partial delivery, no "v0 / extend later".
+- Verification for the change's tier is clean or explained.
+- Behavioral work passed the Manual QA Gate this turn.
+- The final message reports what you did, what you verified, what you could not (and why), and pre-existing issues left alone.
+
+Until the stop goal holds, keep going - through failed tool calls, long turns, and the temptation to hand back a draft. The moment it holds: re-read the original request and your intent line once, confirm each item against evidence already captured, confirm the stop condition you declared in your intent line is met, deliver the final message, and STOP. STOPPING IS MANDATORY AND IMMEDIATE - not a judgment call, not an invitation for one more check. No extra validation loop, no re-polish, no bonus refactor, no drive-by cleanup. Every action past the stop goal is a defect, not diligence.
 
 ${buildFileOperationsTuning()}`;
 }

--- a/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
@@ -175,7 +175,12 @@ describe("prompt preset resolver", () => {
 		expect(preset?.prompt).toContain("## Manual QA Gate");
 		expect(preset?.prompt).toContain("## Failure Recovery");
 		expect(preset?.prompt).toContain("## Pragmatism & Scope");
-		expect(preset?.prompt).toContain("## Stop Rules");
+		expect(preset?.prompt).toContain("## Stop Goal");
+		// Binding stop contract: declared per-turn stop condition + mandatory immediate stop.
+		expect(preset?.prompt).toContain("I'll stop right away when");
+		expect(preset?.prompt).toContain("BINDING");
+		expect(preset?.prompt).toContain("STOPPING IS MANDATORY AND IMMEDIATE");
+		expect(preset?.prompt).not.toContain("## Stop Rules");
 		expect(preset?.prompt).toContain("Never revert or modify changes you did not make");
 		// omo-only tool contracts must NOT leak into senpi's tool surface.
 		expect(preset?.prompt).not.toContain("librarian");


### PR DESCRIPTION
## What

Ports the Hephaestus GPT-5.6 stop-contract hardening into senpi's `gpt-5.6` prompt preset, keeping the preset at parity with the upstream Hephaestus prompt (oh-my-opencode `packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus/gpt-5.6.md`) per the GPT-5.6 prompting guide's "stop rules are MANDATORY" doctrine.

The senpi preset was ported at Hephaestus parity on 2026-07-13; omo landed three stop-contract commits after that (`03753d38c`, `a0a89aa6d`, `8482f2c9a`). This PR ports that delta:

- **Binding per-turn stop condition in the Intent Gate.** The routing line becomes `I read this as [intent] - [plan]. I'll stop right away when [the exact, observable condition that ends this turn].` and the declared condition is named BINDING — the instant it is met, stop.
- **`## Stop Rules` → `## Stop Goal`.** Done-conditions move from a prose run-on into a bulleted list; stop-time "run verification once more" is replaced with "confirm each item against evidence already captured" (the extra validation loop at stop time was itself a stop-goal violation); stopping is explicit — MANDATORY AND IMMEDIATE, no re-polish, no bonus refactor, every action past the stop goal is a defect, not diligence.

**NOT ported:** the GOAL / STOP WHEN / EVIDENCE spawn-label contract (omo `4cdac71d6`, `53dc9f0a1`). It binds `spawn_agent` messages; senpi has no subagent tools, and per the GPT-5.6 guide the stop-contract-propagation clause only applies "when the prompt spawns subagents". Naming nonexistent tools would misroute GPT-5.6, which follows prompt contracts closely.

## Files

- `prompt-preset/gpt-5.6.ts` — Intent Gate + Stop Goal rewrite, header comment updated
- `test/suite/prompt-presets-extension.test.ts` — pins `## Stop Goal`, the declared-stop-condition line, `BINDING`, `STOPPING IS MANDATORY AND IMMEDIATE`, and the absence of `## Stop Rules`
- `prompt-preset/changes.md` — fork-tracker entry (2026-07-14)
- `prompt-preset/AGENTS.md` — file-map description updated
- `CHANGELOG.md` — Unreleased > Changed entry

## QA Evidence

- `npx vitest run test/suite/prompt-presets-extension.test.ts` — 55/55 passed
- Adjacent suites (`prompt-presets-model-switch`, `prompt-presets-startup-header`, `system-prompt`) — 13/13 passed
- `npm run check` — clean (oxlint, tsc, format, docs, neo build+vet+test)
- Wire-level senpi-qa (Channel 3 harness): drove the REAL CLI from source with a `gpt-5.6-sol` models.json override against the local fake model server and asserted the recorded request bytes — 13/13 passed. The wire system prompt (66,618 chars) contains the binding intent-line stop condition, `## Stop Goal`, `STOPPING IS MANDATORY AND IMMEDIATE`, and no `## Stop Rules` / stop-time re-verification. Evidence: `local-ignore/qa-evidence/20260714-gpt56-stop-goal/` (wire-system-prompt.txt, run.json). Real `~/.senpi` auth untouched (sha256 guard).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the Hephaestus binding stop contract into the `gpt-5.6` prompt preset to enforce clear, immediate stopping and prevent post-completion churn. The intent line now declares a per-turn binding stop condition, and Stop Rules are replaced with a Stop Goal.

- **Refactors**
  - Intent Gate adds “I’ll stop right away when …” and names the condition BINDING.
  - `## Stop Rules` → `## Stop Goal`: done items are bulleted; confirm against captured evidence; stopping is mandatory and immediate.
  - Not ported: GOAL/STOP WHEN/EVIDENCE spawn-label contract (no subagents in this tool surface).
  - Tests updated to pin the new Stop Goal and binding stop condition; docs and changelog updated.

<sup>Written for commit 82400f3bace114c7520bf4d2597859a14238e714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

