### PR TITLE
fix(codemode): render single in-place box for eval tool calls

### DIFF
--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,28 @@
 # Core Extensions Changes
 
+## 2026-07-17 - Tool renderer hasResult context
+
+### What changed
+
+- Added optional `ToolRenderContext.hasResult`, true once a partial or final result exists for a tool call.
+- Lets a call renderer that draws self-contained framing (e.g. codemode `eval`) yield to the result renderer instead
+  of stacking a duplicate block, since `ToolExecutionRenderer.update()` renders call-then-result into one container.
+
+### Why
+
+- `renderCall` previously had no way to detect that a result had arrived: `isPartial` is true both for "no result yet"
+  and "partial result", so a self-framing call renderer kept drawing its own box on top of the result box.
+
+### Why extension system couldn't handle this alone
+
+- `ToolRenderContext` is a public host-to-extension contract, and result presence for a tool row is owned by the
+  interactive renderer (`modes/interactive/components/tool-execution-renderer.ts`).
+
+### Expected merge conflict zones
+
+- MEDIUM: `types.ts` around `ToolRenderContext` as upstream adds renderer context fields.
+- LOW: `modes/interactive/components/tool-execution-renderer.ts` around `getRenderContext()`.
+
 ## 2026-07-10 - Tool renderer image protocol context
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -485,6 +485,11 @@ export interface ToolRenderContext<TState = any, TArgs = any> {
 	imageProtocol?: ImageProtocol;
 	/** Whether the current result is an error. */
 	isError: boolean;
+	/**
+	 * Whether a result (partial or final) already exists for this tool call. Lets a call renderer that draws
+	 * self-contained framing yield to the result renderer instead of stacking a duplicate block.
+	 */
+	hasResult?: boolean;
 	spinnerFrame?: number;
 }
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## eval tool call single-box render (2026-07-17)
+
+### What changed
+
+- `components/tool-execution-renderer.ts`: `getRenderContext()` now sets `hasResult: this.state.result !== undefined`
+  so a self-framing call renderer can yield once a result exists (see `../../core/extensions/changes.md` 2026-07-17).
+
+### Why
+
+- The codemode `eval` tool draws a full `╭─ … ╰─` frame in BOTH `renderCall` and `renderResult`. Because
+  `update()` renders call-then-result into one container, a finished eval showed two stacked boxes (a stale
+  pending/running frame above the live done frame). With `hasResult`, the call renderer yields and the result
+  renderer owns a single frame that updates in place pending -> running -> done.
+
+### Why extension system couldn't handle this
+
+- Result presence for a tool row is private host renderer state; only the interactive renderer can populate the
+  public `ToolRenderContext.hasResult` field the extension renderer reads.
+
+### Expected merge conflict zones
+
+- LOW: `components/tool-execution-renderer.ts` around `getRenderContext()`.
+
 ## Transactional post-compaction queue transfer (2026-07-13)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution-renderer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution-renderer.ts
@@ -102,6 +102,7 @@ export class ToolExecutionRenderer extends Container {
 			showImages: this.state.showImages,
 			imageProtocol: getCapabilities().images,
 			isError: this.state.result?.isError ?? false,
+			hasResult: this.state.result !== undefined,
 			spinnerFrame: this.state.spinnerFrame,
 		};
 	}

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -725,6 +725,12 @@ export function renderEvalCall(
 	context: RenderContext,
 ): EvalRenderComponent {
 	const component = componentFor(context);
+	if (context.hasResult === true) {
+		// The result renderer owns the full pending -> running -> done frame once a result exists.
+		// Rendering the call frame too would stack a duplicate box, so yield to it here.
+		component.setBlocks([]);
+		return component;
+	}
 	if (theme === undefined && context.spinnerFrame === undefined) {
 		const title = args.title === undefined ? "" : ` ${args.title}`;
 		const reset = args.reset === true ? " reset" : "";

--- a/packages/senpi-codemode/test/eval-render-fixtures.ts
+++ b/packages/senpi-codemode/test/eval-render-fixtures.ts
@@ -14,6 +14,7 @@ export interface RenderContextOptions {
 	readonly imageProtocol?: ImageProtocol;
 	readonly isError?: boolean;
 	readonly spinnerFrame?: number;
+	readonly hasResult?: boolean;
 	readonly args?: EvalToolInput;
 }
 
@@ -48,6 +49,7 @@ export function callContext(input?: EvalComponent | RenderContextOptions): CallC
 		showImages: options.showImages ?? false,
 		imageProtocol: options.imageProtocol ?? null,
 		isError: options.isError ?? false,
+		...(options.hasResult === undefined ? {} : { hasResult: options.hasResult }),
 		...(options.spinnerFrame === undefined ? {} : { spinnerFrame: options.spinnerFrame }),
 	};
 }

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -211,6 +211,36 @@ describe("eval renderer", () => {
 		expect(renderLines(result)).toEqual(["eval js done", "took 1ms", "", "2"]);
 	});
 
+	it("Given a streaming result exists when the framed call lane renders then it yields an empty component", () => {
+		// Given a framed call render (spinnerFrame set) that would otherwise draw its own pending/running box
+		const withoutResult = renderEvalCall(
+			{ language: "py", code: "print('x')" },
+			undefined,
+			callContext({ spinnerFrame: 0 }),
+		);
+
+		// When the same call lane renders after a result has arrived
+		const withResult = renderEvalCall(
+			{ language: "py", code: "print('x')" },
+			undefined,
+			callContext({ spinnerFrame: 0, hasResult: true }),
+		);
+
+		// Then only the pre-result render draws a frame; the post-result call lane is empty
+		expect.soft(renderLines(withoutResult).some((line) => line.includes("╭─"))).toBe(true);
+		expect.soft(renderLines(withResult)).toEqual([]);
+	});
+
+	it("Given a result exists when the compact call lane renders then it also yields an empty component", () => {
+		// Given the compact call preview (no theme, no spinner) and the same lane once a result exists
+		const compact = renderEvalCall({ language: "js", code: "1 + 1" }, undefined, callContext());
+		const yielded = renderEvalCall({ language: "js", code: "1 + 1" }, undefined, callContext({ hasResult: true }));
+
+		// Then the pre-result preview renders code while the post-result lane is empty
+		expect.soft(renderLines(compact)).toEqual(["eval js", "1 + 1"]);
+		expect.soft(renderLines(yielded)).toEqual([]);
+	});
+
 	it("Given completed cell details when rendered then framed status agent and JSON output are visible", () => {
 		// Given
 		const givenResult = evalResult(

--- a/packages/senpi-codemode/test/eval-tool-execution-render.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-execution-render.test.ts
@@ -1,0 +1,99 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { initTheme, ToolExecutionComponent } from "@code-yeongyu/senpi";
+import type { TUI } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import { renderEvalCall, renderEvalResult } from "../src/tool/render.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+
+// This test drives the REAL interactive ToolExecutionComponent — the exact component the TUI mux
+// renders — through the pending -> running -> done lifecycle of an `eval` tool call. It is the
+// regression guard for the duplicate-box bug: renderEvalCall and renderEvalResult each draw a full
+// `╭─ ... ╰─` frame, and the renderer stacks call-then-result into one container, so once a result
+// existed the TUI showed TWO stacked boxes (a stale "pending" frame above the live one).
+
+type ToolDefParam = NonNullable<ConstructorParameters<typeof ToolExecutionComponent>[4]>;
+type ExecResult = Parameters<ToolExecutionComponent["updateResult"]>[0];
+
+const CODE = "d = {}\nd['favoriteModels'] = ['apitopia/kimi-k3']\nprint(d)";
+const OUTPUT = "{'favoriteModels': ['apitopia/kimi-k3']}";
+
+function countBoxes(lines: readonly string[]): number {
+	return lines.filter((line) => line.includes("╭─")).length;
+}
+
+function stripAnsi(text: string): string {
+	return text.replace(/\u001b\[[0-9;]*m/gu, "");
+}
+
+function evalToolDef(): ToolDefParam {
+	return {
+		name: "eval",
+		label: "Eval",
+		description: "eval",
+		parameters: { type: "object" } as unknown as ToolDefParam["parameters"],
+		execute: async () => ({ content: [] }),
+		renderCall: renderEvalCall as unknown as ToolDefParam["renderCall"],
+		renderResult: renderEvalResult as unknown as ToolDefParam["renderResult"],
+	} as unknown as ToolDefParam;
+}
+
+function cellResult(status: "running" | "complete", output: string, durationMs: number): ExecResult {
+	const details: EvalToolDetails = {
+		language: "py",
+		languages: ["py"],
+		durationMs,
+		toolCalls: [],
+		truncated: false,
+		phase: status === "complete" ? "complete" : "running",
+		cells: [{ index: 0, code: CODE, language: "py", output, status, durationMs }],
+	};
+	const agentResult: AgentToolResult<EvalToolDetails> = { content: [{ type: "text", text: output }], details };
+	return { ...agentResult, isError: false };
+}
+
+describe("eval ToolExecutionComponent lifecycle", () => {
+	beforeAll(() => {
+		initTheme();
+	});
+
+	it("Given the pending -> running -> done lifecycle then exactly one framed box renders at every state", () => {
+		// Given the real interactive tool-execution component for an eval call
+		const ui = { requestRender: () => {} } as unknown as TUI;
+		const component = new ToolExecutionComponent(
+			"eval",
+			"eval-1",
+			{ language: "py", code: CODE },
+			{},
+			evalToolDef(),
+			ui,
+			"/tmp",
+		);
+		component.setArgsComplete();
+
+		// When it is pending (no result yet), the call lane owns the single frame
+		const pending = component.render(80);
+		expect.soft(countBoxes(pending)).toBe(1);
+		expect.soft(stripAnsi(pending.join("\n"))).toContain("pending");
+
+		// When execution starts and streams a partial (running) result
+		component.markExecutionStarted();
+		component.updateResult(cellResult("running", "", 0), true);
+		const running = component.render(80);
+		const runningText = stripAnsi(running.join("\n"));
+		expect.soft(countBoxes(running)).toBe(1); // was 2: a stale pending frame stacked above the running frame
+		expect.soft(runningText).toContain("running");
+		expect.soft(runningText).not.toContain("pending");
+
+		// When the final result arrives
+		component.updateResult(cellResult("complete", OUTPUT, 12), false);
+		const done = component.render(80);
+		const doneText = stripAnsi(done.join("\n"));
+		expect.soft(countBoxes(done)).toBe(1); // was 2: a stale pending frame stacked above the done frame
+		expect.soft(doneText).toContain("done");
+		expect.soft(doneText).not.toContain("pending");
+		expect.soft(doneText).not.toContain("running");
+		expect.soft(doneText).toContain("favoriteModels");
+
+		component.stopAnimation();
+	});
+});


### PR DESCRIPTION
## Problem

In interactive mode, an `eval` (codemode) tool call rendered **two stacked `╭─ … ╰─` boxes** once it finished — a stale `pending`/`running` frame sitting above the live `done` frame — instead of a single box updating in place. Reported from a real session:

```
 ╭─ eval py … favoriteModels pending ○     <- stale
 │ 6 earlier code lines
 ╰─
 ╭─ eval py … favoriteModels done ✓ · <1s  <- live
 │ 6 earlier code lines
 ├─ output
 ╰─
```

## Root cause

The `eval` tool registers **both** `renderCall` and `renderResult`, and each draws a full self-contained frame (`renderCell`). `ToolExecutionRenderer.update()` renders call-then-result into one container:

```ts
container.detachAll();
this.renderCall(container);
if (state.result) this.renderResult(container, state.result);
```

So once a result existed, both frames rendered → two boxes. `renderCall` had no signal that a result had arrived — `isPartial` is `true` both for "no result yet" and "partial result" — so it kept drawing its `pending` frame under the result frame.

## Fix

- **`core/extensions/types.ts`** — add optional `ToolRenderContext.hasResult` (additive, same pattern as the 2026-07-10 `imageProtocol` field).
- **`modes/interactive/components/tool-execution-renderer.ts`** — set `hasResult: this.state.result !== undefined` in `getRenderContext()`.
- **`senpi-codemode/src/tool/render.ts`** — `renderEvalCall` yields an empty component when `hasResult === true`, so the **result renderer owns a single `pending → running → done` frame** that updates in place.

No flicker: the differential TUI renderer only redraws changed lines, and each state emits a stable line set. The call lane draws the `pending` frame only until the first result arrives (kernel acquisition window), then the result lane takes over the same single frame.

## Verification

Real component render, width 72 — one box at every state:

```
 ╭─ eval py pending ○                         ╭─ eval py running ⠋ · <1s          ╭─ eval py done ✓ · <1s
 │ d = {}                                      │ d = {}                            │ d = {}
 │ d['favoriteModels'] = ['apitopia/kimi-k3']  │ …                                 │ …
 │ print(d)                                    │ print(d)                          ├─ output
 ╰─                                            ╰─                                  │ {'favoriteModels': ['apitopia/kimi-k3']}
                                               phase running                       ╰─
```

- **Regression guard**: `eval-tool-execution-render.test.ts` drives the real `ToolExecutionComponent` through the lifecycle and asserts exactly one framed box per state. With the guard disabled it FAILS, reproducing the two-box bug — confirming it defends the contract.
- `packages/senpi-codemode`: **358 tests pass** (incl. new unit + component tests).
- `packages/coding-agent` tool-execution suite: **45 tests pass** — the `hasResult` field/setter regress nothing.
- `biome check --error-on-warnings` on all changed files: clean.
- `tsgo --noEmit` (root) + codemode `tsgo -p tsconfig.json`: clean.

Fork changes recorded in `core/extensions/changes.md` and `modes/interactive/changes.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate stacked boxes for codemode `eval` tool calls in interactive mode by rendering a single box that updates in place. The box now transitions cleanly from pending → running → done.

- **Bug Fixes**
  - Added optional `ToolRenderContext.hasResult` so call renderers know when a result exists.
  - Interactive renderer sets `hasResult`; `renderEvalCall` in `packages/senpi-codemode` yields an empty component once true, letting `renderResult` own the single frame.
  - Tests: unit checks for call-lane yielding and a component-level lifecycle regression test (`eval-tool-execution-render.test.ts`) ensuring exactly one framed box per state.

<sup>Written for commit c9ca4f084e5faa5843c465bca5307687df8ee021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

