### PR TITLE
fix(coding-agent): diagnosable compaction generator failures + output budget

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,56 @@
 # Builtin compaction extension changes
 
+## Diagnosable summary-generation failures + thinking headroom (2026-07-21)
+
+- `speculative.ts` `runExtensionCompaction()` no longer collapses every non-summary
+  outcome into a silent `undefined` (which the handler could only report as
+  "compaction generator returned no summary"). It now resolves `undefined` **only
+  for aborts** and throws a typed `SummaryGenerationError` otherwise:
+  - missing/unresolvable credentials → `kind: "auth"`,
+    `summarization credentials unavailable: <registry error>`.
+  - a completed response with zero text blocks (adaptive-thinking models can burn
+    the whole output budget on thinking; tool-forwarding means a model can also
+    answer with a bare tool call) → `kind: "empty-summary"`,
+    `summarization response contained no text (stopReason: <reason>)`.
+- `index.ts` `session_before_compact` handler maps outcomes precisely:
+  - `SummaryGenerationError` → `{ cancel: true, reason: error.message }` so
+    `/compact` shows the real diagnosis via `compaction_end.errorMessage`.
+  - aborted generation with `event.signal.aborted` → `{ cancel: true }` with **no
+    reason**, letting agent-session's aborted branch render the plain
+    "Compaction cancelled" instead of the misleading "returned no summary"
+    (core hardcodes `aborted: true` for extension cancels and suppresses
+    `errorMessage` only when no extension reason is present).
+  - any other `undefined` keeps the legacy "compaction generator returned no
+    summary" reason as a defensive fallback.
+- `index.ts` `applyBlockingCompaction()` catches `SummaryGenerationError` and
+  degrades to the legacy "unavailable" outcome, so automatic routes
+  (hard-limit/proactive/turn-end recovery/degradation monitor) behave exactly as
+  before instead of erroring the turn; the precise reason still surfaces when the
+  hook route runs.
+- Summarization output budget: the flat `MAX_SUMMARY_TOKENS = 8192` became
+  `summaryMaxTokens(model, contextWindow)` =
+  `min(32768, model.maxTokens, floor(contextWindow / 2))` (the headroom cap
+  applies when the model reports no output cap). Adaptive-thinking models emit
+  reasoning tokens before the summary text, so the 8192 cap could be consumed
+  entirely by thinking and end the stream with zero text — the exact "returned
+  no summary" failure this change diagnoses. The half-window clamp reserves
+  half the window for input so providers enforcing input + output <=
+  contextWindow no longer reject requests up-front (catalog models with
+  contextWindow == maxTokens); oversized conversations still flow through the
+  existing overflow-retry prune. Models with `maxTokens < 8192` also stop
+  receiving an over-cap request.
+- Abort precedence: `runExtensionCompaction()` checks the caller signal before
+  and after credential resolution, so a user abort can never surface as a
+  "summarization credentials unavailable" rejection.
+- Tests: `test/compaction/speculative-compaction.test.ts` (typed errors, token
+  caps) and `test/compaction/before-compact-error-surfacing.test.ts` (handler
+  reason mapping, abort-without-reason).
+
+Expected upstream conflict zones: `builtin/compaction/speculative.ts` around the
+auth check, `getSummaryText` consumption, and stream options;
+`builtin/compaction/index.ts` `session_before_compact` cancel paths and
+`applyBlockingCompaction`.
+
 ## Idle watchdog on local summarization streams (2026-07-21)
 
 - `speculative.ts` `generateSummaryMessage` now drives the summarization stream through a

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -36,6 +36,7 @@ import {
 	runExtensionCompaction,
 	type SpeculativeCompactionResult,
 	type SpeculativeCompactionSnapshot,
+	SummaryGenerationError,
 } from "./speculative.ts";
 import { type CompactionExtensionState, createInitialState, resetTurnCounter } from "./state.ts";
 import * as todoBridge from "./todo-bridge.ts";
@@ -296,9 +297,18 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 				endCompactionFeedback(ctx, feedbackSignal, result);
 				return result;
 			}
-			const compaction = await runExtensionCompaction(ctx, snapshot, feedbackSignal, (delta) =>
-				ctx.updateCompaction?.({ reason: "extension", delta }),
-			);
+			let compaction: CompactionResult | undefined;
+			try {
+				compaction = await runExtensionCompaction(ctx, snapshot, feedbackSignal, (delta) =>
+					ctx.updateCompaction?.({ reason: "extension", delta }),
+				);
+			} catch (error) {
+				// Auto-path parity: summary-generation failures (missing credentials,
+				// text-less response) degrade to "unavailable" exactly as before
+				// instead of erroring the turn; the precise reason still surfaces on
+				// the session_before_compact route.
+				if (!(error instanceof SummaryGenerationError)) throw error;
+			}
 			const result = await applyGeneratedCompaction(ctx, snapshot, () => speculativeGeneration, compaction);
 			endCompactionFeedback(ctx, feedbackSignal, result);
 			return result;
@@ -367,12 +377,21 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 			// re-send the same conversation and burn tokens on the same failure.
 			// The reason threads into compaction_end.errorMessage so the UI shows
 			// the real provider message; ctx.ui.notify would be a duplicate toast.
-			const message = error instanceof Error ? error.message : String(error);
 			pendingMetadata.delete(event.requestId);
+			if (error instanceof SummaryGenerationError) {
+				return { cancel: true, reason: error.message };
+			}
+			const message = error instanceof Error ? error.message : String(error);
 			return { cancel: true, reason: `compaction generator failed: ${message}` };
 		}
 		if (!compaction) {
 			pendingMetadata.delete(event.requestId);
+			if (event.signal.aborted) {
+				// User abort: returning no reason lets agent-session's aborted branch
+				// render the plain "Compaction cancelled" instead of a misleading
+				// "returned no summary" rejection.
+				return { cancel: true };
+			}
 			return { cancel: true, reason: "compaction generator returned no summary" };
 		}
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -32,7 +32,8 @@ import * as truncation from "./tool-truncation.ts";
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const COMPACTION_BUDGET_RATIO = 0.6;
 const EMERGENCY_CONTEXT_TARGET_RATIO = 0.95;
-const MAX_SUMMARY_TOKENS = 8192;
+const SUMMARY_TOKEN_HEADROOM = 32_768;
+const SUMMARY_CONTEXT_WINDOW_RESERVE_RATIO = 0.5;
 const SUMMARY_SCHEMA = "senpi.compaction.summary.v1";
 type CompactionProgressCallback = (delta: string) => void;
 type PruneStep = { messages: AgentMessage[]; removedTokens: number };
@@ -69,6 +70,38 @@ export type SpeculativeCompactionResult = ApplyCompactionResult | { applied: fal
 
 function approxTokens(text: string): number {
 	return Math.ceil(text.length / 4);
+}
+
+/**
+ * Summary-generation failure with a user-facing diagnosis. Distinct from a
+ * user abort (which resolves `undefined`): callers surface `message` on the
+ * manual route and degrade to "unavailable" on automatic routes.
+ */
+export class SummaryGenerationError extends Error {
+	readonly kind: "auth" | "empty-summary";
+
+	constructor(kind: "auth" | "empty-summary", message: string) {
+		super(message);
+		this.name = "SummaryGenerationError";
+		this.kind = kind;
+	}
+}
+
+/**
+ * Output budget for one summarization request. Adaptive-thinking models emit
+ * reasoning tokens before the summary text, so the legacy flat 8192 cap could
+ * be consumed entirely by thinking, ending the stream with zero text blocks.
+ * Grant generous headroom, clamped to what the model can actually emit and to
+ * half the context window: providers that enforce input + output <= window
+ * would otherwise reject the request for models advertising contextWindow ==
+ * maxTokens (every summarization request also carries conversation input).
+ */
+function summaryMaxTokens(model: Model<any>, contextWindow: number): number {
+	const headroom = model.maxTokens > 0 ? Math.min(SUMMARY_TOKEN_HEADROOM, model.maxTokens) : SUMMARY_TOKEN_HEADROOM;
+	if (contextWindow > 0) {
+		return Math.min(headroom, Math.floor(contextWindow * SUMMARY_CONTEXT_WINDOW_RESERVE_RATIO));
+	}
+	return headroom;
 }
 
 function getSummaryText(message: Message): string {
@@ -132,7 +165,7 @@ async function generateSummaryMessage(options: {
 				apiKey: options.auth.apiKey,
 				headers: options.auth.headers,
 				extraBody: options.auth.extraBody,
-				maxTokens: MAX_SUMMARY_TOKENS,
+				maxTokens: summaryMaxTokens(options.snapshot.model, options.snapshot.contextWindow),
 				signal: requestController.signal,
 			},
 		);
@@ -333,14 +366,27 @@ export function createSpeculativeCompactionSnapshot(
 	};
 }
 
+/**
+ * Generate a compaction summary for the snapshot. Resolves `undefined` only
+ * when the request was aborted (caller signal or an aborted stream); every
+ * other failure throws — {@link SummaryGenerationError} for diagnosable
+ * generation failures, the raw provider error otherwise. Abort is checked
+ * before and after credential resolution so a cancelled request never
+ * misreports as an auth failure.
+ */
 export async function runExtensionCompaction(
 	context: SpeculativeCompactionContext,
 	snapshot: SpeculativeCompactionSnapshot,
 	signal?: AbortSignal,
 	onProgress?: CompactionProgressCallback,
 ): Promise<CompactionResult | undefined> {
+	if (signal?.aborted) return undefined;
 	const auth = await context.modelRegistry?.getApiKeyAndHeaders(snapshot.model);
-	if (!auth?.ok || !auth.apiKey) return undefined;
+	if (signal?.aborted) return undefined;
+	if (!auth?.ok || !auth.apiKey) {
+		const detail = auth && !auth.ok ? auth.error : `no API key resolved for provider "${snapshot.model.provider}"`;
+		throw new SummaryGenerationError("auth", `summarization credentials unavailable: ${detail}`);
+	}
 
 	let messages = pruneToolResults(
 		[...snapshot.preparation.messagesToSummarize, ...snapshot.preparation.turnPrefixMessages],
@@ -389,7 +435,13 @@ export async function runExtensionCompaction(
 		}
 
 		const summary = getSummaryText(response);
-		if (!summary) return undefined;
+		if (!summary) {
+			const stopReason = isAssistantMessage(response) ? response.stopReason : "unknown";
+			throw new SummaryGenerationError(
+				"empty-summary",
+				`summarization response contained no text (stopReason: ${stopReason})`,
+			);
+		}
 
 		// Informational only: the core rejects an applied compaction that would
 		// still overflow (_wouldCompactionOverflow). Rejecting here based on the

--- a/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
@@ -1,4 +1,9 @@
-import { type FauxProviderRegistration, fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import {
+	type FauxProviderRegistration,
+	fauxAssistantMessage,
+	fauxThinking,
+	registerFauxProvider,
+} from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { type CompactionPreparation, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
@@ -29,16 +34,19 @@ interface Harness {
 	ctx: ExtensionContext;
 }
 
-function createHarness(): Harness {
+function createHarness(options?: { withAuth?: boolean }): Harness {
+	const withAuth = options?.withAuth ?? true;
 	const registration = registerFauxProvider();
 	registrations.push(registration);
 	const model = registration.getModel();
 	const authStorage = AuthStorage.inMemory();
-	authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	if (withAuth) {
+		authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	}
 	const modelRegistry = ModelRegistry.inMemory(authStorage);
 	modelRegistry.registerProvider(model.provider, {
 		baseUrl: model.baseUrl,
-		apiKey: "faux-key",
+		...(withAuth ? { apiKey: "faux-key" } : {}),
 		api: registration.api,
 		models: registration.models.map((registeredModel) => ({
 			id: registeredModel.id,
@@ -120,7 +128,7 @@ function createPreparation(): CompactionPreparation {
 	};
 }
 
-function createEvent(): SessionBeforeCompactEvent {
+function createEvent(options?: { signal?: AbortSignal }): SessionBeforeCompactEvent {
 	return {
 		type: "session_before_compact",
 		reason: "manual",
@@ -128,7 +136,7 @@ function createEvent(): SessionBeforeCompactEvent {
 		requestId: "manual-compact-1",
 		preparation: createPreparation(),
 		branchEntries: [],
-		signal: new AbortController().signal,
+		signal: options?.signal ?? new AbortController().signal,
 	};
 }
 
@@ -168,5 +176,53 @@ describe("session_before_compact error surfacing", () => {
 		expect(harness.notifications).toHaveLength(0);
 		const call = harness.registration.getCallLog()[0];
 		expect(call?.context.systemPrompt).toBe("TEST AGENT SYSTEM PROMPT");
+	});
+
+	it("cancels with a stop-reason diagnosis when the summarization response has no text", async () => {
+		// Given: the model spends the whole output budget on thinking (adaptive
+		// reasoning models do this without being asked) and the stream ends at
+		// the token cap with zero text content.
+		const harness = createHarness();
+		harness.registration.setResponses([
+			fauxAssistantMessage([fauxThinking("token budget consumed by thinking")], { stopReason: "length" }),
+		]);
+
+		// When
+		const result = await harness.beforeCompact(createEvent(), harness.ctx);
+
+		// Then: the cancel reason names the real failure (no text + stop reason)
+		// instead of the undiagnosable "returned no summary".
+		expect(result?.cancel).toBe(true);
+		expect(result?.reason ?? "").toContain("no text");
+		expect(result?.reason ?? "").toContain("stopReason: length");
+	});
+
+	it("cancels with the credential error when summarization auth is unavailable", async () => {
+		// Given
+		const harness = createHarness({ withAuth: false });
+		harness.registration.setResponses([fauxAssistantMessage("never reached")]);
+
+		// When
+		const result = await harness.beforeCompact(createEvent(), harness.ctx);
+
+		// Then
+		expect(result?.cancel).toBe(true);
+		expect(result?.reason ?? "").toContain("credentials unavailable");
+	});
+
+	it("cancels without a reason when the user aborted the compaction signal", async () => {
+		// Given
+		const harness = createHarness();
+		harness.registration.setResponses([fauxAssistantMessage("never used")]);
+		const controller = new AbortController();
+		controller.abort();
+
+		// When
+		const result = await harness.beforeCompact(createEvent({ signal: controller.signal }), harness.ctx);
+
+		// Then: no extension reason means agent-session's aborted branch renders
+		// the plain "Compaction cancelled" instead of a misleading rejection error.
+		expect(result?.cancel).toBe(true);
+		expect(result && "reason" in result ? result.reason : undefined).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/compaction/speculative-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/speculative-compaction.test.ts
@@ -1,4 +1,10 @@
-import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import {
+	type FauxModelDefinition,
+	fauxAssistantMessage,
+	fauxThinking,
+	fauxToolCall,
+	registerFauxProvider,
+} from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
@@ -27,16 +33,24 @@ afterEach(() => {
 	}
 });
 
-function createContext(options?: { revision?: number }): TestSpeculativeCompactionContext {
-	const registration = registerFauxProvider();
+function createContext(options?: {
+	revision?: number;
+	models?: FauxModelDefinition[];
+	withAuth?: boolean;
+	shrink?: boolean;
+}): TestSpeculativeCompactionContext {
+	const withAuth = options?.withAuth ?? true;
+	const registration = registerFauxProvider(options?.models ? { models: options.models } : {});
 	registrations.push(registration);
 	const model = registration.getModel();
 	const authStorage = AuthStorage.inMemory();
-	authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	if (withAuth) {
+		authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	}
 	const modelRegistry = ModelRegistry.inMemory(authStorage);
 	modelRegistry.registerProvider(model.provider, {
 		baseUrl: model.baseUrl,
-		apiKey: "faux-key",
+		...(withAuth ? { apiKey: "faux-key" } : {}),
 		api: registration.api,
 		models: registration.models.map((registeredModel) => ({
 			id: registeredModel.id,
@@ -51,13 +65,14 @@ function createContext(options?: { revision?: number }): TestSpeculativeCompacti
 		})),
 	});
 	const sessionManager = SessionManager.inMemory();
+	const historyRepeat = options?.shrink ? 120 : 12_000;
 	sessionManager.appendMessage({
 		role: "user",
-		content: [{ type: "text", text: "first user ".repeat(12_000) }],
+		content: [{ type: "text", text: "first user ".repeat(historyRepeat) }],
 		timestamp: Date.now() - 3_000,
 	});
 	sessionManager.appendMessage({
-		...fauxAssistantMessage("first assistant ".repeat(12_000), { timestamp: Date.now() - 2_000 }),
+		...fauxAssistantMessage("first assistant ".repeat(historyRepeat), { timestamp: Date.now() - 2_000 }),
 		api: model.api,
 		provider: model.provider,
 		model: model.id,
@@ -405,6 +420,148 @@ describe("speculative compaction", () => {
 
 		// Then
 		expect(result?.summary).toBe("large-input summary");
+	});
+
+	it("rejects with a typed empty-summary error naming the stop reason", async () => {
+		// Given: adaptive-thinking models can burn the whole output budget on
+		// thinking and end at the cap with no text blocks at all.
+		const context = createContext();
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		context.registration.setResponses([
+			fauxAssistantMessage([fauxThinking("all budget spent thinking")], { stopReason: "length" }),
+		]);
+
+		// When
+		let caught: unknown;
+		try {
+			if (!snapshot) throw new Error("expected snapshot");
+			await runExtensionCompaction(context, snapshot);
+		} catch (error) {
+			caught = error;
+		}
+
+		// Then
+		expect(caught).toBeInstanceOf(Error);
+		expect((caught as Error).name).toBe("SummaryGenerationError");
+		expect((caught as { kind?: string }).kind).toBe("empty-summary");
+		expect((caught as Error).message).toContain("stopReason: length");
+	});
+
+	it("rejects with an empty-summary error when the model answers with a bare tool call", async () => {
+		// Given: the summarization request forwards the agent's tools, so a model
+		// can hijack the request and respond with a tool call instead of text.
+		const context = createContext();
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		context.registration.setResponses([
+			fauxAssistantMessage([fauxToolCall("read", { path: "/tmp/x" })], { stopReason: "toolUse" }),
+		]);
+
+		// When
+		let caught: unknown;
+		try {
+			if (!snapshot) throw new Error("expected snapshot");
+			await runExtensionCompaction(context, snapshot);
+		} catch (error) {
+			caught = error;
+		}
+
+		// Then
+		expect((caught as Error | undefined)?.name).toBe("SummaryGenerationError");
+		expect((caught as Error | undefined)?.message).toContain("stopReason: toolUse");
+	});
+
+	it("rejects with a typed auth error when credentials cannot be resolved", async () => {
+		// Given
+		const context = createContext({ withAuth: false });
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		context.registration.setResponses([fauxAssistantMessage("never reached")]);
+
+		// When
+		let caught: unknown;
+		try {
+			if (!snapshot) throw new Error("expected snapshot");
+			await runExtensionCompaction(context, snapshot);
+		} catch (error) {
+			caught = error;
+		}
+
+		// Then
+		expect((caught as Error | undefined)?.name).toBe("SummaryGenerationError");
+		expect((caught as { kind?: string } | undefined)?.kind).toBe("auth");
+		expect((caught as Error | undefined)?.message).toContain("credentials unavailable");
+	});
+
+	it("caps the summarization request tokens at the model maximum", async () => {
+		// Given: the default faux model advertises maxTokens 16384, below the
+		// summary headroom, so the request must use the model cap.
+		const context = createContext();
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		context.registration.setResponses([fauxAssistantMessage("capped summary")]);
+
+		// When
+		const result = snapshot ? await runExtensionCompaction(context, snapshot) : undefined;
+
+		// Then
+		expect(result?.summary).toBe("capped summary");
+		const call = context.registration.getCallLog()[0];
+		expect(call?.options?.maxTokens).toBe(16_384);
+	});
+
+	it("grants summarization headroom above the legacy 8k cap for large-output models", async () => {
+		// Given: thinking models emit reasoning tokens before the summary text,
+		// so an 8192-token cap can starve the text entirely. Large-output models
+		// get the full 32k headroom.
+		const context = createContext({
+			models: [{ id: "faux-large", contextWindow: 200_000, maxTokens: 131_072 }],
+		});
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		context.registration.setResponses([fauxAssistantMessage("roomy summary")]);
+
+		// When
+		const result = snapshot ? await runExtensionCompaction(context, snapshot) : undefined;
+
+		// Then
+		expect(result?.summary).toBe("roomy summary");
+		const call = context.registration.getCallLog()[0];
+		expect(call?.options?.maxTokens).toBe(32_768);
+	});
+
+	it("leaves half the context window for input when the model advertises no separate output cap", async () => {
+		// Given: some providers enforce input + max_tokens <= contextWindow
+		// (catalog models with contextWindow == maxTokens, e.g. small OpenRouter
+		// models); reserving the whole window for output makes every
+		// summarization request invalid. keepRecentTokens shrinks to the window's
+		// keep cap (0.3*32768), so the prepared history must be tiny.
+		const context = createContext({
+			models: [{ id: "faux-tight", contextWindow: 32_768, maxTokens: 32_768 }],
+			shrink: true,
+		});
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		context.registration.setResponses([fauxAssistantMessage("tight summary")]);
+
+		// When
+		const result = snapshot ? await runExtensionCompaction(context, snapshot) : undefined;
+
+		// Then
+		expect(result?.summary).toBe("tight summary");
+		const call = context.registration.getCallLog()[0];
+		expect(call?.options?.maxTokens).toBeLessThanOrEqual(Math.floor(32_768 / 2));
+	});
+
+	it("treats a pre-aborted signal as an abort even when credentials are unavailable", async () => {
+		// Given: abort must take precedence over failure diagnosis — the user
+		// cancelling a compaction must never read as a credential error.
+		const context = createContext({ withAuth: false });
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		if (!snapshot) throw new Error("expected snapshot");
+		const controller = new AbortController();
+		controller.abort();
+
+		// When
+		const result = await runExtensionCompaction(context, snapshot, controller.signal);
+
+		// Then
+		expect(result).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Problem

A failed compaction surfaced as `Error: Compaction rejected: compaction generator returned no summary` for **four distinct root causes**, making real failures undiagnosable. Observed in production session `019f8422-d228-7ccf-b1fb-09936789fe84` (anthropic/claude-fable-5 via ccapi, xhigh thinking): repeated `/compact` rejections with the same opaque message.

Root cause analysis (`runExtensionCompaction` in `speculative.ts`) returned a silent `undefined` for all of:

1. Credential resolution failure (missing/expired key)
2. Pre-aborted signal (user ESC)
3. Aborted stream (`stopReason: "aborted"`)
4. **Empty summary text** — e.g. an adaptive-thinking model burning the whole output budget on thinking tokens (`stopReason: "length"`, zero text blocks), or a model answering with a bare tool call (the summarization request forwards the agent's tools)

Verified live against ccapi: `claude-fable-5` emits thinking blocks on requests with **no** thinking parameter, and a `max_tokens`-truncated response ends with `stop_reason: max_tokens`. With the hard-coded `MAX_SUMMARY_TOKENS = 8192`, thinking can consume the entire budget before any summary text is produced — the exact "returned no summary" failure.

## Fix (2 commits)

**Commit 1 — diagnostics**: `undefined` now means *aborted only*; auth misses and text-less responses throw a typed `SummaryGenerationError` (`kind: "auth" | "empty-summary"`) carrying the real cause and `stopReason`. The `session_before_compact` handler threads typed errors into the cancel reason, cancels with **no** reason when the user aborted (so core renders plain "Compaction cancelled" via `agent-session._rejectCompaction`, which suppresses `errorMessage` only when `aborted && !extensionReason`), and keeps the legacy reason as a defensive fallback. `applyBlockingCompaction` degrades typed errors to the legacy "unavailable" so automatic routes (hard-limit/proactive/turn-end recovery/degradation monitor) behave **exactly** as before instead of erroring the turn. Abort is checked before and after credential resolution so a user abort never misreports as an auth failure.

**Commit 2 — output budget**: `summaryMaxTokens(model, contextWindow)` = `min(32768, model.maxTokens, floor(contextWindow / 2))` (headroom cap when the model reports no output limit). Gives thinking models room for reasoning + summary text, stops over-capping `maxTokens < 8192` models, and the half-window reserve keeps requests valid for providers enforcing `input + output <= contextWindow` (catalog models with `contextWindow == maxTokens`, e.g. small OpenRouter models).

## Evidence

- **RED→GREEN (TDD)**: 8 new tests failed for the right reasons before implementation (`expected 'compaction generator returned no summ…' to contain 'no text'`; `expected 8192 to be 16384/32768`; typed-error assertions). After fix: `test/compaction` **25 files / 213 tests** green.
- **Blast radius**: 17 additional suites — `agent-session-compaction`, `compaction-race`, `compaction-rejection-feedback`, interactive-mode compaction ×2, `branch-summarization`, `auto-compaction-queue`, `5217-compaction-reason`, post-compaction regressions — **119 tests** green. Full coding-agent suite: **4107 passed, 0 failed**.
- **`npm run check`**: green (tsc + eslint + neo go build/vet/test).
- **Real-CLI QA** (`senpi-qa` harness, fake model server, `--mode rpc`): three real turns build compactable history, then `/compact` with a scripted **empty** summarization response yields `compaction_end.errorMessage = "Compaction rejected: summarization response contained no text (stopReason: stop)"` and the wire request carries output budget **32768** (legacy flat 8192). Channel self-tests: cli-smoke 7/7, rpc-drive 4/4, mock-loop 38/38. Evidence under `local-ignore/qa-evidence/20260721-compaction-generator-diagnostics/` (not committed).
- **Reviewer loop**: independent oracle review — round 1 CHANGES-REQUESTED (context-window clamp missing; abort-vs-auth ordering), both fixed with their own RED→GREEN tests; round 2 APPROVE-WITH-NITS, nits addressed.

## Notes

- Abort (user ESC) real-surface: no RPC compaction-abort command exists (interactive-only); the abort path is pinned by the handler contract test (`{cancel: true}` without reason ⇒ core renders "Compaction cancelled") and the existing `compaction-rejection-feedback` regression suite that pins the renderer contract.
- `packages/coding-agent/src/core/extensions/builtin/compaction/changes.md` updated per fork convention with expected upstream conflict zones.

Plan: no `.omo/plans` file — driven inline via ulw-loop.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make compaction failures diagnosable and size the summarization token budget to the model and context window to avoid empty-summary errors on thinking models. Users see clear reasons on manual compaction; automatic routes keep legacy behavior.

- **Bug Fixes**
  - `runExtensionCompaction` now returns `undefined` only for aborts; other cases throw `SummaryGenerationError` (`kind: "auth" | "empty-summary"`, includes `stopReason`).
  - `session_before_compact` surfaces typed error messages; if aborted, cancels with no reason so UI shows “Compaction cancelled.”
  - `applyBlockingCompaction` degrades typed errors to legacy “unavailable” on auto paths to preserve behavior.
  - Abort is checked before and after credential resolution so user cancels never read as auth failures.

- **New Features**
  - Dynamic output budget: `summaryMaxTokens = min(32768, model.maxTokens, floor(contextWindow / 2))`.
  - Gives thinking models headroom, avoids over-capping small-output models, and stays valid for providers enforcing input + output <= contextWindow.

<sup>Written for commit cd09515dc732d29479fa2726795371189b5fd78e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

