### PR TITLE
feat(codemode): model-aware eval-first batching emphasis in the eval prompt

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added model-aware eval-first batching emphasis: the `eval` tool description and its system-prompt guideline now render in a dialect selected by the active model id (Claude/GLM, OpenAI, Kimi, and a maximum-emphasis default fallback), re-registering on `model_select` so mid-session model switches pick up the matching dialect.
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -35,6 +35,8 @@ const SESSION_LIFECYCLE_EVENTS = [
 
 type SessionLifecycleEvent = (typeof SESSION_LIFECYCLE_EVENTS)[number];
 
+type CodemodeEvent = SessionLifecycleEvent | "model_select";
+
 type TrackedExecution = {
 	readonly promise: Promise<unknown>;
 	readonly controller: AbortController;
@@ -51,7 +53,7 @@ type SessionRuntime = {
 
 export interface CodemodeExtensionAPI {
 	registerTool(tool: ReturnType<typeof createEvalTool>): void;
-	on(event: SessionLifecycleEvent, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void;
+	on(event: CodemodeEvent, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void;
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
 }
@@ -75,6 +77,31 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	const manager = new SessionManagerProxy();
 	const complete = options.complete ?? ((request, ctx) => createCompletionHandler()(ctx)(request));
 	const renderers = { renderCall: renderEvalCall, renderResult: renderEvalResult };
+	let activeRuntime: SessionRuntime | undefined;
+	let activeModelId: string | undefined;
+	const registerEvalForRuntime = (runtime: SessionRuntime, modelId: string | undefined): void => {
+		pi.registerTool(
+			createEvalTool({
+				enabledLanguages: runtime.enabledLanguages,
+				kernelManager: manager,
+				cellTimeoutSeconds: runtime.settings.cellTimeoutSeconds,
+				executeTool: runtime.executeTool,
+				complete,
+				settings: runtime.settings,
+				artifactsDir: runtime.artifactsDir,
+				executionTracker: manager,
+				renderers,
+				spawns: runtime.spawns,
+				spawnDefaultAgent: runtime.settings.taskTools.task,
+				...(modelId === undefined ? {} : { modelId }),
+			}),
+		);
+	};
+	const dropRuntime = async (): Promise<void> => {
+		activeRuntime = undefined;
+		activeModelId = undefined;
+		await manager.dispose();
+	};
 	pi.registerTool(
 		createEvalTool({
 			enabledLanguages: { py: true, js: true, rb: true, jl: true },
@@ -92,25 +119,28 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		const generation = manager.beginReplacement();
 		const runtime = await createRuntime(pi, ctx, event, complete, options);
 		if (!(await manager.replace(generation, runtime.manager))) return;
-		pi.registerTool(
-			createEvalTool({
-				enabledLanguages: runtime.enabledLanguages,
-				kernelManager: manager,
-				cellTimeoutSeconds: runtime.settings.cellTimeoutSeconds,
-				executeTool: runtime.executeTool,
-				complete,
-				settings: runtime.settings,
-				artifactsDir: runtime.artifactsDir,
-				executionTracker: manager,
-				renderers,
-				spawns: runtime.spawns,
-				spawnDefaultAgent: runtime.settings.taskTools.task,
-			}),
-		);
+		activeRuntime = runtime;
+		activeModelId = ctx.model?.id;
+		registerEvalForRuntime(runtime, activeModelId);
 	});
-	pi.on("session_shutdown", async () => manager.dispose());
-	pi.on("session_before_switch", async () => manager.dispose());
-	pi.on("session_before_fork", async () => manager.dispose());
+	pi.on("session_shutdown", async () => dropRuntime());
+	pi.on("session_before_switch", async () => dropRuntime());
+	pi.on("session_before_fork", async () => dropRuntime());
+	pi.on("model_select", async (event) => {
+		const runtime = activeRuntime;
+		if (runtime === undefined) return;
+		const modelId = modelIdFrom(event);
+		if (modelId === undefined || modelId === activeModelId) return;
+		activeModelId = modelId;
+		registerEvalForRuntime(runtime, modelId);
+	});
+}
+
+function modelIdFrom(event: unknown): string | undefined {
+	if (typeof event !== "object" || event === null || !("model" in event)) return undefined;
+	const model = event.model;
+	if (typeof model !== "object" || model === null || !("id" in model)) return undefined;
+	return typeof model.id === "string" ? model.id : undefined;
 }
 
 class SessionManagerProxy implements CodemodeSessionManager, EvalExecutionTracker {

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -14,6 +14,33 @@ export interface EvalPromptParts {
 export interface EvalPromptOptions {
 	readonly spawns: boolean;
 	readonly spawnDefaultAgent?: string;
+	/** Active model id; selects the emphasis dialect of the batching guidance. */
+	readonly modelId?: string;
+}
+
+/** Prompt dialect for the eval-first batching emphasis. */
+export type EvalEmphasisStyle = "default" | "claude" | "codex" | "kimi";
+
+const CLAUDE_MODEL_RE = /(^|[/.:])claude[-.]/i;
+const GLM_MODEL_RE = /(^|[/.:@-])glm[-.]?\d/i;
+const KIMI_MODEL_RE = /(^|[/.:])kimi[-.]/i;
+const OPENAI_MODEL_RE = /(^|[/.:])(gpt|chatgpt|codex)[-.]|(^|[/.:])o[134](?:[-.]|$)/i;
+
+/**
+ * Selects the eval-first batching dialect for a model id:
+ * - `claude`: Claude/GLM — direct imperatives; both are steered most reliably
+ *   by explicit tagged directives (GLM prompting guidance routes to Claude's).
+ * - `codex`: OpenAI reasoning families — terse bounded rules, no emphasis spam.
+ * - `kimi`: Kimi K-series — positive operational constraints; all-caps NEVER
+ *   directives make K2.x overthink instead of comply.
+ * - `default`: everything else (and no model) — maximum-emphasis fallback.
+ */
+export function evalEmphasisStyle(modelId: string | undefined): EvalEmphasisStyle {
+	if (!modelId) return "default";
+	if (CLAUDE_MODEL_RE.test(modelId) || GLM_MODEL_RE.test(modelId)) return "claude";
+	if (KIMI_MODEL_RE.test(modelId)) return "kimi";
+	if (OPENAI_MODEL_RE.test(modelId)) return "codex";
+	return "default";
 }
 
 type ContextValue = string | boolean;
@@ -57,7 +84,21 @@ const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 
 Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
 
-**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
+{{#if styleClaude}}<eval_first_batching>
+\`eval\` is your default execution surface: if a step needs more than one tool call, write ONE cell that performs the whole step — never issue the calls one at a time.
+- Enumerate every lookup the step needs, then run all independent ones simultaneously with \`parallel(thunks)\` inside the cell; keep calls sequential only when one result feeds the next.
+- Write real code around the calls: loop or comprehend over file sets with \`read()\`/stdlib, branch per case, and wrap risky calls in try/except so one failure degrades only its item — recover or retry inside the cell, keep the batch alive.
+- Post-process \`tool.<name>()\` results programmatically and return distilled facts, not raw dumps.
+</eval_first_batching>{{/if}}{{#if styleCodex}}Route multi-call steps through eval: one cell per step, independent lookups dispatched together via \`parallel(thunks)\`; keep work sequential only when one result determines the next action.
+- Loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time; post-process \`tool.<name>()\` results programmatically.
+- Wrap failable calls in try/except inside the cell; a failed item degrades only itself. After two distinct failed strategies for the same fact, fall back to direct tool calls.
+- Reduce large results in-kernel to the facts the task needs before returning.{{/if}}{{#if styleKimi}}Treat eval as the standard way to execute any step involving several tool calls: write one cell that performs the whole step.
+- When lookups are independent, run them together with \`parallel(thunks)\` in that cell; when one result feeds the next, keep them sequential inside the same cell.
+- Loop or comprehend over file sets with \`read()\`/stdlib, post-process \`tool.<name>()\` results programmatically, and put try/except around each risky call so the rest of the batch completes.
+- Filter and aggregate results in the kernel, then return the distilled facts.{{/if}}{{#if styleDefault}}**EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
+- **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
+- **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
+- **DISTILL IN-KERNEL.** Filter, diff, and aggregate in code before returning; return facts, NOT dumps.{{/if}}
 
 Fields:
 
@@ -129,6 +170,7 @@ export function buildEvalPrompt(
 		throw new Error("no kernels enabled for eval prompt");
 	}
 	const spawnDefaultAgent = options.spawnDefaultAgent ?? "task";
+	const style = evalEmphasisStyle(options.modelId);
 	const context: Context = {
 		py: enabled.py,
 		js: enabled.js,
@@ -136,6 +178,10 @@ export function buildEvalPrompt(
 		jl: enabled.jl,
 		spawns: options.spawns,
 		spawnDefaultAgent,
+		styleClaude: style === "claude",
+		styleCodex: style === "codex",
+		styleKimi: style === "kimi",
+		styleDefault: style === "default",
 	};
 	const examples = REUSE_CHAIN_EXAMPLES.filter((example) => enabled[example.language])
 		.map((example) => {
@@ -155,11 +201,25 @@ export function buildEvalPrompt(
 		description,
 		promptSnippet: "Run one incremental code cell in a persistent language kernel.",
 		promptGuidelines: [
-			"Use eval for incremental code execution when a persistent JS, Python, Ruby, or Julia kernel is available.",
+			BATCHING_GUIDELINES[style],
 			"Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
 		],
 	};
 }
+
+/**
+ * System-prompt guideline per emphasis dialect. The default dialect carries
+ * maximum emphasis so unmapped models still batch through eval; the others are
+ * tuned to what steers that family reliably.
+ */
+const BATCHING_GUIDELINES: Record<EvalEmphasisStyle, string> = {
+	default:
+		"**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
+	claude:
+		"Prefer eval for any step needing more than one tool call: one cell that runs independent calls in parallel, handles per-call failures in code, and returns distilled facts.",
+	codex: "Route multi-call steps through eval: one cell per step, independent calls dispatched in parallel; fall back to direct tool calls when one call is sufficient or each result changes the next decision.",
+	kimi: "Treat eval as the standard way to execute multi-call steps: one cell that runs independent calls in parallel, handles failures per item, and returns distilled facts.",
+};
 
 function renderTemplate(template: string, context: Context): string {
 	let index = 0;

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -39,6 +39,8 @@ export interface CreateEvalToolOptions {
 	readonly spawns?: boolean;
 	/** Default agent name surfaced in the agent() helper docs when spawns are enabled. */
 	readonly spawnDefaultAgent?: string;
+	/** Active model id; selects the emphasis dialect of the eval prompt. */
+	readonly modelId?: string;
 }
 
 interface EvalCellInvocation {
@@ -152,6 +154,7 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 	const prompt = buildEvalPrompt(options.enabledLanguages, {
 		spawns: options.spawns ?? false,
 		...(options.spawnDefaultAgent === undefined ? {} : { spawnDefaultAgent: options.spawnDefaultAgent }),
+		...(options.modelId === undefined ? {} : { modelId: options.modelId }),
 	});
 	const languages = enabledLanguageList(options.enabledLanguages);
 	return {

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -9,7 +9,10 @@ exports[`buildEvalPrompt > renders the all with spawns prompt 1`] = `
 
 Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
 
-**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
+**EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
+- **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
+- **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
+- **DISTILL IN-KERNEL.** Filter, diff, and aggregate in code before returning; return facts, NOT dumps.
 
 Fields:
 
@@ -101,7 +104,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`
 </examples>",
   "promptGuidelines": [
-    "Use eval for incremental code execution when a persistent JS, Python, Ruby, or Julia kernel is available.",
+    "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
   ],
   "promptSnippet": "Run one incremental code cell in a persistent language kernel.",
@@ -117,7 +120,10 @@ exports[`buildEvalPrompt > renders the js without spawns prompt 1`] = `
 
 Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
 
-**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
+**EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
+- **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
+- **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
+- **DISTILL IN-KERNEL.** Filter, diff, and aggregate in code before returning; return facts, NOT dumps.
 
 Fields:
 
@@ -164,7 +170,7 @@ phase(title) → None
 Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
 </critical>",
   "promptGuidelines": [
-    "Use eval for incremental code execution when a persistent JS, Python, Ruby, or Julia kernel is available.",
+    "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
   ],
   "promptSnippet": "Run one incremental code cell in a persistent language kernel.",
@@ -180,7 +186,10 @@ exports[`buildEvalPrompt > renders the js-py without spawns prompt 1`] = `
 
 Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
 
-**Batch through eval.** One cell replaces many one-shot tool calls: loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time, post-process \`tool.<name>()\` results programmatically, and fan independent calls through \`parallel(thunks)\` within the cell — never one call per turn.
+**EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
+- **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
+- **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
+- **DISTILL IN-KERNEL.** Filter, diff, and aggregate in code before returning; return facts, NOT dumps.
 
 Fields:
 
@@ -257,7 +266,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`
 </examples>",
   "promptGuidelines": [
-    "Use eval for incremental code execution when a persistent JS, Python, Ruby, or Julia kernel is available.",
+    "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
   ],
   "promptSnippet": "Run one incremental code cell in a persistent language kernel.",

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import type { CodemodeSessionManager } from "../src/extension/session-manager.ts";
 import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
@@ -121,6 +122,21 @@ function extensionContext(cwd = process.cwd()): ExtensionContext {
 	};
 }
 
+function fakeModel(id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "fake-api",
+		provider: "fake",
+		baseUrl: "https://fake.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	};
+}
+
 async function emit(pi: FakePi, event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
 	for (const entry of pi.handlers.filter((handler) => handler.event === event)) {
 		await entry.handler(payload, ctx);
@@ -237,6 +253,61 @@ describe("senpi-codemode extension factory", () => {
 			await emit(pi, "session_shutdown", {}, ctx);
 			await rm(cwd, { recursive: true, force: true });
 		}
+	});
+
+	it("registers the model-tuned dialect at session start and re-registers on model_select", async () => {
+		// Given a session whose active model is a Claude family id
+		const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-modelselect-"));
+		await mkdir(join(cwd, ".senpi"), { recursive: true });
+		await writeFile(
+			join(cwd, ".senpi", "codemode.json"),
+			JSON.stringify({ languages: { py: true, js: true, rb: false, jl: false } }),
+		);
+		const pi = new FakePi();
+		const manager = new DisposableManager();
+		senpiCodemode(pi, { createSessionManager: () => manager });
+		const ctx = { ...extensionContext(cwd), model: fakeModel("claude-opus-4-8") };
+
+		try {
+			// When the session starts with the Claude model active
+			await emit(pi, "session_start", { reason: "startup" }, ctx);
+
+			// Then the registered description carries the Claude dialect
+			const started = pi.registeredTool;
+			if (!started) throw new Error("eval tool was not registered");
+			expect(started.description).toContain("<eval_first_batching>");
+			expect(started.description).not.toContain("EVAL IS YOUR PRIMARY EXECUTION SURFACE");
+
+			// When the model switches to an OpenAI family id
+			await emit(pi, "model_select", { model: fakeModel("gpt-5.6") }, ctx);
+
+			// Then eval is re-registered with the codex dialect
+			const switched = pi.registeredTool;
+			if (!switched) throw new Error("eval tool was not re-registered");
+			expect(switched.description).toContain("Route multi-call steps through eval");
+			expect(switched.description).not.toContain("<eval_first_batching>");
+
+			// And a same-model reselection does not re-register
+			const registrations = pi.tools.length;
+			await emit(pi, "model_select", { model: fakeModel("gpt-5.6") }, ctx);
+			expect(pi.tools.length).toBe(registrations);
+		} finally {
+			await emit(pi, "session_shutdown", {}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores model_select before any session has started", async () => {
+		// Given an extension with no started session
+		const pi = new FakePi();
+		senpiCodemode(pi, { createSessionManager: () => new DisposableManager() });
+		const ctx = extensionContext();
+
+		// When a model_select arrives early
+		await emit(pi, "model_select", { model: fakeModel("gpt-5.6") }, ctx);
+
+		// Then only the load-time registration exists
+		expect(pi.tools).toEqual(["eval"]);
 	});
 
 	it("creates a fresh manager on start/reload and disposes on shutdown, switch, and fork", async () => {

--- a/packages/senpi-codemode/test/factory.test.ts
+++ b/packages/senpi-codemode/test/factory.test.ts
@@ -17,6 +17,12 @@ describe("senpi-codemode extension factory", () => {
 
 		expect(() => senpiCodemode(pi)).not.toThrow();
 		expect(registeredTools).toEqual(["eval"]);
-		expect(events).toEqual(["session_start", "session_shutdown", "session_before_switch", "session_before_fork"]);
+		expect(events).toEqual([
+			"session_start",
+			"session_shutdown",
+			"session_before_switch",
+			"session_before_fork",
+			"model_select",
+		]);
 	});
 });

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildEvalPrompt } from "../src/prompt/eval-prompt.ts";
+import { buildEvalPrompt, evalEmphasisStyle } from "../src/prompt/eval-prompt.ts";
 
 type PromptOptions = {
 	readonly spawns: boolean;
@@ -110,15 +110,81 @@ describe("buildEvalPrompt", () => {
 	});
 
 	it("keeps eval-specific prompt guidelines stable", () => {
-		// Given: a registered eval tool.
+		// Given: a registered eval tool with no active model id.
 		// When: its prompt metadata is built.
 		const guidelines = buildEvalPrompt({ py: true, js: true, rb: true, jl: true }, { spawns: true }).promptGuidelines;
 
-		// Then: the system-prompt guidance remains the eval contract.
+		// Then: the system-prompt guidance carries the maximum-emphasis batching contract.
 		expect(guidelines).toEqual([
-			"Use eval for incremental code execution when a persistent JS, Python, Ruby, or Julia kernel is available.",
+			"**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
 			"Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
 		]);
+	});
+
+	it("maps model ids to emphasis dialects across provider id shapes", () => {
+		// Given: model ids as they appear across bundled provider catalogs.
+		// When/Then: each id resolves to its family dialect; unknown ids fall back to default.
+		const claudeIds = [
+			"claude-opus-4-8",
+			"anthropic/claude-fable-5",
+			"eu.anthropic.claude-sonnet-5",
+			"glm-5.2",
+			"@cf/zai-org/glm-4.7-flash",
+			"accounts/fireworks/models/glm-5p2",
+		];
+		const kimiIds = ["kimi-k2.6", "@cf/moonshotai/kimi-k2.7-code", "accounts/fireworks/models/kimi-k2p6"];
+		const codexIds = ["gpt-5.6", "gpt-5.2-codex", "o3-mini", "@cf/openai/gpt-oss-120b", "codex-mini-latest"];
+		const defaultIds = ["gemini-2.5-flash", "deepseek-chat", "qwen3-coder", "minimax-m2.5"];
+		for (const id of claudeIds) expect(evalEmphasisStyle(id), id).toBe("claude");
+		for (const id of kimiIds) expect(evalEmphasisStyle(id), id).toBe("kimi");
+		for (const id of codexIds) expect(evalEmphasisStyle(id), id).toBe("codex");
+		for (const id of defaultIds) expect(evalEmphasisStyle(id), id).toBe("default");
+		expect(evalEmphasisStyle(undefined)).toBe("default");
+	});
+
+	it("renders exactly one batching dialect selected by the model id", () => {
+		// Given: the same kernel set rendered for each model family.
+		const enabled = { py: true, js: true, rb: false, jl: false };
+		const render = (modelId?: string): string =>
+			buildEvalPrompt(enabled, modelId === undefined ? { spawns: false } : { spawns: false, modelId }).description;
+
+		// When: the descriptions are built.
+		const claude = render("claude-opus-4-8");
+		const codex = render("gpt-5.6");
+		const kimi = render("kimi-k2.6");
+		const fallback = render();
+
+		// Then: each carries only its own dialect marker.
+		expect(claude).toContain("<eval_first_batching>");
+		expect(claude).toContain("your default execution surface");
+		expect(claude).not.toContain("EVAL IS YOUR PRIMARY EXECUTION SURFACE");
+		expect(codex).toContain("Route multi-call steps through eval");
+		expect(codex).not.toContain("<eval_first_batching>");
+		expect(codex).not.toContain("EVAL IS YOUR PRIMARY EXECUTION SURFACE");
+		const kimiInstruction = kimi.slice(0, kimi.indexOf("<prelude>"));
+		expect(kimiInstruction).toContain("Treat eval as the standard way to execute");
+		expect(kimiInstruction).not.toContain("NEVER kills the batch");
+		expect(kimiInstruction).not.toContain("<eval_first_batching>");
+		expect(fallback).toContain("EVAL IS YOUR PRIMARY EXECUTION SURFACE");
+		expect(fallback).toContain("parallel(thunks)");
+	});
+
+	it("tunes the batching guideline to the model dialect", () => {
+		// Given: the same kernel set with model ids from each family.
+		const enabled = { py: true, js: true, rb: true, jl: true };
+		const guideline = (modelId: string): string =>
+			buildEvalPrompt(enabled, { spawns: false, modelId }).promptGuidelines[0];
+
+		// When/Then: the first guideline is the family-tuned batching contract.
+		expect(guideline("claude-opus-4-8")).toBe(
+			"Prefer eval for any step needing more than one tool call: one cell that runs independent calls in parallel, handles per-call failures in code, and returns distilled facts.",
+		);
+		expect(guideline("gpt-5.6")).toBe(
+			"Route multi-call steps through eval: one cell per step, independent calls dispatched in parallel; fall back to direct tool calls when one call is sufficient or each result changes the next decision.",
+		);
+		expect(guideline("kimi-k2.6")).toBe(
+			"Treat eval as the standard way to execute multi-call steps: one cell that runs independent calls in parallel, handles failures per item, and returns distilled facts.",
+		);
 	});
 
 	it("throws when no kernels are enabled", () => {


### PR DESCRIPTION
## Summary

Makes the `eval` tool's batching emphasis **model-aware**. `buildEvalPrompt` now renders the eval-first batching guidance (in both the tool description and the system-prompt guideline) in one of four dialects selected by the active model id, because the wording that reliably steers one model family regresses another:

| Dialect | Models | Rationale |
|---|---|---|
| `claude` | Claude (any namespace: bare, `anthropic/`, Bedrock dotted), GLM | `<eval_first_batching>` XML-tagged block + direct imperatives — the pattern Anthropic's guidance uses to push parallel tool use to ~100%; GLM prompting guidance routes to Claude conventions |
| `codex` | OpenAI (gpt-*/chatgpt/codex/o-series, incl. gpt-oss) | Terse bounded rules with explicit fallback caps ("after two distinct failed strategies… fall back to direct tool calls") per GPT-5.x guidance; no emphasis spam |
| `kimi` | Kimi K-series (incl. Fireworks `k2p6` shapes) | Positive operational constraints only — all-caps NEVER directives are a documented overthinking trigger on K2.x |
| `default` | everything else + no model | Maximum-emphasis fallback (bold + CAPS + MUST/NEVER) so unmapped/weaker-steered models still batch through eval |

All dialects teach the same contract: one cell per multi-call step, independent calls fanned through `parallel(thunks)`, in-cell control flow with per-call try/except so one failure never kills the batch, and in-kernel distillation before returning.

## Implementation

- `src/prompt/eval-prompt.ts`: new `EvalEmphasisStyle` + `evalEmphasisStyle(modelId)` (regex family classifiers covering bare, path-namespaced, Bedrock dotted, `@cf/`, and Fireworks `p`-version id shapes); the template's "Batch through eval." paragraph becomes four style-gated variants; `promptGuidelines[0]` is dialect-tuned with the max-emphasis default.
- `src/tool/eval-tool.ts`: optional `modelId` in `CreateEvalToolOptions`, forwarded to `buildEvalPrompt`.
- `src/index.ts`: `session_start` registers eval with `ctx.model?.id`; a new `model_select` listener re-registers with the newly selected model's dialect (no-op before a session starts, on unchanged model id, and after dispose). Re-registration flows through `registerTool → _refreshToolRegistry → _rebuildSystemPrompt`, so the system-prompt guideline follows mid-session model switches.

## Testing

- `test/prompt.test.ts`: dialect mapping matrix across provider id shapes (Bedrock/`@cf/`/Fireworks/bare/namespaced), exactly-one-dialect rendering per family, dialect-tuned guideline contract, max-emphasis default when no model id.
- `test/extension.test.ts`: session_start registers the Claude dialect from `ctx.model`; `model_select` re-registers with the codex dialect; same-model reselect does not re-register; `model_select` before session start is ignored.
- `test/factory.test.ts`: registration event list now includes `model_select`.
- Full package suite: **358 passed | 6 skipped (52 files)**; `npm run check` at repo root: clean.
- QA (evidence under `local-ignore/qa-evidence/20260717-model-aware-eval-emphasis/`, not committed):
  - `npx tsx scripts/qa-e2e-eval.ts` — exit 0 (LANGS py,js; truncation/spill/rb-rejection asserted)
  - `npx tsx scripts/qa-e2e-eval.ts --abort-scenario` — exit 0 (CANCELLED true, STATE 42)
  - dialect render dump for claude-opus-4-8 / gpt-5.6 / kimi-k2.6 / glm-5.2 / gemini-2.5-pro / no-model — each renders exactly its own dialect.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model-aware batching guidance to the `eval` prompt so the wording matches the active model family, and auto-updates when the model changes mid-session. This improves consistent eval-first batching across Claude/GLM, OpenAI, and Kimi.

- **New Features**
  - `buildEvalPrompt` renders eval-first guidance in dialects: `claude` (Claude/GLM), `codex` (OpenAI `gpt-*`/`chatgpt`/`codex`/`o-series`), `kimi` (K-series), and a max-emphasis `default`.
  - System-prompt guideline is tuned per dialect; `default` keeps strong emphasis for unmapped models.
  - `createEvalTool` accepts optional `modelId`; `session_start` registers with `ctx.model?.id`.
  - Added `model_select` listener to re-register `eval` with the new dialect so mid-session model switches update the system prompt.
  - Model detection covers bare ids, namespaced/provider paths, Bedrock dotted ids, `@cf/` routes, and Fireworks `p`-version shapes.

- **Refactors**
  - Extension tracks the active runtime and model id; extracts `modelIdFrom(event)` and `registerEvalForRuntime(...)`.
  - Disposes and clears runtime on `session_shutdown`, `session_before_switch`, and `session_before_fork`.

<sup>Written for commit 76e53472c274f11a54ae89bfb5c4022daac1578c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

