### PR TITLE
fix(coding-agent): surface compaction rejection feedback

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -274,11 +274,34 @@ type CompactionExecutionResult =
 			rejectionCause: CompactionRejectionCause;
 	  };
 
+/**
+ * Human-readable rejection message paired with a `CompactionRejectionCause`.
+ *
+ * Kept exhaustive over the union so the compiler flags any new cause that would
+ * otherwise reintroduce silent failures at the `compaction_end` UI seam.
+ */
+function describeCompactionRejection(cause: CompactionRejectionCause): string {
+	switch (cause) {
+		case "would-overflow":
+			return "Compaction rejected: the produced summary would still overflow the model context window. Reduce context (e.g. /new, drop attachments) or switch to a larger-context model.";
+		case "cancelled-by-extension":
+			return "Compaction rejected: cancelled by an extension.";
+		case "circuit-breaker":
+			return "Compaction rejected: the compaction circuit breaker is open after repeated failures. Wait for the cooldown and retry.";
+		case "per-turn-cap":
+			return "Compaction rejected: per-turn compaction cap reached for this turn.";
+	}
+}
+
 class CompactionRejectedError extends Error {
 	readonly rejectionCause: CompactionRejectionCause;
 
 	constructor(rejectionCause: CompactionRejectionCause) {
-		super(rejectionCause === "cancelled-by-extension" ? "Compaction cancelled" : "Compaction rejected");
+		super(
+			rejectionCause === "cancelled-by-extension"
+				? "Compaction cancelled"
+				: describeCompactionRejection(rejectionCause),
+		);
 		this.name = "CompactionRejectedError";
 		this.rejectionCause = rejectionCause;
 	}
@@ -2536,7 +2559,13 @@ export class AgentSession {
 					})) as SessionBeforeCompactResult | undefined;
 
 					if (extensionResult?.cancel) {
-						return await this._rejectCompaction(request, requestId, "cancelled-by-extension", true);
+						return await this._rejectCompaction(
+							request,
+							requestId,
+							extensionResult.rejectionCause ?? "cancelled-by-extension",
+							true,
+							extensionResult.reason,
+						);
 					}
 
 					if (extensionResult?.compaction) {
@@ -2654,7 +2683,19 @@ export class AgentSession {
 		requestId: string,
 		rejectionCause: CompactionRejectionCause,
 		aborted: boolean,
+		extensionReason?: string,
 	): Promise<CompactionExecutionResult> {
+		// Per plan Section 1: rejection must never be silent. The compaction_end event
+		// carries a non-empty human-readable errorMessage (unless the user aborted, where
+		// the aborted branch already renders "Compaction cancelled"). session_compact is
+		// also emitted with accepted:false so the compaction extension's circuit-breaker
+		// bookkeeping stops being dead code; other builtin session_compact handlers guard
+		// on event.accepted.
+		const trimmedExtensionReason = extensionReason?.trim();
+		const detailedMessage = trimmedExtensionReason
+			? `Compaction rejected: ${trimmedExtensionReason}`
+			: describeCompactionRejection(rejectionCause);
+		const errorMessage = aborted && !trimmedExtensionReason ? undefined : detailedMessage;
 		this._emit({
 			type: "compaction_end",
 			reason: request.reason,
@@ -2664,6 +2705,16 @@ export class AgentSession {
 			requestId,
 			accepted: false,
 			rejectionCause,
+			errorMessage,
+		});
+		await this._extensionRunner.emit({
+			type: "session_compact",
+			reason: request.reason,
+			requestId,
+			accepted: false,
+			rejectionCause,
+			fromExtension: false,
+			willRetry: false,
 		});
 		return { accepted: false, requestId, rejectionCause };
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,23 @@
 # Builtin compaction extension changes
 
+## Structured rejection reasons on session_before_compact (2026-07-20)
+
+- `index.ts` cancel paths now attach a structured `rejectionCause` plus a
+  human-readable `reason` on the `SessionBeforeCompactResult`:
+  - per-turn cap → `{ rejectionCause: "per-turn-cap", reason: "per-turn compaction cap reached for this turn" }`.
+  - tripped circuit breaker → `{ rejectionCause: "circuit-breaker", reason: "compaction circuit breaker cooling down (Ns left)" }` with the real remaining cooldown.
+  - summarization threw → `{ reason: "compaction generator failed: <message>" }` (no `rejectionCause`; core defaults to `cancelled-by-extension`).
+  - summarization returned no summary → `{ reason: "compaction generator returned no summary" }`.
+  Core threads these into `compaction_end.errorMessage` so `/compact` produces a
+  specific line instead of the bare "Compaction cancelled" the plan flagged.
+- `ctx.ui.notify("Compaction rejected: ...", "warning")` was removed from the
+  `session_compact` `!accepted` branch and `ctx.ui.notify("Compaction failed: ...", "error")`
+  was removed from the provider-throw cancel path. Both facts now travel through
+  the canonical `compaction_end` event; duplicating them as toasts produced
+  double surfaces while the compaction status indicator was still animating
+  (plan §1 Q3). `breaker.recordFailure` in the `!accepted` branch stays live now
+  that core actually emits the rejection event.
+
 ## Native-form summarization requests and honest compaction errors (2026-07-20)
 
 - `speculative.ts` no longer serializes the conversation into one `<conversation>` text dump for the

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -315,9 +315,23 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_before_compact", async (event, ctx) => {
 		invalidateSpeculativeCompaction();
-		if (cap.shouldRejectByCap(state, { reason: event.reason }).cancel) return { cancel: true };
-		if (breaker.isTripped(state, Date.now()) && !breaker.shouldBypass(state, { reason: event.reason }))
-			return { cancel: true };
+		if (cap.shouldRejectByCap(state, { reason: event.reason }).cancel) {
+			return {
+				cancel: true,
+				rejectionCause: "per-turn-cap",
+				reason: "per-turn compaction cap reached for this turn",
+			};
+		}
+		const now = Date.now();
+		if (breaker.isTripped(state, now) && !breaker.shouldBypass(state, { reason: event.reason })) {
+			const remainingMs = state.trippedAt !== null ? Math.max(0, state.trippedAt + breaker.COOLDOWN_MS - now) : 0;
+			const remainingSec = Math.ceil(remainingMs / 1000);
+			return {
+				cancel: true,
+				rejectionCause: "circuit-breaker",
+				reason: `compaction circuit breaker cooling down (${remainingSec}s left)`,
+			};
+		}
 
 		capturePendingMetadata(event.requestId, ctx);
 
@@ -351,14 +365,15 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 			// limit) instead of letting it degrade into a bare "Compaction
 			// cancelled". Cancel rather than fall back: the core route would
 			// re-send the same conversation and burn tokens on the same failure.
+			// The reason threads into compaction_end.errorMessage so the UI shows
+			// the real provider message; ctx.ui.notify would be a duplicate toast.
 			const message = error instanceof Error ? error.message : String(error);
-			ctx.ui.notify(`Compaction failed: ${message}`, "error");
 			pendingMetadata.delete(event.requestId);
-			return { cancel: true };
+			return { cancel: true, reason: `compaction generator failed: ${message}` };
 		}
 		if (!compaction) {
 			pendingMetadata.delete(event.requestId);
-			return { cancel: true };
+			return { cancel: true, reason: "compaction generator returned no summary" };
 		}
 
 		return {
@@ -401,8 +416,10 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 			}
 			return;
 		}
+		// Rejection feedback is emitted by core via compaction_end.errorMessage;
+		// duplicating it as a ctx.ui.notify toast produces double surfaces while
+		// the compaction status indicator is still animating (plan §1 Q3).
 		state = breaker.recordFailure(state, Date.now(), { route: event.reason });
-		ctx.ui.notify(`Compaction rejected: ${event.rejectionCause ?? "unknown"}`, "warning");
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {

--- a/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/nested-agents-md/index.ts
@@ -83,7 +83,9 @@ export default function nestedAgentsMd(pi: ExtensionAPI): void {
 		return { content: [...event.content, textBlock] };
 	});
 
-	pi.on("session_compact", async (_event, ctx) => {
+	pi.on("session_compact", async (event, ctx) => {
+		// Rejected compactions do not mutate session state; keep the cache warm.
+		if (!event.accepted) return;
 		const sessionKey = getSessionKey(ctx);
 		cache.clearSession(sessionKey);
 		filesPerSession.delete(sessionKey);

--- a/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
@@ -63,7 +63,9 @@ export default function piRulesExtension(pi: ExtensionAPI): void {
 		return undefined;
 	});
 
-	pi.on("session_compact", async (_event, ctx) => {
+	pi.on("session_compact", async (event, ctx) => {
+		// Rejected compactions do not mutate session state; do not reset rules.
+		if (!event.accepted) return undefined;
 		engine.resetSession(ctx.cwd);
 		pi.appendEntry("pi-rules.scan", { cwd: ctx.cwd, reason: "compact" });
 		return undefined;

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,48 +1,42 @@
 # Core Extensions Changes
 
-## 2026-07-20 - session_compact discriminated union + rejection emission (plan §1)
+## 2026-07-20 - session_compact `accepted: false` and structured cancel result
 
 ### What changed
 
-- `types.ts`: `SessionCompactEvent` is now the discriminated union
-  `SessionCompactAcceptedEvent | SessionCompactRejectedEvent`, keyed on
-  `accepted`. Accepted events keep the required `compactionEntry`; rejected
-  events carry the `rejectionCause` and set `compactionEntry: undefined`,
-  `fromExtension: false`, `willRetry: false`. The event doc now spells out that
-  rejections fire and that handlers must guard on `event.accepted` before
-  touching state that only exists on the accepted branch.
-- `../agent-session.ts`: `_rejectCompaction` emits `compaction_end` with a
-  non-empty human-readable `errorMessage` derived per `CompactionRejectionCause`
-  (exhaustive `switch` in `describeCompactionRejection`, so a new cause will
-  fail typecheck rather than reintroduce the silent path). It also emits the
-  `session_compact` extension event with `accepted: false, rejectionCause`,
-  making the builtin compaction extension's circuit-breaker `recordFailure`
-  bookkeeping reachable for the first time.
-- `builtin/rules/index.ts`, `builtin/nested-agents-md/index.ts`:
-  `session_compact` handlers now `return` immediately when `!event.accepted`
-  so a rejected compaction no longer resets rules-engine session state or
-  clears the nested-AGENTS.md cache. The compaction and hooks builtins were
-  already guarded via `if (event.accepted)`.
+- `types.ts`: `SessionBeforeCompactResult` gained optional `rejectionCause?: CompactionRejectionCause`
+  and `reason?: string` fields so extensions can attach a structured cause and a
+  human-readable detail when returning `{ cancel: true }`. `SessionCompactEvent.compactionEntry`
+  is now optional and only populated on `accepted: true` events, and the JSDoc
+  spells out that rejection events fire too.
+- `agent-session.ts`: `_rejectCompaction` populates `compaction_end.errorMessage`
+  with a message derived from `rejectionCause` (or the extension-provided
+  `reason` when present) and also emits a `session_compact` event with
+  `accepted: false`. Manual `/compact` used to swallow `would-overflow` and
+  extension cancels silently; this closes plan §1.
+- `builtin/nested-agents-md/index.ts`, `builtin/rules/index.ts`: `session_compact`
+  handlers now guard on `event.accepted` before mutating session state, since
+  the event fires on rejection too and there is no compaction entry to react to.
 
 ### Why
 
-- Plan §1 root cause A: manual `/compact` with `_wouldCompactionOverflow`-based
-  rejection was fully silent — `compaction_end` carried no `errorMessage`, and
-  `session_compact` was only emitted on the accepted path, leaving the
-  compaction extension's `!accepted` branch dead. Users lost the entry point
-  to recovery advice.
+- `_rejectCompaction` emitted `compaction_end` with no `errorMessage` and the
+  interactive-mode handler had no branch for `aborted:false && !result && !errorMessage`,
+  so `/compact` rejected by `_wouldCompactionOverflow` was invisible. The
+  builtin compaction extension's `session_compact` `!accepted` branch was also
+  dead because core never emitted the rejection.
 
 ### Why extension system couldn't handle this alone
 
-- The union shape, exhaustive rejection copy, and the emission sites all live
-  in the core extension surface; extensions cannot add typed variants to
-  `SessionCompactEvent` or make core emit rejections.
+- The event union and the emit sites live in the core extension surface.
+  Extensions cannot add typed fields to `SessionCompactEvent` or make the core
+  emit rejections from outside.
 
 ### Expected merge conflict zones
 
-- HIGH: `types.ts` around `SessionCompactEvent`; `agent-session.ts`
-  `_rejectCompaction` and its call sites.
-- LOW: builtin `session_compact` handlers gaining the `!event.accepted` guard.
+- HIGH: `types.ts` around `SessionBeforeCompactResult` and `SessionCompactEvent`.
+- MEDIUM: `agent-session.ts` `_rejectCompaction` and `_executeCompaction` cancel branch.
+- LOW: builtin `session_compact` handlers guarding on `event.accepted`.
 
 ## 2026-07-19 - Port phased op-based todo tool
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,49 @@
 # Core Extensions Changes
 
+## 2026-07-20 - session_compact discriminated union + rejection emission (plan §1)
+
+### What changed
+
+- `types.ts`: `SessionCompactEvent` is now the discriminated union
+  `SessionCompactAcceptedEvent | SessionCompactRejectedEvent`, keyed on
+  `accepted`. Accepted events keep the required `compactionEntry`; rejected
+  events carry the `rejectionCause` and set `compactionEntry: undefined`,
+  `fromExtension: false`, `willRetry: false`. The event doc now spells out that
+  rejections fire and that handlers must guard on `event.accepted` before
+  touching state that only exists on the accepted branch.
+- `../agent-session.ts`: `_rejectCompaction` emits `compaction_end` with a
+  non-empty human-readable `errorMessage` derived per `CompactionRejectionCause`
+  (exhaustive `switch` in `describeCompactionRejection`, so a new cause will
+  fail typecheck rather than reintroduce the silent path). It also emits the
+  `session_compact` extension event with `accepted: false, rejectionCause`,
+  making the builtin compaction extension's circuit-breaker `recordFailure`
+  bookkeeping reachable for the first time.
+- `builtin/rules/index.ts`, `builtin/nested-agents-md/index.ts`:
+  `session_compact` handlers now `return` immediately when `!event.accepted`
+  so a rejected compaction no longer resets rules-engine session state or
+  clears the nested-AGENTS.md cache. The compaction and hooks builtins were
+  already guarded via `if (event.accepted)`.
+
+### Why
+
+- Plan §1 root cause A: manual `/compact` with `_wouldCompactionOverflow`-based
+  rejection was fully silent — `compaction_end` carried no `errorMessage`, and
+  `session_compact` was only emitted on the accepted path, leaving the
+  compaction extension's `!accepted` branch dead. Users lost the entry point
+  to recovery advice.
+
+### Why extension system couldn't handle this alone
+
+- The union shape, exhaustive rejection copy, and the emission sites all live
+  in the core extension surface; extensions cannot add typed variants to
+  `SessionCompactEvent` or make core emit rejections.
+
+### Expected merge conflict zones
+
+- HIGH: `types.ts` around `SessionCompactEvent`; `agent-session.ts`
+  `_rejectCompaction` and its call sites.
+- LOW: builtin `session_compact` handlers gaining the `!event.accepted` guard.
+
 ## 2026-07-19 - Port phased op-based todo tool
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -659,25 +659,45 @@ export interface SessionBeforeCompactEvent {
 	signal: AbortSignal;
 }
 
-/** Fired after context compaction. Rejections keep `reason` as the route source and explain why via `rejectionCause`. */
-export interface SessionCompactEvent {
+/**
+ * Fired after context compaction, including rejections. Discriminated on
+ * `accepted` so extension handlers get correct narrowing: only accepted events
+ * carry a `compactionEntry`; rejected events carry the `rejectionCause`. Prior
+ * to plan Section 1 the rejected shape was never emitted and its bookkeeping
+ * branches in builtin extensions were dead code.
+ */
+export type SessionCompactEvent = SessionCompactAcceptedEvent | SessionCompactRejectedEvent;
+
+export interface SessionCompactAcceptedEvent {
 	type: "session_compact";
 	/** Route source that requested compaction. Never source-swap this on rejection. */
 	reason: CompactionReason;
 	/** Unique identifier tying before/after compaction events for one request. */
 	requestId: string;
-	/** Whether the compaction result was accepted and appended to the session. */
-	accepted: boolean;
-	/**
-	 * Optional rejection explanation, only set when `accepted` is false.
-	 * Example: an extension cancelling manual compaction emits
-	 * `{ reason: "manual", accepted: false, rejectionCause: "cancelled-by-extension" }`, never `{ reason: "extension" }`.
-	 */
-	rejectionCause?: CompactionRejectionCause;
+	accepted: true;
+	rejectionCause?: never;
+	/** Appended compaction entry. Always present on accepted events. */
 	compactionEntry: CompactionEntry;
 	fromExtension: boolean;
 	/** True when the aborted turn is retried after this compaction (overflow recovery) */
 	willRetry: boolean;
+}
+
+export interface SessionCompactRejectedEvent {
+	type: "session_compact";
+	reason: CompactionReason;
+	requestId: string;
+	accepted: false;
+	/**
+	 * Why this compaction attempt was rejected. Example: an extension cancelling
+	 * manual compaction emits
+	 * `{ reason: "manual", accepted: false, rejectionCause: "cancelled-by-extension" }`,
+	 * never `{ reason: "extension" }`.
+	 */
+	rejectionCause: CompactionRejectionCause;
+	compactionEntry?: undefined;
+	fromExtension: false;
+	willRetry: false;
 }
 
 /** Fired before an extension runtime is torn down due to quit, reload, or session replacement. */
@@ -1200,6 +1220,19 @@ export interface SessionBeforeForkResult {
 export interface SessionBeforeCompactResult {
 	cancel?: boolean;
 	compaction?: CompactionResult;
+	/**
+	 * Optional structured cause when cancelling. Threaded into the
+	 * `compaction_end` event's `rejectionCause` and reused for extension
+	 * bookkeeping (circuit breaker, per-turn cap, etc.). Defaults to
+	 * `"cancelled-by-extension"`.
+	 */
+	rejectionCause?: CompactionRejectionCause;
+	/**
+	 * Optional human-readable reason threaded into the `compaction_end` event's
+	 * `errorMessage`. Prefer a short imperative sentence ("per-turn compaction
+	 * cap reached", "circuit breaker cooling down (2s left)").
+	 */
+	reason?: string;
 }
 
 export interface SessionBeforeTreeResult {

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -4,31 +4,21 @@
 
 ### What changed
 
-- `interactive-mode.ts`: the `compaction_end` handler now has an exhaustive
-  fallback branch. When an event arrives with `accepted === false` but no
-  `errorMessage` on legacy shapes (or a future rejection cause the core
-  helper does not yet describe), the handler renders
-  `Compaction failed (no result); cause: <rejectionCause ?? "unknown">`
-  through `showError` for manual `/compact` and through an inline error line
-  for auto compaction. The pre-existing `aborted / result / errorMessage`
-  branches remain in place; the new branch is a defense-in-depth catch-all.
+- `interactive-mode.ts`: the `compaction_end` handler no longer silently falls
+  through when a rejection carries no `errorMessage` (e.g. legacy shape). It
+  prefers the extension-provided `errorMessage` inside the `aborted` branch so
+  per-turn-cap / circuit-breaker / provider-error cancels render the real cause
+  instead of the generic "Compaction cancelled", and adds a fallback
+  `showError("Compaction failed (no result); cause: <rejectionCause>")` so no
+  future `compaction_end` shape can be ignored.
 
 ### Why
 
-- Plan §1: manual `/compact` used to render nothing when core rejected the
-  proposed summary as would-overflow. Core now populates
-  `compaction_end.errorMessage` for every rejection, but the interactive
-  handler stays exhaustive so any future silent event shape is impossible.
-
-### Why extension system couldn't handle this alone
-
-- The interactive-mode compaction rendering pipeline is a built-in TUI seam;
-  extensions receive `compaction_end` but cannot install a fallback in the
-  built-in event switch.
-
-### Expected merge conflict zones
-
-- LOW: the `case "compaction_end":` block in `interactive-mode.ts`.
+- Manual `/compact` used to render nothing when core rejected the summary as
+  overflow-would-still-happen. The handler only branched on `aborted / result /
+  errorMessage` and `_rejectCompaction` used to emit none of those fields for
+  `would-overflow`. Combined with core now populating `errorMessage`, the
+  interactive fallback closes plan §1.
 
 ## paced streaming tool argument previews (2026-07-20)
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,35 @@
 # changes
 
+## exhaustive compaction_end rendering (2026-07-20)
+
+### What changed
+
+- `interactive-mode.ts`: the `compaction_end` handler now has an exhaustive
+  fallback branch. When an event arrives with `accepted === false` but no
+  `errorMessage` on legacy shapes (or a future rejection cause the core
+  helper does not yet describe), the handler renders
+  `Compaction failed (no result); cause: <rejectionCause ?? "unknown">`
+  through `showError` for manual `/compact` and through an inline error line
+  for auto compaction. The pre-existing `aborted / result / errorMessage`
+  branches remain in place; the new branch is a defense-in-depth catch-all.
+
+### Why
+
+- Plan §1: manual `/compact` used to render nothing when core rejected the
+  proposed summary as would-overflow. Core now populates
+  `compaction_end.errorMessage` for every rejection, but the interactive
+  handler stays exhaustive so any future silent event shape is impossible.
+
+### Why extension system couldn't handle this alone
+
+- The interactive-mode compaction rendering pipeline is a built-in TUI seam;
+  extensions receive `compaction_end` but cannot install a fallback in the
+  built-in event switch.
+
+### Expected merge conflict zones
+
+- LOW: the `case "compaction_end":` block in `interactive-mode.ts`.
+
 ## paced streaming tool argument previews (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3523,8 +3523,15 @@ export class InteractiveMode {
 				this.clearStatusIndicator("compaction");
 				this.autoCompactionProgressText = "";
 				if (event.aborted) {
+					// Prefer the extension-provided reason over the generic "cancelled"
+					// label so per-turn-cap / circuit-breaker / provider-error cancels are
+					// no longer indistinguishable from a user-triggered abort.
+					const cancelMessage = event.errorMessage ?? "Compaction cancelled";
 					if (event.reason === "manual") {
-						this.showError("Compaction cancelled");
+						this.showError(cancelMessage);
+					} else if (event.errorMessage) {
+						this.chatContainer.addChild(new Spacer(1));
+						this.chatContainer.addChild(new Text(theme.fg("error", event.errorMessage), 1, 0));
 					} else {
 						this.showStatus("Auto-compaction cancelled");
 					}
@@ -3546,6 +3553,18 @@ export class InteractiveMode {
 					} else {
 						this.chatContainer.addChild(new Spacer(1));
 						this.chatContainer.addChild(new Text(theme.fg("error", event.errorMessage), 1, 0));
+					}
+				} else if (event.accepted === false) {
+					// Exhaustive fallback per plan Section 1: compaction_end must never fall
+					// through silently. Rejection events without an errorMessage still name
+					// the rejectionCause so the user knows /compact did nothing on purpose.
+					const cause = event.rejectionCause ?? "unknown";
+					const message = `Compaction failed (no result); cause: ${cause}`;
+					if (event.reason === "manual") {
+						this.showError(message);
+					} else {
+						this.chatContainer.addChild(new Spacer(1));
+						this.chatContainer.addChild(new Text(theme.fg("error", message), 1, 0));
 					}
 				}
 				void this.flushCompactionQueue({ willRetry: event.willRetry });

--- a/packages/coding-agent/test/compaction-extensions-example.test.ts
+++ b/packages/coding-agent/test/compaction-extensions-example.test.ts
@@ -50,7 +50,11 @@ describe("Documentation example", () => {
 	it("compact event should have correct fields", () => {
 		const checkCompactEvent = (pi: ExtensionAPI) => {
 			pi.on("session_compact", async (event: SessionCompactEvent) => {
-				// These should all be accessible
+				// The discriminated shape: only accepted events carry compactionEntry.
+				if (!event.accepted) {
+					expect(typeof event.rejectionCause).toBe("string");
+					return;
+				}
 				const entry = event.compactionEntry;
 				const fromExtension = event.fromExtension;
 

--- a/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
@@ -133,7 +133,7 @@ function createEvent(): SessionBeforeCompactEvent {
 }
 
 describe("session_before_compact error surfacing", () => {
-	it("notifies the real provider error and cancels when summarization fails", async () => {
+	it("cancels with a structured reason (no duplicate toast) when summarization fails", async () => {
 		// Given
 		const harness = createHarness();
 		harness.registration.setResponses([
@@ -146,11 +146,13 @@ describe("session_before_compact error surfacing", () => {
 		// When
 		const result = await harness.beforeCompact(createEvent(), harness.ctx);
 
-		// Then
-		expect(result).toEqual({ cancel: true });
-		expect(harness.notifications).toHaveLength(1);
-		expect(harness.notifications[0]?.message).toContain("request blocked by provider policy");
-		expect(harness.notifications[0]?.level).toBe("error");
+		// Then: the real provider error is threaded into the cancel reason so core
+		// can surface it via compaction_end.errorMessage. The ctx.ui.notify path is
+		// intentionally removed to avoid double surfacing while the compaction
+		// status indicator is animating (plan §1 Q3).
+		expect(result?.cancel).toBe(true);
+		expect(result?.reason ?? "").toContain("request blocked by provider policy");
+		expect(harness.notifications).toHaveLength(0);
 	});
 
 	it("returns the generated compaction with the agent system prompt on the request", async () => {

--- a/packages/coding-agent/test/compaction/extension-hooks.test.ts
+++ b/packages/coding-agent/test/compaction/extension-hooks.test.ts
@@ -173,15 +173,17 @@ describe("Compaction extension hooks", () => {
 				expect(result.summary).toBe(customSummary);
 				const compactEvents = capturedEvents.filter(isSessionCompactEvent);
 				expect(compactEvents).toHaveLength(1);
-				expect(compactEvents[0]?.fromExtension).toBe(true);
-				expect(compactEvents[0]?.compactionEntry.summary).toBe(customSummary);
+				const first = compactEvents[0];
+				if (!first?.accepted) throw new Error("expected accepted session_compact event");
+				expect(first.fromExtension).toBe(true);
+				expect(first.compactionEntry.summary).toBe(customSummary);
 			});
 		});
 	});
 
 	describe("Given a session_before_compact handler that returns cancel", () => {
 		describe("When compaction is triggered", () => {
-			it("Then no compaction occurs and no session_compact event is emitted", async () => {
+			it("Then no compaction occurs and a rejected session_compact event is emitted", async () => {
 				// given
 				const extension = createExtension(() => ({ cancel: true }));
 				createSession([extension]);
@@ -193,7 +195,12 @@ describe("Compaction extension hooks", () => {
 				// then
 				await expect(result).rejects.toThrow("Compaction cancelled");
 				const compactEvents = capturedEvents.filter(isSessionCompactEvent);
-				expect(compactEvents).toHaveLength(0);
+				// Rejection is no longer silent: session_compact fires with accepted=false so
+				// extension bookkeeping (circuit breaker, notifications) becomes reachable.
+				expect(compactEvents).toHaveLength(1);
+				expect(compactEvents[0]?.accepted).toBe(false);
+				expect(compactEvents[0]?.rejectionCause).toBe("cancelled-by-extension");
+				expect(compactEvents[0]?.compactionEntry).toBeUndefined();
 			});
 		});
 	});
@@ -248,9 +255,10 @@ describe("Compaction extension hooks", () => {
 				// then
 				const compactEvents = capturedEvents.filter(isSessionCompactEvent);
 				expect(compactEvents).toHaveLength(1);
-				expect(compactEvents[0]?.accepted).toBe(true);
-				expect(compactEvents[0]?.compactionEntry.summary).toBe("Saved compaction summary");
-				expect(compactEvents[0]?.compactionEntry.tokensBefore).toBeGreaterThanOrEqual(0);
+				const first = compactEvents[0];
+				if (!first?.accepted) throw new Error("expected accepted session_compact event");
+				expect(first.compactionEntry.summary).toBe("Saved compaction summary");
+				expect(first.compactionEntry.tokensBefore).toBeGreaterThanOrEqual(0);
 			});
 		});
 	});

--- a/packages/coding-agent/test/integration/compaction-real-api.test.ts
+++ b/packages/coding-agent/test/integration/compaction-real-api.test.ts
@@ -156,6 +156,7 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 		expect(beforeEvent.branchEntries).toBeDefined();
 
 		const afterEvent = compactEvents[0];
+		if (!afterEvent.accepted) throw new Error("expected accepted session_compact event");
 		expect(afterEvent.compactionEntry).toBeDefined();
 		expect(afterEvent.compactionEntry.summary.length).toBeGreaterThan(0);
 		expect(afterEvent.compactionEntry.tokensBefore).toBeGreaterThanOrEqual(0);
@@ -171,8 +172,14 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 
 		await expect(session.compact()).rejects.toThrow("Compaction cancelled");
 
+		// Rejection is no longer silent: session_compact fires with accepted=false so
+		// extension bookkeeping (circuit breaker, notifications) becomes reachable.
 		const compactEvents = capturedEvents.filter((e) => e.type === "session_compact");
-		expect(compactEvents.length).toBe(0);
+		expect(compactEvents.length).toBe(1);
+		expect(compactEvents[0]?.accepted).toBe(false);
+		if (compactEvents[0]?.accepted === false) {
+			expect(compactEvents[0].rejectionCause).toBe("cancelled-by-extension");
+		}
 	}, 120000);
 
 	it("should allow extensions to provide custom compaction", async () => {
@@ -206,7 +213,7 @@ describe.skipIf(!process.env.PI_RUN_INTEGRATION)("Compaction extensions (real AP
 		expect(compactEvents.length).toBe(1);
 
 		const afterEvent = compactEvents[0];
-		if (afterEvent.type === "session_compact") {
+		if (afterEvent.type === "session_compact" && afterEvent.accepted) {
 			expect(afterEvent.compactionEntry.summary).toBe(customSummary);
 			expect(afterEvent.fromExtension).toBe(true);
 		}

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -148,6 +148,61 @@ describe("InteractiveMode compaction events", () => {
 		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
 	});
 
+	test("surfaces a manual would-overflow rejection instead of silently swallowing it", async () => {
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+			autoCompactionLoader: undefined,
+			defaultEditor: {},
+			statusContainer: { clear: vi.fn() },
+			chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			addMessageToChat: vi.fn(),
+			showError: vi.fn(),
+			showWarning: vi.fn(),
+			showStatus: vi.fn(),
+			clearStatusIndicator: vi.fn(),
+			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		};
+
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: {
+				type: "compaction_end";
+				reason: "manual";
+				result: undefined;
+				aborted: false;
+				willRetry: false;
+				accepted: false;
+				rejectionCause: "would-overflow";
+			},
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "manual",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+			accepted: false,
+			rejectionCause: "would-overflow",
+		});
+
+		// The user typed /compact and the compaction was rejected because the summary
+		// would still overflow the context window. Silent failure is the bug: the user
+		// must see feedback that names the rejection cause.
+		const feedback = [
+			...fakeThis.showError.mock.calls.map((call) => String(call[0])),
+			...fakeThis.showWarning.mock.calls.map((call) => String(call[0])),
+			...fakeThis.showStatus.mock.calls.map((call) => String(call[0])),
+		].join("\n");
+		expect(feedback).toMatch(/would.?overflow|overflow|rejected/i);
+		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+	});
+
 	test("sanitizes a detached continuation launch failure before rendering", async () => {
 		const fakeThis = {
 			isInitialized: true,

--- a/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
@@ -1,0 +1,171 @@
+import { Container } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, SessionCompactEvent } from "../../../src/core/extensions/index.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+function seedCompactableSession(harness: Harness): void {
+	const now = Date.now();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "message to compact" }],
+		timestamp: now - 1000,
+	});
+	harness.sessionManager.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: "assistant response to compact" }],
+		model: harness.getModel().id,
+		provider: harness.getModel().provider,
+		api: harness.getModel().api,
+		stopReason: "stop",
+		usage: {
+			input: 100,
+			output: 100,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 200,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: now - 500,
+	});
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "message to keep" }],
+		timestamp: now,
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
+describe("Regression: manual /compact silent rejection", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("emits observable feedback when manual compaction would overflow the context window", async () => {
+		const oversizedSummary = "S".repeat(4000);
+		const compactSessionEvents: SessionCompactEvent[] = [];
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1, reserveTokens: 0 } },
+			models: [{ id: "faux-1", contextWindow: 100, maxTokens: 50 }],
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: oversizedSummary,
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: { source: "regression-oversized" },
+						},
+					}));
+					pi.on("session_compact", async (event) => {
+						compactSessionEvents.push(event);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+
+		await expect(harness.session.compact()).rejects.toThrow(/[Cc]ompaction (rejected|failed)/);
+
+		const compactionEnd = harness.eventsOfType("compaction_end").at(-1);
+		expect(compactionEnd).toBeDefined();
+		expect(compactionEnd?.accepted).toBe(false);
+		expect(compactionEnd?.rejectionCause).toBe("would-overflow");
+		expect(compactionEnd?.errorMessage).toBeDefined();
+		expect(compactionEnd?.errorMessage ?? "").toMatch(/overflow|context window/i);
+
+		const rejectionEvent = compactSessionEvents.find((event) => event.accepted === false);
+		expect(rejectionEvent).toBeDefined();
+		expect(rejectionEvent?.rejectionCause).toBe("would-overflow");
+	});
+
+	it("threads extension cancel reasons through the compaction_end error message", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "per-turn-cap" as const,
+						reason: "per-turn compaction cap reached",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+
+		await expect(harness.session.compact()).rejects.toThrow(/[Cc]ompaction/);
+
+		const compactionEnd = harness.eventsOfType("compaction_end").at(-1);
+		expect(compactionEnd).toBeDefined();
+		expect(compactionEnd?.accepted).toBe(false);
+		expect(compactionEnd?.rejectionCause).toBe("per-turn-cap");
+		expect(compactionEnd?.errorMessage ?? "").toContain("per-turn compaction cap reached");
+	});
+});
+
+describe("Regression: interactive-mode compaction_end fallback", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("renders an error when a compaction_end carries no result, no errorMessage, and no aborted flag", async () => {
+		const statusContainer = new Container();
+		const chatContainer = new Container();
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+			autoCompactionLoader: undefined as { stop(): void } | undefined,
+			autoCompactionProgressText: "",
+			defaultEditor: {} as { onEscape?: () => void },
+			session: { abortCompaction: vi.fn() },
+			statusContainer: Object.assign(statusContainer, { clear: vi.fn() }),
+			chatContainer: Object.assign(chatContainer, { clear: vi.fn(), addChild: vi.fn() }),
+			rebuildChatFromMessages: vi.fn(),
+			addMessageToChat: vi.fn(),
+			showError: vi.fn(),
+			showStatus: vi.fn(),
+			clearStatusIndicator: vi.fn(),
+			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		};
+
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: {
+				type: "compaction_end";
+				reason: "manual";
+				result: undefined;
+				aborted: false;
+				willRetry: false;
+				accepted?: false;
+				rejectionCause?: "would-overflow";
+			},
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "manual",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+			accepted: false,
+			rejectionCause: "would-overflow",
+		});
+
+		expect(fakeThis.showError).toHaveBeenCalledTimes(1);
+		const message = String(fakeThis.showError.mock.calls[0]?.[0] ?? "");
+		expect(message).toMatch(/compaction/i);
+		expect(message).toMatch(/would-overflow|unknown|no result/i);
+	});
+});


### PR DESCRIPTION
## Summary

Manual `/compact` rejections can no longer fail silently. Rejection events now carry a specific reason, rejected compactions reach extension bookkeeping, and the interactive UI has an exhaustive fallback for malformed future rejection events.

## Changes

- Model compaction rejection state explicitly, including `would-overflow`, per-turn cap, and circuit-breaker paths.
- Surface rejection feedback through the interactive UI and keep built-in extension caches unchanged for rejected compactions.
- Add regression coverage for manual overflow, extension-provided cancellation reasons, and extension event contracts.

## QA & Evidence

- **Focused tests:** compaction feedback, interactive mode, extension hooks, and extension example tests passed. This locks the silent-overflow regression and cancellation-reason propagation.
- **Static validation:** `npm run check` passed at tree `db7fab4b8`.
- **Real CLI QA:** isolated Senpi QA passed through mock-loop (all three wire APIs), RPC, TUI via tmux, and CLI smoke.
- **Artifacts:** `local-ignore/qa-evidence/20260720-compaction-feedback-pr1/{check,mock-loop,rpc,tui,cli}.txt` (local, sanitized, gitignored by repository policy).

## Risks & Residuals

The change makes rejected `session_compact` events observable. Built-ins that assume a committed compaction explicitly ignore `accepted: false`; focused hooks coverage validates that contract. No credentials or real provider calls were used in QA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manual `/compact` rejections now show clear reasons instead of failing silently. Core emits structured rejection events with human-readable messages, the interactive UI renders them (with a fallback), and built-ins avoid state changes on rejected compactions.

- **Bug Fixes**
  - Emit `compaction_end` with a human-readable `errorMessage` for every rejection cause (or the extension’s cancel `reason`), and emit `session_compact` with `accepted: false`.
  - Interactive mode renders rejection feedback and adds a fallback when `errorMessage` is missing; removed duplicate toasts in the compaction extension.
  - Guard `nested-agents-md` and `rules` `session_compact` handlers on `event.accepted` to prevent state changes on rejection; the compaction circuit breaker now records failures.
  - `CompactionRejectedError` message now matches the emitted rejection copy.

- **Migration**
  - `SessionCompactEvent` is now a discriminated union. Read `compactionEntry` only when `event.accepted === true`; use `event.rejectionCause` for rejections.
  - `session_before_compact` cancel paths can return `rejectionCause` and `reason` to surface precise errors.

<sup>Written for commit 0e61546834dc9d219305a6d6c7f7f38320726f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

