### PR TITLE
merge: sync upstream Kimi K3 pricing

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Kimi K3 pricing metadata for Moonshot AI and Moonshot AI China.
 - Fixed Kimi Coding K3 thinking-level metadata to expose only the supported `max` level ([#6737](https://github.com/earendil-works/pi/issues/6737)).
 - Fixed catalog generation restoring xAI models removed in 0.80.9 ([#6736](https://github.com/earendil-works/pi/issues/6736)).
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -235,6 +235,12 @@ const KIMI_K3_THINKING_LEVEL_MAP = {
 	max: "max",
 } as const;
 const KIMI_K3_MAX_TOKENS = 131072;
+const KIMI_K3_COST = {
+	input: 3,
+	output: 15,
+	cacheRead: 0.3,
+	cacheWrite: 0,
+} as const;
 const OPENROUTER_KIMI_K3_MODEL_IDS = new Set(["moonshotai/kimi-k3", "~moonshotai/kimi-latest"]);
 
 const ANT_LING_RING_THINKING_LEVEL_MAP = {
@@ -1701,10 +1707,10 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					...(isKimiK3 ? { thinkingLevelMap: KIMI_K3_THINKING_LEVEL_MAP } : {}),
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
+						input: m.cost?.input || (isKimiK3 ? KIMI_K3_COST.input : 0),
+						output: m.cost?.output || (isKimiK3 ? KIMI_K3_COST.output : 0),
+						cacheRead: m.cost?.cache_read || (isKimiK3 ? KIMI_K3_COST.cacheRead : 0),
+						cacheWrite: m.cost?.cache_write || (isKimiK3 ? KIMI_K3_COST.cacheWrite : 0),
 					},
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,

--- a/packages/ai/src/providers/moonshotai-cn.models.ts
+++ b/packages/ai/src/providers/moonshotai-cn.models.ts
@@ -179,9 +179,9 @@ export const MOONSHOTAI_CN_MODELS = {
 		thinkingLevelMap: {"off":null,"minimal":null,"low":null,"medium":null,"high":null,"xhigh":null,"max":"max"},
 		input: ["text", "image"],
 		cost: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
+			input: 3,
+			output: 15,
+			cacheRead: 0.3,
 			cacheWrite: 0,
 		},
 		contextWindow: 1048576,

--- a/packages/ai/src/providers/moonshotai.models.ts
+++ b/packages/ai/src/providers/moonshotai.models.ts
@@ -179,9 +179,9 @@ export const MOONSHOTAI_MODELS = {
 		thinkingLevelMap: {"off":null,"minimal":null,"low":null,"medium":null,"high":null,"xhigh":null,"max":"max"},
 		input: ["text", "image"],
 		cost: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
+			input: 3,
+			output: 15,
+			cacheRead: 0.3,
 			cacheWrite: 0,
 		},
 		contextWindow: 1048576,

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -44,6 +44,18 @@ describe("builtin providers", () => {
 		}
 	});
 
+	it("uses official Kimi K3 pricing for Moonshot providers", () => {
+		const models = builtinModels();
+		for (const provider of ["moonshotai", "moonshotai-cn"]) {
+			expect(models.getModel(provider, "kimi-k3")?.cost).toEqual({
+				input: 3,
+				output: 15,
+				cacheRead: 0.3,
+				cacheWrite: 0,
+			});
+		}
+	});
+
 	it("resolves anthropic auth from env with OAuth token precedence", async () => {
 		const models = createModels({
 			authContext: fakeAuthContext({ ANTHROPIC_API_KEY: "key", ANTHROPIC_OAUTH_TOKEN: "oauth-token" }),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed inherited Kimi K3 pricing metadata for Moonshot AI and Moonshot AI China.
 - Fixed inherited catalog generation restoring xAI models removed in 0.80.9 ([#6736](https://github.com/earendil-works/pi/issues/6736)).
 
 ## [0.80.9] - 2026-07-16


### PR DESCRIPTION
## Summary

- merge the latest `badlogic/pi-mono` default branch, `upstream/main@aba324504c914aa8920b159a6791ee1567e992e5`, with a history-preserving merge commit
- correct Kimi K3 pricing metadata for Moonshot AI and Moonshot AI China
- keep model generation and provider tests aligned with the corrected metadata

## Merge notes

- no conflicts; both Senpi CalVer changelogs merged automatically with the upstream entries under `Unreleased`
- merge commit parents are `origin/main@cde69b56baea10e5c5b96ee45fe4ff61db2661f9` and `upstream/main@aba324504c914aa8920b159a6791ee1567e992e5`

## Validation

- focused provider test: 16 passed
- `npm run check`
- `npm run build`
- `CI=1 npm test`
  - AI: 883 passed, 736 credential-gated skipped
  - coding-agent: 3,615 passed, 31 skipped
  - codemode: 350 passed, 6 skipped
  - all remaining workspace suites passed
- real-CLI QA: RPC 4/4, mock loop 5/5 across all wire formats, CLI smoke 7/7
- `git merge-base --is-ancestor upstream/main HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced upstream and fixed Kimi K3 pricing metadata for Moonshot providers. Updated the model generator to enforce official costs and added tests to lock pricing.

- **Bug Fixes**
  - Set `kimi-k3` costs for `moonshotai` and `moonshotai-cn`: input 3, output 15, cacheRead 0.3, cacheWrite 0.
  - `packages/ai/scripts/generate-models.ts` injects Kimi K3 costs when missing in upstream data.
  - Added provider tests to assert pricing; updated changelogs in `packages/ai` and `packages/coding-agent`.

<sup>Written for commit bcfd845036de32d3e953d9c212305049640003ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

