### PR TITLE
fix(ai,coding-agent): gate Anthropic native web search to supported endpoints

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -228,6 +228,12 @@ function getAnthropicCompat(
 			model.compat?.supportsForcedToolChoice ?? !CLAUDE_FABLE_OR_MYTHOS_MODEL_ID.test(model.id),
 		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
 		supportsToolReferences: model.compat?.supportsToolReferences ?? defaultSupportsToolReferences(model),
+		// Default: first-party Anthropic only. Anthropic-compatible providers
+		// (kimi-coding, fireworks, copilot, gateways) may execute the server-side
+		// search but reject the replayed server_tool_use / web_search_tool_result
+		// blocks on the next request (kimi-coding 400s with `tool_call_id is not
+		// found`).
+		supportsWebSearch: model.compat?.supportsWebSearch ?? model.provider === "anthropic",
 	};
 }
 
@@ -392,6 +398,23 @@ function isAnthropicServerToolUseBlock(raw: unknown): raw is { readonly type: "s
 	return isRecord(raw) && raw.type === "server_tool_use" && typeof raw.id === "string";
 }
 
+// Only tool_use-shaped provider-native blocks (server_tool_use, mcp_tool_use)
+// stream their input via input_json_delta. Result-shaped blocks must replay
+// byte-for-byte (encrypted_content), so never merge an `input` into them.
+function isProviderNativeToolUseBlock(raw: unknown): boolean {
+	return isRecord(raw) && typeof raw.type === "string" && raw.type.endsWith("_tool_use");
+}
+
+// Endpoints without `supportsWebSearch` reject replayed web-search server-tool
+// blocks (kimi-coding 400s with `tool_call_id is not found`), wedging every
+// subsequent request of the session. Dropping the pair loses the searched
+// context but keeps the conversation usable.
+function isAnthropicWebSearchReplayBlock(raw: unknown): boolean {
+	if (!isRecord(raw)) return false;
+	if (raw.type === "web_search_tool_result") return true;
+	return raw.type === "server_tool_use" && raw.name === "web_search";
+}
+
 // tool_use ids referenced by server-tool result blocks in content[0, boundary).
 // A pre-boundary `server_tool_use` whose id is absent here is unpaired — the
 // fallback interrupted the declined attempt before its result arrived — so
@@ -541,6 +564,10 @@ function rejectsComputerUseBeta(model: Model<"anthropic-messages">): boolean {
 	);
 }
 
+function isAnthropicWebSearchToolType(toolType: string): boolean {
+	return toolType.startsWith("web_search_");
+}
+
 function sanitizeUnsupportedNativeTools(
 	model: Model<"anthropic-messages">,
 	params: MessageCreateParamsStreaming,
@@ -550,6 +577,7 @@ function sanitizeUnsupportedNativeTools(
 	const headerSanitization = rejectsComputerUseBeta(model)
 		? removeComputerUseBetaHeader(headers)
 		: ({ changed: false } as const);
+	const rejectsNativeWebSearch = !getAnthropicCompat(model).supportsWebSearch;
 	const tools = payload.tools;
 	const sanitized: AnthropicPayloadWithRequestMetadata = { ...payload };
 	let changed = false;
@@ -563,7 +591,8 @@ function sanitizeUnsupportedNativeTools(
 			if (
 				isRecord(hookTool) &&
 				typeof hookTool.type === "string" &&
-				rejectsNativeComputerTool(model, hookTool.type)
+				(rejectsNativeComputerTool(model, hookTool.type) ||
+					(rejectsNativeWebSearch && isAnthropicWebSearchToolType(hookTool.type)))
 			) {
 				changed = true;
 				if (typeof hookTool.name === "string") {
@@ -934,7 +963,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				| (ThinkingContent & { index?: number })
 				| (TextContent & { index?: number })
 				| ((ToolCall & { partialJson: string }) & { index?: number })
-				| (ProviderNativeContent & { index?: number });
+				| (ProviderNativeContent & { partialJson?: string; index?: number });
 			const blocks = output.content as Block[];
 
 			for await (const event of iterateAnthropicEvents(response, options?.signal)) {
@@ -1039,6 +1068,11 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 								delta: event.delta.partial_json,
 								partial: output,
 							});
+						} else if (block && block.type === "providerNative" && isProviderNativeToolUseBlock(block.raw)) {
+							// Server-side tool blocks (server_tool_use) stream their input
+							// the same way tool_use does; the block captured at
+							// content_block_start still has `input: {}`.
+							block.partialJson = (block.partialJson ?? "") + event.delta.partial_json;
 						}
 					} else if (event.delta.type === "signature_delta") {
 						const index = blocks.findIndex((b) => b.index === event.index);
@@ -1078,6 +1112,12 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 								toolCall: block,
 								partial: output,
 							});
+						} else if (block.type === "providerNative") {
+							const partialJson = block.partialJson;
+							delete block.partialJson;
+							if (partialJson !== undefined && isRecord(block.raw)) {
+								block.raw = { ...block.raw, input: parseStreamingJson(partialJson) };
+							}
 						}
 					}
 				} else if (event.type === "message_delta") {
@@ -1132,6 +1172,13 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 		} catch (error) {
 			for (const block of output.content) {
 				delete (block as { index?: number }).index;
+				// An aborted stream never reaches content_block_stop; keep whatever
+				// provider-native input accumulated, mirroring toolCall's partial
+				// arguments.
+				const scratch = (block as { partialJson?: string }).partialJson;
+				if (block.type === "providerNative" && scratch !== undefined && isRecord(block.raw)) {
+					block.raw = { ...block.raw, input: parseStreamingJson(scratch) };
+				}
 				// partialJson is only a streaming scratch buffer; never persist it.
 				delete (block as { partialJson?: string }).partialJson;
 			}
@@ -1599,6 +1646,7 @@ function convertMessages(
 	// Tool calls from a declined pre-fallback attempt are dropped from their
 	// assistant turn below; drop their tool_results in lockstep so none dangle.
 	const discardedFallbackToolCallIds = collectDiscardedFallbackToolCallIds(transformedMessages, model);
+	const rejectsNativeWebSearchReplay = !getAnthropicCompat(model).supportsWebSearch;
 
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];
@@ -1718,7 +1766,13 @@ function convertMessages(
 						input: block.arguments ?? {},
 					});
 				} else if (block.type === "providerNative") {
-					if (isSameModel && isReplayableAnthropicProviderNativeBlock(block.raw)) blocks.push(block.raw);
+					if (
+						isSameModel &&
+						isReplayableAnthropicProviderNativeBlock(block.raw) &&
+						!(rejectsNativeWebSearchReplay && isAnthropicWebSearchReplayBlock(block.raw))
+					) {
+						blocks.push(block.raw);
+					}
 				}
 			}
 			if (blocks.length === 0) continue;

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -233,7 +233,7 @@ function getAnthropicCompat(
 		// search but reject the replayed server_tool_use / web_search_tool_result
 		// blocks on the next request (kimi-coding 400s with `tool_call_id is not
 		// found`).
-		supportsWebSearch: model.compat?.supportsWebSearch ?? model.provider === "anthropic",
+		supportsWebSearch: model.compat?.supportsWebSearch ?? isAnthropicApiBaseUrl(model.baseUrl),
 	};
 }
 
@@ -402,7 +402,7 @@ function isAnthropicServerToolUseBlock(raw: unknown): raw is { readonly type: "s
 // stream their input via input_json_delta. Result-shaped blocks must replay
 // byte-for-byte (encrypted_content), so never merge an `input` into them.
 function isProviderNativeToolUseBlock(raw: unknown): boolean {
-	return isRecord(raw) && typeof raw.type === "string" && raw.type.endsWith("_tool_use");
+	return isRecord(raw) && (raw.type === "server_tool_use" || raw.type === "mcp_tool_use");
 }
 
 // Endpoints without `supportsWebSearch` reject replayed web-search server-tool
@@ -581,7 +581,6 @@ function sanitizeUnsupportedNativeTools(
 	const tools = payload.tools;
 	const sanitized: AnthropicPayloadWithRequestMetadata = { ...payload };
 	let changed = false;
-	const removedToolNames = new Set<string>();
 
 	if (Array.isArray(tools)) {
 		const supportedTools: typeof tools = [];
@@ -595,9 +594,6 @@ function sanitizeUnsupportedNativeTools(
 					(rejectsNativeWebSearch && isAnthropicWebSearchToolType(hookTool.type)))
 			) {
 				changed = true;
-				if (typeof hookTool.name === "string") {
-					removedToolNames.add(hookTool.name);
-				}
 				continue;
 			}
 
@@ -624,8 +620,12 @@ function sanitizeUnsupportedNativeTools(
 
 	if (changed && isRecord(sanitized.tool_choice)) {
 		const toolChoiceName = sanitized.tool_choice.name;
+		const hasSelectedTool =
+			typeof toolChoiceName === "string" &&
+			Array.isArray(sanitized.tools) &&
+			sanitized.tools.some((tool) => isRecord(tool) && tool.name === toolChoiceName);
 		const shouldRemoveToolChoice =
-			(typeof toolChoiceName === "string" && removedToolNames.has(toolChoiceName)) || sanitized.tools === undefined;
+			sanitized.tools === undefined || (typeof toolChoiceName === "string" && !hasSelectedTool);
 		if (shouldRemoveToolChoice) {
 			delete sanitized.tool_choice;
 		}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,47 @@
 # AI Source Changes
 
+## 2026-07-16 - Anthropic native web_search endpoint guard and server_tool_use input streaming
+
+### What changed and why
+
+- `types.ts`: added `AnthropicMessagesCompat.supportsWebSearch`. Default (resolved in
+  `getAnthropicCompat`): true only for the first-party `anthropic` provider; Anthropic-compatible providers can
+  opt in per model via `compat`.
+- `api/anthropic-messages.ts`: `sanitizeUnsupportedNativeTools` now also strips hook-injected native `web_search_*`
+  tools when the resolved compat does not support them, mirroring the existing native computer tool guard and the
+  OpenAI Responses `web_search_preview` compat guard (2026-05-15). Anthropic-compatible endpoints such as kimi-coding
+  execute the server-side search but reject the replayed `server_tool_use` / `web_search_tool_result` blocks on the
+  next request (kimi-coding 400s with `tool_call_id is not found`), wedging the session.
+- `api/anthropic-messages.ts`: same-model provider-native replay also drops web-search server-tool blocks
+  (`server_tool_use` named `web_search` and `web_search_tool_result`) when the endpoint lacks `supportsWebSearch`.
+  Sessions that already recorded such blocks against an incompatible endpoint were permanently wedged — every
+  request replayed the rejected blocks; dropping the pair loses the searched context but unwedges the session.
+- `api/anthropic-messages.ts`: streaming now accumulates `input_json_delta` for tool_use-shaped provider-native
+  blocks (`*_tool_use`, e.g. `server_tool_use`) and merges the parsed input into the stored raw block at
+  `content_block_stop` (or in the abort/error finalizer for interrupted streams). Previously the block kept the
+  `content_block_start` snapshot (`input: {}`), so every same-model replay sent the server tool call with an empty
+  input. Result-shaped blocks are never touched — their `encrypted_content` must replay byte-for-byte.
+
+### Files modified
+
+- `types.ts`
+- `api/anthropic-messages.ts`
+- `../test/anthropic-native-web-search-compat.test.ts`
+- (see also `../../coding-agent/src/core/changes.md` for the models.json compat schema entry)
+
+### Why the higher-level extension system couldn't handle this alone
+
+- Extensions can inject native `web_search_*` tools via `before_provider_request`; the final payload is only known
+  after all hooks run, so the provider is the last reliable guard before SDK submission (same rationale as the
+  OpenAI Responses guard). Provider-native block capture during streaming happens inside `pi-ai` before any
+  extension sees the message.
+
+### Expected merge conflict zones
+
+- MEDIUM: `api/anthropic-messages.ts` around `getAnthropicCompat`, `sanitizeUnsupportedNativeTools`, and the
+  `content_block_delta` / `content_block_stop` streaming handlers.
+- LOW: `types.ts` `AnthropicMessagesCompat` if upstream adds more compat flags.
+
 ## 2026-07-14 - Anthropic web search replay encrypted content correction
 
 ### What changed and why

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -5,28 +5,34 @@
 ### What changed and why
 
 - `types.ts`: added `AnthropicMessagesCompat.supportsWebSearch`. Default (resolved in
-  `getAnthropicCompat`): true only for the first-party `anthropic` provider; Anthropic-compatible providers can
+  `getAnthropicCompat`): true only for the first-party `api.anthropic.com` endpoint; compatible providers and
+  provider overrides can
   opt in per model via `compat`.
 - `api/anthropic-messages.ts`: `sanitizeUnsupportedNativeTools` now also strips hook-injected native `web_search_*`
   tools when the resolved compat does not support them, mirroring the existing native computer tool guard and the
   OpenAI Responses `web_search_preview` compat guard (2026-05-15). Anthropic-compatible endpoints such as kimi-coding
   execute the server-side search but reject the replayed `server_tool_use` / `web_search_tool_result` blocks on the
-  next request (kimi-coding 400s with `tool_call_id is not found`), wedging the session.
+  next request (kimi-coding 400s with `tool_call_id is not found`), wedging the session. Named `tool_choice` is
+  preserved when a same-name function fallback remains and removed only when the retained tool list no longer
+  contains that choice.
 - `api/anthropic-messages.ts`: same-model provider-native replay also drops web-search server-tool blocks
   (`server_tool_use` named `web_search` and `web_search_tool_result`) when the endpoint lacks `supportsWebSearch`.
   Sessions that already recorded such blocks against an incompatible endpoint were permanently wedged — every
   request replayed the rejected blocks; dropping the pair loses the searched context but unwedges the session.
-- `api/anthropic-messages.ts`: streaming now accumulates `input_json_delta` for tool_use-shaped provider-native
-  blocks (`*_tool_use`, e.g. `server_tool_use`) and merges the parsed input into the stored raw block at
+- `api/anthropic-messages.ts`: streaming now accumulates `input_json_delta` for Anthropic's confirmed
+  provider-native tool-use blocks (`server_tool_use` and beta `mcp_tool_use`) and merges the parsed input into the stored raw block at
   `content_block_stop` (or in the abort/error finalizer for interrupted streams). Previously the block kept the
   `content_block_start` snapshot (`input: {}`), so every same-model replay sent the server tool call with an empty
-  input. Result-shaped blocks are never touched — their `encrypted_content` must replay byte-for-byte.
+  input. Unknown and result-shaped blocks are never touched; their raw provider payload must remain verbatim.
 
 ### Files modified
 
 - `types.ts`
 - `api/anthropic-messages.ts`
 - `../test/anthropic-native-web-search-compat.test.ts`
+- `../test/anthropic-provider-native-replay.test.ts`
+- `../test/anthropic-web-search-replay-encryption.test.ts`
+- `../test/anthropic.provider-native.test.ts`
 - (see also `../../coding-agent/src/core/changes.md` for the models.json compat schema entry)
 
 ### Why the higher-level extension system couldn't handle this alone

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -661,6 +661,15 @@ export interface AnthropicMessagesCompat {
 	 * except Haiku and models older than Claude 4.5; false for other providers.
 	 */
 	supportsToolReferences?: boolean;
+	/**
+	 * Whether the provider executes Anthropic server-side `web_search_*` native
+	 * tools and accepts their `server_tool_use` / `web_search_tool_result`
+	 * blocks on replay. Anthropic-compatible endpoints (e.g., kimi-coding) may
+	 * run the search but reject the replayed server-tool blocks on the next
+	 * request. When false, hook-injected `web_search_*` tools are stripped from
+	 * the payload. Default: true only for the first-party Anthropic endpoint.
+	 */
+	supportsWebSearch?: boolean;
 }
 
 /**

--- a/packages/ai/test/anthropic-native-web-search-compat.test.ts
+++ b/packages/ai/test/anthropic-native-web-search-compat.test.ts
@@ -1,0 +1,267 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import { getModel } from "../src/compat.ts";
+import type { Context, Model } from "../src/types.ts";
+
+function createSseResponse(events: Array<{ event: string; data: string }>): Response {
+	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+const minimalEvents = [
+	{
+		event: "message_start",
+		data: JSON.stringify({
+			type: "message_start",
+			message: {
+				id: "msg_test",
+				usage: {
+					input_tokens: 12,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			},
+		}),
+	},
+	{
+		event: "message_delta",
+		data: JSON.stringify({
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: {
+				input_tokens: 12,
+				output_tokens: 5,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+		}),
+	},
+	{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+];
+
+function createCapturingClient(response: Response, captured?: { params?: Record<string, unknown> }): Anthropic {
+	return {
+		messages: {
+			create: (params: Record<string, unknown>) => {
+				if (captured) captured.params = params;
+				return {
+					asResponse: async () => response,
+				};
+			},
+		},
+	} as unknown as Anthropic;
+}
+
+const nativeWebSearchTool = { type: "web_search_20250305", name: "web_search", max_uses: 8 };
+const functionTool = {
+	name: "read",
+	description: "Read a file.",
+	parameters: Type.Object({ path: Type.String() }),
+};
+
+const kimiCodingModel: Model<"anthropic-messages"> = {
+	...getModel("anthropic", "claude-sonnet-4-5"),
+	provider: "kimi-coding",
+	baseUrl: "https://api.kimi.com/coding",
+};
+
+function createContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+		tools: [functionTool],
+	};
+}
+
+async function captureParams(model: Model<"anthropic-messages">): Promise<Record<string, unknown>> {
+	const captured: { params?: Record<string, unknown> } = {};
+	const stream = streamAnthropic(model, createContext(), {
+		client: createCapturingClient(createSseResponse(minimalEvents), captured),
+		onPayload: (payload) => {
+			const params = payload as Record<string, unknown>;
+			const tools = Array.isArray(params.tools) ? params.tools : [];
+			return { ...params, tools: [...tools, nativeWebSearchTool] };
+		},
+	});
+	await stream.result();
+	if (!captured.params) {
+		throw new Error("Expected the fake client to capture request params");
+	}
+	return captured.params;
+}
+
+function toolTypes(params: Record<string, unknown>): unknown[] {
+	const tools = Array.isArray(params.tools) ? params.tools : [];
+	return tools.map((tool) => (tool as Record<string, unknown>).type);
+}
+
+describe("Anthropic native web_search tool guard", () => {
+	it("strips hook-injected web_search_* tools for Anthropic-compatible endpoints", async () => {
+		// kimi-coding executes the server-side search but rejects the replayed
+		// server_tool_use / web_search_tool_result blocks on the next request
+		// with 400 `tool_call_id is not found`, wedging the session.
+		const params = await captureParams(kimiCodingModel);
+
+		expect(toolTypes(params)).not.toContain("web_search_20250305");
+		const toolNames = (params.tools as Array<Record<string, unknown>>).map((tool) => tool.name);
+		expect(toolNames).toContain("read");
+	});
+
+	it("keeps web_search_* tools for the first-party Anthropic endpoint", async () => {
+		const params = await captureParams(getModel("anthropic", "claude-sonnet-4-5"));
+
+		expect(toolTypes(params)).toContain("web_search_20250305");
+	});
+
+	it("keeps web_search_* tools when a compatible endpoint opts in via compat", async () => {
+		const params = await captureParams({
+			...kimiCodingModel,
+			compat: { supportsWebSearch: true },
+		});
+
+		expect(toolTypes(params)).toContain("web_search_20250305");
+	});
+});
+
+describe("Anthropic web-search replay guard", () => {
+	const usage = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	} as const;
+	const serverToolUse = { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: { query: "x" } };
+	const webSearchToolResult = {
+		type: "web_search_tool_result",
+		tool_use_id: "srvtoolu_1",
+		content: [{ type: "web_search_result", title: "A", url: "https://a.example", encrypted_content: "enc" }],
+	};
+
+	function replayContext(model: Model<"anthropic-messages">): Context {
+		return {
+			messages: [
+				{ role: "user", content: "hello", timestamp: 1 },
+				{
+					role: "assistant",
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					content: [
+						{ type: "providerNative", subtype: "server_tool_use", raw: serverToolUse },
+						{ type: "providerNative", subtype: "web_search_tool_result", raw: webSearchToolResult },
+						{ type: "text", text: "answer" },
+					],
+					usage,
+					stopReason: "stop",
+					timestamp: 2,
+				},
+				{ role: "user", content: "follow up", timestamp: 3 },
+			],
+		};
+	}
+
+	async function captureReplayedAssistantContent(model: Model<"anthropic-messages">): Promise<unknown> {
+		const captured: { params?: Record<string, unknown> } = {};
+		const stream = streamAnthropic(model, replayContext(model), {
+			client: createCapturingClient(createSseResponse(minimalEvents), captured),
+		});
+		await stream.result();
+		const messages = captured.params?.messages as Array<{ role: string; content: unknown }>;
+		return messages.find((message) => message.role === "assistant")?.content;
+	}
+
+	it("drops same-model web-search server-tool blocks for endpoints without supportsWebSearch", async () => {
+		// A session wedged before this fix has these blocks persisted; replaying
+		// them keeps 400ing. Dropping the pair unwedges the session.
+		const content = await captureReplayedAssistantContent(kimiCodingModel);
+
+		expect(content).toEqual([{ type: "text", text: "answer" }]);
+	});
+
+	it("keeps same-model web-search server-tool blocks for the first-party endpoint", async () => {
+		const content = await captureReplayedAssistantContent(getModel("anthropic", "claude-sonnet-4-5"));
+
+		expect(content).toEqual([serverToolUse, webSearchToolResult, { type: "text", text: "answer" }]);
+	});
+});
+
+describe("Anthropic server_tool_use input streaming", () => {
+	it("accumulates input_json_delta into the stored server_tool_use block", async () => {
+		// The block captured at content_block_start has `input: {}`; the actual
+		// input streams via input_json_delta. Without accumulation, the replayed
+		// server_tool_use always carries an empty input.
+		const response = createSseResponse([
+			minimalEvents[0],
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: {} },
+				}),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: '{"query":' },
+				}),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: '"senpi worktree"}' },
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 1,
+					content_block: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvtoolu_1",
+						content: [
+							{
+								type: "web_search_result",
+								title: "Example",
+								url: "https://example.com",
+								encrypted_content: "enc",
+							},
+						],
+					},
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 1 }) },
+			minimalEvents[1],
+			minimalEvents[2],
+		]);
+
+		const stream = streamAnthropic(getModel("anthropic", "claude-sonnet-4-5"), createContext(), {
+			client: createCapturingClient(response),
+		});
+		const result = await stream.result();
+
+		expect(result.errorMessage).toBeUndefined();
+		expect(result.content[0]).toEqual({
+			type: "providerNative",
+			subtype: "server_tool_use",
+			raw: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: { query: "senpi worktree" } },
+		});
+		expect(result.content[1]).toMatchObject({
+			type: "providerNative",
+			subtype: "web_search_tool_result",
+		});
+	});
+});

--- a/packages/ai/test/anthropic-native-web-search-compat.test.ts
+++ b/packages/ai/test/anthropic-native-web-search-compat.test.ts
@@ -64,6 +64,11 @@ const functionTool = {
 	description: "Read a file.",
 	parameters: Type.Object({ path: Type.String() }),
 };
+const webSearchFunctionTool = {
+	name: "web_search",
+	description: "Search the web through a function fallback.",
+	parameters: Type.Object({ query: Type.String() }),
+};
 
 const kimiCodingModel: Model<"anthropic-messages"> = {
 	...getModel("anthropic", "claude-sonnet-4-5"),
@@ -78,10 +83,17 @@ function createContext(): Context {
 	};
 }
 
-async function captureParams(model: Model<"anthropic-messages">): Promise<Record<string, unknown>> {
+async function captureParams(
+	model: Model<"anthropic-messages">,
+	options?: {
+		readonly context?: Context;
+		readonly toolChoice?: { readonly type: "tool"; readonly name: string };
+	},
+): Promise<Record<string, unknown>> {
 	const captured: { params?: Record<string, unknown> } = {};
-	const stream = streamAnthropic(model, createContext(), {
+	const stream = streamAnthropic(model, options?.context ?? createContext(), {
 		client: createCapturingClient(createSseResponse(minimalEvents), captured),
+		...(options?.toolChoice ? { toolChoice: options.toolChoice } : {}),
 		onPayload: (payload) => {
 			const params = payload as Record<string, unknown>;
 			const tools = Array.isArray(params.tools) ? params.tools : [];
@@ -112,10 +124,51 @@ describe("Anthropic native web_search tool guard", () => {
 		expect(toolNames).toContain("read");
 	});
 
+	it("keeps a forced named choice when a same-name function fallback remains", async () => {
+		const params = await captureParams(kimiCodingModel, {
+			context: {
+				messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+				tools: [webSearchFunctionTool],
+			},
+			toolChoice: { type: "tool", name: "web_search" },
+		});
+
+		expect(params.tools).toMatchObject([
+			{
+				name: "web_search",
+				description: "Search the web through a function fallback.",
+				input_schema: webSearchFunctionTool.parameters,
+			},
+		]);
+		expect(params.tool_choice).toEqual({ type: "tool", name: "web_search" });
+	});
+
+	it("removes a forced named choice when its native tool is the only matching tool", async () => {
+		const params = await captureParams(kimiCodingModel, {
+			context: {
+				messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+				tools: [],
+			},
+			toolChoice: { type: "tool", name: "web_search" },
+		});
+
+		expect(params.tools).toBeUndefined();
+		expect(params.tool_choice).toBeUndefined();
+	});
+
 	it("keeps web_search_* tools for the first-party Anthropic endpoint", async () => {
 		const params = await captureParams(getModel("anthropic", "claude-sonnet-4-5"));
 
 		expect(toolTypes(params)).toContain("web_search_20250305");
+	});
+
+	it("strips web_search_* tools when the Anthropic provider is redirected to a custom endpoint", async () => {
+		const params = await captureParams({
+			...getModel("anthropic", "claude-sonnet-4-5"),
+			baseUrl: "https://anthropic-proxy.example/v1",
+		});
+
+		expect(toolTypes(params)).not.toContain("web_search_20250305");
 	});
 
 	it("keeps web_search_* tools when a compatible endpoint opts in via compat", async () => {

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -70,6 +70,9 @@ async function capturePayload(
 	const payloadCaptureModel: Model<"anthropic-messages"> = {
 		...model,
 		baseUrl: "http://127.0.0.1:9",
+		// The localhost override only captures the payload; these tests exercise
+		// first-party replay semantics rather than endpoint capability detection.
+		compat: { ...model.compat, supportsWebSearch: true },
 	};
 	const stream = streamSimple(
 		payloadCaptureModel,

--- a/packages/ai/test/anthropic-web-search-replay-encryption.test.ts
+++ b/packages/ai/test/anthropic-web-search-replay-encryption.test.ts
@@ -25,7 +25,13 @@ async function captureMessages(
 ): Promise<readonly CapturedMessage[]> {
 	let capturedMessages: readonly CapturedMessage[] | undefined;
 	const stream = streamSimple(
-		{ ...model, baseUrl: "http://127.0.0.1:9" },
+		{
+			...model,
+			baseUrl: "http://127.0.0.1:9",
+			// The localhost override only captures the payload; this test exercises
+			// first-party replay semantics rather than endpoint capability detection.
+			compat: { ...model.compat, supportsWebSearch: true },
+		},
 		{ messages },
 		{
 			apiKey: "fake-key",

--- a/packages/ai/test/anthropic.provider-native.test.ts
+++ b/packages/ai/test/anthropic.provider-native.test.ts
@@ -109,4 +109,117 @@ describe("Anthropic provider-native content blocks", () => {
 			raw: webSearchToolResultBlock,
 		});
 	});
+
+	it("preserves unknown tool-use-shaped blocks when input deltas arrive", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+		};
+		const unknownBlock = {
+			type: "metadata_tool_use",
+			id: "meta_1",
+			payload: "verbatim",
+		};
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_test",
+						usage: {
+							input_tokens: 3,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({ type: "content_block_start", index: 0, content_block: unknownBlock }),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: '{"unexpected":true}' },
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: { input_tokens: 3, output_tokens: 1 },
+				}),
+			},
+			{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+		]);
+
+		const result = await streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(response),
+		}).result();
+
+		expect(result.content[0]).toEqual({
+			type: "providerNative",
+			subtype: "metadata_tool_use",
+			raw: unknownBlock,
+		});
+	});
+
+	it("finalizes server tool input when the stream ends before content_block_stop", async () => {
+		const model = getModel("anthropic", "claude-haiku-4-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+		};
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_test",
+						usage: {
+							input_tokens: 3,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "server_tool_use", id: "srvu_1", name: "web_search", input: {} },
+				}),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: '{"query":"interrupted"}' },
+				}),
+			},
+		]);
+
+		const result = await streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(response),
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.content[0]).toEqual({
+			type: "providerNative",
+			subtype: "server_tool_use",
+			raw: { type: "server_tool_use", id: "srvu_1", name: "web_search", input: { query: "interrupted" } },
+		});
+		expect(result.content[0]).not.toHaveProperty("partialJson");
+	});
 });

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## AnthropicMessagesCompat.supportsWebSearch in models.json schema (2026-07-16)
+
+### What changed
+
+- `model-config.ts` (`AnthropicMessagesCompatSchema`): added optional boolean `supportsWebSearch`, mirroring
+  `supportsWebSearchPreview` in `OpenAIResponsesCompatSchema`. This is the models.json opt-in for
+  Anthropic-compatible endpoints that genuinely support server-side web search (see `packages/ai/src/changes.md`
+  2026-07-16); without the schema entry the flag would fail models.json validation.
+
+### Why extension system couldn't handle this alone
+
+- models.json validation happens in core `model-config.ts` before any extension sees the model entry.
+
+### Expected merge conflict zones
+
+- LOW: `model-config.ts` compat schemas if upstream adds more compat flags.
+
 ## Skill-loading trigger reframed with cost asymmetry (2026-07-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/anthropic-web-search/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/anthropic-web-search/index.ts
@@ -1,7 +1,9 @@
-import type { Api } from "@earendil-works/pi-ai";
+import type { AnthropicMessagesCompat, Api, Model } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 
 type ToolDefinition = Record<string, unknown>;
+type AnthropicWebSearchModel = Pick<Model<Api>, "api" | "provider" | "compat">;
+type AnthropicWebSearchTarget = Api | AnthropicWebSearchModel | undefined;
 
 const WEB_SEARCH_MAX_USES = 8;
 const ENABLE_ENV = "PI_ANTHROPIC_WEB_SEARCH";
@@ -35,6 +37,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isWebSearchType(value: unknown): value is string {
 	return typeof value === "string" && value.startsWith("web_search_");
+}
+
+function resolveTarget(target: AnthropicWebSearchTarget): AnthropicWebSearchModel | undefined {
+	if (target === undefined) {
+		return undefined;
+	}
+	if (typeof target === "string") {
+		return {
+			api: target,
+			provider: target === "anthropic-messages" ? "anthropic" : "",
+		};
+	}
+	return target;
+}
+
+// Mirrors pi-ai's `AnthropicMessagesCompat.supportsWebSearch` default:
+// first-party Anthropic only. Anthropic-compatible endpoints (e.g.,
+// kimi-coding) may execute the server-side search but reject the replayed
+// server_tool_use / web_search_tool_result blocks on the next request.
+export function supportsNativeAnthropicWebSearch(target: AnthropicWebSearchTarget): boolean {
+	const model = resolveTarget(target);
+	if (model?.api !== "anthropic-messages") {
+		return false;
+	}
+
+	const compat = model.compat as AnthropicMessagesCompat | undefined;
+	return compat?.supportsWebSearch ?? model.provider === "anthropic";
 }
 
 function parseDomainListEnv(envVar: string): string[] | undefined {
@@ -85,16 +114,43 @@ function sanitizeTools(tools: unknown[]): ToolDefinition[] {
 	return sanitized;
 }
 
-export function addAnthropicWebSearchToPayload(api: Api | undefined, payload: unknown): unknown {
-	if (api !== "anthropic-messages") {
+function stripNativeAnthropicWebSearch(payload: Record<string, unknown>): Record<string, unknown> {
+	const tools = payload.tools;
+	if (!Array.isArray(tools)) {
 		return payload;
 	}
 
-	if (!isAnthropicWebSearchEnabled()) {
+	const sanitizedTools = tools.filter((tool) => !(isRecord(tool) && isWebSearchType(tool.type)));
+	if (sanitizedTools.length === tools.length) {
+		return payload;
+	}
+
+	return {
+		...payload,
+		tools: sanitizedTools,
+	};
+}
+
+export function addAnthropicWebSearchToPayload(target: AnthropicWebSearchTarget, payload: unknown): unknown {
+	const model = resolveTarget(target);
+	if (model?.api !== "anthropic-messages") {
 		return payload;
 	}
 
 	if (!isRecord(payload)) {
+		return payload;
+	}
+
+	if (!supportsNativeAnthropicWebSearch(model)) {
+		// Anthropic-compatible endpoints (e.g., kimi-coding) may execute the
+		// server-side search but reject the replayed server_tool_use /
+		// web_search_tool_result blocks on the next request. Strip any native
+		// web_search_* variant so the session never wedges; a function-tool
+		// web_search (pi-websearch) is left untouched as the working fallback.
+		return stripNativeAnthropicWebSearch(payload);
+	}
+
+	if (!isAnthropicWebSearchEnabled()) {
 		return payload;
 	}
 
@@ -135,7 +191,7 @@ Prefer web_search over guessing when freshness matters.
 
 export default function anthropicWebSearchExtension(pi: ExtensionAPI): void {
 	pi.on("before_provider_request", (event, ctx) => {
-		return addAnthropicWebSearchToPayload(ctx.model?.api, event.payload);
+		return addAnthropicWebSearchToPayload(ctx.model, event.payload);
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -151,7 +207,7 @@ export default function anthropicWebSearchExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
-		if (ctx.model?.api !== "anthropic-messages") {
+		if (!supportsNativeAnthropicWebSearch(ctx.model)) {
 			return undefined;
 		}
 

--- a/packages/coding-agent/src/core/extensions/builtin/anthropic-web-search/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/anthropic-web-search/index.ts
@@ -2,7 +2,7 @@ import type { AnthropicMessagesCompat, Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 
 type ToolDefinition = Record<string, unknown>;
-type AnthropicWebSearchModel = Pick<Model<Api>, "api" | "provider" | "compat">;
+type AnthropicWebSearchModel = Pick<Model<Api>, "api" | "provider" | "baseUrl" | "compat">;
 type AnthropicWebSearchTarget = Api | AnthropicWebSearchModel | undefined;
 
 const WEB_SEARCH_MAX_USES = 8;
@@ -46,14 +46,23 @@ function resolveTarget(target: AnthropicWebSearchTarget): AnthropicWebSearchMode
 	if (typeof target === "string") {
 		return {
 			api: target,
+			baseUrl: target === "anthropic-messages" ? "https://api.anthropic.com" : "",
 			provider: target === "anthropic-messages" ? "anthropic" : "",
 		};
 	}
 	return target;
 }
 
+function isNativeAnthropicEndpoint(model: AnthropicWebSearchModel): boolean {
+	try {
+		return new URL(model.baseUrl).hostname === "api.anthropic.com";
+	} catch {
+		return false;
+	}
+}
+
 // Mirrors pi-ai's `AnthropicMessagesCompat.supportsWebSearch` default:
-// first-party Anthropic only. Anthropic-compatible endpoints (e.g.,
+// first-party api.anthropic.com only. Anthropic-compatible endpoints (e.g.,
 // kimi-coding) may execute the server-side search but reject the replayed
 // server_tool_use / web_search_tool_result blocks on the next request.
 export function supportsNativeAnthropicWebSearch(target: AnthropicWebSearchTarget): boolean {
@@ -63,7 +72,7 @@ export function supportsNativeAnthropicWebSearch(target: AnthropicWebSearchTarge
 	}
 
 	const compat = model.compat as AnthropicMessagesCompat | undefined;
-	return compat?.supportsWebSearch ?? model.provider === "anthropic";
+	return compat?.supportsWebSearch ?? isNativeAnthropicEndpoint(model);
 }
 
 function parseDomainListEnv(envVar: string): string[] | undefined {
@@ -125,10 +134,24 @@ function stripNativeAnthropicWebSearch(payload: Record<string, unknown>): Record
 		return payload;
 	}
 
-	return {
-		...payload,
-		tools: sanitizedTools,
-	};
+	const sanitizedPayload = { ...payload };
+	if (sanitizedTools.length > 0) {
+		sanitizedPayload.tools = sanitizedTools;
+	} else {
+		delete sanitizedPayload.tools;
+	}
+
+	if (isRecord(sanitizedPayload.tool_choice)) {
+		const selectedName = sanitizedPayload.tool_choice.name;
+		const hasSelectedTool =
+			typeof selectedName === "string" &&
+			sanitizedTools.some((tool) => isRecord(tool) && tool.name === selectedName);
+		if (sanitizedTools.length === 0 || (typeof selectedName === "string" && !hasSelectedTool)) {
+			delete sanitizedPayload.tool_choice;
+		}
+	}
+
+	return sanitizedPayload;
 }
 
 export function addAnthropicWebSearchToPayload(target: AnthropicWebSearchTarget, payload: unknown): unknown {

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -6,11 +6,11 @@
 
 - `builtin/anthropic-web-search/index.ts`: the extension now gates on the model instead of the API type,
   mirroring `builtin/openai-web-search`. `supportsNativeAnthropicWebSearch(target)` is true for the first-party
-  `anthropic` provider or an explicit `compat.supportsWebSearch` opt-in. For unsupported
+  `api.anthropic.com` endpoint or an explicit `compat.supportsWebSearch` opt-in. For unsupported
   `anthropic-messages` endpoints the extension no longer
   injects `web_search_20250305`, no longer strips a function-tool `web_search` (pi-websearch keeps working as the
-  fallback), strips any hook-injected native `web_search_*` variant, and skips the web-search system prompt
-  section.
+  fallback), strips any hook-injected native `web_search_*` variant plus an orphaned `tool_choice`, and skips the
+  web-search system prompt section.
 - `test/suite/anthropic-web-search-extension.test.ts`: added kimi-coding-shaped regression coverage for
   non-injection, native-variant stripping, compat opt-in, and prompt-section gating.
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,35 @@
 # Core Extensions Changes
 
+## 2026-07-16 - anthropic-web-search gated to endpoints that support server-side web search
+
+### What changed
+
+- `builtin/anthropic-web-search/index.ts`: the extension now gates on the model instead of the API type,
+  mirroring `builtin/openai-web-search`. `supportsNativeAnthropicWebSearch(target)` is true for the first-party
+  `anthropic` provider or an explicit `compat.supportsWebSearch` opt-in. For unsupported
+  `anthropic-messages` endpoints the extension no longer
+  injects `web_search_20250305`, no longer strips a function-tool `web_search` (pi-websearch keeps working as the
+  fallback), strips any hook-injected native `web_search_*` variant, and skips the web-search system prompt
+  section.
+- `test/suite/anthropic-web-search-extension.test.ts`: added kimi-coding-shaped regression coverage for
+  non-injection, native-variant stripping, compat opt-in, and prompt-section gating.
+
+### Why
+
+- Anthropic-compatible endpoints such as kimi-coding accept the injected native tool and execute the server-side
+  search, but reject the replayed `server_tool_use` / `web_search_tool_result` blocks on the next request
+  (kimi-coding 400s with `tool_call_id is not found`), wedging the session mid-turn.
+
+### Why extension system couldn't handle this alone
+
+- It can (this is the extension-side half); `pi-ai` additionally strips unsupported `web_search_*` tools after all
+  hooks run (see `packages/ai/src/changes.md` 2026-07-16) so payloads from other extensions are covered too.
+
+### Expected merge conflict zones
+
+- MEDIUM: `builtin/anthropic-web-search/index.ts` if upstream reshapes native web tool payload handling.
+- LOW: `test/suite/anthropic-web-search-extension.test.ts` fixtures.
+
 ## 2026-07-10 - Tool renderer image protocol context
 
 ### What changed

--- a/packages/coding-agent/src/core/model-config.ts
+++ b/packages/coding-agent/src/core/model-config.ts
@@ -133,6 +133,7 @@ const AnthropicMessagesCompatSchema = Type.Object({
 	forceAdaptiveThinking: Type.Optional(Type.Boolean()),
 	allowEmptySignature: Type.Optional(Type.Boolean()),
 	supportsToolReferences: Type.Optional(Type.Boolean()),
+	supportsWebSearch: Type.Optional(Type.Boolean()),
 });
 
 const ProviderCompatSchema = Type.Union([

--- a/packages/coding-agent/test/suite/anthropic-web-search-extension.test.ts
+++ b/packages/coding-agent/test/suite/anthropic-web-search-extension.test.ts
@@ -3,12 +3,18 @@ import anthropicWebSearchExtension, {
 	ANTHROPIC_WEB_SEARCH_SECTION,
 	addAnthropicWebSearchToPayload,
 	isAnthropicWebSearchEnabled,
+	supportsNativeAnthropicWebSearch,
 } from "../../src/core/extensions/builtin/anthropic-web-search/index.ts";
 import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
 
 const ENABLE_ENV = "PI_ANTHROPIC_WEB_SEARCH";
 const ALLOWED_DOMAINS_ENV = "PI_ANTHROPIC_WEB_SEARCH_ALLOWED_DOMAINS";
 const BLOCKED_DOMAINS_ENV = "PI_ANTHROPIC_WEB_SEARCH_BLOCKED_DOMAINS";
+
+const kimiCodingModel = {
+	api: "anthropic-messages",
+	provider: "kimi-coding",
+} as const;
 
 type TestUi = {
 	setStatus: (key: string, value: string | undefined) => void;
@@ -108,6 +114,52 @@ describe("anthropic-web-search builtin extension", () => {
 		});
 	});
 
+	it("does not inject the native tool for Anthropic-compatible endpoints", () => {
+		const payload = {
+			tools: [{ name: "web_search", description: "pi-websearch function" }, { name: "other_tool" }],
+		};
+
+		const result = addAnthropicWebSearchToPayload(kimiCodingModel, payload);
+
+		expect(result).toBe(payload);
+	});
+
+	it("strips a hook-injected native web_search tool for Anthropic-compatible endpoints", () => {
+		const payload = {
+			tools: [
+				{ type: "web_search_20250305", name: "web_search", max_uses: 8 },
+				{ name: "web_search", description: "pi-websearch function" },
+				{ name: "other_tool" },
+			],
+		};
+
+		const result = addAnthropicWebSearchToPayload(kimiCodingModel, payload) as {
+			tools: Array<Record<string, unknown>>;
+		};
+
+		expect(result.tools).toEqual([
+			{ name: "web_search", description: "pi-websearch function" },
+			{ name: "other_tool" },
+		]);
+	});
+
+	it("injects the native tool for a compatible endpoint that opts in via compat", () => {
+		const payload = {
+			tools: [{ name: "other_tool" }],
+		};
+
+		const result = addAnthropicWebSearchToPayload(
+			{ ...kimiCodingModel, compat: { supportsWebSearch: true } },
+			payload,
+		) as { tools: unknown[] };
+
+		expect(result.tools).toContainEqual({
+			type: "web_search_20250305",
+			name: "web_search",
+			max_uses: 8,
+		});
+	});
+
 	it("returns original payload reference when explicitly disabled", () => {
 		process.env[ENABLE_ENV] = "0";
 		const payload = {
@@ -133,6 +185,36 @@ describe("anthropic-web-search builtin extension", () => {
 			name: "web_search",
 			max_uses: 8,
 		});
+	});
+});
+
+describe("supportsNativeAnthropicWebSearch", () => {
+	it("supports the first-party Anthropic provider", () => {
+		expect(supportsNativeAnthropicWebSearch({ api: "anthropic-messages", provider: "anthropic" })).toBe(true);
+	});
+
+	it("keeps supporting the bare api string for backwards compatibility", () => {
+		expect(supportsNativeAnthropicWebSearch("anthropic-messages")).toBe(true);
+	});
+
+	it("does not support Anthropic-compatible endpoints by default", () => {
+		expect(supportsNativeAnthropicWebSearch(kimiCodingModel)).toBe(false);
+	});
+
+	it("honors an explicit compat opt-in and opt-out", () => {
+		expect(supportsNativeAnthropicWebSearch({ ...kimiCodingModel, compat: { supportsWebSearch: true } })).toBe(true);
+		expect(
+			supportsNativeAnthropicWebSearch({
+				api: "anthropic-messages",
+				provider: "anthropic",
+				compat: { supportsWebSearch: false },
+			}),
+		).toBe(false);
+	});
+
+	it("does not support non-anthropic-messages APIs", () => {
+		expect(supportsNativeAnthropicWebSearch("openai-responses")).toBe(false);
+		expect(supportsNativeAnthropicWebSearch(undefined)).toBe(false);
 	});
 });
 
@@ -194,7 +276,7 @@ describe("anthropic-web-search before_agent_start", () => {
 
 		type BeforeAgentStartHandler = (
 			event: { systemPrompt: string },
-			ctx: { model?: { api?: string } },
+			ctx: { model?: { api?: string; provider?: string; baseUrl?: string } },
 		) => Promise<{ systemPrompt: string } | undefined>;
 
 		let beforeAgentStartHandler: BeforeAgentStartHandler | undefined;
@@ -211,10 +293,38 @@ describe("anthropic-web-search before_agent_start", () => {
 
 		const result = await beforeAgentStartHandler?.(
 			{ systemPrompt: "system" },
-			{ model: { api: "anthropic-messages" } },
+			{ model: { api: "anthropic-messages", provider: "anthropic" } },
 		);
 
 		expect(result).toBeUndefined();
+	});
+
+	it("appends the web search section only for supported endpoints", async () => {
+		type BeforeAgentStartHandler = (
+			event: { systemPrompt: string },
+			ctx: { model?: { api?: string; provider?: string; baseUrl?: string } },
+		) => Promise<{ systemPrompt: string } | undefined>;
+
+		let beforeAgentStartHandler: BeforeAgentStartHandler | undefined;
+		const pi = {
+			on(eventName: string, handler: unknown) {
+				if (eventName === "before_agent_start") {
+					beforeAgentStartHandler = handler as BeforeAgentStartHandler;
+				}
+			},
+		} satisfies Pick<ExtensionAPI, "on">;
+
+		anthropicWebSearchExtension(pi as ExtensionAPI);
+		expect(beforeAgentStartHandler).toBeDefined();
+
+		const anthropicResult = await beforeAgentStartHandler?.(
+			{ systemPrompt: "system" },
+			{ model: { api: "anthropic-messages", provider: "anthropic" } },
+		);
+		expect(anthropicResult?.systemPrompt).toContain(ANTHROPIC_WEB_SEARCH_SECTION);
+
+		const kimiResult = await beforeAgentStartHandler?.({ systemPrompt: "system" }, { model: kimiCodingModel });
+		expect(kimiResult).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/suite/anthropic-web-search-extension.test.ts
+++ b/packages/coding-agent/test/suite/anthropic-web-search-extension.test.ts
@@ -13,6 +13,7 @@ const BLOCKED_DOMAINS_ENV = "PI_ANTHROPIC_WEB_SEARCH_BLOCKED_DOMAINS";
 
 const kimiCodingModel = {
 	api: "anthropic-messages",
+	baseUrl: "https://api.kimi.com/coding",
 	provider: "kimi-coding",
 } as const;
 
@@ -126,6 +127,7 @@ describe("anthropic-web-search builtin extension", () => {
 
 	it("strips a hook-injected native web_search tool for Anthropic-compatible endpoints", () => {
 		const payload = {
+			tool_choice: { type: "tool", name: "web_search" },
 			tools: [
 				{ type: "web_search_20250305", name: "web_search", max_uses: 8 },
 				{ name: "web_search", description: "pi-websearch function" },
@@ -134,6 +136,7 @@ describe("anthropic-web-search builtin extension", () => {
 		};
 
 		const result = addAnthropicWebSearchToPayload(kimiCodingModel, payload) as {
+			tool_choice?: unknown;
 			tools: Array<Record<string, unknown>>;
 		};
 
@@ -141,6 +144,17 @@ describe("anthropic-web-search builtin extension", () => {
 			{ name: "web_search", description: "pi-websearch function" },
 			{ name: "other_tool" },
 		]);
+		expect(result.tool_choice).toEqual({ type: "tool", name: "web_search" });
+	});
+
+	it("removes orphaned tool_choice when stripping the only native web_search tool", () => {
+		const result = addAnthropicWebSearchToPayload(kimiCodingModel, {
+			tool_choice: { type: "tool", name: "web_search" },
+			tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+		}) as Record<string, unknown>;
+
+		expect(result.tools).toBeUndefined();
+		expect(result.tool_choice).toBeUndefined();
 	});
 
 	it("injects the native tool for a compatible endpoint that opts in via compat", () => {
@@ -190,7 +204,13 @@ describe("anthropic-web-search builtin extension", () => {
 
 describe("supportsNativeAnthropicWebSearch", () => {
 	it("supports the first-party Anthropic provider", () => {
-		expect(supportsNativeAnthropicWebSearch({ api: "anthropic-messages", provider: "anthropic" })).toBe(true);
+		expect(
+			supportsNativeAnthropicWebSearch({
+				api: "anthropic-messages",
+				baseUrl: "https://api.anthropic.com",
+				provider: "anthropic",
+			}),
+		).toBe(true);
 	});
 
 	it("keeps supporting the bare api string for backwards compatibility", () => {
@@ -201,11 +221,22 @@ describe("supportsNativeAnthropicWebSearch", () => {
 		expect(supportsNativeAnthropicWebSearch(kimiCodingModel)).toBe(false);
 	});
 
+	it("does not treat a custom endpoint as native only because its provider id is anthropic", () => {
+		expect(
+			supportsNativeAnthropicWebSearch({
+				api: "anthropic-messages",
+				baseUrl: "https://anthropic-proxy.example/v1",
+				provider: "anthropic",
+			}),
+		).toBe(false);
+	});
+
 	it("honors an explicit compat opt-in and opt-out", () => {
 		expect(supportsNativeAnthropicWebSearch({ ...kimiCodingModel, compat: { supportsWebSearch: true } })).toBe(true);
 		expect(
 			supportsNativeAnthropicWebSearch({
 				api: "anthropic-messages",
+				baseUrl: "https://api.anthropic.com",
 				provider: "anthropic",
 				compat: { supportsWebSearch: false },
 			}),
@@ -293,7 +324,7 @@ describe("anthropic-web-search before_agent_start", () => {
 
 		const result = await beforeAgentStartHandler?.(
 			{ systemPrompt: "system" },
-			{ model: { api: "anthropic-messages", provider: "anthropic" } },
+			{ model: { api: "anthropic-messages", provider: "anthropic", baseUrl: "https://api.anthropic.com" } },
 		);
 
 		expect(result).toBeUndefined();
@@ -319,7 +350,7 @@ describe("anthropic-web-search before_agent_start", () => {
 
 		const anthropicResult = await beforeAgentStartHandler?.(
 			{ systemPrompt: "system" },
-			{ model: { api: "anthropic-messages", provider: "anthropic" } },
+			{ model: { api: "anthropic-messages", provider: "anthropic", baseUrl: "https://api.anthropic.com" } },
 		);
 		expect(anthropicResult?.systemPrompt).toContain(ANTHROPIC_WEB_SEARCH_SECTION);
 

--- a/packages/coding-agent/test/suite/regressions/model-config-controls.test.ts
+++ b/packages/coding-agent/test/suite/regressions/model-config-controls.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { type AnthropicMessagesCompat, getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../../../src/core/auth-storage.ts";
 import { ModelRegistry } from "../../../src/core/model-registry.ts";
@@ -96,6 +96,29 @@ describe("model configuration controls", () => {
 		expect(allModels.filter((model) => model.provider === "anthropic").map((model) => model.id)).toEqual([
 			"claude-sonnet-4-5",
 		]);
+	});
+
+	it("preserves Anthropic native web search compatibility from models.json", () => {
+		writeFileSync(
+			join(agentDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					custom: {
+						api: "anthropic-messages",
+						baseUrl: "https://anthropic-proxy.example/v1",
+						compat: { supportsWebSearch: true },
+						models: [{ id: "custom-claude" }],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const registry = ModelRegistry.create(AuthStorage.inMemory(), join(agentDir, "models.json"));
+		const compat = registry.find("custom", "custom-claude")?.compat as AnthropicMessagesCompat | undefined;
+
+		expect(registry.getError()).toBeUndefined();
+		expect(compat?.supportsWebSearch).toBe(true);
 	});
 
 	it("replaces configured thinking variants instead of merging them", () => {


### PR DESCRIPTION
## Problem

Anthropic-compatible endpoints such as kimi-coding can execute Anthropic's native web search but reject the persisted `server_tool_use` / `web_search_tool_result` blocks on the next request. Replaying that history wedges the session with a 400. The original capability gate also treated any model with provider id `anthropic` as first-party, even when `baseUrl` redirected it through a proxy.

Provider-native `server_tool_use` input also arrives through `input_json_delta`; without accumulation, stored blocks replayed with `input: {}`.

## Fix

- Default native web-search support only for the parsed `api.anthropic.com` hostname. `compat.supportsWebSearch` remains the explicit per-model opt-in/opt-out.
- Strip hook-injected native `web_search_*` tools after payload hooks for unsupported endpoints and drop unsupported historical web-search replay blocks.
- Keep a forced named `tool_choice` when a same-name function fallback survives; remove it when the retained tool list no longer contains that choice.
- Accumulate streamed input only for Anthropic's confirmed `server_tool_use` and beta `mcp_tool_use` blocks, including interrupted/error finalization. Unknown and result-shaped provider-native payloads remain verbatim.
- Gate the coding-agent builtin by the actual model endpoint, preserve the function-tool `web_search` fallback, remove orphaned native choices, and skip the native-search prompt section when unsupported.
- Accept `compat.supportsWebSearch` through `models.json` configuration.

## Behavior change

Custom or compatible `anthropic-messages` endpoints no longer receive native Anthropic web search by default, regardless of provider id. Endpoints that support native search and replay can opt in with:

```json
{ "compat": { "supportsWebSearch": true } }
```

## Validation

- AI focused tests: 20 passed.
- Coding-agent focused tests: 52 passed.
- Root `npm run check`: passed.
- Senpi QA Anthropic mock loop: 3/3 passed, localhost only, real auth unchanged.
- Independent code-quality re-review: approved with no merge blockers.
- Independent security review: no critical/high blockers.

QA receipts are stored under ignored `local-ignore/qa-evidence/` and are not part of the commit.
