### PR TITLE
fix(ai): preserve live tool call result pairing

### DIFF
--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -228,69 +228,81 @@ export function transformMessages<TApi extends Api>(
 		return msg;
 	});
 
-	// Second pass: insert synthetic empty tool results for orphaned tool calls
-	// This preserves thinking signatures and satisfies API requirements
+	// Second pass: pair every replayable tool call with the earliest unconsumed
+	// result after its declaring assistant. Results are emitted adjacent to their
+	// calls because Anthropic requires that ordering. A reused ID starts a new
+	// pairing window, so a later result cannot repair an earlier call.
 	const result: Message[] = [];
-	let pendingToolCalls: ToolCall[] = [];
-	let existingToolResultIds = new Set<string>();
-	const insertSyntheticToolResults = () => {
-		if (pendingToolCalls.length > 0) {
-			for (const tc of pendingToolCalls) {
-				if (!existingToolResultIds.has(tc.id)) {
-					result.push({
-						role: "toolResult",
-						toolCallId: tc.id,
-						toolName: tc.name,
-						content: [{ type: "text", text: "No result provided" }],
-						isError: true,
-						timestamp: Date.now(),
-					} as ToolResultMessage);
-				}
-			}
-			pendingToolCalls = [];
-			existingToolResultIds = new Set();
+	const toolResultsById = new Map<string, { message: ToolResultMessage; sourceIndex: number; consumed: boolean }[]>();
+	const nextToolCallIndexById = new Map<string, number[]>();
+
+	for (let sourceIndex = 0; sourceIndex < transformed.length; sourceIndex++) {
+		const message = transformed[sourceIndex];
+		if (message.role === "toolResult") {
+			const entries = toolResultsById.get(message.toolCallId) ?? [];
+			entries.push({ message, sourceIndex, consumed: false });
+			toolResultsById.set(message.toolCallId, entries);
+			continue;
 		}
-	};
-
-	for (let i = 0; i < transformed.length; i++) {
-		const msg = transformed[i];
-
-		if (msg.role === "assistant") {
-			// If we have pending orphaned tool calls from a previous assistant, insert synthetic results now
-			insertSyntheticToolResults();
-
-			// Skip errored/aborted assistant messages entirely.
-			// These are incomplete turns that shouldn't be replayed:
-			// - May have partial content (reasoning without message, incomplete tool calls)
-			// - Replaying them can cause API errors (e.g., OpenAI "reasoning without following item")
-			// - The model should retry from the last valid state
-			const assistantMsg = msg as AssistantMessage;
-			if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
-				continue;
-			}
-
-			// Track tool calls from this assistant message
-			const toolCalls = assistantMsg.content.filter((b) => b.type === "toolCall") as ToolCall[];
-			if (toolCalls.length > 0) {
-				pendingToolCalls = toolCalls;
-				existingToolResultIds = new Set();
-			}
-
-			result.push(msg);
-		} else if (msg.role === "toolResult") {
-			existingToolResultIds.add(msg.toolCallId);
-			result.push(msg);
-		} else if (msg.role === "user") {
-			// User message interrupts tool flow - insert synthetic results for orphaned calls
-			insertSyntheticToolResults();
-			result.push(msg);
-		} else {
-			result.push(msg);
+		if (message.role !== "assistant" || message.stopReason === "error" || message.stopReason === "aborted") {
+			continue;
+		}
+		for (const block of message.content) {
+			if (block.type !== "toolCall") continue;
+			const indexes = nextToolCallIndexById.get(block.id) ?? [];
+			indexes.push(sourceIndex);
+			nextToolCallIndexById.set(block.id, indexes);
 		}
 	}
 
-	// If the conversation ends with unresolved tool calls, synthesize results now.
-	insertSyntheticToolResults();
+	for (let sourceIndex = 0; sourceIndex < transformed.length; sourceIndex++) {
+		const message = transformed[sourceIndex];
+		if (message.role === "toolResult") {
+			const entry = toolResultsById
+				.get(message.toolCallId)
+				?.find((candidate) => candidate.sourceIndex === sourceIndex);
+			if (!entry?.consumed) result.push(message);
+			continue;
+		}
+		if (message.role !== "assistant") {
+			result.push(message);
+			continue;
+		}
+
+		// Skip errored/aborted assistant messages entirely. These incomplete turns
+		// must not be revived merely because a matching result appears later.
+		if (message.stopReason === "error" || message.stopReason === "aborted") continue;
+
+		result.push(message);
+		for (const block of message.content) {
+			if (block.type !== "toolCall") continue;
+			const laterDeclarations = nextToolCallIndexById.get(block.id) ?? [];
+			const nextDeclarationIndex = laterDeclarations.find((index) => index > sourceIndex) ?? Infinity;
+			const matchedResult = toolResultsById
+				.get(block.id)
+				?.find(
+					(candidate) =>
+						!candidate.consumed &&
+						candidate.sourceIndex > sourceIndex &&
+						candidate.sourceIndex < nextDeclarationIndex,
+				);
+
+			if (matchedResult) {
+				matchedResult.consumed = true;
+				result.push(matchedResult.message);
+				continue;
+			}
+
+			result.push({
+				role: "toolResult",
+				toolCallId: block.id,
+				toolName: block.name,
+				content: [{ type: "text", text: "No result provided" }],
+				isError: true,
+				timestamp: Date.now(),
+			} as ToolResultMessage);
+		}
+	}
 
 	return result;
 }

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,23 @@
 # AI Source Changes
 
+## 2026-07-20 - Live tool-result pairing by source position
+
+### What changed and why
+
+- `api/transform-messages.ts`: live history normalization now indexes tool results and replayable tool calls by
+  source position. Each tool call consumes the earliest still-unconsumed matching result after its declaring
+  assistant, emits that result adjacent to the assistant turn, or emits exactly one synthetic error result.
+  A repeated ID establishes a new pairing window, so a delayed result cannot attach to an earlier call or be
+  replayed twice across an intervening user turn. Aborted and errored assistant turns remain excluded.
+- `../test/transform-messages-copilot-openai-to-anthropic.test.ts`: covers delayed normalized results across a
+  user turn, partial multi-call results, reused IDs with prior orphaned results, trailing unresolved calls, and
+  Anthropic-required tool-result adjacency.
+
+### Expected merge conflict zones
+
+- LOW: `api/transform-messages.ts` second-pass tool-result normalization.
+
+
 ## 2026-07-17 - Video input modality for Kimi K3 (kimi-coding)
 
 ### What changed and why

--- a/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
+++ b/packages/ai/test/transform-messages-copilot-openai-to-anthropic.test.ts
@@ -273,4 +273,123 @@ describe("OpenAI to Anthropic session migration for Copilot Claude", () => {
 			content: [{ type: "text", text: "No result provided" }],
 		});
 	});
+
+	it("moves a delayed normalized tool result ahead of an intervening user turn", () => {
+		const model = makeCopilotClaudeModel();
+		const messages: Message[] = [
+			{ role: "user", content: "read", timestamp: Date.now() },
+			makeAssistantMessage([{ type: "toolCall", id: "call|one", name: "read", arguments: {} }]),
+			{ role: "user", content: "while waiting", timestamp: Date.now() },
+			{
+				role: "toolResult",
+				toolCallId: "call|one",
+				toolName: "read",
+				content: [{ type: "text", text: "file contents" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+
+		expect(
+			result.map((message) =>
+				message.role === "toolResult" ? `${message.role}:${message.toolCallId}` : message.role,
+			),
+		).toEqual(["user", "assistant", "toolResult:call_one", "user"]);
+	});
+
+	it("pairs each multi-call tool use with one real result or one synthetic error", () => {
+		const model = makeCopilotClaudeModel();
+		const messages: Message[] = [
+			{ role: "user", content: "run", timestamp: Date.now() },
+			makeAssistantMessage([
+				{ type: "toolCall", id: "first", name: "read", arguments: {} },
+				{ type: "toolCall", id: "second", name: "bash", arguments: {} },
+			]),
+			{
+				role: "toolResult",
+				toolCallId: "first",
+				toolName: "read",
+				content: [{ type: "text", text: "done" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+
+		expect(
+			result
+				.slice(1)
+				.map((message) => (message.role === "toolResult" ? [message.toolCallId, message.isError] : message.role)),
+		).toEqual(["assistant", ["first", false], ["second", true]]);
+	});
+
+	it("does not attach an earlier orphaned reused ID result to a later call", () => {
+		const model = makeCopilotClaudeModel();
+		const messages: Message[] = [
+			{
+				role: "toolResult",
+				toolCallId: "reused",
+				toolName: "read",
+				content: [{ type: "text", text: "orphan" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: "second", timestamp: Date.now() },
+			makeAssistantMessage([{ type: "toolCall", id: "reused", name: "read", arguments: {} }]),
+			{
+				role: "toolResult",
+				toolCallId: "reused",
+				toolName: "read",
+				content: [{ type: "text", text: "second result" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+		const toolResults = result.filter((message) => message.role === "toolResult");
+
+		expect(toolResults.map((message) => message.content)).toEqual([
+			[{ type: "text", text: "orphan" }],
+			[{ type: "text", text: "second result" }],
+		]);
+		expect(result.map((message) => message.role)).toEqual(["toolResult", "user", "assistant", "toolResult"]);
+	});
+
+	it("does not let a later reused-ID result repair the prior assistant turn", () => {
+		const model = makeCopilotClaudeModel();
+		const messages: Message[] = [
+			{ role: "user", content: "first", timestamp: Date.now() },
+			makeAssistantMessage([{ type: "toolCall", id: "reused", name: "read", arguments: {} }]),
+			{ role: "user", content: "second", timestamp: Date.now() },
+			makeAssistantMessage([{ type: "toolCall", id: "reused", name: "read", arguments: {} }]),
+			{
+				role: "toolResult",
+				toolCallId: "reused",
+				toolName: "read",
+				content: [{ type: "text", text: "second result" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		];
+
+		const result = transformMessages(messages, model, anthropicNormalizeToolCallId);
+		const toolResults = result.filter((message) => message.role === "toolResult");
+
+		expect(toolResults.map((message) => [message.isError, message.content])).toEqual([
+			[true, [{ type: "text", text: "No result provided" }]],
+			[false, [{ type: "text", text: "second result" }]],
+		]);
+		expect(result.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"toolResult",
+			"user",
+			"assistant",
+			"toolResult",
+		]);
+	});
 });


### PR DESCRIPTION
## Summary

Make live history transformation emit Anthropic-valid tool call/result pairs even when results arrive after user messages or tool-call IDs are reused.

## Changes

- Match real tool results by normalized ID and source position, consuming the earliest eligible result after each declaration.
- Move an eligible real result next to its tool call; synthesize exactly one failure result only when no eligible result exists.
- Prevent late/interleaved results from becoming duplicates or binding to a later reused ID.

## QA & Evidence

- Added source-position regressions for delayed normalized results, partial multi-call results, reused IDs, trailing unresolved calls, and Copilot-to-Anthropic adjacency.
- Focused transformer + tool-pair repair suites pass; `npm run check` passed before commit.
- Real mock-loop, RPC, TUI, and CLI smoke passed. Receipts are under `local-ignore/qa-evidence/20260720-live-tool-pairing-pr3/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live message transformation to pair tool calls with the correct results by source position, even across user turns or when IDs are reused. Ensures Anthropic-required adjacency and prevents duplicates or wrong attachments.

- **Bug Fixes**
  - Pair results by normalized ID and source position; consume the earliest eligible result after each call and emit it next to the call.
  - In multi-call turns, attach one real result per call or synthesize a single error when none exists; skip errored/aborted assistant turns.
  - Handle reused IDs safely: keep earlier orphaned results in place and prevent later results from repairing earlier calls or crossing user-message boundaries.

<sup>Written for commit d4672c0bf5119d1ef67704d158e0b0dfffcd14bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

