### PR TITLE
fix(config-reload): break reject-re-register synchronous recursion on restricted targets

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -107,6 +107,7 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	const subscribe = options.subscribe ?? createFsWatchEventSource();
 	const logger = options.logger ?? createConfigReloadLogger(agentDir);
 	const registrations = new Map<string, ConfigWatchRegistration>();
+	const rejectedRegistrations = new Map<string, string>();
 	const eventUnsubscribes: Array<() => void> = [];
 	const pending = new Map<string, PendingChange>();
 	let engine: ConfigReloadWatchEngine | undefined;
@@ -149,11 +150,22 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 
 	const handleRegistration = (payload: unknown): void => {
 		if (!isConfigWatchRegistration(payload)) return;
+		const fingerprint = registrationFingerprint(payload);
+		// A component may synchronously re-register from a CONFIG_WATCH_REJECTED
+		// listener (e.g. sticky-rejection recovery). Rejected registrations are
+		// never stored, so the identity guard below cannot break that recursion;
+		// ignoring an identical payload after one rejection does.
+		if (rejectedRegistrations.get(payload.id) === fingerprint) {
+			logger.debug("registration_rejection_suppressed", { registrationId: payload.id });
+			return;
+		}
 		const cwd = currentContext?.cwd ?? process.cwd();
 		if (registrationHasRestrictedTarget(payload, cwd, agentDir)) {
+			rejectedRegistrations.set(payload.id, fingerprint);
 			rejectRegistration(payload.id, ["Configuration watch target is restricted"]);
 			return;
 		}
+		rejectedRegistrations.delete(payload.id);
 
 		// A component may re-emit its unchanged registration when it receives the
 		// ready event from rebuildWatchers. Rebuilding for that same payload emits
@@ -169,6 +181,7 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 
 	const handleUnregistration = (payload: unknown): void => {
 		if (!isConfigWatchUnregistration(payload)) return;
+		rejectedRegistrations.delete(payload.id);
 		if (!registrations.delete(payload.id)) return;
 		pending.delete(payload.id);
 		logger.info("registration_removed", { id: payload.id });
@@ -732,6 +745,19 @@ function validateKeybindingsFile(path: string): string | undefined {
 	} catch (error) {
 		return `Invalid keybindings.json: ${errorMessage(error)}`;
 	}
+}
+
+function registrationFingerprint(registration: ConfigWatchRegistration): string {
+	return JSON.stringify({
+		id: registration.id,
+		displayName: registration.displayName,
+		targets: registration.targets.map((target) => ({
+			path: target.path,
+			kind: target.kind,
+			filterGlobs: target.filterGlobs ?? null,
+		})),
+		hasValidate: registration.validate !== undefined,
+	});
 }
 
 function registrationHasRestrictedTarget(

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
@@ -17,6 +17,7 @@ export type ConfigReloadLogEvent =
 	| "reload_completed"
 	| "validation_rejected"
 	| "registration_rejected"
+	| "registration_rejection_suppressed"
 	| "watcher_error"
 	| "registration_added"
 	| "registration_removed";
@@ -29,6 +30,7 @@ export interface ConfigReloadLogDetails {
 	reload_completed: { durationMs: number };
 	validation_rejected: { registrationId: string; errorCount: number };
 	registration_rejected: { registrationId: string; errorCount: number };
+	registration_rejection_suppressed: { registrationId: string };
 	watcher_error: { path: string; message: string };
 	registration_added: { id: string };
 	registration_removed: { id: string };

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,16 @@
 # Core Extensions Changes
 
+## 2026-07-22 - Config-reload rejection loop breaker
+
+### What changed
+
+- `builtin/config-reload/index.ts`: rejected watch registrations are now fingerprinted (`id`, `displayName`, `targets`, `hasValidate`) and remembered per registration id. A synchronous re-registration with an identical payload after a rejection is ignored without re-emitting `CONFIG_WATCH_REJECTED`, breaking the reject → re-register synchronous recursion that crashed startup with `RangeError: Maximum call stack size exceeded`. Acceptance and unregistration clear the recorded fingerprint, so a repaired registration with a changed payload is processed normally. Suppressions are logged once at debug level as `registration_rejection_suppressed`.
+- `test/suite/config-reload-extension.test.ts`: regression coverage for the single-rejection loop break and for post-rejection repair with a changed target.
+
+### Why
+
+External plugins that re-register synchronously from a `CONFIG_WATCH_REJECTED` listener (sticky-rejection recovery) recursed unboundedly against restricted-target rejections; the existing identity guard only covered accepted registrations re-emitted on ready, and rejected registrations were never recorded.
+
 ## 2026-07-21 - Look-at and image settings context APIs
 
 ### What changed

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -545,6 +545,79 @@ describe("config reload builtin extension", () => {
 		expect(watches.subscribeCalls.filter((path) => path === join(agentDir, "omo"))).toHaveLength(1);
 	});
 
+	it("rejects a synchronous identical re-registration once without recursing", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-rejection-loop-"));
+		agentDirs.push(agentDir);
+		writeJson(join(agentDir, "settings.json"), { theme: "dark" });
+		const bus = createEventBus();
+		const watches = createWatchProbe();
+		const extension = createManualExtension(bus);
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir }),
+		);
+		const restrictedDir = join(agentDir, "sessions");
+		const createRegistration = () => ({
+			id: "omo",
+			displayName: ".omo config",
+			targets: [{ path: restrictedDir, kind: "dir" as const }],
+		});
+		const rejected: unknown[] = [];
+		bus.on(CONFIG_WATCH_REJECTED, (payload) => {
+			rejected.push(payload);
+			bus.emit(CONFIG_WATCH_REGISTER, createRegistration());
+		});
+
+		bus.emit(CONFIG_WATCH_REGISTER, createRegistration());
+
+		expect(rejected).toHaveLength(1);
+		expect(rejected[0]).toEqual({
+			registrationId: "omo",
+			paths: [],
+			errors: ["Configuration watch target is restricted"],
+		});
+		expect(watches.subscribeCalls).not.toContain(restrictedDir);
+		expect(watches.activeListenerCount(restrictedDir)).toBe(0);
+	});
+
+	it("processes a re-registration with a changed target after a rejection", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-rejection-repair-"));
+		agentDirs.push(agentDir);
+		writeJson(join(agentDir, "settings.json"), { theme: "dark" });
+		const bus = createEventBus();
+		const watches = createWatchProbe();
+		const extension = createManualExtension(bus);
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir }),
+		);
+		const rejected: unknown[] = [];
+		bus.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+		bus.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo",
+			displayName: ".omo config",
+			targets: [{ path: join(agentDir, "sessions"), kind: "dir" }],
+		});
+		expect(rejected).toHaveLength(1);
+
+		const repairedDir = join(agentDir, "omo-config");
+		mkdirSync(repairedDir);
+		bus.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo",
+			displayName: ".omo config",
+			targets: [{ path: repairedDir, kind: "dir" }],
+		});
+
+		expect(rejected).toHaveLength(1);
+		expect(watches.activeListenerCount(repairedDir)).toBe(1);
+	});
+
 	it("buffers factory-time registrations until session_start", async () => {
 		vi.useFakeTimers();
 		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-buffer-"));


### PR DESCRIPTION
## Summary

A startup crash: when an external plugin (e.g. omo's config-watch component) registers a config-watch target that contains a restricted path (`auth.json`, `sessions/`, `logs/`) and synchronously re-registers from its `CONFIG_WATCH_REJECTED` listener, `handleRegistration` recursed unboundedly — `rejectRegistration` emits REJECTED synchronously, the listener re-emits REGISTER, and the cycle repeated until `RangeError: Maximum call stack size exceeded` killed the process on startup/resume.

The existing identity guard (`registrations.get(payload.id) === payload`) only covers **accepted** registrations re-emitted on ready; rejected registrations were never recorded, so the guard could never engage on the rejection path.

## Changes

- `packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts`
  - New `registrationFingerprint()` producing a canonical serialization of the registration-defining fields (`id`, `displayName`, `targets` with normalized key order, `hasValidate`).
  - `handleRegistration` stores the fingerprint in a new `rejectedRegistrations` map **before** emitting REJECTED; an identical re-registration returns silently (single debug-level `registration_rejection_suppressed` log, no warn spam). The loop now breaks after exactly one rejection.
  - Acceptance and `handleUnregistration` clear the fingerprint, so a genuinely changed payload (a repair) is processed normally. The existing ready-reemit identity guard is untouched.
- `packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts`: added the `registration_rejection_suppressed` debug log event.
- `packages/coding-agent/test/suite/config-reload-extension.test.ts`: two regression tests — (1) a restricted registration whose REJECTED listener synchronously re-registers an identical payload completes without recursion, emits exactly one REJECTED, and never subscribes the restricted target; (2) a re-registration with a changed target after rejection is accepted and watched. Test (1) fails on `main` (868 rejections instead of 1).
- `packages/coding-agent/src/core/extensions/changes.md`: fork-change entry.

## QA & Evidence

Evidence receipts: `local-ignore/qa-evidence/20260722-config-reload-loop/`

- `vitest-config-reload-extension.log` — scoped suite: 35/35 passed. The loop test was also verified to fail against unmodified `origin/main` source (restored via `git show`, not stash).
- `cli-smoke-selftest.log` — `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`: 7/7 passed (run from the branch worktree).
- `mock-loop-selftest.log` — `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`: 38/38 passed, zero real provider calls.
- `npm run check` green in the worktree (biome, pinned-deps, ts-imports, shrinkwrap, tsgo, browser smoke, web-ui, neo).

## Risks

- Low. The guard only affects the rejection path of `handleRegistration`; accepted-registration flow and the ready-reemit guard are unchanged. Fingerprint comparison is per-registration-id, so unrelated registrations are unaffected. A payload mutated in place and re-registered with identical defining fields after rejection is suppressed once — the same trade-off as the existing accepted-path identity guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash caused by a reject → re-register loop when a plugin watches restricted paths (e.g., auth.json, sessions/, logs/). We now fingerprint rejected registrations and suppress identical re-registrations once to break the recursion.

- **Bug Fixes**
  - Added rejection fingerprinting (id, displayName, targets, hasValidate) and `registration_rejection_suppressed` debug log.
  - Store the fingerprint before emitting REJECTED; identical retries return silently. Clearing happens on acceptance and unregistration.
  - Kept the accepted-registration identity guard unchanged.
  - Added tests to verify the loop is broken and that a changed re-registration is accepted.

<sup>Written for commit 699d60cf0a9a174c7bfaef7469c873a93622a0b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

