### PR TITLE
feat(coding-agent): add /btw parallel side-question command

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,17 @@
 # changes
 
+## Parallel side questions via `/btw` (2026-07-21)
+
+### What changed
+
+- New builtin extension `core/extensions/builtin/btw/` adds `/btw <question>`: a read-only side LLM query against a synchronously captured snapshot of the current conversation, running in parallel with any in-flight main turn without writing to session history. Details in `core/extensions/builtin/btw/changes.md`.
+- TUI: the answer streams into a dismissable widget above the editor; Escape dismisses the side panel without touching main-turn Escape behavior. Non-TUI modes deliver the answer via `ctx.ui.notify`.
+- `core/extensions/builtin/index.ts` registers the extension between `goal` and `mcp`.
+
+### Why
+
+- Asking a question about the ongoing session previously required waiting for the main turn and polluting its context. `/btw` answers immediately, in parallel, and leaves the main session untouched.
+
 ## Claude text tool-call recovery (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/btw/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/changes.md
@@ -1,0 +1,51 @@
+# changes — btw
+
+## Parallel side questions via `/btw` (2026-07-21)
+
+### What changed
+
+- New builtin extension `btw` registering `/btw <question>`: runs a read-only side
+  LLM query against a snapshot of the current conversation, in parallel with any
+  in-flight main turn, without writing anything back to session history.
+- `side-query.ts`: builds the side context (session system prompt plus a
+  side-question instruction, snapshot history, question as the final user
+  message, `tools: []`) and streams it through `streamSimple` with an
+  establishment timeout (default 30s), abort propagation, and text-delta
+  callbacks. Provider `sessionId` is suffixed `:btw:<uuid>` so provider-side
+  session affinity never collides with the main turn.
+- `index.ts`: the command handler captures the context snapshot synchronously
+  (entries + leaf at invocation time) before its first await, so a concurrent
+  main turn or compaction cannot create a mixed-generation request. A new
+  `/btw` aborts and replaces the previous one; `session_before_switch` aborts
+  any active query.
+- `panel.ts` (TUI only): renders the question and streaming answer in a widget
+  above the editor. Escape always passes through to the main TUI untouched; as a
+  side effect it also dismisses the panel and aborts the side query, so one
+  Escape cancels in-flight side work without ever stealing the main interrupt.
+  A settled panel auto-dismisses on the next submitted message.
+  Non-TUI modes skip the widget and deliver the answer through `ctx.ui.notify`.
+- `builtin/index.ts`: registers the extension after `goal` and before `mcp`.
+- Coverage: `test/suite/btw-side-query.test.ts` proves no history pollution,
+  parallel execution with an in-flight main turn, synchronous snapshot
+  isolation, previous-query abort, provider error propagation, establishment
+  timeout, and pre-aborted signals — all on the faux provider, zero tokens.
+
+### Why
+
+- Users need a way to ask questions about the ongoing session (or anything
+  else) without derailing or polluting the main agent's context, and without
+  waiting for the main turn to finish.
+
+### Known limitations
+
+- Escape is matched as the raw terminal key; the extension API exposes no
+  keybinding lookup from command contexts, so a remapped `app.interrupt` key
+  is not honored by the widget.
+- The side query streams through `streamSimple` directly (same pattern as core
+  compaction): auth resolution goes through the model runtime, but session
+  `before_provider_request` hooks and retry policy do not apply to side calls.
+
+### Merge-conflict zones
+
+- `builtin/index.ts` import block + `builtinExtensions` array (single added
+  line each; keep the `btw` entry ahead of `mcp`).

--- a/packages/coding-agent/src/core/extensions/builtin/btw/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/index.ts
@@ -1,0 +1,132 @@
+import { convertToLlm, filterContextExcludedMessages } from "../../../messages.ts";
+import { buildSessionContext } from "../../../session-manager.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { BtwPanel } from "./panel.ts";
+import { buildSideQueryContext, runSideQuery } from "./side-query.ts";
+
+const WIDGET_KEY = "btw";
+const ESCAPE = "";
+
+interface ActiveBtw {
+	controller: AbortController;
+	panel: BtwPanel | undefined;
+	unsubscribeEscape: (() => void) | undefined;
+	settled: boolean;
+}
+
+export default function btwExtension(pi: ExtensionAPI) {
+	let active: ActiveBtw | undefined;
+
+	function dismiss(ctx: ExtensionContext, options: { abort: boolean }): void {
+		const current = active;
+		if (!current) return;
+		active = undefined;
+		if (options.abort) current.controller.abort();
+		current.unsubscribeEscape?.();
+		if (current.panel) ctx.ui.setWidget(WIDGET_KEY, undefined);
+	}
+
+	pi.on("session_before_switch", (_event, ctx) => {
+		dismiss(ctx, { abort: true });
+	});
+
+	pi.on("session_before_fork", (_event, ctx) => {
+		dismiss(ctx, { abort: true });
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		dismiss(ctx, { abort: true });
+	});
+
+	pi.on("input", (_event, ctx) => {
+		if (active?.settled) dismiss(ctx, { abort: false });
+	});
+
+	pi.registerCommand("btw", {
+		description: "Ask a side question in parallel without touching the main session",
+		argumentHint: "<question>",
+		handler: async (args, ctx) => {
+			const question = args.trim();
+			if (!question) {
+				ctx.ui.notify("Usage: /btw <question>", "warning");
+				return;
+			}
+			const model = ctx.model;
+			if (!model) {
+				ctx.ui.notify("No active model available for /btw.", "error");
+				return;
+			}
+
+			const snapshot = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
+			const history = convertToLlm(filterContextExcludedMessages(snapshot.messages));
+			const systemPrompt = ctx.getSystemPrompt();
+			const thinkingLevel = pi.getThinkingLevel();
+			const sessionId = ctx.sessionManager.getSessionId();
+			const context = buildSideQueryContext({ systemPrompt, history, question });
+
+			dismiss(ctx, { abort: true });
+			const controller = new AbortController();
+			const entry: ActiveBtw = { controller, panel: undefined, unsubscribeEscape: undefined, settled: false };
+			active = entry;
+
+			if (ctx.mode === "tui" && ctx.hasUI) {
+				ctx.ui.setWidget(WIDGET_KEY, (tui, theme) => {
+					const panel = new BtwPanel(question, tui, theme);
+					entry.panel = panel;
+					return panel.component;
+				});
+				entry.unsubscribeEscape = ctx.ui.onTerminalInput((data) => {
+					if (active !== entry || data !== ESCAPE) return undefined;
+					dismiss(ctx, { abort: true });
+					return undefined;
+				});
+			}
+
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+			if (!auth.ok) {
+				if (active !== entry) return;
+				dismiss(ctx, { abort: false });
+				ctx.ui.notify(`/btw: ${auth.error}`, "error");
+				return;
+			}
+
+			try {
+				const { replyText } = await runSideQuery(
+					{
+						model,
+						auth: { apiKey: auth.apiKey, headers: auth.headers, extraBody: auth.extraBody },
+						sessionId,
+						thinkingLevel: thinkingLevel === "off" ? undefined : thinkingLevel,
+					},
+					context,
+					{
+						signal: controller.signal,
+						onTextDelta: (delta) => {
+							if (active === entry) entry.panel?.appendText(delta);
+						},
+					},
+				);
+				if (active !== entry) return;
+				entry.settled = true;
+				if (entry.panel) {
+					entry.panel.markDone();
+				} else {
+					ctx.ui.notify(replyText, "info");
+				}
+			} catch (error) {
+				if (active !== entry) return;
+				entry.settled = true;
+				const message = error instanceof Error ? error.message : String(error);
+				if (controller.signal.aborted) {
+					entry.panel?.markAborted();
+					return;
+				}
+				if (entry.panel) {
+					entry.panel.markError(message);
+				} else {
+					ctx.ui.notify(`/btw failed: ${message}`, "error");
+				}
+			}
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/btw/panel.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/panel.ts
@@ -1,0 +1,76 @@
+import { Container, Text, type TUI } from "@earendil-works/pi-tui";
+import { DynamicBorder } from "../../../../modes/interactive/components/dynamic-border.ts";
+import type { Theme } from "../../../../modes/interactive/theme/theme.ts";
+
+export type BtwPanelStatus = "streaming" | "done" | "error" | "aborted";
+
+export class BtwPanel {
+	private readonly container: Container;
+	private readonly body: Text;
+	private readonly question: string;
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private answer = "";
+	private status: BtwPanelStatus = "streaming";
+	private detail = "";
+
+	constructor(question: string, tui: TUI, theme: Theme) {
+		this.question = question;
+		this.tui = tui;
+		this.theme = theme;
+		this.container = new Container();
+		this.container.addChild(new DynamicBorder((s: string) => this.theme.fg("muted", s)));
+		this.body = new Text("", 1, 0);
+		this.container.addChild(this.body);
+		this.container.addChild(new DynamicBorder((s: string) => this.theme.fg("muted", s)));
+		this.repaint();
+	}
+
+	get component(): Container {
+		return this.container;
+	}
+
+	appendText(delta: string): void {
+		this.answer += delta;
+		this.repaint();
+	}
+
+	markDone(): void {
+		this.status = "done";
+		this.repaint();
+	}
+
+	markError(message: string): void {
+		this.status = "error";
+		this.detail = message;
+		this.repaint();
+	}
+
+	markAborted(): void {
+		this.status = "aborted";
+		this.repaint();
+	}
+
+	private repaint(): void {
+		const thm = this.theme;
+		const header = thm.fg("accent", thm.bold("btw: ")) + thm.fg("text", this.question);
+		const answer = this.answer ? `\n${this.answer}` : "";
+		let footer: string;
+		switch (this.status) {
+			case "streaming":
+				footer = thm.fg("dim", "\nanswering… (Esc to cancel)");
+				break;
+			case "done":
+				footer = thm.fg("dim", "\n(dismisses on next message)");
+				break;
+			case "error":
+				footer = thm.fg("error", `\nerror: ${this.detail}`);
+				break;
+			case "aborted":
+				footer = thm.fg("dim", "\n(dismissed)");
+				break;
+		}
+		this.body.setText(header + answer + footer);
+		this.tui.requestRender();
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/btw/side-query.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/side-query.ts
@@ -1,0 +1,108 @@
+import type {
+	Context,
+	Message,
+	Model,
+	SimpleStreamOptions,
+	StreamFunction,
+	ThinkingLevel,
+} from "@earendil-works/pi-ai/compat";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
+
+export const SIDE_QUERY_INSTRUCTION = [
+	"The user is asking a side question about the conversation so far, outside the main task.",
+	"Answer it directly and concisely from the context above.",
+	"Do not continue any task, do not modify anything, and do not treat this as new work.",
+].join(" ");
+
+export const DEFAULT_ESTABLISHMENT_TIMEOUT_MS = 30_000;
+
+export interface SideQueryContextInput {
+	systemPrompt: string;
+	history: readonly Message[];
+	question: string;
+}
+
+export function buildSideQueryContext(input: SideQueryContextInput): Context {
+	return {
+		systemPrompt: `${input.systemPrompt}\n\n${SIDE_QUERY_INSTRUCTION}`,
+		messages: [...input.history, { role: "user", content: input.question, timestamp: Date.now() }],
+		tools: [],
+	};
+}
+
+export interface SideQueryAuth {
+	apiKey?: string;
+	headers?: Record<string, string>;
+	extraBody?: Record<string, unknown>;
+}
+
+export interface SideQueryDeps {
+	model: Model<any>;
+	auth: SideQueryAuth;
+	sessionId: string;
+	thinkingLevel?: ThinkingLevel;
+	streamFn?: StreamFunction;
+	establishmentTimeoutMs?: number;
+}
+
+export interface SideQueryCallbacks {
+	onTextDelta?: (delta: string) => void;
+	signal?: AbortSignal;
+}
+
+export interface SideQueryResult {
+	replyText: string;
+}
+
+export async function runSideQuery(
+	deps: SideQueryDeps,
+	context: Context,
+	callbacks: SideQueryCallbacks = {},
+): Promise<SideQueryResult> {
+	callbacks.signal?.throwIfAborted();
+	const streamFn = deps.streamFn ?? streamSimple;
+	const establishment = new AbortController();
+	const signal = callbacks.signal ? AbortSignal.any([callbacks.signal, establishment.signal]) : establishment.signal;
+	const timeoutMs = deps.establishmentTimeoutMs ?? DEFAULT_ESTABLISHMENT_TIMEOUT_MS;
+	const timeoutError = new Error(`/btw provider did not produce an event within ${Math.round(timeoutMs / 1000)}s`);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const options: SimpleStreamOptions = {
+			apiKey: deps.auth.apiKey,
+			headers: deps.auth.headers,
+			extraBody: deps.auth.extraBody,
+			sessionId: `${deps.sessionId}:btw:${crypto.randomUUID()}`,
+			reasoning: deps.thinkingLevel,
+			signal,
+		};
+		timer = setTimeout(() => establishment.abort(timeoutError), timeoutMs);
+		timer.unref?.();
+		const stream = await streamFn(deps.model, context, options);
+		let established = false;
+		let replyText = "";
+		for await (const event of stream) {
+			if (!established && event.type !== "start") {
+				established = true;
+				clearTimeout(timer);
+				timer = undefined;
+			}
+			if (event.type === "text_delta") {
+				replyText += event.delta;
+				callbacks.onTextDelta?.(event.delta);
+			} else if (event.type === "done") {
+				break;
+			} else if (event.type === "error") {
+				throw new Error(event.error.errorMessage || "Side query failed");
+			}
+		}
+		signal.throwIfAborted();
+		return { replyText };
+	} catch (error) {
+		if (establishment.signal.aborted && !callbacks.signal?.aborted) {
+			throw timeoutError;
+		}
+		throw error;
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -2,6 +2,7 @@ import type { ExtensionFactory } from "../types.ts";
 import anthropicBashExtension from "./anthropic-bash/index.ts";
 import anthropicWebSearchExtension from "./anthropic-web-search/index.ts";
 import bashTimeoutExtension from "./bash-timeout/index.ts";
+import btwExtension from "./btw/index.ts";
 import compactionExtension from "./compaction/index.ts";
 import diffExtension from "./diff.ts";
 import filesExtension from "./files.ts";
@@ -70,6 +71,7 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "nested-agents-md", factory: nestedAgentsMdExtension },
 	{ id: "rules", factory: piRulesExtension },
 	{ id: "goal", factory: goalExtension },
+	{ id: "btw", factory: btwExtension },
 	// Keep MCP last so its eventual provider-payload tap observes all co-resident builtin mutations.
 	{ id: "mcp", factory: mcpExtension },
 ];

--- a/packages/coding-agent/test/suite/btw-side-query.test.ts
+++ b/packages/coding-agent/test/suite/btw-side-query.test.ts
@@ -1,0 +1,276 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import btwExtension from "../../src/core/extensions/builtin/btw/index.ts";
+import {
+	buildSideQueryContext,
+	runSideQuery,
+	SIDE_QUERY_INSTRUCTION,
+} from "../../src/core/extensions/builtin/btw/side-query.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+describe("buildSideQueryContext", () => {
+	it("appends the side instruction to the system prompt and the question as the final user message", () => {
+		const context = buildSideQueryContext({
+			systemPrompt: "BASE PROMPT",
+			history: [{ role: "user", content: "earlier", timestamp: 1 }],
+			question: "what did I ask?",
+		});
+		expect(context.systemPrompt).toContain("BASE PROMPT");
+		expect(context.systemPrompt).toContain(SIDE_QUERY_INSTRUCTION);
+		expect(context.tools).toEqual([]);
+		expect(context.messages).toHaveLength(2);
+		expect(context.messages[1]).toMatchObject({ role: "user" });
+		expect(getMessageText(context.messages[1])).toBe("what did I ask?");
+	});
+
+	it("does not mutate the caller's history array", () => {
+		const history = [{ role: "user", content: "earlier", timestamp: 1 }] as const;
+		const mutable = [...history];
+		buildSideQueryContext({ systemPrompt: "BASE", history: mutable, question: "q" });
+		expect(mutable).toHaveLength(1);
+	});
+});
+
+describe("runSideQuery", () => {
+	const registrations: Array<{ unregister(): void }> = [];
+
+	afterEach(() => {
+		while (registrations.length > 0) {
+			registrations.pop()?.unregister();
+		}
+	});
+
+	function setup() {
+		const faux = registerFauxProvider();
+		registrations.push(faux);
+		return faux;
+	}
+
+	it("streams deltas and resolves the full reply without touching tools", async () => {
+		const faux = setup();
+		faux.setResponses([fauxAssistantMessage("the answer is 4")]);
+
+		const deltas: string[] = [];
+		const result = await runSideQuery(
+			{
+				model: faux.getModel(),
+				auth: { apiKey: "faux-key" },
+				sessionId: "session-1",
+				establishmentTimeoutMs: 5_000,
+			},
+			buildSideQueryContext({ systemPrompt: "BASE", history: [], question: "2+2?" }),
+			{ onTextDelta: (delta) => deltas.push(delta) },
+		);
+
+		expect(result.replyText).toBe("the answer is 4");
+		expect(deltas.join("")).toBe("the answer is 4");
+		const call = faux.getCallLog().at(-1);
+		expect(call?.context.tools).toEqual([]);
+		expect(call?.options?.sessionId).toMatch(/^session-1:btw:/);
+	});
+
+	it("rejects when the provider errors", async () => {
+		const faux = setup();
+		faux.setResponses([
+			() => {
+				throw new Error("provider exploded");
+			},
+		]);
+
+		await expect(
+			runSideQuery(
+				{
+					model: faux.getModel(),
+					auth: { apiKey: "faux-key" },
+					sessionId: "session-1",
+					establishmentTimeoutMs: 5_000,
+				},
+				buildSideQueryContext({ systemPrompt: "BASE", history: [], question: "q" }),
+				{},
+			),
+		).rejects.toThrow(/provider exploded/);
+	});
+
+	it("times out when the provider never produces an event", async () => {
+		const faux = setup();
+		faux.setResponses([fauxAssistantMessage("unused")]);
+
+		await expect(
+			runSideQuery(
+				{
+					model: faux.getModel(),
+					auth: { apiKey: "faux-key" },
+					sessionId: "session-1",
+					establishmentTimeoutMs: 25,
+					streamFn: ((_model: unknown, _context: unknown, options?: { signal?: AbortSignal }) =>
+						(async function* () {
+							await new Promise((_, reject) => {
+								options?.signal?.addEventListener("abort", () => reject(options.signal?.reason));
+							});
+						})()) as never,
+				},
+				buildSideQueryContext({ systemPrompt: "BASE", history: [], question: "q" }),
+				{},
+			),
+		).rejects.toThrow(/timed? ?out|did not produce/i);
+	});
+
+	it("rejects immediately when the signal is already aborted", async () => {
+		const faux = setup();
+		faux.setResponses([fauxAssistantMessage("unused")]);
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			runSideQuery(
+				{
+					model: faux.getModel(),
+					auth: { apiKey: "faux-key" },
+					sessionId: "session-1",
+					establishmentTimeoutMs: 5_000,
+				},
+				buildSideQueryContext({ systemPrompt: "BASE", history: [], question: "q" }),
+				{ signal: controller.signal },
+			),
+		).rejects.toThrow();
+		expect(faux.state.callCount).toBe(0);
+	});
+});
+
+describe("/btw extension command", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	async function setup() {
+		const harness = await createHarness({ extensionFactories: [btwExtension] });
+		harnesses.push(harness);
+		return harness;
+	}
+
+	it("answers a side question without polluting session history", async () => {
+		const harness = await setup();
+		harness.setResponses([fauxAssistantMessage("main answer"), fauxAssistantMessage("side answer")]);
+
+		await harness.session.prompt("main question");
+		const messagesBefore = harness.session.messages.length;
+		await harness.session.prompt("/btw what did I just ask?");
+
+		expect(harness.session.messages.length).toBe(messagesBefore);
+		const sideCall = harness.faux.getCallLog().at(-1);
+		expect(sideCall?.context.tools).toEqual([]);
+		const sideMessages = sideCall?.context.messages ?? [];
+		expect(getMessageText(sideMessages.at(-1))).toBe("what did I just ask?");
+		expect(sideMessages.some((message) => getMessageText(message) === "main question")).toBe(true);
+		expect(sideCall?.context.systemPrompt).toContain(SIDE_QUERY_INSTRUCTION);
+	});
+
+	it("shows usage feedback instead of calling the provider when the question is empty", async () => {
+		const harness = await setup();
+		harness.setResponses([fauxAssistantMessage("unused")]);
+
+		await harness.session.prompt("/btw");
+
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
+	it("runs in parallel with an in-flight main turn", async () => {
+		const harness = await setup();
+		let releaseMain!: () => void;
+		let mainEntered!: () => void;
+		const mainGate = new Promise<void>((resolve) => {
+			releaseMain = resolve;
+		});
+		const mainInFlight = new Promise<void>((resolve) => {
+			mainEntered = resolve;
+		});
+		harness.setResponses([
+			async () => {
+				mainEntered();
+				await mainGate;
+				return fauxAssistantMessage("main done");
+			},
+			fauxAssistantMessage("side done"),
+		]);
+
+		const mainPrompt = harness.session.prompt("slow main question");
+		await mainInFlight;
+		const sidePrompt = harness.session.prompt("/btw parallel question");
+		await sidePrompt;
+		releaseMain();
+		await mainPrompt;
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+		expect(getMessageText(harness.session.messages[1])).toBe("main done");
+	});
+
+	it("snapshots context synchronously so a concurrent main turn cannot create a mixed generation", async () => {
+		const harness = await setup();
+		let releaseSide!: () => void;
+		const sideGate = new Promise<void>((resolve) => {
+			releaseSide = resolve;
+		});
+		harness.setResponses([
+			fauxAssistantMessage("first answer"),
+			async () => {
+				await sideGate;
+				return fauxAssistantMessage("side answer");
+			},
+			fauxAssistantMessage("second answer"),
+		]);
+
+		await harness.session.prompt("first question");
+		const sidePrompt = harness.session.prompt("/btw snapshot question");
+		await harness.session.prompt("second question");
+		releaseSide();
+		await sidePrompt;
+
+		const sideCall = harness.faux.getCallLog()[1];
+		const userTexts = (sideCall?.context.messages ?? [])
+			.filter((message) => message.role === "user")
+			.map((message) => getMessageText(message));
+		expect(userTexts).toEqual(["first question", "snapshot question"]);
+	});
+
+	it("aborts the previous side query when a new /btw arrives", async () => {
+		const harness = await setup();
+		let firstAborted = false;
+		let firstEntered!: () => void;
+		const firstInFlight = new Promise<void>((resolve) => {
+			firstEntered = resolve;
+		});
+		harness.setResponses([
+			async (_context, options) => {
+				firstEntered();
+				await new Promise<void>((resolve) => {
+					if (options?.signal?.aborted) {
+						firstAborted = true;
+						resolve();
+						return;
+					}
+					options?.signal?.addEventListener("abort", () => {
+						firstAborted = true;
+						resolve();
+					});
+				});
+				throw new Error("aborted");
+			},
+			fauxAssistantMessage("second side answer"),
+		]);
+
+		const first = harness.session.prompt("/btw first");
+		await firstInFlight;
+		const second = harness.session.prompt("/btw second");
+		await Promise.all([first, second]);
+
+		expect(firstAborted).toBe(true);
+		const lastCall = harness.faux.getCallLog().at(-1);
+		expect(getMessageText(lastCall?.context.messages.at(-1))).toBe("second");
+	});
+});


### PR DESCRIPTION
## Summary

Adds `/btw <question>`: a read-only side LLM query that runs **in parallel** with any in-flight main turn, against a snapshot of the current conversation, without writing anything to session history. Inspired by gajae-code's `/btw`, implemented senpi-native as a **builtin extension** with zero changes to `agent-session.ts` / `interactive-mode.ts` (gajae threaded a controller through both).

### Design (how it differs from gajae-code)

- **Extension, not core**: gajae put `runEphemeralTurn` inside `AgentSession` and a `BtwController` in its input controller. Ours uses only the public extension API: `registerCommand` (executes immediately even while streaming), `ctx.ui.setWidget`, `ctx.ui.onTerminalInput`, `modelRegistry`, `sessionManager`. Total core diff: 2 lines in `builtin/index.ts`.
- **Synchronous snapshot**: entries + leaf + system prompt + thinking level + model are captured before the first `await`, so a concurrent main turn or compaction cannot create a mixed-generation request (proven by a dedicated test).
- **Escape never stolen**: gajae consumes the first Escape for the panel. Ours passes Escape through to the main TUI untouched and merely dismisses/aborts the side query as a side effect — one Escape cancels both.
- **Lifecycle**: new `/btw` aborts the previous one; `session_before_switch` / `session_before_fork` / `session_shutdown` all abort; settled panels auto-dismiss on the next submitted message.
- Provider `sessionId` suffixed `:btw:<uuid>`; establishment timeout 30s; `tools: []` on the wire.

### Known limitations (documented in `btw/changes.md`)

- Widget matches raw Escape; the extension API exposes no keybinding lookup from command contexts.
- Side calls stream via `streamSimple` directly (same pattern as core compaction); `before_provider_request` hooks and retry policy do not apply.

## Evidence

- **Unit**: `test/suite/btw-side-query.test.ts` — 11/11 (faux provider, zero tokens): no history pollution, parallel with in-flight main turn, snapshot isolation, previous-query abort, error propagation, establishment timeout, pre-aborted signal.
- **Real-TUI QA** (senpi-qa channel 2, tmux + fake model server, built worktree): 6/6 — panel renders + streams, Escape aborts side query without being consumed, session keeps working, wire-level proof the btw call carries no tools and the main request never sees the btw question. Artifacts in `local-ignore/qa-evidence/20260721-btw/` (pane captures, wire-summary.json, cleanup receipt).
- `npm run check` green; adjacent suites (agent-session-prompt, extensions) 115/115.
- Review: security oracle APPROVE; correctness oracle loop REJECT → fixes → unconditional APPROVE.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/btw <question>` to ask a side question in parallel with any in‑flight turn. It runs on a synchronous snapshot, never writes to session history, and streams the answer in a dismissable TUI panel.

- **New Features**
  - Implemented as a builtin extension using `registerCommand`, `ctx.ui.setWidget`, `ctx.ui.onTerminalInput`, `modelRegistry`, and `sessionManager`; only added to `core/extensions/builtin/index.ts`.
  - Captures the snapshot before the first await to prevent mixed generations; a new `/btw` or session switch/fork/shutdown aborts any active one.
  - TUI: panel streams above the editor; Escape passes through to the main UI and also dismisses/aborts the side query; settled panels auto‑dismiss on the next message. Non‑TUI uses `ctx.ui.notify`.
  - Provider call uses `tools: []`, a `sessionId` suffix `:btw:<uuid>`, and a 30s establishment timeout, with full abort/error propagation.

<sup>Written for commit 20d0acaff822722ea8fb419ef4e8610d43c1819e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

