### PR TITLE
fix(mcp): never block the first turn on a slow or wedged MCP server

### DIFF
--- a/packages/coding-agent/docs/mcp.md
+++ b/packages/coding-agent/docs/mcp.md
@@ -87,6 +87,15 @@ Per-request timeout. Default `30000`.
 ### `connectTimeoutMs`
 Connect + initialize handshake timeout. Default `15000`.
 
+### `startupTimeoutMs`
+Bounded startup window (ms) that a server's first connect + catalog fetch is
+raced against during session attach. A server that does not settle inside the
+window keeps connecting in the background and surfaces its tools when ready, so
+a slow or wedged server never blocks the first turn. Default `250`. Set higher
+to wait for tools before the first turn, `0` to never wait. The
+`SENPI_MCP_STARTUP_TIMEOUT_MS` environment variable overrides this for every
+server.
+
 ### `includeTools`
 Glob allowlist (`*` wildcards) over server-side tool names. Default: all.
 
@@ -199,7 +208,7 @@ Extension-declared servers use bare names (no prefix).
 | `degraded` | transient failure; auto-reconnect with backoff is running | wait, or `/mcp reconnect <name>` |
 | tools missing | server filtered/disabled, or hidden behind search | check `includeTools`/`excludeTools`, ask the model to `tool_search` |
 | child exits at spawn (EOF) | bad `command`/`args`/`env` | `/mcp logs <name>` shows the captured stderr |
-| slow first call | lazy server cold boot | use `lifecycle:"eager"` or `"keep-alive"` |
+| slow first call | lazy server cold boot (tools attach in the background) | raise `startupTimeoutMs`, or use `lifecycle:"eager"` / `"keep-alive"` |
 
 ## Security notes
 

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,45 @@
 # mcp Extension Changes
 
+## Non-blocking startup for cold lazy servers + configurable startup window (2026-07-21)
+
+### What changed
+- `service.ts` (`#syncFromConfig`): every startup connect now runs through
+  `raceMcpStartupConnect` — the branch condition became
+  `shouldRaceMcpStartup(lifecycle) || cachedCatalog === undefined`. A cold
+  `lazy` server (no cached catalog) previously took a fully-blocking
+  `connectAndRefreshMcpCatalog` awaited in `Promise.all(connects)`, so a slow
+  or wedged server (e.g. codegraph stuck indexing) gated `attachSession` ->
+  `before_agent_start` -> the first turn and the TUI silently swallowed
+  prompts. Now the connect is bounded by the startup race and finishes in the
+  background; a cached lazy server still needs no startup connect.
+- `startup-race.ts`: added `MCP_STARTUP_TIMEOUT_ENV`
+  (`SENPI_MCP_STARTUP_TIMEOUT_MS`) and `resolveMcpStartupTimeoutMs`, plus an
+  optional `deadlineMs` on `RaceMcpStartupConnectOptions` threaded into
+  `waitForMcpStartupRace`. Env override (global) > per-server config > default
+  `MCP_STARTUP_RACE_MS` (250); non-numeric/negative env ignored, `0` = never
+  wait.
+- `config-schema.ts` / `config.ts`: new per-server `startupTimeoutMs` field
+  (default 250), sitting beside `connectTimeoutMs`/`requestTimeoutMs`.
+- `docs/mcp.md`: documents `startupTimeoutMs` (required by
+  `scripts/check-mcp-docs.test.mjs`).
+
+### Why
+- A single misbehaving MCP server must never block the agent from starting a
+  turn. The eager/keep-alive paths already backgrounded slow connects via the
+  250ms startup race; the lazy cold path was the one remaining place that
+  blocked. Extending the same race to it closes the "prompt does nothing" bug
+  and makes the wait window operator-tunable.
+
+### Why extension system couldn't handle this alone
+- The blocking connect lives inside the MCP builtin's session-attach path;
+  only the builtin owns per-server lifecycle, the catalog cache, and the
+  startup race primitive.
+
+### Expected merge conflict zones
+- LOW/MEDIUM: `service.ts` `#syncFromConfig` connect branch; `startup-race.ts`
+  option/plumbing; `config-schema.ts`/`config.ts` timeout field lists.
+
+
 ## Trust-aware merge for extension-declared MCP servers (2026-07-17)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/commands.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/commands.ts
@@ -3,6 +3,7 @@ import { handleMcpAuthCommand } from "./auth/commands-auth-dispatch.ts";
 import { addGlobalMcpServer, setGlobalMcpServerEnabled } from "./config-edit.ts";
 import type { McpServerConfig } from "./config-schema.ts";
 import { getMcpService } from "./service.ts";
+import { MCP_STARTUP_RACE_MS } from "./startup-race.ts";
 import { buildMcpStatusRows, formatMcpStatus } from "./status.ts";
 
 const SUBCOMMANDS = [
@@ -211,6 +212,7 @@ function baseServer(endpoint: Pick<McpServerConfig, "type"> & Partial<McpServerC
 		lifecycle: "lazy",
 		logLevel: "info",
 		requestTimeoutMs: 30_000,
+		startupTimeoutMs: MCP_STARTUP_RACE_MS,
 		...endpoint,
 	};
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/config-schema.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/config-schema.ts
@@ -40,6 +40,7 @@ export const ServerSchema = Type.Object(
 		idleTimeoutMin: Type.Optional(Type.Number()),
 		requestTimeoutMs: Type.Optional(Type.Number()),
 		connectTimeoutMs: Type.Optional(Type.Number()),
+		startupTimeoutMs: Type.Optional(Type.Number()),
 		includeTools: Type.Optional(Type.Array(Type.String())),
 		excludeTools: Type.Optional(Type.Array(Type.String())),
 		directTools: Type.Optional(Type.Union([Type.Boolean(), Type.Array(Type.String())])),
@@ -89,6 +90,7 @@ export type McpServerConfig = Static<typeof ServerSchema> & {
 	lifecycle: "lazy" | "eager" | "keep-alive";
 	connectTimeoutMs: number;
 	requestTimeoutMs: number;
+	startupTimeoutMs: number;
 	idleTimeoutMin: number;
 	exposure: "auto" | "direct" | "search" | "proxy";
 	logLevel: Static<typeof LogLevelSchema>;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/config.ts
@@ -16,6 +16,7 @@ import {
 	type ResolvedMcpServer,
 	validateConfig,
 } from "./config-schema.ts";
+import { MCP_STARTUP_RACE_MS } from "./startup-race.ts";
 
 export class McpConfigValidationError extends Error {
 	constructor(message: string) {
@@ -293,6 +294,7 @@ function normalizeServer(server: NonNullable<RawConfig["mcpServers"]>[string]): 
 		lifecycle: server.lifecycle ?? "lazy",
 		logLevel: server.logLevel ?? "info",
 		requestTimeoutMs: server.requestTimeoutMs ?? 30_000,
+		startupTimeoutMs: server.startupTimeoutMs ?? MCP_STARTUP_RACE_MS,
 		type,
 		...server,
 	};
@@ -332,7 +334,13 @@ function interpolateString(value: string, path: string, env: Record<string, stri
 }
 
 function hashConfig(config: McpServerConfig): string {
-	return createHash("sha256").update(stableStringify(config)).digest("hex");
+	// startupTimeoutMs is a client-side startup-race policy, not a connection or
+	// catalog-shape input. Excluding it from the identity hash keeps the catalog
+	// cache valid across upgrades (configs written before the field existed hash
+	// identically) and avoids a needless reconnect when only the window changes.
+	const hashable: Record<string, unknown> = { ...config };
+	delete hashable.startupTimeoutMs;
+	return createHash("sha256").update(stableStringify(hashable)).digest("hex");
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -33,8 +33,8 @@ import type {
 } from "./service-types.ts";
 import {
 	connectAndRefreshMcpCatalog,
-	ignoreStartupNeedsAuth,
 	raceMcpStartupConnect,
+	resolveMcpStartupTimeoutMs,
 	shouldRaceMcpStartup,
 } from "./startup-race.ts";
 
@@ -313,7 +313,13 @@ export class McpService {
 			this.#connections.set(key, entry);
 			this.#connectionKeysByName.set(name, key);
 			this.#wireListChanged(entry);
-			if (shouldRaceMcpStartup(server.config.lifecycle)) {
+			// Every startup connect is bounded by the startup race and continues in
+			// the background past the deadline (eager/keep-alive always; a cold lazy
+			// server that has no cached catalog also races so a slow/wedged server
+			// never gates attachSession -> before_agent_start -> the first turn).
+			// A cached lazy server needs no startup connect: its tools come from the
+			// cache and it connects on demand at tool-call time.
+			if (shouldRaceMcpStartup(server.config.lifecycle) || cachedCatalog === undefined) {
 				connects.push(
 					raceMcpStartupConnect({
 						entry,
@@ -321,10 +327,9 @@ export class McpService {
 						registerDirectTools: (targetPi) => this.#registerDirectTools(targetPi),
 						serverConfig: server.config,
 						shouldRefreshTools: () => !this.#disposed && this.#toolRefreshGeneration === toolRefreshGeneration,
+						deadlineMs: resolveMcpStartupTimeoutMs(server.config.startupTimeoutMs),
 					}),
 				);
-			} else if (cachedCatalog === undefined) {
-				connects.push(ignoreStartupNeedsAuth(entry, connectAndRefreshMcpCatalog(entry, server.config)));
 			}
 		}
 		await Promise.all(connects);

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/startup-race.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/startup-race.ts
@@ -9,6 +9,23 @@ import type { McpConnectionEntry } from "./service-types.ts";
 import { safeTimer } from "./wrap.ts";
 
 export const MCP_STARTUP_RACE_MS = 250;
+export const MCP_STARTUP_TIMEOUT_ENV = "SENPI_MCP_STARTUP_TIMEOUT_MS";
+
+/**
+ * Resolve the startup-race window (ms) a server's attach connect is bounded by.
+ * Precedence: the `SENPI_MCP_STARTUP_TIMEOUT_MS` env override (a global escape
+ * hatch) beats the per-server `startupTimeoutMs`, which beats the default. A
+ * non-numeric or negative env value is ignored; `0` is honored and makes the
+ * startup window non-blocking (connect is backgrounded immediately).
+ */
+export function resolveMcpStartupTimeoutMs(configured?: number): number {
+	const raw = process.env[MCP_STARTUP_TIMEOUT_ENV]?.trim();
+	if (raw !== undefined && raw.length > 0) {
+		const value = Number(raw);
+		if (Number.isFinite(value) && value >= 0) return value;
+	}
+	return configured ?? MCP_STARTUP_RACE_MS;
+}
 
 export type McpStartupRaceResult = "settled" | "timeout";
 export type McpToolRegistrar = Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">;
@@ -19,6 +36,9 @@ interface RaceMcpStartupConnectOptions {
 	readonly registerDirectTools: (pi: McpToolRegistrar) => Promise<void>;
 	readonly serverConfig: ResolvedMcpServer["config"];
 	readonly shouldRefreshTools: () => boolean;
+	// Bounded startup window (ms) before the connect is backgrounded; defaults to
+	// MCP_STARTUP_RACE_MS when omitted.
+	readonly deadlineMs?: number;
 }
 
 export async function raceMcpStartupConnect(options: RaceMcpStartupConnectOptions): Promise<void> {
@@ -26,7 +46,7 @@ export async function raceMcpStartupConnect(options: RaceMcpStartupConnectOption
 		options.entry,
 		connectAndRefreshMcpCatalog(options.entry, options.serverConfig),
 	);
-	const result = await waitForMcpStartupRace(connect);
+	const result = await waitForMcpStartupRace(connect, options.deadlineMs);
 	if (result === "settled" || options.pi === undefined) return;
 	void connect.then(() => refreshMcpToolsAfterStartupRace(options));
 }

--- a/packages/coding-agent/test/mcp/auth-modes.test.ts
+++ b/packages/coding-agent/test/mcp/auth-modes.test.ts
@@ -32,6 +32,7 @@ function baseHttp(url: string, extra: Partial<McpServerConfig> = {}): McpServerC
 		lifecycle: "lazy",
 		connectTimeoutMs: 4000,
 		requestTimeoutMs: 4000,
+		startupTimeoutMs: 250,
 		idleTimeoutMin: 10,
 		exposure: "auto",
 		logLevel: "info",

--- a/packages/coding-agent/test/mcp/connection.test.ts
+++ b/packages/coding-agent/test/mcp/connection.test.ts
@@ -274,6 +274,7 @@ function serverConfig(overrides: Partial<McpServerConfig> = {}): McpServerConfig
 		lifecycle: "lazy",
 		logLevel: "info",
 		requestTimeoutMs: 30_000,
+		startupTimeoutMs: 250,
 		type: "stdio",
 		...overrides,
 	};

--- a/packages/coding-agent/test/mcp/diagnose.test.ts
+++ b/packages/coding-agent/test/mcp/diagnose.test.ts
@@ -186,6 +186,7 @@ function serverConfig(overrides: Partial<McpServerConfig> = {}): McpServerConfig
 		lifecycle: "lazy",
 		logLevel: "info",
 		requestTimeoutMs: 30_000,
+		startupTimeoutMs: 250,
 		type: "stdio",
 		...overrides,
 	};

--- a/packages/coding-agent/test/mcp/fixtures/oauth-race-worker.ts
+++ b/packages/coding-agent/test/mcp/fixtures/oauth-race-worker.ts
@@ -108,6 +108,7 @@ async function runtimeAttempt(
 		lifecycle: "lazy",
 		logLevel: "info",
 		requestTimeoutMs: 4000,
+		startupTimeoutMs: 250,
 		type: "http",
 		url: mcpUrl,
 	};

--- a/packages/coding-agent/test/mcp/fixtures/reconnect.ts
+++ b/packages/coding-agent/test/mcp/fixtures/reconnect.ts
@@ -29,6 +29,7 @@ export function serverConfig(): McpServerConfig {
 		lifecycle: "lazy",
 		logLevel: "info",
 		requestTimeoutMs: 30_000,
+		startupTimeoutMs: 250,
 		type: "stdio",
 	};
 }

--- a/packages/coding-agent/test/mcp/list-changed.test.ts
+++ b/packages/coding-agent/test/mcp/list-changed.test.ts
@@ -148,6 +148,7 @@ function serverConfig(overrides: Partial<McpServerConfig>): McpServerConfig {
 		lifecycle: "lazy",
 		connectTimeoutMs: 4000,
 		requestTimeoutMs: 4000,
+		startupTimeoutMs: 250,
 		idleTimeoutMin: 0,
 		exposure: "auto",
 		logLevel: "info",

--- a/packages/coding-agent/test/mcp/oauth-callback.test.ts
+++ b/packages/coding-agent/test/mcp/oauth-callback.test.ts
@@ -67,6 +67,7 @@ function makeHarness(dir: string, mcpUrl: string, overrides: Partial<McpServerCo
 		lifecycle: "lazy",
 		connectTimeoutMs: 4000,
 		requestTimeoutMs: 4000,
+		startupTimeoutMs: 250,
 		idleTimeoutMin: 10,
 		exposure: "auto",
 		logLevel: "info",

--- a/packages/coding-agent/test/mcp/oauth-headless.test.ts
+++ b/packages/coding-agent/test/mcp/oauth-headless.test.ts
@@ -63,6 +63,7 @@ function makeHarness(
 		lifecycle: "lazy",
 		connectTimeoutMs: 4000,
 		requestTimeoutMs: 4000,
+		startupTimeoutMs: 250,
 		idleTimeoutMin: 10,
 		exposure: "auto",
 		logLevel: "info",

--- a/packages/coding-agent/test/mcp/startup-race.test.ts
+++ b/packages/coding-agent/test/mcp/startup-race.test.ts
@@ -130,6 +130,74 @@ describe("MCP startup race", () => {
 		expect(callElapsedMs).toBeLessThan(30_000);
 		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1"]);
 	});
+
+	it("does not block startup on a slow cold lazy server and registers its tools in the background", async () => {
+		const root = makeStartupRoot("slow-lazy-cold");
+		// --slow-start 800 clears the 250ms startup race window (so attach cannot
+		// settle synchronously) while staying inside connectTimeoutMs, so the
+		// background connect still completes and surfaces tools. This is the cold
+		// lazy analogue of the wedged codegraph server that used to gate the UI.
+		setConfig(root, {
+			fx: { ...stdioServer(["--tools", "2", "--slow-start", "800"]), lifecycle: "lazy", connectTimeoutMs: 5000 },
+		});
+		const pi = capturingPi();
+
+		// A cold lazy server that is slow to initialize must NOT gate attach: the
+		// startup connect is bounded by the startup race and continues in the
+		// background. Before the fix attach awaited the full connect (~800ms+).
+		const elapsedMs = await timedAttach(root, pi);
+		// Bound is well under the pre-fix blocking time (~900ms) with headroom for
+		// spawn + scheduling jitter under CI's single-fork runner.
+		expect(elapsedMs).toBeLessThan(600);
+		expect(getMcpService().getServerSnapshots()).toMatchObject([
+			{ name: "fx", lifecycleState: "connecting", configState: "enabled" },
+		]);
+
+		// The slow server's tools surface via the background refresh once it connects.
+		await waitFor(() => withoutMcpUtilityTools(pi.registeredTools).length === 2, 8000);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
+	});
+
+	it("honors a per-server startupTimeoutMs by waiting for a slow cold lazy server to settle", async () => {
+		const root = makeStartupRoot("configured-startup-timeout");
+		// A generous per-server startupTimeoutMs widens the race window past the
+		// 500ms server start, so attach waits for the connect to settle (tools
+		// registered on return) instead of backgrounding at the 250ms default.
+		setConfig(root, {
+			fx: {
+				...stdioServer(["--tools", "1", "--slow-start", "500"]),
+				lifecycle: "lazy",
+				connectTimeoutMs: 5000,
+				startupTimeoutMs: 5000,
+			},
+		});
+		const pi = capturingPi();
+
+		const elapsedMs = await timedAttach(root, pi);
+		expect(elapsedMs).toBeGreaterThanOrEqual(400);
+		expect(withoutMcpUtilityTools(pi.registeredTools)).toEqual(["mcp_fx_tool_1"]);
+		expect(getMcpService().getServerSnapshots()).toMatchObject([
+			{ name: "fx", lifecycleState: "connected", configState: "enabled" },
+		]);
+	});
+
+	it("keeps the config hash stable across startupTimeoutMs changes so cached catalogs survive", () => {
+		// startupTimeoutMs must not enter the config identity hash: otherwise adding
+		// the field (or changing the window) would invalidate every existing catalog
+		// cache on upgrade and force previously-cached lazy servers to cold-start.
+		const rootA = makeStartupRoot("hash-default");
+		setConfig(rootA, { fx: { ...stdioServer([]), startupTimeoutMs: 250 } });
+		const rootB = makeStartupRoot("hash-custom");
+		setConfig(rootB, { fx: { ...stdioServer([]), startupTimeoutMs: 9999 } });
+
+		const hashA = loadMcpConfig({ agentDir: rootA.agentDir, cwd: rootA.cwd, projectTrusted: true }).servers.fx
+			?.configHash;
+		const hashB = loadMcpConfig({ agentDir: rootB.agentDir, cwd: rootB.cwd, projectTrusted: true }).servers.fx
+			?.configHash;
+
+		expect(hashA).toBeTypeOf("string");
+		expect(hashA).toBe(hashB);
+	});
 });
 
 async function attach(root: TestRoot, pi = capturingPi()): Promise<void> {

--- a/packages/coding-agent/test/mcp/startup-timeout.test.ts
+++ b/packages/coding-agent/test/mcp/startup-timeout.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	MCP_STARTUP_RACE_MS,
+	MCP_STARTUP_TIMEOUT_ENV,
+	resolveMcpStartupTimeoutMs,
+} from "../../src/core/extensions/builtin/mcp/startup-race.ts";
+
+describe("resolveMcpStartupTimeoutMs", () => {
+	let original: string | undefined;
+
+	beforeEach(() => {
+		original = process.env[MCP_STARTUP_TIMEOUT_ENV];
+		delete process.env[MCP_STARTUP_TIMEOUT_ENV];
+	});
+
+	afterEach(() => {
+		if (original === undefined) delete process.env[MCP_STARTUP_TIMEOUT_ENV];
+		else process.env[MCP_STARTUP_TIMEOUT_ENV] = original;
+	});
+
+	it("falls back to the default race window when nothing is configured", () => {
+		expect(resolveMcpStartupTimeoutMs(undefined)).toBe(MCP_STARTUP_RACE_MS);
+	});
+
+	it("honors the configured value from settings", () => {
+		expect(resolveMcpStartupTimeoutMs(500)).toBe(500);
+	});
+
+	it("lets the env override win over the configured value", () => {
+		process.env[MCP_STARTUP_TIMEOUT_ENV] = "750";
+		expect(resolveMcpStartupTimeoutMs(500)).toBe(750);
+	});
+
+	it("ignores a non-numeric env value and keeps the configured value", () => {
+		process.env[MCP_STARTUP_TIMEOUT_ENV] = "not-a-number";
+		expect(resolveMcpStartupTimeoutMs(500)).toBe(500);
+	});
+
+	it("ignores a negative env value and keeps the configured value", () => {
+		process.env[MCP_STARTUP_TIMEOUT_ENV] = "-10";
+		expect(resolveMcpStartupTimeoutMs(500)).toBe(500);
+	});
+
+	it("accepts 0 to make the startup window non-blocking", () => {
+		process.env[MCP_STARTUP_TIMEOUT_ENV] = "0";
+		expect(resolveMcpStartupTimeoutMs(500)).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/mcp/transport.test.ts
+++ b/packages/coding-agent/test/mcp/transport.test.ts
@@ -144,6 +144,7 @@ function serverConfig(overrides: Partial<McpServerConfig> = {}): McpServerConfig
 		lifecycle: "lazy",
 		logLevel: "info",
 		requestTimeoutMs: 30_000,
+		startupTimeoutMs: 250,
 		type: "stdio",
 		...overrides,
 	};


### PR DESCRIPTION
## Problem

Launching senpi in a directory whose MCP stack includes a slow or wedged server (real-world trigger: the omo `codegraph` MCP server stuck indexing, hanging its main thread ~60s and timing out MCP requests) made the interactive TUI **silently swallow prompts** — you type, press Enter, the input clears, and nothing happens: no transcript entry, no spinner, no response.

## Root cause

In the built-in MCP client, `service.ts#syncFromConfig` connected servers per lifecycle:

- `eager` / `keep-alive` → bounded 250ms **startup race** (`raceMcpStartupConnect`): a slow connect settles fast or is backgrounded.
- `lazy` **with no cached catalog** → a fully-blocking `connectAndRefreshMcpCatalog` awaited inside `await Promise.all(connects)`.

That blocking connect is awaited by `attachSession` → the `before_agent_start` hook, so a wedged lazy server gated the very first turn and the TUI dropped the submitted prompt. `codegraph` is a `lazy` server that never caches (its `tools/list` handshake times out), so it hit this path every session.

## Fix

- **Route cold `lazy` connects through the same bounded startup race** (`shouldRaceMcpStartup(lifecycle) || cachedCatalog === undefined`). A server that does not settle within the window keeps connecting in the background and surfaces its tools via the existing post-race refresh; a cached lazy server still skips the startup connect entirely and registers from cache. No MCP server can block turn start anymore.
- **Configurable startup window**: new per-server `startupTimeoutMs` (default `250`, sits beside `connectTimeoutMs`/`requestTimeoutMs`) plus a global `SENPI_MCP_STARTUP_TIMEOUT_MS` env override (`0` = never wait; invalid/negative ignored). References oh-my-pi's `STARTUP_TIMEOUT_MS` + `OMP_MCP_TIMEOUT_MS` and codex's per-server `startup_timeout_sec`.
- **Cache-safe**: `startupTimeoutMs` is excluded from the config identity hash, so existing catalog caches stay valid across upgrades and changing only the window never forces a reconnect.

## Tests (all deterministic, mutation-verified)

- `startup-race.test.ts`: cold slow lazy server does not block attach + tools register in the background; per-server `startupTimeoutMs` is honored (high window → attach waits for settle); config hash is stable across `startupTimeoutMs` changes.
- `startup-timeout.test.ts` (new): `resolveMcpStartupTimeoutMs` precedence/validation units.
- Existing `McpServerConfig` fixtures updated for the new required field.

## Verification

- `test/mcp` suite: **284/284 pass**.
- `npm run check` (biome + root `tsgo --noEmit` + browser-smoke + web-ui + neo): **green**.
- **Real-surface QA** in the actual `omo-desktop-app` dir with the full omo + codegraph stack: prompt processed end-to-end (model replied). Deterministic end-to-end contrast against a guaranteed-wedged MCP server: **published binary 31.7s (turn gated) vs this build 5.8s** (wedge backgrounded).
- Reviewer: consulted the oracle; it caught a catalog-cache-invalidation regression in the first draft (`startupTimeoutMs` leaking into the config hash), which is fixed here and re-approved.

## Notes

The `codegraph` package's own Node-≥25 / main-thread-wedge behavior is external (already gated by omo's node-support check); this PR makes senpi robust to *any* misbehaving MCP server rather than depending on a single server behaving.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the first turn from being blocked by slow or wedged MCP servers by racing all startup connects—including cold lazy servers—against a short deadline and finishing in the background. Adds a configurable startup window with a global override, without breaking existing MCP catalog caches.

- **Bug Fixes**
  - Cold `lazy` servers now use the bounded startup race, so slow/wedged MCP servers no longer gate session attach or the first turn; tools register in the background when ready.

- **New Features**
  - Added per-server `startupTimeoutMs` (default 250ms) and a global `SENPI_MCP_STARTUP_TIMEOUT_MS` env override to control the startup window.
  - Excluded `startupTimeoutMs` from the config identity hash to keep existing catalog caches valid.

<sup>Written for commit fcca2bf3ae2d5582eab95befee36aecd112cea81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

