### PR TITLE
feat(coding-agent): smooth streaming reveal (30-120fps)

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,17 @@
 # Local fork changes
 
+## 2026-07-20 — smooth streaming reveal test coverage
+
+- Changed:
+  - `test/streaming-reveal.test.ts`: deterministic coverage for incremental grapheme counting and slicing, display
+    message construction, fps-invariant reveal timing, and controller lifecycle behavior.
+  - `test/settings-manager.test.ts`: defaults, clamping, and persistence coverage for smooth-streaming settings.
+- Why: the interactive reveal must remain Unicode-safe and time-based across 30–120fps, including live setting and
+  visibility changes.
+- What changed: test-only package surface; runtime changes are tracked in the nearest `src/**/changes.md` files.
+- Why the extension system could not handle this: the tests exercise private built-in TUI lifecycle and settings state.
+- Merge-conflict risk: low. Both suites are focused additions to the package test surface.
+
 ## 2026-07-07 — pi-pty workspace dependency groundwork
 
 - Changed:

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -6,6 +6,8 @@
   - `test/streaming-reveal.test.ts`: deterministic coverage for incremental grapheme counting and slicing, display
     message construction, fps-invariant reveal timing, and controller lifecycle behavior.
   - `test/settings-manager.test.ts`: defaults, clamping, and persistence coverage for smooth-streaming settings.
+  - `test/interactive-mode-compaction-queue-session-rebind.test.ts`: session-rebind test doubles now include the reveal
+    controller `stop` seam so the full CI suite exercises the updated `InteractiveMode` shape.
 - Why: the interactive reveal must remain Unicode-safe and time-based across 30–120fps, including live setting and
   visibility changes.
 - What changed: test-only package surface; runtime changes are tracked in the nearest `src/**/changes.md` files.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## Smooth streaming reveal (2026-07-20)
+
+### What changed
+
+- `modes/interactive/streaming-reveal.ts`: adds a grapheme-safe, time-based controller that reveals streamed assistant
+  text at a stable perceived rate from 30–120fps, catches up bounded backlogs, and flushes immediately at tool-call and
+  lifecycle boundaries.
+- `core/settings-manager.ts` and the interactive settings selector persist smooth-streaming enablement and FPS.
+- `modes/interactive/interactive-mode.ts` routes assistant deltas through the controller and tears it down on final,
+  abort, session-switch, and shutdown paths.
+
+### Why
+
+- Provider chunks often arrive in bursts; rendering each burst verbatim makes otherwise fast responses visually jumpy.
+
+### Why extension system couldn't handle this
+
+- The controller owns private in-flight assistant component updates, TUI render scheduling, and session lifecycle state.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: interactive assistant event handling and settings-selector plumbing.
+- LOW: the fork-only reveal controller and settings accessors.
+
 ## Incremental assistant message re-render (2026-07-19)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## Smooth streaming settings (2026-07-20)
+
+### What changed
+
+- `settings-manager.ts`: added persisted `smoothStreaming` and `smoothStreamingFps` settings. Smoothing defaults on,
+  FPS defaults to 60, and reads clamp the configured value to 30–120.
+
+### Why extension system couldn't handle this alone
+
+- The built-in interactive renderer must read the setting before extensions load and while it owns an active stream.
+
+### Expected merge conflict zones
+
+- LOW: `Settings` fields and accessors near the existing thinking-visibility setting.
+
 ## "video" input modality plumbed through provider composition (2026-07-17)
 
 ### What changed

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -116,6 +116,8 @@ export interface Settings {
 	branchSummary?: BranchSummarySettings;
 	retry?: RetrySettings;
 	hideThinkingBlock?: boolean;
+	smoothStreaming?: boolean; // default: true
+	smoothStreamingFps?: number; // default: 60, clamped to 30-120 when read
 	showCacheMissNotices?: boolean; // default: false - show transcript notices for significant prompt-cache misses
 	externalEditor?: string; // Command for Ctrl+G external editor; takes precedence over VISUAL/EDITOR
 	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows); supports leading ~ expansion
@@ -938,6 +940,18 @@ export class SettingsManager {
 		return this.settings.hideThinkingBlock ?? false;
 	}
 
+	getSmoothStreaming(): boolean {
+		return this.settings.smoothStreaming ?? true;
+	}
+
+	getSmoothStreamingFps(): number {
+		const fps = this.settings.smoothStreamingFps;
+		if (typeof fps !== "number" || !Number.isFinite(fps)) {
+			return 60;
+		}
+		return Math.min(120, Math.max(30, fps));
+	}
+
 	getShowCacheMissNotices(): boolean {
 		return this.settings.showCacheMissNotices ?? false;
 	}
@@ -957,6 +971,18 @@ export class SettingsManager {
 	setHideThinkingBlock(hide: boolean): void {
 		this.globalSettings.hideThinkingBlock = hide;
 		this.markModified("hideThinkingBlock");
+		this.save();
+	}
+
+	setSmoothStreaming(enabled: boolean): void {
+		this.globalSettings.smoothStreaming = enabled;
+		this.markModified("smoothStreaming");
+		this.save();
+	}
+
+	setSmoothStreamingFps(fps: number): void {
+		this.globalSettings.smoothStreamingFps = fps;
+		this.markModified("smoothStreamingFps");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## smooth streaming reveal (2026-07-20)
+
+### What changed
+
+- `streaming-reveal.ts`: adds append-aware grapheme counting/slicing and a real-time reveal controller with 90
+  units/second minimum velocity, a 267ms catchup horizon, 1–100ms delta clamping, and configurable 30–120fps ticks.
+- `interactive-mode.ts`: routes assistant start/update events through one controller, flushes final content directly,
+  stops pacing on abort/session teardown, resyncs live thinking visibility, and applies the TUI FPS cap.
+- `components/settings-selector.ts`: adds “Smooth streaming” and “Streaming fps” controls.
+
+### Why
+
+- Bursty provider deltas should appear as a readable, steady reveal without splitting Korean, emoji ZWJ, combining, or
+  other grapheme clusters.
+
+### Why extension system couldn't handle this
+
+- Extensions cannot replace the built-in in-flight assistant component or coordinate its render timer with session
+  teardown and TUI scheduling.
+
+### Expected merge conflict zones
+
+- MEDIUM: `interactive-mode.ts` assistant event handling and settings callbacks.
+- LOW: the fork-only controller and new selector items.
+
 ## incremental assistant message re-render (2026-07-19)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -66,6 +66,8 @@ export interface SettingsConfig {
 	terminalTheme: TerminalTheme;
 	availableThemes: string[];
 	hideThinkingBlock: boolean;
+	smoothStreaming: boolean;
+	smoothStreamingFps: number;
 	showCacheMissNotices: boolean;
 	collapseChangelog: boolean;
 	enableInstallTelemetry: boolean;
@@ -97,6 +99,8 @@ export interface SettingsCallbacks {
 	onThemeChange: (theme: string) => void;
 	onThemePreview?: (theme: string) => void;
 	onHideThinkingBlockChange: (hidden: boolean) => void;
+	onSmoothStreamingChange: (enabled: boolean) => void;
+	onSmoothStreamingFpsChange: (fps: number) => void;
 	onShowCacheMissNoticesChange: (shown: boolean) => void;
 	onCollapseChangelogChange: (collapsed: boolean) => void;
 	onEnableInstallTelemetryChange: (enabled: boolean) => void;
@@ -525,6 +529,20 @@ export class SettingsSelectorComponent extends Container {
 				values: ["true", "false"],
 			},
 			{
+				id: "smooth-streaming",
+				label: "Smooth streaming",
+				description: "Reveal streamed assistant text at a steady pace",
+				currentValue: config.smoothStreaming ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
+				id: "streaming-fps",
+				label: "Streaming fps",
+				description: "Maximum frame rate for smooth streaming",
+				currentValue: String(config.smoothStreamingFps),
+				values: ["30", "60", "90", "120"],
+			},
+			{
 				id: "cache-miss-notices",
 				label: "Cache miss notices",
 				description: "Show transcript notices for significant prompt-cache misses",
@@ -773,6 +791,12 @@ export class SettingsSelectorComponent extends Container {
 					}
 					case "hide-thinking":
 						callbacks.onHideThinkingBlockChange(newValue === "true");
+						break;
+					case "smooth-streaming":
+						callbacks.onSmoothStreamingChange(newValue === "true");
+						break;
+					case "streaming-fps":
+						callbacks.onSmoothStreamingFpsChange(parseInt(newValue, 10));
 						break;
 					case "cache-miss-notices":
 						callbacks.onShowCacheMissNoticesChange(newValue === "true");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -153,6 +153,7 @@ import { UserMessageSelectorComponent } from "./components/user-message-selector
 import { restoreInteractiveStderr, takeOverInteractiveStderr } from "./interactive-stderr-guard.ts";
 import { getModelSearchText } from "./model-search.ts";
 import { resolveStartupToolPaths } from "./startup-tools.ts";
+import { DEFAULT_SMOOTH_FPS, StreamingRevealController } from "./streaming-reveal.ts";
 import {
 	getAvailableThemes,
 	getAvailableThemesWithPaths,
@@ -453,11 +454,18 @@ export class InteractiveMode {
 	// Streaming message tracking
 	private streamingComponent: AssistantMessageComponent | undefined = undefined;
 	private streamingMessage: AssistantMessage | undefined = undefined;
+	private readonly streamingReveal: StreamingRevealController;
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
 	private requestStreamingRender(): void {
 		this.ui.requestRender();
+	}
+	private applySmoothStreamingRenderFps(): void {
+		const fps = this.settingsManager.getSmoothStreaming()
+			? this.settingsManager.getSmoothStreamingFps()
+			: DEFAULT_SMOOTH_FPS;
+		this.ui.setMaxRenderFps(fps);
 	}
 
 	// Tool output expansion state
@@ -553,6 +561,13 @@ export class InteractiveMode {
 			new ProcessTerminal({ onExternalStdoutWrite: appendHiddenTuiStdout }),
 			this.settingsManager.getShowHardwareCursor(),
 		);
+		this.streamingReveal = new StreamingRevealController({
+			getSmoothStreaming: () => this.settingsManager.getSmoothStreaming(),
+			getSmoothStreamingFps: () => this.settingsManager.getSmoothStreamingFps(),
+			getHideThinkingBlock: () => this.hideThinkingBlock,
+			requestRender: () => this.ui.requestRender(),
+		});
+		this.applySmoothStreamingRenderFps();
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.headerContainer = new Container();
 		this.loadedResourcesContainer = new Container();
@@ -1827,6 +1842,7 @@ export class InteractiveMode {
 		this.footerDataProvider.setCwd(this.sessionManager.getCwd());
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
 		this.outputPad = this.settingsManager.getOutputPad();
+		this.applySmoothStreamingRenderFps();
 		this.ui.setShowHardwareCursor(this.settingsManager.getShowHardwareCursor());
 		const clearOnShrink = this.settingsManager.getClearOnShrink();
 		this.ui.setClearOnShrink(clearOnShrink);
@@ -1878,6 +1894,7 @@ export class InteractiveMode {
 		this.compactionQueuedMessages = [];
 		this.compactionInFlightMessages = [];
 		this.compactionTransferAbortControllers.clear();
+		this.streamingReveal.stop();
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.clearPendingTools();
@@ -3281,7 +3298,7 @@ export class InteractiveMode {
 					this.streamingComponent.setExpanded(this.toolOutputExpanded);
 					this.streamingMessage = event.message;
 					this.chatContainer.addChild(this.streamingComponent);
-					this.streamingComponent.updateContent(this.streamingMessage);
+					this.streamingReveal.begin(this.streamingComponent, this.streamingMessage);
 					this.requestStreamingRender();
 				}
 				break;
@@ -3289,7 +3306,7 @@ export class InteractiveMode {
 			case "message_update":
 				if (this.streamingComponent && event.message.role === "assistant") {
 					this.streamingMessage = event.message;
-					this.streamingComponent.updateContent(this.streamingMessage);
+					this.streamingReveal.setTarget(this.streamingMessage);
 
 					for (const content of this.streamingMessage.content) {
 						if (content.type === "toolCall") {
@@ -3325,6 +3342,7 @@ export class InteractiveMode {
 				if (event.message.role === "user") break;
 				if (this.streamingComponent && event.message.role === "assistant") {
 					this.streamingMessage = event.message;
+					this.streamingReveal.stop();
 					let errorMessage: string | undefined;
 					if (this.streamingMessage.stopReason === "aborted") {
 						errorMessage = abortedErrorLabel(undefined, this.session.retryAttempt);
@@ -3413,6 +3431,7 @@ export class InteractiveMode {
 				this.clearStatusIndicator("working");
 				this.clearActiveToolExecutionStatus();
 				this.clearToolHookStatuses();
+				this.streamingReveal.stop();
 				if (this.streamingComponent) {
 					this.chatContainer.removeChild(this.streamingComponent);
 					this.streamingComponent = undefined;
@@ -4198,7 +4217,7 @@ export class InteractiveMode {
 		// If streaming, re-add the streaming component with updated visibility and re-render
 		if (this.streamingComponent && this.streamingMessage) {
 			this.streamingComponent.setHideThinkingBlock(this.hideThinkingBlock);
-			this.streamingComponent.updateContent(this.streamingMessage);
+			this.streamingReveal.resyncVisibility();
 			this.chatContainer.addChild(this.streamingComponent);
 		}
 
@@ -4574,6 +4593,8 @@ export class InteractiveMode {
 					terminalTheme: this.themeController.getTerminalTheme(),
 					availableThemes: getAvailableThemes(),
 					hideThinkingBlock: this.hideThinkingBlock,
+					smoothStreaming: this.settingsManager.getSmoothStreaming(),
+					smoothStreamingFps: this.settingsManager.getSmoothStreamingFps(),
 					collapseChangelog: this.settingsManager.getCollapseChangelog(),
 					enableInstallTelemetry: this.settingsManager.getEnableInstallTelemetry(),
 					doubleEscapeAction: this.settingsManager.getDoubleEscapeAction(),
@@ -4656,6 +4677,29 @@ export class InteractiveMode {
 						}
 						this.chatContainer.clear();
 						this.rebuildChatFromMessages();
+						if (this.streamingComponent && this.streamingMessage) {
+							this.streamingComponent.setHideThinkingBlock(hidden);
+							this.streamingReveal.resyncVisibility();
+							this.chatContainer.addChild(this.streamingComponent);
+						}
+						this.ui.requestRender();
+					},
+					onSmoothStreamingChange: (enabled) => {
+						this.settingsManager.setSmoothStreaming(enabled);
+						this.applySmoothStreamingRenderFps();
+						if (this.streamingMessage) {
+							this.streamingReveal.setTarget(this.streamingMessage);
+						}
+						this.ui.requestRender();
+					},
+					onSmoothStreamingFpsChange: (fps) => {
+						this.settingsManager.setSmoothStreamingFps(fps);
+						if (this.settingsManager.getSmoothStreaming()) {
+							this.applySmoothStreamingRenderFps();
+							if (this.streamingMessage) {
+								this.streamingReveal.setTarget(this.streamingMessage);
+							}
+						}
 					},
 					onShowCacheMissNoticesChange: (shown) => {
 						this.settingsManager.setShowCacheMissNotices(shown);
@@ -6480,6 +6524,7 @@ export class InteractiveMode {
 	}
 
 	stop(): void {
+		this.streamingReveal.stop();
 		if (this.settingsManager.getShowTerminalProgress()) {
 			this.ui.terminal.setProgress(false);
 		}

--- a/packages/coding-agent/src/modes/interactive/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/interactive/streaming-reveal.ts
@@ -1,0 +1,304 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { getGraphemeSegmenter } from "@earendil-works/pi-tui";
+import type { AssistantMessageComponent } from "./components/assistant-message.ts";
+
+export const MIN_REVEAL_UNITS_PER_SEC = 90;
+export const CATCHUP_WINDOW_MS = 267;
+export const MIN_SMOOTH_FPS = 30;
+export const MAX_SMOOTH_FPS = 120;
+export const DEFAULT_SMOOTH_FPS = 60;
+
+type AssistantContentBlock = AssistantMessage["content"][number];
+type StreamingRevealComponent = Pick<AssistantMessageComponent, "updateContent">;
+type GraphemeCounter = (index: number, text: string) => number;
+type GraphemeSlicer = (index: number, text: string, units: number) => string;
+
+export type StreamingRevealControllerOptions = {
+	readonly getSmoothStreaming: () => boolean;
+	readonly getSmoothStreamingFps: () => number;
+	readonly getHideThinkingBlock: () => boolean;
+	readonly requestRender: () => void;
+};
+
+function countGraphemesFrom(text: string, start: number): { count: number; tailStart: number } {
+	let count = 0;
+	let tailStart = start;
+	for (const segment of getGraphemeSegmenter().segment(start === 0 ? text : text.slice(start))) {
+		count += 1;
+		tailStart = start + segment.index;
+	}
+	return { count, tailStart };
+}
+
+function segmentFrom(text: string, start: number, clusters: number): { count: number; end: number; lastStart: number } {
+	let count = 0;
+	let end = start;
+	let lastStart = start;
+	for (const segment of getGraphemeSegmenter().segment(start === 0 ? text : text.slice(start))) {
+		count += 1;
+		lastStart = start + segment.index;
+		end = lastStart + segment.segment.length;
+		if (count >= clusters) break;
+	}
+	return { count, end, lastStart };
+}
+
+export class BlockUnitCounter {
+	readonly #entries = new Map<number, { text: string; count: number; tailStart: number }>();
+	readonly #sliceEntries = new Map<number, { text: string; units: number; end: number; lastStart: number }>();
+
+	count(index: number, text: string): number {
+		const entry = this.#entries.get(index);
+		if (entry !== undefined) {
+			if (entry.text === text) return entry.count;
+			if (entry.count > 0 && text.length > entry.text.length && text.startsWith(entry.text)) {
+				const tail = countGraphemesFrom(text, entry.tailStart);
+				const next = { text, count: entry.count - 1 + tail.count, tailStart: tail.tailStart };
+				this.#entries.set(index, next);
+				return next.count;
+			}
+		}
+		const full = countGraphemesFrom(text, 0);
+		this.#entries.set(index, { text, count: full.count, tailStart: full.tailStart });
+		return full.count;
+	}
+
+	slice(index: number, text: string, units: number): string {
+		const wholeUnits = Math.floor(units);
+		if (wholeUnits <= 0 || text.length === 0) return "";
+		const entry = this.#sliceEntries.get(index);
+		if (entry?.text === text && entry.units === wholeUnits) {
+			return entry.end >= text.length ? text : text.slice(0, entry.end);
+		}
+		if (entry !== undefined && (entry.text === text || text.startsWith(entry.text)) && wholeUnits >= entry.units) {
+			const segment = segmentFrom(text, entry.lastStart, wholeUnits - entry.units + 1);
+			this.#sliceEntries.set(index, {
+				text,
+				units: entry.units - 1 + segment.count,
+				end: segment.end,
+				lastStart: segment.lastStart,
+			});
+			return segment.end >= text.length ? text : text.slice(0, segment.end);
+		}
+		const segment = segmentFrom(text, 0, wholeUnits);
+		this.#sliceEntries.set(index, {
+			text,
+			units: segment.count,
+			end: segment.end,
+			lastStart: segment.lastStart,
+		});
+		return segment.end >= text.length ? text : text.slice(0, segment.end);
+	}
+
+	reset(): void {
+		this.#entries.clear();
+		this.#sliceEntries.clear();
+	}
+}
+
+function countGraphemes(text: string): number {
+	return countGraphemesFrom(text, 0).count;
+}
+
+function sliceGraphemes(text: string, units: number): string {
+	if (units <= 0 || text.length === 0) return "";
+	const segment = segmentFrom(text, 0, units);
+	return segment.end >= text.length ? text : text.slice(0, segment.end);
+}
+
+function countVisibleUnits(message: AssistantMessage, hideThinking: boolean, countOf: GraphemeCounter): number {
+	let total = 0;
+	for (let index = 0; index < message.content.length; index++) {
+		const block = message.content[index];
+		if (block?.type === "text") {
+			total += countOf(index, block.text);
+		} else if (block?.type === "thinking" && !hideThinking) {
+			total += countOf(index, block.thinking);
+		}
+	}
+	return total;
+}
+
+export function visibleUnits(message: AssistantMessage, hideThinking: boolean): number {
+	return countVisibleUnits(message, hideThinking, (_index, text) => countGraphemes(text));
+}
+
+export function buildDisplayMessage(
+	target: AssistantMessage,
+	revealed: number,
+	hideThinking: boolean,
+	countOf: GraphemeCounter = (_index, text) => countGraphemes(text),
+	sliceOf: GraphemeSlicer = (_index, text, units) => sliceGraphemes(text, units),
+): AssistantMessage {
+	let remaining = Math.max(0, Math.floor(revealed));
+	const content: AssistantContentBlock[] = [];
+	for (let index = 0; index < target.content.length; index++) {
+		const block = target.content[index];
+		if (!block) continue;
+		if (block.type === "text") {
+			const units = countOf(index, block.text);
+			content.push(
+				remaining <= 0
+					? block.text.length === 0
+						? block
+						: { ...block, text: "" }
+					: remaining >= units
+						? block
+						: { ...block, text: sliceOf(index, block.text, remaining) },
+			);
+			remaining = Math.max(0, remaining - units);
+		} else if (block.type === "thinking" && !hideThinking) {
+			const units = countOf(index, block.thinking);
+			content.push(
+				remaining <= 0
+					? block.thinking.length === 0
+						? block
+						: { ...block, thinking: "" }
+					: remaining >= units
+						? block
+						: { ...block, thinking: sliceOf(index, block.thinking, remaining) },
+			);
+			remaining = Math.max(0, remaining - units);
+		} else {
+			content.push(block);
+		}
+	}
+	return { ...target, content };
+}
+
+export function nextStep(backlog: number, dtMs: number): number {
+	if (backlog <= 0) return 0;
+	const dt = Math.min(Math.max(dtMs, 1), 100);
+	const minStep = Math.max(1, Math.round((MIN_REVEAL_UNITS_PER_SEC * dt) / 1000));
+	const catchup = Math.ceil((backlog * dt) / CATCHUP_WINDOW_MS);
+	return Math.min(backlog, Math.max(minStep, catchup));
+}
+
+export class StreamingRevealController {
+	readonly #getSmoothStreaming: () => boolean;
+	readonly #getSmoothStreamingFps: () => number;
+	readonly #getHideThinkingBlock: () => boolean;
+	readonly #requestRender: () => void;
+	readonly #unitCounter = new BlockUnitCounter();
+	readonly #countOf = (index: number, text: string): number => this.#unitCounter.count(index, text);
+	readonly #sliceOf = (index: number, text: string, units: number): string =>
+		this.#unitCounter.slice(index, text, units);
+	#target: AssistantMessage | undefined;
+	#component: StreamingRevealComponent | undefined;
+	#timer: NodeJS.Timeout | undefined;
+	#timerFps: number | undefined;
+	#revealed = 0;
+	#lastTickAt = 0;
+	#hideThinkingBlock = false;
+
+	constructor(options: StreamingRevealControllerOptions) {
+		this.#getSmoothStreaming = options.getSmoothStreaming;
+		this.#getSmoothStreamingFps = options.getSmoothStreamingFps;
+		this.#getHideThinkingBlock = options.getHideThinkingBlock;
+		this.#requestRender = options.requestRender;
+	}
+
+	begin(component: StreamingRevealComponent, message: AssistantMessage): void {
+		this.stop();
+		this.#component = component;
+		this.#target = message;
+		this.#hideThinkingBlock = this.#getHideThinkingBlock();
+		this.#applyTarget();
+	}
+
+	setTarget(message: AssistantMessage): void {
+		this.#target = message;
+		this.#hideThinkingBlock = this.#getHideThinkingBlock();
+		if (this.#component) this.#applyTarget();
+	}
+
+	resyncVisibility(): void {
+		if (!this.#target || !this.#component) return;
+		this.#hideThinkingBlock = this.#getHideThinkingBlock();
+		this.#revealed = Math.min(this.#revealed, this.#visibleUnits(this.#target));
+		this.#applyTarget();
+	}
+
+	stop(): void {
+		this.#stopTimer();
+		this.#target = undefined;
+		this.#component = undefined;
+		this.#revealed = 0;
+		this.#lastTickAt = 0;
+		this.#unitCounter.reset();
+	}
+
+	#applyTarget(): void {
+		const target = this.#target;
+		const component = this.#component;
+		if (!target || !component) return;
+		const total = this.#visibleUnits(target);
+		if (!this.#getSmoothStreaming() || target.content.some((block) => block.type === "toolCall")) {
+			this.#revealed = total;
+			this.#stopTimer();
+			component.updateContent(target);
+			return;
+		}
+		this.#revealed = Math.min(this.#revealed, total);
+		this.#renderCurrent();
+		this.#syncTimer(total);
+	}
+
+	#visibleUnits(message: AssistantMessage): number {
+		return countVisibleUnits(message, this.#hideThinkingBlock, this.#countOf);
+	}
+
+	#renderCurrent(): void {
+		if (!this.#target || !this.#component) return;
+		this.#component.updateContent(
+			buildDisplayMessage(this.#target, this.#revealed, this.#hideThinkingBlock, this.#countOf, this.#sliceOf),
+		);
+	}
+
+	#syncTimer(total: number): void {
+		if (this.#revealed >= total) {
+			this.#stopTimer();
+			return;
+		}
+		this.#startTimer();
+	}
+
+	#startTimer(): void {
+		const configuredFps = this.#getSmoothStreamingFps();
+		const fps = Number.isFinite(configuredFps)
+			? Math.min(MAX_SMOOTH_FPS, Math.max(MIN_SMOOTH_FPS, configuredFps))
+			: DEFAULT_SMOOTH_FPS;
+		if (this.#timer && this.#timerFps === fps) return;
+		this.#stopTimer();
+		this.#lastTickAt = performance.now();
+		const timer = setInterval(() => this.#tick(), 1000 / fps);
+		timer.unref();
+		this.#timer = timer;
+		this.#timerFps = fps;
+	}
+
+	#stopTimer(): void {
+		if (this.#timer) clearInterval(this.#timer);
+		this.#timer = undefined;
+		this.#timerFps = undefined;
+	}
+
+	#tick(): void {
+		const target = this.#target;
+		if (!target || !this.#component) {
+			this.stop();
+			return;
+		}
+		const total = this.#visibleUnits(target);
+		if (this.#revealed >= total) {
+			this.#stopTimer();
+			return;
+		}
+		const now = performance.now();
+		this.#revealed = Math.min(total, this.#revealed + nextStep(total - this.#revealed, now - this.#lastTickAt));
+		this.#lastTickAt = now;
+		this.#renderCurrent();
+		this.#requestRender();
+		if (this.#revealed >= total) this.#stopTimer();
+	}
+}

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
@@ -66,6 +66,7 @@ it("starts a replacement-session flush while an old transfer remains pending", a
 		readonly pendingMessagesContainer: { clear(): void };
 		streamingComponent: undefined;
 		streamingMessage: undefined;
+		readonly streamingReveal: { stop: () => void };
 		readonly clearPendingTools: () => void;
 		readonly clearToolHookStatuses: () => void;
 		readonly renderInitialMessages: () => void;
@@ -91,6 +92,7 @@ it("starts a replacement-session flush while an old transfer remains pending", a
 		pendingMessagesContainer: { clear: vi.fn() },
 		streamingComponent: undefined,
 		streamingMessage: undefined,
+		streamingReveal: { stop: vi.fn() },
 		clearPendingTools: vi.fn(),
 		clearToolHookStatuses: vi.fn(),
 		renderInitialMessages: vi.fn(),
@@ -152,6 +154,7 @@ it("does not render an accepted old-session prompt failure after session rebind"
 		readonly pendingMessagesContainer: { clear(): void };
 		streamingComponent: undefined;
 		streamingMessage: undefined;
+		readonly streamingReveal: { stop: () => void };
 		readonly clearPendingTools: () => void;
 		readonly clearToolHookStatuses: () => void;
 		readonly renderInitialMessages: () => void;
@@ -178,6 +181,7 @@ it("does not render an accepted old-session prompt failure after session rebind"
 		pendingMessagesContainer: { clear: vi.fn() },
 		streamingComponent: undefined,
 		streamingMessage: undefined,
+		streamingReveal: { stop: vi.fn() },
 		clearPendingTools: vi.fn(),
 		clearToolHookStatuses: vi.fn(),
 		renderInitialMessages: vi.fn(),

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -472,6 +472,51 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("smooth streaming", () => {
+		it("defaults smooth streaming on at 60 fps", () => {
+			// Given
+			const manager = SettingsManager.inMemory();
+
+			// When / Then
+			expect(manager.getSmoothStreaming()).toBe(true);
+			expect(manager.getSmoothStreamingFps()).toBe(60);
+		});
+
+		it.each([
+			[29, 30],
+			[30, 30],
+			[90, 90],
+			[120, 120],
+			[121, 120],
+		] as const)("clamps configured streaming fps %s to %s", (configuredFps, expectedFps) => {
+			// Given
+			const manager = SettingsManager.inMemory({ smoothStreamingFps: configuredFps });
+
+			// When
+			const fps = manager.getSmoothStreamingFps();
+
+			// Then
+			expect(fps).toBe(expectedFps);
+		});
+
+		it("persists smooth streaming settings", async () => {
+			// Given
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			// When
+			manager.setSmoothStreaming(false);
+			manager.setSmoothStreamingFps(90);
+			await manager.flush();
+
+			// Then
+			expect(manager.getSmoothStreaming()).toBe(false);
+			expect(manager.getSmoothStreamingFps()).toBe(90);
+			const savedSettings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8"));
+			expect(savedSettings.smoothStreaming).toBe(false);
+			expect(savedSettings.smoothStreamingFps).toBe(90);
+		});
+	});
+
 	describe("shellCommandPrefix", () => {
 		it("should load shellCommandPrefix from settings", () => {
 			const settingsPath = join(agentDir, "settings.json");

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -1,0 +1,361 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { getGraphemeSegmenter } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+	BlockUnitCounter,
+	buildDisplayMessage,
+	CATCHUP_WINDOW_MS,
+	DEFAULT_SMOOTH_FPS,
+	MAX_SMOOTH_FPS,
+	MIN_REVEAL_UNITS_PER_SEC,
+	MIN_SMOOTH_FPS,
+	nextStep,
+	StreamingRevealController,
+	visibleUnits,
+} from "../src/modes/interactive/streaming-reveal.ts";
+
+function makeMessage(
+	content: AssistantMessage["content"],
+	overrides: Partial<Pick<AssistantMessage, "errorMessage" | "stopReason">> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: overrides.stopReason ?? "stop",
+		errorMessage: overrides.errorMessage,
+		timestamp: 0,
+	};
+}
+
+function fullSlice(text: string, units: number): string {
+	if (units <= 0) return "";
+	const segments = [...getGraphemeSegmenter().segment(text)];
+	const segment = segments[Math.floor(units) - 1];
+	return segment === undefined ? text : text.slice(0, segment.index + segment.segment.length);
+}
+
+function textAt(message: AssistantMessage, index = 0): string {
+	const block = message.content[index];
+	if (block?.type !== "text") throw new TypeError(`Expected text block at index ${index}`);
+	return block.text;
+}
+
+function thinkingAt(message: AssistantMessage, index = 0): string {
+	const block = message.content[index];
+	if (block?.type !== "thinking") throw new TypeError(`Expected thinking block at index ${index}`);
+	return block.thinking;
+}
+
+class RecordingComponent {
+	readonly messages: AssistantMessage[] = [];
+
+	updateContent(message: AssistantMessage): void {
+		this.messages.push(message);
+	}
+}
+
+function latestMessage(component: RecordingComponent): AssistantMessage {
+	const message = component.messages.at(-1);
+	if (!message) throw new Error("Expected at least one rendered message");
+	return message;
+}
+
+type ControllerHarness = {
+	readonly component: RecordingComponent;
+	readonly controller: StreamingRevealController;
+	readonly requestRender: ReturnType<typeof vi.fn>;
+};
+
+function makeController(
+	options: {
+		readonly fps?: () => number;
+		readonly hideThinking?: () => boolean;
+		readonly smooth?: () => boolean;
+	} = {},
+): ControllerHarness {
+	const component = new RecordingComponent();
+	const requestRender = vi.fn();
+	const controller = new StreamingRevealController({
+		getSmoothStreaming: options.smooth ?? (() => true),
+		getSmoothStreamingFps: options.fps ?? (() => DEFAULT_SMOOTH_FPS),
+		getHideThinkingBlock: options.hideThinking ?? (() => false),
+		requestRender,
+	});
+	return { component, controller, requestRender };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("BlockUnitCounter", () => {
+	test.each([
+		["ASCII", ["a", "ab", "abc"]],
+		["Korean", ["한", "한글", "한글날"]],
+		["emoji ZWJ", ["👨", "👨‍👩", "👨‍👩‍👧", "👨‍👩‍👧‍👦", "👨‍👩‍👧‍👦!"]],
+		["combining marks", ["e", "e\u0301", "e\u0301x", "e\u0301x\u0323"]],
+	] as const)("#given an append-only %s stream #when counting and slicing deltas #then matches a full grapheme recount", (_name, sequence) => {
+		const counter = new BlockUnitCounter();
+		for (const text of sequence) {
+			const fullCount = [...getGraphemeSegmenter().segment(text)].length;
+			expect(counter.count(0, text)).toBe(fullCount);
+			for (let units = 0; units <= fullCount + 1; units++) {
+				expect(counter.slice(0, text, units)).toBe(fullSlice(text, units));
+			}
+		}
+	});
+
+	test("#given a cached short suffix #when text appends #then slices the new grapheme through the fast path", () => {
+		const counter = new BlockUnitCounter();
+
+		expect(counter.slice(0, "a", 2)).toBe("a");
+		expect(counter.slice(0, "ab", 2)).toBe("ab");
+		expect(counter.slice(1, "abc", 1.2)).toBe("a");
+	});
+});
+
+describe("streaming reveal pure helpers", () => {
+	test("#given PR3 pacing constants #when imported #then pins the literal design contract", () => {
+		expect(MIN_REVEAL_UNITS_PER_SEC).toBe(90);
+		expect(CATCHUP_WINDOW_MS).toBe(267);
+		expect(MIN_SMOOTH_FPS).toBe(30);
+		expect(DEFAULT_SMOOTH_FPS).toBe(60);
+		expect(MAX_SMOOTH_FPS).toBe(120);
+	});
+
+	test("#given mixed ordered blocks #when slicing visible units #then preserves raw thinking and passthrough blocks", () => {
+		const family = "👨‍👩‍👧‍👦";
+		const thinking = { type: "thinking" as const, thinking: "한글" };
+		const providerNative = { type: "providerNative" as const, subtype: "status", raw: { state: "running" } };
+		const toolCall = {
+			type: "toolCall" as const,
+			id: "call-1",
+			name: "read",
+			arguments: { path: "README.md" },
+		};
+		const target = makeMessage([
+			{ type: "text", text: "A" },
+			thinking,
+			providerNative,
+			{ type: "text", text: `${family}B` },
+			toolCall,
+		]);
+
+		const visible = buildDisplayMessage(target, 4, false);
+		const hidden = buildDisplayMessage(target, 2, true);
+
+		expect(visibleUnits(target, false)).toBe(5);
+		expect(thinkingAt(visible, 1)).toBe("한글");
+		expect(textAt(visible, 3)).toBe(family);
+		expect(visible.content[2]).toBe(providerNative);
+		expect(visible.content[4]).toBe(toolCall);
+		expect(visibleUnits(target, true)).toBe(3);
+		expect(hidden.content[1]).toBe(thinking);
+		expect(textAt(hidden, 3)).toBe(family);
+		expect(textAt(target, 3)).toBe(`${family}B`);
+	});
+
+	test("#given a fixed backlog #when stepping at 30 60 and 120fps #then completion times stay within one 30fps tick", () => {
+		const revealTime = (fps: number): number => {
+			const dt = 1000 / fps;
+			let backlog = 9;
+			let elapsed = 0;
+			while (backlog > 0) {
+				backlog -= nextStep(backlog, dt);
+				elapsed += dt;
+			}
+			return elapsed;
+		};
+		const times = [MIN_SMOOTH_FPS, DEFAULT_SMOOTH_FPS, MAX_SMOOTH_FPS].map(revealTime);
+
+		expect(Math.max(...times) - Math.min(...times)).toBeLessThanOrEqual(1000 / MIN_SMOOTH_FPS);
+	});
+
+	test("#given floor catchup and jitter inputs #when choosing a step #then uses the exact time-based bounds", () => {
+		const dt = 1000 / DEFAULT_SMOOTH_FPS;
+		const backlog = 1000;
+		const catchupStep = nextStep(backlog, dt);
+
+		expect(nextStep(0, dt)).toBe(0);
+		expect(nextStep(10, 1000 / MIN_SMOOTH_FPS)).toBe(Math.round(MIN_REVEAL_UNITS_PER_SEC / MIN_SMOOTH_FPS));
+		expect((backlog / catchupStep) * dt).toBeLessThanOrEqual(CATCHUP_WINDOW_MS);
+		expect(nextStep(backlog, 0)).toBe(nextStep(backlog, 1));
+		expect(nextStep(backlog, 1000)).toBe(nextStep(backlog, 100));
+		expect(nextStep(backlog, 100)).toBe(375);
+	});
+});
+
+describe("StreamingRevealController", () => {
+	test("#given an active reveal #when begin replaces it #then cancels the old interval", () => {
+		vi.useFakeTimers();
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "first" }]));
+		controller.begin(new RecordingComponent(), makeMessage([{ type: "text", text: "second" }]));
+
+		expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+		controller.stop();
+	});
+
+	test("#given a growing target #when ticks advance #then rendered prefixes grow monotonically", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const { component, controller, requestRender } = makeController();
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghijklmnopqrst" }]));
+		const beforeTicks = component.messages.length;
+
+		for (let tick = 1; tick <= 4; tick++) {
+			now = tick * (1000 / DEFAULT_SMOOTH_FPS);
+			vi.advanceTimersByTime(17);
+		}
+		const lengths = component.messages.slice(beforeTicks).map((message) => textAt(message).length);
+
+		expect(lengths).toHaveLength(4);
+		expect(lengths.every((length, index) => index === 0 || length > lengths[index - 1]!)).toBe(true);
+		expect(requestRender).toHaveBeenCalledTimes(4);
+		controller.stop();
+	});
+
+	test("#given an event-loop stall #when a tick runs #then clamps real performance delta to 100ms", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const { component, controller } = makeController({ fps: () => MIN_SMOOTH_FPS });
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "a".repeat(1000) }]));
+
+		now = 1000;
+		vi.advanceTimersByTime(34);
+
+		expect(textAt(latestMessage(component))).toHaveLength(nextStep(1000, 100));
+		controller.stop();
+	});
+
+	test("#given an active reveal #when smoothing is disabled #then snaps full and cancels pacing", () => {
+		vi.useFakeTimers();
+		let smooth = true;
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+		const { component, controller, requestRender } = makeController({ smooth: () => smooth });
+		controller.begin(component, makeMessage([{ type: "text", text: "chunk" }]));
+
+		smooth = false;
+		const finalTarget = makeMessage([{ type: "text", text: "chunky" }]);
+		controller.setTarget(finalTarget);
+		const updates = component.messages.length;
+		vi.advanceTimersByTime(1000);
+
+		expect(latestMessage(component)).toBe(finalTarget);
+		expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+		expect(component.messages).toHaveLength(updates);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
+
+	test("#given a partial reveal #when a tool call arrives #then jumps to full text and cancels ticking", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const { component, controller } = makeController({ fps: () => MIN_SMOOTH_FPS });
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghi" }]));
+		now = 1000 / MIN_SMOOTH_FPS;
+		vi.advanceTimersByTime(34);
+		expect(textAt(latestMessage(component))).toBe("abc");
+
+		const withTool = makeMessage([
+			{ type: "text", text: "abcdefghi" },
+			{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } },
+		]);
+		controller.setTarget(withTool);
+		const updates = component.messages.length;
+		vi.advanceTimersByTime(1000);
+
+		expect(latestMessage(component)).toBe(withTool);
+		expect(component.messages).toHaveLength(updates);
+	});
+
+	test("#given an active reveal #when stopped and final content is flushed directly #then no timer overwrites it", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+		controller.begin(component, makeMessage([{ type: "text", text: "streaming" }]));
+
+		controller.stop();
+		const finalMessage = makeMessage([{ type: "text", text: "final" }], { stopReason: "length" });
+		component.updateContent(finalMessage);
+		vi.advanceTimersByTime(1000);
+
+		expect(latestMessage(component)).toBe(finalMessage);
+	});
+
+	test("#given visibility changes mid-stream #when resynced #then hidden thinking consumes no units", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		let hidden = false;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const { component, controller } = makeController({
+			fps: () => MIN_SMOOTH_FPS,
+			hideThinking: () => hidden,
+		});
+		controller.begin(
+			component,
+			makeMessage([
+				{ type: "thinking", thinking: "think" },
+				{ type: "text", text: "answer" },
+			]),
+		);
+		now = 1000 / MIN_SMOOTH_FPS;
+		vi.advanceTimersByTime(34);
+		expect(thinkingAt(latestMessage(component))).toBe("thi");
+
+		hidden = true;
+		controller.resyncVisibility();
+
+		expect(thinkingAt(latestMessage(component))).toBe("think");
+		expect(textAt(latestMessage(component), 1)).toBe("ans");
+		controller.stop();
+	});
+
+	test("#given fps changes while active #when target resyncs #then restarts at the clamped fps", () => {
+		vi.useFakeTimers();
+		let fps = DEFAULT_SMOOTH_FPS;
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+		const { component, controller } = makeController({ fps: () => fps });
+		const target = makeMessage([{ type: "text", text: "a".repeat(100) }]);
+		controller.begin(component, target);
+
+		fps = 500;
+		controller.setTarget(target);
+
+		expect(setIntervalSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 1000 / DEFAULT_SMOOTH_FPS);
+		expect(setIntervalSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 1000 / MAX_SMOOTH_FPS);
+		expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+		controller.stop();
+	});
+
+	test("#given an active reveal #when its timer starts #then the handle is unrefed", () => {
+		const unref = vi.fn();
+		const handle = { unref } as unknown as NodeJS.Timeout;
+		vi.spyOn(globalThis, "setInterval").mockReturnValue(handle);
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "pending" }]));
+
+		expect(unref).toHaveBeenCalledTimes(1);
+		controller.stop();
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds a grapheme-safe, time-based reveal for streamed assistant responses so bursty provider chunks appear at a steady visual pace. Smoothing is enabled by default, supports a 30–120fps render cap, and still flushes full content immediately at tool-call and stream-finalization boundaries.

## Changes

- Add an append-aware reveal controller that counts and slices grapheme clusters incrementally, uses a 90 units/second floor with a 267ms catch-up horizon, clamps real tick deltas to 1–100ms, and releases its timer with `.unref()`.
- Persist `smoothStreaming` and `smoothStreamingFps` settings, expose “Smooth streaming” and “Streaming fps” in the selector, and apply the configured TUI render cap.
- Integrate one controller with assistant start/update/end, abort, session-switch, thinking-visibility, FPS-change, and shutdown paths while leaving pending tool-argument rendering unchanged.
- Add deterministic controller, Unicode, pacing, lifecycle, settings, and adjacent incremental-render regression coverage.

## QA & Evidence

- **What was tested:** From `packages/coding-agent`, the focused reveal, settings, incremental assistant render, and session-start suites.
  **Observed result:** 4 files passed; 81/81 tests passed.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-smooth-streaming-reveal/01-scoped-tests.log`
  **Why sufficient:** Covers grapheme safety, pacing constants and delta clamping, controller lifecycle, settings persistence/clamping, and adjacent render behavior.

- **What was tested:** `npm run check` from the worktree root.
  **Observed result:** Passed Biome, dependency/lock validation, TypeScript `--noEmit`, browser/web checks, and Neo build/vet/tests.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-smooth-streaming-reveal/02-root-check.log`
  **Why sufficient:** Proves the complete repository quality gate remains clean without dependency or lockfile changes.

- **What was tested:** `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`.
  **Observed result:** 5/5 passed with localhost-only provider traffic and unchanged real auth.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-smooth-streaming-reveal/03-mock-loop-self-test.log`
  **Why sufficient:** Validates the real loop against isolated mock endpoints before TUI driving.

- **What was tested:** `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool`.
  **Observed result:** 4/4 passed across two model turns with a completed tool loop and unchanged real auth.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-smooth-streaming-reveal/04-mock-loop-with-tool.log`
  **Why sufficient:** Protects tool-loop behavior while assistant text pacing changes.

- **What was tested:** `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux`.
  **Observed result:** 5/5 passed; the TUI booted, accepted input, rendered, and tore down without leaks or auth changes.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-smooth-streaming-reveal/05-tui-smoke-tmux.log`
  **Why sufficient:** Confirms the real terminal surface remains operable after render scheduling changes.

- **What was tested:** A long streamed mock response driven through the real TUI in tmux, captured about every 100ms.
  **Observed result:** 46 frames; frames 003–042 are 40 consecutive strictly growing prefixes, frame 043 exactly matches the 2,980-character final response, and frames 044–045 remain stable. Cleanup, mock-request isolation, and real-auth integrity all passed.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-smooth-streaming-reveal/{assertions.json,metadata.json,requests.json,cleanup.json,prefix-lengths.tsv,frames/,final-frame.txt}`
  **Why sufficient:** This is the direct feature proof that streamed output is visibly revealed over successive real TUI frames instead of arriving as one burst.

## Risks

- Timer and render-loop regressions are mitigated by real-delta clamping, timer cancellation on every lifecycle boundary, `.unref()`, focused fake-timer tests, and the tmux smoke/capture evidence.
- Unicode splitting is mitigated by tests for Korean, emoji ZWJ sequences, and combining marks. The manual capture payload is intentionally long ASCII text, so multi-codepoint graphemes are proven in deterministic unit coverage rather than the saved frames.
- Tool-call latency is mitigated by immediate full-snapshot behavior and the passing multi-turn tool-loop QA. Pending tool-argument pacing remains out of scope for PR4.
- The QA artifacts are intentionally retained in the required local evidence directory and are not committed to the repository.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a grapheme-safe, time-based smoothing for streamed assistant responses in the TUI so bursty chunks reveal at a steady pace (30–120 fps), with instant flush on tool calls and at stream end. Persists smooth streaming and FPS settings, adds UI controls, and caps render FPS accordingly.

- New Features
  - Introduced `StreamingRevealController` for grapheme-safe, time-based reveal (≥90 units/s, 267ms catch-up, 1–100ms dt clamp; timer `.unref()`).
  - Wired into `interactive-mode.ts` across assistant start/update/finalize, abort, session switch, thinking visibility, and shutdown; tool calls and final flush bypass.
  - Persisted `smoothStreaming` and `smoothStreamingFps` (default 60, clamp 30–120) in `core/settings-manager.ts`; added settings UI; capped TUI render FPS when enabled.
  - Added deterministic tests for Unicode safety, pacing invariants, lifecycle/visibility resync, timer behavior, and settings defaults/clamping.

- Bug Fixes
  - Updated session rebind white-box fixtures to stub `streamingReveal.stop()` in both mock contexts, matching the render-reset path.

<sup>Written for commit db795899a760fc63a3c416aea8361d6b6deed20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

