### PR TITLE
feat(tool-call-middleware): add antml protocol with Claude-Code-style failure tolerance

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added the `antml` tool-call protocol: ANTML `<function_calls>`/`<invoke>` format with Claude-Code-style failure tolerance (parameter aliases, unknown-key filtering, unicode escape repair), validation-gated so repaired calls must still pass the tool schema.
+
 ### Changed
 
 ### Fixed

--- a/packages/ai/src/tool-call-middleware/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/AGENTS.md
@@ -17,7 +17,8 @@ tool-call-middleware/
 │   ├── gemma4.ts               # Gemma 4 delimiter format `<|tool_call>call:name{…}<tool_call|>`
 │   ├── json-mix.ts             # Shared JSON-mix helper (Hermes + delimited variants)
 │   ├── xml-tool-tag-scanner.ts # Streaming XML tag boundary scanner
-│   └── anthropic-xml/          # Legacy <invoke>/<parameter> parser, coercion, scanner, formatter, stream parser
+│   ├── anthropic-xml/          # Legacy <invoke>/<parameter> parser, coercion, scanner, formatter, stream parser
+│   └── antml/                  # ANTML <function_calls>/<invoke> protocol with Claude-Code-style failure tolerance
 ├── TESTING.md                  # Manual test commands per protocol (OpenRouter live API)
 └── changes.md                  # Fork tracker: morph-xml strict mode, yaml+xml, stream error preservation
 ```

--- a/packages/ai/src/tool-call-middleware/TESTING.md
+++ b/packages/ai/src/tool-call-middleware/TESTING.md
@@ -243,7 +243,28 @@ This will show:
 - Parsed tool call structures
 - Tool response formatting
 
-### Verifying Protocol Selection
+### ANTML (antml)
+
+Add an OpenAI-compatible custom model with `"toolCallFormat": "antml"`, then run:
+
+```bash
+senpi --provider <provider> --model <model> -p \
+  "Use the Bash tool to run 'printf antml-ok' and report the output."
+```
+
+**Expected Behavior:**
+- The model emits `<function_calls><invoke name="Bash"><parameter name="command">printf antml-ok</parameter></invoke></function_calls>`.
+- The middleware resolves the tool name, repairs slop (parameter aliases, invented keys, broken unicode escapes), and executes the tool.
+- The tool result or final response contains `antml-ok`.
+
+**Protocol Format Details:**
+- Same `<invoke>`/`<parameter>` body as anthropic-xml; the `<function_calls>` wrapper is canonical in formatted output and optional on input.
+- Failure tolerance mirrors Claude Code: unknown keys are filtered (recursively, e.g. invented `edits[]` fields), documented aliases (`path`→`file_path`, `old_str`→`old_string`, …) are resolved, `\uXXXX` escapes and lone surrogates are repaired.
+- Every repaired call must still pass the tool's JSON-schema validation, or it is rejected like any malformed call.
+
+---
+
+## Verifying Protocol Selection
 
 To confirm which protocol is being used for a model, check the model configuration:
 
@@ -256,6 +277,7 @@ Look for the `toolCallFormat` field in the output. Valid values are:
 - `morph-xml` - For Gemini and XML-based models (`xml` remains a deprecated alias)
 - `gemma4-delimiter` - For Gemma 4 models
 - `anthropic-xml` - For legacy Anthropic invoke/parameter XML
+- `antml` - For ANTML function_calls/invoke with failure tolerance
 - `native` - For models with native tool calling (OpenAI, Anthropic)
 
 ## Summary Table
@@ -266,3 +288,4 @@ Look for the `toolCallFormat` field in the output. Valid values are:
 | MorphXml | openrouter-gemini | google/gemini-3-flash-preview | `senpi --provider openrouter-gemini --model "google/gemini-3-flash-preview" -p "List TypeScript files"` |
 | Gemma4 | openrouter-gemma | google/gemma-4-31b-it | `senpi --provider openrouter-gemma --model "google/gemma-4-31b-it" -p "Run date command"` |
 | Anthropic XML | custom OpenAI-compatible provider | compatible text-tool model | `senpi --provider <provider> --model <model> -p "Use Bash to run printf anthropic-xml-ok"` |
+| ANTML | custom OpenAI-compatible provider | compatible text-tool model | `senpi --provider <provider> --model <model> -p "Use Bash to run printf antml-ok"` |

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -1,5 +1,31 @@
 # Tool Call Middleware Changes
 
+## 2026-07-18 - ANTML protocol with Claude-Code-style failure tolerance
+
+### What changed and why
+
+- Added the `antml` text-tool protocol: the ANTML `<function_calls>`/`<invoke>`/`<parameter>` format
+  Anthropic models are post-trained on (see "Better Models: Worse Tools",
+  https://lucumr.pocoo.org/2026/7/4/better-models-worse-tools/). Newer Claude models (Opus 4.8,
+  Sonnet 5) emit byte-correct tool calls but append invented keys (`requireUnique`, `oldText2`,
+  `type`, ...), substitute parameter aliases (`path` for `file_path`, `old_str` for `old_string`),
+  and occasionally produce broken `\uXXXX` escapes — slop that Claude Code's own harness absorbs
+  silently while strict parsers reject the whole call.
+- The protocol shares the invoke scanner/stream machinery with `anthropic-xml` via a new
+  `InvokeProtocolConfig` (protocol id, label, tool-call id prefix, coercion strategy);
+  `parse.ts`/`stream.ts` in `protocols/anthropic-xml/` were parameterized with zero behavior change
+  for the existing format (messages, ids, and event sequences are byte-identical).
+- `antml` coercion (`protocols/antml/coerce-parameters.ts`) applies validation-gated repairs:
+  case/separator-insensitive property matching, a documented alias table, recursive unknown-key
+  filtering honoring `additionalProperties`, `\u` escape repair plus lone-surrogate replacement,
+  lenient scalar spellings (`" TRUE "`, `'"2"'`), and duplicate-parameter last-wins. Every repaired
+  record must still pass `Value.Check` against the tool schema — repairs only narrow input, never
+  invent it, keeping the middleware's strict-parsing contract.
+- Formatted output wraps the canonical invoke serialization in `<function_calls>`; input accepts
+  both wrapped and bare invokes. Truncation-at-finish recovery inherits the R1-R4 boundary from the
+  shared stream core.
+
+
 ## 2026-07-17 - Truncation-recovery boundary for text tool-call protocols
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/context-transformer.ts
+++ b/packages/ai/src/tool-call-middleware/context-transformer.ts
@@ -15,6 +15,13 @@ import {
 	parseAnthropicXmlGeneratedText,
 } from "./protocols/anthropic-xml/index.ts";
 import {
+	antmlFormatToolCall,
+	antmlFormatToolResponse,
+	antmlFormatToolsSystemPrompt,
+	createAntmlStreamParser,
+	parseAntmlGeneratedText,
+} from "./protocols/antml/index.ts";
+import {
 	gemma4CreateStreamParser,
 	gemma4FormatToolCall,
 	gemma4FormatToolResponse,
@@ -85,6 +92,14 @@ const gemma4Protocol: ToolCallProtocol = {
 	createStreamParser: gemma4CreateStreamParser,
 };
 
+const antmlProtocol: ToolCallProtocol = {
+	formatToolsSystemPrompt: antmlFormatToolsSystemPrompt,
+	formatToolResponse: antmlFormatToolResponse,
+	formatToolCall: antmlFormatToolCall,
+	parseGeneratedText: parseAntmlGeneratedText,
+	createStreamParser: createAntmlStreamParser,
+};
+
 const anthropicXmlProtocol: ToolCallProtocol = {
 	formatToolsSystemPrompt: anthropicXmlFormatToolsSystemPrompt,
 	formatToolResponse: anthropicXmlFormatToolResponse,
@@ -98,6 +113,7 @@ const anthropicXmlProtocol: ToolCallProtocol = {
  */
 const protocolRegistry: Record<ToolCallFormat, ToolCallProtocol> = {
 	"anthropic-xml": anthropicXmlProtocol,
+	antml: antmlProtocol,
 	hermes: hermesProtocol,
 	xml: morphXmlProtocol,
 	"morph-xml": morphXmlProtocol,

--- a/packages/ai/src/tool-call-middleware/index.ts
+++ b/packages/ai/src/tool-call-middleware/index.ts
@@ -33,7 +33,8 @@ export function getToolCallFormat<TApi extends Api>(model: Model<TApi>): ToolCal
 		format === "morph-xml" ||
 		format === "yaml-xml" ||
 		format === "gemma4-delimiter" ||
-		format === "anthropic-xml"
+		format === "anthropic-xml" ||
+		format === "antml"
 	) {
 		return format;
 	}

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/coerce-parameters.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/coerce-parameters.ts
@@ -15,7 +15,7 @@ const INVALID: CoercionResult = { ok: false };
 const LEADING_RAW_NEWLINE = /^(?:\r\n|\r|\n)/;
 const TRAILING_RAW_NEWLINE = /(?:\r\n|\r|\n)$/;
 
-function trimRawBoundaryNewlines(value: string): string {
+export function trimRawBoundaryNewlines(value: string): string {
 	return value.replace(LEADING_RAW_NEWLINE, "").replace(TRAILING_RAW_NEWLINE, "");
 }
 

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/format.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/format.ts
@@ -10,7 +10,7 @@ function serializeToolValue(value: unknown): string {
 	return String(value);
 }
 
-function renderToolDefinitions(tools: Tool[]): string {
+export function renderToolDefinitions(tools: Tool[]): string {
 	const json = JSON.stringify(
 		tools.map((tool) => ({
 			name: tool.name,

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/invoke-protocol.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/invoke-protocol.ts
@@ -1,0 +1,26 @@
+import type { Tool } from "../../../types.ts";
+import { coerceParameters } from "./coerce-parameters.ts";
+import type { InvokeParameter } from "./invoke-tag-scanner.ts";
+
+/**
+ * Behavior knobs shared by every `<invoke>`/`<parameter>`-shaped protocol.
+ * The scanner, batch parser, and stream parser are format-agnostic; a config
+ * supplies the protocol identity and the schema-aware argument coercion.
+ */
+export type InvokeProtocolConfig = {
+	/** Wire-format identifier reported in onError metadata. */
+	readonly protocol: string;
+	/** Human-readable protocol label used in error messages. */
+	readonly label: string;
+	/** Tool-call id prefix; ids are `${idPrefix}-${index}`. */
+	readonly idPrefix: string;
+	/** Schema-aware parameter coercion for structurally complete invokes. */
+	readonly coerce: (parameters: readonly InvokeParameter[], tool: Tool) => Record<string, unknown> | null;
+};
+
+export const anthropicXmlInvokeConfig: InvokeProtocolConfig = {
+	protocol: "anthropic-xml",
+	label: "Anthropic XML",
+	idPrefix: "anthropic-xml-tool",
+	coerce: coerceParameters,
+};

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/parse.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/parse.ts
@@ -1,11 +1,17 @@
 import type { Tool } from "../../../types.ts";
 import type { ParsedToolCall, ParserOptions } from "../../types.ts";
-import { coerceParameters } from "./coerce-parameters.ts";
 import { findNextInvokeMatch } from "./invoke-match.ts";
+import type { InvokeProtocolConfig } from "./invoke-protocol.ts";
+import { anthropicXmlInvokeConfig } from "./invoke-protocol.ts";
 import { findInvokeOpenTag, scanInvokeBlock } from "./invoke-tag-scanner.ts";
 import { createToolResolver } from "./tool-resolver.ts";
 
-export function parseAnthropicXmlGeneratedText(text: string, tools: Tool[], options?: ParserOptions): ParsedToolCall[] {
+export function parseInvokeGeneratedText(
+	text: string,
+	tools: Tool[],
+	config: InvokeProtocolConfig,
+	options?: ParserOptions,
+): ParsedToolCall[] {
 	if (text.length === 0 || tools.length === 0) {
 		return [];
 	}
@@ -47,9 +53,9 @@ export function parseAnthropicXmlGeneratedText(text: string, tools: Tool[], opti
 			continue;
 		}
 
-		const argumentsRecord = block.parameters ? coerceParameters(block.parameters, tool) : null;
+		const argumentsRecord = block.parameters ? config.coerce(block.parameters, tool) : null;
 		if (!argumentsRecord) {
-			options?.onError?.("Could not process anthropic-xml tool call, keeping original text.", {
+			options?.onError?.(`Could not process ${config.protocol} tool call, keeping original text.`, {
 				toolCall: originalCallText,
 			});
 			continue;
@@ -59,4 +65,8 @@ export function parseAnthropicXmlGeneratedText(text: string, tools: Tool[], opti
 	}
 
 	return parsedToolCalls;
+}
+
+export function parseAnthropicXmlGeneratedText(text: string, tools: Tool[], options?: ParserOptions): ParsedToolCall[] {
+	return parseInvokeGeneratedText(text, tools, anthropicXmlInvokeConfig, options);
 }

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/stream.ts
@@ -1,8 +1,9 @@
 import type { Tool } from "../../../types.ts";
 import { validateToolArguments } from "../../../utils/validation.ts";
 import type { ParserOptions, StreamParser, StreamParserEvent } from "../../types.ts";
-import { coerceParameters } from "./coerce-parameters.ts";
 import { findNextInvokeMatch } from "./invoke-match.ts";
+import type { InvokeProtocolConfig } from "./invoke-protocol.ts";
+import { anthropicXmlInvokeConfig } from "./invoke-protocol.ts";
 import {
 	findIncompleteInvokeOpenTag,
 	findInvokeOpenTag,
@@ -11,7 +12,7 @@ import {
 	scanInvokeBlock,
 	scanTruncatedInvokeBlock,
 } from "./invoke-tag-scanner.ts";
-import { parseAnthropicXmlGeneratedText } from "./parse.ts";
+import { parseInvokeGeneratedText } from "./parse.ts";
 import {
 	ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH,
 	createPendingFragment,
@@ -28,7 +29,6 @@ const FUNCTION_CALLS_COMPLETE_TAG = /^<\s*\/?\s*function_calls\s*>/;
 const FUNCTION_CALLS_OPEN_PREFIX = "<function_calls>";
 const FUNCTION_CALLS_CLOSE_PREFIX = "</function_calls>";
 const EAGER_OPEN_TAG_SCAN_LENGTH = 128;
-const RETAINED_FRAGMENT_OVERFLOW_MESSAGE = `Anthropic XML streaming fragment exceeded the ${ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH}-character retained-input limit.`;
 
 type FunctionCallsTag = {
 	readonly index: number;
@@ -90,11 +90,12 @@ function reportError(options: ParserOptions | undefined, message: string, toolCa
 }
 
 function coerceStreamParameters(
-	parameters: Parameters<typeof coerceParameters>[0],
+	parameters: Parameters<InvokeProtocolConfig["coerce"]>[0],
 	tool: Tool,
+	config: InvokeProtocolConfig,
 	allowJsonSchemaFallback = false,
 ): Record<string, unknown> | null {
-	const coercedParameters = coerceParameters(parameters, tool);
+	const coercedParameters = config.coerce(parameters, tool);
 	if (coercedParameters !== null || !allowJsonSchemaFallback) {
 		return coercedParameters;
 	}
@@ -114,8 +115,14 @@ function coerceStreamParameters(
 	return argumentsRecord;
 }
 
-export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOptions): StreamParser {
+export function createInvokeStreamParser(
+	tools: Tool[],
+	config: InvokeProtocolConfig,
+	options?: ParserOptions,
+): StreamParser {
 	const resolveTool = createToolResolver(tools);
+	const retainedFragmentOverflowMessage = `${config.label} streaming fragment exceeded the ${ANTHROPIC_XML_MAX_RETAINED_FRAGMENT_LENGTH}-character retained-input limit.`;
+	const truncatedAtFinishMessage = `${config.label} tool call truncated at finish`;
 	let buffer = "";
 	let nextToolCallIndex = 0;
 	let pendingFragment: PendingFragment | null = null;
@@ -128,7 +135,7 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 		const retainedFragment = buffer;
 		buffer = "";
 		pendingFragment = null;
-		reportError(options, RETAINED_FRAGMENT_OVERFLOW_MESSAGE, retainedFragment);
+		reportError(options, retainedFragmentOverflowMessage, retainedFragment);
 
 		const events: StreamParserEvent[] = [];
 		if (shouldEmitRawToolCallTextOnError(options)) {
@@ -164,7 +171,7 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 
 				const wrapperEnd = functionCallsCloseTag.index + functionCallsCloseTag.length;
 				const wrapperContent = buffer.slice(functionCallsOpenTag.length, functionCallsCloseTag.index);
-				if (parseAnthropicXmlGeneratedText(wrapperContent, tools).length > 0) {
+				if (parseInvokeGeneratedText(wrapperContent, tools, config).length > 0) {
 					buffer = wrapperContent + buffer.slice(wrapperEnd);
 				} else {
 					emitText(events, buffer.slice(0, wrapperEnd));
@@ -212,14 +219,14 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 
 				const index = nextToolCallIndex;
 				nextToolCallIndex += 1;
-				const id = `anthropic-xml-tool-${index}`;
+				const id = `${config.idPrefix}-${index}`;
 				const argumentsRecord = block.parameters
-					? coerceStreamParameters(block.parameters, tool, allowJsonSchemaFallback)
+					? coerceStreamParameters(block.parameters, tool, config, allowJsonSchemaFallback)
 					: null;
 				if (argumentsRecord === null) {
 					reportError(
 						options,
-						"Could not process streaming Anthropic XML tool call, keeping original text.",
+						`Could not process streaming ${config.label} tool call, keeping original text.`,
 						originalCallText,
 					);
 					if (shouldEmitRawToolCallTextOnError(options)) {
@@ -310,13 +317,13 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 			const tool = invokeOpenTag?.index === 0 ? resolveTool(invokeOpenTag.toolName) : undefined;
 			if (invokeOpenTag && tool) {
 				const scannedBlock = scanTruncatedInvokeBlock(buffer, invokeOpenTag);
-				const coercedArguments = coerceStreamParameters(scannedBlock.parameters, tool, true);
+				const coercedArguments = coerceStreamParameters(scannedBlock.parameters, tool, config, true);
 				let recoveredArguments: Record<string, unknown> | null = null;
 				if (scannedBlock.isStructurallyComplete && coercedArguments !== null) {
 					try {
 						recoveredArguments = validateToolArguments(tool, {
 							type: "toolCall",
-							id: "anthropic-xml-finish-recovery",
+							id: `${config.protocol}-finish-recovery`,
 							name: tool.name,
 							arguments: coercedArguments,
 						});
@@ -327,7 +334,7 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 
 				const index = nextToolCallIndex;
 				nextToolCallIndex += 1;
-				const id = `anthropic-xml-tool-${index}`;
+				const id = `${config.idPrefix}-${index}`;
 				const argumentsRecord = recoveredArguments ?? coercedArguments ?? {};
 				events.push({ type: "toolcall_start", index, name: tool.name, id });
 				events.push({ type: "toolcall_delta", index, argumentsDelta: JSON.stringify(argumentsRecord) });
@@ -343,16 +350,16 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 						incomplete: true,
 						errorMessage: "Tool call was truncated mid-arguments",
 					});
-					options?.onError?.("Anthropic XML tool call truncated at finish", {
-						protocol: "anthropic-xml",
+					options?.onError?.(truncatedAtFinishMessage, {
+						protocol: config.protocol,
 						retainedLength: buffer.length,
 					});
 				}
 			} else if (invokeOpenTag?.index === 0) {
 				emitText(events, buffer);
 			} else if (isPotentialProtocolStart(buffer)) {
-				options?.onError?.("Anthropic XML tool call truncated at finish", {
-					protocol: "anthropic-xml",
+				options?.onError?.(truncatedAtFinishMessage, {
+					protocol: config.protocol,
 					retainedLength: buffer.length,
 				});
 			} else {
@@ -362,4 +369,8 @@ export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOp
 			return events;
 		},
 	};
+}
+
+export function createAnthropicXmlStreamParser(tools: Tool[], options?: ParserOptions): StreamParser {
+	return createInvokeStreamParser(tools, anthropicXmlInvokeConfig, options);
 }

--- a/packages/ai/src/tool-call-middleware/protocols/antml/coerce-parameters.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/coerce-parameters.ts
@@ -1,0 +1,237 @@
+import type { TSchema } from "typebox";
+import { IsArray, IsBoolean, IsInteger, IsNumber, IsObject, IsString } from "typebox";
+import { Value } from "typebox/value";
+import type { Tool } from "../../../types.ts";
+import { trimRawBoundaryNewlines } from "../anthropic-xml/coerce-parameters.ts";
+import { decodeXmlEntities } from "../anthropic-xml/xml-entities.ts";
+import { repairLoneSurrogates, repairStringsDeep, repairUnicodeEscapes } from "./repair.ts";
+
+type RawParameter = {
+	readonly name: string;
+	readonly rawValue: string;
+};
+
+type CoercionResult = { readonly ok: true; readonly value: unknown } | { readonly ok: false };
+
+const INVALID: CoercionResult = { ok: false };
+
+/**
+ * Parameter spellings Claude-family models substitute for each other under
+ * pressure (mirrors Claude Code's per-tool alias tables). Names inside one
+ * group resolve to whichever member the tool schema actually declares.
+ */
+const ALIAS_GROUPS: readonly (readonly string[])[] = [
+	["file_path", "path", "filename", "file"],
+	["old_string", "old_str", "old_text"],
+	["new_string", "new_str", "new_text"],
+	["command", "cmd"],
+];
+
+function normalizeName(name: string): string {
+	return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+const ALIAS_LOOKUP: ReadonlyMap<string, readonly string[]> = new Map(
+	ALIAS_GROUPS.flatMap((group) => group.map((name) => [normalizeName(name), group] as const)),
+);
+
+function setOwn(record: Record<string, unknown>, key: string, value: unknown): void {
+	Object.defineProperty(record, key, { configurable: true, enumerable: true, value, writable: true });
+}
+
+/**
+ * Resolves a model-emitted key to a declared schema property: exact match
+ * first, then case/separator-insensitive match, then the alias table.
+ * Returns undefined for keys the schema does not know (they are filtered).
+ */
+function resolvePropertyName(rawName: string, properties: Record<string, TSchema>): string | undefined {
+	if (Object.hasOwn(properties, rawName)) {
+		return rawName;
+	}
+
+	const normalized = normalizeName(rawName);
+	const byNormalized = Object.keys(properties).filter((property) => normalizeName(property) === normalized);
+	if (byNormalized.length === 1) {
+		return byNormalized[0];
+	}
+	if (byNormalized.length > 1) {
+		return undefined;
+	}
+
+	const aliasGroup = ALIAS_LOOKUP.get(normalized);
+	if (!aliasGroup) {
+		return undefined;
+	}
+	const byAlias = Object.keys(properties).filter((property) => {
+		const propertyNormalized = normalizeName(property);
+		return (
+			propertyNormalized !== normalized && aliasGroup.some((alias) => normalizeName(alias) === propertyNormalized)
+		);
+	});
+	return byAlias.length === 1 ? byAlias[0] : undefined;
+}
+
+function getAdditionalPropertiesSchema(schema: TSchema): TSchema | true | undefined {
+	const additional = (schema as { additionalProperties?: unknown }).additionalProperties;
+	if (additional === true) {
+		return true;
+	}
+	if (typeof additional === "object" && additional !== null) {
+		return additional as TSchema;
+	}
+	return undefined;
+}
+
+/**
+ * Recursively drops object keys a schema does not declare, resolving each key
+ * through the same alias table on the way. Repairs only ever narrow a value;
+ * the final schema validation decides whether the repaired call is accepted.
+ */
+function filterUnknownKeysDeep(value: unknown, schema: TSchema): unknown {
+	if (IsArray(schema) && Array.isArray(value) && schema.items !== undefined && !Array.isArray(schema.items)) {
+		return value.map((entry) => filterUnknownKeysDeep(entry, schema.items as TSchema));
+	}
+
+	if (IsObject(schema) && typeof value === "object" && value !== null && !Array.isArray(value)) {
+		const properties = schema.properties ?? {};
+		const additional = getAdditionalPropertiesSchema(schema);
+		const filtered: Record<string, unknown> = {};
+		for (const [rawKey, entry] of Object.entries(value)) {
+			const propertyName = resolvePropertyName(rawKey, properties);
+			if (propertyName !== undefined) {
+				const propertySchema = properties[propertyName];
+				setOwn(filtered, propertyName, propertySchema ? filterUnknownKeysDeep(entry, propertySchema) : entry);
+				continue;
+			}
+			if (additional === true) {
+				setOwn(filtered, rawKey, entry);
+			} else if (additional !== undefined) {
+				setOwn(filtered, rawKey, filterUnknownKeysDeep(entry, additional));
+			}
+		}
+		return filtered;
+	}
+
+	return value;
+}
+
+function tryParseJsonTolerant(value: string): CoercionResult {
+	for (const candidate of [value, repairUnicodeEscapes(value)]) {
+		try {
+			return { ok: true, value: repairStringsDeep(JSON.parse(candidate)) };
+		} catch (error) {
+			if (!(error instanceof SyntaxError)) {
+				throw error;
+			}
+		}
+	}
+	return INVALID;
+}
+
+function unwrapJsonScalar(value: string): string {
+	const parsed = tryParseJsonTolerant(value.trim());
+	return parsed.ok && (typeof parsed.value === "string" || typeof parsed.value === "number")
+		? String(parsed.value)
+		: value;
+}
+
+function coerceKnownValue(rawValue: string, schema: TSchema): CoercionResult {
+	const value = decodeXmlEntities(rawValue);
+
+	if (IsString(schema)) {
+		return { ok: true, value: repairLoneSurrogates(value) };
+	}
+
+	if (IsNumber(schema) || IsInteger(schema)) {
+		const candidate = unwrapJsonScalar(value).trim();
+		if (candidate.length === 0) {
+			return INVALID;
+		}
+		const parsed = Number(candidate);
+		if (!Number.isFinite(parsed) || (IsInteger(schema) && !Number.isInteger(parsed))) {
+			return INVALID;
+		}
+		return { ok: true, value: parsed };
+	}
+
+	if (IsBoolean(schema)) {
+		const candidate = unwrapJsonScalar(value).trim().toLowerCase();
+		if (candidate === "true") {
+			return { ok: true, value: true };
+		}
+		if (candidate === "false") {
+			return { ok: true, value: false };
+		}
+		return INVALID;
+	}
+
+	if (IsArray(schema)) {
+		const parsed = tryParseJsonTolerant(value);
+		return parsed.ok && Array.isArray(parsed.value)
+			? { ok: true, value: filterUnknownKeysDeep(parsed.value, schema) }
+			: INVALID;
+	}
+
+	if (IsObject(schema)) {
+		const parsed = tryParseJsonTolerant(value);
+		return parsed.ok && typeof parsed.value === "object" && parsed.value !== null && !Array.isArray(parsed.value)
+			? { ok: true, value: filterUnknownKeysDeep(parsed.value, schema) }
+			: INVALID;
+	}
+
+	return { ok: true, value: coerceUnknownValue(rawValue) };
+}
+
+function coerceUnknownValue(rawValue: string): unknown {
+	const value = decodeXmlEntities(rawValue);
+	const parsed = tryParseJsonTolerant(value);
+	return parsed.ok ? parsed.value : repairLoneSurrogates(value);
+}
+
+/**
+ * Failure-tolerant ANTML argument coercion. Mirrors the repairs Claude Code
+ * applies to model tool calls — parameter aliases, unknown-key filtering,
+ * unicode escape repair, lenient scalar spellings, duplicate last-wins —
+ * while keeping the strict gate: the repaired record must pass the tool's
+ * schema validation or the call is rejected (never a best-effort guess).
+ */
+export function coerceAntmlParameters(rawParams: readonly RawParameter[], tool: Tool): Record<string, unknown> | null {
+	if (!IsObject(tool.parameters)) {
+		return null;
+	}
+
+	const properties = tool.parameters.properties ?? {};
+	const additional = getAdditionalPropertiesSchema(tool.parameters);
+	const argumentsRecord: Record<string, unknown> = {};
+
+	for (const rawParam of rawParams) {
+		const rawValue = trimRawBoundaryNewlines(rawParam.rawValue);
+		const propertyName = resolvePropertyName(rawParam.name, properties);
+
+		if (propertyName === undefined) {
+			if (additional === undefined) {
+				continue;
+			}
+			const result =
+				additional === true
+					? { ok: true as const, value: coerceUnknownValue(rawValue) }
+					: coerceKnownValue(rawValue, additional);
+			if (result.ok) {
+				setOwn(argumentsRecord, rawParam.name, result.value);
+			}
+			continue;
+		}
+
+		const propertySchema = properties[propertyName];
+		if (propertySchema === undefined) {
+			continue;
+		}
+		const result = coerceKnownValue(rawValue, propertySchema);
+		if (!result.ok) {
+			return null;
+		}
+		setOwn(argumentsRecord, propertyName, result.value);
+	}
+
+	return Value.Check(tool.parameters, argumentsRecord) ? argumentsRecord : null;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/antml/config.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/config.ts
@@ -1,0 +1,9 @@
+import type { InvokeProtocolConfig } from "../anthropic-xml/invoke-protocol.ts";
+import { coerceAntmlParameters } from "./coerce-parameters.ts";
+
+export const antmlInvokeConfig: InvokeProtocolConfig = {
+	protocol: "antml",
+	label: "antml",
+	idPrefix: "antml-tool",
+	coerce: coerceAntmlParameters,
+};

--- a/packages/ai/src/tool-call-middleware/protocols/antml/format.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/format.ts
@@ -1,0 +1,42 @@
+import type { Tool } from "../../../types.ts";
+import type { ToolResultContent } from "../../types.ts";
+import {
+	anthropicXmlFormatToolCall,
+	anthropicXmlFormatToolResponse,
+	renderToolDefinitions,
+} from "../anthropic-xml/format.ts";
+
+export function antmlFormatToolsSystemPrompt(tools: Tool[]): string {
+	if (tools.length === 0) {
+		return "";
+	}
+
+	return `# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures as JSON within <tools></tools> XML tags:
+<tools>${renderToolDefinitions(tools)}</tools>
+
+# Format
+
+Emit every tool call inside one <function_calls> block.
+For each function call, emit one <invoke> element with the tool name in its name attribute.
+Put each argument in one <parameter> element with its name in the name attribute.
+String and scalar parameters are written as-is; arrays and objects are written as JSON.
+
+# Example
+<function_calls>
+<invoke name="get_weather">
+<parameter name="city">Seoul</parameter>
+</invoke>
+</function_calls>`;
+}
+
+export function antmlFormatToolCall(name: string, args: Record<string, unknown>): string {
+	return ["<function_calls>", anthropicXmlFormatToolCall(name, args), "</function_calls>"].join("\n");
+}
+
+export function antmlFormatToolResponse(toolName: string, toolCallId: string, content: ToolResultContent[]): string {
+	return anthropicXmlFormatToolResponse(toolName, toolCallId, content);
+}

--- a/packages/ai/src/tool-call-middleware/protocols/antml/index.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/index.ts
@@ -1,0 +1,5 @@
+export { coerceAntmlParameters } from "./coerce-parameters.ts";
+export { antmlFormatToolCall, antmlFormatToolResponse, antmlFormatToolsSystemPrompt } from "./format.ts";
+export { parseAntmlGeneratedText } from "./parse.ts";
+export { repairLoneSurrogates, repairStringsDeep, repairUnicodeEscapes } from "./repair.ts";
+export { createAntmlStreamParser } from "./stream.ts";

--- a/packages/ai/src/tool-call-middleware/protocols/antml/parse.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/parse.ts
@@ -1,0 +1,8 @@
+import type { Tool } from "../../../types.ts";
+import type { ParsedToolCall, ParserOptions } from "../../types.ts";
+import { parseInvokeGeneratedText } from "../anthropic-xml/parse.ts";
+import { antmlInvokeConfig } from "./config.ts";
+
+export function parseAntmlGeneratedText(text: string, tools: Tool[], options?: ParserOptions): ParsedToolCall[] {
+	return parseInvokeGeneratedText(text, tools, antmlInvokeConfig, options);
+}

--- a/packages/ai/src/tool-call-middleware/protocols/antml/repair.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/repair.ts
@@ -1,0 +1,51 @@
+const BROKEN_UNICODE_ESCAPE = /\\u(?![0-9a-fA-F]{4})/g;
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+const REPLACEMENT_CHARACTER = "\uFFFD";
+
+function isEscapedBackslashRun(text: string, backslashIndex: number): boolean {
+	let precedingBackslashes = 0;
+	for (let index = backslashIndex - 1; index >= 0 && text[index] === "\\"; index -= 1) {
+		precedingBackslashes += 1;
+	}
+	return precedingBackslashes % 2 === 1;
+}
+
+/**
+ * Fixes `\uXXXX` escape sequences that would make JSON.parse throw: a `\u`
+ * not followed by four hex digits becomes a literal `\\u` so the surrounding
+ * JSON stays parseable. Valid escapes and already-escaped backslashes are
+ * left untouched.
+ */
+export function repairUnicodeEscapes(json: string): string {
+	return json.replace(BROKEN_UNICODE_ESCAPE, (match, offset: number) =>
+		isEscapedBackslashRun(json, offset) ? match : "\\\\u",
+	);
+}
+
+/** Replaces unpaired UTF-16 surrogates with U+FFFD so values stay valid Unicode. */
+export function repairLoneSurrogates(value: string): string {
+	return value.replace(LONE_SURROGATE, REPLACEMENT_CHARACTER);
+}
+
+/** Applies {@link repairLoneSurrogates} to every string (keys included) in a JSON value. */
+export function repairStringsDeep(value: unknown): unknown {
+	if (typeof value === "string") {
+		return repairLoneSurrogates(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => repairStringsDeep(entry));
+	}
+	if (typeof value === "object" && value !== null) {
+		const repaired: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			Object.defineProperty(repaired, repairLoneSurrogates(key), {
+				configurable: true,
+				enumerable: true,
+				value: repairStringsDeep(entry),
+				writable: true,
+			});
+		}
+		return repaired;
+	}
+	return value;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/antml/stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/stream.ts
@@ -1,0 +1,8 @@
+import type { Tool } from "../../../types.ts";
+import type { ParserOptions, StreamParser } from "../../types.ts";
+import { createInvokeStreamParser } from "../anthropic-xml/stream.ts";
+import { antmlInvokeConfig } from "./config.ts";
+
+export function createAntmlStreamParser(tools: Tool[], options?: ParserOptions): StreamParser {
+	return createInvokeStreamParser(tools, antmlInvokeConfig, options);
+}

--- a/packages/ai/src/tool-call-middleware/types.ts
+++ b/packages/ai/src/tool-call-middleware/types.ts
@@ -8,8 +8,16 @@ import type { ImageContent, TextContent, Tool } from "../types.ts";
  * - "yaml-xml": YAML arguments inside XML tool tags
  * - "gemma4-delimiter": Gemma 4 specific delimiter format
  * - "anthropic-xml": Legacy Anthropic invoke/parameter XML format
+ * - "antml": ANTML function_calls/invoke format with Claude-Code-style failure tolerance
  */
-export type ToolCallFormat = "hermes" | "xml" | "morph-xml" | "yaml-xml" | "gemma4-delimiter" | "anthropic-xml";
+export type ToolCallFormat =
+	| "hermes"
+	| "xml"
+	| "morph-xml"
+	| "yaml-xml"
+	| "gemma4-delimiter"
+	| "anthropic-xml"
+	| "antml";
 
 /**
  * Content type for tool results (text or image)

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -574,7 +574,7 @@ export interface OpenAICompletionsCompat {
 	/**
 	 * Tool call format for models that don't natively support tool calling.
 	 * When set, the middleware will intercept tool calls and format them as text.
-	 * Supported values: "hermes", "morph-xml", "xml" (deprecated alias for "morph-xml"), "yaml-xml", "gemma4-delimiter", "anthropic-xml"
+	 * Supported values: "hermes", "morph-xml", "xml" (deprecated alias for "morph-xml"), "yaml-xml", "gemma4-delimiter", "anthropic-xml", "antml"
 	 */
 	toolCallFormat?: string;
 	/** Cache control convention for prompt caching. "anthropic" applies Anthropic-style `cache_control` markers to the system prompt, last tool definition, and last user/assistant text content. */

--- a/packages/ai/test/tool-call-middleware/antml-coerce.test.ts
+++ b/packages/ai/test/tool-call-middleware/antml-coerce.test.ts
@@ -1,0 +1,242 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { coerceAntmlParameters } from "../../src/tool-call-middleware/protocols/antml/coerce-parameters.ts";
+import type { Tool } from "../../src/types.ts";
+
+function createTool(parameters: Tool["parameters"]): Tool {
+	return {
+		name: "probe",
+		description: "Probe tool",
+		parameters,
+	};
+}
+
+const editTool = createTool(
+	Type.Object({
+		file_path: Type.String(),
+		edits: Type.Array(
+			Type.Object({
+				oldText: Type.String(),
+				newText: Type.String(),
+			}),
+		),
+	}),
+);
+
+describe("coerceAntmlParameters", () => {
+	it("filters invented trailing keys inside nested array items (Pi edits[] regression)", () => {
+		// given: the exact failure shape from Opus 4.8 against Pi's edit tool
+		const rawEdits =
+			'[{"oldText":"text to replace","newText":"replacement text","requireUnique":true,"oldText2":"","newText2":""}]';
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "file_path", rawValue: "some/file.py" },
+				{ name: "edits", rawValue: rawEdits },
+			],
+			editTool,
+		);
+
+		// then
+		expect(result).toEqual({
+			file_path: "some/file.py",
+			edits: [{ oldText: "text to replace", newText: "replacement text" }],
+		});
+	});
+
+	it("silently filters unknown top-level parameters", () => {
+		// given
+		const tool = createTool(Type.Object({ command: Type.String() }));
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "command", rawValue: "echo hi" },
+				{ name: "requireUnique", rawValue: "true" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ command: "echo hi" });
+	});
+
+	it("resolves documented parameter aliases to schema names", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				file_path: Type.String(),
+				old_string: Type.String(),
+				new_string: Type.String(),
+			}),
+		);
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "path", rawValue: "a.py" },
+				{ name: "old_str", rawValue: "before" },
+				{ name: "new_str", rawValue: "after" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ file_path: "a.py", old_string: "before", new_string: "after" });
+	});
+
+	it("matches parameter names across case and separator conventions", () => {
+		// given
+		const tool = createTool(Type.Object({ oldText: Type.String(), newText: Type.String() }));
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "old_text", rawValue: "a" },
+				{ name: "NewText", rawValue: "b" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ oldText: "a", newText: "b" });
+	});
+
+	it("resolves nested object keys through the same alias table", () => {
+		// given: Pi-style oldText schema receiving Claude-Code-style old_str keys
+		const result = coerceAntmlParameters(
+			[
+				{ name: "file_path", rawValue: "b.py" },
+				{ name: "edits", rawValue: '[{"old_str":"x","new_str":"y"}]' },
+			],
+			editTool,
+		);
+
+		// then
+		expect(result).toEqual({ file_path: "b.py", edits: [{ oldText: "x", newText: "y" }] });
+	});
+
+	it("keeps the last value when a parameter repeats", () => {
+		// given
+		const tool = createTool(Type.Object({ command: Type.String() }));
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "command", rawValue: "first" },
+				{ name: "command", rawValue: "second" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ command: "second" });
+	});
+
+	it("repairs broken unicode escapes inside JSON parameters", () => {
+		// given
+		const tool = createTool(Type.Object({ options: Type.Object({ text: Type.String() }) }));
+
+		// when
+		const result = coerceAntmlParameters(
+			[{ name: "options", rawValue: String.raw`{"text":"bad\uZZZZescape"}` }],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ options: { text: String.raw`bad\uZZZZescape` } });
+	});
+
+	it("replaces lone surrogates in string values", () => {
+		// given
+		const tool = createTool(Type.Object({ message: Type.String() }));
+
+		// when
+		const result = coerceAntmlParameters([{ name: "message", rawValue: `a${"\uD800"}b` }], tool);
+
+		// then
+		expect(result).toEqual({ message: "a\uFFFDb" });
+	});
+
+	it("coerces tolerant scalar spellings for booleans and numbers", () => {
+		// given
+		const tool = createTool(
+			Type.Object({
+				enabled: Type.Boolean(),
+				verbose: Type.Boolean(),
+				count: Type.Number(),
+				index: Type.Integer(),
+			}),
+		);
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "enabled", rawValue: " TRUE " },
+				{ name: "verbose", rawValue: '"false"' },
+				{ name: "count", rawValue: " 1.25 " },
+				{ name: "index", rawValue: '"2"' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ enabled: true, verbose: false, count: 1.25, index: 2 });
+	});
+
+	it("rejects values that stay invalid after every repair", () => {
+		// given
+		const numberTool = createTool(Type.Object({ count: Type.Number() }));
+		const integerTool = createTool(Type.Object({ index: Type.Integer() }));
+		const arrayTool = createTool(Type.Object({ items: Type.Array(Type.String()) }));
+
+		// when / then
+		expect(coerceAntmlParameters([{ name: "count", rawValue: "not-a-number" }], numberTool)).toBeNull();
+		expect(coerceAntmlParameters([{ name: "index", rawValue: "1.5" }], integerTool)).toBeNull();
+		expect(coerceAntmlParameters([{ name: "items", rawValue: "{bad" }], arrayTool)).toBeNull();
+	});
+
+	it("rejects missing required parameters at the validation boundary", () => {
+		// given
+		const tool = createTool(Type.Object({ command: Type.String() }));
+
+		// when / then
+		expect(coerceAntmlParameters([], tool)).toBeNull();
+	});
+
+	it("keeps schema-typed additional properties instead of filtering them", () => {
+		// given
+		const tool = createTool(Type.Object({ known: Type.String() }, { additionalProperties: Type.String() }));
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "known", rawValue: "ok" },
+				{ name: "extra", rawValue: "kept" },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ known: "ok", extra: "kept" });
+	});
+
+	it("drops a __proto__ parameter without polluting prototypes", () => {
+		// given
+		const tool = createTool(Type.Object({ command: Type.String() }));
+
+		// when
+		const result = coerceAntmlParameters(
+			[
+				{ name: "command", rawValue: "echo safe" },
+				{ name: "__proto__", rawValue: '{"polluted":true}' },
+			],
+			tool,
+		);
+
+		// then
+		expect(result).toEqual({ command: "echo safe" });
+		expect({} as { polluted?: boolean }).not.toHaveProperty("polluted");
+	});
+});

--- a/packages/ai/test/tool-call-middleware/antml-e2e.test.ts
+++ b/packages/ai/test/tool-call-middleware/antml-e2e.test.ts
@@ -1,0 +1,101 @@
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { fauxAssistantMessage, registerFauxProvider } from "../../src/providers/faux.ts";
+import { stream } from "../../src/stream.ts";
+import {
+	getProtocol,
+	getToolCallFormat,
+	wrapStreamWithToolCallMiddleware,
+} from "../../src/tool-call-middleware/index.ts";
+import type { AssistantMessage, AssistantMessageEvent, Model, Tool } from "../../src/types.ts";
+
+const editTool: Tool = {
+	name: "Edit",
+	description: "Edit a file",
+	parameters: Type.Object({
+		file_path: Type.String(),
+		edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+	}),
+};
+
+const registrations: Array<ReturnType<typeof registerFauxProvider>> = [];
+type ToolCallEndEvent = Extract<AssistantMessageEvent, { type: "toolcall_end" }>;
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+async function runFauxResponse(text: string): Promise<{ events: AssistantMessageEvent[]; result: AssistantMessage }> {
+	const faux = registerFauxProvider({
+		api: "openai-completions",
+		tokenSize: { min: 1, max: 1 },
+		schedulerHook: () => undefined,
+	});
+	registrations.push(faux);
+	const model = {
+		...faux.getModel(),
+		api: "openai-completions",
+		compat: { toolCallFormat: "antml" },
+	} satisfies Model<"openai-completions">;
+	const format = getToolCallFormat(model);
+	if (format === undefined) {
+		throw new Error("Expected antml compatibility format");
+	}
+
+	faux.setResponses([fauxAssistantMessage(text, { stopReason: "stop" })]);
+	const innerStream = stream(model, { messages: [{ role: "user", content: "Edit it", timestamp: 0 }] });
+	const wrappedStream = wrapStreamWithToolCallMiddleware(innerStream, getProtocol(format), [editTool]);
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of wrappedStream) {
+		events.push(event);
+	}
+	return { events, result: await wrappedStream.result() };
+}
+
+function toolCallEnds(events: readonly AssistantMessageEvent[]): ToolCallEndEvent[] {
+	return events.filter((event): event is ToolCallEndEvent => event.type === "toolcall_end");
+}
+
+describe("antml faux-provider e2e", () => {
+	it("executes a slop-laden wrapped Edit call with repaired canonical arguments", async () => {
+		// given: invented keys and an aliased path, exactly the Opus 4.8 failure mode
+		const response =
+			"Fixing the file now.\n" +
+			"<function_calls>\n" +
+			'<invoke name="Edit">\n' +
+			'<parameter name="path">some/file.py</parameter>\n' +
+			'<parameter name="edits">[{"oldText":"before","newText":"after","requireUnique":true,"type":"edit"}]</parameter>\n' +
+			"</invoke>\n" +
+			"</function_calls>\n" +
+			"Done.";
+
+		// when
+		const run = await runFauxResponse(response);
+
+		// then
+		const [toolCall] = toolCallEnds(run.events);
+		if (toolCall === undefined) {
+			throw new Error("Expected one Edit tool call");
+		}
+		expect(toolCall.toolCall).toMatchObject({
+			name: "Edit",
+			arguments: {
+				file_path: "some/file.py",
+				edits: [{ oldText: "before", newText: "after" }],
+			},
+		});
+		expect(run.result.stopReason).toBe("toolUse");
+		expect(run.result.content).toEqual([
+			{ type: "text", text: "Fixing the file now.\n\n" },
+			{
+				type: "toolCall",
+				id: "antml-tool-0",
+				name: "Edit",
+				arguments: { file_path: "some/file.py", edits: [{ oldText: "before", newText: "after" }] },
+			},
+			{ type: "text", text: "\n\nDone." },
+		]);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/antml-format.test.ts
+++ b/packages/ai/test/tool-call-middleware/antml-format.test.ts
@@ -1,0 +1,87 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import {
+	antmlFormatToolCall,
+	antmlFormatToolResponse,
+	antmlFormatToolsSystemPrompt,
+} from "../../src/tool-call-middleware/protocols/antml/format.ts";
+import type { ToolResultContent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({
+		city: Type.String(),
+		unit: Type.Optional(Type.String()),
+	}),
+};
+
+describe("antmlFormatToolsSystemPrompt", () => {
+	it("renders JSON tool definitions and a function_calls-wrapped example", () => {
+		// given
+		const tools = [weatherTool];
+
+		// when
+		const prompt = antmlFormatToolsSystemPrompt(tools);
+		const toolsStart = prompt.lastIndexOf("<tools>") + "<tools>".length;
+		const toolsEnd = prompt.lastIndexOf("</tools>");
+
+		// then
+		expect(JSON.parse(prompt.slice(toolsStart, toolsEnd))).toEqual([
+			{
+				name: weatherTool.name,
+				description: weatherTool.description,
+				parameters: weatherTool.parameters,
+			},
+		]);
+		expect(prompt).toContain("<function_calls>");
+		expect(prompt).toContain('<invoke name="get_weather">');
+		expect(prompt).toContain("</function_calls>");
+	});
+
+	it("returns an empty prompt without tools", () => {
+		// when / then
+		expect(antmlFormatToolsSystemPrompt([])).toBe("");
+	});
+});
+
+describe("antmlFormatToolCall", () => {
+	it("wraps the canonical invoke serialization in a function_calls block", () => {
+		// given
+		const args = { city: "Seoul", tags: ["today", "local"] };
+
+		// when
+		const formatted = antmlFormatToolCall("get_weather", args);
+
+		// then
+		expect(formatted).toBe(
+			"<function_calls>\n" +
+				'<invoke name="get_weather">\n' +
+				'<parameter name="city">Seoul</parameter>\n' +
+				'<parameter name="tags">["today","local"]</parameter>\n' +
+				"</invoke>\n" +
+				"</function_calls>",
+		);
+	});
+});
+
+describe("antmlFormatToolResponse", () => {
+	it("formats tool output as Anthropic-style function results", () => {
+		// given
+		const content: ToolResultContent[] = [{ type: "text", text: "sunny" }];
+
+		// when
+		const formatted = antmlFormatToolResponse("get_weather", "call-1", content);
+
+		// then
+		expect(formatted).toBe(
+			"<function_results>\n" +
+				"<result>\n" +
+				"<tool_name>get_weather</tool_name>\n" +
+				"<stdout>sunny</stdout>\n" +
+				"</result>\n" +
+				"</function_results>",
+		);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/antml-parser.test.ts
+++ b/packages/ai/test/tool-call-middleware/antml-parser.test.ts
@@ -1,0 +1,107 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { parseAntmlGeneratedText } from "../../src/tool-call-middleware/protocols/antml/parse.ts";
+import type { Tool } from "../../src/types.ts";
+
+const bashTool: Tool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({ command: Type.String() }),
+};
+
+const editTool: Tool = {
+	name: "Edit",
+	description: "Edit a file",
+	parameters: Type.Object({
+		file_path: Type.String(),
+		edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+	}),
+};
+
+describe("parseAntmlGeneratedText", () => {
+	it("parses a function_calls-wrapped invoke", () => {
+		// given
+		const text =
+			'<function_calls><invoke name="Bash"><parameter name="command">echo hi</parameter></invoke></function_calls>';
+
+		// when
+		const parsed = parseAntmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command: "echo hi" } }]);
+	});
+
+	it("parses multiple invokes inside one function_calls block", () => {
+		// given
+		const text =
+			"<function_calls>\n" +
+			'<invoke name="Bash"><parameter name="command">one</parameter></invoke>\n' +
+			'<invoke name="Bash"><parameter name="command">two</parameter></invoke>\n' +
+			"</function_calls>";
+
+		// when
+		const parsed = parseAntmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed.map((call) => call.arguments.command)).toEqual(["one", "two"]);
+	});
+
+	it("parses a bare invoke without the wrapper", () => {
+		// given
+		const text = '<invoke name="Bash"><parameter name="command">ls</parameter></invoke>';
+
+		// when
+		const parsed = parseAntmlGeneratedText(text, [bashTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "Bash", arguments: { command: "ls" } }]);
+	});
+
+	it("repairs the Pi edits[] regression instead of rejecting the call", () => {
+		// given: byte-correct edit plus invented trailing keys
+		const text =
+			'<invoke name="Edit">' +
+			'<parameter name="file_path">some/file.py</parameter>' +
+			'<parameter name="edits">[{"oldText":"a","newText":"b","requireUnique":true}]</parameter>' +
+			'<parameter name="notes">extra</parameter>' +
+			"</invoke>";
+
+		// when
+		const parsed = parseAntmlGeneratedText(text, [editTool]);
+
+		// then
+		expect(parsed).toEqual([
+			{
+				name: "Edit",
+				arguments: { file_path: "some/file.py", edits: [{ oldText: "a", newText: "b" }] },
+			},
+		]);
+	});
+
+	it("keeps unknown-tool invokes out of the parse result", () => {
+		// given
+		const text = '<invoke name="Missing"><parameter name="command">x</parameter></invoke>';
+
+		// when / then
+		expect(parseAntmlGeneratedText(text, [bashTool])).toEqual([]);
+	});
+
+	it("reports unrecoverably malformed calls through onError", () => {
+		// given
+		const onError = vi.fn();
+		const text = '<invoke name="Bash"><parameter name="command"></parameter></invoke>';
+		const strictTool: Tool = {
+			...bashTool,
+			parameters: Type.Object({ command: Type.String({ minLength: 1 }) }),
+		};
+
+		// when
+		const parsed = parseAntmlGeneratedText(text, [strictTool], { onError });
+
+		// then
+		expect(parsed).toEqual([]);
+		expect(onError).toHaveBeenCalledWith("Could not process antml tool call, keeping original text.", {
+			toolCall: text,
+		});
+	});
+});

--- a/packages/ai/test/tool-call-middleware/antml-repair.test.ts
+++ b/packages/ai/test/tool-call-middleware/antml-repair.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+	repairLoneSurrogates,
+	repairStringsDeep,
+	repairUnicodeEscapes,
+} from "../../src/tool-call-middleware/protocols/antml/repair.ts";
+
+describe("repairUnicodeEscapes", () => {
+	it("escapes a broken \\u sequence so JSON.parse succeeds", () => {
+		// given
+		const brokenJson = String.raw`{"text":"bad\uZZZZescape"}`;
+
+		// when
+		const repaired = repairUnicodeEscapes(brokenJson);
+
+		// then
+		expect(() => JSON.parse(brokenJson)).toThrow();
+		expect(JSON.parse(repaired)).toEqual({ text: String.raw`bad\uZZZZescape` });
+	});
+
+	it("escapes a truncated \\u sequence with fewer than four hex digits", () => {
+		// given
+		const brokenJson = String.raw`{"text":"cut\u12"}`;
+
+		// when
+		const repaired = repairUnicodeEscapes(brokenJson);
+
+		// then
+		expect(JSON.parse(repaired)).toEqual({ text: String.raw`cut\u12` });
+	});
+
+	it("leaves valid unicode escapes untouched", () => {
+		// given
+		const validJson = String.raw`{"text":"ok\u0041"}`;
+
+		// when
+		const repaired = repairUnicodeEscapes(validJson);
+
+		// then
+		expect(repaired).toBe(validJson);
+		expect(JSON.parse(repaired)).toEqual({ text: "okA" });
+	});
+
+	it("leaves an escaped backslash before u untouched", () => {
+		// given
+		const validJson = String.raw`{"path":"C:\\users"}`;
+
+		// when
+		const repaired = repairUnicodeEscapes(validJson);
+
+		// then
+		expect(repaired).toBe(validJson);
+		expect(JSON.parse(repaired)).toEqual({ path: String.raw`C:\users` });
+	});
+});
+
+describe("repairLoneSurrogates", () => {
+	it("replaces lone high and low surrogates with the replacement character", () => {
+		// given
+		const loneHigh = `bad${"\uD800"}end`;
+		const loneLow = `bad${"\uDC00"}end`;
+
+		// when / then
+		expect(repairLoneSurrogates(loneHigh)).toBe("bad\uFFFDend");
+		expect(repairLoneSurrogates(loneLow)).toBe("bad\uFFFDend");
+	});
+
+	it("keeps valid surrogate pairs intact", () => {
+		// given
+		const emoji = "ok\u{1F600}done";
+
+		// when / then
+		expect(repairLoneSurrogates(emoji)).toBe(emoji);
+	});
+
+	it("replaces a reversed surrogate pair entirely", () => {
+		// given
+		const reversed = `x${"\uDC00"}${"\uD800"}y`;
+
+		// when / then
+		expect(repairLoneSurrogates(reversed)).toBe("x\uFFFD\uFFFDy");
+	});
+});
+
+describe("repairStringsDeep", () => {
+	it("repairs lone surrogates in nested strings and keys", () => {
+		// given
+		const value = {
+			[`k${"\uD800"}`]: [`v${"\uDC00"}`, 1, { inner: `w${"\uD800"}` }],
+		};
+
+		// when
+		const repaired = repairStringsDeep(value);
+
+		// then
+		expect(repaired).toEqual({ "k\uFFFD": ["v\uFFFD", 1, { inner: "w\uFFFD" }] });
+	});
+});

--- a/packages/ai/test/tool-call-middleware/antml-stream.test.ts
+++ b/packages/ai/test/tool-call-middleware/antml-stream.test.ts
@@ -1,0 +1,171 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { createAntmlStreamParser } from "../../src/tool-call-middleware/protocols/antml/stream.ts";
+import type { StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+import { FIXTURE_TOOLS, TRUNCATION_FIXTURES } from "./truncation-fixtures.ts";
+
+const bashTool: Tool = {
+	name: "Bash",
+	description: "Run a shell command",
+	parameters: Type.Object({ command: Type.String() }),
+};
+
+const editTool: Tool = {
+	name: "Edit",
+	description: "Edit a file",
+	parameters: Type.Object({
+		file_path: Type.String(),
+		edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+	}),
+};
+
+function textOutput(events: StreamParserEvent[]): string {
+	return events
+		.filter((event): event is Extract<StreamParserEvent, { type: "text" }> => event.type === "text")
+		.map((event) => event.text)
+		.join("");
+}
+
+function toolCallEnds(events: StreamParserEvent[]): Extract<StreamParserEvent, { type: "toolcall_end" }>[] {
+	return events.filter(
+		(event): event is Extract<StreamParserEvent, { type: "toolcall_end" }> => event.type === "toolcall_end",
+	);
+}
+
+describe("createAntmlStreamParser", () => {
+	it("emits a complete invoke as one tool call with antml ids", () => {
+		// given
+		const parser = createAntmlStreamParser([bashTool]);
+
+		// when
+		const events = [
+			...parser.feed('<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>'),
+			...parser.finish(),
+		];
+
+		// then
+		expect(events).toEqual([
+			{ type: "toolcall_start", index: 0, name: "Bash", id: "antml-tool-0" },
+			{ type: "toolcall_delta", index: 0, argumentsDelta: '{"command":"echo hi"}' },
+			{ type: "toolcall_end", index: 0, name: "Bash", id: "antml-tool-0", arguments: { command: "echo hi" } },
+		]);
+	});
+
+	it("drops the function_calls wrapper while preserving surrounding prose", () => {
+		// given
+		const parser = createAntmlStreamParser([bashTool]);
+		const input =
+			'Before <function_calls><invoke name="Bash"><parameter name="command">ls</parameter></invoke></function_calls> after';
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toHaveLength(1);
+		expect(textOutput(events)).toBe("Before  after");
+		expect(textOutput(events)).not.toContain("function_calls");
+	});
+
+	it("repairs sloppy nested arguments in the streaming path", () => {
+		// given
+		const parser = createAntmlStreamParser([editTool]);
+		const input =
+			'<invoke name="Edit">' +
+			'<parameter name="path">f.py</parameter>' +
+			'<parameter name="edits">[{"oldText":"a","newText":"b","requireUnique":true}]</parameter>' +
+			"</invoke>";
+
+		// when
+		const events = [...parser.feed(input), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toEqual([
+			expect.objectContaining({
+				name: "Edit",
+				arguments: { file_path: "f.py", edits: [{ oldText: "a", newText: "b" }] },
+			}),
+		]);
+	});
+
+	it("suppresses an unrecoverably malformed known invoke and reports it", () => {
+		// given
+		const onError = vi.fn();
+		const countTool: Tool = {
+			name: "Count",
+			description: "Count",
+			parameters: Type.Object({ count: Type.Number() }),
+		};
+		const parser = createAntmlStreamParser([countTool], { onError });
+		const call = '<invoke name="Count"><parameter name="count">not-a-number</parameter></invoke>';
+
+		// when
+		const events = [...parser.feed(`Before ${call} after`), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toHaveLength(0);
+		expect(textOutput(events)).toBe("Before  after");
+		expect(onError).toHaveBeenCalledWith("Could not process streaming antml tool call, keeping original text.", {
+			toolCall: call,
+		});
+	});
+
+	it("flags an incomplete known invoke at finish", () => {
+		// given
+		const onError = vi.fn();
+		const parser = createAntmlStreamParser([bashTool], { onError });
+
+		// when
+		const events = [...parser.feed('<invoke name="Bash"><parameter name="command">ls'), ...parser.finish()];
+
+		// then
+		expect(toolCallEnds(events)).toEqual([
+			expect.objectContaining({
+				incomplete: true,
+				errorMessage: "Tool call was truncated mid-arguments",
+			}),
+		]);
+		expect(onError).toHaveBeenCalledWith("antml tool call truncated at finish", {
+			protocol: "antml",
+			retainedLength: expect.any(Number),
+		});
+	});
+
+	it.each(TRUNCATION_FIXTURES["anthropic-xml"])("handles truncation fixture: $title", (fixture) => {
+		// given: invoke-level truncation semantics are shared with anthropic-xml
+		const onError = vi.fn();
+		const parser = createAntmlStreamParser(FIXTURE_TOOLS, {
+			emitRawToolCallTextOnError: true,
+			onError,
+		});
+
+		// when
+		const events = [...parser.feed(fixture.input), ...parser.finish()];
+		const ends = toolCallEnds(events);
+
+		// then
+		switch (fixture.expected.kind) {
+			case "recovered":
+				expect(ends).toEqual([
+					expect.objectContaining({ name: fixture.tool, arguments: fixture.expected.arguments }),
+				]);
+				expect(ends[0]?.incomplete).toBeUndefined();
+				break;
+			case "incomplete":
+				expect(ends).toEqual([expect.objectContaining({ name: fixture.tool, incomplete: true })]);
+				expect(textOutput(events)).not.toContain("<invoke");
+				expect(JSON.stringify(onError.mock.calls)).not.toContain(fixture.input);
+				break;
+			case "dropped":
+				expect(ends).toEqual([]);
+				expect(events.filter((event) => event.type.startsWith("toolcall_"))).toEqual([]);
+				expect(textOutput(events)).not.toContain(fixture.input);
+				expect(onError).toHaveBeenCalledOnce();
+				break;
+			case "text":
+				expect(ends).toEqual([]);
+				expect(textOutput(events)).toContain(fixture.input);
+				break;
+		}
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added `antml` as a valid `compat.toolCallFormat` in custom `models.json` provider and model definitions: ANTML `<function_calls>`/`<invoke>` text-tool protocol with Claude-Code-style failure tolerance.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/test/antml-registration.test.ts
+++ b/packages/coding-agent/test/antml-registration.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { getProtocol, getToolCallFormat } from "../../ai/src/tool-call-middleware/index.ts";
+import type { Model, Tool } from "../../ai/src/types.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRegistry } from "../src/core/model-registry.ts";
+
+const editTool: Tool = {
+	name: "Edit",
+	description: "Edit a file",
+	parameters: Type.Object({
+		file_path: Type.String(),
+		edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+	}),
+};
+
+const antmlModel = {
+	id: "antml-model",
+	name: "ANTML model",
+	api: "openai-completions",
+	provider: "registration-test",
+	baseUrl: "https://example.invalid/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 1024,
+	compat: { toolCallFormat: "antml" },
+} satisfies Model<"openai-completions">;
+
+describe("antml registration", () => {
+	let tempDir: string | undefined;
+
+	afterEach(() => {
+		if (tempDir !== undefined) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
+
+	it("repairs a sloppy Edit invocation when the antml protocol is resolved", () => {
+		// Given
+		const generatedText =
+			"<function_calls>" +
+			'<invoke name="Edit">' +
+			'<parameter name="path">a.py</parameter>' +
+			'<parameter name="edits">[{"oldText":"x","newText":"y","requireUnique":true}]</parameter>' +
+			"</invoke>" +
+			"</function_calls>";
+
+		// When
+		const parsed = getProtocol("antml").parseGeneratedText(generatedText, [editTool]);
+
+		// Then
+		expect(parsed).toEqual([
+			{
+				name: "Edit",
+				arguments: { file_path: "a.py", edits: [{ oldText: "x", newText: "y" }] },
+			},
+		]);
+	});
+
+	it("activates antml for an openai-completions model with compat", () => {
+		// When
+		const format = getToolCallFormat(antmlModel);
+
+		// Then
+		expect(format).toBe("antml");
+	});
+
+	it("accepts antml in a models.json compatibility block", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-antml-registration-"));
+		const modelsJsonPath = join(tempDir, "models.json");
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"registration-test": {
+						api: "openai-completions",
+						baseUrl: "https://example.invalid/v1",
+						compat: { toolCallFormat: "antml" },
+						models: [{ id: "antml-model" }],
+					},
+				},
+			}),
+		);
+
+		// When
+		const registry = ModelRegistry.create(AuthStorage.create(join(tempDir, "auth.json")), modelsJsonPath);
+
+		// Then
+		expect(registry.getError()).toBeUndefined();
+		expect(registry.find("registration-test", "antml-model")?.id).toBe("antml-model");
+	});
+});


### PR DESCRIPTION
## Summary

Newer Claude models (Opus 4.8, Sonnet 5) emit byte-correct tool calls but append invented trailing keys (`requireUnique`, `oldText2`, `type`, …), substitute parameter aliases (`path` for `file_path`, `old_str` for `old_string`), and occasionally produce broken `\uXXXX` escapes — slop that Claude Code's own harness absorbs silently while a strict parser rejects the entire call and forces a retry. This was documented in Armin Ronacher's *Better Models: Worse Tools* (2026-07-04) against Pi's nested `edits[]` edit tool.

This PR ports **ANTML** — the `<function_calls>` / `<invoke>` / `<parameter>` format Anthropic models are post-trained on — as a new `antml` text-tool protocol with Claude-Code-style failure tolerance, so these calls succeed instead of bouncing.

After this change, a custom OpenAI-compatible model can set `"toolCallFormat": "antml"` in `models.json` and have sloppy ANTML tool calls repaired and executed instead of rejected.

## Changes

**Shared core refactor** (`protocols/anthropic-xml/parse.ts`, `stream.ts`, new `invoke-protocol.ts`)
- Introduced `InvokeProtocolConfig` (protocol id, label, tool-call id prefix, coercion strategy) and routed the shared `<invoke>`/`<parameter>` batch + stream parsers through it. anthropic-xml's behavior is byte-identical — same messages, ids, and event sequence; this only extracts the knobs so a sibling protocol reuses the battle-tested scanner/stream machinery instead of forking it.

**New `antml` protocol** (`protocols/antml/`)
- `repair.ts` — `\u` escape repair (so broken escapes stay JSON-parseable) and lone-surrogate replacement with U+FFFD.
- `coerce-parameters.ts` — validation-gated repairs mirroring Claude Code: case/separator-insensitive property matching plus a documented alias table; recursive unknown-key filtering honoring `additionalProperties`; lenient scalar spellings (`" TRUE "`, `'"2"'`); duplicate-parameter last-wins. Every repaired record must still pass the tool's JSON-schema `Value.Check`, so repairs only *narrow* input, never invent it — preserving the middleware's strict-parsing contract.
- `format.ts` — formatted output wraps the canonical invoke serialization in `<function_calls>`; input accepts both wrapped and bare invokes.
- Registered in the protocol registry, `ToolCallFormat` union, the `getToolCallFormat()` whitelist (the only enforcement point for `compat.toolCallFormat`), and the `types.ts` doc comment. Truncation-at-finish recovery inherits the shared R1–R4 boundary.

**Docs** — middleware `AGENTS.md`, `changes.md` fork tracker, `TESTING.md` manual-test matrix, and the ai + coding-agent changelogs.

## QA & Evidence

- **What was tested:** 6 new test files (repair, coerce, format, parser, stream, faux-provider e2e) + coding-agent registration test, plus the full existing anthropic-xml suite to prove the refactor didn't regress it.
  **Observed result:** `packages/ai` tool-call-middleware suite — 366/366 pass. `packages/coding-agent` full suite — 424 files / 3703 tests, 0 failures.
  **Why sufficient:** covers the unit coercion contract, streaming/truncation boundary, and the registered wire format end to end.

- **What was tested:** `npm run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, tsgo, browser smoke, web-ui, neo).
  **Observed result:** exit 0.
  **Why sufficient:** the repo's full static validation gate.

- **What was tested:** a senpi-qa mock-loop driver (`local-ignore/antml-mock-loop.mjs`) that runs the **real CLI** against a local fake model server with `toolCallFormat: "antml"`. The scripted turn emits ANTML slop text — an aliased `cmd` parameter plus invented `requireUnique`/`type` keys — and the run asserts the middleware canonicalizes `cmd`→`command`, filters the slop, executes bash, and feeds the result back to the model.
  **Observed result:** 7/7 checks pass; turn-2 request shows the canonical `<parameter name="command">echo ANTML-LOOP-OK-5f21</parameter>` and `<function_results><stdout>ANTML-LOOP-OK-5f21</stdout></function_results>` with the invented keys removed.
  **Artifact:** `local-ignore/qa-evidence/20260718-antml-protocol/` (sanitized requests, stdout/stderr, summary).
  **Why sufficient:** proves the real binary activates the middleware and completes the repair→execute→feedback loop, not just the unit contract.

## Risks & Residuals

- **Risk:** the `anthropic-xml` refactor could have changed behavior. **Mitigated:** its messages, ids, and event sequence are byte-identical; the full pre-existing anthropic-xml suite (batch, stream, scanner, e2e, truncation) still passes unchanged.
- **Risk:** tolerance could let genuinely-malformed calls through. **Mitigated:** every repair is gated by schema validation — a call that can't be repaired to a schema-valid record is rejected exactly like before.
- **Residual:** truncation-e2e matrix isn't extended to `antml` yet; antml's truncation behavior is covered by the shared-core truncation fixtures reused in `antml-stream.test.ts` (all six anthropic-xml fixtures transfer identically).

## Related

Inspired by https://lucumr.pocoo.org/2026/7/4/better-models-worse-tools/ and earendil-works/pi#6278.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `antml` tool-call protocol that parses ANTML `<function_calls>/<invoke>` and repairs sloppy calls (aliases, extra keys, broken `\u` escapes) so they execute instead of being rejected. Also parameterizes the invoke parse/stream core so `anthropic-xml` remains byte-identical while `antml` reuses it.

- **New Features**
  - `antml` protocol with Claude-Code-style failure tolerance: resolves parameter aliases, filters unknown keys recursively (respects `additionalProperties`), repairs unicode escapes and lone surrogates, and accepts lenient scalar spellings; all repairs are schema-validated.
  - Accepts wrapped or bare invokes on input; formats output wrapped in `<function_calls>`; streaming drops the wrapper and emits `antml-tool-*` ids with the same truncation handling as `anthropic-xml`.
  - Enable via `compat.toolCallFormat: "antml"` in `models.json`; docs and tests added, existing suites pass.

- **Refactors**
  - Introduces `InvokeProtocolConfig` to drive a shared `<invoke>`/`<parameter>` parser and stream; `anthropic-xml` behavior is unchanged while `antml` plugs in its own coercion strategy.

<sup>Written for commit 7af4302407f90fe87ca0e735e88a129c673015b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

