### PR TITLE
feat(coding-agent): per-model fallback chains with refusal pinning and cache-safe revert

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -12,6 +12,7 @@ import type {
 	AnthropicMessagesCompat,
 	Api,
 	AssistantMessage,
+	AssistantStopDetails,
 	CacheRetention,
 	Context,
 	ImageContent,
@@ -1150,6 +1151,9 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 						if (stopReasonResult.errorMessage) {
 							output.errorMessage = stopReasonResult.errorMessage;
 						}
+						if (stopReasonResult.stopDetails) {
+							output.stopDetails = stopReasonResult.stopDetails;
+						}
 					}
 					// Only update usage fields if present (not null).
 					// Preserves input_tokens from message_start when proxies omit it in message_delta.
@@ -1907,7 +1911,8 @@ function convertTools(
 function mapStopReason(
 	reason: Anthropic.Messages.StopReason | string,
 	stopDetails?: RefusalStopDetails | null,
-): { stopReason: StopReason; errorMessage?: string } {
+): { stopReason: StopReason; errorMessage?: string; stopDetails?: AssistantStopDetails } {
+	const explanation = stopDetails?.explanation;
 	switch (reason) {
 		case "end_turn":
 			return { stopReason: "stop" };
@@ -1918,14 +1923,15 @@ function mapStopReason(
 		case "refusal":
 			return {
 				stopReason: "error",
-				errorMessage: stopDetails?.explanation || `The model refused to complete the request`,
+				errorMessage: explanation || `The model refused to complete the request`,
+				stopDetails: explanation == null ? { type: "refusal" } : { type: "refusal", explanation },
 			};
 		case "pause_turn": // Stop is good enough -> resubmit
 			return { stopReason: "stop" };
 		case "stop_sequence":
 			return { stopReason: "stop" }; // We don't supply stop sequences, so this should never happen
 		case "sensitive": // Content flagged by safety filters (not yet in SDK types)
-			return { stopReason: "error" };
+			return { stopReason: "error", stopDetails: { type: "sensitive" } };
 		default:
 			// Handle unknown stop reasons gracefully (API may add new values)
 			throw new Error(`Unhandled stop reason: ${reason}`);

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,11 @@
 # AI Source Changes
 
+## 2026-07-20 - Typed classifier stop details
+
+- Added optional typed refusal/sensitive stop details to assistant messages, preserving Anthropic classifier outcomes through streaming and faux provider errors.
+- Exported `isClassifierRefusal` and excluded classifier outcomes from generic same-model retry classification.
+
+
 ## 2026-07-17 - Video input modality for Kimi K3 (kimi-coding)
 
 ### What changed and why

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -42,6 +42,7 @@ export * from "./utils/event-stream.ts";
 export * from "./utils/json-parse.ts";
 export * from "./utils/overflow.ts";
 export * from "./utils/retry.ts";
+export * from "./utils/stop-details.ts";
 export * from "./utils/tool-pair-repair.ts";
 export * from "./utils/typebox-helpers.ts";
 export * from "./utils/validation.ts";

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -76,6 +76,7 @@ export function fauxAssistantMessage(
 	options: {
 		stopReason?: AssistantMessage["stopReason"];
 		errorMessage?: string;
+		stopDetails?: AssistantMessage["stopDetails"];
 		responseId?: string;
 		timestamp?: number;
 	} = {},
@@ -88,6 +89,7 @@ export function fauxAssistantMessage(
 		model: DEFAULT_MODEL_ID,
 		usage: DEFAULT_USAGE,
 		stopReason: options.stopReason ?? "stop",
+		stopDetails: options.stopDetails,
 		errorMessage: options.errorMessage,
 		responseId: options.responseId,
 		timestamp: options.timestamp ?? Date.now(),

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -421,6 +421,8 @@ export interface Usage {
 
 export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 
+export type AssistantStopDetails = { type: "refusal"; explanation?: string } | { type: "sensitive" };
+
 export interface UserMessage {
 	role: "user";
 	content: string | (TextContent | ImageContent)[];
@@ -438,6 +440,7 @@ export interface AssistantMessage {
 	diagnostics?: AssistantMessageDiagnostic[]; // Redacted provider/runtime diagnostics for failures and recoveries.
 	usage: Usage;
 	stopReason: StopReason;
+	stopDetails?: AssistantStopDetails;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
 }

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -95,7 +95,14 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
  * before restarting the assistant turn.
  */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
-	if (message.stopReason !== "error" || !message.errorMessage) return false;
+	if (
+		message.stopReason !== "error" ||
+		message.stopDetails?.type === "refusal" ||
+		message.stopDetails?.type === "sensitive" ||
+		!message.errorMessage
+	) {
+		return false;
+	}
 	const errorMessage = message.errorMessage;
 	if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) return false;
 	return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);

--- a/packages/ai/src/utils/stop-details.ts
+++ b/packages/ai/src/utils/stop-details.ts
@@ -1,0 +1,9 @@
+import type { AssistantMessage } from "../types.ts";
+
+/** Returns true when an assistant error was classified as a refusal or sensitive stop. */
+export function isClassifierRefusal(message: AssistantMessage): boolean {
+	return (
+		message.stopReason === "error" &&
+		(message.stopDetails?.type === "refusal" || message.stopDetails?.type === "sensitive")
+	);
+}

--- a/packages/ai/test/stop-details.test.ts
+++ b/packages/ai/test/stop-details.test.ts
@@ -1,0 +1,143 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { describe, expect, it } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import { getModel, stream } from "../src/compat.ts";
+import { fauxAssistantMessage, registerFauxProvider } from "../src/providers/faux.ts";
+import type { AssistantMessageEvent, Context } from "../src/types.ts";
+import { isRetryableAssistantError } from "../src/utils/retry.ts";
+import { isClassifierRefusal } from "../src/utils/stop-details.ts";
+
+function createSseResponse(
+	stopReason: "refusal" | "sensitive" | "end_turn" | "max_tokens",
+	stopDetails?: { explanation?: string },
+): Response {
+	const events = [
+		{
+			event: "message_start",
+			data: JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_stop_details",
+					usage: { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+				},
+			}),
+		},
+		{
+			event: "message_delta",
+			data: JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: stopReason, stop_details: stopDetails },
+				usage: { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+			}),
+		},
+		{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+	];
+	return new Response(events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n"), {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createFakeAnthropicClient(response: Response): Anthropic {
+	return {
+		messages: { create: () => ({ asResponse: async () => response }) },
+	} as unknown as Anthropic;
+}
+
+async function collectEvents(streamResult: ReturnType<typeof stream>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of streamResult) events.push(event);
+	return events;
+}
+
+const context: Context = { messages: [{ role: "user", content: "blocked", timestamp: 1 }] };
+
+describe("classifier stop details", () => {
+	it("maps Anthropic refusal and sensitive stops to typed error details", async () => {
+		const model = getModel("anthropic", "claude-fable-5");
+		const refusal = await streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(createSseResponse("refusal", { explanation: "policy classifier" })),
+		}).result();
+		const sensitive = await streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(createSseResponse("sensitive")),
+		}).result();
+
+		expect(refusal).toMatchObject({
+			stopReason: "error",
+			errorMessage: "policy classifier",
+			stopDetails: { type: "refusal", explanation: "policy classifier" },
+		});
+		expect(sensitive).toMatchObject({ stopReason: "error", stopDetails: { type: "sensitive" } });
+		expect(isClassifierRefusal(refusal)).toBe(true);
+		expect(isClassifierRefusal(sensitive)).toBe(true);
+	});
+
+	it("leaves successful and length-limited Anthropic stops unclassified", async () => {
+		const model = getModel("anthropic", "claude-fable-5");
+		const completed = await streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(createSseResponse("end_turn")),
+		}).result();
+		const lengthLimited = await streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(createSseResponse("max_tokens")),
+		}).result();
+
+		expect(completed.stopReason).toBe("stop");
+		expect(completed.stopDetails).toBeUndefined();
+		expect(isClassifierRefusal(completed)).toBe(false);
+		expect(lengthLimited.stopReason).toBe("length");
+		expect(lengthLimited.stopDetails).toBeUndefined();
+		expect(isClassifierRefusal(lengthLimited)).toBe(false);
+	});
+
+	it("recognizes only typed classifier errors", () => {
+		const classifierRefusal = fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "refusal" } });
+		const classifierSensitive = fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "sensitive" } });
+		const nonError = fauxAssistantMessage("", { stopDetails: { type: "refusal" } });
+		const absent = { ...classifierRefusal, stopDetails: undefined };
+
+		expect(isClassifierRefusal(classifierRefusal)).toBe(true);
+		expect(isClassifierRefusal(classifierSensitive)).toBe(true);
+		expect(isClassifierRefusal(nonError)).toBe(false);
+		expect(isClassifierRefusal(absent)).toBe(false);
+	});
+
+	it("passes classifier details through faux error stream events and excludes them from retry", async () => {
+		const registration = registerFauxProvider();
+		registration.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded",
+				stopDetails: { type: "refusal", explanation: "classified" },
+			}),
+		]);
+
+		const events = await collectEvents(stream(registration.getModel(), context));
+		const errorEvent = events.find((event) => event.type === "error");
+		expect(errorEvent).toMatchObject({
+			type: "error",
+			error: { stopReason: "error", stopDetails: { type: "refusal", explanation: "classified" } },
+		});
+		expect(
+			isRetryableAssistantError(fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded" })),
+		).toBe(true);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "overloaded",
+					stopDetails: { type: "refusal" },
+				}),
+			),
+		).toBe(false);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "overloaded",
+					stopDetails: { type: "sensitive" },
+				}),
+			),
+		).toBe(false);
+		registration.unregister();
+	});
+});

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -12,7 +12,7 @@ Extensions are TypeScript modules that extend pi's behavior. They can subscribe 
 - **User interaction** - Prompt users via `ctx.ui` (select, confirm, input, notify)
 - **Custom UI components** - Full TUI components with keyboard input via `ctx.ui.custom()` for complex interactions
 - **Custom commands** - Register commands like `/mycommand` via `pi.registerCommand()`
-- **Model fallback** - The bundled `/fallback` command manages global per-model retry chains. Use `/fallback <target> <fallback1> [fallback2 ...]` for scripts, or `/fallback` in the TUI to view and edit chains. `--no-model-fallback` and `SENPI_NO_FALLBACK=1` request a per-run escape hatch.
+- **Model fallback** - The bundled [`/fallback`](#bundled-fallback-command) command manages global per-model retry chains. Use `/fallback <target> <fallback1> [fallback2 ...]` for scripts, or `/fallback` in the TUI to view and edit chains. `--no-model-fallback` and `SENPI_NO_FALLBACK=1` disable it for one run.
 - **Session persistence** - Store state that survives restarts via `pi.appendEntry()`
 - **Custom rendering** - Control how tool calls/results and messages appear in TUI
 
@@ -32,6 +32,7 @@ See [examples/extensions/](../examples/extensions/) for working implementations.
 ## Table of Contents
 
 - [Quick Start](#quick-start)
+- [Bundled /fallback Command](#bundled-fallback-command)
 - [Extension Locations](#extension-locations)
 - [Available Imports](#available-imports)
 - [Writing an Extension](#writing-an-extension)
@@ -106,6 +107,32 @@ Test with `--extension` (or `-e`) flag:
 ```bash
 pi -e ./my-extension.ts
 ```
+
+## Bundled /fallback Command
+
+The bundled `model-fallback` extension registers `/fallback` to manage global per-model retry fallback chains. The command writes through the active session settings manager, so a saved chain is available to the current session's next retry without restarting Senpi. See [Settings](settings.md#model-fallback-chains) for selector syntax and runtime behavior.
+
+Use the quick-set form in scripts or any non-TUI mode:
+
+```text
+/fallback anthropic/claude-fable-5 ccapi/kimi-k3:max
+```
+
+The first argument is the exact primary model selector; each later argument is an ordered fallback selector. Quick-set validates selectors before saving. At least one fallback is required:
+
+```text
+/fallback <target> <fallback1> [fallback2 ...]
+```
+
+Run `/fallback` without arguments in the TUI for a menu that can:
+
+- show configured chains and live fallback state;
+- add or edit a chain by choosing the target, each fallback, and either an explicit or inherited thinking level;
+- remove a chain;
+- toggle `retry.modelFallback`; and
+- choose `retry.fallbackRevertPolicy` (`cooldown-expiry` or `never`).
+
+Use quick-set in non-TUI modes; the no-argument menu requires interactive UI. Pass `--no-model-fallback` or set `SENPI_NO_FALLBACK=1` to disable fallback for that process without modifying saved settings.
 
 ## Extension Locations
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -12,6 +12,7 @@ Extensions are TypeScript modules that extend pi's behavior. They can subscribe 
 - **User interaction** - Prompt users via `ctx.ui` (select, confirm, input, notify)
 - **Custom UI components** - Full TUI components with keyboard input via `ctx.ui.custom()` for complex interactions
 - **Custom commands** - Register commands like `/mycommand` via `pi.registerCommand()`
+- **Model fallback** - The bundled `/fallback` command manages global per-model retry chains. Use `/fallback <target> <fallback1> [fallback2 ...]` for scripts, or `/fallback` in the TUI to view and edit chains. `--no-model-fallback` and `SENPI_NO_FALLBACK=1` request a per-run escape hatch.
 - **Session persistence** - Store state that survives restarts via `pi.appendEntry()`
 - **Custom rendering** - Control how tool calls/results and messages appear in TUI
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -206,6 +206,9 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the senpi version update check. Use `--
 | `retry.enabled` | boolean | `true` | Enable automatic agent-level retry on transient errors |
 | `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
+| `retry.modelFallback` | boolean | `true` | Let eligible retry failures advance through configured per-model fallback chains |
+| `retry.fallbackChains` | `Record<string, string[]>` | `{}` | Ordered exact model-selector to fallback-selector chains |
+| `retry.fallbackRevertPolicy` | `"cooldown-expiry"` \| `"never"` | `"cooldown-expiry"` | Automatic primary-model restoration policy |
 | `retry.provider.timeoutMs` | number | `300000` | Provider/SDK request timeout and stream idle timeout in milliseconds |
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
@@ -228,6 +231,38 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
   }
 }
 ```
+
+#### Model fallback chains
+
+`retry.fallbackChains` maps one exact primary-model selector to an ordered list of fallback selectors. A selector is `provider/model` with an optional `:thinking-level` suffix. For example, this switches Fable 5 to Kimi K3 at `max` thinking when an eligible failure occurs:
+
+```json
+{
+  "retry": {
+    "modelFallback": true,
+    "fallbackChains": {
+      "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"]
+    },
+    "fallbackRevertPolicy": "cooldown-expiry"
+  }
+}
+```
+
+A chain is only for the exact primary model it names: selector lookup first considers an exact thinking-level selector, then the same `provider/model` without its thinking suffix. Wildcard selectors, role keys such as `default`, and other catch-all chains are not supported.
+
+A fallback entry with `:thinking-level` requests that level on the target model; a bare entry inherits the current thinking level. Either value is clamped to the target model's supported levels. When an unpinned fallback later returns to the primary, it restores the original thinking level unless you changed it while using the fallback.
+
+`/fallback` writes these settings to the global settings file. Project settings are still merged when read; because `fallbackChains` is a nested map, a project `retry.fallbackChains` replaces the global map rather than merging individual chain keys.
+
+#### Fallback behavior and diagnostics
+
+With `retry.enabled` and `retry.modelFallback` enabled, Senpi can switch from a transient or eligible hard provider failure to the next configured candidate. The switch continues the current turn without changing the existing conversation prefix, preserving prompt-cache inputs; fallback lifecycle events are never added to model context. Returning to a primary model happens only at a turn boundary, never while a response is streaming.
+
+Anthropic streaming refusals are identified from typed `stopDetails`. A configured candidate receives an immediate **pinned** fallback switch with a user-visible fallback notice: Senpi does not retry the refusing model and a pinned fallback never auto-reverts. Set `retry.fallbackRevertPolicy` to `"cooldown-expiry"` (the default) to return an unpinned fallback to its primary after the primary's cooldown expires, or `"never"` to keep the fallback until you change models.
+
+Fallback decisions are process-local. A `senpi-task` or subagent child process reads its own settings and maintains its own in-memory suppression state; it does not affect its parent process. Disable fallback for one run without changing settings with `--no-model-fallback` or `SENPI_NO_FALLBACK=1`.
+
+For diagnostics, Senpi writes sanitized NDJSON records for candidate skips, cooldowns, switches, reverts, manual clears, and validation warnings to `<agentDir>/logs/fallback.log`. The file is mode `0600` and rotates at 5 MB (`fallback.log.1`).
 
 ### Message Delivery
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,31 @@
 # changes
 
+- `core/agent-session.ts` now centralizes active-model switching, preserving manual selection behavior while supporting non-persistent, non-notifying ephemeral fallback switches.
+- `core/session-manager.ts` records optional fallback model-change metadata and restores the primary model rather than a fallback-period assistant model after restart.
+
+- `core/retry-fallback/validate.ts`: validate fallback-chain configuration with deterministic warnings.
+
+- `core/retry-fallback/log.ts`: add a bounded, sanitized 0600 NDJSON fallback debug logger.
+
+## Retry fallback settings (2026-07-20)
+
+### What changed
+
+- `core/settings-manager.ts` now persists global per-model retry fallback chains, fallback enablement, and the
+  fallback revert policy. Reads provide safe defaults when those optional settings are unset or malformed.
+- Project `retry` settings retain the established one-level merge behavior: a project `fallbackChains` map replaces
+  the global map rather than merging individual chain keys.
+
+### Why
+
+- Model fallback behavior needs a durable, user-configurable chain without adding another settings file or allowing
+  fallback controls to write project settings.
+
+
+- `core/retry-fallback/chains.ts`: adds pure, canonical selector parsing and fallback-chain resolution.
+
+- `core/retry-fallback/cooldown.ts`: adds per-session, lazy-expiry selector cooldowns with provider retry-after and error-derived durations.
+
 ## Model-runtime upstream model id and model-config service tier (2026-07-19)
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,7 @@
 # changes
 
+- `core/agent-session.ts` and `core/retry-fallback/controller.ts`: non-retryable provider errors now advance immediately through an eligible fallback chain without replaying the failed model or waiting for backoff. Hard-failing selectors receive the normal session-local cooldown; overflows, aborted responses, refusals, and error responses containing tool calls continue to settle through their existing paths.
+
 - `core/agent-session.ts`: typed classifier refusals now bypass same-model retries and immediately advance through a pinned fallback chain without cooldowns. Switched refusal messages are removed from active context while retained in session history; exhausted chains leave only the final refusal visible.
 
 - `ExtensionContext.sessionSettings` now gives the model-fallback builtin the live session-owned retry settings and retry status; `/fallback` writes are immediately visible to the retry controller, while `--no-model-fallback` and `SENPI_NO_FALLBACK=1` apply a non-persistent session override.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,9 @@
 # changes
 
+- `core/agent-session.ts`: typed classifier refusals now bypass same-model retries and immediately advance through a pinned fallback chain without cooldowns. Switched refusal messages are removed from active context while retained in session history; exhausted chains leave only the final refusal visible.
+
+- `ExtensionContext.sessionSettings` now gives the model-fallback builtin the live session-owned retry settings and retry status; `/fallback` writes are immediately visible to the retry controller, while `--no-model-fallback` and `SENPI_NO_FALLBACK=1` apply a non-persistent session override.
+
 - `core/agent-session.ts` now centralizes active-model switching, preserving manual selection behavior while supporting non-persistent, non-notifying ephemeral fallback switches.
 - `core/session-manager.ts` records optional fallback model-change metadata and restores the primary model rather than a fallback-period assistant model after restart.
 
@@ -261,3 +265,14 @@
 ### Expected merge conflict zones on next upstream sync
 
 - LOW: self-update command parsing/help and package metadata.
+
+## Per-model transient retry fallback engine (2026-07-20)
+
+### What changed
+
+- `core/retry-fallback/controller.ts`: added the session-local fallback-chain controller. It canonicalizes configured selectors, suppresses transiently failing models, skips unavailable candidates with scoped logging, applies ephemeral thinking levels, and emits fallback lifecycle events.
+- `core/agent-session.ts`: retryable transient failures now switch to a configured fallback without persisting the selected model, emitting a zero-delay retry and retaining the existing failed-assistant removal behavior. A fallback success event is emitted after the next successful response.
+
+### Why extension system couldn't handle this
+
+The retry budget, abortable retry sleep, provider continuation, and active model state all belong to `AgentSession`; an extension cannot safely replace a model inside that lifecycle without persisting it or rebuilding context.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -278,3 +278,4 @@
 ### Why extension system couldn't handle this
 
 The retry budget, abortable retry sleep, provider continuation, and active model state all belong to `AgentSession`; an extension cannot safely replace a model inside that lifecycle without persisting it or rebuilding context.
+- Retry fallback revert-to-primary at turn boundaries: unpinned fallback state under the `cooldown-expiry` policy restores the original model once its selector cooldown lapses (checked at prompt entry and between the retry sleep and continuation), emits `retry_fallback_reverted`, preserves user thinking-level overrides, and is abandoned on manual `setModel`/`cycleModel` (which also abort a pending fallback retry sleep).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -43,6 +43,7 @@ import type {
 } from "@earendil-works/pi-ai/compat";
 import {
 	cleanupSessionResources,
+	isClassifierRefusal,
 	isContextOverflow,
 	isRetryableAssistantError,
 	modelsAreEqual,
@@ -914,6 +915,10 @@ export class AgentSession {
 		const lastAssistant = this._lastAssistantMessage ?? this._findLastAssistantInMessages(messages);
 		if (!lastAssistant || !this._isRetryableError(lastAssistant)) {
 			return false;
+		}
+
+		if (isClassifierRefusal(lastAssistant)) {
+			return this._retryAttempt + 1 <= settings.maxRetries && this._retryFallback.canTryFallback();
 		}
 
 		if (this._retryAttempt + 1 > settings.maxRetries) {
@@ -3593,10 +3598,11 @@ export class AgentSession {
 	 * Context overflow errors are NOT retryable (handled by compaction instead).
 	 */
 	private _isRetryableError(message: AssistantMessage): boolean {
-		if (!message.errorMessage) return false;
-
 		// Context overflow is handled by compaction, not retry.
 		if (isContextOverflow(message, this.model?.contextWindow ?? 0)) return false;
+
+		if (isClassifierRefusal(message)) return true;
+		if (!message.errorMessage) return false;
 
 		if (message.stopReason === "aborted") {
 			return /timed? out|timeout/i.test(message.errorMessage);
@@ -3659,35 +3665,55 @@ export class AgentSession {
 			});
 		}
 
-		this._retryAttempt++;
 		const errorMessage = message.errorMessage || "Unknown error";
+		const isRefusal = isClassifierRefusal(message);
 		let switchedFallback = false;
-		if (this._retryAttempt > settings.maxRetries) {
-			switchedFallback = await this._retryFallback.tryFallback("transient", {
-				errorMessage,
-				retryAfterMs: this._getProviderRetryDelayMs(errorMessage),
-			});
-			if (switchedFallback) {
-				// The new model receives a fresh retry budget; the failed model does not.
-				this._retryAttempt = 1;
-			} else {
+		if (isRefusal) {
+			// Refusals are only retried through a new chain candidate. They never use
+			// same-model retries or the transient over-budget fallback escape hatch.
+			if (this._retryAttempt + 1 > settings.maxRetries) {
+				this._resolveRetry();
+				return false;
+			}
+			switchedFallback = await this._retryFallback.tryFallback("refusal", {});
+			if (!switchedFallback) {
 				const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
 				if (exhaustedChainKey) {
 					this._emit({ type: "retry_fallback_exhausted", chainKey: exhaustedChainKey, lastError: errorMessage });
 				}
-				this._emit({
-					type: "auto_retry_end",
-					success: false,
-					attempt: this._retryAttempt - 1,
-					finalError: message.errorMessage,
-				});
-				this._retryAttempt = 0;
 				this._resolveRetry();
 				return false;
 			}
+			this._retryAttempt++;
+		} else {
+			this._retryAttempt++;
+			if (this._retryAttempt > settings.maxRetries) {
+				switchedFallback = await this._retryFallback.tryFallback("transient", {
+					errorMessage,
+					retryAfterMs: this._getProviderRetryDelayMs(errorMessage),
+				});
+				if (switchedFallback) {
+					// The new model receives a fresh retry budget; the failed model does not.
+					this._retryAttempt = 1;
+				} else {
+					const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+					if (exhaustedChainKey) {
+						this._emit({ type: "retry_fallback_exhausted", chainKey: exhaustedChainKey, lastError: errorMessage });
+					}
+					this._emit({
+						type: "auto_retry_end",
+						success: false,
+						attempt: this._retryAttempt - 1,
+						finalError: message.errorMessage,
+					});
+					this._retryAttempt = 0;
+					this._resolveRetry();
+					return false;
+				}
+			}
 		}
 
-		const providerDelayMs = this._getProviderRetryDelayMs(errorMessage);
+		const providerDelayMs = isRefusal ? undefined : this._getProviderRetryDelayMs(errorMessage);
 		const maxRetryDelayMs = this.settingsManager.getProviderRetrySettings().maxRetryDelayMs;
 		if (providerDelayMs !== undefined && providerDelayMs > maxRetryDelayMs) {
 			this._emit({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2160,22 +2160,59 @@ export class AgentSession {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
 
+		return await this._switchActiveModel(model, {
+			persistDefault: true,
+			appendSessionEntry: true,
+			emitModelSelect: true,
+			invalidateCompaction: true,
+		});
+	}
+
+	private async _switchActiveModel(
+		model: Model<any>,
+		opts: {
+			persistDefault: boolean;
+			appendSessionEntry: boolean;
+			entryReason?: "fallback" | "fallback-revert";
+			emitModelSelect: boolean;
+			invalidateCompaction: boolean;
+			ephemeralThinkingLevel?: ThinkingLevel;
+		},
+	): Promise<SystemPromptChangeEvent | undefined> {
 		const previousModel = this.model;
-		const invalidatesCompaction = this._modelSelectionChangesContext(previousModel, model);
-		if (invalidatesCompaction) {
+		if (opts.invalidateCompaction && this._modelSelectionChangesContext(previousModel, model)) {
 			this._invalidateCompactionForModelSelection();
 		}
-		const thinkingLevel = this._getThinkingLevelForModelSwitch();
+		const thinkingLevel = this._getThinkingLevelForModelSwitch(opts.ephemeralThinkingLevel);
 		this.agent.state.model = model;
-		this.sessionManager.appendModelChange(model.provider, model.id);
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		if (opts.appendSessionEntry) {
+			this.sessionManager.appendModelChange(
+				model.provider,
+				model.id,
+				opts.entryReason,
+				previousModel?.provider,
+				previousModel?.id,
+			);
+		}
+		if (opts.persistDefault) {
+			this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		}
 
 		const scopedMatch = this._scopedModels.find((sm) => modelsAreEqual(sm.model, model));
 		this._currentServiceTier = this._resolveServiceTier(model, scopedMatch?.serviceTier);
 
-		this.setThinkingLevel(thinkingLevel);
+		if (opts.ephemeralThinkingLevel !== undefined) {
+			this._applyEphemeralThinkingLevel(thinkingLevel);
+		} else {
+			this.setThinkingLevel(thinkingLevel);
+		}
 
+		if (!opts.emitModelSelect) return undefined;
 		return await this._emitModelSelect(model, previousModel, "set");
+	}
+
+	private _applyEphemeralThinkingLevel(level: ThinkingLevel): void {
+		this.agent.state.thinkingLevel = level;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -477,6 +477,7 @@ export class AgentSession {
 
 	private _modelRuntime: ModelRuntime;
 	private _modelRegistry: ModelRegistry;
+	private readonly _fallbackValidationWarnings: readonly string[];
 	private readonly _retryFallback: RetryFallbackController;
 
 	// Tool registry for extension getTools/setTools
@@ -513,10 +514,11 @@ export class AgentSession {
 		this._modelRuntime = modelRuntime;
 		this._modelRegistry = config.modelRegistry ?? new ModelRegistry(modelRuntime);
 		const fallbackLogger = createFallbackLogger(config.agentDir ?? getAgentDir());
-		for (const warning of validateFallbackChains(
+		this._fallbackValidationWarnings = validateFallbackChains(
 			this.settingsManager.getRetryFallbackSettings().chains,
 			this._modelRegistry,
-		)) {
+		);
+		for (const warning of this._fallbackValidationWarnings) {
 			fallbackLogger.warn("validation_warning", { warning });
 		}
 		this._retryFallback = new RetryFallbackController({
@@ -3447,6 +3449,11 @@ export class AgentSession {
 				},
 			},
 		);
+	}
+
+	/** Fallback-chain configuration warnings calculated when this session started. */
+	get fallbackValidationWarnings(): readonly string[] {
+		return this._fallbackValidationWarnings;
 	}
 
 	private _refreshToolRegistry(options?: { activeToolNames?: string[]; includeAllExtensionTools?: boolean }): void {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -234,6 +234,8 @@ export interface AgentSessionConfig {
 	cwd: string;
 	/** Directory containing runtime logs and global agent configuration. */
 	agentDir?: string;
+	/** Clock override for fallback selector cooldowns (tests only). */
+	fallbackNow?: () => number;
 	/** Global model narrowing for selectors and startup model choice (from --models / enabledModels) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel; serviceTier?: ServiceTier }>;
 	/** Favorite models to cycle through with Ctrl+P */
@@ -520,14 +522,14 @@ export class AgentSession {
 		this._retryFallback = new RetryFallbackController({
 			getSettings: () => this.settingsManager.getRetryFallbackSettings(),
 			registry: this._modelRegistry,
-			cooldowns: new SelectorCooldowns(() => Date.now()),
+			cooldowns: new SelectorCooldowns(config.fallbackNow ?? (() => Date.now())),
 			logger: fallbackLogger,
-			switchModel: async (model, thinking) => {
+			switchModel: async (model, thinking, reason) => {
 				await this._switchActiveModel(model, {
 					persistDefault: false,
 					appendSessionEntry: true,
-					entryReason: "fallback",
-					emitModelSelect: false,
+					entryReason: reason,
+					emitModelSelect: reason === "fallback-revert",
 					invalidateCompaction: false,
 					ephemeralThinkingLevel: thinking,
 				});
@@ -1631,6 +1633,11 @@ export class AgentSession {
 			throwIfCancelled();
 		}
 
+		// Turn boundary: restore the primary model if the fallback cooldown expired.
+		if (!this.isStreaming) {
+			await this._maybeRestoreFallbackPrimary();
+		}
+
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
 		const promptDisposition = options?.promptDisposition;
@@ -2240,12 +2247,29 @@ export class AgentSession {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
 
+		// A manual model change abandons any active fallback window; if a fallback
+		// retry sleep is still pending, cancel it so no surprise continuation fires.
+		const hadActiveFallback = this._retryFallback.activeState !== undefined;
+		this._retryFallback.clearForManualModelChange(model);
+		if (hadActiveFallback && this._retryAbortController) {
+			this.abortRetry();
+		}
+
 		return await this._switchActiveModel(model, {
 			persistDefault: true,
 			appendSessionEntry: true,
 			emitModelSelect: true,
 			invalidateCompaction: true,
 		});
+	}
+
+	private async _maybeRestoreFallbackPrimary(): Promise<void> {
+		try {
+			await this._retryFallback.maybeRestorePrimary(this.settingsManager.getRetryFallbackSettings().revertPolicy);
+		} catch (error) {
+			this._retryFallback.clear();
+			console.error("fallback revert failed; cleared fallback state", error);
+		}
 	}
 
 	private async _switchActiveModel(
@@ -2330,6 +2354,7 @@ export class AgentSession {
 		if (invalidatesCompaction) {
 			this._invalidateCompactionForModelSelection();
 		}
+		this._retryFallback.clearForManualModelChange(next.model);
 		const thinkingLevel = this._getThinkingLevelForModelSwitch(next.thinkingLevel);
 
 		this.agent.state.model = next.model;
@@ -2368,6 +2393,9 @@ export class AgentSession {
 		// Only persist if actually changing
 		const previousLevel = this.agent.state.thinkingLevel;
 		const isChanging = effectiveLevel !== previousLevel;
+		if (isChanging) {
+			this._retryFallback.noteManualThinkingLevel();
+		}
 
 		this.agent.state.thinkingLevel = effectiveLevel;
 
@@ -3814,6 +3842,10 @@ export class AgentSession {
 			return false;
 		}
 		this._retryAbortController = undefined;
+
+		// Turn boundary: a suppression that expired during the backoff sleep lets
+		// the retry continue on the restored primary instead of the fallback model.
+		await this._maybeRestoreFallbackPrimary();
 
 		// Retry via continue() - use setTimeout to break out of event handler chain
 		setTimeout(() => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -49,6 +49,7 @@ import {
 	resetApiProviders,
 	streamSimple,
 } from "@earendil-works/pi-ai/compat";
+import { getAgentDir } from "../config.ts";
 import { getThemeByName, theme } from "../modes/interactive/theme/theme.ts";
 import { stripFrontmatter } from "../utils/frontmatter.ts";
 import { resolvePath } from "../utils/paths.ts";
@@ -114,6 +115,10 @@ import { getModelNarrowingPatterns, resolveModelScope } from "./model-resolver.t
 import type { ModelRuntime } from "./model-runtime.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
+import { RetryFallbackController } from "./retry-fallback/controller.ts";
+import { SelectorCooldowns } from "./retry-fallback/cooldown.ts";
+import { createFallbackLogger } from "./retry-fallback/log.ts";
+import { validateFallbackChains } from "./retry-fallback/validate.ts";
 import type { BranchSummaryEntry, CompactionEntry, SessionEntry, SessionManager } from "./session-manager.ts";
 import {
 	buildSessionContext,
@@ -191,6 +196,16 @@ export type AgentSessionEvent =
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	| {
+			type: "retry_fallback_applied";
+			from: string;
+			to: string;
+			chainKey: string;
+			reason: "transient" | "refusal" | "hard-error";
+	  }
+	| { type: "retry_fallback_succeeded"; model: string; chainKey: string }
+	| { type: "retry_fallback_reverted"; from: string; to: string }
+	| { type: "retry_fallback_exhausted"; chainKey: string; lastError: string }
 	// Auth login flow (task 13) is additive with event-only completion. The
 	// login_start command responds immediately, then the OAuth URL and the
 	// terminal result arrive here, because an interactive browser round-trip
@@ -216,6 +231,8 @@ export interface AgentSessionConfig {
 	sessionManager: SessionManager;
 	settingsManager: SettingsManager;
 	cwd: string;
+	/** Directory containing runtime logs and global agent configuration. */
+	agentDir?: string;
 	/** Global model narrowing for selectors and startup model choice (from --models / enabledModels) */
 	scopedModels?: Array<{ model: Model<any>; thinkingLevel?: ThinkingLevel; serviceTier?: ServiceTier }>;
 	/** Favorite models to cycle through with Ctrl+P */
@@ -457,6 +474,7 @@ export class AgentSession {
 
 	private _modelRuntime: ModelRuntime;
 	private _modelRegistry: ModelRegistry;
+	private readonly _retryFallback: RetryFallbackController;
 
 	// Tool registry for extension getTools/setTools
 	private _toolRegistry: Map<string, AgentTool> = new Map();
@@ -474,6 +492,12 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
 		this.settingsManager = config.settingsManager;
+		const noModelFallback =
+			config.resourceLoader.getExtensions().runtime.flagValues.get("no-model-fallback") === true ||
+			process.env.SENPI_NO_FALLBACK === "1";
+		if (noModelFallback) {
+			this.settingsManager.applyOverrides({ retry: { modelFallback: false } });
+		}
 		this._scopedModels = config.scopedModels ?? [];
 		this._favoriteModels = config.favoriteModels ?? [];
 		this._resourceLoader = config.resourceLoader;
@@ -485,6 +509,32 @@ export class AgentSession {
 		}
 		this._modelRuntime = modelRuntime;
 		this._modelRegistry = config.modelRegistry ?? new ModelRegistry(modelRuntime);
+		const fallbackLogger = createFallbackLogger(config.agentDir ?? getAgentDir());
+		for (const warning of validateFallbackChains(
+			this.settingsManager.getRetryFallbackSettings().chains,
+			this._modelRegistry,
+		)) {
+			fallbackLogger.warn("validation_warning", { warning });
+		}
+		this._retryFallback = new RetryFallbackController({
+			getSettings: () => this.settingsManager.getRetryFallbackSettings(),
+			registry: this._modelRegistry,
+			cooldowns: new SelectorCooldowns(() => Date.now()),
+			logger: fallbackLogger,
+			switchModel: async (model, thinking) => {
+				await this._switchActiveModel(model, {
+					persistDefault: false,
+					appendSessionEntry: true,
+					entryReason: "fallback",
+					emitModelSelect: false,
+					invalidateCompaction: false,
+					ephemeralThinkingLevel: thinking,
+				});
+			},
+			emit: (event) => this._emit(event),
+			getCurrentSelector: () => (this.model ? { model: this.model, thinkingLevel: this.thinkingLevel } : undefined),
+			isAuthAvailable: (provider) => this._modelRuntime.hasConfiguredAuth(provider),
+		});
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._allowedToolNames = config.allowedToolNames ? new Set(config.allowedToolNames) : undefined;
@@ -867,7 +917,7 @@ export class AgentSession {
 		}
 
 		if (this._retryAttempt + 1 > settings.maxRetries) {
-			return false;
+			return this._retryFallback.canTryFallback();
 		}
 
 		const errorMessage = lastAssistant.errorMessage || "Unknown error";
@@ -884,6 +934,7 @@ export class AgentSession {
 		// This ensures the UI sees the updated queue state
 		if (event.type === "message_start" && event.message.role === "user") {
 			this._overflowRecoveryAttempted = false;
+			this._retryFallback.resetTurn();
 			const messageText = this._getUserMessageText(event.message);
 			if (messageText) {
 				// Check steering queue first
@@ -945,6 +996,14 @@ export class AgentSession {
 				// Reset retry counter immediately on successful assistant response
 				// This prevents accumulation across multiple LLM calls within a turn
 				if (assistantMsg.stopReason !== "error" && this._retryAttempt > 0) {
+					const fallback = this._retryFallback.activeState;
+					if (fallback) {
+						this._emit({
+							type: "retry_fallback_succeeded",
+							model: this.model ? `${this.model.provider}/${this.model.id}` : "",
+							chainKey: fallback.chainKey,
+						});
+					}
 					this._emit({
 						type: "auto_retry_end",
 						success: true,
@@ -2169,7 +2228,7 @@ export class AgentSession {
 	}
 
 	private async _switchActiveModel(
-		model: Model<any>,
+		model: Model<Api>,
 		opts: {
 			persistDefault: boolean;
 			appendSessionEntry: boolean;
@@ -3237,6 +3296,36 @@ export class AgentSession {
 				},
 				getContextUsage: () => this.getContextUsage(),
 				getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
+				sessionSettings: {
+					getRetryFallbackSettings: () => this.settingsManager.getRetryFallbackSettings(),
+					setFallbackChain: async (key, entries) => {
+						this.settingsManager.setFallbackChain(key, [...entries]);
+						await this.settingsManager.flush();
+					},
+					removeFallbackChain: async (key) => {
+						this.settingsManager.removeFallbackChain(key);
+						await this.settingsManager.flush();
+					},
+					setModelFallbackEnabled: async (enabled) => {
+						this.settingsManager.setModelFallbackEnabled(enabled);
+						await this.settingsManager.flush();
+					},
+					setFallbackRevertPolicy: async (policy) => {
+						this.settingsManager.setFallbackRevertPolicy(policy);
+						await this.settingsManager.flush();
+					},
+					reload: () => this.settingsManager.reload(),
+					getFallbackStatus: () => {
+						const active = this._retryFallback.activeState;
+						if (!active) return undefined;
+						return {
+							active: true,
+							currentModel: this.model ? `${this.model.provider}/${this.model.id}` : undefined,
+							originalSelector: active.originalSelector,
+							pinned: active.pinned,
+						};
+					},
+				},
 				compact: (options) => {
 					void (async () => {
 						this._disconnectFromAgent();
@@ -3571,21 +3660,33 @@ export class AgentSession {
 		}
 
 		this._retryAttempt++;
-
+		const errorMessage = message.errorMessage || "Unknown error";
+		let switchedFallback = false;
 		if (this._retryAttempt > settings.maxRetries) {
-			// Max retries exceeded, emit final failure and reset
-			this._emit({
-				type: "auto_retry_end",
-				success: false,
-				attempt: this._retryAttempt - 1,
-				finalError: message.errorMessage,
+			switchedFallback = await this._retryFallback.tryFallback("transient", {
+				errorMessage,
+				retryAfterMs: this._getProviderRetryDelayMs(errorMessage),
 			});
-			this._retryAttempt = 0;
-			this._resolveRetry(); // Resolve so waitForRetry() completes
-			return false;
+			if (switchedFallback) {
+				// The new model receives a fresh retry budget; the failed model does not.
+				this._retryAttempt = 1;
+			} else {
+				const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+				if (exhaustedChainKey) {
+					this._emit({ type: "retry_fallback_exhausted", chainKey: exhaustedChainKey, lastError: errorMessage });
+				}
+				this._emit({
+					type: "auto_retry_end",
+					success: false,
+					attempt: this._retryAttempt - 1,
+					finalError: message.errorMessage,
+				});
+				this._retryAttempt = 0;
+				this._resolveRetry();
+				return false;
+			}
 		}
 
-		const errorMessage = message.errorMessage || "Unknown error";
 		const providerDelayMs = this._getProviderRetryDelayMs(errorMessage);
 		const maxRetryDelayMs = this.settingsManager.getProviderRetrySettings().maxRetryDelayMs;
 		if (providerDelayMs !== undefined && providerDelayMs > maxRetryDelayMs) {
@@ -3600,7 +3701,13 @@ export class AgentSession {
 			return false;
 		}
 
-		const delayMs = providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1);
+		if (!switchedFallback) {
+			switchedFallback = await this._retryFallback.tryFallback("transient", {
+				errorMessage,
+				retryAfterMs: providerDelayMs,
+			});
+		}
+		const delayMs = switchedFallback ? 0 : (providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1));
 		// Prepare before auto_retry_start so an immediate Esc can cancel the retry sleep.
 		this._retryAbortController = new AbortController();
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -515,7 +515,7 @@ export class AgentSession {
 		this._modelRegistry = config.modelRegistry ?? new ModelRegistry(modelRuntime);
 		const fallbackLogger = createFallbackLogger(config.agentDir ?? getAgentDir());
 		this._fallbackValidationWarnings = validateFallbackChains(
-			this.settingsManager.getRetryFallbackSettings().chains,
+			this.settingsManager.getRawFallbackChains(),
 			this._modelRegistry,
 		);
 		for (const warning of this._fallbackValidationWarnings) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -853,7 +853,10 @@ export class AgentSession {
 		}
 
 		const lastAssistant = this._findLastAssistantInMessages(event.messages);
-		if (!lastAssistant || !this._isRetryableError(lastAssistant)) {
+		if (
+			!lastAssistant ||
+			(!this._isRetryableError(lastAssistant) && !this._isHardErrorFallbackEligible(lastAssistant))
+		) {
 			return;
 		}
 
@@ -913,7 +916,16 @@ export class AgentSession {
 		}
 
 		const lastAssistant = this._lastAssistantMessage ?? this._findLastAssistantInMessages(messages);
-		if (!lastAssistant || !this._isRetryableError(lastAssistant)) {
+		if (!lastAssistant) {
+			return false;
+		}
+
+		const retryableError = this._isRetryableError(lastAssistant);
+		if (!retryableError && this._isHardErrorFallbackEligible(lastAssistant)) {
+			return true;
+		}
+
+		if (!retryableError) {
 			return false;
 		}
 
@@ -1027,11 +1039,15 @@ export class AgentSession {
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
 
-			// Check for retryable errors first (overloaded, rate limit, server errors)
-			if (this._isRetryableError(msg)) {
-				const didRetry = await this._handleRetryableError(msg);
-				if (didRetry) return; // Retry was initiated, don't proceed to compaction
+			// Retry transient failures normally and eligible hard errors only through a fallback.
+			const retryableError = this._isRetryableError(msg);
+			let didRetry = false;
+			if (retryableError) {
+				didRetry = await this._handleRetryableError(msg);
+			} else if (this._isHardErrorFallbackEligible(msg)) {
+				didRetry = await this._handleRetryableError(msg, { hardErrorFallback: true });
 			}
+			if (didRetry) return; // Retry was initiated, don't proceed to compaction
 
 			this._resolveRetry();
 			launchedContinuation = await this._checkCompaction(msg);
@@ -3611,6 +3627,16 @@ export class AgentSession {
 		return isRetryableAssistantError(message);
 	}
 
+	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
+		return (
+			message.stopReason === "error" &&
+			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&
+			!isClassifierRefusal(message) &&
+			!message.content.some((content) => content.type === "toolCall") &&
+			this._retryFallback.canTryFallback()
+		);
+	}
+
 	private _getProviderRetryDelayMs(errorMessage: string): number | undefined {
 		const retryAfterMsMatch = errorMessage.match(/\bretry[-_ ]?after[-_ ]?ms\s*[:=]\s*(\d+(?:\.\d+)?)/i);
 		if (retryAfterMsMatch) {
@@ -3650,7 +3676,10 @@ export class AgentSession {
 	 * Handle retryable errors with exponential backoff.
 	 * @returns true if retry was initiated, false if max retries exceeded or disabled
 	 */
-	private async _handleRetryableError(message: AssistantMessage): Promise<boolean> {
+	private async _handleRetryableError(
+		message: AssistantMessage,
+		options: { hardErrorFallback?: boolean } = {},
+	): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
 			this._resolveRetry();
@@ -3667,8 +3696,18 @@ export class AgentSession {
 
 		const errorMessage = message.errorMessage || "Unknown error";
 		const isRefusal = isClassifierRefusal(message);
+		const hardErrorFallback = options.hardErrorFallback === true;
 		let switchedFallback = false;
-		if (isRefusal) {
+		if (hardErrorFallback) {
+			// A non-retryable provider failure must never replay on the same model.
+			switchedFallback = await this._retryFallback.tryFallback("hard-error", { errorMessage });
+			if (!switchedFallback) {
+				this._resolveRetry();
+				return false;
+			}
+			// The fallback starts fresh; the failed model's transient attempts do not carry over.
+			this._retryAttempt = 1;
+		} else if (isRefusal) {
 			// Refusals are only retried through a new chain candidate. They never use
 			// same-model retries or the transient over-budget fallback escape hatch.
 			if (this._retryAttempt + 1 > settings.maxRetries) {
@@ -3698,7 +3737,11 @@ export class AgentSession {
 				} else {
 					const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
 					if (exhaustedChainKey) {
-						this._emit({ type: "retry_fallback_exhausted", chainKey: exhaustedChainKey, lastError: errorMessage });
+						this._emit({
+							type: "retry_fallback_exhausted",
+							chainKey: exhaustedChainKey,
+							lastError: errorMessage,
+						});
 					}
 					this._emit({
 						type: "auto_retry_end",
@@ -3713,7 +3756,7 @@ export class AgentSession {
 			}
 		}
 
-		const providerDelayMs = isRefusal ? undefined : this._getProviderRetryDelayMs(errorMessage);
+		const providerDelayMs = isRefusal || hardErrorFallback ? undefined : this._getProviderRetryDelayMs(errorMessage);
 		const maxRetryDelayMs = this.settingsManager.getProviderRetrySettings().maxRetryDelayMs;
 		if (providerDelayMs !== undefined && providerDelayMs > maxRetryDelayMs) {
 			this._emit({

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -11,6 +11,7 @@ import historySearchExtension from "./history-search/index.ts";
 import hooksExtension from "./hooks/index.ts";
 import importReproExtension from "./import-repro.ts";
 import mcpExtension from "./mcp/index.ts";
+import modelFallbackExtension from "./model-fallback/index.ts";
 import nestedAgentsMdExtension from "./nested-agents-md/index.ts";
 import openaiWebSearchExtension from "./openai-web-search/index.ts";
 import permissionSystemExtension from "./permission-system/index.ts";
@@ -53,6 +54,7 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "anthropic-bash", factory: anthropicBashExtension },
 	{ id: "openai-web-search", factory: openaiWebSearchExtension },
 	{ id: "service-tier", factory: serviceTierExtension },
+	{ id: "model-fallback", factory: modelFallbackExtension },
 	{ id: "bash-timeout", factory: bashTimeoutExtension },
 	// Terminal follows bash-timeout so its injected default reaches the PTY bash, and follows
 	// anthropic-bash so mutual-exclusion (companion step-aside) is evaluated after it registers.

--- a/packages/coding-agent/src/core/extensions/builtin/model-fallback/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/model-fallback/index.ts
@@ -1,0 +1,68 @@
+import { validateFallbackChains } from "../../../retry-fallback/validate.ts";
+import type { ExtensionAPI, ExtensionCommandContext } from "../../types.ts";
+import { loadFallbackSettings, updateFallbackSettings } from "./settings.ts";
+import { runFallbackMenu } from "./ui.ts";
+
+const FLAG_NAME = "no-model-fallback";
+
+export default function modelFallbackExtension(pi: ExtensionAPI): void {
+	pi.registerFlag(FLAG_NAME, {
+		type: "boolean",
+		default: false,
+		description: "Disable retry model fallback for this run.",
+	});
+	pi.registerCommand("fallback", {
+		description: "View and manage retry model fallback chains.",
+		argumentHint: "[target [fallback1 fallback2 ...]]",
+		handler: async (rawArgs, ctx) => handleFallbackCommand(rawArgs, ctx),
+	});
+}
+
+async function handleFallbackCommand(rawArgs: string, ctx: ExtensionCommandContext): Promise<void> {
+	const args = rawArgs.trim().split(/\s+/).filter(Boolean);
+	if (args.length === 0) {
+		const settings = loadFallbackSettings(ctx.sessionSettings);
+		await runFallbackMenu(ctx, settings, {
+			setChain: (target, entries) => saveChain(ctx, target, entries),
+			removeChain: async (target) => {
+				await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+					sessionSettings.removeFallbackChain(target),
+				);
+				ctx.ui.notify(`Removed fallback chain for ${target}.`);
+			},
+			toggle: async () => {
+				await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+					sessionSettings.setModelFallbackEnabled(!settings.modelFallback),
+				);
+				ctx.ui.notify(`Model fallback ${settings.modelFallback ? "disabled" : "enabled"}.`);
+			},
+			setRevertPolicy: async (policy) => {
+				await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+					sessionSettings.setFallbackRevertPolicy(policy),
+				);
+				ctx.ui.notify(`Fallback revert policy set to ${policy}.`);
+			},
+		});
+		return;
+	}
+	if (args.length < 2) {
+		ctx.ui.notify("Usage: /fallback <target> <fallback1> [fallback2 ...]", "error");
+		return;
+	}
+	await saveChain(ctx, args[0], args.slice(1));
+}
+
+async function saveChain(ctx: ExtensionCommandContext, target: string, entries: string[]): Promise<boolean> {
+	const warnings = validateFallbackChains({ [target]: entries }, ctx.modelRegistry);
+	if (warnings.length > 0) {
+		ctx.ui.notify(warnings.join("\n"), "warning");
+		return false;
+	}
+	await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+		sessionSettings.setFallbackChain(target, entries),
+	);
+	ctx.ui.notify(`Fallback chain saved for ${target}.`);
+	return true;
+}
+
+export { isModelFallbackDisabled } from "./settings.ts";

--- a/packages/coding-agent/src/core/extensions/builtin/model-fallback/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/model-fallback/settings.ts
@@ -1,0 +1,19 @@
+import type { ExtensionSessionSettings, RetryFallbackSettings } from "../../types.ts";
+
+export type FallbackSettings = RetryFallbackSettings;
+
+export function loadFallbackSettings(settings: ExtensionSessionSettings): FallbackSettings {
+	return settings.getRetryFallbackSettings();
+}
+
+export async function updateFallbackSettings(
+	settings: ExtensionSessionSettings,
+	update: (settings: ExtensionSessionSettings) => Promise<void>,
+): Promise<FallbackSettings> {
+	await update(settings);
+	return settings.getRetryFallbackSettings();
+}
+
+export function isModelFallbackDisabled(flag: boolean | string | undefined, environment = process.env): boolean {
+	return flag === true || environment.SENPI_NO_FALLBACK === "1";
+}

--- a/packages/coding-agent/src/core/extensions/builtin/model-fallback/ui.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/model-fallback/ui.ts
@@ -1,0 +1,83 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { getSupportedThinkingLevels } from "../../../thinking-levels.ts";
+import type { ExtensionCommandContext } from "../../types.ts";
+import type { FallbackSettings } from "./settings.ts";
+
+const MENU = [
+	"Show chains & live state",
+	"Add/edit chain",
+	"Remove chain",
+	"Toggle model fallback",
+	"Revert policy",
+] as const;
+
+export function formatModel(model: Model<Api>): string {
+	return `${model.provider}/${model.id}`;
+}
+
+export function renderFallbackState(ctx: ExtensionCommandContext, settings: FallbackSettings): string {
+	const rows = Object.entries(settings.chains).map(([target, entries]) => `${target} -> ${entries.join(", ")}`);
+	const chains = rows.length > 0 ? rows.join("\n") : "No fallback chains configured.";
+	const status = ctx.sessionSettings.getFallbackStatus();
+	const live = status?.active
+		? `active on ${status.currentModel ?? "unknown"} from ${status.originalSelector ?? "unknown"}${status.pinned ? " (pinned)" : ""}`
+		: "inactive";
+	return `${chains}\nModel fallback: ${settings.modelFallback ? "enabled" : "disabled"}\nRevert policy: ${settings.revertPolicy}\nLive retry state: ${live}`;
+}
+
+export async function runFallbackMenu(
+	ctx: ExtensionCommandContext,
+	settings: FallbackSettings,
+	actions: {
+		setChain(target: string, entries: string[]): Promise<boolean>;
+		removeChain(target: string): Promise<void>;
+		toggle(): Promise<void>;
+		setRevertPolicy(policy: "cooldown-expiry" | "never"): Promise<void>;
+	},
+): Promise<void> {
+	if (!ctx.hasUI) {
+		ctx.ui.notify("Fallback menu requires interactive UI. Use /fallback <target> <fallback...>.", "error");
+		return;
+	}
+	const choice = await ctx.ui.select("Model fallback", [...MENU]);
+	if (!choice) return;
+	if (choice === MENU[0]) {
+		ctx.ui.notify(renderFallbackState(ctx, settings));
+		return;
+	}
+	if (choice === MENU[1]) {
+		await editChain(ctx, actions);
+		return;
+	}
+	if (choice === MENU[2]) {
+		const target = await ctx.ui.select("Remove fallback chain", Object.keys(settings.chains));
+		if (target) await actions.removeChain(target);
+		return;
+	}
+	if (choice === MENU[3]) {
+		await actions.toggle();
+		return;
+	}
+	const policy = await ctx.ui.select("Fallback revert policy", ["cooldown-expiry", "never"]);
+	if (policy === "cooldown-expiry" || policy === "never") await actions.setRevertPolicy(policy);
+}
+
+async function editChain(
+	ctx: ExtensionCommandContext,
+	actions: { setChain(target: string, entries: string[]): Promise<boolean> },
+): Promise<void> {
+	const available = ctx.modelRegistry.getAvailable();
+	const target = await ctx.ui.select("Fallback target model", available.map(formatModel));
+	if (!target) return;
+	const entries: string[] = [];
+	while (true) {
+		const fallback = await ctx.ui.select("Fallback model (Done to save)", ["Done", ...available.map(formatModel)]);
+		if (!fallback || fallback === "Done") break;
+		const model = available.find((item) => formatModel(item) === fallback);
+		if (!model) return;
+		const thinking = await ctx.ui.select("Thinking level", ["inherit", ...getSupportedThinkingLevels(model)]);
+		if (!thinking) return;
+		entries.push(thinking === "inherit" ? fallback : `${fallback}:${thinking}`);
+	}
+	if (entries.length > 0) await actions.setChain(target, entries);
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,14 @@
 # Core Extensions Changes
 
+## 2026-07-20 - Model fallback command builtin
+
+- Added the `model-fallback` builtin and `/fallback` command for viewing, creating, removing, enabling, and setting the revert policy for global retry fallback chains.
+- Quick-set form validates selectors before persisting; headless runs support quick-set and report that the menu requires interactive UI.
+- Registered `--no-model-fallback` and `SENPI_NO_FALLBACK=1` as the per-run fallback escape-hatch inputs.
+- `ExtensionContext.sessionSettings` delegates command writes to the active session's `SettingsManager`, so quick-set changes are immediately visible to the retry controller. Its read-only fallback status accessor powers the menu's live-state view.
+- `--no-model-fallback` and `SENPI_NO_FALLBACK=1` apply a non-persistent `retry.modelFallback=false` override at session bootstrap.
+
+
 ## 2026-07-19 - Port phased op-based todo tool
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -12,6 +12,7 @@ import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
 import type { ModelRegistry } from "../model-registry.ts";
 import type { SessionManager } from "../session-manager.ts";
+import { SettingsManager } from "../settings-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import { drainPendingProviderRegistrations } from "./loader.ts";
 import type {
@@ -291,6 +292,31 @@ export async function emitProjectTrustEvent(
 	return { errors };
 }
 
+function createNoOpSessionSettings(): ExtensionContextActions["sessionSettings"] {
+	const settings = SettingsManager.inMemory();
+	return {
+		getRetryFallbackSettings: () => settings.getRetryFallbackSettings(),
+		setFallbackChain: async (key, entries) => {
+			settings.setFallbackChain(key, [...entries]);
+			await settings.flush();
+		},
+		removeFallbackChain: async (key) => {
+			settings.removeFallbackChain(key);
+			await settings.flush();
+		},
+		setModelFallbackEnabled: async (enabled) => {
+			settings.setModelFallbackEnabled(enabled);
+			await settings.flush();
+		},
+		setFallbackRevertPolicy: async (policy) => {
+			settings.setFallbackRevertPolicy(policy);
+			await settings.flush();
+		},
+		reload: () => settings.reload(),
+		getFallbackStatus: () => undefined,
+	};
+}
+
 const noOpUIContext: ExtensionUIContext = {
 	select: async () => undefined,
 	confirm: async () => false,
@@ -347,6 +373,7 @@ export class ExtensionRunner {
 		reserveTokens: 16384,
 		keepRecentTokens: 20000,
 	});
+	private sessionSettingsFn: ExtensionContextActions["sessionSettings"] = createNoOpSessionSettings();
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private beginCompactionFn: ExtensionContextActions["beginCompaction"] = undefined;
 	private updateCompactionFn: ExtensionContextActions["updateCompaction"] = undefined;
@@ -432,6 +459,7 @@ export class ExtensionRunner {
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.getCompactionSettingsFn = contextActions.getCompactionSettings;
+		this.sessionSettingsFn = contextActions.sessionSettings;
 		this.compactFn = contextActions.compact;
 		this.beginCompactionFn = contextActions.beginCompaction;
 		this.updateCompactionFn = contextActions.updateCompaction;
@@ -915,6 +943,10 @@ export class ExtensionRunner {
 			getCompactionSettings: () => {
 				runner.assertActive();
 				return runner.getCompactionSettingsFn();
+			},
+			get sessionSettings() {
+				runner.assertActive();
+				return runner.sessionSettingsFn;
 			},
 			compact: (options) => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -290,6 +290,30 @@ export interface ExtensionUIContext {
 // Extension Context
 // ============================================================================
 
+export interface RetryFallbackSettings {
+	modelFallback: boolean;
+	chains: Readonly<Record<string, readonly string[]>>;
+	revertPolicy: "cooldown-expiry" | "never";
+}
+
+export interface RetryFallbackStatus {
+	active: boolean;
+	currentModel?: string;
+	originalSelector?: string;
+	pinned: boolean;
+}
+
+/** Narrow session-owned settings access for extensions that manage retry fallback. */
+export interface ExtensionSessionSettings {
+	getRetryFallbackSettings(): RetryFallbackSettings;
+	setFallbackChain(key: string, entries: readonly string[]): Promise<void>;
+	removeFallbackChain(key: string): Promise<void>;
+	setModelFallbackEnabled(enabled: boolean): Promise<void>;
+	setFallbackRevertPolicy(policy: "cooldown-expiry" | "never"): Promise<void>;
+	reload(): Promise<void>;
+	getFallbackStatus(): RetryFallbackStatus | undefined;
+}
+
 export interface ContextUsage {
 	/** Estimated context tokens, or null if unknown (e.g. right after compaction, before next LLM response). */
 	tokens: number | null;
@@ -365,6 +389,8 @@ export interface ExtensionContext {
 	getContextUsage(): ContextUsage | undefined;
 	/** Get resolved compaction settings from global/project/user overrides. */
 	getCompactionSettings(): CompactionPreparation["settings"];
+	/** Manage retry fallback through the SettingsManager owned by this session. */
+	sessionSettings: ExtensionSessionSettings;
 	/** Trigger compaction without awaiting completion. */
 	compact(options?: CompactOptions): void;
 	/** Start user-visible compaction feedback before an extension has a precomputed summary to apply. */
@@ -1248,6 +1274,8 @@ export interface RegisteredCommand {
 	name: string;
 	sourceInfo: SourceInfo;
 	description?: string;
+	/** Compact usage hint shown alongside the command in compatible UIs. */
+	argumentHint?: string;
 	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null | Promise<AutocompleteItem[] | null>;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 }
@@ -1793,6 +1821,7 @@ export interface ExtensionContextActions {
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	getCompactionSettings: () => CompactionPreparation["settings"];
+	sessionSettings: ExtensionSessionSettings;
 	compact: (options?: CompactOptions) => void;
 	beginCompaction?: (options: BeginCompactionOptions) => AbortSignal | undefined;
 	updateCompaction?: (options: UpdateCompactionOptions) => void;

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -20,7 +20,7 @@ function availableModels(lookup: FallbackModelLookup): Model<Api>[] {
 
 function selectorReference(raw: string): { reference: string; thinkingLevel?: ThinkingLevel } | undefined {
 	const trimmed = raw.trim();
-	if (!trimmed || !trimmed.includes("/") || trimmed.includes("*")) return undefined;
+	if (!trimmed.includes("/") || trimmed.includes("*")) return undefined;
 
 	const lastColon = trimmed.lastIndexOf(":");
 	if (lastColon === -1) return { reference: trimmed };

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -1,0 +1,142 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { isValidThinkingLevel } from "../../cli/args.ts";
+import { findExactModelReferenceMatch, parseModelPattern } from "../model-resolver.ts";
+
+export interface FallbackSelector {
+	raw: string;
+	provider: string;
+	id: string;
+	thinkingLevel?: ThinkingLevel;
+}
+
+export type FallbackChains = Readonly<Record<string, readonly string[]>>;
+
+export type FallbackModelLookup = readonly Model<Api>[] | { getAll(): Model<Api>[] };
+
+function availableModels(lookup: FallbackModelLookup): Model<Api>[] {
+	return "getAll" in lookup ? lookup.getAll() : [...lookup];
+}
+
+function selectorReference(raw: string): { reference: string; thinkingLevel?: ThinkingLevel } | undefined {
+	const trimmed = raw.trim();
+	if (!trimmed || !trimmed.includes("/") || trimmed.includes("*")) return undefined;
+
+	const lastColon = trimmed.lastIndexOf(":");
+	if (lastColon === -1) return { reference: trimmed };
+
+	const prefix = trimmed.slice(0, lastColon);
+	const suffix = trimmed.slice(lastColon + 1).toLowerCase();
+	if (!isValidThinkingLevel(suffix)) return { reference: trimmed };
+	return { reference: prefix, thinkingLevel: suffix };
+}
+
+/**
+ * Resolves only complete provider/model selectors. The full input is resolved first
+ * so colons belonging to a model id remain part of that id; aliases then resolve
+ * against the model-id portion while retaining the explicitly selected provider.
+ */
+export function parseFallbackSelector(raw: string, lookup: FallbackModelLookup): FallbackSelector | undefined {
+	const models = availableModels(lookup);
+	const trimmed = raw.trim();
+	const parsedReference = selectorReference(trimmed);
+	if (!parsedReference) return undefined;
+
+	const fullMatch = findExactModelReferenceMatch(trimmed, models);
+	if (fullMatch) {
+		return { raw: trimmed, provider: fullMatch.provider, id: fullMatch.id };
+	}
+
+	const slashIndex = parsedReference.reference.indexOf("/");
+	const provider = parsedReference.reference.slice(0, slashIndex).trim();
+	const modelPattern = parsedReference.reference.slice(slashIndex + 1).trim();
+	if (!provider || !modelPattern) return undefined;
+
+	const parsed = parseModelPattern(
+		parsedReference.thinkingLevel ? `${modelPattern}:${parsedReference.thinkingLevel}` : modelPattern,
+		models,
+		{ allowInvalidThinkingLevelFallback: false },
+	);
+	if (!parsed.model || parsed.warning || parsed.model.provider.toLowerCase() !== provider.toLowerCase()) return undefined;
+	if (parsedReference.thinkingLevel && !parsed.thinkingLevel) return undefined;
+
+	return {
+		raw: trimmed,
+		provider: parsed.model.provider,
+		id: parsed.model.id,
+		thinkingLevel: parsed.thinkingLevel,
+	};
+}
+
+export function formatSelector(model: Model<Api>, thinkingLevel?: ThinkingLevel): string {
+	const base = `${model.provider}/${model.id}`;
+	return thinkingLevel ? `${base}:${thinkingLevel}` : base;
+}
+
+export function baseSelector(selector: Pick<FallbackSelector, "provider" | "id">): string {
+	return `${selector.provider}/${selector.id}`;
+}
+
+/** Converts validated configuration to canonical selector strings for runtime lookup. */
+export function canonicalizeFallbackChains(chains: FallbackChains, lookup: FallbackModelLookup): FallbackChains {
+	const canonical: Record<string, readonly string[]> = {};
+
+	for (const [key, entries] of Object.entries(chains)) {
+		const parsedKey = parseFallbackSelector(key, lookup);
+		if (!parsedKey || !Array.isArray(entries)) continue;
+
+		const canonicalEntries = entries.flatMap((entry) => {
+			const parsedEntry = parseFallbackSelector(entry, lookup);
+			return parsedEntry ? [formatParsedSelector(parsedEntry)] : [];
+		});
+		canonical[formatParsedSelector(parsedKey)] = canonicalEntries;
+	}
+
+	return canonical;
+}
+
+export function resolveChainKey(
+	currentModel: Model<Api>,
+	currentThinking: ThinkingLevel | undefined,
+	chains: FallbackChains,
+): string | undefined {
+	const base = formatSelector(currentModel);
+	const exact = currentThinking ? `${base}:${currentThinking}` : base;
+	if (Object.hasOwn(chains, exact)) return exact;
+	return Object.hasOwn(chains, base) ? base : undefined;
+}
+
+function formatParsedSelector(selector: FallbackSelector): string {
+	const base = baseSelector(selector);
+	return selector.thinkingLevel ? `${base}:${selector.thinkingLevel}` : base;
+}
+
+function normalizedBase(selector: FallbackSelector | string): string {
+	if (typeof selector !== "string") return baseSelector(selector).toLowerCase();
+
+	const normalized = selector.trim().toLowerCase();
+	const lastColon = normalized.lastIndexOf(":");
+	if (lastColon === -1 || !isValidThinkingLevel(normalized.slice(lastColon + 1))) return normalized;
+	return normalized.slice(0, lastColon);
+}
+
+function normalizedExact(selector: FallbackSelector | string): string {
+	return typeof selector === "string" ? selector.trim().toLowerCase() : formatParsedSelector(selector).toLowerCase();
+}
+
+/**
+ * Returns entries after the current fallback. A primary or unknown selector starts
+ * from the beginning, which also makes re-entry after stale runtime state safe.
+ */
+export function candidatesAfter(
+	chainEntries: readonly string[],
+	currentSelector: FallbackSelector | string,
+): readonly string[] {
+	const exact = normalizedExact(currentSelector);
+	const exactIndex = chainEntries.findIndex((entry) => entry.toLowerCase() === exact);
+	if (exactIndex !== -1) return chainEntries.slice(exactIndex + 1);
+
+	const base = normalizedBase(currentSelector);
+	const baseIndex = chainEntries.findIndex((entry) => normalizedBase(entry) === base);
+	return baseIndex === -1 ? chainEntries : chainEntries.slice(baseIndex + 1);
+}

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -57,7 +57,8 @@ export function parseFallbackSelector(raw: string, lookup: FallbackModelLookup):
 		models,
 		{ allowInvalidThinkingLevelFallback: false },
 	);
-	if (!parsed.model || parsed.warning || parsed.model.provider.toLowerCase() !== provider.toLowerCase()) return undefined;
+	if (!parsed.model || parsed.warning || parsed.model.provider.toLowerCase() !== provider.toLowerCase())
+		return undefined;
 	if (parsedReference.thinkingLevel && !parsed.thinkingLevel) return undefined;
 
 	return {

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -74,7 +74,7 @@ export class RetryFallbackController {
 	}
 
 	canTryFallback(): boolean {
-		return this.nextCandidate() !== undefined;
+		return this.nextCandidate(false) !== undefined;
 	}
 
 	async tryFallback(
@@ -106,7 +106,7 @@ export class RetryFallbackController {
 		return true;
 	}
 
-	private nextCandidate(): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
+	private nextCandidate(reserve = true): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
 		const settings = this.deps.getSettings();
 		const current = this.deps.getCurrentSelector();
 		if (!settings.modelFallback || !current) return undefined;
@@ -114,9 +114,7 @@ export class RetryFallbackController {
 		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
 		const entries = chainKey ? chains[chainKey] : undefined;
 		if (!chainKey || !entries) return undefined;
-		let foundCandidate = false;
 		for (const raw of candidatesAfter(entries, formatSelector(current.model, current.thinkingLevel))) {
-			foundCandidate = true;
 			const selector = parseFallbackSelector(raw, this.deps.registry);
 			if (!selector) {
 				this.skip(raw, "unknown");
@@ -140,10 +138,10 @@ export class RetryFallbackController {
 				this.skip(raw, "unknown");
 				continue;
 			}
-			this.triedSelectors.add(base);
+			if (reserve) this.triedSelectors.add(base);
 			return { chainKey, selector, model };
 		}
-		if (foundCandidate) this.lastExhaustedChainKey = chainKey;
+		this.lastExhaustedChainKey = chainKey;
 		return undefined;
 	}
 

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -166,11 +166,18 @@ export class RetryFallbackController {
 		const chains = canonicalizeFallbackChains(settings.chains, this.deps.registry);
 		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
 		const entries = chainKey ? chains[chainKey] : undefined;
-		if (!chainKey || !entries) return undefined;
+		if (!chainKey || !entries) {
+			if (reserve) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });
+			return undefined;
+		}
 		for (const raw of candidatesAfter(entries, formatSelector(current.model, current.thinkingLevel))) {
 			const selector = parseFallbackSelector(raw, this.deps.registry);
 			if (!selector) {
 				this.skip(raw, "unknown");
+				continue;
+			}
+			if (selector.provider === current.model.provider && selector.id === current.model.id) {
+				this.skip(raw, "self");
 				continue;
 			}
 			const base = baseSelector(selector);
@@ -195,6 +202,7 @@ export class RetryFallbackController {
 			return { chainKey, selector, model };
 		}
 		this.lastExhaustedChainKey = chainKey;
+		if (reserve) this.deps.logger.info("candidates_exhausted", { chainKey });
 		return undefined;
 	}
 

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -33,14 +33,18 @@ export interface RetryFallbackControllerDeps {
 	registry: { find(provider: string, id: string): Model<Api> | undefined; getAll(): Model<Api>[] };
 	cooldowns: SelectorCooldowns;
 	logger: FallbackLogger;
-	switchModel(model: Model<Api>, thinking: ThinkingLevel, reason: "fallback"): Promise<void>;
-	emit(event: {
-		type: "retry_fallback_applied";
-		from: string;
-		to: string;
-		chainKey: string;
-		reason: FallbackReason;
-	}): void;
+	switchModel(model: Model<Api>, thinking: ThinkingLevel, reason: "fallback" | "fallback-revert"): Promise<void>;
+	emit(
+		event:
+			| {
+					type: "retry_fallback_applied";
+					from: string;
+					to: string;
+					chainKey: string;
+					reason: FallbackReason;
+			  }
+			| { type: "retry_fallback_reverted"; from: string; to: string },
+	): void;
 	getCurrentSelector(): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined;
 	isAuthAvailable(provider: string): boolean;
 }
@@ -75,6 +79,53 @@ export class RetryFallbackController {
 
 	canTryFallback(): boolean {
 		return this.nextCandidate(false) !== undefined;
+	}
+
+	/**
+	 * Revert to the chain's original model at a turn boundary. Only fires for
+	 * unpinned state under the cooldown-expiry policy once the original selector
+	 * is no longer suppressed and is still usable; pinned (refusal) state and the
+	 * "never" policy always hold the fallback model.
+	 */
+	async maybeRestorePrimary(revertPolicy: "cooldown-expiry" | "never"): Promise<boolean> {
+		const state = this.state;
+		if (!state || state.pinned || revertPolicy !== "cooldown-expiry") return false;
+		if (this.deps.cooldowns.isSuppressed(state.originalSelector)) return false;
+		const selector = parseFallbackSelector(state.originalSelector, this.deps.registry);
+		if (!selector || !this.deps.isAuthAvailable(selector.provider)) return false;
+		const model = this.deps.registry.find(selector.provider, selector.id);
+		const current = this.deps.getCurrentSelector();
+		if (!model || !current) return false;
+		// User override wins: only restore the original thinking level when the
+		// current level still equals the level the fallback switch applied. A manual
+		// setThinkingLevel clears lastAppliedThinkingLevel (see noteManualThinkingLevel).
+		const thinking =
+			current.thinkingLevel === state.lastAppliedThinkingLevel
+				? (state.originalThinkingLevel ?? current.thinkingLevel ?? "off")
+				: (current.thinkingLevel ?? "off");
+		await this.deps.switchModel(model, thinking, "fallback-revert");
+		const from = formatSelector(current.model);
+		this.state = undefined;
+		this.deps.logger.info("fallback_reverted", { from, to: state.originalSelector });
+		this.deps.emit({ type: "retry_fallback_reverted", from, to: state.originalSelector });
+		return true;
+	}
+
+	/**
+	 * A user-driven setThinkingLevel makes the current level a deliberate choice,
+	 * so the revert restore-rule must no longer treat it as fallback-applied.
+	 */
+	noteManualThinkingLevel(): void {
+		if (this.state) this.state.lastAppliedThinkingLevel = undefined;
+	}
+
+	/** A user-driven model change abandons the fallback window entirely. */
+	clearForManualModelChange(model: Model<Api>): void {
+		if (this.state) {
+			this.deps.logger.info("fallback_cleared_manual", { selector: formatSelector(model) });
+		}
+		this.state = undefined;
+		this.deps.cooldowns.clear(formatSelector(model));
 	}
 
 	async tryFallback(

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -85,7 +85,7 @@ export class RetryFallbackController {
 		const candidate = this.nextCandidate();
 		if (!current || !candidate) return false;
 		const currentBase = formatSelector(current.model);
-		if (reason === "transient") {
+		if (reason === "transient" || reason === "hard-error") {
 			this.deps.cooldowns.note(currentBase, failure);
 			this.deps.logger.info("cooldown_noted", { selector: currentBase, errorMessage: failure.errorMessage });
 		}
@@ -106,7 +106,9 @@ export class RetryFallbackController {
 		return true;
 	}
 
-	private nextCandidate(reserve = true): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
+	private nextCandidate(
+		reserve = true,
+	): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
 		const settings = this.deps.getSettings();
 		const current = this.deps.getCurrentSelector();
 		if (!settings.modelFallback || !current) return undefined;

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -1,0 +1,163 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { getSupportedThinkingLevels } from "../thinking-levels.ts";
+import {
+	baseSelector,
+	candidatesAfter,
+	canonicalizeFallbackChains,
+	type FallbackSelector,
+	formatSelector,
+	parseFallbackSelector,
+	resolveChainKey,
+} from "./chains.ts";
+import type { SelectorCooldowns } from "./cooldown.ts";
+import type { FallbackLogger } from "./log.ts";
+
+export interface ActiveFallbackState {
+	chainKey: string;
+	originalSelector: string;
+	originalThinkingLevel?: ThinkingLevel;
+	lastAppliedThinkingLevel?: ThinkingLevel;
+	pinned: boolean;
+}
+
+type FallbackReason = "transient" | "refusal" | "hard-error";
+
+interface FallbackSettings {
+	modelFallback: boolean;
+	chains: Readonly<Record<string, readonly string[]>>;
+}
+
+export interface RetryFallbackControllerDeps {
+	getSettings(): FallbackSettings;
+	registry: { find(provider: string, id: string): Model<Api> | undefined; getAll(): Model<Api>[] };
+	cooldowns: SelectorCooldowns;
+	logger: FallbackLogger;
+	switchModel(model: Model<Api>, thinking: ThinkingLevel, reason: "fallback"): Promise<void>;
+	emit(event: {
+		type: "retry_fallback_applied";
+		from: string;
+		to: string;
+		chainKey: string;
+		reason: FallbackReason;
+	}): void;
+	getCurrentSelector(): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined;
+	isAuthAvailable(provider: string): boolean;
+}
+
+export class RetryFallbackController {
+	private readonly deps: RetryFallbackControllerDeps;
+	private readonly triedSelectors = new Set<string>();
+	private state: ActiveFallbackState | undefined;
+	private lastExhaustedChainKey: string | undefined;
+
+	constructor(deps: RetryFallbackControllerDeps) {
+		this.deps = deps;
+	}
+
+	get activeState(): Readonly<ActiveFallbackState> | undefined {
+		return this.state;
+	}
+
+	get exhaustedChainKey(): string | undefined {
+		return this.lastExhaustedChainKey;
+	}
+
+	resetTurn(): void {
+		this.triedSelectors.clear();
+		this.lastExhaustedChainKey = undefined;
+	}
+
+	clear(): void {
+		this.state = undefined;
+		this.resetTurn();
+	}
+
+	canTryFallback(): boolean {
+		return this.nextCandidate() !== undefined;
+	}
+
+	async tryFallback(
+		reason: FallbackReason,
+		failure: { errorMessage?: string; retryAfterMs?: number },
+	): Promise<boolean> {
+		const current = this.deps.getCurrentSelector();
+		const candidate = this.nextCandidate();
+		if (!current || !candidate) return false;
+		const currentBase = formatSelector(current.model);
+		if (reason === "transient") {
+			this.deps.cooldowns.note(currentBase, failure);
+			this.deps.logger.info("cooldown_noted", { selector: currentBase, errorMessage: failure.errorMessage });
+		}
+
+		const thinking = this.selectThinking(candidate.selector, candidate.model, current.thinkingLevel);
+		await this.deps.switchModel(candidate.model, thinking, "fallback");
+		const from = formatSelector(current.model);
+		const to = formatSelector(candidate.model);
+		this.state = {
+			chainKey: candidate.chainKey,
+			originalSelector: this.state?.originalSelector ?? from,
+			originalThinkingLevel: this.state?.originalThinkingLevel ?? current.thinkingLevel,
+			lastAppliedThinkingLevel: thinking,
+			pinned: this.state?.pinned === true || reason === "refusal",
+		};
+		this.deps.logger.info("fallback_applied", { from, to, chainKey: candidate.chainKey, reason });
+		this.deps.emit({ type: "retry_fallback_applied", from, to, chainKey: candidate.chainKey, reason });
+		return true;
+	}
+
+	private nextCandidate(): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
+		const settings = this.deps.getSettings();
+		const current = this.deps.getCurrentSelector();
+		if (!settings.modelFallback || !current) return undefined;
+		const chains = canonicalizeFallbackChains(settings.chains, this.deps.registry);
+		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
+		const entries = chainKey ? chains[chainKey] : undefined;
+		if (!chainKey || !entries) return undefined;
+		let foundCandidate = false;
+		for (const raw of candidatesAfter(entries, formatSelector(current.model, current.thinkingLevel))) {
+			foundCandidate = true;
+			const selector = parseFallbackSelector(raw, this.deps.registry);
+			if (!selector) {
+				this.skip(raw, "unknown");
+				continue;
+			}
+			const base = baseSelector(selector);
+			if (this.triedSelectors.has(base)) {
+				this.skip(raw, "tried");
+				continue;
+			}
+			if (this.deps.cooldowns.isSuppressed(base)) {
+				this.skip(raw, "suppressed");
+				continue;
+			}
+			if (!this.deps.isAuthAvailable(selector.provider)) {
+				this.skip(raw, "unauthenticated");
+				continue;
+			}
+			const model = this.deps.registry.find(selector.provider, selector.id);
+			if (!model) {
+				this.skip(raw, "unknown");
+				continue;
+			}
+			this.triedSelectors.add(base);
+			return { chainKey, selector, model };
+		}
+		if (foundCandidate) this.lastExhaustedChainKey = chainKey;
+		return undefined;
+	}
+
+	private selectThinking(
+		selector: FallbackSelector,
+		model: Model<Api>,
+		inherited: ThinkingLevel | undefined,
+	): ThinkingLevel {
+		const requested = selector.thinkingLevel ?? inherited ?? "off";
+		const supported = getSupportedThinkingLevels(model);
+		return supported.includes(requested) ? requested : (supported[supported.length - 1] ?? "off");
+	}
+
+	private skip(candidate: string, skipReason: string): void {
+		this.deps.logger.debug("candidate_skipped", { candidate, skipReason });
+	}
+}

--- a/packages/coding-agent/src/core/retry-fallback/cooldown.ts
+++ b/packages/coding-agent/src/core/retry-fallback/cooldown.ts
@@ -1,0 +1,52 @@
+/**
+ * Runtime-only selector suppression. A SelectorCooldowns instance belongs to one
+ * AgentSession and is deliberately never persisted to settings or session files.
+ * Callers provide canonical base selectors without a thinking suffix.
+ */
+export class SelectorCooldowns {
+	private readonly expiresAtBySelector = new Map<string, number>();
+	private readonly now: () => number;
+	private readonly random: () => number;
+
+	constructor(now: () => number, random: () => number = Math.random) {
+		this.now = now;
+		this.random = random;
+	}
+
+	note(baseSelector: string, failure: { retryAfterMs?: number; errorMessage?: string }): void {
+		this.expiresAtBySelector.set(baseSelector, this.now() + this.durationFor(failure));
+	}
+
+	isSuppressed(baseSelector: string): boolean {
+		const expiresAt = this.expiresAtBySelector.get(baseSelector);
+		if (expiresAt === undefined) return false;
+		if (this.now() < expiresAt) return true;
+		this.expiresAtBySelector.delete(baseSelector);
+		return false;
+	}
+
+	clear(baseSelector: string): void {
+		this.expiresAtBySelector.delete(baseSelector);
+	}
+
+	clearAll(): void {
+		this.expiresAtBySelector.clear();
+	}
+
+	private durationFor({ retryAfterMs, errorMessage }: { retryAfterMs?: number; errorMessage?: string }): number {
+		if (retryAfterMs !== undefined && Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+			return retryAfterMs;
+		}
+
+		const message = errorMessage?.toLowerCase() ?? "";
+		if (/usage[- ]limit|quota|insufficient_quota|billing/.test(message)) return 30 * 60_000;
+		if (/rate[ -]?limit|429|too many requests/.test(message)) return 30_000;
+		if (/overloaded|capacity/.test(message)) return 45_000 + this.capacityJitterMs();
+		if (/5xx|\b5\d\d\b|server|internal error/.test(message)) return 20_000;
+		return 5 * 60_000;
+	}
+
+	private capacityJitterMs(): number {
+		return Math.round(Math.min(1, Math.max(0, this.random())) * 30_000);
+	}
+}

--- a/packages/coding-agent/src/core/retry-fallback/log.ts
+++ b/packages/coding-agent/src/core/retry-fallback/log.ts
@@ -1,0 +1,140 @@
+import { chmodSync, closeSync, mkdirSync, openSync, renameSync, rmSync, statSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const MAX_STRING_LENGTH = 200;
+const BLOCKED_KEY =
+	/^(?:__proto__|constructor|prototype|headers?|env(?:ironment)?|authorization|credential(?:s)?|password|secret|token|api_?key|client_?secret)$/i;
+const ALLOWED_DATA_KEY =
+	/^(?:selector|candidate|currentSelector|originalSelector|from|to|model|chainKey|reason|skipReason|classification|thinkingLevel|durationMs|retryAfterMs|error|errorMessage|warning)$/;
+const SENSITIVE_TEXT =
+	/((?:authorization\s*[:=]\s*(?:bearer|basic)\s+)|(?:bearer\s+)|(?:[?&](?:api[_-]?key|token|secret|password|auth(?:orization)?)=))[^\s&,"'}\]]+/gi;
+
+export interface FallbackLogger {
+	debug(event: string, data?: Record<string, unknown>): void;
+	info(event: string, data?: Record<string, unknown>): void;
+	warn(event: string, data?: Record<string, unknown>): void;
+}
+
+export interface FallbackLoggerOptions {
+	maxBytes?: number;
+}
+
+export function createFallbackLogger(agentDir: string, options: FallbackLoggerOptions = {}): FallbackLogger {
+	const filePath = join(agentDir, "logs", "fallback.log");
+	const maxBytes = validMaxBytes(options.maxBytes);
+	let reportedWriteFailure = false;
+
+	function log(level: "debug" | "info" | "warn", event: string, data?: Record<string, unknown>): void {
+		try {
+			const line = formatLine(level, event, data);
+			writeLine(filePath, line, maxBytes);
+		} catch (error) {
+			if (!reportedWriteFailure) {
+				reportedWriteFailure = true;
+				console.error("Unable to write retry fallback debug log", error);
+			}
+		}
+	}
+
+	return {
+		debug: (event, data) => log("debug", event, data),
+		info: (event, data) => log("info", event, data),
+		warn: (event, data) => log("warn", event, data),
+	};
+}
+
+function validMaxBytes(value: number | undefined): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : DEFAULT_MAX_BYTES;
+}
+
+function formatLine(
+	level: "debug" | "info" | "warn",
+	event: string,
+	data: Record<string, unknown> | undefined,
+): string {
+	const entry: Record<string, unknown> = {
+		ts: new Date().toISOString(),
+		level,
+		event: safeText(event),
+	};
+	if (data !== undefined) {
+		for (const [key, value] of safeEntries(data)) {
+			if (ALLOWED_DATA_KEY.test(key) && !BLOCKED_KEY.test(key)) {
+				const safeValue = serializeValue(value, new WeakSet<object>());
+				if (safeValue !== undefined) entry[key] = safeValue;
+			}
+		}
+	}
+	return JSON.stringify(entry);
+}
+
+function writeLine(filePath: string, line: string, maxBytes: number): void {
+	mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
+	const text = `${line}\n`;
+	if (fileExceedsCap(filePath, Buffer.byteLength(text), maxBytes)) {
+		rmSync(`${filePath}.1`, { force: true });
+		renameSync(filePath, `${filePath}.1`);
+		chmodSync(`${filePath}.1`, 0o600);
+	}
+	const descriptor = openSync(filePath, "a", 0o600);
+	try {
+		writeSync(descriptor, text);
+	} finally {
+		closeSync(descriptor);
+	}
+	chmodSync(filePath, 0o600);
+}
+
+function fileExceedsCap(filePath: string, incomingBytes: number, maxBytes: number): boolean {
+	try {
+		return statSync(filePath).size + incomingBytes > maxBytes;
+	} catch (error) {
+		if (isMissingFileError(error)) return false;
+		throw error;
+	}
+}
+
+function isMissingFileError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function serializeValue(value: unknown, seen: WeakSet<object>): unknown {
+	if (typeof value === "string") return safeText(value);
+	if (typeof value === "bigint") return value.toString();
+	if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+	if (typeof value === "undefined") return undefined;
+	if (typeof value === "function" || typeof value === "symbol") return String(value);
+	if (seen.has(value)) return "[Circular]";
+	seen.add(value);
+	if (Array.isArray(value)) return value.map((item) => serializeValue(item, seen) ?? null);
+	const result: Record<string, unknown> = {};
+	for (const [key, item] of safeEntries(value)) {
+		if (!BLOCKED_KEY.test(key)) {
+			const safeValue = serializeValue(item, seen);
+			if (safeValue !== undefined) result[key] = safeValue;
+		}
+	}
+	return result;
+}
+
+function safeEntries(value: object): Array<[string, unknown]> {
+	try {
+		const entries: Array<[string, unknown]> = [];
+		for (const key of Object.keys(value)) {
+			try {
+				entries.push([key, value[key as keyof typeof value]]);
+			} catch {
+				entries.push([key, "[Unreadable]"]);
+			}
+		}
+		return entries;
+	} catch {
+		return [["unserializable", "[Unreadable]"]];
+	}
+}
+
+function safeText(value: string): string {
+	const redacted = value.replace(SENSITIVE_TEXT, "$1[redacted]");
+	return redacted.length <= MAX_STRING_LENGTH ? redacted : `${redacted.slice(0, MAX_STRING_LENGTH - 3)}...`;
+}

--- a/packages/coding-agent/src/core/retry-fallback/log.ts
+++ b/packages/coding-agent/src/core/retry-fallback/log.ts
@@ -123,7 +123,8 @@ function safeEntries(value: object): Array<[string, unknown]> {
 		const entries: Array<[string, unknown]> = [];
 		for (const key of Object.keys(value)) {
 			try {
-				entries.push([key, value[key as keyof typeof value]]);
+				const item: unknown = Reflect.get(value, key);
+				entries.push([key, item]);
 			} catch {
 				entries.push([key, "[Unreadable]"]);
 			}

--- a/packages/coding-agent/src/core/retry-fallback/validate.ts
+++ b/packages/coding-agent/src/core/retry-fallback/validate.ts
@@ -1,0 +1,84 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { getSupportedThinkingLevels } from "../thinking-levels.js";
+import { baseSelector, parseFallbackSelector } from "./chains.js";
+
+export interface FallbackModelRegistry {
+	find(provider: string, id: string): Model<Api> | undefined;
+	getAll(): Model<Api>[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function invalidSelectorWarning(kind: "key" | "entry", selector: string, key?: string): string {
+	const subject =
+		kind === "key" ? `Fallback chain key "${selector}"` : `Fallback chain entry "${selector}" for "${key}"`;
+	return `${subject} is not a valid or known model selector.`;
+}
+
+function validateThinkingLevel(
+	selector: { thinkingLevel?: ThinkingLevel; provider: string; id: string },
+	model: Model<Api>,
+	subject: string,
+	warnings: string[],
+): void {
+	if (selector.thinkingLevel && !getSupportedThinkingLevels(model).includes(selector.thinkingLevel)) {
+		warnings.push(
+			`${subject} uses thinking level "${selector.thinkingLevel}", which is unsupported by ${selector.provider}/${selector.id}.`,
+		);
+	}
+}
+
+/** Returns configuration warnings without changing malformed fallback-chain settings. */
+export function validateFallbackChains(chains: unknown, registry: FallbackModelRegistry): string[] {
+	if (!isPlainObject(chains)) return ["Fallback chains must be a plain object."];
+
+	const warnings: string[] = [];
+	const models = registry.getAll();
+
+	for (const [key, entries] of Object.entries(chains)) {
+		const hasProvider = key.includes("/");
+		const hasWildcard = key.includes("*");
+		if (!hasProvider) {
+			warnings.push(`Fallback chain key "${key}" must use a provider/model selector; roles are unsupported.`);
+		}
+		if (hasWildcard) warnings.push(`Fallback chain key "${key}" cannot contain wildcards.`);
+
+		const parsedKey = hasProvider && !hasWildcard ? parseFallbackSelector(key, models) : undefined;
+		const keyModel = parsedKey ? registry.find(parsedKey.provider, parsedKey.id) : undefined;
+		if (hasProvider && !hasWildcard && (!parsedKey || !keyModel)) {
+			warnings.push(invalidSelectorWarning("key", key));
+		}
+		if (parsedKey && keyModel) {
+			validateThinkingLevel(parsedKey, keyModel, `Fallback chain key "${key}"`, warnings);
+		}
+
+		if (!Array.isArray(entries) || entries.some((entry) => typeof entry !== "string")) {
+			warnings.push(`Fallback chain "${key}" entries must be an array of strings.`);
+			continue;
+		}
+		if (entries.length === 0) {
+			warnings.push(`Fallback chain "${key}" must contain at least one entry.`);
+			continue;
+		}
+
+		for (const entry of entries) {
+			const parsedEntry = parseFallbackSelector(entry, models);
+			const entryModel = parsedEntry ? registry.find(parsedEntry.provider, parsedEntry.id) : undefined;
+			if (!parsedEntry || !entryModel) {
+				warnings.push(invalidSelectorWarning("entry", entry, key));
+				continue;
+			}
+			if (parsedKey && baseSelector(parsedEntry) === baseSelector(parsedKey)) {
+				warnings.push(`Fallback chain entry "${entry}" for "${key}" cannot reference the same model.`);
+			}
+			validateThinkingLevel(parsedEntry, entryModel, `Fallback chain entry "${entry}"`, warnings);
+		}
+	}
+
+	return warnings;
+}

--- a/packages/coding-agent/src/core/retry-fallback/validate.ts
+++ b/packages/coding-agent/src/core/retry-fallback/validate.ts
@@ -1,7 +1,7 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { getSupportedThinkingLevels } from "../thinking-levels.js";
-import { baseSelector, parseFallbackSelector } from "./chains.js";
+import { getSupportedThinkingLevels } from "../thinking-levels.ts";
+import { baseSelector, parseFallbackSelector } from "./chains.ts";
 
 export interface FallbackModelRegistry {
 	find(provider: string, id: string): Model<Api> | undefined;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -420,6 +420,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		sessionManager,
 		settingsManager,
 		cwd,
+		agentDir,
 		scopedModels,
 		favoriteModels,
 		resourceLoader,

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -87,6 +87,11 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	type: "model_change";
 	provider: string;
 	modelId: string;
+	/** Transient fallback changes are excluded from restored session defaults. */
+	reason?: "fallback" | "fallback-revert";
+	/** The model active before a fallback window, retained for restart restoration. */
+	originalProvider?: string;
+	originalModelId?: string;
 }
 
 export interface CompactionEntry<T = unknown> extends SessionEntryBase {
@@ -381,13 +386,24 @@ function buildSessionPath(
 function getSessionContextSettings(path: SessionEntry[]): Pick<SessionContext, "thinkingLevel" | "model"> {
 	let thinkingLevel = "off";
 	let model: { provider: string; modelId: string } | null = null;
+	let isInFallbackWindow = false;
 
 	for (const entry of path) {
 		if (entry.type === "thinking_level_change") {
 			thinkingLevel = entry.thinkingLevel;
 		} else if (entry.type === "model_change") {
-			model = { provider: entry.provider, modelId: entry.modelId };
-		} else if (entry.type === "message" && entry.message.role === "assistant") {
+			if (entry.reason === "fallback") {
+				if (!isInFallbackWindow && entry.originalProvider && entry.originalModelId) {
+					model = { provider: entry.originalProvider, modelId: entry.originalModelId };
+				}
+				isInFallbackWindow = true;
+			} else if (entry.reason === "fallback-revert") {
+				isInFallbackWindow = false;
+			} else {
+				isInFallbackWindow = false;
+				model = { provider: entry.provider, modelId: entry.modelId };
+			}
+		} else if (entry.type === "message" && entry.message.role === "assistant" && !isInFallbackWindow) {
 			model = { provider: entry.message.provider, modelId: entry.message.model };
 		}
 	}
@@ -1077,7 +1093,13 @@ export class SessionManager {
 	}
 
 	/** Append a model change as child of current leaf, then advance leaf. Returns entry id. */
-	appendModelChange(provider: string, modelId: string): string {
+	appendModelChange(
+		provider: string,
+		modelId: string,
+		reason?: "fallback" | "fallback-revert",
+		originalProvider?: string,
+		originalModelId?: string,
+	): string {
 		const entry: ModelChangeEntry = {
 			type: "model_change",
 			id: generateId(this.byId),
@@ -1085,6 +1107,9 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			provider,
 			modelId,
+			reason,
+			originalProvider,
+			originalModelId,
 		};
 		this._appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -899,17 +899,18 @@ export class SettingsManager {
 			for (const [key, entries] of Object.entries(fallbackChains)) {
 				if (!Array.isArray(entries) || !entries.every((entry) => typeof entry === "string")) {
 					return {
-						modelFallback: typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
+						modelFallback:
+							typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
 						chains: {},
-						revertPolicy:
-							this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
+						revertPolicy: this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
 					};
 				}
 				chains[key] = [...entries];
 			}
 		}
 		return {
-			modelFallback: typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
+			modelFallback:
+				typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
 			chains,
 			revertPolicy: this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
 		};

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -38,6 +38,9 @@ export interface RetrySettings {
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
 	provider?: ProviderRetrySettings;
+	modelFallback?: boolean; // default: true
+	fallbackChains?: Record<string, string[]>;
+	fallbackRevertPolicy?: "cooldown-expiry" | "never"; // default: "cooldown-expiry"
 }
 
 export interface TerminalSettings {
@@ -168,7 +171,10 @@ export interface NeoDaemonSettings {
 	idleShutdownMs?: number;
 }
 
-/** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
+/**
+ * Merge settings one object level deep: project/overrides take precedence.
+ * Nested settings such as retry.fallbackChains replace wholesale per scope.
+ */
 function deepMergeSettings(base: Settings, overrides: Settings): Settings {
 	const result: Settings = { ...base };
 
@@ -880,6 +886,89 @@ export class SettingsManager {
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
 		};
+	}
+
+	getRetryFallbackSettings(): {
+		modelFallback: boolean;
+		chains: Readonly<Record<string, readonly string[]>>;
+		revertPolicy: "cooldown-expiry" | "never";
+	} {
+		const fallbackChains = this.settings.retry?.fallbackChains;
+		const chains: Record<string, readonly string[]> = {};
+		if (typeof fallbackChains === "object" && fallbackChains !== null && !Array.isArray(fallbackChains)) {
+			for (const [key, entries] of Object.entries(fallbackChains)) {
+				if (!Array.isArray(entries) || !entries.every((entry) => typeof entry === "string")) {
+					return {
+						modelFallback: typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
+						chains: {},
+						revertPolicy:
+							this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
+					};
+				}
+				chains[key] = [...entries];
+			}
+		}
+		return {
+			modelFallback: typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
+			chains,
+			revertPolicy: this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
+		};
+	}
+
+	setFallbackChain(key: string, entries: string[]): void {
+		if (!this.globalSettings.retry) {
+			this.globalSettings.retry = {};
+		}
+		const chains = this.getGlobalFallbackChains();
+		this.globalSettings.retry.fallbackChains = { ...chains, [key]: [...entries] };
+		this.markModified("retry", "fallbackChains");
+		this.save();
+	}
+
+	removeFallbackChain(key: string): void {
+		const chains = this.getGlobalFallbackChains();
+		if (!(key in chains)) {
+			return;
+		}
+		if (!this.globalSettings.retry) {
+			this.globalSettings.retry = {};
+		}
+		delete chains[key];
+		this.globalSettings.retry.fallbackChains = chains;
+		this.markModified("retry", "fallbackChains");
+		this.save();
+	}
+
+	setModelFallbackEnabled(enabled: boolean): void {
+		if (!this.globalSettings.retry) {
+			this.globalSettings.retry = {};
+		}
+		this.globalSettings.retry.modelFallback = enabled;
+		this.markModified("retry", "modelFallback");
+		this.save();
+	}
+
+	setFallbackRevertPolicy(policy: "cooldown-expiry" | "never"): void {
+		if (!this.globalSettings.retry) {
+			this.globalSettings.retry = {};
+		}
+		this.globalSettings.retry.fallbackRevertPolicy = policy;
+		this.markModified("retry", "fallbackRevertPolicy");
+		this.save();
+	}
+
+	private getGlobalFallbackChains(): Record<string, string[]> {
+		const fallbackChains = this.globalSettings.retry?.fallbackChains;
+		if (typeof fallbackChains !== "object" || fallbackChains === null || Array.isArray(fallbackChains)) {
+			return {};
+		}
+		const chains: Record<string, string[]> = {};
+		for (const [key, entries] of Object.entries(fallbackChains)) {
+			if (Array.isArray(entries) && entries.every((entry) => typeof entry === "string")) {
+				chains[key] = [...entries];
+			}
+		}
+		return chains;
 	}
 
 	getHttpIdleTimeoutMs(): number {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -888,6 +888,11 @@ export class SettingsManager {
 		};
 	}
 
+	/** Raw retry.fallbackChains value before sanitization, for startup validation warnings. */
+	getRawFallbackChains(): unknown {
+		return this.settings.retry?.fallbackChains;
+	}
+
 	getRetryFallbackSettings(): {
 		modelFallback: boolean;
 		chains: Readonly<Record<string, readonly string[]>>;

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## model fallback lifecycle notices (2026-07-20)
+
+### What changed
+
+- `interactive-mode.ts`: renders fallback apply, success, revert, and exhaustion notices; maintains a keyed `fallback`
+  footer status while a fallback model is active; and suppresses the retry spinner for immediate fallback retries.
+- Startup now shows fallback-chain validation warnings that were calculated by `AgentSession` when the session was created.
+
+### Why
+
+- A fallback model change is user-visible state. The chat and footer now make the active model and its lifecycle clear
+  without adding synthetic messages to model context.
+
+### Why extension system couldn't handle this
+
+- Retry lifecycle events and session-start validation state are owned by the core session and rendered through the
+  built-in interactive event handler.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-mode.ts` retry event switch and startup warning block.
+
 ## paced streaming tool argument previews (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -213,6 +213,14 @@ type ToolExecutionEndEvent = Extract<AgentSessionEvent, { type: "tool_execution_
 type ToolHookStatusStartEvent = Extract<AgentSessionEvent, { type: "tool_hook_status"; phase: "start" }>;
 type ToolHookStatusEvent = Extract<AgentSessionEvent, { type: "tool_hook_status" }>;
 
+type PendingZeroDelayRetryIndicator = {
+	fallbackApplied: boolean;
+};
+
+export function shouldShowRetryIndicator(delayMs: number, fallbackApplied: boolean): boolean {
+	return delayMs !== 0 || !fallbackApplied;
+}
+
 function getStreamingToolCallPartialJson(content: unknown): string | undefined {
 	if (typeof content !== "object" || content === null || !("partialJson" in content)) return undefined;
 	return typeof content.partialJson === "string" ? content.partialJson : undefined;
@@ -233,6 +241,7 @@ function isCustomSessionEntry(item: RenderSessionItem): item is Extract<SessionE
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 const DEFAULT_WORKING_STATUS_REFRESH_INTERVAL_MS = 600;
 const DEFAULT_WORKING_STATUS_MESSAGE_ANIMATION_INTERVAL_MS = 32;
+const FALLBACK_STATUS_KEY = "fallback";
 const RGB_FOREGROUND_PATTERN = /\x1b\[38;2;(\d+);(\d+);(\d+)m/;
 
 const DARK_DEFAULT_WORKING_TEXT_RGB: WorkingStatusRgbColor = { r: 229, g: 229, b: 231 };
@@ -504,6 +513,8 @@ export class InteractiveMode {
 
 	// Auto-retry state
 	private retryEscapeHandler?: () => void;
+	private fallbackAppliedBeforeRetryStart = false;
+	private pendingZeroDelayRetryIndicator: PendingZeroDelayRetryIndicator | undefined = undefined;
 
 	// Messages queued while compaction is running
 	private compactionQueuedMessages: CompactionQueuedMessage[] = [];
@@ -1024,6 +1035,10 @@ export class InteractiveMode {
 
 		if (modelFallbackMessage) {
 			this.showWarning(modelFallbackMessage);
+		}
+
+		for (const warning of this.session.fallbackValidationWarnings) {
+			this.showWarning(warning);
 		}
 
 		void this.maybeWarnAboutAnthropicSubscriptionAuth();
@@ -3554,20 +3569,58 @@ export class InteractiveMode {
 				break;
 			}
 
+			case "retry_fallback_applied": {
+				if (this.pendingZeroDelayRetryIndicator) {
+					this.pendingZeroDelayRetryIndicator.fallbackApplied = true;
+				} else {
+					this.fallbackAppliedBeforeRetryStart = true;
+				}
+				this.showWarning(`Model fallback: ${event.from} -> ${event.to} (${event.reason})`);
+				this.setExtensionStatus(FALLBACK_STATUS_KEY, `fallback: ${event.to}`);
+				break;
+			}
+
+			case "retry_fallback_succeeded":
+				this.showStatus(`Fallback model ${event.model} responded`);
+				break;
+
+			case "retry_fallback_reverted":
+				this.showStatus(`Reverted to ${event.to}`);
+				this.setExtensionStatus(FALLBACK_STATUS_KEY, undefined);
+				break;
+
+			case "retry_fallback_exhausted":
+				this.showError(`Fallback chain exhausted for ${event.chainKey}: ${event.lastError}`);
+				this.setExtensionStatus(FALLBACK_STATUS_KEY, undefined);
+				break;
+
 			case "auto_retry_start": {
 				// During retry waits, isStreaming flips false between attempts. The main Esc handler
 				// keys off both isStreaming and retryAttempt so we keep the same close-out path here;
 				// no separate retry-only handler is installed (the prior one only called
 				// session.abortRetry() and left queued steering messages stranded).
 				this.retryEscapeHandler = undefined;
-				this.showStatusIndicator(
-					new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs),
-				);
-				this.ui.requestRender();
+				const fallbackApplied = this.fallbackAppliedBeforeRetryStart;
+				this.fallbackAppliedBeforeRetryStart = false;
+				if (event.delayMs === 0) {
+					const pending = { fallbackApplied };
+					this.pendingZeroDelayRetryIndicator = pending;
+					queueMicrotask(() => {
+						if (this.pendingZeroDelayRetryIndicator !== pending) return;
+						this.pendingZeroDelayRetryIndicator = undefined;
+						if (shouldShowRetryIndicator(event.delayMs, pending.fallbackApplied)) {
+							this.showRetryStatusIndicator(event);
+						}
+					});
+				} else {
+					this.showRetryStatusIndicator(event);
+				}
 				break;
 			}
 
 			case "auto_retry_end": {
+				this.pendingZeroDelayRetryIndicator = undefined;
+				this.fallbackAppliedBeforeRetryStart = false;
 				// Restore escape handler
 				if (this.retryEscapeHandler) {
 					this.defaultEditor.onEscape = this.retryEscapeHandler;
@@ -3582,6 +3635,11 @@ export class InteractiveMode {
 				break;
 			}
 		}
+	}
+
+	private showRetryStatusIndicator(event: Extract<AgentSessionEvent, { type: "auto_retry_start" }>): void {
+		this.showStatusIndicator(new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs));
+		this.ui.requestRender();
 	}
 
 	/** Extract text content from a user message */

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1948,6 +1948,7 @@ export class InteractiveMode {
 			},
 			getContextUsage: () => this.session.getContextUsage(),
 			getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
+			sessionSettings: extensionRunner.createContext().sessionSettings,
 			compact: (options) => {
 				void (async () => {
 					try {

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Model-fallback event pass-through (2026-07-20)
+
+### What changed
+
+- `test/suite/rpc-fallback-events.test.ts` verifies that a faux-provider fallback run sends
+  `retry_fallback_applied`, `retry_fallback_succeeded`, and `retry_fallback_exhausted` as LF-delimited RPC JSONL events.
+
+### Why
+
+- RPC forwards complete `AgentSessionEvent` payloads without an event whitelist; this test preserves that contract as
+  model-fallback lifecycle events evolve.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: test-only coverage of the existing connection-handler event subscription.
+
 Fork tracker for `src/modes/rpc/` — this directory exists upstream, so every
 fork change here is a merge-conflict surface on upstream syncs.
 

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage, Context, Model, StreamOptions, Usage } from "@ea
 import { readFileSync } from "fs";
 import { join } from "path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 
 const { completeMock } = vi.hoisted(() => ({
 	completeMock: vi.fn(),
@@ -273,6 +274,7 @@ function createExtensionContext(overrides: Partial<ExtensionContext>): Extension
 		endCompaction: vi.fn(),
 		getSystemPrompt: () => "",
 		...overrides,
+		sessionSettings: overrides.sessionSettings ?? createInMemoryExtensionSessionSettings(),
 	};
 }
 

--- a/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
+++ b/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
@@ -7,7 +7,6 @@ import {
 	type UserMessage,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { estimateContextTokens } from "../../src/core/compaction/index.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import type {
@@ -20,6 +19,7 @@ import type {
 	ExtensionHandler,
 } from "../../src/core/extensions/index.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 
 const registrations: Array<{ unregister: () => void }> = [];
 

--- a/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
+++ b/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
@@ -7,6 +7,7 @@ import {
 	type UserMessage,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { estimateContextTokens } from "../../src/core/compaction/index.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import type {
@@ -107,6 +108,7 @@ function createContext(contextWindow: number, maxTokens = contextWindow, compact
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens: contextWindow + 1, contextWindow, percent: 1.01 }),
 		getCompactionSettings: () => ({ enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 }),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact,
 		getMessageRevision: () => 0,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),
@@ -156,6 +158,7 @@ function createCompactionContext(): ExtensionContext {
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens: 9_950, contextWindow: 10_000, percent: 99.5 }),
 		getCompactionSettings: () => ({ enabled: true, reserveTokens: 100, keepRecentTokens: 2_000 }),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact: vi.fn(),
 		getMessageRevision: () => 1,
 		applyCompaction,

--- a/packages/coding-agent/test/compaction/metadata-side-effects.test.ts
+++ b/packages/coding-agent/test/compaction/metadata-side-effects.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { type CompactionPreparation, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import type {
@@ -81,6 +82,7 @@ function createExtensionContext(entries: SessionEntry[]): ExtensionContext {
 		shutdown: vi.fn(),
 		getContextUsage: () => undefined,
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact: vi.fn(),
 		getMessageRevision: () => 1,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),

--- a/packages/coding-agent/test/compaction/metadata-side-effects.test.ts
+++ b/packages/coding-agent/test/compaction/metadata-side-effects.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { type CompactionPreparation, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import type {
@@ -11,6 +10,7 @@ import type {
 	SessionCompactEvent,
 } from "../../src/core/extensions/index.ts";
 import type { CompactionEntry, SessionEntry } from "../../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 
 const CHECKPOINT_CUSTOM_TYPE = "compaction.agent-checkpoint";
 const TODO_SNAPSHOT_CUSTOM_TYPE = "compaction.todo-snapshot";

--- a/packages/coding-agent/test/compaction/restoration-tracker.test.ts
+++ b/packages/coding-agent/test/compaction/restoration-tracker.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { type CompactionSettings, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import {
@@ -20,6 +19,7 @@ import type {
 	ToolCallEventResult,
 } from "../../src/core/extensions/index.ts";
 import type { SessionEntry } from "../../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 
 interface RestorationGateHarness {
 	toolCall: ExtensionHandler<ToolCallEvent, ToolCallEventResult>;

--- a/packages/coding-agent/test/compaction/restoration-tracker.test.ts
+++ b/packages/coding-agent/test/compaction/restoration-tracker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { type CompactionSettings, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import {
@@ -90,6 +91,7 @@ function createGateExtensionContext(settings: CompactionSettings): ExtensionCont
 		shutdown: vi.fn(),
 		getContextUsage: () => undefined,
 		getCompactionSettings: () => settings,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact: vi.fn(),
 		getMessageRevision: () => 1,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1,3 +1,4 @@
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 import { createModelRegistry } from "./model-runtime-test-utils.ts";
 /**
  * Tests for ExtensionRunner - conflict detection, error handling, tool wrapping.
@@ -147,6 +148,7 @@ describe("ExtensionRunner", () => {
 		getMessageRevision: () => 0,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		getSystemPrompt: () => "",
 		getLoadedHookSources: () => ({
 			agentDir: tempDir,

--- a/packages/coding-agent/test/footer-data-provider.test.ts
+++ b/packages/coding-agent/test/footer-data-provider.test.ts
@@ -118,6 +118,19 @@ describe("FooterDataProvider reftable branch detection", () => {
 		}
 	});
 
+	it("sets and clears the fallback footer status by key", () => {
+		const provider = new FooterDataProvider(tempDir);
+		try {
+			provider.setExtensionStatus("fallback", "fallback: faux/faux-2");
+			expect(Array.from(provider.getExtensionStatuses())).toEqual([["fallback", "fallback: faux/faux-2"]]);
+
+			provider.setExtensionStatus("fallback", undefined);
+			expect(Array.from(provider.getExtensionStatuses())).toEqual([]);
+		} finally {
+			provider.dispose();
+		}
+	});
+
 	it("uses HEAD directly in a regular repo from a nested directory", () => {
 		const repoDir = createPlainRepo(tempDir);
 		const nestedDir = join(repoDir, "src", "nested");

--- a/packages/coding-agent/test/helpers/extension-session-settings.ts
+++ b/packages/coding-agent/test/helpers/extension-session-settings.ts
@@ -1,0 +1,28 @@
+import type { ExtensionSessionSettings } from "../../src/core/extensions/types.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+/** Creates an isolated, in-memory settings facade for extension context fixtures. */
+export function createInMemoryExtensionSessionSettings(): ExtensionSessionSettings {
+	const settings = SettingsManager.inMemory();
+	return {
+		getRetryFallbackSettings: () => settings.getRetryFallbackSettings(),
+		setFallbackChain: async (key, entries) => {
+			settings.setFallbackChain(key, [...entries]);
+			await settings.flush();
+		},
+		removeFallbackChain: async (key) => {
+			settings.removeFallbackChain(key);
+			await settings.flush();
+		},
+		setModelFallbackEnabled: async (enabled) => {
+			settings.setModelFallbackEnabled(enabled);
+			await settings.flush();
+		},
+		setFallbackRevertPolicy: async (policy) => {
+			settings.setFallbackRevertPolicy(policy);
+			await settings.flush();
+		},
+		reload: () => settings.reload(),
+		getFallbackStatus: () => undefined,
+	};
+}

--- a/packages/coding-agent/test/interactive-mode-fallback.test.ts
+++ b/packages/coding-agent/test/interactive-mode-fallback.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+import { InteractiveMode, shouldShowRetryIndicator } from "../src/modes/interactive/interactive-mode.ts";
+
+type FallbackLifecycleFixture = {
+	isInitialized: true;
+	footer: { invalidate: () => void };
+	fallbackAppliedBeforeRetryStart: boolean;
+	showWarning: (message: string) => void;
+	showStatus: (message: string) => void;
+	showError: (message: string) => void;
+	setExtensionStatus: (key: string, text: string | undefined) => void;
+};
+
+type InteractiveEventHandler = {
+	handleEvent(this: FallbackLifecycleFixture, event: AgentSessionEvent): Promise<void>;
+};
+
+function createFixture(): FallbackLifecycleFixture {
+	return {
+		isInitialized: true,
+		footer: { invalidate: vi.fn() },
+		fallbackAppliedBeforeRetryStart: false,
+		showWarning: vi.fn(),
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		setExtensionStatus: vi.fn(),
+	};
+}
+
+const handleEvent = (InteractiveMode.prototype as unknown as InteractiveEventHandler).handleEvent;
+
+describe("InteractiveMode fallback lifecycle", () => {
+	it("renders fallback notices and maintains the fallback footer status", async () => {
+		const fixture = createFixture();
+
+		await handleEvent.call(fixture, {
+			type: "retry_fallback_applied",
+			from: "faux/faux-1",
+			to: "faux/faux-2",
+			chainKey: "faux/faux-1",
+			reason: "transient",
+		});
+		await handleEvent.call(fixture, {
+			type: "retry_fallback_succeeded",
+			model: "faux/faux-2",
+			chainKey: "faux/faux-1",
+		});
+		await handleEvent.call(fixture, {
+			type: "retry_fallback_reverted",
+			from: "faux/faux-2",
+			to: "faux/faux-1",
+		});
+		await handleEvent.call(fixture, {
+			type: "retry_fallback_exhausted",
+			chainKey: "faux/faux-1",
+			lastError: "all models unavailable",
+		});
+
+		expect(fixture.showWarning).toHaveBeenCalledWith("Model fallback: faux/faux-1 -> faux/faux-2 (transient)");
+		expect(fixture.showStatus).toHaveBeenNthCalledWith(1, "Fallback model faux/faux-2 responded");
+		expect(fixture.showStatus).toHaveBeenNthCalledWith(2, "Reverted to faux/faux-1");
+		expect(fixture.showError).toHaveBeenCalledWith(
+			"Fallback chain exhausted for faux/faux-1: all models unavailable",
+		);
+		expect(fixture.setExtensionStatus).toHaveBeenNthCalledWith(1, "fallback", "fallback: faux/faux-2");
+		expect(fixture.setExtensionStatus).toHaveBeenNthCalledWith(2, "fallback", undefined);
+		expect(fixture.setExtensionStatus).toHaveBeenNthCalledWith(3, "fallback", undefined);
+	});
+});
+
+describe("shouldShowRetryIndicator", () => {
+	it("suppresses only zero-delay retries that immediately apply a fallback", () => {
+		expect(shouldShowRetryIndicator(0, true)).toBe(false);
+		expect(shouldShowRetryIndicator(0, false)).toBe(true);
+		expect(shouldShowRetryIndicator(1, true)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -110,6 +110,7 @@ describe("InteractiveMode startup input", () => {
 			options: {},
 			session: {
 				modelRuntime: { getError: vi.fn(() => undefined) },
+				fallbackValidationWarnings: [],
 				prompt,
 			},
 			checkForPackageUpdates: vi.fn(async (): Promise<string[]> => []),

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -35,6 +35,7 @@ type RunContext = {
 	options: Record<string, never>;
 	session: {
 		modelRuntime: { getError: () => string | undefined };
+		fallbackValidationWarnings: readonly string[];
 		prompt: (text: string, options?: unknown) => Promise<void>;
 	};
 	checkForPackageUpdates: () => Promise<string[]>;

--- a/packages/coding-agent/test/permission/multi-mode.test.ts
+++ b/packages/coding-agent/test/permission/multi-mode.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import { createLocalEventEmitter } from "../../src/core/extensions/builtin/permission-system/events.ts";
 import { handleNoUI } from "../../src/core/extensions/builtin/permission-system/non-interactive.ts";
@@ -83,6 +84,7 @@ function createMockContext(overrides: { hasUI?: boolean; ui?: ExtensionUIContext
 		getMessageRevision: vi.fn().mockReturnValue(0),
 		applyCompaction: vi.fn().mockResolvedValue({ applied: false, reason: "rejected" }),
 		getCompactionSettings: vi.fn().mockReturnValue(DEFAULT_COMPACTION_SETTINGS),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		getSystemPrompt: vi.fn().mockReturnValue(""),
 	};
 }

--- a/packages/coding-agent/test/permission/multi-mode.test.ts
+++ b/packages/coding-agent/test/permission/multi-mode.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import { createLocalEventEmitter } from "../../src/core/extensions/builtin/permission-system/events.ts";
 import { handleNoUI } from "../../src/core/extensions/builtin/permission-system/non-interactive.ts";
@@ -12,6 +11,7 @@ import {
 	type Ruleset,
 } from "../../src/core/extensions/builtin/permission-system/types.ts";
 import type { ExtensionContext, ExtensionUIContext } from "../../src/core/extensions/types.ts";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
 
 // =============================================================================
 // Test Helpers

--- a/packages/coding-agent/test/session-manager/fallback-model-restore.test.ts
+++ b/packages/coding-agent/test/session-manager/fallback-model-restore.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	while (temporaryDirectories.length > 0) {
+		const directory = temporaryDirectories.pop();
+		if (directory) rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function openFallbackSession(reason: string): SessionManager {
+	const directory = join(tmpdir(), `fallback-model-restore-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	temporaryDirectories.push(directory);
+	mkdirSync(directory, { recursive: true });
+	const file = join(directory, "session.jsonl");
+	const entries = [
+		{ type: "session", version: 3, id: "fallback-restore", timestamp: "2026-07-20T00:00:00.000Z", cwd: directory },
+		{
+			type: "model_change",
+			id: "primary",
+			parentId: null,
+			timestamp: "2026-07-20T00:00:01.000Z",
+			provider: "primary",
+			modelId: "one",
+		},
+		{
+			type: "model_change",
+			id: "fallback",
+			parentId: "primary",
+			timestamp: "2026-07-20T00:00:02.000Z",
+			provider: "fallback",
+			modelId: "two",
+			reason,
+			originalProvider: "primary",
+			originalModelId: "one",
+		},
+		{
+			type: "message",
+			id: "fallback-answer",
+			parentId: "fallback",
+			timestamp: "2026-07-20T00:00:03.000Z",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "fallback response" }],
+				provider: "fallback",
+				model: "two",
+				api: "openai-completions",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+				stopReason: "stop",
+				timestamp: 1,
+			},
+		},
+	];
+	writeFileSync(file, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+	return SessionManager.open(file, directory);
+}
+
+describe("fallback model session restoration", () => {
+	it("uses the primary model when a trailing fallback window contains assistant messages", () => {
+		const session = openFallbackSession("fallback");
+
+		expect(session.buildSessionContext().model).toEqual({ provider: "primary", modelId: "one" });
+	});
+
+	it("tolerates unknown reason values in forward-compatible session files", () => {
+		const session = openFallbackSession("future-reason");
+
+		expect(session.buildSessionContext().model).toEqual({ provider: "fallback", modelId: "two" });
+	});
+});

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CONFIG_DIR_NAME } from "../src/config.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+const tempDirs: string[] = [];
+
+function createPaths(): { agentDir: string; projectDir: string } {
+	const root = mkdtempSync(join(tmpdir(), "senpi-retry-fallback-"));
+	tempDirs.push(root);
+	const agentDir = join(root, "agent");
+	const projectDir = join(root, "project");
+	mkdirSync(agentDir);
+	mkdirSync(join(projectDir, CONFIG_DIR_NAME), { recursive: true });
+	return { agentDir, projectDir };
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("SettingsManager retry fallback settings", () => {
+	it("returns defaults when fallback settings are unset or malformed", () => {
+		const { agentDir, projectDir } = createPaths();
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
+			modelFallback: true,
+			chains: {},
+			revertPolicy: "cooldown-expiry",
+		});
+
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				retry: {
+					modelFallback: "enabled",
+					fallbackChains: "not a chain map",
+					fallbackRevertPolicy: "later",
+				},
+			}),
+		);
+
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
+			modelFallback: true,
+			chains: {},
+			revertPolicy: "cooldown-expiry",
+		});
+	});
+
+	it("persists global fallback settings and a later instance reads them", async () => {
+		const { agentDir, projectDir } = createPaths();
+		const manager = SettingsManager.create(projectDir, agentDir);
+		manager.setModelFallbackEnabled(false);
+		manager.setFallbackRevertPolicy("never");
+		manager.setFallbackChain("anthropic/claude-fable-5", ["ccapi/kimi-k3:max"]);
+		await manager.flush();
+
+		const reloaded = SettingsManager.create(projectDir, agentDir);
+		expect(reloaded.getRetryFallbackSettings()).toEqual({
+			modelFallback: false,
+			chains: { "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"] },
+			revertPolicy: "never",
+		});
+
+		reloaded.removeFallbackChain("missing/model");
+		await reloaded.flush();
+		expect(existsSync(join(projectDir, CONFIG_DIR_NAME, "settings.json"))).toBe(false);
+
+		reloaded.removeFallbackChain("anthropic/claude-fable-5");
+		await reloaded.flush();
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual({});
+	});
+
+	it("uses project retry settings over global settings, replacing chains wholesale", () => {
+		const { agentDir, projectDir } = createPaths();
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				retry: {
+					modelFallback: false,
+					fallbackChains: { "anthropic/primary": ["ccapi/global"] },
+					fallbackRevertPolicy: "never",
+				},
+			}),
+		);
+		const projectSettingsDir = join(projectDir, CONFIG_DIR_NAME);
+		writeFileSync(
+			join(projectSettingsDir, "settings.json"),
+			JSON.stringify({ retry: { fallbackChains: { "anthropic/project": ["ccapi/project"] } } }),
+		);
+
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
+			modelFallback: false,
+			chains: { "anthropic/project": ["ccapi/project"] },
+			revertPolicy: "never",
+		});
+		expect(readFileSync(join(projectSettingsDir, "settings.json"), "utf-8")).toContain("anthropic/project");
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -14,7 +14,7 @@ describe("AgentSession model and extension characterization", () => {
 		}
 	});
 
-	it("setModel saves the model and emits model_select", async () => {
+	it("setModel preserves its model-selection persistence and lifecycle contract", async () => {
 		const modelEvents: string[] = [];
 		const harness = await createHarness({
 			models: [
@@ -32,9 +32,16 @@ describe("AgentSession model and extension characterization", () => {
 		harnesses.push(harness);
 		const nextModel = harness.getModel("faux-2")!;
 
+		const initialRevision = harness.session.getMessageRevision();
+		harness.session.setThinkingLevel("high");
 		await harness.session.setModel(nextModel);
 
 		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.session.getMessageRevision()).toBeGreaterThan(initialRevision);
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(harness.settingsManager.getDefaultProvider()).toBe(nextModel.provider);
+		expect(harness.settingsManager.getDefaultModel()).toBe(nextModel.id);
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("high");
 		expect(modelEvents).toEqual(["faux-1->faux-2:set"]);
 		expect(
 			harness.sessionManager

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -79,6 +79,7 @@ export interface HarnessOptions {
 	onPayload?: (payload: unknown) => void;
 	persistSession?: boolean;
 	autoTitleSessions?: boolean;
+	fallbackNow?: () => number;
 }
 
 export interface Harness {
@@ -211,6 +212,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		excludedToolNames: options.excludedToolNames,
 		extensionRunnerRef,
 		autoTitleSessions: options.autoTitleSessions,
+		fallbackNow: options.fallbackNow,
 	});
 
 	const events: AgentSessionEvent[] = [];

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -72,6 +72,7 @@ export interface HarnessOptions {
 	excludedToolNames?: string[];
 	resourceLoader?: ResourceLoader;
 	extensionFactories?: Array<InlineExtension | CreateTestExtensionsResultInput>;
+	extensionFlagValues?: Map<string, boolean | string>;
 	withConfiguredAuth?: boolean;
 	upstreamModelId?: string;
 	serviceTier?: "auto" | "flex" | "priority";
@@ -93,6 +94,7 @@ export interface Harness {
 	appendResponses: (responses: FauxResponseStep[]) => void;
 	getPendingResponseCount: () => number;
 	events: AgentSessionEvent[];
+	getExtensionRunner(): ExtensionRunner;
 	eventsOfType<T extends AgentSessionEvent["type"]>(type: T): Extract<AgentSessionEvent, { type: T }>[];
 	tempDir: string;
 	cleanup: () => void;
@@ -188,6 +190,11 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	const extensionsResult = options.extensionFactories
 		? await createTestExtensionsResult(options.extensionFactories, tempDir)
 		: undefined;
+	if (extensionsResult && options.extensionFlagValues) {
+		for (const [name, value] of options.extensionFlagValues) {
+			extensionsResult.runtime.flagValues.set(name, value);
+		}
+	}
 	const resourceLoader =
 		options.resourceLoader ?? createTestResourceLoader(extensionsResult ? { extensionsResult } : undefined);
 
@@ -223,6 +230,11 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		appendResponses: fauxProvider.appendResponses,
 		getPendingResponseCount: fauxProvider.getPendingResponseCount,
 		events,
+		getExtensionRunner() {
+			const runner = extensionRunnerRef.current;
+			if (!runner) throw new Error("Extension runner was not initialized");
+			return runner;
+		},
 		eventsOfType<T extends AgentSessionEvent["type"]>(type: T) {
 			return events.filter((event): event is Extract<AgentSessionEvent, { type: T }> => event.type === type);
 		},

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -204,6 +204,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		sessionManager,
 		settingsManager,
 		cwd: tempDir,
+		agentDir: join(tempDir, "agent"),
 		modelRuntime: getModelRuntime(modelRegistry),
 		resourceLoader,
 		baseToolsOverride: toolMap,

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import modelFallbackExtension, {
+	isModelFallbackDisabled,
+} from "../../src/core/extensions/builtin/model-fallback/index.ts";
+import type { ExtensionAPI, ExtensionCommandContext } from "../../src/core/extensions/types.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+const dirs: string[] = [];
+let previousAgentDir: string | undefined;
+const primary = model("anthropic", "claude-fable-5", true);
+const fallback = model("ccapi", "kimi-k3", true);
+
+type Command = {
+	description?: string;
+	argumentHint?: string;
+	handler(args: string, ctx: ExtensionCommandContext): Promise<void>;
+};
+
+function model(provider: string, id: string, reasoning: boolean): Model<Api> {
+	return {
+		provider,
+		id,
+		name: id,
+		api: "faux",
+		reasoning,
+		thinkingLevelMap: { max: "max" },
+		input: ["text"],
+		contextWindow: 1,
+		maxTokens: 1,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	};
+}
+
+function harness(): Map<string, Command> {
+	const commands = new Map<string, Command>();
+	const pi = {
+		registerCommand: (name: string, command: Command) => commands.set(name, command),
+		registerFlag: () => {},
+		getFlag: () => false,
+		on: () => {},
+	} as unknown as ExtensionAPI;
+	modelFallbackExtension(pi);
+	return commands;
+}
+
+async function context(dir: string, notices: string[], choices: string[] = []): Promise<ExtensionCommandContext> {
+	const settings = SettingsManager.create(dir);
+	return {
+		cwd: dir,
+		hasUI: choices.length > 0,
+		modelRegistry: {
+			getAll: () => [primary, fallback],
+			getAvailable: () => [primary, fallback],
+			find: (provider: string, id: string) =>
+				[primary, fallback].find((item) => item.provider === provider && item.id === id),
+		},
+		sessionSettings: {
+			getRetryFallbackSettings: () => settings.getRetryFallbackSettings(),
+			setFallbackChain: async (key, entries) => {
+				settings.setFallbackChain(key, [...entries]);
+				await settings.flush();
+			},
+			removeFallbackChain: async (key) => {
+				settings.removeFallbackChain(key);
+				await settings.flush();
+			},
+			setModelFallbackEnabled: async (enabled) => {
+				settings.setModelFallbackEnabled(enabled);
+				await settings.flush();
+			},
+			setFallbackRevertPolicy: async (policy) => {
+				settings.setFallbackRevertPolicy(policy);
+				await settings.flush();
+			},
+			reload: () => settings.reload(),
+			getFallbackStatus: () => undefined,
+		},
+		ui: { notify: (message: string) => notices.push(message), select: async () => choices.shift() },
+	} as unknown as ExtensionCommandContext;
+}
+
+describe("model fallback builtin command", () => {
+	beforeEach(async () => {
+		previousAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+		const agentDir = await mkdtemp(join(tmpdir(), "senpi-fallback-agent-"));
+		dirs.push(agentDir);
+		process.env.SENPI_CODING_AGENT_DIR = agentDir;
+	});
+	afterEach(async () => {
+		if (previousAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+		else process.env.SENPI_CODING_AGENT_DIR = previousAgentDir;
+		await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+	});
+
+	it("registers /fallback with its quick-set hint", () => {
+		const command = harness().get("fallback");
+		expect(command?.argumentHint).toBe("[target [fallback1 fallback2 ...]]");
+		expect(command?.description).toContain("fallback");
+	});
+
+	it("quick-set validates and persists a chain visible after a session-side reload", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
+		dirs.push(dir);
+		const notices: string[] = [];
+		const command = harness().get("fallback");
+		const sessionSideSettings = SettingsManager.create(dir);
+		await command?.handler("anthropic/claude-fable-5 ccapi/kimi-k3:max", await context(dir, notices));
+		await sessionSideSettings.reload();
+		expect(sessionSideSettings.getRetryFallbackSettings().chains).toEqual({
+			"anthropic/claude-fable-5": ["ccapi/kimi-k3:max"],
+		});
+		expect(notices).toContain("Fallback chain saved for anthropic/claude-fable-5.");
+	});
+
+	it("rejects an invalid quick-set without writing settings", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
+		dirs.push(dir);
+		const notices: string[] = [];
+		await harness()
+			.get("fallback")
+			?.handler("bogus/model nope", await context(dir, notices));
+		expect(SettingsManager.create(dir).getRetryFallbackSettings().chains).toEqual({});
+		expect(notices.join("\n")).toContain("not a valid or known model selector");
+	});
+
+	it("maps the CLI flag and environment escape hatch to a disabled run override", () => {
+		expect(isModelFallbackDisabled(true, {})).toBe(true);
+		expect(isModelFallbackDisabled(false, { SENPI_NO_FALLBACK: "1" })).toBe(true);
+		expect(isModelFallbackDisabled(false, {})).toBe(false);
+	});
+
+	it("handles a headless menu invocation cleanly", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
+		dirs.push(dir);
+		const notices: string[] = [];
+		await harness()
+			.get("fallback")
+			?.handler("", await context(dir, notices));
+		expect(notices).toContain("Fallback menu requires interactive UI. Use /fallback <target> <fallback...>.");
+	});
+});

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -189,9 +189,7 @@ describe("model fallback builtin command", () => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
 		dirs.push(dir);
 		const notices: string[] = [];
-		await (await harness())
-			.get("fallback")
-			?.handler("bogus/model nope", await context(dir, notices));
+		await (await harness()).get("fallback")?.handler("bogus/model nope", await context(dir, notices));
 		expect(SettingsManager.create(dir).getRetryFallbackSettings().chains).toEqual({});
 		expect(notices.join("\n")).toContain("not a valid or known model selector");
 	});

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -3,11 +3,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import { createEventBus } from "../../src/core/event-bus.ts";
 import modelFallbackExtension, {
 	isModelFallbackDisabled,
 } from "../../src/core/extensions/builtin/model-fallback/index.ts";
-import type { ExtensionAPI, ExtensionCommandContext } from "../../src/core/extensions/types.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import type { ExtensionCommandContext, ExtensionUIContext } from "../../src/core/extensions/types.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
 import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { theme } from "../../src/modes/interactive/theme/theme.ts";
 
 const dirs: string[] = [];
 let previousAgentDir: string | undefined;
@@ -26,6 +33,7 @@ function model(provider: string, id: string, reasoning: boolean): Model<Api> {
 		id,
 		name: id,
 		api: "faux",
+		baseUrl: "https://models.example.test/v1",
 		reasoning,
 		thinkingLevelMap: { max: "max" },
 		input: ["text"],
@@ -35,52 +43,113 @@ function model(provider: string, id: string, reasoning: boolean): Model<Api> {
 	};
 }
 
-function harness(): Map<string, Command> {
-	const commands = new Map<string, Command>();
-	const pi = {
-		registerCommand: (name: string, command: Command) => commands.set(name, command),
-		registerFlag: () => {},
-		getFlag: () => false,
-		on: () => {},
-	} as unknown as ExtensionAPI;
-	modelFallbackExtension(pi);
-	return commands;
+async function harness(): Promise<Map<string, Command>> {
+	const extension = await loadExtensionFromFactory(
+		modelFallbackExtension,
+		process.cwd(),
+		createEventBus(),
+		createExtensionRuntime(),
+	);
+	return new Map(extension.commands);
+}
+
+function createUi(notices: string[], choices: string[]): ExtensionUIContext {
+	return {
+		select: async () => choices.shift(),
+		confirm: async () => false,
+		input: async () => undefined,
+		notify: (message: string) => notices.push(message),
+		onTerminalInput: () => () => {},
+		setStatus: () => {},
+		setWorkingMessage: () => {},
+		setWorkingVisible: () => {},
+		setWorkingIndicator: () => {},
+		setHiddenThinkingLabel: () => {},
+		setWidget: () => {},
+		setFooter: () => {},
+		setHeader: () => {},
+		setTitle: () => {},
+		custom: async <T>(): Promise<T> => {
+			throw new Error("Fallback command tests do not render custom UI");
+		},
+		pasteToEditor: () => {},
+		setEditorText: () => {},
+		getEditorText: () => "",
+		editor: async () => undefined,
+		addAutocompleteProvider: () => {},
+		setEditorComponent: () => {},
+		getEditorComponent: () => undefined,
+		theme,
+		getAllThemes: () => [],
+		getTheme: () => undefined,
+		setTheme: () => ({ success: false, error: "UI not available" }),
+		getToolsExpanded: () => false,
+		setToolsExpanded: () => {},
+	};
+}
+
+function createModelRegistry(): ModelRegistry {
+	const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory());
+	modelRegistry.getAll = () => [primary, fallback];
+	modelRegistry.getAvailable = () => [primary, fallback];
+	modelRegistry.find = (provider: string, id: string) =>
+		[primary, fallback].find((registeredModel) => registeredModel.provider === provider && registeredModel.id === id);
+	return modelRegistry;
 }
 
 async function context(dir: string, notices: string[], choices: string[] = []): Promise<ExtensionCommandContext> {
 	const settings = SettingsManager.create(dir);
+	const modelRegistry = createModelRegistry();
 	return {
-		cwd: dir,
+		ui: createUi(notices, choices),
+		mode: choices.length > 0 ? "tui" : "print",
 		hasUI: choices.length > 0,
-		modelRegistry: {
-			getAll: () => [primary, fallback],
-			getAvailable: () => [primary, fallback],
-			find: (provider: string, id: string) =>
-				[primary, fallback].find((item) => item.provider === provider && item.id === id),
-		},
+		cwd: dir,
+		sessionManager: SessionManager.inMemory(),
+		modelRegistry,
+		model: undefined,
+		serviceTier: undefined,
+		isIdle: () => true,
+		isProjectTrusted: () => true,
+		signal: undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
 		sessionSettings: {
 			getRetryFallbackSettings: () => settings.getRetryFallbackSettings(),
-			setFallbackChain: async (key, entries) => {
+			setFallbackChain: async (key: string, entries: readonly string[]) => {
 				settings.setFallbackChain(key, [...entries]);
 				await settings.flush();
 			},
-			removeFallbackChain: async (key) => {
+			removeFallbackChain: async (key: string) => {
 				settings.removeFallbackChain(key);
 				await settings.flush();
 			},
-			setModelFallbackEnabled: async (enabled) => {
+			setModelFallbackEnabled: async (enabled: boolean) => {
 				settings.setModelFallbackEnabled(enabled);
 				await settings.flush();
 			},
-			setFallbackRevertPolicy: async (policy) => {
+			setFallbackRevertPolicy: async (policy: "cooldown-expiry" | "never") => {
 				settings.setFallbackRevertPolicy(policy);
 				await settings.flush();
 			},
 			reload: () => settings.reload(),
 			getFallbackStatus: () => undefined,
 		},
-		ui: { notify: (message: string) => notices.push(message), select: async () => choices.shift() },
-	} as unknown as ExtensionCommandContext;
+		compact: () => {},
+		getMessageRevision: () => 0,
+		applyCompaction: async () => ({ applied: false, reason: "rejected" }),
+		getSystemPrompt: () => "",
+		getSystemPromptOptions: () => ({ cwd: dir }),
+		waitForIdle: async () => {},
+		newSession: async () => ({ cancelled: false }),
+		fork: async () => ({ cancelled: false }),
+		navigateTree: async () => ({ cancelled: false }),
+		switchSession: async () => ({ cancelled: false }),
+		reload: async () => {},
+	};
 }
 
 describe("model fallback builtin command", () => {
@@ -96,8 +165,8 @@ describe("model fallback builtin command", () => {
 		await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 	});
 
-	it("registers /fallback with its quick-set hint", () => {
-		const command = harness().get("fallback");
+	it("registers /fallback with its quick-set hint", async () => {
+		const command = (await harness()).get("fallback");
 		expect(command?.argumentHint).toBe("[target [fallback1 fallback2 ...]]");
 		expect(command?.description).toContain("fallback");
 	});
@@ -106,7 +175,7 @@ describe("model fallback builtin command", () => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
 		dirs.push(dir);
 		const notices: string[] = [];
-		const command = harness().get("fallback");
+		const command = (await harness()).get("fallback");
 		const sessionSideSettings = SettingsManager.create(dir);
 		await command?.handler("anthropic/claude-fable-5 ccapi/kimi-k3:max", await context(dir, notices));
 		await sessionSideSettings.reload();
@@ -120,7 +189,7 @@ describe("model fallback builtin command", () => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
 		dirs.push(dir);
 		const notices: string[] = [];
-		await harness()
+		await (await harness())
 			.get("fallback")
 			?.handler("bogus/model nope", await context(dir, notices));
 		expect(SettingsManager.create(dir).getRetryFallbackSettings().chains).toEqual({});
@@ -137,9 +206,7 @@ describe("model fallback builtin command", () => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
 		dirs.push(dir);
 		const notices: string[] = [];
-		await harness()
-			.get("fallback")
-			?.handler("", await context(dir, notices));
+		await (await harness()).get("fallback")?.handler("", await context(dir, notices));
 		expect(notices).toContain("Fallback menu requires interactive UI. Use /fallback <target> <fallback...>.");
 	});
 });

--- a/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
@@ -1,0 +1,82 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import modelFallbackExtension from "../../src/core/extensions/builtin/model-fallback/index.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+function getFallbackCommand(harness: Harness) {
+	const command = harness.getExtensionRunner().getCommand("fallback");
+	if (!command) throw new Error("Fallback command was not registered");
+	return command;
+}
+
+describe("model fallback host wiring", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("makes a quick-set chain visible to the running retry engine", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1 } },
+			extensionFactories: [{ factory: modelFallbackExtension }],
+		});
+		harnesses.push(harness);
+		const context = harness.getExtensionRunner().createCommandContext();
+
+		expect(harness.settingsManager.getRetryFallbackSettings().chains).toEqual({});
+		await getFallbackCommand(harness).handler(`${primary} ${fallback}`, context);
+		expect(harness.settingsManager.getRetryFallbackSettings().chains).toEqual({ [primary]: [fallback] });
+
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("recovered"),
+		]);
+		await harness.session.prompt("retry with the chain written above");
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([{ from: primary, to: fallback }]);
+	});
+
+	it("applies the flag and environment escape hatches as session-only overrides", async () => {
+		const flagHarness = await createHarness({
+			settings: { retry: { modelFallback: true } },
+			extensionFactories: [{ factory: modelFallbackExtension }],
+			extensionFlagValues: new Map([["no-model-fallback", true]]),
+		});
+		harnesses.push(flagHarness);
+		expect(flagHarness.settingsManager.getRetryFallbackSettings().modelFallback).toBe(false);
+
+		const previous = process.env.SENPI_NO_FALLBACK;
+		process.env.SENPI_NO_FALLBACK = "1";
+		try {
+			const environmentHarness = await createHarness({ settings: { retry: { modelFallback: true } } });
+			harnesses.push(environmentHarness);
+			expect(environmentHarness.settingsManager.getRetryFallbackSettings().modelFallback).toBe(false);
+		} finally {
+			if (previous === undefined) delete process.env.SENPI_NO_FALLBACK;
+			else process.env.SENPI_NO_FALLBACK = previous;
+		}
+	});
+
+	it("exposes active retry state through the live menu accessor", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("recovered"),
+		]);
+		await harness.session.prompt("create an active fallback");
+
+		expect(harness.getExtensionRunner().createContext().sessionSettings.getFallbackStatus()).toEqual({
+			active: true,
+			currentModel: fallback,
+			originalSelector: primary,
+			pinned: false,
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -1,0 +1,103 @@
+import { getModel } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	baseSelector,
+	candidatesAfter,
+	canonicalizeFallbackChains,
+	formatSelector,
+	parseFallbackSelector,
+	resolveChainKey,
+} from "../../src/core/retry-fallback/chains.ts";
+
+const models = [
+	getModel("openai", "gpt-5.4"),
+	getModel("anthropic", "claude-sonnet-4-5"),
+	{
+		...getModel("openai", "gpt-5.4"),
+		provider: "openrouter",
+		id: "qwen/qwen3-coder:exacto",
+		name: "Qwen3 Coder Exacto",
+	},
+];
+
+describe("fallback chain selectors", () => {
+	it("parses case-insensitive selectors and preserves colon-containing model ids", () => {
+		expect(parseFallbackSelector("OpenAI/gpt-5.4:HIGH", models)).toMatchObject({
+		provider: "openai",
+		id: "gpt-5.4",
+		thinkingLevel: "high",
+	});
+		expect(parseFallbackSelector("OPENROUTER/qwen/qwen3-coder:exacto:MAX", models)).toMatchObject({
+		provider: "openrouter",
+		id: "qwen/qwen3-coder:exacto",
+		thinkingLevel: "max",
+	});
+	});
+
+	it("canonicalizes aliases to a dated-only registry model", () => {
+		const datedOnlyModels = [
+			{
+				...getModel("anthropic", "claude-sonnet-4-5"),
+				id: "claude-sonnet-4-5-20250929",
+			},
+		];
+
+		expect(parseFallbackSelector("anthropic/claude-sonnet-4-5", datedOnlyModels)).toMatchObject({
+			provider: "anthropic",
+			id: "claude-sonnet-4-5-20250929",
+		});
+		expect(parseFallbackSelector("anthropic/claude-sonnet-4-5:high", datedOnlyModels)).toMatchObject({
+			provider: "anthropic",
+			id: "claude-sonnet-4-5-20250929",
+			thinkingLevel: "high",
+		});
+	});
+
+	it("rejects malformed, partial, role, wildcard, unknown, and unsupported selectors", () => {
+		for (const selector of ["", "gpt-5.4", "default", "openai/*", "openai/gpt-5.4:invalid", "missing/gpt-5.4"])
+			expect(parseFallbackSelector(selector, models)).toBeUndefined();
+	});
+
+	it("formats canonical selectors", () => {
+		const model = getModel("openai", "gpt-5.4");
+		expect(formatSelector(model)).toBe("openai/gpt-5.4");
+		expect(formatSelector(model, "high")).toBe("openai/gpt-5.4:high");
+		expect(baseSelector({ provider: "openai", id: "gpt-5.4" })).toBe("openai/gpt-5.4");
+	});
+
+	it("canonicalizes chain keys and entries at load", () => {
+		expect(
+		canonicalizeFallbackChains(
+			{
+				"OpenAI/gpt-5.4:HIGH": ["ANTHROPIC/claude-sonnet-4-5:MAX"],
+				default: ["anthropic/claude-sonnet-4-5"],
+			},
+			models,
+		),
+		).toEqual({ "openai/gpt-5.4:high": ["anthropic/claude-sonnet-4-5:max"] });
+	});
+
+	it("prefers an exact thinking key, then the base key", () => {
+		const chains = {
+			"openai/gpt-5.4": ["anthropic/claude-sonnet-4-5"],
+			"openai/gpt-5.4:high": ["openrouter/qwen/qwen3-coder:exacto:max"],
+		};
+		const model = getModel("openai", "gpt-5.4");
+
+		expect(resolveChainKey(model, "high", chains)).toBe("openai/gpt-5.4:high");
+		expect(resolveChainKey(model, "max", chains)).toBe("openai/gpt-5.4");
+	});
+
+	it("returns candidates after the current entry, using base matching when thinking differs", () => {
+		const entries = [
+			"anthropic/claude-sonnet-4-5:max",
+			"openrouter/qwen/qwen3-coder:exacto",
+			"openai/gpt-5.4",
+		];
+
+		expect(candidatesAfter(entries, "openai/primary:high")).toEqual(entries);
+		expect(candidatesAfter(entries, "openai/gpt-5.4:high")).toEqual([]);
+		expect(candidatesAfter(entries, "anthropic/claude-sonnet-4-5:high")).toEqual(entries.slice(1));
+		expect(candidatesAfter(entries, "unknown/model")).toEqual(entries);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -23,15 +23,15 @@ const models = [
 describe("fallback chain selectors", () => {
 	it("parses case-insensitive selectors and preserves colon-containing model ids", () => {
 		expect(parseFallbackSelector("OpenAI/gpt-5.4:HIGH", models)).toMatchObject({
-		provider: "openai",
-		id: "gpt-5.4",
-		thinkingLevel: "high",
-	});
+			provider: "openai",
+			id: "gpt-5.4",
+			thinkingLevel: "high",
+		});
 		expect(parseFallbackSelector("OPENROUTER/qwen/qwen3-coder:exacto:MAX", models)).toMatchObject({
-		provider: "openrouter",
-		id: "qwen/qwen3-coder:exacto",
-		thinkingLevel: "max",
-	});
+			provider: "openrouter",
+			id: "qwen/qwen3-coder:exacto",
+			thinkingLevel: "max",
+		});
 	});
 
 	it("canonicalizes aliases to a dated-only registry model", () => {
@@ -67,13 +67,13 @@ describe("fallback chain selectors", () => {
 
 	it("canonicalizes chain keys and entries at load", () => {
 		expect(
-		canonicalizeFallbackChains(
-			{
-				"OpenAI/gpt-5.4:HIGH": ["ANTHROPIC/claude-sonnet-4-5:MAX"],
-				default: ["anthropic/claude-sonnet-4-5"],
-			},
-			models,
-		),
+			canonicalizeFallbackChains(
+				{
+					"OpenAI/gpt-5.4:HIGH": ["ANTHROPIC/claude-sonnet-4-5:MAX"],
+					default: ["anthropic/claude-sonnet-4-5"],
+				},
+				models,
+			),
 		).toEqual({ "openai/gpt-5.4:high": ["anthropic/claude-sonnet-4-5:max"] });
 	});
 
@@ -89,11 +89,7 @@ describe("fallback chain selectors", () => {
 	});
 
 	it("returns candidates after the current entry, using base matching when thinking differs", () => {
-		const entries = [
-			"anthropic/claude-sonnet-4-5:max",
-			"openrouter/qwen/qwen3-coder:exacto",
-			"openai/gpt-5.4",
-		];
+		const entries = ["anthropic/claude-sonnet-4-5:max", "openrouter/qwen/qwen3-coder:exacto", "openai/gpt-5.4"];
 
 		expect(candidatesAfter(entries, "openai/primary:high")).toEqual(entries);
 		expect(candidatesAfter(entries, "openai/gpt-5.4:high")).toEqual([]);

--- a/packages/coding-agent/test/suite/retry-fallback-cooldown.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-cooldown.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { SelectorCooldowns } from "../../src/core/retry-fallback/cooldown.ts";
+
+describe("SelectorCooldowns", () => {
+	it("prefers a positive provider retry-after duration", () => {
+		let time = 1_000;
+		const cooldowns = new SelectorCooldowns(() => time);
+
+		cooldowns.note("anthropic/claude", { retryAfterMs: 5_000, errorMessage: "quota exceeded" });
+
+		time += 4_999;
+		expect(cooldowns.isSuppressed("anthropic/claude")).toBe(true);
+		time += 1;
+		expect(cooldowns.isSuppressed("anthropic/claude")).toBe(false);
+	});
+
+	it.each([
+		["usage limits", "usage limit reached", 30 * 60_000],
+		["quota", "insufficient_quota", 30 * 60_000],
+		["billing", "Billing limit reached", 30 * 60_000],
+		["rate limit", "rate limit exceeded", 30_000],
+		["HTTP 429", "HTTP 429", 30_000],
+		["too many requests", "Too Many Requests", 30_000],
+		["overloaded", "service overloaded", 45_000],
+		["capacity", "capacity unavailable", 45_000],
+		["5xx", "HTTP 503", 20_000],
+		["server", "server error", 20_000],
+		["internal", "internal error", 20_000],
+		["unknown", undefined, 5 * 60_000],
+		["empty", "", 5 * 60_000],
+	])("uses the %s duration class", (_name, errorMessage, durationMs) => {
+		let time = 0;
+		const cooldowns = new SelectorCooldowns(
+			() => time,
+			() => 0,
+		);
+
+		cooldowns.note("openai/gpt", { errorMessage });
+
+		time = durationMs - 1;
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(true);
+		time = durationMs;
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(false);
+	});
+
+	it("adds deterministic jitter of up to 30 seconds for overloaded capacity", () => {
+		let time = 0;
+		const cooldowns = new SelectorCooldowns(
+			() => time,
+			() => 1,
+		);
+
+		cooldowns.note("openai/gpt", { errorMessage: "capacity exhausted" });
+
+		time = 74_999;
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(true);
+		time = 75_000;
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(false);
+	});
+
+	it("evicts expired selectors lazily at the expiry boundary", () => {
+		let time = 0;
+		const cooldowns = new SelectorCooldowns(() => time);
+
+		cooldowns.note("openai/gpt", { retryAfterMs: 100 });
+		time = 99;
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(true);
+		time = 100;
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(false);
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(false);
+	});
+
+	it("clears one selector or every selector", () => {
+		const cooldowns = new SelectorCooldowns(() => 0);
+		cooldowns.note("anthropic/claude", { retryAfterMs: 100 });
+		cooldowns.note("openai/gpt", { retryAfterMs: 100 });
+
+		cooldowns.clear("anthropic/claude");
+		expect(cooldowns.isSuppressed("anthropic/claude")).toBe(false);
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(true);
+
+		cooldowns.clearAll();
+		expect(cooldowns.isSuppressed("openai/gpt")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -1,0 +1,358 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+type EventTranscriptEntry =
+  | { type: "message_start" | "message_end"; role: string }
+  | { type: "message_update"; update: string }
+  | { type: "agent_end"; willRetry: boolean }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | {
+      type: "auto_retry_end";
+      success: boolean;
+      attempt: number;
+      finalError?: string;
+    }
+  | { type: string };
+
+function retryTranscript(events: Harness["events"]): EventTranscriptEntry[] {
+  return events.map((event) => {
+    switch (event.type) {
+      case "message_start":
+      case "message_end":
+        return { type: event.type, role: event.message.role };
+      case "message_update":
+        return { type: event.type, update: event.assistantMessageEvent.type };
+      case "agent_end":
+        return { type: event.type, willRetry: event.willRetry };
+      case "auto_retry_start":
+        return {
+          type: event.type,
+          attempt: event.attempt,
+          maxAttempts: event.maxAttempts,
+          delayMs: event.delayMs,
+          errorMessage: event.errorMessage,
+        };
+      case "auto_retry_end":
+        return {
+          type: event.type,
+          success: event.success,
+          attempt: event.attempt,
+          ...(event.finalError === undefined
+            ? {}
+            : { finalError: event.finalError }),
+        };
+      default:
+        return { type: event.type };
+    }
+  });
+}
+
+describe("retry fallback engine", () => {
+  const harnesses: Harness[] = [];
+  afterEach(() => {
+    while (harnesses.length) harnesses.pop()?.cleanup();
+  });
+
+  it("switches immediately to a configured fallback and reports success", async () => {
+    const harness = await createHarness({
+      models: [{ id: "faux-1" }, { id: "faux-2" }],
+      settings: {
+        retry: {
+          enabled: true,
+          baseDelayMs: 100,
+          fallbackChains: { [primary]: [fallback] },
+        },
+      },
+    });
+    harnesses.push(harness);
+    harness.setResponses([
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      fauxAssistantMessage("fallback answer"),
+    ]);
+
+    await harness.session.prompt("hello");
+
+    expect(
+      harness.eventsOfType("auto_retry_start").map((event) => event.delayMs),
+    ).toEqual([0]);
+    expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+      { from: primary, to: fallback, chainKey: primary },
+    ]);
+    expect(harness.eventsOfType("retry_fallback_succeeded")).toMatchObject([
+      { model: fallback, chainKey: primary },
+    ]);
+    expect(harness.faux.state.callCount).toBe(2);
+    expect(
+      harness.eventsOfType("agent_end").map((event) => event.willRetry),
+    ).toEqual([true, false]);
+  });
+
+  it("removes only the failed assistant while preserving state across a fallback switch", async () => {
+    const snapshotTool: AgentTool = {
+      name: "snapshot",
+      label: "Snapshot",
+      description: "Provides stable tool state for fallback assertions.",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "snapshot" }],
+        details: {},
+      }),
+    };
+    const harness = await createHarness({
+      models: [{ id: "faux-1" }, { id: "faux-2" }],
+      tools: [snapshotTool],
+      settings: {
+        retry: {
+          enabled: true,
+          baseDelayMs: 1,
+          fallbackChains: { [primary]: [fallback] },
+        },
+      },
+    });
+    harnesses.push(harness);
+    harness.setResponses([
+      fauxAssistantMessage("first"),
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      fauxAssistantMessage("recovered"),
+    ]);
+    await harness.session.prompt("first turn");
+
+    let stateBeforeFailedAssistant:
+      | typeof harness.session.state.messages
+      | undefined;
+    let systemPromptBeforeFailedAssistant: string | undefined;
+    let toolsBeforeFailedAssistant: unknown;
+    let fallbackRequestMessages: unknown;
+    let stateAtFallbackRequest:
+      | typeof harness.session.state.messages
+      | undefined;
+    harness.session.subscribe((event) => {
+      if (event.type === "auto_retry_start") {
+        stateBeforeFailedAssistant = structuredClone(
+          harness.session.state.messages,
+        );
+        systemPromptBeforeFailedAssistant = harness.session.state.systemPrompt;
+        toolsBeforeFailedAssistant = JSON.parse(
+          JSON.stringify(harness.session.state.tools),
+        );
+      }
+    });
+    harness.setResponses([
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      (context) => {
+        fallbackRequestMessages = structuredClone(context.messages);
+        stateAtFallbackRequest = structuredClone(
+          harness.session.state.messages,
+        );
+        return fauxAssistantMessage("recovered");
+      },
+    ]);
+
+    await harness.session.prompt("second turn");
+
+    if (
+      !stateBeforeFailedAssistant ||
+      systemPromptBeforeFailedAssistant === undefined ||
+      !toolsBeforeFailedAssistant
+    ) {
+      throw new Error("Missing pre-error fallback snapshot");
+    }
+    expect(stateAtFallbackRequest).toEqual(
+      stateBeforeFailedAssistant.slice(0, -1),
+    );
+    expect(fallbackRequestMessages).toEqual(
+      stateBeforeFailedAssistant.slice(0, -1),
+    );
+    expect(harness.session.state.systemPrompt).toBe(
+      systemPromptBeforeFailedAssistant,
+    );
+    expect(JSON.stringify(harness.session.state.systemPrompt)).toBe(
+      JSON.stringify(systemPromptBeforeFailedAssistant),
+    );
+    expect(JSON.stringify(harness.session.state.tools)).toBe(
+      JSON.stringify(toolsBeforeFailedAssistant),
+    );
+  });
+
+  it("submits a complete fallback request rather than reusing primary continuation state", async () => {
+    const harness = await createHarness({
+      models: [{ id: "faux-1" }, { id: "faux-2" }],
+      settings: {
+        retry: {
+          enabled: true,
+          baseDelayMs: 1,
+          fallbackChains: { [primary]: [fallback] },
+        },
+      },
+    });
+    harnesses.push(harness);
+    harness.setResponses([
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      fauxAssistantMessage("recovered"),
+    ]);
+
+    await harness.session.prompt("full fallback request");
+
+    const fallbackRequest = harness.faux.getCallLog()[1];
+    if (!fallbackRequest) throw new Error("Missing fallback provider request");
+    expect(fallbackRequest.modelId).toBe("faux-2");
+    expect(fallbackRequest.context.messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: [{ type: "text", text: "full fallback request" }],
+      }),
+    ]);
+    expect(fallbackRequest.context.messages).toHaveLength(1);
+    expect(fallbackRequest.options).not.toHaveProperty("previous_response_id");
+  });
+
+  it("cancels a configured fallback retry before it can continue", async () => {
+    const harness = await createHarness({
+      models: [{ id: "faux-1" }, { id: "faux-2" }],
+      settings: {
+        retry: {
+          enabled: true,
+          baseDelayMs: 100,
+          fallbackChains: { [primary]: [fallback] },
+        },
+      },
+    });
+    harnesses.push(harness);
+    harness.setResponses([
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      fauxAssistantMessage("zombie fallback response"),
+    ]);
+    let abortPromise: Promise<void> | undefined;
+    const sawFallbackRetry = new Promise<void>((resolve) => {
+      const unsubscribe = harness.session.subscribe((event) => {
+        if (event.type === "auto_retry_start" && event.delayMs === 0) {
+          unsubscribe();
+          abortPromise = harness.session.abort();
+          resolve();
+        }
+      });
+    });
+
+    const promptPromise = harness.session.prompt("abort fallback retry");
+    await sawFallbackRetry;
+    if (!abortPromise) throw new Error("Fallback retry did not trigger abort");
+    await abortPromise;
+    await promptPromise;
+
+    expect(harness.session.isIdle).toBe(true);
+    expect(harness.session.isRetrying).toBe(false);
+    expect(harness.session.retryAttempt).toBe(0);
+    expect(harness.faux.state.callCount).toBe(1);
+    expect(harness.getPendingResponseCount()).toBe(1);
+    expect(harness.eventsOfType("auto_retry_end")).toMatchObject([
+      { success: false, finalError: "Retry cancelled" },
+    ]);
+  });
+
+  it("keeps the byte-for-byte no-chain retry event contract", async () => {
+    const harness = await createHarness({
+      settings: { retry: { enabled: true, baseDelayMs: 1 } },
+    });
+    harnesses.push(harness);
+    harness.setResponses([
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      fauxAssistantMessage("recovered"),
+    ]);
+
+    await harness.session.prompt("hello");
+
+    expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+    expect(retryTranscript(harness.events)).toEqual([
+      { type: "agent_start" },
+      { type: "turn_start" },
+      { type: "message_start", role: "user" },
+      { type: "message_end", role: "user" },
+      { type: "message_start", role: "assistant" },
+      { type: "message_update", update: "text_start" },
+      { type: "message_update", update: "text_delta" },
+      { type: "message_update", update: "text_end" },
+      { type: "message_end", role: "assistant" },
+      { type: "turn_end" },
+      { type: "agent_end", willRetry: true },
+      {
+        type: "auto_retry_start",
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 1,
+        errorMessage: "overloaded_error",
+      },
+      { type: "agent_start" },
+      { type: "turn_start" },
+      { type: "message_start", role: "assistant" },
+      { type: "message_update", update: "text_start" },
+      { type: "message_update", update: "text_delta" },
+      { type: "message_update", update: "text_end" },
+      { type: "message_end", role: "assistant" },
+      { type: "auto_retry_end", success: true, attempt: 1 },
+      { type: "turn_end" },
+      { type: "agent_end", willRetry: false },
+      { type: "agent_settled" },
+    ]);
+  });
+
+  it("settles through the existing failure path when no fallback can be selected", async () => {
+    const harness = await createHarness({
+      settings: {
+        retry: {
+          enabled: true,
+          maxRetries: 1,
+          baseDelayMs: 1,
+          fallbackChains: { [primary]: [] },
+        },
+      },
+    });
+    harnesses.push(harness);
+    harness.setResponses([
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+      fauxAssistantMessage("", {
+        stopReason: "error",
+        errorMessage: "overloaded_error",
+      }),
+    ]);
+
+    await harness.session.prompt("hello");
+
+    expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+    expect(
+      harness.eventsOfType("auto_retry_end").map((event) => event.success),
+    ).toEqual([false]);
+  });
+});

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -8,351 +8,321 @@ const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
 
 type EventTranscriptEntry =
-  | { type: "message_start" | "message_end"; role: string }
-  | { type: "message_update"; update: string }
-  | { type: "agent_end"; willRetry: boolean }
-  | {
-      type: "auto_retry_start";
-      attempt: number;
-      maxAttempts: number;
-      delayMs: number;
-      errorMessage: string;
-    }
-  | {
-      type: "auto_retry_end";
-      success: boolean;
-      attempt: number;
-      finalError?: string;
-    }
-  | { type: string };
+	| { type: "message_start" | "message_end"; role: string }
+	| { type: "message_update"; update: string }
+	| { type: "agent_end"; willRetry: boolean }
+	| {
+			type: "auto_retry_start";
+			attempt: number;
+			maxAttempts: number;
+			delayMs: number;
+			errorMessage: string;
+	  }
+	| {
+			type: "auto_retry_end";
+			success: boolean;
+			attempt: number;
+			finalError?: string;
+	  }
+	| { type: string };
 
 function retryTranscript(events: Harness["events"]): EventTranscriptEntry[] {
-  return events.map((event) => {
-    switch (event.type) {
-      case "message_start":
-      case "message_end":
-        return { type: event.type, role: event.message.role };
-      case "message_update":
-        return { type: event.type, update: event.assistantMessageEvent.type };
-      case "agent_end":
-        return { type: event.type, willRetry: event.willRetry };
-      case "auto_retry_start":
-        return {
-          type: event.type,
-          attempt: event.attempt,
-          maxAttempts: event.maxAttempts,
-          delayMs: event.delayMs,
-          errorMessage: event.errorMessage,
-        };
-      case "auto_retry_end":
-        return {
-          type: event.type,
-          success: event.success,
-          attempt: event.attempt,
-          ...(event.finalError === undefined
-            ? {}
-            : { finalError: event.finalError }),
-        };
-      default:
-        return { type: event.type };
-    }
-  });
+	return events.map((event) => {
+		switch (event.type) {
+			case "message_start":
+			case "message_end":
+				return { type: event.type, role: event.message.role };
+			case "message_update":
+				return { type: event.type, update: event.assistantMessageEvent.type };
+			case "agent_end":
+				return { type: event.type, willRetry: event.willRetry };
+			case "auto_retry_start":
+				return {
+					type: event.type,
+					attempt: event.attempt,
+					maxAttempts: event.maxAttempts,
+					delayMs: event.delayMs,
+					errorMessage: event.errorMessage,
+				};
+			case "auto_retry_end":
+				return {
+					type: event.type,
+					success: event.success,
+					attempt: event.attempt,
+					...(event.finalError === undefined ? {} : { finalError: event.finalError }),
+				};
+			default:
+				return { type: event.type };
+		}
+	});
 }
 
 describe("retry fallback engine", () => {
-  const harnesses: Harness[] = [];
-  afterEach(() => {
-    while (harnesses.length) harnesses.pop()?.cleanup();
-  });
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length) harnesses.pop()?.cleanup();
+	});
 
-  it("switches immediately to a configured fallback and reports success", async () => {
-    const harness = await createHarness({
-      models: [{ id: "faux-1" }, { id: "faux-2" }],
-      settings: {
-        retry: {
-          enabled: true,
-          baseDelayMs: 100,
-          fallbackChains: { [primary]: [fallback] },
-        },
-      },
-    });
-    harnesses.push(harness);
-    harness.setResponses([
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      fauxAssistantMessage("fallback answer"),
-    ]);
+	it("switches immediately to a configured fallback and reports success", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 100,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			fauxAssistantMessage("fallback answer"),
+		]);
 
-    await harness.session.prompt("hello");
+		await harness.session.prompt("hello");
 
-    expect(
-      harness.eventsOfType("auto_retry_start").map((event) => event.delayMs),
-    ).toEqual([0]);
-    expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
-      { from: primary, to: fallback, chainKey: primary },
-    ]);
-    expect(harness.eventsOfType("retry_fallback_succeeded")).toMatchObject([
-      { model: fallback, chainKey: primary },
-    ]);
-    expect(harness.faux.state.callCount).toBe(2);
-    expect(
-      harness.eventsOfType("agent_end").map((event) => event.willRetry),
-    ).toEqual([true, false]);
-  });
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([0]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, chainKey: primary },
+		]);
+		expect(harness.eventsOfType("retry_fallback_succeeded")).toMatchObject([{ model: fallback, chainKey: primary }]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, false]);
+	});
 
-  it("removes only the failed assistant while preserving state across a fallback switch", async () => {
-    const snapshotTool: AgentTool = {
-      name: "snapshot",
-      label: "Snapshot",
-      description: "Provides stable tool state for fallback assertions.",
-      parameters: Type.Object({}),
-      execute: async () => ({
-        content: [{ type: "text", text: "snapshot" }],
-        details: {},
-      }),
-    };
-    const harness = await createHarness({
-      models: [{ id: "faux-1" }, { id: "faux-2" }],
-      tools: [snapshotTool],
-      settings: {
-        retry: {
-          enabled: true,
-          baseDelayMs: 1,
-          fallbackChains: { [primary]: [fallback] },
-        },
-      },
-    });
-    harnesses.push(harness);
-    harness.setResponses([
-      fauxAssistantMessage("first"),
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      fauxAssistantMessage("recovered"),
-    ]);
-    await harness.session.prompt("first turn");
+	it("removes only the failed assistant while preserving state across a fallback switch", async () => {
+		const snapshotTool: AgentTool = {
+			name: "snapshot",
+			label: "Snapshot",
+			description: "Provides stable tool state for fallback assertions.",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text", text: "snapshot" }],
+				details: {},
+			}),
+		};
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			tools: [snapshotTool],
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("first"),
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			fauxAssistantMessage("recovered"),
+		]);
+		await harness.session.prompt("first turn");
 
-    let stateBeforeFailedAssistant:
-      | typeof harness.session.state.messages
-      | undefined;
-    let systemPromptBeforeFailedAssistant: string | undefined;
-    let toolsBeforeFailedAssistant: unknown;
-    let fallbackRequestMessages: unknown;
-    let stateAtFallbackRequest:
-      | typeof harness.session.state.messages
-      | undefined;
-    harness.session.subscribe((event) => {
-      if (event.type === "auto_retry_start") {
-        stateBeforeFailedAssistant = structuredClone(
-          harness.session.state.messages,
-        );
-        systemPromptBeforeFailedAssistant = harness.session.state.systemPrompt;
-        toolsBeforeFailedAssistant = JSON.parse(
-          JSON.stringify(harness.session.state.tools),
-        );
-      }
-    });
-    harness.setResponses([
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      (context) => {
-        fallbackRequestMessages = structuredClone(context.messages);
-        stateAtFallbackRequest = structuredClone(
-          harness.session.state.messages,
-        );
-        return fauxAssistantMessage("recovered");
-      },
-    ]);
+		let stateBeforeFailedAssistant: typeof harness.session.state.messages | undefined;
+		let systemPromptBeforeFailedAssistant: string | undefined;
+		let toolsBeforeFailedAssistant: unknown;
+		let fallbackRequestMessages: unknown;
+		let stateAtFallbackRequest: typeof harness.session.state.messages | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") {
+				stateBeforeFailedAssistant = structuredClone(harness.session.state.messages);
+				systemPromptBeforeFailedAssistant = harness.session.state.systemPrompt;
+				toolsBeforeFailedAssistant = JSON.parse(JSON.stringify(harness.session.state.tools));
+			}
+		});
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			(context) => {
+				fallbackRequestMessages = structuredClone(context.messages);
+				stateAtFallbackRequest = structuredClone(harness.session.state.messages);
+				return fauxAssistantMessage("recovered");
+			},
+		]);
 
-    await harness.session.prompt("second turn");
+		await harness.session.prompt("second turn");
 
-    if (
-      !stateBeforeFailedAssistant ||
-      systemPromptBeforeFailedAssistant === undefined ||
-      !toolsBeforeFailedAssistant
-    ) {
-      throw new Error("Missing pre-error fallback snapshot");
-    }
-    expect(stateAtFallbackRequest).toEqual(
-      stateBeforeFailedAssistant.slice(0, -1),
-    );
-    expect(fallbackRequestMessages).toEqual(
-      stateBeforeFailedAssistant.slice(0, -1),
-    );
-    expect(harness.session.state.systemPrompt).toBe(
-      systemPromptBeforeFailedAssistant,
-    );
-    expect(JSON.stringify(harness.session.state.systemPrompt)).toBe(
-      JSON.stringify(systemPromptBeforeFailedAssistant),
-    );
-    expect(JSON.stringify(harness.session.state.tools)).toBe(
-      JSON.stringify(toolsBeforeFailedAssistant),
-    );
-  });
+		if (
+			!stateBeforeFailedAssistant ||
+			systemPromptBeforeFailedAssistant === undefined ||
+			!toolsBeforeFailedAssistant
+		) {
+			throw new Error("Missing pre-error fallback snapshot");
+		}
+		expect(stateAtFallbackRequest).toEqual(stateBeforeFailedAssistant.slice(0, -1));
+		expect(fallbackRequestMessages).toEqual(stateBeforeFailedAssistant.slice(0, -1));
+		expect(harness.session.state.systemPrompt).toBe(systemPromptBeforeFailedAssistant);
+		expect(JSON.stringify(harness.session.state.systemPrompt)).toBe(
+			JSON.stringify(systemPromptBeforeFailedAssistant),
+		);
+		expect(JSON.stringify(harness.session.state.tools)).toBe(JSON.stringify(toolsBeforeFailedAssistant));
+	});
 
-  it("submits a complete fallback request rather than reusing primary continuation state", async () => {
-    const harness = await createHarness({
-      models: [{ id: "faux-1" }, { id: "faux-2" }],
-      settings: {
-        retry: {
-          enabled: true,
-          baseDelayMs: 1,
-          fallbackChains: { [primary]: [fallback] },
-        },
-      },
-    });
-    harnesses.push(harness);
-    harness.setResponses([
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      fauxAssistantMessage("recovered"),
-    ]);
+	it("submits a complete fallback request rather than reusing primary continuation state", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			fauxAssistantMessage("recovered"),
+		]);
 
-    await harness.session.prompt("full fallback request");
+		await harness.session.prompt("full fallback request");
 
-    const fallbackRequest = harness.faux.getCallLog()[1];
-    if (!fallbackRequest) throw new Error("Missing fallback provider request");
-    expect(fallbackRequest.modelId).toBe("faux-2");
-    expect(fallbackRequest.context.messages).toEqual([
-      expect.objectContaining({
-        role: "user",
-        content: [{ type: "text", text: "full fallback request" }],
-      }),
-    ]);
-    expect(fallbackRequest.context.messages).toHaveLength(1);
-    expect(fallbackRequest.options).not.toHaveProperty("previous_response_id");
-  });
+		const fallbackRequest = harness.faux.getCallLog()[1];
+		if (!fallbackRequest) throw new Error("Missing fallback provider request");
+		expect(fallbackRequest.modelId).toBe("faux-2");
+		expect(fallbackRequest.context.messages).toEqual([
+			expect.objectContaining({
+				role: "user",
+				content: [{ type: "text", text: "full fallback request" }],
+			}),
+		]);
+		expect(fallbackRequest.context.messages).toHaveLength(1);
+		expect(fallbackRequest.options).not.toHaveProperty("previous_response_id");
+	});
 
-  it("cancels a configured fallback retry before it can continue", async () => {
-    const harness = await createHarness({
-      models: [{ id: "faux-1" }, { id: "faux-2" }],
-      settings: {
-        retry: {
-          enabled: true,
-          baseDelayMs: 100,
-          fallbackChains: { [primary]: [fallback] },
-        },
-      },
-    });
-    harnesses.push(harness);
-    harness.setResponses([
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      fauxAssistantMessage("zombie fallback response"),
-    ]);
-    let abortPromise: Promise<void> | undefined;
-    const sawFallbackRetry = new Promise<void>((resolve) => {
-      const unsubscribe = harness.session.subscribe((event) => {
-        if (event.type === "auto_retry_start" && event.delayMs === 0) {
-          unsubscribe();
-          abortPromise = harness.session.abort();
-          resolve();
-        }
-      });
-    });
+	it("cancels a configured fallback retry before it can continue", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 100,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			fauxAssistantMessage("zombie fallback response"),
+		]);
+		let abortPromise: Promise<void> | undefined;
+		const sawFallbackRetry = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "auto_retry_start" && event.delayMs === 0) {
+					unsubscribe();
+					abortPromise = harness.session.abort();
+					resolve();
+				}
+			});
+		});
 
-    const promptPromise = harness.session.prompt("abort fallback retry");
-    await sawFallbackRetry;
-    if (!abortPromise) throw new Error("Fallback retry did not trigger abort");
-    await abortPromise;
-    await promptPromise;
+		const promptPromise = harness.session.prompt("abort fallback retry");
+		await sawFallbackRetry;
+		if (!abortPromise) throw new Error("Fallback retry did not trigger abort");
+		await abortPromise;
+		await promptPromise;
 
-    expect(harness.session.isIdle).toBe(true);
-    expect(harness.session.isRetrying).toBe(false);
-    expect(harness.session.retryAttempt).toBe(0);
-    expect(harness.faux.state.callCount).toBe(1);
-    expect(harness.getPendingResponseCount()).toBe(1);
-    expect(harness.eventsOfType("auto_retry_end")).toMatchObject([
-      { success: false, finalError: "Retry cancelled" },
-    ]);
-  });
+		expect(harness.session.isIdle).toBe(true);
+		expect(harness.session.isRetrying).toBe(false);
+		expect(harness.session.retryAttempt).toBe(0);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.getPendingResponseCount()).toBe(1);
+		expect(harness.eventsOfType("auto_retry_end")).toMatchObject([{ success: false, finalError: "Retry cancelled" }]);
+	});
 
-  it("keeps the byte-for-byte no-chain retry event contract", async () => {
-    const harness = await createHarness({
-      settings: { retry: { enabled: true, baseDelayMs: 1 } },
-    });
-    harnesses.push(harness);
-    harness.setResponses([
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      fauxAssistantMessage("recovered"),
-    ]);
+	it("keeps the byte-for-byte no-chain retry event contract", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			fauxAssistantMessage("recovered"),
+		]);
 
-    await harness.session.prompt("hello");
+		await harness.session.prompt("hello");
 
-    expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
-    expect(retryTranscript(harness.events)).toEqual([
-      { type: "agent_start" },
-      { type: "turn_start" },
-      { type: "message_start", role: "user" },
-      { type: "message_end", role: "user" },
-      { type: "message_start", role: "assistant" },
-      { type: "message_update", update: "text_start" },
-      { type: "message_update", update: "text_delta" },
-      { type: "message_update", update: "text_end" },
-      { type: "message_end", role: "assistant" },
-      { type: "turn_end" },
-      { type: "agent_end", willRetry: true },
-      {
-        type: "auto_retry_start",
-        attempt: 1,
-        maxAttempts: 3,
-        delayMs: 1,
-        errorMessage: "overloaded_error",
-      },
-      { type: "agent_start" },
-      { type: "turn_start" },
-      { type: "message_start", role: "assistant" },
-      { type: "message_update", update: "text_start" },
-      { type: "message_update", update: "text_delta" },
-      { type: "message_update", update: "text_end" },
-      { type: "message_end", role: "assistant" },
-      { type: "auto_retry_end", success: true, attempt: 1 },
-      { type: "turn_end" },
-      { type: "agent_end", willRetry: false },
-      { type: "agent_settled" },
-    ]);
-  });
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(retryTranscript(harness.events)).toEqual([
+			{ type: "agent_start" },
+			{ type: "turn_start" },
+			{ type: "message_start", role: "user" },
+			{ type: "message_end", role: "user" },
+			{ type: "message_start", role: "assistant" },
+			{ type: "message_update", update: "text_start" },
+			{ type: "message_update", update: "text_delta" },
+			{ type: "message_update", update: "text_end" },
+			{ type: "message_end", role: "assistant" },
+			{ type: "turn_end" },
+			{ type: "agent_end", willRetry: true },
+			{
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 1,
+				errorMessage: "overloaded_error",
+			},
+			{ type: "agent_start" },
+			{ type: "turn_start" },
+			{ type: "message_start", role: "assistant" },
+			{ type: "message_update", update: "text_start" },
+			{ type: "message_update", update: "text_delta" },
+			{ type: "message_update", update: "text_end" },
+			{ type: "message_end", role: "assistant" },
+			{ type: "auto_retry_end", success: true, attempt: 1 },
+			{ type: "turn_end" },
+			{ type: "agent_end", willRetry: false },
+			{ type: "agent_settled" },
+		]);
+	});
 
-  it("settles through the existing failure path when no fallback can be selected", async () => {
-    const harness = await createHarness({
-      settings: {
-        retry: {
-          enabled: true,
-          maxRetries: 1,
-          baseDelayMs: 1,
-          fallbackChains: { [primary]: [] },
-        },
-      },
-    });
-    harnesses.push(harness);
-    harness.setResponses([
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-      fauxAssistantMessage("", {
-        stopReason: "error",
-        errorMessage: "overloaded_error",
-      }),
-    ]);
+	it("settles through the existing failure path when no fallback can be selected", async () => {
+		const harness = await createHarness({
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "overloaded_error",
+			}),
+		]);
 
-    await harness.session.prompt("hello");
+		await harness.session.prompt("hello");
 
-    expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
-    expect(
-      harness.eventsOfType("auto_retry_end").map((event) => event.success),
-    ).toEqual([false]);
-  });
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+	});
 });

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -1,0 +1,126 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SelectorCooldowns } from "../../src/core/retry-fallback/cooldown.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+const insufficientQuota = "billing error: insufficient_quota";
+
+type RetryFallbackInternals = {
+	_retryFallback?: { deps?: { cooldowns?: SelectorCooldowns } };
+};
+
+function cooldownsFor(harness: Harness): SelectorCooldowns {
+	const cooldowns = (harness.session as unknown as RetryFallbackInternals)._retryFallback?.deps?.cooldowns;
+	if (!cooldowns) throw new Error("Expected retry fallback cooldowns");
+	return cooldowns;
+}
+
+describe("retry fallback hard errors", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("switches immediately after an insufficient-quota error and suppresses the failed selector", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 60_000, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: insufficientQuota }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(
+			harness.events
+				.filter(
+					(event) =>
+						event.type === "retry_fallback_applied" ||
+						event.type === "auto_retry_start" ||
+						event.type === "retry_fallback_succeeded",
+				)
+				.map((event) => {
+					if (event.type === "retry_fallback_applied") return `${event.type}:${event.reason}`;
+					if (event.type === "auto_retry_start") return `${event.type}:${event.delayMs}`;
+					return event.type;
+				}),
+		).toEqual(["retry_fallback_applied:hard-error", "auto_retry_start:0", "retry_fallback_succeeded"]);
+		expect(cooldownsFor(harness).isSuppressed(primary)).toBe(true);
+	});
+
+	it("settles an insufficient-quota error without a configured fallback", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: insufficientQuota })]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.session.state.messages.at(-1)).toMatchObject({ errorMessage: insufficientQuota });
+	});
+
+	it("does not replay a hard error that contains a tool call", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("unsafe", {})], {
+				stopReason: "error",
+				errorMessage: insufficientQuota,
+			}),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+
+	it("does not treat context overflow as a hard-error fallback", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "Error Code context_too_large: Your input exceeds the context window of this model.",
+			}),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+
+	it("does not treat an aborted response as a hard-error fallback", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request aborted by user." }),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+import type { Settings } from "../../src/core/settings-manager.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+const overloaded = () => fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" });
+
+function fallbackLogLines(harness: Harness): Array<Record<string, unknown>> {
+	const logPath = join(harness.tempDir, "agent", "logs", "fallback.log");
+	return readFileSync(logPath, "utf8")
+		.split("\n")
+		.filter((line) => line.trim().length > 0)
+		.map((line) => {
+			const parsed: Record<string, unknown> = JSON.parse(line);
+			return parsed;
+		});
+}
+
+describe("retry fallback hardening", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length) harnesses.pop()?.cleanup();
+	});
+
+	it("logs a startup validation warning for malformed raw chain config", async () => {
+		const retrySettings: Partial<Settings> = JSON.parse(
+			`{"retry":{"enabled":true,"fallbackChains":{"${primary}":"not-an-array"}}}`,
+		);
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: retrySettings,
+		});
+		harnesses.push(harness);
+
+		const warnings = fallbackLogLines(harness).filter((line) => line.event === "validation_warning");
+		expect(warnings.length).toBeGreaterThan(0);
+	});
+
+	it("refuses a self-referential-only chain and logs the exhaustion decision", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, baseDelayMs: 1, maxRetries: 1, fallbackChains: { [primary]: [primary] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), overloaded()]);
+
+		await harness.session.prompt("self chain");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(0);
+		expect(harness.session.model?.id).toBe("faux-1");
+		const events = fallbackLogLines(harness).map((line) => line.event);
+		expect(events).toContain("candidates_exhausted");
+	});
+
+	it("skips a self-referential entry and lands on the next candidate", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [primary, fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("self first");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(1);
+		expect(harness.faux.getCallLog()[1]?.modelId).toBe("faux-2");
+	});
+
+	it("logs the no-chain decision for an unconfigured model", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, maxRetries: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), fauxAssistantMessage("recovered")]);
+
+		await harness.session.prompt("no chain here");
+
+		const events = fallbackLogLines(harness).map((line) => line.event);
+		expect(events).toContain("no_chain");
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
@@ -75,6 +75,25 @@ describe("retry fallback hardening", () => {
 		expect(harness.faux.getCallLog()[1]?.modelId).toBe("faux-2");
 	});
 
+
+	it("submits a clean full request for a responses-API fallback candidate", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			api: "openai-responses",
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("responses api fallback");
+
+		const fallbackRequest = harness.faux.getCallLog()[1];
+		if (!fallbackRequest) throw new Error("missing fallback request");
+		expect(fallbackRequest.modelId).toBe("faux-2");
+		expect(fallbackRequest.options).not.toHaveProperty("previous_response_id");
+		expect(JSON.stringify(fallbackRequest.context.messages)).toContain("responses api fallback");
+	});
+
 	it("logs the no-chain decision for an unconfigured model", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],

--- a/packages/coding-agent/test/suite/retry-fallback-log.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-log.test.ts
@@ -1,0 +1,98 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFallbackLogger } from "../../src/core/retry-fallback/log.ts";
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-retry-fallback-log-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("retry fallback logger", () => {
+	it("writes parseable 0600 NDJSON and safely serializes malformed data", () => {
+		const agentDir = createTempDir();
+		const circular: { count?: bigint; self?: unknown } = { count: 1n };
+		circular.self = circular;
+		const logger = createFallbackLogger(agentDir);
+
+		expect(() =>
+			logger.debug("candidate_skipped", {
+				selector: "ccapi/kimi-k3:max",
+				error: circular,
+				missing: undefined,
+			}),
+		).not.toThrow();
+
+		const logPath = join(agentDir, "logs", "fallback.log");
+		const entry = JSON.parse(readFileSync(logPath, "utf8")) as Record<string, unknown>;
+		expect(entry).toMatchObject({
+			level: "debug",
+			event: "candidate_skipped",
+			selector: "ccapi/kimi-k3:max",
+			error: { count: "1", self: "[Circular]" },
+		});
+		expect(entry.ts).toEqual(expect.any(String));
+		expect(entry).not.toHaveProperty("missing");
+		expect(statSync(logPath).mode & 0o777).toBe(0o600);
+	});
+
+	it("truncates external error text and omits credential-bearing fields", () => {
+		const agentDir = createTempDir();
+		const logger = createFallbackLogger(agentDir);
+		const longError = "x".repeat(240);
+
+		logger.warn("candidate_failed", {
+			error: longError,
+			errorMessage: "Authorization: Bearer should-not-appear",
+			headers: { authorization: "Bearer should-not-appear" },
+			apiKey: "should-not-appear",
+			env: { SECRET: "should-not-appear" },
+		});
+
+		const text = readFileSync(join(agentDir, "logs", "fallback.log"), "utf8");
+		const entry = JSON.parse(text) as Record<string, unknown>;
+		expect(entry.error).toBe(`${"x".repeat(197)}...`);
+		expect(entry.errorMessage).toBe("Authorization: Bearer [redacted]");
+		expect(text).not.toContain("should-not-appear");
+		expect(entry).not.toHaveProperty("headers");
+		expect(entry).not.toHaveProperty("apiKey");
+		expect(entry).not.toHaveProperty("env");
+	});
+
+	it("rotates once the next line would exceed the configured cap", () => {
+		const agentDir = createTempDir();
+		const logger = createFallbackLogger(agentDir, { maxBytes: 150 });
+
+		logger.info("first", { selector: "a/one" });
+		logger.info("second", { selector: "b/two" });
+
+		const logPath = join(agentDir, "logs", "fallback.log");
+		expect(existsSync(`${logPath}.1`)).toBe(true);
+		expect(readFileSync(`${logPath}.1`, "utf8")).toContain('"event":"first"');
+		expect(readFileSync(logPath, "utf8")).toContain('"event":"second"');
+	});
+
+	it("never throws and reports a filesystem failure only once", () => {
+		const agentDir = createTempDir();
+		writeFileSync(join(agentDir, "logs"), "not a directory");
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logger = createFallbackLogger(agentDir);
+
+		expect(() => {
+			logger.info("write_failed", { selector: "a/one" });
+			logger.warn("still_safe", { selector: "b/two" });
+		}).not.toThrow();
+		expect(error).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-log.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-log.test.ts
@@ -35,7 +35,7 @@ describe("retry fallback logger", () => {
 		).not.toThrow();
 
 		const logPath = join(agentDir, "logs", "fallback.log");
-		const entry = JSON.parse(readFileSync(logPath, "utf8")) as Record<string, unknown>;
+		const entry: Record<string, unknown> = JSON.parse(readFileSync(logPath, "utf8"));
 		expect(entry).toMatchObject({
 			level: "debug",
 			event: "candidate_skipped",
@@ -61,7 +61,7 @@ describe("retry fallback logger", () => {
 		});
 
 		const text = readFileSync(join(agentDir, "logs", "fallback.log"), "utf8");
-		const entry = JSON.parse(text) as Record<string, unknown>;
+		const entry: Record<string, unknown> = JSON.parse(text);
 		expect(entry.error).toBe(`${"x".repeat(197)}...`);
 		expect(entry.errorMessage).toBe("Authorization: Bearer [redacted]");
 		expect(text).not.toContain("should-not-appear");

--- a/packages/coding-agent/test/suite/retry-fallback-refusal.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-refusal.test.ts
@@ -1,0 +1,132 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+const nextFallback = "faux/faux-3";
+
+function refusal(text: string): ReturnType<typeof fauxAssistantMessage> {
+	return fauxAssistantMessage(text, {
+		stopReason: "error",
+		errorMessage: "misleading_success_output",
+		stopDetails: { type: "refusal" },
+	});
+}
+
+function fallbackState(harness: Harness): { pinned: boolean } | undefined {
+	return (
+		harness.session as unknown as {
+			_retryFallback: { activeState: { pinned: boolean } | undefined };
+		}
+	)._retryFallback.activeState;
+}
+
+describe("retry fallback classifier refusals", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("pins a configured fallback and retries it immediately after a classifier refusal", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "refusal" },
+		]);
+		expect(harness.eventsOfType("auto_retry_start")).toMatchObject([{ delayMs: 0 }]);
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(fallbackState(harness)?.pinned).toBe(true);
+
+		harness.setResponses([fauxAssistantMessage("second prompt")]);
+		await harness.session.prompt("stale state must remain pinned");
+		expect(harness.faux.getCallLog()[2]?.modelId).toBe("faux-2");
+	});
+
+	it("settles a refusal without a chain without consuming retry budget", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: true, baseDelayMs: 1 } } });
+		harnesses.push(harness);
+		harness.setResponses([refusal("visible final refusal")]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+		expect(harness.session.retryAttempt).toBe(0);
+		expect(harness.session.state.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			errorMessage: "misleading_success_output",
+		});
+	});
+
+	it("does not use an over-budget fallback switch for a refusal", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("budget exhausted refusal")]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.session.retryAttempt).toBe(0);
+	});
+
+	it("walks a refusal from a fallback to the next candidate while pinned", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }, { id: "faux-3" }],
+			settings: {
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback, nextFallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), refusal("fallback refusal"), fauxAssistantMessage("next answer")]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "refusal" },
+			{ from: fallback, to: nextFallback, reason: "refusal" },
+		]);
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2", "faux-3"]);
+		expect(fallbackState(harness)?.pinned).toBe(true);
+	});
+
+	it("keeps only the final refusal active when every chain candidate refuses", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }, { id: "faux-3" }],
+			settings: {
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback, nextFallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("first refusal"), refusal("second refusal"), refusal("final refusal")]);
+
+		await harness.session.prompt("hello");
+
+		const activeRefusals = harness.session.state.messages.filter(
+			(message) => message.role === "assistant" && message.stopDetails?.type === "refusal",
+		);
+		const historyRefusals = harness.sessionManager
+			.getEntries()
+			.filter((entry) => entry.type === "message" && entry.message.role === "assistant" && entry.message.stopDetails?.type === "refusal");
+		expect(activeRefusals).toHaveLength(1);
+		expect(activeRefusals[0]).toMatchObject({ errorMessage: "misleading_success_output" });
+		expect(historyRefusals).toHaveLength(3);
+		expect(harness.eventsOfType("retry_fallback_exhausted")).toMatchObject([{ chainKey: primary }]);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([0, 0]);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-refusal.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-refusal.test.ts
@@ -93,7 +93,11 @@ describe("retry fallback classifier refusals", () => {
 			},
 		});
 		harnesses.push(harness);
-		harness.setResponses([refusal("primary refusal"), refusal("fallback refusal"), fauxAssistantMessage("next answer")]);
+		harness.setResponses([
+			refusal("primary refusal"),
+			refusal("fallback refusal"),
+			fauxAssistantMessage("next answer"),
+		]);
 
 		await harness.session.prompt("hello");
 
@@ -122,7 +126,12 @@ describe("retry fallback classifier refusals", () => {
 		);
 		const historyRefusals = harness.sessionManager
 			.getEntries()
-			.filter((entry) => entry.type === "message" && entry.message.role === "assistant" && entry.message.stopDetails?.type === "refusal");
+			.filter(
+				(entry) =>
+					entry.type === "message" &&
+					entry.message.role === "assistant" &&
+					entry.message.stopDetails?.type === "refusal",
+			);
 		expect(activeRefusals).toHaveLength(1);
 		expect(activeRefusals[0]).toMatchObject({ errorMessage: "misleading_success_output" });
 		expect(historyRefusals).toHaveLength(3);

--- a/packages/coding-agent/test/suite/retry-fallback-revert.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-revert.test.ts
@@ -21,7 +21,11 @@ describe("retry fallback revert-to-primary", () => {
 			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
 		});
 		harnesses.push(harness);
-		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer"), fauxAssistantMessage("primary answer")]);
+		harness.setResponses([
+			overloaded(),
+			fauxAssistantMessage("fallback answer"),
+			fauxAssistantMessage("primary answer"),
+		]);
 
 		await harness.session.prompt("first");
 		expect(harness.session.model?.id).toBe("faux-2");
@@ -41,7 +45,9 @@ describe("retry fallback revert-to-primary", () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			fallbackNow: () => now,
-			settings: { retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } } },
+			settings: {
+				retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } },
+			},
 		});
 		harnesses.push(harness);
 		harness.setResponses([overloaded(), overloaded(), fauxAssistantMessage("primary recovered")]);
@@ -90,17 +96,26 @@ describe("retry fallback revert-to-primary", () => {
 		expect(harness.faux.getCallLog()[2]?.modelId).toBe("faux-2");
 	});
 
-	it("(d) never auto-reverts when revertPolicy is \"never\"", async () => {
+	it('(d) never auto-reverts when revertPolicy is "never"', async () => {
 		let now = 0;
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			fallbackNow: () => now,
 			settings: {
-				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] }, fallbackRevertPolicy: "never" },
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+					fallbackRevertPolicy: "never",
+				},
 			},
 		});
 		harnesses.push(harness);
-		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer"), fauxAssistantMessage("fallback again")]);
+		harness.setResponses([
+			overloaded(),
+			fauxAssistantMessage("fallback answer"),
+			fauxAssistantMessage("fallback again"),
+		]);
 
 		await harness.session.prompt("first");
 		expect(harness.session.model?.id).toBe("faux-2");
@@ -123,7 +138,11 @@ describe("retry fallback revert-to-primary", () => {
 			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
 		});
 		harnesses.push(harness);
-		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer"), fauxAssistantMessage("primary answer")]);
+		harness.setResponses([
+			overloaded(),
+			fauxAssistantMessage("fallback answer"),
+			fauxAssistantMessage("primary answer"),
+		]);
 
 		await harness.session.prompt("first");
 		expect(harness.session.model?.id).toBe("faux-2");
@@ -143,7 +162,9 @@ describe("retry fallback revert-to-primary", () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			fallbackNow: () => now,
-			settings: { retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } } },
+			settings: {
+				retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } },
+			},
 		});
 		harnesses.push(harness);
 		harness.setResponses([overloaded(), overloaded(), fauxAssistantMessage("should never be requested")]);
@@ -176,7 +197,9 @@ describe("retry fallback revert-to-primary", () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			fallbackNow: () => now,
-			settings: { retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } } },
+			settings: {
+				retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } },
+			},
 		});
 		harnesses.push(harness);
 		harness.setResponses([overloaded(), overloaded(), fauxAssistantMessage("recovered with steering")]);

--- a/packages/coding-agent/test/suite/retry-fallback-revert.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-revert.test.ts
@@ -1,0 +1,222 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+const overloaded = () => fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" });
+
+describe("retry fallback revert-to-primary", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length) harnesses.pop()?.cleanup();
+	});
+
+	it("(a) reverts at the next prompt after the primary cooldown expires", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer"), fauxAssistantMessage("primary answer")]);
+
+		await harness.session.prompt("first");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		now += 10 * 60_000; // past overloaded cooldown (45s + <=30s jitter)
+		await harness.session.prompt("second");
+
+		const reverted = harness.eventsOfType("retry_fallback_reverted");
+		expect(reverted).toHaveLength(1);
+		expect(reverted[0]).toMatchObject({ from: fallback, to: primary });
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.faux.getCallLog()[2]?.modelId).toBe("faux-1");
+	});
+
+	it("(b) reverts between the retry sleep and the continuation when suppression expires mid-backoff", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), overloaded(), fauxAssistantMessage("primary recovered")]);
+		// The second error exhausts chain candidates, so the retry sleeps with real
+		// backoff; advancing the clock during that sleep expires the primary cooldown.
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && event.delayMs > 0) now += 10 * 60_000;
+		});
+
+		await harness.session.prompt("flaky twice");
+
+		const reverted = harness.eventsOfType("retry_fallback_reverted");
+		expect(reverted).toHaveLength(1);
+		expect(reverted[0]).toMatchObject({ from: fallback, to: primary });
+		const callLog = harness.faux.getCallLog();
+		expect(callLog).toHaveLength(3);
+		expect(callLog[2]?.modelId).toBe("faux-1");
+	});
+
+	it("(c) never auto-reverts a pinned refusal fallback", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "Stream ended with refusal",
+				stopDetails: { type: "refusal" },
+			}),
+			fauxAssistantMessage("fallback answer"),
+			fauxAssistantMessage("fallback again"),
+		]);
+
+		await harness.session.prompt("touchy");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		now += 60 * 60_000;
+		await harness.session.prompt("second");
+
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(0);
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.faux.getCallLog()[2]?.modelId).toBe("faux-2");
+	});
+
+	it("(d) never auto-reverts when revertPolicy is \"never\"", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] }, fallbackRevertPolicy: "never" },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer"), fauxAssistantMessage("fallback again")]);
+
+		await harness.session.prompt("first");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		now += 10 * 60_000;
+		await harness.session.prompt("second");
+
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(0);
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+
+	it("(e) preserves a user thinking-level override through the revert", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", reasoning: true },
+				{ id: "faux-2", reasoning: true },
+			],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), fauxAssistantMessage("fallback answer"), fauxAssistantMessage("primary answer")]);
+
+		await harness.session.prompt("first");
+		expect(harness.session.model?.id).toBe("faux-2");
+		harness.session.setThinkingLevel("high");
+		expect(harness.session.thinkingLevel).toBe("high");
+
+		now += 10 * 60_000;
+		await harness.session.prompt("second");
+
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(1);
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.session.thinkingLevel).toBe("high");
+	});
+
+	it("(f) manual setModel during an active fallback clears state and aborts the pending retry", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), overloaded(), fauxAssistantMessage("should never be requested")]);
+		let switched = false;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && event.delayMs > 0 && !switched) {
+				switched = true;
+				const manual = harness.getModel("faux-1");
+				if (!manual) throw new Error("missing faux-1");
+				void harness.session.setModel(manual);
+			}
+		});
+
+		await harness.session.prompt("flaky then manual");
+
+		// The manual change aborted the pending fallback retry sleep and cleared
+		// fallback state: no third provider call, no later surprise revert.
+		expect(harness.faux.getCallLog()).toHaveLength(2);
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(0);
+		now += 10 * 60_000;
+		harness.setResponses([fauxAssistantMessage("after manual")]);
+		await harness.session.prompt("after manual");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(0);
+		expect(harness.session.model?.id).toBe("faux-1");
+	});
+
+	it("(g) delivers queued steering on the next turn regardless of the active model", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 200, maxRetries: 3, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([overloaded(), overloaded(), fauxAssistantMessage("recovered with steering")]);
+		let steered = false;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && event.delayMs > 0 && !steered) {
+				steered = true;
+				void harness.session.steer("steer note");
+				now += 10 * 60_000;
+			}
+		});
+
+		await harness.session.prompt("flaky with steering");
+
+		const finalRequest = harness.faux.getCallLog()[2];
+		if (!finalRequest) throw new Error("missing final provider request");
+		const serialized = JSON.stringify(finalRequest.context.messages);
+		expect(serialized).toContain("steer note");
+	});
+
+	it("(h) overflow on the fallback model triggers neither fallback nor revert", async () => {
+		const now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			overloaded(),
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "prompt is too long: 200000 tokens > 100000 maximum",
+			}),
+		]);
+
+		await harness.session.prompt("overflowing");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(1);
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(0);
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-validate.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-validate.test.ts
@@ -1,6 +1,7 @@
 import { type Api, getModel, type Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { validateFallbackChains } from "../../src/core/retry-fallback/validate.ts";
+import { createHarness } from "./harness.ts";
 
 const primary = getModel("openai", "gpt-5.4");
 const fallback = getModel("anthropic", "claude-sonnet-4-5");
@@ -16,6 +17,19 @@ const registry = {
 };
 
 describe("validateFallbackChains", () => {
+	it("exposes the warnings calculated when the session starts", async () => {
+		const harness = await createHarness({
+			settings: { retry: { fallbackChains: { smol: ["faux/faux-1"] } } },
+		});
+		try {
+			expect(harness.session.fallbackValidationWarnings).toEqual([
+				'Fallback chain key "smol" must use a provider/model selector; roles are unsupported.',
+			]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it.each([
 		{
 			name: "non-object values",

--- a/packages/coding-agent/test/suite/retry-fallback-validate.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-validate.test.ts
@@ -1,0 +1,84 @@
+import { type Api, getModel, type Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { validateFallbackChains } from "../../src/core/retry-fallback/validate.ts";
+
+const primary = getModel("openai", "gpt-5.4");
+const fallback = getModel("anthropic", "claude-sonnet-4-5");
+const nonReasoningFallback: Model<Api> = { ...fallback, provider: "test", id: "no-reasoning", reasoning: false };
+const models = [primary, fallback, nonReasoningFallback];
+const registry = {
+	find(provider: string, id: string): Model<Api> | undefined {
+		return models.find((model) => model.provider === provider && model.id === id);
+	},
+	getAll(): Model<Api>[] {
+		return models;
+	},
+};
+
+describe("validateFallbackChains", () => {
+	it.each([
+		{
+			name: "non-object values",
+			chains: null,
+			warnings: ["Fallback chains must be a plain object."],
+		},
+		{
+			name: "arrays and nested garbage",
+			chains: ["openai/gpt-5.4"],
+			warnings: ["Fallback chains must be a plain object."],
+		},
+		{
+			name: "role and wildcard keys",
+			chains: { default: [], "openai/*": [] },
+			warnings: [
+				'Fallback chain key "default" must use a provider/model selector; roles are unsupported.',
+				'Fallback chain "default" must contain at least one entry.',
+				'Fallback chain key "openai/*" cannot contain wildcards.',
+				'Fallback chain "openai/*" must contain at least one entry.',
+			],
+		},
+		{
+			name: "invalid and unknown selectors",
+			chains: {
+				"openai/missing": ["anthropic/missing", "not a selector"],
+			},
+			warnings: [
+				'Fallback chain key "openai/missing" is not a valid or known model selector.',
+				'Fallback chain entry "anthropic/missing" for "openai/missing" is not a valid or known model selector.',
+				'Fallback chain entry "not a selector" for "openai/missing" is not a valid or known model selector.',
+			],
+		},
+		{
+			name: "non-string and empty entry lists",
+			chains: {
+				"openai/gpt-5.4": ["anthropic/claude-sonnet-4-5", 42],
+				"anthropic/claude-sonnet-4-5": [],
+				"test/no-reasoning": "anthropic/claude-sonnet-4-5",
+			},
+			warnings: [
+				'Fallback chain "openai/gpt-5.4" entries must be an array of strings.',
+				'Fallback chain "anthropic/claude-sonnet-4-5" must contain at least one entry.',
+				'Fallback chain "test/no-reasoning" entries must be an array of strings.',
+			],
+		},
+		{
+			name: "self-references and unsupported thinking",
+			chains: {
+				"openai/gpt-5.4": ["openai/gpt-5.4:high", "test/no-reasoning:high"],
+			},
+			warnings: [
+				'Fallback chain entry "openai/gpt-5.4:high" for "openai/gpt-5.4" cannot reference the same model.',
+				'Fallback chain entry "test/no-reasoning:high" uses thinking level "high", which is unsupported by test/no-reasoning.',
+			],
+		},
+		{
+			name: "clean configurations",
+			chains: {
+				"openai/gpt-5.4": ["anthropic/claude-sonnet-4-5:high"],
+			},
+			warnings: [],
+		},
+	] as const)("warns for $name", ({ chains, warnings }) => {
+		expect(validateFallbackChains(chains, registry)).toEqual(warnings);
+	});
+});

--- a/packages/coding-agent/test/suite/rpc-fallback-events.test.ts
+++ b/packages/coding-agent/test/suite/rpc-fallback-events.test.ts
@@ -1,0 +1,164 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../../src/core/agent-session.ts";
+import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.ts";
+import {
+	createRpcConnectionHandler,
+	type RpcConnectionHandler,
+	type RpcConnectionSink,
+} from "../../src/modes/rpc/connection-handler.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+function createRuntimeHost(session: AgentSession): AgentSessionRuntime {
+	return {
+		session,
+		newSession: async () => ({ cancelled: true }),
+		switchSession: async () => ({ cancelled: true }),
+		fork: async () => ({ cancelled: true, selectedText: "" }),
+		dispose: async () => {},
+		setRebindSession: () => {},
+	} as unknown as AgentSessionRuntime;
+}
+
+function jsonLines(chunks: readonly string[]): unknown[] {
+	return chunks
+		.flatMap((chunk) => chunk.split("\n"))
+		.filter((line) => line.length > 0)
+		.map((line) => JSON.parse(line));
+}
+
+function isEventType(value: unknown, type: string): boolean {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string" &&
+		value.type === type
+	);
+}
+
+function eventSignal(type: string): {
+	readonly observe: (chunk: string) => void;
+	readonly wait: (timeoutMs: number) => Promise<void>;
+} {
+	let resolveEvent = () => {};
+	const event = new Promise<void>((resolve) => {
+		resolveEvent = resolve;
+	});
+	return {
+		observe(chunk) {
+			if (jsonLines([chunk]).some((line) => isEventType(line, type))) {
+				resolveEvent();
+			}
+		},
+		wait(timeoutMs) {
+			return new Promise((resolve, reject) => {
+				const timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${type} over RPC JSONL`)),
+					timeoutMs,
+				);
+				void event.then(
+					() => {
+						clearTimeout(timeout);
+						resolve();
+					},
+					(error: unknown) => {
+						clearTimeout(timeout);
+						reject(error);
+					},
+				);
+			});
+		},
+	};
+}
+
+function createHandler(
+	harness: Harness,
+	chunks: string[],
+	signal: ReturnType<typeof eventSignal>,
+): RpcConnectionHandler {
+	const sink: RpcConnectionSink = {
+		writeRaw(chunk) {
+			chunks.push(chunk);
+			signal.observe(chunk);
+		},
+		waitForBackpressure: async () => {},
+	};
+	return createRpcConnectionHandler(createRuntimeHost(harness.session), sink);
+}
+
+function refusal(text: string): ReturnType<typeof fauxAssistantMessage> {
+	return fauxAssistantMessage(text, {
+		stopReason: "error",
+		errorMessage: "misleading_success_output",
+		stopDetails: { type: "refusal" },
+	});
+}
+
+describe("RPC fallback events", () => {
+	const harnesses: Harness[] = [];
+	const handlers: RpcConnectionHandler[] = [];
+
+	afterEach(async () => {
+		while (handlers.length > 0) await handlers.pop()?.dispose();
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("streams applied and succeeded fallback events over JSONL", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		const chunks: string[] = [];
+		const succeeded = eventSignal("retry_fallback_succeeded");
+		const handler = createHandler(harness, chunks, succeeded);
+		handlers.push(handler);
+		await handler.ready;
+
+		await handler.handleInputLine(JSON.stringify({ id: "fallback-success", type: "prompt", message: "hello" }));
+		await succeeded.wait(2_000);
+
+		const events = jsonLines(chunks);
+		expect(events).toContainEqual({
+			type: "retry_fallback_applied",
+			from: primary,
+			to: fallback,
+			chainKey: primary,
+			reason: "transient",
+		});
+		expect(events).toContainEqual({ type: "retry_fallback_succeeded", model: fallback, chainKey: primary });
+	});
+
+	it("streams fallback exhaustion over JSONL", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), refusal("fallback refusal")]);
+
+		const chunks: string[] = [];
+		const exhausted = eventSignal("retry_fallback_exhausted");
+		const handler = createHandler(harness, chunks, exhausted);
+		handlers.push(handler);
+		await handler.ready;
+
+		await handler.handleInputLine(JSON.stringify({ id: "fallback-exhausted", type: "prompt", message: "hello" }));
+		await exhausted.wait(2_000);
+
+		expect(jsonLines(chunks)).toContainEqual({
+			type: "retry_fallback_exhausted",
+			chainKey: primary,
+			lastError: "misleading_success_output",
+		});
+	});
+});

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 import triggerCompactExtension from "../examples/extensions/trigger-compact.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../src/core/extensions/index.ts";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 
 function createContext(tokens: number | null, compact = vi.fn()): ExtensionContext {
 	return {

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 import triggerCompactExtension from "../examples/extensions/trigger-compact.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../src/core/extensions/index.ts";
@@ -24,6 +25,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		getMessageRevision: () => 0,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		getSystemPrompt: () => "",
 	};
 }

--- a/packages/coding-agent/test/websearch-native-tool.test.ts
+++ b/packages/coding-agent/test/websearch-native-tool.test.ts
@@ -1,7 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
-
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
 import { createWebSearchTool } from "../src/core/extensions/builtin/websearch/websearch/tool.ts";
@@ -11,6 +9,7 @@ import type {
 } from "../src/core/extensions/builtin/websearch/websearch/types.ts";
 import type { ExtensionContext } from "../src/core/extensions/types.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 
 function successfulSearchResponse(): Response {
 	return new Response(

--- a/packages/coding-agent/test/websearch-native-tool.test.ts
+++ b/packages/coding-agent/test/websearch-native-tool.test.ts
@@ -1,5 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
@@ -53,6 +54,7 @@ function toolContext(model: Model<Api> | undefined, modelRegistry: ModelRegistry
 		shutdown: vi.fn(),
 		getContextUsage: () => undefined,
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact: vi.fn(),
 		getMessageRevision: () => 0,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),

--- a/packages/coding-agent/test/websearch-progress.test.ts
+++ b/packages/coding-agent/test/websearch-progress.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
-
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
 import { renderSearchResult } from "../src/core/extensions/builtin/websearch/websearch/renderers.ts";
@@ -11,6 +9,7 @@ import type {
 } from "../src/core/extensions/builtin/websearch/websearch/types.ts";
 import type { ExtensionContext } from "../src/core/extensions/types.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 
 function minimalToolContext(): ExtensionContext {
 	return {

--- a/packages/coding-agent/test/websearch-progress.test.ts
+++ b/packages/coding-agent/test/websearch-progress.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
 
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
@@ -29,6 +30,7 @@ function minimalToolContext(): ExtensionContext {
 		shutdown: vi.fn(),
 		getContextUsage: () => undefined,
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact: vi.fn(),
 		getMessageRevision: () => 0,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),

--- a/packages/neo/internal/app/transcript.go
+++ b/packages/neo/internal/app/transcript.go
@@ -45,20 +45,24 @@ const (
 // feed entry, with the surface that owns it instead. The exhaustiveness test
 // asserts handled ∪ ignored ∪ deferred covers the whole mirror.
 var transcriptIgnoredEvents = map[string]string{
-	"agent_settled":          "RPC completion marker; transcript state is finalized by agent_end/message_end",
-	"turn_start":             "turn boundaries render nothing; content arrives via message_* events",
-	"turn_end":               "turn boundaries render nothing; tool results arrive via tool_execution_end",
-	"compaction_start":       "status-indicator surface (shell status line, todo 7)",
-	"compaction_progress":    "status-indicator surface (shell status line, todo 7)",
-	"entry_appended":         "custom entry renderers are extension-owned (todo 6); classic renders nothing without one",
-	"session_info_changed":   "terminal title + footer surface (todo 7/9)",
-	"system_prompt_change":   "status-line surface (shell status line, todo 7)",
-	"thinking_level_changed": "footer surface (todo 7)",
-	"auto_retry_start":       "retry status-indicator surface (shell status line, todo 7)",
-	"auto_retry_end":         "retry status-indicator surface (shell status line, todo 7)",
-	"auth_login_url":         "auth login overlay (todo 13)",
-	"auth_login_end":         "auth login overlay (todo 13)",
-	"extension_error":        "delivered as ExtensionErrorMsg by the session adapter demux, never as an EventMsg",
+	"agent_settled":            "RPC completion marker; transcript state is finalized by agent_end/message_end",
+	"turn_start":               "turn boundaries render nothing; content arrives via message_* events",
+	"turn_end":                 "turn boundaries render nothing; tool results arrive via tool_execution_end",
+	"compaction_start":         "status-indicator surface (shell status line, todo 7)",
+	"compaction_progress":      "status-indicator surface (shell status line, todo 7)",
+	"entry_appended":           "custom entry renderers are extension-owned (todo 6); classic renders nothing without one",
+	"session_info_changed":     "terminal title + footer surface (todo 7/9)",
+	"system_prompt_change":     "status-line surface (shell status line, todo 7)",
+	"thinking_level_changed":   "footer surface (todo 7)",
+	"auto_retry_start":         "retry status-indicator surface (shell status line, todo 7)",
+	"auto_retry_end":           "retry status-indicator surface (shell status line, todo 7)",
+	"retry_fallback_applied":   "fallback status rendering is not part of Neo's transcript projection",
+	"retry_fallback_succeeded": "fallback status rendering is not part of Neo's transcript projection",
+	"retry_fallback_reverted":  "fallback status rendering is not part of Neo's transcript projection",
+	"retry_fallback_exhausted": "fallback status rendering is not part of Neo's transcript projection",
+	"auth_login_url":           "auth login overlay (todo 13)",
+	"auth_login_end":           "auth login overlay (todo 13)",
+	"extension_error":          "delivered as ExtensionErrorMsg by the session adapter demux, never as an EventMsg",
 }
 
 // Transcript translates the session adapter's EventMsg stream into transcript

--- a/packages/neo/internal/bridge/types.go
+++ b/packages/neo/internal/bridge/types.go
@@ -216,6 +216,9 @@ var eventTypes = []string{
 	"system_prompt_change", // SystemPromptChangeEvent
 	"thinking_level_changed",
 	"auto_retry_start", "auto_retry_end",
+	// --- retry fallback lifecycle (agent-session.ts) ---
+	"retry_fallback_applied", "retry_fallback_succeeded",
+	"retry_fallback_reverted", "retry_fallback_exhausted",
 	// --- auth login flow (task 13): additive, event-only completion ---
 	"auth_login_url", "auth_login_end",
 	// --- emitted by the connection handler (not in AgentSessionEvent) ---

--- a/packages/senpi-codemode/test/eval/fakes.ts
+++ b/packages/senpi-codemode/test/eval/fakes.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_COMPACTION_SETTINGS, type ExtensionContext } from "@code-yeongyu/senpi";
+import { createInMemoryExtensionSessionSettings } from "../../../coding-agent/test/helpers/extension-session-settings.ts";
 import type { KernelToHostMessage } from "../../src/bridge/protocol.ts";
 import type { EvalKernel, EvalKernelManager } from "../../src/tool/eval-tool.ts";
 import type { EvalKernelRunInput } from "../../src/tool/types.ts";
@@ -229,6 +230,7 @@ export function fakeExtensionContext(): ExtensionContext {
 		shutdown: () => {},
 		getContextUsage: () => undefined,
 		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		sessionSettings: createInMemoryExtensionSessionSettings(),
 		compact: () => {},
 		getMessageRevision: () => 0,
 		applyCompaction: async () => ({ applied: false, reason: "rejected" }),


### PR DESCRIPTION
## Summary

When a model fails mid-conversation — rate limits, server errors, or a safety refusal — senpi now automatically switches to a per-model fallback you configure (with its own reasoning level, e.g. `{"anthropic/claude-fable-5": ["ccapi/kimi-k3:max"]}`), continues the same turn, shows a notice in the TUI, and returns to your primary model once it recovers. Refusals (Anthropic streaming `refusal`/`sensitive` stop reasons) are detected via typed provider stop details rather than text matching, and trigger a **pinned** fallback that holds until you change models yourself. The switch never overwrites your saved default model, and the replayed request keeps the conversation prefix byte-identical (prompt-cache safe); switching back only happens at turn boundaries.

Configure chains in `settings.json` (`retry.fallbackChains`, `retry.modelFallback`, `retry.fallbackRevertPolicy`) or interactively with the new `/fallback` command (model picker + thinking-level picker + quick-set args). Escape hatches: `--no-model-fallback` flag and `SENPI_NO_FALLBACK=1`. Every decision is NDJSON-logged to `<agentDir>/logs/fallback.log` (5MB rotation, secret-redacting).

## Changes

- **packages/ai — typed refusal detection**: new optional `AssistantMessage.stopDetails` (`{ type: "refusal" | "sensitive" }`) plumbed from the Anthropic SDK stop details through `mapStopReason`/`message_delta`; `isClassifierRefusal` guard; faux provider can inject stopDetails; `isRetryableAssistantError` never retries refusals on the same model.
- **Fallback engine (`core/retry-fallback/`)**: new modules `chains.ts` (selector parsing/canonicalization/slicing), `cooldown.ts` (session-local suppression with error-class durations), `log.ts` (redacting NDJSON logger), `validate.ts` (config warnings), `controller.ts` (candidate selection, thinking-level mapping with clamping, pin-on-refusal, per-turn try-once-per-candidate, revert-to-primary).
- **AgentSession wiring**: transient retryable errors switch immediately (zero delay, fresh retry budget on the new model only); non-retryable "hard" errors (billing/quota, no tool calls) covered by a chain switch without same-model backoff; revert-to-primary at prompt entry and between retry sleep and continuation when the primary's cooldown expires; manual `setModel`/`cycleModel` abandons the fallback window and aborts a pending fallback retry; fallback model switches never persist the default model, never emit `model_select` mid-turn (system prompt stays byte-stable), never invalidate compaction, and start a clean provider continuation (no `previous_response_id` reuse); ephemeral `fallback`/`fallback-revert` model_change entries are skipped by session restore, which also ignores fallback-period assistant-message model metadata.
- **Settings**: `retry.modelFallback` (default on), `retry.fallbackChains` (exact per-model keys only — no wildcards/roles), `retry.fallbackRevertPolicy` (`"cooldown-expiry"` | `"never"`); global scope; malformed config produces startup warnings (validated against the raw value) instead of silent drops.
- **`/fallback` builtin command + extension runtime**: selector-driven menu (list/add/edit/remove chains, toggle, revert policy, live status) and `/fallback <target> <f1> [f2...]` quick-set; a new narrow `sessionSettings` accessor on `ExtensionContext` makes command writes visible to the running session in-process (no stale-read), plus `--no-model-fallback` / `SENPI_NO_FALLBACK=1` per-run overrides.
- **TUI**: `retry_fallback_applied/succeeded/reverted/exhausted` events render as warning/status lines; a persistent footer `fallback: <model>` indicator while a fallback is active; zero-delay fallback retries don't flash the retry spinner; startup chain-validation warnings surface through the config-warning path.
- **RPC/app-server/Neo**: the four events flow through the RPC JSONL wire; app-server pass-through confirmed safe; Neo bridge mirror + transcript ignore-list updated.
- **Docs**: `retry.*` fallback settings reference with the Fable→Kimi example, `/fallback` docs, cache-preservation/refusal behavior notes, log path, escape hatches.

## QA & Evidence

Evidence root (this repo, `local-ignore/qa-evidence/20260720-model-fallback-chains/`): full transcripts, request logs, screenshots, and verifier reports.

- **Unit/integration (TDD, RED-first)**: 15 fallback test files / 109 focused tests green; every behavior change has failing-first captures (`task-*-model-fallback-chains.txt`). Mutation checks proved key assertions bite (e.g. pinned-guard removal fails the pinned test).
- **Full gates**: `npm run check` exit 0 (biome `--error-on-warnings`, tsgo, shrinkwrap, neo build+vet+test); `packages/ai` suite 1074 tests green; `packages/coding-agent` suite green under `CI=1` (3960 tests). Two pre-existing app-server process-spawn tests are flaky under parallel load on this machine — green in isolation, on clean `main`, and under CI=1; unrelated to this branch.
- **Mock-loop e2e (real CLI, fake server, zero tokens)**: S1 transient 429 → `auto_retry_start(delayMs 0)` → `retry_fallback_applied` → fallback answer; S2 refusal → pinned switch, request sequence `primary → fallback → fallback` across two turns; S3 retried request's messages **byte-identical** to the first (cache-prefix proof from server-side request logs); S4 chain exhaustion → error surfaced, `--print` exit 1. (`task-17-*`)
- **TUI smoke + visual (tmux + xterm.js/Chrome screenshots)**: V1 `/fallback` menu add-chain flow with settings diff; V2 transient fallback warning + footer `fallback: <model>` + status line; V3 refusal pinned notice persisting next turn. (`task-18-*`)
- **Independent adversarial verification**: every engine todo passed a separate-context verifier; F1 plan-compliance, F2 code-quality, F4 scope-fidelity reports on disk (initial findings — alias canonicalization bug, missing cache-prefix/cancel tests, validation-sanitization gap, self-reference guard, decision-logging gaps, cast violations — all fixed and re-verified); F3 re-ran S1/S2 from a clean sandbox after the hardening commits with fresh evidence and cleanup receipts.

## Risks & Residuals

- `agent-session.ts` carries a 22-hunk feature diff on an upstream-conflict-prone file; each hunk is feature-owned (F2 audit) and setModel's manual behavior is pinned by characterization tests. Mitigated: restore/retry regression suites + mock-loop e2e.
- Suppression state is deliberately session-local (not persisted) — a new session starts with a clean cooldown map. Accepted, documented.
- Revert emits `model_select` at turn boundaries (may re-derive the system prompt there); mid-turn switches never do. Accepted trade-off, documented in plan.
- Pre-existing flake note above for the two app-server process tests.

Plan: `.omo/plans/model-fallback-chains.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-model fallback chains with refusal pinning and cache-safe revert. Improves reliability by auto-switching models on rate limits, server errors, or safety refusals, then reverting to the primary when it recovers.

- **New Features**
  - Per-model fallback chains with thinking-level mapping, session-local selector cooldowns, and immediate advance on transient and covered hard errors.
  - Typed classifier stop details on assistant errors via `AssistantMessage.stopDetails` (includes `explanation`); exported `isClassifierRefusal` and excluded classifier outcomes from same-model retries in `packages/ai`. Faux provider can emit stop details; `@anthropic-ai/sdk` streams preserve them.
  - Pinned fallback on classifier refusals; fallback retries remove refusal messages from active context; exhausted chains surface the final refusal.
  - Byte-identical request replay for prompt-cache safety; mid-turn switches do not emit `model_select`; revert only at turn boundaries.
  - Config validation at session start against raw `fallbackChains` with warnings; self-referential candidates are skipped; thinking-level clamped to supported values.
  - `/fallback` command builtin with live session-owned settings (`ExtensionContext.sessionSettings`), quick-set, `--no-model-fallback` and `SENPI_NO_FALLBACK=1` overrides, and a live-state view.
  - TUI notices for apply/success/revert/exhausted, a persistent `fallback: <model>` footer indicator, and suppressed spinner on zero-delay fallback retries; startup shows chain-validation warnings.
  - RPC forwards `retry_fallback_applied/succeeded/reverted/exhausted`; Neo bridge/types updated and transcript mirrors ignore them.
  - Scoped NDJSON fallback logger with redaction and 5MB rotation; logs `no_chain` and `candidates_exhausted`.
  - Session restore ignores ephemeral `model_change` entries with `reason: "fallback" | "fallback-revert"` and preserves the original default model.

- **Migration**
  - Configure chains in `settings.json`: `retry.modelFallback`, `retry.fallbackChains`, `retry.fallbackRevertPolicy` (`"cooldown-expiry"` | `"never"`). Exact selectors only; optional thinking level via `provider/model:LEVEL`.
  - Manage chains with `/fallback <target> <f1> [f2...]` or `/fallback`. Disable per run with `--no-model-fallback` or `SENPI_NO_FALLBACK=1`.
  - If you consume assistant errors, read `stopDetails` or use `isClassifierRefusal` from `packages/ai`.

<sup>Written for commit 4c972363d856a8740f60cfa2a0787ee7ed99d092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

