### PR TITLE
fix(coding-agent): unfreeze post-bash compaction stalls and bound PTY bash output

### DIFF
--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,38 @@
 # changes.md — compaction
 
+## Summarization stream idle watchdog (2026-07-21)
+
+### What changed
+
+- `stream-watchdog.ts` (new, fork-owned): `consumeStreamWithIdleTimeout()` drains an event stream
+  and throws `StreamIdleTimeoutError` when no provider event arrives within the idle budget
+  (default 300s, `DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS`, matching the agent stream idle-timeout
+  default). On trip it aborts a request-local controller and returns the iterator; caller aborts
+  end the wait quietly so ESC still reads as the stream's own aborted result.
+- `compaction.ts` `completeSummarization()`: both the `streamSimple` and custom-`streamFn` routes
+  now consume the summarization stream through the watchdog under a request-local
+  `AbortController` linked to the caller's signal, instead of awaiting `completeSimple()` /
+  `stream.result()` with no bound.
+
+### Why
+
+Local compaction summarization had no timeout at any layer: a stalled provider/gateway connection
+hung the session on "Compacting…" forever (observed: 11+ minutes, recovered only by ESC abort).
+The agent loop has had this protection for main turns (`StreamIdleTimeoutError` in
+packages/agent); this ports the same guarantee to compaction requests.
+
+### Why extension system couldn't handle this
+
+- The core `compact()` fallback route (`session_before_compact` handlers returning no result)
+  dispatches its own summarization request inside core; extensions cannot bound a request they
+  never see.
+
+### Expected merge conflict zones
+
+- MEDIUM: `compaction.ts` around `completeSummarization()` and the pi-ai/compat import
+  (`completeSimple` → `streamSimple`).
+- NONE: `stream-watchdog.ts` is a new file.
+
 ## Base64-aware token estimation (2026-07-18)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -7,7 +7,7 @@
 
 import type { AgentMessage, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@earendil-works/pi-ai/compat";
-import { completeSimple } from "@earendil-works/pi-ai/compat";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { convertToLlm, filterContextExcludedMessages, isContextExcludedCustomMessage } from "../messages.ts";
 import {
 	buildSessionContext,
@@ -15,6 +15,7 @@ import {
 	type SessionEntry,
 	sessionEntryToContextMessages,
 } from "../session-manager.ts";
+import { consumeStreamWithIdleTimeout, DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS } from "./stream-watchdog.ts";
 import {
 	computeFileLists,
 	createFileOps,
@@ -584,11 +585,29 @@ async function completeSummarization(
 	options: SimpleStreamOptions,
 	streamFn?: SummarizationStreamFn,
 ): Promise<AssistantMessage> {
-	if (!streamFn) {
-		return completeSimple(model, context, options);
+	// Request-local controller: the idle watchdog must be able to tear down a
+	// stalled summarization request without aborting the caller's own signal.
+	const requestController = new AbortController();
+	const callerSignal = options.signal;
+	const onCallerAbort = () => requestController.abort(callerSignal?.reason);
+	if (callerSignal) {
+		if (callerSignal.aborted) onCallerAbort();
+		else callerSignal.addEventListener("abort", onCallerAbort, { once: true });
 	}
-	const stream = await streamFn(model, context, options);
-	return stream.result();
+	try {
+		const requestOptions = { ...options, signal: requestController.signal };
+		const responseStream = streamFn
+			? await streamFn(model, context, requestOptions)
+			: streamSimple(model, context, requestOptions);
+		await consumeStreamWithIdleTimeout(responseStream, {
+			idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+			abort: () => requestController.abort(),
+			signal: callerSignal,
+		});
+		return await responseStream.result();
+	} finally {
+		if (callerSignal) callerSignal.removeEventListener("abort", onCallerAbort);
+	}
 }
 
 async function transformSummarySource(

--- a/packages/coding-agent/src/core/compaction/stream-watchdog.ts
+++ b/packages/coding-agent/src/core/compaction/stream-watchdog.ts
@@ -1,0 +1,91 @@
+/**
+ * Idle watchdog for compaction summarization streams.
+ *
+ * A provider connection can stall — open but silent — for far longer than any
+ * user will wait, and compaction previously had no bound at all: the session
+ * sat on "Compacting…" until ESC aborted it. The agent loop's main-turn
+ * reader already has this shape of protection (`StreamIdleTimeoutError` in
+ * packages/agent); this brings the same guarantee to summarization requests.
+ */
+
+export class StreamIdleTimeoutError extends Error {
+	readonly idleTimeoutMs: number;
+	constructor(idleTimeoutMs: number) {
+		super(`Summarization stream stalled: no provider events for ${idleTimeoutMs}ms; treating the request as dead`);
+		this.name = "StreamIdleTimeoutError";
+		this.idleTimeoutMs = idleTimeoutMs;
+	}
+}
+
+/** Matches the agent stream idle-timeout default (`httpIdleTimeoutMs`). */
+export const DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS = 300_000;
+
+export interface ConsumeStreamWithIdleTimeoutOptions<T> {
+	/** Silence budget per read; the timer resets on every event. */
+	readonly idleTimeoutMs: number;
+	/** Tear down the underlying request (abort the request-local controller). */
+	readonly abort: () => void;
+	readonly onEvent?: (event: T) => void;
+	/** Caller cancellation; an abort here ends the wait without an idle error. */
+	readonly signal?: AbortSignal;
+}
+
+const IDLE_TRIP = "idle-trip" as const;
+const CALLER_ABORTED = "caller-aborted" as const;
+
+/**
+ * Drain an event stream, failing with {@link StreamIdleTimeoutError} when no
+ * event arrives within `idleTimeoutMs`. Caller aborts propagate as the
+ * stream's own abort outcome, never masked as an idle timeout.
+ */
+export async function consumeStreamWithIdleTimeout<T>(
+	stream: AsyncIterable<T>,
+	options: ConsumeStreamWithIdleTimeoutOptions<T>,
+): Promise<void> {
+	const iterator = stream[Symbol.asyncIterator]();
+	const { idleTimeoutMs, abort, onEvent, signal } = options;
+	let removeAbortListener: (() => void) | undefined;
+	let callerAbortPromise: Promise<typeof CALLER_ABORTED> | undefined;
+	if (signal !== undefined) {
+		if (signal.aborted) {
+			void iterator.return?.();
+			return;
+		}
+		const { promise, resolve } = Promise.withResolvers<typeof CALLER_ABORTED>();
+		const onAbort = () => resolve(CALLER_ABORTED);
+		signal.addEventListener("abort", onAbort, { once: true });
+		removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+		callerAbortPromise = promise;
+	}
+	try {
+		while (true) {
+			const { promise: idlePromise, resolve: resolveIdle } = Promise.withResolvers<typeof IDLE_TRIP>();
+			const timer = setTimeout(() => resolveIdle(IDLE_TRIP), idleTimeoutMs);
+			timer.unref?.();
+			const contenders: Array<Promise<IteratorResult<T> | typeof IDLE_TRIP | typeof CALLER_ABORTED>> = [
+				iterator.next(),
+				idlePromise,
+			];
+			if (callerAbortPromise) contenders.push(callerAbortPromise);
+			let result: IteratorResult<T> | typeof IDLE_TRIP | typeof CALLER_ABORTED;
+			try {
+				result = await Promise.race(contenders);
+			} finally {
+				clearTimeout(timer);
+			}
+			if (result === IDLE_TRIP) {
+				abort();
+				void iterator.return?.();
+				throw new StreamIdleTimeoutError(idleTimeoutMs);
+			}
+			if (result === CALLER_ABORTED) {
+				void iterator.return?.();
+				return;
+			}
+			if (result.done) return;
+			onEvent?.(result.value);
+		}
+	} finally {
+		removeAbortListener?.();
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,23 @@
 # Builtin compaction extension changes
 
+## Idle watchdog on local summarization streams (2026-07-21)
+
+- `speculative.ts` `generateSummaryMessage` now drives the summarization stream through a
+  request-local `AbortController` (linked to the caller's signal) and
+  `consumeStreamWithIdleTimeout()` (`core/compaction/stream-watchdog.ts`,
+  `DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS` = 300s, matching the agent stream idle-timeout default).
+  A provider connection that goes silent mid-summary — previously an unbounded "Compacting…"
+  stall recoverable only by ESC — now tears the request down and throws `StreamIdleTimeoutError`,
+  which the existing failure paths surface as `compaction generator failed: Summarization stream
+  stalled …` (manual/blocking route) or reject the speculative job. Caller aborts still read as
+  the stream's own aborted result, unchanged from the pre-watchdog behavior.
+- This stays in the builtin extension because the summarization request lifecycle is
+  extension-owned; the shared helper and the core `compact()` route live in
+  `core/compaction/` (see `core/compaction/changes.md`).
+
+Expected upstream conflict zones: `builtin/compaction/speculative.ts` around
+`generateSummaryMessage`.
+
 ## Structured rejection reasons on session_before_compact (2026-07-20)
 
 - `index.ts` cancel paths now attach a structured `rejectionCause` plus a

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -16,6 +16,10 @@ import {
 	estimateTokens,
 	prepareCompaction,
 } from "../../../compaction/index.ts";
+import {
+	consumeStreamWithIdleTimeout,
+	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+} from "../../../compaction/stream-watchdog.ts";
 import { convertToLlm } from "../../../messages.ts";
 import type { ModelRegistry } from "../../../model-registry.ts";
 import type { ReadonlySessionManager } from "../../../session-manager.ts";
@@ -101,34 +105,51 @@ async function generateSummaryMessage(options: {
 	// ("reverse engineering or duplicating model outputs"), while the same
 	// content as native blocks with the agent's system prompt and tools passes.
 	const conversationMessages = repairOrphanedToolResults(convertToLlm(options.messages));
-	const responseStream = stream(
-		options.snapshot.model,
-		{
-			systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
-			messages: [
-				...conversationMessages,
-				{
-					role: "user",
-					content: [{ type: "text", text: options.prompt.user }],
-					timestamp: Date.now(),
-				},
-			],
-			...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
-		},
-		{
-			apiKey: options.auth.apiKey,
-			headers: options.auth.headers,
-			extraBody: options.auth.extraBody,
-			maxTokens: MAX_SUMMARY_TOKENS,
-			signal: options.signal,
-		},
-	);
-	for await (const event of responseStream) {
-		if (event.type === "text_delta" && event.delta) {
-			options.onProgress?.(event.delta);
-		}
+	// Request-local controller: the idle watchdog must be able to tear down a
+	// stalled summarization request without aborting the caller's own signal.
+	const requestController = new AbortController();
+	const onCallerAbort = () => requestController.abort(options.signal?.reason);
+	if (options.signal) {
+		if (options.signal.aborted) onCallerAbort();
+		else options.signal.addEventListener("abort", onCallerAbort, { once: true });
 	}
-	return await responseStream.result();
+	try {
+		const responseStream = stream(
+			options.snapshot.model,
+			{
+				systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
+				messages: [
+					...conversationMessages,
+					{
+						role: "user",
+						content: [{ type: "text", text: options.prompt.user }],
+						timestamp: Date.now(),
+					},
+				],
+				...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
+			},
+			{
+				apiKey: options.auth.apiKey,
+				headers: options.auth.headers,
+				extraBody: options.auth.extraBody,
+				maxTokens: MAX_SUMMARY_TOKENS,
+				signal: requestController.signal,
+			},
+		);
+		await consumeStreamWithIdleTimeout(responseStream, {
+			idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+			abort: () => requestController.abort(),
+			signal: options.signal,
+			onEvent: (event) => {
+				if (event.type === "text_delta" && event.delta) {
+					options.onProgress?.(event.delta);
+				}
+			},
+		});
+		return await responseStream.result();
+	} finally {
+		if (options.signal) options.signal.removeEventListener("abort", onCallerAbort);
+	}
 }
 
 function pruneToolResults(messages: AgentMessage[], contextWindow: number): AgentMessage[] {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,38 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Model-facing output is sanitized and bounded (2026-07-21)
+
+### What changed
+
+- `output-format.ts` (new): `sanitizeTerminalOutput()` strips ANSI escape sequences (OSC/CSI/
+  designate/single-char) and folds carriage-return/backspace redraw semantics so spinner and
+  progress frames collapse to their final visible state; `formatTerminalToolOutput()` then
+  tail-truncates to the core-bash budget (`TERMINAL_TOOL_MAX_LINES` 2000 / `TERMINAL_TOOL_MAX_BYTES`
+  50 KB via `core/tools/truncate.ts`) with an "earlier output dropped" marker.
+- `tools/bash.ts`: foreground results now go through `formatTerminalToolOutput()` instead of
+  returning the raw scrollback (up to 1 MB of ANSI soup) verbatim; truncated results carry
+  `details.truncation`. Background start-grace output is formatted the same way.
+- `tools/bash.ts` + `tools/spawn.ts` + `shared.ts`: foreground spawns merge
+  `FOREGROUND_ENV_OVERRIDES` (`NO_COLOR=1`, `TERM=dumb`, `COLORTERM=`, `PAGER/GIT_PAGER/GH_PAGER=cat`,
+  codex-style) over `ctx.getEnv()` so cooperative tools never emit spinner/color frames; background
+  (interactive) sessions keep the user's real `TERM`.
+- `tools/bash-output.ts`: `bash_output` log-view deltas are sanitized and bounded the same way.
+
+### Why
+
+A single `gh run view --log-failed` returned 999,998 chars (the 1 MB session buffer) straight into
+the conversation — context jumped 154k → 404k tokens and forced an emergency compaction; a
+`gh pr checks --watch` result was 118k chars of raw spinner frames. Real session evidence:
+`--Users-yeongyu-local-workspaces-omo--/2026-07-21T03-07-29-890Z_019f82a4-...` (two compactions
+within 15 minutes, both driven by oversized bash results).
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `tools/bash.ts` `runForeground` result construction and `runBackground` early-output block.
+- LOW: `tools/bash-output.ts` log-view result construction.
+- LOW: `tools/spawn.ts` `SpawnRequest` shape and `manager.create` env merge.
+
 ## Core files touched (2026-07-07)
 
 - `core/extensions/builtin/index.ts`: register `terminal` after `bash-timeout`/`anthropic-bash`

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/output-format.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/output-format.ts
@@ -1,0 +1,83 @@
+/**
+ * Model-facing formatting for PTY terminal output.
+ *
+ * The PTY bash tools capture a raw terminal stream: escape sequences, and one
+ * redraw frame per spinner tick. Returned unbounded (up to the 1 MB session
+ * buffer), a single `gh run view --log-failed` injected ~1M chars of ANSI soup
+ * into the conversation and forced emergency compactions. Before output
+ * reaches the model it is (a) sanitized — escape sequences stripped and
+ * carriage-return/backspace redraws collapsed — then (b) tail-truncated to the
+ * same budget the core bash tool enforces.
+ */
+
+import { formatSize, type TruncationResult, truncateTail } from "../../../tools/truncate.ts";
+
+/** Mirrors the core bash tool budget (`DEFAULT_MAX_LINES` / `DEFAULT_MAX_BYTES`). */
+export const TERMINAL_TOOL_MAX_LINES = 2000;
+export const TERMINAL_TOOL_MAX_BYTES = 50 * 1024;
+
+// Order matters: OSC can contain characters that later patterns would eat.
+const OSC_PATTERN = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+const CSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const DESIGNATE_AND_SINGLE_PATTERN = /\x1b(?:[()#%*+][0-9A-Za-z]|[0-9<=>@-Z\\-_])/g;
+// `\x08` (backspace) and `\r` are excluded: the redraw fold applies their semantics.
+const C0_CONTROL_PATTERN = /[\x00-\x07\x0b\x0c\x0e-\x1f\x7f]/g;
+
+function stripEscapeSequences(text: string): string {
+	return text
+		.replace(OSC_PATTERN, "")
+		.replace(CSI_PATTERN, "")
+		.replace(DESIGNATE_AND_SINGLE_PATTERN, "")
+		.replace(C0_CONTROL_PATTERN, "");
+}
+
+/**
+ * Fold terminal redraw semantics into a flat line: `\r` returns the cursor to
+ * column 0 so spinner/progress frames overwrite each other, and `\b` steps the
+ * cursor back one cell. Only the final visible state survives.
+ */
+function collapseRedraws(line: string): string {
+	const cells: string[] = [];
+	let cursor = 0;
+	for (const ch of line) {
+		if (ch === "\r") {
+			cursor = 0;
+		} else if (ch === "\b") {
+			if (cursor > 0) cursor -= 1;
+		} else {
+			cells[cursor] = ch;
+			cursor += 1;
+		}
+	}
+	return cells.join("");
+}
+
+/** Strip escape sequences and collapse carriage-return/backspace redraws. */
+export function sanitizeTerminalOutput(raw: string): string {
+	return stripEscapeSequences(raw).replace(/\r\n/g, "\n").split("\n").map(collapseRedraws).join("\n");
+}
+
+export interface FormattedTerminalToolOutput {
+	readonly text: string;
+	readonly truncated: boolean;
+	readonly truncation: TruncationResult;
+}
+
+/**
+ * Sanitize `raw` PTY output and bound it to the core-bash budget, keeping the
+ * tail (where exit status and errors live) with a marker when content was cut.
+ */
+export function formatTerminalToolOutput(raw: string): FormattedTerminalToolOutput {
+	const sanitized = sanitizeTerminalOutput(raw).trimEnd();
+	const truncation = truncateTail(sanitized, {
+		maxLines: TERMINAL_TOOL_MAX_LINES,
+		maxBytes: TERMINAL_TOOL_MAX_BYTES,
+	});
+	if (!truncation.truncated) {
+		return { text: sanitized, truncated: false, truncation };
+	}
+	const marker = truncation.lastLinePartial
+		? `[Showing last ${formatSize(truncation.outputBytes)} of a single line; earlier output dropped]`
+		: `[Showing lines ${truncation.totalLines - truncation.outputLines + 1}-${truncation.totalLines} of ${truncation.totalLines}; earlier output dropped]`;
+	return { text: `${truncation.content}\n\n${marker}`, truncated: true, truncation };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
@@ -34,6 +34,21 @@ export const KILLED_SESSION_EXIT_GRACE_MS = 5000;
 export const DEFAULT_OUTPUT_WAIT_TIMEOUT_SECONDS = 30;
 
 /**
+ * Non-interactive environment for foreground one-shot commands (codex-style):
+ * cooperative tools (`gh`, `git`, pagers, color libs) skip spinners/colors at
+ * the source instead of flooding the captured stream with redraw frames.
+ * Background sessions keep the user's real TERM for interactive apps.
+ */
+export const FOREGROUND_ENV_OVERRIDES: Readonly<Record<string, string>> = {
+	NO_COLOR: "1",
+	TERM: "dumb",
+	COLORTERM: "",
+	PAGER: "cat",
+	GIT_PAGER: "cat",
+	GH_PAGER: "cat",
+};
+
+/**
  * Named-key aliases the model can send via `bash_input {keys:[...]}`. Values are the
  * raw byte sequences a PTY expects (control chars + xterm cursor/function escapes).
  */

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "typebox";
+import { formatTerminalToolOutput } from "../output-format.ts";
 import type { TerminalRuntimeSession } from "../runtime-session.ts";
 import { DEFAULT_OUTPUT_WAIT_TIMEOUT_SECONDS, safeRegExp, TERMINAL_OUTPUT_TOOL } from "../shared.ts";
 import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
@@ -78,9 +79,9 @@ export function createBashOutputTool(ctx: TerminalToolContext) {
 			}
 
 			const delta = runtime.readDelta();
-			const filtered = applyFilter(delta.text, input.filter).trimEnd();
+			const formatted = formatTerminalToolOutput(applyFilter(delta.text, input.filter));
 			const dropped = delta.droppedChars > 0 ? `[${delta.droppedChars} earlier chars dropped]\n` : "";
-			return textResult(`${statusLine(runtime)}\n${dropped}${filtered || "(no new output)"}`);
+			return textResult(`${statusLine(runtime)}\n${dropped}${formatted.text || "(no new output)"}`);
 		},
 	};
 }

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
@@ -1,9 +1,11 @@
 import { type Static, Type } from "typebox";
+import { formatTerminalToolOutput } from "../output-format.ts";
 import type { TerminalRuntimeSession } from "../runtime-session.ts";
 import {
 	BACKGROUND_START_GRACE_MS,
 	DEFAULT_COLS,
 	DEFAULT_ROWS,
+	FOREGROUND_ENV_OVERRIDES,
 	KILLED_SESSION_EXIT_GRACE_MS,
 	TERMINAL_BASH_TOOL,
 } from "../shared.ts";
@@ -100,7 +102,14 @@ async function runForeground(
 ): Promise<TerminalToolResult> {
 	if (signal?.aborted) return errorResult("Command aborted");
 	const timeoutMs = input.timeout !== undefined ? Math.trunc(input.timeout * 1000) : undefined;
-	const { id, runtime } = await spawnCommandSession(ctx, { command: input.command, cols, rows, timeoutMs, cwd });
+	const { id, runtime } = await spawnCommandSession(ctx, {
+		command: input.command,
+		cols,
+		rows,
+		timeoutMs,
+		cwd,
+		envOverrides: FOREGROUND_ENV_OVERRIDES,
+	});
 	// Interrupt means "stop now": SIGKILL the whole process group in one shot.
 	// kill() is one-shot idempotent, so a gentle SIGTERM first would block any
 	// escalation, and a SIGTERM-ignoring command would pin the agent forever.
@@ -121,7 +130,8 @@ async function runForeground(
 		// `stopping`, so later /exit teardown cannot hang on its exit wait.
 		void ctx.manager.stop(id).catch(() => {});
 	}
-	const output = runtime.fullOutput().trimEnd();
+	const formatted = formatTerminalToolOutput(runtime.fullOutput());
+	const output = formatted.text;
 	// Aborted runs report "Command aborted" (core bash parity) whether the exit
 	// settled normally or the kill grace released the wait. `outcome` matters
 	// beyond that only for the timeout grace, where exitResult is still null.
@@ -136,7 +146,12 @@ async function runForeground(
 	if (exit && exit.exitCode !== 0 && exit.exitCode !== null) {
 		return errorResult(`${output ? `${output}\n\n` : ""}Command exited with code ${exit.exitCode}`);
 	}
-	return textResult(output || "(no output)", { details: { status } });
+	return textResult(output || "(no output)", {
+		details: {
+			status,
+			...(formatted.truncated ? { truncation: formatted.truncation } : {}),
+		},
+	});
 }
 
 async function runBackground(
@@ -153,7 +168,7 @@ async function runBackground(
 
 	// Capture any output the command emits within a short grace window (or its exit).
 	await Promise.race([delay(BACKGROUND_START_GRACE_MS), runtime.session.waitExit()]);
-	const early = runtime.readDelta().text.trimEnd();
+	const early = formatTerminalToolOutput(runtime.readDelta().text).text;
 	const header = `Command running in background with ID: ${id}`;
 	const backendNote =
 		runtime.backend === "pipe-fallback"

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/spawn.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/spawn.ts
@@ -11,6 +11,8 @@ export interface SpawnRequest {
 	readonly timeoutMs?: number;
 	/** Working directory override (execute-time `ctx.cwd`); falls back to the tool context cwd. */
 	readonly cwd?: string;
+	/** Environment overrides merged over `ctx.getEnv()` (foreground non-interactive env). */
+	readonly envOverrides?: Readonly<Record<string, string>>;
 }
 
 /**
@@ -30,7 +32,7 @@ export async function spawnCommandSession(
 		command: shell.shell,
 		args,
 		cwd: request.cwd ?? ctx.cwd,
-		env: ctx.getEnv() as Record<string, string | undefined>,
+		env: { ...ctx.getEnv(), ...request.envOverrides } as Record<string, string | undefined>,
 		cols: request.cols,
 		rows: request.rows,
 		timeoutMs: request.timeoutMs,

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -3,17 +3,26 @@ import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type CompactionPreparation, compact, generateSummary } from "../src/core/compaction/index.ts";
 
-const { completeSimpleMock } = vi.hoisted(() => ({
-	completeSimpleMock: vi.fn(),
+const { streamSimpleMock } = vi.hoisted(() => ({
+	streamSimpleMock: vi.fn(),
 }));
 
 vi.mock("@earendil-works/pi-ai/compat", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@earendil-works/pi-ai/compat")>();
 	return {
 		...actual,
-		completeSimple: completeSimpleMock,
+		streamSimple: streamSimpleMock,
 	};
 });
+
+function fakeSummaryStream(response: AssistantMessage) {
+	return {
+		async *[Symbol.asyncIterator]() {
+			// The watchdog-driven consumer drains events; none are needed here.
+		},
+		result: async () => response,
+	};
+}
 
 function createModel(reasoning: boolean, maxTokens = 8192): Model<"anthropic-messages"> {
 	return {
@@ -52,8 +61,8 @@ const messages: AgentMessage[] = [{ role: "user", content: "Summarize this.", ti
 
 describe("generateSummary reasoning options", () => {
 	beforeEach(() => {
-		completeSimpleMock.mockReset();
-		completeSimpleMock.mockResolvedValue(mockSummaryResponse);
+		streamSimpleMock.mockReset();
+		streamSimpleMock.mockReturnValue(fakeSummaryStream(mockSummaryResponse));
 	});
 
 	it("uses the provided thinking level for reasoning-capable models", async () => {
@@ -70,8 +79,8 @@ describe("generateSummary reasoning options", () => {
 			"medium",
 		);
 
-		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
-		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
+		expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+		expect(streamSimpleMock.mock.calls[0][2]).toMatchObject({
 			reasoning: "medium",
 			apiKey: "test-key",
 		});
@@ -91,11 +100,11 @@ describe("generateSummary reasoning options", () => {
 			"off",
 		);
 
-		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
-		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
+		expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+		expect(streamSimpleMock.mock.calls[0][2]).toMatchObject({
 			apiKey: "test-key",
 		});
-		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
+		expect(streamSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
 	});
 
 	it("does not set reasoning for non-reasoning models", async () => {
@@ -112,11 +121,11 @@ describe("generateSummary reasoning options", () => {
 			"medium",
 		);
 
-		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
-		expect(completeSimpleMock.mock.calls[0][2]).toMatchObject({
+		expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+		expect(streamSimpleMock.mock.calls[0][2]).toMatchObject({
 			apiKey: "test-key",
 		});
-		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
+		expect(streamSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
 	});
 
 	it("clamps compaction summary maxTokens to the model output cap", async () => {
@@ -132,6 +141,6 @@ describe("generateSummary reasoning options", () => {
 
 		await compact(preparation, createModel(false, 128000), "test-key");
 
-		expect(completeSimpleMock.mock.calls.map((call) => call[2]?.maxTokens)).toEqual([128000, 128000]);
+		expect(streamSimpleMock.mock.calls.map((call) => call[2]?.maxTokens)).toEqual([128000, 128000]);
 	});
 });

--- a/packages/coding-agent/test/compaction/summarization-stream-watchdog.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-stream-watchdog.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	consumeStreamWithIdleTimeout,
+	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+	StreamIdleTimeoutError,
+} from "../../src/core/compaction/stream-watchdog.ts";
+
+/**
+ * Compaction summarization streams must not wait forever on a dead provider
+ * connection. A stalled stream (connected but silent) previously hung the
+ * session until the user pressed ESC; now an idle watchdog tears the request
+ * down and surfaces a typed error through the normal compaction failure path.
+ *
+ * Time is driven by fake timers: the watchdog is timer behavior, and real
+ * delays would only flake under CI load.
+ */
+
+async function* stalledStream(): AsyncIterable<{ type: string }> {
+	// Simulates a hung gateway: connection open, no bytes ever.
+	await new Promise(() => {});
+	yield { type: "never" };
+}
+
+type Tick = { type: string };
+
+/** A pull-driven stream: each `advance()` releases exactly one scripted event. */
+/** A pull-driven stream: each `advance()` releases exactly one scripted event. */
+function scriptedStream(events: Tick[]): { stream: AsyncIterable<Tick>; advance: () => Promise<void> } {
+	let index = 0;
+	let waiter: (() => void) | undefined;
+	const stream = {
+		async *[Symbol.asyncIterator]() {
+			while (index < events.length) {
+				const { promise, resolve } = Promise.withResolvers<void>();
+				waiter = resolve;
+				await promise;
+				const current = events[index] as Tick;
+				index += 1;
+				yield current;
+			}
+		},
+	};
+	const advance = async () => {
+		waiter?.();
+		// Flush microtasks so the generator produces and the consumer observes it.
+		for (let i = 0; i < 10; i++) await Promise.resolve();
+	};
+	return { stream, advance };
+}
+
+describe("consumeStreamWithIdleTimeout", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("rejects with StreamIdleTimeoutError and aborts when the stream goes silent", async () => {
+		let aborted = false;
+		const outcome = consumeStreamWithIdleTimeout(stalledStream(), {
+			idleTimeoutMs: 50,
+			abort: () => {
+				aborted = true;
+			},
+		}).catch((caught: unknown) => caught);
+		await vi.advanceTimersByTimeAsync(50);
+		const error = await outcome;
+		expect(error).toBeInstanceOf(StreamIdleTimeoutError);
+		expect((error as StreamIdleTimeoutError).message).toContain("50ms");
+		expect(aborted).toBe(true);
+	});
+
+	it("passes every event through for a healthy stream", async () => {
+		const { stream, advance } = scriptedStream([{ type: "a" }, { type: "b" }, { type: "c" }]);
+		const seen: string[] = [];
+		const done = consumeStreamWithIdleTimeout(stream, {
+			idleTimeoutMs: 1000,
+			abort: () => {},
+			onEvent: (event) => seen.push(event.type),
+		});
+		await advance();
+		await advance();
+		await advance();
+		await done;
+		expect(seen).toEqual(["a", "b", "c"]);
+	});
+
+	it("resets the idle timer on every event", async () => {
+		const { stream, advance } = scriptedStream([{ type: "a" }, { type: "b" }, { type: "c" }]);
+		const seen: string[] = [];
+		let aborted = false;
+		const done = consumeStreamWithIdleTimeout(stream, {
+			idleTimeoutMs: 100,
+			abort: () => {
+				aborted = true;
+			},
+			onEvent: (event) => seen.push(event.type),
+		});
+		for (let i = 0; i < 3; i++) {
+			// Each event arrives just under the idle budget; the watchdog must never trip.
+			await vi.advanceTimersByTimeAsync(90);
+			await advance();
+		}
+		await done;
+		expect(seen).toEqual(["a", "b", "c"]);
+		expect(aborted).toBe(false);
+	});
+
+	it("ends the wait quietly on caller abort instead of masking it as an idle timeout", async () => {
+		const controller = new AbortController();
+		const outcome = consumeStreamWithIdleTimeout(stalledStream(), {
+			idleTimeoutMs: 60_000,
+			abort: () => {
+				throw new Error("watchdog fired on caller abort");
+			},
+			signal: controller.signal,
+		});
+		controller.abort();
+		// Resolves quietly: the stream's own aborted result is surfaced by the
+		// caller through stream.result(), exactly as an ESC abort reads today.
+		await outcome;
+	});
+
+	it("exposes a 5 minute default aligned with the agent stream idle timeout", () => {
+		expect(DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS).toBe(300_000);
+	});
+});

--- a/packages/coding-agent/test/terminal-bash-tool-output.test.ts
+++ b/packages/coding-agent/test/terminal-bash-tool-output.test.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TerminalManager } from "../src/core/extensions/builtin/terminal/manager.ts";
+import { TERMINAL_TOOL_MAX_BYTES } from "../src/core/extensions/builtin/terminal/output-format.ts";
+import { createPtyBashTool } from "../src/core/extensions/builtin/terminal/tools/bash.ts";
+import type { TerminalToolContext, TerminalToolResult } from "../src/core/extensions/builtin/terminal/tools/context.ts";
+
+/**
+ * Model-facing output of the PTY bash tool must be bounded and sanitized:
+ * raw 1 MB scrollback dumps and ANSI spinner floods used to go straight into
+ * the conversation, instantly blowing the context past the compaction
+ * threshold. Foreground spawns also inject a non-interactive environment
+ * (NO_COLOR / TERM=dumb / cat pagers) so cooperative tools never emit the
+ * escape soup in the first place; background interactive sessions keep the
+ * user's real TERM.
+ */
+
+function resultText(result: TerminalToolResult): string {
+	return result.content.map((block) => block.text).join("\n");
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timeoutId = setTimeout(() => reject(new Error(`${label}: did not settle within ${ms}ms`)), ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timeoutId);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timeoutId);
+				reject(error);
+			},
+		);
+	});
+}
+
+function nodeEval(script: string): string {
+	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+describe.skipIf(process.platform === "win32")("PTY bash tool model-facing output", () => {
+	let testDir: string;
+	let manager: TerminalManager;
+	let ctx: TerminalToolContext;
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `senpi-pty-output-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(testDir, { recursive: true });
+		manager = new TerminalManager();
+		ctx = {
+			manager,
+			cwd: testDir,
+			defaultCols: 80,
+			defaultRows: 24,
+			getEnv: () => ({ ...process.env }),
+		};
+	});
+
+	afterEach(async () => {
+		await withTimeout(manager.teardown(), 15000, "manager teardown");
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("bounds a huge foreground result instead of dumping the full scrollback", async () => {
+		const tool = createPtyBashTool(ctx);
+		const script = `process.stdout.write("y".repeat(${TERMINAL_TOOL_MAX_BYTES * 4}))`;
+		const result = await withTimeout(
+			tool.execute("call-big", { command: nodeEval(script) }, undefined, undefined, undefined),
+			30000,
+			"huge foreground command",
+		);
+		const text = resultText(result);
+		expect(text.length).toBeLessThan(TERMINAL_TOOL_MAX_BYTES * 2);
+		expect(text).toContain("earlier output dropped");
+	});
+
+	it("strips ANSI sequences and collapses spinner frames in foreground results", async () => {
+		const tool = createPtyBashTool(ctx);
+		const frame = `\\r\\x1b[K\\x1b[36m⣾\\x1b[0m`;
+		const script = `process.stdout.write("${frame}".repeat(2000) + "\\r\\x1b[K\\x1b[32m✓\\x1b[0m finished\\n")`;
+		const result = await withTimeout(
+			tool.execute("call-ansi", { command: nodeEval(script) }, undefined, undefined, undefined),
+			30000,
+			"spinner command",
+		);
+		const text = resultText(result);
+		expect(text).toContain("✓ finished");
+		expect(text).not.toContain("\x1b[");
+		expect(text.length).toBeLessThan(2000);
+	});
+
+	it("injects a non-interactive environment for foreground commands", async () => {
+		const tool = createPtyBashTool({ ...ctx, getEnv: () => ({ ...process.env, TERM: "xterm-256color" }) });
+		const result = await withTimeout(
+			tool.execute(
+				"call-env",
+				{ command: 'printf \'%s|%s|%s|%s\' "$NO_COLOR" "$TERM" "$PAGER" "$GH_PAGER"' },
+				undefined,
+				undefined,
+				undefined,
+			),
+			30000,
+			"env probe",
+		);
+		expect(resultText(result)).toContain("1|dumb|cat|cat");
+	});
+
+	it("does not inject the non-interactive environment into background sessions", async () => {
+		const tool = createPtyBashTool({ ...ctx, getEnv: () => ({ ...process.env, TERM: "xterm-256color" }) });
+		const result = await withTimeout(
+			tool.execute(
+				"call-bg",
+				{ command: "printf 'TERM=%s\n' \"$TERM\"", run_in_background: true },
+				undefined,
+				undefined,
+				undefined,
+			),
+			30000,
+			"background env probe",
+		);
+		expect(resultText(result)).toContain("TERM=xterm-256color");
+	});
+});

--- a/packages/coding-agent/test/terminal-output-format.test.ts
+++ b/packages/coding-agent/test/terminal-output-format.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatTerminalToolOutput,
+	sanitizeTerminalOutput,
+	TERMINAL_TOOL_MAX_BYTES,
+	TERMINAL_TOOL_MAX_LINES,
+} from "../src/core/extensions/builtin/terminal/output-format.ts";
+
+/**
+ * The PTY-backed bash tools return raw terminal streams. Before the output
+ * reaches the model it must be (a) stripped of escape/control sequences and
+ * carriage-return redraw frames, and (b) bounded to the same budget the core
+ * bash tool enforces — a single `gh run view --log-failed` used to inject
+ * ~1 MB of raw ANSI soup into the context and force emergency compactions.
+ */
+
+describe("sanitizeTerminalOutput", () => {
+	it("passes plain text through unchanged", () => {
+		expect(sanitizeTerminalOutput("hello world\nsecond line")).toBe("hello world\nsecond line");
+	});
+
+	it("strips CSI color and cursor sequences", () => {
+		expect(sanitizeTerminalOutput("\x1b[1m\x1b[31mred bold\x1b[0m plain")).toBe("red bold plain");
+		expect(sanitizeTerminalOutput("\x1b[2m$\x1b[0m \x1b[1mls\x1b[0m")).toBe("$ ls");
+	});
+
+	it("strips private mode and keypad escapes", () => {
+		expect(sanitizeTerminalOutput("\x1b[?1h\x1b=\r\nok\x1b[?1l\x1b>")).toBe("\nok");
+	});
+
+	it("strips OSC hyperlinks and title sequences", () => {
+		expect(sanitizeTerminalOutput("\x1b]8;;https://example.com\x07link\x1b]8;;\x07")).toBe("link");
+		expect(sanitizeTerminalOutput("\x1b]11;?\x1b\\done")).toBe("done");
+	});
+
+	it("normalizes CRLF newlines to LF", () => {
+		expect(sanitizeTerminalOutput("one\r\ntwo\r\nthree")).toBe("one\ntwo\nthree");
+	});
+
+	it("collapses carriage-return spinner frames to the final frame", () => {
+		const spinner = "\r\x1b[K\x1b[36m⣾\x1b[0m\r\x1b[K\x1b[36m⣽\x1b[0m\r\x1b[K\x1b[36m⣻\x1b[0m done";
+		expect(sanitizeTerminalOutput(spinner)).toBe("⣻ done");
+	});
+
+	it("keeps the tail of a longer line when a shorter redraw overwrites it", () => {
+		expect(sanitizeTerminalOutput("abcdef\rXY")).toBe("XYcdef");
+	});
+
+	it("applies carriage returns per line independently", () => {
+		expect(sanitizeTerminalOutput("first-aaa\rfirst-b\nsecond-ccc\rsecond-d")).toBe("first-baa\nsecond-dcc");
+	});
+
+	it("handles backspace overwrites", () => {
+		expect(sanitizeTerminalOutput("abc\x08\x08XY")).toBe("aXY");
+	});
+
+	it("strips remaining C0 control characters but keeps tabs", () => {
+		expect(sanitizeTerminalOutput("a\x00b\x07c\td")).toBe("abc\td");
+	});
+});
+
+describe("formatTerminalToolOutput", () => {
+	it("returns sanitized output untouched when within budget", () => {
+		const result = formatTerminalToolOutput("\x1b[32mok\x1b[0m\n");
+		expect(result.truncated).toBe(false);
+		expect(result.text).toBe("ok");
+	});
+
+	it("keeps the tail of over-line-budget output with a marker", () => {
+		const lines = Array.from({ length: TERMINAL_TOOL_MAX_LINES + 500 }, (_, i) => `line-${i}`);
+		const result = formatTerminalToolOutput(lines.join("\n"));
+		expect(result.truncated).toBe(true);
+		expect(result.text).toContain(`line-${TERMINAL_TOOL_MAX_LINES + 499}`);
+		expect(result.text).not.toContain("line-0");
+		expect(result.text).toContain("Showing lines");
+		expect(result.text).toContain("earlier output dropped");
+	});
+
+	it("keeps over-byte-budget output within the byte limit", () => {
+		const result = formatTerminalToolOutput("x".repeat(TERMINAL_TOOL_MAX_BYTES * 4));
+		expect(result.truncated).toBe(true);
+		expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(TERMINAL_TOOL_MAX_BYTES + 512);
+	});
+
+	it("sanitizes before truncating so escape bytes cannot starve the budget", () => {
+		// 60k chars of spinner frames must collapse to nearly nothing rather than
+		// filling the byte budget with redraw garbage.
+		const frame = "\r\x1b[K\x1b[36m⣾\x1b[0m";
+		const result = formatTerminalToolOutput(`${frame.repeat(3000)}\r\x1b[K\x1b[32m✓\x1b[0m finished`);
+		expect(result.truncated).toBe(false);
+		expect(result.text).toBe("✓ finished");
+	});
+});


### PR DESCRIPTION
## Summary

Two cooperating defects made sessions freeze mid-run and churn emergency compactions after ordinary bash work:

1. **Unbounded compaction summarization streams.** Both local summarization routes (the builtin compaction extension's `session_before_compact` handler and core `compact()`) consumed provider streams with no timeout at any layer. A gateway connection that went silent hung the session on "Compacting…" indefinitely — observed for 11+ minutes — and only ESC (manual abort) recovered it. Main-turn streams have had an idle timeout for a while; compaction had none.
2. **PTY bash tool dumped raw, unbounded scrollback into the conversation.** The PTY-backed `bash` swap returned up to the 1 MB session buffer verbatim, escape sequences included. Session evidence (`019f82a4-…`, 2026-07-21): one `gh run view --log-failed` returned exactly 999,998 chars (context jumped 154k → 404k tokens, forcing an emergency compaction), and a `gh pr checks --watch` result carried ~118k chars of raw spinner frames. Two emergency compactions fired within 15 minutes, both driven by oversized bash results; the core bash tool has always truncated to 50 KB / 2000 lines, and the PTY path bypassed that entirely.

After this PR: stalled summarization requests fail closed with a typed `StreamIdleTimeoutError` after 300s of silence (matching the `httpIdleTimeoutMs` default) and surface through the existing compaction failure paths, and all model-facing PTY bash output is ANSI-sanitized, redraw-collapsed, and tail-truncated to the same budget the core bash tool enforces.

## Changes

**Compaction stall watchdog (commit 1)**
- `core/compaction/stream-watchdog.ts` (new): `consumeStreamWithIdleTimeout()` drains an event stream and throws `StreamIdleTimeoutError` when no provider event arrives within the idle budget (default 300s). On trip it aborts a request-local controller; caller aborts (ESC) still end the wait quietly so the stream's own aborted result is surfaced exactly as before.
- `core/compaction/compaction.ts` `completeSummarization()`: both the `streamSimple` and custom-`streamFn` routes now consume the stream through the watchdog under a request-local `AbortController` linked to the caller's signal (previously `completeSimple()` / `stream.result()` with no bound).
- `builtin/compaction/speculative.ts` `generateSummaryMessage()`: same watchdog wiring, so speculative, blocking, and manual compactions are all bounded. Failure surfaces as the existing honest error (`compaction generator failed: Summarization stream stalled …`).
- `test/compaction-summary-reasoning.test.ts`: updated to the `streamSimple` mock seam (the old `completeSimple` seam no longer intercepts).

**PTY bash output sanitization + bounding (commit 2)**
- `builtin/terminal/output-format.ts` (new): `sanitizeTerminalOutput()` strips OSC/CSI/designate escape sequences and folds carriage-return/backspace redraw semantics (spinner/progress frames collapse to their final visible state); `formatTerminalToolOutput()` tail-truncates to the core-bash budget (2000 lines / 50 KB via `core/tools/truncate.ts`) with an "earlier output dropped" marker.
- `builtin/terminal/tools/bash.ts`: foreground results and background start-grace output go through the formatter; truncated results carry `details.truncation`.
- `builtin/terminal/tools/bash-output.ts`: `bash_output` log-view deltas formatted the same way.
- `builtin/terminal/tools/spawn.ts` + `shared.ts`: foreground spawns merge codex-style non-interactive env overrides (`NO_COLOR=1`, `TERM=dumb`, `COLORTERM=`, `PAGER`/`GIT_PAGER`/`GH_PAGER=cat`) so cooperative tools never emit redraw frames; interactive background sessions keep the user's real `TERM`.

**Fork bookkeeping**: `changes.md` entries added for `core/compaction/`, `builtin/compaction/`, and `builtin/terminal/` with expected upstream conflict zones.

**Deliberately not changed**: the degradation-monitor recovery compaction stays awaited inside the serialized agent-event queue — that serialization is what keeps the compaction state rewrite from racing the next provider request. With the watchdog, its worst-case block is now bounded (300s) instead of infinite.

## QA & Evidence

- **What was tested:** new unit + integration tests (`terminal-output-format.test.ts`, `summarization-stream-watchdog.test.ts`, `terminal-bash-tool-output.test.ts` — real PTY, real flood/spinner/env-probe commands)
- **Observed result:** 23/23 pass; watchdog trips deterministically under fake timers and never on a live stream; a 200 KB foreground result returns < 100 KB with the drop marker; 60 KB of spinner frames collapses to `✓ finished`; foreground env probe sees `1|dumb|cat|cat`, background keeps `xterm-256color`
- **Artifact:** tests are in the diff
- **Why sufficient:** pins the sanitize/fold/truncate contract, the watchdog trip/reset/abort semantics, and the env injection split at the exact seams that regressed

- **What was tested:** related suites — `test/compaction/` (21 files), terminal/bash abort+hang suites, agent-session compaction queue, interactive-mode compaction, branch summarization
- **Observed result:** 206+ tests pass; `npm run check` (biome, pinned deps, ts-imports, shrinkwrap, tsgo, browser smoke, web-ui, neo) green
- **Why sufficient:** covers compaction policy modules, queue/settlement behavior, and PTY lifecycle against the wired code

- **What was tested:** full `packages/coding-agent` vitest run
- **Observed result:** failures only in CLI-spawn files (`rpc`, `session-id-readonly`, `session-file-invalid`, `startup-session-name`, `stdout-cleanliness`); a stash-cycle comparison shows **identical failure sets with and without this PR** (26 = 26) — pre-existing worktree environment issues, not regressions
- **Why sufficient:** proves the diff adds no new failures

- **What was tested:** senpi-qa real-CLI channels in an isolated sandbox (`common` self-check, mock-loop all three wire formats, mock-loop `--with-tool`, rpc-drive, pty-drive, cli-smoke, tui-smoke)
- **Observed result:** 9/9, 5/5, 4/4, 4/4, 7/7, 7/7, 5/5 — all pass; real `~/.senpi` auth untouched
- **Artifact:** `local-ignore/qa-evidence/20260721-compaction-bash-freeze/` (in the worktree, gitignored)
- **Why sufficient:** end-to-end proof the real agent loop, PTY tools, RPC, TUI, and CLI surfaces still work after the change

## Risks & Residuals

- **Slow-but-silent providers:** a summarization request that emits nothing for 300s (e.g., a buffering proxy in front of a thinking model) will now be torn down and reported as stalled. 300s matches the main-turn idle-timeout default; the next turn's pre-prompt gate re-triggers compaction, and the circuit breaker counts repeated failures. Accepted.
- **Foreground `TERM=dumb`:** one-shot commands that require a smart terminal (rare; full-screen apps belong in `run_in_background` sessions, which keep the real `TERM`) will degrade to line mode. Accepted — codex made the same call for its exec sessions.
- **No full-output temp file:** unlike core bash, dropped PTY output is not persisted to a file; the marker says it was dropped. The raw buffer is already swept with the session. Accepted (the marker is honest; persistence machinery would be new surface area).
- **Hook dispatch stalls:** user shell hooks remain bounded by their own 600s default + abort wiring — verified, not changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops "Compacting…" stalls and runaway context after bash by adding a 300s idle watchdog to summarization and sanitizing/truncating PTY bash output to the core-bash budget.

- **Bug Fixes**
  - Bounded compaction summarization streams with a 300s idle watchdog; on silence, aborts the request and surfaces a typed timeout error. Applied to both core `compact()` and the builtin compaction flow. Caller abort behavior is unchanged.
  - PTY `bash` output is now ANSI-sanitized, redraw-collapsed, and tail-truncated to 2000 lines / 50 KB with an "earlier output dropped" marker; truncation details are included in results.
  - Foreground `bash` uses a non-interactive env to prevent spinner/color floods (`NO_COLOR=1`, `TERM=dumb`, `PAGER/GIT_PAGER/GH_PAGER=cat`, `COLORTERM=`). Background sessions keep the user's real `TERM`.

<sup>Written for commit c16daeded35a3039aa0b09d83af7ff4c502f28f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

