### PR TITLE
feat(extensions): registerMcpServer API + extension-declared MCP servers

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1376,6 +1376,52 @@ pi.registerTool({
 });
 ```
 
+### pi.registerMcpServer(name, config)
+
+Register an MCP server that the agent can use. This is a **factory-time only**
+API: it must be called inside the extension factory before the factory returns.
+Calling it after startup throws because registration is tied to extension load.
+
+`config` accepts the same fields as `mcpServers.<name>` in `mcp.json` (see the
+[MCP server fields reference](mcp.md#server-fields-mcpserversname)): `type`,
+`command`, `args`, `env`, `cwd`, `url`, `headers`, `auth`, `enabled`,
+`lifecycle`, timeouts, `includeTools`, `excludeTools`, `directTools`,
+`exposure`, and `logLevel`.
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerMcpServer("docs", {
+    type: "stdio",
+    command: "npx",
+    args: ["-y", "@example/docs-mcp"],
+    env: { DOCS_TOKEN: "${DOCS_TOKEN}" },
+  });
+}
+```
+
+Validation runs synchronously when you call `registerMcpServer`. An invalid
+declaration (unknown fields, a stdio server without `command`, an http server
+without `url`, etc.) throws an error and fails **only** the declaring extension;
+other extensions still load.
+
+Same-name precedence:
+
+- User config from `mcp.json` (`global`, imported `claude`, or trusted
+  `project`) wins over an extension-declared server, including `enabled: false`.
+- An extension-declared server replaces an untrusted placeholder from an
+  untrusted project config and records a diagnostic.
+- Across extensions, the first loaded extension wins; later collisions log a
+  warning naming both extension paths.
+
+A stdio declaration that omits `cwd` defaults to the extension's registration
+cwd (the cwd passed to the factory), not the ambient `process.cwd()`.
+
+Extension factories re-run on `/reload`, so declarations are refreshed then.
+In-process senpi-task children load no extensions, so they see no
+extension-declared MCP servers.
+
 ### pi.sendMessage(message, options?)
 
 Inject a custom message into the session. Custom messages participate in LLM context. For durable TUI-only content that should not be sent to the LLM, use [`pi.appendEntry()`](#piappendentrycustomtype-data) with [`pi.registerEntryRenderer()`](#piregisterentryrenderercustomtype-renderer).

--- a/packages/coding-agent/docs/mcp.md
+++ b/packages/coding-agent/docs/mcp.md
@@ -149,6 +149,22 @@ Skills can carry MCP servers too (an `mcp.json` sidecar next to SKILL.md, or a
 reveal their `includeTools` matches when the skill loads. A name collision
 with a configured server resolves in favor of your config.
 
+### Server sources
+
+Servers are merged from these sources, in precedence order:
+
+- `global` — `<agentDir>/mcp.json`
+- `claude` — imported `.mcp.json` (requires project trust)
+- `project` — `.senpi/mcp.json` (requires project trust)
+- `extension` — declared by an extension via `pi.registerMcpServer()` during
+  factory load (see [extensions.md](extensions.md#piregistermcpservername-config))
+- `skill` — declared in a skill's `mcp.json` sidecar or SKILL.md frontmatter
+
+A name collision resolves as follows: trusted user config (including an
+`enabled: false` entry) wins over extension declarations; an extension
+declaration replaces an untrusted placeholder and records a diagnostic.
+Extension-declared servers use bare names (no prefix).
+
 ## Resources and prompts
 
 - `mcp_list_resources` / `mcp_read_resource` register automatically when a

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,55 @@
 # mcp Extension Changes
 
+## Trust-aware merge for extension-declared MCP servers (2026-07-17)
+
+### What changed
+- `config-schema.ts`: added `"extension"` to the `McpServerSource` union;
+  exported `McpServerDeclaration` and `validateMcpServerDeclaration`.
+- `config.ts`: added `resolveExtensionMcpServer` (preserves declared
+  `exposure`/`directTools`/filters/lifecycle/`enabled`, defaults stdio `cwd` to
+  the extension's registration cwd) and `mergeExtensionMcpServers` with
+  trust-aware rules: trusted file sources win (including `enabled:false`),
+  extension declarations replace `untrusted` placeholders with a diagnostic.
+
+### Why
+- The new `pi.registerMcpServer()` extension API needs a merge seam that
+  respects the existing trust model: user config must still win, and untrusted
+  project placeholders must not block extension-provided defaults.
+
+### Why extension system couldn't handle this alone
+- The merge runs inside the MCP builtin but consumes runner-aggregated
+  declarations; the builtin cannot know trust rules or normalize server configs.
+
+### Expected merge conflict zones
+- MEDIUM: `config.ts` around `resolveSkillMcpServer` and the trusted/untrusted
+  merge helpers.
+
+## Attach extension-declared MCP servers on every session attach (2026-07-17)
+
+### What changed
+- `service-types.ts`: `McpSessionContext` gained optional
+  `getRegisteredMcpServers`; `McpServerSnapshot` gained a `source` field.
+- `service-snapshot.ts`: populates `source` from the resolved server.
+- `status.ts`: status rows now render `origin=<source>`.
+- `service.ts`: `attachSession` calls `mergeExtensionMcpServers` from
+  `ctx.getRegisteredMcpServers()` on every invocation, so session start,
+  reattach, and `/mcp` command paths all pick up current declarations.
+- `docs/mcp.md`: documented the `extension` source and cross-linked to
+  `extensions.md`.
+
+### Why
+- Declarations are aggregated by the runner, but the MCP builtin must read them
+  from the context on every attach to survive reattach and reload without
+  caching stale declarations.
+
+### Why extension system couldn't handle this alone
+- The runner owns the aggregation and context accessor; the builtin only sees
+  the narrow `McpSessionContext` passed into `attachSession`.
+
+### Expected merge conflict zones
+- LOW: `service.ts` `attachSession` ordering.
+- LOW: `status.ts` row format.
+
 ## Overview
 Built-in MCP (Model Context Protocol) client support as an in-tree builtin
 extension. Fork-native: upstream pi-mono deliberately ships no MCP support, so

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/config-schema.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/config-schema.ts
@@ -93,9 +93,11 @@ export type McpServerConfig = Static<typeof ServerSchema> & {
 	exposure: "auto" | "direct" | "search" | "proxy";
 	logLevel: Static<typeof LogLevelSchema>;
 };
+/** Public raw type for extension-declared MCP servers. */
+export type McpServerDeclaration = Static<typeof ServerSchema>;
 export type McpSettings = Required<Pick<Static<typeof SettingsSchema>, "toolPrefix">> &
 	Omit<Static<typeof SettingsSchema>, "toolPrefix">;
-export type McpServerSource = "global" | "claude" | "project" | "skill";
+export type McpServerSource = "global" | "claude" | "project" | "skill" | "extension";
 export type McpServerState = "enabled" | "disabled" | "untrusted";
 
 export interface ResolvedMcpServer {
@@ -136,6 +138,32 @@ export function getServerEndpointValidationError(config: RawConfig): string | un
 }
 
 export const validateConfig = Compile(ConfigSchema);
+const validateServer = Compile(ServerSchema);
+
+/**
+ * Validate a single extension-declared MCP server.
+ * Returns a descriptive error string, or null when valid.
+ */
+export function validateMcpServerDeclaration(name: string, raw: unknown): string | null {
+	if (!validateServer.Check(raw)) {
+		const error = Array.from(validateServer.Errors(raw))[0];
+		const path =
+			error.instancePath
+				.replace(/^\//, "")
+				.split("/")
+				.map((p) => p.replace(/~1/g, "/").replace(/~0/g, "~"))
+				.join(".") || "$";
+		const message = error.message === "must be array" ? "Expected array" : error.message;
+		return `Invalid MCP server declaration "${name}": ${path}: ${message}`;
+	}
+	const server = raw as McpServerDeclaration;
+	const endpointError = getServerEndpointValidationError({ mcpServers: { [name]: server } });
+	if (endpointError) {
+		return `Invalid MCP server declaration "${name}": ${endpointError}`;
+	}
+	return null;
+}
+
 export const defaultSettings: McpSettings = {
 	outputGuard: { maxBytes: 50 * 1024, maxLines: 2000 },
 	searchThreshold: 10,

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/config.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { TLocalizedValidationError } from "typebox/error";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../../../config.ts";
+import type { RegisteredMcpServerDeclaration } from "../../types.ts";
 import {
 	defaultSettings,
 	getServerEndpointValidationError,
@@ -201,6 +202,61 @@ function readServerNames(raw: unknown): string[] {
 	const servers = (raw as { mcpServers?: unknown }).mcpServers;
 	if (typeof servers !== "object" || servers === null || Array.isArray(servers)) return [];
 	return Object.keys(servers);
+}
+
+/**
+ * Resolve an extension-declared MCP server. Preserves the declared exposure,
+ * directTools, filters, lifecycle, and enabled state. A stdio declaration
+ * without an explicit `cwd` defaults to the extension's registration cwd.
+ */
+export function resolveExtensionMcpServer(
+	name: string,
+	raw: NonNullable<RawConfig["mcpServers"]>[string],
+	sourcePath: string,
+	registrationCwd: string,
+): ResolvedMcpServer {
+	const withCwd = { ...raw, cwd: raw.cwd ?? registrationCwd };
+	const config = normalizeServer(withCwd);
+	return {
+		config,
+		configHash: hashConfig(config),
+		name,
+		source: "extension",
+		sourcePath,
+		state: config.enabled ? "enabled" : "disabled",
+		transport: config.type,
+	};
+}
+
+/**
+ * Merge extension-declared MCP servers into a resolved config. Trusted file
+ * sources (global/claude/project) win, including disabled entries. An
+ * extension entry replaces an untrusted placeholder and records a diagnostic.
+ */
+export function mergeExtensionMcpServers(
+	result: ResolvedMcpConfig,
+	declarations: readonly RegisteredMcpServerDeclaration[],
+): void {
+	for (const decl of declarations) {
+		const existing = result.servers[decl.name];
+		if (existing !== undefined && existing.state !== "untrusted") {
+			result.diagnostics.push(
+				`Extension MCP server '${decl.name}' from ${decl.extensionPath} skipped; ${existing.source} config at ${existing.sourcePath} wins.`,
+			);
+			continue;
+		}
+		if (existing !== undefined) {
+			result.diagnostics.push(
+				`Extension MCP server '${decl.name}' from ${decl.extensionPath} replaces untrusted ${existing.source} placeholder from ${existing.sourcePath}.`,
+			);
+		}
+		result.servers[decl.name] = resolveExtensionMcpServer(
+			decl.name,
+			decl.config,
+			decl.extensionPath,
+			decl.registrationCwd,
+		);
+	}
 }
 
 /**

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service-snapshot.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service-snapshot.ts
@@ -13,6 +13,7 @@ export function buildMcpServerSnapshot(
 		name,
 		configState: server?.state ?? "removed",
 		configHash: server?.configHash ?? null,
+		source: server?.source ?? null,
 		sourcePath: server?.sourcePath ?? null,
 		lifecycleState:
 			connection?.state === "idle" && connection.generation === 0 && entry?.cachedCatalog !== undefined

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service-types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service-types.ts
@@ -13,6 +13,17 @@ export type McpSessionContext = Pick<ExtensionContext, "cwd" | "isProjectTrusted
 	 * requirement narrow lets tests pass a two-line fake.
 	 */
 	sessionManager?: Pick<ExtensionContext["sessionManager"], "getEntries">;
+	/**
+	 * Extension-declared MCP servers. Read on every attach so reattach/reload
+	 * paths pick up the current declarations without caching them in the MCP
+	 * builtin.
+	 */
+	getRegisteredMcpServers?: () => readonly {
+		name: string;
+		config: Record<string, unknown>;
+		extensionPath: string;
+		registrationCwd: string;
+	}[];
 };
 
 export interface McpSessionOptions {
@@ -36,6 +47,7 @@ export interface McpServerSnapshot {
 	name: string;
 	configState: ResolvedMcpServer["state"] | "removed";
 	configHash: string | null;
+	source: ResolvedMcpServer["source"] | null;
 	sourcePath: string | null;
 	lifecycleState: ServerConnectionState | "cached" | "not_spawned";
 	generation: number | null;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, SessionShutdownEvent, SessionStartEvent } from "../.
 import { detectLiteralBearerWarnings, resolveServerAuth } from "./auth/context.ts";
 import { collectToolCatalog } from "./catalog.ts";
 import { getValidCachedServer, readMcpCatalogCache } from "./catalog-cache.ts";
-import { loadMcpConfig, resolveSkillMcpServer, visitSpawnableMcpServers } from "./config.ts";
+import { loadMcpConfig, mergeExtensionMcpServers, resolveSkillMcpServer, visitSpawnableMcpServers } from "./config.ts";
 import type { McpServerConfig, ResolvedMcpConfig, ResolvedMcpServer } from "./config-schema.ts";
 import { ServerConnection } from "./connection.ts";
 import { mapMcpCatalogNames } from "./expose/register.ts";
@@ -75,6 +75,7 @@ export class McpService {
 			env: options.env,
 			projectTrusted: options.projectTrusted ?? ctx.isProjectTrusted(),
 		});
+		mergeExtensionMcpServers(config, ctx.getRegisteredMcpServers?.() ?? []);
 		this.#config = config;
 		this.#pi = _pi;
 		this.#authAgentDir = options.agentDir;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/status.ts
@@ -32,6 +32,7 @@ function formatRow(row: McpStatusRow): string {
 		snapshot.name,
 		snapshot.configState,
 		`state=${snapshot.lifecycleState}`,
+		`origin=${snapshot.source ?? "n/a"}`,
 		`source=${snapshot.sourcePath ?? "n/a"}`,
 		`tools=${row.exposure.toolCount ?? "?"}`,
 		`uptime=${formatUptime(snapshot.uptimeMs)}`,

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,44 @@
 # Core Extensions Changes
 
+## 2026-07-17 - Factory-time `pi.registerMcpServer()` API
+
+### What changed
+- `src/core/extensions/builtin/mcp/config-schema.ts`: added `"extension"` to
+  `McpServerSource`; exported a public raw `McpServerDeclaration` type and a
+  single-server `validateMcpServerDeclaration(name, raw)` validator.
+- `src/core/extensions/types.ts`: added `ExtensionAPI.registerMcpServer(name,
+  config)`, `RegisteredMcpServerDeclaration`, and `Extension.mcpServers` +
+  `registrationCwd` storage; added optional
+  `ExtensionContext.getRegisteredMcpServers()`.
+- `src/core/extensions/loader.ts`: `createExtension` stores `registrationCwd`;
+  `createExtensionAPI` implements `registerMcpServer` with synchronous
+  ServerSchema + endpoint validation that throws only for the declaring
+  extension.
+- `src/core/extensions/runner.ts`: added
+  `ExtensionRunner.getRegisteredMcpServers()` with first-wins aggregation and a
+  conflict warning naming both extension paths; exposed it on
+  `ExtensionContext`.
+- `src/core/extensions/index.ts` + `src/index.ts`: re-export `McpServerDeclaration`.
+- `docs/extensions.md`: documented the factory-time-only contract, validation,
+  precedence, cwd defaulting, reload, and child-session behavior.
+
+### Why
+- Extensions need a first-class way to declare MCP servers that are available on
+  turn 1. Factory-time registration is the only seam that runs before
+  `session_start`, so servers can be connected and their tools registered before
+  the first model request.
+
+### Why extension system couldn't handle this alone
+- This is a public extension API addition: the declaration type, validator,
+  per-extension storage, runner aggregation, and context accessor all live in
+  the extension system.
+
+### Expected merge conflict zones
+- HIGH: `types.ts` around `ExtensionAPI` and `Extension` definitions.
+- MEDIUM: `loader.ts` `createExtension` / `createExtensionAPI`.
+- MEDIUM: `runner.ts` around `createContext()` and the aggregation helpers.
+- LOW: `src/index.ts` extension type re-exports.
+
 ## 2026-07-17 - Tool renderer hasResult context
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -4,6 +4,7 @@
 
 export type { SlashCommandInfo, SlashCommandSource } from "../slash-commands.ts";
 export type { SourceInfo } from "../source-info.ts";
+export type { McpServerDeclaration } from "./builtin/mcp/config-schema.ts";
 export {
 	createExtensionRuntime,
 	discoverAndLoadExtensions,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -31,6 +31,7 @@ import type { ExecOptions } from "../exec.ts";
 import { execCommand } from "../exec.ts";
 import { createSyntheticSourceInfo } from "../source-info.ts";
 import { time } from "../timings.ts";
+import { validateMcpServerDeclaration } from "./builtin/mcp/config-schema.ts";
 import type {
 	EntryRenderer,
 	Extension,
@@ -41,6 +42,7 @@ import type {
 	MessageRenderer,
 	ProviderConfig,
 	RegisteredCommand,
+	RegisteredMcpServerDeclaration,
 	ToolDefinition,
 } from "./types.ts";
 
@@ -350,6 +352,20 @@ function createExtensionAPI(
 			extension.entryRenderers.set(customType, renderer as EntryRenderer);
 		},
 
+		registerMcpServer(name: string, config: RegisteredMcpServerDeclaration["config"]): void {
+			runtime.assertActive();
+			const error = validateMcpServerDeclaration(name, config);
+			if (error) {
+				throw new Error(error);
+			}
+			extension.mcpServers.set(name, {
+				name,
+				config,
+				extensionPath: extension.path,
+				registrationCwd: extension.registrationCwd,
+			});
+		},
+
 		// Flag access - checks extension registered it, reads from runtime
 		getFlag(name: string): boolean | string | undefined {
 			runtime.assertActive();
@@ -491,7 +507,7 @@ async function loadExtensionModule(
 /**
  * Create an Extension object with empty collections.
  */
-function createExtension(extensionPath: string, resolvedPath: string): Extension {
+function createExtension(extensionPath: string, resolvedPath: string, registrationCwd: string): Extension {
 	const source =
 		extensionPath.startsWith("<") && extensionPath.endsWith(">")
 			? extensionPath.slice(1, -1).split(":")[0] || "temporary"
@@ -505,10 +521,12 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		handlers: new Map(),
 		tools: new Map(),
 		messageRenderers: new Map(),
-		entryRenderers: new Map(),
+		entryRenderers: undefined,
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),
+		mcpServers: new Map(),
+		registrationCwd,
 	};
 }
 
@@ -532,7 +550,7 @@ async function loadExtension(
 			return { extension: null, error: `Extension does not export a valid factory function: ${extensionPath}` };
 		}
 
-		const extension = createExtension(extensionPath, resolvedPath);
+		const extension = createExtension(extensionPath, resolvedPath, cwd);
 		const api = createExtensionAPI(extension, runtime, cwd, eventBus);
 		await factory(api);
 		time(`${extensionPath} factory`, "extensions");
@@ -554,8 +572,8 @@ export async function loadExtensionFromFactory(
 	runtime: ExtensionRuntime,
 	extensionPath = "<inline>",
 ): Promise<Extension> {
-	const extension = createExtension(extensionPath, extensionPath);
 	const resolvedCwd = resolvePath(cwd);
+	const extension = createExtension(extensionPath, extensionPath, resolvedCwd);
 	const api = createExtensionAPI(extension, runtime, resolvedCwd, eventBus);
 	await factory(api);
 	time(`${extensionPath} factory`, "extensions");

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -50,6 +50,7 @@ import type {
 	ProjectTrustEventResult,
 	ProviderConfig,
 	RegisteredCommand,
+	RegisteredMcpServerDeclaration,
 	RegisteredTool,
 	ReplacedSessionContext,
 	ResolvedCommand,
@@ -529,6 +530,24 @@ export class ExtensionRunner {
 		return Array.from(toolsByName.values());
 	}
 
+	/** Get extension-declared MCP servers (first declaration per name wins). */
+	getRegisteredMcpServers(): readonly RegisteredMcpServerDeclaration[] {
+		const serversByName = new Map<string, RegisteredMcpServerDeclaration>();
+		for (const ext of this.extensions) {
+			for (const decl of ext.mcpServers.values()) {
+				const existing = serversByName.get(decl.name);
+				if (existing === undefined) {
+					serversByName.set(decl.name, decl);
+				} else {
+					console.warn(
+						`MCP server '${decl.name}' declared by both ${existing.extensionPath} and ${ext.path}; keeping first declaration from ${existing.extensionPath}.`,
+					);
+				}
+			}
+		}
+		return Array.from(serversByName.values());
+	}
+
 	/** Get a tool definition by name. Returns undefined if not found. */
 	getToolDefinition(toolName: string): RegisteredTool["definition"] | undefined {
 		for (const ext of this.extensions) {
@@ -912,6 +931,10 @@ export class ExtensionRunner {
 			getLoadedHookSources: () => {
 				runner.assertActive();
 				return runner.getLoadedHookSourcesFn();
+			},
+			getRegisteredMcpServers: () => {
+				runner.assertActive();
+				return runner.getRegisteredMcpServers();
 			},
 		};
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -80,6 +80,7 @@ import type {
 	ReadToolInput,
 	WriteToolInput,
 } from "../tools/index.ts";
+import type { McpServerDeclaration } from "./builtin/mcp/config-schema.ts";
 
 export type { ExecOptions, ExecResult } from "../exec.ts";
 export type { AppKeybinding, KeybindingsManager } from "../keybindings.ts";
@@ -379,6 +380,8 @@ export interface ExtensionContext {
 	getSystemPrompt(): string;
 	/** Get hook source paths currently visible to the builtin hooks extension. */
 	getLoadedHookSources?(): LoadedHookSources;
+	/** Get extension-declared MCP servers aggregated across all extensions (first-wins). */
+	getRegisteredMcpServers?(): readonly RegisteredMcpServerDeclaration[];
 	/**
 	 * Report what the currently running tool_call/tool_result handler is doing.
 	 * Updates the live "Running PreToolUse/PostToolUse hook" status row in the TUI.
@@ -1321,6 +1324,9 @@ export interface ExtensionAPI {
 		tool: ToolDefinition<TParams, TDetails, TState>,
 	): void;
 
+	/** Register an MCP server that the agent can use. Factory-time only. */
+	registerMcpServer(name: string, config: McpServerDeclaration): void;
+
 	// =========================================================================
 	// Command, Shortcut, Flag Registration
 	// =========================================================================
@@ -1811,6 +1817,13 @@ export interface ExtensionCommandContextActions {
 export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {}
 
 /** Loaded extension with all registered items. */
+export interface RegisteredMcpServerDeclaration {
+	name: string;
+	config: McpServerDeclaration;
+	extensionPath: string;
+	registrationCwd: string;
+}
+
 export interface Extension {
 	path: string;
 	resolvedPath: string;
@@ -1822,6 +1835,8 @@ export interface Extension {
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;
+	mcpServers: Map<string, RegisteredMcpServerDeclaration>;
+	registrationCwd: string;
 }
 
 /** Result of loading extensions. */

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -99,6 +99,7 @@ export type {
 	KeybindingsManager,
 	LoadExtensionsResult,
 	LsToolCallEvent,
+	McpServerDeclaration,
 	MessageRenderer,
 	MessageRenderOptions,
 	ProjectTrustContext,

--- a/packages/coding-agent/test/compaction/extension-hooks.test.ts
+++ b/packages/coding-agent/test/compaction/extension-hooks.test.ts
@@ -100,6 +100,8 @@ describe("Compaction extension hooks", () => {
 			commands: new Map(),
 			flags: new Map(),
 			shortcuts: new Map(),
+			mcpServers: new Map(),
+			registrationCwd: process.cwd(),
 		};
 	}
 

--- a/packages/coding-agent/test/extensions-loader.test.ts
+++ b/packages/coding-agent/test/extensions-loader.test.ts
@@ -1,8 +1,11 @@
 import type { PathLike } from "node:fs";
 import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEventBus } from "../src/core/event-bus.ts";
 import type { ExtensionAPI, ExtensionFactory } from "../src/core/extensions/types.ts";
 
+// loader.ts is dynamically imported in tests because the same file mocks
+// jiti/static and node:fs via vi.doMock.
 describe("extension loader", () => {
 	afterEach(() => {
 		vi.doUnmock("node:fs");
@@ -77,5 +80,97 @@ describe("extension loader", () => {
 		// transitive deps are installed beside the coding-agent package
 		expect(result.errors).toHaveLength(0);
 		expect(capturedOptions?.alias?.["@earendil-works/pi-tui"]).toContain(bundledTuiEntry);
+	});
+
+	describe("registerMcpServer", () => {
+		const bus = createEventBus();
+
+		it("stores a valid stdio declaration with extension path and registration cwd", async () => {
+			const { createExtensionRuntime, loadExtensionFromFactory } = await import("../src/core/extensions/loader.ts");
+			const ext = await loadExtensionFromFactory(
+				(pi) => {
+					pi.registerMcpServer("stdio-fixture", {
+						type: "stdio",
+						command: "node",
+						args: ["server.js"],
+					});
+				},
+				"/tmp/ext-cwd",
+				bus,
+				createExtensionRuntime(),
+				"<stdio-ext>",
+			);
+			const decl = ext.mcpServers.get("stdio-fixture");
+			expect(decl).toBeDefined();
+			expect(decl?.config).toMatchObject({ type: "stdio", command: "node", args: ["server.js"] });
+			expect(decl?.extensionPath).toBe("<stdio-ext>");
+			expect(decl?.registrationCwd).toBe("/tmp/ext-cwd");
+		});
+
+		it("stores a valid http declaration", async () => {
+			const { createExtensionRuntime, loadExtensionFromFactory } = await import("../src/core/extensions/loader.ts");
+			const ext = await loadExtensionFromFactory(
+				(pi) => {
+					pi.registerMcpServer("http-fixture", { type: "http", url: "http://localhost:3000" });
+				},
+				"/tmp",
+				bus,
+				createExtensionRuntime(),
+			);
+			expect(ext.mcpServers.get("http-fixture")?.config).toMatchObject({
+				type: "http",
+				url: "http://localhost:3000",
+			});
+		});
+
+		it("rejects an invalid declaration and fails only the declaring extension", async () => {
+			const { createExtensionRuntime, loadExtensions } = await import("../src/core/extensions/loader.ts");
+			const broken: ExtensionFactory = (pi) => {
+				pi.registerMcpServer("broken", {});
+			};
+			const healthy: ExtensionFactory = (pi) => {
+				pi.registerMcpServer("healthy", { type: "stdio", command: "node" });
+			};
+			const result = await loadExtensions(
+				["/tmp/broken.ts", "/tmp/healthy.ts"],
+				"/tmp",
+				bus,
+				createExtensionRuntime(),
+				{
+					factoryResolver: (p) => (p.includes("broken") ? broken : healthy),
+				},
+			);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0]?.error).toContain('Invalid MCP server declaration "broken"');
+			expect(result.extensions.flatMap((e) => [...e.mcpServers.keys()])).toEqual(["healthy"]);
+		});
+
+		it("last registration wins within one factory", async () => {
+			const { createExtensionRuntime, loadExtensionFromFactory } = await import("../src/core/extensions/loader.ts");
+			const ext = await loadExtensionFromFactory(
+				(pi) => {
+					pi.registerMcpServer("dup", { type: "stdio", command: "first" });
+					pi.registerMcpServer("dup", { type: "stdio", command: "second" });
+				},
+				"/tmp",
+				bus,
+				createExtensionRuntime(),
+			);
+			expect(ext.mcpServers.get("dup")?.config.command).toBe("second");
+		});
+
+		it("rejects unknown fields", async () => {
+			const { createExtensionRuntime, loadExtensionFromFactory } = await import("../src/core/extensions/loader.ts");
+			await expect(
+				loadExtensionFromFactory(
+					(pi) => {
+						pi.registerMcpServer("bad", { command: "node", bogus: true } as Record<string, unknown>);
+					},
+					"/tmp",
+					bus,
+					createExtensionRuntime(),
+				),
+			).rejects.toThrow('Invalid MCP server declaration "bad"');
+		});
 	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1493,4 +1493,84 @@ describe("ExtensionRunner", () => {
 			expect(errors[0].error).toContain("header handler boom");
 		});
 	});
+
+	describe("getRegisteredMcpServers", () => {
+		it("returns declarations from all extensions with distinct names", async () => {
+			const a = await loadExtensionFromFactory(
+				(pi) => pi.registerMcpServer("alpha", { type: "stdio", command: "node", args: ["a.js"] }),
+				tempDir,
+				createEventBus(),
+				createExtensionRuntime(),
+				"<ext-a>",
+			);
+			const b = await loadExtensionFromFactory(
+				(pi) => pi.registerMcpServer("beta", { type: "stdio", command: "node" }),
+				tempDir,
+				createEventBus(),
+				createExtensionRuntime(),
+				"<ext-b>",
+			);
+			const runner = new ExtensionRunner([a, b], createExtensionRuntime(), tempDir, sessionManager, modelRegistry);
+			const servers = runner.getRegisteredMcpServers();
+			expect(servers.map((s) => s.name).sort()).toEqual(["alpha", "beta"]);
+			expect(servers.find((s) => s.name === "alpha")?.extensionPath).toBe("<ext-a>");
+		});
+
+		it("first extension wins on name collision and warns naming both paths", async () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const a = await loadExtensionFromFactory(
+				(pi) => pi.registerMcpServer("dup", { type: "stdio", command: "first" }),
+				tempDir,
+				createEventBus(),
+				createExtensionRuntime(),
+				"<ext-a>",
+			);
+			const b = await loadExtensionFromFactory(
+				(pi) => pi.registerMcpServer("dup", { type: "stdio", command: "second" }),
+				tempDir,
+				createEventBus(),
+				createExtensionRuntime(),
+				"<ext-b>",
+			);
+			const runner = new ExtensionRunner([a, b], createExtensionRuntime(), tempDir, sessionManager, modelRegistry);
+			const servers = runner.getRegisteredMcpServers();
+			expect(servers).toHaveLength(1);
+			expect(servers[0]?.extensionPath).toBe("<ext-a>");
+			expect(servers[0]?.config.command).toBe("first");
+			const warning = warn.mock.calls.map((c) => c.join(" ")).find((t) => t.includes("dup"));
+			expect(warning).toContain("<ext-a>");
+			expect(warning).toContain("<ext-b>");
+			warn.mockRestore();
+		});
+
+		it("returns an empty array when no extension declares MCP servers", () => {
+			const runner = new ExtensionRunner([], createExtensionRuntime(), tempDir, sessionManager, modelRegistry);
+			expect(runner.getRegisteredMcpServers()).toEqual([]);
+		});
+
+		it("exposes the aggregate via ExtensionContext in session_start handlers", async () => {
+			let captured: ReturnType<typeof runner.getRegisteredMcpServers> | undefined;
+			const a = await loadExtensionFromFactory(
+				(pi) => pi.registerMcpServer("gamma", { type: "stdio", command: "node" }),
+				tempDir,
+				createEventBus(),
+				createExtensionRuntime(),
+				"<ext-a>",
+			);
+			const b = await loadExtensionFromFactory(
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						captured = ctx.getRegisteredMcpServers?.();
+					});
+				},
+				tempDir,
+				createEventBus(),
+				createExtensionRuntime(),
+				"<ext-b>",
+			);
+			const runner = new ExtensionRunner([a, b], createExtensionRuntime(), tempDir, sessionManager, modelRegistry);
+			await runner.emit({ type: "session_start", reason: "startup" });
+			expect(captured?.map((s) => s.name)).toEqual(["gamma"]);
+		});
+	});
 });

--- a/packages/coding-agent/test/integration/compaction-real-api.test.ts
+++ b/packages/coding-agent/test/integration/compaction-real-api.test.ts
@@ -87,6 +87,8 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 			commands: new Map(),
 			flags: new Map(),
 			shortcuts: new Map(),
+			mcpServers: new Map(),
+			registrationCwd: process.cwd(),
 		};
 	}
 
@@ -260,6 +262,8 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 			commands: new Map(),
 			flags: new Map(),
 			shortcuts: new Map(),
+			mcpServers: new Map(),
+			registrationCwd: process.cwd(),
 		};
 
 		await createSession([throwingExtension]);
@@ -309,6 +313,8 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 			commands: new Map(),
 			flags: new Map(),
 			shortcuts: new Map(),
+			mcpServers: new Map(),
+			registrationCwd: process.cwd(),
 		};
 
 		const extension2: Extension = {
@@ -340,6 +346,8 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 			commands: new Map(),
 			flags: new Map(),
 			shortcuts: new Map(),
+			mcpServers: new Map(),
+			registrationCwd: process.cwd(),
 		};
 
 		await createSession([extension1, extension2]);

--- a/packages/coding-agent/test/mcp/commands.test.ts
+++ b/packages/coding-agent/test/mcp/commands.test.ts
@@ -4,15 +4,19 @@ import { setTimeout as delay } from "node:timers/promises";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../src/config.ts";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { createEventBus } from "../../src/core/event-bus.ts";
 import mcpExtension from "../../src/core/extensions/builtin/mcp/index.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../../src/core/extensions/runner.ts";
 import type { Extension, SessionStartEvent } from "../../src/core/extensions/types.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
 import { createHarness, type Harness } from "../suite/harness.ts";
 import { createCtx, createUi, lastNotification, normalize, notification } from "./fixtures/commands.ts";
 import { toolResultTexts } from "./fixtures/register-call.ts";
-import { cleanupRoots, makeRoot, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+import { cleanupRoots, fakePi, makeRoot, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 import { stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -57,13 +61,13 @@ describe("/mcp command suite", () => {
 
 		expect(normalize(ui.selectCalls[0]?.title, root)).toMatchInlineSnapshot(`
 			"MCP servers
-			disabled disabled state=not_spawned source=<agentDir>/mcp.json tools=? uptime=n/a calls=0 errors=0 latency=0ms reconnects=0
-			fx enabled state=connected source=<agentDir>/mcp.json tools=2 uptime=<1s calls=0 errors=0 latency=0ms reconnects=0"
+			disabled disabled state=not_spawned origin=global source=<agentDir>/mcp.json tools=? uptime=n/a calls=0 errors=0 latency=0ms reconnects=0
+			fx enabled state=connected origin=global source=<agentDir>/mcp.json tools=2 uptime=<1s calls=0 errors=0 latency=0ms reconnects=0"
 		`);
 		expect(normalize(lastNotification(ui)?.message, root)).toMatchInlineSnapshot(`
 			"MCP status
-			disabled disabled state=not_spawned source=<agentDir>/mcp.json tools=? uptime=n/a calls=0 errors=0 latency=0ms reconnects=0
-			fx enabled state=connected source=<agentDir>/mcp.json tools=2 uptime=<1s calls=0 errors=0 latency=0ms reconnects=0"
+			disabled disabled state=not_spawned origin=global source=<agentDir>/mcp.json tools=? uptime=n/a calls=0 errors=0 latency=0ms reconnects=0
+			fx enabled state=connected origin=global source=<agentDir>/mcp.json tools=2 uptime=<1s calls=0 errors=0 latency=0ms reconnects=0"
 		`);
 	});
 
@@ -191,6 +195,64 @@ describe("/mcp command suite", () => {
 			expect.arrayContaining(["mcp_fx_tool_1", "mcp_fx_tool_2"]),
 		);
 		expect(toolResultTexts(harness, "mcp_fx_tool_2")).toEqual(["fixture tool_2 value=fresh mode=alpha"]);
+	});
+
+	it("retains an extension-declared server through the /mcp reconnect reattach path", async () => {
+		const root = makeCommandRoot("reattach-ext");
+		const fixture = stdioFixtureCommand();
+		const decl = {
+			name: "fixture",
+			config: {
+				type: "stdio" as const,
+				...fixture,
+				args: [...fixture.args, "--tools", "1"],
+			},
+			extensionPath: "<ext>",
+			registrationCwd: root.cwd,
+		};
+		const ctxWithDecl = {
+			cwd: root.cwd,
+			isProjectTrusted: () => true,
+			getRegisteredMcpServers: () => [decl],
+		};
+		const pi = fakePi();
+		await getMcpService().attachSession({ type: "session_start", reason: "startup" }, ctxWithDecl, pi, {
+			agentDir: root.agentDir,
+		});
+		expect(
+			getMcpService()
+				.getServerSnapshots()
+				.some((s) => s.name === "fixture" && s.source === "extension"),
+		).toBe(true);
+
+		const ext = await loadExtensionFromFactory(
+			(api) => {
+				api.registerMcpServer("fixture", decl.config);
+			},
+			root.cwd,
+			createEventBus(),
+			createExtensionRuntime(),
+			"<ext>",
+		);
+		const authStorage = AuthStorage.create(join(root.agentDir, "auth.json"));
+		const runner = new ExtensionRunner(
+			[ext],
+			createExtensionRuntime(),
+			root.cwd,
+			SessionManager.inMemory(),
+			await ModelRegistry.create(authStorage),
+		);
+		runner.setUIContext(createUi(), "tui");
+		const ctx = runner.createCommandContext();
+
+		const { command } = await loadCommand();
+		await command.handler("reconnect fixture", ctx);
+
+		const snapshot = getMcpService()
+			.getServerSnapshots()
+			.find((s) => s.name === "fixture");
+		expect(snapshot?.source).toBe("extension");
+		expect(pi.activeTools).toContain("mcp_fixture_tool_1");
 	});
 
 	it("reports fixture test success with elapsed milliseconds", async () => {

--- a/packages/coding-agent/test/mcp/config.test.ts
+++ b/packages/coding-agent/test/mcp/config.test.ts
@@ -1,6 +1,10 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { loadMcpConfig, McpConfigValidationError } from "../../src/core/extensions/builtin/mcp/config.ts";
+import {
+	loadMcpConfig,
+	McpConfigValidationError,
+	mergeExtensionMcpServers,
+} from "../../src/core/extensions/builtin/mcp/config.ts";
 import { makeRoot, writeJson } from "./config-test-helpers.ts";
 
 const TOKEN_EXPR = "$" + "{TOKEN}";
@@ -196,6 +200,64 @@ describe("mcp config", () => {
 		expect(result.servers.keepAlive.config).toMatchObject({
 			command: "node",
 			lifecycle: "keep-alive",
+		});
+	});
+
+	describe("mergeExtensionMcpServers", () => {
+		const extDecl = (
+			name: string,
+			config: { type: "stdio"; command: string; exposure?: "direct" | "search" | "auto" | "proxy" },
+		) => ({
+			name,
+			config,
+			extensionPath: "<ext>",
+			registrationCwd: "/tmp/ext",
+		});
+
+		it("lets trusted global entries win over extension declarations", () => {
+			const root = makeRoot();
+			writeJson(join(root.agentDir, "mcp.json"), { mcpServers: { dup: { command: "global" } } });
+			const config = loadMcpConfig({ agentDir: root.agentDir, cwd: root.cwd, projectTrusted: true });
+			mergeExtensionMcpServers(config, [extDecl("dup", { type: "stdio", command: "ext" })]);
+			expect(config.servers.dup).toMatchObject({ source: "global", state: "enabled" });
+			expect(config.diagnostics.some((d) => d.includes("dup") && d.includes("global"))).toBe(true);
+		});
+
+		it("lets trusted disabled entries win and keeps the server disabled", () => {
+			const root = makeRoot();
+			writeJson(join(root.agentDir, "mcp.json"), { mcpServers: { dup: { command: "global", enabled: false } } });
+			const config = loadMcpConfig({ agentDir: root.agentDir, cwd: root.cwd, projectTrusted: true });
+			mergeExtensionMcpServers(config, [extDecl("dup", { type: "stdio", command: "ext" })]);
+			expect(config.servers.dup).toMatchObject({ source: "global", state: "disabled" });
+		});
+
+		it("replaces untrusted placeholders and records a diagnostic", () => {
+			const root = makeRoot();
+			writeJson(join(root.cwd, ".senpi", "mcp.json"), { mcpServers: { shadow: { command: "evil" } } });
+			const config = loadMcpConfig({ agentDir: root.agentDir, cwd: root.cwd, projectTrusted: false });
+			expect(config.servers.shadow?.state).toBe("untrusted");
+			mergeExtensionMcpServers(config, [extDecl("shadow", { type: "stdio", command: "node" })]);
+			expect(config.servers.shadow).toMatchObject({ source: "extension", state: "enabled" });
+			expect(config.diagnostics.some((d) => d.includes("shadow") && d.includes("untrusted"))).toBe(true);
+		});
+
+		it("inserts fresh names with source extension, preserving exposure and defaulting cwd", () => {
+			const root = makeRoot();
+			const config = loadMcpConfig({ agentDir: root.agentDir, cwd: root.cwd, projectTrusted: true });
+			mergeExtensionMcpServers(config, [extDecl("fresh", { type: "stdio", command: "node", exposure: "direct" })]);
+			expect(config.servers.fresh).toMatchObject({ source: "extension", state: "enabled" });
+			expect(config.servers.fresh?.config?.exposure).toBe("direct");
+			expect(config.servers.fresh?.config?.cwd).toBe("/tmp/ext");
+		});
+
+		it("keeps configHash stable for identical declarations", () => {
+			const root = makeRoot();
+			const config = loadMcpConfig({ agentDir: root.agentDir, cwd: root.cwd, projectTrusted: true });
+			mergeExtensionMcpServers(config, [extDecl("stable", { type: "stdio", command: "node" })]);
+			const first = config.servers.stable?.configHash;
+			delete (config.servers as Record<string, unknown>).stable;
+			mergeExtensionMcpServers(config, [extDecl("stable", { type: "stdio", command: "node" })]);
+			expect(config.servers.stable?.configHash).toBe(first);
 		});
 	});
 

--- a/packages/coding-agent/test/mcp/extension-load.test.ts
+++ b/packages/coding-agent/test/mcp/extension-load.test.ts
@@ -4,6 +4,8 @@ import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
 import type { Extension, SessionShutdownEvent, SessionStartEvent } from "../../src/core/extensions/types.ts";
+import { fakePi } from "./fixtures/service-lifecycle.ts";
+import { stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
 
 describe("mcp builtin extension load", () => {
 	beforeEach(() => {
@@ -88,6 +90,39 @@ describe("mcp builtin extension load", () => {
 			sessionStartCount: 1,
 			hasSessionContext: true,
 		});
+	});
+
+	it("registers tools from an extension-declared MCP server with source=extension", async () => {
+		const fixture = stdioFixtureCommand();
+		const pi = fakePi();
+		await getMcpService().attachSession(
+			{ type: "session_start", reason: "startup" },
+			{
+				cwd: process.cwd(),
+				isProjectTrusted: () => true,
+				getRegisteredMcpServers: () => [
+					{
+						name: "fixture",
+						config: { type: "stdio", ...fixture, args: [...fixture.args, "--tools", "2"] },
+						extensionPath: "<ext>",
+						registrationCwd: process.cwd(),
+					},
+				],
+			},
+			pi,
+		);
+
+		const snapshot = getMcpService()
+			.getServerSnapshots()
+			.find((s) => s.name === "fixture");
+		const tools = getMcpService()
+			.getTierBSearchable()
+			.map((t) => t.name)
+			.filter((n) => n.startsWith("mcp_fixture_"));
+		expect(snapshot?.source).toBe("extension");
+		expect(tools.length).toBeGreaterThan(0);
+		expect(pi.activeTools).toContain("mcp_fixture_tool_1");
+		await getMcpService().dispose("quit");
 	});
 });
 

--- a/packages/coding-agent/test/mcp/service-lifecycle.test.ts
+++ b/packages/coding-agent/test/mcp/service-lifecycle.test.ts
@@ -18,7 +18,7 @@ import {
 	tool,
 	writeProjectConfig,
 } from "./fixtures/service-lifecycle.ts";
-import { assertProcessDead } from "./fixtures/spawn-fixture.ts";
+import { assertProcessDead, stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
 
@@ -187,6 +187,75 @@ describe("McpService session lifecycle", () => {
 			await assertProcessDead(pid);
 		}
 		expect(service.getServerSnapshots()).toEqual([]);
+	});
+
+	it("does not respawn an extension-declared server with the same config hash", async () => {
+		const root = makeRoot("ext-reattach", cleanupTasks);
+		const counterFile = join(root.agentDir, "ext-reattach-spawns.txt");
+		const fixture = stdioFixtureCommand();
+		const decl = {
+			name: "fixture",
+			config: {
+				type: "stdio" as const,
+				...fixture,
+				args: [...fixture.args, "--tools", "1", "--spawn-counter-file", counterFile],
+			},
+			extensionPath: "<ext>",
+			registrationCwd: root.cwd,
+		};
+		const ctx = { cwd: root.cwd, isProjectTrusted: () => true, getRegisteredMcpServers: () => [decl] };
+		const service = getMcpService();
+
+		await service.attachSession({ type: "session_start", reason: "startup" }, ctx, fakePi(), {
+			agentDir: root.agentDir,
+		});
+		const pid1 = requiredPid(service, "fixture");
+		expect(await readCounter(counterFile)).toBe(1);
+
+		await service.handleSessionShutdown({ type: "session_shutdown", reason: "new" });
+		await service.attachSession({ type: "session_start", reason: "new" }, ctx, fakePi(), {
+			agentDir: root.agentDir,
+		});
+		const pid2 = requiredPid(service, "fixture");
+
+		expect(pid2).toBe(pid1);
+		expect(await readCounter(counterFile)).toBe(1);
+	});
+
+	it("respawns an extension-declared server on reload", async () => {
+		const root = makeRoot("ext-reload", cleanupTasks);
+		const counterFile = join(root.agentDir, "ext-reload-spawns.txt");
+		const fixture = stdioFixtureCommand();
+		const decl = {
+			name: "fixture",
+			config: {
+				type: "stdio" as const,
+				...fixture,
+				args: [...fixture.args, "--tools", "1", "--spawn-counter-file", counterFile],
+			},
+			extensionPath: "<ext>",
+			registrationCwd: root.cwd,
+		};
+		const ctx = { cwd: root.cwd, isProjectTrusted: () => true, getRegisteredMcpServers: () => [decl] };
+		const serviceBeforeReload = getMcpService();
+
+		await serviceBeforeReload.attachSession({ type: "session_start", reason: "startup" }, ctx, fakePi(), {
+			agentDir: root.agentDir,
+		});
+		const pid1 = requiredPid(serviceBeforeReload, "fixture");
+		await serviceBeforeReload.handleSessionShutdown({ type: "session_shutdown", reason: "reload" });
+		await assertProcessDead(pid1);
+
+		const serviceAfterReload = getMcpService();
+		await serviceAfterReload.attachSession({ type: "session_start", reason: "reload" }, ctx, fakePi(), {
+			agentDir: root.agentDir,
+		});
+		const pid2 = requiredPid(serviceAfterReload, "fixture");
+
+		expect(serviceAfterReload).not.toBe(serviceBeforeReload);
+		expect(pid2).not.toBe(pid1);
+		expect(await readCounter(counterFile)).toBe(2);
+		await assertAlive(pid2);
 	});
 });
 


### PR DESCRIPTION
## Summary
Adds a factory-time API for extensions to declare MCP servers (`pi.registerMcpServer(name, config)`), with first-wins aggregation, trust-aware merging against user config, and consumption on every session attach.

## Changes
- `ExtensionAPI.registerMcpServer` with per-extension declaration storage
- `ExtensionRunner` aggregates declarations and exposes them via `ExtensionContext.getRegisteredMcpServers()`
- Trust-aware merge: extension declarations merge into `ResolvedMcpConfig` with user-wins / placeholder-replacement semantics
- `attachSession` consumes extension declarations on `session_start`, `command_reattach`, and reload
- `McpServerSnapshot.source` + status rendering with `origin=<source>`
- Docs: `docs/extensions.md` and `docs/mcp.md` registerMcpServer sections

## Verification
- `test/extensions-loader.test.ts` +7 tests
- `test/extensions-runner.test.ts` +4 tests
- `test/mcp/config.test.ts` +5 / `config-security.test.ts` trust rules
- `test/mcp/extension-load.test.ts`, `service-lifecycle.test.ts`, `commands.test.ts` attach/reattach coverage
- `npm run check` passes (biome, pinned deps, tsgo, browser smoke, web-ui, neo)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a factory-time `pi.registerMcpServer()` API so extensions can declare MCP servers that load before the first turn. Declarations merge with user config using trust rules and are applied on every session attach, reattach, and reload.

- **New Features**
  - `ExtensionAPI.registerMcpServer(name, config)` with synchronous schema validation; errors fail only the declaring extension.
  - Runner aggregates declarations across extensions (first-wins) and exposes them via `ExtensionContext.getRegisteredMcpServers()`.
  - MCP config adds `"extension"` as a source and merges trust-aware: user config (`global`, `claude`, trusted `project`) wins; untrusted placeholders are replaced by extension entries. Stdio `cwd` defaults to the extension’s registration cwd.
  - MCP service merges these on every attach so tools are ready on turn 1; `mcp status` now shows `origin=<source>`. Docs updated in `extensions.md` and `mcp.md`.

<sup>Written for commit c6337b9405294991c039426cb25e22531eb4c7b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

