### PR TITLE
test(coding-agent): avoid npm in runtime import probe

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,16 @@
 # Local fork changes
 
+## 2026-07-22 — app-server runtime import test without npm subprocess
+
+- Changed: `test/suite/app-server-protocol.test.ts` now executes its runtime `.js` import probe with
+  `node --import tsx --eval` instead of `npx tsx -e`.
+- Why: npm configuration warnings are unrelated to the protocol import contract but are emitted on the spawned
+  subprocess stderr in CI, making the otherwise-successful test fail.
+- What changed: test runner invocation only; the imported module, assertions, and runtime behavior are unchanged.
+- Why the extension system could not handle this: this is hermetic package test infrastructure, not runtime extension
+  behavior.
+- Merge-conflict risk: low. The only conflict zone is the subprocess invocation in the focused protocol metadata test.
+
 ## 2026-07-22 — Fully self-contained publish tarball (npm packaging MODULE_NOT_FOUND fix)
 
 - Changed:

--- a/packages/coding-agent/test/suite/app-server-protocol.test.ts
+++ b/packages/coding-agent/test/suite/app-server-protocol.test.ts
@@ -270,10 +270,11 @@ describe("app-server protocol metadata", () => {
 		const manifest = readCapabilityManifest();
 		const stableCount = manifest.implemented.stable.length + manifest.out.stable.length;
 		const result = spawnSync(
-			"npx",
+			process.execPath,
 			[
+				"--import",
 				"tsx",
-				"-e",
+				"--eval",
 				'import {EXPERIMENTAL_SERVER_NOTIFICATION_METHODS,STABLE_CLIENT_REQUEST_METHODS} from "./src/modes/app-server/protocol/methods.js"; console.log("STABLE="+STABLE_CLIENT_REQUEST_METHODS.length,"EXPERIMENTAL_NOTIFICATIONS="+EXPERIMENTAL_SERVER_NOTIFICATION_METHODS.length,STABLE_CLIENT_REQUEST_METHODS.includes("thread/start"),EXPERIMENTAL_SERVER_NOTIFICATION_METHODS.includes("thread/settings/updated"))',
 			],
 			{


### PR DESCRIPTION
## Summary

- run the app-server runtime `.js` import probe with `node --import tsx --eval`
- remove the `npx` subprocess whose npm configuration warnings polluted stderr in CI
- preserve the imported module, metadata assertions, and runtime behavior

## Failure fixed

`origin/main` CI run `29900791220` failed because npm emitted `min-release-age-exclude` warnings to the spawned `npx` process stderr, while the test correctly expects the runtime import probe itself to be silent.

## Verification

- direct Node/tsx probe returned `STABLE=92 EXPERIMENTAL_NOTIFICATIONS=14 true true`
- focused protocol suite: 6/6 passed normally
- focused protocol suite: 6/6 passed with `npm_config_min_release_age_exclude` set
- repository static/type checks passed
- independent portability/root-cause review: PASS, no blocking findings

## Unrelated local gate

The local Neo real-daemon integration gate timed out twice in untouched code. It passed in the preceding worktree and in the repository's CI terminal matrix; this PR does not alter Neo.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the app-server runtime .js import probe with `node --import tsx --eval` instead of `npx tsx -e` to avoid `npm` warnings on stderr in CI. This fixes the failing test while keeping the imported module, metadata assertions, and runtime behavior unchanged.

<sup>Written for commit 5df2f47eeda51377ba598f4d251137d60f1b35e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

