### PR TITLE
test(coding-agent): harden todo completion strike animation coverage

### DIFF
--- a/packages/coding-agent/test/suite/todo-extension.test.ts
+++ b/packages/coding-agent/test/suite/todo-extension.test.ts
@@ -7,6 +7,7 @@ import {
 	getTodoWidgetLines,
 	TODO_STATE_ENTRY_TYPE,
 	type TodoPhase,
+	type TodoToolDetails,
 } from "../../src/core/extensions/builtin/todotools/state.ts";
 import {
 	phaseRomanNumeral,
@@ -16,7 +17,7 @@ import {
 import { discoverAndLoadExtensions } from "../../src/core/extensions/loader.ts";
 import type { ExtensionAPI, ToolDefinition, ToolRenderContext } from "../../src/core/extensions/types.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
-import { initTheme, type Theme, theme } from "../../src/modes/interactive/theme/theme.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../../src/utils/ansi.ts";
 import { createTestResourceLoader, userMsg } from "../utilities.ts";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
@@ -26,6 +27,33 @@ const TODO_EXTENSION_PATH = fileURLToPath(
 );
 const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
 type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
+
+const markerTheme = {
+	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
+	bold: (text: string) => `<bold>${text}</bold>`,
+	strikethrough: (text: string) => `<s>${text}</s>`,
+};
+
+const animationResult = {
+	content: [{ type: "text", text: "summary" }],
+	details: {
+		op: "done",
+		storage: "memory",
+		phases: [
+			{
+				name: "Animation",
+				tasks: [
+					{ content: "Task A", status: "completed" },
+					{ content: "Task B", status: "completed" },
+					{ content: "Active task", status: "in_progress" },
+					{ content: "Dropped task", status: "abandoned" },
+					{ content: "Queued task", status: "pending" },
+				],
+			},
+		],
+		completedTasks: [{ phase: "Animation", content: "Task A" }],
+	},
+} satisfies { content: { type: "text"; text: string }[]; details: TodoToolDetails };
 
 beforeAll(() => initTheme("dark"));
 
@@ -587,17 +615,12 @@ describe("todo extension", () => {
 		expect(rendered).toContain("[ ] Run checks");
 	});
 
-	it("preserves the settled todo phase tree golden output", async () => {
+	it("preserves the settled todo renderer output", async () => {
 		const tool = await captureTodoTool();
 		if (!tool.renderResult) throw new Error("Expected todo result renderer");
-		const markerTheme = {
-			fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
-			bold: (text: string) => text,
-			strikethrough: (text: string) => `<s>${text}</s>`,
-		} as Theme;
 		const context: ToolRenderContext<unknown, TodoParams> = {
-			args: { op: "done", task: "A" },
-			toolCallId: "todo-golden",
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-settled-render",
 			invalidate: () => {},
 			lastComponent: undefined,
 			state: undefined,
@@ -615,52 +638,47 @@ describe("todo extension", () => {
 				content: [{ type: "text", text: "summary" }],
 				details: {
 					op: "done",
+					storage: "memory",
 					phases: [
 						{
-							name: "P",
+							name: "Animation",
 							tasks: [
-								{ content: "A", status: "completed" },
-								{ content: "B", status: "in_progress" },
-								{ content: "C", status: "abandoned" },
-								{ content: "D", status: "pending" },
+								{ content: "Task A", status: "completed" },
+								{ content: "Task B", status: "completed" },
+								{ content: "Active task", status: "in_progress" },
+								{ content: "Dropped task", status: "abandoned" },
+								{ content: "Queued task", status: "pending" },
 							],
 						},
 					],
-					storage: "memory",
-					completedTasks: [{ phase: "P", content: "A" }],
+					completedTasks: [{ phase: "Animation", content: "Task A" }],
 				},
 			},
 			{ expanded: false, isPartial: false },
-			markerTheme,
+			markerTheme as never,
 			context,
 		);
 
-		const settledGolden = [
-			"<fg:accent>I. P</fg:accent>".padEnd(160),
-			"  <fg:dim><s>[✓] A</s></fg:dim>".padEnd(160),
-			"  <fg:accent>[•] B</fg:accent>".padEnd(160),
-			"  <fg:dim>[×] C</fg:dim>".padEnd(160),
-			"  [ ] D".padEnd(160),
-		].join("\n");
-		expect(component.render(160).join("\n")).toBe(settledGolden);
+		const goldenContentLines = [
+			"<fg:accent><bold>I. Animation</bold></fg:accent>",
+			"  <fg:dim><s>[✓] Task A</s></fg:dim>",
+			"  <fg:dim><s>[✓] Task B</s></fg:dim>",
+			"  <fg:accent><bold>[•] Active task</bold></fg:accent>",
+			"  <fg:dim>[×] Dropped task</fg:dim>",
+			"  [ ] Queued task",
+		];
+		// render(160) pads every row to the render width with trailing spaces; pin those
+		// bytes structurally instead of committing literal end-of-line whitespace.
+		const golden = goldenContentLines.map((line) => line.padEnd(160)).join("\n");
+		expect(component.render(160).join("\n")).toBe(golden);
 	});
 
-	async function renderCompletionFrame(
-		spinnerFrame: number | undefined,
-		options: { content?: string; isError?: boolean; theme?: Theme; width?: number; includeSecond?: boolean } = {},
-	): Promise<string> {
+	it.each([0, 1, 2])("holds the completion strike at frame %i", async (spinnerFrame) => {
 		const tool = await captureTodoTool();
 		if (!tool.renderResult) throw new Error("Expected todo result renderer");
-		const markerTheme =
-			options.theme ??
-			({
-				fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
-				bold: (text: string) => text,
-				strikethrough: (text: string) => `<s>${text}</s>`,
-			} as Theme);
 		const context: ToolRenderContext<unknown, TodoParams> = {
-			args: { op: "done", task: "A" },
-			toolCallId: "todo-frame",
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-hold-render",
 			invalidate: () => {},
 			lastComponent: undefined,
 			state: undefined,
@@ -670,128 +688,276 @@ describe("todo extension", () => {
 			isPartial: false,
 			expanded: false,
 			showImages: false,
-			isError: options.isError ?? false,
+			isError: false,
 			spinnerFrame,
 		};
-		const content = options.content ?? "A";
-		const tasks: TodoPhase["tasks"] = [
-			{ content, status: "completed" },
-			...(options.includeSecond === false ? [] : [{ content: "B", status: "completed" } as const]),
-			{ content: "C", status: "in_progress" },
-		];
-		return tool
+		const rendered = tool
+			.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("<fg:dim>[✓] Task A</fg:dim>");
+		expect(rendered).toContain("<fg:dim><s>[✓] Task B</s></fg:dim>");
+		expect(rendered).not.toContain("<s>[✓] Task A</s>");
+	});
+
+	it("partially strikes only the newly completed task at frame 8", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-partial-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: 8,
+		};
+		const rendered = tool
+			.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("<fg:dim><s>[✓] T</s>ask A</fg:dim>");
+		expect(rendered).toContain("<fg:dim><s>[✓] Task B</s></fg:dim>");
+	});
+
+	it.each([14, 20])("settles the completion strike at frame %i", async (spinnerFrame) => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-complete-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame,
+		};
+		const rendered = tool
+			.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+			.render(160)
+			.join("\n");
+
+		expect(rendered).toContain("<fg:dim><s>[✓] Task A</s></fg:dim>");
+	});
+
+	it("increases the strike reveal monotonically at animation boundaries", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const revealedCounts: number[] = [];
+		for (const spinnerFrame of [4, 8, 12]) {
+			const context: ToolRenderContext<unknown, TodoParams> = {
+				args: { op: "done", task: "Task A" },
+				toolCallId: `todo-boundary-${spinnerFrame}`,
+				invalidate: () => {},
+				lastComponent: undefined,
+				state: undefined,
+				cwd: REPO_ROOT,
+				executionStarted: true,
+				argsComplete: true,
+				isPartial: false,
+				expanded: false,
+				showImages: false,
+				isError: false,
+				spinnerFrame,
+			};
+			const rendered = tool
+				.renderResult(animationResult, { expanded: false, isPartial: false }, markerTheme as never, context)
+				.render(160)
+				.join("\n");
+			const match = rendered.match(/<fg:dim><s>(.*?)<\/s>/);
+			if (!match) throw new Error("Expected a partial strike marker");
+			revealedCounts.push([...match[1]].length);
+		}
+
+		expect(revealedCounts[0]).toBeLessThan(revealedCounts[1]!);
+		expect(revealedCounts[1]).toBeLessThan(revealedCounts[2]!);
+	});
+
+	it("renders error results as plain text without completion markers", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const context: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: "Task A" },
+			toolCallId: "todo-error-render",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: true,
+			spinnerFrame: 8,
+		};
+		const rendered = tool
 			.renderResult(
-				{
-					content: [{ type: "text", text: "error text" }],
-					details: {
-						op: "done",
-						phases: [
-							{
-								name: "P",
-								tasks,
-							},
-						],
-						storage: "memory",
-						completedTasks: [{ phase: "P", content }],
-					},
-				},
+				{ content: [{ type: "text", text: "unable to complete" }], details: animationResult.details },
 				{ expanded: false, isPartial: false },
-				markerTheme,
+				markerTheme as never,
 				context,
 			)
-			.render(options.width ?? 160)
+			.render(160)
 			.join("\n");
-	}
 
-	it("preserves byte-identical fully struck completion output without a spinner frame", async () => {
-		const rendered = await renderCompletionFrame(undefined);
-		expect(rendered).toContain("<fg:dim><s>[✓] A</s></fg:dim>");
-		expect(rendered).toContain("<fg:dim><s>[✓] B</s></fg:dim>");
-	});
-
-	it("holds the newly completed task unstruck through frames zero to two", async () => {
-		for (const frame of [0, 1, 2]) {
-			const rendered = await renderCompletionFrame(frame);
-			expect(rendered).toContain("<fg:dim>[✓] A</fg:dim>");
-			expect(rendered).toContain("<fg:dim><s>[✓] B</s></fg:dim>");
-			expect(rendered).not.toContain("<s>[✓] A</s>");
-		}
-	});
-
-	it("reveals exactly six twelfths of the sanitized full task line at frame eight", async () => {
-		const rendered = await renderCompletionFrame(8);
-		const line = "[✓] A";
-		const reveal = Math.ceil(([...line].length * 6) / 12);
-		expect(rendered).toContain(
-			`<fg:dim><s>${[...line].slice(0, reveal).join("")}</s>${[...line].slice(reveal).join("")}</fg:dim>`,
-		);
-		expect(rendered).toContain("<fg:dim><s>[✓] B</s></fg:dim>");
-	});
-
-	it("fully strikes the newly completed task at and after frame fourteen", async () => {
-		for (const frame of [14, 20]) {
-			expect(await renderCompletionFrame(frame)).toContain("<fg:dim><s>[✓] A</s></fg:dim>");
-		}
-	});
-
-	it("increases the reveal boundary monotonically between frames four, eight, and twelve", async () => {
-		const counts = await Promise.all(
-			[4, 8, 12].map(async (frame) => {
-				const matched = (await renderCompletionFrame(frame)).match(/<fg:dim><s>(.*?)<\/s>/);
-				if (!matched) throw new Error("Expected a partial strikethrough marker");
-				return [...matched[1]].length;
-			}),
-		);
-		expect(counts[0]).toBeLessThan(counts[1] ?? 0);
-		expect(counts[1]).toBeLessThan(counts[2] ?? 0);
-	});
-
-	it("keeps error results on the plain text renderer path", async () => {
-		const rendered = await renderCompletionFrame(8, { isError: true });
+		expect(rendered).toContain("unable to complete");
 		expect(rendered).not.toContain("<s>");
-		expect(rendered).toContain("error text");
 	});
 
-	it("preserves the reveal boundary across wrapped display lines", async () => {
-		const content = "x".repeat(60);
+	it("preserves ANSI strike coverage while wrapping a partial completion", async () => {
+		const tool = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const longTask = "A completed task whose display text safely wraps across multiple physical rows";
+		const result = {
+			content: [{ type: "text", text: "summary" }],
+			details: {
+				op: "done",
+				storage: "memory" as const,
+				phases: [
+					{
+						name: "Wrap",
+						tasks: [
+							{ content: longTask, status: "completed" as const },
+							{ content: "Stable completed", status: "completed" as const },
+						],
+					},
+				],
+				completedTasks: [{ phase: "Wrap", content: longTask }],
+			},
+		} satisfies { content: { type: "text"; text: string }[]; details: TodoToolDetails };
 		const ansiTheme = {
 			fg: (_name: string, text: string) => text,
 			bold: (text: string) => text,
 			strikethrough: (text: string) => `\u001b[9m${text}\u001b[29m`,
-		} as Theme;
-		const rendered = await renderCompletionFrame(8, { content, theme: ansiTheme, width: 24, includeSecond: false });
-		const expected = Math.ceil(([...`[✓] ${content}`].length * 6) / 12);
-		const physicalLines = rendered.split("\n").slice(1);
-		// The first source-space is carried into the SGR-9 padding after the marker by pi-tui's word wrapper.
-		const markerSpaceIsStruck = physicalLines[0]?.startsWith("  \u001b[9m[✓]") ?? false;
-		let struck = markerSpaceIsStruck ? 1 : 0;
-		let seenUnstruck = false;
-		for (const physicalLine of physicalLines) {
-			// SGR 9 may carry into padding at wraps (pre-existing pi-tui behavior); task glyphs only matter here.
-			const taskPart = physicalLine.replace(/^\s+/, "").replace(/\s+$/, "");
-			let active = false;
-			for (let index = 0; index < taskPart.length; ) {
-				if (taskPart.startsWith("\u001b[9m", index)) {
-					active = true;
-					index += 4;
-					continue;
+		};
+		const animatedContext: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: longTask },
+			toolCallId: "todo-wrap-animated",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: 8,
+		};
+		const settledContext: ToolRenderContext<unknown, TodoParams> = {
+			args: { op: "done", task: longTask },
+			toolCallId: "todo-wrap-settled",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: undefined,
+			cwd: REPO_ROOT,
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			isError: false,
+			spinnerFrame: undefined,
+		};
+		const animatedLines = tool
+			.renderResult(result, { expanded: false, isPartial: false }, ansiTheme as never, animatedContext)
+			.render(24);
+		const settledLines = tool
+			.renderResult(result, { expanded: false, isPartial: false }, ansiTheme as never, settledContext)
+			.render(24);
+		const strikeCoverage = (lines: readonly string[]) => {
+			let striking = false;
+			return lines.map((physicalLine) => {
+				const line = physicalLine.trim();
+				let coverage = 0;
+				for (let index = 0; index < line.length; ) {
+					if (line.startsWith("\u001b[9m", index)) {
+						striking = true;
+						index += "\u001b[9m".length;
+						continue;
+					}
+					if (line.startsWith("\u001b[29m", index)) {
+						striking = false;
+						index += "\u001b[29m".length;
+						continue;
+					}
+					const glyph = String.fromCodePoint(line.codePointAt(index) ?? 0);
+					if (striking) coverage += 1;
+					index += glyph.length;
 				}
-				if (taskPart.startsWith("\u001b[29m", index)) {
-					active = false;
-					index += 5;
-					continue;
+				return coverage;
+			});
+		};
+		const stableLineIndex = (lines: readonly string[]) =>
+			lines.findIndex((line) => stripAnsi(line).trim().includes("Stable completed"));
+		const animatedStableIndex = stableLineIndex(animatedLines);
+		const settledStableIndex = stableLineIndex(settledLines);
+		if (animatedStableIndex < 0 || settledStableIndex < 0) throw new Error("Expected the stable completed row");
+		const animatedCoverage = strikeCoverage(animatedLines);
+		const settledCoverage = strikeCoverage(settledLines);
+
+		const fullDisplayLine = `[✓] ${longTask}`;
+		const expectedRevealCount = Math.ceil(([...fullDisplayLine].length * 6) / 12);
+		const wrappedRevealCount = animatedCoverage
+			.slice(0, animatedStableIndex)
+			.reduce((total, coverage) => total + coverage, 0);
+		// Text's physical rows reserve the two-space tree indentation before the SGR span.
+		expect(wrappedRevealCount + 2).toBe(expectedRevealCount);
+		expect(animatedCoverage[animatedStableIndex]).toBe(settledCoverage[settledStableIndex]);
+
+		// Positional assertion: within the animated task's wrapped rows, no glyph beyond
+		// the reveal boundary is struck — struck flags form a contiguous prefix.
+		const strikeFlags = (lines: readonly string[]) => {
+			let striking = false;
+			return lines.map((physicalLine) => {
+				// Mirror strikeCoverage: each physical row reserves tree indentation; strip
+				// it (and end padding) so flags track only display-line glyphs.
+				const line = physicalLine.trim();
+				const flags: boolean[] = [];
+				for (let index = 0; index < line.length; ) {
+					if (line.startsWith("\u001b[9m", index)) {
+						striking = true;
+						index += "\u001b[9m".length;
+						continue;
+					}
+					if (line.startsWith("\u001b[29m", index)) {
+						striking = false;
+						index += "\u001b[29m".length;
+						continue;
+					}
+					const glyph = String.fromCodePoint(line.codePointAt(index) ?? 0);
+					flags.push(striking);
+					index += glyph.length;
 				}
-				const glyph = String.fromCodePoint(taskPart.codePointAt(index) ?? 0);
-				if (active) {
-					expect(seenUnstruck).toBe(false);
-					struck += 1;
-				} else if (glyph.trim() !== "") {
-					seenUnstruck = true;
-				}
-				index += glyph.length;
-			}
-		}
-		expect(struck).toBe(expected);
+				return flags;
+			});
+		};
+		const animatedFlags = (() => {
+			// Restrict to the animated task's own wrapped rows: from the first struck row
+			// to the stable completed row (excludes the unstruck phase header above it).
+			const firstStruck = animatedCoverage.findIndex((coverage) => coverage > 0);
+			if (firstStruck < 0) throw new Error("Expected a struck row");
+			return strikeFlags(animatedLines.slice(firstStruck, animatedStableIndex)).flatMap((flags) => flags);
+		})();
+		const firstUnstruck = animatedFlags.indexOf(false);
+		const struckBeyondBoundary = firstUnstruck >= 0 && animatedFlags.slice(firstUnstruck + 1).some((flag) => flag);
+		expect(struckBeyondBoundary).toBe(false);
 	});
 
 	it("registers exactly one todo tool with the op schema", async () => {

--- a/packages/coding-agent/test/todo-strike.test.ts
+++ b/packages/coding-agent/test/todo-strike.test.ts
@@ -3,52 +3,93 @@ import {
 	hasCompletedTodoTasks,
 	partialStrikethrough,
 	strikeRevealCount,
+	TODO_STRIKE_HOLD_FRAMES,
 	TODO_STRIKE_TOTAL_FRAMES,
 } from "../src/modes/interactive/components/todo-strike.ts";
 
 const markerStrike = (text: string): string => `<s>${text}</s>`;
 
-describe("todo strike helpers", () => {
-	test("returns undefined when the animation frame is undefined", () => {
-		expect(strikeRevealCount("abcdefghijkl", undefined)).toBeUndefined();
+describe("strikeRevealCount", () => {
+	test("undefined frame returns undefined", () => {
+		expect(strikeRevealCount("abc", undefined)).toBeUndefined();
 	});
 
-	test("holds the strike reveal for the initial frames", () => {
-		for (const frame of [0, 1, 2]) {
-			expect(strikeRevealCount("abcdefghijkl", frame)).toBe(0);
-		}
+	test("hold frames 0, 1, 2 return 0", () => {
+		expect(strikeRevealCount("abc", 0)).toBe(0);
+		expect(strikeRevealCount("abc", 1)).toBe(0);
+		expect(strikeRevealCount("abc", 2)).toBe(0);
+		expect(strikeRevealCount("abc", TODO_STRIKE_HOLD_FRAMES)).toBe(0);
 	});
 
-	test("reveals one character on the first reveal frame", () => {
-		expect(strikeRevealCount("abcdefghijkl", 3)).toBe(1);
+	test("frame 3 with 12-char text reveals 1 code point", () => {
+		expect(strikeRevealCount("123456789012", 3)).toBe(1);
 	});
 
-	test("reveals all characters at the total frame and beyond", () => {
-		expect(strikeRevealCount("abcdefghijkl", TODO_STRIKE_TOTAL_FRAMES)).toBe(12);
-		expect(strikeRevealCount("abcdefghijkl", TODO_STRIKE_TOTAL_FRAMES + 1)).toBe(12);
+	test("frame >= TOTAL reveals full length", () => {
+		expect(strikeRevealCount("abc", TODO_STRIKE_TOTAL_FRAMES)).toBe(3);
+		expect(strikeRevealCount("abc", TODO_STRIKE_TOTAL_FRAMES + 5)).toBe(3);
 	});
 
-	test("returns undefined for empty text after the hold frames", () => {
-		expect(strikeRevealCount("", 3)).toBeUndefined();
+	test("empty string returns undefined for a revealing frame", () => {
+		expect(strikeRevealCount("", TODO_STRIKE_HOLD_FRAMES + 1)).toBeUndefined();
 	});
 
-	test("counts Unicode code points rather than UTF-16 code units", () => {
-		expect(strikeRevealCount("ab🎉cd", 8)).toBe(3);
+	test("splits on code points, not UTF-16 units", () => {
+		// "ab🎉cd" is 5 code points but 6 UTF-16 code units (🎉 is a surrogate pair).
+		const text = "ab🎉cd";
+		expect([...text].length).toBe(5);
+		// Full reveal reports 5 code points, not 6 UTF-16 units.
+		expect(strikeRevealCount(text, TODO_STRIKE_TOTAL_FRAMES)).toBe(5);
+		// First reveal step: ceil(5 * 1 / 12) = 1 code point.
+		expect(strikeRevealCount(text, TODO_STRIKE_HOLD_FRAMES + 1)).toBe(1);
+	});
+});
+
+describe("partialStrikethrough", () => {
+	test("visibleChars <= 0 returns text unchanged", () => {
+		expect(partialStrikethrough("abc", 0, markerStrike)).toBe("abc");
+		expect(partialStrikethrough("abc", -3, markerStrike)).toBe("abc");
+	});
+
+	test("visibleChars >= length strikes the whole text", () => {
+		expect(partialStrikethrough("abc", 3, markerStrike)).toBe("<s>abc</s>");
+		expect(partialStrikethrough("abc", 10, markerStrike)).toBe("<s>abc</s>");
+	});
+
+	test("mid boundary strikes the prefix only", () => {
+		expect(partialStrikethrough("abc", 2, markerStrike)).toBe("<s>ab</s>c");
+	});
+
+	test("splits on code points, not UTF-16 units", () => {
+		// visibleChars=3 strikes "ab🎉" (3 code points), leaving "cd" unstriked.
 		expect(partialStrikethrough("ab🎉cd", 3, markerStrike)).toBe("<s>ab🎉</s>cd");
 	});
+});
 
-	test("applies partial strikethrough at the boundary values", () => {
-		expect(partialStrikethrough("abcd", 0, markerStrike)).toBe("abcd");
-		expect(partialStrikethrough("abcd", 2, markerStrike)).toBe("<s>ab</s>cd");
-		expect(partialStrikethrough("abcd", 4, markerStrike)).toBe("<s>abcd</s>");
+describe("hasCompletedTodoTasks", () => {
+	test("true when completedTasks is a non-empty array", () => {
+		expect(hasCompletedTodoTasks({ completedTasks: [{ label: "x" }] })).toBe(true);
 	});
 
-	test("recognizes non-empty completed task arrays structurally", () => {
-		expect(hasCompletedTodoTasks({ completedTasks: [{ content: "done" }] })).toBe(true);
+	test("false when completedTasks is an empty array", () => {
 		expect(hasCompletedTodoTasks({ completedTasks: [] })).toBe(false);
-		expect(hasCompletedTodoTasks({})).toBe(false);
+	});
+
+	test("false when completedTasks is missing", () => {
+		expect(hasCompletedTodoTasks({ other: 1 })).toBe(false);
+	});
+
+	test("false for null", () => {
 		expect(hasCompletedTodoTasks(null)).toBe(false);
-		expect(hasCompletedTodoTasks(false)).toBe(false);
-		expect(hasCompletedTodoTasks("not details")).toBe(false);
+	});
+
+	test("false for non-object primitives", () => {
+		expect(hasCompletedTodoTasks(42)).toBe(false);
+		expect(hasCompletedTodoTasks("str")).toBe(false);
+		expect(hasCompletedTodoTasks(undefined)).toBe(false);
+	});
+
+	test("false when completedTasks is not an array", () => {
+		expect(hasCompletedTodoTasks({ completedTasks: "nope" })).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -43,6 +43,70 @@ function createFakeTuiWithRenderSpy(requestRender: () => void): TUI {
 	} as TUI;
 }
 
+function createCompletedTodoResult(isError = false): Parameters<ToolExecutionComponent["updateResult"]>[0] {
+	return {
+		content: [{ type: "text" as const, text: "ok" }],
+		details: {
+			op: "done",
+			phases: [{ name: "P", tasks: [{ content: "t", status: "completed" }] }],
+			storage: "memory" as const,
+			completedTasks: [{ phase: "P", content: "t" }],
+		},
+		isError,
+	};
+}
+
+function getSpinnerFrame(component: ToolExecutionComponent): number | undefined {
+	return (component as unknown as { spinnerFrame?: number }).spinnerFrame;
+}
+
+function captureTodoTool(): ToolDefinition<typeof TODO_PARAMS_SCHEMA> {
+	let capturedTool: ToolDefinition<typeof TODO_PARAMS_SCHEMA> | undefined;
+	const pi = {
+		registerTool(tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA>) {
+			capturedTool = tool;
+		},
+		appendEntry() {},
+	};
+	registerTodoTool(pi as unknown as ExtensionAPI, {
+		getCurrentPhases: () => [],
+		setCurrentPhases: () => {},
+		syncWidget: () => {},
+	});
+	if (!capturedTool) throw new Error("Expected todo tool registration");
+	return capturedTool;
+}
+
+type InteractiveModeStopThis = {
+	streamingReveal: { stop(): void };
+	toolResultReveal: { stop(): void };
+	settingsManager: { getShowTerminalProgress(): boolean };
+	ui: { terminal: { setProgress(value: boolean): void }; stop(): void };
+	clearStatusIndicator(): void;
+	clearPendingTools(): void;
+	stopChatToolAnimations(): void;
+	clearActiveToolExecutionStatus(): void;
+	clearToolHookStatuses(): void;
+	themeController: { disableAutoSync(): void };
+	clearExtensionTerminalInputListeners(): void;
+	footer: { dispose(): void };
+	footerDataProvider: { dispose(): void };
+	unsubscribe: (() => void) | undefined;
+	isInitialized: boolean;
+	unregisterSignalHandlers(): void;
+};
+type InteractiveModeStopPrototype = {
+	stop(this: InteractiveModeStopThis): void;
+};
+type StopChatToolAnimationsThis = {
+	chatContainer: Container;
+	ui: Pick<TUI, "requestRender">;
+};
+
+type StopChatToolAnimationsPrototype = {
+	stopChatToolAnimations(this: StopChatToolAnimationsThis): void;
+};
+
 const markerTheme = {
 	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
 	bg: (name: string, text: string) => `<bg:${name}>${text}</bg:${name}>`,
@@ -698,243 +762,217 @@ describe("ToolExecutionComponent parity", () => {
 			expect(collapsed.indexOf(":120-329")).toBeLessThan(collapsed.indexOf("to expand"));
 		});
 	}
-});
 
-function completedTodoResult(isError = false) {
-	return {
-		content: [{ type: "text" as const, text: "ok" }],
-		details: {
-			op: "done",
-			phases: [{ name: "P", tasks: [{ content: "t", status: "completed" as const }] }],
-			storage: "memory" as const,
-			completedTasks: [{ phase: "P", content: "t" }],
-		},
-		isError,
-	};
-}
-
-function createTodoComponent(
-	requestRender = vi.fn(),
-	toolDefinition: ToolDefinition = createBaseToolDefinition("todo"),
-) {
-	return new ToolExecutionComponent(
-		"todo",
-		"todo-strike",
-		{},
-		{},
-		toolDefinition,
-		createFakeTuiWithRenderSpy(requestRender),
-		process.cwd(),
-	);
-}
-
-function captureTodoTool(): ToolDefinition<typeof TODO_PARAMS_SCHEMA> {
-	let capturedTool: ToolDefinition<typeof TODO_PARAMS_SCHEMA> | undefined;
-	const mockPi = {
-		registerTool(tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA>) {
-			capturedTool = tool;
-		},
-		appendEntry() {},
-	} as Pick<ExtensionAPI, "registerTool" | "appendEntry"> as ExtensionAPI;
-
-	registerTodoTool(mockPi, {
-		getCurrentPhases: () => [],
-		setCurrentPhases: () => {},
-		syncWidget: () => {},
-	});
-	if (!capturedTool) throw new Error("Expected todo tool to be registered");
-	return capturedTool;
-}
-
-describe("ToolExecutionComponent todo completion strike animation", () => {
-	test("animates completed todo tasks through all strike frames and settles", () => {
+	test("animates completed todo tasks through the strike reveal and settles", () => {
 		vi.useFakeTimers();
 		try {
 			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-happy",
+				{},
+				{},
+				createBaseToolDefinition("todo"),
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
 			component.markExecutionStarted();
-			component.updateResult(completedTodoResult());
-			const rendersBeforeFrame = requestRender.mock.calls.length;
+			component.updateResult(createCompletedTodoResult(), false);
 
+			const rendersBeforeFrame = requestRender.mock.calls.length;
 			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
 			expect(requestRender.mock.calls.length).toBeGreaterThan(rendersBeforeFrame);
 
-			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS * TODO_STRIKE_TOTAL_FRAMES);
-			const rendersAfterSettle = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(650);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterSettle);
+			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS * (TODO_STRIKE_TOTAL_FRAMES + 1));
+			const rendersAfterCompletion = requestRender.mock.calls.length;
+			vi.advanceTimersByTime(2_000);
+			expect(requestRender.mock.calls.length).toBe(rendersAfterCompletion);
+			expect(getSpinnerFrame(component)).toBeUndefined();
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	test("does not animate errored todo results", () => {
+	const todoAnimationScenarios: Array<{
+		title: string;
+		result: Parameters<ToolExecutionComponent["updateResult"]>[0];
+		isPartial: boolean;
+	}> = [
+		{ title: "does not animate errored todo results", result: createCompletedTodoResult(true), isPartial: false },
+		{
+			title: "does not animate todo results without completedTasks",
+			result: {
+				content: [{ type: "text" as const, text: "ok" }],
+				details: { op: "done", phases: [], storage: "memory" },
+				isError: false,
+			},
+			isPartial: false,
+		},
+		{
+			title: "does not animate todo results with empty completedTasks",
+			result: {
+				content: [{ type: "text" as const, text: "ok" }],
+				details: { op: "done", phases: [], storage: "memory", completedTasks: [] },
+				isError: false,
+			},
+			isPartial: false,
+		},
+		{ title: "does not animate partial todo results", result: createCompletedTodoResult(), isPartial: true },
+	];
+	for (const scenario of todoAnimationScenarios) {
+		test(scenario.title, () => {
+			vi.useFakeTimers();
+			try {
+				const requestRender = vi.fn();
+				const component = new ToolExecutionComponent(
+					"todo",
+					`tool-todo-strike-${scenario.title}`,
+					{},
+					{},
+					createBaseToolDefinition("todo"),
+					createFakeTuiWithRenderSpy(requestRender),
+					process.cwd(),
+				);
+				component.markExecutionStarted();
+				component.updateResult(scenario.result, scenario.isPartial);
+				requestRender.mockClear();
+				vi.advanceTimersByTime(2_000);
+				expect(requestRender).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	}
+
+	test("stops completed todo strike animation on stopAnimation and dispose", () => {
 		vi.useFakeTimers();
 		try {
-			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
-			component.markExecutionStarted();
-			component.updateResult(completedTodoResult(true));
-			const rendersAfterResult = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
+			for (const teardown of [
+				(component: ToolExecutionComponent) => component.stopAnimation(),
+				(component: ToolExecutionComponent) => component.dispose(),
+			]) {
+				const requestRender = vi.fn();
+				const component = new ToolExecutionComponent(
+					"todo",
+					"tool-todo-strike-teardown",
+					{},
+					{},
+					createBaseToolDefinition("todo"),
+					createFakeTuiWithRenderSpy(requestRender),
+					process.cwd(),
+				);
+				component.markExecutionStarted();
+				component.updateResult(createCompletedTodoResult(), false);
+				teardown(component);
+				requestRender.mockClear();
+				vi.advanceTimersByTime(2_000);
+				expect(requestRender).not.toHaveBeenCalled();
+			}
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	test("does not animate todo results without completed tasks", () => {
+	test("does not replay todo completion animation while rendering restored results", () => {
 		vi.useFakeTimers();
 		try {
 			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
-			component.markExecutionStarted();
-			const result = completedTodoResult();
-			result.details.completedTasks = [];
-			component.updateResult(result);
-			const rendersAfterResult = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	test("does not animate partial todo results", () => {
-		vi.useFakeTimers();
-		try {
-			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
-			component.markExecutionStarted();
-			component.updateResult(completedTodoResult(), true);
-			const rendersAfterResult = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	test("stops todo strike animation through stopAnimation", () => {
-		vi.useFakeTimers();
-		try {
-			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
-			component.markExecutionStarted();
-			component.updateResult(completedTodoResult());
-			component.stopAnimation();
-			const rendersAfterStop = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterStop);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	test("stops todo strike animation through dispose", () => {
-		vi.useFakeTimers();
-		try {
-			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
-			component.markExecutionStarted();
-			component.updateResult(completedTodoResult());
-			component.dispose();
-			const rendersAfterDispose = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterDispose);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	test("does not replay todo strike animation for rebuilt historical results", () => {
-		vi.useFakeTimers();
-		try {
-			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender, captureTodoTool());
-			component.updateResult(completedTodoResult());
-			const rendersAfterResult = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterResult);
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-restored",
+				{ op: "done", task: "t" },
+				{},
+				captureTodoTool(),
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
+			component.updateResult(createCompletedTodoResult(), false);
+			requestRender.mockClear();
+			vi.advanceTimersByTime(2_000);
+			expect(requestRender).not.toHaveBeenCalled();
 			expect(component.render(120).join("\n")).toContain(theme.strikethrough("[✓] t"));
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	test("stops completed todo strike animations when interactive mode stops", () => {
+	test("interactive mode stop wires chat tool animation teardown after clearPendingTools", () => {
+		const clearPendingTools = vi.fn();
+		const stopChatToolAnimations = vi.fn();
+		const fakeThis: InteractiveModeStopThis = {
+			streamingReveal: { stop: vi.fn() },
+			toolResultReveal: { stop: vi.fn() },
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { terminal: { setProgress: vi.fn() }, stop: vi.fn() },
+			clearStatusIndicator: vi.fn(),
+			clearPendingTools,
+			stopChatToolAnimations,
+			clearActiveToolExecutionStatus: vi.fn(),
+			clearToolHookStatuses: vi.fn(),
+			themeController: { disableAutoSync: vi.fn() },
+			clearExtensionTerminalInputListeners: vi.fn(),
+			footer: { dispose: vi.fn() },
+			footerDataProvider: { dispose: vi.fn() },
+			unsubscribe: undefined,
+			isInitialized: false,
+			unregisterSignalHandlers: vi.fn(),
+		};
+		const prototype = InteractiveMode.prototype as unknown as InteractiveModeStopPrototype;
+		prototype.stop.call(fakeThis);
+		expect(stopChatToolAnimations).toHaveBeenCalledTimes(1);
+		expect(stopChatToolAnimations.mock.invocationCallOrder[0]).toBeGreaterThan(
+			clearPendingTools.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	test("stops completed todo strike animation when interactive mode stops chat tool animations", () => {
 		vi.useFakeTimers();
 		try {
 			const requestRender = vi.fn();
-			const component = createTodoComponent(requestRender);
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-mode-stop",
+				{},
+				{},
+				createBaseToolDefinition("todo"),
+				createFakeTuiWithRenderSpy(requestRender),
+				process.cwd(),
+			);
 			component.markExecutionStarted();
-			component.updateResult(completedTodoResult());
+			component.updateResult(createCompletedTodoResult(), false);
 			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
 			const chatContainer = new Container();
 			chatContainer.addChild(component);
-			const proto = InteractiveMode.prototype as unknown as {
-				stopChatToolAnimations(this: { chatContainer: Container }): void;
-			};
-			proto.stopChatToolAnimations.call({ chatContainer });
-			const rendersAfterStop = requestRender.mock.calls.length;
-			vi.advanceTimersByTime(2000);
-			expect(requestRender.mock.calls.length).toBe(rendersAfterStop);
+			const fakeThis: StopChatToolAnimationsThis = { chatContainer, ui: { requestRender: vi.fn() } };
+			const prototype = InteractiveMode.prototype as unknown as StopChatToolAnimationsPrototype;
+			prototype.stopChatToolAnimations.call(fakeThis);
+			requestRender.mockClear();
+			vi.advanceTimersByTime(2_000);
+			expect(requestRender).not.toHaveBeenCalled();
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	test("wires stop to stop completed todo strike animations", () => {
-		const stopChatToolAnimations = vi.fn();
-		const proto = InteractiveMode.prototype as unknown as {
-			stop(this: {
-				streamingReveal: { stop(): void };
-				toolResultReveal: { stop(): void };
-				settingsManager: { getShowTerminalProgress(): boolean };
-				clearStatusIndicator(): void;
-				clearPendingTools(): void;
-				stopChatToolAnimations(): void;
-				clearActiveToolExecutionStatus(): void;
-				clearToolHookStatuses(): void;
-				themeController: { disableAutoSync(): void };
-				clearExtensionTerminalInputListeners(): void;
-				footer: { dispose(): void };
-				footerDataProvider: { dispose(): void };
-				unsubscribe: undefined;
-				isInitialized: false;
-				unregisterSignalHandlers(): void;
-			}): void;
-		};
-		proto.stop.call({
-			streamingReveal: { stop() {} },
-			toolResultReveal: { stop() {} },
-			settingsManager: { getShowTerminalProgress: () => false },
-			clearStatusIndicator() {},
-			clearPendingTools() {},
-			stopChatToolAnimations,
-			clearActiveToolExecutionStatus() {},
-			clearToolHookStatuses() {},
-			themeController: { disableAutoSync() {} },
-			clearExtensionTerminalInputListeners() {},
-			footer: { dispose() {} },
-			footerDataProvider: { dispose() {} },
-			unsubscribe: undefined,
-			isInitialized: false,
-			unregisterSignalHandlers() {},
-		});
-		expect(stopChatToolAnimations).toHaveBeenCalledTimes(1);
-	});
-
-	test("renders consecutive todo strike frames differently", () => {
+	test("invalidates memoized todo output for each strike animation frame", () => {
 		vi.useFakeTimers();
 		try {
 			const toolDefinition: ToolDefinition = {
 				...createBaseToolDefinition("todo"),
-				renderResult: (_result, _options, _theme, context) => new Text(`frame:${context.spinnerFrame}`, 0, 0),
+				renderResult: (_result, _options, _theme, context) =>
+					new Text(`frame:${String(context.spinnerFrame)}`, 0, 0),
 			};
-			const component = createTodoComponent(vi.fn(), toolDefinition);
+			const component = new ToolExecutionComponent(
+				"todo",
+				"tool-todo-strike-memo",
+				{},
+				{},
+				toolDefinition,
+				createFakeTuiWithRenderSpy(vi.fn()),
+				process.cwd(),
+			);
 			component.markExecutionStarted();
-			component.updateResult(completedTodoResult());
+			component.updateResult(createCompletedTodoResult(), false);
 			const firstFrame = component.render(120).join("\n");
 			vi.advanceTimersByTime(TODO_STRIKE_FRAME_INTERVAL_MS);
 			const secondFrame = component.render(120).join("\n");


### PR DESCRIPTION
## Summary

Follow-up to #267 (todo completion strikethrough reveal animation, merged): salvages the significantly stronger test suite built and QA-verified in the twin session behind #269. Test-only change; production code untouched. All 83 tests pass against main's implementation (verified on this branch).

Adds over the merged suite: byte-exact settled-output golden for all four task statuses (structural `padEnd(160)` padding — no literal trailing whitespace), hold/partial/settle frame boundaries, monotonic reveal counts, width-24 wrap safety with both count and positional prefix assertions, no-replay-on-rebuild using the real todotools renderer, `stopAnimation()`/`dispose()`/`InteractiveMode.stop()` teardown coverage including a `stop()` wiring-order regression, and fake-timer driver tests for error/empty/partial/self-termination/memo-invariant paths.

## Test plan

- `npx vitest --run test/todo-strike.test.ts test/tool-execution-component.test.ts test/suite/todo-extension.test.ts` — 83/83 green on this branch (run twice: pre-push and in review)
- `git diff --check origin/main` clean
- The full feature QA (real-CLI PTY evidence, F1-F4 review) was performed on #269's identical-behavior implementation; receipts in `.omo/evidence/todo-completion-strike-animation/` and `local-ignore/qa-evidence/20260721-todo-strike-anim/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened tests for the todo completion strikethrough animation to lock in renderer output and frame-by-frame behavior. Test-only changes; production code unchanged.

- **Refactors**
  - Pins byte-exact settled renderer output for all task statuses using structural padding.
  - Verifies animation boundaries: hold (0–2), partial reveal, and settle frames with monotonic counts.
  - Ensures ANSI-safe wrapping at narrow widths with both count and positional prefix checks.
  - Prevents replay on transcript rebuilds using the real `todotools` renderer.
  - Adds teardown coverage (`stopAnimation`, `dispose`, `InteractiveMode.stop` wiring) and timer-driven tests for error/empty/partial paths.

<sup>Written for commit a1226ea1de9325090bdd6e777990c7c806fe7094. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

