### PR TITLE
feat(coding-agent): paced streamed tool-arg previews

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,19 @@
 # Local fork changes
 
+## 2026-07-20 — paced streaming tool argument preview coverage
+
+- Changed:
+  - `test/tool-args-reveal.test.ts`: deterministic fake-timer coverage for initial visibility, monotonic catch-up,
+    64-unit parse batching, surrogate-safe slicing, exact per-call/all-call flushes, disabled-setting cancellation, and
+    live FPS refreshes.
+  - `test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts`: extends the prototype harness with the
+    tool-argument reveal flush seam used when pending components are rebuilt.
+- Why: streamed tool arguments need the same stable cadence as assistant text without exposing malformed Unicode or
+  allowing a stale timer to overwrite exact execution arguments.
+- What changed: focused package test coverage; runtime changes are tracked in the nearest `src/**/changes.md` files.
+- Why the extension system could not handle this: the tests pin private interactive pending-tool and timer lifecycles.
+- Merge-conflict risk: low. The suite and controller are fork-only; runtime wiring risk is documented under `src/`.
+
 ## 2026-07-20 — smooth streaming reveal test coverage
 
 - Changed:

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -8,6 +8,8 @@
     live FPS refreshes.
   - `test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts`: extends the prototype harness with the
     tool-argument reveal flush seam used when pending components are rebuilt.
+  - `test/interactive-mode-status.test.ts`: extends the active-tool lifecycle fixture with the tool-argument reveal
+    flush/finish seams and direct exact-argument update surface.
 - Why: streamed tool arguments need the same stable cadence as assistant text without exposing malformed Unicode or
   allowing a stale timer to overwrite exact execution arguments.
 - What changed: focused package test coverage; runtime changes are tracked in the nearest `src/**/changes.md` files.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Paced streaming tool argument previews (2026-07-20)
+
+### What changed
+
+- `modes/interactive/tool-args-reveal.ts` paces append-only partial JSON independently per tool call, reusing the smooth
+  streaming FPS and catch-up policy while batching parser work and preserving UTF-16 surrogate boundaries.
+- `modes/interactive/interactive-mode.ts` flushes exact arguments before completion or execution and tears down reveal
+  state anywhere pending tool components are cleared.
+
+### Why
+
+- Provider bursts should not make large tool-call previews jump or force a full partial-JSON parse for every timer tick.
+
+### Why extension system couldn't handle this
+
+- Pending tool components and their streaming/execution transition state are private to the built-in interactive mode.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: interactive tool-call event handling and smooth-streaming settings callbacks.
+- LOW: the fork-only reveal controller.
+
 ## Smooth streaming reveal (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,31 @@
 # changes
 
+## paced streaming tool argument previews (2026-07-20)
+
+### What changed
+
+- `tool-args-reveal.ts`: adds per-tool-call pacing for streaming partial JSON. The first usable prefix appears
+  immediately, later append-only growth follows the smooth-streaming cadence, parsing is batched in at least 64
+  UTF-16-unit increments, and reveal boundaries never split surrogate pairs.
+- `interactive-mode.ts`: routes in-flight tool arguments through the controller, flushes exact arguments at message and
+  execution boundaries, cancels stale state on direct-update paths, publishes buffered arguments before teardown, and
+  refreshes timers after live smooth streaming setting changes.
+
+### Why
+
+- Large tool arguments can arrive in provider bursts. Parsing and rendering every burst makes previews jump abruptly
+  and repeatedly reparses nearly identical JSON prefixes.
+
+### Why extension system couldn't handle this
+
+- Extensions cannot own the built-in pending-tool component map or coordinate its private argument updates with
+  assistant-message, tool-execution, settings, and teardown lifecycles.
+
+### Expected merge conflict zones
+
+- MEDIUM: `interactive-mode.ts` around streamed tool-call handling and lifecycle flushes.
+- LOW: the fork-only argument reveal controller.
+
 ## smooth streaming reveal (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -168,6 +168,7 @@ import {
 	theme,
 } from "./theme/theme.ts";
 import { InteractiveThemeController } from "./theme/theme-controller.ts";
+import { ToolArgsRevealController } from "./tool-args-reveal.ts";
 import {
 	blendWorkingStatusShimmerRgbColor,
 	formatActiveToolWorkingLabel,
@@ -211,6 +212,11 @@ type ToolExecutionStartEvent = Extract<AgentSessionEvent, { type: "tool_executio
 type ToolExecutionEndEvent = Extract<AgentSessionEvent, { type: "tool_execution_end" }>;
 type ToolHookStatusStartEvent = Extract<AgentSessionEvent, { type: "tool_hook_status"; phase: "start" }>;
 type ToolHookStatusEvent = Extract<AgentSessionEvent, { type: "tool_hook_status" }>;
+
+function getStreamingToolCallPartialJson(content: unknown): string | undefined {
+	if (typeof content !== "object" || content === null || !("partialJson" in content)) return undefined;
+	return typeof content.partialJson === "string" ? content.partialJson : undefined;
+}
 
 function formatToolHookTerminalTitle(event: ToolHookStatusStartEvent): string {
 	const hookName = sanitizeWorkingStatusPlainText(event.hookName) || "hook";
@@ -455,6 +461,7 @@ export class InteractiveMode {
 	private streamingComponent: AssistantMessageComponent | undefined = undefined;
 	private streamingMessage: AssistantMessage | undefined = undefined;
 	private readonly streamingReveal: StreamingRevealController;
+	private readonly toolArgsReveal: ToolArgsRevealController;
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
@@ -565,6 +572,11 @@ export class InteractiveMode {
 			getSmoothStreaming: () => this.settingsManager.getSmoothStreaming(),
 			getSmoothStreamingFps: () => this.settingsManager.getSmoothStreamingFps(),
 			getHideThinkingBlock: () => this.hideThinkingBlock,
+			requestRender: () => this.ui.requestRender(),
+		});
+		this.toolArgsReveal = new ToolArgsRevealController({
+			getSmoothStreaming: () => this.settingsManager.getSmoothStreaming(),
+			getSmoothStreamingFps: () => this.settingsManager.getSmoothStreamingFps(),
 			requestRender: () => this.ui.requestRender(),
 		});
 		this.applySmoothStreamingRenderFps();
@@ -2087,6 +2099,7 @@ export class InteractiveMode {
 	}
 
 	private clearPendingTools(): void {
+		this.toolArgsReveal.flushAll();
 		for (const component of this.pendingTools.values()) {
 			component.stopAnimation();
 		}
@@ -3310,8 +3323,9 @@ export class InteractiveMode {
 
 					for (const content of this.streamingMessage.content) {
 						if (content.type === "toolCall") {
-							if (!this.pendingTools.has(content.id)) {
-								const component = new ToolExecutionComponent(
+							let component = this.pendingTools.get(content.id);
+							if (!component) {
+								component = new ToolExecutionComponent(
 									content.name,
 									content.id,
 									content.arguments,
@@ -3326,11 +3340,13 @@ export class InteractiveMode {
 								component.setExpanded(this.toolOutputExpanded);
 								this.chatContainer.addChild(component);
 								this.pendingTools.set(content.id, component);
+							}
+							const partialJson = getStreamingToolCallPartialJson(content);
+							if (partialJson && this.settingsManager.getSmoothStreaming()) {
+								this.toolArgsReveal.update(content.id, component, partialJson);
 							} else {
-								const component = this.pendingTools.get(content.id);
-								if (component) {
-									component.updateArgs(content.arguments);
-								}
+								this.toolArgsReveal.finish(content.id);
+								component.updateArgs(content.arguments);
 							}
 						}
 					}
@@ -3343,6 +3359,14 @@ export class InteractiveMode {
 				if (this.streamingComponent && event.message.role === "assistant") {
 					this.streamingMessage = event.message;
 					this.streamingReveal.stop();
+					for (const content of this.streamingMessage.content) {
+						if (content.type !== "toolCall") continue;
+						const component = this.pendingTools.get(content.id);
+						if (component && !this.toolArgsReveal.flush(content.id, content.arguments)) {
+							component.updateArgs(content.arguments);
+						}
+					}
+					this.toolArgsReveal.flushAll();
 					let errorMessage: string | undefined;
 					if (this.streamingMessage.stopReason === "aborted") {
 						errorMessage = abortedErrorLabel(undefined, this.session.retryAttempt);
@@ -3395,6 +3419,9 @@ export class InteractiveMode {
 					this.chatContainer.addChild(component);
 					this.pendingTools.set(event.toolCallId, component);
 				}
+				if (!this.toolArgsReveal.flush(event.toolCallId, event.args)) {
+					component.updateArgs(event.args);
+				}
 				component.markExecutionStarted();
 				this.ui.requestRender();
 				break;
@@ -3415,6 +3442,7 @@ export class InteractiveMode {
 
 			case "tool_execution_end": {
 				this.handleToolExecutionEnd(event);
+				this.toolArgsReveal.finish(event.toolCallId);
 				const component = this.pendingTools.get(event.toolCallId);
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
@@ -4687,6 +4715,7 @@ export class InteractiveMode {
 					onSmoothStreamingChange: (enabled) => {
 						this.settingsManager.setSmoothStreaming(enabled);
 						this.applySmoothStreamingRenderFps();
+						this.toolArgsReveal.refresh();
 						if (this.streamingMessage) {
 							this.streamingReveal.setTarget(this.streamingMessage);
 						}
@@ -4694,6 +4723,7 @@ export class InteractiveMode {
 					},
 					onSmoothStreamingFpsChange: (fps) => {
 						this.settingsManager.setSmoothStreamingFps(fps);
+						this.toolArgsReveal.refresh();
 						if (this.settingsManager.getSmoothStreaming()) {
 							this.applySmoothStreamingRenderFps();
 							if (this.streamingMessage) {

--- a/packages/coding-agent/src/modes/interactive/tool-args-reveal.ts
+++ b/packages/coding-agent/src/modes/interactive/tool-args-reveal.ts
@@ -1,0 +1,182 @@
+import { parseStreamingJson } from "@earendil-works/pi-ai";
+import type { ToolExecutionComponent } from "./components/tool-execution.ts";
+import { DEFAULT_SMOOTH_FPS, MAX_SMOOTH_FPS, MIN_SMOOTH_FPS, nextStep } from "./streaming-reveal.ts";
+
+export const MIN_TOOL_ARGS_PARSE_DELTA = 64;
+
+type ToolArgsRevealComponent = Pick<ToolExecutionComponent, "updateArgs">;
+
+type ToolArgsRevealState = {
+	component: ToolArgsRevealComponent;
+	target: string;
+	revealed: number;
+	rendered: number;
+	lastTickAt: number;
+};
+
+export type ToolArgsRevealControllerOptions = {
+	readonly getSmoothStreaming: () => boolean;
+	readonly getSmoothStreamingFps: () => number;
+	readonly requestRender: () => void;
+};
+
+function isHighSurrogate(code: number): boolean {
+	return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+	return code >= 0xdc00 && code <= 0xdfff;
+}
+
+function advancePastSurrogateBoundary(text: string, end: number): number {
+	if (end <= 0 || end >= text.length) return end;
+	return isHighSurrogate(text.charCodeAt(end - 1)) && isLowSurrogate(text.charCodeAt(end)) ? end + 1 : end;
+}
+
+export class ToolArgsRevealController {
+	readonly #getSmoothStreaming: () => boolean;
+	readonly #getSmoothStreamingFps: () => number;
+	readonly #requestRender: () => void;
+	readonly #states = new Map<string, ToolArgsRevealState>();
+	#timer: NodeJS.Timeout | undefined;
+	#timerFps: number | undefined;
+
+	constructor(options: ToolArgsRevealControllerOptions) {
+		this.#getSmoothStreaming = options.getSmoothStreaming;
+		this.#getSmoothStreamingFps = options.getSmoothStreamingFps;
+		this.#requestRender = options.requestRender;
+	}
+
+	update(id: string, component: ToolArgsRevealComponent, partialJson: string): boolean {
+		if (!this.#getSmoothStreaming() || partialJson.length === 0) {
+			this.finish(id);
+			return false;
+		}
+
+		const existing = this.#states.get(id);
+		if (existing === undefined || existing.component !== component || !partialJson.startsWith(existing.target)) {
+			component.updateArgs(parseStreamingJson(partialJson));
+			this.#states.set(id, {
+				component,
+				target: partialJson,
+				revealed: partialJson.length,
+				rendered: partialJson.length,
+				lastTickAt: performance.now(),
+			});
+			this.#syncTimer();
+			return true;
+		}
+
+		const wasCaughtUp = existing.revealed >= existing.target.length;
+		existing.target = partialJson;
+		if (wasCaughtUp && existing.revealed < partialJson.length) {
+			existing.lastTickAt = performance.now();
+		}
+		this.#syncTimer();
+		return true;
+	}
+
+	flush(id: string, exactArgs: unknown): boolean {
+		const state = this.#states.get(id);
+		if (state === undefined) return false;
+		state.component.updateArgs(exactArgs);
+		this.#states.delete(id);
+		this.#syncTimer();
+		return true;
+	}
+
+	flushAll(): void {
+		for (const state of this.#states.values()) {
+			state.component.updateArgs(parseStreamingJson(state.target));
+		}
+		this.#states.clear();
+		this.#stopTimer();
+	}
+
+	finish(id: string): void {
+		if (!this.#states.delete(id)) return;
+		this.#syncTimer();
+	}
+
+	refresh(): void {
+		if (!this.#getSmoothStreaming()) {
+			this.flushAll();
+			return;
+		}
+		if (!this.#hasBacklog()) {
+			this.#stopTimer();
+			return;
+		}
+		this.#startTimer(true);
+	}
+
+	stop(): void {
+		this.#stopTimer();
+		this.#states.clear();
+	}
+
+	#syncTimer(): void {
+		if (!this.#hasBacklog()) {
+			this.#stopTimer();
+			return;
+		}
+		this.#startTimer(false);
+	}
+
+	#hasBacklog(): boolean {
+		for (const state of this.#states.values()) {
+			if (state.revealed < state.target.length) return true;
+		}
+		return false;
+	}
+
+	#startTimer(restart: boolean): void {
+		const configuredFps = this.#getSmoothStreamingFps();
+		const fps = Number.isFinite(configuredFps)
+			? Math.min(MAX_SMOOTH_FPS, Math.max(MIN_SMOOTH_FPS, configuredFps))
+			: DEFAULT_SMOOTH_FPS;
+		if (!restart && this.#timer !== undefined && this.#timerFps === fps) return;
+		this.#stopTimer();
+		const now = performance.now();
+		for (const state of this.#states.values()) {
+			if (state.revealed < state.target.length) state.lastTickAt = now;
+		}
+		const timer = setInterval(() => this.#tick(), 1000 / fps);
+		timer.unref();
+		this.#timer = timer;
+		this.#timerFps = fps;
+	}
+
+	#stopTimer(): void {
+		if (this.#timer !== undefined) clearInterval(this.#timer);
+		this.#timer = undefined;
+		this.#timerFps = undefined;
+	}
+
+	#tick(): void {
+		if (!this.#getSmoothStreaming()) {
+			this.flushAll();
+			this.#requestRender();
+			return;
+		}
+
+		const now = performance.now();
+		let rendered = false;
+		for (const state of this.#states.values()) {
+			const backlog = state.target.length - state.revealed;
+			if (backlog <= 0) continue;
+			const step = nextStep(backlog, now - state.lastTickAt);
+			state.revealed = advancePastSurrogateBoundary(
+				state.target,
+				Math.min(state.target.length, state.revealed + step),
+			);
+			state.lastTickAt = now;
+			if (state.revealed - state.rendered < MIN_TOOL_ARGS_PARSE_DELTA) continue;
+			state.component.updateArgs(parseStreamingJson(state.target.slice(0, state.revealed)));
+			state.rendered = state.revealed;
+			rendered = true;
+		}
+		if (rendered) this.#requestRender();
+		this.#syncTimer();
+	}
+}

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -149,6 +149,7 @@ type ActiveToolLifecycleThis = TerminalTitleThis & {
 		string,
 		{
 			markExecutionStarted(): void;
+			updateArgs(args: unknown): void;
 			updateResult(result: unknown): void;
 		}
 	>;
@@ -160,6 +161,11 @@ type ActiveToolLifecycleThis = TerminalTitleThis & {
 	settingsManager: {
 		getImageWidthCells(): number;
 		getShowImages(): boolean;
+	};
+	toolArgsReveal: {
+		flush(id: string, args: unknown): boolean;
+		finish(id: string): void;
+		flushAll(): void;
 	};
 	toolOutputExpanded: boolean;
 	workingMessage: string | undefined;
@@ -331,6 +337,7 @@ describe("InteractiveMode terminal title state", () => {
 		const setMessage = vi.fn();
 		const toolComponent = {
 			markExecutionStarted: vi.fn(),
+			updateArgs: vi.fn(),
 			updateResult: vi.fn(),
 		};
 		const fakeThis: ActiveToolLifecycleThis = {
@@ -365,6 +372,11 @@ describe("InteractiveMode terminal title state", () => {
 			},
 			startToolHookStatusTimer: vi.fn(),
 			stopToolHookStatusTimer: vi.fn(),
+			toolArgsReveal: {
+				flush: vi.fn(() => false),
+				finish: vi.fn(),
+				flushAll: vi.fn(),
+			},
 			toolOutputExpanded: false,
 			workingMessage: "Thinking",
 			workingMessageBeforeActiveTool: undefined,

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -36,6 +36,7 @@ type RenderSessionItems = (
 type RenderSessionContextThis = {
 	activeToolExecutions: Map<string, string>;
 	pendingTools: Map<string, ToolExecutionComponent>;
+	toolArgsReveal: { finish(id: string): void; flushAll(): void };
 	chatContainer: Container;
 	footer: { invalidate(): void };
 	ui: Pick<TUI, "requestRender">;
@@ -69,6 +70,7 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 	return {
 		activeToolExecutions: new Map<string, string>(),
 		pendingTools: new Map<string, ToolExecutionComponent>(),
+		toolArgsReveal: { finish: vi.fn(), flushAll: vi.fn() },
 		chatContainer,
 		footer: { invalidate: vi.fn() },
 		ui: { requestRender: vi.fn() },

--- a/packages/coding-agent/test/tool-args-reveal.test.ts
+++ b/packages/coding-agent/test/tool-args-reveal.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { DEFAULT_SMOOTH_FPS } from "../src/modes/interactive/streaming-reveal.ts";
+import { MIN_TOOL_ARGS_PARSE_DELTA, ToolArgsRevealController } from "../src/modes/interactive/tool-args-reveal.ts";
+
+class RecordingArgsComponent {
+	readonly updates: unknown[] = [];
+
+	updateArgs(args: unknown): void {
+		this.updates.push(args);
+	}
+}
+
+function latestArgs(component: RecordingArgsComponent): unknown {
+	const args = component.updates.at(-1);
+	if (args === undefined) throw new Error("Expected at least one argument update");
+	return args;
+}
+
+function commandOf(args: unknown): string {
+	if (typeof args !== "object" || args === null || !("command" in args) || typeof args.command !== "string") {
+		throw new TypeError("Expected parsed command arguments");
+	}
+	return args.command;
+}
+
+function makePartial(command: string): string {
+	return `{"command":"${command}`;
+}
+
+function makeController(
+	options: { readonly getSmoothStreaming?: () => boolean; readonly getSmoothStreamingFps?: () => number } = {},
+): { readonly controller: ToolArgsRevealController; readonly requestRender: ReturnType<typeof vi.fn> } {
+	const requestRender = vi.fn();
+	return {
+		controller: new ToolArgsRevealController({
+			getSmoothStreaming: options.getSmoothStreaming ?? (() => true),
+			getSmoothStreamingFps: options.getSmoothStreamingFps ?? (() => DEFAULT_SMOOTH_FPS),
+			requestRender,
+		}),
+		requestRender,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("ToolArgsRevealController", () => {
+	test("#given a first partial and a later burst #when reveal ticks run #then the first value is complete and later prefixes grow monotonically", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const component = new RecordingArgsComponent();
+		const { controller } = makeController();
+		const first = makePartial("seed");
+
+		expect(controller.update("call-1", component, first)).toBe(true);
+		expect(commandOf(latestArgs(component))).toBe("seed");
+
+		controller.update("call-1", component, `${first}${"x".repeat(1024)}`);
+		const lengths = [commandOf(latestArgs(component)).length];
+		for (let tick = 1; tick <= 2; tick++) {
+			now = tick * 100;
+			vi.advanceTimersByTime(17);
+			lengths.push(commandOf(latestArgs(component)).length);
+		}
+
+		expect(lengths[0]).toBe(4);
+		expect(lengths[1]).toBeGreaterThan(lengths[0]);
+		expect(lengths[2]).toBeGreaterThan(lengths[1]);
+		expect(lengths[2]).toBeLessThan(1028);
+		controller.stop();
+	});
+
+	test("#given less than one parse batch is revealed #when ticks accumulate #then parsing waits for the 64th UTF-16 unit", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const component = new RecordingArgsComponent();
+		const { controller } = makeController();
+		const first = makePartial("seed");
+		controller.update("call-1", component, first);
+		controller.update("call-1", component, `${first}${"x".repeat(100)}`);
+		const initialUpdateCount = component.updates.length;
+
+		for (let tick = 1; tick < MIN_TOOL_ARGS_PARSE_DELTA; tick++) {
+			now = tick;
+			vi.advanceTimersToNextTimer();
+		}
+
+		expect(component.updates).toHaveLength(initialUpdateCount);
+		now = MIN_TOOL_ARGS_PARSE_DELTA;
+		vi.advanceTimersToNextTimer();
+
+		expect(component.updates).toHaveLength(initialUpdateCount + 1);
+		expect(commandOf(latestArgs(component))).toBe(`seed${"x".repeat(MIN_TOOL_ARGS_PARSE_DELTA)}`);
+		controller.stop();
+	});
+
+	test("#given a reveal step landing inside an emoji surrogate pair #when the prefix is parsed #then no broken surrogate is exposed", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const component = new RecordingArgsComponent();
+		const { controller } = makeController();
+		const first = makePartial("start ");
+		const appended = `${"a".repeat(63)}😀${"b".repeat(105)}`;
+		controller.update("call-1", component, first);
+		controller.update("call-1", component, `${first}${appended}`);
+
+		now = 100;
+		vi.advanceTimersByTime(17);
+
+		const command = commandOf(latestArgs(component));
+		expect(command).toBe(`start ${"a".repeat(63)}😀`);
+		expect(command).not.toContain("�");
+		controller.stop();
+	});
+
+	test("#given two independently buffered tool calls #when one flushes exactly and all remaining calls flush #then each final value is rendered once and timers stop", () => {
+		vi.useFakeTimers();
+		const firstComponent = new RecordingArgsComponent();
+		const secondComponent = new RecordingArgsComponent();
+		const { controller } = makeController();
+		const first = makePartial("first");
+		const second = makePartial("second");
+		controller.update("call-1", firstComponent, first);
+		controller.update("call-2", secondComponent, second);
+		controller.update("call-1", firstComponent, `${first}-buffered`);
+		controller.update("call-2", secondComponent, `${second}-buffered`);
+
+		expect(controller.flush("call-1", { command: "exact-first" })).toBe(true);
+		expect(controller.flush("missing", { command: "unused" })).toBe(false);
+		controller.flushAll();
+		const firstUpdateCount = firstComponent.updates.length;
+		const secondUpdateCount = secondComponent.updates.length;
+		vi.advanceTimersByTime(1000);
+
+		expect(commandOf(latestArgs(firstComponent))).toBe("exact-first");
+		expect(commandOf(latestArgs(secondComponent))).toBe("second-buffered");
+		expect(firstComponent.updates).toHaveLength(firstUpdateCount);
+		expect(secondComponent.updates).toHaveLength(secondUpdateCount);
+	});
+
+	test("#given stale paced state #when smoothing becomes disabled #then update bypasses pacing and cannot overwrite the caller's direct args", () => {
+		vi.useFakeTimers();
+		let smooth = true;
+		let now = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => now);
+		const component = new RecordingArgsComponent();
+		const { controller } = makeController({ getSmoothStreaming: () => smooth });
+		const first = makePartial("seed");
+		controller.update("call-1", component, first);
+		controller.update("call-1", component, `${first}${"x".repeat(256)}`);
+
+		smooth = false;
+		expect(controller.update("call-1", component, `${first}${"y".repeat(256)}`)).toBe(false);
+		component.updateArgs({ command: "direct" });
+		now = 1000;
+		vi.advanceTimersByTime(1000);
+
+		expect(commandOf(latestArgs(component))).toBe("direct");
+	});
+
+	test("#given an active reveal #when the configured fps changes #then refresh replaces the interval with the new PR3 cadence", () => {
+		vi.useFakeTimers();
+		let fps = 30;
+		const intervalSpy = vi.spyOn(globalThis, "setInterval");
+		const component = new RecordingArgsComponent();
+		const { controller } = makeController({ getSmoothStreamingFps: () => fps });
+		const first = makePartial("seed");
+		controller.update("call-1", component, first);
+		controller.update("call-1", component, `${first}${"x".repeat(256)}`);
+
+		expect(intervalSpy.mock.calls.at(-1)?.[1]).toBeCloseTo(1000 / 30);
+		fps = 120;
+		controller.refresh();
+
+		expect(intervalSpy.mock.calls.at(-1)?.[1]).toBeCloseTo(1000 / 120);
+		controller.stop();
+	});
+});


### PR DESCRIPTION
## Summary

Pace streamed tool-call argument previews in the classic interactive TUI so provider bursts grow smoothly inside pending tool cards instead of appearing all at once.

## Changes

- Add a per-tool-call `ToolArgsRevealController` that reuses PR3's `nextStep` pacing and smooth-streaming FPS settings.
- Show the first buffered `partialJson` immediately, then pace append-only growth with real-time 30–120fps cadence.
- Parse revealed JSON only after 64 additional UTF-16 units (or on first display/flush) and avoid splitting surrogate pairs.
- Route only non-empty streamed `partialJson` through pacing; preserve direct argument updates when smoothing is disabled or no partial buffer is present.
- Flush exact final arguments at assistant-message and tool-execution boundaries, cancel stale timers on lifecycle teardown, and refresh active cadence after setting changes.
- Add focused controller coverage and update the affected InteractiveMode prototype fixture plus the nearest fork change records.

## QA & Evidence

- **What:** focused coding-agent tests for the new controller, PR3 pacing, pending-tool regression, and session-rebind fixture.
  **Result:** 4 files, 28/28 tests passed from `packages/coding-agent`.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-paced-tool-args/scoped-tests.txt`.
  **Why:** pins monotonic pacing, 64-unit batching, surrogate safety, exact flushes, disabled bypass, FPS refresh, and affected lifecycle seams.
- **What:** root `npm run check`.
  **Result:** clean, including Biome, dependency/import/lock checks, `tsgo --noEmit`, browser/web checks, and Neo build/vet/tests.
  **Artifact:** `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-paced-tool-args/npm-run-check.txt`.
  **Why:** verifies repository-wide static and build compatibility.
- **What:** standard senpi-qa tool loop and TUI smoke.
  **Result:** `mock-loop.mjs --with-tool` 4/4 and `tui-smoke.mjs --self-test --driver tmux` 5/5; real auth unchanged and no leaked session/process.
  **Artifacts:** `mock-loop-with-tool.txt` and `tui-smoke-tmux.txt` in the evidence directory above.
  **Why:** protects the existing tool-call loop and interactive terminal lifecycle.
- **What:** real source-TUI paced argument capture using delayed OpenAI Responses SSE deltas and a long bash command containing `🎉`.
  **Result:** 14 frames at ~100ms cadence; visible prefixes grew strictly `9 → 75 → 141 → 195` UTF-16 units, the final command matched exactly, no replacement/broken-surrogate glyph appeared, the bash loop completed, and server/tmux/sandbox cleanup passed.
  **Artifacts:** `result.json`, `paced-tool-args-transcript.txt`, `visual-qa.json`, `cleanup-receipt.json`, and `frames/` in `/Users/yeongyu/local-workspaces/senpi/local-ignore/qa-evidence/20260719-paced-tool-args/`.
  **Why:** this is the feature-level evidence that arguments are visibly paced rather than rendered in one burst.

## Risks

- Streaming providers expose transient, incomplete JSON. The controller keeps state per tool-call ID, uses the existing repairing parser, batches parse work, and replaces previews with exact final/execution arguments before tools run.
- Timer state could otherwise overwrite final arguments. Direct-update, flush, setting-change, abort, session rebuild, tool completion, and shutdown paths all remove or flush controller state before later renders.
- UTF-16 prefix slicing can bisect emoji. Reveal boundaries advance past high/low surrogate pairs, covered by deterministic tests and real tmux capture evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smoothly pace streamed tool-call argument previews in the interactive TUI so arguments grow over time instead of appearing in bursts. Flush exact values at assistant-message and tool-execution boundaries.

- New Features
  - Added `ToolArgsRevealController` to pace per-tool-call `partialJson` with the existing smooth streaming cadence (30–120fps).
  - Show the first usable prefix immediately; then batch parsing in 64 UTF-16-unit steps and avoid splitting surrogate pairs.
  - Route only non-empty `partialJson` through pacing; bypass when smoothing is disabled or no buffer exists.
  - Flush exact arguments on assistant-message and tool-execution boundaries; cancel timers on teardown; refresh cadence on settings change.
  - Added focused tests in `packages/coding-agent` for pacing, batching, surrogate safety, flush behavior, disabled bypass, and FPS refresh.

- Bug Fixes
  - Updated `packages/coding-agent/test/interactive-mode-status.test.ts` to stub `toolArgsReveal` and `updateArgs` in the tool-lifecycle mock and record the status fixture coverage to match the `tool_execution_start` wiring.

<sup>Written for commit ace9feee21abf9e58b6d55d2a883fb2afa64750c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

