### PR TITLE
fix(tui): unify tool progress durations

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## unified tool progress durations (2026-07-22)
+
+### What changed
+
+- `tool-progress.ts`: elapsed and maximum wait durations now share `formatWorkingElapsedSeconds()`, so progress rows use
+  one seconds/minutes/hours grammar (`4m 28s / max 5m 00s`) instead of mixing humanized elapsed time with raw maximum
+  seconds (`4m 28s / max 300s`).
+
+### Why
+
+- A single progress row should not force users to mentally convert the timeout while the elapsed side is already
+  human-readable.
+
+### Why extension system couldn't handle this
+
+- The progress suffix is composed by the built-in interactive tool renderer after extension result rendering.
+
+### Expected merge conflict zones
+
+- LOW: `tool-progress.ts` around the maximum-wait suffix.
+
 ## todo completion strike reveal (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tool-progress.ts
+++ b/packages/coding-agent/src/modes/interactive/tool-progress.ts
@@ -24,7 +24,7 @@ export function formatToolProgressLine(progress: ToolProgressDetails, now: numbe
 	const activity = progress.activity || "working";
 	const elapsed = formatWorkingElapsedSeconds((now - progress.startedAt) / 1_000);
 	const maxWait =
-		progress.maxWaitMs === undefined ? "" : ` / max ${Math.max(0, Math.floor(progress.maxWaitMs / 1_000))}s`;
+		progress.maxWaitMs === undefined ? "" : ` / max ${formatWorkingElapsedSeconds(progress.maxWaitMs / 1_000)}`;
 	const spinner = spinnerFrame === undefined ? "⏵" : ["⏵", "⏷", "⏴", "⏶"][spinnerFrame % 4];
 	return `${spinner} ${activity} · ${elapsed}${maxWait}`;
 }

--- a/packages/coding-agent/test/tool-progress.test.ts
+++ b/packages/coding-agent/test/tool-progress.test.ts
@@ -46,7 +46,10 @@ describe("tool progress", () => {
 
 		expect(formatToolProgressLine({ startedAt: 1_000 }, 13_900)).toBe("⏵ working · 12s");
 		expect(formatToolProgressLine({ activity: "waiting", startedAt: 1_000 }, 68_000)).toBe("⏵ waiting · 1m 07s");
-		expect(formatToolProgressLine(progress, 13_900, 0)).toBe("⏵ waiting for /BUILD OK/ · 12s / max 300s");
+		expect(formatToolProgressLine(progress, 13_900, 0)).toBe("⏵ waiting for /BUILD OK/ · 12s / max 5m 00s");
+		expect(formatToolProgressLine({ activity: "waiting", startedAt: 1_000, maxWaitMs: 5_400_000 }, 3_662_000)).toBe(
+			"⏵ waiting · 1h 01m 01s / max 1h 30m 00s",
+		);
 	});
 
 	test("renders the progress line for fallback and custom renderer shells, then removes it on final result", () => {
@@ -64,7 +67,7 @@ describe("tool progress", () => {
 				process.cwd(),
 			);
 			fallback.updateResult({ content: [{ type: "text", text: "partial output" }], details, isError: false }, true);
-			expect(stripAnsi(fallback.render(120).join("\n"))).toContain("⏵ waiting for /BUILD OK/ · 12s / max 300s");
+			expect(stripAnsi(fallback.render(120).join("\n"))).toContain("⏵ waiting for /BUILD OK/ · 12s / max 5m 00s");
 
 			const custom = new ToolExecutionComponent(
 				"progress_custom",
@@ -78,7 +81,7 @@ describe("tool progress", () => {
 			custom.updateResult({ content: [{ type: "text", text: "partial output" }], details, isError: false }, true);
 			const partial = stripAnsi(custom.render(120).join("\n"));
 			expect(partial).toContain("custom result");
-			expect(partial).toContain("⏵ waiting for /BUILD OK/ · 12s / max 300s");
+			expect(partial).toContain("⏵ waiting for /BUILD OK/ · 12s / max 5m 00s");
 
 			custom.updateResult({ content: [{ type: "text", text: "complete" }], details, isError: false });
 			const final = stripAnsi(custom.render(120).join("\n"));


### PR DESCRIPTION
## Summary

- format maximum tool wait time with the same shared duration formatter used for elapsed time
- render minute-scale progress as `4m 28s / max 5m 00s`
- render hour-scale progress as `1h 01m 01s / max 1h 30m 00s`
- document the fork-visible interactive rendering change

## Why

Tool progress mixed a human-readable elapsed duration with a raw-seconds timeout, for example `4m 28s / max 300s`. Reusing `formatWorkingElapsedSeconds()` removes the mental conversion and keeps one seconds/minutes/hours grammar.

## QA and evidence

RED:
- focused `tool-progress.test.ts` received `max 300s` and `max 5400s` where `max 5m 00s` and `max 1h 30m 00s` were required

GREEN:
- `cd packages/coding-agent && npm test -- tool-progress.test.ts` - 3 passed, 18 assertions
- `npm run check` - passed after rebase onto `origin/main@29fb8dcde`
- isolated Senpi TUI smoke - 5/5 passed, typed input reached the composer, sandbox cleaned, real auth unchanged
- xterm.js visual evidence showed:
  - `4m 28s / max 5m 00s`
  - `1h 01m 01s / max 1h 30m 00s`

Local sanitized evidence:
`local-ignore/qa-evidence/20260722-tool-progress-duration-format/`

## Review

Five review lanes approved: goal/constraints, code quality, security, hands-on QA, and repository context.

## Coordination

PR #288 merged while this PR was waiting. Its braille-spinner intent and this duration-format intent were preserved together in merge commit `691b6eb10`:
- braille progress frames remain intact
- maximum wait time uses the same h/m/s formatter as elapsed time

Post-merge focused tests, root checks, TUI smoke, and xterm visual QA all pass.

## Risk

Low. One production expression now reuses an existing, already-tested formatter. No data model, persistence, protocol, or timing behavior changes.
