### PR TITLE
fix: omit invalid "custom" item ids when replaying custom tool calls to the Responses API

### DIFF
--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -261,9 +261,14 @@ export function convertResponsesMessages<TApi extends Api>(
 							input: getFreeformToolInput(toolCall.arguments),
 						} satisfies ResponseCustomToolCallItem);
 					} else {
+						// The Responses API rejects function_call input items whose id does
+						// not begin with "fc". Custom tool calls replayed without their
+						// freeform tool (e.g. compaction summarization requests) carry the
+						// "<call_id>|custom" sentinel, not a server-issued id; omit it.
+						const replayableItemId = itemId?.startsWith("fc") ? itemId : undefined;
 						output.push({
 							type: "function_call",
-							id: itemId,
+							...(replayableItemId ? { id: replayableItemId } : {}),
 							call_id: callId,
 							name: toolCall.name,
 							arguments: JSON.stringify(toolCall.arguments),

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,23 @@
 # AI Source Changes
 
+## 2026-07-22 - Omit non-"fc" item ids when replaying tool calls as function_call
+
+- `api/openai-responses-shared.ts` `convertResponsesMessages()`: a `function_call` input
+  item's `id` is now emitted only when it begins with "fc" — the Responses API rejects
+  anything else (`Invalid 'input[N].id': 'custom'. Expected an ID that begins with 'fc'.`).
+  Custom tool calls are stored with the `<call_id>|custom` sentinel (a `custom_tool_call`
+  output carries no server-issued item id), so replaying them without their freeform tool
+  registered — compaction summarization strips `freeform` from its tool list — previously
+  sent `id: "custom"` and hard-failed the whole request, tripping the compaction circuit
+  breaker. Omitting mirrors the existing different-model pairing-validation skip;
+  server-issued `fc_…` ids still replay unchanged.
+- `../test/openai-responses-custom-tools.test.ts`: sentinel omission plus a pin that
+  genuine `fc` ids survive same-model replay.
+
+### Expected merge conflict zones
+
+- LOW: `convertResponsesMessages` function_call emission branch.
+
 ## 2026-07-20 - Typed classifier stop details
 
 - Added optional typed refusal/sensitive stop details to assistant messages, preserving Anthropic classifier outcomes through streaming and faux provider errors.

--- a/packages/ai/test/openai-responses-custom-tools.test.ts
+++ b/packages/ai/test/openai-responses-custom-tools.test.ts
@@ -24,6 +24,17 @@ const model = {
 	reasoning: true,
 } as Model<"openai-responses">;
 
+function zeroUsage() {
+	return {
+		input: 1,
+		output: 1,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 2,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
 describe("openai responses custom tool support", () => {
 	it("converts freeform tools into custom response tools", () => {
 		expect(convertResponsesTools([applyPatchTool])).toEqual([
@@ -93,6 +104,101 @@ describe("openai responses custom tool support", () => {
 				name: "apply_patch",
 				output: "ok",
 			},
+		]);
+	});
+
+	it("omits the sentinel item id when replaying a custom tool call without its freeform tool", () => {
+		// processResponsesStream stores custom_tool_call blocks with the
+		// "<call_id>|custom" id sentinel. Requests that replay history without
+		// the freeform tool registered (compaction strips `freeform` from its
+		// summarization tool list) fall into the function_call branch — and the
+		// Responses API rejects any function_call item id not beginning with "fc".
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							id: "call_1|custom",
+							name: "apply_patch",
+							arguments: { input: "*** Begin Patch\n*** End Patch" },
+						},
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt-5",
+					usage: zeroUsage(),
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_1|custom",
+					toolName: "apply_patch",
+					content: [{ type: "text", text: "ok" }],
+					details: undefined,
+					isError: false,
+					timestamp: 2,
+				},
+			],
+			tools: [
+				{
+					name: "apply_patch",
+					description: "freeform stripped, as compaction summarization tools are",
+					parameters: Type.Object({ input: Type.String() }),
+				},
+			],
+		};
+
+		const items = convertResponsesMessages(model, context, new Set(["openai"]));
+		expect(items).toEqual([
+			{
+				type: "function_call",
+				call_id: "call_1",
+				name: "apply_patch",
+				arguments: JSON.stringify({ input: "*** Begin Patch\n*** End Patch" }),
+			},
+			{ type: "function_call_output", call_id: "call_1", output: "ok" },
+		]);
+		expect(items[0]).not.toHaveProperty("id");
+	});
+
+	it("keeps server-issued fc item ids on same-model function_call replay", () => {
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call_2|fc_item_2", name: "bash", arguments: { cmd: "npm test" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt-5",
+					usage: zeroUsage(),
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_2|fc_item_2",
+					toolName: "bash",
+					content: [{ type: "text", text: "ok" }],
+					details: undefined,
+					isError: false,
+					timestamp: 2,
+				},
+			],
+			tools: [],
+		};
+
+		expect(convertResponsesMessages(model, context, new Set(["openai"]))).toEqual([
+			{
+				type: "function_call",
+				id: "fc_item_2",
+				call_id: "call_2",
+				name: "bash",
+				arguments: JSON.stringify({ cmd: "npm test" }),
+			},
+			{ type: "function_call_output", call_id: "call_2", output: "ok" },
 		]);
 	});
 });

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,18 @@
 # Builtin compaction extension changes
 
+## Omit non-"fc" item ids in remote-compaction tool-call replay (2026-07-22)
+
+- `openai-remote.ts` `convertToolCall()` now spreads the replayed item `id` only when it
+  begins with "fc", matching the Responses API item-id rule. A custom tool call stored as
+  `<call_id>|custom` previously produced `id: "custom"` in remote-compaction input, which
+  the API rejects with `Invalid 'input[N].id': 'custom'`.
+- Tests: `test/compaction/openai-remote-compaction.test.ts` (sentinel omission in the
+  remote request input) and `test/compaction/custom-tool-call-id-replay.test.ts`
+  (wire-level: drives `runExtensionCompaction` against a local Responses server that
+  enforces the id rule, proving the poisoned history compacts successfully).
+
+Expected upstream conflict zones: `builtin/compaction/openai-remote.ts` `convertToolCall()`.
+
 ## Diagnosable summary-generation failures + thinking headroom (2026-07-21)
 
 - `speculative.ts` `runExtensionCompaction()` no longer collapses every non-summary

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -291,7 +291,9 @@ function convertToolCall(block: ToolCall): OpenAiFunctionCallItem {
 	const [callId = block.id, itemId] = block.id.split("|");
 	return {
 		type: "function_call",
-		...(itemId ? { id: itemId } : {}),
+		// The Responses API rejects item ids not beginning with "fc"; custom tool
+		// calls carry the "<call_id>|custom" sentinel, not a server-issued id.
+		...(itemId?.startsWith("fc") ? { id: itemId } : {}),
 		call_id: callId,
 		name: block.name,
 		arguments: JSON.stringify(block.arguments ?? {}),

--- a/packages/coding-agent/test/compaction/custom-tool-call-id-replay.test.ts
+++ b/packages/coding-agent/test/compaction/custom-tool-call-id-replay.test.ts
@@ -1,0 +1,262 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import {
+	createSpeculativeCompactionSnapshot,
+	runExtensionCompaction,
+	type SpeculativeCompactionContext,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+/**
+ * Reproduces the production failure where a compaction summarization request
+ * replayed a custom tool call (stored with the "<call_id>|custom" sentinel) as
+ * a function_call item with id "custom", and the OpenAI Responses API rejected
+ * the whole request:
+ *   Invalid 'input[166].id': 'custom'. Expected an ID that begins with 'fc'.
+ *
+ * The wiremock server applies the API's id rule to every function_call input
+ * item and answers 400 with that exact error shape when violated, so this test
+ * fails against the real wire path whenever an invalid id leaks into a request.
+ */
+
+const PROVIDER = "openai";
+const MODEL_ID = "gpt-5.4";
+const SUMMARY_TEXT = "Wiremock compaction summary: patch applied.";
+
+interface WiremockRequestBody {
+	input?: unknown;
+	model?: unknown;
+}
+
+interface InputItem {
+	type?: string;
+	id?: unknown;
+	name?: unknown;
+}
+
+function findInvalidFunctionCallId(input: unknown): { index: number; id: string } | undefined {
+	if (!Array.isArray(input)) return undefined;
+	for (let index = 0; index < input.length; index++) {
+		const item = input[index] as InputItem | null;
+		if (item?.type === "function_call" && typeof item.id === "string" && !item.id.startsWith("fc")) {
+			return { index, id: item.id };
+		}
+	}
+	return undefined;
+}
+
+function startWiremockServer(): Promise<{ url: string; bodies: WiremockRequestBody[]; stop: () => Promise<void> }> {
+	const bodies: WiremockRequestBody[] = [];
+	const server: Server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (chunk: Buffer) => chunks.push(chunk));
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			const body = (raw ? JSON.parse(raw) : {}) as WiremockRequestBody;
+			bodies.push(body);
+
+			const invalid = findInvalidFunctionCallId(body.input);
+			if (invalid) {
+				res.writeHead(400, { "content-type": "application/json" });
+				res.end(
+					JSON.stringify({
+						error: {
+							message: `Invalid 'input[${invalid.index}].id': '${invalid.id}'. Expected an ID that begins with 'fc'.`,
+							type: "invalid_request_error",
+							param: `input[${invalid.index}].id`,
+							code: "invalid_value",
+						},
+					}),
+				);
+				return;
+			}
+
+			res.writeHead(200, {
+				"content-type": "text/event-stream",
+				"cache-control": "no-cache",
+				connection: "keep-alive",
+			});
+			let seq = 0;
+			const emit = (type: string, data: Record<string, unknown>) =>
+				res.write(`event: ${type}\ndata: ${JSON.stringify({ type, sequence_number: seq++, ...data })}\n\n`);
+			const modelId = typeof body.model === "string" ? body.model : MODEL_ID;
+			const responseId = "resp_wiremock";
+			const itemId = "msg_wiremock";
+			emit("response.created", {
+				response: { id: responseId, object: "response", status: "in_progress", model: modelId, output: [] },
+			});
+			emit("response.output_item.added", {
+				output_index: 0,
+				item: { id: itemId, type: "message", status: "in_progress", role: "assistant", content: [] },
+			});
+			emit("response.content_part.added", {
+				item_id: itemId,
+				output_index: 0,
+				content_index: 0,
+				part: { type: "output_text", text: "", annotations: [] },
+			});
+			emit("response.output_text.delta", {
+				item_id: itemId,
+				output_index: 0,
+				content_index: 0,
+				delta: SUMMARY_TEXT,
+			});
+			const doneItem = {
+				id: itemId,
+				type: "message",
+				status: "completed",
+				role: "assistant",
+				content: [{ type: "output_text", text: SUMMARY_TEXT, annotations: [] }],
+			};
+			emit("response.output_item.done", { output_index: 0, item: doneItem });
+			emit("response.completed", {
+				response: {
+					id: responseId,
+					object: "response",
+					status: "completed",
+					model: modelId,
+					output: [doneItem],
+					usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+				},
+			});
+			res.end();
+		});
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address() as AddressInfo;
+			resolve({
+				url: `http://127.0.0.1:${address.port}/v1`,
+				bodies,
+				stop: () => new Promise((done) => server.close(() => done())),
+			});
+		});
+	});
+}
+
+function createWiremockContext(serverUrl: string): SpeculativeCompactionContext {
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey(PROVIDER, "wiremock-key");
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	modelRegistry.registerProvider(PROVIDER, {
+		baseUrl: serverUrl,
+		apiKey: "wiremock-key",
+		api: "openai-responses",
+		models: [
+			{
+				id: MODEL_ID,
+				name: "GPT-5.4",
+				api: "openai-responses",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 200_000,
+				maxTokens: 16_384,
+				baseUrl: serverUrl,
+			},
+		],
+	});
+	const model = modelRegistry.find(PROVIDER, MODEL_ID);
+	if (!model) throw new Error("wiremock model registration failed");
+
+	const sessionManager = SessionManager.inMemory();
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "first user ".repeat(12_000) }],
+		timestamp: Date.now() - 3_000,
+	});
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{ type: "text", text: "Applying the patch now." },
+			{
+				type: "toolCall",
+				id: "call_patch|custom",
+				name: "apply_patch",
+				arguments: { input: "*** Begin Patch\n*** End Patch" },
+			},
+		],
+		api: "openai-responses",
+		provider: PROVIDER,
+		model: MODEL_ID,
+		usage: {
+			input: 50_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 50_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now() - 2_000,
+	};
+	sessionManager.appendMessage(assistant);
+	sessionManager.appendMessage({
+		role: "toolResult",
+		toolCallId: "call_patch|custom",
+		toolName: "apply_patch",
+		content: [{ type: "text", text: "patch applied" }],
+		isError: false,
+		timestamp: Date.now() - 1_500,
+	});
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "second user ".repeat(12_000) }],
+		timestamp: Date.now() - 1_000,
+	});
+
+	return {
+		model,
+		modelRegistry,
+		sessionManager,
+		getContextUsage: () => ({ tokens: 50_000, contextWindow: 200_000, percent: 25 }),
+		getMessageRevision: () => 1,
+		applyCompaction: async () => ({ applied: true, reason: "ok" }),
+	};
+}
+
+describe("compaction replay of custom tool calls over the wire", () => {
+	let server: { url: string; bodies: WiremockRequestBody[]; stop: () => Promise<void> } | undefined;
+
+	afterEach(async () => {
+		await server?.stop();
+		server = undefined;
+	});
+
+	it("replays a custom-tool-call history without invalid Responses item ids", async () => {
+		server = await startWiremockServer();
+		const context = createWiremockContext(server.url);
+		// getSummarizationTools() strips `freeform` — mirror that exact shape.
+		const snapshot = createSpeculativeCompactionSnapshot(context, {
+			generation: 1,
+			tools: [
+				{
+					name: "apply_patch",
+					description: "Apply a patch to files.",
+					parameters: Type.Object({ input: Type.String() }),
+				},
+			],
+		});
+		expect(snapshot).toBeDefined();
+		if (!snapshot) return;
+
+		const result = await runExtensionCompaction(context, snapshot, undefined);
+
+		expect(result?.summary).toBe(SUMMARY_TEXT);
+		expect(server.bodies.length).toBeGreaterThan(0);
+		const inputs = server.bodies.flatMap((body) => (Array.isArray(body.input) ? (body.input as InputItem[]) : []));
+		// Vacuous-test guard: the poisoned call must actually reach the wire.
+		expect(inputs.some((item) => item.type === "function_call" && item.name === "apply_patch")).toBe(true);
+		for (const item of inputs) {
+			if (item.type === "function_call" && typeof item.id === "string") {
+				expect(item.id.startsWith("fc")).toBe(true);
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -146,6 +146,79 @@ describe("OpenAI remote compaction", () => {
 		]);
 	});
 
+	it("omits the sentinel id when replaying a custom tool call as a function call", () => {
+		// Custom tool calls are stored with the "<call_id>|custom" id sentinel
+		// (processResponsesStream). The Responses API rejects any function_call
+		// item id not beginning with "fc", so the remote-compaction replay must
+		// omit the sentinel instead of failing the whole compaction request.
+		const branch: SessionEntry[] = [
+			{
+				type: "model_change",
+				id: "model",
+				parentId: null,
+				timestamp: new Date(1_775_000_000_000).toISOString(),
+				provider: "openai",
+				modelId: "gpt-5.4",
+			},
+			messageEntry("u1", "model", {
+				role: "user",
+				content: [{ type: "text", text: "Patch it." }],
+				timestamp: 1,
+			}),
+			messageEntry("a1", "u1", {
+				role: "assistant",
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-5.4",
+				content: [
+					{
+						type: "toolCall",
+						id: "call_patch|custom",
+						name: "apply_patch",
+						arguments: { input: "*** Begin Patch\n*** End Patch" },
+					},
+				],
+				usage: {
+					input: 100,
+					output: 20,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 120,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: 2,
+			}),
+			messageEntry("t1", "a1", {
+				role: "toolResult",
+				toolCallId: "call_patch|custom",
+				toolName: "apply_patch",
+				content: [{ type: "text", text: "patch applied" }],
+				isError: false,
+				timestamp: 3,
+			}),
+		];
+
+		const request = createOpenAiRemoteCompactionRequest({
+			model: OPENAI_MODEL,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+
+		expect(request?.body.input).toContainEqual({
+			type: "function_call",
+			call_id: "call_patch",
+			name: "apply_patch",
+			arguments: JSON.stringify({ input: "*** Begin Patch\n*** End Patch" }),
+		});
+		expect(request?.body.input).toContainEqual({
+			type: "function_call_output",
+			call_id: "call_patch",
+			output: "patch applied",
+		});
+	});
+
 	it("builds a Codex-style Responses WebSocket compaction payload", () => {
 		const request = createOpenAiRemoteCompactionRequest({
 			model: OPENAI_MODEL,


### PR DESCRIPTION
## Summary

A Codex (OpenAI Responses API) session that overflows its context window can no longer compact: every compaction attempt fails with `Compaction rejected: compaction generator failed: Invalid 'input[N].id': 'custom'. Expected an ID that begins with 'fc'.` and the circuit breaker bricks the session.

Root cause: custom tool calls (e.g. the `apply_patch` freeform tool) are stored with the tool-call id sentinel `<call_id>|custom` — the Responses API issues no `fc_…` item id for `custom_tool_call` output. The compaction summarization request replays history as native messages with a tool list that strips `freeform`, so the replay can no longer recognize the call as a custom tool and emits it as a `function_call` input item carrying `id: "custom"`, which the API rejects outright. The same sentinel leaks through the OpenAI remote-compaction replay path.

Fix: both replay converters now emit a `function_call` item `id` only when it begins with `fc` (the API's documented id rule); otherwise the id is omitted — the same degradation the codebase already uses for different-model replay to dodge id-pairing validation. Genuine server-issued `fc_…` ids replay unchanged.

## Changes

- **`packages/ai` — shared Responses conversion:** `convertResponsesMessages()` emits `id` on `function_call` input items only when it starts with `fc`. Covers `openai-responses`, `openai-codex-responses` (incl. the WebSocket delta-continuation path), and `azure-openai-responses`, plus every caller that replays history without the freeform tool registered (compaction, title generation, branch summaries).
- **`packages/coding-agent` — remote compaction:** `convertToolCall()` in `builtin/compaction/openai-remote.ts` applies the same rule when building the remote-compaction request input.
- **Tests:**
  - `packages/ai/test/openai-responses-custom-tools.test.ts`: sentinel omission for `call_1|custom` without the freeform tool, plus a pin that `fc_…` ids survive same-model replay.
  - `packages/coding-agent/test/compaction/openai-remote-compaction.test.ts`: remote-compaction input contains the call as `function_call` with no `id`.
  - `packages/coding-agent/test/compaction/custom-tool-call-id-replay.test.ts` (new): drives the real `runExtensionCompaction` against a local Responses server that enforces the API id rule — fails with the exact production error before the fix, compacts successfully after.
- **Changelog bookkeeping:** `packages/ai/src/changes.md` and `builtin/compaction/changes.md` entries per repo convention.

## QA & Evidence

- **What was tested:** RED→GREEN unit/integration tests above (failing-first proofs captured: `id: "custom"` in conversion output; `OpenAI API error (400): Invalid 'input[3].id': 'custom'` over the real wire path).
- **Observed result:** all three suites green; neighboring Responses-replay suites (model-switch characterization/policy, partial-json cleanup, tool-pair-guard, speculative/remote compaction) green.
- **What was tested:** `npm run check` (biome, tsgo, import/pinned-deps/shrinkwrap gates, browser-smoke, web-ui, check:neo).
- **Observed result:** exit 0.
- **What was tested:** full `npm test` (all workspaces, sequential run).
- **Observed result:** green (see Risks for the one caveat).
- **What was tested:** real CLI via the senpi-qa harness in an isolated sandbox — mock-loop `--with-tool --api openai-responses` (2-turn agent loop over the Responses wire), rpc-drive `--self-test`, cli-smoke `--self-test`.
- **Observed result:** 4/4, 4/4, 7/7 passed; real `~/.senpi` auth untouched.
- **Artifact:** `local-ignore/qa-evidence/20260722-custom-tool-id-replay/` (not committed, per repo rule).
- **Why sufficient:** the wire-level test reproduces the production failure verbatim (same extension entry point, same provider wire conversion, same API id rule enforced server-side), and the CLI channels prove normal Responses traffic is unaffected.

## Risks & Residuals

- **Id-pairing state:** omitting an `id` drops reasoning-item↔function-call pairing linkage for calls that never had a server-issued id — there is nothing to pair, so no regression surface. Mitigated by the existing different-model omission precedent.
- **Non-`fc` ids from other Responses-compatible providers (e.g. opencode):** now omitted rather than sent and rejected; the API contract (`begins with 'fc'`) makes any non-`fc` id a guaranteed 400, so omission is strictly safer.
- **Full-suite caveat:** an earlier `npm test` attempt raced a concurrent `npm run build` in the same worktree and showed 4 dist-resolution failures; all three files pass standalone after the build, and CI's build-before-test order removes the race.
- **`getSummarizationTools()` still strips `freeform`:** replay fidelity for custom tools during compaction could be improved (replay as `custom_tool_call`), but that is a larger behavioral change and unnecessary for correctness; deliberately out of scope.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction failures by omitting invalid item IDs when replaying custom tool calls as `function_call` items to the Responses API. Prevents 400s like “Invalid 'input[N].id': 'custom'” and unblocks Codex compaction.

- **Bug Fixes**
  - `packages/ai`: `convertResponsesMessages()` now sets `id` only if it starts with `fc`; otherwise it omits it for `function_call` items across `openai-responses` and `azure-openai-responses` replay paths.
  - `packages/coding-agent`: remote compaction `convertToolCall()` applies the same rule when building request input.
  - Tests: unit pins for sentinel omission and `fc_…` preservation, remote-compaction input check, and a wire-level regression test that reproduces and verifies the fix.

<sup>Written for commit d9edfaab6e03177d1a21d685dab38f3fea8d30a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

