### PR TITLE
feat(prompt): workstation block with dialect-tuned execution-context instruction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added a `<workstation>` block (OS/kernel, arch, CPU, GPU, terminal) to the dynamic system prompt, followed by a dialect-tuned execution-context instruction telling the model that `bash`/`eval` run on this workstation while written code may target other machines. Presets pass their model-family dialect (Claude/GLM, GPT, Kimi); the fallback prompt uses a maximum-emphasis default.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/src/core/dynamic-prompt/build.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/build.ts
@@ -10,6 +10,7 @@ import { categorizeTools } from "./tool-categorization.ts";
 import { buildToolSection } from "./tool-section.ts";
 import type { AvailableTool } from "./types.ts";
 import { buildVerificationSection } from "./verification.ts";
+import { buildWorkstationSection, type WorkstationDialect } from "./workstation.ts";
 
 /** Context handed to a `corePrompt` override so it can reuse the dynamic pieces. */
 export interface DynamicPromptCoreContext {
@@ -32,6 +33,12 @@ export interface BuildDynamicSystemPromptOptions {
 	 * date, and cwd assembly stay in this builder.
 	 */
 	corePrompt?: (context: DynamicPromptCoreContext) => string;
+	/**
+	 * Wording dialect for the workstation execution-context instruction.
+	 * Presets pass their model family; the fallback prompt uses `default`
+	 * (maximum emphasis).
+	 */
+	workstationDialect?: WorkstationDialect;
 }
 
 function buildContextFilesSection(contextFiles: Array<{ path: string; content: string }>): string {
@@ -96,6 +103,14 @@ export function buildDynamicSystemPrompt(options: BuildDynamicSystemPromptOption
 	if (skillsSection) {
 		sections.push(skillsSection);
 	}
+
+	sections.push(
+		"",
+		buildWorkstationSection({
+			selectedTools: options.selectedTools,
+			dialect: options.workstationDialect ?? "default",
+		}),
+	);
 
 	sections.push("", `Current date: ${date}`, `Current working directory: ${promptCwd}`);
 

--- a/packages/coding-agent/src/core/dynamic-prompt/changes.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/changes.md
@@ -1,5 +1,21 @@
 # changes.md — dynamic-prompt
 
+## Workstation block + execution-context instruction (2026-07-17)
+
+### What changed
+
+- `workstation.ts` (new): synchronous host-facts collector (`os.platform`/`type`/`release`/`arch`, CPU model with `/proc/cpuinfo` fallback on Linux, core count via `os.availableParallelism()`, Apple-Silicon GPU derivation, TERM_PROGRAM terminal) cached per process, plus `buildWorkstationSection()` rendering a `<workstation>` facts block followed by an execution-context instruction in one of four dialects (`default` max-emphasis, `claude` tagged imperatives, `codex` terse, `kimi` positive constraints). The instruction names the active local executors (`bash`/`eval`) from `selectedTools`.
+- `build.ts`: `BuildDynamicSystemPromptOptions.workstationDialect?: WorkstationDialect`; the section is assembled right before the date/cwd footer (applies to `corePrompt` presets too).
+- All 15 `prompt-preset` builders pass their family dialect.
+
+### Why extension system couldn't handle this alone
+
+- The workstation facts belong to every prompt (fallback included), and the instruction must sit directly under the facts block for context proximity; a preset-level `tuningSection` lands before context files, far from the footer.
+
+### Expected merge conflict zones
+
+- LOW: `build.ts` footer assembly if upstream reshapes it. Resolution: keep the workstation push before the date/cwd push.
+
 ## AGENTS.md precedence contract in Project Context (2026-07-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/dynamic-prompt/workstation.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/workstation.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from "node:fs";
+import * as os from "node:os";
+
+/** Snapshot of host facts rendered into the workstation block. */
+export interface WorkstationFacts {
+	/** `os.platform()`, e.g. `darwin`. */
+	readonly osLine: string;
+	/** Kernel identity: `<uname -s> <uname -r>`, e.g. `Darwin 25.3.0`. */
+	readonly kernel: string;
+	/** `os.arch()`, e.g. `arm64`. */
+	readonly arch: string;
+	/** CPU model plus logical core count, e.g. `Apple M5 Max (18 cores)`. */
+	readonly cpu?: string;
+	/** GPU model when cheaply derivable (Apple Silicon shares the SoC name). */
+	readonly gpu?: string;
+	/** Terminal emulator name/version from TERM_PROGRAM/TERM. */
+	readonly terminal?: string;
+}
+
+/**
+ * Wording dialect for the execution-context instruction under the facts.
+ * Families follow the prompt-preset conventions: Claude/GLM take direct
+ * imperatives in a tagged block, GPT (codex) takes terse bounded rules, Kimi
+ * takes positive operational constraints (all-caps directives make K2.x
+ * overthink), and `default` is the maximum-emphasis fallback for unmatched
+ * models.
+ */
+export type WorkstationDialect = "default" | "claude" | "codex" | "kimi";
+
+// Kernel identity: `<uname -s> <uname -r>` (`Darwin 25.3.0`, `Linux 6.8.0-45-generic`).
+// Deliberately NOT `os.version()` — Node returns the full xnu build string on
+// macOS (noisy) and some runtimes return the literal "unknown", which makes
+// models misidentify the host platform.
+
+function cpuModel(): string | undefined {
+	if (process.platform === "linux") {
+		try {
+			const cpuInfo = readFileSync("/proc/cpuinfo", "utf8");
+			const match = /^model name\s*:\s*(.+)$/m.exec(cpuInfo);
+			if (match?.[1]) return match[1].trim();
+		} catch {
+			// fall through to os.cpus()
+		}
+	}
+	return os.cpus()[0]?.model?.trim() || undefined;
+}
+
+// GPU: only derivable without a subprocess on Apple Silicon, where the SoC
+// name doubles as the GPU name. Other platforms would need nvidia-smi/lspci —
+// deliberately skipped to keep prompt assembly synchronous.
+
+function terminalName(): string | undefined {
+	const program = process.env.TERM_PROGRAM?.trim();
+	if (program) {
+		const version = process.env.TERM_PROGRAM_VERSION?.trim();
+		return version ? `${program} ${version}` : program;
+	}
+	return process.env.TERM?.trim() || undefined;
+}
+
+let cachedFacts: WorkstationFacts | undefined;
+
+/** Collect host facts once per process; every call after the first is free. */
+export function collectWorkstationFacts(): WorkstationFacts {
+	if (cachedFacts) return cachedFacts;
+	const cpu = cpuModel();
+	const cores = os.availableParallelism();
+	const gpu = process.platform === "darwin" && os.arch() === "arm64" && cpu?.startsWith("Apple ") ? cpu : undefined;
+	const terminal = terminalName();
+	const facts: WorkstationFacts = {
+		osLine: os.platform(),
+		kernel: `${os.type()} ${os.release()}`.trim(),
+		arch: os.arch(),
+		...(cpu === undefined ? {} : { cpu: `${cpu} (${cores} cores)` }),
+		...(gpu === undefined ? {} : { gpu }),
+		...(terminal === undefined ? {} : { terminal }),
+	};
+	cachedFacts = facts;
+	return facts;
+}
+
+/** Subject + verb naming the local executors, e.g. "`bash` and `eval` execute". */
+function executorPhrase(selectedTools: readonly string[]): string {
+	const executors = ["bash", "eval"].filter((name) => selectedTools.includes(name));
+	if (executors.length === 0) return "Everything you run executes";
+	return `${executors.map((name) => `\`${name}\``).join(" and ")} execute${executors.length === 1 ? "s" : ""}`;
+}
+
+const INSTRUCTIONS: Record<WorkstationDialect, (executors: string) => string> = {
+	claude: (executors) =>
+		`<execution_context>
+${executors} on THIS workstation. Match commands, paths, package managers, and parallel pool sizes to it. Code you write may target any machine; code you run always runs here.
+</execution_context>`,
+	codex: (executors) =>
+		`${executors} on this workstation; match commands, paths, and parallelism to it. Written code may target other platforms — executed code runs here.`,
+	kimi: (executors) =>
+		`${executors} on this workstation — choose commands, paths, and parallelism that fit it. When writing code for another target platform, keep the code portable; only the execution happens here.`,
+	default: (executors) =>
+		`**EXECUTION HAPPENS HERE.** ${executors} on THIS machine — you MUST match commands, paths, package managers, and parallel pool sizes to the workstation above. Code you WRITE may target a different machine; anything you RUN executes HERE.`,
+};
+
+export interface BuildWorkstationSectionOptions {
+	readonly selectedTools: readonly string[];
+	readonly dialect?: WorkstationDialect;
+	/** Override collected facts (tests). */
+	readonly facts?: WorkstationFacts;
+}
+
+/** Render the `<workstation>` facts block plus the dialect-tuned execution-context instruction. */
+export function buildWorkstationSection(options: BuildWorkstationSectionOptions): string {
+	const facts = options.facts ?? collectWorkstationFacts();
+	const dialect = options.dialect ?? "default";
+	const lines = [
+		`- OS: ${facts.osLine} (kernel ${facts.kernel})`,
+		`- Arch: ${facts.arch}`,
+		...(facts.cpu ? [`- CPU: ${facts.cpu}`] : []),
+		...(facts.gpu ? [`- GPU: ${facts.gpu}`] : []),
+		...(facts.terminal ? [`- Terminal: ${facts.terminal}`] : []),
+	];
+	const instruction = INSTRUCTIONS[dialect](executorPhrase(options.selectedTools));
+	return `<workstation>\n${lines.join("\n")}\n</workstation>\n${instruction}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5.ts
@@ -13,5 +13,9 @@ Do not stop, summarize, or suggest a new session on account of context limits. C
 }
 
 export function buildClaudeFable5Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildClaudeFable5Tuning() });
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildClaudeFable5Tuning(),
+		workstationDialect: "claude",
+	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-5.ts
@@ -7,5 +7,9 @@ Do not wrap up early because the context window is running low; the harness auto
 }
 
 export function buildClaudeOpus45Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildClaudeOpus45Tuning() });
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildClaudeOpus45Tuning(),
+		workstationDialect: "claude",
+	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-6.ts
@@ -7,5 +7,9 @@ Do not wrap up early because the context window is running low; the harness auto
 }
 
 export function buildClaudeOpus46Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildClaudeOpus46Tuning() });
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildClaudeOpus46Tuning(),
+		workstationDialect: "claude",
+	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-7.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-7.ts
@@ -11,5 +11,9 @@ Do not wrap up early because the context window is running low; the harness auto
 }
 
 export function buildClaudeOpus47Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildClaudeOpus47Tuning() });
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildClaudeOpus47Tuning(),
+		workstationDialect: "claude",
+	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-8.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-8.ts
@@ -11,5 +11,9 @@ Do not wrap up early because the context window is running low; the harness auto
 }
 
 export function buildClaudeOpus48Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildClaudeOpus48Tuning() });
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildClaudeOpus48Tuning(),
+		workstationDialect: "claude",
+	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5-2.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5-2.ts
@@ -11,5 +11,5 @@ The intent gate routing line is non-optional every turn. For non-trivial tasks, 
 }
 
 export function buildGlm52Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGlm52Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGlm52Tuning(), workstationDialect: "claude" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.2.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.2.ts
@@ -14,5 +14,5 @@ ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt52Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt52Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt52Tuning(), workstationDialect: "codex" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.3-codex.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.3-codex.ts
@@ -12,5 +12,5 @@ ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt53CodexPrompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt53CodexTuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt53CodexTuning(), workstationDialect: "codex" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.4.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.4.ts
@@ -12,5 +12,5 @@ ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt54Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt54Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt54Tuning(), workstationDialect: "codex" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.5.ts
@@ -80,5 +80,5 @@ ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt55Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, corePrompt: buildGpt55Core });
+	return buildDynamicSystemPrompt({ ...options, corePrompt: buildGpt55Core, workstationDialect: "codex" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
@@ -142,5 +142,5 @@ ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt56Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, corePrompt: buildGpt56Core });
+	return buildDynamicSystemPrompt({ ...options, corePrompt: buildGpt56Core, workstationDialect: "codex" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.ts
@@ -10,5 +10,5 @@ ${buildFileOperationsTuning()}`;
 }
 
 export function buildGpt5Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt5Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGpt5Tuning(), workstationDialect: "codex" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k2-6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k2-6.ts
@@ -7,5 +7,5 @@ The intent gate routing line is required every turn. On confirmation turns where
 }
 
 export function buildKimiK26Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK26Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK26Tuning(), workstationDialect: "kimi" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k2-7.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k2-7.ts
@@ -7,5 +7,5 @@ The intent gate routing line is required every turn. When the user has already c
 }
 
 export function buildKimiK27Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK27Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK27Tuning(), workstationDialect: "kimi" });
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
@@ -13,5 +13,5 @@ Do not stop, summarize, or suggest a new session on account of context limits; t
 }
 
 export function buildKimiK3Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK3Tuning() });
+	return buildDynamicSystemPrompt({ ...options, tuningSection: buildKimiK3Tuning(), workstationDialect: "kimi" });
 }

--- a/packages/coding-agent/test/dynamic-prompt/workstation.test.ts
+++ b/packages/coding-agent/test/dynamic-prompt/workstation.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+import { buildDynamicSystemPrompt } from "../../src/core/dynamic-prompt/build.ts";
+import {
+	buildWorkstationSection,
+	collectWorkstationFacts,
+	type WorkstationFacts,
+} from "../../src/core/dynamic-prompt/workstation.ts";
+
+const FACTS: WorkstationFacts = {
+	osLine: "darwin",
+	kernel: "Darwin 25.3.0",
+	arch: "arm64",
+	cpu: "Apple M5 Max (18 cores)",
+	gpu: "Apple M5 Max",
+	terminal: "ghostty 1.3.1",
+};
+
+describe("buildWorkstationSection", () => {
+	test("renders every provided fact as a tagged block", () => {
+		const section = buildWorkstationSection({ selectedTools: ["bash"], facts: FACTS });
+
+		expect(section).toContain("<workstation>");
+		expect(section).toContain("</workstation>");
+		expect(section).toContain("- OS: darwin (kernel Darwin 25.3.0)");
+		expect(section).toContain("- Arch: arm64");
+		expect(section).toContain("- CPU: Apple M5 Max (18 cores)");
+		expect(section).toContain("- GPU: Apple M5 Max");
+		expect(section).toContain("- Terminal: ghostty 1.3.1");
+	});
+
+	test("omits missing optional facts instead of rendering empty lines", () => {
+		const section = buildWorkstationSection({
+			selectedTools: ["bash"],
+			facts: { osLine: "linux", kernel: "Linux 6.8.0-x86_64", arch: "x64" },
+		});
+
+		expect(section).not.toContain("- CPU:");
+		expect(section).not.toContain("- GPU:");
+		expect(section).not.toContain("- Terminal:");
+	});
+
+	test("names the active local executors in the instruction", () => {
+		const both = buildWorkstationSection({ selectedTools: ["bash", "eval", "read"], facts: FACTS });
+		const bashOnly = buildWorkstationSection({ selectedTools: ["bash", "read"], facts: FACTS });
+		const none = buildWorkstationSection({ selectedTools: ["read", "edit"], facts: FACTS });
+
+		expect(both).toContain("`bash` and `eval` execute");
+		expect(bashOnly).toContain("`bash` executes");
+		expect(bashOnly).not.toContain("`eval`");
+		expect(none).toContain("Everything you run executes");
+	});
+
+	test("claude dialect wraps the instruction in an execution_context tag with direct imperatives", () => {
+		const section = buildWorkstationSection({ selectedTools: ["bash", "eval"], dialect: "claude", facts: FACTS });
+
+		expect(section).toContain("<execution_context>");
+		expect(section).toContain("</execution_context>");
+		expect(section).toContain("Code you write may target any machine; code you run always runs here.");
+	});
+
+	test("codex dialect is terse without tags or shouting", () => {
+		const section = buildWorkstationSection({ selectedTools: ["bash", "eval"], dialect: "codex", facts: FACTS });
+		const instruction = section.slice(section.indexOf("</workstation>"));
+
+		expect(instruction).toContain("executed code runs here");
+		expect(instruction).not.toContain("<execution_context>");
+		expect(instruction).not.toContain("MUST");
+		expect(instruction).not.toContain("EXECUTION HAPPENS HERE");
+	});
+
+	test("kimi dialect uses positive constraints without all-caps directives", () => {
+		const section = buildWorkstationSection({ selectedTools: ["bash", "eval"], dialect: "kimi", facts: FACTS });
+		const instruction = section.slice(section.indexOf("</workstation>"));
+
+		expect(instruction).toContain("keep the code portable");
+		expect(instruction).not.toMatch(/\b[A-Z]{4,}\b/);
+		expect(instruction).not.toContain("<execution_context>");
+	});
+
+	test("default dialect carries maximum emphasis", () => {
+		const section = buildWorkstationSection({ selectedTools: ["bash", "eval"], facts: FACTS });
+
+		expect(section).toContain("**EXECUTION HAPPENS HERE.**");
+		expect(section).toContain("anything you RUN executes HERE");
+	});
+});
+
+describe("collectWorkstationFacts", () => {
+	test("reports this host and caches the snapshot", () => {
+		const first = collectWorkstationFacts();
+		const second = collectWorkstationFacts();
+
+		expect(first.osLine.startsWith(process.platform)).toBe(true);
+		expect(first.arch.length).toBeGreaterThan(0);
+		expect(first.kernel.toLowerCase()).not.toContain("unknown");
+		expect(second).toBe(first);
+	});
+});
+
+describe("buildDynamicSystemPrompt workstation integration", () => {
+	const baseOptions = {
+		cwd: "/test/project",
+		selectedTools: ["read", "bash", "edit", "write"],
+		toolSnippets: { bash: "Execute shell commands" },
+		promptGuidelines: [],
+		contextFiles: [],
+		skills: [],
+	};
+
+	test("renders the workstation block before the date/cwd footer", () => {
+		const prompt = buildDynamicSystemPrompt(baseOptions);
+
+		const workstation = prompt.indexOf("<workstation>");
+		const cwd = prompt.indexOf("Current working directory:");
+		expect(workstation).toBeGreaterThanOrEqual(0);
+		expect(cwd).toBeGreaterThan(workstation);
+		expect(prompt).toContain("**EXECUTION HAPPENS HERE.**");
+	});
+
+	test("applies the preset-provided dialect", () => {
+		const prompt = buildDynamicSystemPrompt({ ...baseOptions, workstationDialect: "claude" });
+
+		expect(prompt).toContain("<execution_context>");
+		expect(prompt).not.toContain("EXECUTION HAPPENS HERE");
+	});
+});

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a host-sizing note to the `eval` prompt: the extension now passes a preformatted host line (platform, arch, CPU model, core count) at registration so the prompt tells the model to size `parallel(thunks)` pools to the local cores and keep shell commands platform-appropriate.
 - Added model-aware eval-first batching emphasis: the `eval` tool description and its system-prompt guideline now render in a dialect selected by the active model id (Claude/GLM, OpenAI, Kimi, and a maximum-emphasis default fallback), re-registering on `model_select` so mid-session model switches pick up the matching dialect.
 
 ### Changed

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import type { ExtensionContext } from "@code-yeongyu/senpi";
 import type { KernelToHostMessage } from "./bridge/protocol.ts";
 import type { AgentExecuteTool } from "./bridges/agent-bridge.ts";
@@ -93,6 +94,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				renderers,
 				spawns: runtime.spawns,
 				spawnDefaultAgent: runtime.settings.taskTools.task,
+				hostLine: hostLine(),
 				...(modelId === undefined ? {} : { modelId }),
 			}),
 		);
@@ -112,6 +114,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			settings: defaultCodemodeSettings,
 			executionTracker: manager,
 			renderers,
+			hostLine: hostLine(),
 		}),
 	);
 
@@ -134,6 +137,13 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		activeModelId = modelId;
 		registerEvalForRuntime(runtime, modelId);
 	});
+}
+
+function hostLine(): string {
+	const cpu = os.cpus()[0]?.model?.trim();
+	return [`${os.platform()} ${os.arch()}`, cpu, `${os.availableParallelism()} cores`]
+		.filter((part): part is string => !!part)
+		.join(" \u00b7 ");
 }
 
 function modelIdFrom(event: unknown): string | undefined {

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -16,6 +16,8 @@ export interface EvalPromptOptions {
 	readonly spawnDefaultAgent?: string;
 	/** Active model id; selects the emphasis dialect of the batching guidance. */
 	readonly modelId?: string;
+	/** Preformatted host line (e.g. "darwin arm64 · Apple M5 Max · 18 cores"); enables the host-sizing note. */
+	readonly hostLine?: string;
 }
 
 /** Prompt dialect for the eval-first batching emphasis. */
@@ -99,6 +101,9 @@ Work incrementally: imports in one call, define in the next, test, then use — 
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
 - **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
 - **DISTILL IN-KERNEL.** Filter, diff, and aggregate in code before returning; return facts, NOT dumps.{{/if}}
+{{#if hostLine}}
+Host: {{hostLine}} — cells execute here. Size \`parallel(thunks)\` pools to its cores; \`tool.<name>()\` shell commands must fit this platform, even when the code you are writing targets another machine.
+{{/if}}
 
 Fields:
 
@@ -182,6 +187,7 @@ export function buildEvalPrompt(
 		styleCodex: style === "codex",
 		styleKimi: style === "kimi",
 		styleDefault: style === "default",
+		hostLine: options.hostLine ?? "",
 	};
 	const examples = REUSE_CHAIN_EXAMPLES.filter((example) => enabled[example.language])
 		.map((example) => {

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -41,6 +41,8 @@ export interface CreateEvalToolOptions {
 	readonly spawnDefaultAgent?: string;
 	/** Active model id; selects the emphasis dialect of the eval prompt. */
 	readonly modelId?: string;
+	/** Preformatted host line rendered into the prompt's host-sizing note. */
+	readonly hostLine?: string;
 }
 
 interface EvalCellInvocation {
@@ -155,6 +157,7 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		spawns: options.spawns ?? false,
 		...(options.spawnDefaultAgent === undefined ? {} : { spawnDefaultAgent: options.spawnDefaultAgent }),
 		...(options.modelId === undefined ? {} : { modelId: options.modelId }),
+		...(options.hostLine === undefined ? {} : { hostLine: options.hostLine }),
 	});
 	const languages = enabledLanguageList(options.enabledLanguages);
 	return {

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -187,6 +187,21 @@ describe("buildEvalPrompt", () => {
 		);
 	});
 
+	it("renders the host-sizing note only when a host line is provided", () => {
+		// Given: the same kernel set with and without a preformatted host line.
+		const enabled = { py: true, js: true, rb: false, jl: false };
+		const withHost = buildEvalPrompt(enabled, {
+			spawns: false,
+			hostLine: "darwin arm64 \u00b7 Apple M5 Max \u00b7 18 cores",
+		}).description;
+		const withoutHost = buildEvalPrompt(enabled, { spawns: false }).description;
+
+		// Then: the note names the host and the sizing rule, and disappears without one.
+		expect(withHost).toContain("Host: darwin arm64 \u00b7 Apple M5 Max \u00b7 18 cores — cells execute here.");
+		expect(withHost).toContain("Size `parallel(thunks)` pools to its cores");
+		expect(withoutHost).not.toContain("Host:");
+	});
+
 	it("throws when no kernels are enabled", () => {
 		expect(() => buildEvalPrompt({ py: false, js: false, rb: false, jl: false })).toThrow(/no kernels enabled/i);
 	});


### PR DESCRIPTION
## Summary

Adds host awareness to the senpi system prompt and the `eval` tool, so the model knows that **execution happens on this workstation even when the code it writes targets another machine**.

1. **`<workstation>` block in every dynamic system prompt** (`packages/coding-agent/src/core/dynamic-prompt/workstation.ts`, new): OS/kernel, arch, CPU model + logical cores, GPU (Apple Silicon derivation — no subprocess probes), and terminal. Facts are collected once per process (all `node:os` sync calls; `/proc/cpuinfo` fallback for Linux CPU names) and rendered right before the date/cwd footer, for `corePrompt` presets too.
2. **Dialect-tuned execution-context instruction** directly under the facts block, naming the active local executors (`bash`/`eval`) from `selectedTools`:
   - `claude` (Claude + GLM presets): `<execution_context>` tagged block, direct imperatives
   - `codex` (GPT presets): terse two-sentence rule, no emphasis spam
   - `kimi` (Kimi presets): positive operational constraints, no all-caps (K2.x overthinking trigger)
   - `default` (fallback prompt): maximum emphasis (**bold + CAPS + MUST**) for unmapped models
   All four state the same contract: match commands/paths/package managers/parallelism to this host; written code may target any machine — executed code runs here.
3. **All 15 prompt presets** pass their family dialect via the new `workstationDialect` option on `buildDynamicSystemPromptOptions`.
4. **`eval` host-sizing note** (`packages/senpi-codemode`): registration now passes a preformatted host line (`darwin arm64 · Apple M5 Max · 18 cores`), and the prompt tells the model to size `parallel(thunks)` pools to the local cores and keep `tool.<name>()` shell commands platform-appropriate. Rendered only when a host line is provided, so existing embedding callers are unaffected.

## Testing

- New `test/dynamic-prompt/workstation.test.ts`: facts rendering + optional-fact omission, executor naming (`bash`+`eval` / single / none), per-dialect wording contracts (tag presence, no-caps for kimi, max-emphasis default), collector caching + non-`unknown` kernel, build integration (block before cwd footer, preset dialect applied).
- codemode `test/prompt.test.ts`: host note renders with a host line and disappears without one.
- coding-agent scoped: 118 passed (dynamic-prompt + preset suites); codemode: 359 passed | 6 skipped; repo root `npm run check`: clean.
- QA (evidence under `local-ignore/qa-evidence/20260717-workstation-execution-context/`, not committed): `qa-e2e-eval.ts` exit 0; real-host render dump of all four dialects.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `<workstation>` block and a dialect-tuned execution-context instruction to all dynamic system prompts so the model aligns `bash`/`eval` execution with this machine. Also adds a host-sizing note to the `eval` prompt in `senpi-codemode` so parallel pools match local cores.

- **New Features**
  - `<workstation>` block with OS/kernel, arch, CPU (with core count), Apple Silicon GPU, and terminal; collected once per process.
  - Dialect-specific instruction (`claude`, `codex`, `kimi`, `default`) placed under the block, naming active local executors from `selectedTools`, and telling the model to match commands/paths/package managers/parallelism to this host.
  - All 15 prompt presets now pass `workstationDialect` via `buildDynamicSystemPrompt`.
  - `eval` prompt (`senpi-codemode`) renders an optional host line (`darwin arm64 · Apple M5 Max · 18 cores`) and instructs to size `parallel(thunks)` to local cores and keep `tool.<name>()` shell commands platform-appropriate.

- **Migration**
  - No changes required for callers; `workstationDialect` defaults to `default`.
  - The `eval` host line is optional; prompts render the host-sizing note only when provided.

<sup>Written for commit e948786c06eff79a1795f8c6efd24bfb4e74c6ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

