### PR TITLE
fix(webfetch): cap tool output so one fetch cannot force compaction

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/external-versions.json
+++ b/packages/coding-agent/src/core/extensions/builtin/external-versions.json
@@ -27,7 +27,7 @@
 		},
 		"webfetch": {
 			"packageName": "pi-webfetch",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"source": "../pi-extensions/pi-webfetch"
 		},
 		"nested-agents-md": {

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/renderers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/renderers.ts
@@ -59,7 +59,8 @@ export function renderWebfetchResult(
 	const format = theme.fg("accent", details.format);
 	const size = theme.fg("muted", formatBytes(details.bytes));
 	const converted = details.converted ? theme.fg("dim", " converted") : "";
-	const header = `${status} ${theme.fg("muted", "•")} ${format} ${theme.fg("muted", "•")} ${size}${converted}`;
+	const truncatedNote = details.outputTruncated ? theme.fg("warning", " truncated") : "";
+	const header = `${status} ${theme.fg("muted", "•")} ${format} ${theme.fg("muted", "•")} ${size}${converted}${truncatedNote}`;
 
 	if (!options.expanded) {
 		const preview = previewText(text, theme);

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/tool.ts
@@ -27,7 +27,14 @@ export interface WebfetchDetails {
 	bytes: number;
 	timeoutSeconds: number;
 	converted: boolean;
+	/** Whether the network response body was truncated at the {@link MAX_RESPONSE_SIZE_BYTES} fetch limit. */
 	truncated: boolean;
+	/** Whether the text handed to the model was capped below the raw content size. */
+	outputTruncated: boolean;
+	/** Byte length of the text handed to the model (excluding the truncation notice). */
+	outputBytes: number;
+	/** Byte length of the full converted text before the output cap. */
+	outputTotalBytes: number;
 }
 
 export interface WebfetchProgressDetails {
@@ -80,6 +87,8 @@ export const webfetch = defineTool<typeof Params, WebfetchRenderDetails>({
 			converted = true;
 		}
 
+		const capped = capWebfetchOutput(text);
+
 		const details: WebfetchDetails = {
 			url: params.url,
 			finalUrl: fetched.url,
@@ -91,10 +100,13 @@ export const webfetch = defineTool<typeof Params, WebfetchRenderDetails>({
 			timeoutSeconds,
 			converted,
 			truncated: fetched.truncated,
+			outputTruncated: capped.truncated,
+			outputBytes: capped.outputBytes,
+			outputTotalBytes: capped.totalBytes,
 		};
 
 		return {
-			content: [{ type: "text", text }],
+			content: [{ type: "text", text: capped.text }],
 			details,
 		};
 	},
@@ -106,4 +118,73 @@ export function parseWebfetchFormat(value: unknown): WebfetchFormat {
 		if (value === format) return format;
 	}
 	return "markdown";
+}
+
+/** Byte ceiling for the text handed to the model, mirroring senpi's read-tool output cap. */
+export const DEFAULT_OUTPUT_MAX_BYTES = 50 * 1024;
+
+export interface WebfetchOutputCap {
+	/** Model-facing text after the output cap, with a notice appended when truncated. */
+	text: string;
+	/** Whether the text was capped below the full converted size. */
+	truncated: boolean;
+	/** Byte length of {@link WebfetchOutputCap.text} excluding the appended notice. */
+	outputBytes: number;
+	/** Byte length of the full converted text before capping. */
+	totalBytes: number;
+}
+
+/**
+ * Bound the text handed to the model so a single fetch cannot flood the context
+ * window and force an unwanted compaction. Keeps whole leading lines until the
+ * byte ceiling is hit; when the first line alone exceeds the ceiling (minified
+ * JSON, single-line payloads) it falls back to a UTF-8-safe byte prefix so the
+ * head is preserved instead of dropped.
+ */
+export function capWebfetchOutput(text: string): WebfetchOutputCap {
+	const totalBytes = Buffer.byteLength(text, "utf-8");
+	if (totalBytes <= DEFAULT_OUTPUT_MAX_BYTES) {
+		return { text, truncated: false, outputBytes: totalBytes, totalBytes };
+	}
+
+	const head = takeHeadBytes(text, DEFAULT_OUTPUT_MAX_BYTES);
+	const outputBytes = Buffer.byteLength(head, "utf-8");
+	const notice = `\n\n[Output truncated: ${formatByteSize(outputBytes)} of ${formatByteSize(
+		totalBytes,
+	)} shown (${formatByteSize(DEFAULT_OUTPUT_MAX_BYTES)} limit). Re-fetch a more specific URL or use web_search for targeted content.]`;
+	return { text: head + notice, truncated: true, outputBytes, totalBytes };
+}
+
+/** Keep whole leading lines within the byte ceiling; fall back to a UTF-8-safe byte prefix for one oversized line. */
+function takeHeadBytes(text: string, maxBytes: number): string {
+	const lines: string[] = [];
+	let usedBytes = 0;
+	let start = 0;
+	while (start <= text.length) {
+		const newlineIndex = text.indexOf("\n", start);
+		const line = newlineIndex === -1 ? text.slice(start) : text.slice(start, newlineIndex);
+		const lineBytes = Buffer.byteLength(line, "utf-8") + (lines.length > 0 ? 1 : 0);
+		if (usedBytes + lineBytes > maxBytes) break;
+		lines.push(line);
+		usedBytes += lineBytes;
+		if (newlineIndex === -1) break;
+		start = newlineIndex + 1;
+	}
+	return lines.length === 0 ? sliceUtf8Head(text, maxBytes) : lines.join("\n");
+}
+
+/** Slice the first {@link maxBytes} bytes of a UTF-8 string without leaving a split code point. */
+function sliceUtf8Head(value: string, maxBytes: number): string {
+	const buffer = Buffer.from(value, "utf-8");
+	if (buffer.length <= maxBytes) return value;
+	const decoded = new TextDecoder("utf-8").decode(buffer.subarray(0, maxBytes));
+	// A trailing partial code point decodes to U+FFFD; drop it so no split byte remains.
+	return decoded.endsWith("\uFFFD") ? decoded.slice(0, -1) : decoded;
+}
+
+/** Human-readable byte size (B / KB / MB). */
+function formatByteSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes}B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }

--- a/packages/coding-agent/test/suite/webfetch-output-truncation.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-output-truncation.test.ts
@@ -1,0 +1,115 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Static } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	DEFAULT_OUTPUT_MAX_BYTES,
+	type WebfetchDetails,
+	webfetch,
+} from "../../src/core/extensions/builtin/webfetch/webfetch/tool.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+
+type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void;
+type WebfetchParams = Static<typeof webfetch.parameters>;
+
+const servers: Server[] = [];
+const context = {} as ExtensionContext;
+
+async function createFixtureServer(handler: RouteHandler): Promise<{ readonly baseUrl: string }> {
+	const server = createServer(handler);
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (typeof address !== "object" || address === null) {
+		throw new Error("Expected TCP server address");
+	}
+	servers.push(server);
+	return { baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function executeWebfetch(params: WebfetchParams) {
+	return webfetch.execute("tool", params, undefined, undefined, context);
+}
+
+function textContent(result: Awaited<ReturnType<typeof executeWebfetch>>): string {
+	const first = result.content[0];
+	if (first?.type !== "text") {
+		throw new Error("Expected text content");
+	}
+	return first.text;
+}
+
+function webfetchDetails(result: Awaited<ReturnType<typeof executeWebfetch>>): WebfetchDetails {
+	const details = result.details;
+	if (details === undefined || !("status" in details)) {
+		throw new Error("Expected webfetch result details");
+	}
+	return details;
+}
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+afterEach(async () => {
+	await Promise.all(servers.splice(0).map(closeServer));
+});
+
+describe("webfetch output truncation", () => {
+	it("caps a huge single-line JSON body so it cannot blow the context window", async () => {
+		// Reproduces the reported bug: fetching models.dev/api.json (~3MB of
+		// minified, single-line JSON) returned the entire payload to the model
+		// and forced an unwanted compaction. The body is one line, so line-aware
+		// truncation alone would drop everything — a byte-accurate fallback must
+		// keep the head.
+		const hugeJson = `{"data":"${"x".repeat(2 * 1024 * 1024)}"}`;
+		const { baseUrl } = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "application/json" });
+			response.end(hugeJson);
+		});
+
+		const result = await executeWebfetch({ url: baseUrl, format: "text" });
+		const text = textContent(result);
+		const details = webfetchDetails(result);
+
+		// Model-facing output is bounded, not the full ~2MB payload.
+		expect(details.outputTruncated).toBe(true);
+		expect(details.outputBytes).toBeLessThanOrEqual(DEFAULT_OUTPUT_MAX_BYTES);
+		expect(details.outputTotalBytes).toBeGreaterThan(2 * 1024 * 1024);
+		expect(details.outputBytes).toBeLessThan(details.outputTotalBytes);
+		// Head content is preserved (not empty) and an actionable notice is appended.
+		expect(text).toContain('{"data":"xxxx');
+		expect(text).toContain("truncated");
+	});
+
+	it("truncates a large multi-line body while keeping whole leading lines", async () => {
+		const bigText = `${Array.from({ length: 5000 }, (_, i) => `line-${i}-${"y".repeat(40)}`).join("\n")}\n`;
+		const { baseUrl } = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/plain" });
+			response.end(bigText);
+		});
+
+		const result = await executeWebfetch({ url: baseUrl, format: "text" });
+		const text = textContent(result);
+		const details = webfetchDetails(result);
+
+		expect(details.outputTruncated).toBe(true);
+		expect(details.outputBytes).toBeLessThanOrEqual(DEFAULT_OUTPUT_MAX_BYTES);
+		expect(text.startsWith("line-0-")).toBe(true);
+		expect(text).toContain("truncated");
+	});
+
+	it("returns a small body verbatim with no truncation notice", async () => {
+		const body = "hello world\nsecond line\n";
+		const { baseUrl } = await createFixtureServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/plain" });
+			response.end(body);
+		});
+
+		const result = await executeWebfetch({ url: baseUrl, format: "text" });
+		const text = textContent(result);
+		const details = webfetchDetails(result);
+
+		expect(details.outputTruncated).toBe(false);
+		expect(text).toBe(body);
+		expect(text).not.toContain("truncated");
+	});
+});


### PR DESCRIPTION
## Problem

In session `019f6ee3-d1c5-71dd-b6db-6b4e67d3562e`, a single `webfetch` of `https://models.dev/api.json` (~3MB of minified, single-line JSON) returned the **entire body** to the model. That one tool result pushed context tokens past `contextWindow - reserveTokens`, so `shouldCompact()` fired and an **unwanted auto-compaction** happened immediately after the tool call — exactly the "weird compaction from just a tool call" the user reported.

Root cause: `webfetch` was the only content-returning builtin with **no cap on model-facing output**. `read`/`bash`/`grep` all truncate via `truncateHead`/`truncateTail` (50KB / 2000 lines); `webfetch` returned raw text up to the 5MB *network* limit straight into context.

## Fix

Cap the text handed to the model at **50KB** (`DEFAULT_OUTPUT_MAX_BYTES`), mirroring the read-tool cap:
- Keep whole leading lines until the byte ceiling.
- A single oversized line (minified JSON / single-line payloads) falls back to a **UTF-8-safe byte prefix** so the head is preserved instead of dropped (line-aware truncation alone would return empty here).
- Append an actionable notice; expose `outputTruncated` / `outputBytes` / `outputTotalBytes` on the result details, surfaced as a `truncated` marker in the renderer header.

The canonical fix lives in the vendored **source** repo `code-yeongyu/pi-webfetch@0.1.2` (committed upstream, self-contained — no senpi-core import) and is re-vendored here through `scripts/sync-builtin-extensions.mjs` (webfetch is a `MANUAL_PACKAGES` entry; `external-versions.json` bumped 0.1.1 → 0.1.2).

## Testing

**Unit (TDD, red→green):** `packages/coding-agent/test/suite/webfetch-output-truncation.test.ts` — huge single-line JSON is capped with head preserved; large multi-line body keeps whole leading lines; small body passes through verbatim. All webfetch suites green (14 tests).

**Manual QA on the real CLI** (senpi-qa mock-loop harness, hermetic, zero tokens): scripted a `webfetch` of a live 3MB payload server and inspected the session JSONL.

| Metric | Before (bug session) | After (this PR) |
|---|---|---|
| `toolResult` block size | text(3195860) | **text(51328)** |
| Result | forced compaction | notice appended, no compaction |

Notice observed: `[Output truncated: 50.0KB of 3.0MB shown (50.0KB limit). Re-fetch a more specific URL or use web_search for targeted content.]`

Static gates green: `tsgo --noEmit`, `biome check --error-on-warnings`, `check:ts-imports`, `check:pinned-deps`. Real `~/.senpi/auth.json` sha256 unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `webfetch` model-facing output at 50KB to stop a single large fetch from blowing the context window and triggering auto-compaction. Preserves leading lines or a UTF-8-safe head for single-line payloads, and adds a clear truncation notice.

- **Bug Fixes**
  - Cap model-facing text to 50KB (`DEFAULT_OUTPUT_MAX_BYTES`) with line-aware truncation and a UTF‑8-safe prefix for single-line bodies.
  - Append a truncation notice; expose `outputTruncated`, `outputBytes`, and `outputTotalBytes`; show a “truncated” marker in the renderer header.
  - Add unit tests covering huge single-line JSON, large multi-line text, and small bodies.

- **Dependencies**
  - Re-vendored `pi-webfetch` to `0.1.2`.

<sup>Written for commit df3682d789d6b117ccf397c4f264d2ec3fb37d1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

