### PR TITLE
feat(coding-agent): abbreviate footer token counts in oh-my-pi K/M/B notation

### DIFF
--- a/.agents/skills/senpi-qa/scripts/footer-abbrev-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/footer-abbrev-qa.mjs
@@ -1,0 +1,124 @@
+/**
+ * Surface QA: footer context-usage abbreviation in the REAL TUI.
+ * Boots the interactive TUI in tmux against the local fake model server
+ * (model contextWindow = 1,000,000), drives one prompt so token counters
+ * populate, then asserts the footer shows oh-my-pi-style abbreviated
+ * notation (e.g. "1M", "K") and never comma-grouped "1,000,000".
+ */
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	cliEntry,
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+	stripAnsi,
+	tsxEntry,
+} from "./lib/common.mjs";
+import { startFakeModelServer } from "./lib/fake-model-server.mjs";
+import { hermeticEnv, writeMockModelsJson } from "./lib/mock-loop-support.mjs";
+import { readFileSync } from "node:fs";
+
+const checks = createChecks("footer-abbrev-tui");
+const guard = guardRealAuth();
+installCleanupHooks();
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`;
+
+const ev = evidenceDir("footer-abbrev");
+const box = makeSandbox("footer-abbrev-tui");
+const root = repoRoot();
+
+// Fake model server; patch contextWindow up to 1,000,000 after writing.
+const server = await startFakeModelServer({ turns: [{ text: "FOOTER-QA-OK" }] });
+writeMockModelsJson(box.agentDir, server, "openai-completions");
+const modelsPath = join(box.agentDir, "models.json");
+const models = JSON.parse(readFileSync(modelsPath, "utf8"));
+models.providers.mock.models[0].contextWindow = 1_000_000;
+writeFileSync(modelsPath, JSON.stringify(models, null, 2));
+
+const session = `senpi-qa-footer-${process.pid}`;
+const tmux = (...args) => execFileSync("tmux", args, { encoding: "utf8" });
+const capture = () => {
+	try {
+		return tmux("capture-pane", "-t", session, "-p");
+	} catch {
+		return "";
+	}
+};
+
+try {
+	execFileSync("tmux", ["kill-session", "-t", session], { stdio: "ignore" });
+} catch {}
+
+const env = hermeticEnv({
+	SENPI_CODING_AGENT_DIR: box.agentDir,
+	SENPI_CODING_AGENT_SESSION_DIR: box.sessionDir,
+	PI_OFFLINE: "1",
+	PI_TELEMETRY: "0",
+});
+const envExports = Object.entries(env)
+	.map(([k, v]) => `export ${k}=${shq(v)}`)
+	.join(" && ");
+
+try {
+	tmux("new-session", "-d", "-s", session, "-x", "120", "-y", "30");
+	tmux(
+		"send-keys",
+		"-t",
+		session,
+		`cd ${shq(box.cwd)} && ${envExports} && exec ${shq(process.execPath)} ${shq(tsxEntry(root))} --tsconfig ${shq(join(root, "tsconfig.json"))} ${shq(cliEntry(root))} --no-context-files --no-skills --no-extensions --approve --provider mock --model mock-model`,
+		"Enter",
+	);
+
+	// Wait for boot (footer present), then drive one prompt.
+	let booted = "";
+	for (let i = 0; i < 60; i++) {
+		await sleep(1000);
+		booted = capture();
+		if (/\(auto\)/.test(stripAnsi(booted))) break;
+	}
+	writeFileSync(join(ev, "footer-before-prompt.txt"), stripAnsi(booted));
+
+	tmux("send-keys", "-t", session, "say FOOTER-QA-OK", "Enter");
+	let after = "";
+	for (let i = 0; i < 45; i++) {
+		await sleep(1000);
+		after = capture();
+		if (stripAnsi(after).includes("FOOTER-QA-OK") && /K\/1M|M\/1M/.test(stripAnsi(after))) break;
+	}
+	const plain = stripAnsi(after);
+	writeFileSync(join(ev, "footer-after-prompt.txt"), plain);
+
+	const footerLine = plain.split("\n").find((l) => l.includes("(auto)")) ?? "";
+	checks.ok("TUI booted with mock model", booted.trim().length > 0, `footer=${footerLine.trim()}`);
+	checks.ok(
+		"footer context window abbreviated to 1M",
+		footerLine.includes("/1M"),
+		`footer=${footerLine.trim()}`,
+	);
+	checks.ok(
+		"footer shows no comma-grouped window (1,000,000)",
+		!footerLine.includes("1,000,000"),
+		`footer=${footerLine.trim()}`,
+	);
+	checks.ok(
+		"mock turn completed (FOOTER-QA-OK visible)",
+		plain.includes("FOOTER-QA-OK"),
+		"turn output present",
+	);
+	const tokenFooter = /[0-9.,]+[KMB]?\/1M \([0-9.]+%\)/.test(footerLine);
+	checks.ok("footer context usage is abbreviated tokens/1M (pct%)", tokenFooter, `footer=${footerLine.trim()}`);
+} finally {
+	try {
+		execFileSync("tmux", ["kill-session", "-t", session], { stdio: "ignore" });
+	} catch {}
+	await server.stop();
+	box.cleanup();
+	checks.ok("real auth unchanged", guard.assertUnchanged(), "auth.json sha256 stable");
+	checks.finish();
+}

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## abbreviated footer token notation (2026-07-20)
+
+### What changed
+
+- `components/footer.ts`: `formatTokens` now renders oh-my-pi-style K/M/B abbreviations (e.g. `546K`, `1M`, `1.5M`)
+  instead of comma-grouped `toLocaleString` output. The footer context-usage display now reads
+  `546K/1M (54.6%)` instead of `545,661/1,000,000 (54.6%)`; the same notation applies to the ↑/↓/cache counters and
+  the `interactive-mode.ts` token readouts that reuse `formatTokens`.
+
+### Why
+
+- Comma-grouped raw counts are wide and hard to scan in the status line; abbreviated notation matches oh-my-pi's
+  status-line style and keeps the footer compact at narrow widths.
+
+### Why extension system couldn't handle this
+
+- Footer token formatting is a core display primitive, not an extension-registered status segment.
+
 ## paced streaming tool argument previews (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -17,10 +17,24 @@ function sanitizeStatusText(text: string): string {
 }
 
 /**
- * Format token counts for footer display.
+ * Format token counts for footer display using oh-my-pi-style K/M/B abbreviation.
+ * Examples: "999", "6.8K", "546K", "1M", "1.5M", "2B".
  */
 export function formatTokens(count: number): string {
-	return Math.round(count).toLocaleString("en-US");
+	const n = Math.round(count);
+	if (n < 1_000) return n.toString();
+	if (n < 10_000) return `${trim1(n / 1_000)}K`;
+	if (n < 1_000_000) return `${Math.round(n / 1_000)}K`;
+	if (n < 10_000_000) return `${trim1(n / 1_000_000)}M`;
+	if (n < 1_000_000_000) return `${Math.round(n / 1_000_000)}M`;
+	if (n < 10_000_000_000) return `${trim1(n / 1_000_000_000)}B`;
+	return `${Math.round(n / 1_000_000_000)}B`;
+}
+
+/** Format with up to 1 decimal place, dropping trailing `.0`. */
+function trim1(n: number): string {
+	const s = n.toFixed(1);
+	return s.endsWith(".0") ? s.slice(0, -2) : s;
 }
 
 export function formatCwdForFooter(cwd: string, home: string | undefined): string {

--- a/packages/coding-agent/test/footer-token-format.test.ts
+++ b/packages/coding-agent/test/footer-token-format.test.ts
@@ -56,8 +56,22 @@ function createFooterData(): unknown {
 	};
 }
 
+describe("formatTokens abbreviation", () => {
+	it("abbreviates with oh-my-pi K/M/B notation", async () => {
+		const { formatTokens } = await import("../src/modes/interactive/components/footer.ts");
+		expect(formatTokens(0)).toBe("0");
+		expect(formatTokens(999)).toBe("999");
+		expect(formatTokens(6_800)).toBe("6.8K");
+		expect(formatTokens(44_000)).toBe("44K");
+		expect(formatTokens(545_661)).toBe("546K");
+		expect(formatTokens(1_000_000)).toBe("1M");
+		expect(formatTokens(1_500_000)).toBe("1.5M");
+		expect(formatTokens(800_000)).toBe("800K");
+	});
+});
+
 describe("FooterComponent token formatting", () => {
-	it("renders comma-formatted token counters and context window usage", async () => {
+	it("renders oh-my-pi-style abbreviated token counters and context window usage", async () => {
 		// given
 		const { FooterComponent } = await import("../src/modes/interactive/components/footer.ts");
 		const Footer = FooterComponent as new (
@@ -71,16 +85,16 @@ describe("FooterComponent token formatting", () => {
 
 		// then
 		expect(rendered).toContain("↑49");
-		expect(rendered).toContain("↓6,800");
-		expect(rendered).toContain("cache 1,500,000/44,000");
-		expect(rendered).toContain("44,000/800,000 (5.5%) (auto)");
-		expect(rendered).not.toContain("23.4K (3%)");
+		expect(rendered).toContain("↓6.8K");
+		expect(rendered).toContain("cache 1.5M/44K");
+		expect(rendered).toContain("44K/800K (5.5%) (auto)");
+		expect(rendered).not.toContain("44,000/800,000");
+		expect(rendered).not.toContain("↓6,800");
+		expect(rendered).not.toContain("cache 1,500,000/44,000");
 		expect(rendered).not.toContain("↓6.8k");
 		expect(rendered).not.toContain("R1,500,000");
 		expect(rendered).not.toContain("W44,000");
-		expect(rendered).not.toContain("R1.5M");
-		expect(rendered).not.toContain("W44k");
-		expect(rendered).not.toContain("5.5%/800,000 (auto)");
+		expect(rendered).not.toContain("5.5%/800K (auto)");
 		expect(rendered).not.toContain("5.5%/800k (auto)");
 	});
 });


### PR DESCRIPTION
## What

The interactive footer rendered context usage with comma-grouped raw counts — `545,661/1,000,000 (54.6%)` — which is wide and hard to scan. `formatTokens` in `packages/coding-agent/src/modes/interactive/components/footer.ts` now uses oh-my-pi's `formatNumber` abbreviation algorithm, so the footer reads `546K/1M (54.6%)`.

The same notation applies consistently to the `↑`/`↓`/`cache` counters and the `interactive-mode.ts` token readouts that reuse `formatTokens`.

## Behavior

| Before | After |
|---|---|
| `44,000/800,000 (5.5%) (auto)` | `44K/800K (5.5%) (auto)` |
| `545,661/1,000,000 (54.6%)` | `546K/1M (54.6%)` |
| `↓6,800` | `↓6.8K` |
| `cache 1,500,000/44,000` | `cache 1.5M/44K` |

Counts under 1,000 stay exact (`↑49` unchanged).

## Evidence

- **TDD RED→GREEN**: `packages/coding-agent/test/footer-token-format.test.ts` updated to assert abbreviated notation; failed against the old implementation for the right reason, passes after the change (16/16 footer tests green).
- **Real CLI QA (senpi-qa)**: new `.agents/skills/senpi-qa/scripts/footer-abbrev-qa.mjs` boots the real TUI in tmux against the fake model server (contextWindow = 1,000,000), drives a real mock-loop turn, and asserts the footer renders abbreviated notation: 6/6 PASS — captured footer: `… • ↑1 • ↓1 • 2/1M (0.0%) (auto)`. Artifacts under `local-ignore/qa-evidence/20260720-footer-abbrev/`.
- `npm run check` passes (biome, pinned-deps, ts-imports, shrinkwrap, tsgo, browser smoke, web-ui, neo).
- Real `~/.senpi` auth untouched (sha256 guard); all QA tmux sessions/servers torn down.

## Notes

- Fork-visible change recorded in `packages/coding-agent/src/modes/interactive/changes.md`.
- Algorithm mirrors oh-my-pi `packages/utils/src/format.ts` `formatNumber` (K/M/B with 1-decimal trim below 10K/10M/10B).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened interactive footer token counts using `oh-my-pi` K/M/B notation for better readability. Applies to context usage, I/O arrows, and cache counters across interactive mode.

- **New Features**
  - `formatTokens` in `packages/coding-agent/src/modes/interactive/components/footer.ts` now abbreviates counts (e.g., 6.8K, 546K, 1.5M); values under 1,000 stay exact.
  - Footer now renders like `546K/1M (54.6%)`; all counters that reuse `formatTokens` follow the same style.
  - Added `.agents/skills/senpi-qa/scripts/footer-abbrev-qa.mjs` for end-to-end TUI verification; updated `packages/coding-agent/test/footer-token-format.test.ts` and `packages/coding-agent/src/modes/interactive/changes.md` to assert and document the new format.

<sup>Written for commit f2d10277a0484ce7a48c6c2b047ca51457473b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

