### PR TITLE
fix(tui): use braille tool progress spinner

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## braille tool progress spinner (2026-07-22)
+
+### What changed
+
+- `tool-progress.ts`: partial tool progress rows now use the same ten-frame braille spinner sequence as other Senpi
+  waiting surfaces instead of cycling directional triangles (`⏵`, `⏷`, `⏴`, `⏶`).
+
+### Why
+
+- Long-running task, team-wait, and terminal progress rows should read as active work rather than a rotating disclosure
+  marker. The existing 80ms component ticker already advances frames; the formatter now presents that animation with
+  standard terminal spinner glyphs.
+
+### Why extension system couldn't handle this
+
+- Generic partial-progress rows are composed by the built-in `ToolExecutionRenderer` after extension result renderers
+  run, so an individual tool extension cannot replace the host-owned progress prefix consistently.
+
+### Expected merge conflict zones
+
+- LOW: `tool-progress.ts` around `formatToolProgressLine()`.
+
 ## todo completion strike reveal (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tool-progress.ts
+++ b/packages/coding-agent/src/modes/interactive/tool-progress.ts
@@ -1,5 +1,7 @@
 import { formatWorkingElapsedSeconds } from "./working-status.ts";
 
+const TOOL_PROGRESS_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+
 export interface ToolProgressDetails {
 	readonly activity?: string;
 	readonly startedAt: number;
@@ -25,6 +27,8 @@ export function formatToolProgressLine(progress: ToolProgressDetails, now: numbe
 	const elapsed = formatWorkingElapsedSeconds((now - progress.startedAt) / 1_000);
 	const maxWait =
 		progress.maxWaitMs === undefined ? "" : ` / max ${Math.max(0, Math.floor(progress.maxWaitMs / 1_000))}s`;
-	const spinner = spinnerFrame === undefined ? "⏵" : ["⏵", "⏷", "⏴", "⏶"][spinnerFrame % 4];
+	const spinner =
+		TOOL_PROGRESS_SPINNER_FRAMES[(spinnerFrame ?? 0) % TOOL_PROGRESS_SPINNER_FRAMES.length] ??
+		TOOL_PROGRESS_SPINNER_FRAMES[0];
 	return `${spinner} ${activity} · ${elapsed}${maxWait}`;
 }

--- a/packages/coding-agent/test/tool-progress.test.ts
+++ b/packages/coding-agent/test/tool-progress.test.ts
@@ -44,9 +44,10 @@ describe("tool progress", () => {
 		expect(readToolProgress({ progress: { startedAt: "soon" } })).toBeUndefined();
 		expect(readToolProgress(null)).toBeUndefined();
 
-		expect(formatToolProgressLine({ startedAt: 1_000 }, 13_900)).toBe("⏵ working · 12s");
-		expect(formatToolProgressLine({ activity: "waiting", startedAt: 1_000 }, 68_000)).toBe("⏵ waiting · 1m 07s");
-		expect(formatToolProgressLine(progress, 13_900, 0)).toBe("⏵ waiting for /BUILD OK/ · 12s / max 300s");
+		expect(formatToolProgressLine({ startedAt: 1_000 }, 13_900)).toBe("⠋ working · 12s");
+		expect(formatToolProgressLine({ activity: "waiting", startedAt: 1_000 }, 68_000)).toBe("⠋ waiting · 1m 07s");
+		expect(formatToolProgressLine(progress, 13_900, 0)).toBe("⠋ waiting for /BUILD OK/ · 12s / max 300s");
+		expect(formatToolProgressLine(progress, 13_900, 4)).toBe("⠼ waiting for /BUILD OK/ · 12s / max 300s");
 	});
 
 	test("renders the progress line for fallback and custom renderer shells, then removes it on final result", () => {
@@ -64,7 +65,7 @@ describe("tool progress", () => {
 				process.cwd(),
 			);
 			fallback.updateResult({ content: [{ type: "text", text: "partial output" }], details, isError: false }, true);
-			expect(stripAnsi(fallback.render(120).join("\n"))).toContain("⏵ waiting for /BUILD OK/ · 12s / max 300s");
+			expect(stripAnsi(fallback.render(120).join("\n"))).toContain("⠋ waiting for /BUILD OK/ · 12s / max 300s");
 
 			const custom = new ToolExecutionComponent(
 				"progress_custom",
@@ -78,7 +79,7 @@ describe("tool progress", () => {
 			custom.updateResult({ content: [{ type: "text", text: "partial output" }], details, isError: false }, true);
 			const partial = stripAnsi(custom.render(120).join("\n"));
 			expect(partial).toContain("custom result");
-			expect(partial).toContain("⏵ waiting for /BUILD OK/ · 12s / max 300s");
+			expect(partial).toContain("⠋ waiting for /BUILD OK/ · 12s / max 300s");
 
 			custom.updateResult({ content: [{ type: "text", text: "complete" }], details, isError: false });
 			const final = stripAnsi(custom.render(120).join("\n"));
@@ -111,8 +112,11 @@ describe("tool progress", () => {
 				true,
 			);
 
+			expect(stripAnsi(component.render(120).join("\n"))).toContain("⠋ waiting · 0s");
 			vi.advanceTimersByTime(80);
 			expect(requestRender).toHaveBeenCalledTimes(1);
+			vi.advanceTimersByTime(80);
+			expect(stripAnsi(component.render(120).join("\n"))).toContain("⠙ waiting · 0s");
 
 			component.updateResult({ content: [], details: {}, isError: false });
 			requestRender.mockClear();


### PR DESCRIPTION
## Summary

- replace the directional `⏵ ⏷ ⏴ ⏶` tool-progress animation with Senpi's standard ten-frame braille spinner
- keep the existing 80ms partial-progress ticker and completion teardown unchanged
- cover default, representative, rendered, advancing, and stopped spinner states

## Why Senpi only

OMO task/team waiting tools publish structured `details.progress`; Senpi owns the generic animated progress row appended by the interactive tool renderer. OMO's separate background-task widget already uses braille frames, so no OMO source change is required.

## Verification

- RED: `npm test -- tool-progress.test.ts` failed 3/3 against the old triangle formatter
- GREEN: `npm test -- tool-progress.test.ts` passed 3/3
- `npm run check`
- Senpi TUI smoke: 5/5 passed with clean teardown and unchanged auth
- xterm.js visual QA: actual `ToolExecutionComponent` frames `⠋ ⠋ ⠙ ⠹ ⠸ ⠼ ⠴`; 42/80 columns, no overflow, border drift, or wide-character drift
- three independent reviewers: PASS, no blocking findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the directional triangle tool-progress animation with Senpi’s 10-frame braille spinner to match other waiting surfaces and better signal active work. Keep the 80ms ticker and completion teardown unchanged; update tests to cover default, frame advance, rendered output, and stopped states.

<sup>Written for commit 511d84dc3c3bdb5ef29d35b46e8df347d2aabd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

