### PR TITLE
fix(release): vendor the full runtime closure into the senpi publish tarball

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,32 @@
 # Local fork changes
 
+## 2026-07-22 — Fully self-contained publish tarball (npm packaging MODULE_NOT_FOUND fix)
+
+- Changed:
+  - `scripts/prepare-senpi-bundled-workspaces.mjs`
+  - `scripts/prepare-senpi-bundled-workspaces.test.mjs`
+  - `scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs`
+  - `scripts/publish.mjs`
+  - `scripts/AGENTS.md`
+- Why: fresh `npm i -g @code-yeongyu/senpi` (both 2026.7.20-2 and 2026.7.22) nondeterministically
+  dropped registry runtime deps (cross-spawn, which, @modelcontextprotocol/sdk), leaving the CLI
+  dead with ERR_MODULE_NOT_FOUND. The publish tarball vendored only the 5 bundled workspace
+  packages + their closure; npm arborist, forced to fetch the remaining 39 runtime deps from the
+  registry, could hit ETARGET on the registry-absent `^2026.x` workspace specs and abort reify
+  mid-flight, leaving a half-installed tree.
+- What changed: staging now vendors the ENTIRE runtime closure (all registry deps + transitives
+  from `publish-deps.lock.json`, as before via `copyPublishDependencies`) and
+  `stagePublishManifest` rewrites the publish manifest at staging time so `bundleDependencies`
+  (and the `bundledDependencies` alias) lists every staged package. All `dependencies` edges —
+  including the 5 `^2026.x` workspace specs — are preserved; with the complete bundle npm needs
+  no registry fetch at install time. `stagePublishManifest` also rejects `file:`/`link:`/
+  `workspace:` specs and any declared runtime dep missing from the staged node_modules.
+  `assertSenpiPackedWorkspaceFiles` gained a `runtimeDependencies` pack check (wired in
+  `scripts/publish.mjs`) so a tarball missing any vendored runtime dep fails before publish.
+  `publish-deps.lock.json` remains staging-only and is never shipped; no new lifecycle-script
+  dependencies were added.
+- Merge-conflict risk: low. Release tooling only; no runtime source touched.
+
 ## 2026-07-21 — Codex HEAD app-server parity documentation refresh
 
 - Changed:

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -54,6 +54,16 @@ Manages workspace packages embedded in the published `@code-yeongyu/senpi` tarba
 - Validates every `requiredFiles` entry exists before staging; aborts with a clear list on failure.
 - `@earendil-works/pi-pty` also requires `native/index.js` and a platform prebuild file.
 
+The publish tarball is fully self-contained: `copyPublishDependencies` stages the ENTIRE
+runtime closure from `publish-deps.lock.json` (all registry deps + transitives, not just the
+workspace closure) into `packages/coding-agent/node_modules`, and `stagePublishManifest`
+rewrites the publish manifest so `bundleDependencies` lists every staged package while all
+`dependencies` edges (including the registry-absent `^2026.x` workspace specs) stay intact.
+npm then needs no registry fetch at install time; the previous partial bundle let arborist
+abort reify mid-flight and drop arbitrary registry deps (ERR_MODULE_NOT_FOUND).
+Staging dirties `packages/coding-agent/package.json`; restore it with `git checkout --`
+after packing/publishing.
+
 ## check-mcp-docs.test.mjs
 
 Reads `config-schema.ts` as raw text and extracts object-literal keys rather than importing

--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -91,6 +91,71 @@ export function directNodeModulesPackageName(lockPath) {
 	return parts.length === 1 ? parts[0] : undefined;
 }
 
+export function listStagedPublishPackageNames(codingAgentNodeModules) {
+	const packageNames = [];
+	for (const entry of readdirSync(codingAgentNodeModules, { withFileTypes: true })) {
+		if (!entry.isDirectory() || entry.name.startsWith(".")) {
+			continue;
+		}
+		if (entry.name.startsWith("@")) {
+			const scopeDir = join(codingAgentNodeModules, entry.name);
+			for (const scoped of readdirSync(scopeDir, { withFileTypes: true })) {
+				if (scoped.isDirectory()) {
+					packageNames.push(`${entry.name}/${scoped.name}`);
+				}
+			}
+			continue;
+		}
+		packageNames.push(entry.name);
+	}
+	return packageNames.sort((a, b) => a.localeCompare(b));
+}
+
+// The publish tarball must be fully self-contained: every runtime dependency edge in
+// the coding-agent manifest (registry deps AND the 5 vendored workspace packages) is
+// staged into packages/coding-agent/node_modules, and bundleDependencies lists every
+// staged package. npm then never needs the registry at install time. The historical
+// partial bundle (only the 5 workspace packages + their closure) forced npm to fetch
+// the other runtime deps from the registry, where arborist nondeterministically tried
+// to resolve the registry-absent `^2026.x` workspace specs (ETARGET) and aborted reify
+// mid-flight, leaving arbitrary deps (cross-spawn, which, @modelcontextprotocol/sdk)
+// missing from the installed CLI (ERR_MODULE_NOT_FOUND).
+export function stagePublishManifest(repoRoot) {
+	const codingAgentDir = join(repoRoot, "packages/coding-agent");
+	const manifestPath = join(codingAgentDir, "package.json");
+	const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+	const stagedPackageNames = listStagedPublishPackageNames(join(codingAgentDir, "node_modules"));
+	const stagedSet = new Set(stagedPackageNames);
+
+	const runtimeDependencyFields = ["dependencies", "optionalDependencies"];
+	const missing = [];
+	for (const field of runtimeDependencyFields) {
+		for (const [name, spec] of Object.entries(manifest[field] ?? {})) {
+			if (/^(file|link|workspace):/.test(spec)) {
+				throw new Error(
+					`packages/coding-agent/package.json ${field}.${name} uses a local spec (${spec}); the published tarball must not reference local paths.`,
+				);
+			}
+			if (!stagedSet.has(name)) {
+				missing.push(name);
+			}
+		}
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`packages/coding-agent/node_modules is missing staged runtime dependencies: ${missing.join(", ")}. Run npm install before publishing.`,
+		);
+	}
+
+	manifest.bundleDependencies = stagedPackageNames;
+	// npm accepts both spellings; the checked-in manifest carries both, so keep them in sync.
+	if (manifest.bundledDependencies !== undefined) {
+		manifest.bundledDependencies = [...stagedPackageNames];
+	}
+	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, "\t")}\n`);
+	return stagedPackageNames;
+}
+
 export function copyPublishDependencies(repoRoot) {
 	// Staging manifest for the bundled publish tree. NOT npm-shrinkwrap.json: shipping a
 	// file named npm-shrinkwrap.json breaks bundleDependencies installs (see the guard in
@@ -125,6 +190,23 @@ export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
 	const nativeTargets = options.nativePrebuildTargets ?? [nativePrebuildTarget()];
 	const prebuildFiles = new Set(nativeTargets.map(nativePrebuildFile));
 	const filePaths = new Set((packed.files ?? []).map((file) => file.path));
+
+	// Every runtime dependency of the publish manifest must be vendored in the tarball.
+	// npm only packs node_modules entries reachable from bundleDependencies, so a dep
+	// missing here means it would be fetched from the registry at install time — the
+	// exact failure mode (nondeterministic ERR_MODULE_NOT_FOUND) the full bundle removes.
+	const missingRuntimeDependencies = [];
+	for (const dependencyName of options.runtimeDependencies ?? []) {
+		const packageJsonPath = `node_modules/${dependencyName}/package.json`;
+		if (!filePaths.has(`package/${packageJsonPath}`) && !filePaths.has(packageJsonPath)) {
+			missingRuntimeDependencies.push(dependencyName);
+		}
+	}
+	if (missingRuntimeDependencies.length > 0) {
+		throw new Error(
+			`senpi package tarball is missing vendored runtime dependencies: ${missingRuntimeDependencies.join(", ")}. Run scripts/prepare-senpi-bundled-workspaces.mjs before packing.`,
+		);
+	}
 
 	// npm ALWAYS packs a file literally named npm-shrinkwrap.json (files[]/.npmignore
 	// cannot exclude it). Shipped alongside bundleDependencies it is fatal: npm treats
@@ -202,6 +284,14 @@ export function prepareSenpiBundledWorkspaces(repoRoot = root) {
 			filter: (sourcePath) => shouldCopyWorkspaceFile(sourceRoot, sourcePath, workspace.sourceOnly),
 		});
 	}
+
+	// Rewrite the publish manifest LAST: bundleDependencies must mirror the staged
+	// node_modules exactly (all registry runtime deps + the 5 workspace packages), so
+	// npm pack vendors the complete runtime closure into the tarball. This dirties
+	// packages/coding-agent/package.json in the working tree; restore it with
+	// `git checkout -- packages/coding-agent/package.json` after packing/publishing.
+	const stagedPackageNames = stagePublishManifest(repoRoot);
+	console.log(`Staged ${stagedPackageNames.length} bundled packages for @code-yeongyu/senpi publish.`);
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {

--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -33,6 +33,24 @@ function writeShrinkwrap(root, packages) {
 	});
 }
 
+const BUNDLED_WORKSPACE_NAMES = [
+	"@earendil-works/pi-agent-core",
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-pty",
+	"@earendil-works/pi-tui",
+	"@code-yeongyu/senpi-codemode",
+];
+
+function writeCodingAgentManifest(root) {
+	writeJson(join(root, "packages", "coding-agent", "package.json"), {
+		name: "@code-yeongyu/senpi",
+		version: "2026.7.22",
+		dependencies: Object.fromEntries(BUNDLED_WORKSPACE_NAMES.map((name) => [name, "^2026.7.22"])),
+		bundleDependencies: [...BUNDLED_WORKSPACE_NAMES],
+		bundledDependencies: [...BUNDLED_WORKSPACE_NAMES],
+	});
+}
+
 function bundledWorkspaceFiles(workspace) {
 	if (workspace === "pty") {
 		return ["package.json", "dist/index.js", "native/index.js", nativePrebuildFile(nativePrebuildTarget())];
@@ -63,6 +81,7 @@ describe("prepareSenpiBundledWorkspaces", () => {
 		// Given
 		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-workspaces-"));
 		writeShrinkwrap(tempDir, { "": { dependencies: {} } });
+		writeCodingAgentManifest(tempDir);
 		for (const workspace of ["agent", "ai", "pty", "tui", "senpi-codemode"]) {
 			writeBundledWorkspace(tempDir, workspace);
 		}
@@ -92,6 +111,7 @@ describe("prepareSenpiBundledWorkspaces", () => {
 		// Given: every loader-visible file present, but the host native prebuild absent.
 		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-pty-prebuild-"));
 		writeShrinkwrap(tempDir, { "": { dependencies: {} } });
+		writeCodingAgentManifest(tempDir);
 		for (const workspace of ["agent", "ai", "tui", "senpi-codemode"]) {
 			writeBundledWorkspace(tempDir, workspace);
 		}
@@ -124,10 +144,50 @@ describe("prepareSenpiBundledWorkspaces", () => {
 		);
 	});
 
+	it("rewrites the publish manifest so bundleDependencies covers every staged package", () => {
+		// Given: a registry runtime dep (cross-spawn) plus its hoisted transitive (which) are
+		// installed at the repo root and enumerated by the staging lock.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-manifest-"));
+		writeShrinkwrap(tempDir, {
+			"": { dependencies: { "cross-spawn": "7.0.6" } },
+			"node_modules/cross-spawn": { version: "7.0.6" },
+			"node_modules/which": { version: "2.0.2" },
+		});
+		writeCodingAgentManifest(tempDir);
+		for (const workspace of ["agent", "ai", "pty", "tui", "senpi-codemode"]) {
+			writeBundledWorkspace(tempDir, workspace);
+		}
+		for (const name of ["cross-spawn", "which"]) {
+			writeJson(join(tempDir, "node_modules", name, "package.json"), { name, version: "1.0.0" });
+		}
+
+		// When
+		prepareSenpiBundledWorkspaces(tempDir);
+
+		// Then: the registry dep AND its transitive are staged...
+		for (const name of ["cross-spawn", "which"]) {
+			assert.equal(
+				JSON.parse(
+					readFileSync(join(tempDir, "packages", "coding-agent", "node_modules", name, "package.json"), "utf8"),
+				).name,
+				name,
+			);
+		}
+		// ...and the manifest lists every staged package while preserving the ^2026.x edges.
+		const manifest = JSON.parse(readFileSync(join(tempDir, "packages", "coding-agent", "package.json"), "utf8"));
+		const expectedBundle = [...BUNDLED_WORKSPACE_NAMES, "cross-spawn", "which"].sort((a, b) => a.localeCompare(b));
+		assert.deepEqual(manifest.bundleDependencies, expectedBundle);
+		assert.deepEqual(manifest.bundledDependencies, expectedBundle);
+		for (const name of BUNDLED_WORKSPACE_NAMES) {
+			assert.equal(manifest.dependencies[name], "^2026.7.22");
+		}
+	});
+
 	it("fails before bundling pty when a loader-visible file is missing", () => {
 		// Given: the hard-required loader file native/index.js is absent.
 		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-pty-loader-"));
 		writeShrinkwrap(tempDir, { "": { dependencies: {} } });
+		writeCodingAgentManifest(tempDir);
 		for (const workspace of ["agent", "ai", "tui"]) {
 			writeBundledWorkspace(tempDir, workspace);
 		}

--- a/scripts/prepare-senpi-bundled-workspaces.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.test.mjs
@@ -9,8 +9,10 @@ import {
 	bundledWorkspacePackageChecks,
 	copyPublishDependencies,
 	directNodeModulesPackageName,
+	listStagedPublishPackageNames,
 	nativePrebuildFile,
 	nativePrebuildTarget,
+	stagePublishManifest,
 } from "./prepare-senpi-bundled-workspaces.mjs";
 
 let tempDir;
@@ -51,6 +53,117 @@ describe("directNodeModulesPackageName", () => {
 		assert.equal(directNodeModulesPackageName("node_modules/@scope/pkg"), "@scope/pkg");
 		assert.equal(directNodeModulesPackageName("node_modules/typebox/node_modules/nested"), undefined);
 		assert.equal(directNodeModulesPackageName("packages/coding-agent"), undefined);
+	});
+});
+
+describe("listStagedPublishPackageNames", () => {
+	it("lists top-level and scoped packages, skipping dot directories", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-staged-names-"));
+		const nodeModules = join(tempDir, "node_modules");
+		mkdirSync(join(nodeModules, ".bin"), { recursive: true });
+		writePackage(tempDir, "typebox");
+		writePackage(tempDir, "@scope/pkg");
+
+		// When / Then
+		assert.deepEqual(listStagedPublishPackageNames(nodeModules), ["@scope/pkg", "typebox"]);
+	});
+});
+
+describe("stagePublishManifest", () => {
+	function writeCodingAgentManifest(root, overrides = {}) {
+		writeJson(join(root, "packages", "coding-agent", "package.json"), {
+			name: "@code-yeongyu/senpi",
+			version: "2026.7.22",
+			dependencies: {
+				"@earendil-works/pi-ai": "^2026.7.22",
+				"cross-spawn": "7.0.6",
+			},
+			optionalDependencies: {
+				"@mariozechner/clipboard": "0.3.9",
+			},
+			bundleDependencies: ["@earendil-works/pi-ai"],
+			bundledDependencies: ["@earendil-works/pi-ai"],
+			...overrides,
+		});
+	}
+
+	function stagePackage(root, name) {
+		const packageDir = join(root, "packages", "coding-agent", "node_modules", name);
+		mkdirSync(packageDir, { recursive: true });
+		writeJson(join(packageDir, "package.json"), { name, version: "1.0.0" });
+	}
+
+	function stageAllRuntimePackages(root) {
+		for (const name of ["@earendil-works/pi-ai", "cross-spawn", "@mariozechner/clipboard", "which"]) {
+			stagePackage(root, name);
+		}
+	}
+
+	function readStagedManifest(root) {
+		return JSON.parse(readFileSync(join(root, "packages", "coding-agent", "package.json"), "utf8"));
+	}
+
+	it("lists every staged runtime dependency and transitive in bundleDependencies", () => {
+		// Given: cross-spawn's transitive dep `which` is staged but only reachable via an edge.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-manifest-"));
+		writeCodingAgentManifest(tempDir);
+		stageAllRuntimePackages(tempDir);
+
+		// When
+		const staged = stagePublishManifest(tempDir);
+
+		// Then
+		const manifest = readStagedManifest(tempDir);
+		const expected = ["@earendil-works/pi-ai", "@mariozechner/clipboard", "cross-spawn", "which"];
+		assert.deepEqual(staged, expected);
+		assert.deepEqual(manifest.bundleDependencies, expected);
+		assert.deepEqual(manifest.bundledDependencies, expected);
+	});
+
+	it("preserves all dependency edges, including the vendored ^2026.x workspace specs", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-edges-"));
+		writeCodingAgentManifest(tempDir);
+		stageAllRuntimePackages(tempDir);
+
+		// When
+		stagePublishManifest(tempDir);
+
+		// Then: no dependency edge is dropped or rewritten, and no local specs exist.
+		const manifest = readStagedManifest(tempDir);
+		assert.deepEqual(manifest.dependencies, {
+			"@earendil-works/pi-ai": "^2026.7.22",
+			"cross-spawn": "7.0.6",
+		});
+		assert.deepEqual(manifest.optionalDependencies, { "@mariozechner/clipboard": "0.3.9" });
+		for (const spec of [...Object.values(manifest.dependencies), ...Object.values(manifest.optionalDependencies)]) {
+			assert.doesNotMatch(spec, /^(file|link|workspace):/);
+		}
+	});
+
+	it("throws when a declared runtime dependency is not staged", () => {
+		// Given: cross-spawn is declared but missing from the staged node_modules.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-missing-"));
+		writeCodingAgentManifest(tempDir);
+		stagePackage(tempDir, "@earendil-works/pi-ai");
+		stagePackage(tempDir, "@mariozechner/clipboard");
+
+		// When / Then
+		assert.throws(() => stagePublishManifest(tempDir), /missing staged runtime dependencies: cross-spawn/);
+	});
+
+	it("throws when a dependency spec uses a local file:/link: protocol", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-local-spec-"));
+		writeCodingAgentManifest(tempDir, {
+			dependencies: { "local-pkg": "file:../local-pkg" },
+		});
+		stagePackage(tempDir, "local-pkg");
+		stagePackage(tempDir, "@mariozechner/clipboard");
+
+		// When / Then
+		assert.throws(() => stagePublishManifest(tempDir), /must not reference local paths/);
 	});
 });
 
@@ -109,6 +222,32 @@ describe("copyPublishDependencies", () => {
 		);
 	});
 
+	it("copies transitive dependencies nested inside a staged package directory", () => {
+		// Given: nested-dep is not hoisted; it lives inside typebox's own node_modules.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-transitive-"));
+		writePackage(tempDir, "typebox");
+		writePackage(join(tempDir, "node_modules", "typebox"), "nested-dep");
+		writeShrinkwrap(tempDir, {
+			"": { dependencies: { typebox: "1.0.0" } },
+			"node_modules/typebox": { version: "1.0.0" },
+			"node_modules/typebox/node_modules/nested-dep": { version: "1.0.0" },
+		});
+
+		// When
+		copyPublishDependencies(tempDir);
+
+		// Then: the transitive dependency rides along with its parent's directory copy.
+		assert.equal(
+			JSON.parse(
+				readFileSync(
+					join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "node_modules", "nested-dep", "package.json"),
+					"utf8",
+				),
+			).name,
+			"nested-dep",
+		);
+	});
+
 	it("throws when a required publish dependency is not installed", () => {
 		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-"));
 		writeShrinkwrap(tempDir, {
@@ -131,6 +270,66 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 		assert.throws(
 			() => assertSenpiPackedWorkspaceFiles(packed),
 			/package tarball is missing bundled workspace files: .*@earendil-works\/pi-ai/,
+		);
+	});
+
+	it("rejects a packed tarball that omits a declared runtime dependency", () => {
+		// Given: workspace bundles are present, but the cross-spawn registry dep is not vendored.
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/which/package.json" },
+			],
+		};
+
+		// When / Then
+		assert.throws(
+			() => assertSenpiPackedWorkspaceFiles(packed, { runtimeDependencies: ["cross-spawn", "which"] }),
+			/missing vendored runtime dependencies: cross-spawn/,
+		);
+	});
+
+	it("accepts a packed tarball whose declared runtime dependencies are all vendored", () => {
+		// Given
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/cross-spawn/package.json" },
+				{ path: "package/node_modules/@modelcontextprotocol/sdk/package.json" },
+			],
+		};
+
+		// When / Then
+		assert.doesNotThrow(() =>
+			assertSenpiPackedWorkspaceFiles(packed, { runtimeDependencies: ["cross-spawn", "@modelcontextprotocol/sdk"] }),
 		);
 	});
 

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -64,7 +64,12 @@ function validatePack(directory) {
 	const packed = JSON.parse(result.stdout)[0];
 	const packageJson = readPackageJson(directory);
 	if (directory === "packages/coding-agent") {
-		assertSenpiPackedWorkspaceFiles(packed);
+		assertSenpiPackedWorkspaceFiles(packed, {
+			runtimeDependencies: [
+				...Object.keys(packageJson.dependencies ?? {}),
+				...Object.keys(packageJson.optionalDependencies ?? {}),
+			],
+		});
 	}
 	if (sourceOnlyPackages.has(packageJson.name)) {
 		const filePaths = new Set((packed.files ?? []).map((file) => file.path));


### PR DESCRIPTION
## Summary

Fixes the npm packaging defect where fresh `npm i -g @code-yeongyu/senpi` (both 2026.7.20-2 and 2026.7.22) **nondeterministically dropped registry runtime deps** — cross-spawn, which, @modelcontextprotocol/sdk — leaving the CLI dead with `ERR_MODULE_NOT_FOUND` on startup (reproduced 100% on Docker `node:24` / npm 11.16 fresh installs).

**Root cause:** the publish tarball vendored only the 5 `bundleDependencies` workspace packages + their closure. npm arborist, forced to fetch the remaining 39 runtime deps from the registry, could try to resolve the registry-absent `^2026.x` workspace specs (ETARGET) and abort reify mid-flight, leaving a half-installed tree. Stripping the 5 edges is not an option either — npm prunes edge-less `bundleDependencies` entries as extraneous (verified experimentally).

**Fix (validated direction):** make the tarball fully self-contained. Staging already copies the entire runtime closure from `publish-deps.lock.json`; the publish manifest now lists **every staged package** in `bundleDependencies` (258 packages), so npm needs **no registry fetch at install time**. All dependency edges — including the 5 `^2026.x` workspace specs — are preserved unchanged.

## Changes

- `scripts/prepare-senpi-bundled-workspaces.mjs`
  - New `stagePublishManifest`: scans the staged `packages/coding-agent/node_modules`, verifies every declared runtime dep is staged, rejects `file:`/`link:`/`workspace:` specs, and rewrites `bundleDependencies` (and the `bundledDependencies` alias) to the full staged list. Called last by `prepareSenpiBundledWorkspaces`.
  - `assertSenpiPackedWorkspaceFiles` gains a `runtimeDependencies` option: the pack gate now fails if any declared runtime dep is missing from the tarball.
- `scripts/publish.mjs`: passes the coding-agent runtime deps to the pack gate.
- Tests: transitive-copy coverage, manifest-rewrite coverage (edges preserved, missing-dep and local-spec rejection), pack-gate coverage, and an end-to-end `prepareSenpiBundledWorkspaces` manifest test.
- `scripts/AGENTS.md` + `packages/coding-agent/changes.md`: document the new self-contained-bundle contract.

`publish-deps.lock.json` stays staging-only (never shipped); no new lifecycle-script dependencies.

## QA & Evidence

Evidence dir: `local-ignore/qa-evidence/20260722-publish-vendoring/` (see `SUMMARY.md` there).

- **Docker matrix (`node:24`, npm 11.16.0 — the version that failed 100% before):**
  - (a) fresh `npm i -g` of the fixed tarball → `senpi --version` prints `2026.7.22`; `require.resolve` of cross-spawn / which / @modelcontextprotocol/sdk / @earendil-works/pi-tui all resolve inside the installed tree — `docker-fresh-fixed.log`
  - (b) install 2026.7.20-2, then `npm i -g` the fixed tarball (update path) → same checks pass — `docker-update-from-20-2.log`
  - (c) control: fresh `npm i -g` of the UNFIXED 2026.7.22 tarball → still dies with `ERR_MODULE_NOT_FOUND` (cross-spawn) — `docker-fresh-unfixed-control.log`
- Pack gate over `npm pack --dry-run --json`: all declared runtime deps vendored — `pack-assertion.log`
- `node --test scripts/prepare-senpi-bundled-workspaces*.test.mjs`: 23/23 pass; `npm run test:scripts`: 57/57 pass; `npm run check`: green
- senpi-qa harness self-tests from the worktree: cli-smoke 7/7, mock-loop 38/38, tui-smoke 5/5

Note: staging intentionally dirties `packages/coding-agent/package.json` (rewritten `bundleDependencies`); it is restored after packing and never committed — every release flow (`publish.mjs`, root `publish`/`publish:dry`, `local-release.mjs`) stages before packing.

## Risks

- Tarball grows (~34 MB packed) because the full runtime tree is vendored — expected and required for self-containment.
- Optional platform variants of `@mariozechner/clipboard` for non-host platforms are not staged (optional dep; npm tolerates their absence) — same tradeoff as before, now limited to one optional package.
- npm's treatment of the registry-absent `^2026.x` edges with a complete in-bundle tree is verified empirically on npm 11.16.0 (fresh + update paths); older/newer npm majors were not re-tested here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `@code-yeongyu/senpi` publish tarball fully self-contained by bundling the entire runtime dependency tree, fixing nondeterministic `ERR_MODULE_NOT_FOUND` on fresh installs (e.g., missing `cross-spawn`, `which`, `@modelcontextprotocol/sdk`). Installs no longer hit the registry; the CLI starts reliably.

- **Bug Fixes**
  - Tarball now vendors all runtime packages, not just the 5 bundled workspaces.
  - Added `stagePublishManifest` to rewrite `bundleDependencies` to every staged package; preserves edges; rejects `file:`/`link:`/`workspace:` specs and missing staged deps.
  - Pack gate checks that all runtime deps are vendored via `assertSenpiPackedWorkspaceFiles`; wired in `scripts/publish.mjs`.
  - Tests cover transitive copy, manifest rewrite, and pack gate; docs updated in `scripts/AGENTS.md` and `packages/coding-agent/changes.md`.

<sup>Written for commit 7ffb0ea14d5bc35ead39977fee915f32eb86b1b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

