### PR TITLE
feat(mcp): rename mcp_search tool to tool_search

### DIFF
--- a/packages/coding-agent/docs/mcp.md
+++ b/packages/coding-agent/docs/mcp.md
@@ -26,7 +26,7 @@ catalog costs almost nothing until the model actually needs it.
    summary, `/mcp add <name> <command...>` to add servers interactively.
 3. Servers needing OAuth: `/mcp login <name>` (see [Auth](#auth)).
 4. Use it: small catalogs register directly; big ones surface through
-   `mcp_search` (see [Exposure tiers](#exposure-tiers)).
+   `tool_search` (see [Exposure tiers](#exposure-tiers)).
 
 ## Configuration reference
 
@@ -95,7 +95,7 @@ Glob denylist applied after `includeTools`.
 
 ### `directTools`
 `true` = every filtered tool active immediately; or an array of names/globs
-that stay active while the rest goes behind `mcp_search`. Default: none.
+that stay active while the rest goes behind `tool_search`. Default: none.
 
 ### `exposure`
 `"auto"` (default), `"direct"`, `"search"`, or `"proxy"`. See
@@ -134,14 +134,14 @@ the stub for the full schema in place. Default `false`.
 ### `nativeToolSearch`
 `"auto"` (default) | `true` | `false`. On Anthropic models, defers inactive
 MCP tools to the provider's native tool-search; any 400 falls back to the
-local `mcp_search` for the session.
+local `tool_search` for the session.
 
 ## Exposure tiers
 
 | Tier | When | Cost profile |
 |---|---|---|
 | direct | `exposure:"direct"`, `directTools:true`, or `auto` at/below `searchThreshold` | Every tool schema on every request |
-| search (Tier-B) | `exposure:"search"` or `auto` above the threshold | Full catalog registered, ~135 tokens resident (`mcp_search` only); matches promote next turn; promotions survive resume/compaction |
+| search (Tier-B) | `exposure:"search"` or `auto` above the threshold | Full catalog registered, ~135 tokens resident (`tool_search` only); matches promote next turn; promotions survive resume/compaction |
 | proxy (Tier-C) | `exposure:"proxy"` only — never `auto` | One `mcp_<server>` gateway tool (`search`/`describe`/`call` with JSON-string args); cheapest, but no provider-side argument validation |
 
 Skills can carry MCP servers too (an `mcp.json` sidecar next to SKILL.md, or a
@@ -181,7 +181,7 @@ with a configured server resolves in favor of your config.
 | `needs_auth` | 401 and no usable token | `/mcp login <name>` |
 | `suspended` | reconnect circuit breaker opened (5 failures/30s) | fix the server, then `/mcp reconnect <name>` |
 | `degraded` | transient failure; auto-reconnect with backoff is running | wait, or `/mcp reconnect <name>` |
-| tools missing | server filtered/disabled, or hidden behind search | check `includeTools`/`excludeTools`, ask the model to `mcp_search` |
+| tools missing | server filtered/disabled, or hidden behind search | check `includeTools`/`excludeTools`, ask the model to `tool_search` |
 | child exits at spawn (EOF) | bad `command`/`args`/`env` | `/mcp logs <name>` shows the captured stderr |
 | slow first call | lazy server cold boot | use `lifecycle:"eager"` or `"keep-alive"` |
 

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -49,7 +49,7 @@ every file under `builtin/mcp/` is fork-owned. Uses the exact-pinned official
 - `expose/tier-b.ts`: `registerMcpTierBTools` now returns a
   `McpTierBRegistration` handle (`searchable` + `rehydrateFromHistory`) instead
   of a bare searchable array; the rehydrate closure replays history activation
-  markers through the SAME activation path `mcp_search` uses (stub swap +
+  markers through the SAME activation path `tool_search` uses (stub swap +
   stable ordering), skipping already-active names.
 - `service.ts`: stores the tier-B handle per registration and exposes
   `rehydrateActiveToolsFromHistory(messages)` plus a once-per-registration
@@ -86,14 +86,14 @@ every file under `builtin/mcp/` is fork-owned. Uses the exact-pinned official
   name+description with a server-name field boost; normalised exact-name match
   (hyphen/underscore/case-insensitive) short-circuits before BM25; snake/camel/
   kebab tokenizer; deterministic ranking (tie-break by ascending name).
-- New `expose/tool-search.ts`: always-active `mcp_search` tool that ranks the
+- New `expose/tool-search.ts`: always-active `tool_search` tool that ranks the
   full catalog and promotes matches via `setActiveTools` (union, stable-sorted,
-  effective next turn). Results embed a stable `[mcp_search:activated]` marker;
+  effective next turn). Results embed a stable `[tool_search:activated]` marker;
   `rehydrateActiveToolsFromHistory` replays activations after compaction/restart,
   restoring only names still in the catalog.
 - New `expose/tier-b.ts`: completes `exposure:"auto"`. A server above
   `searchThreshold` enters SEARCH mode — full catalog registered, only
-  directTools active, `mcp_search` active. Prompt-cache mitigations: stable
+  directTools active, `tool_search` active. Prompt-cache mitigations: stable
   name sort; activation turns accept a cache miss (default mode); opt-in
   `settings.stubSwap` registers 30-70-token stubs so the tools array is
   length-stable and only the promoted entry's bytes change (stub -> full).
@@ -104,14 +104,14 @@ every file under `builtin/mcp/` is fork-owned. Uses the exact-pinned official
   and the Tier-B search catalog share one collision-resolved naming source.
 - `expose/session.ts`: registration routes through `registerMcpTierBTools`.
 - `expose/status.ts`: `/mcp status` reports total exposed tools + a search-mode
-  hint (`N active now, M searchable via mcp_search`).
+  hint (`N active now, M searchable via tool_search`).
 - New `expose/native-search.ts` (todo 33, Anthropic half — spike verdict
   GO-pure-extension): `addAnthropicNativeToolSearch` injects the native
   `tool_search_tool_bm25_20251119` tool + per-tool `defer_loading:true` under
   the HARD RULES (never defer the search tool, never defer+cache_control on one
   tool, >=1 non-deferred, <=10k tools), idempotently per rebuilt request;
   `AnthropicNativeToolSearchAdapter` disables native + falls back to local
-  mcp_search on an injected 400. `index.ts` registers a `before_provider_request`
+  tool_search on an injected 400. `index.ts` registers a `before_provider_request`
   (inject) + `after_provider_response` (400 detector) handler pair — a no-op
   unless `settings.nativeToolSearch` is auto|true and the model is
   anthropic-messages. The OpenAI half is deferred (spike = GO-with-ai-seam;
@@ -133,7 +133,7 @@ every file under `builtin/mcp/` is fork-owned. Uses the exact-pinned official
 Large MCP servers (30+ tools) blow the context budget if every tool is resident.
 Tier-B keeps inactive tools at ZERO payload contribution (proven by
 before_provider_request/context.tools capture: a 30-tool search-mode server
-resides in <1k tokens) while `mcp_search` gives the model on-demand access. This
+resides in <1k tokens) while `tool_search` gives the model on-demand access. This
 is the provider-agnostic P3 path that ships regardless of the native-search
 spike outcome (todo 29).
 

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/native-search.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/native-search.ts
@@ -17,7 +17,7 @@ export const ANTHROPIC_TOOL_SEARCH_NAME = "tool_search";
 export const ANTHROPIC_MAX_TOOLS = 10000;
 
 export interface AnthropicNativeInjectionConfig {
-	/** Never defer this tool (our custom mcp_search), and it is non-deferrable. */
+	/** Never defer this tool (our custom tool_search), and it is non-deferrable. */
 	readonly searchToolName?: string;
 	/** True for MCP catalog tools eligible for deferral. */
 	readonly isDeferrable: (toolName: string) => boolean;
@@ -102,7 +102,7 @@ export class AnthropicNativeToolSearchAdapter {
 		if (status !== 400 || !this.#injectedLastRequest || this.#disabled) return;
 		this.#disabled = true;
 		this.#fallbackReason =
-			"Anthropic returned 400 for native tool-search; disabled it and fell back to local mcp_search for this session.";
+			"Anthropic returned 400 for native tool-search; disabled it and fell back to local tool_search for this session.";
 		this.#deps.onFallback?.(this.#fallbackReason);
 	}
 

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/policy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/policy.ts
@@ -53,7 +53,7 @@ export function computeMcpExposurePolicy(
 		};
 	}
 	// Tier-B search mode: register the full catalog but keep only directTools
-	// active; mcp_search promotes the rest on demand.
+	// active; tool_search promotes the rest on demand.
 	if (config.exposure === "search") {
 		return searchResult(filteredEntries, directEntries, "explicit");
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/status.ts
@@ -21,7 +21,7 @@ export function getMcpCatalogExposureStatus(
 	// Report the total exposed tools; in search mode note how many are active now.
 	const hint =
 		policy.mode === "search"
-			? `search mode: ${policy.activeEntries.length} active now, ${policy.registeredEntries.length} searchable via mcp_search`
+			? `search mode: ${policy.activeEntries.length} active now, ${policy.registeredEntries.length} searchable via tool_search`
 			: undefined;
 	return { hint, toolCount: policy.registeredEntries.length, mode: policy.mode };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tier-b.ts
@@ -2,7 +2,7 @@
 //
 // Completes exposure:"auto": a server whose filtered tool count exceeds
 // searchThreshold enters SEARCH mode — the full catalog is registered but only
-// directTools stay active, and an always-active mcp_search promotes the rest on
+// directTools stay active, and an always-active tool_search promotes the rest on
 // demand. Prompt-cache mitigations (SPEC §5): stable name sort everywhere;
 // activation turns accept a cache miss (documented); opt-in settings.stubSwap
 // registers 30-70-token stubs so the tools array stays length-stable and only
@@ -24,9 +24,9 @@ import {
 } from "./register.ts";
 import {
 	createMcpSearchTool,
-	MCP_SEARCH_TOOL_NAME,
 	rehydrateActiveToolsFromHistory,
 	type SearchableMcpTool,
+	TOOL_SEARCH_TOOL_NAME,
 	unionStable,
 } from "./tool-search.ts";
 
@@ -52,13 +52,13 @@ export interface McpTierBRegistration {
 	readonly searchable: SearchableMcpTool[];
 	/**
 	 * Replay activation markers found in session history through the SAME
-	 * activation path mcp_search uses (stub swap + stable ordering), so a
+	 * activation path tool_search uses (stub swap + stable ordering), so a
 	 * resumed/compacted session restores its promoted tools without
 	 * re-searching. Returns the newly activated names (empty when nothing new).
 	 */
 	rehydrateFromHistory(messages: readonly unknown[]): string[];
 	/** Activate registered tools by name through the same stable path
-	 * mcp_search uses (skill lazy-reveal, todo 37). Unknown names ignored. */
+	 * tool_search uses (skill lazy-reveal, todo 37). Unknown names ignored. */
 	activate(names: readonly string[]): void;
 }
 
@@ -130,15 +130,15 @@ export function registerMcpTierBTools(
 		return fresh;
 	};
 
-	// mcp_search carries a distinct param schema, so register it on its own
+	// tool_search carries a distinct param schema, so register it on its own
 	// rather than mixing it into the broadly-typed catalog def array.
 	pi.registerTool(searchTool);
 
 	if (!stubSwap) {
-		// Default search mode: full defs registered, only directTools + mcp_search
+		// Default search mode: full defs registered, only directTools + tool_search
 		// active. Newly promoted tools enter the array on their activation turn
 		// (an accepted cache miss).
-		const active = orderActiveSet([...currentBase, MCP_SEARCH_TOOL_NAME, ...activeMcpNames], reference);
+		const active = orderActiveSet([...currentBase, TOOL_SEARCH_TOOL_NAME, ...activeMcpNames], reference);
 		registerToolsPreservingActiveSet(pi, fullDefs, active);
 		return { activate, searchable, rehydrateFromHistory };
 	}
@@ -151,7 +151,10 @@ export function registerMcpTierBTools(
 		stubbed.add(def.name);
 		return buildMcpStubDefinition(def.name);
 	});
-	const active = orderActiveSet([...currentBase, MCP_SEARCH_TOOL_NAME, ...fullDefs.map((def) => def.name)], reference);
+	const active = orderActiveSet(
+		[...currentBase, TOOL_SEARCH_TOOL_NAME, ...fullDefs.map((def) => def.name)],
+		reference,
+	);
 	registerToolsPreservingActiveSet(pi, toRegister, active);
 	return { activate, searchable, rehydrateFromHistory };
 }
@@ -173,7 +176,7 @@ function swapStubsToFull(
 
 /** Order the active set deterministically WITHOUT disturbing non-MCP (base)
  * tools: base tools keep their existing relative order (by `reference` index,
- * new ones appended), MCP tools (incl. mcp_search) are sorted for cache
+ * new ones appended), MCP tools (incl. tool_search) are sorted for cache
  * stability. Sorting base tools would churn the system-prompt tool listing. */
 function orderActiveSet(names: readonly string[], reference: readonly string[]): string[] {
 	const unique = [...new Set(names)];
@@ -186,17 +189,17 @@ function orderActiveSet(names: readonly string[], reference: readonly string[]):
 }
 
 /** A 30-70 token placeholder for an inactive search-mode tool. Keeps the tools
- * array length-stable under stubSwap; guides the model to mcp_search. */
+ * array length-stable under stubSwap; guides the model to tool_search. */
 export function buildMcpStubDefinition(name: string): McpToolDefinition {
 	return {
 		name,
 		label: name,
-		description: `Inactive MCP tool. Run mcp_search to activate ${name}, then call it on your next turn.`,
+		description: `Inactive MCP tool. Run tool_search to activate ${name}, then call it on your next turn.`,
 		parameters: Type.Object({}),
 		executionMode: "parallel",
 		async execute(): Promise<AgentToolResult<McpToolDetails | undefined>> {
 			return {
-				content: [{ type: "text", text: `${name} is not active. Use mcp_search to activate it, then call it.` }],
+				content: [{ type: "text", text: `${name} is not active. Use tool_search to activate it, then call it.` }],
 				details: undefined,
 			};
 		},

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tool-search.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/tool-search.ts
@@ -1,6 +1,6 @@
-// mcp_search tool + promotion engine (todo 31).
+// tool_search tool + promotion engine (todo 31).
 //
-// `mcp_search` is an always-active tool that ranks the full MCP catalog with
+// `tool_search` is an always-active tool that ranks the full MCP catalog with
 // the local BM25 engine and PROMOTES matched tools into the active set via
 // setActiveTools (effective the NEXT turn — senpi semantics). Promotion state
 // is derivable from history: each result embeds a stable activation marker so a
@@ -14,10 +14,10 @@ import { type Static, Type } from "typebox";
 import type { ToolDefinition } from "../../../types.ts";
 import { type Bm25Doc, buildBm25Index } from "./bm25.ts";
 
-export const MCP_SEARCH_TOOL_NAME = "mcp_search";
+export const TOOL_SEARCH_TOOL_NAME = "tool_search";
 /** Stable, machine-parseable marker embedded in every activating result so
  * activations survive compaction/restart. Kept human-readable on purpose. */
-export const MCP_SEARCH_ACTIVATION_MARKER = "[mcp_search:activated]";
+export const TOOL_SEARCH_ACTIVATION_MARKER = "[tool_search:activated]";
 const MAX_RESULTS = 10;
 
 export type SearchableMcpTool = Bm25Doc;
@@ -46,7 +46,7 @@ type McpSearchTool = ToolDefinition<typeof ParamsSchema, McpSearchDetails, unkno
 
 export function createMcpSearchTool(deps: McpSearchDeps): McpSearchTool {
 	return {
-		name: MCP_SEARCH_TOOL_NAME,
+		name: TOOL_SEARCH_TOOL_NAME,
 		label: "MCP tool search",
 		description:
 			"Search the catalog of available MCP tools by capability. Matched tools are activated and become callable on your NEXT turn. Use this before calling an MCP tool that is not already active.",
@@ -69,13 +69,13 @@ export function createMcpSearchTool(deps: McpSearchDeps): McpSearchTool {
 		},
 		renderCall(args, theme) {
 			const filter = args.server ? ` @${args.server}` : "";
-			return new Text(theme.fg("toolTitle", theme.bold(`${MCP_SEARCH_TOOL_NAME} "${args.query}"${filter}`)), 0, 0);
+			return new Text(theme.fg("toolTitle", theme.bold(`${TOOL_SEARCH_TOOL_NAME} "${args.query}"${filter}`)), 0, 0);
 		},
 		renderResult(result, options, theme) {
 			const count = result.details?.activated.length ?? 0;
 			const title = options.isPartial
-				? `${MCP_SEARCH_TOOL_NAME}: searching`
-				: `${MCP_SEARCH_TOOL_NAME}: ${count} tool(s) activated`;
+				? `${TOOL_SEARCH_TOOL_NAME}: searching`
+				: `${TOOL_SEARCH_TOOL_NAME}: ${count} tool(s) activated`;
 			return new Text(theme.fg("toolOutput", title), 0, 0);
 		},
 	};
@@ -93,7 +93,7 @@ export function buildMcpSearchResultText(
 ): string {
 	const scope = server ? ` on server "${server}"` : "";
 	if (matches.length === 0) {
-		return `No MCP tools matched "${query}"${scope}. No tools were activated; try different keywords or run mcp_search with a broader query. Your active tool set is unchanged.`;
+		return `No MCP tools matched "${query}"${scope}. No tools were activated; try different keywords or run tool_search with a broader query. Your active tool set is unchanged.`;
 	}
 	const bullets = matches
 		.map((match) => `- ${match.name} — ${oneLine(match.doc.description) ?? "(no description)"}`)
@@ -104,12 +104,12 @@ export function buildMcpSearchResultText(
 		"",
 		bullets,
 		"",
-		`${MCP_SEARCH_ACTIVATION_MARKER} ${names}`,
+		`${TOOL_SEARCH_ACTIVATION_MARKER} ${names}`,
 	].join("\n");
 }
 
 /**
- * Replay mcp_search activations recorded in prior history so a
+ * Replay tool_search activations recorded in prior history so a
  * compacted/restarted session restores its active tool set without re-searching.
  * Only names still present in `validNames` are restored (removed tools stay
  * dropped). Deterministic: returns a de-duplicated, sorted list.
@@ -137,14 +137,14 @@ function extractActivationSegments(message: unknown): string[] {
 		return [];
 	}
 	const segments: string[] = [];
-	let cursor = blob.indexOf(MCP_SEARCH_ACTIVATION_MARKER);
+	let cursor = blob.indexOf(TOOL_SEARCH_ACTIVATION_MARKER);
 	while (cursor >= 0) {
-		const rest = blob.slice(cursor + MCP_SEARCH_ACTIVATION_MARKER.length);
+		const rest = blob.slice(cursor + TOOL_SEARCH_ACTIVATION_MARKER.length);
 		// Tool names are [a-zA-Z0-9_-]; stop at the first JSON string terminator
 		// (quote / escape) or newline so we never swallow the rest of the blob.
 		const end = rest.search(/["\\\n]/);
 		segments.push(end < 0 ? rest : rest.slice(0, end));
-		cursor = blob.indexOf(MCP_SEARCH_ACTIVATION_MARKER, cursor + MCP_SEARCH_ACTIVATION_MARKER.length);
+		cursor = blob.indexOf(TOOL_SEARCH_ACTIVATION_MARKER, cursor + TOOL_SEARCH_ACTIVATION_MARKER.length);
 	}
 	return segments;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../ty
 import { registerMcpCommands } from "./commands.ts";
 import { setMcpElicitationUiProvider } from "./elicitation.ts";
 import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
-import { MCP_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
+import { TOOL_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
 import { createMcpLogger } from "./log.ts";
 import { registerMcpPromptCommands } from "./prompts.ts";
@@ -31,19 +31,19 @@ export default function mcpExtension(pi: ExtensionAPI): void {
 	// Native provider tool-search adapter (todo 33 — Anthropic, spike = GO).
 	// Runs on every request but is a no-op unless settings.nativeToolSearch is
 	// auto|true and the model is anthropic-messages; a 400 disables it for the
-	// session and falls back to the always-registered local mcp_search.
+	// session and falls back to the always-registered local tool_search.
 	const nativeAdapter = new AnthropicNativeToolSearchAdapter({
 		enabled: () => {
 			const setting = getMcpService().getNativeToolSearchSetting();
 			return setting === true || setting === "auto";
 		},
-		isDeferrable: (name) => name.startsWith("mcp_") && name !== MCP_SEARCH_TOOL_NAME,
+		isDeferrable: (name) => name.startsWith("mcp_") && name !== TOOL_SEARCH_TOOL_NAME,
 		onFallback: (reason) => createMcpLogger("service").warn(reason),
-		searchToolName: MCP_SEARCH_TOOL_NAME,
+		searchToolName: TOOL_SEARCH_TOOL_NAME,
 	});
 	pi.on("before_provider_request", (event, ctx) => nativeAdapter.applyBeforeRequest(ctx.model?.api, event.payload));
 	pi.on("after_provider_response", (event) => nativeAdapter.noteResponseStatus(event.status));
-	// Resumed/compacted sessions carry mcp_search activation markers in their
+	// Resumed/compacted sessions carry tool_search activation markers in their
 	// history but re-enter search mode with only directTools active. The context
 	// event (fired before each LLM call, with the full message history) replays
 	// the markers as a safety net; the primary replay happens at attach time so

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -146,7 +146,7 @@ export class McpService {
 	}
 
 	/** Reveal skill-owned tools (todo 37): activation is effective the next
-	 * turn, exactly like an mcp_search promotion. Unknown names are ignored. */
+	 * turn, exactly like an tool_search promotion. Unknown names are ignored. */
 	activateSkillMcpTools(names: readonly string[]): void {
 		this.#tierBRegistration?.activate(names);
 	}
@@ -380,7 +380,7 @@ export class McpService {
 	}
 
 	/**
-	 * Replay mcp_search activation markers from session history through the
+	 * Replay tool_search activation markers from session history through the
 	 * live tier-B activation path (see tool-search.ts). Returns newly activated
 	 * names; safe to call repeatedly (already-active names are skipped).
 	 */

--- a/packages/coding-agent/test/mcp/exposure-policy.test.ts
+++ b/packages/coding-agent/test/mcp/exposure-policy.test.ts
@@ -79,12 +79,12 @@ describe("MCP Tier-A exposure policy", () => {
 		setConfig(elevenRoot, { fx: stdioServer(["--tools", "11"]) });
 		const elevenPi = capturingPi();
 		await attach(elevenRoot, elevenPi);
-		// All 11 tools are registered (catalog present) plus mcp_search...
+		// All 11 tools are registered (catalog present) plus tool_search...
 		expect([...withoutMcpUtilityTools(elevenPi.registeredTools)].sort()).toEqual(
-			[...toolNames(11), "mcp_search"].sort(),
+			[...toolNames(11), "tool_search"].sort(),
 		);
-		// ...but only mcp_search is active: the 11 tools cost zero tokens until promoted.
-		expect(withoutMcpUtilityTools(elevenPi.activeTools)).toEqual(["mcp_search"]);
+		// ...but only tool_search is active: the 11 tools cost zero tokens until promoted.
+		expect(withoutMcpUtilityTools(elevenPi.activeTools)).toEqual(["tool_search"]);
 		// The W1 pending-W4 warning fallback is gone.
 		expect(logContains("fx", "pending-W4")).toBe(false);
 	});
@@ -102,32 +102,32 @@ describe("MCP Tier-A exposure policy", () => {
 
 		await attach(root, pi);
 
-		// Search mode keeps directTools active alongside the always-active mcp_search.
+		// Search mode keeps directTools active alongside the always-active tool_search.
 		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual([
 			"bash",
+			"tool_search",
 			"mcp_fx_tool_1",
 			"mcp_fx_tool_12",
 			"mcp_fx_tool_2",
-			"mcp_search",
 		]);
 		expect(withoutMcpUtilityTools(pi.setActiveCalls[pi.setActiveCalls.length - 1])).toEqual([
 			"bash",
+			"tool_search",
 			"mcp_fx_tool_1",
 			"mcp_fx_tool_12",
 			"mcp_fx_tool_2",
-			"mcp_search",
 		]);
 	});
 
-	it("registers a 30-tool fixture in search mode: full catalog registered, only mcp_search active", async () => {
+	it("registers a 30-tool fixture in search mode: full catalog registered, only tool_search active", async () => {
 		const root = mcpRoot("large-search");
 		setConfig(root, { fx: stdioServer(["--tools", "30"]) });
 		const pi = capturingPi();
 
 		await attach(root, pi);
 
-		expect([...withoutMcpUtilityTools(pi.registeredTools)].sort()).toEqual([...toolNames(30), "mcp_search"].sort());
-		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_search"]);
+		expect([...withoutMcpUtilityTools(pi.registeredTools)].sort()).toEqual([...toolNames(30), "tool_search"].sort());
+		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["tool_search"]);
 		expect(logContains("fx", "pending-W4")).toBe(false);
 	});
 

--- a/packages/coding-agent/test/mcp/exposure-tierb.test.ts
+++ b/packages/coding-agent/test/mcp/exposure-tierb.test.ts
@@ -42,11 +42,11 @@ interface ToolShape {
 	name: string;
 	json: string;
 }
-// Scope to MCP tools (mcp_search + mcp_<server>_<tool>); the harness's default
+// Scope to MCP tools (tool_search + mcp_<server>_<tool>); the harness's default
 // base tools (bash/read/write) are separate senpi cost, not MCP resident cost.
 function toolShapes(context: { tools?: { name: string; parameters?: unknown }[] }): ToolShape[] {
 	return (context.tools ?? [])
-		.filter((tool) => tool.name.startsWith("mcp_"))
+		.filter((tool) => tool.name.startsWith("mcp_") || tool.name === "tool_search")
 		.map((tool) => ({ name: tool.name, json: JSON.stringify(tool) }))
 		.sort(byName);
 }
@@ -64,7 +64,7 @@ async function harnessFor(root: TestRoot): Promise<Harness> {
 }
 
 describe("todo32 tier-B: searchThreshold flip", () => {
-	it("10 filtered tools stay direct; 11 flip to search mode (only mcp_search resident)", async () => {
+	it("10 filtered tools stay direct; 11 flip to search mode (only tool_search resident)", async () => {
 		const tenRoot = mcpRoot("flip-10");
 		writeConfig(tenRoot, { fx: stdioServer(["--tools", "10"]) });
 		const ten = await harnessFor(tenRoot);
@@ -77,7 +77,7 @@ describe("todo32 tier-B: searchThreshold flip", () => {
 		]);
 		await ten.session.prompt("go");
 		expect(tenTools).toHaveLength(10);
-		expect(tenTools).not.toContain("mcp_search");
+		expect(tenTools).not.toContain("tool_search");
 
 		const elevenRoot = mcpRoot("flip-11");
 		writeConfig(elevenRoot, { fx: stdioServer(["--tools", "11"]) });
@@ -90,7 +90,7 @@ describe("todo32 tier-B: searchThreshold flip", () => {
 			},
 		]);
 		await eleven.session.prompt("go");
-		expect(elevenTools).toEqual(["mcp_search"]);
+		expect(elevenTools).toEqual(["tool_search"]);
 	});
 });
 
@@ -108,7 +108,7 @@ describe("todo32 tier-B: exposure override matrix", () => {
 		]);
 		await direct.session.prompt("go");
 		expect(directTools).toHaveLength(15);
-		expect(directTools).not.toContain("mcp_search");
+		expect(directTools).not.toContain("tool_search");
 
 		const searchRoot = mcpRoot("override-search");
 		writeConfig(searchRoot, { fx: { ...stdioServer(["--tools", "5"]), exposure: "search" } });
@@ -121,7 +121,7 @@ describe("todo32 tier-B: exposure override matrix", () => {
 			},
 		]);
 		await search.session.prompt("go");
-		expect(searchTools).toEqual(["mcp_search"]);
+		expect(searchTools).toEqual(["tool_search"]);
 	});
 });
 
@@ -143,7 +143,7 @@ describe("todo32 tier-B: resident token cost", () => {
 			},
 		]);
 		await harness.session.prompt("go");
-		expect(residentNames).toEqual(["mcp_search"]);
+		expect(residentNames).toEqual(["tool_search"]);
 		// Method: chars/4 char-per-token approximation over the serialized tools array.
 		const approxTokens = Math.ceil(residentJson.length / 4);
 		expect(approxTokens).toBeLessThan(1000);
@@ -160,12 +160,12 @@ describe("todo32 tier-B: stubSwap keeps the tools array byte-stable", () => {
 			(context) => {
 				turns.push(toolShapes(context));
 				// Exact-name promote just mcp_fx_tool_5.
-				return fauxAssistantMessage(fauxToolCall("mcp_search", { query: "tool_5" }), { stopReason: "toolUse" });
+				return fauxAssistantMessage(fauxToolCall("tool_search", { query: "tool_5" }), { stopReason: "toolUse" });
 			},
 			(context) => {
 				turns.push(toolShapes(context));
 				// Flap: search the same tool again.
-				return fauxAssistantMessage(fauxToolCall("mcp_search", { query: "tool_5" }), { stopReason: "toolUse" });
+				return fauxAssistantMessage(fauxToolCall("tool_search", { query: "tool_5" }), { stopReason: "toolUse" });
 			},
 			(context) => {
 				turns.push(toolShapes(context));
@@ -175,7 +175,7 @@ describe("todo32 tier-B: stubSwap keeps the tools array byte-stable", () => {
 		await harness.session.prompt("promote tool_5");
 
 		const [turn1, turn2, turn3] = turns as [ToolShape[], ToolShape[], ToolShape[]];
-		// stubSwap keeps all 12 tools + mcp_search resident every turn (stable length).
+		// stubSwap keeps all 12 tools + tool_search resident every turn (stable length).
 		expect(turn1).toHaveLength(13);
 		expect(turn2).toHaveLength(13);
 		expect(turn3).toHaveLength(13);

--- a/packages/coding-agent/test/mcp/native-anthropic.test.ts
+++ b/packages/coding-agent/test/mcp/native-anthropic.test.ts
@@ -20,8 +20,8 @@ import {
 } from "./fixtures/native-search-mocks.ts";
 
 const CONFIG = {
-	searchToolName: "mcp_search",
-	isDeferrable: (name: string) => name.startsWith("mcp_") && name !== "mcp_search",
+	searchToolName: "tool_search",
+	isDeferrable: (name: string) => name.startsWith("mcp_") && name !== "tool_search",
 };
 
 function toolsOf(payload: unknown): Record<string, unknown>[] {
@@ -37,7 +37,7 @@ function searchTool(tools: Record<string, unknown>[]): Record<string, unknown>[]
 }
 
 function mcpToolsPayload(count: number): { tools: Record<string, unknown>[] } {
-	const tools: Record<string, unknown>[] = [{ name: "mcp_search", description: "search", input_schema: {} }];
+	const tools: Record<string, unknown>[] = [{ name: "tool_search", description: "search", input_schema: {} }];
 	for (let i = 1; i <= count; i += 1) {
 		tools.push({ name: `mcp_docs_tool-${i}`, description: `tool ${i}`, input_schema: {} });
 	}
@@ -49,8 +49,8 @@ describe("todo33 anthropic native: injection + HARD RULES (validator 400s on vio
 		const out = addAnthropicNativeToolSearch("anthropic-messages", mcpToolsPayload(3), CONFIG);
 		const tools = toolsOf(out);
 		expect(searchTool(tools)).toHaveLength(1);
-		// mcp_search itself is never deferred; the three catalog tools are.
-		expect(named(tools, "mcp_search")?.defer_loading).toBeUndefined();
+		// tool_search itself is never deferred; the three catalog tools are.
+		expect(named(tools, "tool_search")?.defer_loading).toBeUndefined();
 		expect(named(tools, "mcp_docs_tool-1")?.defer_loading).toBe(true);
 		expect(validateAnthropicToolSearchPayload(out)).toEqual({ status: 200 });
 	});
@@ -122,7 +122,7 @@ describe("todo33 anthropic native: 400 -> local fallback", () => {
 
 		adapter.noteResponseStatus(400);
 		expect(adapter.disabled).toBe(true);
-		expect(fallback).toContain("fell back to local mcp_search");
+		expect(fallback).toContain("fell back to local tool_search");
 
 		// Subsequent requests are byte-identical (no injection): session continues.
 		const next = mcpToolsPayload(3);
@@ -152,7 +152,7 @@ describe("todo33 anthropic native: M5 co-residence with web-search + cache tail 
 		const base: Record<string, unknown> = {
 			service_tier: "auto",
 			tools: [
-				{ name: "mcp_search", description: "search", input_schema: {} },
+				{ name: "tool_search", description: "search", input_schema: {} },
 				{ name: "mcp_docs_a", description: "a", input_schema: {} },
 				{ name: "mcp_docs_b", description: "b", input_schema: {}, cache_control: { type: "ephemeral" } },
 			],

--- a/packages/coding-agent/test/mcp/rehydration-wiring.test.ts
+++ b/packages/coding-agent/test/mcp/rehydration-wiring.test.ts
@@ -5,10 +5,10 @@
 // (`--continue`) re-entered search mode with all promotions lost (caught by
 // the W4 real-surface QA driver: CLAIM 5 rehydrated=false). These tests pin
 // the service-level wiring: history containing activation markers restores
-// promoted tools through the same tier-B activation path mcp_search uses.
+// promoted tools through the same tier-B activation path tool_search uses.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { MCP_SEARCH_ACTIVATION_MARKER } from "../../src/core/extensions/builtin/mcp/expose/tool-search.ts";
+import { TOOL_SEARCH_ACTIVATION_MARKER } from "../../src/core/extensions/builtin/mcp/expose/tool-search.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
@@ -34,27 +34,27 @@ function historyWithActivation(names: string): unknown[] {
 		{ role: "user", content: "find me a tool" },
 		{
 			role: "toolResult",
-			toolName: "mcp_search",
-			content: [{ type: "text", text: `Found tools.\n\n${MCP_SEARCH_ACTIVATION_MARKER} ${names}` }],
+			toolName: "tool_search",
+			content: [{ type: "text", text: `Found tools.\n\n${TOOL_SEARCH_ACTIVATION_MARKER} ${names}` }],
 		},
 	];
 }
 
-describe("mcp_search rehydration wiring", () => {
+describe("tool_search rehydration wiring", () => {
 	it("restores marker-recorded promotions through the live tier-B activation path", async () => {
 		const root = mcpRoot("rehydrate-live");
 		setConfig(root, { fx: { ...stdioServer(["--tools", "3"]), exposure: "search" } });
 		const pi = capturingPi();
 		await attach(root, pi);
 
-		expect(pi.getActiveTools()).toContain("mcp_search");
+		expect(pi.getActiveTools()).toContain("tool_search");
 		expect(pi.getActiveTools()).not.toContain("mcp_fx_tool_2");
 
 		const restored = getMcpService().rehydrateActiveToolsFromHistory(historyWithActivation("mcp_fx_tool_2"));
 		expect(restored).toEqual(["mcp_fx_tool_2"]);
 		expect(pi.getActiveTools()).toContain("mcp_fx_tool_2");
-		// mcp_search must survive rehydration (stable active set, not replaced).
-		expect(pi.getActiveTools()).toContain("mcp_search");
+		// tool_search must survive rehydration (stable active set, not replaced).
+		expect(pi.getActiveTools()).toContain("tool_search");
 	});
 
 	it("is a no-op for unknown names, repeated scans, and direct-mode servers", async () => {
@@ -93,7 +93,7 @@ describe("mcp_search rehydration wiring", () => {
 		);
 		// No explicit rehydrate call: attach itself must have replayed history.
 		expect(pi.getActiveTools()).toContain("mcp_fx_tool_2");
-		expect(pi.getActiveTools()).toContain("mcp_search");
+		expect(pi.getActiveTools()).toContain("tool_search");
 	});
 
 	it("marks history as scanned so per-turn context events stay cheap", async () => {

--- a/packages/coding-agent/test/mcp/tool-search-promotion.test.ts
+++ b/packages/coding-agent/test/mcp/tool-search-promotion.test.ts
@@ -1,4 +1,4 @@
-// Todo 31 — mcp_search tool + promotion engine.
+// Todo 31 — tool_search tool + promotion engine.
 //
 // Proves: turn-1 search lists full names + "next turn" and activates matches;
 // turn-2 the promoted tool is callable; inactive tools contribute ZERO tokens
@@ -12,10 +12,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	buildMcpSearchResultText,
 	createMcpSearchTool,
-	MCP_SEARCH_ACTIVATION_MARKER,
-	MCP_SEARCH_TOOL_NAME,
 	rehydrateActiveToolsFromHistory,
 	type SearchableMcpTool,
+	TOOL_SEARCH_ACTIVATION_MARKER,
+	TOOL_SEARCH_TOOL_NAME,
 	unionStable,
 } from "../../src/core/extensions/builtin/mcp/expose/tool-search.ts";
 import type { ExtensionAPI, ExtensionFactory, ToolDefinition } from "../../src/core/extensions/types.ts";
@@ -49,7 +49,7 @@ function fakeMcpTool(name: string): ToolDefinition {
 }
 
 // Extension that registers the catalog tools (inactive) + an always-active
-// mcp_search wired to promote via pi.setActiveTools.
+// tool_search wired to promote via pi.setActiveTools.
 function toolSearchExtension(): ExtensionFactory {
 	return (pi: ExtensionAPI) => {
 		for (const entry of CATALOG) pi.registerTool(fakeMcpTool(entry.name));
@@ -64,8 +64,8 @@ function toolSearchExtension(): ExtensionFactory {
 		pi.on("before_agent_start", async () => {
 			if (armed) return undefined;
 			armed = true;
-			// Only mcp_search is active initially; catalog tools stay inactive.
-			pi.setActiveTools([MCP_SEARCH_TOOL_NAME]);
+			// Only tool_search is active initially; catalog tools stay inactive.
+			pi.setActiveTools([TOOL_SEARCH_TOOL_NAME]);
 			return undefined;
 		});
 	};
@@ -82,14 +82,14 @@ async function makeHarness(): Promise<Harness> {
 	return harness;
 }
 
-describe("todo31 mcp_search: two-turn promotion + zero-token inactive tools", () => {
+describe("todo31 tool_search: two-turn promotion + zero-token inactive tools", () => {
 	it("turn1 search activates matches; turn2 they are callable; unmatched stay inactive", async () => {
 		const harness = await makeHarness();
 		const providerToolNames: string[][] = [];
 		harness.setResponses([
 			(context) => {
 				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
-				return fauxAssistantMessage(fauxToolCall("mcp_search", { query: "library documentation" }), {
+				return fauxAssistantMessage(fauxToolCall("tool_search", { query: "library documentation" }), {
 					stopReason: "toolUse",
 				});
 			},
@@ -105,11 +105,11 @@ describe("todo31 mcp_search: two-turn promotion + zero-token inactive tools", ()
 
 		await harness.session.prompt("find a docs tool");
 
-		// Turn 1: only mcp_search was exposed — inactive catalog tools cost 0 tokens.
-		expect(providerToolNames[0]).toEqual(["mcp_search"]);
-		// Turn 2: the two matched docs tools are now active alongside mcp_search;
+		// Turn 1: only tool_search was exposed — inactive catalog tools cost 0 tokens.
+		expect(providerToolNames[0]).toEqual(["tool_search"]);
+		// Turn 2: the two matched docs tools are now active alongside tool_search;
 		// the unmatched mcp_fs_read-file is still absent (zero contribution).
-		expect(providerToolNames[1]).toEqual(["mcp_docs_get-library-docs", "mcp_docs_resolve-library-id", "mcp_search"]);
+		expect(providerToolNames[1]).toEqual(["mcp_docs_get-library-docs", "mcp_docs_resolve-library-id", "tool_search"]);
 		expect(providerToolNames[1]).not.toContain("mcp_fs_read-file");
 		// The promoted tool actually ran.
 		expect(harness.session.getActiveToolNames()).toContain("mcp_docs_get-library-docs");
@@ -121,7 +121,7 @@ describe("todo31 mcp_search: two-turn promotion + zero-token inactive tools", ()
 		harness.setResponses([
 			(context) => {
 				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
-				return fauxAssistantMessage(fauxToolCall("mcp_search", { query: "teleportation quantum xyzzy" }), {
+				return fauxAssistantMessage(fauxToolCall("tool_search", { query: "teleportation quantum xyzzy" }), {
 					stopReason: "toolUse",
 				});
 			},
@@ -133,13 +133,13 @@ describe("todo31 mcp_search: two-turn promotion + zero-token inactive tools", ()
 
 		await harness.session.prompt("search for a capability that does not exist");
 
-		expect(providerToolNames[0]).toEqual(["mcp_search"]);
+		expect(providerToolNames[0]).toEqual(["tool_search"]);
 		// No activation -> next turn identical.
-		expect(providerToolNames[1]).toEqual(["mcp_search"]);
+		expect(providerToolNames[1]).toEqual(["tool_search"]);
 	});
 });
 
-describe("todo31 mcp_search: result text + rehydration", () => {
+describe("todo31 tool_search: result text + rehydration", () => {
 	it("result text lists full names, a next-turn notice, and the activation marker", () => {
 		const matches = [
 			{ name: "mcp_docs_get-library-docs", doc: CATALOG[0] as SearchableMcpTool },
@@ -149,12 +149,12 @@ describe("todo31 mcp_search: result text + rehydration", () => {
 		expect(text).toContain("NEXT turn");
 		expect(text).toContain("mcp_docs_get-library-docs");
 		expect(text).toContain("Fetch up-to-date documentation");
-		expect(text).toContain(`${MCP_SEARCH_ACTIVATION_MARKER} mcp_docs_get-library-docs mcp_docs_resolve-library-id`);
+		expect(text).toContain(`${TOOL_SEARCH_ACTIVATION_MARKER} mcp_docs_get-library-docs mcp_docs_resolve-library-id`);
 	});
 
 	it("empty result carries no activation marker", () => {
 		const text = buildMcpSearchResultText("nope", [], undefined);
-		expect(text).not.toContain(MCP_SEARCH_ACTIVATION_MARKER);
+		expect(text).not.toContain(TOOL_SEARCH_ACTIVATION_MARKER);
 		expect(text).toContain("unchanged");
 	});
 
@@ -164,7 +164,7 @@ describe("todo31 mcp_search: result text + rehydration", () => {
 			{ role: "user", content: "find docs tools" },
 			{
 				role: "toolResult",
-				toolName: MCP_SEARCH_TOOL_NAME,
+				toolName: TOOL_SEARCH_TOOL_NAME,
 				content: [
 					{
 						type: "text",
@@ -190,7 +190,7 @@ describe("todo31 mcp_search: result text + rehydration", () => {
 		// Real session: run a search, then reconstruct activations from history.
 		const harness = await makeHarness();
 		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("mcp_search", { query: "library documentation" }), {
+			fauxAssistantMessage(fauxToolCall("tool_search", { query: "library documentation" }), {
 				stopReason: "toolUse",
 			}),
 			fauxAssistantMessage("done"),
@@ -211,6 +211,6 @@ describe("todo31 mcp_search: result text + rehydration", () => {
 	});
 
 	it("unionStable dedupes and sorts", () => {
-		expect(unionStable(["mcp_search", "b"], ["a", "b"])).toEqual(["a", "b", "mcp_search"]);
+		expect(unionStable(["tool_search", "b"], ["a", "b"])).toEqual(["a", "b", "tool_search"]);
 	});
 });


### PR DESCRIPTION
## Summary

Renames the local MCP catalog-search tool from `mcp_search` to `tool_search` across the entire MCP extension. This aligns the user-facing tool name with the standard terminology used by OpenAI (`{"type":"tool_search"}`), Anthropic, and Kimi documentation, and removes the redundant `mcp_` prefix from a tool that is already scoped to the MCP extension.

## Changes

- **Core tool definition** (`expose/tool-search.ts`): renamed public constants `MCP_SEARCH_TOOL_NAME` → `TOOL_SEARCH_TOOL_NAME` and `MCP_SEARCH_ACTIVATION_MARKER` → `TOOL_SEARCH_ACTIVATION_MARKER`; the registered tool is now `tool_search` and emits `[tool_search:activated]` markers.
- **Tier-B wiring** (`expose/tier-b.ts`, `index.ts`, `service.ts`): updated active-set ordering, stub descriptions, and native-adapter references to use `tool_search`.
- **Status & UX** (`expose/status.ts`, `expose/native-search.ts`): user-visible hints and fallback messages now mention `tool_search`.
- **Tests** (`test/mcp/*`): updated expectations for the new tool name and adjusted the tier-B harness filter to include `tool_search` even though it no longer starts with `mcp_`.
- **Docs** (`docs/mcp.md`, `changes.md`): all user-facing references updated to `tool_search`.

## QA & Evidence

- `npm run check` passed (typecheck, lint, shrinkwrap, neo build+test).
- MCP rename test suite passed:
  ```
  npx vitest run test/mcp/tool-search-promotion.test.ts \
                 test/mcp/exposure-policy.test.ts \
                 test/mcp/exposure-tierb.test.ts \
                 test/mcp/rehydration-wiring.test.ts \
                 test/mcp/native-anthropic.test.ts
  ```
  Result: 5 files / 30 tests passed.

## Risks & Residuals

- **Breaking change**: users who explicitly listed `"mcp_search"` in `directTools`, `includeTools`, or skill activation globs must update to `"tool_search"`. No backward-compatibility shim is provided per the request to treat this as the ideal from-scratch state.
- Resumed sessions that contain the old `[mcp_search:activated]` marker will not restore previously promoted tools. This is accepted as part of the clean cut.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the MCP catalog-search tool from `mcp_search` to `tool_search` to match provider terminology and simplify the name. This updates tool registration, activation markers, wiring, docs, and tests.

- **Refactors**
  - Core: tool name and activation marker updated (`tool_search`, `[tool_search:activated]`).
  - Tier-B: active-set ordering and promotion path now use `tool_search`.
  - Anthropic adapter: deferral rules and fallback messaging reference `tool_search`.
  - Docs/Tests: all references switched to `tool_search`.

- **Migration**
  - Update configs and skills: replace `"mcp_search"` in `directTools`, `includeTools`, and activation globs with `"tool_search"`.
  - Sessions containing `[mcp_search:activated]` will not restore promotions; re-run `tool_search` if needed.

<sup>Written for commit d60a2f3bc101c4509091b3dc4deed31c8a8cc7d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

