### PR TITLE
fix(ai): recover unsigned Anthropic thinking replay

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -230,6 +230,30 @@ const UNSUPPORTED_NATIVE_COMPUTER_TOOL_MODEL_MARKERS = [
 	"opus-4.8",
 ] as const;
 
+type UnsignedThinkingReplay = "text" | "empty-signature";
+
+// A provider can reject its own empty signatures. Learn that capability for one
+// conversation without changing the shared model definition used by other sessions.
+const unsignedThinkingTextReplayFallbacks = new Set<string>();
+
+function unsignedThinkingFallbackKey(
+	model: Model<"anthropic-messages">,
+	sessionId: string | undefined,
+): string | undefined {
+	return sessionId === undefined ? undefined : `${sessionId}\u0000${model.baseUrl}\u0000${model.id}`;
+}
+
+function isInvalidUnsignedThinkingSignatureError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"status" in error &&
+		(error as { status?: unknown }).status === 400 &&
+		error instanceof Error &&
+		/Invalid signature in thinking block/i.test(error.message)
+	);
+}
+
 function getAnthropicCompat(
 	model: Model<"anthropic-messages">,
 ): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking">> {
@@ -250,6 +274,8 @@ function getAnthropicCompat(
 		supportsForcedToolChoice:
 			model.compat?.supportsForcedToolChoice ?? !CLAUDE_FABLE_OR_MYTHOS_MODEL_ID.test(model.id),
 		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
+		unsignedThinkingReplay:
+			model.compat?.unsignedThinkingReplay ?? (model.compat?.allowEmptySignature ? "empty-signature" : "text"),
 		supportsToolReferences: model.compat?.supportsToolReferences ?? defaultSupportsToolReferences(model),
 		// Default: first-party Anthropic only. Anthropic-compatible providers
 		// (kimi-coding, fireworks, copilot, gateways) may execute the server-side
@@ -953,32 +979,54 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				client = created.client;
 				isOAuth = created.isOAuthToken;
 			}
-			let params = buildParams(model, context, isOAuth, options);
-			const nextParams = await options?.onPayload?.(params, model);
-			if (nextParams !== undefined) {
-				params = nextParams as MessageCreateParamsStreaming;
-			}
-			params = sanitizeAdaptiveThinkingPayload(model, params, options);
-			params = sanitizeUnsupportedNativeTools(model, params);
-			const payloadRequestMetadata = extractPayloadRequestMetadata(params);
-			params = payloadRequestMetadata.params;
-			const requestOptions = {
-				...(options?.signal ? { signal: options.signal } : {}),
-				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
-				...(payloadRequestMetadata.headers ? { headers: payloadRequestMetadata.headers } : {}),
+			const fallbackKey = unsignedThinkingFallbackKey(model, options?.sessionId);
+			let unsignedThinkingReplay: UnsignedThinkingReplay =
+				fallbackKey && unsignedThinkingTextReplayFallbacks.has(fallbackKey)
+					? "text"
+					: getAnthropicCompat(model).unsignedThinkingReplay;
+			const createRequest = async (): Promise<{ params: MessageCreateParamsStreaming; response: Response }> => {
+				let params = buildParams(model, context, isOAuth, options, unsignedThinkingReplay);
+				const nextParams = await options?.onPayload?.(params, model);
+				if (nextParams !== undefined) {
+					params = nextParams as MessageCreateParamsStreaming;
+				}
+				params = sanitizeAdaptiveThinkingPayload(model, params, options);
+				params = sanitizeUnsupportedNativeTools(model, params);
+				const payloadRequestMetadata = extractPayloadRequestMetadata(params);
+				params = payloadRequestMetadata.params;
+				const requestOptions = {
+					...(options?.signal ? { signal: options.signal } : {}),
+					...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
+					maxRetries: options?.maxRetries ?? 0,
+					...(payloadRequestMetadata.headers ? { headers: payloadRequestMetadata.headers } : {}),
+				};
+				try {
+					const response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
+					return { params, response };
+				} catch (error) {
+					if (isForcedToolChoiceUnsupportedError(error, isForcedAnthropicToolChoice(params.tool_choice))) {
+						params = omitToolChoiceParam(params);
+						const response = await client.messages
+							.create({ ...params, stream: true }, requestOptions)
+							.asResponse();
+						return { params, response };
+					}
+					throw error;
+				}
 			};
-			let response: Response;
+			let request: { params: MessageCreateParamsStreaming; response: Response };
 			try {
-				response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
+				request = await createRequest();
 			} catch (error) {
-				if (isForcedToolChoiceUnsupportedError(error, isForcedAnthropicToolChoice(params.tool_choice))) {
-					params = omitToolChoiceParam(params);
-					response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
+				if (unsignedThinkingReplay !== "text" && isInvalidUnsignedThinkingSignatureError(error)) {
+					unsignedThinkingReplay = "text";
+					if (fallbackKey) unsignedThinkingTextReplayFallbacks.add(fallbackKey);
+					request = await createRequest();
 				} else {
 					throw error;
 				}
 			}
+			const { response } = request;
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
@@ -1458,6 +1506,7 @@ function buildParams(
 	context: Context,
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
+	unsignedThinkingReplay = getAnthropicCompat(model).unsignedThinkingReplay,
 ): MessageCreateParamsStreaming {
 	const compat = getAnthropicCompat(model);
 	const { cacheControl } = getCacheControl(model, options?.cacheRetention ?? model.cacheRetention, options?.env);
@@ -1492,7 +1541,7 @@ function buildParams(
 			model,
 			isOAuthToken,
 			cacheControl,
-			compat.allowEmptySignature,
+			unsignedThinkingReplay,
 			deferredToolNames,
 			normalizeToolName,
 		),
@@ -1662,7 +1711,7 @@ function convertMessages(
 	model: Model<"anthropic-messages">,
 	isOAuthToken: boolean,
 	cacheControl?: CacheControlEphemeral,
-	allowEmptySignature = false,
+	unsignedThinkingReplay: UnsignedThinkingReplay = "text",
 	deferredToolNames: ReadonlySet<string> = new Set(),
 	normalizeToolName: (name: string) => string = (name) => name,
 ): MessageParam[] {
@@ -1774,7 +1823,7 @@ function convertMessages(
 					// and accept empty signatures, so let marked models preserve the block.
 					if (!hasThinkingSignature) {
 						blocks.push(
-							allowEmptySignature
+							unsignedThinkingReplay === "empty-signature"
 								? {
 										type: "thinking",
 										thinking: sanitizeSurrogates(block.thinking),

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,24 @@
 # AI Source Changes
 
+## 2026-07-20 - Retry unsigned Anthropic thinking replay as text
+
+### What changed and why
+
+- `AnthropicMessagesCompat.unsignedThinkingReplay` now explicitly controls replay of thinking blocks without a usable signature. The safe default is text replay for first-party/signing endpoints; the legacy `allowEmptySignature` flag remains an alias for Kimi-compatible empty-signature replay.
+- When an endpoint rejects an empty replay signature with a pre-stream HTTP 400 containing `Invalid signature in thinking block`, the Anthropic adapter rebuilds the request with unsigned thinking demoted to text and retries exactly once. That learned fallback is scoped to the session, base URL, and model ID, without mutating shared `Model` metadata.
+- Signed and redacted thinking replay remains byte-for-byte/native-state preserving. Non-signature 400s and errors after SSE content begins do not retry.
+
+### Files modified
+
+- `types.ts`
+- `api/anthropic-messages.ts`
+- `../test/anthropic-unsigned-thinking-replay.test.ts`
+
+### Expected merge conflict zones
+
+- LOW: `AnthropicMessagesCompat` replay options and Anthropic request creation.
+
+
 ## 2026-07-17 - Video input modality for Kimi K3 (kimi-coding)
 
 ### What changed and why

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -672,6 +672,14 @@ export interface AnthropicMessagesCompat {
 	/** Whether to replay empty thinking signatures as `signature: ""` instead of converting thinking to text. Default: false. */
 	allowEmptySignature?: boolean;
 	/**
+	 * How to replay thinking blocks that have no usable Anthropic signature.
+	 * `"text"` demotes them to text; `"empty-signature"` preserves Anthropic's
+	 * thinking shape with `signature: ""`. Defaults to `"text"`; the legacy
+	 * `allowEmptySignature` setting remains a compatibility alias for
+	 * `"empty-signature"`.
+	 */
+	unsignedThinkingReplay?: "text" | "empty-signature";
+	/**
 	 * Whether the provider supports deferred tools loaded by `tool_reference`
 	 * blocks in tool results. Default: true for first-party Anthropic models
 	 * except Haiku and models older than Claude 4.5; false for other providers.

--- a/packages/ai/test/anthropic-unsigned-thinking-replay.test.ts
+++ b/packages/ai/test/anthropic-unsigned-thinking-replay.test.ts
@@ -1,0 +1,196 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
+
+interface RequestBody {
+	messages?: Array<{
+		role: string;
+		content: Array<{ type: string; text?: string; thinking?: string; signature?: string }>;
+	}>;
+}
+
+function createModel(baseUrl: string, compat?: Model<"anthropic-messages">["compat"]): Model<"anthropic-messages"> {
+	return {
+		id: "kimi-k3",
+		name: "Kimi K3",
+		api: "anthropic-messages",
+		provider: "kimi-coding",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32000,
+		compat: { allowEmptySignature: true, ...compat },
+	};
+}
+
+function createContext(): Context {
+	const previousAssistant: AssistantMessage = {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "kimi-coding",
+		model: "kimi-k3",
+		content: [
+			{ type: "thinking", thinking: "unsigned replayed thought", thinkingSignature: "" },
+			{ type: "toolCall", id: "toolu_1", name: "lookup", arguments: {} },
+		],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+	return {
+		messages: [
+			{ role: "user", content: "Use lookup", timestamp: Date.now() },
+			previousAssistant,
+			{
+				role: "toolResult",
+				toolCallId: "toolu_1",
+				toolName: "lookup",
+				content: [{ type: "text", text: "result" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		],
+	};
+}
+
+async function readBody(request: IncomingMessage): Promise<RequestBody> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	return JSON.parse(Buffer.concat(chunks).toString("utf8")) as RequestBody;
+}
+
+function writeEmptySse(response: ServerResponse): void {
+	response.writeHead(200, { "content-type": "text/event-stream" });
+	response.end();
+}
+
+function writeError(response: ServerResponse, message: string): void {
+	response.writeHead(400, { "content-type": "application/json" });
+	response.end(JSON.stringify({ type: "error", error: { type: "invalid_request_error", message } }));
+}
+
+function writeInvalidSignature(response: ServerResponse): void {
+	writeError(response, "Invalid signature in thinking block");
+}
+
+function writeStartedSseThenError(response: ServerResponse): void {
+	response.writeHead(200, { "content-type": "text/event-stream" });
+	response.write(
+		'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}\n\n',
+	);
+	response.end('event: error\ndata: {"type":"error","error":{"message":"Invalid signature in thinking block"}}\n\n');
+}
+
+async function run(model: Model<"anthropic-messages">, sessionId: string) {
+	const response = streamAnthropic(model, createContext(), { apiKey: "test-key", cacheRetention: "none", sessionId });
+	for await (const event of response) {
+		if (event.type === "done" || event.type === "error") break;
+	}
+	return response.result();
+}
+
+describe("Anthropic unsigned thinking replay fallback", () => {
+	it("retries an invalid unsigned thinking signature once, then caches text replay for the session", async () => {
+		const requests: RequestBody[] = [];
+		const server = createServer(async (request, response) => {
+			requests.push(await readBody(request));
+			if (requests.length === 1) {
+				writeInvalidSignature(response);
+			} else {
+				writeEmptySse(response);
+			}
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+		const model = createModel(`http://127.0.0.1:${address.port}`);
+
+		try {
+			await run(model, "session-a");
+			await run(model, "session-a");
+		} finally {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		}
+
+		expect(requests).toHaveLength(3);
+		const firstThinking = requests[0].messages?.[1]?.content[0];
+		const retriedThinking = requests[1].messages?.[1]?.content[0];
+		const cachedThinking = requests[2].messages?.[1]?.content[0];
+		expect(firstThinking).toEqual({ type: "thinking", thinking: "unsigned replayed thought", signature: "" });
+		expect(retriedThinking).toEqual({ type: "text", text: "unsigned replayed thought" });
+		expect(cachedThinking).toEqual({ type: "text", text: "unsigned replayed thought" });
+	});
+
+	it("uses explicit text replay policy while preserving Kimi's legacy empty signatures", async () => {
+		const requests: RequestBody[] = [];
+		const server = createServer(async (request, response) => {
+			requests.push(await readBody(request));
+			writeEmptySse(response);
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+		const baseUrl = `http://127.0.0.1:${address.port}`;
+
+		try {
+			await run(createModel(baseUrl, { unsignedThinkingReplay: "text" }), "signing-session");
+			await run(createModel(baseUrl), "kimi-session");
+		} finally {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		}
+
+		expect(requests[0].messages?.[1]?.content[0]).toEqual({ type: "text", text: "unsigned replayed thought" });
+		expect(requests[1].messages?.[1]?.content[0]).toEqual({
+			type: "thinking",
+			thinking: "unsigned replayed thought",
+			signature: "",
+		});
+	});
+
+	it("does not retry unrelated 400 responses", async () => {
+		let requestCount = 0;
+		const server = createServer((_request, response) => {
+			requestCount += 1;
+			writeError(response, "A different invalid request");
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+
+		try {
+			const result = await run(createModel(`http://127.0.0.1:${address.port}`), "unrelated-session");
+			expect(result.stopReason).toBe("error");
+		} finally {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		}
+
+		expect(requestCount).toBe(1);
+	});
+
+	it("does not retry a signature error after content has started", async () => {
+		let requestCount = 0;
+		const server = createServer((_request, response) => {
+			requestCount += 1;
+			writeStartedSseThenError(response);
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+
+		try {
+			const result = await run(createModel(`http://127.0.0.1:${address.port}`), "post-content-session");
+			expect(result.stopReason).toBe("error");
+		} finally {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		}
+
+		expect(requestCount).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Recover from Anthropic signing proxies that reject otherwise replayable unsigned thinking blocks without wedging the conversation.

## Changes

- Add an explicit unsigned-thinking replay policy separate from Kimi's legacy `allowEmptySignature` compatibility behavior.
- Retry a pre-content `Invalid signature in thinking block` response exactly once with unsigned thinking demoted to text.
- Cache the learned fallback per session/base URL/model without mutating shared model configuration.
- Keep signed and redacted thinking untouched; unrelated 400s and post-content failures never retry.

## QA & Evidence

- New deterministic mock-server coverage proves retry, cache reuse, explicit text policy, legacy Kimi preservation, unrelated-400 no retry, and post-content no retry.
- Existing Anthropic native replay coverage passes alongside the new suite.
- `npm run check` passed.
- Real Senpi mock-loop, RPC, TUI, and CLI smoke all passed in isolation.
- Local sanitized receipts: `local-ignore/qa-evidence/20260720-unsigned-thinking-pr2/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers from signing proxies that reject unsigned Anthropic thinking by retrying once as text and caching that fallback per session. Prevents stuck conversations without changing shared model config.

- **Bug Fixes**
  - Added `unsignedThinkingReplay` compat option (defaults to "text"); `allowEmptySignature` remains a Kimi alias for `"empty-signature"`.
  - On a pre-stream 400 "Invalid signature in thinking block", retry exactly once with text; cache the learned fallback by session + base URL + model.
  - No retries for other 400s or after SSE starts; signed and redacted thinking stay intact.
  - Added deterministic tests for retry, cached fallback reuse, explicit policy, Kimi preservation, and no-retry paths.

<sup>Written for commit 5fe1077c22dccffd7fb78bd74d00316615a5ba90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

