### PR TITLE
fix(compaction): weight base64 runs in token estimation

### DIFF
--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,31 @@
 # changes.md — compaction
 
+## Base64-aware token estimation (2026-07-18)
+
+### What changed
+
+- `compaction.ts`: `estimateTokens()` now weights long unbroken base64-ish runs (512+ chars of `[A-Za-z0-9+/=_-]`) at
+  ~1 token per character instead of the chars/4 prose heuristic. Applied to string/text-block content, tool-call
+  arguments, and bash output via a shared `weightedChars()` helper.
+
+### Why
+
+- Providers tokenize base64 near 1 token/char. A tool result carrying a ~1 MB inline screenshot data URL estimated at
+  ~256K tokens while Anthropic counted ~1M, so pre-flight compaction never triggered and the provider rejected the
+  request (`prompt is too long: 1029893 tokens > 1000000 maximum`). Real reproducer: session
+  `019f711b-587a-75ba-9eda-48fd5b2c2c01` (compaction recorded `tokensBefore: 319506` for a context the provider
+  counted at 1.03M).
+
+### Why extension system couldn't handle this
+
+- `estimateTokens()` is core and feeds `estimateContextTokens()`, which `agent-session.ts` uses for the pre-prompt
+  compaction gate before any extension sees the turn.
+
+### Expected merge conflict zones
+
+- LOW: `compaction.ts` around `estimateTextAndImageContentChars()` and the `estimateTokens()` switch arms. Keep the
+  weighting applied to every text surface the estimator counts.
+
 ## Split-turn compaction serialization sync (2026-07-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -244,15 +244,33 @@ export function shouldCompact(contextTokens: number, contextWindow: number, sett
 
 const ESTIMATED_IMAGE_CHARS = 4800;
 
+/**
+ * Long unbroken base64-ish runs (base64 payloads, data URLs, hex dumps) tokenize
+ * near 1 token per character, not the ~4 chars/token of prose. Weight such runs
+ * 4x so the shared chars/4 heuristic stays conservative for them; otherwise a
+ * 1 MB inline screenshot estimates at ~256K tokens while providers count ~1M.
+ */
+const BASE64_RUN_RE = /[A-Za-z0-9+/=_-]{512,}/g;
+const BASE64_CHAR_WEIGHT = 4;
+
+function weightedChars(text: string): number {
+	let chars = text.length;
+	BASE64_RUN_RE.lastIndex = 0;
+	for (const match of text.matchAll(BASE64_RUN_RE)) {
+		chars += match[0].length * (BASE64_CHAR_WEIGHT - 1);
+	}
+	return chars;
+}
+
 function estimateTextAndImageContentChars(content: string | Array<{ type: string; text?: string }>): number {
 	if (typeof content === "string") {
-		return content.length;
+		return weightedChars(content);
 	}
 
 	let chars = 0;
 	for (const block of content) {
 		if (block.type === "text" && block.text) {
-			chars += block.text.length;
+			chars += weightedChars(block.text);
 		} else if (block.type === "image") {
 			chars += ESTIMATED_IMAGE_CHARS;
 		}
@@ -282,7 +300,7 @@ export function estimateTokens(message: AgentMessage): number {
 				} else if (block.type === "thinking") {
 					chars += block.thinking.length;
 				} else if (block.type === "toolCall") {
-					chars += block.name.length + JSON.stringify(block.arguments).length;
+					chars += block.name.length + weightedChars(JSON.stringify(block.arguments));
 				}
 			}
 			return Math.ceil(chars / 4);
@@ -293,7 +311,7 @@ export function estimateTokens(message: AgentMessage): number {
 			return Math.ceil(chars / 4);
 		}
 		case "bashExecution": {
-			chars = message.command.length + message.output.length;
+			chars = message.command.length + weightedChars(message.output);
 			return Math.ceil(chars / 4);
 		}
 		case "branchSummary":

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -34,6 +34,7 @@ import {
 	calculateContextTokens,
 	DEFAULT_COMPACTION_SETTINGS,
 	estimateContextTokens,
+	estimateTokens,
 	findCutPoint,
 	getLastAssistantUsage,
 	prepareCompaction,
@@ -481,6 +482,50 @@ describe("estimateContextTokens", () => {
 		expect(estimate.lastUsageIndex).toBe(1);
 		expect(estimate.trailingTokens).toBeGreaterThan(0);
 		expect(estimate.tokens).toBe(150 + estimate.trailingTokens);
+	});
+});
+
+describe("estimateTokens base64 weighting", () => {
+	const base64Run = "iVBORw0KGgoAAAANSUhEUg".repeat(4096); // ~90K unbroken base64 chars
+
+	it("weights long base64 runs in tool results near 1 token per char", () => {
+		const message: AgentMessage = {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "get_app_state",
+			content: [{ type: "text", text: `{"screenshot":{"url":"data:image/png;base64,${base64Run}"}}` }],
+			details: undefined,
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		// chars/4 alone would report ~25% of the run length; providers count ~1
+		// token per base64 char, which previously let 1M-token prompts pass the
+		// pre-flight compaction check (session 019f711b: estimated 319K, actual 1.03M).
+		expect(estimateTokens(message)).toBeGreaterThanOrEqual(base64Run.length);
+	});
+
+	it("keeps the chars/4 heuristic for prose without long runs", () => {
+		const prose = "The quick brown fox jumps over the lazy dog. ".repeat(100);
+		expect(estimateTokens(createUserMessage(prose))).toBe(Math.ceil(prose.length / 4));
+	});
+
+	it("does not weight short base64-ish identifiers", () => {
+		const text = "commit 0123456789abcdef0123456789abcdef01234567 fixed the bug";
+		expect(estimateTokens(createUserMessage(text))).toBe(Math.ceil(text.length / 4));
+	});
+
+	it("weights base64 embedded in bash output", () => {
+		const message: AgentMessage = {
+			role: "bashExecution",
+			command: "base64 screenshot.png",
+			output: base64Run,
+			exitCode: 0,
+			cancelled: false,
+			truncated: false,
+			timestamp: Date.now(),
+		};
+		expect(estimateTokens(message)).toBeGreaterThanOrEqual(base64Run.length);
 	});
 });
 


### PR DESCRIPTION
# What changed for users

Sessions that receive large base64 payloads in tool results (inline screenshots, data URLs, `base64`/hex dumps in bash output) no longer sail past the pre-prompt compaction gate and die on a provider `prompt is too long` rejection. The token estimator now weights long unbroken base64-ish runs at ~1 token per character — matching how providers actually tokenize them — instead of the ~4 chars/token prose heuristic.

## The failure this fixes

Session `019f711b-587a-75ba-9eda-48fd5b2c2c01` (2026-07-17): a computer-use extension returned one tool result whose text block held a 1,046,118-char base64 screenshot data URL.

- `estimateTokens` counted it at ~262K tokens; `estimateContextTokens` reported ~319K total (the compaction entry later recorded `tokensBefore: 319506`).
- The gate saw plenty of headroom and sent the turn; Anthropic counted the real context at **1,029,893 tokens**, answered 429 then `400 prompt is too long: 1029893 tokens > 1000000 maximum`, and the turn died into overflow recovery.

With the fix, the same message estimates at ≥1M tokens, the pre-prompt gate fires, and compaction runs *before* the wasted provider round-trips.

# Change surface

- `packages/coding-agent/src/core/compaction/compaction.ts` — new `weightedChars()`: text runs matching `[A-Za-z0-9+/=_-]{512,}` count 4x (so the shared `ceil(chars/4)` yields ~1 token/char for them). Applied to: string/text-block content (`estimateTextAndImageContentChars`), assistant tool-call arguments, and `bashExecution` output. Real image content blocks keep the existing flat `ESTIMATED_IMAGE_CHARS` estimate; prose and short identifiers (git SHAs, UUIDs) are below the 512-char floor and unchanged.
- `packages/coding-agent/src/core/compaction/changes.md` — fork-change entry per repo convention.
- `packages/coding-agent/test/compaction.test.ts` — 4 regression tests: base64 tool result ≥ 1 token/char, prose stays chars/4, short base64-ish identifiers unweighted, bash output weighted.

The 512-char floor is deliberately conservative: no natural-language or code line produces a 512+ char run of pure `[A-Za-z0-9+/=_-]` without whitespace or punctuation, so false positives are practically impossible, while every meaningful base64 payload (any image > ~384 bytes) is caught.

# QA / Evidence

- `npx vitest run test/compaction.test.ts` — 37/37 passed (33 existing + 4 new).
- `npm run check` — full static validation passed (TS + Go).
- senpi-qa Channel 3 (mock loop): `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` — 5/5 passed across all three wire formats, zero real provider calls, real auth untouched. Artifact: `local-ignore/qa-evidence/20260718-base64-token-estimation/mock-loop-self-test.txt`.
- Root-cause math verified against the session JSONL: 1,046,118-char block ÷ 4 ≈ 262K (old estimate) vs provider-counted 1,029,893; weighted estimate ≈ 1.05M ≥ actual.

# Residual risks

- **Risk**: overestimation triggers compaction earlier than strictly needed for tokenizers that compress base64 better (some OpenAI BPEs reach ~2.4 chars/token). **Evidence**: the estimator is documented as intentionally conservative ("overestimates tokens"); early compaction costs one summary turn, late compaction costs a dead provider round-trip and overflow recovery. **Conclusion**: conservative direction is the correct trade-off.
- **Risk**: regex scan cost on hot paths. **Evidence**: `estimateContextTokens` only scans messages *after* the last assistant usage anchor (typically a handful); the regex is linear, no backtracking. **Conclusion**: negligible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix token estimation for large base64 payloads by weighting long unbroken base64-like runs at ~1 token per character. This ensures the pre-prompt compaction gate triggers correctly and avoids provider “prompt is too long” errors.

- **Bug Fixes**
  - Added `weightedChars()` that weights `[A-Za-z0-9+/=_-]{512,}` runs 4x so `ceil(chars/4)` ≈ 1 token/char for those segments.
  - Applied weighting to string/text content, tool-call `arguments` JSON, and `bashExecution` `output`; image blocks keep `ESTIMATED_IMAGE_CHARS`.
  - Added regression tests to verify base64 is weighted while prose and short IDs remain chars/4.

<sup>Written for commit 404b14bac9d15a520679558db7bc881e2b7d44b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

