### PR TITLE
docs(agents): refresh hierarchical guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Generated: 2026-07-14
 Commit: `2c3a87858`
-Branch: `docs/init-deep-20260714`
+Branch: `main`
 
 Metadata above records the source state used for this generation pass.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Senpi Repository Guide
 
-Generated: 2026-07-12
-Commit: `0d776f916`
-Branch: `main`
+Generated: 2026-07-14
+Commit: `2c3a87858`
+Branch: `docs/init-deep-20260714`
 
 Metadata above records the source state used for this generation pass.
 
@@ -34,6 +34,8 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 | Change agent-loop semantics | `packages/agent/src/agent-loop.ts` |
 | Change interactive rendering | `packages/coding-agent/src/modes/interactive/` and `packages/tui/src/tui.ts` |
 | Change app-server/RPC | `packages/coding-agent/src/modes/app-server/` or `packages/coding-agent/src/modes/rpc/` |
+| Add or change coding-agent tests | `packages/coding-agent/test/` |
+| Add or change extension examples | `packages/coding-agent/examples/` |
 | Change PTY behavior | `packages/pty/` and, for native behavior, `crates/senpi-pty/` |
 | Add provider setup docs | `packages/ai/README.md` and `packages/coding-agent/docs/providers.md` |
 | Audit changelogs | `.github/agent/commands/cl.md` |

--- a/packages/coding-agent/AGENTS.md
+++ b/packages/coding-agent/AGENTS.md
@@ -16,6 +16,8 @@ src/modes/app-server/              App-server transport and RPC registry
 src/modes/rpc/                     JSONL RPC mode/client/types
 src/modes/print-mode.ts            One-shot mode
 test/suite/harness.ts              Preferred faux-provider harness
+test/                              Test domains, fixtures, QA, integration gates
+examples/                          Extension and SDK examples
 src/changes.md                     Root fork-change record
 ```
 
@@ -30,6 +32,7 @@ src/changes.md                     Root fork-change record
 | Change interactive UI | `src/modes/interactive/` |
 | Change RPC/app-server | matching directory under `src/modes/` |
 | Add regression | `test/suite/regressions/` |
+| Add or update an example | `examples/` and the matching public docs |
 
 ## CONVENTIONS
 
@@ -56,4 +59,5 @@ src/changes.md                     Root fork-change record
 - Run changed test files from this package; issue regressions use `<issue>-<slug>.test.ts`.
 - Code changes require root `npm run check` plus the applicable `senpi-qa` CLI channel and saved evidence.
 - Interactive changes also follow `src/modes/interactive/AGENTS.md`; extension/tool changes follow their nearest child guide.
+- App-server, test, and example changes follow their local `AGENTS.md` files.
 - Keep `src/changes.md`, nested `changes.md`, public docs, and examples aligned with fork behavior.

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/examples
 
-Runnable examples for the public Senpi SDK and extension API. Examples are documentation-quality code and must reflect shipped APIs, not private core internals. Paths below are relative to this directory unless they start with `packages/`.
+Runnable examples for the public Senpi SDK and extension API. Examples are documentation-quality code and must reflect shipped APIs, not private core internals. Unqualified paths below are relative to this directory; `packages/...` paths are repository-relative.
 
 ## STRUCTURE
 
@@ -13,7 +13,7 @@ rpc-extension-ui.ts RPC-compatible extension UI example
 
 ## CONVENTIONS
 
-- Import public package surfaces such as `@code-yeongyu/senpi` and `@earendil-works/pi-ai`; do not reach into `src/core/` internals.
+- Import public package surfaces such as `@code-yeongyu/senpi` and `@earendil-works/pi-ai`; do not reach into `packages/coding-agent/src/core/` internals.
 - Keep examples small enough to teach one pattern, while preserving real error, cleanup, cancellation, and persistence behavior where relevant.
 - Extension factories have no top-level runtime side effects. Register work through the public `pi.*` API and lifecycle events.
 - New interactive examples should use configurable keybindings and themed TUI helpers. Existing demos may keep fixed controls when the control scheme is part of the example. Direct terminal writes belong only in examples explicitly teaching a terminal protocol; ordinary SDK examples may use normal stdout.
@@ -23,7 +23,7 @@ rpc-extension-ui.ts RPC-compatible extension UI example
 
 ## DOCUMENTATION CONTRACT
 
-- Keep `extensions/README.md`, `docs/extensions.md`, and `docs/sdk.md` aligned with public API changes.
+- Keep `extensions/README.md`, `packages/coding-agent/docs/extensions.md`, and `packages/coding-agent/docs/sdk.md` aligned with public API changes.
 - New public extension capabilities should include a focused example when usage is not obvious from types alone.
 - Do not present experimental or internal behavior as stable API.
 

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -1,0 +1,34 @@
+# packages/coding-agent/examples
+
+Runnable examples for the public Senpi SDK and extension API. Examples are documentation-quality code and must reflect shipped APIs, not private core internals.
+
+## STRUCTURE
+
+```text
+extensions/        Tools, commands, UI, providers, hooks, resources
+extensions/*/      Multi-file examples and nested private workspaces
+sdk/               Programmatic SDK usage
+rpc-extension-ui.ts RPC-compatible extension UI example
+```
+
+## CONVENTIONS
+
+- Import public package surfaces such as `@code-yeongyu/senpi` and `@earendil-works/pi-ai`; do not reach into `src/core/` internals.
+- Keep examples small enough to teach one pattern, while preserving real error, cleanup, cancellation, and persistence behavior where relevant.
+- Extension factories have no top-level runtime side effects. Register work through the public `pi.*` API and lifecycle events.
+- Use configurable keybindings and themed TUI helpers rather than hardcoded keys, colors, or raw terminal writes.
+- Tool string enums use the shared `StringEnum` helper for provider compatibility.
+- Stateful examples persist reconstructable state in session entries or tool-result details so fork/resume behavior remains valid.
+- Nested example packages are private workspaces with exact-pinned dependencies. Treat their manifests and lock impact as production dependency changes.
+
+## DOCUMENTATION CONTRACT
+
+- Keep `extensions/README.md`, `docs/extensions.md`, and `docs/sdk.md` aligned with public API changes.
+- New public extension capabilities should include a focused example when usage is not obvious from types alone.
+- Do not present experimental or internal behavior as stable API.
+
+## VALIDATION
+
+- Run the focused tests for the public API demonstrated by the example.
+- Typecheck examples through root `npm run check`.
+- Interactive examples require real CLI or visual QA when their behavior changes.

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/examples
 
-Runnable examples for the public Senpi SDK and extension API. Examples are documentation-quality code and must reflect shipped APIs, not private core internals.
+Runnable examples for the public Senpi SDK and extension API. Examples are documentation-quality code and must reflect shipped APIs, not private core internals. Paths below are relative to this directory unless they start with `packages/`.
 
 ## STRUCTURE
 
@@ -16,7 +16,7 @@ rpc-extension-ui.ts RPC-compatible extension UI example
 - Import public package surfaces such as `@code-yeongyu/senpi` and `@earendil-works/pi-ai`; do not reach into `src/core/` internals.
 - Keep examples small enough to teach one pattern, while preserving real error, cleanup, cancellation, and persistence behavior where relevant.
 - Extension factories have no top-level runtime side effects. Register work through the public `pi.*` API and lifecycle events.
-- Interactive examples use configurable keybindings and themed TUI helpers. Direct terminal writes belong only in examples explicitly teaching a terminal protocol; ordinary SDK examples may use normal stdout.
+- New interactive examples should use configurable keybindings and themed TUI helpers. Existing demos may keep fixed controls when the control scheme is part of the example. Direct terminal writes belong only in examples explicitly teaching a terminal protocol; ordinary SDK examples may use normal stdout.
 - Tool string enums use the shared `StringEnum` helper for provider compatibility.
 - Stateful examples persist reconstructable state in session entries or tool-result details so fork/resume behavior remains valid.
 - Nested example packages are private workspaces with exact-pinned dependencies. Treat their manifests and lock impact as production dependency changes.

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -16,7 +16,7 @@ rpc-extension-ui.ts RPC-compatible extension UI example
 - Import public package surfaces such as `@code-yeongyu/senpi` and `@earendil-works/pi-ai`; do not reach into `src/core/` internals.
 - Keep examples small enough to teach one pattern, while preserving real error, cleanup, cancellation, and persistence behavior where relevant.
 - Extension factories have no top-level runtime side effects. Register work through the public `pi.*` API and lifecycle events.
-- Use configurable keybindings and themed TUI helpers rather than hardcoded keys, colors, or raw terminal writes.
+- Interactive examples use configurable keybindings and themed TUI helpers. Direct terminal writes belong only in examples explicitly teaching a terminal protocol; ordinary SDK examples may use normal stdout.
 - Tool string enums use the shared `StringEnum` helper for provider compatibility.
 - Stateful examples persist reconstructable state in session entries or tool-result details so fork/resume behavior remains valid.
 - Nested example packages are private workspaces with exact-pinned dependencies. Treat their manifests and lock impact as production dependency changes.

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -39,7 +39,7 @@ turn-adapter.ts       Agent/session events to app-server turn events
 ## GENERATED PROTOCOL
 
 - The pinned raw protocol comes from Codex and is regenerated with `packages/coding-agent/scripts/generate-app-server-protocol.sh`.
-- Keep `protocol/generated/**/*.ts` byte-identical to generator output. The local `generated/package.json` is only a compilation shim.
+- Keep `protocol/generated/**/*.ts` byte-identical to generator output. The local `protocol/generated/package.json` is only a compilation shim.
 - Wire compatibility is defined by runtime message shape and the app-facing facade. Existing type-only imports from the generated tree are compatibility gaps, not permission to add runtime dependencies on it.
 
 ## VALIDATION

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/modes/app-server
 
-Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports.
+Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports. Paths below are relative to this directory unless they start with `packages/`.
 
 ## STRUCTURE
 

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/modes/app-server
 
-Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports. Paths below are relative to this directory unless they start with `packages/`.
+Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports. Unqualified paths below are relative to this directory; `packages/...` paths are repository-relative.
 
 ## STRUCTURE
 
@@ -34,7 +34,7 @@ turn-adapter.ts       Agent/session events to app-server turn events
 | Change thread/session projection | `threads/` |
 | Change transport behavior | `transports/` |
 | Change approvals | `server/approval-*.ts`, `server/approvals.ts` |
-| Change wire types | `protocol/` and `docs/app-server.md` |
+| Change wire types | `protocol/` and `packages/coding-agent/docs/app-server.md` |
 
 ## GENERATED PROTOCOL
 
@@ -46,6 +46,6 @@ turn-adapter.ts       Agent/session events to app-server turn events
 
 - Run focused app-server Vitest suites from `packages/coding-agent`.
 - Run `npm run qa:app-server` for the handshake, multiclient, approval, and real-client probes.
-- Run the matching `test/qa/app-server/` driver for focused Unix-socket, malformed-input, and lifecycle scenarios.
-- Protocol or documentation changes must keep `docs/app-server.md` examples and `test/qa/app-server/` checks aligned.
+- Run the matching `packages/coding-agent/test/qa/app-server/` driver for focused Unix-socket, malformed-input, and lifecycle scenarios.
+- Protocol or documentation changes must keep `packages/coding-agent/docs/app-server.md` examples and `packages/coding-agent/test/qa/app-server/` checks aligned.
 - Runtime changes also require root `npm run check` and the applicable real CLI QA evidence gate.

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -22,8 +22,8 @@ turn-adapter.ts       Agent/session events to app-server turn events
 - Stdio uses one UTF-8 JSON object per LF-delimited line; stdout is protocol-only and diagnostics go to stderr.
 - WebSocket listeners bind IP literals. Bearer auth is required unless explicitly disabled for loopback, and `Origin` requests remain rejected.
 - Keep connection subscriptions, thread ownership, archive/unload, and turn cancellation consistent across disconnect and daemon shutdown.
-- Approval payloads and diagnostics can contain sensitive material. Preserve redaction and restricted token-file permissions.
-- Generated files under `protocol/generated/` are evidence, not build input. Never import or edit them directly; use the non-generated facade.
+- Approval payloads and diagnostics can contain sensitive material. Keep token-file permissions restricted, do not assume diagnostics are redacted, and add explicit redaction before exposing them beyond the local process.
+- Generated files under `protocol/generated/` are evidence, not build input. Never edit them directly. Prefer the non-generated facade; keep any necessary type-only imports isolated until the facade covers them.
 
 ## WHERE TO LOOK
 
@@ -40,11 +40,12 @@ turn-adapter.ts       Agent/session events to app-server turn events
 
 - The pinned raw protocol comes from Codex and is regenerated with `packages/coding-agent/scripts/generate-app-server-protocol.sh`.
 - Keep `protocol/generated/**/*.ts` byte-identical to generator output. The local `generated/package.json` is only a compilation shim.
-- Wire compatibility is defined by runtime message shape and the app-facing facade, not by importing raw generated modules.
+- Wire compatibility is defined by runtime message shape and the app-facing facade. Existing type-only imports from the generated tree are compatibility gaps, not permission to add runtime dependencies on it.
 
 ## VALIDATION
 
 - Run focused app-server Vitest suites from `packages/coding-agent`.
-- Run `npm run qa:app-server` for the real stdio, WebSocket, Unix-socket, handshake, and lifecycle scenarios.
+- Run `npm run qa:app-server` for the handshake, multiclient, approval, and real-client probes.
+- Run the matching `test/qa/app-server/` driver for focused Unix-socket, malformed-input, and lifecycle scenarios.
 - Protocol or documentation changes must keep `docs/app-server.md` examples and `test/qa/app-server/` checks aligned.
 - Runtime changes also require root `npm run check` and the applicable real CLI QA evidence gate.

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -1,0 +1,50 @@
+# packages/coding-agent/src/modes/app-server
+
+Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-RPC-shaped stdio, Unix-socket, and authenticated WebSocket transports.
+
+## STRUCTURE
+
+```text
+index.ts              Mode entry and listener selection
+cli-args.ts           app-server argument parsing
+daemon/               Background process probing and lifecycle
+rpc/                  Envelopes, errors, NDJSON framing, method registry
+server/               Connection state, approvals, notifications, dispatch
+threads/              Session-backed thread registry, projection, turns
+transports/           stdio, Unix socket, WebSocket auth/backpressure
+protocol/             App-facing facade plus pinned generated Codex evidence
+turn-adapter.ts       Agent/session events to app-server turn events
+```
+
+## INVARIANTS
+
+- Clients initialize exactly once before other methods. Preserve correlated request/response IDs and JSON-RPC error codes.
+- Stdio uses one UTF-8 JSON object per LF-delimited line; stdout is protocol-only and diagnostics go to stderr.
+- WebSocket listeners bind IP literals. Bearer auth is required unless explicitly disabled for loopback, and `Origin` requests remain rejected.
+- Keep connection subscriptions, thread ownership, archive/unload, and turn cancellation consistent across disconnect and daemon shutdown.
+- Approval payloads and diagnostics can contain sensitive material. Preserve redaction and restricted token-file permissions.
+- Generated files under `protocol/generated/` are evidence, not build input. Never import or edit them directly; use the non-generated facade.
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| Add a method | `rpc/registry.ts` and the matching handler |
+| Change connection lifecycle | `server/connection.ts`, `server/server-core.ts` |
+| Change thread/session projection | `threads/` |
+| Change transport behavior | `transports/` |
+| Change approvals | `server/approval-*.ts`, `server/approvals.ts` |
+| Change wire types | `protocol/` and `docs/app-server.md` |
+
+## GENERATED PROTOCOL
+
+- The pinned raw protocol comes from Codex and is regenerated with `packages/coding-agent/scripts/generate-app-server-protocol.sh`.
+- Keep `protocol/generated/**/*.ts` byte-identical to generator output. The local `generated/package.json` is only a compilation shim.
+- Wire compatibility is defined by runtime message shape and the app-facing facade, not by importing raw generated modules.
+
+## VALIDATION
+
+- Run focused app-server Vitest suites from `packages/coding-agent`.
+- Run `npm run qa:app-server` for the real stdio, WebSocket, Unix-socket, handshake, and lifecycle scenarios.
+- Protocol or documentation changes must keep `docs/app-server.md` examples and `test/qa/app-server/` checks aligned.
+- Runtime changes also require root `npm run check` and the applicable real CLI QA evidence gate.

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -23,7 +23,7 @@ turn-adapter.ts       Agent/session events to app-server turn events
 - WebSocket listeners bind IP literals. Bearer auth is required unless explicitly disabled for loopback, and `Origin` requests remain rejected.
 - Keep connection subscriptions, thread ownership, archive/unload, and turn cancellation consistent across disconnect and daemon shutdown.
 - Approval payloads and diagnostics can contain sensitive material. Keep token-file permissions restricted, do not assume diagnostics are redacted, and add explicit redaction before exposing them beyond the local process.
-- Generated files under `protocol/generated/` are evidence, not build input. Never edit them directly. Prefer the non-generated facade; keep any necessary type-only imports isolated until the facade covers them.
+- Generated files under `protocol/generated/` are protocol evidence and compile-time type inputs, not runtime implementations. Never edit them directly. Prefer the non-generated facade; keep direct type-only imports isolated until the facade covers them.
 
 ## WHERE TO LOOK
 

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/test
 
-Vitest coverage for the Senpi CLI, sessions, extensions, modes, transports, and regressions. Tests are deterministic by default and must not spend tokens.
+Vitest coverage for the Senpi CLI, sessions, extensions, modes, transports, and regressions. New default tests must be deterministic and must not spend tokens.
 
 ## STRUCTURE
 
@@ -20,6 +20,7 @@ fixtures/, goldens/ Shared deterministic inputs and snapshots
 
 - Prefer `suite/harness.ts` and the faux provider for new lifecycle and extension coverage.
 - Do not use real provider APIs, API keys, network calls, or paid tokens in default tests.
+- Some legacy tests outside `integration/` still activate from ambient Anthropic credentials. Run the suite hermetically and do not copy that activation pattern into new tests.
 - Use `suite/regressions/<issue>-<slug>.test.ts` for issue regressions.
 - Do not extend the legacy `test-harness.ts` unless the preferred harness lacks a required capability.
 - Keep fixtures deterministic, local, and secret-free. Spawned process tests must clean up children, sockets, and temporary directories.
@@ -28,7 +29,7 @@ fixtures/, goldens/ Shared deterministic inputs and snapshots
 ## LIVE AND MANUAL SURFACES
 
 - `integration/` is opt-in only with `PI_RUN_INTEGRATION=1`; it may use real credentials and incur cost.
-- `qa/app-server/` is driven by `npm run qa:app-server` and proves real protocol behavior beyond unit tests.
+- `qa/app-server/` contains focused real-surface drivers. The separate `npm run qa:app-server` command runs the packaged handshake, multiclient, approval, and real-client probes.
 - Runtime changes covered here still require the repository's `senpi-qa` evidence gate when the root guide requires it.
 
 ## VALIDATION

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -1,0 +1,38 @@
+# packages/coding-agent/test
+
+Vitest coverage for the Senpi CLI, sessions, extensions, modes, transports, and regressions. Tests are deterministic by default and must not spend tokens.
+
+## STRUCTURE
+
+```text
+suite/             Preferred AgentSession/AgentSessionRuntime harness tests
+suite/regressions/ Issue-specific regressions
+mcp/               MCP transports, fixtures, security, lifecycle
+permission/        Permission-system behavior
+compaction/        Compaction mechanics and policy
+session-manager/   Persistence, branching, context construction
+qa/app-server/     Real app-server surface drivers
+integration/       Explicitly gated real-provider tests
+fixtures/, goldens/ Shared deterministic inputs and snapshots
+```
+
+## TEST RULES
+
+- Prefer `suite/harness.ts` and the faux provider for new lifecycle and extension coverage.
+- Do not use real provider APIs, API keys, network calls, or paid tokens in default tests.
+- Use `suite/regressions/<issue>-<slug>.test.ts` for issue regressions.
+- Do not extend the legacy `test-harness.ts` unless the preferred harness lacks a required capability.
+- Keep fixtures deterministic, local, and secret-free. Spawned process tests must clean up children, sockets, and temporary directories.
+- Tests involving PTY, MCP, app-server, or other subprocess-heavy surfaces must remain reliable with `CI=1`, where Vitest uses one fork.
+
+## LIVE AND MANUAL SURFACES
+
+- `integration/` is opt-in only with `PI_RUN_INTEGRATION=1`; it may use real credentials and incur cost.
+- `qa/app-server/` is driven by `npm run qa:app-server` and proves real protocol behavior beyond unit tests.
+- Runtime changes covered here still require the repository's `senpi-qa` evidence gate when the root guide requires it.
+
+## VALIDATION
+
+- Run every added or changed test file directly until green.
+- Run the narrow owning directory or package suite when shared harnesses, fixtures, or lifecycle behavior change.
+- Root `npm run check` is static validation and does not replace tests.

--- a/packages/neo/AGENTS.md
+++ b/packages/neo/AGENTS.md
@@ -40,3 +40,4 @@ neo-test.sh           Source test launcher
 - Root `npm run check:neo` is the repository integration gate.
 - UI changes run the matching `go run ./internal/<area>/qaharness` command and verify captured manifests with `node qa/xterm-render.mjs verify-manifest <manifest.json>` at representative widths.
 - Protocol changes require bridge fixture, transport, handshake, and exhaustive compatibility tests.
+- Read `internal/bridge/AGENTS.md` for protocol/daemon work and `internal/ui/AGENTS.md` for visual or interaction work.

--- a/packages/neo/internal/bridge/AGENTS.md
+++ b/packages/neo/internal/bridge/AGENTS.md
@@ -1,0 +1,35 @@
+# packages/neo/internal/bridge
+
+Go bridge between the Neo TUI and Senpi's TypeScript RPC/daemon surfaces. This directory owns framing, correlation, protocol mirrors, spawn/attach, and recovery.
+
+## STRUCTURE
+
+```text
+types.go              TypeScript RPC contract mirror
+codec.go, demux.go    JSONL encode/decode and response/event routing
+transport.go          Request correlation and connection lifecycle
+connect.go            Connection establishment and handshake
+daemonclient.go       Neo daemon control client
+spawn*.go             Cross-platform child process startup
+socket*.go            Unix socket / Windows pipe selection
+recovery.go           Reconnect and self-heal behavior
+runtimeopts.go        CLI option projection
+testdata/              Generated real-protocol JSONL fixtures
+attachqa/              Real attach/recovery QA harness
+```
+
+## INVARIANTS
+
+- Preserve newline-delimited JSON framing and request/response correlation; events and responses may arrive interleaved.
+- Disconnect, shutdown, and child exit must settle pending requests and background readers exactly once.
+- `types.go` mirrors the TypeScript RPC contract. Update exhaustive tests and real fixtures whenever either side changes.
+- Keep Unix and Windows socket, signal, process-liveness, and spawn implementations paired.
+- Recovery must not create duplicate daemons or clients; registry repair and spawn races converge on one live endpoint.
+- Diagnostics must not expose tokens, auth headers, or inherited secret-bearing environments.
+
+## FIXTURES AND VALIDATION
+
+- Generate protocol fixtures through `testdata/gen-fixtures.mjs`; do not hand-author replacements for real wire captures.
+- Run focused bridge tests, then `go test ./internal/bridge/...` from `packages/neo`.
+- Transport or daemon changes also run `go build ./...`, `go vet ./...`, `go test ./...`, and the relevant `attachqa` scenario.
+- Cross-protocol changes require the matching TypeScript coding-agent RPC/app-server tests.

--- a/packages/neo/internal/bridge/AGENTS.md
+++ b/packages/neo/internal/bridge/AGENTS.md
@@ -25,11 +25,11 @@ attachqa/              Real attach/recovery QA harness
 - `types.go` mirrors the TypeScript RPC contract. Update exhaustive tests and real fixtures whenever either side changes.
 - Keep Unix and Windows socket, signal, process-liveness, and spawn implementations paired.
 - Recovery must not create duplicate daemons or clients; registry repair and spawn races converge on one live endpoint.
-- Diagnostics must not expose tokens, auth headers, or inherited secret-bearing environments.
+- Child processes currently inherit the environment and raw stderr may enter errors. Treat diagnostics as secret-bearing, avoid widening their exposure, and do not claim redaction without implementing it.
 
 ## FIXTURES AND VALIDATION
 
 - Generate protocol fixtures through `testdata/gen-fixtures.mjs`; do not hand-author replacements for real wire captures.
 - Run focused bridge tests, then `go test ./internal/bridge/...` from `packages/neo`.
 - Transport or daemon changes also run `go build ./...`, `go vet ./...`, `go test ./...`, and the relevant `attachqa` scenario.
-- Cross-protocol changes require the matching TypeScript coding-agent RPC/app-server tests.
+- RPC contract changes require the matching TypeScript coding-agent RPC tests; add app-server coverage only when shared daemon or transport behavior changes.

--- a/packages/neo/internal/ui/AGENTS.md
+++ b/packages/neo/internal/ui/AGENTS.md
@@ -28,9 +28,9 @@ extui/         Remote extension UI projection
 
 ## VISUAL QA
 
-- Use the matching `internal/ui/<area>/qaharness` for behavior and rendering changes.
-- Captures are ANSI/HTML/grid triplets under `qa/triplets/`; registered claims live in `qa/visual-claims*.json`.
-- Verify manifests with `node qa/xterm-render.mjs verify-manifest <manifest.json>` at representative widths and capability modes.
+- Use the matching `<area>/qaharness` for behavior and rendering changes.
+- Captures are ANSI/HTML/grid triplets under `packages/neo/qa/triplets/`; registered claims live in `packages/neo/qa/visual-claims*.json`.
+- Verify manifests with `node packages/neo/qa/xterm-render.mjs verify-manifest <manifest.json>` at representative widths and capability modes.
 - Never update snapshots or claims merely to hide a rendering regression; inspect the cell grid and terminal output first.
 
 ## VALIDATION

--- a/packages/neo/internal/ui/AGENTS.md
+++ b/packages/neo/internal/ui/AGENTS.md
@@ -1,0 +1,40 @@
+# packages/neo/internal/ui
+
+Bubble Tea UI domains for editing, transcript rendering, overlays, commands, extension UI, and shell interaction.
+
+## STRUCTURE
+
+```text
+editor/        Multiline editor, width, selection, completion
+transcript/    Messages, wrapping, images, streamed output
+markdown/      Markdown parsing and styled rendering
+overlays/      Modal composition, focus, sizing, stacking
+keybindings/   Configurable action mapping
+slash/         Slash command parsing and completion
+shell/         Interactive shell UI
+builtinext/    Builtin extension presentation
+extui/         Remote extension UI projection
+*/qaharness/   Deterministic real-render drivers
+```
+
+## INVARIANTS
+
+- Bubble Tea `Update` paths remain deterministic and non-blocking; long work returns commands/messages.
+- Keybindings and colors come from registries/themes. Do not hardcode shortcuts or styling in feature code.
+- Preserve Unicode cell width, grapheme, wrapping, cursor, selection, and terminal-image behavior across viewport sizes.
+- Overlay focus, stacking, cancellation, and resize behavior must remain explicit. Components may not write directly around the renderer.
+- Remote extension UI input is untrusted protocol data; validate shapes and keep lifecycle cleanup bounded to the owning request/session.
+- Platform and terminal-capability fallbacks must degrade predictably without claiming unsupported visual behavior.
+
+## VISUAL QA
+
+- Use the matching `internal/ui/<area>/qaharness` for behavior and rendering changes.
+- Captures are ANSI/HTML/grid triplets under `qa/triplets/`; registered claims live in `qa/visual-claims*.json`.
+- Verify manifests with `node qa/xterm-render.mjs verify-manifest <manifest.json>` at representative widths and capability modes.
+- Never update snapshots or claims merely to hide a rendering regression; inspect the cell grid and terminal output first.
+
+## VALIDATION
+
+- Run focused Go tests for the changed UI package.
+- Run `go build ./...`, `go vet ./...`, and `go test ./...` from `packages/neo` for shared UI contracts.
+- User-visible changes require real TUI inspection plus the relevant committed visual evidence.

--- a/packages/neo/internal/ui/AGENTS.md
+++ b/packages/neo/internal/ui/AGENTS.md
@@ -19,7 +19,7 @@ extui/         Remote extension UI projection
 
 ## INVARIANTS
 
-- Bubble Tea `Update` paths remain deterministic and non-blocking; long work returns commands/messages.
+- Keep Bubble Tea `Update` paths deterministic and non-blocking; new long-running work should return commands/messages. Treat the existing editor autocomplete goroutine and direct state update as a compatibility exception, not a pattern to extend.
 - Keybindings and colors come from registries/themes. Do not hardcode shortcuts or styling in feature code.
 - Preserve Unicode cell width, grapheme, wrapping, cursor, selection, and terminal-image behavior across viewport sizes.
 - Overlay focus, stacking, cancellation, and resize behavior must remain explicit. Components may not write directly around the renderer.


### PR DESCRIPTION
## Summary

Refresh the repository's hierarchical `AGENTS.md` knowledge base from the current `main` source state. The existing package guides were already broadly accurate, so this adds focused guidance only at five high-complexity boundaries that lacked local ownership rules and refreshes the root generation metadata.

## Changes

- Add local app-server guidance for transports, thread lifecycle, approvals, and generated Codex protocol ownership.
- Add coding-agent test guidance covering the preferred faux-provider harness, regression placement, live-test gates, subprocess cleanup, and app-server QA.
- Add coding-agent example guidance for public API usage, nested private workspaces, state persistence, and documentation alignment.
- Add Neo bridge guidance for JSONL framing, RPC type mirroring, cross-platform spawn/recovery, and generated fixtures.
- Add Neo UI guidance for Bubble Tea update rules, keybindings/themes, Unicode layout, overlays, and visual evidence.
- Link the new scopes from the root, coding-agent, and Neo package guides.

## QA & Evidence

- **What was tested:** nearest-guide ancestry for representative app-server, test, example, Neo bridge, and Neo UI source files.
  **Observed result:** every path resolves its new local guide, package guide, and root guide.
  **Artifact:** `local-ignore/qa-evidence/20260714-init-deep/summary.txt` in the task worktree.
  **Why sufficient:** proves the generated hierarchy is discoverable at the intended edit surfaces.
- **What was tested:** `git diff --check`.
  **Observed result:** passed.
  **Why sufficient:** catches whitespace and patch-format defects in the documentation diff.
- **What was tested:** `npm run check`.
  **Observed result:** passed, including generated-lock checks, TypeScript checks, browser/web UI checks, and Neo build/vet/tests.
  **Why sufficient:** matches the repository static integration gate.
- **What was tested:** `npm run build`.
  **Observed result:** passed for all workspace build phases.
  **Why sufficient:** proves the new nested instruction files do not disturb packaging or build discovery.
- **What was tested:** `CI=1 npm test`.
  **Observed result:** passed: scripts 48, agent 190, AI 827, coding-agent 3593, orchestrator 3, PTY 42, senpi-codemode 350, plus the full TUI Node suite. Explicit live/integration suites remained skipped by their normal gates.
  **Why sufficient:** reproduces CI's serialized coding-agent worker mode and covers the full workspace test surface.

## Risks & Residuals

- Codegraph centrality scoring was unavailable because the configured index returned unrelated workspace content. Placement decisions instead use current filesystem counts, package manifests, source documentation, test topology, and six independent repository explorers.
- This is documentation-only; repository policy does not require runtime `senpi-qa` channels. The matching documentation surface was exercised through nearest-guide resolution.

## Related Issues

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed hierarchical `AGENTS.md` guidance across the repo and synced root generation metadata to current `main`. Added scoped guides for the `packages/coding-agent` app-server, tests, and examples, and for the `packages/neo` bridge and UI; clarified generated‑protocol evidence and tightened cross-scope invariants.

- New Features
  - App-server guidance for transports, thread/session projection, approvals, and JSON‑RPC/NDJSON framing, plus facade‑vs‑generated protocol ownership.
  - Test rules for the faux-provider harness, deterministic fixtures, CI‑safe subprocess cleanup, and live/integration gates; added QA drivers for the app‑server.
  - Examples conventions for public API usage, nested private workspaces, and docs alignment; Neo bridge/UI guides for correlation, spawn/recovery, deterministic Bubble Tea updates, themed keybindings, Unicode/layout, and visual QA triplets; added root and package pointers to these scopes.

- Bug Fixes
  - Corrected the generated protocol compilation shim path in the app‑server guide to `protocol/generated/package.json`.

<sup>Written for commit 3754a458e59f21fe2adf2ca2d4e53766b62a20a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

