### PR TITLE
fix(ai): drop tool results of errored/aborted assistants in transformMessages

### DIFF
--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -235,6 +235,10 @@ export function transformMessages<TApi extends Api>(
 	const result: Message[] = [];
 	const toolResultsById = new Map<string, { message: ToolResultMessage; sourceIndex: number; consumed: boolean }[]>();
 	const nextToolCallIndexById = new Map<string, number[]>();
+	// Tool calls declared only by assistants the emit loop drops (errored/aborted).
+	// Their results must not be emitted either: a strict provider rejects a tool
+	// message whose tool_call_id no assistant in the request declares.
+	const droppedCallIds = new Set<string>();
 
 	for (let sourceIndex = 0; sourceIndex < transformed.length; sourceIndex++) {
 		const message = transformed[sourceIndex];
@@ -244,7 +248,13 @@ export function transformMessages<TApi extends Api>(
 			toolResultsById.set(message.toolCallId, entries);
 			continue;
 		}
-		if (message.role !== "assistant" || message.stopReason === "error" || message.stopReason === "aborted") {
+		if (message.role !== "assistant") {
+			continue;
+		}
+		if (message.stopReason === "error" || message.stopReason === "aborted") {
+			for (const block of message.content) {
+				if (block.type === "toolCall") droppedCallIds.add(block.id);
+			}
 			continue;
 		}
 		for (const block of message.content) {
@@ -261,7 +271,14 @@ export function transformMessages<TApi extends Api>(
 			const entry = toolResultsById
 				.get(message.toolCallId)
 				?.find((candidate) => candidate.sourceIndex === sourceIndex);
-			if (!entry?.consumed) result.push(message);
+			if (!entry?.consumed) {
+				// Skip results whose call was declared only by a dropped
+				// (errored/aborted) assistant. An id re-declared by a kept assistant
+				// still pairs through the normal windows, so keep those results.
+				if (!droppedCallIds.has(message.toolCallId) || nextToolCallIndexById.has(message.toolCallId)) {
+					result.push(message);
+				}
+			}
 			continue;
 		}
 		if (message.role !== "assistant") {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,33 @@
 # AI Source Changes
 
+## 2026-07-22 - Drop tool results of errored/aborted assistants in transformMessages
+
+### What changed and why
+
+- `api/transform-messages.ts`: the pairing pass now records the toolCall ids of every assistant it skips
+  because `stopReason === "error" | "aborted"` into `droppedCallIds` (mirroring the existing skip condition),
+  and the emit loop no longer emits a toolResult whose `toolCallId` is in that set — unless the id is also
+  declared by a kept assistant (`nextToolCallIndexById`), which still pairs through the normal windows.
+  Previously the errored assistant was dropped while its result (a real one, or a placeholder synthesized by
+  the compaction pipeline's `repairOrphanedToolResults`) survived, so the request carried a `role:"tool"`
+  message whose `tool_call_id` no assistant declared; strict providers (apitopia/kimi openai-completions)
+  reject it with `400 tool_call_id ... is not found`, permanently bricking compaction for the session.
+  True orphans (id declared nowhere) and results of kept assistants are unchanged, and kept assistants'
+  unanswered calls still get the synthetic "No result provided" result.
+- `utils/tool-pair-repair.ts`: `repairOrphanedToolResults` no longer synthesizes placeholder results for
+  toolCalls declared by errored/aborted assistants (defense in depth; those assistants are dropped by
+  `transformMessages` anyway). The coding-agent compaction copy received the identical guard; the two
+  files remain verbatim copies.
+- `../test/transform-messages-errored-tool-results.test.ts`: drop cases (errored + real result, aborted +
+  synthesized placeholder), preservation cases (kept pair, "No result provided" synthesis, true orphan
+  passthrough), and an id re-declared by a later kept assistant. `../test/tool-pair-repair.test.ts`: no
+  synthesis for errored/aborted assistants, synthesis kept for a kept re-declaration.
+
+### Expected merge conflict zones
+
+- LOW: `api/transform-messages.ts` second-pass pairing loop and toolResult emit branch;
+  `utils/tool-pair-repair.ts` dangling-call synthesis loop.
+
 ## 2026-07-21 - OpenAI Responses provider-native completion reconciliation
 
 ### What changed and why

--- a/packages/ai/src/utils/tool-pair-repair.ts
+++ b/packages/ai/src/utils/tool-pair-repair.ts
@@ -47,6 +47,9 @@ export function repairOrphanedToolResults(messages: Message[]): Message[] {
 
 		output.push(message);
 		if (message.role === "assistant") {
+			// Errored/aborted assistants are dropped downstream by transformMessages;
+			// synthesizing results for their calls would only create orphans there.
+			if (message.stopReason === "error" || message.stopReason === "aborted") continue;
 			for (const block of message.content) {
 				if (block.type !== "toolCall" || !dangling.has(block.id)) continue;
 				const incomplete = block.incomplete === true;

--- a/packages/ai/test/tool-pair-repair.test.ts
+++ b/packages/ai/test/tool-pair-repair.test.ts
@@ -225,4 +225,45 @@ describe("repairOrphanedToolResults", () => {
 		expect(synth.isError).toBe(true);
 		expect(resultText(synth)).toBe("custom truncation reason. Re-issue the tool call with complete arguments.");
 	});
+
+	it("does not synthesize a result for a dangling call of an errored assistant", () => {
+		const messages: Message[] = [
+			userMsg("run", 1),
+			{ ...assistantWithCall("call-dead", "edit", 2), stopReason: "error" as const },
+		];
+
+		const result = repairOrphanedToolResults(messages);
+
+		expect(result).toEqual(messages);
+	});
+
+	it("does not synthesize a result for a dangling call of an aborted assistant", () => {
+		const messages: Message[] = [
+			userMsg("run", 1),
+			{ ...assistantWithCall("call-dead", "edit", 2), stopReason: "aborted" as const },
+		];
+
+		const result = repairOrphanedToolResults(messages);
+
+		expect(result).toEqual(messages);
+	});
+
+	it("still synthesizes for a kept assistant re-declaring an id an errored assistant used", () => {
+		const messages: Message[] = [
+			userMsg("run", 1),
+			{ ...assistantWithCall("call-reused", "edit", 2), stopReason: "error" as const },
+			assistantWithCall("call-reused", "edit", 3),
+		];
+
+		const result = repairOrphanedToolResults(messages);
+
+		expect(result).toHaveLength(4);
+		expect(result[3]).toMatchObject({
+			role: "toolResult",
+			toolCallId: "call-reused",
+			toolName: "edit",
+			content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+			isError: false,
+		});
+	});
 });

--- a/packages/ai/test/transform-messages-errored-tool-results.test.ts
+++ b/packages/ai/test/transform-messages-errored-tool-results.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "../src/api/transform-messages.ts";
+import type { Api, AssistantMessage, Message, Model, ToolResultMessage, UserMessage } from "../src/types.ts";
+
+function makeModel(): Model<Api> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "openai-completions",
+		provider: "test",
+		baseUrl: "https://example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100000,
+		maxTokens: 4096,
+	} as Model<Api>;
+}
+
+function userMsg(text: string, timestamp: number): UserMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function assistantWithCall(
+	id: string,
+	name: string,
+	timestamp: number,
+	stopReason: AssistantMessage["stopReason"] = "toolUse",
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name, arguments: { path: "." } }],
+		api: "openai-completions",
+		provider: "test",
+		model: "test-model",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp,
+	};
+}
+
+function toolResult(id: string, name: string, timestamp: number, text = "ok"): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: name,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+describe("transformMessages errored/aborted assistant tool results", () => {
+	it("drops an errored assistant's toolCall and its real result", () => {
+		const result = transformMessages(
+			[
+				userMsg("edit the file", 1),
+				assistantWithCall("call-err", "edit", 2, "error"),
+				toolResult("call-err", "edit", 3),
+			],
+			makeModel(),
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].role).toBe("user");
+	});
+
+	it("drops an aborted assistant's toolCall and its downstream-synthesized placeholder result", () => {
+		const result = transformMessages(
+			[
+				userMsg("edit the file", 1),
+				assistantWithCall("call-aborted", "edit", 2, "aborted"),
+				toolResult("call-aborted", "edit", 3, "Tool output unavailable (context compacted)"),
+			],
+			makeModel(),
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].role).toBe("user");
+	});
+
+	it("preserves a kept assistant's toolCall and result", () => {
+		const result = transformMessages(
+			[userMsg("list files", 1), assistantWithCall("call-ok", "ls", 2), toolResult("call-ok", "ls", 3)],
+			makeModel(),
+		);
+		expect(result).toHaveLength(3);
+		expect(result[1].role).toBe("assistant");
+		expect(result[2]).toMatchObject({ role: "toolResult", toolCallId: "call-ok" });
+	});
+
+	it("still synthesizes a 'No result provided' result for a kept assistant's unanswered call", () => {
+		const result = transformMessages(
+			[userMsg("list files", 1), assistantWithCall("call-open", "ls", 2)],
+			makeModel(),
+		);
+		expect(result).toHaveLength(3);
+		const synth = result[2] as ToolResultMessage;
+		expect(synth.role).toBe("toolResult");
+		expect(synth.toolCallId).toBe("call-open");
+		expect(synth.isError).toBe(true);
+		expect(synth.content).toEqual([{ type: "text", text: "No result provided" }]);
+	});
+
+	it("keeps a result whose id a later kept assistant re-declares", () => {
+		const messages: Message[] = [
+			userMsg("go", 1),
+			assistantWithCall("call-reused", "edit", 2, "error"),
+			toolResult("call-reused", "edit", 3, "stale"),
+			assistantWithCall("call-reused", "edit", 4),
+			toolResult("call-reused", "edit", 5, "fresh"),
+		];
+		const result = transformMessages(messages, makeModel());
+		expect(result.map((m) => m.role)).toEqual(["user", "toolResult", "assistant", "toolResult"]);
+		expect((result[2] as AssistantMessage).stopReason).toBe("toolUse");
+		expect((result[3] as ToolResultMessage).content).toEqual([{ type: "text", text: "fresh" }]);
+	});
+
+	it("still emits true orphan results whose id no assistant declares", () => {
+		const result = transformMessages([userMsg("hi", 1), toolResult("call-unknown", "ls", 2)], makeModel());
+		expect(result).toHaveLength(2);
+		expect(result[1]).toMatchObject({ role: "toolResult", toolCallId: "call-unknown" });
+	});
+});

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,21 @@
 # Builtin compaction extension changes
 
+## Skip placeholder synthesis for errored/aborted assistants (2026-07-22)
+
+- `repair-tool-pairs.ts` no longer synthesizes placeholder tool results for toolCalls declared by
+  assistant messages with `stopReason "error" | "aborted"`. `transformMessages`
+  (`packages/ai/src/api/transform-messages.ts`) drops those assistants from every provider request, so a
+  synthesized placeholder became a `role:"tool"` message whose `tool_call_id` no assistant declared —
+  strict providers (apitopia/kimi openai-completions) answered `400 tool_call_id ... is not found` and the
+  session's compaction was permanently rejected. The primary fix lives in `transformMessages` (results of
+  dropped assistants are no longer emitted); this guard is defense in depth. The sibling copy
+  `packages/ai/src/utils/tool-pair-repair.ts` received the identical change; the files remain verbatim
+  copies, so the "duplicated verbatim" comments still hold.
+- Tests: `test/compaction/tool-pair-repair.test.ts` asserts no synthesis for errored/aborted assistants.
+
+Expected upstream conflict zones: `builtin/compaction/repair-tool-pairs.ts` dangling-call synthesis loop
+and the shared `packages/ai/src/utils/tool-pair-repair.ts` copy.
+
 ## Omit non-"fc" item ids in remote-compaction tool-call replay (2026-07-22)
 
 - `openai-remote.ts` `convertToolCall()` now spreads the replayed item `id` only when it

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/repair-tool-pairs.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/repair-tool-pairs.ts
@@ -47,6 +47,9 @@ export function repairOrphanedToolResults(messages: Message[]): Message[] {
 
 		output.push(message);
 		if (message.role === "assistant") {
+			// Errored/aborted assistants are dropped downstream by transformMessages;
+			// synthesizing results for their calls would only create orphans there.
+			if (message.stopReason === "error" || message.stopReason === "aborted") continue;
 			for (const block of message.content) {
 				if (block.type !== "toolCall" || !dangling.has(block.id)) continue;
 				const incomplete = block.incomplete === true;

--- a/packages/coding-agent/test/compaction/tool-pair-repair.test.ts
+++ b/packages/coding-agent/test/compaction/tool-pair-repair.test.ts
@@ -343,4 +343,19 @@ describe("compaction tool-pair repair behavior", () => {
 			});
 		});
 	});
+
+	describe("Given session with a dangling tool call on an errored/aborted assistant", () => {
+		describe("When tool-pair-repair runs", () => {
+			it("Then no synthetic result is added (transformMessages drops the assistant downstream)", () => {
+				for (const stopReason of ["error", "aborted"] as const) {
+					const messages = buildToolCallWithoutResultSession();
+					messages[1] = { ...(messages[1] as AssistantMessage), stopReason };
+
+					const reconstructed = repairOrphanedToolResults(messages);
+
+					expect(reconstructed).toEqual(messages);
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Summary

When an assistant message ends with `stopReason: "error" | "aborted"` while carrying a complete toolCall (e.g. a terminated stream persisted with a fully-formed `edit` call), `transformMessages` dropped the assistant but still emitted its toolResult. Combined with compaction's `repairOrphanedToolResults`, which synthesizes a placeholder result (`Tool output unavailable (context compacted)`) for exactly such dangling calls, the wire request contained a `role:"tool"` message whose `tool_call_id` no assistant declared. Strict providers (apitopia/kimi openai-completions) reject this with `400 tool_call_id ... is not found`, so every compaction attempt failed and the session was permanently bricked at high context.

Root-cause analysis: `local-ignore/analysis-2026-07-22-senpi-startup-and-compaction-bugs.md` (버그 3), verified end-to-end against the real session file.

## Changes

- **Primary (`packages/ai/src/api/transform-messages.ts`)** — single seam covering every adapter: the pairing pass now records the toolCall ids of assistants it skips (`stopReason "error" | "aborted"`) into `droppedCallIds`, and the emit loop no longer emits a result whose `toolCallId` is in that set — unless the id is also declared by a kept assistant (`nextToolCallIndexById`), which still pairs through the normal reused-id windows. Unchanged: true orphans (id declared nowhere) still pass through, kept assistants' results are preserved, and kept assistants' unanswered calls still get the synthetic `No result provided` result.
- **Secondary (`repair-tool-pairs.ts`, defense in depth)** — `repairOrphanedToolResults` no longer synthesizes placeholder results for toolCalls of errored/aborted assistants. Applied identically to both verbatim copies (`packages/ai/src/utils/tool-pair-repair.ts` and the compaction builtin copy); the files remain verbatim, so the "duplicated verbatim" comments still hold.
- **Tests** — new `packages/ai/test/transform-messages-errored-tool-results.test.ts` (drop errored+aborted pairs incl. downstream-synthesized placeholder; preserve kept pairs; keep `No result provided` synthesis; id re-declared by a later kept assistant; true-orphan passthrough) plus no-synthesis cases in both `tool-pair-repair` test files. The new drop tests fail on `origin/main` (verified by reverting the transform change) and pass with the fix.
- changes.md entries in `packages/ai/src/changes.md` and the compaction builtin's `changes.md`.

## QA & Evidence

Evidence dir: `local-ignore/qa-evidence/20260722-transform-orphans/`

- Ground-truth pipeline repro (real session jsonl through `prepareCompaction → convertToLlm → repairOrphanedToolResults → convertMessages` for apitopia/kimi openai-completions, no tokens): `repro-main-unfixed-baseline.txt` = `BAD tool params: 1`; `repro-worktree-fixed.txt` = `BAD tool params: 0`.
- Scoped tests: `packages/ai` transform-messages + tool-pair-repair (31 passed), `packages/coding-agent` compaction suite (170 passed). `npm run check` green.
- senpi-qa from the worktree: `mock-loop.mjs --self-test` 38/38, `cli-smoke.mjs --self-test` 7/7, `tui-smoke.mjs --self-test` 5/5 (receipts in the evidence dir).

## Risks

- Low. The only newly-dropped outputs are results whose declaring assistant is itself dropped — messages no provider could accept anyway. Reused-id windows, orphan passthrough, and kept-assistant synthesis are pinned by tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops tool results from assistants that ended with `error` or `aborted` to prevent orphan `tool_call_id`s. This avoids 400s on strict providers and stops compaction from getting stuck.

- **Bug Fixes**
  - `packages/ai/src/api/transform-messages.ts`: track tool calls from dropped assistants and skip their results; keep results if the id is re-declared by a kept assistant.
  - `packages/ai/src/utils/tool-pair-repair.ts` and `packages/coding-agent/src/core/extensions/builtin/compaction/repair-tool-pairs.ts`: `repairOrphanedToolResults` no longer synthesizes placeholders for errored/aborted assistants.
  - Tests added for transform behavior and tool-pair repair to cover drops, kept pairs, “No result provided,” id reuse, and true-orphan passthrough.

<sup>Written for commit c8eaf88959dfd04d22a13812acd574857de9bfa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

