### PR TITLE
fix(coding-agent): incremental assistant message re-render

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## Incremental assistant message re-render (2026-07-19)
+
+### What changed
+
+- `modes/interactive/components/assistant-message.ts`: assistant content is now planned as flat render descriptors
+  and reconciled against the previous child list. Unchanged children stay mounted, growing text/thinking Markdown
+  updates through `Markdown.setText()`, and structural changes rebuild only the divergent suffix.
+- `../test/assistant-message-incremental-render.test.ts`: exact raw-render parity covers text, thinking,
+  provider-native blocks, error tails, hidden thinking, expansion, and output padding; identity assertions pin the
+  incremental reuse contract.
+
+### Why
+
+- Streaming updates previously cleared the entire content container, so every delta recreated all Markdown children
+  and discarded their instance render caches even when only the final block grew.
+
+### Why extension system couldn't handle this
+
+- The built-in assistant component owns transcript child identity, disposal, render caching, and OSC marker behavior;
+  extensions cannot reconcile its private render tree.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `modes/interactive/components/assistant-message.ts` around content construction and streaming cache reuse.
+
 ## Neo launch handoff and daemon dispatch (2026-07-06)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## incremental assistant message re-render (2026-07-19)
+
+### What changed
+
+- `components/assistant-message.ts`: replaces full child teardown on every assistant streaming delta with a flat
+  descriptor reconciliation. Stable children are reused, same-kind Markdown changes update in place, and the first
+  kind/text/list divergence rebuilds only the remaining suffix.
+- `../../../test/assistant-message-incremental-render.test.ts`: compares incremental output byte-for-byte with fresh
+  components across the supported block shapes and verifies leading and growing Markdown identities remain stable.
+
+### Why
+
+- Clearing the content container made every streamed token recreate preceding Markdown components, keeping their
+  instance caches cold and repeatedly re-lexing already-finished blocks.
+
+### Why extension system couldn't handle this
+
+- Assistant transcript child reconciliation is private host-renderer state; an extension cannot retain or replace the
+  built-in component's nested children.
+
+### Expected merge conflict zones
+
+- MEDIUM: `components/assistant-message.ts` around descriptor construction, child reconciliation, and render-cache
+  invalidation.
+
 ## eval tool call single-box render (2026-07-17)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import { type Component, Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import { formatProviderNativeBody, formatProviderNativeSummary } from "../../provider-native-rendering.ts";
 import { getMarkdownTheme, theme } from "../theme/theme.ts";
 import { createBoundedRenderSignature } from "./render-signature.ts";
@@ -8,13 +8,34 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
-/**
- * Component that renders a complete assistant message
- */
+type MarkdownDescriptorKind = "text-md" | "thinking-md";
+type TextDescriptorKind = "thinking-label" | "provider-native-summary" | "provider-native-body" | "error-text";
+type RenderDescriptorKind = "spacer" | MarkdownDescriptorKind | TextDescriptorKind;
+type RenderDescriptor = { readonly kind: RenderDescriptorKind; readonly text: string };
+
+const SPACER_DESCRIPTOR = { kind: "spacer", text: "" } as const satisfies RenderDescriptor;
+
+function assertNever(value: never): never {
+	throw new TypeError(`Unexpected assistant render variant: ${String(value)}`);
+}
+
+function isVisibleContent(content: AssistantMessage["content"][number], providerNativeVisible: boolean): boolean {
+	switch (content.type) {
+		case "text":
+			return Boolean(content.text.trim());
+		case "thinking":
+			return Boolean(content.thinking.trim());
+		case "providerNative":
+			return providerNativeVisible;
+		case "toolCall":
+			return false;
+		default:
+			return assertNever(content);
+	}
+}
+
 export class AssistantMessageComponent extends Container {
-	private cachedLines?: string[];
-	private cachedSignature?: string;
-	private cachedWidth?: number;
+	private renderCache?: { readonly lines: string[]; readonly signature: string; readonly width: number };
 	private contentContainer: Container;
 	private hideThinkingBlock: boolean;
 	private markdownTheme: MarkdownTheme;
@@ -22,6 +43,7 @@ export class AssistantMessageComponent extends Container {
 	private outputPad: number;
 	private lastMessage?: AssistantMessage;
 	private lastMessageSignature?: string;
+	private renderDescriptors: readonly RenderDescriptor[] = [];
 	private hasToolCalls = false;
 	private expanded = false;
 
@@ -43,61 +65,44 @@ export class AssistantMessageComponent extends Container {
 		this.contentContainer = new Container();
 		this.addChild(this.contentContainer);
 
-		if (message) {
-			this.updateContent(message);
-		}
+		if (message) this.updateContent(message);
 	}
 
 	override invalidate(): void {
-		this.invalidateRenderCache();
+		this.renderCache = undefined;
 		super.invalidate();
-		if (this.lastMessage) {
-			this.lastMessageSignature = undefined;
-			this.updateContent(this.lastMessage);
-		}
+		this.renderDescriptors = [];
+		this.refreshContent();
 	}
 
 	setHideThinkingBlock(hide: boolean): void {
 		if (this.hideThinkingBlock === hide) return;
 		this.hideThinkingBlock = hide;
-		if (this.lastMessage) {
-			this.lastMessageSignature = undefined;
-			this.updateContent(this.lastMessage);
-		}
+		this.refreshContent();
 	}
 
 	setHiddenThinkingLabel(label: string): void {
 		if (this.hiddenThinkingLabel === label) return;
 		this.hiddenThinkingLabel = label;
-		if (this.lastMessage) {
-			this.lastMessageSignature = undefined;
-			this.updateContent(this.lastMessage);
-		}
+		this.refreshContent();
 	}
 
 	setExpanded(expanded: boolean): void {
-		if (this.expanded === expanded) {
-			return;
-		}
+		if (this.expanded === expanded) return;
 		this.expanded = expanded;
-		if (this.lastMessage) {
-			this.lastMessageSignature = undefined;
-			this.updateContent(this.lastMessage);
-		}
+		this.refreshContent();
 	}
 
 	setOutputPad(padding: number): void {
 		this.outputPad = padding;
-		if (this.lastMessage) {
-			this.lastMessageSignature = undefined;
-			this.updateContent(this.lastMessage);
-		}
+		this.renderDescriptors = [];
+		this.refreshContent();
 	}
 
 	override render(width: number): string[] {
 		const signature = this.lastMessageSignature ?? "";
-		if (this.cachedLines && this.cachedWidth === width && this.cachedSignature === signature) {
-			return [...this.cachedLines];
+		if (this.renderCache?.width === width && this.renderCache.signature === signature) {
+			return [...this.renderCache.lines];
 		}
 
 		const lines = super.render(width);
@@ -120,121 +125,132 @@ export class AssistantMessageComponent extends Container {
 			return;
 		}
 		this.lastMessageSignature = messageSignature;
-		this.invalidateRenderCache();
+		this.renderCache = undefined;
+		this.hasToolCalls = message.content.some((content) => content.type === "toolCall");
+		const descriptors = this.createRenderDescriptors(message);
+		this.reconcileRenderDescriptors(descriptors);
+	}
 
-		// Clear content container
-		this.contentContainer.clear();
-
-		const hasVisibleContent = message.content.some(
-			(c) =>
-				(c.type === "text" && c.text.trim()) ||
-				(c.type === "thinking" && c.thinking.trim()) ||
-				c.type === "providerNative",
-		);
-
-		if (hasVisibleContent) {
-			this.contentContainer.addChild(new Spacer(1));
-		}
-
-		// Render content in order
+	private createRenderDescriptors(message: AssistantMessage): readonly RenderDescriptor[] {
+		const descriptors: RenderDescriptor[] = [];
+		if (message.content.some((content) => isVisibleContent(content, true))) descriptors.push(SPACER_DESCRIPTOR);
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
-			if (content.type === "text" && content.text.trim()) {
-				// Assistant text messages with no background - trim the text
-				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), this.outputPad, 0, this.markdownTheme));
-			} else if (content.type === "thinking") {
-				const thinkingBlocks: string[] = [];
-				for (; i < message.content.length; i++) {
-					const thinkingContent = message.content[i];
-					if (thinkingContent.type !== "thinking") {
-						break;
+			switch (content.type) {
+				case "text": {
+					const text = content.text.trim();
+					if (text) descriptors.push({ kind: "text-md", text });
+					break;
+				}
+				case "thinking": {
+					const thinkingBlocks: string[] = [];
+					for (; i < message.content.length; i++) {
+						const thinkingContent = message.content[i];
+						if (thinkingContent.type !== "thinking") break;
+						const thinking = thinkingContent.thinking.trim();
+						if (thinking) thinkingBlocks.push(thinking);
 					}
-					const thinking = thinkingContent.thinking.trim();
-					if (thinking) {
-						thinkingBlocks.push(thinking);
-					}
+					i--;
+					if (thinkingBlocks.length === 0) break;
+					const text = this.hideThinkingBlock
+						? theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel))
+						: thinkingBlocks.join("\n\n");
+					descriptors.push({ kind: this.hideThinkingBlock ? "thinking-label" : "thinking-md", text });
+					if (message.content.slice(i + 1).some((following) => isVisibleContent(following, false)))
+						descriptors.push(SPACER_DESCRIPTOR);
+					break;
 				}
-				i--;
-
-				if (thinkingBlocks.length === 0) {
-					continue;
-				}
-
-				// Add spacing only when another visible assistant content block follows.
-				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
-				const hasVisibleContentAfter = message.content
-					.slice(i + 1)
-					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
-
-				if (this.hideThinkingBlock) {
-					// Show one static label for each run of thinking blocks when hidden.
-					this.contentContainer.addChild(
-						new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), this.outputPad, 0),
+				case "providerNative":
+					descriptors.push(
+						{
+							kind: "provider-native-summary",
+							text: theme.fg("muted", formatProviderNativeSummary(message, content, this.expanded)),
+						},
+						{
+							kind: "provider-native-body",
+							text: theme.fg("dim", formatProviderNativeBody(content, this.expanded)),
+						},
 					);
-				} else {
-					// Render each run of thinking blocks as one Markdown section.
-					this.contentContainer.addChild(
-						new Markdown(thinkingBlocks.join("\n\n"), this.outputPad, 0, this.markdownTheme, {
-							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
-						}),
-					);
-				}
-				if (hasVisibleContentAfter) {
-					this.contentContainer.addChild(new Spacer(1));
-				}
-			} else if (content.type === "providerNative") {
-				this.contentContainer.addChild(
-					new Text(theme.fg("muted", formatProviderNativeSummary(message, content, this.expanded)), 1, 0),
-				);
-				this.contentContainer.addChild(
-					new Text(theme.fg("dim", formatProviderNativeBody(content, this.expanded)), 3, 0),
-				);
-				const hasVisibleContentAfter = message.content
-					.slice(i + 1)
-					.some(
-						(c) =>
-							(c.type === "text" && c.text.trim()) ||
-							(c.type === "thinking" && c.thinking.trim()) ||
-							c.type === "providerNative",
-					);
-				if (hasVisibleContentAfter) {
-					this.contentContainer.addChild(new Spacer(1));
-				}
+					if (message.content.slice(i + 1).some((following) => isVisibleContent(following, true)))
+						descriptors.push(SPACER_DESCRIPTOR);
+					break;
+				case "toolCall":
+					break;
+				default:
+					assertNever(content);
 			}
 		}
-
-		// Check if incomplete/failed - show after partial content.
-		// For aborted/error tool calls, tool execution components show the error.
-		// Length stops can happen before a tool call is complete, so surface them here too.
-		const hasToolCalls = message.content.some((c) => c.type === "toolCall");
-		this.hasToolCalls = hasToolCalls;
-		if (message.stopReason === "length") {
-			this.contentContainer.addChild(new Spacer(1));
-			this.contentContainer.addChild(
-				new Text(
-					theme.fg(
-						"error",
-						"Error: Model stopped because it reached the maximum output token limit. The response may be incomplete.",
-					),
-					this.outputPad,
-					0,
-				),
-			);
-		} else if (!hasToolCalls) {
-			if (message.stopReason === "aborted") {
+		const addError = (text: string): void => {
+			descriptors.push(SPACER_DESCRIPTOR, { kind: "error-text", text: theme.fg("error", text) });
+		};
+		switch (message.stopReason) {
+			case "length":
+				addError(
+					"Error: Model stopped because it reached the maximum output token limit. The response may be incomplete.",
+				);
+				break;
+			case "aborted": {
+				if (this.hasToolCalls) break;
 				const abortMessage =
 					message.errorMessage && message.errorMessage !== "Request was aborted"
 						? message.errorMessage
 						: "Operation aborted";
-				this.contentContainer.addChild(new Spacer(1));
-				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), this.outputPad, 0));
-			} else if (message.stopReason === "error") {
-				const errorMsg = message.errorMessage || "Unknown error";
-				this.contentContainer.addChild(new Spacer(1));
-				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), this.outputPad, 0));
+				addError(abortMessage);
+				break;
 			}
+			case "error":
+				if (!this.hasToolCalls) addError(`Error: ${message.errorMessage || "Unknown error"}`);
+				break;
+			case "stop":
+			case "toolUse":
+				break;
+			default:
+				assertNever(message.stopReason);
+		}
+		return descriptors;
+	}
+
+	private reconcileRenderDescriptors(descriptors: readonly RenderDescriptor[]): void {
+		let divergentIndex = 0;
+		const sharedLength = Math.min(this.renderDescriptors.length, descriptors.length);
+		while (divergentIndex < sharedLength) {
+			const previous = this.renderDescriptors[divergentIndex];
+			const next = descriptors[divergentIndex];
+			const child = this.contentContainer.children[divergentIndex];
+			if (!previous || !next || !child || previous.kind !== next.kind) break;
+			if (previous.text !== next.text) {
+				if ((next.kind === "text-md" || next.kind === "thinking-md") && child instanceof Markdown) {
+					child.setText(next.text);
+				} else break;
+			}
+			divergentIndex++;
+		}
+		for (const child of this.contentContainer.children.splice(divergentIndex)) child.dispose?.();
+		for (const descriptor of descriptors.slice(divergentIndex))
+			this.contentContainer.addChild(this.createRenderChild(descriptor));
+		this.renderDescriptors = descriptors;
+	}
+
+	private createRenderChild(descriptor: RenderDescriptor): Component {
+		switch (descriptor.kind) {
+			case "spacer":
+				return new Spacer(1);
+			case "text-md":
+				return new Markdown(descriptor.text, this.outputPad, 0, this.markdownTheme);
+			case "thinking-md":
+				return new Markdown(descriptor.text, this.outputPad, 0, this.markdownTheme, {
+					color: (text: string) => theme.fg("thinkingText", text),
+					italic: true,
+				});
+			case "thinking-label":
+			case "error-text":
+				return new Text(descriptor.text, this.outputPad, 0);
+			case "provider-native-summary":
+				return new Text(descriptor.text, 1, 0);
+			case "provider-native-body":
+				return new Text(descriptor.text, 3, 0);
+			default:
+				return assertNever(descriptor.kind);
 		}
 	}
 
@@ -249,14 +265,12 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	private cacheRender(width: number, signature: string, lines: string[]): void {
-		this.cachedWidth = width;
-		this.cachedSignature = signature;
-		this.cachedLines = [...lines];
+		this.renderCache = { lines: [...lines], signature, width };
 	}
 
-	private invalidateRenderCache(): void {
-		this.cachedLines = undefined;
-		this.cachedSignature = undefined;
-		this.cachedWidth = undefined;
+	private refreshContent(): void {
+		if (!this.lastMessage) return;
+		this.lastMessageSignature = undefined;
+		this.updateContent(this.lastMessage);
 	}
 }

--- a/packages/coding-agent/test/assistant-message-incremental-render.test.ts
+++ b/packages/coding-agent/test/assistant-message-incremental-render.test.ts
@@ -1,0 +1,231 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { type Component, Container, Markdown } from "@earendil-works/pi-tui";
+import { beforeEach, describe, expect, test } from "vitest";
+import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+type RenderConfiguration = {
+	readonly expanded?: boolean;
+	readonly hideThinkingBlock?: boolean;
+	readonly outputPad?: number;
+};
+
+type RenderParityCase = {
+	readonly configuration?: RenderConfiguration;
+	readonly finalMessage: AssistantMessage;
+	readonly initialMessage: AssistantMessage;
+	readonly name: string;
+	readonly width?: number;
+};
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	overrides: Partial<Pick<AssistantMessage, "errorMessage" | "stopReason">> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o-mini",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: overrides.stopReason ?? "stop",
+		errorMessage: overrides.errorMessage,
+		timestamp: 0,
+	};
+}
+
+function createComponent(
+	message: AssistantMessage,
+	configuration: RenderConfiguration = {},
+): AssistantMessageComponent {
+	const component = new AssistantMessageComponent(message, configuration.hideThinkingBlock ?? false);
+	if (configuration.expanded !== undefined) {
+		component.setExpanded(configuration.expanded);
+	}
+	if (configuration.outputPad !== undefined) {
+		component.setOutputPad(configuration.outputPad);
+	}
+	return component;
+}
+
+function getContentChildren(component: AssistantMessageComponent): readonly Component[] {
+	const contentContainer = component.children[0];
+	if (!(contentContainer instanceof Container)) {
+		throw new TypeError("Assistant message content child must be a Container");
+	}
+	return contentContainer.children;
+}
+
+function getRequiredChild(component: AssistantMessageComponent, index: number): Component {
+	const child = getContentChildren(component)[index];
+	if (!child) {
+		throw new RangeError(`Missing assistant content child at index ${index}`);
+	}
+	return child;
+}
+
+function getRequiredMarkdown(component: AssistantMessageComponent, index: number): Markdown {
+	const markdownChildren = getContentChildren(component).filter(
+		(child): child is Markdown => child instanceof Markdown,
+	);
+	const child = markdownChildren[index];
+	if (!child) {
+		throw new RangeError(`Missing assistant Markdown child at index ${index}`);
+	}
+	return child;
+}
+
+const renderParityCases: readonly RenderParityCase[] = [
+	{
+		name: "text-only streaming",
+		initialMessage: createAssistantMessage([{ type: "text", text: "draft" }]),
+		finalMessage: createAssistantMessage([{ type: "text", text: "final **answer**" }]),
+	},
+	{
+		name: "visible adjacent thinking and text",
+		initialMessage: createAssistantMessage([
+			{ type: "thinking", thinking: "first thought" },
+			{ type: "text", text: "partial" },
+		]),
+		finalMessage: createAssistantMessage([
+			{ type: "thinking", thinking: "first thought" },
+			{ type: "thinking", thinking: "second thought" },
+			{ type: "text", text: "complete" },
+		]),
+	},
+	{
+		name: "collapsed provider-native content",
+		initialMessage: createAssistantMessage([
+			{ type: "providerNative", subtype: "status", raw: { status: "running" } },
+		]),
+		finalMessage: createAssistantMessage([
+			{ type: "providerNative", subtype: "status", raw: { status: "complete", result: "ready" } },
+		]),
+	},
+	{
+		name: "expanded provider-native content",
+		configuration: { expanded: true },
+		initialMessage: createAssistantMessage([
+			{ type: "providerNative", subtype: "status", raw: { status: "running" } },
+		]),
+		finalMessage: createAssistantMessage([
+			{ type: "providerNative", subtype: "status", raw: { status: "complete", result: "ready" } },
+		]),
+		width: 120,
+	},
+	{
+		name: "length stop tail",
+		initialMessage: createAssistantMessage([{ type: "text", text: "partial" }]),
+		finalMessage: createAssistantMessage([{ type: "text", text: "partial" }], { stopReason: "length" }),
+	},
+	{
+		name: "aborted stop tail",
+		initialMessage: createAssistantMessage([{ type: "text", text: "partial" }]),
+		finalMessage: createAssistantMessage([{ type: "text", text: "partial" }], {
+			stopReason: "aborted",
+			errorMessage: "Request was aborted",
+		}),
+	},
+	{
+		name: "error stop tail",
+		initialMessage: createAssistantMessage([{ type: "text", text: "partial" }]),
+		finalMessage: createAssistantMessage([{ type: "text", text: "partial" }], {
+			stopReason: "error",
+			errorMessage: "network disconnected",
+		}),
+	},
+	{
+		name: "hidden adjacent thinking with custom output padding",
+		configuration: { hideThinkingBlock: true, outputPad: 2 },
+		initialMessage: createAssistantMessage([{ type: "thinking", thinking: "first thought" }]),
+		finalMessage: createAssistantMessage([
+			{ type: "thinking", thinking: "first thought" },
+			{ type: "thinking", thinking: "second thought" },
+			{ type: "text", text: "answer" },
+		]),
+	},
+];
+
+describe("AssistantMessageComponent incremental rendering", () => {
+	beforeEach(() => {
+		initTheme("dark");
+	});
+
+	for (const parityCase of renderParityCases) {
+		test(`#given ${parityCase.name} #when content updates incrementally #then raw output matches a fresh final render`, () => {
+			const incremental = createComponent(parityCase.initialMessage, parityCase.configuration);
+			incremental.updateContent(parityCase.finalMessage);
+			const fresh = createComponent(parityCase.finalMessage, parityCase.configuration);
+			const width = parityCase.width ?? 80;
+
+			expect(incremental.render(width)).toEqual(fresh.render(width));
+		});
+	}
+
+	test("#given an unchanged leading block #when tail Markdown grows #then preserves the leading child identity", () => {
+		const component = createComponent(
+			createAssistantMessage([
+				{ type: "text", text: "prefix" },
+				{ type: "text", text: "tail" },
+			]),
+		);
+		const leadingMarkdown = getRequiredMarkdown(component, 0);
+
+		component.updateContent(
+			createAssistantMessage([
+				{ type: "text", text: "prefix" },
+				{ type: "text", text: "tail grows" },
+			]),
+		);
+
+		expect(getRequiredMarkdown(component, 0)).toBe(leadingMarkdown);
+	});
+
+	test("#given a streaming Markdown block #when its text grows #then preserves identity and updates output", () => {
+		const component = createComponent(createAssistantMessage([{ type: "text", text: "draft" }]));
+		const markdown = getRequiredMarkdown(component, 0);
+		const before = component.render(80);
+
+		component.updateContent(createAssistantMessage([{ type: "text", text: "complete answer" }]));
+		const after = component.render(80);
+
+		expect(getRequiredMarkdown(component, 0)).toBe(markdown);
+		expect(after).not.toEqual(before);
+		expect(after.join("\n")).toContain("complete answer");
+		expect(after.join("\n")).not.toContain("draft");
+	});
+
+	test("#given a stable prefix #when kind and list shape diverge #then rebuilds only the suffix", () => {
+		const component = createComponent(
+			createAssistantMessage([
+				{ type: "text", text: "prefix" },
+				{ type: "text", text: "tail" },
+			]),
+		);
+		const initialSpacer = getRequiredChild(component, 0);
+		const initialPrefix = getRequiredChild(component, 1);
+		const initialTail = getRequiredChild(component, 2);
+		const initialLength = getContentChildren(component).length;
+
+		component.updateContent(
+			createAssistantMessage([
+				{ type: "text", text: "prefix" },
+				{ type: "thinking", thinking: "new reasoning" },
+				{ type: "text", text: "tail" },
+			]),
+		);
+
+		expect(getRequiredChild(component, 0)).toBe(initialSpacer);
+		expect(getRequiredChild(component, 1)).toBe(initialPrefix);
+		expect(getRequiredChild(component, 2)).not.toBe(initialTail);
+		expect(getContentChildren(component).length).toBeGreaterThan(initialLength);
+	});
+});


### PR DESCRIPTION
## Summary

Assistant streaming updates now reconcile the existing rendered child list instead of clearing and recreating every child for each delta. Unchanged leading blocks remain mounted, growing Markdown updates through `Markdown.setText()`, and only the first divergent suffix is rebuilt, keeping completed-block caches warm without changing visible output.

## Changes

- **Incremental rendering:** Build a flat descriptor sequence for spacers, text/thinking Markdown, hidden-thinking labels, provider-native summary/body rows, and error tails, then reconcile it against the previous sequence.
- **Lifecycle preservation:** Retain identical children, update changed same-kind Markdown in place, and dispose/rebuild only the divergent suffix. Existing signature short-circuiting, render caching, OSC markers, output padding, expanded state, thinking visibility, provider-native rendering, and stop-reason behavior remain intact.
- **Regression coverage:** Add exact incremental-vs-fresh raw-line parity cases plus object-identity assertions for stable prefixes, growing Markdown, and suffix-only reconstruction.
- **Fork records:** Document the renderer change in the root coding-agent and nearest interactive `changes.md` files.

## QA & Evidence

- **What was tested:** Focused coding-agent component and render-signature suites.
  - **Observed result:** 3 files, 28/28 tests passed, including the output-parity matrix and identity/rebuild assertions.
  - **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/scoped-tests.txt`
  - **Why sufficient:** Directly covers unchanged leading identity, growing Markdown reuse, divergent-suffix rebuilding, and byte-for-byte render parity across text, thinking, provider-native, error-tail, hidden-thinking, expansion, and padding states.
- **What was tested:** TUI renderer regression plus the full repository static gate.
  - **Observed result:** TUI render test exited 0; `npm run check` exited 0 with no formatter changes and all TypeScript, lock, web, browser, and Neo checks clean.
  - **Artifacts:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/tui-render-test.txt`, `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/npm-run-check.txt`
  - **Why sufficient:** Covers adjacent terminal rendering and repository-wide compile/static compatibility.
- **What was tested:** Deterministic zero-token real CLI loops from source.
  - **Observed result:** Mock loop self-test passed 5/5; bash-tool loop passed 4/4; real auth remained unchanged.
  - **Artifacts:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/mock-loop-self-test.txt`, `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/mock-loop-with-tool.txt`
  - **Why sufficient:** Exercises the actual source CLI across streaming and tool-turn paths without paid provider calls.
- **What was tested:** Real source TUI boot/input/teardown and fresh browser-rendered terminal inspection.
  - **Observed result:** TUI smoke passed 5/5; the 100x28 capture had `maxWidth=100`, no overflow, no border drift, and two independent visual reviewers returned PASS/HIGH with no blockers.
  - **Artifacts:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/tui-smoke.txt`, `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-assistant-incremental-render/visual-tui/`
  - **Why sufficient:** Confirms the user-facing TUI still boots, accepts input, renders the updated assistant path cleanly, and tears down without residue.

## Risks

- Descriptor reconciliation could otherwise leave stale spacing, styling, or error rows. The incremental-vs-fresh parity matrix and existing render/signature tests mitigate this across every affected block shape.
- Child reuse could otherwise retain stale caches or dispose stable children. Identity assertions, failing-first evidence, compiler/static gates, and independent code/QA/gate reviews mitigate that risk.
- `main` advanced through the disjoint TUI FPS-cap PR after this branch was created. The final gate verified that its five TUI files do not overlap or alter the `Container`/`Markdown` contracts used here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assistant message streaming now updates incrementally by reconciling the existing child list instead of rebuilding on every delta. This removes flicker, keeps `Markdown` caches warm, and preserves identical output.

- **Refactors**
  - Build a flat descriptor list (spacer, text/thinking Markdown, hidden-thinking label, provider-native summary/body, error tail) and reconcile it with the previous list.
  - Reuse identical children; update same-kind Markdown in place via `Markdown.setText()`; rebuild only the divergent suffix.
  - Preserve existing behavior: render signatures, OSC markers, output padding, expanded state, thinking visibility, provider-native rendering, and stop-reason handling.
  - Add tests for byte-for-byte parity and identity (stable prefixes, growing Markdown, suffix-only rebuild).

<sup>Written for commit ac4ed1e36fbd897e8a7d380cbfaf5ecbb95a1099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

