### PR TITLE
feat(coding-agent): animate todo completion strikethrough reveal

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -69,3 +69,19 @@
   (no new custom type), so the branch scanner and compaction bridge read them
   unchanged; the agent notification is a hidden `todotools.user-edit` custom
   message delivered next turn.
+
+## 2026-07-21 - Progressive completion strikethrough reveal
+
+### What changed
+
+- `tools/todo.ts`: `renderTodoPhases` threads the renderer's `spinnerFrame` through to `formatTaskLine` and builds per-phase `completionKeys` (`Map<phaseName, Set<content>>`) from `completedTasks`, keyed by raw `transition.content`.
+- `formatTaskLine` strikes a completed row with `partialStrikethrough` when its raw `task.content` is in the phase's completion set and a frame is supplied; the reveal count is computed against the sanitized line (`${marker} ${sanitizeTodoText(content)}`), and once the frame settles or stops (`undefined`) the row falls back to full `theme.strikethrough(line)` — byte-identical to the pre-animation render.
+- Reuses `strikeRevealCount`/`partialStrikethrough` from the fork-only `modes/interactive/components/todo-strike.ts`.
+
+### Why
+
+- A completed todo row should sweep left-to-right rather than snap to struck. Keying the completion set on raw content (not the sanitized/marked line) keeps it stable across rendering details, and the settled state matches the original full strikethrough so the animation leaves no residual diff.
+
+### Expected merge conflict zones
+
+- MEDIUM: `tools/todo.ts` `renderTodoPhases`/`formatTaskLine` signatures and the cross-layer import of the fork-only `todo-strike.ts` module from `modes/interactive/components/`.

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
@@ -5,6 +5,7 @@
 
 import { Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
+import { partialStrikethrough, strikeRevealCount } from "../../../../../modes/interactive/components/todo-strike.ts";
 import type { Theme } from "../../../../../modes/interactive/theme/theme.ts";
 import type {
 	AgentToolResult,
@@ -30,6 +31,8 @@ import {
 	type TodoStateEntry,
 	type TodoToolDetails,
 } from "../state.ts";
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
 
 const TodoOperationSchema = Type.Union([
 	Type.Literal("init"),
@@ -148,12 +151,24 @@ function formatPhaseSummary(phase: TodoPhase, index: number, theme: Theme): stri
 	);
 }
 
-function formatTaskLine(task: TodoPhase["tasks"][number], theme: Theme): string {
+function formatTaskLine(
+	task: TodoPhase["tasks"][number],
+	theme: Theme,
+	completionKeys: ReadonlySet<string>,
+	frame: number | undefined,
+): string {
 	const content = sanitizeTodoText(task.content);
 	const line = `${getTodoMarker(task.status)} ${content}`;
 	switch (task.status) {
-		case "completed":
-			return theme.fg("dim", theme.strikethrough(line));
+		case "completed": {
+			const reveal = completionKeys.has(task.content) ? strikeRevealCount(line, frame) : undefined;
+			return reveal === undefined
+				? theme.fg("dim", theme.strikethrough(line))
+				: theme.fg(
+						"dim",
+						partialStrikethrough(line, reveal, (text) => theme.strikethrough(text)),
+					);
+		}
 		case "in_progress":
 			return theme.fg("accent", theme.bold(line));
 		case "abandoned":
@@ -196,7 +211,17 @@ function renderTodoPhases(
 	options: ToolRenderResultOptions,
 	args: TodoParams,
 	theme: Theme,
+	frame: number | undefined,
 ): string {
+	const completionKeysByPhase = new Map<string, Set<string>>();
+	for (const transition of completedTasks) {
+		let completionKeys = completionKeysByPhase.get(transition.phase);
+		if (!completionKeys) {
+			completionKeys = new Set();
+			completionKeysByPhase.set(transition.phase, completionKeys);
+		}
+		completionKeys.add(transition.content);
+	}
 	const visiblePhases = phases.filter((phase) => phase.tasks.length > 0);
 	if (visiblePhases.length === 0) return "";
 
@@ -211,7 +236,9 @@ function renderTodoPhases(
 			continue;
 		}
 		lines.push(formatPhaseHeader(phase.name, oneBasedIndex, theme));
-		for (const task of phase.tasks) lines.push(`  ${formatTaskLine(task, theme)}`);
+		for (const task of phase.tasks) {
+			lines.push(`  ${formatTaskLine(task, theme, completionKeysByPhase.get(phase.name) ?? EMPTY_SET, frame)}`);
+		}
 	}
 	return lines.join("\n");
 }
@@ -278,7 +305,14 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 				return new Text(theme.fg("toolOutput", getTextContent(result)), 0, 0);
 			}
 			const phases = result.details?.phases ?? [];
-			const rendered = renderTodoPhases(phases, result.details?.completedTasks ?? [], options, context.args, theme);
+			const rendered = renderTodoPhases(
+				phases,
+				result.details?.completedTasks ?? [],
+				options,
+				context.args,
+				theme,
+				context.spinnerFrame,
+			);
 			const text = rendered || getTextContent(result) || "Todo list is empty.";
 			return new Text(text, 0, 0);
 		},

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## todo completion strike animation (2026-07-21)
+
+### What changed
+
+- `components/todo-strike.ts` (new, fork-only): pure strike primitives — frame constants (`TODO_STRIKE_HOLD_FRAMES = 2`, `TODO_STRIKE_REVEAL_FRAMES = 12`, `TODO_STRIKE_FRAME_INTERVAL_MS = 65`), code-point-aware `strikeRevealCount` (hold-then-linear reveal), `partialStrikethrough` (prefix strike that never splits surrogate pairs), and `hasCompletedTodoTasks` (details shape guard).
+- `components/tool-execution.ts`: adds a `todoStrikeInterval` driver that, for a non-partial, non-error `todo` result with `completedTasks`, ticks the shared `spinnerFrame` 0→14 at 65ms (2 hold + 12 reveal frames) and self-stops at `TODO_STRIKE_TOTAL_FRAMES`. The driver is gated on `executionStarted` so replayed/rebuilt transcript rows never restart the sweep, and tears down via `stopAnimation()` and a new `override dispose()`.
+- `interactive-mode.ts`: adds `stopChatToolAnimations()` (iterates `chatContainer.children`, calls `stopAnimation()` on each `ToolExecutionComponent`) and invokes it in session teardown alongside `clearPendingTools()`.
+
+### Why
+
+- A completed todo row should read as a deliberate left-to-right strike sweep, not an instantaneous restyle. Animating only live executions and stopping on teardown keeps the sweep from replaying when the transcript is rebuilt.
+
+### Why extension system couldn't handle this
+
+- The pending/done tool row lifecycle, spinner frame, and per-component render cache are private `ToolExecutionComponent` state; extensions cannot own its interval or coordinate teardown with session shutdown.
+
+### Expected merge conflict zones
+
+- MEDIUM: `components/tool-execution.ts` around spinner/strike interval ownership and `dispose()`.
+- LOW: `interactive-mode.ts` teardown block; the fork-only `todo-strike.ts` module.
+
 ## model fallback lifecycle notices (2026-07-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/todo-strike.ts
+++ b/packages/coding-agent/src/modes/interactive/components/todo-strike.ts
@@ -1,0 +1,44 @@
+export const TODO_STRIKE_HOLD_FRAMES = 2;
+export const TODO_STRIKE_REVEAL_FRAMES = 12;
+export const TODO_STRIKE_TOTAL_FRAMES = TODO_STRIKE_HOLD_FRAMES + TODO_STRIKE_REVEAL_FRAMES;
+export const TODO_STRIKE_FRAME_INTERVAL_MS = 65;
+
+export function strikeRevealCount(text: string, frame: number | undefined): number | undefined {
+	if (frame === undefined) {
+		return undefined;
+	}
+	if (frame <= TODO_STRIKE_HOLD_FRAMES) {
+		return 0;
+	}
+
+	const chars = [...text];
+	if (chars.length === 0) {
+		return undefined;
+	}
+
+	return Math.ceil(
+		(chars.length * Math.min(frame - TODO_STRIKE_HOLD_FRAMES, TODO_STRIKE_REVEAL_FRAMES)) / TODO_STRIKE_REVEAL_FRAMES,
+	);
+}
+
+export function partialStrikethrough(text: string, visibleChars: number, strike: (text: string) => string): string {
+	if (visibleChars <= 0) {
+		return text;
+	}
+
+	const chars = [...text];
+	if (visibleChars >= chars.length) {
+		return strike(text);
+	}
+
+	return strike(chars.slice(0, visibleChars).join("")) + chars.slice(visibleChars).join("");
+}
+
+export function hasCompletedTodoTasks(details: unknown): boolean {
+	if (details === null || typeof details !== "object") {
+		return false;
+	}
+
+	const completedTasks = (details as { completedTasks?: unknown }).completedTasks;
+	return Array.isArray(completedTasks) && completedTasks.length > 0;
+}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -2,6 +2,7 @@ import { Container, Spacer, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDef } from "../../../core/tools/index.ts";
 import { readToolProgress } from "../tool-progress.ts";
 import { createBoundedRenderSignature } from "./render-signature.ts";
+import { hasCompletedTodoTasks, TODO_STRIKE_FRAME_INTERVAL_MS, TODO_STRIKE_TOTAL_FRAMES } from "./todo-strike.ts";
 import { ToolExecutionImages } from "./tool-execution-images.ts";
 import { ToolExecutionRenderer } from "./tool-execution-renderer.ts";
 import type { ToolExecutionIdentity, ToolExecutionRenderState, ToolExecutionResult } from "./tool-execution-types.ts";
@@ -27,6 +28,7 @@ export class ToolExecutionComponent extends Container {
 	private argsComplete = false;
 	private spinnerFrame?: number;
 	private spinnerInterval?: NodeJS.Timeout;
+	private todoStrikeInterval?: NodeJS.Timeout;
 	private result?: ToolExecutionResult;
 	private cachedLines?: string[];
 	private cachedSignature?: string;
@@ -91,6 +93,7 @@ export class ToolExecutionComponent extends Container {
 		if (!isPartial) this.argsComplete = true;
 		this.lastDisplaySignature = undefined;
 		this.updateSpinnerAnimation();
+		this.updateTodoStrikeAnimation();
 		this.updateDisplay();
 		this.images.updateResult(result);
 		this.invalidateRenderCache();
@@ -98,6 +101,12 @@ export class ToolExecutionComponent extends Container {
 
 	stopAnimation(): void {
 		this.stopSpinnerAnimation();
+		this.stopTodoStrikeAnimation();
+	}
+
+	override dispose(): void {
+		this.stopAnimation();
+		super.dispose();
 	}
 
 	setExpanded(expanded: boolean): void {
@@ -204,8 +213,50 @@ export class ToolExecutionComponent extends Container {
 		if (!this.spinnerInterval) return;
 		clearInterval(this.spinnerInterval);
 		this.spinnerInterval = undefined;
-		this.spinnerFrame = undefined;
+		if (!this.todoStrikeInterval) this.spinnerFrame = undefined;
 		this.invalidateRenderCache();
+	}
+
+	private updateTodoStrikeAnimation(): void {
+		const shouldAnimate =
+			this.identity.toolName === "todo" &&
+			this.executionStarted &&
+			!this.isPartial &&
+			this.result !== undefined &&
+			!this.result.isError &&
+			hasCompletedTodoTasks(this.result.details);
+		if (!shouldAnimate) {
+			this.stopTodoStrikeAnimation();
+			return;
+		}
+		if (this.todoStrikeInterval) return;
+
+		this.spinnerFrame = 0;
+		this.todoStrikeInterval = setInterval(() => {
+			const next = (this.spinnerFrame ?? 0) + 1;
+			if (next > TODO_STRIKE_TOTAL_FRAMES) {
+				this.stopTodoStrikeAnimation();
+				return;
+			}
+			this.spinnerFrame = next;
+			this.invalidateRenderCache();
+			this.updateDisplay();
+			this.ui.requestRender();
+		}, TODO_STRIKE_FRAME_INTERVAL_MS);
+		this.todoStrikeInterval.unref?.();
+	}
+
+	private stopTodoStrikeAnimation(): void {
+		if (this.todoStrikeInterval) {
+			clearInterval(this.todoStrikeInterval);
+			this.todoStrikeInterval = undefined;
+		}
+		if (!this.spinnerInterval && this.spinnerFrame !== undefined) {
+			this.spinnerFrame = undefined;
+			this.invalidateRenderCache();
+			this.updateDisplay();
+			this.ui.requestRender();
+		}
 	}
 
 	private invalidateRenderCache(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2123,6 +2123,12 @@ export class InteractiveMode {
 		this.applyTerminalTitle();
 	}
 
+	private stopChatToolAnimations(): void {
+		for (const child of this.chatContainer.children) {
+			if (child instanceof ToolExecutionComponent) child.stopAnimation();
+		}
+	}
+
 	private clearPendingTools(): void {
 		this.toolArgsReveal.flushAll();
 		for (const component of this.pendingTools.values()) {
@@ -6663,6 +6669,7 @@ export class InteractiveMode {
 		}
 		this.clearStatusIndicator();
 		this.clearPendingTools();
+		this.stopChatToolAnimations();
 		this.clearActiveToolExecutionStatus();
 		this.clearToolHookStatuses();
 		this.themeController.disableAutoSync();

--- a/packages/coding-agent/test/suite/todo-extension.test.ts
+++ b/packages/coding-agent/test/suite/todo-extension.test.ts
@@ -7,6 +7,7 @@ import {
 	getTodoWidgetLines,
 	TODO_STATE_ENTRY_TYPE,
 	type TodoPhase,
+	type TodoToolDetails,
 } from "../../src/core/extensions/builtin/todotools/state.ts";
 import {
 	phaseRomanNumeral,
@@ -26,6 +27,33 @@ const TODO_EXTENSION_PATH = fileURLToPath(
 );
 const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
 type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
+
+const markerTheme = {
+	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
+	bold: (text: string) => `<bold>${text}</bold>`,
+	strikethrough: (text: string) => `<s>${text}</s>`,
+};
+
+const animationResult = {
+	content: [{ type: "text", text: "summary" }],
+	details: {
+		op: "done",
+		storage: "memory",
+		phases: [
+			{
+				name: "Animation",
+				tasks: [
+					{ content: "Task A", status: "completed" },
+					{ content: "Task B", status: "completed" },
+					{ content: "Active task", status: "in_progress" },
+					{ content: "Dropped task", status: "abandoned" },
+					{ content: "Queued task", status: "pending" },
+				],
+			},
+		],
+		completedTasks: [{ phase: "Animation", content: "Task A" }],
+	},
+} satisfies { content: { type: "text"; text: string }[]; details: TodoToolDetails };
 
 beforeAll(() => initTheme("dark"));
 
@@ -585,6 +613,351 @@ describe("todo extension", () => {
 		expect(rendered).toContain("II. Auth — 1/1 done");
 		expect(rendered).toContain("III. Verification");
 		expect(rendered).toContain("[ ] Run checks");
+	});
+
+	it("preserves the settled todo renderer output", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-settled-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: undefined,
+		};
+		const component = tool.renderResult(
+			{
+				content: [{ type: "text", text: "summary" }],
+				details: {
+					op: "done",
+					storage: "memory",
+					phases: [
+						{
+							name: "Animation",
+							tasks: [
+								{ content: "Task A", status: "completed" },
+								{ content: "Task B", status: "completed" },
+								{ content: "Active task", status: "in_progress" },
+								{ content: "Dropped task", status: "abandoned" },
+								{ content: "Queued task", status: "pending" },
+							],
+						},
+					],
+					completedTasks: [{ phase: "Animation", content: "Task A" }],
+				},
+			},
+			{ expanded: false, isPartial: false },
+			markerTheme as never,
+			context,
+		);
+
+		const goldenContentLines = [
+			"<fg:accent><bold>I. Animation</bold></fg:accent>",
+			"  <fg:dim><s>[✓] Task A</s></fg:dim>",
+			"  <fg:dim><s>[✓] Task B</s></fg:dim>",
+			"  <fg:accent><bold>[•] Active task</bold></fg:accent>",
+			"  <fg:dim>[×] Dropped task</fg:dim>",
+			"  [ ] Queued task",
+		];
+		// render(160) pads every row to the render width with trailing spaces; pin those
+		// bytes structurally instead of committing literal end-of-line whitespace.
+		const golden = goldenContentLines.map((line) => line.padEnd(160)).join("\n");
+		expect(component.render(160).join("\n")).toBe(golden);
+	});
+
+	it.each([0, 1, 2])("holds the completion strike at frame %i", async (spinnerFrame) => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-hold-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame,
+		};
+		const rendered = tool
+			.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("<fg:dim>[✓] Task A</fg:dim>");
+		expect(rendered).toContain("<fg:dim><s>[✓] Task B</s></fg:dim>");
+		expect(rendered).not.toContain("<s>[✓] Task A</s>");
+	});
+
+	it("partially strikes only the newly completed task at frame 8", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-partial-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: 8,
+		};
+		const rendered = tool
+			.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("<fg:dim><s>[✓] T</s>ask A</fg:dim>");
+		expect(rendered).toContain("<fg:dim><s>[✓] Task B</s></fg:dim>");
+	});
+
+	it.each([14, 20])("settles the completion strike at frame %i", async (spinnerFrame) => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-complete-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame,
+		};
+		const rendered = tool
+			.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("<fg:dim><s>[✓] Task A</s></fg:dim>");
+	});
+
+	it("increases the strike reveal monotonically at animation boundaries", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const revealedCounts: number[] = [];
+		for (const spinnerFrame of [4, 8, 12]) {
+			const context: ToolRenderContext<unknown, TodoParams> = {
+				args: { op: "done", task: "Task A" },
+				toolCallId: `todo-boundary-${spinnerFrame}`,
+				invalidate: () => {},
+				lastComponent: undefined,
+				state: undefined,
+				cwd: REPO_ROOT,
+				executionStarted: true,
+				argsComplete: true,
+				isPartial: false,
+				expanded: false,
+				showImages: false,
+				isError: false,
+				spinnerFrame,
+			};
+			const rendered = tool
+				.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+				.render(160)
+				.join("\n");
+			const match = rendered.match(/<fg:dim><s>(.*?)<\/s>/);
+			if (!match) throw new Error("Expected a partial strike marker");
+			revealedCounts.push([...match[1]].length);
+		}
+
+		expect(revealedCounts[0]).toBeLessThan(revealedCounts[1]!);
+		expect(revealedCounts[1]).toBeLessThan(revealedCounts[2]!);
+	});
+
+	it("renders error results as plain text without completion markers", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-error-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: true,
+			spinnerFrame: 8,
+		};
+		const rendered = tool
+			.renderResult(
+				{ content: [{ type: "text", text: "unable to complete" }], details: animationResult.details },
+				{ expanded: false, isPartial: false },
+				markerTheme as never,
+				context,
+			)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("unable to complete");
+		expect(rendered).not.toContain("<s>");
+	});
+
+	it("preserves ANSI strike coverage while wrapping a partial completion", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const longTask = "A completed task whose display text safely wraps across multiple physical rows";
+		const result = {
+			content: [{ type: "text", text: "summary" }],
+			details: {
+				op: "done",
+				storage: "memory" as const,
+				phases: [
+					{
+						name: "Wrap",
+						tasks: [
+							{ content: longTask, status: "completed" as const },
+							{ content: "Stable completed", status: "completed" as const },
+						],
+					},
+				],
+				completedTasks: [{ phase: "Wrap", content: longTask }],
+			},
+		} satisfies { content: { type: "text"; text: string }[]; details: TodoToolDetails };
+		const ansiTheme = {
+			fg: (_name: string, text: string) => text,
+			bold: (text: string) => text,
+			strikethrough: (text: string) => `\u001b[9m${text}\u001b[29m`,
+		};
+		const animatedContext: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: longTask },
+			toolCallId: "todo-wrap-animated",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: 8,
+		};
+		const settledContext: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: longTask },
+			toolCallId: "todo-wrap-settled",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: undefined,
+		};
+		const animatedLines = tool
+			.renderResult(result, { expanded: false, isPartial: false }, ansiTheme as never, animatedContext)
+			.render(24);
+		const settledLines = tool
+			.renderResult(result, { expanded: false, isPartial: false }, ansiTheme as never, settledContext)
+			.render(24);
+		const strikeCoverage = (lines: readonly string[]) => {
+			let striking = false;
+			return lines.map((physicalLine) => {
+				const line = physicalLine.trim();
+				let coverage = 0;
+				for (let index = 0; index < line.length; ) {
+					if (line.startsWith("\u001b[9m", index)) {
+						striking = true;
+						index += "\u001b[9m".length;
+						continue;
+					}
+					if (line.startsWith("\u001b[29m", index)) {
+						striking = false;
+						index += "\u001b[29m".length;
+						continue;
+					}
+					const glyph = String.fromCodePoint(line.codePointAt(index) ?? 0);
+					if (striking) coverage += 1;
+					index += glyph.length;
+				}
+				return coverage;
+			});
+		};
+		const stableLineIndex = (lines: readonly string[]) =>
+			lines.findIndex((line) => stripAnsi(line).trim().includes("Stable completed"));
+		const animatedStableIndex = stableLineIndex(animatedLines);
+		const settledStableIndex = stableLineIndex(settledLines);
+		if (animatedStableIndex < 0 || settledStableIndex < 0) throw new Error("Expected the stable completed row");
+		const animatedCoverage = strikeCoverage(animatedLines);
+		const settledCoverage = strikeCoverage(settledLines);
+
+		const fullDisplayLine = `[✓] ${longTask}`;
+		const expectedRevealCount = Math.ceil(([...fullDisplayLine].length * 6) / 12);
+		const wrappedRevealCount = animatedCoverage
+			.slice(0, animatedStableIndex)
+			.reduce((total, coverage) => total + coverage, 0);
+		// Text's physical rows reserve the two-space tree indentation before the SGR span.
+		expect(wrappedRevealCount + 2).toBe(expectedRevealCount);
+		expect(animatedCoverage[animatedStableIndex]).toBe(settledCoverage[settledStableIndex]);
+
+		// Positional assertion: within the animated task's wrapped rows, no glyph beyond
+		// the reveal boundary is struck — struck flags form a contiguous prefix.
+		const strikeFlags = (lines: readonly string[]) => {
+			let striking = false;
+			return lines.map((physicalLine) => {
+				// Mirror strikeCoverage: each physical row reserves tree indentation; strip
+				// it (and end padding) so flags track only display-line glyphs.
+				const line = physicalLine.trim();
+				const flags: boolean[] = [];
+				for (let index = 0; index < line.length; ) {
+					if (line.startsWith("\u001b[9m", index)) {
+						striking = true;
+						index += "\u001b[9m".length;
+						continue;
+					}
+					if (line.startsWith("\u001b[29m", index)) {
+						striking = false;
+						index += "\u001b[29m".length;
+						continue;
+					}
+					const glyph = String.fromCodePoint(line.codePointAt(index) ?? 0);
+					flags.push(striking);
+					index += glyph.length;
+				}
+				return flags;
+			});
+		};
+		const animatedFlags = (() => {
+			// Restrict to the animated task's own wrapped rows: from the first struck row
+			// to the stable completed row (excludes the unstruck phase header above it).
+			const firstStruck = animatedCoverage.findIndex((coverage) => coverage > 0);
+			if (firstStruck < 0) throw new Error("Expected a struck row");
+			return strikeFlags(animatedLines.slice(firstStruck, animatedStableIndex)).flatMap((flags) => flags);
+		})();
+		const firstUnstruck = animatedFlags.indexOf(false);
+		const struckBeyondBoundary = firstUnstruck >= 0 && animatedFlags.slice(firstUnstruck + 1).some((flag) => flag);
+		expect(struckBeyondBoundary).toBe(false);
 	});
 
 	it("registers exactly one todo tool with the op schema", async () => {

--- a/packages/coding-agent/test/todo-strike.test.ts
+++ b/packages/coding-agent/test/todo-strike.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import {
+	hasCompletedTodoTasks,
+	partialStrikethrough,
+	strikeRevealCount,
+	TODO_STRIKE_HOLD_FRAMES,
+	TODO_STRIKE_TOTAL_FRAMES,
+} from "../src/modes/interactive/components/todo-strike.ts";
+
+const markerStrike = (text: string): string => `<s>${text}</s>`;
+
+describe("strikeRevealCount", () => {
+	test("undefined frame returns undefined", () => {
+		expect(strikeRevealCount("abc", undefined)).toBeUndefined();
+	});
+
+	test("hold frames 0, 1, 2 return 0", () => {
+		expect(strikeRevealCount("abc", 0)).toBe(0);
+		expect(strikeRevealCount("abc", 1)).toBe(0);
+		expect(strikeRevealCount("abc", 2)).toBe(0);
+		expect(strikeRevealCount("abc", TODO_STRIKE_HOLD_FRAMES)).toBe(0);
+	});
+
+	test("frame 3 with 12-char text reveals 1 code point", () => {
+		expect(strikeRevealCount("123456789012", 3)).toBe(1);
+	});
+
+	test("frame >= TOTAL reveals full length", () => {
+		expect(strikeRevealCount("abc", TODO_STRIKE_TOTAL_FRAMES)).toBe(3);
+		expect(strikeRevealCount("abc", TODO_STRIKE_TOTAL_FRAMES + 5)).toBe(3);
+	});
+
+	test("empty string returns undefined for a revealing frame", () => {
+		expect(strikeRevealCount("", TODO_STRIKE_HOLD_FRAMES + 1)).toBeUndefined();
+	});
+
+	test("splits on code points, not UTF-16 units", () => {
+		// "ab🎉cd" is 5 code points but 6 UTF-16 code units (🎉 is a surrogate pair).
+		const text = "ab🎉cd";
+		expect([...text].length).toBe(5);
+		// Full reveal reports 5 code points, not 6 UTF-16 units.
+		expect(strikeRevealCount(text, TODO_STRIKE_TOTAL_FRAMES)).toBe(5);
+		// First reveal step: ceil(5 * 1 / 12) = 1 code point.
+		expect(strikeRevealCount(text, TODO_STRIKE_HOLD_FRAMES + 1)).toBe(1);
+	});
+});
+
+describe("partialStrikethrough", () => {
+	test("visibleChars <= 0 returns text unchanged", () => {
+		expect(partialStrikethrough("abc", 0, markerStrike)).toBe("abc");
+		expect(partialStrikethrough("abc", -3, markerStrike)).toBe("abc");
+	});
+
+	test("visibleChars >= length strikes the whole text", () => {
+		expect(partialStrikethrough("abc", 3, markerStrike)).toBe("<s>abc</s>");
+		expect(partialStrikethrough("abc", 10, markerStrike)).toBe("<s>abc</s>");
+	});
+
+	test("mid boundary strikes the prefix only", () => {
+		expect(partialStrikethrough("abc", 2, markerStrike)).toBe("<s>ab</s>c");
+	});
+
+	test("splits on code points, not UTF-16 units", () => {
+		// visibleChars=3 strikes "ab🎉" (3 code points), leaving "cd" unstriked.
+		expect(partialStrikethrough("ab🎉cd", 3, markerStrike)).toBe("<s>ab🎉</s>cd");
+	});
+});
+
+describe("hasCompletedTodoTasks", () => {
+	test("true when completedTasks is a non-empty array", () => {
+		expect(hasCompletedTodoTasks({ completedTasks: [{ label: "x" }] })).toBe(true);
+	});
+
+	test("false when completedTasks is an empty array", () => {
+		expect(hasCompletedTodoTasks({ completedTasks: [] })).toBe(false);
+	});
+
+	test("false when completedTasks is missing", () => {
+		expect(hasCompletedTodoTasks({ other: 1 })).toBe(false);
+	});
+
+	test("false for null", () => {
+		expect(hasCompletedTodoTasks(null)).toBe(false);
+	});
+
+	test("false for non-object primitives", () => {
+		expect(hasCompletedTodoTasks(42)).toBe(false);
+		expect(hasCompletedTodoTasks("str")).toBe(false);
+		expect(hasCompletedTodoTasks(undefined)).toBe(false);
+	});
+
+	test("false when completedTasks is not an array", () => {
+		expect(hasCompletedTodoTasks({ completedTasks: "nope" })).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -1,14 +1,20 @@
 import { join, resolve } from "node:path";
-import { Text, type TUI } from "@earendil-works/pi-tui";
+import { Container, Text, type TUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getReadmePath } from "../src/config.ts";
-import type { ToolDefinition } from "../src/core/extensions/types.ts";
+import { registerTodoTool, type TODO_PARAMS_SCHEMA } from "../src/core/extensions/builtin/todotools/tools/todo.ts";
+import type { ExtensionAPI, ToolDefinition } from "../src/core/extensions/types.ts";
 import { type BashOperations, createBashToolDefinition } from "../src/core/tools/bash.ts";
 import { renderToolDiff } from "../src/core/tools/diff-render.ts";
 import { createReadTool, createReadToolDefinition } from "../src/core/tools/read.ts";
 import { createWriteToolDefinition } from "../src/core/tools/write.ts";
+import {
+	TODO_STRIKE_FRAME_INTERVAL_MS,
+	TODO_STRIKE_TOTAL_FRAMES,
+} from "../src/modes/interactive/components/todo-strike.ts";
 import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 
@@ -36,6 +42,70 @@ function createFakeTuiWithRenderSpy(requestRender: () => void): TUI {
 		requestRender,
 	} as TUI;
 }
+
+function createCompletedTodoResult(isError = false): Parameters<ToolExecutionComponent["updateResult"]>[0] {
+	return {
+		content: [{ type: "text" as const, text: "ok" }],
+		details: {
+			op: "done",
+			phases: [{ name: "P", tasks: [{ content: "t", status: "completed" }] }],
+			storage: "memory" as const,
+			completedTasks: [{ phase: "P", content: "t" }],
+		},
+		isError,
+	};
+}
+
+function getSpinnerFrame(component: ToolExecutionComponent): number | undefined {
+	return (component as unknown as { spinnerFrame?: number }).spinnerFrame;
+}
+
+function captureTodoTool(): ToolDefinition<typeof TODO_PARAMS_SCHEMA> {
+	let capturedTool: ToolDefinition<typeof TODO_PARAMS_SCHEMA> | undefined;
+	const pi = {
+		registerTool(tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA>) {
+			capturedTool = tool;
+		},
+		appendEntry() {},
+	};
+	registerTodoTool(pi as unknown as ExtensionAPI, {
+		getCurrentPhases: () => [],
+		setCurrentPhases: () => {},
+		syncWidget: () => {},
+	});
+	if (!capturedTool) throw new Error("Expected todo tool registration");
+	return capturedTool;
+}
+
+type InteractiveModeStopThis = {
+	streamingReveal: { stop(): void };
+	toolResultReveal: { stop(): void };
+	settingsManager: { getShowTerminalProgress(): boolean };
+	ui: { terminal: { setProgress(value: boolean): void }; stop(): void };
+	clearStatusIndicator(): void;
+	clearPendingTools(): void;
+	stopChatToolAnimations(): void;
+	clearActiveToolExecutionStatus(): void;
+	clearToolHookStatuses(): void;
+	themeController: { disableAutoSync(): void };
+	clearExtensionTerminalInputListeners(): void;
+	footer: { dispose(): void };
+	footerDataProvider: { dispose(): void };
+	unsubscribe: (() => void) | undefined;
+	isInitialized: boolean;
+	unregisterSignalHandlers(): void;
+};
+type InteractiveModeStopPrototype = {
+	stop(this: InteractiveModeStopThis): void;
+};
+type StopChatToolAnimationsThis = {
+	chatContainer: Container;
+	ui: Pick<TUI, "requestRender">;
+};
+
+type StopChatToolAnimationsPrototype = {
+	stopChatToolAnimations(this: StopChatToolAnimationsThis): void;
+};
 
 const markerTheme = {
 	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
@@ -692,4 +762,223 @@ describe("ToolExecutionComponent parity", () => {
 			expect(collapsed.indexOf(":120-329")).toBeLessThan(collapsed.indexOf("to expand"));
 		});
 	}
+
+	test("animates completed todo tasks through the strike reveal and settles", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-happy",
+				{},
+				{},
+				createBaseToolDefinition("todo"),
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
+			component.markExecutionStarted();
+			component.updateResult(createCompletedTodoResult(), false);
+
+			const rendersBeforeFrame = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
+			expect(requestRender.mock.calls.length).toBeGreaterThan(rendersBeforeFrame);
+
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS * (TODO_STRIKE_TOTAL_FRAMES + 1));
+			const rendersAfterCompletion = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2_000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterCompletion);
+			expect(getSpinnerFrame(component)).toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	const todoAnimationScenarios: Array<{
+		title: string;
+		result: Parameters<ToolExecutionComponent["updateResult"]>[0];
+		isPartial: boolean;
+	}> = [
+		{ title: "does not animate errored todo results", result: createCompletedTodoResult(true), isPartial: false },
+		{
+			title: "does not animate todo results without completedTasks",
+			result: {
+				content: [{ type: "text" as const, text: "ok" }],
+				details: { op: "done", phases: [], storage: "memory" },
+				isError: false,
+			},
+			isPartial: false,
+		},
+		{
+			title: "does not animate todo results with empty completedTasks",
+			result: {
+				content: [{ type: "text" as const, text: "ok" }],
+				details: { op: "done", phases: [], storage: "memory", completedTasks: [] },
+				isError: false,
+			},
+			isPartial: false,
+		},
+		{ title: "does not animate partial todo results", result: createCompletedTodoResult(), isPartial: true },
+	];
+	for (const scenario of todoAnimationScenarios) {
+		test(scenario.title, () => {
+			vi.useFakeTimers();
+			try {
+				const requestRender = vi.fn();
+				const component = new ToolExecutionComponent(
+					"todo",
+					`tool-todo-strike-${scenario.title}`,
+					{},
+					{},
+					createBaseToolDefinition("todo"),
+					createFakeTuiWithRenderSpy(requestRender),
+					process.cwd(),
+				);
+				component.markExecutionStarted();
+				component.updateResult(scenario.result, scenario.isPartial);
+				requestRender.mockClear();
+				vi.advanceTimersByTime(2_000);
+				expect(requestRender).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	}
+
+	test("stops completed todo strike animation on stopAnimation and dispose", () => {
+		vi.useFakeTimers();
+		try {
+			for (const teardown of [
+				(component: ToolExecutionComponent) => component.stopAnimation(),
+				(component: ToolExecutionComponent) => component.dispose(),
+			]) {
+				const requestRender = vi.fn();
+				const component = new ToolExecutionComponent(
+					"todo",
+					"tool-todo-strike-teardown",
+					{},
+					{},
+					createBaseToolDefinition("todo"),
+					createFakeTuiWithRenderSpy(requestRender),
+					process.cwd(),
+				);
+				component.markExecutionStarted();
+				component.updateResult(createCompletedTodoResult(), false);
+				teardown(component);
+				requestRender.mockClear();
+				vi.advanceTimersByTime(2_000);
+				expect(requestRender).not.toHaveBeenCalled();
+			}
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("does not replay todo completion animation while rendering restored results", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-restored",
+				{ op: "done", task: "t" },
+				{},
+				captureTodoTool(),
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
+			component.updateResult(createCompletedTodoResult(), false);
+			requestRender.mockClear();
+			vi.advanceTimersByTime(2_000);
+			expect(requestRender).not.toHaveBeenCalled();
+			expect(component.render(120).join("\n")).toContain(theme.strikethrough("[✓] t"));
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("interactive mode stop wires chat tool animation teardown after clearPendingTools", () => {
+		const clearPendingTools = vi.fn();
+		const stopChatToolAnimations = vi.fn();
+		const fakeThis: InteractiveModeStopThis = {
+			streamingReveal: { stop: vi.fn() },
+			toolResultReveal: { stop: vi.fn() },
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { terminal: { setProgress: vi.fn() }, stop: vi.fn() },
+			clearStatusIndicator: vi.fn(),
+			clearPendingTools,
+			stopChatToolAnimations,
+			clearActiveToolExecutionStatus: vi.fn(),
+			clearToolHookStatuses: vi.fn(),
+			themeController: { disableAutoSync: vi.fn() },
+			clearExtensionTerminalInputListeners: vi.fn(),
+			footer: { dispose: vi.fn() },
+			footerDataProvider: { dispose: vi.fn() },
+			unsubscribe: undefined,
+			isInitialized: false,
+			unregisterSignalHandlers: vi.fn(),
+		};
+		const prototype = InteractiveMode.prototype as unknown as InteractiveModeStopPrototype;
+		prototype.stop.call(fakeThis);
+		expect(stopChatToolAnimations).toHaveBeenCalledTimes(1);
+		expect(stopChatToolAnimations.mock.invocationCallOrder[0]).toBeGreaterThan(
+			clearPendingTools.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	test("stops completed todo strike animation when interactive mode stops chat tool animations", () => {
+		vi.useFakeTimers();
+		try {
+			const requestRender = vi.fn();
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-mode-stop",
+				{},
+				{},
+				createBaseToolDefinition("todo"),
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
+			component.markExecutionStarted();
+			component.updateResult(createCompletedTodoResult(), false);
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
+			const chatContainer = new Container();
+			chatContainer.addChild(component);
+			const fakeThis: StopChatToolAnimationsThis = { chatContainer, ui: { requestRender: vi.fn() } };
+			const prototype = InteractiveMode.prototype as unknown as StopChatToolAnimationsPrototype;
+			prototype.stopChatToolAnimations.call(fakeThis);
+			requestRender.mockClear();
+			vi.advanceTimersByTime(2_000);
+			expect(requestRender).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("invalidates memoized todo output for each strike animation frame", () => {
+		vi.useFakeTimers();
+		try {
+			const toolDefinition: ToolDefinition = {
+				...createBaseToolDefinition("todo"),
+				renderResult: (_result, _options, _theme, context) =>
+					new Text(`frame:${String(context.spinnerFrame)}`, 0, 0),
+			};
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-memo",
+				{},
+				{},
+				toolDefinition,
+				createFakeTuiWithRenderSpy(vi.fn()),
+				process.cwd(),
+			);
+			component.markExecutionStarted();
+			component.updateResult(createCompletedTodoResult(), false);
+			const firstFrame = component.render(120).join("\n");
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
+			const secondFrame = component.render(120).join("\n");
+			expect(secondFrame).not.toBe(firstFrame);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Ports oh-my-pi's todo completion strikethrough reveal into senpi's interactive mode: when a final, non-error `todo` result reports `details.completedTasks`, the just-completed task rows play a left-to-right strike sweep (65ms x 14 frames: 2 hold + 12 reveal, ~910ms) and then settle to **byte-identical** static rendering. Two deliberate improvements over upstream: transcript rebuilds (session resume / branch switch / compaction) never replay the animation (`executionStarted` gate), and teardown is deterministic (`stopAnimation()`, `dispose()`, and `InteractiveMode.stop()` -> `stopChatToolAnimations()` all kill a mid-flight interval; interval is `unref`'d and self-terminating).

Files: new pure module `modes/interactive/components/todo-strike.ts` (zero imports); driver in `tool-execution.ts` + stop-wiring in `interactive-mode.ts`; frame-aware reveal in `todotools/tools/todo.ts`; 3 test files; 2 changes.md notes. No settings, no schema/state/prompt changes, no animation in sidebar/`/todo`/export/RPC/print modes.

## Test plan (all evidence captured)

- `npx vitest --run test/todo-strike.test.ts test/tool-execution-component.test.ts test/suite/todo-extension.test.ts` — **83/83 green** (`.omo/evidence/todo-completion-strike-animation/task-4-vitest.txt`, with command + EXIT_CODE provenance)
- `npm run check` — **exit 0** (`task-4-check.txt`); `git diff --check origin/main` clean
- Settled-output golden (all four statuses) pinned pre-change and kept byte-identical; RED proofs captured for module math and frame-8 boundary
- Timer lifecycle: fake-timer tests for happy/negative/teardown/no-replay/mode-stop/memo-invariant; `InteractiveMode.stop()` wiring regression asserts order after `clearPendingTools()`
- Real-CLI QA (senpi-qa contract, sandboxed, faux model server, zero tokens): raw PTY byte streams via senpi's own `packages/pty` native backend — `local-ignore/qa-evidence/20260721-todo-strike-anim/SUMMARY.md`: (a) partial strict-prefix SGR-9 strike (frames 7-16, monotonic part1->part21), (b) settled full strike (frame 17), (c) no other task row gains strike coverage, (d) `--continue` resume replays nothing and renders settled; failure session: nonexistent-task done stays static with no error text, schema-invalid call renders the real validation error with no animation. Cleanup receipt: sandboxes removed, no PTY/server leaks, auth untouched
- Independent verification wave: F1 plan-compliance, F2 code-quality, F3 fresh QA rerun from raw bytes, F4 scope-fidelity — all APPROVE (`.omo/evidence/todo-completion-strike-animation/f1-f4`)

Plan: `.omo/plans/todo-completion-strike-animation.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a left-to-right strikethrough reveal for newly completed todo tasks in interactive mode. The sweep runs for ~910ms (2 hold + 12 reveal frames at 65ms) and then falls back to the exact same static rendering as before.

- **New Features**
  - Animates only the just-completed rows using a shared `spinnerFrame` (0–14) and a code-point-aware partial strike.
  - No replay on transcript rebuilds; gated by `executionStarted`.
  - Deterministic teardown: `stopAnimation()`/`dispose()` cancel intervals; interactive mode calls `stopChatToolAnimations()` during stop.
  - Renderer threads `spinnerFrame` into `todo` output and keys completion by raw task content; settled output remains byte-identical.
  - Scope-limited to interactive mode; no changes to sidebar, `/todo`, export, RPC, or print modes.

<sup>Written for commit c2e2de9023a943368f0bc6febd45d567bb977db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

