### PR TITLE
feat(coding-agent): /todo command suite with Markdown round-trip

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -14,10 +14,11 @@ Copyright (c) 2025-2026 Can Bölük
 
 ## Todo tool
 
-The phased `todo` tool in
-`packages/coding-agent/src/core/extensions/builtin/todotools/` is ported and
-adapted from oh-my-pi's `packages/coding-agent/src/tools/todo.ts` and
-`src/prompts/tools/todo.md`, which are MIT-licensed:
+The phased `todo` tool and `/todo` command in
+`packages/coding-agent/src/core/extensions/builtin/todotools/` are ported and
+adapted from oh-my-pi's `packages/coding-agent/src/tools/todo.ts`,
+`src/prompts/tools/todo.md`, and
+`src/modes/controllers/todo-command-controller.ts`, which are MIT-licensed:
 
 [`oh-my-pi`](https://github.com/can1357/oh-my-pi)
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added a `/todo` command for user-side todo management: view, overlay `edit` (Markdown checklist), `copy`, `export`/`import` (default `TODO.md`), and fuzzy-matched `append`/`start`/`done`/`drop`/`rm`; user edits persist as `senpi.todo-state` entries and notify the agent next turn.
 - Added `antml` as a valid `compat.toolCallFormat` in custom `models.json` provider and model definitions: ANTML `<function_calls>`/`<invoke>` text-tool protocol with Claude-Code-style failure tolerance.
 - Added built-in llama.cpp router support with `/login` connection setup and `/llama` Hugging Face model search and downloads, explicit loading, unloading, and live progress. See [llama.cpp](docs/llama-cpp.md).
 - Added extension registration for complete pi-ai providers, including native authentication, model refresh, filtering, and streaming behavior.

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -10,7 +10,7 @@
 | 2 | `permission-system` | `permission-system/` | Full opencode-style permission port: rules, JSONL storage, prompts |
 | 3 | `gpt-apply-patch` | `gpt-apply-patch/` | Codex-style `apply_patch` tool with rich render + freeform grammar |
 | 4 | `prompt-preset` | `prompt-preset/` | Per-model system prompts (gpt-5.x, claude-fable-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3) |
-| 5 | `todowrite` | `todotools/` | Op-based oh-my-pi todo port; fully diverged from `../pi-extensions/pi-todotools` |
+| 5 | `todowrite` | `todotools/` | Op-based oh-my-pi todo port + `/todo` command; fully diverged from `../pi-extensions/pi-todotools` |
 | 6 | `redraws` | `redraws.ts` | Force-redraw event hooks for stable streaming visuals |
 | 7 | `anthropic-web-search` | `anthropic-web-search/` | Anthropic-native web search tool |
 | 8 | `anthropic-bash` | `anthropic-bash/` | Anthropic-native bash tool variant |

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -41,3 +41,31 @@
   oh-my-pi todo implementation.
 - MEDIUM: `index.ts`, compaction bridge, and todo tests because senpi owns
   extension lifecycle and session compatibility.
+
+## 2026-07-20 - Port oh-my-pi's /todo command suite
+
+### Source
+
+- `packages/coding-agent/src/modes/controllers/todo-command-controller.ts` and the
+  Markdown round-trip half of `src/tools/todo.ts` from the same oh-my-pi commit
+  (`9fd6e97113f5ed3a847e66d346970efdf8afcad9`, v17.0.5, MIT).
+
+### What was ported
+
+- `markdown.ts`: `phasesToMarkdown`/`markdownToPhases` (`[ ]`/`[x]`/`[/]`/`[-]`
+  markers) and `resolveTodoMarkdownPath` (default `TODO.md`).
+- `commands.ts`: `/todo` verbs — show, `edit`, `copy`, `export`, `import`,
+  `append`, `start`, `done`, `drop`, `rm` — with quote-aware tokenizing and
+  phase/task fuzzy matching, plus the user-edit system reminder (including the
+  explicit removal-intent wording).
+
+### senpi adaptations
+
+- Registered via `pi.registerCommand` on the extension API instead of an
+  interactive-mode controller class.
+- `edit` uses the built-in `ctx.ui.editor` overlay instead of suspending the
+  TUI for an external `$EDITOR`.
+- User edits persist as `senpi.todo-state` v2 entries with `source: "user"`
+  (no new custom type), so the branch scanner and compaction bridge read them
+  unchanged; the agent notification is a hidden `todotools.user-edit` custom
+  message delivered next turn.

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/commands.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/commands.ts
@@ -15,6 +15,7 @@ import { markdownToPhases, phasesToMarkdown, resolveTodoMarkdownPath } from "./m
 import {
 	applyOpsToPhases,
 	clonePhases,
+	DEFAULT_INIT_PHASE,
 	TODO_STATE_ENTRY_TYPE,
 	type TodoItem,
 	type TodoPhase,
@@ -171,7 +172,9 @@ export function registerTodoCommand(pi: ExtensionAPI, accessors: TodoCommandAcce
 	async function editInOverlay(ctx: ExtensionCommandContext): Promise<void> {
 		const current = accessors.getCurrentPhases();
 		const initialMarkdown =
-			current.length > 0 ? phasesToMarkdown(current) : "# Todos\n- [ ] (replace this with your tasks)\n";
+			current.length > 0
+				? phasesToMarkdown(current)
+				: `# ${DEFAULT_INIT_PHASE}\n- [ ] (replace this with your tasks)\n`;
 		const edited = await ctx.ui.editor("Edit todos (Markdown checklist)", initialMarkdown);
 		if (edited === undefined || edited === initialMarkdown) {
 			ctx.ui.notify("Todos unchanged.", "info");
@@ -263,7 +266,7 @@ export function registerTodoCommand(pi: ExtensionAPI, accessors: TodoCommandAcce
 		} else if (next.length > 0) {
 			targetPhase = next[next.length - 1];
 		} else {
-			targetPhase = { name: "Todos", tasks: [] };
+			targetPhase = { name: DEFAULT_INIT_PHASE, tasks: [] };
 			next.push(targetPhase);
 		}
 

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/commands.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/commands.ts
@@ -1,0 +1,426 @@
+// /todo slash command: user-facing todo management.
+//
+// Ported and adapted from oh-my-pi's
+// `packages/coding-agent/src/modes/controllers/todo-command-controller.ts`
+// (MIT — see NOTICE.md). senpi adaptations: the command registers through the
+// extension API, edits happen in the built-in `ctx.ui.editor` overlay instead
+// of a suspended external $EDITOR, and user edits persist as `senpi.todo-state`
+// entries with `source: "user"` so the branch scanner and compaction bridge
+// pick them up unchanged.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { copyToClipboard } from "../../../../utils/clipboard.ts";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../types.ts";
+import { markdownToPhases, phasesToMarkdown, resolveTodoMarkdownPath } from "./markdown.ts";
+import {
+	applyOpsToPhases,
+	clonePhases,
+	TODO_STATE_ENTRY_TYPE,
+	type TodoItem,
+	type TodoPhase,
+	type TodoStateEntry,
+} from "./state.ts";
+
+const USAGE = [
+	"Usage: /todo <verb> [args]",
+	"  /todo                              Show current todos",
+	"  /todo edit                         Edit todos as Markdown in an overlay",
+	"  /todo copy                         Copy todos as Markdown to clipboard",
+	"  /todo export [<path>]              Write todos to file (default: TODO.md)",
+	"  /todo import [<path>]              Replace todos from file (default: TODO.md)",
+	"  /todo append [<phase>] <task...>   Append a task; phase fuzzy-matched or created",
+	"  /todo start  <task>                Mark task in_progress (fuzzy match)",
+	"  /todo done   [<task|phase>]        Mark task/phase/all completed",
+	"  /todo drop   [<task|phase>]        Mark task/phase/all abandoned",
+	"  /todo rm     [<task|phase>]        Remove task/phase/all",
+].join("\n");
+
+const VERBS = ["edit", "copy", "export", "import", "append", "start", "done", "drop", "rm", "help"] as const;
+
+export type TodoCommandAccessors = {
+	getCurrentPhases: () => TodoPhase[];
+	setCurrentPhases: (phases: TodoPhase[]) => void;
+	syncWidget: (ctx: ExtensionContext) => void;
+};
+
+/** Tokenizer honoring double-quoted strings and backslash escapes. */
+export function tokenizeTodoArgs(input: string): string[] {
+	const tokens: string[] = [];
+	let current = "";
+	let inQuote = false;
+	for (let index = 0; index < input.length; index += 1) {
+		const char = input[index];
+		if (char === "\\" && index + 1 < input.length) {
+			current += input[index + 1];
+			index += 1;
+			continue;
+		}
+		if (char === '"') {
+			inQuote = !inQuote;
+			continue;
+		}
+		if (!inQuote && /\s/.test(char)) {
+			if (current) {
+				tokens.push(current);
+				current = "";
+			}
+			continue;
+		}
+		current += char;
+	}
+	if (current) tokens.push(current);
+	return tokens;
+}
+
+/** Exact name first, then unique prefix, then unique substring (case-insensitive). */
+export function findPhaseFuzzy(phases: TodoPhase[], query: string): TodoPhase | undefined {
+	const q = query.trim().toLowerCase();
+	if (!q) return undefined;
+	const byName = phases.find((phase) => phase.name.toLowerCase() === q);
+	if (byName) return byName;
+	const prefixMatches = phases.filter((phase) => phase.name.toLowerCase().startsWith(q));
+	if (prefixMatches.length === 1) return prefixMatches[0];
+	const substringMatches = phases.filter((phase) => phase.name.toLowerCase().includes(q));
+	if (substringMatches.length === 1) return substringMatches[0];
+	return undefined;
+}
+
+/** Exact content first, then unique substring; ambiguity resolved toward open work. */
+export function findTaskFuzzy(phases: TodoPhase[], query: string): { task: TodoItem; phase: TodoPhase } | undefined {
+	const q = query.trim().toLowerCase();
+	if (!q) return undefined;
+	for (const phase of phases) {
+		for (const task of phase.tasks) {
+			if (task.content.toLowerCase() === q) return { task, phase };
+		}
+	}
+	const matches: Array<{ task: TodoItem; phase: TodoPhase }> = [];
+	for (const phase of phases) {
+		for (const task of phase.tasks) {
+			if (task.content.toLowerCase().includes(q)) matches.push({ task, phase });
+		}
+	}
+	if (matches.length === 1) return matches[0];
+	const open = matches.filter((hit) => hit.task.status === "in_progress" || hit.task.status === "pending");
+	if (open.length === 1) return open[0];
+	return undefined;
+}
+
+function titleCaseWords(text: string): string {
+	return text
+		.split(/\s+/)
+		.filter(Boolean)
+		.map((word) => word[0].toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
+function titleCaseSentence(text: string): string {
+	const trimmed = text.trim();
+	if (!trimmed) return trimmed;
+	return trimmed[0].toUpperCase() + trimmed.slice(1);
+}
+
+function buildUserEditReminder(action: string, phases: readonly TodoPhase[], removed: boolean): string {
+	const markdown = phases.length === 0 ? "(empty)" : phasesToMarkdown(phases).trimEnd();
+	const lines = ["<system-reminder>", `The user manually modified the todo list (${action}).`];
+	if (removed) {
+		lines.push(
+			phases.length === 0
+				? "The user intentionally cleared the todo list. Do NOT recreate or re-populate it unless the user explicitly asks; continue the current request without a todo list."
+				: "The user intentionally removed the entries no longer shown below. Do NOT re-add them unless the user explicitly asks.",
+		);
+	}
+	lines.push("Current todo list:", "", markdown, "</system-reminder>");
+	return lines.join("\n");
+}
+
+export function registerTodoCommand(pi: ExtensionAPI, accessors: TodoCommandAccessors): void {
+	function commit(
+		ctx: ExtensionCommandContext,
+		nextPhases: TodoPhase[],
+		action: string,
+		options?: { removed?: boolean },
+	): void {
+		accessors.setCurrentPhases(clonePhases(nextPhases));
+		pi.appendEntry(TODO_STATE_ENTRY_TYPE, {
+			schema: "v2",
+			phases: clonePhases(nextPhases),
+			source: "user",
+			action,
+		} satisfies TodoStateEntry & { source: string; action: string });
+		accessors.syncWidget(ctx);
+		pi.sendMessage(
+			{
+				customType: "todotools.user-edit",
+				content: buildUserEditReminder(action, nextPhases, options?.removed ?? false),
+				display: false,
+			},
+			{ triggerTurn: false, deliverAs: "nextTurn" },
+		);
+	}
+
+	function showCurrent(ctx: ExtensionCommandContext): void {
+		const phases = accessors.getCurrentPhases();
+		if (phases.length === 0) {
+			ctx.ui.notify("No todos. Use /todo append <task> to start one.", "info");
+			return;
+		}
+		ctx.ui.notify(phasesToMarkdown(phases).trimEnd(), "info");
+	}
+
+	async function editInOverlay(ctx: ExtensionCommandContext): Promise<void> {
+		const current = accessors.getCurrentPhases();
+		const initialMarkdown =
+			current.length > 0 ? phasesToMarkdown(current) : "# Todos\n- [ ] (replace this with your tasks)\n";
+		const edited = await ctx.ui.editor("Edit todos (Markdown checklist)", initialMarkdown);
+		if (edited === undefined || edited === initialMarkdown) {
+			ctx.ui.notify("Todos unchanged.", "info");
+			return;
+		}
+		const { phases, errors } = markdownToPhases(edited);
+		if (errors.length > 0) {
+			ctx.ui.notify(`Could not parse Markdown:\n  ${errors.join("\n  ")}`, "error");
+			return;
+		}
+		commit(ctx, phases, "/todo edit");
+		const taskCount = phases.reduce((sum, phase) => sum + phase.tasks.length, 0);
+		ctx.ui.notify(`Todos updated: ${phases.length} phase(s), ${taskCount} task(s).`, "info");
+	}
+
+	async function copyMarkdown(ctx: ExtensionCommandContext): Promise<void> {
+		const phases = accessors.getCurrentPhases();
+		if (phases.length === 0) {
+			ctx.ui.notify("No todos to copy.", "warning");
+			return;
+		}
+		try {
+			await copyToClipboard(phasesToMarkdown(phases));
+			ctx.ui.notify("Copied todos as Markdown to clipboard.", "info");
+		} catch (error) {
+			ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+		}
+	}
+
+	async function exportToFile(ctx: ExtensionCommandContext, rest: string): Promise<void> {
+		const phases = accessors.getCurrentPhases();
+		if (phases.length === 0) {
+			ctx.ui.notify("No todos to export.", "warning");
+			return;
+		}
+		try {
+			const target = resolveTodoMarkdownPath(rest, ctx.cwd);
+			await writeFile(target, phasesToMarkdown(phases), "utf8");
+			ctx.ui.notify(`Wrote todos to ${target}`, "info");
+		} catch (error) {
+			ctx.ui.notify(`Failed to write todos: ${error instanceof Error ? error.message : String(error)}`, "error");
+		}
+	}
+
+	async function importFromFile(ctx: ExtensionCommandContext, rest: string): Promise<void> {
+		let source = "";
+		let content: string;
+		try {
+			source = resolveTodoMarkdownPath(rest, ctx.cwd);
+			content = await readFile(source, "utf8");
+		} catch (error) {
+			ctx.ui.notify(`Failed to read todos: ${error instanceof Error ? error.message : String(error)}`, "error");
+			return;
+		}
+		const { phases, errors } = markdownToPhases(content);
+		if (errors.length > 0) {
+			ctx.ui.notify(`Could not parse ${source}:\n  ${errors.join("\n  ")}`, "error");
+			return;
+		}
+		commit(ctx, phases, `/todo import ${source}`);
+		const taskCount = phases.reduce((sum, phase) => sum + phase.tasks.length, 0);
+		ctx.ui.notify(`Imported ${phases.length} phase(s), ${taskCount} task(s) from ${source}.`, "info");
+	}
+
+	function append(ctx: ExtensionCommandContext, rest: string): void {
+		const tokens = tokenizeTodoArgs(rest);
+		if (tokens.length === 0) {
+			ctx.ui.notify("Usage: /todo append [<phase>] <task...>", "error");
+			return;
+		}
+
+		const next = clonePhases(accessors.getCurrentPhases());
+		let phaseName: string | undefined;
+		let content: string;
+		if (tokens.length === 1) {
+			content = tokens[0];
+		} else {
+			phaseName = tokens[0];
+			content = tokens.slice(1).join(" ");
+		}
+
+		let targetPhase: TodoPhase | undefined;
+		if (phaseName) {
+			targetPhase = findPhaseFuzzy(next, phaseName);
+			if (!targetPhase) {
+				targetPhase = { name: titleCaseWords(phaseName), tasks: [] };
+				next.push(targetPhase);
+			}
+		} else if (next.length > 0) {
+			targetPhase = next[next.length - 1];
+		} else {
+			targetPhase = { name: "Todos", tasks: [] };
+			next.push(targetPhase);
+		}
+
+		const finalContent = titleCaseSentence(content);
+		targetPhase.tasks.push({ content: finalContent, status: "pending" });
+		commit(ctx, next, `/todo append → ${targetPhase.name}`);
+		ctx.ui.notify(`Appended to ${targetPhase.name}: ${finalContent}`, "info");
+	}
+
+	function start(ctx: ExtensionCommandContext, rest: string): void {
+		if (!rest) {
+			ctx.ui.notify("Usage: /todo start <task>", "error");
+			return;
+		}
+		const current = accessors.getCurrentPhases();
+		const hit = findTaskFuzzy(current, rest);
+		if (!hit) {
+			ctx.ui.notify(`No task matched "${rest}". Use /todo to list current tasks.`, "error");
+			return;
+		}
+		const { phases, errors } = applyOpsToPhases(current, [{ op: "start", task: hit.task.content }]);
+		if (errors.length > 0) {
+			ctx.ui.notify(errors.join("; "), "error");
+			return;
+		}
+		commit(ctx, phases, `/todo start ${hit.task.content}`);
+		ctx.ui.notify(`Started: ${hit.task.content}`, "info");
+	}
+
+	function mutateStatus(ctx: ExtensionCommandContext, rest: string, target: "completed" | "abandoned"): void {
+		const op = target === "completed" ? ("done" as const) : ("drop" as const);
+		const current = accessors.getCurrentPhases();
+		const trimmed = rest.trim();
+		if (!trimmed) {
+			const { phases, errors } = applyOpsToPhases(current, [{ op }]);
+			if (errors.length > 0) {
+				ctx.ui.notify(errors.join("; "), "error");
+				return;
+			}
+			commit(ctx, phases, `/todo ${op} (all)`);
+			ctx.ui.notify(`Marked all tasks ${target}.`, "info");
+			return;
+		}
+
+		const taskHit = findTaskFuzzy(current, trimmed);
+		if (taskHit) {
+			const { phases, errors } = applyOpsToPhases(current, [{ op, task: taskHit.task.content }]);
+			if (errors.length > 0) {
+				ctx.ui.notify(errors.join("; "), "error");
+				return;
+			}
+			commit(ctx, phases, `/todo ${op} ${taskHit.task.content}`);
+			ctx.ui.notify(`Marked ${target}: ${taskHit.task.content}`, "info");
+			return;
+		}
+
+		const phaseHit = findPhaseFuzzy(current, trimmed);
+		if (phaseHit) {
+			const { phases, errors } = applyOpsToPhases(current, [{ op, phase: phaseHit.name }]);
+			if (errors.length > 0) {
+				ctx.ui.notify(errors.join("; "), "error");
+				return;
+			}
+			commit(ctx, phases, `/todo ${op} ${phaseHit.name}`);
+			ctx.ui.notify(`Marked phase ${phaseHit.name} ${target}.`, "info");
+			return;
+		}
+
+		ctx.ui.notify(`No task or phase matched "${trimmed}".`, "error");
+	}
+
+	function remove(ctx: ExtensionCommandContext, rest: string): void {
+		const current = accessors.getCurrentPhases();
+		const trimmed = rest.trim();
+		if (!trimmed) {
+			commit(ctx, [], "/todo rm (all)", { removed: true });
+			ctx.ui.notify("Cleared all todos.", "info");
+			return;
+		}
+		const taskHit = findTaskFuzzy(current, trimmed);
+		if (taskHit) {
+			const { phases, errors } = applyOpsToPhases(current, [{ op: "rm", task: taskHit.task.content }]);
+			if (errors.length > 0) {
+				ctx.ui.notify(errors.join("; "), "error");
+				return;
+			}
+			commit(ctx, phases, `/todo rm ${taskHit.task.content}`, { removed: true });
+			ctx.ui.notify(`Removed: ${taskHit.task.content}`, "info");
+			return;
+		}
+		const phaseHit = findPhaseFuzzy(current, trimmed);
+		if (phaseHit) {
+			const { phases, errors } = applyOpsToPhases(current, [{ op: "rm", phase: phaseHit.name }]);
+			if (errors.length > 0) {
+				ctx.ui.notify(errors.join("; "), "error");
+				return;
+			}
+			commit(ctx, phases, `/todo rm ${phaseHit.name}`, { removed: true });
+			ctx.ui.notify(`Removed phase: ${phaseHit.name}`, "info");
+			return;
+		}
+		ctx.ui.notify(`No task or phase matched "${trimmed}".`, "error");
+	}
+
+	pi.registerCommand("todo", {
+		description: "Show or edit the todo list (edit/copy/export/import/append/start/done/drop/rm)",
+		getArgumentCompletions: (argumentPrefix: string) => {
+			const prefix = argumentPrefix.trim().toLowerCase();
+			const matches = VERBS.filter((verb) => verb.startsWith(prefix));
+			if (matches.length === 0) return null;
+			return matches.map((verb) => ({ value: verb, label: verb }));
+		},
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
+			const trimmed = args.trim();
+			if (!trimmed) {
+				showCurrent(ctx);
+				return;
+			}
+			const spaceIndex = trimmed.search(/\s/);
+			const verb = (spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex)).toLowerCase();
+			const rest = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex + 1).trim();
+
+			switch (verb) {
+				case "edit":
+					await editInOverlay(ctx);
+					return;
+				case "copy":
+					await copyMarkdown(ctx);
+					return;
+				case "export":
+					await exportToFile(ctx, rest);
+					return;
+				case "import":
+					await importFromFile(ctx, rest);
+					return;
+				case "help":
+				case "?":
+					ctx.ui.notify(USAGE, "info");
+					return;
+				case "append":
+					append(ctx, rest);
+					return;
+				case "start":
+					start(ctx, rest);
+					return;
+				case "done":
+					mutateStatus(ctx, rest, "completed");
+					return;
+				case "drop":
+					mutateStatus(ctx, rest, "abandoned");
+					return;
+				case "rm":
+					remove(ctx, rest);
+					return;
+				default:
+					ctx.ui.notify(`Unknown /todo verb "${verb}".\n${USAGE}`, "error");
+			}
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { registerTodoCommand } from "./commands.ts";
 import { TASK_MANAGEMENT_SECTION } from "./prompt.ts";
 import { clonePhases, getLatestPhasesFromBranchEntries, getTodoWidgetLines, type TodoPhase } from "./state.ts";
 import { registerTodoTool } from "./tools/todo.ts";
@@ -40,8 +41,11 @@ export default function todotoolsExtension(pi: ExtensionAPI): void {
 	});
 
 	registerTodoTool(pi, { getCurrentPhases, setCurrentPhases, syncWidget });
+	registerTodoCommand(pi, { getCurrentPhases, setCurrentPhases, syncWidget });
 }
 
+export { findPhaseFuzzy, findTaskFuzzy, registerTodoCommand, tokenizeTodoArgs } from "./commands.ts";
+export { markdownToPhases, phasesToMarkdown, resolveTodoMarkdownPath } from "./markdown.ts";
 export { TASK_MANAGEMENT_SECTION } from "./prompt.ts";
 export {
 	appendItems,

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/markdown.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/markdown.ts
@@ -6,7 +6,7 @@
 // `[x]` completed, `[-]` abandoned.
 
 import { isAbsolute, resolve } from "node:path";
-import { normalizeInProgressTask, type TodoPhase, type TodoStatus } from "./state.ts";
+import { DEFAULT_INIT_PHASE, normalizeInProgressTask, type TodoPhase, type TodoStatus } from "./state.ts";
 
 const STATUS_TO_MARKER: Record<TodoStatus, string> = {
 	pending: " ",
@@ -37,7 +37,7 @@ export function resolveTodoMarkdownPath(input: string, cwd: string): string {
 
 /** Render todo phases as a Markdown checklist suitable for editing/copying. */
 export function phasesToMarkdown(phases: readonly TodoPhase[]): string {
-	if (phases.length === 0) return "# Todos\n";
+	if (phases.length === 0) return `# ${DEFAULT_INIT_PHASE}\n`;
 	const out: string[] = [];
 	for (let index = 0; index < phases.length; index += 1) {
 		if (index > 0) out.push("");
@@ -70,7 +70,7 @@ export function markdownToPhases(markdown: string): { phases: TodoPhase[]; error
 		const taskMatch = /^[-*+]\s*\[(.?)\]\s+(.+?)\s*$/.exec(trimmed);
 		if (taskMatch) {
 			if (!currentPhase) {
-				currentPhase = { name: "Todos", tasks: [] };
+				currentPhase = { name: DEFAULT_INIT_PHASE, tasks: [] };
 				phases.push(currentPhase);
 			}
 			const status = MARKER_TO_STATUS[taskMatch[1]];

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/markdown.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/markdown.ts
@@ -1,0 +1,90 @@
+// Markdown round-trip for the phased todo model.
+//
+// Ported and adapted from oh-my-pi's `packages/coding-agent/src/tools/todo.ts`
+// (MIT — see NOTICE.md). Phases render as `# <name>` headings and tasks as
+// checklist rows whose marker encodes status: `[ ]` pending, `[/]` in_progress,
+// `[x]` completed, `[-]` abandoned.
+
+import { isAbsolute, resolve } from "node:path";
+import { normalizeInProgressTask, type TodoPhase, type TodoStatus } from "./state.ts";
+
+const STATUS_TO_MARKER: Record<TodoStatus, string> = {
+	pending: " ",
+	in_progress: "/",
+	completed: "x",
+	abandoned: "-",
+};
+
+const MARKER_TO_STATUS: Record<string, TodoStatus> = {
+	" ": "pending",
+	"": "pending",
+	x: "completed",
+	X: "completed",
+	"/": "in_progress",
+	">": "in_progress",
+	"-": "abandoned",
+	"~": "abandoned",
+};
+
+/** Default file name for `/todo export` and `/todo import`. */
+export const DEFAULT_TODO_MARKDOWN_FILE = "TODO.md";
+
+/** Resolve a user-supplied path argument against cwd; empty input → TODO.md. */
+export function resolveTodoMarkdownPath(input: string, cwd: string): string {
+	const raw = input.trim().replace(/^["']|["']$/g, "") || DEFAULT_TODO_MARKDOWN_FILE;
+	return isAbsolute(raw) ? raw : resolve(cwd, raw);
+}
+
+/** Render todo phases as a Markdown checklist suitable for editing/copying. */
+export function phasesToMarkdown(phases: readonly TodoPhase[]): string {
+	if (phases.length === 0) return "# Todos\n";
+	const out: string[] = [];
+	for (let index = 0; index < phases.length; index += 1) {
+		if (index > 0) out.push("");
+		out.push(`# ${phases[index].name}`);
+		for (const task of phases[index].tasks) {
+			out.push(`- [${STATUS_TO_MARKER[task.status]}] ${task.content}`);
+		}
+	}
+	return `${out.join("\n")}\n`;
+}
+
+/** Parse a Markdown checklist back into todo phases. */
+export function markdownToPhases(markdown: string): { phases: TodoPhase[]; errors: string[] } {
+	const errors: string[] = [];
+	const phases: TodoPhase[] = [];
+	let currentPhase: TodoPhase | undefined;
+
+	const lines = markdown.split(/\r?\n/);
+	for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
+		const trimmed = lines[lineNumber].trim();
+		if (!trimmed) continue;
+
+		const headingMatch = /^#{1,6}\s+(.+?)\s*$/.exec(trimmed);
+		if (headingMatch) {
+			currentPhase = { name: headingMatch[1].trim(), tasks: [] };
+			phases.push(currentPhase);
+			continue;
+		}
+
+		const taskMatch = /^[-*+]\s*\[(.?)\]\s+(.+?)\s*$/.exec(trimmed);
+		if (taskMatch) {
+			if (!currentPhase) {
+				currentPhase = { name: "Todos", tasks: [] };
+				phases.push(currentPhase);
+			}
+			const status = MARKER_TO_STATUS[taskMatch[1]];
+			if (!status) {
+				errors.push(`Line ${lineNumber + 1}: unknown status marker "[${taskMatch[1]}]" (use [ ], [x], [/], [-])`);
+				continue;
+			}
+			currentPhase.tasks.push({ content: taskMatch[2].trim(), status });
+			continue;
+		}
+
+		errors.push(`Line ${lineNumber + 1}: unrecognized syntax "${trimmed}"`);
+	}
+
+	normalizeInProgressTask(phases);
+	return { phases, errors };
+}

--- a/packages/coding-agent/test/suite/todo-command.test.ts
+++ b/packages/coding-agent/test/suite/todo-command.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	findPhaseFuzzy,
+	findTaskFuzzy,
+	registerTodoCommand,
+	tokenizeTodoArgs,
+} from "../../src/core/extensions/builtin/todotools/commands.ts";
+import {
+	markdownToPhases,
+	phasesToMarkdown,
+	resolveTodoMarkdownPath,
+} from "../../src/core/extensions/builtin/todotools/markdown.ts";
+import {
+	clonePhases,
+	TODO_STATE_ENTRY_TYPE,
+	type TodoPhase,
+} from "../../src/core/extensions/builtin/todotools/state.ts";
+import type { ExtensionAPI, ExtensionCommandContext } from "../../src/core/extensions/types.ts";
+
+type CommandHandler = (args: string, ctx: ExtensionCommandContext) => Promise<void>;
+
+function samplePhases(): TodoPhase[] {
+	return [
+		{
+			name: "Foundation",
+			tasks: [
+				{ content: "Scaffold workspace", status: "completed" },
+				{ content: "Wire entrypoint", status: "in_progress" },
+			],
+		},
+		{ name: "Verification", tasks: [{ content: "Run focused tests", status: "pending" }] },
+	];
+}
+
+function createCommandFixture(initialPhases: TodoPhase[] = [], options: { editorText?: string; cwd?: string } = {}) {
+	let phases = clonePhases(initialPhases);
+	const appendedEntries: Array<{ customType: string; data: unknown }> = [];
+	const sentMessages: Array<{ customType: string; content: string }> = [];
+	const notifications: Array<{ message: string; type: string | undefined }> = [];
+	const commands = new Map<string, CommandHandler>();
+
+	const api = {
+		registerCommand(name: string, command: { handler: CommandHandler }) {
+			commands.set(name, command.handler);
+		},
+		appendEntry(customType: string, data?: unknown) {
+			appendedEntries.push({ customType, data });
+		},
+		sendMessage(message: { customType: string; content: string }) {
+			sentMessages.push({ customType: message.customType, content: message.content });
+		},
+	} as unknown as ExtensionAPI;
+
+	registerTodoCommand(api, {
+		getCurrentPhases: () => clonePhases(phases),
+		setCurrentPhases: (next) => {
+			phases = clonePhases(next);
+		},
+		syncWidget: () => {},
+	});
+
+	const ctx = {
+		cwd: options.cwd ?? "/tmp",
+		hasUI: true,
+		ui: {
+			notify: (message: string, type?: string) => {
+				notifications.push({ message, type });
+			},
+			editor: vi.fn(async () => options.editorText),
+		},
+	} as unknown as ExtensionCommandContext;
+
+	const handler = commands.get("todo");
+	if (!handler) throw new Error("Expected /todo command to be registered");
+
+	return {
+		run: (args: string) => handler(args, ctx),
+		getPhases: () => clonePhases(phases),
+		appendedEntries,
+		sentMessages,
+		notifications,
+		ctx,
+	};
+}
+
+describe("todo markdown round-trip", () => {
+	it("renders phases as a checklist and parses it back verbatim", () => {
+		const phases: TodoPhase[] = [
+			{
+				name: "Foundation",
+				tasks: [
+					{ content: "Done work", status: "completed" },
+					{ content: "Active work", status: "in_progress" },
+					{ content: "Dropped work", status: "abandoned" },
+				],
+			},
+			{ name: "Verification", tasks: [{ content: "Open work", status: "pending" }] },
+		];
+
+		const markdown = phasesToMarkdown(phases);
+		expect(markdown).toBe(
+			[
+				"# Foundation",
+				"- [x] Done work",
+				"- [/] Active work",
+				"- [-] Dropped work",
+				"",
+				"# Verification",
+				"- [ ] Open work",
+				"",
+			].join("\n"),
+		);
+
+		const parsed = markdownToPhases(markdown);
+		expect(parsed.errors).toEqual([]);
+		expect(parsed.phases).toEqual(phases);
+	});
+
+	it("reports unknown markers and unrecognized lines with line numbers", () => {
+		const { errors } = markdownToPhases("# Phase\n- [?] Mystery\nplain prose\n");
+		expect(errors).toEqual([
+			'Line 2: unknown status marker "[?]" (use [ ], [x], [/], [-])',
+			'Line 3: unrecognized syntax "plain prose"',
+		]);
+	});
+
+	it("synthesizes a Todos phase for headerless checklists and normalizes in_progress", () => {
+		const { phases, errors } = markdownToPhases("- [/] First\n- [/] Second\n");
+		expect(errors).toEqual([]);
+		expect(phases).toEqual([
+			{
+				name: "Todos",
+				tasks: [
+					{ content: "First", status: "in_progress" },
+					{ content: "Second", status: "pending" },
+				],
+			},
+		]);
+	});
+
+	it("resolves export/import paths against cwd with a TODO.md default", () => {
+		expect(resolveTodoMarkdownPath("", "/work")).toBe("/work/TODO.md");
+		expect(resolveTodoMarkdownPath("notes/plan.md", "/work")).toBe("/work/notes/plan.md");
+		expect(resolveTodoMarkdownPath('"/abs/plan.md"', "/work")).toBe("/abs/plan.md");
+	});
+});
+
+describe("todo command helpers", () => {
+	it("tokenizes quoted arguments and escapes", () => {
+		expect(tokenizeTodoArgs('Auth "Wire the flow" done\\ deal')).toEqual(["Auth", "Wire the flow", "done deal"]);
+	});
+
+	it("fuzzy-matches phases by exact name, unique prefix, and unique substring", () => {
+		const phases = samplePhases();
+		expect(findPhaseFuzzy(phases, "foundation")?.name).toBe("Foundation");
+		expect(findPhaseFuzzy(phases, "verif")?.name).toBe("Verification");
+		expect(findPhaseFuzzy(phases, "missing")).toBeUndefined();
+	});
+
+	it("fuzzy-matches tasks and prefers open work on ambiguity", () => {
+		const phases: TodoPhase[] = [
+			{
+				name: "Tasks",
+				tasks: [
+					{ content: "Ship feature", status: "completed" },
+					{ content: "Ship feature docs", status: "pending" },
+				],
+			},
+		];
+		expect(findTaskFuzzy(phases, "ship feature")?.task.content).toBe("Ship feature");
+		expect(findTaskFuzzy(phases, "ship")?.task.content).toBe("Ship feature docs");
+	});
+});
+
+describe("/todo command", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		while (tempDirs.length > 0) {
+			const dir = tempDirs.pop();
+			if (dir) rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("appends a task, persists a user-sourced v2 entry, and notifies the agent", async () => {
+		const fixture = createCommandFixture(samplePhases());
+
+		await fixture.run("append Verification Audit the logs");
+
+		expect(fixture.getPhases()[1].tasks.map((task) => task.content)).toEqual(["Run focused tests", "Audit the logs"]);
+		const entry = fixture.appendedEntries.at(-1);
+		expect(entry?.customType).toBe(TODO_STATE_ENTRY_TYPE);
+		expect(entry?.data).toMatchObject({ schema: "v2", source: "user" });
+		expect(fixture.sentMessages.at(-1)?.customType).toBe("todotools.user-edit");
+		expect(fixture.sentMessages.at(-1)?.content).toContain("The user manually modified the todo list");
+	});
+
+	it("marks a fuzzy-matched task done and auto-promotes the earliest open task", async () => {
+		const fixture = createCommandFixture(samplePhases());
+
+		await fixture.run("done wire entry");
+
+		const phases = fixture.getPhases();
+		expect(phases[0].tasks[1]).toEqual({ content: "Wire entrypoint", status: "completed" });
+		expect(phases[1].tasks[0].status).toBe("in_progress");
+	});
+
+	it("rm without arguments clears the list and flags the removal intent", async () => {
+		const fixture = createCommandFixture(samplePhases());
+
+		await fixture.run("rm");
+
+		expect(fixture.getPhases()).toEqual([]);
+		expect(fixture.sentMessages.at(-1)?.content).toContain("intentionally cleared");
+	});
+
+	it("exports and imports a Markdown checklist round-trip through disk", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "todo-cmd-"));
+		tempDirs.push(dir);
+		const target = join(dir, "TODO.md");
+		const fixture = createCommandFixture(samplePhases(), { cwd: dir });
+
+		await fixture.run("export");
+		expect(readFileSync(target, "utf8")).toBe(phasesToMarkdown(samplePhases()));
+
+		writeFileSync(target, "# Replacement\n- [ ] Fresh task\n");
+		await fixture.run("import");
+		expect(fixture.getPhases()).toEqual([
+			{ name: "Replacement", tasks: [{ content: "Fresh task", status: "in_progress" }] },
+		]);
+	});
+
+	it("edit applies overlay-editor markdown and rejects unparseable edits", async () => {
+		const good = createCommandFixture(samplePhases(), {
+			editorText: "# Only Phase\n- [x] Everything shipped\n",
+		});
+		await good.run("edit");
+		expect(good.getPhases()).toEqual([
+			{ name: "Only Phase", tasks: [{ content: "Everything shipped", status: "completed" }] },
+		]);
+
+		const bad = createCommandFixture(samplePhases(), { editorText: "# Phase\n- [?] broken\n" });
+		const before = bad.getPhases();
+		await bad.run("edit");
+		expect(bad.getPhases()).toEqual(before);
+		expect(bad.notifications.at(-1)?.type).toBe("error");
+	});
+
+	it("rejects unknown verbs with usage help", async () => {
+		const fixture = createCommandFixture();
+		await fixture.run("frobnicate");
+		expect(fixture.notifications.at(-1)?.type).toBe("error");
+		expect(fixture.notifications.at(-1)?.message).toContain("Usage: /todo");
+	});
+});

--- a/packages/coding-agent/test/suite/todo-command.test.ts
+++ b/packages/coding-agent/test/suite/todo-command.test.ts
@@ -132,7 +132,7 @@ describe("todo markdown round-trip", () => {
 		expect(errors).toEqual([]);
 		expect(phases).toEqual([
 			{
-				name: "Todos",
+				name: "Tasks",
 				tasks: [
 					{ content: "First", status: "in_progress" },
 					{ content: "Second", status: "pending" },


### PR DESCRIPTION
## Summary

Adds the user-side half of the todo port (#242): a `/todo` slash command with Markdown round-trip. Users can now view, edit (overlay Markdown checklist), copy, export/import, and mutate the phased todo list directly — with fuzzy phase/task matching — while the agent is informed of every manual change on its next turn. Ported from oh-my-pi's `todo-command-controller.ts` (MIT; NOTICE.md updated).

## Changes

**`builtin/todotools/markdown.ts` (new)**
- `phasesToMarkdown` / `markdownToPhases`: `# Phase` headings + checklist rows with status markers `[ ]` pending, `[/]` in_progress, `[x]` completed, `[-]` abandoned; line-numbered parse errors; headerless lists synthesize a `Todos` phase; parse normalizes to ≤1 `in_progress`.
- `resolveTodoMarkdownPath`: cwd-relative with `TODO.md` default, quote stripping.

**`builtin/todotools/commands.ts` (new)**
- `/todo` — show current list as Markdown; `help`/`?` — usage.
- `/todo edit` — built-in `ctx.ui.editor` overlay (senpi adaptation: no TUI suspension/external `$EDITOR`); unparseable edits are rejected wholesale.
- `/todo copy | export [path] | import [path]` — clipboard + disk round-trip.
- `/todo append [phase] task…`, `start`, `done`, `drop`, `rm` — quote-aware tokenizer, fuzzy matching (exact → unique prefix → unique substring; ambiguous task matches resolve toward open work), no-arg `done`/`drop`/`rm` apply to all.
- Every mutation persists a `senpi.todo-state` v2 entry with `source: "user"` (readable by the existing branch scanner and compaction bridge with zero changes) and sends a hidden `todotools.user-edit` system reminder next turn — removals carry explicit do-not-recreate intent.
- Verb autocomplete via `getArgumentCompletions`.

**Wiring/docs**: `index.ts` registers the command beside the tool and re-exports helpers; NOTICE.md attribution extended to the controller source; fork tracker, CHANGELOG, builtin AGENTS.md inventory updated.

## QA & Evidence

Evidence: `local-ignore/qa-evidence/20260720-todo-command-suite/SUMMARY.md` (gitignored, retained locally).

- **Unit**: `npx vitest run test/suite/todo-extension.test.ts test/suite/todo-command.test.ts test/suite/task-management-section.test.ts test/compaction/` — 22 files / 176 tests green (13 new: round-trip incl. all four markers, marker/syntax error reporting, tokenizer escapes, fuzzy matching incl. open-work preference, append persistence + agent notification, done auto-promotion, rm-all removal intent, disk export/import round-trip, overlay edit accept/reject, unknown-verb usage).
- **Static**: `npm run check` — exit 0.
- **senpi-qa Ch.3** `mock-loop.mjs --with-tool` — 4/4: full deterministic agent turn with the extension (tool + command) registered.
- **senpi-qa Ch.2** `tui-smoke.mjs --self-test` — 5/5: real TUI boots with `/todo` registered.
- **senpi-qa** `common.mjs --self-check` — 9/9; real auth sha256 unchanged in every channel.

## Risks & Residuals

- Persistence reuses `senpi.todo-state` (no new custom type), so scanner/bridge behavior is provably unchanged — mitigated by existing + new tests.
- `/todo edit` requires dialog-capable UI; in print/RPC modes `ctx.ui.editor` resolves undefined and the command reports "Todos unchanged." — accepted.
- User-edit reminder uses `deliverAs: "nextTurn"` without triggering a turn: informing, not interrupting — matches oh-my-pi behavior.

## Related Issues

Follow-up to #242 (op-based todo tool port).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/todo` command for managing phased todos with a simple Markdown round-trip. Users can view, edit in an overlay, copy, export/import, and update tasks; all changes persist and notify the agent on the next turn.

- New Features
  - Verbs: show, edit, copy, export/import (default `TODO.md`), append/start/done/drop/rm; quote-aware args; fuzzy phase/task matching (exact → unique prefix → unique substring; prefers open tasks); verb autocomplete.
  - Markdown: `# Phase` headings and checklist markers `[ ]`, `[/]`, `[x]`, `[-]`; headerless lists synthesize a `Tasks` phase; parse errors include line numbers; normalizes to ≤1 `in_progress`.
  - Persistence/agent: Writes `senpi.todo-state` v2 entries with `source: "user"` and sends a hidden `todotools.user-edit` reminder for the next turn; removals carry explicit do-not-recreate intent.
  - Wiring: Command registered in `todotools`; exports `tokenizeTodoArgs`, `findPhaseFuzzy`, `findTaskFuzzy`, and Markdown helpers.

- Bug Fixes
  - Markdown import now uses `DEFAULT_INIT_PHASE` (`Tasks`) for synthesized phase names to match other flows and remove the Todos/Tasks naming split.

<sup>Written for commit 64877a65bae2207d1ade094e49f7c09194357ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

