### PR TITLE
fix(coding-agent): replay MCP session state after raced registration + process-group QA cleanup

### DIFF
--- a/packages/coding-agent/scripts/qa-app-server/lib/cleanup-fixture.mjs
+++ b/packages/coding-agent/scripts/qa-app-server/lib/cleanup-fixture.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const mode = process.argv[2];
+
+if (mode === "leaf") {
+	process.on("SIGTERM", () => {});
+	if (process.send === undefined) throw new Error("cleanup fixture leaf requires an IPC channel");
+	process.send({ type: "ready" }, (error) => {
+		if (error) throw error;
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+	});
+} else if (mode === "leader") {
+	const fixturePath = fileURLToPath(import.meta.url);
+	const leaf = spawn(process.execPath, [fixturePath, "leaf"], {
+		stdio: ["ignore", "ignore", "inherit", "ipc"],
+	});
+	leaf.once("error", (error) => {
+		process.stderr.write(`${error.stack ?? error.message}\n`);
+		process.exit(1);
+	});
+	leaf.once("message", (message) => {
+		if (message?.type !== "ready") return;
+		process.stdout.write(`${JSON.stringify({ leaderPid: process.pid, leafPid: leaf.pid })}\n`);
+	});
+	process.once("SIGTERM", () => process.exit(0));
+} else {
+	throw new Error(`Unknown cleanup fixture mode: ${mode ?? "missing"}`);
+}

--- a/packages/coding-agent/scripts/qa-app-server/lib/cleanup.mjs
+++ b/packages/coding-agent/scripts/qa-app-server/lib/cleanup.mjs
@@ -1,70 +1,72 @@
-const trackedChildren = new Set();
+const trackedChildren = new Map();
 const trackedClosers = new Set();
 const detachChildren = process.platform !== "win32";
+let signalCleanupStarted = false;
 
 export function installCleanupHooks() {
 	const cleanup = () => cleanupAll();
 	process.once("exit", cleanup);
 	for (const signal of ["SIGINT", "SIGTERM"]) {
 		process.once(signal, () => {
-			cleanupAll();
-			process.exit(130);
+			if (signalCleanupStarted) return;
+			signalCleanupStarted = true;
+			cleanupAllAndWait().then(
+				() => process.exit(130),
+				(error) => {
+					process.stderr.write(`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`);
+					process.exit(1);
+				},
+			);
 		});
 	}
 }
 
 export function cleanupAll() {
-	for (const child of trackedChildren) {
-		if (child.exitCode === null && child.signalCode === null) {
-			killChild(child, "SIGKILL");
-		}
+	const children = [...trackedChildren.values()];
+	for (const tracked of children) {
+		if (trackedChildIsAlive(tracked)) killTrackedChild(tracked, "SIGKILL");
+		const { child } = tracked;
 		child.stdin?.destroy();
 		child.stdout?.destroy();
 		child.stderr?.destroy();
 		child.unref();
 	}
 	trackedChildren.clear();
-	for (const close of trackedClosers) {
-		close();
-	}
-	trackedClosers.clear();
+	if (liveChildIds(children).length === 0) closeTrackedClosers();
 }
 
 export async function cleanupAllAndWait(timeoutMs = 10000) {
-	const children = [...trackedChildren];
-	for (const child of children) {
-		if (child.exitCode === null && child.signalCode === null) {
-			killChild(child, "SIGTERM");
-		}
+	const children = [...trackedChildren.values()];
+	const deadline = Date.now() + timeoutMs;
+	for (const tracked of children) {
+		if (trackedChildIsAlive(tracked)) killTrackedChild(tracked, "SIGTERM");
 	}
-	let closed = await waitForChildrenClose(children, Math.min(3000, timeoutMs));
+	const termGraceMs = Math.min(3000, Math.max(0, Math.floor(timeoutMs / 2)));
+	let closed = await waitForChildrenClose(children, Math.min(deadline, Date.now() + termGraceMs));
 	if (!closed) {
-		for (const child of children) {
-			if (child.exitCode === null && child.signalCode === null) {
-				killChild(child, "SIGKILL");
-			}
+		for (const tracked of children) {
+			if (trackedChildIsAlive(tracked)) killTrackedChild(tracked, "SIGKILL");
 		}
-		closed = await waitForChildrenClose(children, timeoutMs);
+		closed = await waitForChildrenClose(children, deadline);
 	}
 	if (!closed) {
-		throw new Error(`Timed out waiting for child processes to close: ${liveChildPids(children).join(", ")}`);
+		throw new Error(`Timed out waiting for child processes to close: ${liveChildIds(children).join(", ")}`);
 	}
-	for (const child of children) {
+	for (const tracked of children) {
+		const { child } = tracked;
 		child.stdin?.destroy();
 		child.stdout?.destroy();
 		child.stderr?.destroy();
 		child.unref();
 		trackedChildren.delete(child);
 	}
-	for (const close of trackedClosers) {
-		close();
-	}
-	trackedClosers.clear();
+	closeTrackedClosers();
 }
 
 export function trackChild(child) {
-	trackedChildren.add(child);
-	child.once("close", () => trackedChildren.delete(child));
+	const tracked = { child, processGroupId: detachChildren ? child.pid : undefined };
+	trackedChildren.set(child, tracked);
+	if (!detachChildren) child.once("close", () => trackedChildren.delete(child));
 }
 
 export function trackCloser(close) {
@@ -79,26 +81,36 @@ export function shouldDetachChildren() {
 	return detachChildren;
 }
 
-async function waitForChildrenClose(children, timeoutMs) {
-	const deadline = Date.now() + timeoutMs;
+async function waitForChildrenClose(children, deadline) {
 	while (Date.now() < deadline) {
-		if (liveChildPids(children).length === 0) return true;
+		if (liveChildIds(children).length === 0) return true;
 		await new Promise((resolve) => setTimeout(resolve, 50));
 	}
-	return liveChildPids(children).length === 0;
+	return liveChildIds(children).length === 0;
 }
 
-function liveChildPids(children) {
-	return children
-		.filter((child) => child.exitCode === null && child.signalCode === null)
-		.map((child) => String(child.pid ?? "unknown"));
+function liveChildIds(children) {
+	return children.filter(trackedChildIsAlive).map(({ child, processGroupId }) =>
+		processGroupId === undefined ? String(child.pid ?? "unknown") : `pgid:${processGroupId}`,
+	);
 }
 
-function killChild(child, signal) {
-	if (child.pid === undefined) return;
-	if (detachChildren) {
+function trackedChildIsAlive({ child, processGroupId }) {
+	if (processGroupId === undefined) return child.exitCode === null && child.signalCode === null;
+	try {
+		process.kill(-processGroupId, 0);
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ESRCH") return false;
+		if (error instanceof Error && "code" in error && error.code === "EPERM") return true;
+		throw error;
+	}
+}
+
+function killTrackedChild({ child, processGroupId }, signal) {
+	if (processGroupId !== undefined) {
 		try {
-			process.kill(-child.pid, signal);
+			process.kill(-processGroupId, signal);
 			return;
 		} catch (error) {
 			if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") {
@@ -106,5 +118,11 @@ function killChild(child, signal) {
 			}
 		}
 	}
+	if (child.pid === undefined) return;
 	child.kill(signal);
+}
+
+function closeTrackedClosers() {
+	for (const close of trackedClosers) close();
+	trackedClosers.clear();
 }

--- a/packages/coding-agent/scripts/qa-app-server/lib/cleanup.test.mjs
+++ b/packages/coding-agent/scripts/qa-app-server/lib/cleanup.test.mjs
@@ -1,14 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { test } from "node:test";
+import { test } from "vitest";
 import { cleanupAllAndWait, trackChild } from "./cleanup.mjs";
 
 const fixturePath = fileURLToPath(new URL("./cleanup-fixture.mjs", import.meta.url));
 
-test(
+test.skipIf(process.platform === "win32")(
 	"cleanupAllAndWait removes the owned process group when its leader exits before a SIGTERM-resistant child",
-	{ skip: process.platform === "win32" },
 	async () => {
 		// Given: a detached leader and same-group leaf with opposite SIGTERM behavior.
 		const leader = spawn(process.execPath, [fixturePath, "leader"], {

--- a/packages/coding-agent/scripts/qa-app-server/lib/cleanup.test.mjs
+++ b/packages/coding-agent/scripts/qa-app-server/lib/cleanup.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { cleanupAllAndWait, trackChild } from "./cleanup.mjs";
+
+const fixturePath = fileURLToPath(new URL("./cleanup-fixture.mjs", import.meta.url));
+
+test(
+	"cleanupAllAndWait removes the owned process group when its leader exits before a SIGTERM-resistant child",
+	{ skip: process.platform === "win32" },
+	async () => {
+		// Given: a detached leader and same-group leaf with opposite SIGTERM behavior.
+		const leader = spawn(process.execPath, [fixturePath, "leader"], {
+			detached: true,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const processGroupId = leader.pid;
+		assert.notEqual(processGroupId, undefined, "fixture leader did not expose a PID");
+		trackChild(leader);
+
+		try {
+			const ready = await fixtureReady(leader);
+			assert.equal(ready.leaderPid, processGroupId);
+
+			// When: cleanup TERM-signals the group and the leader exits first.
+			await cleanupAllAndWait(500);
+
+			// Then: cleanup must not return while the resistant same-group leaf survives.
+			assert.equal(
+				processGroupIsAlive(processGroupId),
+				false,
+				`cleanup returned with process group ${processGroupId} still alive (leaf ${ready.leafPid})`,
+			);
+		} finally {
+			killExactProcessGroup(processGroupId);
+			const closed = await waitForProcessGroupExit(processGroupId, 1000);
+			await cleanupAllAndWait(1000);
+			if (!closed) throw new Error(`fixture process group ${processGroupId} survived exact-PGID SIGKILL cleanup`);
+		}
+	},
+);
+
+function fixtureReady(child) {
+	return new Promise((resolveReady, rejectReady) => {
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+			const newline = stdout.indexOf("\n");
+			if (newline === -1) return;
+			resolveReady(JSON.parse(stdout.slice(0, newline)));
+		});
+		child.once("error", rejectReady);
+		child.once("exit", (code, signal) => {
+			rejectReady(new Error(`fixture leader exited before readiness: code=${code} signal=${signal} stderr=${stderr}`));
+		});
+	});
+}
+
+function processGroupIsAlive(processGroupId) {
+	try {
+		process.kill(-processGroupId, 0);
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ESRCH") return false;
+		if (error instanceof Error && "code" in error && error.code === "EPERM") return true;
+		throw error;
+	}
+}
+
+function killExactProcessGroup(processGroupId) {
+	try {
+		process.kill(-processGroupId, "SIGKILL");
+	} catch (error) {
+		if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") throw error;
+	}
+}
+
+async function waitForProcessGroupExit(processGroupId, timeoutMs) {
+	const deadline = Date.now() + timeoutMs;
+	while (processGroupIsAlive(processGroupId) && Date.now() < deadline) {
+		await new Promise((resolveImmediate) => setImmediate(resolveImmediate));
+	}
+	return !processGroupIsAlive(processGroupId);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,38 @@
 # mcp Extension Changes
 
+## Raced background registration replays session state (2026-07-21)
+
+### What changed
+- `service.ts` (`#syncFromConfig`): the `registerDirectTools` continuation that
+  runs when a raced startup connect finishes in the background now also
+  (a) replays `#rehydrateFromSessionHistory` from the stored session context
+  and (b) rebuilds the session `<mcp_instructions>` block via
+  `refreshMcpInstructionsForSession`. Both were captured once at attach
+  completion, which — after PR #260 routed cold lazy servers through the
+  bounded startup race — can predate the backgrounded connect, so a resumed
+  session lost its restored (tool_search-promoted) tools on the first turn
+  and the first turn's system prompt carried no server instructions.
+- Tests: `rehydration-wiring.test.ts` awaits the raced registration before
+  asserting the first-turn payload; `instructions.test.ts` attaches the
+  harness session explicitly and awaits registration; mcp suites broadly
+  await raced background completion via new fixture seams
+  (`awaitMcpToolRegistration`/`awaitMcpTool` in `fixtures/register-call.ts`,
+  `awaitMcpConnected` in `fixtures/service-lifecycle.ts`).
+
+### Why
+- The attach-time replay and instructions capture assume the catalog exists
+  when attach returns. The startup race deliberately breaks that assumption
+  for slow servers; the background continuation must refresh every piece of
+  session state derived from the catalog, not just the tool registrations.
+
+### Why extension system couldn't handle this alone
+- The continuation lives inside the MCP builtin's startup-race plumbing;
+  only the builtin holds the session context, tier-B registration, and the
+  instructions module state.
+
+### Expected merge conflict zones
+- LOW: `service.ts` `#syncFromConfig` raced-connect options block.
+
 ## Non-blocking startup for cold lazy servers + configurable startup window (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -324,7 +324,13 @@ export class McpService {
 					raceMcpStartupConnect({
 						entry,
 						pi,
-						registerDirectTools: (targetPi) => this.#registerDirectTools(targetPi),
+						registerDirectTools: async (targetPi) => {
+							await this.#registerDirectTools(targetPi);
+							// A raced attach ran its history replay before this catalog
+							// existed; replay now so restored tools still land on the
+							// first turn's payload (idempotent: already-active names skip).
+							if (this.#sessionContext !== null) this.#rehydrateFromSessionHistory(this.#sessionContext);
+						},
 						serverConfig: server.config,
 						shouldRefreshTools: () => !this.#disposed && this.#toolRefreshGeneration === toolRefreshGeneration,
 						deadlineMs: resolveMcpStartupTimeoutMs(server.config.startupTimeoutMs),

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -11,6 +11,7 @@ import type { McpServerExposureStatus } from "./expose/status.ts";
 import { cleanupMcpOutputArtifacts } from "./guard/output-guard.ts";
 import { markMcpConnectionNeedsAuth } from "./health.ts";
 import { configureMcpConnectionLifecycle, disposeMcpConnectionLifecycle } from "./idle.ts";
+import { refreshMcpInstructionsForSession } from "./instructions.ts";
 import { createMcpLogger } from "./log.ts";
 import {
 	buildMcpTombstoneDefinition,
@@ -330,6 +331,10 @@ export class McpService {
 							// existed; replay now so restored tools still land on the
 							// first turn's payload (idempotent: already-active names skip).
 							if (this.#sessionContext !== null) this.#rehydrateFromSessionHistory(this.#sessionContext);
+							// The session instructions block was likewise captured at attach
+							// time, before this server connected; rebuild it so the first
+							// turn carries this server's instructions after a raced connect.
+							refreshMcpInstructionsForSession(this);
 						},
 						serverConfig: server.config,
 						shouldRefreshTools: () => !this.#disposed && this.#toolRefreshGeneration === toolRefreshGeneration,

--- a/packages/coding-agent/test/mcp/catalog-cache.test.ts
+++ b/packages/coding-agent/test/mcp/catalog-cache.test.ts
@@ -6,6 +6,7 @@ import { loadMcpConfig } from "../../src/core/extensions/builtin/mcp/config.ts";
 import { getMcpService, McpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import {
 	attach,
+	awaitMcpToolRegistration,
 	capturingPi,
 	registeredTool,
 	testContext,
@@ -63,8 +64,10 @@ describe("MCP disk metadata cache", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
+		await awaitCacheTools(root, 2);
 
-		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+		expect(dedupedRegisteredTools(pi)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 		expect(await readCounter(counterFile)).toBe(1);
 		const cache = await readCache(root);
 		expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1", "tool_2"]);
@@ -78,8 +81,10 @@ describe("MCP disk metadata cache", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
+		await awaitCacheTools(root, 1);
 
-		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
+		expect(dedupedRegisteredTools(pi)).toEqual(["mcp_fx_tool_1"]);
 		const cache = await readCache(root);
 		expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1"]);
 	});
@@ -92,8 +97,10 @@ describe("MCP disk metadata cache", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
+		await awaitCacheTools(root, 1);
 
-		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
+		expect(dedupedRegisteredTools(pi)).toEqual(["mcp_fx_tool_1"]);
 		expect(withoutMcpUtilityTools(pi.registeredTools)).not.toContain("mcp_fx_fake_999");
 		expect(await readCounter(counterFile)).toBe(1);
 		const cache = await readCache(root);
@@ -134,6 +141,15 @@ describe("MCP disk metadata cache", () => {
 					agentDir: root.agentDir,
 				}),
 			]);
+			// Both attaches are race-bounded; the cache refresh completes in the
+			// background continuation, so await the torn-write window closing.
+			await waitForCondition(async () => {
+				try {
+					return (await readCache(root)).servers.fx.tools.length === 3;
+				} catch {
+					return false;
+				}
+			}, 10_000);
 			const cache = await readCache(root);
 			expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1", "tool_2", "tool_3"]);
 		} finally {
@@ -157,6 +173,26 @@ function cachePath(root: TestRoot): string {
 function writeCache(root: TestRoot, servers: Record<string, CacheServer>): void {
 	mkdirSync(join(root.agentDir, "cache"), { recursive: true });
 	writeFileSync(cachePath(root), `${JSON.stringify({ version: 1, servers }, null, 2)}\n`);
+}
+
+/** The raced attach can register the same catalog twice: the continuation
+ * scheduled at the race deadline and attach's own registration pass when the
+ * connect lands between the two. Production registerTool replaces by name, so
+ * assert the deduped set (same invariant as the exposure-policy suite). */
+function dedupedRegisteredTools(pi: ReturnType<typeof capturingPi>): string[] {
+	return [...new Set(withoutMcpUtilityTools(pi.registeredTools))];
+}
+
+/** The raced background continuation writes the disk cache after the in-memory
+ * catalog is set; await the file landing before asserting its contents. */
+async function awaitCacheTools(root: TestRoot, count: number): Promise<void> {
+	await waitForCondition(async () => {
+		try {
+			return (await readCache(root)).servers.fx.tools.length === count;
+		} catch {
+			return false;
+		}
+	}, 10_000);
 }
 
 async function readCache(root: TestRoot): Promise<CacheFile> {

--- a/packages/coding-agent/test/mcp/commands.test.ts
+++ b/packages/coding-agent/test/mcp/commands.test.ts
@@ -15,8 +15,16 @@ import { ModelRegistry } from "../../src/core/model-registry.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 import { createHarness, type Harness } from "../suite/harness.ts";
 import { createCtx, createUi, lastNotification, normalize, notification } from "./fixtures/commands.ts";
-import { toolResultTexts } from "./fixtures/register-call.ts";
-import { cleanupRoots, fakePi, makeRoot, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+import { attachHarnessSession, awaitMcpToolRegistration, toolResultTexts } from "./fixtures/register-call.ts";
+import {
+	awaitMcpConnected,
+	cleanupRoots,
+	fakePi,
+	makeRoot,
+	setConfig,
+	stdioServer,
+	type TestRoot,
+} from "./fixtures/service-lifecycle.ts";
 import { stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -55,6 +63,7 @@ describe("/mcp command suite", () => {
 		const { command, extension } = await loadCommand();
 		const ui = createUi({ selectResult: undefined });
 		await emitSessionStart(extension, root);
+		await awaitMcpConnected(getMcpService(), "fx");
 
 		await command.handler("", createCtx(root, ui));
 		await command.handler("status", createCtx(root, ui));
@@ -105,6 +114,9 @@ describe("/mcp command suite", () => {
 		const fixture = stdioFixtureCommand();
 		const addArgs = [fixture.command, ...fixture.args, "--tools", "2"].map((part) => JSON.stringify(part)).join(" ");
 		await harness.session.prompt(`/mcp add fx ${addArgs}`);
+		// The add path's reattach is race-bounded; await the background
+		// registration so /mcp status and the tool call see the connected server.
+		await awaitMcpToolRegistration("fx");
 		await harness.session.prompt("/mcp status");
 
 		harness.setResponses([
@@ -128,11 +140,13 @@ describe("/mcp command suite", () => {
 		const { command, extension } = await loadCommand();
 		const ui = createUi();
 		await emitSessionStart(extension, root);
+		await awaitMcpConnected(getMcpService(), "fx");
 
 		await command.handler("disable fx", createCtx(root, ui));
 		expect(JSON.parse(readFileSync(join(root.agentDir, "mcp.json"), "utf8")).mcpServers.fx.enabled).toBe(false);
 
 		await command.handler("enable fx", createCtx(root, ui));
+		await awaitMcpConnected(getMcpService(), "fx");
 		expect(JSON.parse(readFileSync(join(root.agentDir, "mcp.json"), "utf8")).mcpServers.fx.enabled).toBe(true);
 
 		await command.handler("logs fx", createCtx(root, ui));
@@ -156,6 +170,7 @@ describe("/mcp command suite", () => {
 			extensionFactories: [mcpExtension],
 		});
 		harnesses.push(harness);
+		await attachHarnessSession(harness, "fx");
 
 		harness.setResponses([
 			(context) => {
@@ -181,6 +196,7 @@ describe("/mcp command suite", () => {
 		expect(providerToolNames[providerToolNames.length - 1]).not.toContain("mcp_fx_tool_1");
 
 		await harness.session.prompt("/mcp enable fx");
+		await awaitMcpToolRegistration("fx");
 		harness.setResponses([
 			(context) => {
 				providerToolNames.push((context.tools ?? []).map((toolInfo) => toolInfo.name).sort());
@@ -219,6 +235,7 @@ describe("/mcp command suite", () => {
 		await getMcpService().attachSession({ type: "session_start", reason: "startup" }, ctxWithDecl, pi, {
 			agentDir: root.agentDir,
 		});
+		await awaitMcpToolRegistration("fixture");
 		expect(
 			getMcpService()
 				.getServerSnapshots()
@@ -247,6 +264,7 @@ describe("/mcp command suite", () => {
 
 		const { command } = await loadCommand();
 		await command.handler("reconnect fixture", ctx);
+		await awaitMcpToolRegistration("fixture");
 
 		const snapshot = getMcpService()
 			.getServerSnapshots()
@@ -261,6 +279,7 @@ describe("/mcp command suite", () => {
 		const { command, extension } = await loadCommand();
 		const ui = createUi();
 		await emitSessionStart(extension, root);
+		await awaitMcpConnected(getMcpService(), "fx");
 
 		await command.handler("test fx", createCtx(root, ui));
 

--- a/packages/coding-agent/test/mcp/exposure-policy.test.ts
+++ b/packages/coding-agent/test/mcp/exposure-policy.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { attach, capturingPi, mcpRoot as makeMcpRoot, withoutMcpUtilityTools } from "./fixtures/register-call.ts";
-import { cleanupRoots, setConfig, stdioServer } from "./fixtures/service-lifecycle.ts";
+import {
+	attach,
+	awaitMcpToolRegistration,
+	capturingPi,
+	mcpRoot as makeMcpRoot,
+	withoutMcpUtilityTools,
+} from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, stdioServer, waitForCondition } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
 
@@ -35,12 +41,14 @@ describe("MCP Tier-A exposure policy", () => {
 		setConfig(includeRoot, { fx: { ...stdioServer(["--tools", "5"]), includeTools: ["tool_[13]"] } });
 		const includePi = capturingPi();
 		await attach(includeRoot, includePi);
+		await awaitMcpToolRegistration("fx");
 		expect(withoutMcpUtilityTools(includePi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_3"]);
 
 		const excludeRoot = mcpRoot("exclude-only");
 		setConfig(excludeRoot, { fx: { ...stdioServer(["--tools", "5"]), excludeTools: ["tool_[24]"] } });
 		const excludePi = capturingPi();
 		await attach(excludeRoot, excludePi);
+		await awaitMcpToolRegistration("fx");
 		expect(withoutMcpUtilityTools(excludePi.activeTools)).toEqual([
 			"mcp_fx_tool_1",
 			"mcp_fx_tool_3",
@@ -53,12 +61,14 @@ describe("MCP Tier-A exposure policy", () => {
 		});
 		const bothPi = capturingPi();
 		await attach(bothRoot, bothPi);
+		await awaitMcpToolRegistration("fx");
 		expect(withoutMcpUtilityTools(bothPi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 
 		const starRoot = mcpRoot("star");
 		setConfig(starRoot, { fx: { ...stdioServer(["--tools", "5"]), excludeTools: ["tool_5"], includeTools: ["*"] } });
 		const starPi = capturingPi();
 		await attach(starRoot, starPi);
+		await awaitMcpToolRegistration("fx");
 		expect(withoutMcpUtilityTools(starPi.activeTools)).toEqual([
 			"mcp_fx_tool_1",
 			"mcp_fx_tool_2",
@@ -72,6 +82,7 @@ describe("MCP Tier-A exposure policy", () => {
 		setConfig(tenRoot, { fx: stdioServer(["--tools", "10"]) });
 		const tenPi = capturingPi();
 		await attach(tenRoot, tenPi);
+		await awaitMcpToolRegistration("fx");
 		expect(withoutMcpUtilityTools(tenPi.registeredTools)).toEqual(toolNames(10));
 		expect(withoutMcpUtilityTools(tenPi.activeTools)).toEqual(toolNames(10));
 
@@ -79,6 +90,7 @@ describe("MCP Tier-A exposure policy", () => {
 		setConfig(elevenRoot, { fx: stdioServer(["--tools", "11"]) });
 		const elevenPi = capturingPi();
 		await attach(elevenRoot, elevenPi);
+		await awaitMcpToolRegistration("fx");
 		// All 11 tools are registered (catalog present) plus tool_search...
 		expect([...withoutMcpUtilityTools(elevenPi.registeredTools)].sort()).toEqual(
 			[...toolNames(11), "tool_search"].sort(),
@@ -101,6 +113,7 @@ describe("MCP Tier-A exposure policy", () => {
 		const pi = capturingPi(["bash"]);
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		// Search mode keeps directTools active alongside the always-active tool_search.
 		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual([
@@ -125,6 +138,7 @@ describe("MCP Tier-A exposure policy", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		expect([...withoutMcpUtilityTools(pi.registeredTools)].sort()).toEqual([...toolNames(30), "tool_search"].sort());
 		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["tool_search"]);
@@ -137,10 +151,18 @@ describe("MCP Tier-A exposure policy", () => {
 		const pi = capturingPi(["bash", "mcp_fx_tool_1"]);
 
 		await attach(root, pi);
+		// Zero exposed tools: the searchable catalog stays empty, so await the
+		// registration pass itself via its exposure-policy warning.
+		await waitForCondition(() => logContains("fx", "0 exposed"), 10_000);
 
 		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual([]);
 		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["bash"]);
-		expect(pi.setActiveCalls.map((call) => withoutMcpUtilityTools(call))).toEqual([["bash"]]);
+		// A raced attach registers twice (empty pass at attach, catalog pass after
+		// the background connect); every pass must keep the base-only active set.
+		expect(pi.setActiveCalls.length).toBeGreaterThan(0);
+		for (const call of pi.setActiveCalls) {
+			expect(withoutMcpUtilityTools(call)).toEqual(["bash"]);
+		}
 		expect(logContains("fx", "0 exposed")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/mcp/exposure-tierb.test.ts
+++ b/packages/coding-agent/test/mcp/exposure-tierb.test.ts
@@ -12,7 +12,12 @@ import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { createHarness, type Harness } from "../suite/harness.ts";
-import { mcpRoot as makeMcpRoot, mcpExtensionFor, withoutMcpUtilityTools } from "./fixtures/register-call.ts";
+import {
+	attachHarnessSession,
+	mcpRoot as makeMcpRoot,
+	mcpExtensionFor,
+	withoutMcpUtilityTools,
+} from "./fixtures/register-call.ts";
 import type { TestRoot } from "./fixtures/service-lifecycle.ts";
 import { cleanupRoots, stdioServer } from "./fixtures/service-lifecycle.ts";
 
@@ -60,6 +65,9 @@ function names(shapes: ToolShape[]): string[] {
 async function harnessFor(root: TestRoot): Promise<Harness> {
 	const harness = await createHarness({ extensionFactories: [mcpExtensionFor(root.agentDir)] });
 	harnesses.push(harness);
+	// The harness never emits session_start on its own; attach + await the
+	// raced registration so the first prompt's tool snapshot is deterministic.
+	await attachHarnessSession(harness, "fx");
 	return harness;
 }
 

--- a/packages/coding-agent/test/mcp/extension-load.test.ts
+++ b/packages/coding-agent/test/mcp/extension-load.test.ts
@@ -4,6 +4,7 @@ import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
 import type { Extension, SessionShutdownEvent, SessionStartEvent } from "../../src/core/extensions/types.ts";
+import { awaitMcpToolRegistration } from "./fixtures/register-call.ts";
 import { fakePi } from "./fixtures/service-lifecycle.ts";
 import { stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
 
@@ -111,6 +112,7 @@ describe("mcp builtin extension load", () => {
 			},
 			pi,
 		);
+		await awaitMcpToolRegistration("fixture");
 
 		const snapshot = getMcpService()
 			.getServerSnapshots()

--- a/packages/coding-agent/test/mcp/fixtures/register-call.ts
+++ b/packages/coding-agent/test/mcp/fixtures/register-call.ts
@@ -12,7 +12,7 @@ import type {
 	ToolDefinition,
 } from "../../../src/core/extensions/types.ts";
 import { getMessageText, type Harness } from "../../suite/harness.ts";
-import { type FakePi, fakePi, makeRoot, type TestRoot } from "./service-lifecycle.ts";
+import { type FakePi, fakePi, makeRoot, type TestRoot, waitForCondition } from "./service-lifecycle.ts";
 
 export type RegisteredMcpTool = ToolDefinition<TSchema, unknown, unknown>;
 
@@ -34,6 +34,46 @@ export async function attach(
 		pi,
 		{ agentDir: root.agentDir },
 	);
+}
+
+/**
+ * Await the startup-race background registration for the given servers.
+ * Attach is bounded by MCP_STARTUP_RACE_MS: a connect slower than the race
+ * registers its tools in a background continuation, so tests asserting the
+ * post-attach tool set must await that refresh the way production consumers
+ * (the next turn's tool snapshot) do.
+ */
+export async function awaitMcpToolRegistration(
+	serverNames: string | readonly string[],
+	timeoutMs = 10_000,
+): Promise<void> {
+	const names = typeof serverNames === "string" ? [serverNames] : serverNames;
+	await waitForCondition(
+		() =>
+			names.every((name) =>
+				getMcpService()
+					.getTierBSearchable()
+					.some((tool) => tool.server === name),
+			),
+		timeoutMs,
+	);
+}
+
+/** Await registration of one specific tool on a capturing pi (use for proxy
+ * gateways / zero-searchable-tool servers where getTierBSearchable stays empty). */
+export async function awaitMcpTool(pi: CapturingPi, toolName: string, timeoutMs = 10_000): Promise<void> {
+	await waitForCondition(() => pi.toolDefinitions.has(toolName), timeoutMs);
+}
+
+/**
+ * Harness counterpart of attach(): the harness never emits session_start, so
+ * the MCP extension would otherwise attach on the first prompt's
+ * before_agent_start. Emit it now and await the raced registration so the
+ * first prompt's tool snapshot is deterministic.
+ */
+export async function attachHarnessSession(harness: Harness, serverNames: string | readonly string[]): Promise<void> {
+	await harness.getExtensionRunner().emit({ type: "session_start", reason: "startup" });
+	await awaitMcpToolRegistration(serverNames);
 }
 
 export function mcpExtensionFor(agentDir: string, activeTools?: string[]): ExtensionFactory {

--- a/packages/coding-agent/test/mcp/fixtures/service-lifecycle.ts
+++ b/packages/coding-agent/test/mcp/fixtures/service-lifecycle.ts
@@ -88,6 +88,16 @@ export async function readCounter(file: string): Promise<number> {
 	return Number(raw.trim());
 }
 
+/** Await the raced attach-time connect for a server: attach is bounded by the
+ * startup race, so a slow connect completes in a background continuation. */
+export async function awaitMcpConnected(
+	service: ReturnType<typeof getMcpService>,
+	name: string,
+	timeoutMs = 10_000,
+): Promise<void> {
+	await waitForCondition(() => service.getConnection(name)?.state === "connected", timeoutMs);
+}
+
 export async function waitForCondition(assertion: () => boolean | Promise<boolean>, timeoutMs: number): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {

--- a/packages/coding-agent/test/mcp/idle.test.ts
+++ b/packages/coding-agent/test/mcp/idle.test.ts
@@ -149,6 +149,7 @@ describe("MCP idle lifecycle", () => {
 		setConfig(root, { fx: { ...stdioServer(["--tools", "1"]), idleTimeoutMin: 0.001 } });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await waitForCondition(() => getMcpService().getConnection("fx")?.state === "connected", 30_000);
 		const connection = getMcpService().getConnection("fx");
 		if (connection === undefined) throw new Error("missing fx connection");
 

--- a/packages/coding-agent/test/mcp/instructions.test.ts
+++ b/packages/coding-agent/test/mcp/instructions.test.ts
@@ -6,6 +6,7 @@ import mcpExtension from "../../src/core/extensions/builtin/mcp/index.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import type { ExtensionFactory } from "../../src/core/extensions/types.ts";
 import { createHarness, type Harness } from "../suite/harness.ts";
+import { attachHarnessSession } from "./fixtures/register-call.ts";
 import { cleanupRoots, makeRoot, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -41,7 +42,7 @@ describe("MCP server instructions injection", () => {
 		const root = makeInstructionsRoot("single");
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--instructions", "Use fixture echo carefully."]) });
 
-		const systemPrompt = await captureSystemPrompt(root);
+		const systemPrompt = await captureSystemPrompt(root, "fx");
 
 		expect(blockCount(systemPrompt)).toBe(1);
 		expect(systemPrompt).toContain(
@@ -53,7 +54,7 @@ describe("MCP server instructions injection", () => {
 		const root = makeInstructionsRoot("cap");
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--instructions", "a".repeat(5000)]) });
 
-		const systemPrompt = await captureSystemPrompt(root);
+		const systemPrompt = await captureSystemPrompt(root, "fx");
 		const content = instructionContent(systemPrompt, "fx");
 
 		expect(blockCount(systemPrompt)).toBe(1);
@@ -65,12 +66,12 @@ describe("MCP server instructions injection", () => {
 		const root = makeInstructionsRoot("stable");
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--instructions", "first instructions"]) });
 
-		const harness = await createInstructionsHarness(root);
+		const harness = await createInstructionsHarness(root, "fx");
 		const first = await promptAndCaptureSystemPrompt(harness);
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--instructions", "second instructions"]) });
 		getMcpService().getConnection("fx")?.markToolsChanged();
 		const sameSession = await promptAndCaptureSystemPrompt(harness);
-		const nextSession = await captureSystemPrompt(root);
+		const nextSession = await captureSystemPrompt(root, "fx");
 
 		expect(sameSession).toBe(first);
 		expect(first).toContain("first instructions");
@@ -89,7 +90,7 @@ describe("MCP server instructions injection", () => {
 			]),
 		});
 
-		const systemPrompt = await captureSystemPrompt(root);
+		const systemPrompt = await captureSystemPrompt(root, 'fx" bad');
 
 		expect(blockCount(systemPrompt)).toBe(1);
 		expect(systemPrompt).toContain(`<mcp_instructions server="fx&quot; bad">`);
@@ -107,15 +108,18 @@ function makeInstructionsRoot(slug: string): TestRoot {
 	return root;
 }
 
-async function captureSystemPrompt(root: TestRoot): Promise<string> {
-	const harness = await createInstructionsHarness(root);
+async function captureSystemPrompt(root: TestRoot, serverName?: string): Promise<string> {
+	const harness = await createInstructionsHarness(root, serverName);
 	return promptAndCaptureSystemPrompt(harness);
 }
 
-async function createInstructionsHarness(root: TestRoot): Promise<Harness> {
+async function createInstructionsHarness(root: TestRoot, serverName?: string): Promise<Harness> {
 	process.env[ENV_AGENT_DIR] = root.agentDir;
 	const harness = await createHarness({ extensionFactories: [mcpExtension as ExtensionFactory] });
 	harnesses.push(harness);
+	// The harness never emits session_start on its own; attach + await the
+	// raced registration so the first prompt's instructions are deterministic.
+	if (serverName !== undefined) await attachHarnessSession(harness, serverName);
 	return harness;
 }
 

--- a/packages/coding-agent/test/mcp/oauth-headless.test.ts
+++ b/packages/coding-agent/test/mcp/oauth-headless.test.ts
@@ -22,6 +22,7 @@ import { registerMcpServiceDirectTools } from "../../src/core/extensions/builtin
 import type { McpConnectionEntry } from "../../src/core/extensions/builtin/mcp/service-types.ts";
 import { connectAndRefreshMcpCatalog } from "../../src/core/extensions/builtin/mcp/startup-race.ts";
 import { capturingPi, registeredTool, testContext, textContent } from "./fixtures/register-call.ts";
+import { waitForCondition } from "./fixtures/service-lifecycle.ts";
 import { type IdpFixture, spawnOAuthIdp } from "./fixtures/spawn-idp.ts";
 
 const cleanups: (() => Promise<void>)[] = [];
@@ -386,6 +387,7 @@ describe("headless oauth flows", () => {
 			pi,
 			{ agentDir: dir },
 		);
+		await waitForCondition(() => service.getConnection("fix")?.state === "needs_auth", 10_000);
 
 		expect(service.getServerSnapshots()).toMatchObject([
 			{
@@ -413,6 +415,7 @@ describe("headless oauth flows", () => {
 			capturingPi(),
 			{ agentDir: dir },
 		);
+		await waitForCondition(() => service.getConnection("fix")?.state === "connected", 10_000);
 		expect(service.getConnection("fix")?.state).toBe("connected");
 		await poisonRefreshToken(harness);
 

--- a/packages/coding-agent/test/mcp/output-guard.test.ts
+++ b/packages/coding-agent/test/mcp/output-guard.test.ts
@@ -7,6 +7,7 @@ import { applyMcpOutputGuard } from "../../src/core/extensions/builtin/mcp/guard
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import {
 	attach,
+	awaitMcpToolRegistration,
 	capturingPi,
 	mcpRoot as makeMcpRoot,
 	registeredTool,
@@ -46,6 +47,7 @@ describe("MCP output guard", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "0", "--huge-output-tool", "1048576/4096"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const result = await registeredTool(pi, "mcp_fx_huge_output_tool").execute(
 			"tc-huge",
@@ -70,6 +72,7 @@ describe("MCP output guard", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const result = await registeredTool(pi, "mcp_fx_tool_1").execute(
 			"tc-small",
@@ -103,6 +106,7 @@ describe("MCP output guard", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "0", "--huge-output-tool", "65536/256"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_huge_output_tool");
 
 		const [first, second] = await Promise.all([
@@ -122,6 +126,7 @@ describe("MCP output guard", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "0", "--huge-output-tool", "65536/256"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const result = await registeredTool(pi, "mcp_fx_huge_output_tool").execute(
 			"tc-cleanup",
@@ -153,6 +158,7 @@ describe("MCP output guard", () => {
 		);
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		await expect(
 			registeredTool(pi, "mcp_fx_iserror_tool").execute("tc-error", {}, undefined, undefined, testContext()),
@@ -167,6 +173,7 @@ describe("MCP output guard", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "0", "--huge-output-tool", "65536/256"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const result = await registeredTool(pi, "mcp_fx_huge_output_tool").execute(
 			"tc-unwritable",

--- a/packages/coding-agent/test/mcp/ping-on-call.test.ts
+++ b/packages/coding-agent/test/mcp/ping-on-call.test.ts
@@ -7,6 +7,7 @@ import { disposeMcpReconnect } from "../../src/core/extensions/builtin/mcp/recon
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import {
 	attach,
+	awaitMcpToolRegistration,
 	capturingPi,
 	mcpRoot as makeMcpRoot,
 	registeredTool,
@@ -40,6 +41,7 @@ describe("MCP ping-on-call health", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--pid-file", pidFile]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 
 		const first = await tool.execute("tc-first", { value: "first" }, undefined, undefined, testContext());
@@ -62,6 +64,7 @@ describe("MCP ping-on-call health", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--ping-counter-file", pingCounterFile]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 
 		await tool.execute("tc-first", { value: "first" }, undefined, undefined, testContext());
@@ -86,6 +89,7 @@ describe("MCP ping-on-call health", () => {
 		});
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		// This test's contract is the STALE-CALL PING path only: exactly one renewal
 		// attempt, surfaced as a bounded typed error. The background reconnect
 		// controller independently reacts to the SIGKILL's "degraded" transition on
@@ -119,6 +123,7 @@ describe("MCP ping-on-call health", () => {
 		});
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 
 		const [first, second] = await Promise.all([

--- a/packages/coding-agent/test/mcp/prompts-commands.test.ts
+++ b/packages/coding-agent/test/mcp/prompts-commands.test.ts
@@ -9,7 +9,7 @@ import {
 	resetMcpPromptCommandsForTests,
 } from "../../src/core/extensions/builtin/mcp/prompts.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { attach, awaitMcpToolRegistration, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -68,6 +68,7 @@ describe("mcp prompts as slash commands", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const recorder = commandRecorder();
 		const added = registerMcpPromptCommands(recorder as never, getMcpService().getMcpPromptServers());

--- a/packages/coding-agent/test/mcp/proxy-mode.test.ts
+++ b/packages/coding-agent/test/mcp/proxy-mode.test.ts
@@ -9,6 +9,7 @@ import { computeMcpExposurePolicy } from "../../src/core/extensions/builtin/mcp/
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import {
 	attach,
+	awaitMcpTool,
 	capturingPi,
 	mcpRoot as makeMcpRoot,
 	registeredTool,
@@ -40,6 +41,7 @@ describe("tier-C proxy mode", () => {
 		setConfig(root, { fx: { ...stdioServer(["--tools", "5"]), exposure: "proxy" } });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpTool(pi, "mcp_fx");
 
 		const mcpActive = withoutMcpUtilityTools(pi.getActiveTools()).filter((name) => name.startsWith("mcp_"));
 		expect(mcpActive).toEqual(["mcp_fx"]);

--- a/packages/coding-agent/test/mcp/reconnect.test.ts
+++ b/packages/coding-agent/test/mcp/reconnect.test.ts
@@ -11,6 +11,7 @@ import { getMcpService, resetMcpServiceForTests } from "../../src/core/extension
 import { delay, readNumberFile, readNumberFileOrZero, serverConfig, waitFor } from "./fixtures/reconnect.ts";
 import {
 	attach,
+	awaitMcpToolRegistration,
 	capturingPi,
 	mcpRoot as makeMcpRoot,
 	registeredTool,
@@ -74,6 +75,7 @@ describe("MCP auto reconnect", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile, "--crash-after", "1"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 
 		const first = await tool.execute("tc-first", { value: "first" }, undefined, undefined, testContext());
@@ -93,7 +95,10 @@ describe("MCP auto reconnect", () => {
 		const pi = capturingPi();
 		await attach(root, pi);
 
-		await waitFor(() => getMcpService().getConnection("fx")?.state === "suspended");
+		// The breaker opens only after five spawn+crash cycles; with Math.random
+		// mocked to 0 the backoff is zeroed, so the bound is fixture process
+		// churn, which stretches well past 5s under full-suite fork parallelism.
+		await waitFor(() => getMcpService().getConnection("fx")?.state === "suspended", 20_000);
 		await delay(500);
 
 		expect(readNumberFile(counterFile)).toBeLessThanOrEqual(6);
@@ -113,6 +118,7 @@ describe("MCP auto reconnect", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const connection = getMcpService().getConnection("fx");
 		if (connection === undefined) throw new Error("missing fx connection");
 		connection.markSuspended(new Error("test breaker open"));
@@ -139,6 +145,7 @@ describe("MCP auto reconnect", () => {
 		});
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 
 		await expect(tool.execute("tc-crash", { value: "once" }, undefined, undefined, testContext())).rejects.toThrow(
@@ -164,6 +171,7 @@ describe("MCP auto reconnect", () => {
 		});
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const connection = getMcpService().getConnection("fx");
 		if (connection === undefined) throw new Error("missing fx connection");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
@@ -200,6 +208,7 @@ describe("MCP auto reconnect", () => {
 		});
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const connection = getMcpService().getConnection("fx");
 		if (connection === undefined) throw new Error("missing fx connection");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
@@ -239,6 +248,7 @@ describe("MCP auto reconnect", () => {
 		});
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 		const firstPid = readNumberFile(pidFile);
 		process.kill(firstPid, "SIGKILL");

--- a/packages/coding-agent/test/mcp/register-call.test.ts
+++ b/packages/coding-agent/test/mcp/register-call.test.ts
@@ -6,6 +6,8 @@ import { getMcpService, resetMcpServiceForTests } from "../../src/core/extension
 import { createHarness, type Harness } from "../suite/harness.ts";
 import {
 	attach,
+	attachHarnessSession,
+	awaitMcpToolRegistration,
 	capturingPi,
 	expectFileToContain,
 	mcpRoot as makeMcpRoot,
@@ -44,6 +46,7 @@ describe("MCP catalog + registerTool bridge", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual([
 			"mcp_fx_tool_1",
@@ -63,6 +66,7 @@ describe("MCP catalog + registerTool bridge", () => {
 			extensionFactories: [mcpExtensionFor(root.agentDir)],
 		});
 		harnesses.push(harness);
+		await attachHarnessSession(harness, "fx");
 		harness.setResponses([
 			(context) => {
 				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
@@ -84,6 +88,7 @@ describe("MCP catalog + registerTool bridge", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "0", "--iserror-tool"]) });
 		const harness = await createHarness({ extensionFactories: [mcpExtensionFor(root.agentDir)] });
 		harnesses.push(harness);
+		await attachHarnessSession(harness, "fx");
 		harness.setResponses([
 			fauxAssistantMessage(fauxToolCall("mcp_fx_iserror_tool", {}), { stopReason: "toolUse" }),
 			fauxAssistantMessage("continued after error"),
@@ -104,6 +109,7 @@ describe("MCP catalog + registerTool bridge", () => {
 		const pi = capturingPi();
 
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const tool = registeredTool(pi, "mcp_fx_huge_schema_tool");
 		const expected = convertJsonSchemaToTypeBox(readSchemaFixture("nasty-input.schema.json"));
@@ -117,6 +123,7 @@ describe("MCP catalog + registerTool bridge", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--slow-tool-call", "2000", "--cancel-log", cancelLog]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 		const controller = new AbortController();
 		let sawProgress = (): void => {};
@@ -143,6 +150,7 @@ describe("MCP catalog + registerTool bridge", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1", "--slow-tool-call", "50"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const tool = registeredTool(pi, "mcp_fx_tool_1");
 
 		const [first, second] = await Promise.all([
@@ -162,6 +170,10 @@ describe("MCP catalog + registerTool bridge", () => {
 			extensionFactories: [mcpExtensionFor(root.agentDir, ["mcp_fx_tool_1"])],
 		});
 		harnesses.push(harness);
+		await attachHarnessSession(harness, "fx");
+		// Registration resets the active set to the exposure default; re-apply the
+		// restricted subset deterministically after the raced refresh landed.
+		harness.session.setActiveToolsByName(["mcp_fx_tool_1"]);
 		harness.setResponses([
 			(context) => {
 				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());

--- a/packages/coding-agent/test/mcp/rehydration-wiring.test.ts
+++ b/packages/coding-agent/test/mcp/rehydration-wiring.test.ts
@@ -10,8 +10,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { TOOL_SEARCH_ACTIVATION_MARKER } from "../../src/core/extensions/builtin/mcp/expose/tool-search.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
-import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
+import { attach, awaitMcpToolRegistration, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig, stdioServer, type TestRoot, waitForCondition } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
 
@@ -46,6 +46,7 @@ describe("tool_search rehydration wiring", () => {
 		setConfig(root, { fx: { ...stdioServer(["--tools", "3"]), exposure: "search" } });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		expect(pi.getActiveTools()).toContain("tool_search");
 		expect(pi.getActiveTools()).not.toContain("mcp_fx_tool_2");
@@ -62,6 +63,7 @@ describe("tool_search rehydration wiring", () => {
 		setConfig(root, { fx: { ...stdioServer(["--tools", "3"]), exposure: "search" } });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		// Names no longer in the catalog stay dropped.
 		expect(getMcpService().rehydrateActiveToolsFromHistory(historyWithActivation("mcp_fx_tool_99"))).toEqual([]);
@@ -91,6 +93,9 @@ describe("tool_search rehydration wiring", () => {
 			pi,
 			{ agentDir: root.agentDir },
 		);
+		// The raced attach replays history again once the background registration
+		// lands; await the restore before asserting the first-turn payload.
+		await waitForCondition(() => pi.getActiveTools().includes("mcp_fx_tool_2"), 10_000);
 		// No explicit rehydrate call: attach itself must have replayed history.
 		expect(pi.getActiveTools()).toContain("mcp_fx_tool_2");
 		expect(pi.getActiveTools()).toContain("tool_search");
@@ -101,6 +106,7 @@ describe("tool_search rehydration wiring", () => {
 		setConfig(root, { fx: { ...stdioServer(["--tools", "3"]), exposure: "search" } });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		expect(getMcpService().maybeRehydrateFromHistory(historyWithActivation("mcp_fx_tool_2"))).toEqual([
 			"mcp_fx_tool_2",

--- a/packages/coding-agent/test/mcp/resources.test.ts
+++ b/packages/coding-agent/test/mcp/resources.test.ts
@@ -13,6 +13,7 @@ import {
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import {
 	attach,
+	awaitMcpToolRegistration,
 	capturingPi,
 	mcpRoot as makeMcpRoot,
 	registeredTool,
@@ -57,6 +58,7 @@ describe("mcp resources", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		expect(pi.getActiveTools()).toContain("mcp_list_resources");
 		const list = await registeredTool(pi, "mcp_list_resources").execute(
@@ -96,6 +98,7 @@ describe("mcp resources", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 		const servers = () => getMcpService().getMcpResourceServers();
 
 		const ok = await expandMcpResourceMentions("Use @mcp:fx/fixture://resource/one please", servers);

--- a/packages/coding-agent/test/mcp/service-lifecycle.test.ts
+++ b/packages/coding-agent/test/mcp/service-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
 import {
 	assertAlive,
 	attach,
+	awaitMcpConnected,
 	cleanupRoots,
 	fakePi,
 	makeRoot,
@@ -16,6 +17,7 @@ import {
 	setConfig,
 	stdioServer,
 	tool,
+	waitForCondition,
 	writeProjectConfig,
 } from "./fixtures/service-lifecycle.ts";
 import { assertProcessDead, stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
@@ -42,6 +44,7 @@ describe("McpService session lifecycle", () => {
 		const service = getMcpService();
 
 		await attach(service, root, "startup");
+		await awaitMcpConnected(service, "shared");
 		const firstPid = service.getConnection("shared")?.getRootPid();
 		await service.handleSessionShutdown({ type: "session_shutdown", reason: "new" });
 		await attach(service, root, "new");
@@ -64,12 +67,14 @@ describe("McpService session lifecycle", () => {
 		const serviceBeforeReload = getMcpService();
 
 		await attach(serviceBeforeReload, root, "startup");
+		await awaitMcpConnected(serviceBeforeReload, "reloadable");
 		const firstPid = requiredPid(serviceBeforeReload, "reloadable");
 		await serviceBeforeReload.handleSessionShutdown({ type: "session_shutdown", reason: "reload" });
 		await assertProcessDead(firstPid);
 
 		const serviceAfterReload = getMcpService();
 		await attach(serviceAfterReload, root, "reload");
+		await awaitMcpConnected(serviceAfterReload, "reloadable");
 		const secondPid = requiredPid(serviceAfterReload, "reloadable");
 
 		expect(serviceAfterReload).not.toBe(serviceBeforeReload);
@@ -89,6 +94,8 @@ describe("McpService session lifecycle", () => {
 		const service = getMcpService();
 
 		await attach(service, root, "startup");
+		await awaitMcpConnected(service, "changed");
+		await awaitMcpConnected(service, "stable");
 		const changedPidBefore = requiredPid(service, "changed");
 		const stablePidBefore = requiredPid(service, "stable");
 		await service.handleSessionShutdown({ type: "session_shutdown", reason: "new" });
@@ -98,6 +105,7 @@ describe("McpService session lifecycle", () => {
 			stable: stdioServer(["--tools", "1", "--spawn-counter-file", stableCounter]),
 		});
 		await attach(service, root, "new");
+		await awaitMcpConnected(service, "changed");
 		const changedPidAfter = requiredPid(service, "changed");
 		const stablePidAfter = requiredPid(service, "stable");
 
@@ -124,6 +132,7 @@ describe("McpService session lifecycle", () => {
 		const service = getMcpService();
 
 		await attach(service, root, "startup", false);
+		await awaitMcpConnected(service, "live");
 		const livePid = requiredPid(service, "live");
 		expect(await readCounter(liveCounter)).toBe(1);
 		await expect(readCounter(disabledCounter)).rejects.toMatchObject({ code: "ENOENT" });
@@ -156,6 +165,7 @@ describe("McpService session lifecycle", () => {
 		const service = getMcpService();
 
 		await attach(service, root, "startup");
+		await waitForCondition(() => service.getConnection("needsAuth")?.state === "degraded", 10_000);
 
 		expect(service.getConnection("needsAuth")?.getRootPid()).toBeNull();
 		expect(service.getServerSnapshots()).toMatchObject([
@@ -180,6 +190,8 @@ describe("McpService session lifecycle", () => {
 		const service = getMcpService();
 
 		await attach(service, root, "startup");
+		await awaitMcpConnected(service, "first");
+		await awaitMcpConnected(service, "second");
 		const pids = [requiredPid(service, "first"), requiredPid(service, "second")];
 		await service.handleSessionShutdown({ type: "session_shutdown", reason: "quit" });
 
@@ -209,6 +221,7 @@ describe("McpService session lifecycle", () => {
 		await service.attachSession({ type: "session_start", reason: "startup" }, ctx, fakePi(), {
 			agentDir: root.agentDir,
 		});
+		await awaitMcpConnected(service, "fixture");
 		const pid1 = requiredPid(service, "fixture");
 		expect(await readCounter(counterFile)).toBe(1);
 
@@ -242,6 +255,7 @@ describe("McpService session lifecycle", () => {
 		await serviceBeforeReload.attachSession({ type: "session_start", reason: "startup" }, ctx, fakePi(), {
 			agentDir: root.agentDir,
 		});
+		await awaitMcpConnected(serviceBeforeReload, "fixture");
 		const pid1 = requiredPid(serviceBeforeReload, "fixture");
 		await serviceBeforeReload.handleSessionShutdown({ type: "session_shutdown", reason: "reload" });
 		await assertProcessDead(pid1);
@@ -250,6 +264,7 @@ describe("McpService session lifecycle", () => {
 		await serviceAfterReload.attachSession({ type: "session_start", reason: "reload" }, ctx, fakePi(), {
 			agentDir: root.agentDir,
 		});
+		await awaitMcpConnected(serviceAfterReload, "fixture");
 		const pid2 = requiredPid(serviceAfterReload, "fixture");
 
 		expect(serviceAfterReload).not.toBe(serviceBeforeReload);

--- a/packages/coding-agent/test/mcp/skills-sidecar.test.ts
+++ b/packages/coding-agent/test/mcp/skills-sidecar.test.ts
@@ -13,7 +13,7 @@ import {
 	type SkillLike,
 	skillActivationTargets,
 } from "../../src/core/extensions/builtin/mcp/skills.ts";
-import { attach, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { attach, awaitMcpToolRegistration, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -95,6 +95,7 @@ describe("skills-carry-MCP live registration", () => {
 		);
 		const warnings = await getMcpService().attachSkillMcpServers(declared);
 		expect(warnings).toEqual([]);
+		await awaitMcpToolRegistration("fx2");
 
 		// 0 exposure pre-load: catalog registered, nothing active.
 		const active = pi.getActiveTools();
@@ -113,6 +114,7 @@ describe("skills-carry-MCP live registration", () => {
 		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
 		const pi = capturingPi();
 		await attach(root, pi);
+		await awaitMcpToolRegistration("fx");
 
 		const skill = makeSkill(root, "clasher", { sidecar: { fx: { command: "node", args: ["evil"] } } });
 		const decls = parseSkillMcpDeclarations([skill]);


### PR DESCRIPTION
## What (reworked after #260)
Originally Bug B (extend MCP startup race to lazy) + Bug C (QA cleanup orphan leak). PR #260 landed the lazy-race core on main with equal semantics plus startupTimeoutMs, so this PR was rebased and reduced to what main still needs:

- Bug C: process-group-aware QA cleanup (port from feat/app-server-parity; leader-only liveness let esbuild descendants escape SIGTERM and orphan to PID 1 — 95 live orphans observed)
- Rehydration replay fix: session-history rehydration now replays after a raced background connect (was lost against the not-yet-existing catalog)
- mcp_instructions block rebuilt after raced background registration
- test/mcp await-hardening: 21 files await raced background completion via fixture seams (fixes 74/284 test/mcp failures that plain main shows under parallel load)

## Measured evidence
- Orphans: 95 -> 0 after one-time reap; handshake.mjs probe on the fixed branch leaves count at 0 (f3-orphan-reap.txt, t5-cleanup-port.txt)
- Cross-fix live QA (F2): first footer render 2.12s (baseline >=12s blank), prompt at T+2s answered in 0.29s, no attach stall in ~/local-workspaces with codegraph enabled (f2-live-qa.txt)
- Full gate on the rebased branch: npm run check + npm run test exit 0, 477 files / 4059 tests (pr2-rework-gate.txt)

## Evidence
- t4-mcp-race.txt (original T4 proof: prompt->first-token 1.05s with a 10s-hanging lazy server; production half superseded by #260)
- t5-cleanup-port.txt, pr2-rework-gate.txt, f1-branch2-refix.txt

Plan: .omo/plans/senpi-render-hotpath-and-startup-fixes.md