### PR TITLE
fix(coding-agent): account goal token usage mid-turn

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -5,6 +5,36 @@ Persistent per-thread goal tracking as an in-tree builtin. Ports the standalone
 `pi-goal` extension into senpi with no dependency on it, file-based persistence,
 codex-aligned tool naming, and the budget concept removed.
 
+## Mid-turn token usage accounting via message_end (2026-07-20)
+
+### What changed
+- New `turn-usage.ts`: `TurnUsageTracker` accumulates assistant usage from `message_end` events
+  (`pending`), tracks what mid-turn checkpoints already stored (`flushed`), and at `agent_end` accounts
+  only `collectAssistantUsage(messages) - flushed` (clamped per field) so nothing is double counted.
+- `index.ts`: subscribes to `message_end`, resets the tracker on `agent_start`, and
+  `accountCurrentAgentTurn(ctx, mode, agentRunMessages?)` now sources usage from the tracker
+  (pending for mid-turn checkpoints, remaining for `agent_end`) instead of taking a usage argument.
+  `beginAgentGoalAccounting` discards pending usage when a new accounting window opens so a goal
+  created or replaced mid-turn is not charged tokens streamed before it existed (matching the
+  existing time-window semantics).
+- `tool-registration.ts` / `command-registration.ts`: `accountCurrentAgentTurn` deps drop the
+  `EMPTY_USAGE` argument; `get_goal` checkpoints before reading so its snapshot carries fresh
+  tokens and elapsed time.
+
+### Why
+- Long goal-driven runs complete inside one agent turn; usage was only harvested at `agent_end`,
+  so `update_goal`/`get_goal` reported `tokensUsed: 0` after hours of work (observed: a completed
+  goal reporting `tokensUsed: 0, timeUsedSeconds: 6652` while the session had consumed ~379K tokens).
+
+### Why extension system couldn't handle this differently
+- `message_end` already delivers each finalized assistant message with usage through the public
+  `pi.on` API; the fix is entirely builtin-local with no core change.
+
+### Expected merge conflict zones on next upstream sync
+- MEDIUM in `index.ts` around `accountCurrentAgentTurn`/`agent_end` if standalone `pi-goal`
+  reworks usage accounting; the standalone package needs the same tracker on its next sync.
+- LOW in `tool-registration.ts`/`command-registration.ts` deps signatures.
+
 ## Live elapsed footer ticker (2026-07-17)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/command-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/command-registration.ts
@@ -2,21 +2,16 @@ import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { parseGoalCommand } from "./command.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { clearGoal, createGoal, readGoal, updateGoal } from "./store.ts";
-import type { Goal, GoalAccountingMode, GoalStoreRef, TokenUsageSnapshot } from "./types.ts";
+import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
 
 const GOAL_USAGE = "Usage: /goal <objective>";
 const GOAL_EMPTY_HINT = "No goal is currently set.";
 const REPLACE_GOAL_CHOICE = "Replace current goal";
 const CANCEL_REPLACE_GOAL_CHOICE = "Cancel";
-const EMPTY_USAGE: TokenUsageSnapshot = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
 
 export type GoalCommandRegistrationDeps = {
 	readonly goalStoreRef: (ctx: ExtensionContext) => GoalStoreRef;
-	readonly accountCurrentAgentTurn: (
-		ctx: ExtensionContext,
-		usage: TokenUsageSnapshot,
-		mode: GoalAccountingMode,
-	) => Promise<Goal | null>;
+	readonly accountCurrentAgentTurn: (ctx: ExtensionContext, mode: GoalAccountingMode) => Promise<Goal | null>;
 	readonly beginAgentGoalAccounting: (goal: Goal) => void;
 	readonly stopAgentGoalAccounting: (goalId: string) => void;
 	readonly clearAgentGoalAccounting: () => void;
@@ -46,7 +41,7 @@ export function registerGoalCommand(pi: ExtensionAPI, deps: GoalCommandRegistrat
 					}
 					case "setStatus": {
 						if (command.status === "paused") {
-							await deps.accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
+							await deps.accountCurrentAgentTurn(ctx, "active");
 						}
 						const goal = await updateGoal(deps.goalStoreRef(ctx), { status: command.status });
 						if (goal.status === "active") {
@@ -60,7 +55,7 @@ export function registerGoalCommand(pi: ExtensionAPI, deps: GoalCommandRegistrat
 						return;
 					}
 					case "clear": {
-						await deps.accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
+						await deps.accountCurrentAgentTurn(ctx, "active");
 						const cleared = await clearGoal(deps.goalStoreRef(ctx));
 						deps.clearAgentGoalAccounting();
 						deps.refreshGoalUi(ctx, null);
@@ -92,7 +87,7 @@ async function setGoalObjective(
 	}
 
 	if (current?.status === "active") {
-		await deps.accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
+		await deps.accountCurrentAgentTurn(ctx, "active");
 	}
 	const goal = current === null ? await createGoal(ref, objective) : await updateGoal(ref, { objective });
 	if (goal.status === "active") deps.beginAgentGoalAccounting(goal);

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -9,20 +9,15 @@ import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { buildContinuationPrompt } from "./prompt.ts";
 import { accountGoalUsage, readGoal, updateGoal } from "./store.ts";
 import { registerGoalTools } from "./tool-registration.ts";
-import type { Goal, GoalAccountingMode, GoalStoreRef, TokenUsageSnapshot } from "./types.ts";
-import { isRecord } from "./types.ts";
+import { TurnUsageTracker } from "./turn-usage.ts";
+import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
 import { updateGoalUi } from "./ui.ts";
 
 const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
 const RESUME_GOAL_CHOICE = "Resume goal";
 const LEAVE_GOAL_PAUSED_CHOICE = "Leave paused";
-const EMPTY_USAGE: TokenUsageSnapshot = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
 const STALE_EXTENSION_CONTEXT_ERROR_PREFIX = "This extension ctx is stale after session replacement or reload.";
 
-type AssistantUsageMessage = {
-	role: "assistant";
-	usage: Record<string, unknown>;
-};
 type AgentGoalAccounting = {
 	goalId: string;
 	measuredFromMilliseconds: number;
@@ -32,6 +27,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let agentTurnInProgress = false;
 	let agentGoalAccounting: AgentGoalAccounting | null = null;
 	let completedThisTurnGoalId: string | null = null;
+	const turnUsage = new TurnUsageTracker();
 
 	const goalTicker = new GoalElapsedTicker({
 		render: (renderCtx, renderGoal, live) => {
@@ -80,6 +76,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	pi.on("agent_start", async (_event, ctx) => {
 		agentTurnInProgress = true;
 		completedThisTurnGoalId = null;
+		turnUsage.reset();
 		const goal = await readGoal(goalStoreRef(ctx));
 		if (goal?.status === "active") {
 			beginAgentGoalAccounting(goal);
@@ -88,9 +85,13 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		}
 	});
 
+	pi.on("message_end", async (event) => {
+		turnUsage.noteMessageEnd(event.message);
+	});
+
 	pi.on("agent_end", async (event, ctx) => {
 		const mode: GoalAccountingMode = completedThisTurnGoalId === null ? "active" : "activeOrComplete";
-		const goal = await accountCurrentAgentTurn(ctx, collectAssistantUsage(event.messages), mode);
+		const goal = await accountCurrentAgentTurn(ctx, mode, event.messages);
 		agentTurnInProgress = false;
 		completedThisTurnGoalId = null;
 		if (goal?.status === "active") {
@@ -110,7 +111,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		if (agentGoalAccounting !== null) {
-			await accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
+			await accountCurrentAgentTurn(ctx, "active");
 		}
 		clearAgentGoalAccounting();
 		goalTicker.stop();
@@ -143,6 +144,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	function beginAgentGoalAccounting(goal: Goal): void {
 		if (goal.status !== "active") return;
 		if (agentGoalAccounting?.goalId === goal.id) return;
+		turnUsage.discardPending();
 		agentGoalAccounting = { goalId: goal.id, measuredFromMilliseconds: Date.now() };
 	}
 
@@ -189,13 +191,15 @@ export default function goalExtension(pi: ExtensionAPI): void {
 
 	async function accountCurrentAgentTurn(
 		ctx: ExtensionContext,
-		usage: TokenUsageSnapshot,
 		mode: GoalAccountingMode,
+		agentRunMessages?: unknown[],
 	): Promise<Goal | null> {
 		const accounting = agentGoalAccounting;
 		const ref = goalStoreRef(ctx);
 		if (accounting === null) return readGoal(ref);
 
+		const usage =
+			agentRunMessages === undefined ? turnUsage.takePending() : turnUsage.takeRemaining(agentRunMessages);
 		const now = Date.now();
 		const elapsedSeconds = Math.max(0, Math.round((now - accounting.measuredFromMilliseconds) / 1000));
 		const goal = await accountGoalUsage(ref, usage, elapsedSeconds, mode, accounting.goalId);
@@ -246,27 +250,4 @@ function goalStoreRef(ctx: ExtensionContext): GoalStoreRef {
 
 function cwdStoreKey(cwd: string): string {
 	return createHash("sha256").update(cwd).digest("hex").slice(0, 24);
-}
-
-function collectAssistantUsage(messages: unknown[]): TokenUsageSnapshot {
-	const usage: TokenUsageSnapshot = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
-	for (const message of messages) {
-		if (!isAssistantUsageMessage(message)) continue;
-		usage.input += numericUsageField(message.usage, "input");
-		usage.output += numericUsageField(message.usage, "output");
-		usage.cacheRead += numericUsageField(message.usage, "cacheRead");
-		usage.cacheWrite += numericUsageField(message.usage, "cacheWrite");
-		usage.totalTokens += numericUsageField(message.usage, "totalTokens");
-	}
-	return usage;
-}
-
-function isAssistantUsageMessage(message: unknown): message is AssistantUsageMessage {
-	if (!isRecord(message)) return false;
-	return message.role === "assistant" && isRecord(message.usage);
-}
-
-function numericUsageField(usage: Record<string, unknown>, key: string): number {
-	const value = usage[key];
-	return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
@@ -2,20 +2,14 @@ import { Type } from "typebox";
 import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { formatGoalToolResponse } from "./format.ts";
 import { createGoal, readGoal, updateGoal } from "./store.ts";
-import type { Goal, GoalAccountingMode, GoalStoreRef, TokenUsageSnapshot } from "./types.ts";
+import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
 import { COMPLETABLE_GOAL_STATUS_VALUES } from "./types.ts";
-
-const EMPTY_USAGE: TokenUsageSnapshot = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
 
 type GoalToolResult = AgentToolResult<Record<string, never>>;
 
 export type GoalToolRegistrationDeps = {
 	readonly goalStoreRef: (ctx: ExtensionContext) => GoalStoreRef;
-	readonly accountCurrentAgentTurn: (
-		ctx: ExtensionContext,
-		usage: TokenUsageSnapshot,
-		mode: GoalAccountingMode,
-	) => Promise<Goal | null>;
+	readonly accountCurrentAgentTurn: (ctx: ExtensionContext, mode: GoalAccountingMode) => Promise<Goal | null>;
 	readonly beginAgentGoalAccounting: (goal: Goal) => void;
 	readonly markGoalCompletedThisTurn: (goal: Goal) => void;
 	readonly refreshGoalUi: (ctx: ExtensionContext, goal: Goal | null) => void;
@@ -73,7 +67,7 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 					"update_goal can only mark the existing goal complete; pause and resume are controlled by the user or system",
 				);
 			}
-			await deps.accountCurrentAgentTurn(ctx, EMPTY_USAGE, "active");
+			await deps.accountCurrentAgentTurn(ctx, "active");
 			const goal = await updateGoal(deps.goalStoreRef(ctx), { status: "complete" });
 			deps.markGoalCompletedThisTurn(goal);
 			deps.refreshGoalUi(ctx, goal);
@@ -87,7 +81,7 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 		description: "Get the current goal for this thread, including status, token and elapsed-time usage.",
 		parameters: Type.Object({}, { additionalProperties: false }),
 		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-			const goal = await readGoal(deps.goalStoreRef(ctx));
+			const goal = await deps.accountCurrentAgentTurn(ctx, "active");
 			deps.refreshGoalUi(ctx, goal);
 			return toolText(formatGoalToolResponse(goal));
 		},

--- a/packages/coding-agent/src/core/extensions/builtin/goal/turn-usage.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/turn-usage.ts
@@ -1,0 +1,65 @@
+import type { TokenUsageSnapshot } from "./types.ts";
+import { isRecord } from "./types.ts";
+
+const USAGE_FIELDS = ["input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const;
+
+export function emptyUsage(): TokenUsageSnapshot {
+	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
+}
+
+export function collectAssistantUsage(messages: unknown[]): TokenUsageSnapshot {
+	const usage = emptyUsage();
+	for (const message of messages) addAssistantMessageUsage(usage, message);
+	return usage;
+}
+
+/**
+ * Accumulates assistant token usage streamed during the current agent run so
+ * goal accounting can checkpoint mid-turn (tool calls, commands, shutdown)
+ * without waiting for `agent_end` and without double counting when it fires.
+ */
+export class TurnUsageTracker {
+	private pending = emptyUsage();
+	private flushed = emptyUsage();
+
+	reset(): void {
+		this.pending = emptyUsage();
+		this.flushed = emptyUsage();
+	}
+
+	noteMessageEnd(message: unknown): void {
+		addAssistantMessageUsage(this.pending, message);
+	}
+
+	takePending(): TokenUsageSnapshot {
+		const taken = this.pending;
+		this.pending = emptyUsage();
+		for (const field of USAGE_FIELDS) this.flushed[field] += taken[field];
+		return taken;
+	}
+
+	/** Drop usage streamed before a new accounting window opened mid-turn. */
+	discardPending(): void {
+		this.takePending();
+	}
+
+	/** Return the run's total usage minus what checkpoints already accounted. */
+	takeRemaining(agentRunMessages: unknown[]): TokenUsageSnapshot {
+		const collected = collectAssistantUsage(agentRunMessages);
+		const remaining = emptyUsage();
+		for (const field of USAGE_FIELDS) {
+			remaining[field] = Math.max(0, collected[field] - this.flushed[field]);
+			this.flushed[field] = Math.max(this.flushed[field], collected[field]);
+		}
+		this.pending = emptyUsage();
+		return remaining;
+	}
+}
+
+function addAssistantMessageUsage(target: TokenUsageSnapshot, message: unknown): void {
+	if (!isRecord(message) || message.role !== "assistant" || !isRecord(message.usage)) return;
+	for (const field of USAGE_FIELDS) {
+		const value = message.usage[field];
+		if (typeof value === "number" && Number.isFinite(value)) target[field] += value;
+	}
+}

--- a/packages/coding-agent/test/suite/goal-e2e.test.ts
+++ b/packages/coding-agent/test/suite/goal-e2e.test.ts
@@ -61,6 +61,40 @@ describe("goal extension end-to-end through the real AgentSession", () => {
 		expect(JSON.parse(updateResults[0] ?? "{}").goal).toMatchObject({ status: "complete" });
 	}, 20_000);
 
+	it("reports token usage accumulated after goal creation when update_goal completes mid-run", async () => {
+		const harness = await createHarness({ extensionFactories: [goalExtension] });
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("create_goal", { objective: "Track tokens" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage([fauxToolCall("update_goal", { status: "complete" })], { stopReason: "toolUse" }),
+			fauxAssistantMessage("goal achieved"),
+		]);
+		await harness.session.prompt("set the goal and finish it");
+
+		const assistantUsages = harness.sessionManager
+			.getEntries()
+			.filter((entry) => entry.type === "message")
+			.map((entry) => entry.message)
+			.filter((message): message is typeof message & { role: "assistant" } => message.role === "assistant")
+			.map((message) => (message as { usage: { input: number; output: number } }).usage);
+		expect(assistantUsages).toHaveLength(3);
+
+		// The goal is created by the first assistant message's tool call, so only the
+		// second message (the one invoking update_goal) is charged at completion time.
+		const chargedUsage = assistantUsages[1];
+		const expectedTokens = (chargedUsage?.input ?? 0) + (chargedUsage?.output ?? 0);
+		expect(expectedTokens).toBeGreaterThan(0);
+
+		const updateResults = toolResultTexts(harness, "update_goal");
+		expect(updateResults).toHaveLength(1);
+		const completed = JSON.parse(updateResults[0] ?? "{}");
+		expect(completed.goal.status).toBe("complete");
+		expect(completed.goal.tokensUsed).toBe(expectedTokens);
+	}, 20_000);
+
 	it("does not queue another hidden continuation after aborting a retrying goal turn", async () => {
 		const harness = await createHarness({
 			extensionFactories: [goalExtension],

--- a/packages/coding-agent/test/suite/goal-turn-usage.test.ts
+++ b/packages/coding-agent/test/suite/goal-turn-usage.test.ts
@@ -1,0 +1,183 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it } from "vitest";
+import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
+import { readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
+
+type AnyTool = ToolDefinition<any, any, any>;
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+interface GoalHarness {
+	tools: Map<string, AnyTool>;
+	handlers: Map<string, Handler[]>;
+}
+
+function createGoalHarness(): GoalHarness {
+	const tools = new Map<string, AnyTool>();
+	const handlers = new Map<string, Handler[]>();
+	const pi = {
+		registerTool: (tool: AnyTool) => tools.set(tool.name, tool),
+		registerCommand: () => {},
+		on: (event: string, handler: Handler) => {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		},
+		sendMessage: () => {},
+	} as unknown as ExtensionAPI;
+	goalExtension(pi);
+	return { tools, handlers };
+}
+
+const tempDirs: string[] = [];
+
+async function makeCtx(threadId = "thread-usage"): Promise<ExtensionContext> {
+	const dir = await mkdtemp(join(tmpdir(), "senpi-goal-usage-"));
+	tempDirs.push(dir);
+	return {
+		hasUI: false,
+		cwd: dir,
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		signal: undefined,
+		ui: { notify: () => {}, select: async () => undefined, setStatus: () => {} },
+		sessionManager: {
+			getSessionFile: () => join(dir, "session.jsonl"),
+			getSessionDir: () => dir,
+			getSessionId: () => threadId,
+		},
+	} as unknown as ExtensionContext;
+}
+
+function storeRefFor(ctx: ExtensionContext) {
+	return {
+		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+		threadId: ctx.sessionManager.getSessionId(),
+	};
+}
+
+function assistantMessage(input: number, output: number): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "" }],
+		api: "faux",
+		provider: "faux",
+		model: "faux",
+		usage: {
+			input,
+			output,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: input + output,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+async function runHandlers(
+	handlers: Map<string, Handler[]>,
+	event: string,
+	payload: unknown,
+	ctx: ExtensionContext,
+): Promise<void> {
+	for (const handler of handlers.get(event) ?? []) {
+		await handler(payload, ctx);
+	}
+}
+
+async function streamAssistantMessage(
+	harness: GoalHarness,
+	ctx: ExtensionContext,
+	message: AgentMessage,
+): Promise<void> {
+	await runHandlers(harness.handlers, "message_end", { type: "message_end", message }, ctx);
+}
+
+function textOf(result: { content?: Array<{ type: string; text?: string }> } | undefined): string {
+	return result?.content?.find((part) => part.type === "text")?.text ?? "";
+}
+
+function tokensUsedOf(result: unknown): number {
+	const parsed = JSON.parse(textOf(result as { content?: Array<{ type: string; text?: string }> }));
+	return parsed.goal.tokensUsed;
+}
+
+describe("goal mid-turn token usage accounting", () => {
+	afterEach(async () => {
+		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+	});
+
+	it("update_goal completed mid-turn reports tokens accumulated from streamed assistant messages", async () => {
+		const harness = createGoalHarness();
+		const ctx = await makeCtx();
+		await harness.tools.get("create_goal")?.execute("c1", { objective: "Ship it" }, undefined, undefined, ctx);
+		await runHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await streamAssistantMessage(harness, ctx, assistantMessage(100, 50));
+
+		const completed = await harness.tools
+			.get("update_goal")
+			?.execute("u1", { status: "complete" }, undefined, undefined, ctx);
+
+		expect(tokensUsedOf(completed)).toBe(150);
+	});
+
+	it("get_goal mid-turn reports tokens accumulated from streamed assistant messages", async () => {
+		const harness = createGoalHarness();
+		const ctx = await makeCtx();
+		await harness.tools.get("create_goal")?.execute("c1", { objective: "Ship it" }, undefined, undefined, ctx);
+		await runHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await streamAssistantMessage(harness, ctx, assistantMessage(100, 50));
+
+		const snapshot = await harness.tools.get("get_goal")?.execute("g1", {}, undefined, undefined, ctx);
+
+		expect(tokensUsedOf(snapshot)).toBe(150);
+	});
+
+	it("agent_end accounts only the remaining usage after a mid-turn completion", async () => {
+		const harness = createGoalHarness();
+		const ctx = await makeCtx();
+		const first = assistantMessage(100, 50);
+		const second = assistantMessage(10, 5);
+		await harness.tools.get("create_goal")?.execute("c1", { objective: "Ship it" }, undefined, undefined, ctx);
+		await runHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await streamAssistantMessage(harness, ctx, first);
+		await harness.tools.get("update_goal")?.execute("u1", { status: "complete" }, undefined, undefined, ctx);
+		await streamAssistantMessage(harness, ctx, second);
+
+		await runHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [first, second] }, ctx);
+
+		expect((await readGoal(storeRefFor(ctx)))?.tokensUsed).toBe(165);
+	});
+
+	it("session_shutdown accounts streamed usage not yet checkpointed", async () => {
+		const harness = createGoalHarness();
+		const ctx = await makeCtx();
+		await harness.tools.get("create_goal")?.execute("c1", { objective: "Ship it" }, undefined, undefined, ctx);
+		await runHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await streamAssistantMessage(harness, ctx, assistantMessage(100, 50));
+
+		await runHandlers(harness.handlers, "session_shutdown", { type: "session_shutdown" }, ctx);
+
+		expect((await readGoal(storeRefFor(ctx)))?.tokensUsed).toBe(150);
+	});
+
+	it("a goal created mid-turn is not charged usage streamed before it existed", async () => {
+		const harness = createGoalHarness();
+		const ctx = await makeCtx();
+		const before = assistantMessage(1000, 500);
+		const after = assistantMessage(10, 5);
+		await runHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await streamAssistantMessage(harness, ctx, before);
+		await harness.tools.get("create_goal")?.execute("c1", { objective: "Late goal" }, undefined, undefined, ctx);
+		await streamAssistantMessage(harness, ctx, after);
+
+		await runHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [before, after] }, ctx);
+
+		expect((await readGoal(storeRefFor(ctx)))?.tokensUsed).toBe(15);
+	});
+});


### PR DESCRIPTION
## Summary
Fix goal token accounting when `update_goal` or `get_goal` runs inside a long agent turn.

The builtin previously waited for `agent_end` to aggregate assistant usage, so an in-turn completion reported `tokensUsed: 0` despite real session usage. It now tracks finalized assistant messages through `message_end`, checkpoints pending usage for goal tools and commands, and subtracts previously checkpointed usage at `agent_end` to prevent double counting.

## Verification
- RED -> GREEN: `npx vitest run test/suite/goal-turn-usage.test.ts ...` (4 initial failures: `0 != 150`, `1515 != 15`; final goal suite: 54 passed)
- Real AgentSession e2e: `goal-e2e.test.ts` proves `update_goal` reports independently persisted assistant usage mid-run.
- `npm run check`: TypeScript/Biome/browser/web-ui checks passed. Unrelated Neo `TestIntegrationAttachToHealthyRealDaemon` timed out only in the full parallel run; it passed standalone in both the worktree and main checkout.
- Real CLI QA evidence: `local-ignore/qa-evidence/20260720-goal-mid-turn-token-usage/`
  - mock loop self-test 5/5
  - mock loop with tool 4/4
  - CLI smoke 7/7
  - RPC state round-trip
  - each verified real `auth.json` unchanged and self-cleaned its sandbox.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes goal token usage accounting in `coding-agent` so `update_goal` and `get_goal` report accurate tokens mid-turn, without double counting at `agent_end`. Adds a lightweight tracker fed by `message_end` events.

- **Bug Fixes**
  - Added `TurnUsageTracker` to accumulate assistant usage from `message_end` and checkpoint mid-turn.
  - At `agent_end`, account only remaining usage (collected minus flushed) to prevent double counting.
  - Discard pending usage when a goal starts mid-turn so earlier tokens aren’t charged.
  - Updated goal tools/command to use the new accounting flow; added tests for mid-turn and end-of-run scenarios.

<sup>Written for commit ec25e8d61d91ebe5b532701fb4b3bef3e666ea69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

