### PR TITLE
fix(coding-agent): stop tool result reveal on session rebind

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1930,6 +1930,7 @@ export class InteractiveMode {
 		this.compactionInFlightMessages = [];
 		this.compactionTransferAbortControllers.clear();
 		this.streamingReveal.stop();
+		this.toolResultReveal.stop();
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
 		this.clearPendingTools();

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
@@ -67,6 +67,7 @@ it("starts a replacement-session flush while an old transfer remains pending", a
 		streamingComponent: undefined;
 		streamingMessage: undefined;
 		readonly streamingReveal: { stop: () => void };
+		readonly toolResultReveal: { stop: () => void };
 		readonly clearPendingTools: () => void;
 		readonly clearToolHookStatuses: () => void;
 		readonly renderInitialMessages: () => void;
@@ -93,6 +94,7 @@ it("starts a replacement-session flush while an old transfer remains pending", a
 		streamingComponent: undefined,
 		streamingMessage: undefined,
 		streamingReveal: { stop: vi.fn() },
+		toolResultReveal: { stop: vi.fn() },
 		clearPendingTools: vi.fn(),
 		clearToolHookStatuses: vi.fn(),
 		renderInitialMessages: vi.fn(),
@@ -155,6 +157,7 @@ it("does not render an accepted old-session prompt failure after session rebind"
 		streamingComponent: undefined;
 		streamingMessage: undefined;
 		readonly streamingReveal: { stop: () => void };
+		readonly toolResultReveal: { stop: () => void };
 		readonly clearPendingTools: () => void;
 		readonly clearToolHookStatuses: () => void;
 		readonly renderInitialMessages: () => void;
@@ -182,6 +185,7 @@ it("does not render an accepted old-session prompt failure after session rebind"
 		streamingComponent: undefined,
 		streamingMessage: undefined,
 		streamingReveal: { stop: vi.fn() },
+		toolResultReveal: { stop: vi.fn() },
 		clearPendingTools: vi.fn(),
 		clearToolHookStatuses: vi.fn(),
 		renderInitialMessages: vi.fn(),

--- a/packages/coding-agent/test/tool-execution-update-wiring.test.ts
+++ b/packages/coding-agent/test/tool-execution-update-wiring.test.ts
@@ -151,6 +151,44 @@ describe("InteractiveMode tool execution update wiring", () => {
 		expect(updateResult).toHaveBeenCalledOnce();
 	});
 
+	test("stops pending tool result reveal ticks when the session is rebound", async () => {
+		const updateResult = vi.fn<ToolComponent["updateResult"]>();
+		const fixture = createFixture(() => true, { updateResult });
+
+		await handleEvent.call(fixture, {
+			type: "tool_execution_update",
+			toolCallId: "tool-a",
+			toolName: "bash",
+			args: {},
+			partialResult: partialResult("one"),
+		});
+		await handleEvent.call(fixture, {
+			type: "tool_execution_update",
+			toolCallId: "tool-a",
+			toolName: "bash",
+			args: {},
+			partialResult: partialResult("one two three four"),
+		});
+		expect(updateResult).toHaveBeenCalledOnce();
+
+		const renderCurrentSessionState = (
+			InteractiveMode.prototype as unknown as {
+				renderCurrentSessionState(this: Record<string, unknown>): void;
+			}
+		).renderCurrentSessionState;
+		renderCurrentSessionState.call({
+			...fixture,
+			loadedResourcesContainer: { clear: vi.fn() },
+			chatContainer: { clear: vi.fn() },
+			pendingMessagesContainer: { clear: vi.fn() },
+			compactionTransferAbortControllers: new Map(),
+			renderInitialMessages: vi.fn(),
+		});
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(updateResult).toHaveBeenCalledOnce();
+	});
+
 	test("applies partial tool results directly when smooth streaming is disabled", async () => {
 		const updateResult = vi.fn<ToolComponent["updateResult"]>();
 		const fixture = createFixture(() => false, { updateResult });


### PR DESCRIPTION
## Summary

Final-gate code review of #262 found one lifecycle defect: `renderCurrentSessionState()` (session rebind) stopped `streamingReveal` but not `toolResultReveal`, so a session switch during a partial tool-result reveal left the controller's interval and detached component state alive (stale renders, accumulated component graphs on repeated rebinds).

## Changes

- `interactive-mode.ts`: call `this.toolResultReveal.stop()` alongside `this.streamingReveal.stop()` in `renderCurrentSessionState()`.
- Regression test: reveal backlog → rebind → advance fake timers → no further component updates (RED before the fix, GREEN after).
- Fixture stubs: `toolResultReveal` added to the partial `fakeThis` fixtures in `interactive-mode-compaction-queue-session-rebind.test.ts` (same pattern as `toolArgsReveal`).

## QA & Evidence

- RED→GREEN: new test fails on main (`renderCurrentSessionState` leaves reveal ticking), passes with the fix.
- `npm run check`: exit 0.
- Full coding-agent suite: 483 files / 4096 tests pass.
- Review finding: `.omo/ulw-loop/realtime-tool-progress/final-code-review.md` (MAJOR #1).

## Risks & Residuals

One-line lifecycle call on an already-guarded path; no behavior change outside session rebind during an active reveal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops pending tool result reveal when a session is rebound to prevent lingering intervals, stale renders, and duplicated component graphs in the coding agent’s interactive mode.

- **Bug Fixes**
  - In `renderCurrentSessionState()`, call `this.toolResultReveal.stop()` alongside `this.streamingReveal.stop()`.
  - Added a regression test to ensure no further tool result updates after rebind; updated test fixtures to include a `toolResultReveal` stub.

<sup>Written for commit d27a966e190f9e29a93bda5d1d39ceb88afed4f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

