### PR TITLE
fix(goal): tick the Pursuing goal footer elapsed time live

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -20,6 +20,7 @@ goal/
 ├── format.ts         # Tool/UI formatting + goalToolResponse snapshot
 ├── command.ts        # parseGoalCommand (show|pause|resume|clear|setObjective)
 ├── ui.ts             # ctx.ui.setStatus footer segment for the active goal
+├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
 ├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
 └── changes.md        # Fork tracker (port + budget removal)
 ```
@@ -54,6 +55,7 @@ Do not return an `isError` property; it is ignored.
 | Adjust status transitions / persistence | `store.ts` |
 | Tune the continuation prompt | `prompt.ts` |
 | Change the footer status text | `ui.ts` |
+| Change the live footer elapsed ticker | `elapsed-ticker.ts` (+ `refreshGoalUi` in `index.ts`) |
 | `/goal` argument parsing | `command.ts` |
 
 ## CONVENTIONS
@@ -65,10 +67,15 @@ Do not return an `isError` property; it is ignored.
   is `active`, idle, and there are no pending messages.
 - **Usage accounting is display-only**: `accountGoalUsage` increments
   `tokensUsed`/`timeUsedSeconds`; it never changes status.
+- **Live footer is ticker-driven**: `refreshGoalUi` (index.ts) drives
+  `GoalElapsedTicker` to refresh `Pursuing goal (…)` once per second while a goal
+  is `active` and its accounting window is open, so the footer advances live
+  instead of freezing between `agent_end` accounting checkpoints. The ticker only
+  runs when `ctx.hasUI` and is stopped on pause/complete/clear and session shutdown.
 
 ## NOTES
 
 - Tests: `test/suite/goal-store.test.ts`, `goal-modules.test.ts`,
-  `goal-extension.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
+  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
 - Registered last in `builtin/index.ts` `builtinExtensions`; inert until a goal
   is created.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -5,6 +5,32 @@ Persistent per-thread goal tracking as an in-tree builtin. Ports the standalone
 `pi-goal` extension into senpi with no dependency on it, file-based persistence,
 codex-aligned tool naming, and the budget concept removed.
 
+## Live elapsed footer ticker (2026-07-17)
+
+### What changed
+- New `elapsed-ticker.ts`: `GoalElapsedTicker` drives a once-per-second footer refresh, plus the pure
+  `goalLiveElapsedSeconds(goal, measuredFromMs, nowMs)` helper (committed `timeUsedSeconds` + whole seconds since
+  the current measurement window opened, mirroring `accountCurrentAgentTurn`'s rounding).
+- `ui.ts`: `goalStatusText`/`updateGoalUi` accept an optional `liveElapsedSeconds`; when present, an active goal
+  renders `Pursuing goal (…)` from the live value (including `0s`) instead of the frozen `timeUsedSeconds`.
+- `index.ts`: added `refreshGoalUi` — while `ctx.hasUI` and the goal is `active` with a matching open accounting
+  window, it syncs the ticker (live refresh); otherwise it stops the ticker and falls back to a static
+  `updateGoalUi`. The ticker is stopped on pause/complete/clear and `session_shutdown`. `refreshGoalUi` is injected
+  into `command-registration.ts` and `tool-registration.ts`, replacing their direct `updateGoalUi` calls.
+
+### Why
+- The footer showed a stale `Pursuing goal (…)` (or no time at all on a fresh goal) because `timeUsedSeconds` only
+  advances at `agent_end`/`session_shutdown`/`/goal` checkpoints and the footer was only re-set at those same
+  points. Users pursuing a goal saw the elapsed time freeze instead of ticking live.
+
+### Why extension system couldn't handle this differently
+- `setStatus` is fire-and-forget with no scheduler; the per-second refresh must be owned by the builtin. It is
+  implemented entirely via the public `pi.*` API + `ctx.ui.setStatus`; no core change.
+
+### Expected merge conflict zones on next upstream sync
+- LOW in `ui.ts`/`index.ts` if standalone `pi-goal` restyles the footer or refactors UI wiring.
+- The standalone `pi-goal` package needs the same ticker on its next sync (it shares this `ui.ts`/`format.ts` shape).
+
 ## Atomic goal store and narrow stale-brace recovery (2026-07-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/command-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/command-registration.ts
@@ -3,7 +3,6 @@ import { parseGoalCommand } from "./command.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { clearGoal, createGoal, readGoal, updateGoal } from "./store.ts";
 import type { Goal, GoalAccountingMode, GoalStoreRef, TokenUsageSnapshot } from "./types.ts";
-import { updateGoalUi } from "./ui.ts";
 
 const GOAL_USAGE = "Usage: /goal <objective>";
 const GOAL_EMPTY_HINT = "No goal is currently set.";
@@ -22,6 +21,7 @@ export type GoalCommandRegistrationDeps = {
 	readonly stopAgentGoalAccounting: (goalId: string) => void;
 	readonly clearAgentGoalAccounting: () => void;
 	readonly queueGoalContinuation: (pi: ExtensionAPI, ctx: ExtensionContext, goal: Goal) => void;
+	readonly refreshGoalUi: (ctx: ExtensionContext, goal: Goal | null) => void;
 };
 
 export function registerGoalCommand(pi: ExtensionAPI, deps: GoalCommandRegistrationDeps): void {
@@ -33,7 +33,7 @@ export function registerGoalCommand(pi: ExtensionAPI, deps: GoalCommandRegistrat
 				switch (command.kind) {
 					case "show": {
 						const goal = await readGoal(deps.goalStoreRef(ctx));
-						updateGoalUi(ctx, goal);
+						deps.refreshGoalUi(ctx, goal);
 						ctx.ui.notify(
 							goal === null ? `${GOAL_USAGE}\n${GOAL_EMPTY_HINT}` : formatGoalForTool(goal),
 							goal ? "info" : "warning",
@@ -54,7 +54,7 @@ export function registerGoalCommand(pi: ExtensionAPI, deps: GoalCommandRegistrat
 						} else {
 							deps.stopAgentGoalAccounting(goal.id);
 						}
-						updateGoalUi(ctx, goal);
+						deps.refreshGoalUi(ctx, goal);
 						ctx.ui.notify(`Goal ${goalStatusLabel(goal.status)}\n${formatGoalForTool(goal)}`, "info");
 						deps.queueGoalContinuation(pi, ctx, goal);
 						return;
@@ -63,7 +63,7 @@ export function registerGoalCommand(pi: ExtensionAPI, deps: GoalCommandRegistrat
 						await deps.accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
 						const cleared = await clearGoal(deps.goalStoreRef(ctx));
 						deps.clearAgentGoalAccounting();
-						updateGoalUi(ctx, null);
+						deps.refreshGoalUi(ctx, null);
 						ctx.ui.notify(
 							cleared ? "Goal cleared" : "No goal to clear\nThis thread does not currently have a goal.",
 							cleared ? "info" : "warning",
@@ -96,7 +96,7 @@ async function setGoalObjective(
 	}
 	const goal = current === null ? await createGoal(ref, objective) : await updateGoal(ref, { objective });
 	if (goal.status === "active") deps.beginAgentGoalAccounting(goal);
-	updateGoalUi(ctx, goal);
+	deps.refreshGoalUi(ctx, goal);
 	ctx.ui.notify(`Goal ${goalStatusLabel(goal.status)}\n${formatGoalForTool(goal)}`, "info");
 	deps.queueGoalContinuation(pi, ctx, goal);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/elapsed-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/elapsed-ticker.ts
@@ -1,0 +1,79 @@
+import type { ExtensionContext } from "../../types.ts";
+import type { Goal } from "./types.ts";
+
+/** Footer live-elapsed refresh cadence while a goal is actively pursued. */
+export const GOAL_ELAPSED_TICK_INTERVAL_MS = 1000;
+
+/** Renders the goal footer segment for the current live elapsed second count. */
+export type GoalElapsedRender = (ctx: ExtensionContext, goal: Goal, liveElapsedSeconds: number) => void;
+
+export interface GoalElapsedTickerOptions {
+	readonly render: GoalElapsedRender;
+	/** Injectable clock for tests; defaults to Date.now. */
+	readonly now?: () => number;
+}
+
+/**
+ * Live elapsed seconds for an actively pursued goal: the committed
+ * `timeUsedSeconds` plus whole seconds since the current measurement window
+ * opened. Mirrors the rounding in `accountCurrentAgentTurn` so the footer never
+ * disagrees with what the next turn commits.
+ */
+export function goalLiveElapsedSeconds(goal: Goal, measuredFromMilliseconds: number, nowMilliseconds: number): number {
+	const elapsedSeconds = Math.max(0, Math.round((nowMilliseconds - measuredFromMilliseconds) / 1000));
+	return goal.timeUsedSeconds + elapsedSeconds;
+}
+
+/**
+ * Drives a once-per-second footer refresh while a goal is active so the
+ * "Pursuing goal (…)" elapsed time advances live instead of freezing between
+ * usage-accounting checkpoints. The interval is unref'd so it never keeps the
+ * process alive.
+ */
+export class GoalElapsedTicker {
+	private readonly render: GoalElapsedRender;
+	private readonly now: () => number;
+	private intervalId: NodeJS.Timeout | undefined;
+	private ctx: ExtensionContext | undefined;
+	private goal: Goal | undefined;
+	private measuredFromMilliseconds = 0;
+
+	constructor(options: GoalElapsedTickerOptions) {
+		this.render = options.render;
+		this.now = options.now ?? Date.now;
+	}
+
+	get running(): boolean {
+		return this.intervalId !== undefined;
+	}
+
+	/**
+	 * Point the ticker at the current goal and measurement window, render once
+	 * immediately, and start the interval if it is not already running.
+	 */
+	sync(ctx: ExtensionContext, goal: Goal, measuredFromMilliseconds: number): void {
+		this.ctx = ctx;
+		this.goal = goal;
+		this.measuredFromMilliseconds = measuredFromMilliseconds;
+		this.tick();
+		if (this.intervalId !== undefined) return;
+		const handle = setInterval(() => this.tick(), GOAL_ELAPSED_TICK_INTERVAL_MS);
+		handle.unref();
+		this.intervalId = handle;
+	}
+
+	/** Stop the interval and drop the retained context/goal snapshot. */
+	stop(): void {
+		if (this.intervalId !== undefined) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+		this.ctx = undefined;
+		this.goal = undefined;
+	}
+
+	private tick(): void {
+		if (this.ctx === undefined || this.goal === undefined) return;
+		this.render(this.ctx, this.goal, goalLiveElapsedSeconds(this.goal, this.measuredFromMilliseconds, this.now()));
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -4,6 +4,7 @@ import { getAgentDir } from "../../../../config.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { registerGoalCommand } from "./command-registration.ts";
 import { shouldQueueGoalContinuationAfterAgentEnd, shouldQueueGoalContinuationWhenIdle } from "./continuation.ts";
+import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { buildContinuationPrompt } from "./prompt.ts";
 import { accountGoalUsage, readGoal, updateGoal } from "./store.ts";
@@ -32,11 +33,23 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let agentGoalAccounting: AgentGoalAccounting | null = null;
 	let completedThisTurnGoalId: string | null = null;
 
+	const goalTicker = new GoalElapsedTicker({
+		render: (renderCtx, renderGoal, live) => {
+			try {
+				updateGoalUi(renderCtx, renderGoal, live);
+			} catch (error) {
+				if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) return;
+				throw error;
+			}
+		},
+	});
+
 	registerGoalTools(pi, {
 		goalStoreRef,
 		accountCurrentAgentTurn,
 		beginAgentGoalAccounting,
 		markGoalCompletedThisTurn,
+		refreshGoalUi,
 	});
 	registerGoalCommand(pi, {
 		goalStoreRef,
@@ -45,6 +58,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		stopAgentGoalAccounting,
 		clearAgentGoalAccounting,
 		queueGoalContinuation,
+		refreshGoalUi,
 	});
 
 	pi.on("session_start", async (event, ctx) => {
@@ -54,7 +68,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		} else {
 			clearAgentGoalAccounting();
 		}
-		updateGoalUi(ctx, goal);
+		refreshGoalUi(ctx, goal);
 		if (await maybePromptResumePausedGoal(pi, ctx, event.reason, goal)) {
 			return;
 		}
@@ -84,7 +98,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		} else {
 			clearAgentGoalAccounting();
 		}
-		updateGoalUiBestEffort(ctx, goal);
+		refreshGoalUiBestEffort(ctx, goal);
 		if (
 			goal?.status === "active" &&
 			!ctx.signal?.aborted &&
@@ -99,6 +113,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			await accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
 		}
 		clearAgentGoalAccounting();
+		goalTicker.stop();
 	});
 
 	async function maybePromptResumePausedGoal(
@@ -119,7 +134,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 
 		const resumed = await updateGoal(goalStoreRef(ctx), { status: "active" });
 		beginAgentGoalAccounting(resumed);
-		updateGoalUi(ctx, resumed);
+		refreshGoalUi(ctx, resumed);
 		ctx.ui.notify(`Goal ${goalStatusLabel(resumed.status)}\n${formatGoalForTool(resumed)}`, "info");
 		queueGoalContinuation(pi, ctx, resumed);
 		return true;
@@ -151,6 +166,27 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		completedThisTurnGoalId = null;
 	}
 
+	function refreshGoalUi(ctx: ExtensionContext, goal: Goal | null): void {
+		const accounting = agentGoalAccounting;
+		if (ctx.hasUI && goal?.status === "active" && accounting?.goalId === goal.id) {
+			goalTicker.sync(ctx, goal, accounting.measuredFromMilliseconds);
+			return;
+		}
+		goalTicker.stop();
+		updateGoalUi(ctx, goal);
+	}
+
+	function refreshGoalUiBestEffort(ctx: ExtensionContext, goal: Goal | null): void {
+		try {
+			refreshGoalUi(ctx, goal);
+		} catch (error) {
+			if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) {
+				return;
+			}
+			throw error;
+		}
+	}
+
 	async function accountCurrentAgentTurn(
 		ctx: ExtensionContext,
 		usage: TokenUsageSnapshot,
@@ -169,17 +205,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			clearAgentGoalAccounting();
 		}
 		return goal;
-	}
-}
-
-function updateGoalUiBestEffort(ctx: ExtensionContext, goal: Goal | null): void {
-	try {
-		updateGoalUi(ctx, goal);
-	} catch (error) {
-		if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) {
-			return;
-		}
-		throw error;
 	}
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
@@ -4,7 +4,6 @@ import { formatGoalToolResponse } from "./format.ts";
 import { createGoal, readGoal, updateGoal } from "./store.ts";
 import type { Goal, GoalAccountingMode, GoalStoreRef, TokenUsageSnapshot } from "./types.ts";
 import { COMPLETABLE_GOAL_STATUS_VALUES } from "./types.ts";
-import { updateGoalUi } from "./ui.ts";
 
 const EMPTY_USAGE: TokenUsageSnapshot = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
 
@@ -19,6 +18,7 @@ export type GoalToolRegistrationDeps = {
 	) => Promise<Goal | null>;
 	readonly beginAgentGoalAccounting: (goal: Goal) => void;
 	readonly markGoalCompletedThisTurn: (goal: Goal) => void;
+	readonly refreshGoalUi: (ctx: ExtensionContext, goal: Goal | null) => void;
 };
 
 export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDeps): void {
@@ -45,7 +45,7 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 			}
 			const goal = await createGoal(ref, params.objective);
 			deps.beginAgentGoalAccounting(goal);
-			updateGoalUi(ctx, goal);
+			deps.refreshGoalUi(ctx, goal);
 			return toolText(formatGoalToolResponse(goal));
 		},
 	});
@@ -76,7 +76,7 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 			await deps.accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
 			const goal = await updateGoal(deps.goalStoreRef(ctx), { status: "complete" });
 			deps.markGoalCompletedThisTurn(goal);
-			updateGoalUi(ctx, goal);
+			deps.refreshGoalUi(ctx, goal);
 			return toolText(formatGoalToolResponse(goal));
 		},
 	});
@@ -88,7 +88,7 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 		parameters: Type.Object({}, { additionalProperties: false }),
 		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
 			const goal = await readGoal(deps.goalStoreRef(ctx));
-			updateGoalUi(ctx, goal);
+			deps.refreshGoalUi(ctx, goal);
 			return toolText(formatGoalToolResponse(goal));
 		},
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/goal/ui.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/ui.ts
@@ -4,17 +4,21 @@ import type { Goal } from "./types.ts";
 
 export const STATUS_KEY = "goal";
 
-export function updateGoalUi(ctx: ExtensionContext, goal: Goal | null): void {
+export function updateGoalUi(ctx: ExtensionContext, goal: Goal | null, liveElapsedSeconds?: number): void {
 	if (!ctx.hasUI) return;
-	ctx.ui.setStatus(STATUS_KEY, goal === null ? undefined : goalStatusText(goal));
+	ctx.ui.setStatus(STATUS_KEY, goal === null ? undefined : goalStatusText(goal, liveElapsedSeconds));
 }
 
-export function goalStatusText(goal: Goal): string {
+export function goalStatusText(goal: Goal, liveElapsedSeconds?: number): string {
 	switch (goal.status) {
-		case "active":
+		case "active": {
+			if (liveElapsedSeconds !== undefined) {
+				return `Pursuing goal (${formatGoalElapsedSeconds(liveElapsedSeconds)})`;
+			}
 			return goal.timeUsedSeconds > 0
 				? `Pursuing goal (${formatGoalElapsedSeconds(goal.timeUsedSeconds)})`
 				: "Pursuing goal";
+		}
 		case "paused":
 			return "Goal paused (/goal resume)";
 		case "complete":

--- a/packages/coding-agent/test/suite/goal-elapsed-ticker.test.ts
+++ b/packages/coding-agent/test/suite/goal-elapsed-ticker.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	GOAL_ELAPSED_TICK_INTERVAL_MS,
+	GoalElapsedTicker,
+	goalLiveElapsedSeconds,
+} from "../../src/core/extensions/builtin/goal/elapsed-ticker.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+	return {
+		id: "goal-1",
+		threadId: "thread-1",
+		objective: "Ship the feature",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+		...overrides,
+	};
+}
+
+const fakeCtx = { hasUI: true } as unknown as ExtensionContext;
+
+describe("goalLiveElapsedSeconds", () => {
+	it("adds whole seconds elapsed since the measurement start to the committed time", () => {
+		const goal = makeGoal({ timeUsedSeconds: 10 });
+		expect(goalLiveElapsedSeconds(goal, 1_000_000, 1_000_000)).toBe(10);
+		expect(goalLiveElapsedSeconds(goal, 1_000_000, 1_000_999)).toBe(11); // rounds 0.999s -> 1s
+		expect(goalLiveElapsedSeconds(goal, 1_000_000, 1_002_400)).toBe(12); // rounds 2.4s -> 2s
+	});
+
+	it("never counts negative elapsed when the clock moves backwards", () => {
+		const goal = makeGoal({ timeUsedSeconds: 7 });
+		expect(goalLiveElapsedSeconds(goal, 5_000, 1_000)).toBe(7);
+	});
+});
+
+describe("GoalElapsedTicker", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("unrefs the interval handle so it never keeps the process alive", () => {
+		const unref = vi.fn();
+		const fakeHandle = { unref, ref: vi.fn(), hasRef: () => true } as unknown as NodeJS.Timeout;
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(fakeHandle);
+		const ticker = new GoalElapsedTicker({ render: () => {}, now: () => 1_000_000 });
+
+		ticker.sync(fakeCtx, makeGoal({ status: "active" }), 1_000_000);
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+		expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), GOAL_ELAPSED_TICK_INTERVAL_MS);
+		expect(unref).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders immediately on sync and once per second afterwards", () => {
+		vi.useFakeTimers();
+		const renders: number[] = [];
+		const ticker = new GoalElapsedTicker({ render: (_ctx, _goal, live) => renders.push(live) });
+		const measuredFrom = Date.now();
+
+		ticker.sync(fakeCtx, makeGoal({ timeUsedSeconds: 10 }), measuredFrom);
+		expect(renders).toEqual([10]);
+
+		vi.advanceTimersByTime(1000);
+		expect(renders).toEqual([10, 11]);
+
+		vi.advanceTimersByTime(2000);
+		expect(renders).toEqual([10, 11, 12, 13]);
+
+		ticker.stop();
+		vi.advanceTimersByTime(5000);
+		expect(renders).toEqual([10, 11, 12, 13]);
+	});
+
+	it("re-syncing the same goal keeps a single interval and refreshes the goal snapshot", () => {
+		vi.useFakeTimers();
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+		const renders: number[] = [];
+		const ticker = new GoalElapsedTicker({ render: (_ctx, _goal, live) => renders.push(live) });
+		const measuredFrom = Date.now();
+
+		ticker.sync(fakeCtx, makeGoal({ timeUsedSeconds: 0 }), measuredFrom);
+		vi.advanceTimersByTime(1000);
+		// A new turn committed 5s and reset the measurement window to "now".
+		ticker.sync(fakeCtx, makeGoal({ timeUsedSeconds: 5 }), Date.now());
+		vi.advanceTimersByTime(1000);
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+		expect(renders).toEqual([0, 1, 5, 6]);
+
+		ticker.stop();
+	});
+
+	it("stop is idempotent and safe before any sync", () => {
+		const ticker = new GoalElapsedTicker({ render: () => {} });
+		expect(ticker.running).toBe(false);
+		expect(() => ticker.stop()).not.toThrow();
+		expect(ticker.running).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -57,6 +57,18 @@ async function makeCtx(threadId = "thread-test"): Promise<ExtensionContext> {
 	} as unknown as ExtensionContext;
 }
 
+async function makeUiCtx(
+	onStatus: (key: string, text: string | undefined) => void,
+	threadId = "thread-ui",
+): Promise<ExtensionContext> {
+	const base = await makeCtx(threadId);
+	return {
+		...base,
+		hasUI: true,
+		ui: { notify: () => {}, select: async () => undefined, setStatus: onStatus },
+	} as unknown as ExtensionContext;
+}
+
 function storeRefFor(ctx: ExtensionContext) {
 	return {
 		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
@@ -185,6 +197,23 @@ describe("goal extension contract (budget-free)", () => {
 		);
 
 		expect(sent).toHaveLength(0);
+	});
+
+	it("renders a live elapsed footer segment while a goal is actively pursued", async () => {
+		const statuses: Array<string | undefined> = [];
+		const { tools, commands } = createGoalHarness();
+		const ctx = await makeUiCtx((key, text) => {
+			if (key === "goal") statuses.push(text);
+		});
+
+		await tools.get("create_goal")?.execute("c1", { objective: "Ship it live" }, undefined, undefined, ctx);
+		// The ticker syncs immediately on the active goal, so the footer already
+		// carries the parenthesized live elapsed time rather than a frozen label.
+		expect(statuses.at(-1)).toBe("Pursuing goal (0s)");
+
+		// Clearing stops the ticker interval and wipes the footer segment.
+		await commands.get("goal")?.handler("clear", ctx);
+		expect(statuses.at(-1)).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -167,6 +167,13 @@ describe("goal status UI", () => {
 		expect(goalStatusText(makeGoal({ status: "complete" }))).toBe("Goal achieved");
 	});
 
+	it("renders live elapsed seconds for an active goal, ignoring it otherwise", () => {
+		expect(goalStatusText(makeGoal({ status: "active", timeUsedSeconds: 0 }), 0)).toBe("Pursuing goal (0s)");
+		expect(goalStatusText(makeGoal({ status: "active", timeUsedSeconds: 5 }), 42)).toBe("Pursuing goal (42s)");
+		expect(goalStatusText(makeGoal({ status: "paused" }), 99)).toBe("Goal paused (/goal resume)");
+		expect(goalStatusText(makeGoal({ status: "complete" }), 99)).toBe("Goal achieved");
+	});
+
 	it("sets and clears the status segment, respecting hasUI", () => {
 		const calls: Array<{ key: string; text: string | undefined }> = [];
 		const ctx = {


### PR DESCRIPTION
## Summary
When a goal is active, the footer shows `Pursuing goal (…)`, but the elapsed time was **frozen**: `goal.timeUsedSeconds` is only advanced by usage accounting at `agent_end` / `session_shutdown` / `/goal` checkpoints, and the footer segment was only re-set at those same discrete points. So while you were actually pursuing a goal the time never moved — and on a brand-new goal (`timeUsedSeconds === 0`) it showed no time at all. This PR makes the footer tick live, once per second, so it reflects how long the goal has really been running.

## Changes
**New live ticker (`goal/elapsed-ticker.ts`)**
- `goalLiveElapsedSeconds(goal, measuredFromMs, nowMs)` — pure helper returning committed `timeUsedSeconds` plus whole seconds since the current measurement window opened. Uses the exact `Math.round((now - measuredFrom)/1000)` math as `accountCurrentAgentTurn`, so the live footer never disagrees with what the next turn commits.
- `GoalElapsedTicker` — owns a single `setInterval` (unref'd, like the hook-status ticker) that re-renders the footer every second; `sync()` renders immediately and (re)points at the current goal/window, `stop()` clears it.

**UI (`goal/ui.ts`)**
- `goalStatusText` / `updateGoalUi` take an optional `liveElapsedSeconds`. When present on an active goal, the footer renders `Pursuing goal (Ns)` from the live value (including `0s`); all other states are unchanged.

**Wiring (`goal/index.ts`, `command-registration.ts`, `tool-registration.ts`)**
- New `refreshGoalUi`: while `ctx.hasUI` and the goal is `active` with a matching open accounting window, it syncs the ticker (live refresh); otherwise it stops the ticker and falls back to the static `setStatus`. The ticker is stopped on pause / complete / clear and on `session_shutdown`.
- `refreshGoalUi` is injected into the command and tool registrations, replacing their direct `updateGoalUi` calls, so every goal mutation path routes through the same live/stop decision. Non-interactive modes (RPC/print, `hasUI === false`) never start an interval.

## QA & Evidence
Isolated sandbox, offline, real `~/.senpi/auth.json` sha256 asserted unchanged throughout (senpi-qa harness).

- **Live footer tick (the actual bug) — real TUI via tmux, `/goal <objective>`, no agent turn.** Sampled the footer once per second:
  - Observed: `Pursuing goal (1s) → (2s) → (3s) → (4s) → (5s) → (6s) → (7s)` — `distinctElapsed` had 7 values, `liveAdvanced=true`.
  - Artifact: `local-ignore/qa-evidence/20260717-goal-live-elapsed/footer-timeseries.txt`
  - Why sufficient: proves the elapsed time now advances live on the real footer with zero tokens; before this change it stayed frozen.
- **Scoped unit + integration tests:** `vitest --run` over `goal-elapsed-ticker`, `goal-modules`, `goal-extension`, `goal-store`, `goal-e2e` → **49 passed**. Covers the rounding helper, ticker start/stop/unref/idempotency, live-vs-static status text, and an end-to-end assertion that `create_goal` renders `Pursuing goal (0s)` and `/goal clear` wipes it.
- **TUI smoke:** `tui-smoke.mjs --self-test` → 5/5 (boot, render, keystroke, teardown, auth unchanged).
- **Baseline harness:** `common --self-check` 9/9, `cli-smoke` 7/7, `mock-loop --self-test` 5/5.
- **Static gate:** `npm run check` (biome `--error-on-warnings`, pinned-deps, ts-imports, shrinkwrap, install-lock, `tsgo --noEmit`, browser/web-ui/neo) → exit 0. LSP diagnostics clean on all five changed sources.

## Risks & Residuals
- **Idle time counts toward elapsed:** the ticker advances whenever the accounting window is open (including between turns), which is intentional — it mirrors exactly the wall-clock time the next `accountGoalUsage` will commit, so display and accounting stay consistent. Mitigated by the shared rounding helper.
- **Process lifetime:** interval is `unref()`'d, so it never keeps the process alive; verified by the ticker unref unit test.
- **Non-TUI modes:** guarded by `ctx.hasUI`; RPC/print never start an interval.
- **Fork sync:** the standalone `pi-goal` package shares this `ui.ts`/`format.ts` shape and will need the same ticker on its next sync — noted in `goal/changes.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the frozen elapsed time in the goal footer by adding a live ticker that updates once per second to match accounting. The footer now shows “Pursuing goal (Ns)” advancing in real time, including “0s” on new goals.

- **Bug Fixes**
  - Added a live ticker (`elapsed-ticker.ts`) with `goalLiveElapsedSeconds` and `GoalElapsedTicker` using the same rounding as accounting.
  - Introduced `refreshGoalUi` to start/stop the ticker when appropriate; wired into command and tool paths to replace direct `updateGoalUi` calls.
  - Updated UI to accept `liveElapsedSeconds` and render “Pursuing goal (Ns)” for active goals, including 0s.
  - Lifecycle: ticker runs only when `ctx.hasUI`, stops on pause/complete/clear and `session_shutdown`, and the interval is `unref()` so it won’t keep the process alive.
  - Tests cover rounding, ticker start/stop/idempotency/unref, UI text, and an end-to-end render check.

<sup>Written for commit e088b3839e8e2e8abdbadfe9ef307d8008a18a1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

