### PR TITLE
feat(tui): configurable render fps cap (30-120)

### DIFF
--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,28 @@
 # TUI delta rendering fork changes
 
+## 2026-07-19: configurable render fps cap and shared segmenter exports
+
+### What changed
+
+- `packages/tui/src/tui.ts`: the static 16ms render throttle (`MIN_RENDER_INTERVAL_MS`) is now an instance field
+  `#minRenderIntervalMs` (default 16ms — behavior unchanged for existing callers) plus `setMaxRenderFps(fps)`:
+  fps is clamped to 30-120 and stored as `Math.floor(1000 / fps)` (120fps ⇒ 8ms interval).
+- `packages/tui/src/index.ts`: exports `getGraphemeSegmenter` and `getWordSegmenter` from `utils.ts` so consumers
+  (smooth-streaming reveal in coding-agent) share the single `Intl.Segmenter` instances.
+- Tests: `packages/tui/test/render-fps-cap.test.ts` (mocked-timer throttle-delay assertions) and
+  `packages/tui/test/segmenter-exports.test.ts` (root re-export identity).
+
+### Why this cannot be expressed externally
+
+The render throttle is `TUI`-private scheduler state; extensions and components can request renders but cannot
+safely replace the minimum frame interval. The segmenters already existed as module singletons in `utils.ts` — only
+the package-root export surface was missing.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/tui.ts` around the scheduler field declarations and `scheduleRender()`.
+- LOW: `packages/tui/src/index.ts` around the `utils.ts` re-export list.
+
 ## 2026-07-04: terminal ownership and restart hardening
 
 ### What changed

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -118,4 +118,11 @@ export {
 	TUI,
 } from "./tui.ts";
 // Utilities
-export { sliceByColumn, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "./utils.ts";
+export {
+	getGraphemeSegmenter,
+	getWordSegmenter,
+	sliceByColumn,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "./utils.ts";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -473,7 +473,8 @@ export class TUI extends Container {
 	private renderRequested = false;
 	private renderTimer: NodeJS.Timeout | undefined;
 	private lastRenderAt = 0;
-	private static readonly MIN_RENDER_INTERVAL_MS = 16;
+	/** Minimum interval between scheduled renders. Default preserves the historic ~60fps cap. */
+	#minRenderIntervalMs = 16;
 	private inputRenderPending = false;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
@@ -953,12 +954,22 @@ export class TUI extends Container {
 		process.nextTick(() => this.scheduleRender());
 	}
 
+	/**
+	 * Cap the render scheduler at `fps` frames per second. Values are clamped
+	 * to 30-120fps (120fps yields an 8ms minimum interval). Never calling this
+	 * preserves the historic 16ms (~60fps) throttle.
+	 */
+	setMaxRenderFps(fps: number): void {
+		const clamped = Math.min(120, Math.max(30, Math.round(fps)));
+		this.#minRenderIntervalMs = Math.floor(1000 / clamped);
+	}
+
 	private scheduleRender(): void {
 		if (this.stopped || this.renderTimer || !this.renderRequested) {
 			return;
 		}
 		const elapsed = performance.now() - this.lastRenderAt;
-		const delay = Math.max(0, TUI.MIN_RENDER_INTERVAL_MS - elapsed);
+		const delay = Math.max(0, this.#minRenderIntervalMs - elapsed);
 		this.renderTimer = setTimeout(() => {
 			this.renderTimer = undefined;
 			if (this.stopped || !this.renderRequested) {

--- a/packages/tui/test/render-fps-cap.test.ts
+++ b/packages/tui/test/render-fps-cap.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert";
+import { describe, it, mock } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class TestComponent implements Component {
+	lines: string[] = [];
+	render(_width: number): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+function flushNextTick(): Promise<void> {
+	return new Promise((resolve) => process.nextTick(resolve));
+}
+
+function viewportHas(terminal: VirtualTerminal, text: string): boolean {
+	return terminal.getViewport().some((line) => line.includes(text));
+}
+
+/** Deterministic: setTimeout and performance.now() are both mocked, no wall-clock is read. */
+async function measureRenderIntervalMs(configure?: (tui: TUI) => void): Promise<number> {
+	mock.timers.enable({ apis: ["setTimeout"], now: 1_000 });
+	let fakeNow = 1_000;
+	mock.method(performance, "now", () => fakeNow);
+	// Advance both mocked clocks 1ms, then flush xterm's zero-delay parse timer and real nextTicks.
+	const pump = async (): Promise<void> => {
+		fakeNow += 1;
+		mock.timers.tick(1);
+		mock.timers.tick(0);
+		await flushNextTick();
+	};
+	try {
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		component.lines = ["first"];
+		tui.addChild(component);
+		configure?.(tui);
+		tui.start();
+
+		// First render: elapsed since t=0 exceeds any throttle interval, so it
+		// fires as soon as timers advance and seeds lastRenderAt.
+		let firstRendered = false;
+		for (let waited = 0; waited < 200 && !firstRendered; waited++) {
+			await pump();
+			firstRendered = viewportHas(terminal, "first");
+		}
+		assert.ok(firstRendered, "initial render never happened");
+
+		// Second render: time has not advanced since the first render fired, so
+		// scheduleRender() applies the full throttle delay.
+		component.lines = ["second"];
+		tui.requestRender();
+		await flushNextTick();
+		for (let delay = 1; delay <= 200; delay++) {
+			await pump();
+			if (viewportHas(terminal, "second")) {
+				tui.stop();
+				return delay;
+			}
+		}
+		assert.fail("throttled render never happened");
+	} finally {
+		mock.restoreAll();
+		mock.timers.reset();
+	}
+}
+
+describe("TUI render fps cap", () => {
+	it("keeps the historic 16ms throttle by default", async () => {
+		assert.strictEqual(await measureRenderIntervalMs(), 16);
+	});
+
+	it("keeps a 16ms interval at 60fps", async () => {
+		assert.strictEqual(await measureRenderIntervalMs((tui) => tui.setMaxRenderFps(60)), 16);
+	});
+
+	it("sets a 33ms interval at 30fps", async () => {
+		assert.strictEqual(await measureRenderIntervalMs((tui) => tui.setMaxRenderFps(30)), 33);
+	});
+
+	it("sets an 8ms interval at 120fps", async () => {
+		assert.strictEqual(await measureRenderIntervalMs((tui) => tui.setMaxRenderFps(120)), 8);
+	});
+
+	it("floors the interval (90fps -> 11ms)", async () => {
+		assert.strictEqual(await measureRenderIntervalMs((tui) => tui.setMaxRenderFps(90)), 11);
+	});
+
+	it("clamps sub-30fps values up to 30fps", async () => {
+		assert.strictEqual(await measureRenderIntervalMs((tui) => tui.setMaxRenderFps(29)), 33);
+	});
+
+	it("clamps above-120fps values down to 120fps", async () => {
+		assert.strictEqual(await measureRenderIntervalMs((tui) => tui.setMaxRenderFps(121)), 8);
+	});
+});

--- a/packages/tui/test/segmenter-exports.test.ts
+++ b/packages/tui/test/segmenter-exports.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { getGraphemeSegmenter, getWordSegmenter } from "../src/index.ts";
+import * as utils from "../src/utils.ts";
+
+describe("segmenter package-root exports", () => {
+	it("re-exports the shared grapheme segmenter", () => {
+		assert.strictEqual(getGraphemeSegmenter, utils.getGraphemeSegmenter);
+		const segmenter = getGraphemeSegmenter();
+		assert.strictEqual(segmenter, getGraphemeSegmenter(), "expected one shared instance");
+		assert.strictEqual(segmenter.resolvedOptions().granularity, "grapheme");
+		const segments = [...segmenter.segment("a👍🏽b")];
+		assert.strictEqual(segments.length, 3, "emoji modifier sequence must stay one cluster");
+	});
+
+	it("re-exports the shared word segmenter", () => {
+		assert.strictEqual(getWordSegmenter, utils.getWordSegmenter);
+		assert.strictEqual(getWordSegmenter(), getWordSegmenter(), "expected one shared instance");
+		assert.strictEqual(getWordSegmenter().resolvedOptions().granularity, "word");
+	});
+});


### PR DESCRIPTION
## Summary

Makes the TUI render throttle configurable. The differential renderer previously capped scheduled renders at a hardcoded static 16ms (~60fps). It is now an instance field (default still 16ms, so existing behavior is unchanged) with a new `TUI.setMaxRenderFps(fps)` setter that clamps to 30-120fps and stores `Math.floor(1000 / fps)` as the minimum render interval — 120fps yields an 8ms interval.

This is the foundation PR for token-level smooth streaming: the reveal controller ticks at a configurable fps and needs the render scheduler to keep up. Also exports the shared `getGraphemeSegmenter()` / `getWordSegmenter()` from the package root so consumers (the upcoming reveal controller) reuse the single `Intl.Segmenter` instances instead of constructing their own.

Observable change: none by default. Only callers that invoke `setMaxRenderFps()` see a higher/lower render cap.

## Changes

- **`packages/tui/src/tui.ts`** — render scheduler: `private static readonly MIN_RENDER_INTERVAL_MS = 16` replaced by instance field `#minRenderIntervalMs = 16`; new `setMaxRenderFps(fps)` (clamp 30-120, `floor(1000/fps)`); the single usage in `scheduleRender()` updated.
- **`packages/tui/src/index.ts`** — package-root exports: `getGraphemeSegmenter`, `getWordSegmenter` re-exported from `utils.ts` alongside the existing width helpers.
- **`packages/tui/test/render-fps-cap.test.ts`** (new) — deterministic scheduler tests.
- **`packages/tui/test/segmenter-exports.test.ts`** (new) — export identity tests.
- **`packages/tui/src/changes.md`** — fork change entry per repo convention.

## QA & Evidence

- **Scoped unit tests**: `npm test` in `packages/tui` — 990 tests, exit 0. Log: `tui-npm-test.txt`.
- **New throttle tests**: 7 cases assert the exact scheduled delay between two renders under fully mocked timers (`mock.timers` for `setTimeout`, `mock.method` for `performance.now`; no wall-clock read, no timing luck): default 16ms, 60fps→16ms, 30fps→33ms, 120fps→8ms, 90fps→11ms (floor), 29→33ms (clamp up), 121→8ms (clamp down). Sufficient because `scheduleRender()`'s delay is the only behavioral surface of the change and it is measured exactly, not approximated.
- **Segmenter export tests**: root re-exports are `strictEqual` to the `utils.ts` functions and return one shared instance; grapheme segmentation keeps an emoji modifier sequence as one cluster.
- **Static validation**: `npm run check` from repo root — exit 0 (all workspaces + `check:neo` Go build/vet/test). Log: `npm-run-check.txt`.
- **senpi-qa Channel 2 (TUI smoke, tmux driver)**: `--self-test` 5/5 — TUI boots, renders non-empty screen, keystroke reaches composer, clean teardown, real auth untouched. Artifacts: `tui-smoke.txt`, `tui-smoke-tmux.txt`.
- **senpi-qa Channel 4 (CLI smoke)**: `--self-test` 7/7 — `--help`/`--version`/offline `--list-models`/unknown-flag handling. Transcript: `cli-smoke.txt`.
- Evidence root: `local-ignore/qa-evidence/20260719-tui-render-fps-cap/`.

## Risks

- **Default behavior unchanged**: the field default is the previous static value (16ms), and nothing in this PR calls `setMaxRenderFps`, so current users see zero difference.
- **Higher fps = more renders**: future callers setting 120fps get 8ms scheduling; the differential renderer already handles per-frame diffing, and this PR only widens the cap — it does not change any render-path logic (frame guards, viewport strategies, cursor bookkeeping untouched).
- **New API surface**: `setMaxRenderFps` is additive; no signatures were removed or altered.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the `TUI` render throttle configurable (30–120 fps) to enable smoother streaming; default remains ~60 fps with no change unless set. Also exported shared segmenters from the `packages/tui` root so consumers reuse one `Intl.Segmenter` instance.

- **New Features**
  - `TUI.setMaxRenderFps(fps)` clamps to 30–120 and sets `Math.floor(1000 / fps)` as the min render interval (120 fps → 8 ms).
  - Root exports `getGraphemeSegmenter` and `getWordSegmenter` for shared `Intl.Segmenter` instances.

<sup>Written for commit e91ea471085992b1762cda663c59fed24bd0f94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

