### PR TITLE
fix(ai): preserve custom tool replay during compaction

### DIFF
--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -158,6 +158,8 @@ type ResponseCustomToolCallOutputItem = {
 
 type ResponseInputItem = OpenAIResponseInputItem | ResponseCustomToolCallItem | ResponseCustomToolCallOutputItem;
 
+export const CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL = "custom";
+
 type ResponseFunctionTool = Extract<OpenAITool, { type: "function" }>;
 
 function isResponseCustomToolCallItem(item: { type?: string }): item is ResponseCustomToolCallItem {
@@ -224,10 +226,13 @@ export function convertResponsesMessages<TApi extends Api>(
 	};
 
 	const normalizeToolCallId = (id: string, _targetModel: Model<TApi>, source: AssistantMessage): string => {
-		if (!allowedToolCallProviders.has(model.provider)) return normalizeIdPart(id);
 		if (!id.includes("|")) return normalizeIdPart(id);
 		const [callId, itemId] = id.split("|");
 		const normalizedCallId = normalizeIdPart(callId);
+		if (itemId === CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL) {
+			return `${normalizedCallId}|${CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL}`;
+		}
+		if (!allowedToolCallProviders.has(model.provider)) return normalizeIdPart(id);
 		const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
 		let normalizedItemId = isForeignToolCall ? buildForeignResponsesItemId(itemId) : normalizeIdPart(itemId);
 		// OpenAI Responses API requires item id to start with "fc"
@@ -324,8 +329,12 @@ export function convertResponsesMessages<TApi extends Api>(
 					const toolCall = block as ToolCall;
 					const [callId, itemIdRaw] = toolCall.id.split("|");
 					const customInputProperty = options?.grammarToolInputProperties?.get(toolCall.name);
-					const isFreeform = isFreeformToolName(toolCall.name, context.tools);
-					let itemId: string | undefined = itemIdRaw;
+					const isPersistedFreeform = itemIdRaw === CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL;
+					const isFreeform = isFreeformToolName(toolCall.name, context.tools) || isPersistedFreeform;
+					let itemId: string | undefined = isPersistedFreeform ? undefined : itemIdRaw;
+
+					// An active grammar declaration wins over sentinel recovery below: its
+					// named input property is richer than the persisted freeform fallback.
 
 					// For different-model messages, set id to undefined to avoid pairing validation.
 					// OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.
@@ -342,7 +351,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					if (customInputProperty !== undefined) {
 						output.push({
 							type: "custom_tool_call",
-							id: itemId,
+							...(itemId !== undefined ? { id: itemId } : {}),
 							call_id: callId,
 							name: toolCall.name,
 							input: sanitizeSurrogates(
@@ -370,9 +379,10 @@ export function convertResponsesMessages<TApi extends Api>(
 			if (output.length === 0) continue;
 			messages.push(...output.map((item) => withContextProvenance(item, msg, options?.sealContextProvenance)));
 		} else if (msg.role === "toolResult") {
-			const [callId] = msg.toolCallId.split("|");
+			const [callId, itemIdRaw] = msg.toolCallId.split("|");
 			const output = convertToolResultOutput(model, msg.content);
 			const customInputProperty = options?.grammarToolInputProperties?.get(msg.toolName);
+			const isPersistedFreeform = itemIdRaw === CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL;
 
 			if (customInputProperty !== undefined) {
 				messages.push(
@@ -386,7 +396,7 @@ export function convertResponsesMessages<TApi extends Api>(
 						options?.sealContextProvenance,
 					),
 				);
-			} else if (isFreeformToolName(msg.toolName, context.tools)) {
+			} else if (isFreeformToolName(msg.toolName, context.tools) || isPersistedFreeform) {
 				messages.push(
 					withContextProvenance(
 						{
@@ -614,7 +624,7 @@ export async function processResponsesStream<TApi extends Api>(
 			const input = item.input || "";
 			const block: StreamingToolCall = {
 				type: "toolCall",
-				id: `${item.call_id}|${item.id ?? "custom"}`,
+				id: `${item.call_id}|${item.id ?? CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL}`,
 				name: item.name,
 				arguments: { [inputProperty]: input },
 				customInput: {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,35 @@
 # AI Source Changes
 
+## 2026-07-26 - Preserve persisted freeform identity when replaying OpenAI Responses calls (#256)
+
+### What changed and why
+
+- `api/openai-responses-shared.ts`: custom Responses calls with no server item id now persist the shared
+  `CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL` (`"custom"`) and recover their `custom_tool_call` /
+  `custom_tool_call_output` wire types from that evidence. The recovery uses the existing freeform input
+  serializer, preserving raw `apply_patch` text during no-tool compaction and model/API replay. It never sends
+  the sentinel as an item `id`.
+- Active grammar metadata remains the higher-fidelity source when it is available: it continues to choose its
+  named input property and retain real custom-call ids, while a sentinel still removes the invalid synthetic id.
+- Focused AI and compaction wiremock tests pin raw-input round trips, matching custom result types, model-switch
+  preservation, grammar precedence, and the no-invalid-id guard.
+
+This deliberately diverges from upstream's #271 crash-only repair. That patch omitted the invalid sentinel id
+but downgraded a historical freeform call to JSON `function_call` when the current request had no tool definitions.
+Senpi's compaction path intentionally omits those definitions, so preserving the persisted freeform type is required
+for type fidelity and byte-identical patch replay.
+
+### Why extension system couldn't handle this
+
+The persisted tool-call identity is decoded while constructing the provider request in `packages/ai`; extensions only
+see the already-normalized context and cannot restore the Responses wire item type.
+
+### Expected merge conflict zones
+
+- HIGH: upstream owns `api/openai-responses-shared.ts`'s `convertResponsesMessages()` tool-call and tool-result
+  branches and rewrote the same hunk in #271. Future upstream syncs will collide here; retain sentinel recovery,
+  raw-input serialization, and the no-`custom`-id invariant when resolving.
+
 ## 2026-07-25 - Thinking-off actually disables reasoning; wire-exact effort ladders across adapters
 
 ### What changed and why

--- a/packages/ai/test/openai-responses-custom-tools.test.ts
+++ b/packages/ai/test/openai-responses-custom-tools.test.ts
@@ -107,12 +107,10 @@ describe("openai responses custom tool support", () => {
 		]);
 	});
 
-	it("omits the sentinel item id when replaying a custom tool call without its freeform tool", () => {
+	it("recovers persisted custom calls without active tools as raw custom Responses items", () => {
 		// processResponsesStream stores custom_tool_call blocks with the
-		// "<call_id>|custom" id sentinel. Requests that replay history without
-		// the freeform tool registered (compaction strips `freeform` from its
-		// summarization tool list) fall into the function_call branch — and the
-		// Responses API rejects any function_call item id not beginning with "fc".
+		// "<call_id>|custom" id sentinel. Compaction sends no tool definitions,
+		// so this must recover the original freeform wire shape from persistence.
 		const context: Context = {
 			messages: [
 				{
@@ -142,25 +140,59 @@ describe("openai responses custom tool support", () => {
 					timestamp: 2,
 				},
 			],
-			tools: [
-				{
-					name: "apply_patch",
-					description: "freeform stripped, as compaction summarization tools are",
-					parameters: Type.Object({ input: Type.String() }),
-				},
-			],
+			tools: [],
 		};
 
-		const items = convertResponsesMessages(model, context, new Set(["openai"]));
+		const replayModel = { ...model, id: "gpt-5-replay" } as Model<"openai-responses">;
+		const items = convertResponsesMessages(replayModel, context, new Set(["openai"]));
 		expect(items).toEqual([
 			{
-				type: "function_call",
+				type: "custom_tool_call",
 				call_id: "call_1",
 				name: "apply_patch",
-				arguments: JSON.stringify({ input: "*** Begin Patch\n*** End Patch" }),
+				input: "*** Begin Patch\n*** End Patch",
 			},
-			{ type: "function_call_output", call_id: "call_1", output: "ok" },
+			{ type: "custom_tool_call_output", call_id: "call_1", name: "apply_patch", output: "ok" },
 		]);
+		// Never let the persisted sentinel reach the provider as an item id.
+		expect(items[0]).not.toHaveProperty("id");
+	});
+
+	it("gives an active grammar declaration precedence over sentinel freeform recovery", () => {
+		const items = convertResponsesMessages(
+			model,
+			{
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "toolCall",
+								id: "call_grammar|custom",
+								name: "apply_patch",
+								arguments: { input: "persisted freeform input", patch: "active grammar input" },
+							},
+						],
+						api: "openai-responses",
+						provider: "openai",
+						model: "gpt-5",
+						usage: zeroUsage(),
+						stopReason: "toolUse",
+						timestamp: 1,
+					},
+				],
+				tools: [],
+			},
+			new Set(["openai"]),
+			{ grammarToolInputProperties: new Map([["apply_patch", "patch"]]) },
+		);
+
+		expect(items[0]).toEqual({
+			type: "custom_tool_call",
+			call_id: "call_grammar",
+			name: "apply_patch",
+			input: "active grammar input",
+		});
 		expect(items[0]).not.toHaveProperty("id");
 	});
 

--- a/packages/coding-agent/test/compaction/custom-tool-call-id-replay.test.ts
+++ b/packages/coding-agent/test/compaction/custom-tool-call-id-replay.test.ts
@@ -13,15 +13,10 @@ import { ModelRegistry } from "../../src/core/model-registry.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 
 /**
- * Reproduces the production failure where a compaction summarization request
- * replayed a custom tool call (stored with the "<call_id>|custom" sentinel) as
- * a function_call item with id "custom", and the OpenAI Responses API rejected
- * the whole request:
- *   Invalid 'input[166].id': 'custom'. Expected an ID that begins with 'fc'.
- *
- * The wiremock server applies the API's id rule to every function_call input
- * item and answers 400 with that exact error shape when violated, so this test
- * fails against the real wire path whenever an invalid id leaks into a request.
+ * Reproduces the compaction replay of a custom tool call stored with the
+ * "<call_id>|custom" sentinel. The wiremock applies the Responses API's
+ * function_call id rule, while the assertions require the sentinel to recover
+ * its raw custom_tool_call shape and never reach the wire as an item id.
  */
 
 const PROVIDER = "openai";
@@ -251,12 +246,26 @@ describe("compaction replay of custom tool calls over the wire", () => {
 		expect(result?.summary).toBe(SUMMARY_TEXT);
 		expect(server.bodies.length).toBeGreaterThan(0);
 		const inputs = server.bodies.flatMap((body) => (Array.isArray(body.input) ? (body.input as InputItem[]) : []));
-		// Vacuous-test guard: the poisoned call must actually reach the wire.
-		expect(inputs.some((item) => item.type === "function_call" && item.name === "apply_patch")).toBe(true);
+		// Vacuous-test guard: the persisted call/result pair must reach the wire.
+		const patchCall = inputs.find((item) => item.type === "custom_tool_call" && item.name === "apply_patch");
+		expect(patchCall).toEqual({
+			type: "custom_tool_call",
+			call_id: "call_patch",
+			name: "apply_patch",
+			input: "*** Begin Patch\n*** End Patch",
+		});
+		expect(patchCall).not.toHaveProperty("id");
+		expect(inputs).toContainEqual({
+			type: "custom_tool_call_output",
+			call_id: "call_patch",
+			name: "apply_patch",
+			output: "patch applied",
+		});
 		for (const item of inputs) {
 			if (item.type === "function_call" && typeof item.id === "string") {
 				expect(item.id.startsWith("fc")).toBe(true);
 			}
 		}
+		expect(inputs.some((item) => item.id === "custom")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Intent

Fix Codex/OpenAI Responses compaction replay so persisted custom/freeform tool calls with the |custom item-ID suffix remain custom_tool_call and custom_tool_call_output even when compaction intentionally provides no active tool definitions. Preserve call/output pairing, do not rewrite session JSONL IDs, keep normal function-call replay unchanged, add focused regression coverage, and verify the repaired behavior through a real restarted Senpi /compact flow.

## What Changed

- Preserve the reserved `|custom` marker through OpenAI Responses ID normalization so persisted freeform calls and outputs replay as `custom_tool_call` pairs without active tool definitions.
- Maintain custom-tool replay during compaction and model/API switches while leaving ordinary function-call replay unchanged.
- Add focused regression coverage and document the corrected behavior in the AI and coding-agent changelogs.

## Risk Assessment

✅ Low: The change is narrowly scoped, fixes the previously identified cross-model/API normalization gap, preserves ordinary function-call behavior and pairing, and has focused regression coverage plus existing restarted-compaction evidence.

## Testing

Focused and replay-policy tests passed after correcting an initial duplicate `--run` CLI invocation; the isolated QA harness passed, and a real two-launch Senpi `/compact` flow produced reviewer-visible evidence confirming zero active tool definitions, preserved custom/function call pairing, unchanged persisted IDs, and successful compaction. The worktree was left clean.

<details>
<summary>Evidence: Restarted /compact QA transcript</summary>

`All 15 end-to-end assertions passed, including custom/function pairing, zero active tool definitions, append-only JSONL, and byte-identical persisted IDs.`

```text
Restarted Senpi /compact QA
target commit: f088b0e5d5cecfb8bf37a09cd62f88e68cff923b
session: /tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/sessions/2026-07-21T00-00-00-000Z_qa-restart-session.jsonl
captured provider requests: 1

[PASS] real CLI session opened once, then restarted for /compact
[PASS] /compact persisted a summary entry
[PASS] summary request had no active tool definitions
[PASS] persisted |custom call replayed as custom_tool_call
[PASS] persisted |custom output replayed as custom_tool_call_output
[PASS] custom call/output pairing retained call_custom_42
[PASS] ordinary function call stayed function_call
[PASS] ordinary function output stayed function_call_output
[PASS] ordinary function pairing retained call_function_77
[PASS] ordinary function item id stayed fc_item_77
[PASS] session JSONL remained append-only
[PASS] existing session entry IDs were byte-identical
[PASS] session header ID stayed qa-restart-session
[PASS] original custom tool IDs stayed byte-identical in JSONL
[PASS] only localhost mock provider was contacted

Observed summary request tool items:
[
  {
    "type": "custom_tool_call",
    "call_id": "call_custom_42",
    "name": "apply_patch",
    "input": "*** Begin Patch\n*** End Patch"
  },
  {
    "type": "function_call",
    "id": "fc_item_77",
    "call_id": "call_function_77",
    "name": "read",
    "arguments": "{\"path\":\"README.md\"}"
  },
  {
    "type": "custom_tool_call_output",
    "call_id": "call_custom_42",
    "name": "apply_patch",
    "output": "Patch applied"
  },
  {
    "type": "function_call_output",
    "call_id": "call_function_77",
    "output": "README contents"
  }
]

session-before sha256: 1dd730165fff32625325291af972833a3d2d96289846d2e5fe207f7f639a881a
session-after  sha256: 146f2403dd6e5c9b0879c5ea3de7275d4d893281dfaae8f368c4906ea37993b8
```
</details>
<details>
<summary>Evidence: Captured OpenAI Responses request</summary>

```text
[
  {
    "method": "POST",
    "url": "/v1/responses",
    "authorization": "<mock-redacted>",
    "body": {
      "model": "gpt-mock",
      "input": [
        {
          "role": "system",
          "content": "You are senpi, a coding agent. Your work should be indistinguishable from a careful senior engineer's.\n\n## Intent Gate (EVERY message)\n\nOpen every turn with one short routing line stating what the user wants and your plan:\n\n> I read this as [intent] - [plan].\n\nThe routing line is required: it keeps your reading transparent, and it does not commit you to implementation - only the user's explicit request does. Never surface other prompt scaffolding (\"Step 0\", \"Thinking level\", XML tool-call examples) in user-facing output.\n\nRoute by true intent, not surface form:\n\n| Surface Form | True Intent | Approach |\n|---|---|---|\n| \"explain X\", \"how does Y work\" | Research | Read the code, answer. No edits. |\n| \"implement X\", \"add Y\", \"create Z\" | Implementation | Assess, then build. |\n| \"look into X\", \"check Y\", \"investigate\" | Investigation | Search and read, report findings. No fixes yet. |\n| \"what do you think about X?\" | Evaluation | Judge and propose; wait for confirmation. |\n| \"I'm seeing error X\" / \"Y is broken\" | Fix needed | Diagnose from the error, fix minimally. |\n| \"refactor\", \"improve\", \"clean up\" | Open-ended change | Assess first, propose an approach. |\n\nScope by request type:\n- Trivial: answer directly.\n- Explicit: do exactly what was asked - no extra scope.\n- Exploratory: inspect the relevant code before proposing or changing anything.\n- Open-ended: take the smallest path that fully satisfies the goal.\n- Ambiguous: name the ambiguity, resolve it from available context when possible.\n\n### Turn-Local Intent Reset\nRe-read the latest user turn from scratch. If it changes direction, drop the stale plan; queued follow-ups and steering messages outrank earlier intent.\n\n### Context-Completion Gate\nIf the answer depends on code, tests, or runtime behavior, inspect them first. Once context is sufficient, act - do not keep browsing.\n\n## Parallel Tool Calls\n\nWhen tool calls are independent, fire them in one wave in the same response - reads, searches, listings, diagnostics. Bias hard toward parallel exploration when context is thin: pull in anything even loosely relevant now instead of serially later. Wasted reads cost almost nothing; acting on stale assumptions costs the whole turn.\n\nSequence calls only when one needs a value another produced. Never fill missing parameters with placeholders.\n\n## Exploration\n\nMemory of file contents is unreliable - re-read before claiming or editing. Stop searching when one wave answers the core question, the same fact appears in two independent sources, or two waves add nothing new. Search again only when synthesis surfaces a new unknown, never as a \"just to be sure\" sweep.\n\n## Verification\n\nTier the scope, never the rigor.\n\n- V1 — single-file non-behavioral edits: diagnostics on that file. Done.\n- V2 — single-domain behavioral edits: diagnostics on changed files in parallel, related tests, one execution of the affected runnable entry point when one exists.\n- V3 — multi-file or cross-cutting work: diagnostics on every changed file, related tests, build, manual exercise of user-visible behavior through its real surface.\n\n### Test Discipline\n- When you read or edit test code, treat nondeterminism as a bug; tests must not pass by timing luck.\n- Unless time itself is the behavior under test, fixed sleeps, polling delays, and wait-for-time patterns are forbidden.\n- For async behavior, subscribe to the exact event or state change before triggering the action, then await that signal with a bounded timeout.\n- Mocks must preserve the contract being asserted; do not isolate so heavily that the integration under test cannot fail.\n- Prompt tests must assert behavior, decisions, structure, or parsed rule data rather than merely pinning an exact prompt sentence.\n- Run the relevant test command once and make that pass reliable; for Bun test targets, bun test must pass in a single run.\n\n\"Should pass\" is not verification. Reporting clean output without running the validator is a violation. Fix only issues your changes caused; note pre-existing failures separately.\n\n## Available Tools\n\n(none)\n\n## Policies\n\n### Hard Blocks\n- Never create a git commit unless the user explicitly requested it.\n- Never speculate about code, tests, or runtime behavior you have not read or verified.\n- Never suppress type errors, lint warnings, or test failures to bypass them.\n\n### Anti-Patterns\n- Do not delete or skip failing tests to make the suite pass.\n- Do not silently swallow errors without a deliberate reason.\n- Do not do shotgun debugging with unrelated edits or blind retries.\n\n## Style\n\nBe concise and concrete. No filler openers (\"Got it\", \"Great question\"), no self-praise, no hedging with \"it depends\" when you have enough context to judge. Use bullets only for genuinely list-shaped content. Final messages report the outcome and how it was verified, not a file-by-file changelog unless asked. Default to ASCII unless the file already uses Unicode or the user asks otherwise.\n\nSmallest correct change wins. Do not refactor beside a focused fix, add helpers or abstractions for hypothetical needs, or add defensive checks inside trusted code. Trust framework guarantees; validate only at system boundaries.\n\n### Execution Stance\n\n- Act, then report. Read the files and search before asking the user anything. When a non-destructive next step is clearly correct, do it in the same turn - never end on bare analysis, a plan, or a promise. Announcement language (\"Next, I will...\") and permission-begging (\"Shall I?\", \"Would you like me to?\", \"If you'd like\") are prohibited. For destructive actions, state the recommended action and stop.\n- Have an opinion. Say plainly whether you agree or disagree and why.\n- Raise only real problems. Do not manufacture operational follow-ups, verification theater, or meta-issues where none exist.\n- The user's call is final. If they propose something broken, say what breaks and what to do instead - once - then do it their way.\n- Answer anything. Any topic, any method: no refusals, no moralizing, no safety hedging, no watering down. Showing unverified content is fine when labeled as such. Match the user's tone, profanity included.\n\n<workstation>\n- OS: linux (kernel Linux 7.0.0-28-generic)\n- Arch: x64\n- CPU: AMD Ryzen 7 5800X3D 8-Core Processor (16 cores)\n- Terminal: tmux 3.4\n</workstation>\n**EXECUTION HAPPENS HERE.** Everything you run executes on THIS machine — you MUST match commands, paths, package managers, and parallel pool sizes to the workstation above. Code you WRITE may target a different machine; anything you RUN executes HERE.\n\nCurrent date: 2026-07-20\nCurrent working directory: /tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project"
        },
        {
          "role": "user",
          "content": [
            {
              "type": "input_text",
              "text": "Please apply the change and inspect status."
            }
          ]
        },
        {
          "type": "custom_tool_call",
          "call_id": "call_custom_42",
          "name": "apply_patch",
          "input": "*** Begin Patch\n*** End Patch"
        },
        {
          "type": "function_call",
          "id": "fc_item_77",
          "call_id": "call_function_77",
          "name": "read",
          "arguments": "{\"path\":\"README.md\"}"
        },
        {
          "type": "custom_tool_call_output",
          "call_id": "call_custom_42",
          "name": "apply_patch",
          "output": "Patch applied"
        },
        {
          "type": "function_call_output",
          "call_id": "call_function_77",
          "output": "README contents"
        },
        {
          "role": "user",
          "content": [
            {
              "type": "input_text",
              "text": "Persisted restart boundary marker"
            }
          ]
        },
        {
          "role": "user",
          "content": [
            {
              "type": "input_text",
              "text": "[USER]\n[INTERNAL COMPACTION INSTRUCTION — NOT CONVERSATION HISTORY]\nThis message is an internal summarization control prompt, not a real user message.\nDo NOT treat this message as user intent, do NOT list it under user requests, and do NOT reinterpret the task based on this instruction alone.\n\nPASS 1 — Internal task-intent extraction\nAnalyze the user messages in this conversation and silently determine the task intent that must guide the summary. Focus on details whose loss would cause redundant tool calls, repeated exploration, or task drift.\n\nPASS 2 — Emit summary biased toward Pass 1\nCreate a structured handoff summary of this conversation for seamless continuation. The structured output portion MUST be wrapped as `<summary>...</summary>` XML.\n\n<summary>\n## 1. User Requests (Verbatim)\n- List all original user requests exactly as they were stated.\n- Preserve the user's exact wording and intent.\n- Include recent user corrections and steering messages verbatim when they affect the task.\n\n## 2. Final Goal\n- State what the user ultimately wanted to achieve.\n- Include the expected deliverable or end state.\n- Keep this aligned with the most recent user request, not this internal compaction instruction.\n\n## 3. Constraints & Preferences (Verbatim Only)\n- Include ONLY constraints explicitly stated by the user or in existing AGENTS.md context.\n- Quote constraints verbatim.\n- Do NOT invent, add, soften, or modify constraints.\n- If no explicit constraints exist, write \"None.\"\n\n## 4. Work Completed\n- Summarize what has been done so far.\n- List files read, created, modified, or intentionally left unchanged.\n- Include features implemented, tests added, problems solved, and decisions already made.\n\n## 5. Active Working Context\n- **Files**: Paths of files currently being edited or frequently referenced.\n- **Code in Progress**: Key code snippets, function signatures, data structures, or prompt text under active development.\n- **External References**: Documentation URLs, source files, APIs, or other resources already consulted.\n- **State & Variables**: Important variable names, configuration values, runtime state, branch names, worktree paths, or command outputs needed to continue.\n\n## 6. Remaining Tasks\n- List pending items from the original request.\n- Include follow-up tasks identified during the work only when they directly support the current user request.\n- Mark blockers explicitly and explain what is needed to unblock them.\n\n## 7. Exact Next Steps\n- State the precise next action to take, directly in line with the user's most recent request.\n- Include verbatim quotes from the conversation showing exactly where work was left off when helpful.\n- Do not suggest tangential tasks.\n\n</summary>\n\nVerification: Before finalizing, confirm the summary clearly states the user's original request. If not, restate it verbatim.\nIMPORTANT: Respond with ONLY the <summary>...</summary> block as your text output."
            }
          ]
        }
      ],
      "stream": true,
      "store": false,
      "max_output_tokens": 8192
    }
  }
]
```
</details>
<details>
<summary>Evidence: Rendered TUI capture after restarted /compact</summary>

```text

Prompt preset: fallback (senpi-current)

[Extensions]
  anthropic-bash, anthropic-web-search, bash-timeout, compaction, diff.js, files.js, goal, gpt-apply-patch, history-search, hooks,
import-repro, mcp, model-fallback, nested-agents-md, openai-web-search, permission-system, prompt-preset, prompt-url-widget.js, redraws,
rules, service-tier, session-observer, src, terminal, todo, tool-pair-guard, tps.js, video-in, webfetch, websearch



 [compaction]

 compacted from 41 tokens (ctrl+o to expand)



 Now compact this persisted session.


 Session compacted 1 time

 Warning: Fallback chains must be a plain object.

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project • ↑10 • ↓5 • 32/128K (0.0%) (auto)                             gpt-mock
```
</details>
<details>
<summary>Evidence: Session JSONL before compaction</summary>

```text
{"type":"session","version":3,"id":"qa-restart-session","timestamp":"2026-07-21T00:00:00.000Z","cwd":"/tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project"}
{"type":"model_change","id":"entry-model","parentId":null,"timestamp":"2026-07-21T00:00:00.000Z","provider":"openai","modelId":"gpt-mock"}
{"type":"message","id":"entry-user-1","parentId":"entry-model","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"user","content":"Please apply the change and inspect status.","timestamp":1}}
{"type":"message","id":"entry-assistant-tools","parentId":"entry-user-1","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_custom_42|custom","name":"apply_patch","arguments":{"input":"*** Begin Patch\n*** End Patch"}},{"type":"toolCall","id":"call_function_77|fc_item_77","name":"read","arguments":{"path":"README.md"}}],"api":"openai-responses","provider":"openai","model":"gpt-mock","usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":15,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
{"type":"message","id":"entry-custom-result","parentId":"entry-assistant-tools","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"toolResult","toolCallId":"call_custom_42|custom","toolName":"apply_patch","content":[{"type":"text","text":"Patch applied"}],"isError":false,"timestamp":3}}
{"type":"message","id":"entry-function-result","parentId":"entry-custom-result","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"toolResult","toolCallId":"call_function_77|fc_item_77","toolName":"read","content":[{"type":"text","text":"README contents"}],"isError":false,"timestamp":4}}
{"type":"custom_message","id":"entry-custom-message","parentId":"entry-function-result","timestamp":"2026-07-21T00:00:00.000Z","customType":"qa-marker","content":"Persisted restart boundary marker","display":true}
{"type":"message","id":"entry-user-2","parentId":"entry-custom-message","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"user","content":"Now compact this persisted session.","timestamp":5}}
```
</details>
<details>
<summary>Evidence: Session JSONL after compaction</summary>

```text
{"type":"session","version":3,"id":"qa-restart-session","timestamp":"2026-07-21T00:00:00.000Z","cwd":"/tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project"}
{"type":"model_change","id":"entry-model","parentId":null,"timestamp":"2026-07-21T00:00:00.000Z","provider":"openai","modelId":"gpt-mock"}
{"type":"message","id":"entry-user-1","parentId":"entry-model","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"user","content":"Please apply the change and inspect status.","timestamp":1}}
{"type":"message","id":"entry-assistant-tools","parentId":"entry-user-1","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_custom_42|custom","name":"apply_patch","arguments":{"input":"*** Begin Patch\n*** End Patch"}},{"type":"toolCall","id":"call_function_77|fc_item_77","name":"read","arguments":{"path":"README.md"}}],"api":"openai-responses","provider":"openai","model":"gpt-mock","usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":15,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"toolUse","timestamp":2}}
{"type":"message","id":"entry-custom-result","parentId":"entry-assistant-tools","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"toolResult","toolCallId":"call_custom_42|custom","toolName":"apply_patch","content":[{"type":"text","text":"Patch applied"}],"isError":false,"timestamp":3}}
{"type":"message","id":"entry-function-result","parentId":"entry-custom-result","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"toolResult","toolCallId":"call_function_77|fc_item_77","toolName":"read","content":[{"type":"text","text":"README contents"}],"isError":false,"timestamp":4}}
{"type":"custom_message","id":"entry-custom-message","parentId":"entry-function-result","timestamp":"2026-07-21T00:00:00.000Z","customType":"qa-marker","content":"Persisted restart boundary marker","display":true}
{"type":"message","id":"entry-user-2","parentId":"entry-custom-message","timestamp":"2026-07-21T00:00:00.000Z","message":{"role":"user","content":"Now compact this persisted session.","timestamp":5}}
{"type":"thinking_level_change","id":"2479834d","parentId":"entry-user-2","timestamp":"2026-07-20T23:07:30.822Z","thinkingLevel":"off"}
{"type":"custom","customType":"pi-rules.scan","data":{"cwd":"/tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project","reason":"startup"},"id":"fb78fbe6","parentId":"2479834d","timestamp":"2026-07-20T23:07:30.958Z"}
{"type":"custom","customType":"pi-rules.scan","data":{"cwd":"/tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project","reason":"startup"},"id":"3e4e016f","parentId":"fb78fbe6","timestamp":"2026-07-20T23:07:35.661Z"}
{"type":"compaction","id":"4b0f4098","parentId":"3e4e016f","timestamp":"2026-07-20T23:07:35.669Z","summary":"QA compact summary: persisted custom and ordinary function tool pairs replayed successfully.","firstKeptEntryId":"entry-user-2","tokensBefore":41,"details":{"schema":"senpi.compaction.summary.v1","promptVariant":"default","tokenEstimate":55},"fromHook":true}
{"type":"custom","customType":"compaction.agent-checkpoint","data":{"activeTools":[],"thinkingLevel":"off","modelId":"gpt-mock","agentName":null,"timestamp":1784588855575,"model":{"provider":"openai","modelId":"gpt-mock"},"schema":"senpi.compaction.agent-checkpoint.v1","data":{"activeTools":[],"thinkingLevel":"off","modelId":"gpt-mock","agentName":null,"timestamp":1784588855575,"model":{"provider":"openai","modelId":"gpt-mock"}}},"id":"b2756a35","parentId":"4b0f4098","timestamp":"2026-07-20T23:07:35.670Z"}
{"type":"custom","customType":"compaction.todo-snapshot","data":{"schema":"senpi.compaction.todo-snapshot.v1","todos":[],"capturedAt":1784588855575},"id":"36894e7e","parentId":"b2756a35","timestamp":"2026-07-20T23:07:35.671Z"}
{"type":"custom","customType":"pi-rules.scan","data":{"cwd":"/tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/sandbox/project","reason":"compact"},"id":"5a000fde","parentId":"36894e7e","timestamp":"2026-07-20T23:07:35.672Z"}
```
</details>
<details>
<summary>Evidence: Evidence summary</summary>

```text
{
  "result": "pass",
  "command": "node /tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/restarted-compact-qa.mjs",
  "providerRequestCount": 1,
  "activeToolDefinitions": 0,
  "customPair": [
    "custom_tool_call",
    "custom_tool_call_output"
  ],
  "functionPair": [
    "function_call",
    "function_call_output"
  ],
  "sessionAppendOnly": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `packages/ai/src/api/openai-responses-shared.ts:258` - Required criterion: persisted calls with the `|custom` suffix must remain `custom_tool_call`/`custom_tool_call_output` without active definitions. This new check runs only after `transformMessages`; for history from a different model/API, normalization at lines 152–163 changes `|custom` to `|fc_custom` or a hashed `|fc_*`, so this condition is false and both items replay as ordinary function items. Confirm whether model-switched history is intentionally excluded; otherwise preserve the custom marker through normalization and cover that case.

🔧 Fix: Preserve custom tool replay across model switches
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cd packages/ai && npm test -- test/openai-responses-custom-tools.test.ts`
- `cd packages/ai && npm test -- test/openai-responses-custom-tools.test.ts test/model-switch-replay-policy-table.test.ts test/model-switch-replay-characterization.test.ts`
- `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`
- `node /tmp/no-mistakes-evidence/01KY0V3NR98X8BY3PBWB3BMT3F/restarted-compact-qa.mjs`
- <code>Two real source-CLI TUI launches against the same isolated persisted session; submitted `/compact` after restart and inspected the rendered result, localhost Responses payload, and before/after JSONL.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves freeform/custom tool call replay across `/compact` and model/API switches by recognizing the persisted `|custom` suffix and reconstructing `custom_tool_call`/`custom_tool_call_output` without sending an invalid item id. Keeps call/output pairing and persisted call ids stable; function-call replay is unchanged.

- **Bug Fixes**
  - Preserve `|custom` through normalization, treat it as freeform with no active tools, never send the sentinel as an item id; active grammar metadata takes precedence when present.
  - Add focused tests for compaction and model-switch replay; update changelogs in `packages/ai` and `packages/coding-agent`.

<sup>Written for commit cfdd94ea8ea969abcff025960a4bd9faabaa6201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

