### PR TITLE
feat(coding-agent): animate todo completion strikethrough reveal

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -69,3 +69,65 @@
   (no new custom type), so the branch scanner and compaction bridge read them
   unchanged; the agent notification is a hidden `todotools.user-edit` custom
   message delivered next turn.
+
+## 2026-07-21 - Port oh-my-pi's todo completion strike reveal
+
+### Source
+
+- Upstream repository: [oh-my-pi](https://github.com/can1357/oh-my-pi)
+- Source files: `packages/coding-agent/src/tools/todo.ts` (reveal math at
+  `:817-824`, renderer integration at `:826-849`, per-phase completion keying
+  at `:966-972`, call site at `:1014-1036`).
+- Port source commit: `9fd6e97113f5ed3a847e66d346970efdf8afcad9`
+- Upstream version: `v17.0.5`
+- License: MIT; attribution is recorded in the source headers and the
+  repository `NOTICE.md`.
+
+### What was ported
+
+- The frame-aware progressive strikethrough reveal: a hold phase (2 frames
+  with no strike), then a left-to-right strike sweep over 12 frames at
+  65ms/frame, then settle to the static full-strikethrough rendering.
+- The reveal-count math (`Math.ceil(chars.length * min(frame - HOLD, REVEAL) /
+  REVEAL)` over code points) and per-phase completion keying (only tasks listed
+  in `details.completedTasks` for the SAME phase animate; previously-completed
+  tasks in other phases stay statically struck).
+
+### Senpi adaptations
+
+- The reveal module lives in `modes/interactive/components/todo-strike.ts` and
+  is imported by this renderer (extension -> core dependency direction
+  preserved); the module is pure (zero imports), so non-interactive load paths
+  (print/RPC/app-server) gain no interactive-runtime dependency.
+- Reveal runs over the FULL sanitized display line (`marker + space +
+  sanitizeTodoText(content)`) — the exact string being rendered — so the final
+  frame is byte-identical to senpi's existing `theme.fg("dim",
+  theme.strikethrough(line))` settled rendering. Oh-my-pi's content-only /
+  success-color style is NOT copied; senpi's dim+strikethrough settled style
+  wins.
+- Strike styling flows through the injected `theme.strikethrough` callback via
+  `partialStrikethrough(line, reveal, (t) => theme.strikethrough(t))`; no raw
+  ANSI `\x1b[9m` literals live in the renderer.
+- The frame is sourced from `context.spinnerFrame` (provided by
+  `tool-execution-renderer.ts`), so a `spinnerFrame: undefined` render path
+  (settled, error, partial, non-interactive) renders byte-identically to
+  pre-change output.
+
+### Pre-existing pi-tui behavior pinned, not fixed
+
+- pi-tui's `AnsiCodeTracker.getLineEndReset` closes only underline/hyperlink
+  SGR spans at a wrap boundary, NOT SGR 9 (strikethrough). An active strike may
+  therefore legally style trailing wrap-padding cells at a wrap boundary. This
+  carryover is pre-existing — today's settled full-line strike wraps identically
+  — and stays out of scope. The renderer test pins the display-line glyph count
+  inside SGR-9 spans (measured over the same full display line the reveal count
+  is computed over) and explicitly makes NO assertion about padding cells.
+
+### Expected merge conflict zones
+
+- HIGH: `tools/todo.ts` around `formatTaskLine` (new `completionKeys` + `frame`
+  parameters and the completed-branch reveal logic) and `renderTodoPhases` (new
+  `frame` parameter, the per-phase `completionKeysByPhase` map, and the
+  `renderResult` call site).
+- LOW: the shared `modes/interactive/components/todo-strike.ts` module
+  (fork-only).

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
@@ -5,6 +5,7 @@
 
 import { Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
+import { partialStrikethrough, strikeRevealCount } from "../../../../../modes/interactive/components/todo-strike.ts";
 import type { Theme } from "../../../../../modes/interactive/theme/theme.ts";
 import type {
 	AgentToolResult,
@@ -148,12 +149,24 @@ function formatPhaseSummary(phase: TodoPhase, index: number, theme: Theme): stri
 	);
 }
 
-function formatTaskLine(task: TodoPhase["tasks"][number], theme: Theme): string {
+function formatTaskLine(
+	task: TodoPhase["tasks"][number],
+	theme: Theme,
+	completionKeys: ReadonlySet<string>,
+	frame: number | undefined,
+): string {
 	const content = sanitizeTodoText(task.content);
 	const line = `${getTodoMarker(task.status)} ${content}`;
 	switch (task.status) {
-		case "completed":
-			return theme.fg("dim", theme.strikethrough(line));
+		case "completed": {
+			const reveal = completionKeys.has(task.content) ? strikeRevealCount(line, frame) : undefined;
+			return reveal === undefined
+				? theme.fg("dim", theme.strikethrough(line))
+				: theme.fg(
+						"dim",
+						partialStrikethrough(line, reveal, (text) => theme.strikethrough(text)),
+					);
+		}
 		case "in_progress":
 			return theme.fg("accent", theme.bold(line));
 		case "abandoned":
@@ -190,18 +203,30 @@ function computeTouchedPhases(
 	return touched.size > 0 ? touched : null;
 }
 
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
 function renderTodoPhases(
 	phases: readonly TodoPhase[],
 	completedTasks: readonly TodoCompletionTransition[],
 	options: ToolRenderResultOptions,
 	args: TodoParams,
 	theme: Theme,
+	frame: number | undefined,
 ): string {
 	const visiblePhases = phases.filter((phase) => phase.tasks.length > 0);
 	if (visiblePhases.length === 0) return "";
 
 	const touched =
 		options.expanded || visiblePhases.length === 1 ? null : computeTouchedPhases(args, visiblePhases, completedTasks);
+	const completionKeysByPhase = new Map<string, Set<string>>();
+	for (const transition of completedTasks) {
+		let completionKeys = completionKeysByPhase.get(transition.phase);
+		if (!completionKeys) {
+			completionKeys = new Set();
+			completionKeysByPhase.set(transition.phase, completionKeys);
+		}
+		completionKeys.add(transition.content);
+	}
 	const lines: string[] = [];
 	for (let index = 0; index < visiblePhases.length; index += 1) {
 		const phase = visiblePhases[index];
@@ -211,7 +236,8 @@ function renderTodoPhases(
 			continue;
 		}
 		lines.push(formatPhaseHeader(phase.name, oneBasedIndex, theme));
-		for (const task of phase.tasks) lines.push(`  ${formatTaskLine(task, theme)}`);
+		const completionKeys = completionKeysByPhase.get(phase.name) ?? EMPTY_SET;
+		for (const task of phase.tasks) lines.push(`  ${formatTaskLine(task, theme, completionKeys, frame)}`);
 	}
 	return lines.join("\n");
 }
@@ -278,7 +304,14 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 				return new Text(theme.fg("toolOutput", getTextContent(result)), 0, 0);
 			}
 			const phases = result.details?.phases ?? [];
-			const rendered = renderTodoPhases(phases, result.details?.completedTasks ?? [], options, context.args, theme);
+			const rendered = renderTodoPhases(
+				phases,
+				result.details?.completedTasks ?? [],
+				options,
+				context.args,
+				theme,
+				context.spinnerFrame,
+			);
 			const text = rendered || getTextContent(result) || "Todo list is empty.";
 			return new Text(text, 0, 0);
 		},

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,67 @@
 # changes
 
+## todo completion strike reveal (2026-07-21)
+
+### What changed
+
+- `components/todo-strike.ts` (new): pure, zero-import module exporting the strike
+  reveal constants (`TODO_STRIKE_HOLD_FRAMES = 2`, `TODO_STRIKE_REVEAL_FRAMES = 12`,
+  `TODO_STRIKE_TOTAL_FRAMES = 14`, `TODO_STRIKE_FRAME_INTERVAL_MS = 65`),
+  `strikeRevealCount(text, frame)` (frame-to-visible-char-count math over code
+  points), `partialStrikethrough(text, visibleChars, strike)` (code-point-safe
+  splitter; strike styling comes ONLY from the injected `strike` callback — no
+  raw ANSI literals), and `hasCompletedTodoTasks(details)`. Purity keeps the
+  todotools extension free of interactive-runtime dependencies on non-interactive
+  load paths and keeps the interactive core free of built-in-extension imports.
+- `components/tool-execution.ts`: `updateResult()` also calls
+  `updateTodoStrikeAnimation()`, which starts an `unref`'d, self-terminating
+  `setInterval` (65ms, stops after `TODO_STRIKE_TOTAL_FRAMES`) when the result is
+  a final non-error `todo` result with non-empty `completedTasks` AND
+  `this.executionStarted` is set. Each tick advances `spinnerFrame`, busts the
+  render cache, repaints, and requests a render; the settle tick restores the
+  static full-strike rendering. `stopTodoStrikeAnimation()` clears the interval
+  and resets `spinnerFrame` only when no spinner is running.
+  `stopSpinnerAnimation()` leaves `spinnerFrame` to the strike owner while a
+  strike is in flight. `stopAnimation()` also stops the strike. New
+  `override dispose()` calls `stopAnimation()` before `super.dispose()` so pi-tui
+  `Container.clear()`/`Container.dispose()` child propagation kills a mid-flight
+  interval on chat teardown (also closes the pre-existing spinner teardown hole).
+- `interactive-mode.ts`: new private `stopChatToolAnimations()` iterates
+  `this.chatContainer.children` and calls `stopAnimation()` on every
+  `ToolExecutionComponent`; `stop()` calls it immediately after
+  `clearPendingTools()`. A completed mid-strike todo block has already left
+  `pendingTools` (deleted at `tool_execution_end`) and `ui.stop()` does not
+  dispose the component tree, so without this the interval would repaint a
+  stopped UI until self-termination.
+
+### Why
+
+- A completion checkmark should land visibly. Without an animation, a finished
+  task row silently switches from accent to dim+strikethrough and the user can
+  miss which item just completed. A bounded ~910ms left-to-right reveal (2 hold
+  frames + 12 sweep frames at 65ms/frame) makes the just-completed task
+  unmistakable, then settles to byte-identical pre-change rendering.
+
+### Why extension system couldn't handle this
+
+- The strike interval is component-scoped and drives `ToolExecutionComponent`'s
+  render-cache invalidation, `spinnerFrame` render signature, and lifecycle hooks
+  (`updateResult`, `stopAnimation`, `dispose`); extensions cannot own built-in
+  component private state or hook `Container.clear()`/`dispose()` propagation,
+  and the per-frame repaint must route through the host's `requestRender` to
+  respect the TUI FPS cap.
+- The `executionStarted` rebuild-replay suppressor is core-private state set
+  only on the live path (`renderSessionItems` rebuilds never call
+  `markExecutionStarted()`); an extension cannot gate historical replay this way.
+
+### Expected merge conflict zones
+
+- MEDIUM: `components/tool-execution.ts` around `updateResult`, `stopAnimation`,
+  `dispose`, and the `spinnerFrame`-reset guard in `stopSpinnerAnimation`.
+- LOW: `interactive-mode.ts` around `stop()` and the new `stopChatToolAnimations`
+  helper.
+- LOW: the fork-only `components/todo-strike.ts` module.
+
 ## model fallback lifecycle notices (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/todo-strike.ts
+++ b/packages/coding-agent/src/modes/interactive/components/todo-strike.ts
@@ -1,0 +1,44 @@
+export const TODO_STRIKE_HOLD_FRAMES = 2;
+export const TODO_STRIKE_REVEAL_FRAMES = 12;
+export const TODO_STRIKE_TOTAL_FRAMES = TODO_STRIKE_HOLD_FRAMES + TODO_STRIKE_REVEAL_FRAMES;
+export const TODO_STRIKE_FRAME_INTERVAL_MS = 65;
+
+export function strikeRevealCount(text: string, frame: number | undefined): number | undefined {
+	if (frame === undefined) {
+		return undefined;
+	}
+	if (frame <= TODO_STRIKE_HOLD_FRAMES) {
+		return 0;
+	}
+
+	const chars = [...text];
+	if (chars.length === 0) {
+		return undefined;
+	}
+
+	return Math.ceil(
+		(chars.length * Math.min(frame - TODO_STRIKE_HOLD_FRAMES, TODO_STRIKE_REVEAL_FRAMES)) / TODO_STRIKE_REVEAL_FRAMES,
+	);
+}
+
+export function partialStrikethrough(text: string, visibleChars: number, strike: (text: string) => string): string {
+	if (visibleChars <= 0) {
+		return text;
+	}
+
+	const chars = [...text];
+	if (visibleChars >= chars.length) {
+		return strike(text);
+	}
+
+	return strike(chars.slice(0, visibleChars).join("")) + chars.slice(visibleChars).join("");
+}
+
+export function hasCompletedTodoTasks(details: unknown): boolean {
+	if (details === null || typeof details !== "object") {
+		return false;
+	}
+
+	const completedTasks = (details as { completedTasks?: unknown }).completedTasks;
+	return Array.isArray(completedTasks) && completedTasks.length > 0;
+}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -2,6 +2,7 @@ import { Container, Spacer, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDef } from "../../../core/tools/index.ts";
 import { readToolProgress } from "../tool-progress.ts";
 import { createBoundedRenderSignature } from "./render-signature.ts";
+import { hasCompletedTodoTasks, TODO_STRIKE_FRAME_INTERVAL_MS, TODO_STRIKE_TOTAL_FRAMES } from "./todo-strike.ts";
 import { ToolExecutionImages } from "./tool-execution-images.ts";
 import { ToolExecutionRenderer } from "./tool-execution-renderer.ts";
 import type { ToolExecutionIdentity, ToolExecutionRenderState, ToolExecutionResult } from "./tool-execution-types.ts";
@@ -27,6 +28,7 @@ export class ToolExecutionComponent extends Container {
 	private argsComplete = false;
 	private spinnerFrame?: number;
 	private spinnerInterval?: NodeJS.Timeout;
+	private todoStrikeInterval?: NodeJS.Timeout;
 	private result?: ToolExecutionResult;
 	private cachedLines?: string[];
 	private cachedSignature?: string;
@@ -91,6 +93,7 @@ export class ToolExecutionComponent extends Container {
 		if (!isPartial) this.argsComplete = true;
 		this.lastDisplaySignature = undefined;
 		this.updateSpinnerAnimation();
+		this.updateTodoStrikeAnimation();
 		this.updateDisplay();
 		this.images.updateResult(result);
 		this.invalidateRenderCache();
@@ -98,6 +101,12 @@ export class ToolExecutionComponent extends Container {
 
 	stopAnimation(): void {
 		this.stopSpinnerAnimation();
+		this.stopTodoStrikeAnimation();
+	}
+
+	override dispose(): void {
+		this.stopAnimation();
+		super.dispose();
 	}
 
 	setExpanded(expanded: boolean): void {
@@ -189,6 +198,48 @@ export class ToolExecutionComponent extends Container {
 		else this.stopSpinnerAnimation();
 	}
 
+	private updateTodoStrikeAnimation(): void {
+		const shouldAnimate =
+			this.identity.toolName === "todo" &&
+			this.executionStarted &&
+			!this.isPartial &&
+			this.result !== undefined &&
+			!this.result.isError &&
+			hasCompletedTodoTasks(this.result.details);
+		if (!shouldAnimate) {
+			this.stopTodoStrikeAnimation();
+			return;
+		}
+		if (this.todoStrikeInterval) return;
+
+		this.spinnerFrame = 0;
+		this.todoStrikeInterval = setInterval(() => {
+			const next = (this.spinnerFrame ?? 0) + 1;
+			if (next > TODO_STRIKE_TOTAL_FRAMES) {
+				this.stopTodoStrikeAnimation();
+				return;
+			}
+			this.spinnerFrame = next;
+			this.invalidateRenderCache();
+			this.updateDisplay();
+			this.ui.requestRender();
+		}, TODO_STRIKE_FRAME_INTERVAL_MS);
+		this.todoStrikeInterval.unref?.();
+	}
+
+	private stopTodoStrikeAnimation(): void {
+		if (this.todoStrikeInterval) {
+			clearInterval(this.todoStrikeInterval);
+			this.todoStrikeInterval = undefined;
+		}
+		if (!this.spinnerInterval && this.spinnerFrame !== undefined) {
+			this.spinnerFrame = undefined;
+			this.invalidateRenderCache();
+			this.updateDisplay();
+			this.ui.requestRender();
+		}
+	}
+
 	private startSpinnerAnimation(): void {
 		if (this.spinnerInterval) return;
 		this.spinnerInterval = setInterval(() => {
@@ -204,7 +255,7 @@ export class ToolExecutionComponent extends Container {
 		if (!this.spinnerInterval) return;
 		clearInterval(this.spinnerInterval);
 		this.spinnerInterval = undefined;
-		this.spinnerFrame = undefined;
+		if (!this.todoStrikeInterval) this.spinnerFrame = undefined;
 		this.invalidateRenderCache();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2123,6 +2123,12 @@ export class InteractiveMode {
 		this.applyTerminalTitle();
 	}
 
+	private stopChatToolAnimations(): void {
+		for (const child of this.chatContainer.children) {
+			if (child instanceof ToolExecutionComponent) child.stopAnimation();
+		}
+	}
+
 	private clearPendingTools(): void {
 		this.toolArgsReveal.flushAll();
 		for (const component of this.pendingTools.values()) {
@@ -6663,6 +6669,7 @@ export class InteractiveMode {
 		}
 		this.clearStatusIndicator();
 		this.clearPendingTools();
+		this.stopChatToolAnimations();
 		this.clearActiveToolExecutionStatus();
 		this.clearToolHookStatuses();
 		this.themeController.disableAutoSync();

--- a/packages/coding-agent/test/suite/todo-extension.test.ts
+++ b/packages/coding-agent/test/suite/todo-extension.test.ts
@@ -16,7 +16,7 @@ import {
 import { discoverAndLoadExtensions } from "../../src/core/extensions/loader.ts";
 import type { ExtensionAPI, ToolDefinition, ToolRenderContext } from "../../src/core/extensions/types.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
-import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+import { initTheme, type Theme, theme } from "../../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../../src/utils/ansi.ts";
 import { createTestResourceLoader, userMsg } from "../utilities.ts";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
@@ -585,6 +585,213 @@ describe("todo extension", () => {
 		expect(rendered).toContain("II. Auth — 1/1 done");
 		expect(rendered).toContain("III. Verification");
 		expect(rendered).toContain("[ ] Run checks");
+	});
+
+	it("preserves the settled todo phase tree golden output", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const markerTheme = {
+			fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
+			bold: (text: string) => text,
+			strikethrough: (text: string) => `<s>${text}</s>`,
+		} as Theme;
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "A" },
+			toolCallId: "todo-golden",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: undefined,
+		};
+		const component = tool.renderResult(
+			{
+				content: [{ type: "text", text: "summary" }],
+				details: {
+					op: "done",
+					phases: [
+						{
+							name: "P",
+							tasks: [
+								{ content: "A", status: "completed" },
+								{ content: "B", status: "in_progress" },
+								{ content: "C", status: "abandoned" },
+								{ content: "D", status: "pending" },
+							],
+						},
+					],
+					storage: "memory",
+					completedTasks: [{ phase: "P", content: "A" }],
+				},
+			},
+			{ expanded: false, isPartial: false },
+			markerTheme,
+			context,
+		);
+
+		const settledGolden = [
+			"<fg:accent>I. P</fg:accent>".padEnd(160),
+			"  <fg:dim><s>[✓] A</s></fg:dim>".padEnd(160),
+			"  <fg:accent>[•] B</fg:accent>".padEnd(160),
+			"  <fg:dim>[×] C</fg:dim>".padEnd(160),
+			"  [ ] D".padEnd(160),
+		].join("\n");
+		expect(component.render(160).join("\n")).toBe(settledGolden);
+	});
+
+	async function renderCompletionFrame(
+		spinnerFrame: number | undefined,
+		options: { content?: string; isError?: boolean; theme?: Theme; width?: number; includeSecond?: boolean } = {},
+	): Promise<string> {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const markerTheme =
+			options.theme ??
+			({
+				fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
+				bold: (text: string) => text,
+				strikethrough: (text: string) => `<s>${text}</s>`,
+			} as Theme);
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "A" },
+			toolCallId: "todo-frame",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: options.isError ?? false,
+			spinnerFrame,
+		};
+		const content = options.content ?? "A";
+		const tasks: TodoPhase["tasks"] = [
+			{ content, status: "completed" },
+			...(options.includeSecond === false ? [] : [{ content: "B", status: "completed" } as const]),
+			{ content: "C", status: "in_progress" },
+		];
+		return tool
+			.renderResult(
+				{
+					content: [{ type: "text", text: "error text" }],
+					details: {
+						op: "done",
+						phases: [
+							{
+								name: "P",
+								tasks,
+							},
+						],
+						storage: "memory",
+						completedTasks: [{ phase: "P", content }],
+					},
+				},
+				{ expanded: false, isPartial: false },
+				markerTheme,
+				context,
+			)
+			.render(options.width ?? 160)
+			.join("\n");
+	}
+
+	it("preserves byte-identical fully struck completion output without a spinner frame", async () => {
+		const rendered = await renderCompletionFrame(undefined);
+		expect(rendered).toContain("<fg:dim><s>[✓] A</s></fg:dim>");
+		expect(rendered).toContain("<fg:dim><s>[✓] B</s></fg:dim>");
+	});
+
+	it("holds the newly completed task unstruck through frames zero to two", async () => {
+		for (const frame of [0, 1, 2]) {
+			const rendered = await renderCompletionFrame(frame);
+			expect(rendered).toContain("<fg:dim>[✓] A</fg:dim>");
+			expect(rendered).toContain("<fg:dim><s>[✓] B</s></fg:dim>");
+			expect(rendered).not.toContain("<s>[✓] A</s>");
+		}
+	});
+
+	it("reveals exactly six twelfths of the sanitized full task line at frame eight", async () => {
+		const rendered = await renderCompletionFrame(8);
+		const line = "[✓] A";
+		const reveal = Math.ceil(([...line].length * 6) / 12);
+		expect(rendered).toContain(
+			`<fg:dim><s>${[...line].slice(0, reveal).join("")}</s>${[...line].slice(reveal).join("")}</fg:dim>`,
+		);
+		expect(rendered).toContain("<fg:dim><s>[✓] B</s></fg:dim>");
+	});
+
+	it("fully strikes the newly completed task at and after frame fourteen", async () => {
+		for (const frame of [14, 20]) {
+			expect(await renderCompletionFrame(frame)).toContain("<fg:dim><s>[✓] A</s></fg:dim>");
+		}
+	});
+
+	it("increases the reveal boundary monotonically between frames four, eight, and twelve", async () => {
+		const counts = await Promise.all(
+			[4, 8, 12].map(async (frame) => {
+				const matched = (await renderCompletionFrame(frame)).match(/<fg:dim><s>(.*?)<\/s>/);
+				if (!matched) throw new Error("Expected a partial strikethrough marker");
+				return [...matched[1]].length;
+			}),
+		);
+		expect(counts[0]).toBeLessThan(counts[1] ?? 0);
+		expect(counts[1]).toBeLessThan(counts[2] ?? 0);
+	});
+
+	it("keeps error results on the plain text renderer path", async () => {
+		const rendered = await renderCompletionFrame(8, { isError: true });
+		expect(rendered).not.toContain("<s>");
+		expect(rendered).toContain("error text");
+	});
+
+	it("preserves the reveal boundary across wrapped display lines", async () => {
+		const content = "x".repeat(60);
+		const ansiTheme = {
+			fg: (_name: string, text: string) => text,
+			bold: (text: string) => text,
+			strikethrough: (text: string) => `\u001b[9m${text}\u001b[29m`,
+		} as Theme;
+		const rendered = await renderCompletionFrame(8, { content, theme: ansiTheme, width: 24, includeSecond: false });
+		const expected = Math.ceil(([...`[✓] ${content}`].length * 6) / 12);
+		const physicalLines = rendered.split("\n").slice(1);
+		// The first source-space is carried into the SGR-9 padding after the marker by pi-tui's word wrapper.
+		const markerSpaceIsStruck = physicalLines[0]?.startsWith("  \u001b[9m[✓]") ?? false;
+		let struck = markerSpaceIsStruck ? 1 : 0;
+		let seenUnstruck = false;
+		for (const physicalLine of physicalLines) {
+			// SGR 9 may carry into padding at wraps (pre-existing pi-tui behavior); task glyphs only matter here.
+			const taskPart = physicalLine.replace(/^\s+/, "").replace(/\s+$/, "");
+			let active = false;
+			for (let index = 0; index < taskPart.length; ) {
+				if (taskPart.startsWith("\u001b[9m", index)) {
+					active = true;
+					index += 4;
+					continue;
+				}
+				if (taskPart.startsWith("\u001b[29m", index)) {
+					active = false;
+					index += 5;
+					continue;
+				}
+				const glyph = String.fromCodePoint(taskPart.codePointAt(index) ?? 0);
+				if (active) {
+					expect(seenUnstruck).toBe(false);
+					struck += 1;
+				} else if (glyph.trim() !== "") {
+					seenUnstruck = true;
+				}
+				index += glyph.length;
+			}
+		}
+		expect(struck).toBe(expected);
 	});
 
 	it("registers exactly one todo tool with the op schema", async () => {

--- a/packages/coding-agent/test/todo-strike.test.ts
+++ b/packages/coding-agent/test/todo-strike.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import {
+	hasCompletedTodoTasks,
+	partialStrikethrough,
+	strikeRevealCount,
+	TODO_STRIKE_TOTAL_FRAMES,
+} from "../src/modes/interactive/components/todo-strike.ts";
+
+const markerStrike = (text: string): string => `<s>${text}</s>`;
+
+describe("todo strike helpers", () => {
+	test("returns undefined when the animation frame is undefined", () => {
+		expect(strikeRevealCount("abcdefghijkl", undefined)).toBeUndefined();
+	});
+
+	test("holds the strike reveal for the initial frames", () => {
+		for (const frame of [0, 1, 2]) {
+			expect(strikeRevealCount("abcdefghijkl", frame)).toBe(0);
+		}
+	});
+
+	test("reveals one character on the first reveal frame", () => {
+		expect(strikeRevealCount("abcdefghijkl", 3)).toBe(1);
+	});
+
+	test("reveals all characters at the total frame and beyond", () => {
+		expect(strikeRevealCount("abcdefghijkl", TODO_STRIKE_TOTAL_FRAMES)).toBe(12);
+		expect(strikeRevealCount("abcdefghijkl", TODO_STRIKE_TOTAL_FRAMES + 1)).toBe(12);
+	});
+
+	test("returns undefined for empty text after the hold frames", () => {
+		expect(strikeRevealCount("", 3)).toBeUndefined();
+	});
+
+	test("counts Unicode code points rather than UTF-16 code units", () => {
+		expect(strikeRevealCount("ab🎉cd", 8)).toBe(3);
+		expect(partialStrikethrough("ab🎉cd", 3, markerStrike)).toBe("<s>ab🎉</s>cd");
+	});
+
+	test("applies partial strikethrough at the boundary values", () => {
+		expect(partialStrikethrough("abcd", 0, markerStrike)).toBe("abcd");
+		expect(partialStrikethrough("abcd", 2, markerStrike)).toBe("<s>ab</s>cd");
+		expect(partialStrikethrough("abcd", 4, markerStrike)).toBe("<s>abcd</s>");
+	});
+
+	test("recognizes non-empty completed task arrays structurally", () => {
+		expect(hasCompletedTodoTasks({ completedTasks: [{ content: "done" }] })).toBe(true);
+		expect(hasCompletedTodoTasks({ completedTasks: [] })).toBe(false);
+		expect(hasCompletedTodoTasks({})).toBe(false);
+		expect(hasCompletedTodoTasks(null)).toBe(false);
+		expect(hasCompletedTodoTasks(false)).toBe(false);
+		expect(hasCompletedTodoTasks("not details")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -1,14 +1,20 @@
 import { join, resolve } from "node:path";
-import { Text, type TUI } from "@earendil-works/pi-tui";
+import { Container, Text, type TUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getReadmePath } from "../src/config.ts";
-import type { ToolDefinition } from "../src/core/extensions/types.ts";
+import { registerTodoTool, type TODO_PARAMS_SCHEMA } from "../src/core/extensions/builtin/todotools/tools/todo.ts";
+import type { ExtensionAPI, ToolDefinition } from "../src/core/extensions/types.ts";
 import { type BashOperations, createBashToolDefinition } from "../src/core/tools/bash.ts";
 import { renderToolDiff } from "../src/core/tools/diff-render.ts";
 import { createReadTool, createReadToolDefinition } from "../src/core/tools/read.ts";
 import { createWriteToolDefinition } from "../src/core/tools/write.ts";
+import {
+	TODO_STRIKE_FRAME_INTERVAL_MS,
+	TODO_STRIKE_TOTAL_FRAMES,
+} from "../src/modes/interactive/components/todo-strike.ts";
 import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 
@@ -692,4 +698,249 @@ describe("ToolExecutionComponent parity", () => {
 			expect(collapsed.indexOf(":120-329")).toBeLessThan(collapsed.indexOf("to expand"));
 		});
 	}
+});
+
+function completedTodoResult(isError = false) {
+	return {
+		content: [{ type: "text" as const, text: "ok" }],
+		details: {
+			op: "done",
+			phases: [{ name: "P", tasks: [{ content: "t", status: "completed" as const }] }],
+			storage: "memory" as const,
+			completedTasks: [{ phase: "P", content: "t" }],
+		},
+		isError,
+	};
+}
+
+function createTodoComponent(
+	requestRender = vi.fn(),
+	toolDefinition: ToolDefinition = createBaseToolDefinition("todo"),
+) {
+	return new ToolExecutionComponent(
+		"todo",
+		"todo-strike",
+		{},
+		{},
+		toolDefinition,
+		createFakeTuiWithRenderSpy(requestRender),
+		process.cwd(),
+	);
+}
+
+function captureTodoTool(): ToolDefinition<typeof TODO_PARAMS_SCHEMA> {
+	let capturedTool: ToolDefinition<typeof TODO_PARAMS_SCHEMA> | undefined;
+	const mockPi = {
+		registerTool(tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA>) {
+			capturedTool = tool;
+		},
+		appendEntry() {},
+	} as Pick<ExtensionAPI, "registerTool" | "appendEntry"> as ExtensionAPI;
+
+	registerTodoTool(mockPi, {
+		getCurrentPhases: () => [],
+		setCurrentPhases: () => {},
+		syncWidget: () => {},
+	});
+	if (!capturedTool) throw new Error("Expected todo tool to be registered");
+	return capturedTool;
+}
+
+describe("ToolExecutionComponent todo completion strike animation", () => {
+	test("animates completed todo tasks through all strike frames and settles", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult());
+			const rendersBeforeFrame = requestRender.mock.calls.length;
+
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
+			expect(requestRender.mock.calls.length).toBeGreaterThan(rendersBeforeFrame);
+
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS * TODO_STRIKE_TOTAL_FRAMES);
+			const rendersAfterSettle = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(650);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterSettle);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("does not animate errored todo results", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult(true));
+			const rendersAfterResult = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("does not animate todo results without completed tasks", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			const result = completedTodoResult();
+			result.details.completedTasks = [];
+			component.updateResult(result);
+			const rendersAfterResult = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("does not animate partial todo results", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult(), true);
+			const rendersAfterResult = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("stops todo strike animation through stopAnimation", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult());
+			component.stopAnimation();
+			const rendersAfterStop = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterStop);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("stops todo strike animation through dispose", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult());
+			component.dispose();
+			const rendersAfterDispose = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterDispose);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("does not replay todo strike animation for rebuilt historical results", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender, captureTodoTool());
+			component.updateResult(completedTodoResult());
+			const rendersAfterResult = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
+			expect(component.render(120).join("\n")).toContain(theme.strikethrough("[✓] t"));
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("stops completed todo strike animations when interactive mode stops", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = createTodoComponent(requestRender);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult());
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
+			const chatContainer = new Container();
+			chatContainer.addChild(component);
+			const proto = InteractiveMode.prototype as unknown as {
+				stopChatToolAnimations(this: { chatContainer: Container }): void;
+			};
+			proto.stopChatToolAnimations.call({ chatContainer });
+			const rendersAfterStop = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterStop);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("wires stop to stop completed todo strike animations", () => {
+		const stopChatToolAnimations = vi.fn();
+		const proto = InteractiveMode.prototype as unknown as {
+			stop(this: {
+				streamingReveal: { stop(): void };
+				toolResultReveal: { stop(): void };
+				settingsManager: { getShowTerminalProgress(): boolean };
+				clearStatusIndicator(): void;
+				clearPendingTools(): void;
+				stopChatToolAnimations(): void;
+				clearActiveToolExecutionStatus(): void;
+				clearToolHookStatuses(): void;
+				themeController: { disableAutoSync(): void };
+				clearExtensionTerminalInputListeners(): void;
+				footer: { dispose(): void };
+				footerDataProvider: { dispose(): void };
+				unsubscribe: undefined;
+				isInitialized: false;
+				unregisterSignalHandlers(): void;
+			}): void;
+		};
+		proto.stop.call({
+			streamingReveal: { stop() {} },
+			toolResultReveal: { stop() {} },
+			settingsManager: { getShowTerminalProgress: () => false },
+			clearStatusIndicator() {},
+			clearPendingTools() {},
+			stopChatToolAnimations,
+			clearActiveToolExecutionStatus() {},
+			clearToolHookStatuses() {},
+			themeController: { disableAutoSync() {} },
+			clearExtensionTerminalInputListeners() {},
+			footer: { dispose() {} },
+			footerDataProvider: { dispose() {} },
+			unsubscribe: undefined,
+			isInitialized: false,
+			unregisterSignalHandlers() {},
+		});
+		expect(stopChatToolAnimations).toHaveBeenCalledTimes(1);
+	});
+
+	test("renders consecutive todo strike frames differently", () => {
+		vi.useFakeTimers();
+		try {
+			const toolDefinition: ToolDefinition = {
+				...createBaseToolDefinition("todo"),
+				renderResult: (_result, _options, _theme, context) => new Text(`frame:${context.spinnerFrame}`, 0, 0),
+			};
+			const component = createTodoComponent(vi.fn(), toolDefinition);
+			component.markExecutionStarted();
+			component.updateResult(completedTodoResult());
+			const firstFrame = component.render(120).join("\n");
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
+			const secondFrame = component.render(120).join("\n");
+			expect(secondFrame).not.toBe(firstFrame);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
When the agent completes a todo task in interactive mode, the just-finished task line now plays a quick left-to-right strikethrough reveal (~2 hold frames then a 12-frame sweep at 65ms/frame, ~0.9s total), then settles to exactly the static rendering senpi has today. This mirror-ports oh-my-pi's proven todo completion animation. Two deliberate improvements over upstream: reopening a session never replays the animation (gated on `executionStarted`), and session/mode teardown deterministically kills a mid-flight interval (`dispose()` override + `InteractiveMode.stopChatToolAnimations()`).

## Changes
- **Shared strike module** (`components/todo-strike.ts`, new): pure zero-import module with the frame constants, `strikeRevealCount()` (frame→visible-char math over code points), `partialStrikethrough()` (code-point-safe split, styling via injected callback — no raw ANSI), and `hasCompletedTodoTasks()`.
- **Component driver** (`components/tool-execution.ts`): `updateResult()` starts a bounded, `unref`'d, self-terminating strike interval only for final non-error `todo` results with non-empty `details.completedTasks`; settle tick restores the static full-strike render; `stopAnimation()`/`dispose()` clear it.
- **Mode teardown** (`interactive-mode.ts`): `stopChatToolAnimations()` stops animations on all chat-resident tool components (completed blocks have already left `pendingTools`), called from `stop()`.
- **Renderer** (`todotools/tools/todo.ts`): `renderResult` reads `context.spinnerFrame`; per-phase completion keys decide which completed lines animate; reveal runs over the sanitized full `marker + content` line under `fg("dim")`; settled output (frame `undefined`) is byte-identical to before.
- **Changelogs**: fork entries in `modes/interactive/changes.md` and `todotools/changes.md`.

## QA & Evidence
- **Unit tests (73, one run):** `npx vitest --run test/todo-strike.test.ts test/tool-execution-component.test.ts test/suite/todo-extension.test.ts` — reveal math boundaries, driver happy/negative/teardown/no-replay/mode-stop/memo-invariant (fake timers only), renderer hold/partial/full/monotonic/error/wrap-safety + settled byte-parity golden. Mutation red-proofs captured for the new assertions. Artifacts: `.omo/evidence/todo-completion-strike-animation/task-{1,2,3,4}-*.txt` (not committed; evidence dirs).
- **Static gates:** `npm run check` exit 0. No `any`, no suppressions.
- **Real-CLI QA (senpi-qa, mock model, isolated sandbox):** PTY raw-byte capture over render transactions (FRAME_BEGIN/END), text+SGR-9-state-bound assertions — (a) partial-strike frame observed, (b) later full-strike frame, (c) no other task row flickers, (d) `--continue` resume replays no animation (2s+ observation), plus failure paths: nonexistent-task `done` = static tree + no error text + no animation; schema-invalid call = real `isError` render, no animation. Receipts: `local-ignore/qa-evidence/20260721-todo-strike-anim/` (SUMMARY.md + frames/failure/resume raw logs). Note: node-pty `posix_spawnp` is broken on the QA host; the driver used the byte-preserving tmux pipe-pane fallback (recorded in `pty-backend.txt`).
- **Independent verification:** F1 compliance, F2 code quality, F3 independent QA re-run from raw bytes, F4 scope fidelity — all APPROVE (`.omo/evidence/todo-completion-strike-animation/f{1..4}-*.md`).

## Risks & Residuals
- Animation replay on session rebuilds: suppressed by design (improvement over upstream), proven by resume QA assertion (d).
- Timer leak on teardown: bounded + `unref`'d + cleared via `stopAnimation()`/`dispose()`/`stop()`, proven by teardown tests.
- SGR-9 may carry into wrap padding at width boundaries: pre-existing pi-tui behavior, pinned by test, noted in changes.md; not changed here.
- Settled rendering regression: ruled out by the byte-parity golden (all four statuses).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a short left-to-right strikethrough reveal for newly completed todo items in interactive mode to make completions obvious. The animation runs ~0.9s and then settles to the exact same static output as before.

- **New Features**
  - Strikethrough reveal on completed `todo` lines (2 hold + 12 sweep frames at 65ms).
  - Only animates tasks in `details.completedTasks` for the current phase; others stay static.
  - Renderer keys off `context.spinnerFrame`; the final frame is byte-identical to prior dim+strike output.
  - New helper `modes/interactive/components/todo-strike.ts` with constants, `strikeRevealCount`, `partialStrikethrough`, and `hasCompletedTodoTasks`.

- **Bug Fixes**
  - No replay after session rebuilds (gated on `executionStarted`).
  - Deterministic teardown of timers: `ToolExecutionComponent.stopAnimation()`/`dispose()` and `InteractiveMode.stopChatToolAnimations()`; intervals are bounded and `unref`'d.
  - Spinner/strike coordination to avoid flicker; `spinnerFrame` resets only when both stop.
  - Tests added to pin reveal math, lifecycle, and byte-parity of settled renders.

<sup>Written for commit c19baf9eba6695fb47b8947c56b03a5224ac5b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

