### PR TITLE
style(coding-agent): biome format fallback hardening test

### DIFF
--- a/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
@@ -2,8 +2,8 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import { createHarness, type Harness } from "./harness.ts";
 import type { Settings } from "../../src/core/settings-manager.ts";
+import { createHarness, type Harness } from "./harness.ts";
 
 const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
@@ -74,7 +74,6 @@ describe("retry fallback hardening", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(1);
 		expect(harness.faux.getCallLog()[1]?.modelId).toBe("faux-2");
 	});
-
 
 	it("submits a clean full request for a responses-API fallback candidate", async () => {
 		const harness = await createHarness({


### PR DESCRIPTION
Biome formatting drift left by the merged #252 (import order + blank line in test/suite/retry-fallback-hardening.test.ts). No behavior change; the repo check script auto-fixes this at every run, landing it here for hygiene.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Biome formatting drift in packages/coding-agent/test/suite/retry-fallback-hardening.test.ts to keep repo checks passing. Reorders imports and removes a stray blank line; no behavior change.

<sup>Written for commit a5681eec7ce1aa66131597187a0da0ad7a741ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

