### PR TITLE
fix(senpi-codemode): stop injecting omp intent field into py tool bridge calls

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed the Python kernel's `tool.<name>()` proxy injecting an omp-only `i` ("py prelude") intent field into every bridged tool call. Senpi tool schemas never declare `i`, so strict tools (`additionalProperties: false`, e.g. `web_search`) rejected every eval-bridged call with `Validation failed for tool …: must not have additional properties`. Args now pass through verbatim, matching the JS/Ruby/Julia preludes.
+
 ### Removed
 
 ## [2026.7.17-5] - 2026-07-17

--- a/packages/senpi-codemode/src/kernels/py/prelude.py
+++ b/packages/senpi-codemode/src/kernels/py/prelude.py
@@ -326,7 +326,6 @@ class ToolCallable:
                 f"tool.{self._name}(...) expects a dict of arguments (got {type(args).__name__})"
             )
         merged.update(kwargs)
-        merged.setdefault("i", "py prelude")
         return bridge_post(
             "/call",
             {"callId": f"py-{uuid.uuid4()}", "toolName": self._name, "args": merged},

--- a/packages/senpi-codemode/test/py-kernel.test.ts
+++ b/packages/senpi-codemode/test/py-kernel.test.ts
@@ -137,7 +137,11 @@ describe.skipIf(!(await hasPython3()))("PythonKernel live", () => {
 				valueRepr: expect.stringContaining("'echoed': True"),
 			});
 			expect(requests).toHaveLength(1);
-			expect(requests[0]).toMatchObject({ toolName: "echo_tool", args: { q: "hi" } });
+			expect(requests[0]?.toolName).toBe("echo_tool");
+			// Strict equality: the prelude must forward args verbatim — no injected
+			// harness fields (e.g. omp's `i` intent key) that strict tool schemas
+			// (additionalProperties: false) would reject at executeTool validation.
+			expect(requests[0]?.args).toEqual({ q: "hi" });
 			expect(requests[0]?.callId).toMatch(/^py-/);
 		} finally {
 			await kernel.close();


### PR DESCRIPTION
## Summary

The Python kernel's `tool.<name>()` proxy injected an omp-only intent field — `"i": "py prelude"` — into every bridged tool call. Senpi has no intent-field convention: no tool schema declares `i`, and `pi.executeTool` runs the same argument preflight as the agent loop (`prepareAgentToolCall` → `validateToolArguments`). Any tool with a strict schema (`additionalProperties: false`, e.g. a `web_search` extension tool) therefore rejected **every** eval-bridged call:

```
Validation failed for tool "web_search":
  - root: must not have additional properties

Received arguments:
{
  "query": "Super Mario Bros World 1-1 layout ...",
  "i": "py prelude"
}
```

After this PR the Python prelude forwards args verbatim, matching the JS/Ruby/Julia preludes (none of which inject anything).

## Root cause

`packages/senpi-codemode` is a port of oh-my-pi's eval subsystem. oh-my-pi injects `INTENT_FIELD` (`i`) in its preludes as a transcript label, and tolerates it everywhere: its model path strips it via `extractIntent`, its MCP bridge strips it via `stripHarnessIntent`, and its eval bridge calls `tool.execute` without schema validation. The injection line (`merged.setdefault("i", "py prelude")`) was carried over in the port, but Senpi validates bridged calls against the real tool schema — so the omp-ism became a hard failure. Only the Python prelude had it.

## Changes

- **`src/kernels/py/prelude.py`** — removed the `merged.setdefault("i", "py prelude")` line from `ToolCallable.__call__`. Args now pass through exactly as the cell wrote them.
- **`test/py-kernel.test.ts`** — the loopback-bridge test previously used `toMatchObject`, which tolerates extra keys (exactly why this slipped through). It now asserts strict equality on the bridged args (`toEqual({ q: "hi" })`), so any future injected field fails the suite.
- **`CHANGELOG.md`** — `[Unreleased] > Fixed` entry.

## QA & Evidence

Evidence dir: `local-ignore/qa-evidence/20260719-py-prelude-intent-field/` (in the working tree; `local-ignore/` is untracked by design).

- **What was tested:** End-to-end repro driver — real `PythonKernel` + real loopback bridge whose `onCall` mirrors `agent-session.executeTool` (`validateToolArguments` with a strict `additionalProperties: false` `web_search` schema).
  - **On `main` (unfixed):** cell fails; bridged args = `{"query": ..., "i": "py prelude"}`; error is byte-for-byte the one from the originating session (`must not have additional properties`). → reproduces the bug.
  - **On this branch:** cell succeeds; bridged args = `{"query": ...}`; no `i`. → fix verified on the real kernel, not a mock.
  - **Artifacts:** `qa-repro-main.txt`, `qa-fixed-worktree.txt`, `qa-driver.mts`.
- **What was tested:** Mutation check — temporarily restoring the injection line and running the updated `py-kernel.test.ts`.
  - **Observed:** the new strict assertion fails (1 failed). → the regression test actually defends the contract.
- **What was tested:** Full `senpi-codemode` suite and repo gate.
  - **Observed:** `52 test files / 365 tests passed`; `npm run check` exits 0 (biome, pinned deps, ts-imports, shrinkwrap, install-lock, tsgo, browser smoke, web-ui check, neo build+vet+test). Artifact: `npm-check.log`.
- **Originating failure:** senpi session `mario-omo-fable5` 2026-07-19T10:32 (dys-launched senpi run); excerpt saved as `failing-session-excerpt.txt`.

## Risks & Residuals

- The `i` key was consumed by nothing on the Senpi side (no renderer, no status event reads it) — verified by grep across `senpi-codemode/src`. Removing it changes no observable behavior other than un-breaking strict tools. Risk: none identified.
- JS/Ruby/Julia preludes never injected the field; no parity ledger (`test/PARITY.md`) entry pins the injection. Confirmed no other test asserts `i` exists.
- A model may still *habitually* pass `i` itself (trained on omp-style guides); that is user input, surfaces the same clear validation error, and is out of scope here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the omp-only `i` intent field from Python `tool.<name>()` bridge calls so strict tools stop rejecting eval-bridged calls. Args now pass through verbatim, matching the JS/Ruby/Julia preludes.

- **Bug Fixes**
  - Removed injection of `i` ("py prelude") in Python kernel tool calls, fixing failures with strict schemas (e.g. `web_search`).
  - Tightened the loopback test to assert exact args (`toEqual`) to guard against future injected keys.
  - Updated `CHANGELOG.md`.

<sup>Written for commit 5a93aaec1551df9997916ae1dd70069ac4de928c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

