### PR TITLE
fix(ai): normalize tool parameters for Moonshot-flavored OpenAI backends

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -40,6 +40,10 @@ import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { isForcedToolChoiceUnsupportedError, omitToolChoiceParam } from "../utils/tool-choice-fallback.ts";
+import {
+	normalizeToolParametersForMoonshot,
+	normalizeToolParametersForOpenAICompat,
+} from "../utils/tool-schema-compat.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import {
@@ -179,11 +183,12 @@ interface OpenAICompatCacheControl {
 
 type ResolvedOpenAICompletionsCompat = Omit<
 	Required<OpenAICompletionsCompat>,
-	"cacheControlFormat" | "toolCallFormat" | "deferredToolsMode"
+	"cacheControlFormat" | "toolCallFormat" | "deferredToolsMode" | "toolSchemaFlavor"
 > & {
 	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
 	toolCallFormat?: OpenAICompletionsCompat["toolCallFormat"];
 	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	toolSchemaFlavor?: OpenAICompletionsCompat["toolSchemaFlavor"];
 };
 
 type ResolvedChatTemplateKwargValue = string | number | boolean | null;
@@ -1230,12 +1235,17 @@ function convertTools(
 			throw new Error("Freeform tools cannot be sent to OpenAI Chat Completions; use Responses API");
 		}
 
+		const normalizedParameters =
+			compat.toolSchemaFlavor === "moonshot-mfjs"
+				? normalizeToolParametersForMoonshot(tool.parameters as Record<string, unknown>)
+				: normalizeToolParametersForOpenAICompat(tool.parameters as Record<string, unknown>);
+
 		return {
 			type: "function",
 			function: {
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters as FunctionParameters,
+				parameters: normalizedParameters as FunctionParameters,
 				// Only include strict if provider supports it. Some reject unknown fields.
 				...(compat.supportsStrictMode !== false && { strict: false }),
 			},
@@ -1383,6 +1393,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		chatTemplateKwargs: {},
 		zaiToolStream: false,
 		supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia,
+		toolSchemaFlavor: isMoonshot ? "moonshot-mfjs" : undefined,
 		supportsDisabledThinking: true,
 		toolCallFormat: undefined,
 		cacheControlFormat,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -562,6 +562,11 @@ export interface OpenAICompletionsCompat {
 	/** Whether the provider supports the `strict` field in tool definitions. Default: true. */
 	supportsStrictMode?: boolean;
 	/**
+	 * Provider-specific JSON Schema flavor for tool parameters. `"moonshot-mfjs"`
+	 * normalizes schemas for Moonshot / Kimi backends that enforce a stricter subset.
+	 */
+	toolSchemaFlavor?: "moonshot-mfjs";
+	/**
 	 * Tool call format for models that don't natively support tool calling.
 	 * When set, the middleware will intercept tool calls and format them as text.
 	 * Supported values: "hermes", "xml", "yaml-xml", "gemma4-delimiter"

--- a/packages/ai/src/utils/tool-schema-compat.ts
+++ b/packages/ai/src/utils/tool-schema-compat.ts
@@ -1,0 +1,193 @@
+/**
+ * JSON Schema normalization for tool parameters sent to OpenAI-compatible
+ * backends. Some gateways (e.g. Apitopia → Kimi / Moonshot) enforce a stricter
+ * subset that rejects a sibling `type` keyword on schemas that also declare
+ * `anyOf` / `oneOf` / `allOf`. This helper removes that redundancy while
+ * preserving the schema's semantics.
+ */
+
+export type ToolSchemaFlavor = "moonshot-mfjs";
+
+const COMBINER_KEYS = ["anyOf", "oneOf", "allOf"] as const;
+const SCHEMA_MAP_KEYS = ["properties", "patternProperties", "$defs", "definitions"] as const;
+const SCHEMA_SINGLE_KEYS = [
+	"items",
+	"additionalProperties",
+	"contains",
+	"propertyNames",
+	"if",
+	"then",
+	"else",
+	"not",
+] as const;
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isScalarType(type: unknown): type is "string" | "number" | "integer" | "boolean" {
+	return type === "string" || type === "number" || type === "integer" || type === "boolean";
+}
+
+/**
+ * Move a parent-level `type` keyword into combiner branches that do not already
+ * declare one, then drop the parent `type`. This keeps the schema equivalent
+ * while satisfying validators that require `type` to live inside each branch.
+ */
+function moveTypeIntoCombinerBranches(node: Record<string, unknown>): void {
+	if (!("type" in node)) return;
+
+	const parentType = node.type;
+	for (const combiner of COMBINER_KEYS) {
+		const branches = node[combiner];
+		if (!Array.isArray(branches)) continue;
+
+		for (const branch of branches) {
+			if (isJsonObject(branch) && !("type" in branch)) {
+				branch.type = parentType;
+			}
+		}
+	}
+
+	delete node.type;
+}
+
+/**
+ * Collapse a homogeneous all-`const` union into a typed `enum`. This is the
+ * wire shape many OpenAI-compatible gateways expect for literal unions.
+ */
+function collapseConstUnion(node: Record<string, unknown>): void {
+	const branches = node.anyOf;
+	if (!Array.isArray(branches) || branches.length < 2) return;
+	if ("type" in node) return;
+
+	const values: unknown[] = [];
+	let sharedType: string | undefined;
+
+	for (const branch of branches) {
+		if (!isJsonObject(branch)) return;
+		if (!Object.hasOwn(branch, "const")) return;
+
+		const keys = Object.keys(branch);
+		if (keys.length !== 2 || !keys.includes("type")) return;
+
+		const branchType = branch.type;
+		if (!isScalarType(branchType)) return;
+
+		if (sharedType === undefined) {
+			sharedType = branchType;
+		} else if (sharedType !== branchType) {
+			return;
+		}
+
+		values.push(branch.const);
+	}
+
+	if (sharedType === undefined || values.length === 0) return;
+
+	delete node.anyOf;
+	node.type = sharedType;
+	node.enum = values;
+}
+
+function normalizeNode(node: unknown): unknown {
+	if (Array.isArray(node)) {
+		return node.map((child) => normalizeNode(child));
+	}
+
+	if (!isJsonObject(node)) {
+		return node;
+	}
+
+	const hasCombiner = COMBINER_KEYS.some((key) => Array.isArray(node[key]));
+	if (hasCombiner) {
+		moveTypeIntoCombinerBranches(node);
+	}
+
+	for (const combiner of COMBINER_KEYS) {
+		const branches = node[combiner];
+		if (Array.isArray(branches)) {
+			node[combiner] = branches.map((branch) => normalizeNode(branch));
+		}
+	}
+
+	if (Array.isArray(node.anyOf)) {
+		collapseConstUnion(node);
+	}
+
+	for (const key of SCHEMA_SINGLE_KEYS) {
+		if (Object.hasOwn(node, key)) {
+			node[key] = normalizeNode(node[key]);
+		}
+	}
+
+	for (const key of SCHEMA_MAP_KEYS) {
+		const map = node[key];
+		if (!isJsonObject(map)) continue;
+		for (const name of Object.keys(map)) {
+			map[name] = normalizeNode(map[name]);
+		}
+	}
+
+	return node;
+}
+
+/**
+ * Return a deep-normalized copy of a tool's JSON Schema parameters, suitable
+ * for OpenAI-compatible Chat Completions backends.
+ */
+export function normalizeToolParametersForOpenAICompat(schema: Record<string, unknown>): Record<string, unknown> {
+	return normalizeNode(structuredClone(schema)) as Record<string, unknown>;
+}
+
+/**
+ * Moonshot-flavored JSON Schema subset: in addition to the OpenAI-compatible
+ * normalization, drop non-structural annotation keywords that Moonshot rejects.
+ */
+export function normalizeToolParametersForMoonshot(schema: Record<string, unknown>): Record<string, unknown> {
+	const normalized = normalizeToolParametersForOpenAICompat(schema);
+	return stripMoonshotAnnotations(normalized);
+}
+
+function stripMoonshotAnnotations(node: unknown): Record<string, unknown> {
+	if (Array.isArray(node)) {
+		return node.map((child) => stripMoonshotAnnotations(child)) as unknown as Record<string, unknown>;
+	}
+
+	if (!isJsonObject(node)) {
+		return node as Record<string, unknown>;
+	}
+
+	// Moonshot does not support JSON Schema validators like `format` or
+	// annotation-only keywords like `examples` inside function parameters.
+	delete node.format;
+	delete node.examples;
+	delete node.readOnly;
+	delete node.writeOnly;
+	delete node.deprecated;
+	delete node.$schema;
+	delete node.$id;
+
+	for (const combiner of COMBINER_KEYS) {
+		const branches = node[combiner];
+		if (Array.isArray(branches)) {
+			node[combiner] = branches.map((branch) => stripMoonshotAnnotations(branch));
+		}
+	}
+
+	for (const key of SCHEMA_SINGLE_KEYS) {
+		if (Object.hasOwn(node, key)) {
+			node[key] = stripMoonshotAnnotations(node[key]);
+		}
+	}
+
+	for (const key of SCHEMA_MAP_KEYS) {
+		const map = node[key];
+		if (!isJsonObject(map)) continue;
+		for (const name of Object.keys(map)) {
+			map[name] = stripMoonshotAnnotations(map[name]);
+		}
+	}
+
+	return node;
+}

--- a/packages/ai/test/openai-completions-thinking-as-text.test.ts
+++ b/packages/ai/test/openai-completions-thinking-as-text.test.ts
@@ -38,15 +38,20 @@ const compat = {
 	chatTemplateKwargs: {},
 	zaiToolStream: false,
 	supportsStrictMode: true,
+	toolSchemaFlavor: undefined,
 	toolCallFormat: undefined,
 	cacheControlFormat: undefined,
 	sendSessionAffinityHeaders: false,
 	sessionAffinityFormat: "openai",
 	supportsLongCacheRetention: true,
-} satisfies Omit<Required<OpenAICompletionsCompat>, "cacheControlFormat" | "toolCallFormat" | "deferredToolsMode"> & {
+} satisfies Omit<
+	Required<OpenAICompletionsCompat>,
+	"cacheControlFormat" | "toolCallFormat" | "deferredToolsMode" | "toolSchemaFlavor"
+> & {
 	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
 	toolCallFormat?: OpenAICompletionsCompat["toolCallFormat"];
 	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	toolSchemaFlavor?: OpenAICompletionsCompat["toolSchemaFlavor"];
 };
 
 function buildModel(baseUrl = "http://127.0.0.1:1"): Model<"openai-completions"> {

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -36,15 +36,20 @@ const compat = {
 	chatTemplateKwargs: {},
 	zaiToolStream: false,
 	supportsStrictMode: true,
+	toolSchemaFlavor: undefined,
 	toolCallFormat: undefined,
 	cacheControlFormat: "anthropic",
 	sendSessionAffinityHeaders: false,
 	sessionAffinityFormat: "openai",
 	supportsLongCacheRetention: true,
-} satisfies Omit<Required<OpenAICompletionsCompat>, "cacheControlFormat" | "toolCallFormat" | "deferredToolsMode"> & {
+} satisfies Omit<
+	Required<OpenAICompletionsCompat>,
+	"cacheControlFormat" | "toolCallFormat" | "deferredToolsMode" | "toolSchemaFlavor"
+> & {
 	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
 	toolCallFormat?: OpenAICompletionsCompat["toolCallFormat"];
 	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	toolSchemaFlavor?: OpenAICompletionsCompat["toolSchemaFlavor"];
 };
 
 function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {

--- a/packages/ai/test/openai-completions-tool-schema-compat.test.ts
+++ b/packages/ai/test/openai-completions-tool-schema-compat.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+	normalizeToolParametersForMoonshot,
+	normalizeToolParametersForOpenAICompat,
+} from "../src/utils/tool-schema-compat.ts";
+
+describe("tool-schema-compat", () => {
+	describe("normalizeToolParametersForOpenAICompat", () => {
+		it("removes a sibling type keyword from anyOf nodes", () => {
+			const schema = {
+				type: "object",
+				properties: {
+					mode: {
+						type: "string",
+						anyOf: [
+							{ type: "string", const: "fast" },
+							{ type: "string", const: "slow" },
+						],
+					},
+				},
+			};
+
+			const normalized = normalizeToolParametersForOpenAICompat(schema);
+
+			expect(normalized).toEqual({
+				type: "object",
+				properties: {
+					mode: {
+						type: "string",
+						enum: ["fast", "slow"],
+					},
+				},
+			});
+		});
+
+		it("moves a parent type into untyped combiner branches", () => {
+			const schema = {
+				type: "object",
+				anyOf: [{ properties: { a: { type: "string" } } }, { properties: { b: { type: "number" } } }],
+			};
+
+			const normalized = normalizeToolParametersForOpenAICompat(schema);
+
+			expect(normalized).toEqual({
+				anyOf: [
+					{ type: "object", properties: { a: { type: "string" } } },
+					{ type: "object", properties: { b: { type: "number" } } },
+				],
+			});
+		});
+
+		it("collapses a homogeneous const union into a typed enum", () => {
+			const schema = {
+				anyOf: [
+					{ type: "string", const: "alpha" },
+					{ type: "string", const: "beta" },
+				],
+			};
+
+			const normalized = normalizeToolParametersForOpenAICompat(schema);
+
+			expect(normalized).toEqual({ type: "string", enum: ["alpha", "beta"] });
+		});
+
+		it("recurses through nested properties and items", () => {
+			const schema = {
+				type: "object",
+				properties: {
+					tags: {
+						type: "array",
+						items: {
+							type: "string",
+							anyOf: [
+								{ type: "string", const: "x" },
+								{ type: "string", const: "y" },
+							],
+						},
+					},
+				},
+			};
+
+			const normalized = normalizeToolParametersForOpenAICompat(schema);
+
+			expect(normalized).toEqual({
+				type: "object",
+				properties: {
+					tags: {
+						type: "array",
+						items: { type: "string", enum: ["x", "y"] },
+					},
+				},
+			});
+		});
+	});
+
+	describe("normalizeToolParametersForMoonshot", () => {
+		it("strips format and examples annotations", () => {
+			const schema = {
+				type: "object",
+				properties: {
+					when: {
+						type: "string",
+						format: "date-time",
+						examples: ["2025-01-01T00:00:00Z"],
+						anyOf: [{ type: "string", const: "now" }],
+					},
+				},
+			};
+
+			const normalized = normalizeToolParametersForMoonshot(schema);
+
+			expect(normalized).toEqual({
+				type: "object",
+				properties: {
+					when: {
+						anyOf: [{ type: "string", const: "now" }],
+					},
+				},
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Requests to Apitopia → Kimi K3 were failing with:

```
Error: 400: {"message":"tools.function.parameters is not a valid moonshot flavored json schema, details: <At path 'root': when using anyOf, type should be defined in anyOf items instead of the parent schema>","type":"invalid_request_error"}
```

The OpenAI-completions provider was sending raw TypeBox JSON Schemas without normalizing the `type` / `anyOf` sibling pattern that Moonshot’s stricter JSON Schema subset rejects.

## Change

- Add `packages/ai/src/utils/tool-schema-compat.ts` with two normalizers:
  - `normalizeToolParametersForOpenAICompat` — removes a sibling `type` from `anyOf`/`oneOf`/`allOf` nodes (moving it into untyped branches when needed) and collapses homogeneous `const` unions into typed `enum`s.
  - `normalizeToolParametersForMoonshot` — additionally strips annotation/validator keywords such as `format`, `examples`, `$schema`, etc.
- Wire the normalizer into `convertTools` in `packages/ai/src/api/openai-completions.ts`.
- Add `toolSchemaFlavor?: "moonshot-mfjs"` to `OpenAICompletionsCompat` and auto-detect it for native Moonshot hosts.
- Update existing test fixtures that build a `ResolvedOpenAICompletionsCompat` literal to include the new optional field.
- Add `packages/ai/test/openai-completions-tool-schema-compat.test.ts` covering the failing shape and the Moonshot flavor.

## Verification

- `packages/ai` unit tests: `906 passed | 738 skipped`.
- `npx tsgo --noEmit`: clean.
- Manual reproduction against `https://apitopia.labs.mengmota.com/v1/chat/completions` with the previously-failing schema now succeeds.
- senpi QA harness:
  - `mock-loop.mjs --self-test` ✅
  - `mock-loop.mjs --with-tool --api openai-completions` ✅
  - `cli-smoke.mjs --self-test` ✅

Evidence captured under `local-ignore/qa-evidence/20260717-kimi-tool-schema-*`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 400 errors from Apitopia → Kimi by normalizing tool JSON Schema for Moonshot-flavored OpenAI backends. The OpenAI-completions provider now auto-detects Moonshot and applies the stricter schema.

- **Bug Fixes**
  - Normalize tool parameters: move parent `type` into `anyOf`/`oneOf`/`allOf` branches, collapse homogeneous `const` unions into typed `enum`s, and strip annotation keywords (e.g., `format`, `examples`) for Moonshot.
  - Apply the normalizer in `convertTools`; add `toolSchemaFlavor?: "moonshot-mfjs"` to `OpenAICompletionsCompat` and auto-detect it for native Moonshot hosts.
  - Add unit tests for schema compatibility and update existing fixtures under `packages/ai`; Apitopia → Kimi requests now succeed.

<sup>Written for commit 7774f6c0ee8dde41b769f9d4cdb3834121376153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

