### PR TITLE
docs(agents): refresh AGENTS.md knowledge base to 92fc96389

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Senpi Repository Guide
 
-Generated: 2026-07-14
-Commit: `2c3a87858`
+Generated: 2026-07-17
+Commit: `92fc96389`
 Branch: `main`
 
 Metadata above records the source state used for this generation pass.
@@ -38,13 +38,15 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 | Add or change extension examples | `packages/coding-agent/examples/` |
 | Change PTY behavior | `packages/pty/` and, for native behavior, `crates/senpi-pty/` |
 | Add provider setup docs | `packages/ai/README.md` and `packages/coding-agent/docs/providers.md` |
+| Change model/provider runtime | `packages/ai/src/models.ts`, `packages/ai/src/auth/`, `packages/ai/src/providers/` |
+| Change eval prompt/rendering | `packages/senpi-codemode/src/prompt/` and `src/tool/` |
 | Audit changelogs | `.github/agent/commands/cl.md` |
 | Prepare a release | `scripts/release.mjs` and `scripts/release-packages.mjs` |
 
 ## CODE MAP
 
 ```text
-Model/auth catalog -> packages/ai/src/providers -> packages/ai/src/api
+Models/auth runtime -> packages/ai/src/models.ts + src/auth/ -> providers -> api
                                          |
 Agent state -> packages/agent/src/agent-loop.ts
                                          |

--- a/packages/ai/AGENTS.md
+++ b/packages/ai/AGENTS.md
@@ -10,9 +10,11 @@ src/compat.ts                   Temporary legacy dispatch, registry, catalogs
 src/api/                        Wire/API implementations and lazy wrappers
 src/providers/                  Provider factories, catalogs, shared transforms
 src/auth/                       Credential stores, contexts, auth helpers/types
-src/models*.ts                  Runtime model catalogs; generated files committed
+src/models.ts                   Models/provider/auth/refresh runtime (owns provider registration, auth resolution, dynamic catalog refresh, stream delegation)
+src/models.generated.ts         Generated static catalog
 src/env-api-keys.ts             Browser-safe credential detection boundary
 src/tool-call-middleware/       Text-encoded tool protocols
+src/utils/tool-schema-compat.ts OpenAI/Moonshot tool JSON-Schema normalization
 scripts/generate-models.ts      Model catalog source of truth
 scripts/generate-image-models.ts Image catalog source of truth
 test/                           Faux-first and opt-in live tests
@@ -36,6 +38,7 @@ test/                           Faux-first and opt-in live tests
 | Cross-provider message coercion | `src/api/transform-messages.ts` |
 | Add auth detection | `src/env-api-keys.ts` |
 | Change auth context/storage | `src/auth/` |
+| Model runtime/provider auth/refresh | `src/models.ts`, `src/auth/`, `src/providers/all.ts` |
 | Change model inventory | `scripts/generate-models.ts` |
 | Add text-tool protocol | `src/tool-call-middleware/` |
 | Provider checklist | `README.md` provider section |

--- a/packages/ai/src/api/AGENTS.md
+++ b/packages/ai/src/api/AGENTS.md
@@ -1,0 +1,49 @@
+# packages/ai/src/api
+
+Provider wire protocol implementations and stream adapters. Each provider ships as a concrete module plus a `.lazy.ts` wrapper that uses `lazyApi()` from `lazy.ts`.
+
+## MODULE PAIRS
+
+| Concrete | Lazy wrapper |
+|---|---|
+| `anthropic-messages.ts` | `anthropic-messages.lazy.ts` |
+| `openai-responses.ts` | `openai-responses.lazy.ts` |
+| `openai-completions.ts` | `openai-completions.lazy.ts` |
+| `openai-codex-responses.ts` | `openai-codex-responses.lazy.ts` |
+| `azure-openai-responses.ts` | `azure-openai-responses.lazy.ts` |
+| `google-generative-ai.ts` | `google-generative-ai.lazy.ts` |
+| `google-vertex.ts` | `google-vertex.lazy.ts` |
+| `bedrock-converse-stream.ts` | `bedrock-converse-stream.lazy.ts` |
+| `mistral-conversations.ts` | `mistral-conversations.lazy.ts` |
+| `pi-messages.ts` | `pi-messages.lazy.ts` |
+| `openrouter-images.ts` | `openrouter-images.lazy.ts` |
+
+Utility modules with no lazy wrapper: `cloudflare.ts`, `github-copilot-headers.ts`, `openai-prompt-cache.ts`.
+
+## LAZY BOUNDARY
+
+`lazy.ts` exports `lazyApi()` and `lazyStream()`. A `.lazy.ts` wrapper is the **only** sanctioned dynamic-import boundary in this package. Concrete modules use top-level imports only. `src/compat.ts` (one level up) re-exports all lazy wrappers and registers them via the api-registry.
+
+`openai-codex-responses.ts` cannot use top-level `node:os` or `node:zlib` imports because the module loads in browser/Vite builds. It uses `process.getBuiltinModule?.("node:os")` behind a runtime check. The file carries an explicit `// NEVER convert to top-level runtime imports` comment. Keep it.
+
+## SHARED LOGIC
+
+- `simple-options.ts` `applyExtraBody()`: merges caller-supplied `extraBody` into a provider request, skipping keys in the provider's `reservedKeys` set. Never overwrite `model`, `messages`, `stream`, tool-call fields, or reasoning fields. Each provider declares its own `RESERVED_BODY_KEYS` set (e.g., `OPENAI_COMPLETIONS_RESERVED_BODY_KEYS`).
+- `transform-messages.ts`: cross-provider message coercion (image downgrade, tool-result flattening). Returns new structures; never mutates shared message arrays. Cross-model transforms drop incompatible opaque state (provider-native content that can't round-trip). Same-model provider-native state (Anthropic signed thinking, redacted thinking blocks, encrypted web-search state) is byte-sensitive and must be preserved exactly.
+- `openai-responses-shared.ts`: shared logic for both `openai-responses.ts` and `openai-codex-responses.ts`.
+- `google-shared.ts`: shared logic for both `google-generative-ai.ts` and `google-vertex.ts`.
+
+## PROVIDERSTREAMS CONTRACT
+
+Every concrete module exports an object implementing `ProviderStreams` (`types.ts`): `stream()` and `streamSimple()`. Both must preserve usage counters, stop reasons, error events, abort behavior, and partial-JSON tool call chunks across the full response lifetime. Lazy wrappers forward these invariants transparently via `lazyStream`.
+
+## EXPORTS
+
+All files in this directory are wildcarded in `package.json` under the `./api/*` subpath export. Don't add internal-only helpers here; they'll leak into the public surface.
+
+## ANTI-PATTERNS
+
+- No ordinary dynamic imports in concrete modules; all dynamic loading goes through `.lazy.ts` wrappers.
+- Don't duplicate shared conversion logic in a single adapter; put it in `simple-options.ts`, `transform-messages.ts`, `openai-responses-shared.ts`, or `google-shared.ts`.
+- Don't hand-edit `src/models.generated.ts`; regenerate with `scripts/generate-models.ts`.
+- Don't add top-level Node built-in imports to any module consumed in browser builds.

--- a/packages/ai/src/providers/AGENTS.md
+++ b/packages/ai/src/providers/AGENTS.md
@@ -10,6 +10,8 @@ all.ts                   Builtin provider/model aggregation
 faux.ts                  Deterministic public test provider
 *-models.ts              Provider model/catalog helpers where present
 images/                  Image-provider metadata and factories
+radius.ts                Dynamic Radius provider with persisted model refresh
+radius-config.ts         Radius gateway/model catalog loading
 ```
 
 ## ADD OR CHANGE A PROVIDER
@@ -25,6 +27,7 @@ images/                  Image-provider metadata and factories
 ## INVARIANTS
 
 - Do not put wire clients back into provider factories or restore lazy registration in `register-builtins.ts`.
+- Dynamic providers expose last-known models synchronously and refresh through the ModelsStore/auth-aware refresh path; implement `refreshModels`, cache restore/write, abort handling, and failure retention.
 - `../api/transform-messages.ts` is the canonical cross-provider coercion boundary and must not mutate source messages.
 - Keep provider-specific quirks local; shared behavior belongs in clearly named shared modules.
 - Every API stream must preserve tool calls, thinking blocks, usage accounting, stop reasons, setup errors, and abort semantics.

--- a/packages/ai/src/tool-call-middleware/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/AGENTS.md
@@ -16,7 +16,8 @@ tool-call-middleware/
 │   ├── yaml-xml.ts             # YAML body inside XML tags
 │   ├── gemma4.ts               # Gemma 4 delimiter format `<|tool_call>call:name{…}<tool_call|>`
 │   ├── json-mix.ts             # Shared JSON-mix helper (Hermes + delimited variants)
-│   └── xml-tool-tag-scanner.ts # Streaming XML tag boundary scanner
+│   ├── xml-tool-tag-scanner.ts # Streaming XML tag boundary scanner
+│   └── anthropic-xml/          # Legacy <invoke>/<parameter> parser, coercion, scanner, formatter, stream parser
 ├── TESTING.md                  # Manual test commands per protocol (OpenRouter live API)
 └── changes.md                  # Fork tracker: morph-xml strict mode, yaml+xml, stream error preservation
 ```
@@ -33,7 +34,7 @@ tool-call-middleware/
 
 ## ADD A PROTOCOL (5 steps)
 
-1. Implement `Protocol` interface in `protocols/<name>.ts` (parse, format, stream).
+1. Implement `Protocol` interface in `protocols/<name>.ts` or `protocols/<name>/index.ts` plus focused helpers (parse, format, stream).
 2. Add system-prompt rendering for tools to `context-transformer.ts`.
 3. Export from `index.ts` and register in the protocol registry.
 4. Add `"<name>"` to the `ToolCallFormat` union in `types.ts` (this dir), the literal whitelist in `getToolCallFormat()` in `index.ts`, and the `toolCallFormat` TypeBox union in `packages/coding-agent/src/core/model-registry.ts` (validates `~/.senpi/agent/models.json`).
@@ -55,6 +56,6 @@ tool-call-middleware/
 
 ## NOTES
 
-- `TESTING.md` documents the canonical live-API test commands per protocol (Qwen for Hermes, Gemini for MorphXML, Gemma 4 for delimiter). Update it when adding new protocols.
+- `TESTING.md` documents the canonical live-API test commands per protocol (Qwen for Hermes, Gemini for MorphXML, Gemma 4 for delimiter, and Anthropic XML). Update it when adding new protocols.
 - This package's middleware is fork-modified — see `changes.md` for the architectural rewrite toward `minpeter/ai-sdk-tool-call-middleware` style.
 - `compat.toolCallFormat` on a custom model in `~/.senpi/agent/models.json` is what activates middleware for that model.

--- a/packages/coding-agent/AGENTS.md
+++ b/packages/coding-agent/AGENTS.md
@@ -6,9 +6,17 @@
 
 ```text
 src/cli.ts, cli-main.ts, main.ts   Bootstrap, args, mode dispatch
+src/package-manager-cli.ts         install/update/config subcommands (incl. `senpi update --models`)
 src/core/agent-session.ts          Session lifecycle and runtime
+src/core/dynamic-prompt/           Dynamic system-prompt assembly + workstation facts
+src/core/model-runtime.ts          Model runtime bootstrap
+src/core/model-config.ts           Per-model config resolution
+src/core/models-store.ts           Persisted model store
+src/core/provider-composer.ts      Provider payload composition
+src/core/remote-catalog-provider.ts Remote model-catalog fetch
+src/core/runtime-credentials.ts    Credential resolution and refresh
 src/core/extensions/               Public extension API and loader
-src/core/extensions/builtin/       Fork features implemented as extensions
+src/core/extensions/builtin/       In-tree fork extensions; bundled extensions (e.g. codemode) resolved via resource-loader.ts
 src/core/tools/                    Upstream-parity built-in tools
 src/core/compaction/               Core compaction mechanics
 src/modes/interactive/             TUI mode and components
@@ -28,6 +36,7 @@ src/changes.md                     Root fork-change record
 | Add tool, command, flag, or hook | `src/core/extensions/builtin/` |
 | Change extension contract | `src/core/extensions/types.ts` and `src/core/extensions/changes.md` |
 | Change session lifecycle | `src/core/agent-session.ts` |
+| Change model/provider/catalog/auth runtime | `src/core/model-runtime.ts` + related `model-*/provider-*` modules |
 | Change keybinding | `src/core/keybindings.ts` |
 | Change interactive UI | `src/modes/interactive/` |
 | Change RPC/app-server | matching directory under `src/modes/` |
@@ -43,7 +52,7 @@ src/changes.md                     Root fork-change record
 - Keep branding consistent: package `@code-yeongyu/senpi`, binary `senpi`, config directory `.senpi`.
 - Preserve the inlined UUIDv7 implementation; do not add a `uuid` dependency.
 - Do not run real providers in tests. Use `test/suite/harness.ts` and the faux provider.
-- RPC/app-server streams are LF-framed and request-correlated; preserve pending-work rejection on disconnect or child exit. Current readers/buffers are not size-bounded, so do not claim bounded/backpressured behavior without implementation and tests.
+- RPC/app-server streams are LF-framed and request-correlated; preserve pending-work rejection on disconnect or child exit. Inbound NDJSON readers are not size-bounded; outbound stdio waits for stdout backpressure (`transports/stdio.ts`) and WebSocket closes slow clients at queue cap (`transports/websocket-connection-handler.ts`); preserve those contracts.
 - MCP token/log storage preserves restricted directory/file permissions; do not widen inherited child environments. RPC child stderr is currently emitted and embedded raw, so treat diagnostics as potentially secret-bearing and do not claim redaction without implementing it.
 
 ## ANTI-PATTERNS

--- a/packages/coding-agent/docs/AGENTS.md
+++ b/packages/coding-agent/docs/AGENTS.md
@@ -1,0 +1,70 @@
+# packages/coding-agent/docs/
+
+Public documentation for `@code-yeongyu/senpi`. Shipped inside the npm package: `package.json`
+`files` array includes `"docs"`, so every file here lands in the published tarball.
+
+## Navigation manifest
+
+`docs.json` has two top-level keys: `navigation` (ordered section and page list) and `redirects`.
+Page paths are relative to this directory.
+
+- Every new `.md` file needs an entry in `docs.json` under `navigation`.
+- Renamed or moved pages need a `redirects` entry to avoid broken links.
+- Navigation-only stubs without real content belong in `redirects`, not `navigation`.
+
+## Landing page and images
+
+`index.md` is the landing page. Images live under `docs/images/`:
+`doom-extension.png`, `exy.png`, `interactive-mode.png`, `tree-view.png`.
+
+New images go in `docs/images/`. Don't reference images by absolute URL when a relative path works.
+
+## Protocol and reference pages
+
+These pages must track their implementation counterparts. Treat them as specs, not tutorials.
+
+| Page | Tracks |
+|------|--------|
+| `rpc.md` | `packages/coding-agent/src/modes/rpc/` |
+| `app-server.md` | `packages/coding-agent/src/modes/app-server/` |
+| `json.md` | JSONL wire format and record shapes |
+| `session-format.md` | Session file structure and field types |
+
+Preserve LF line endings and exact field names in these pages. Field spellings and JSONL record
+structures are asserted by tests; prose-only rewording can still break them.
+
+## Validators
+
+- `scripts/check-mcp-docs.test.mjs`: Parses `config-schema.ts` key names as raw text and
+  checks that every field has a `### \`field\`` heading in `mcp.md`. Runs under
+  `npm run test:scripts`. Schema additions without a matching doc heading break CI.
+
+- `packages/coding-agent/test/qa/app-server/task20-doc-example-check.ts`: Spins up a live
+  app-server process and validates that JSON examples in `app-server.md` match actual server
+  behavior. Prose edits to `app-server.md` that change JSON shapes will fail this test.
+
+## Terminology
+
+Docs mix `senpi` and upstream `Pi` branding in legacy text. Don't do broad rebrand sweeps
+during focused edits; update only the immediate context you're working in.
+
+Consistent names: CLI binary is `senpi`, config directory is `.senpi`, npm package is
+`@code-yeongyu/senpi`. Don't use `codex`, `pi`, or `openai-codex` in new prose.
+
+## Security rules
+
+- `bearerTokenEnv` names an environment variable, not a token value. Examples must never put
+  a literal token in the JSON config; the implementation warns when it detects one.
+- OAuth tokens persist under the agent directory at runtime. Don't surface them in doc examples
+  or log snippets.
+- MCP config values are not shell-expanded. Don't document or imply `$VAR` substitution in
+  JSON config examples.
+- `mcp.md` must not advertise URL-mode elicitation; it's not a shipped feature.
+
+## Anti-patterns
+
+- No new `.md` file without a `docs.json` entry.
+- Don't edit protocol page prose without checking whether `task20-doc-example-check.ts` or
+  `check-mcp-docs.test.mjs` would break.
+- Don't copy claims from upstream Pi docs without verifying they apply to the senpi fork.
+- Don't embed bearer tokens, session IDs, or raw API keys in example output.

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -9,6 +9,7 @@ extensions/        Tools, commands, UI, providers, hooks, resources
 extensions/*/      Multi-file examples and nested private workspaces
 sdk/               Programmatic SDK usage
 rpc-extension-ui.ts RPC-compatible extension UI example
+extensions/kimi-deferred-tools.ts  Deferred tool discovery/activation example
 ```
 
 ## CONVENTIONS
@@ -18,6 +19,8 @@ rpc-extension-ui.ts RPC-compatible extension UI example
 - Extension factories have no top-level runtime side effects. Register work through the public `pi.*` API and lifecycle events.
 - New interactive examples should use configurable keybindings and themed TUI helpers. Existing demos may keep fixed controls when the control scheme is part of the example. Direct terminal writes belong only in examples explicitly teaching a terminal protocol; ordinary SDK examples may use normal stdout.
 - Tool string enums use the shared `StringEnum` helper for provider compatibility.
+- SDK examples should use `ModelRuntime` for auth/custom-model/session composition; deprecated static catalog helpers import from `@earendil-works/pi-ai/compat`.
+- Deferred-tool examples preserve the Kimi flow: expose search first, activate via `pi.setActiveTools()`, and register lifecycle work in `session_start`.
 - Stateful examples persist reconstructable state in session entries or tool-result details so fork/resume behavior remains valid.
 - Nested example packages are private workspaces with exact-pinned dependencies. Treat their manifests and lock impact as production dependency changes.
 

--- a/packages/coding-agent/src/core/extensions/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions
 
-The extension system. **The fork's most important architectural surface** — every fork feature that *can* be an extension *is* one. `types.ts` is ~1700 lines of public API contract. Treat changes here as breaking until proven otherwise.
+The extension system. **The fork's most important architectural surface** — every fork feature that *can* be an extension *is* one. `types.ts` is ~1844 lines of public API contract. Treat changes here as breaking until proven otherwise.
 
 ## FILES
 
@@ -8,14 +8,14 @@ The extension system. **The fork's most important architectural surface** — ev
 extensions/
 ├── types.ts             # Public API: ExtensionAPI, Extension, ExtensionContext, ExtensionUIContext,
 │                        # ExtensionEvent union (30+ events), all *EventResult types, ToolDefinition.
-│                        # ~1700 LOC — VERY HIGH merge-conflict risk on every upstream sync.
+│                        # ~1844 LOC — VERY HIGH merge-conflict risk on every upstream sync.
 ├── loader.ts            # Discovery + jiti-based TS import. Shared importer per `loadExtensions()` batch
 │                        # (perf fix 2026-05-08). Aliases `@mariozechner/pi-*` → workspace packages.
 ├── runner.ts            # ExtensionRunner — owns the runtime, dispatches events, holds shutdown handlers,
 │                        # exposes `bindCore()` to wire `pi.*` stubs to real implementations.
 ├── wrapper.ts           # 30-line wrapper utility used to track extension origin per UI message
 ├── index.ts             # Re-exports from runner/loader/types
-├── builtin/             # 22 builtin extensions + 4 global defaults — see builtin/AGENTS.md
+├── builtin/             # 23 builtin extensions + bundled codemode (`core/resource-loader.ts`) — see builtin/AGENTS.md
 └── changes.md           # Fork tracker — DENSE. Every public-API change must add a section.
 ```
 
@@ -31,6 +31,8 @@ extensions/
 | Providers | `registerProvider`, `unregisterProvider` | New LLM provider (extension-local) |
 | Messages | `sendMessage`, `sendUserMessage`, `appendEntry`, `registerMessageRenderer` | Inject messages/entries into the session |
 | Model | `setModel`, `getThinkingLevel`, `setThinkingLevel` | Model + thinking-level control |
+| Session metadata | `setSessionName`, `getSessionName`, `setLabel` | Session display name + entry labels |
+| Tool execution | `executeTool` | Run a tool through the normal validation/hook/permission pipeline |
 | Events | `on(<event>, handler)` | 30+ events (session_start, tool_call, message_update, before_provider_request, before_agent_start, model_select, system_prompt_change, session_before_compact, session_compact, resources_discover, etc.) |
 | Context | `ctx: ExtensionContext` — second parameter of every event handler | Read cwd, model, session manager, compaction settings, system prompt; `ctx.ui` for TUI dialogs/widgets |
 
@@ -38,9 +40,10 @@ extensions/
 
 ## LOADING ORDER
 
-1. Builtin factories from `builtin/index.ts`, in `builtinExtensions` array order — affects permission/agent stacking precedence.
-2. Generated default global extensions (`globalDefaultExtensionFactories`: `diff`, `files`, `prompt-url-widget`, `tps`) — fast-path resolved by `core/resource-loader.ts` (avoids jiti for unchanged stub files).
-3. User extensions from `~/.senpi/agent/extensions/`, `.senpi/extensions/` (directory name comes from `CONFIG_DIR_NAME` in `config.ts`), settings.json paths, `-e` CLI flag.
+1. In-tree factories from `builtin/index.ts`, in `builtinExtensions` array order — affects permission/agent stacking precedence.
+2. Bundled extensions (currently codemode; `core/resource-loader.ts`) — resolved via package JSON entries, loaded through the same jiti path as user extensions.
+3. Inline SDK/runtime factories passed to the runtime constructor (`core/resource-loader.ts`).
+4. Resolved global/project/user/settings/CLI paths (includes global default extensions: `diff`, `files`, `prompt-url-widget`, `tps`; user paths from `~/.senpi/agent/extensions/`, `.senpi/extensions/`, settings.json, `-e` flag).
 
 ## CONVENTIONS
 
@@ -59,5 +62,6 @@ extensions/
 
 ## NOTES
 
-- The ~1700-line `types.ts` is "the API"; treat its diffs like a public package release.
+- The ~1844-line `types.ts` is "the API"; treat its diffs like a public package release.
+- `ToolRenderContext` now includes `imageProtocol` (terminal image protocol, or null when images can't render) and `hasResult` (lets a call renderer yield to the result renderer).
 - `changes.md` already documents major fork-introduced APIs: `ModelSelectEventResult`, `SystemPromptChangeEvent`, `getCompactionSettings`, lazy/shared jiti, default-extension factory resolver. Read it before extending.

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions/builtin
 
-22 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
+23 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
 
 ## INVENTORY (registration order from `builtin/index.ts`)
 
@@ -9,7 +9,7 @@
 | 1 | `hooks` | `hooks/` | Settings-configured lifecycle command hooks (PreToolUse/PostToolUse-style) with trust hashing + live status |
 | 2 | `permission-system` | `permission-system/` | Full opencode-style permission port: rules, JSONL storage, prompts |
 | 3 | `gpt-apply-patch` | `gpt-apply-patch/` | Codex-style `apply_patch` tool with rich render + freeform grammar |
-| 4 | `prompt-preset` | `prompt-preset/` | Per-model system prompts (gpt-5.x, claude-opus-4-{5,6,7}, kimi-k2-{6,7}) |
+| 4 | `prompt-preset` | `prompt-preset/` | Per-model system prompts (gpt-5.x, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3) |
 | 5 | `todowrite` | `todotools/` | Plan/task tools; synced from `../pi-extensions/pi-todotools` |
 | 6 | `redraws` | `redraws.ts` | Force-redraw event hooks for stable streaming visuals |
 | 7 | `anthropic-web-search` | `anthropic-web-search/` | Anthropic-native web search tool |
@@ -17,19 +17,20 @@
 | 9 | `openai-web-search` | `openai-web-search/` | OpenAI-native web search |
 | 10 | `service-tier` | `service-tier.ts` | Per-model service-tier (e.g., priority-tier mapping) |
 | 11 | `bash-timeout` | `bash-timeout/` | Bash tool timeout + handlers |
-| 12 | `tool-pair-guard` | `tool-pair-guard/` | Repairs orphaned tool_use/tool_result pairs (compaction safety) |
-| 13 | `compaction` | `compaction/` | Plugsuit-style speculative + emergency compaction with restoration |
-| 14 | `history-search` | `history-search/` | Cross-session transcript search overlay (indexes session files) |
-| 15 | `import-repro` | `import-repro.ts` | `/ir` command — import an issue-analysis CI session gist and switch to it |
-| 16 | `session-observer` | `session-observer/` | `/sessions` command — peek at previous session transcripts in a HUD |
-| 17 | `websearch` | `websearch/` | Provider-backed `web_search` tool + `/websearch` (providers incl. kimi); vendored from `../pi-extensions/pi-websearch` |
-| 18 | `webfetch` | `webfetch/` | `webfetch` tool (md/text/html, gated by `PI_WEBFETCH`); vendored from `../pi-extensions/pi-webfetch` |
-| 19 | `nested-agents-md` | `nested-agents-md/` | Auto-injects nearby `AGENTS.md` + `/nested-agents`; vendored from `../pi-extensions/pi-nested-agents-md` |
-| 20 | `rules` | `rules/` | Rule-file discovery + `/rules`/`/reload-rules`; vendored from `../pi-extensions/pi-rules` |
-| 21 | `goal` | `goal/` | Budget-free goal tools + `/goal`; vendored from `../pi-extensions/pi-goal` |
-| 22 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — see `mcp/changes.md` |
+| 12 | `terminal` | `terminal/` | Persistent PTY-backed bash + bash_output/bash_input/bash_resize/kill_bash tools |
+| 13 | `tool-pair-guard` | `tool-pair-guard/` | Repairs orphaned tool_use/tool_result pairs (compaction safety) |
+| 14 | `compaction` | `compaction/` | Plugsuit-style speculative + emergency compaction with restoration |
+| 15 | `history-search` | `history-search/` | Cross-session transcript search overlay (indexes session files) |
+| 16 | `import-repro` | `import-repro.ts` | `/ir` command — import an issue-analysis CI session gist and switch to it |
+| 17 | `session-observer` | `session-observer/` | `/sessions` command — peek at previous session transcripts in a HUD |
+| 18 | `websearch` | `websearch/` | Provider-backed `web_search` tool + `/websearch` (providers incl. kimi); vendored from `../pi-extensions/pi-websearch` |
+| 19 | `webfetch` | `webfetch/` | `webfetch` tool (md/text/html, gated by `PI_WEBFETCH`); vendored from `../pi-extensions/pi-webfetch` |
+| 20 | `nested-agents-md` | `nested-agents-md/` | Auto-injects nearby `AGENTS.md` + `/nested-agents`; vendored from `../pi-extensions/pi-nested-agents-md` |
+| 21 | `rules` | `rules/` | Rule-file discovery + `/rules`/`/reload-rules`; vendored from `../pi-extensions/pi-rules` |
+| 22 | `goal` | `goal/` | Budget-free goal tools + `/goal`; vendored from `../pi-extensions/pi-goal` |
+| 23 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — see `mcp/changes.md` |
 
-Plus 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`).
+Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by resource-loader.ts) and 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`).
 
 ## ADDING A NEW BUILTIN EXTENSION
 
@@ -43,9 +44,9 @@ Plus 4 **global default extensions** (resolved fast-path): `diff`, `files`, `pro
 
 - **Subdirectory extensions** ship multi-file: `index.ts` + supporting `.ts` (`registry.ts`, `types.ts`, `parsers.ts`, etc.).
 - **Single-file extensions** are kept flat (`diff.ts`, `files.ts`, `redraws.ts`, `service-tier.ts`, `tps.ts`, `prompt-url-widget.ts`).
-- **`prompt-preset/`** has per-model files (`gpt-5.5.ts`, `claude-opus-4-7.ts`, …) and a shared `file-operations.ts` tuning block. New model = new preset file + entry in `presets.ts`.
+- **`prompt-preset/`** has per-model files (`gpt-5.5.ts`, `claude-opus-4-7.ts`, …) and a shared `file-operations.ts` tuning block. New model = new preset file + entry in `presets.ts`. Models covered: gpt-5.x, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3.
 - **`permission-system/` is a full port** of opencode's permission flow.
-- **`compaction/`** is policy-rich (`policy.ts`, `speculative.ts`, `restoration-tracker.ts`, `circuit-breaker.ts`, `degradation-monitor.ts`, `per-turn-cap.ts`, `tool-truncation.ts`, `checkpoint-state.ts`, `context-reduction.ts`, `openai-remote.ts`, `repair-tool-pairs.ts`, `state.ts`, `todo-bridge.ts`). Touch only with policy tests in lock-step.
+- **`compaction/`** is policy-rich (`policy.ts`, `speculative.ts`, `restoration-tracker.ts`, `circuit-breaker.ts`, `degradation-monitor.ts`, `per-turn-cap.ts`, `tool-truncation.ts`, `checkpoint-state.ts`, `context-reduction.ts`, `openai-remote.ts`, `repair-tool-pairs.ts`, `state.ts`, `todo-bridge.ts`, `prompts.ts`). Touch only with policy tests in lock-step.
 - **External versions**: `external-versions.json` pins versions of sibling `../pi-extensions` packages used as vendored builtins; refresh with `packages/coding-agent/scripts/sync-builtin-extensions.mjs`.
 
 ## ANTI-PATTERNS
@@ -60,4 +61,6 @@ Plus 4 **global default extensions** (resolved fast-path): `diff`, `files`, `pro
 
 - `permission-system/storage.ts` writes JSONL approval logs; don't change the line shape without a migration.
 - `compaction/restoration-tracker.ts` powers the post-compact context restoration feature — see `compaction/changes.md`.
+- `goal/elapsed-ticker.ts` drives the live 'Pursuing goal...' footer refresh on a one-second cadence.
+- MCP search exposure tool is `tool_search` (mcp/expose/tool-search.ts). Do not reintroduce `mcp_search` references anywhere.
 - Prompt presets routinely append the shared `file-operations.ts` tuning block. Mirror this when adding GPT-5.x presets — see `prompt-preset/changes.md` 2026-05-07.

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/AGENTS.md
@@ -1,0 +1,48 @@
+# packages/coding-agent/src/core/extensions/builtin/mcp
+
+Fork-native builtin MCP client. Registration #23 in `builtin/index.ts` — kept last so its provider-payload tap observes all co-resident builtin mutations. Entry: `index.ts` exports `default function mcpExtension(pi: ExtensionAPI): void`. `changes.md` is the active fork ledger; every divergence from upstream MCP SDK behavior goes there.
+
+## SUBTREES
+
+- `auth/` OAuth 2.1: discovery, PKCE S256, RFC 8707 resource binding, loopback callback or paste flow. Token store in `auth/token-store.ts`: `<agentDir>/mcp-auth/<sha256(serverUrl)>/tokens.json`, dir 0700, files 0600, cross-process lock via `proper-lockfile`.
+- `expose/` Tool naming (`naming.ts`), exposure policy (`policy.ts`), pagination, BM25 search, proxy gateway, schema compat. Tool names: `mcp_<server>_<tool>`, sanitized, 64-char hard cap (`MCP_TOOL_NAME_MAX_LENGTH = 64`), hash suffix on collision.
+- `guard/output-guard.ts` Output size limits + spill file creation.
+
+## CONFIG
+
+TypeBox schema in `config-schema.ts`. Config loader in `config.ts`: reads global `<agentDir>/mcp.json`, project `.senpi/mcp.json`, and optional Claude `.mcp.json` (only when `importConfigs` includes `"claude"`). Skill MCP sidecars are a fourth source.
+
+`${VAR}` interpolation only. Command substitution is rejected: values starting with `!` or containing `$(` throw `McpConfigValidationError` at load time.
+
+## COMMANDS AND TRANSPORT
+
+`/mcp` command namespace lives in `commands.ts`. Transport in `transport.ts`: stdio + Streamable HTTP. Stdio command is never shell-evaluated; child spawned with explicit env. Shutdown sequences `reapProcessTree` to reap descendant processes.
+
+## EXPOSURE MODES
+
+Three modes: `direct` (tools register immediately), `search` (full catalog in tier-B, only `directTools` active, `tool_search` promotes on demand), `proxy` (single gateway tool, catalog hidden). `auto` never selects `proxy`; spec evidence: -27.3pp GSM8K structured-output regression (see `policy.ts` comment). Search tool name constant: `TOOL_SEARCH_TOOL_NAME = "tool_search"`.
+
+## ATTACH AND SESSION LIFECYCLE
+
+Attach is **single-flight**: `attachPromise` memoizes the in-flight `attachSession` so `before_agent_start` awaits the original promise rather than starting a second attach that would collect an empty catalog.
+
+**Resumed sessions**: `#rehydrateFromSessionHistory` runs at attach time so the first wire payload already carries previously promoted tools. `maybeRehydrateFromHistory` on the `context` event is a safety-net replay.
+
+**`list_changed`**: Added tools enter INACTIVE (rug-pull defense). Removed tools are force-dropped and tombstoned; stale `execute()` returns a clean `isError`. See `notifications.ts`.
+
+## ELICITATION
+
+`elicitation.ts` implements MCP elicitation as form-only (no free-text). Must work headless and over RPC; the UI provider is injected at `before_agent_start` time via `setMcpElicitationUiProvider`.
+
+## TESTS AND DOCS
+
+Tests: `packages/coding-agent/test/mcp/` (40+ test files by feature).
+Docs contract: `packages/coding-agent/docs/mcp.md` + `scripts/check-mcp-docs.test.mjs` (root scripts dir). The doc-check test fails if schema fields diverge from prose.
+
+## ANTI-PATTERNS
+
+- No widened token or log permissions.
+- No raw secrets in config values; use `${ENV_VAR}` references.
+- Proxy mode is never selected automatically; opt-in only via `exposure: "proxy"`.
+- New tools from `list_changed` are never active by default; only `directTools` entries become active immediately.
+- Never import from `core/` directly; use `pi.*` API only.

--- a/packages/coding-agent/src/core/tools/AGENTS.md
+++ b/packages/coding-agent/src/core/tools/AGENTS.md
@@ -17,12 +17,13 @@ tools/
 ├── find.ts                      # Path search tool (gitignore-aware)
 ├── ls.ts                        # Directory listing
 ├── file-mutation-queue.ts       # Serializes write/edit/apply_patch on the same file
-├── output-accumulator.ts        # Streams long stdout; truncate-tail with line cap
+├── tail-window.ts               # Bounded decoded tail window used by OutputAccumulator
+├── output-accumulator.ts        # Bounded streaming output snapshots; temp-file fallback preserves full output
 ├── path-utils.ts                # Path normalization, repo-root resolution
 ├── render-utils.ts              # ANSI / chalk / panel helpers shared across renders
 ├── tool-definition-wrapper.ts   # Helper to wire ToolDefinition + render + execute
 ├── truncate.ts                  # Output truncation policy
-└── changes.md                   # Fork tracker (currently: bash promptSnippet `grep` → `rg`)
+└── changes.md                   # Fork tracker: bash timeout validation, shared diff rendering (edit/write/apply_patch), bash prompt tuning (rg over grep, elapsed display, syntax highlighting)
 ```
 
 ## TOOL DEFINITION SHAPE

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -11,13 +11,21 @@ mcp/               MCP transports, fixtures, security, lifecycle
 permission/        Permission-system behavior
 compaction/        Compaction mechanics and policy
 session-manager/   Persistence, branching, context construction
+dynamic-prompt/    Dynamic system-prompt + workstation fact coverage
+tool-pair-guard/   Provider payload tool-pair sanitization tests
+helpers/           Shared subprocess/QA/fixture helpers
+manual-qa/         Explicit manual QA scripts (not part of default suite)
 qa/app-server/     Real app-server surface drivers
 integration/       Explicitly gated real-provider tests
 fixtures/, goldens/ Shared deterministic inputs and snapshots
+model-runtime*.test.ts / models-store.test.ts / remote-catalog-provider.test.ts / runtime-credentials.test.ts
+                   Model/catalog/auth runtime coverage
 ```
 
 ## TEST RULES
 
+- `test/setup.ts` quarantines `SENPI_CODING_AGENT_DIR` into a unique temp directory by default; preserve that isolation in all new tests.
+- Model catalog refresh tests must stay mocked/offline; only `integration/` and `qa/` surfaces may use real credentials or incur network cost.
 - Prefer `suite/harness.ts` and the faux provider for new lifecycle and extension coverage.
 - Do not use real provider APIs, API keys, network calls, or paid tokens in default tests.
 - Some legacy tests outside `integration/` still activate from ambient Anthropic credentials. Run the suite hermetically and do not copy that activation pattern into new tests.

--- a/packages/neo/internal/ui/editor/AGENTS.md
+++ b/packages/neo/internal/ui/editor/AGENTS.md
@@ -1,0 +1,67 @@
+# packages/neo/internal/ui/editor
+
+Independent Go multiline editor. Contract-faithful port of `packages/tui/src/components/editor.ts`; `keys.go` ports `packages/tui/src/keys.ts`. Source parity with the TS originals is a convention, not a mechanical sync.
+
+## FILE MAP
+
+| File | Contents |
+|---|---|
+| `editor.go` | Public `Editor` struct, `New`, `SetText`, `InsertTextAtCursor`, `Cursor`, `SetFocused`, `AddToHistory` |
+| `bubbletea.go` | `Update(msg tea.Msg)`, `ViewCursor(rows, originX, originY)` |
+| `render.go` | `Render(width int) []string`, fake reverse-video cursor marker |
+| `edit_ops.go` | Character/line insertion and deletion |
+| `kill_ops.go` | Kill-to-line-end/start, kill-word |
+| `killring.go` | Kill ring accumulation + yank-pop state |
+| `movement.go` | Cursor movement, sticky columns |
+| `wordnav.go`, `wordnav_find.go` | UAX-29 word navigation |
+| `autocomplete.go` | `SetAutocompleteProvider`, `AdvanceDebounce`, `WaitForAutocompleteInFlight`, `WaitForAutocompleteRequestsSettled`, debounce gate |
+| `autocomplete_req.go` | In-flight async request lifecycle, cancel-on-keystroke |
+| `acpopup.go` | Completion popup rendering |
+| `keymap.go` | `Action` string constants, `Keymap` interface (`Matches`, `SubmitKeys`), `DefaultKeymap()` |
+| `keys.go` | Kitty CSI-u (`kittyCSIuRe`) + xterm modifyOtherKeys (`modifyOtherKeysRe`) decoders |
+| `visualmap.go` | Logical-to-visual line mapping |
+| `wrap.go`, `wrapcache.go` | Soft-wrap layout, invalidation cache |
+| `markers.go` | `cursorMarker` constant and paste-marker helpers |
+| `state.go` | `editorState` (lines, cursor), `undoStack` |
+| `textwidth/` | Terminal-cell grapheme width (wraps `uniseg`) |
+| `dispatch.go`, `helpers.go`, `runes.go` | Internal utilities |
+
+Tests: `editor_<feature>_test.go` (cursor, history, killring, pastemarker, sticky, undo, unicode, wrap, autocomplete, jump). Manual entry: `qaharness/main.go`.
+
+## KEY ENTRY POINTS
+
+- `New(opts Options) *Editor` constructs with defaults (keymap, acMaxVisible clamp 3..20, paddingX clamp >= 0).
+- `Update(msg tea.Msg) *Editor` feeds a Bubble Tea message; returns receiver for chaining.
+- `Render(width int) []string` produces display rows with the fake reverse-video cursor embedded (when focused).
+- `ViewCursor(rows []string, originX, originY int) *tea.Cursor` locates the zero-width cursor marker in Render output to pin the hardware cursor for IME.
+- `SetAutocompleteProvider(p AutocompleteProvider)` installs a provider and resets trigger chars.
+
+## INVARIANTS
+
+**Keys**: Every raw sequence resolves through `Keymap.Matches(raw, action)`. No feature code compares raw byte sequences inline.
+
+**Column math**: Logical columns are rune indices into a line string. Display width uses `textwidth/` (grapheme cluster width, CJK/emoji aware). Never use byte offsets or UTF-16 code unit counts.
+
+**Cursor**: `Render` embeds `cursorMarker` for fake reverse-video when `focused = false` or terminal lacks hardware cursor. `ViewCursor` finds the marker and returns the hardware cursor position for IME candidate window placement. Both invariants must survive viewport resize.
+
+**Undo**: `undoStack` push happens before every mutation. Insert runs coalesce (history draft is saved on `exitHistoryBrowsing`).
+
+**Kill ring**: `ctrl+w/u/k` accumulate into the ring when `lastAction == actionKill`. `ctrl+y` yanks, `alt+y` pops. Stored in `killRing` field.
+
+**Sticky columns**: Vertical movement preserves `preferredVisualCol`; horizontal movement clears it via `setCursorCol`.
+
+**Paste**: CRLF and CR normalized to `\n`. Tabs expanded. Control characters filtered. Large pastes stored in `pastes` map and referenced via `[paste #N]` markers; `GetExpandedText` expands them back.
+
+**Async autocomplete**: Tests use `AdvanceDebounce()`, `WaitForAutocompleteInFlight()`, `WaitForAutocompleteRequestsSettled()` as deterministic seams. No wall-clock sleeps.
+
+## CONSUMERS
+
+- `internal/app/input.go`: `EditorBuffer` interface; `var _ EditorBuffer = (*editor.Editor)(nil)` compile check.
+- `internal/ui/extui/dialogs.go`: dialog text-entry fields.
+
+## ANTI-PATTERNS
+
+- Feature code with `if raw == "\x1b[A"` or any hardcoded escape sequence. Use `keymap.Matches`.
+- `len(line)` for column positions. Use rune index or grapheme width from `textwidth/`.
+- `time.Sleep` or polling in tests. Use the `WaitFor*` / `AdvanceDebounce` seams.
+- Snapshot acceptance that masks a changed cursor column or cell width. Inspect the cell grid first.

--- a/packages/orchestrator/AGENTS.md
+++ b/packages/orchestrator/AGENTS.md
@@ -23,6 +23,7 @@ src/cli.ts            CLI source; package currently declares no bin entry
 - Correlate requests and responses explicitly and close pending operations on disconnect.
 - The supervisor owns spawned children and must clean them up on stop, error, and partial startup.
 - Radius disconnect/reconnect paths settle listeners and pending work without leaking sockets.
+- Radius presence owns machine/Pi heartbeat retry backoff and re-registration after repeated 404s; credential lookup uses coding-agent stored credentials (`readStoredCredential("radius")`) with `SENPI_RADIUS_API_KEY` as fallback.
 - Never log credentials, tokens, raw auth headers, or secret-bearing environments.
 - Treat the package as unstable and private. Do not promise a CLI install surface until `package.json` declares one.
 
@@ -33,7 +34,7 @@ src/cli.ts            CLI source; package currently declares no bin entry
 | IPC schema/framing | `src/ipc/` |
 | Child RPC lifecycle | `src/rpc-process.ts` and `src/supervisor.ts` |
 | Daemon request handling | `src/handler.ts` and `src/serve.ts` |
-| Radius integration | `src/radius.ts` |
+| Radius credentials + heartbeat/re-registration | `src/radius.ts` |
 | Config/storage | `src/config.ts`, `src/storage.ts` |
 
 ## VALIDATION

--- a/packages/senpi-codemode/AGENTS.md
+++ b/packages/senpi-codemode/AGENTS.md
@@ -6,7 +6,8 @@ the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia.
 ## STRUCTURE
 
 ```text
-src/index.ts                     Extension factory and session-start re-registration
+src/index.ts                     Extension factory: registers baseline eval, re-registers at session_start after runtime resolution, re-registers on model_select when active model changes
+src/prompt/                      Model-aware eval prompt templates and batching dialect selection
 src/config/                      Settings schema, defaults, env overrides
 src/extension/                   Session generations and kernel ownership
 src/tool/                        Eval schema, cell execution, status events, rendering
@@ -27,6 +28,7 @@ test/                            Vitest contracts and the omp parity ledger
 
 - `eval` is registered at extension load and re-registered at `session_start`
   after settings, interpreter availability, and active task-tool names resolve.
+- Eval prompt dialect is selected from the active model id; host/workstation context is explicit; renderer/status semantics are structured.
 - Session generations fence old kernels and callbacks. A retired generation
   must not emit into a newer session.
 - Kernels persist state per language, while per-cell callbacks are rebound for
@@ -52,6 +54,8 @@ test/                            Vitest contracts and the omp parity ledger
 | Task | Path |
 | --- | --- |
 | Register or narrow eval | `src/index.ts`, `src/tool/eval-tool.ts` |
+| Prompt behavior | `src/prompt/eval-prompt.ts` |
+| Call/result rendering | `src/tool/render.ts` |
 | Cell settlement and output | `src/tool/cell-handler.ts`, `src/output/` |
 | Session and kernel ownership | `src/extension/session-manager.ts`, `src/index.ts` |
 | Bridge auth and protocol | `src/bridge/` |

--- a/packages/tui/AGENTS.md
+++ b/packages/tui/AGENTS.md
@@ -25,6 +25,7 @@ test/*.test.ts              Node test-runner coverage
 - `start()` and `stop()` reset queued render state so stale scheduled frames cannot leak across lifecycles.
 - `ProcessTerminal` owns external stdout while running; components must not write around it.
 - Terminal title output strips control characters.
+- Visible tabs are normalized to a fixed three-column width at the terminal-output boundary; ANSI/OSC/APC escape sequences are untouched (`test/tab-width.test.ts`).
 - High-frequency consumer components are responsible for memoization; preserve the Senpi streaming caches.
 
 ## WHERE TO LOOK
@@ -37,6 +38,7 @@ test/*.test.ts              Node test-runner coverage
 | Key parsing/defaults | `src/keys.ts`, `src/keybindings.ts` |
 | Paste handling | `src/stdin-buffer.ts` |
 | Width/wrapping | `src/utils.ts` |
+| Terminal-output normalization/tab width | `src/utils.ts` (`normalizeTerminalOutput`, `visibleWidth`) and `src/tui.ts` |
 | Images | `src/terminal-image.ts` |
 
 ## ANTI-PATTERNS

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,70 @@
+# scripts/
+
+Build, validation, release, publish, lockfile, and environment tooling for the senpi monorepo.
+
+## Script anatomy
+
+All `.mjs` files carry `#!/usr/bin/env node` and run as ES modules.
+Shell wrappers `devenv-setup.sh` and `devenv-setup.ps1` locate Node and delegate to `devenv-setup.mjs`; they own no logic of their own.
+Colocated `*.test.mjs` files run via root `npm run test:scripts` (`node --test scripts/*.test.mjs`).
+
+## Naming convention
+
+| Prefix | Role |
+|--------|------|
+| `build-*` | Compile and bundle steps |
+| `check-*` | Validation and gate scripts |
+| `generate-*` | Artifact generation (shrinkwrap, install-lock) |
+| `prepare-*` | Publish staging |
+| `release-*` | Sub-tasks composed by `release.mjs` |
+| `publish-*` | npm publish workflows |
+| `sync-*` | Version synchronization |
+
+## Key entry points
+
+- `build-all.mjs`: PM-agnostic build orchestrator. Detects npm/Bun/pnpm via `npm_execpath`
+  and `npm_config_user_agent`; strips pnpm-only `npm_config_*` env keys before spawning
+  children. `BUILD_PHASES` is an exported constant; tests consume it directly.
+
+- `release.mjs`: CalVer release. Composes `calver.mjs`, `release-packages.mjs`,
+  `release-artifacts.mjs`, `release-changelog.mjs`. Pre-flight checks run in sequence:
+  must be on `main`, working tree must be clean (dry-run only warns), computed version
+  must be a valid CalVer string. Accepts `--dry-run` to preview all commands and file
+  writes without modifying anything.
+
+- `local-release.mjs`: Smoke-test release to a temp directory. Doesn't push tags.
+
+- `publish.mjs`: Publishes the four standalone packages (`@earendil-works/pi-ai`,
+  `@earendil-works/pi-agent-core`, `@earendil-works/pi-tui`, `@code-yeongyu/senpi`).
+  `@code-yeongyu/senpi-orchestrator` is `private: true` and explicitly excluded.
+
+- `build-binaries.sh`: Mirrors `.github/workflows/build-binaries.yml` for local
+  cross-platform binary builds.
+
+- `devenv-setup.mjs`: Universal, idempotent dev-environment setup. Both shell wrappers
+  delegate here after locating Node.
+
+## prepare-senpi-bundled-workspaces.mjs
+
+Manages workspace packages embedded in the published `@code-yeongyu/senpi` tarball.
+
+- `sourceOnly: false`: workspace ships `dist/index.js`; a build is required before staging.
+- `sourceOnly: true`: workspace ships `src/` directly without a build step.
+  `@code-yeongyu/senpi-codemode` is the only current source-only entry.
+- Validates every `requiredFiles` entry exists before staging; aborts with a clear list on failure.
+- `@earendil-works/pi-pty` also requires `native/index.js` and a platform prebuild file.
+
+## check-mcp-docs.test.mjs
+
+Reads `config-schema.ts` as raw text and extracts object-literal keys rather than importing
+TypeScript. Compares extracted field names against `### \`field\`` headings in `docs/mcp.md`.
+Schema drift fails CI with no TS toolchain dependency.
+
+## Anti-patterns
+
+- Don't hardcode `npm` as the child process manager. Use the detected PM from `build-all.mjs`.
+- Never hand-edit `publish-deps.lock.json` or `coding-agent-install-lock.json`.
+  Regenerate with `generate-coding-agent-shrinkwrap.mjs` / `generate-coding-agent-install-lock.mjs`.
+- Never invoke `node scripts/publish.mjs` without a prior build. The script checks for
+  `dist/` existence but not for stale output.
+- Never commit `.env` files or print credentials in build log output.


### PR DESCRIPTION
## What

`/init-deep` update pass over the hierarchical AGENTS.md knowledge base. Previous generation was at `2c3a87858` (2026-07-14); this pass refreshes it to `92fc96389`.

## Changes

**Updated (13 guides)** for post-baseline deltas:
- Root: generation metadata, model-runtime WHERE TO LOOK rows, CODE MAP first line
- `packages/coding-agent`: model runtime modules (`model-runtime`, `models-store`, `provider-composer`, `remote-catalog-provider`, `runtime-credentials`), `dynamic-prompt/`, `package-manager-cli.ts`, corrected backpressure claim (outbound bounded, inbound not)
- `core/extensions` + `builtin`: 23 extensions (missing `terminal` row added, order renumbered - verified against `builtin/index.ts`), bundled codemode loading order, `executeTool`/session-metadata API rows, `tool_search` note
- `core/tools`: `tail-window.ts`, updated changes.md summary
- `test`: new test dirs (dynamic-prompt, tool-pair-guard, helpers, manual-qa), model-runtime coverage, setup.ts quarantine rule
- `packages/ai` + `providers` + `tool-call-middleware`: models.ts runtime role, Radius dynamic provider, tool-schema-compat, anthropic-xml protocol
- `tui` (tab normalization), `orchestrator` (Radius heartbeat/credentials), `senpi-codemode` (prompt dialects, model_select re-registration), `examples` (kimi-deferred-tools, ModelRuntime convention)

**Created (5 guides)** for previously uncovered high-complexity domains:
- `scripts/` - build/release/publish tooling and its guard rails
- `packages/coding-agent/docs/` - shipped docs surface, docs.json manifest, validator contracts
- `builtin/mcp/` - MCP extension: auth, exposure modes, lifecycle races, security invariants
- `packages/ai/src/api/` - wire adapters, lazy-import boundary, replay invariants
- `packages/neo/internal/ui/editor/` - Go editor port contract and Unicode/key invariants

## QA

Documentation-only change. Per repo rules: no runtime QA required.
- `git diff --check` clean
- All factual claims spot-checked against source by the generation pass (registration order verified directly against `builtin/index.ts`)
- No validator consumes docs.json navigation completeness in-repo; new `docs/AGENTS.md` is agent guidance, not a doc page


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed the hierarchical AGENTS.md knowledge base across the repo, updating 13 guides and adding 5 new ones. Clarifies model/runtime ownership, extension load order, dynamic providers, tool-call middleware, tests, TUI, and scripts; docs-only change.

- New Features
  - Added guides for `scripts/`, `packages/coding-agent/docs/`, `packages/ai/src/api/`, `packages/coding-agent/src/core/extensions/builtin/mcp/`, and `packages/neo/internal/ui/editor/`.

- Bug Fixes
  - Corrected builtin extension inventory/order (now 23; added `terminal`) and documented bundled `codemode`.
  - Updated model/runtime docs: `packages/ai/src/models.ts` ownership, Radius dynamic provider, auth/refresh flow.
  - Added `anthropic-xml` protocol notes and tool schema compat helper; clarified `tool_search` naming.
  - Fixed stream/backpressure claim and documented TUI tab normalization; expanded tests and isolation notes.

<sup>Written for commit 7013964872e66bdd0524a3e2856a11bdf38b5258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

