### PR TITLE
fix(deps): remediate npm audit findings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
 min-release-age=2
+min-release-age-exclude=@hono/node-server@2.0.10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,12 +1524,12 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.14",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+			"integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.14.1"
+				"node": ">=20"
 			},
 			"peerDependencies": {
 				"hono": "^4"
@@ -4099,9 +4099,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -4323,15 +4323,15 @@
 			}
 		},
 		"node_modules/concurrently": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-			"integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+			"integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "4.1.2",
 				"rxjs": "7.8.2",
-				"shell-quote": "1.8.3",
+				"shell-quote": "1.9.0",
 				"supports-color": "8.1.1",
 				"tree-kill": "1.2.2",
 				"yargs": "17.7.2"
@@ -4375,19 +4375,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/concurrently/node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/content-disposition": {
@@ -5028,9 +5015,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"funding": [
 				{
 					"type": "github",
@@ -7017,9 +7004,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -7460,9 +7447,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.4",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+			"integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -9172,7 +9159,7 @@
 			"devDependencies": {
 				"@mariozechner/mini-lit": "0.2.1",
 				"@tailwindcss/cli": "4.3.0",
-				"concurrently": "9.2.1",
+				"concurrently": "9.2.4",
 				"tailwindcss": "4.3.0",
 				"typescript": "6.0.3"
 			},

--- a/package.json
+++ b/package.json
@@ -64,9 +64,13 @@
 		"get-east-asian-width": "1.6.0"
 	},
 	"overrides": {
+		"@hono/node-server": "2.0.10",
+		"brace-expansion": "5.0.7",
 		"esbuild": "0.28.1",
-		"protobufjs": "7.6.4",
+		"fast-uri": "3.1.4",
+		"protobufjs": "7.6.5",
 		"rimraf": "6.1.2",
+		"shell-quote": "1.9.0",
 		"vite": "8.0.16",
 		"ws": "8.21.0",
 		"gaxios": {

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -902,15 +902,15 @@
 			"hasInstallScript": true
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.14",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+			"integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"hono": "^4"
 			},
 			"engines": {
-				"node": ">=18.14.1"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@mariozechner/clipboard": {
@@ -1541,9 +1541,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -1945,9 +1945,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"license": "BSD-3-Clause",
 			"funding": [
 				{
@@ -2873,9 +2873,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",

--- a/packages/coding-agent/install-lock/package.json
+++ b/packages/coding-agent/install-lock/package.json
@@ -7,6 +7,7 @@
 		"@code-yeongyu/senpi": "2026.7.22"
 	},
 	"overrides": {
+		"@hono/node-server": "2.0.10",
 		"rimraf": "6.1.2",
 		"gaxios": {
 			"rimraf": "6.1.2"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -89,6 +89,7 @@
 		"@earendil-works/pi-tui"
 	],
 	"overrides": {
+		"@hono/node-server": "2.0.10",
 		"rimraf": "6.1.2",
 		"gaxios": {
 			"rimraf": "6.1.2"

--- a/packages/coding-agent/publish-deps.lock.json
+++ b/packages/coding-agent/publish-deps.lock.json
@@ -856,15 +856,15 @@
 			"hasInstallScript": true
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.14",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+			"integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"hono": "^4"
 			},
 			"engines": {
-				"node": ">=18.14.1"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@mariozechner/clipboard": {
@@ -1495,9 +1495,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -1899,9 +1899,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"license": "BSD-3-Clause",
 			"funding": [
 				{
@@ -2839,9 +2839,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -40,7 +40,7 @@
 	"devDependencies": {
 		"@mariozechner/mini-lit": "0.2.1",
 		"@tailwindcss/cli": "4.3.0",
-		"concurrently": "9.2.1",
+		"concurrently": "9.2.4",
 		"tailwindcss": "4.3.0",
 		"typescript": "6.0.3"
 	},

--- a/scripts/generate-coding-agent-install-lock.mjs
+++ b/scripts/generate-coding-agent-install-lock.mjs
@@ -26,7 +26,7 @@ const internalPackagePrefixes = ["@earendil-works/pi-", "@code-yeongyu/senpi"];
 const installPackageName = "@code-yeongyu/senpi-install";
 const allowedInstallScriptPackages = new Map([
 	["@google/genai@1.52.0", "preinstall is a no-op in the published package"],
-	["protobufjs@7.6.4", "postinstall only warns about protobufjs version scheme mismatches"],
+	["protobufjs@7.6.5", "postinstall only warns about protobufjs version scheme mismatches"],
 ]);
 
 const args = new Set(process.argv.slice(2));

--- a/scripts/generate-coding-agent-shrinkwrap.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.mjs
@@ -19,7 +19,7 @@ const shrinkwrapPath = join(repoRoot, manifestRelPath);
 const internalPackagePrefixes = ["@earendil-works/pi-", "@code-yeongyu/senpi-codemode"];
 const allowedInstallScriptPackages = new Map([
 	["@google/genai@1.52.0", "preinstall is a no-op in the published package"],
-	["protobufjs@7.6.4", "postinstall only warns about protobufjs version scheme mismatches"],
+	["protobufjs@7.6.5", "postinstall only warns about protobufjs version scheme mismatches"],
 ]);
 
 const args = new Set(process.argv.slice(2));


### PR DESCRIPTION
## Summary

- remediate every current npm advisory without downgrading MCP SDK or Google GenAI
- pin the first fixed transitive versions through exact root overrides
- upgrade the direct web-ui `concurrently` dependency
- regenerate root, publish, and installer locks
- keep the two-day package quarantine while allowing only the verified Hono security release

## Audit before

### All dependencies

- 2 critical
- 2 high
- 4 moderate
- 8 total

### Production audit

- 3 high
- 4 moderate
- 7 total

Affected nodes:

- `concurrently@9.2.1`
- `shell-quote@1.8.3` and `1.8.4`
- `brace-expansion@5.0.6`
- `fast-uri@3.1.3`
- `protobufjs@7.6.4`
- `@hono/node-server@1.19.14`
- propagated MCP SDK and Google GenAI entries

## Remediation

| Package | Before | After |
|---|---:|---:|
| `concurrently` | `9.2.1` | `9.2.4` |
| `shell-quote` | `1.8.3` / `1.8.4` | `1.9.0` |
| `brace-expansion` | `5.0.6` | `5.0.7` |
| `fast-uri` | `3.1.3` | `3.1.4` |
| `protobufjs` | `7.6.4` | `7.6.5` |
| `@hono/node-server` | `1.19.14` | `2.0.10` |

`npm audit fix --force` suggested backward MCP/GenAI versions. This PR instead
keeps `@modelcontextprotocol/sdk@1.29.0` and `@google/genai@1.52.0`, replacing
only their vulnerable transitive nodes.

`@hono/node-server@2.0.10` was newer than the repository's two-day quarantine.
Its advisory range, registry integrity/signature, maintainer, Git commit,
package contents, and `2.0.5..2.0.10` diff were reviewed. `.npmrc` excludes only
that exact package/version; the quarantine remains enabled for everything else.

The protobuf postinstall script is unchanged and only warns about protobufjs
version-scheme mismatches. Both generated-lock allowlists were moved from
`protobufjs@7.6.4` to `protobufjs@7.6.5`.

## Audit after

```text
npm audit --audit-level=low --json
0 vulnerabilities

npm audit --omit=dev --audit-level=low --json
0 vulnerabilities

npm audit signatures
520 packages have verified registry signatures
104 packages have verified attestations
```

## Verification

- clean `npm ci --ignore-scripts`: pass, 0 vulnerabilities
- root `npm run check`: pass
- root `npm run build`: pass
- full AI suite: 136 files / 1173 tests passed
- dependency-sensitive coding-agent suite: 5 files / 14 tests passed
- web-ui static check: pass
- publish dependency lock check: pass
- installer lock check: pass
- Hono 2.0.10 loopback server: HTTP 200 with expected JSON
- concurrently 9.2.4 executed two child commands
- Anthropic sandbox runtime imported with shell-quote 1.9.0
- Senpi CLI smoke: 7/7
- deterministic OpenAI Completions mock loop: pass

The complete workspace suite surfaced the existing app-server daemon
full-suite concurrency flake. The daemon, stdio, and lifecycle files passed
when run individually. Required PR CI remains the final merge gate.

QA receipt:
`local-ignore/qa-evidence/20260722-npm-audit-remediation/receipt.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all npm audit findings by upgrading `concurrently` and pinning safe transitive versions, while keeping `@modelcontextprotocol/sdk@1.29.0` and `@google/genai@1.52.0`. Adds a one-off `.npmrc` allowlist for `@hono/node-server@2.0.10` and propagates its override to coding-agent packages; audits now show 0 vulnerabilities.

- **Dependencies**
  - `@hono/node-server` 1.19.14 → 2.0.10 (override propagated to coding-agent installer and package)
  - `concurrently` 9.2.1 → 9.2.4 (web-ui)
  - `shell-quote` 1.8.3/1.8.4 → 1.9.0
  - `brace-expansion` 5.0.6 → 5.0.7
  - `fast-uri` 3.1.3 → 3.1.4
  - `protobufjs` 7.6.4 → 7.6.5
  - Added root overrides to pin the above; regenerated root, publish, and installer lockfiles.

- **Migration**
  - Ensure Node 20+ for any services using `@hono/node-server`.
  - Run `npm ci` to apply the updated locks.

<sup>Written for commit 173dc0e6fa54c2359d04d53ba12f1beb1b13f323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

