### PR TITLE
feat(coding-agent): add kimi-k3 prompt preset

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -84,7 +84,7 @@ Permission rules are a confirmation policy, not a sandbox. Senpi, extensions, pa
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
-| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, `"gpt-5.5"`, or `"gpt-5.6"` |
+| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"kimi-k3"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, `"gpt-5.5"`, or `"gpt-5.6"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/prompt-preset
 
-Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
+Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
 
 ## FILES
 
@@ -24,6 +24,7 @@ prompt-preset/
 ├── glm-5-2.ts           # GLM 5.2 preset
 ├── kimi-k2-6.ts         # Kimi K2.6 preset
 ├── kimi-k2-7.ts         # Kimi K2.7 preset
+├── kimi-k3.ts           # Kimi K3 preset — K2-family loop discipline + Opus 4.8/Fable 5 distillation traits
 └── changes.md           # Fork tracker (model-family rename 2026-04-30, file-operations 2026-05-07)
 ```
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -11,6 +11,24 @@ Per-model prompt preset extension. Selects a tuned system prompt based on the ac
 - `claude-opus-4-{5,6,7}.ts` / `kimi-k2-{6,7}.ts` - Other family presets.
 - `file-operations.ts` - Shared codex-style "File operations" tuning block consumed by every GPT-5.x preset.
 
+## Kimi K3 preset (2026-07-17)
+
+### What changed
+- `kimi-k3.ts`: new preset for the Kimi K3 family. K3 is distilled from Claude Opus 4.8 and Claude Fable 5 on top of the K2-line, so the tuning blends the three: K2 Thinking-class loop discipline (commit to one path, act directly on mechanical work, deep reasoning only where correctness is at risk — per the K2.6/K2.7 presets), Opus 4.8 traits (scope literalism with explicit scope statement; prefer tool calls over reasoning past a lookup-able fact), and Fable 5 traits (act when you have enough information; recommendation-not-survey; audit progress claims against tool results; no text-only promise endings — do the work; outcome-first final summaries in complete sentences; no context-limit wrap-up).
+- `presets.ts`: `hasKimiK3Signal` matches `kimi-k3` boundaries plus the bare `k3` id (the `kimi-coding` provider's catalog id); checked via id or display name, ordered before the K2.7/K2.6 checks. Dispatch case added.
+- `settings.ts`: `"kimi-k3"` joins `PromptPresetName` and `VALID_PRESETS`.
+- `docs/settings.md`, `AGENTS.md`: preset lists updated.
+- `test/suite/prompt-presets-kimi-k3.test.ts`: resolution across kimi-coding/moonshotai/moonshotai-cn/openrouter/vercel-ai-gateway/opencode-go ids (incl. `:thinking` tag and display-name matching), non-routing of K2.x/`kimi-for-coding`/`kimi-latest`/`grok-3`, K2.x/K3 tuning isolation, settings + model-metadata override, catalog sweep.
+
+### Why
+- Kimi K3 shipped in the model catalogs (packages/ai) without a preset, so it fell back to the untuned dynamic prompt. Its lineage (K2 base, Opus 4.8 + Fable 5 distillation) means the documented behavioral quirks of all three families apply, and each tuning line addresses a quirk documented in the respective prompting guide.
+
+### Why extension system couldn't handle this differently
+- Content-only addition inside this builtin; follows the thin-wrapper preset architecture (tuningSection only).
+
+### Expected merge conflict zones on next upstream sync
+- LOW: `kimi-k3.ts` is fork-only; `presets.ts`/`settings.ts` touch shared lists — trivial adjacent-line conflicts if upstream adds presets.
+
 ## GPT-5.6 omo-parity refinements (2026-07-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
@@ -1,0 +1,17 @@
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+
+function buildKimiK3Tuning(): string {
+	return `You are running on Kimi K3 - decisive and evidence-first. When you have enough information to act, act: decide one path, execute it, and reopen it only when new evidence contradicts it. Act directly on mechanical or already-specified work; save deep reasoning for where correctness is genuinely at risk - ambiguity, failure, irreversible operations. When weighing a choice for the user, give a recommendation, not a survey.
+
+Prefer a tool call over reasoning when a tool can resolve the question directly; do not reason past a fact you can look up, and do not re-derive facts already established in the conversation. Apply instructions at the scope the user evidently intends: "every", "all", and "each" mean the full set rather than the first item, and a fix that plainly recurs covers every occurrence. State the scope you applied.
+
+Before reporting progress, audit each claim against a tool result from this session. Only report work you can point to evidence for; if something is not yet verified, say so explicitly, and if tests fail, say so with the output. Before ending your turn, check your last paragraph: if it is a plan, a question, or a promise about work you have not done, do that work now with tool calls.
+
+The intent gate routing line is required every turn. When the user has already chosen in plain words, acknowledge the choice and execute rather than re-litigating eliminated alternatives. Terse shorthand between tool calls is fine; your final summary is for a reader who did not see it - lead with the outcome in complete sentences, then supporting detail.
+
+Do not stop, summarize, or suggest a new session on account of context limits; the harness auto-compacts context. Keep working until the task is complete.`;
+}
+
+export function buildKimiK3Prompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK3Tuning() });
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -14,6 +14,7 @@ import { buildGpt56Prompt } from "./gpt-5.6.ts";
 import { buildGpt5Prompt } from "./gpt-5.ts";
 import { buildKimiK26Prompt } from "./kimi-k2-6.ts";
 import { buildKimiK27Prompt } from "./kimi-k2-7.ts";
+import { buildKimiK3Prompt } from "./kimi-k3.ts";
 import { type PromptPresetName, type PromptPresetSettings, parsePromptPreset } from "./settings.ts";
 
 export type { PromptPresetSettings } from "./settings.ts";
@@ -71,6 +72,15 @@ function isKimiK27Model(model: ModelWithPromptPresetMetadata): boolean {
 	return hasKimiK27Signal(model.id) || (model.name !== undefined && hasKimiK27Signal(model.name));
 }
 
+function hasKimiK3Signal(value: string): boolean {
+	const normalized = normalizeModelId(value);
+	return normalized === "k3" || /(?:^|[/@._-])kimi-k3(?:$|[/@._:-])/.test(normalized);
+}
+
+function isKimiK3Model(model: ModelWithPromptPresetMetadata): boolean {
+	return hasKimiK3Signal(model.id) || (model.name !== undefined && hasKimiK3Signal(model.name));
+}
+
 function hasGlm52Signal(value: string): boolean {
 	return /(?:^|[/@._-])glm(?:[._-]|p)5(?:[._-]|p)2(?:$|[/@._:-])/.test(normalizeModelId(value));
 }
@@ -119,6 +129,9 @@ export function resolvePresetName(
 	if (gpt5Version) {
 		return gpt5Version;
 	}
+	if (isKimiK3Model(model)) {
+		return "kimi-k3";
+	}
 	if (isKimiK27Model(model)) {
 		return "kimi-k2-7";
 	}
@@ -154,6 +167,8 @@ function buildPreset(name: ResolvedPresetName, options: BuildDynamicSystemPrompt
 			return { name, prompt: buildGpt5Prompt(options) };
 		case "glm-5.2":
 			return { name, prompt: buildGlm52Prompt(options) };
+		case "kimi-k3":
+			return { name, prompt: buildKimiK3Prompt(options) };
 		case "kimi-k2-7":
 			return { name, prompt: buildKimiK27Prompt(options) };
 		case "kimi-k2-6":

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
@@ -8,6 +8,7 @@ export type PromptPresetName =
 	| "claude-opus-4-6"
 	| "claude-opus-4-5"
 	| "glm-5.2"
+	| "kimi-k3"
 	| "kimi-k2-7"
 	| "kimi-k2-6"
 	| "gpt-5"
@@ -31,6 +32,7 @@ const VALID_PRESETS: ReadonlySet<string> = new Set<PromptPresetName>([
 	"claude-opus-4-6",
 	"claude-opus-4-5",
 	"glm-5.2",
+	"kimi-k3",
 	"kimi-k2-7",
 	"kimi-k2-6",
 	"gpt-5",

--- a/packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts
@@ -1,0 +1,162 @@
+import { type Api, getModels, getProviders, type Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	type PromptPresetSettings,
+	resolvePreset,
+	resolvePresetName,
+} from "../../src/core/extensions/builtin/prompt-preset/presets.ts";
+
+function createModel(id: string, provider: string, api: Api = "openai-responses"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api,
+		provider,
+		baseUrl: "https://example.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+	};
+}
+
+function hasKimiK3CatalogSignal(model: Model<Api>): boolean {
+	const searchable = `${model.id} ${model.name}`.toLowerCase().replace(/\s+/g, "-");
+	return /(?:^|[/@._-])kimi-k3(?:$|[/@._:-])/.test(searchable);
+}
+
+function getKimiK3CatalogModels(): Model<Api>[] {
+	return getProviders().flatMap((provider) => (getModels(provider) as Model<Api>[]).filter(hasKimiK3CatalogSignal));
+}
+
+describe("Kimi K3 prompt preset", () => {
+	it.each([
+		{ id: "k3", provider: "kimi-coding", api: "anthropic-messages" as const },
+		{ id: "kimi-k3", provider: "moonshotai", api: "anthropic-messages" as const },
+		{ id: "kimi-k3", provider: "moonshotai-cn", api: "anthropic-messages" as const },
+		{ id: "moonshotai/kimi-k3", provider: "openrouter", api: "openai-responses" as const },
+		{ id: "moonshotai/kimi-k3:thinking", provider: "openrouter", api: "openai-responses" as const },
+		{ id: "Kimi K3", provider: "custom", api: "openai-responses" as const },
+	])("resolves $provider/$id to the kimi-k3 preset", ({ id, provider, api }) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(id, provider, api);
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("kimi-k3");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt).toContain("## Intent Gate");
+		expect(preset?.prompt).toContain("running on Kimi K3");
+		expect(preset?.prompt).toContain("audit each claim against a tool result");
+		expect(preset?.prompt).toContain("a recommendation, not a survey");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it.each([
+		"kimi-k2.6-0528",
+		"kimi-k2.7-code",
+		"kimi-for-coding",
+		"kimi-latest",
+		"grok-3",
+		"deepseek-r1-k3b",
+	])("does not route %s to the kimi-k3 preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "moonshot");
+
+		// when
+		const presetName = resolvePresetName(model, settings);
+
+		// then
+		expect(presetName).not.toBe("kimi-k3");
+	});
+
+	it("keeps Kimi K3 distinct from the K2.6 and K2.7 presets", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+
+		// when
+		const k3 = resolvePreset(createModel("kimi-k3", "moonshotai", "anthropic-messages"), settings);
+		const k26 = resolvePreset(createModel("kimi-k2.6-0528", "moonshot"), settings);
+		const k27 = resolvePreset(createModel("kimi-k2.7-0711", "moonshot"), settings);
+
+		// then
+		expect(k3?.name).toBe("kimi-k3");
+		expect(k3?.prompt).not.toContain("running on Kimi K2.7");
+		expect(k3?.prompt).not.toContain("filler verification language");
+		expect(k26?.name).toBe("kimi-k2-6");
+		expect(k26?.prompt).not.toContain("running on Kimi K3");
+		expect(k27?.name).toBe("kimi-k2-7");
+		expect(k27?.prompt).not.toContain("running on Kimi K3");
+	});
+
+	it("allows settings.json to force kimi-k3 regardless of model id", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "kimi-k3" };
+		const model = createModel("some-random-model", "custom");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("kimi-k3");
+		expect(preset?.prompt).toContain("running on Kimi K3");
+	});
+
+	it("respects model-level promptPreset metadata naming kimi-k3", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = {
+			...createModel("provider-specific-k3-alias", "custom"),
+			promptPreset: "kimi-k3",
+		};
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("kimi-k3");
+	});
+
+	it("does not include GPT tuning in the kimi-k3 preset", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel("kimi-k3", "moonshotai", "anthropic-messages");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("kimi-k3");
+		expect(preset?.prompt).not.toContain("apply_patch");
+	});
+
+	it("returns kimi-k3 preset for every Kimi K3 built-in catalog model", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const catalogModels = getKimiK3CatalogModels();
+		const catalogModelIds = catalogModels.map((model) => `${model.provider}/${model.id}`);
+
+		// when
+		const misses = catalogModels
+			.filter((model) => resolvePresetName(model, settings) !== "kimi-k3")
+			.map((model) => `${model.provider}/${model.id}`);
+
+		// then
+		expect(catalogModelIds).toEqual(
+			expect.arrayContaining([
+				"kimi-coding/k3",
+				"moonshotai/kimi-k3",
+				"moonshotai-cn/kimi-k3",
+				"openrouter/moonshotai/kimi-k3",
+				"vercel-ai-gateway/moonshotai/kimi-k3",
+				"opencode-go/kimi-k3",
+			]),
+		);
+		expect(misses).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

Adds a `kimi-k3` system prompt preset. Kimi K3 already ships in the model catalogs (`packages/ai`: kimi-coding `k3`, moonshotai / moonshotai-cn / openrouter / vercel-ai-gateway / opencode-go `kimi-k3`) but had no preset, so it fell back to the untuned dynamic prompt.

## Why this tuning

K3 is distilled from Claude Opus 4.8 and Claude Fable 5 on top of the K2 line, so the preset blends the documented behavioral quirks of all three families (per the prompting guides for each), sitting between Opus 4.8 and the K2.x presets:

| Trait | Source family | Line in tuning |
|---|---|---|
| Commit to one path, act directly on mechanical work, deep reasoning only where correctness is at risk | K2 Thinking-class (K2.6/K2.7 presets) | para 1 |
| Recommendation, not a survey | Fable 5 (anti-overplanning) | para 1 |
| Prefer tool calls over reasoning past a lookup-able fact; don't re-derive established facts | Opus 4.8 (reasoning-over-tools bias) | para 2 |
| Scope literalism: "every/all/each" = full set; state the scope applied | Opus 4.8 (literal instruction following) | para 2 |
| Audit progress claims against tool results; failing tests reported with output | Fable 5 (grounded progress claims) | para 3 |
| No text-only promise endings — do the work now | Fable 5 (early-stopping) | para 3 |
| Intent gate every turn; acknowledge-and-execute on confirmations; outcome-first final summary in complete sentences | K2.x presets + Fable 5 readability | para 4 |
| No context-limit wrap-up (harness auto-compacts) | Opus 4.8 + Fable 5 | para 5 |

Thin-wrapper architecture preserved: `tuningSection` only, no core duplication, no GPT-only `file-operations` block.

## Matching

`hasKimiK3Signal` matches `kimi-k3` at id-token boundaries (incl. `:thinking` tags) **plus** the bare `k3` id (the `kimi-coding` catalog id), via model id or display name — same shape as the K2.6/K2.7 matchers. Ordered before the K2 checks in `resolvePresetName`. `"kimi-k3"` joins `PromptPresetName`/`VALID_PRESETS` and `docs/settings.md`.

## QA (evidence: `local-ignore/qa-evidence/20260717-kimi-k3-preset/`)

- `npx vitest run test/suite/prompt-presets-*.test.ts` — 6 files, **99 tests passed** (new `prompt-presets-kimi-k3.test.ts`: resolution across all six catalog providers, `:thinking` tag, display-name matching, non-routing of K2.x / `kimi-for-coding` / `kimi-latest` / `grok-3`, K2↔K3 tuning isolation, settings + model-metadata override, full catalog sweep).
- `npm run check` — full workspace pass.
- **Wire-level QA (real CLI, senpi-qa Channel-3 style)** — 10/10: a real `--print` turn on model id `kimi-k3` against a local fake server sends a system prompt containing the K3 tuning (`running on Kimi K3`, scope literalism, evidence audit, commitment framing) while a control model id does not; `auth.json` sha unchanged.
- Harness self-tests: `common.mjs --self-check` 9/9, `cli-smoke` 7/7, `mock-loop --self-test` 5/5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `kimi-k3` system prompt preset so Kimi K3 models get a tuned system prompt instead of the generic dynamic prompt. This improves tool use, scope handling, and progress reporting for `k3` across providers.

- **New Features**
  - New preset (`kimi-k3.ts`) with K3-specific tuning: commit to one path and act; prefer tool calls over re-deriving facts; scope literalism (“every/all/each” = full set); evidence-audited progress; no plan-only endings; intent gate every turn; outcome-first summaries; no context-limit wrap-up.
  - Routing updates: match `kimi-k3` by id or display name (incl. `:thinking`) and the bare `k3` id; resolved before K2 checks. Added to `PromptPresetName`/`VALID_PRESETS`; docs updated in `docs/settings.md` and `AGENTS.md`.
  - Tests: new `prompt-presets-kimi-k3.test.ts` verifies resolution across catalogs, non-routing of K2.x/other models, forced settings and metadata overrides.

<sup>Written for commit 4a093d3a05cc65ea2a169a5fd48474a23e4613e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

