### PR TITLE
fix: make ESC interrupt reliably release a running bash tool

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -61,3 +61,25 @@ subscribe before a session created by the convenience factory has already starte
 merges, preserve the close-writer → close-master → join-reader sequence, the N-API delivery
 acknowledgement, and listener-before-start construction. Expected conflict zones are native session
 lifecycle code, the N-API `startPtySession` callback, and terminal runtime construction.
+
+## Foreground abort/timeout must release the tool (2026-07-18)
+
+- `tools/bash.ts`: foreground abort now sends one decisive group `SIGKILL` (the pi-pty `kill()` is one-shot
+  idempotent, so a first gentle SIGTERM would block escalation and a SIGTERM-ignoring command pinned the agent
+  forever). The exit wait is raced against `KILLED_SESSION_EXIT_GRACE_MS` (new in `shared.ts`, 5s) armed on abort
+  and on `timeoutMs + grace`: the native wait joins the PTY reader thread, which blocks while any surviving
+  descendant (own process group, inherited slave fd) holds the PTY open — previously ESC appeared dead while
+  "Running bash" counted up for hours. When the grace releases the wait, the session entry may settle later
+  through the registry's own `onExit` subscription (an unkillable holder can keep it `stopping`).
+- Aborted foreground runs now report `Command aborted` (core bash parity) instead of `Command exited with code
+  137`; timeout-grace releases report the standard `Command timed out after N seconds`.
+- A signal already aborted at execute-entry returns `Command aborted` without spawning a session; the
+  timeout-grace timer is not armed when `timeoutMs + grace` exceeds the 32-bit `setTimeout` range (no false
+  early timeout); on a grace release the tool sweeps the session via `ctx.manager.stop(id)` (fire-and-forget).
+- `@earendil-works/pi-pty` `SessionRegistry` gained `stopExitGraceMs` (default 5s): `stop()`/`teardown()` now
+  bound their exit wait and mark a never-settling session `stopping` instead of hanging — without this, the
+  terminal extension's awaited `manager.teardown()` made `/exit` hang on the same held-open PTY. Residual: a
+  `stopping` entry still occupies a registry slot until its exit finally settles (capacity cap 32).
+- Regression coverage: `test/terminal-bash-abort.test.ts` (pre-aborted signal spawns nothing, SIGTERM-ignoring
+  command, PTY held open across abort and timeout, plain-run pin) and `packages/pty/test/registry.test.ts`
+  (bounded stop/teardown on a session that never reports exit).

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
@@ -24,6 +24,13 @@ export const DEFAULT_MAX_SESSIONS = 32;
 export const MAX_SESSION_OUTPUT_CHARS = 1_000_000;
 /** Grace window used to capture a background command's early output before returning its id. */
 export const BACKGROUND_START_GRACE_MS = 250;
+/**
+ * After a foreground session has been killed (abort or timeout), how long to keep
+ * waiting for its exit to settle before releasing the tool anyway. A surviving
+ * descendant that holds the PTY open (or a kill that never lands) must not keep
+ * the agent blocked forever.
+ */
+export const KILLED_SESSION_EXIT_GRACE_MS = 5000;
 export const DEFAULT_OUTPUT_WAIT_TIMEOUT_SECONDS = 30;
 
 /**

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
@@ -1,5 +1,12 @@
 import { type Static, Type } from "typebox";
-import { BACKGROUND_START_GRACE_MS, DEFAULT_COLS, DEFAULT_ROWS, TERMINAL_BASH_TOOL } from "../shared.ts";
+import type { TerminalRuntimeSession } from "../runtime-session.ts";
+import {
+	BACKGROUND_START_GRACE_MS,
+	DEFAULT_COLS,
+	DEFAULT_ROWS,
+	KILLED_SESSION_EXIT_GRACE_MS,
+	TERMINAL_BASH_TOOL,
+} from "../shared.ts";
 import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
 import { describeExit, spawnCommandSession } from "./spawn.ts";
 
@@ -33,6 +40,56 @@ function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+type ForegroundWaitOutcome = "exited" | "abort_grace" | "timeout_grace";
+
+/**
+ * Wait for the session's exit to settle, but stop waiting a bounded grace after
+ * the session has been killed. The native wait joins the PTY reader thread,
+ * which blocks while any surviving descendant holds the PTY open — without the
+ * grace, an aborted or timed-out command can pin the agent forever.
+ */
+function raceExitWithKillGrace(
+	runtime: TerminalRuntimeSession,
+	signal: AbortSignal | undefined,
+	timeoutMs: number | undefined,
+): Promise<ForegroundWaitOutcome> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let abortGraceTimer: ReturnType<typeof setTimeout> | undefined;
+		let timeoutGraceTimer: ReturnType<typeof setTimeout> | undefined;
+		let armAbortGrace: (() => void) | undefined;
+		const settle = (finish: () => void) => {
+			if (settled) return;
+			settled = true;
+			if (abortGraceTimer) clearTimeout(abortGraceTimer);
+			if (timeoutGraceTimer) clearTimeout(timeoutGraceTimer);
+			if (signal && armAbortGrace) signal.removeEventListener("abort", armAbortGrace);
+			finish();
+		};
+		runtime.session.waitExit().then(
+			() => settle(() => resolve("exited")),
+			(error: unknown) => settle(() => reject(error instanceof Error ? error : new Error(String(error)))),
+		);
+		if (timeoutMs !== undefined) {
+			const timeoutGraceDeadlineMs = timeoutMs + KILLED_SESSION_EXIT_GRACE_MS;
+			// Beyond the 32-bit setTimeout range the deadline cannot be represented;
+			// keep the unbounded wait rather than firing a false early timeout.
+			if (timeoutGraceDeadlineMs <= MAX_TIMEOUT_MS) {
+				timeoutGraceTimer = setTimeout(() => settle(() => resolve("timeout_grace")), timeoutGraceDeadlineMs);
+			}
+		}
+		if (signal) {
+			armAbortGrace = () => {
+				abortGraceTimer ??= setTimeout(() => settle(() => resolve("abort_grace")), KILLED_SESSION_EXIT_GRACE_MS);
+			};
+			if (signal.aborted) armAbortGrace();
+			else signal.addEventListener("abort", armAbortGrace, { once: true });
+		}
+	});
+}
+
 async function runForeground(
 	ctx: TerminalToolContext,
 	input: PtyBashInput,
@@ -41,25 +98,41 @@ async function runForeground(
 	signal: AbortSignal | undefined,
 	cwd: string | undefined,
 ): Promise<TerminalToolResult> {
+	if (signal?.aborted) return errorResult("Command aborted");
 	const timeoutMs = input.timeout !== undefined ? Math.trunc(input.timeout * 1000) : undefined;
-	const { runtime } = await spawnCommandSession(ctx, { command: input.command, cols, rows, timeoutMs, cwd });
-	const onAbort = () => runtime.session.kill();
+	const { id, runtime } = await spawnCommandSession(ctx, { command: input.command, cols, rows, timeoutMs, cwd });
+	// Interrupt means "stop now": SIGKILL the whole process group in one shot.
+	// kill() is one-shot idempotent, so a gentle SIGTERM first would block any
+	// escalation, and a SIGTERM-ignoring command would pin the agent forever.
+	const onAbort = () => runtime.session.kill("SIGKILL");
 	if (signal) {
 		if (signal.aborted) onAbort();
 		else signal.addEventListener("abort", onAbort, { once: true });
 	}
+	let outcome: ForegroundWaitOutcome;
 	try {
-		await runtime.session.waitExit();
+		outcome = await raceExitWithKillGrace(runtime, signal, timeoutMs);
 	} finally {
 		signal?.removeEventListener("abort", onAbort);
 	}
 
+	if (outcome !== "exited") {
+		// Sweep the never-settling session: the bounded registry stop marks it
+		// `stopping`, so later /exit teardown cannot hang on its exit wait.
+		void ctx.manager.stop(id).catch(() => {});
+	}
 	const output = runtime.fullOutput().trimEnd();
-	const status = describeExit(runtime);
+	// Aborted runs report "Command aborted" (core bash parity) whether the exit
+	// settled normally or the kill grace released the wait. `outcome` matters
+	// beyond that only for the timeout grace, where exitResult is still null.
+	if (signal?.aborted) {
+		return errorResult(`${output ? `${output}\n\n` : ""}Command aborted`);
+	}
 	const exit = runtime.exitResult;
-	if (exit?.timedOut) {
+	if (outcome === "timeout_grace" || exit?.timedOut) {
 		return errorResult(`${output ? `${output}\n\n` : ""}Command timed out after ${input.timeout} seconds`);
 	}
+	const status = describeExit(runtime);
 	if (exit && exit.exitCode !== 0 && exit.exitCode !== null) {
 		return errorResult(`${output ? `${output}\n\n` : ""}Command exited with code ${exit.exitCode}`);
 	}

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -108,8 +108,13 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 			if (child.pid) trackDetachedChildPid(child.pid);
 			let timedOut = false;
 			let timeoutHandle: NodeJS.Timeout | undefined;
+			// Fires once the process tree has been killed so waitForChildProcess
+			// stops preserving output tails; descendants that survive the group
+			// kill must not keep the aborted command running forever.
+			const killedController = new AbortController();
 			const onAbort = () => {
 				if (child.pid) killProcessTree(child.pid);
+				killedController.abort();
 			};
 
 			try {
@@ -117,7 +122,7 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 				if (timeoutMs !== undefined) {
 					timeoutHandle = setTimeout(() => {
 						timedOut = true;
-						if (child.pid) killProcessTree(child.pid);
+						onAbort();
 					}, timeoutMs);
 				}
 				// Stream stdout and stderr.
@@ -130,7 +135,7 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 				}
 				// Handle shell spawn errors and wait for the process to terminate without hanging
 				// on inherited stdio handles held by detached descendants.
-				const exitCode = await waitForChildProcess(child);
+				const exitCode = await waitForChildProcess(child, { signal: killedController.signal });
 				if (signal?.aborted) {
 					throw new Error("aborted");
 				}
@@ -139,7 +144,18 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 				}
 				return { exitCode };
 			} finally {
-				if (child.pid) untrackDetachedChildPid(child.pid);
+				const pid = child.pid;
+				if (pid !== undefined) {
+					if (child.exitCode !== null || child.signalCode !== null) {
+						untrackDetachedChildPid(pid);
+					} else {
+						// The kill grace released the wait while the child is still
+						// alive (kill pending): keep it tracked so shutdown cleanup
+						// retries, and unref it so it cannot pin the event loop.
+						child.unref();
+						child.once("exit", () => untrackDetachedChildPid(pid));
+					}
+				}
 				if (timeoutHandle) clearTimeout(timeoutHandle);
 				if (signal) signal.removeEventListener("abort", onAbort);
 			}

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -113,3 +113,30 @@
 ### Files modified
 
 - `bash.ts`
+
+## Bash abort releases the wait despite surviving descendants (2026-07-18)
+
+### What changed
+
+- `bash.ts` (`createLocalBashOperations`): abort and timeout kills now also abort an internal `killedController`
+  whose signal is passed to `waitForChildProcess`. Once the tree has been killed, the wait stops preserving output
+  tails and resolves within a bounded grace even when an escaped descendant keeps the inherited stdout/stderr pipe
+  open (see `utils/changes.md` same date).
+
+### Why
+
+- ESC-abort (and timeout) killed the detached process group, but the tool only returns when
+  `waitForChildProcess` resolves. Descendants in their own process group that survived `kill(-pid)` and kept
+  chattering re-armed the idle grace forever: "Running bash" counted up for hours and repeated ESC was a no-op.
+
+- When the grace releases the wait while the child is still alive (kill pending), the pid stays in the
+  detached-children shutdown cleanup set until the child actually exits, and the child is `unref()`ed so an
+  abandoned handle cannot pin the event loop.
+
+### Why extension system couldn't handle this
+
+- The hang is inside the core tool's own exec/wait loop; extensions cannot interpose on it.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: the abort/timeout handler block inside `createLocalBashOperations`.

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -137,3 +137,28 @@
 ### Expected merge conflict zones on next upstream sync
 
 - LOW: version-check URL and user-agent formatting utilities.
+
+## Bash abort/timeout wait release (2026-07-18)
+
+### What changed
+
+- `child-process.ts`: `waitForChildProcess` accepts `options?: { signal?: AbortSignal; abortExitGraceMs?: number }`.
+  When the signal aborts (the caller has killed the process and abandoned its output), tail preservation ends: the
+  stdio pipes are destroyed so descendants that survived the kill cannot re-arm the post-exit idle grace forever,
+  and the wait resolves on `exit` — or after `abortExitGraceMs` (default 5s) when the kill never lands
+  (uninterruptible IO, failed `taskkill`).
+
+### Why
+
+- Aborting (ESC) or timing out a bash command killed the process group but completion still waited on
+  `waitForChildProcess`, whose pi#5303 idle grace re-arms on every chunk. A daemonized/`detached` descendant that
+  escaped the group kill and kept writing into the inherited pipe pinned the tool — and the agent's abort — forever.
+
+### Why extension system couldn't handle this
+
+- The wait lives inside the core bash tool's local execution backend; no extension hook can release a promise the
+  core tool is awaiting.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `waitForChildProcess` signature and the listener wiring around the pi#5303 idle-grace logic.

--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -14,6 +14,19 @@ import type { Readable } from "node:stream";
 import crossSpawn from "cross-spawn";
 
 const EXIT_STDIO_GRACE_MS = 250;
+const ABORT_EXIT_GRACE_MS = 5000;
+
+export interface WaitForChildProcessOptions {
+	/**
+	 * Abort when the caller has killed the process and no longer needs its
+	 * output. The wait then stops preserving stdio tails (descendants that
+	 * survived the kill can no longer hold it open) and resolves as soon as
+	 * the process exits, or after `abortExitGraceMs` if it never does.
+	 */
+	signal?: AbortSignal;
+	/** Post-abort deadline for `exit` before resolving anyway. Default 5s. */
+	abortExitGraceMs?: number;
+}
 
 export function spawnProcess(
 	command: string,
@@ -45,13 +58,20 @@ export function spawnProcessSync(
  * the grace timer is re-armed on every chunk, so an actively writing descendant keeps
  * us reading, while a quiet inherited handle (e.g. a Windows daemonized descendant
  * that never lets `close` fire) still releases us after the grace elapses.
+ *
+ * When `options.signal` aborts, the caller has killed the process and
+ * abandoned its output: tail preservation ends, the pipes are destroyed, and
+ * the wait resolves on `exit` — or after `abortExitGraceMs` when the kill
+ * never lands (uninterruptible IO, failed taskkill).
  */
-export function waitForChildProcess(child: ChildProcess): Promise<number | null> {
+export function waitForChildProcess(child: ChildProcess, options?: WaitForChildProcessOptions): Promise<number | null> {
 	return new Promise((resolve, reject) => {
 		let settled = false;
 		let exited = false;
 		let exitCode: number | null = null;
 		let postExitTimer: NodeJS.Timeout | undefined;
+		let abortGraceTimer: NodeJS.Timeout | undefined;
+		let detachAbortListener: (() => void) | undefined;
 		let stdoutEnded = child.stdout === null;
 		let stderrEnded = child.stderr === null;
 
@@ -59,6 +79,14 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 			if (postExitTimer) {
 				clearTimeout(postExitTimer);
 				postExitTimer = undefined;
+			}
+			if (abortGraceTimer) {
+				clearTimeout(abortGraceTimer);
+				abortGraceTimer = undefined;
+			}
+			if (detachAbortListener) {
+				detachAbortListener();
+				detachAbortListener = undefined;
 			}
 			child.removeListener("error", onError);
 			child.removeListener("exit", onExit);
@@ -126,6 +154,21 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 			finalize(code);
 		};
 
+		const onAbortRelease = () => {
+			// The caller killed the process and abandoned its output: destroy our
+			// read ends so surviving descendants cannot re-arm the idle grace
+			// forever, then wait only for `exit`, bounded by the abort grace.
+			child.stdout?.destroy();
+			child.stderr?.destroy();
+			stdoutEnded = true;
+			stderrEnded = true;
+			if (exited) {
+				maybeFinalizeAfterExit();
+				return;
+			}
+			abortGraceTimer = setTimeout(() => finalize(exitCode), options?.abortExitGraceMs ?? ABORT_EXIT_GRACE_MS);
+		};
+
 		child.stdout?.once("end", onStdoutEnd);
 		child.stderr?.once("end", onStderrEnd);
 		child.stdout?.on("data", onData);
@@ -133,5 +176,15 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 		child.once("error", onError);
 		child.once("exit", onExit);
 		child.once("close", onClose);
+
+		const abortSignal = options?.signal;
+		if (abortSignal) {
+			if (abortSignal.aborted) {
+				onAbortRelease();
+			} else {
+				abortSignal.addEventListener("abort", onAbortRelease, { once: true });
+				detachAbortListener = () => abortSignal.removeEventListener("abort", onAbortRelease);
+			}
+		}
 	});
 }

--- a/packages/coding-agent/test/bash-abort-hang.test.ts
+++ b/packages/coding-agent/test/bash-abort-hang.test.ts
@@ -1,0 +1,182 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createLocalBashOperations } from "../src/core/tools/bash.ts";
+import { waitForChildProcess } from "../src/utils/child-process.ts";
+
+/**
+ * Aborting a bash command must release the tool promptly even when a
+ * descendant process survives the process-group SIGKILL.
+ *
+ * `createLocalBashOperations` kills the detached shell's process group on
+ * abort/timeout, but completion is gated on `waitForChildProcess`, whose
+ * post-exit idle grace re-arms on every stdio chunk (pi#5303 tail
+ * preservation). A descendant that escaped the group kill (own process
+ * group / daemonized) and keeps writing to the inherited stdout pipe
+ * therefore re-arms the grace forever: the tool never returns, the agent's
+ * abort awaits it forever, and ESC appears dead while "Running bash"
+ * counts up. These tests pin that abort/timeout always release the wait.
+ */
+
+function toShellSingleQuotedArg(value: string): string {
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/**
+ * Direct child spawns a chattering grandchild in its OWN process group
+ * (detached) that inherits stdout, records its pid, then stays alive until
+ * killed. Killing the shell's process group leaves the grandchild running
+ * and writing into the inherited pipe every 40ms.
+ */
+const ORPHAN_PARENT_SCRIPT = `
+const { spawn } = require("node:child_process");
+const { writeFileSync } = require("node:fs");
+const child = spawn(process.execPath, ["-e", "setInterval(() => console.log('orphan-tick'), 40);"], {
+	detached: true,
+	stdio: ["ignore", "inherit", "ignore"],
+});
+writeFileSync(process.argv[2], String(child.pid));
+child.unref();
+console.log("parent-ready");
+setInterval(() => {}, 1000);
+`;
+
+function killPidFromFile(pidFile: string): void {
+	if (!existsSync(pidFile)) {
+		return;
+	}
+	const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+	if (Number.isFinite(pid) && pid > 0) {
+		try {
+			process.kill(pid, "SIGKILL");
+		} catch {
+			// Already gone.
+		}
+	}
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timeoutId = setTimeout(() => {
+			reject(new Error(`${label}: wait did not release within ${ms}ms`));
+		}, ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timeoutId);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timeoutId);
+				reject(error);
+			},
+		);
+	});
+}
+
+describe.skipIf(process.platform === "win32")("bash abort releases the wait", () => {
+	let testDir: string;
+	let scriptPath: string;
+	const pidFiles: string[] = [];
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `senpi-bash-abort-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(testDir, { recursive: true });
+		scriptPath = join(testDir, "orphan-parent.cjs");
+		writeFileSync(scriptPath, ORPHAN_PARENT_SCRIPT);
+	});
+
+	afterEach(() => {
+		for (const pidFile of pidFiles) {
+			killPidFromFile(pidFile);
+		}
+		pidFiles.length = 0;
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	function orphanCommand(pidFile: string): string {
+		pidFiles.push(pidFile);
+		return `${toShellSingleQuotedArg(process.execPath)} ${toShellSingleQuotedArg(scriptPath)} ${toShellSingleQuotedArg(pidFile)}`;
+	}
+
+	it("rejects with aborted when a plain long-running command is interrupted", async () => {
+		const ops = createLocalBashOperations();
+		const controller = new AbortController();
+		let aborted = false;
+
+		const execPromise = ops.exec("echo started; sleep 60", testDir, {
+			onData: (data) => {
+				if (!aborted && data.toString().includes("started")) {
+					aborted = true;
+					controller.abort();
+				}
+			},
+			signal: controller.signal,
+		});
+
+		await expect(withTimeout(execPromise, 8000, "plain abort")).rejects.toThrow("aborted");
+	});
+
+	it("rejects with aborted while an escaped descendant keeps writing to the inherited pipe", async () => {
+		const ops = createLocalBashOperations();
+		const controller = new AbortController();
+		const pidFile = join(testDir, "orphan-abort.pid");
+		let aborted = false;
+
+		const execPromise = ops.exec(orphanCommand(pidFile), testDir, {
+			onData: (data) => {
+				// First tick proves the escaped grandchild is alive and chattering.
+				if (!aborted && data.toString().includes("orphan-tick")) {
+					aborted = true;
+					controller.abort();
+				}
+			},
+			signal: controller.signal,
+		});
+
+		await expect(withTimeout(execPromise, 8000, "abort with chattering orphan")).rejects.toThrow("aborted");
+	});
+
+	it("rejects with timeout while an escaped descendant keeps writing to the inherited pipe", async () => {
+		const ops = createLocalBashOperations();
+		const pidFile = join(testDir, "orphan-timeout.pid");
+
+		const execPromise = ops.exec(orphanCommand(pidFile), testDir, {
+			onData: () => {},
+			timeout: 1,
+		});
+
+		await expect(withTimeout(execPromise, 8000, "timeout with chattering orphan")).rejects.toThrow("timeout:1");
+	});
+
+	it("resolves after the abort exit grace when the killed process never exits", async () => {
+		// Nobody kills the child here: this simulates a kill that did not take
+		// effect (uninterruptible IO, taskkill failure). The abort grace must
+		// still release the wait instead of blocking the agent forever.
+		const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const controller = new AbortController();
+
+		const wait = waitForChildProcess(child, { signal: controller.signal, abortExitGraceMs: 300 });
+		controller.abort();
+
+		try {
+			const exitCode = await withTimeout(wait, 8000, "abort exit grace");
+			expect(exitCode).toBeNull();
+			// The wait gave up on the process, not the other way round.
+			expect(() => {
+				if (child.pid) process.kill(child.pid, 0);
+			}).not.toThrow();
+		} finally {
+			if (child.pid) {
+				try {
+					process.kill(child.pid, "SIGKILL");
+				} catch {
+					// Already gone.
+				}
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/terminal-bash-abort.test.ts
+++ b/packages/coding-agent/test/terminal-bash-abort.test.ts
@@ -1,0 +1,191 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TerminalManager } from "../src/core/extensions/builtin/terminal/manager.ts";
+import { createPtyBashTool } from "../src/core/extensions/builtin/terminal/tools/bash.ts";
+import type { TerminalToolContext, TerminalToolResult } from "../src/core/extensions/builtin/terminal/tools/context.ts";
+
+/**
+ * Interrupting the PTY-backed `bash` tool must release the tool promptly.
+ *
+ * Two production hangs are pinned here:
+ * - abort used to send a one-shot group SIGTERM, so a command that survives
+ *   SIGTERM kept `waitExit` blocked forever;
+ * - even after the shell died, the native wait joins the PTY reader thread,
+ *   which blocks while an escaped descendant (own process group, inherited
+ *   slave fd) holds the PTY open — ESC appeared dead while "Running bash"
+ *   counted up for hours.
+ */
+
+const ORPHAN_PARENT_SCRIPT = `
+const { spawn } = require("node:child_process");
+const { writeFileSync } = require("node:fs");
+const tickerSrc =
+	"const fs=require('node:fs');let first=true;" +
+	"setInterval(()=>{console.log('orphan-tick');if(first){first=false;fs.writeFileSync(process.argv[1],'1');}},40);";
+const child = spawn(process.execPath, ["-e", tickerSrc, process.argv[2] + ".ticked"], {
+	detached: true,
+	stdio: ["ignore", "inherit", "ignore"],
+});
+writeFileSync(process.argv[2], String(child.pid));
+child.unref();
+console.log("parent-ready");
+setInterval(() => {}, 1000);
+`;
+
+function toShellSingleQuotedArg(value: string): string {
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function resultText(result: TerminalToolResult): string {
+	return result.content.map((block) => block.text).join("\n");
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<void> {
+	const start = Date.now();
+	while (!existsSync(path)) {
+		if (Date.now() - start > timeoutMs) throw new Error(`file did not appear within ${timeoutMs}ms: ${path}`);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timeoutId = setTimeout(() => {
+			reject(new Error(`${label}: did not release within ${ms}ms`));
+		}, ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timeoutId);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timeoutId);
+				reject(error);
+			},
+		);
+	});
+}
+
+describe.skipIf(process.platform === "win32")("PTY bash tool abort releases the wait", () => {
+	let testDir: string;
+	let scriptPath: string;
+	let manager: TerminalManager;
+	let ctx: TerminalToolContext;
+	const pidFiles: string[] = [];
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `senpi-pty-abort-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(testDir, { recursive: true });
+		scriptPath = join(testDir, "orphan-parent.cjs");
+		writeFileSync(scriptPath, ORPHAN_PARENT_SCRIPT);
+		manager = new TerminalManager();
+		ctx = {
+			manager,
+			cwd: testDir,
+			defaultCols: 80,
+			defaultRows: 24,
+			getEnv: () => ({ ...process.env }),
+		};
+	});
+
+	afterEach(async () => {
+		for (const pidFile of pidFiles) {
+			if (!existsSync(pidFile)) continue;
+			const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+			if (Number.isFinite(pid) && pid > 0) {
+				try {
+					process.kill(pid, "SIGKILL");
+				} catch {
+					// Already gone.
+				}
+			}
+		}
+		pidFiles.length = 0;
+		await withTimeout(manager.teardown(), 15000, "manager teardown");
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	function orphanCommand(pidFile: string): string {
+		pidFiles.push(pidFile);
+		return `${toShellSingleQuotedArg(process.execPath)} ${toShellSingleQuotedArg(scriptPath)} ${toShellSingleQuotedArg(pidFile)}`;
+	}
+
+	it("returns aborted without spawning when the signal is already aborted", async () => {
+		const tool = createPtyBashTool(ctx);
+		const controller = new AbortController();
+		controller.abort();
+
+		const result = await withTimeout(
+			tool.execute("call-0", { command: "echo never-runs" }, controller.signal, undefined, undefined),
+			5000,
+			"pre-aborted execute",
+		);
+		expect(result.isError).toBe(true);
+		expect(resultText(result)).toContain("Command aborted");
+		expect(manager.size).toBe(0);
+	});
+
+	it("runs a plain command to completion", async () => {
+		const tool = createPtyBashTool(ctx);
+		const result = await withTimeout(
+			tool.execute("call-1", { command: "echo pty-ok" }, undefined, undefined, undefined),
+			10000,
+			"plain command",
+		);
+		expect(result.isError).toBeFalsy();
+		expect(resultText(result)).toContain("pty-ok");
+	});
+
+	it("aborts a command that ignores SIGTERM", async () => {
+		const tool = createPtyBashTool(ctx);
+		const controller = new AbortController();
+		const marker = join(testDir, "trap-ready");
+		const command = `trap '' TERM; touch ${toShellSingleQuotedArg(marker)}; while :; do sleep 0.2; done`;
+
+		const execution = tool.execute("call-2", { command }, controller.signal, undefined, undefined);
+		await waitForFile(marker, 10000);
+		controller.abort();
+
+		const result = await withTimeout(execution, 4000, "abort of SIGTERM-ignoring command");
+		expect(resultText(result)).toContain("Command aborted");
+	});
+
+	it("aborts within the exit grace while an escaped descendant holds the PTY open", async () => {
+		const tool = createPtyBashTool(ctx);
+		const controller = new AbortController();
+		const pidFile = join(testDir, "orphan-abort.pid");
+
+		const execution = tool.execute(
+			"call-3",
+			{ command: orphanCommand(pidFile) },
+			controller.signal,
+			undefined,
+			undefined,
+		);
+		await waitForFile(`${pidFile}.ticked`, 10000);
+		controller.abort();
+
+		const result = await withTimeout(execution, 8000, "abort with PTY held open");
+		expect(result.isError).toBe(true);
+		expect(resultText(result)).toContain("Command aborted");
+	});
+
+	it("times out within the exit grace while an escaped descendant holds the PTY open", async () => {
+		const tool = createPtyBashTool(ctx);
+		const pidFile = join(testDir, "orphan-timeout.pid");
+
+		const execution = tool.execute(
+			"call-4",
+			{ command: orphanCommand(pidFile), timeout: 1 },
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const result = await withTimeout(execution, 10000, "timeout with PTY held open");
+		expect(result.isError).toBe(true);
+		expect(resultText(result)).toContain("Command timed out after 1 seconds");
+	});
+});

--- a/packages/pty/src/registry-session.ts
+++ b/packages/pty/src/registry-session.ts
@@ -39,11 +39,30 @@ export async function stopTerminalSession(session: SessionRegistrySession): Prom
 	if (session.signal) await session.signal(DEFAULT_SIGNAL);
 }
 
-export async function waitForTerminalSessionExit(session: SessionRegistrySession): Promise<boolean> {
+export async function waitForTerminalSessionExit(session: SessionRegistrySession, graceMs?: number): Promise<boolean> {
 	if (isTerminalSessionExited(session)) return true;
 	// Invoke via the session object (not a detached reference) so `this` is preserved.
-	if (session.waitExit) await session.waitExit();
-	else if (session.wait) await session.wait();
-	else return false;
+	const wait = session.waitExit ? session.waitExit() : session.wait ? session.wait() : null;
+	if (wait === null) return false;
+	if (graceMs === undefined) {
+		await wait;
+		return isTerminalSessionExited(session);
+	}
+	let graceTimer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const exitSettled = await Promise.race([
+			Promise.resolve(wait).then(() => true),
+			new Promise<false>((resolve) => {
+				graceTimer = setTimeout(() => resolve(false), graceMs);
+			}),
+		]);
+		if (!exitSettled) {
+			// The wait may still settle (or reject) long after we stopped caring.
+			void Promise.resolve(wait).catch(() => {});
+			return false;
+		}
+	} finally {
+		if (graceTimer) clearTimeout(graceTimer);
+	}
 	return isTerminalSessionExited(session);
 }

--- a/packages/pty/src/registry-types.ts
+++ b/packages/pty/src/registry-types.ts
@@ -73,6 +73,12 @@ export interface SessionRegistryOptions<TSession extends SessionRegistrySession 
 	readonly killProcess?: (target: number, signal: TerminalSessionSignal) => void;
 	readonly now?: () => number;
 	readonly platform?: string;
+	/**
+	 * How long `stop()` waits for a killed session to report exit before marking
+	 * it `stopping` and returning. Guards against sessions whose exit never
+	 * settles (e.g. a surviving descendant holding the PTY open). Default 5s.
+	 */
+	readonly stopExitGraceMs?: number;
 }
 
 export type StoredSessionRegistryEntry<TSession extends SessionRegistrySession> = {

--- a/packages/pty/src/registry.ts
+++ b/packages/pty/src/registry.ts
@@ -37,6 +37,8 @@ import { SessionRegistryCapacityError } from "./registry-types.ts";
 
 const DEFAULT_MAX_SESSIONS = 32;
 const DEFAULT_COMMAND = "bash";
+const DEFAULT_STOP_EXIT_GRACE_MS = 5000;
+const MAX_STOP_EXIT_GRACE_MS = 2_147_483_647;
 
 export class SessionRegistry<TSession extends SessionRegistrySession = SessionRegistrySession> {
 	private readonly entries = new Map<string, StoredSessionRegistryEntry<TSession>>();
@@ -47,9 +49,16 @@ export class SessionRegistry<TSession extends SessionRegistrySession = SessionRe
 	private readonly platform: string;
 	private sequence = 0;
 	readonly maxSessions: number;
+	private readonly stopExitGraceMs: number;
 
 	constructor(options: SessionRegistryOptions<TSession> = {}) {
 		this.maxSessions = normalizeMaxSessions(options.maxSessions);
+		this.stopExitGraceMs =
+			options.stopExitGraceMs !== undefined &&
+			Number.isFinite(options.stopExitGraceMs) &&
+			options.stopExitGraceMs > 0
+				? Math.min(options.stopExitGraceMs, MAX_STOP_EXIT_GRACE_MS)
+				: DEFAULT_STOP_EXIT_GRACE_MS;
 		this.createSession = options.createSession ?? null;
 		this.killProcess = options.killProcess ?? defaultKillProcess;
 		this.now = options.now ?? Date.now;
@@ -193,7 +202,7 @@ export class SessionRegistry<TSession extends SessionRegistrySession = SessionRe
 		await this.cleanupDetachedChildren(entry);
 		if (entry.state !== "exited") {
 			await stopTerminalSession(entry.session);
-			if (await waitForTerminalSessionExit(entry.session)) {
+			if (await waitForTerminalSessionExit(entry.session, this.stopExitGraceMs)) {
 				this.markExited(entry);
 			} else {
 				entry.state = "stopping";

--- a/packages/pty/test/registry.test.ts
+++ b/packages/pty/test/registry.test.ts
@@ -257,3 +257,56 @@ describe("sessionIdPrefix", () => {
 		expect(sessionIdPrefix("pwsh.exe")).toBe("pwsh");
 	});
 });
+
+class HeldOpenSession implements SessionRegistrySession {
+	readonly command = "bash";
+	stopCalls = 0;
+
+	get isExited(): boolean {
+		return false;
+	}
+
+	stop(): void {
+		this.stopCalls += 1;
+	}
+
+	waitExit(): Promise<unknown> {
+		return new Promise(() => {});
+	}
+}
+
+async function resolvesWithin<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const watchdog = setTimeout(() => reject(new Error(`${label} hung past ${ms}ms`)), ms);
+		promise.then(
+			(value) => {
+				clearTimeout(watchdog);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(watchdog);
+				reject(error);
+			},
+		);
+	});
+}
+
+describe("SessionRegistry stop grace", () => {
+	it("stop resolves within the grace when a killed session never reports exit", async () => {
+		const registry = new SessionRegistry({ stopExitGraceMs: 100 });
+		const session = new HeldOpenSession();
+		const entry = await registry.create({ session });
+
+		await expect(resolvesWithin(registry.stop(entry.id), 3000, "stop")).resolves.toBe(true);
+		expect(session.stopCalls).toBe(1);
+		expect(registry.get(entry.id)?.state).toBe("stopping");
+	});
+
+	it("teardown resolves while a killed session still holds its PTY open", async () => {
+		const registry = new SessionRegistry({ stopExitGraceMs: 100 });
+		await registry.create({ session: new HeldOpenSession() });
+
+		await expect(resolvesWithin(registry.teardown(), 3000, "teardown")).resolves.toBeUndefined();
+		expect(registry.size).toBe(0);
+	});
+});


### PR DESCRIPTION
## Problem

Pressing ESC on a running `bash` tool sometimes does nothing: `Running bash: … (4h 37m • esc to interrupt)` keeps counting forever and repeated ESC is a no-op. `/exit` could hang on the same condition.

## Root causes (all verified by failing-first tests)

1. **Core bash tool** (`core/tools/bash.ts` + `utils/child-process.ts`): abort/timeout SIGKILLs the detached process group, but completion waits on `waitForChildProcess`, whose post-exit idle grace (pi#5303 tail preservation) is re-armed on every stdio chunk. A descendant that escaped the group kill (own process group) and keeps writing into the inherited pipe re-arms it forever.
2. **PTY terminal builtin — the default `bash` tool** (`extensions/builtin/terminal/`): abort sent a one-shot group SIGTERM (`pi-pty` `kill()` is idempotent, so no escalation), which SIGTERM-ignoring commands survive; and even after the shell dies, the native wait joins the PTY reader thread, which blocks while any surviving descendant holds the PTY slave open.
3. **`pi-pty` `SessionRegistry`**: `stop()`/`teardown()` awaited the same never-settling exit, so the terminal extension's awaited `manager.teardown()` reproduced the hang on `/exit`.

## Fix

- `waitForChildProcess(child, { signal, abortExitGraceMs })`: once the caller has killed the process, tail preservation ends — pipes are destroyed and the wait resolves on exit or after a bounded grace (5s). Both abort and timeout kills use it. Non-aborted runs are untouched (pi#5303 behavior pinned by its regression test).
- PTY foreground bash: decisive group SIGKILL on abort; exit wait raced against `KILLED_SESSION_EXIT_GRACE_MS` armed on abort and on `timeout + grace`; pre-aborted signals return without spawning; grace releases sweep the session via the registry; aborted runs report `Command aborted` (core-bash parity).
- `SessionRegistry` gains `stopExitGraceMs` (default 5s): `stop()`/`teardown()` bound their exit wait and mark a never-settling session `stopping` instead of hanging.

`changes.md` entries added in `src/utils/`, `src/core/tools/`, and `builtin/terminal/` per the fork contract.

## Why not an extension

The hangs live inside the core tool's own exec/wait loop, the terminal builtin, and `pi-pty` — no extension hook can release a promise the tool is awaiting.

## Verification

- New failing-first regression tests (all hung before the fix, bounded-green after):
  - `packages/coding-agent/test/bash-abort-hang.test.ts` — plain abort pin; abort and timeout with a chattering escaped descendant; abort-exit grace when the kill never lands.
  - `packages/coding-agent/test/terminal-bash-abort.test.ts` — pre-aborted signal spawns nothing; SIGTERM-ignoring command; PTY held open across abort and timeout; plain-run pin.
  - `packages/pty/test/registry.test.ts` — bounded `stop()`/`teardown()` on a session that never reports exit.
- Suites: `packages/pty` 41 passed; `packages/coding-agent` full vitest 3725 passed / 0 failed; `tsgo --noEmit`, Biome, pinned-deps/ts-imports/shrinkwrap/install-lock/browser-smoke/web-ui/neo checks all green.
- Real-CLI QA (senpi-qa harness, isolated sandbox, mock model; receipts under `local-ignore/qa-evidence/20260718-esc-bash-abort/`):
  - RPC channel: turn runs bash spawning an escaped chattering grandchild; `{"type":"abort"}` releases the turn in ~5.0s, session idle, `Command aborted` in the event stream.
  - Real TUI in tmux: literal ESC keypress renders `Command aborted` ~5.1s later and the working row disappears — previously infinite.
  - Real `~/.senpi` auth untouched; all spawned processes/sessions cleaned up.

## Known residual (documented, follow-up)

A `stopping` registry entry still occupies one of 32 session slots while an unkillable holder lives; freeing it early needs a force-close API in `pi-pty` with its own exactly-once exit-race review. Adjacent surfaces sharing the same seam (`core/exec.ts` execCommand, hooks `command-runner.ts`) were audited and left unchanged to keep this PR scoped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ESC now reliably interrupts running `bash` tools and releases control within ~5 seconds. Fixes hangs where abort/timeout could wait forever if a descendant kept stdout/PTY open.

- **Bug Fixes**
  - Core `bash`: `waitForChildProcess(child, { signal, abortExitGraceMs })` ends tail preservation after kill, destroys pipes, and resolves on exit or after a 5s grace; used for both abort and timeout.
  - PTY `bash`: send one group `SIGKILL` on abort; foreground wait bounded by `KILLED_SESSION_EXIT_GRACE_MS` (5s); pre-aborted signals return without spawning; errors show “Command aborted” or “Command timed out after N seconds”.
  - `@earendil-works/pi-pty` `SessionRegistry`: `stop()`/`teardown()` bound by `stopExitGraceMs` (default 5s) and mark stuck sessions `stopping`, preventing `/exit` from hanging.

<sup>Written for commit b08522469533fc3029ecc89e0224d7bd06adb357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

