### PR TITLE
feat(compaction): capability-gated OpenAI remote compaction with faithful history degradation

### DIFF
--- a/.agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs
@@ -1,0 +1,333 @@
+/**
+ * Compaction-route QA — OpenAI remote compaction with a MIXED-provider history.
+ *
+ * Drives the real CLI (`--mode rpc`) against a local mock that serves Anthropic
+ * Messages SSE, OpenAI Responses SSE, and the OpenAI `/v1/responses/compact`
+ * endpoint. The session first completes a turn on a mock ANTHROPIC model, then
+ * switches to a mock OpenAI Responses model, compacts, and takes one more turn.
+ *
+ * Proves the capability-gated route end to end:
+ *   1. compaction calls `/v1/responses/compact` even though the branch carries
+ *      an anthropic assistant message (history provenance no longer gates),
+ *   2. the compact request input replays that anthropic turn as a degraded
+ *      assistant output_text item,
+ *   3. the RPC `compact` response carries `senpi.compaction.openai-remote.v1`
+ *      details,
+ *   4. the next turn's `/v1/responses` payload replays the native compaction
+ *      item (payload rewrite active after remote compaction).
+ *
+ * Usage: node compaction-remote-qa.mjs --self-test [--evidence SLUG]
+ */
+
+import { createServer } from "node:http";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	spawnCli,
+} from "./lib/common.mjs";
+import { checkRealAuthUnchanged, hermeticEnv } from "./lib/mock-loop-support.mjs";
+
+const CLAUDE_TEXT = `CLAUDE-TURN-7f3a ${"anthropic history that must degrade into an output_text item. ".repeat(6)}`;
+const GPT_TEXT = `GPT-TURN-22b8 ${"openai native turn that stays in the branch. ".repeat(6)}`;
+const AFTER_TEXT = "AFTER-COMPACTION-TURN-9c1d";
+
+function sseHead(res) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+}
+
+function writeAnthropicSse(res, text, modelId) {
+	sseHead(res);
+	const ev = (event, data) => res.write(`event: ${event}\ndata: ${JSON.stringify({ type: event, ...data })}\n\n`);
+	ev("message_start", {
+		message: { id: "msg_mock", type: "message", role: "assistant", model: modelId, content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 50, output_tokens: 0 } },
+	});
+	ev("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+	ev("content_block_delta", { index: 0, delta: { type: "text_delta", text } });
+	ev("content_block_stop", { index: 0 });
+	ev("message_delta", { delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 80 } });
+	ev("message_stop", {});
+	res.end();
+}
+
+function writeResponsesSse(res, text, modelId) {
+	sseHead(res);
+	let seq = 0;
+	const ev = (type, data) => res.write(`event: ${type}\ndata: ${JSON.stringify({ type, sequence_number: seq++, ...data })}\n\n`);
+	ev("response.created", { response: { id: "resp_mock", object: "response", status: "in_progress", model: modelId, output: [] } });
+	ev("response.output_item.added", { output_index: 0, item: { id: "msg_mock", type: "message", status: "in_progress", role: "assistant", content: [] } });
+	ev("response.content_part.added", { item_id: "msg_mock", output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } });
+	ev("response.output_text.delta", { item_id: "msg_mock", output_index: 0, content_index: 0, delta: text });
+	const item = { id: "msg_mock", type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text, annotations: [] }] };
+	ev("response.output_item.done", { output_index: 0, item });
+	ev("response.completed", {
+		response: { id: "resp_mock", object: "response", status: "completed", model: modelId, output: [item], usage: { input_tokens: 50, output_tokens: 80, total_tokens: 130 } },
+	});
+	res.end();
+}
+
+function startMockServer() {
+	const requests = [];
+	const server = createServer((req, res) => {
+		const chunks = [];
+		req.on("data", (c) => chunks.push(c));
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			let body;
+			try {
+				body = raw ? JSON.parse(raw) : {};
+			} catch {
+				body = { unparseable: raw.slice(0, 200) };
+			}
+			const url = req.url ?? "";
+			requests.push({ method: req.method, url, body });
+			if (url.endsWith("/messages")) return writeAnthropicSse(res, CLAUDE_TEXT, body.model ?? "mock-claude");
+			if (url.endsWith("/responses/compact")) {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.end(
+					JSON.stringify({
+						id: "resp_compact_mock",
+						created_at: 1_775_000_010,
+						object: "response.compaction",
+						output: [
+							{ type: "message", id: "msg_retained", role: "user", content: [{ type: "input_text", text: "retained user context" }] },
+							{ type: "compaction", id: "cmp_mock", encrypted_content: "encrypted-mock-summary" },
+						],
+						usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 },
+					}),
+				);
+				return;
+			}
+			if (url.endsWith("/responses")) {
+				const priorTurns = requests.filter((r) => r.url.endsWith("/responses")).length;
+				return writeResponsesSse(res, priorTurns > 1 ? AFTER_TEXT : GPT_TEXT, body.model ?? "mock-gpt");
+			}
+			res.writeHead(404, { "content-type": "application/json" });
+			res.end(JSON.stringify({ error: { message: `no route: ${req.method} ${url}` } }));
+		});
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address();
+			resolve({
+				requests,
+				origin: `http://127.0.0.1:${port}`,
+				stop: () => new Promise((done) => server.close(done)),
+			});
+		});
+	});
+}
+
+class RpcClient {
+	constructor({ env, cwd }) {
+		this.child = spawnCli(["--mode", "rpc", "--no-context-files"], { env, cwd });
+		this.pending = new Map();
+		this.events = [];
+		this.seq = 0;
+		this._buf = "";
+		this.stderr = "";
+		this.child.stdout.on("data", (chunk) => this._onData(chunk));
+		this.child.stderr.on("data", (d) => {
+			this.stderr += d.toString();
+		});
+	}
+
+	_onData(chunk) {
+		this._buf += chunk.toString();
+		let nl;
+		while ((nl = this._buf.indexOf("\n")) >= 0) {
+			const line = this._buf.slice(0, nl).trim();
+			this._buf = this._buf.slice(nl + 1);
+			if (!line) continue;
+			let msg;
+			try {
+				msg = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (msg && msg.type === "response") {
+				const waiter = msg.id !== undefined ? this.pending.get(msg.id) : undefined;
+				if (waiter) {
+					this.pending.delete(msg.id);
+					waiter(msg);
+				}
+			} else if (msg && msg.type) {
+				this.events.push(msg);
+			}
+		}
+	}
+
+	send(cmd, { timeoutMs = 90000 } = {}) {
+		const id = cmd.id ?? `req-${++this.seq}`;
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RPC timeout ${cmd.type} (stderr: ${this.stderr.slice(-400)})`));
+			}, timeoutMs);
+			this.pending.set(id, (m) => {
+				clearTimeout(timer);
+				resolve(m);
+			});
+			this.child.stdin.write(`${JSON.stringify({ ...cmd, id })}\n`);
+		});
+	}
+
+	async waitForEvent(pred, { timeoutMs = 90000 } = {}) {
+		const start = Date.now();
+		const from = this.events.length;
+		for (;;) {
+			const hit = this.events.slice(from).find(pred);
+			if (hit) return hit;
+			if (Date.now() - start > timeoutMs) throw new Error(`event wait timeout (stderr: ${this.stderr.slice(-400)})`);
+			await new Promise((r) => setTimeout(r, 50));
+		}
+	}
+
+	close() {
+		try {
+			this.child.stdin.end();
+		} catch {}
+	}
+}
+
+function writeSandboxConfig(agentDir, server) {
+	const modelEntry = (api, id, baseUrl) => ({
+		id,
+		api,
+		baseUrl,
+		contextWindow: 128000,
+		maxTokens: 4096,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	});
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				anthropic: {
+					baseUrl: server.origin,
+					apiKey: "sk-ant-mock-7f3a",
+					api: "anthropic-messages",
+					models: [modelEntry("anthropic-messages", "mock-claude", server.origin)],
+				},
+				openai: {
+					baseUrl: `${server.origin}/v1`,
+					apiKey: "sk-openai-mock-7f3a",
+					api: "openai-responses",
+					models: [modelEntry("openai-responses", "mock-gpt", `${server.origin}/v1`)],
+				},
+			},
+		}),
+	);
+	writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ compaction: { keepRecentTokens: 40 } }));
+}
+
+async function selfTest(evidenceSlug) {
+	installCleanupHooks();
+	const checks = createChecks("compaction-remote-qa.mjs --self-test");
+	const guard = guardRealAuth();
+	const box = makeSandbox("compaction-remote-qa");
+	const server = await startMockServer();
+	writeSandboxConfig(box.agentDir, server);
+
+	const client = new RpcClient({ env: hermeticEnv(box.env), cwd: box.cwd });
+	let compactResponse;
+	try {
+		const prompt = async (message) => {
+			const res = await client.send({ type: "prompt", message });
+			if (res.success !== true) throw new Error(`prompt rejected: ${JSON.stringify(res)}`);
+		};
+		await client.send({ type: "set_model", provider: "anthropic", modelId: "mock-claude" });
+		await prompt("Turn one: lay out the plan.");
+		await client.waitForEvent((e) => e.type === "agent_end");
+
+		await client.send({ type: "set_model", provider: "openai", modelId: "mock-gpt" });
+		await prompt("Turn two: keep going.");
+		await client.waitForEvent((e) => e.type === "agent_end", { timeoutMs: 90000 });
+
+		compactResponse = await client.send({ type: "compact" });
+
+		await prompt("Turn three: after compaction.");
+		await client.waitForEvent((e) => e.type === "agent_end");
+	} catch (error) {
+		console.error("SCENARIO FAILURE DIAGNOSTICS");
+		console.error("server urls:", JSON.stringify(server.requests.map((r) => `${r.method} ${r.url}`)));
+		console.error("last events:", JSON.stringify(client.events.slice(-15).map((e) => e.type)));
+		console.error("stderr tail:", client.stderr.slice(-1500));
+		throw error;
+	} finally {
+		client.close();
+	}
+
+	const compactCalls = server.requests.filter((r) => r.url.endsWith("/responses/compact"));
+	checks.ok(
+		"remote compaction called /v1/responses/compact despite anthropic turn in history",
+		compactCalls.length === 1,
+		`compactCalls=${compactCalls.length}`,
+	);
+
+	const compactInput = compactCalls[0]?.body?.input ?? [];
+	const degraded = compactInput.some(
+		(item) => item?.type === "message" && item?.role === "assistant" && JSON.stringify(item).includes("CLAUDE-TURN-7f3a"),
+	);
+	checks.ok("anthropic turn degraded into an assistant output_text item in the compact input", degraded);
+
+	const details = compactResponse?.data?.details;
+	checks.ok(
+		"RPC compact response carries senpi.compaction.openai-remote.v1 details",
+		compactResponse?.success === true && details?.schema === "senpi.compaction.openai-remote.v1",
+		`schema=${details?.schema ?? "none"}`,
+	);
+
+	const responsesCalls = server.requests.filter((r) => r.url.endsWith("/responses") && !r.url.endsWith("/responses/compact"));
+	const postCompact = responsesCalls[responsesCalls.length - 1];
+	const replayed = (postCompact?.body?.input ?? []).some((item) => item?.type === "compaction" && typeof item?.encrypted_content === "string");
+	checks.ok(
+		"post-compaction /v1/responses payload replays the native compaction item",
+		responsesCalls.length >= 2 && replayed,
+		`responsesCalls=${responsesCalls.length} replayed=${replayed}`,
+	);
+
+	checkRealAuthUnchanged(checks, guard);
+
+	if (evidenceSlug) {
+		const dir = evidenceDir(evidenceSlug);
+		writeFileSync(
+			join(dir, "compaction-remote-qa.json"),
+			JSON.stringify(
+				{
+					compactCalls: compactCalls.map((c) => ({ url: c.url, body: c.body })),
+					responsesCallCount: responsesCalls.length,
+					responsesCalls: responsesCalls.map((c) => ({ url: c.url, body: c.body })),
+					postCompactInput: postCompact?.body?.input ?? [],
+					compactResponse: compactResponse ?? null,
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(join(dir, "rpc-stderr.log"), client.stderr);
+	}
+
+	await server.stop();
+	box.cleanup();
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+const evidenceSlug = process.argv.includes("--evidence") ? process.argv[process.argv.indexOf("--evidence") + 1] : undefined;
+if (process.argv.includes("--self-test")) {
+	selfTest(evidenceSlug).catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+} else {
+	console.log("usage: node compaction-remote-qa.mjs --self-test [--evidence SLUG]");
+}

--- a/.agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs
@@ -296,6 +296,11 @@ async function selfTest(evidenceSlug) {
 		`responsesCalls=${responsesCalls.length} replayed=${replayed}`,
 	);
 
+	const promptPreserved = (postCompact?.body?.input ?? []).some((item) =>
+		JSON.stringify(item).includes("Turn three: after compaction."),
+	);
+	checks.ok("post-compaction /v1/responses payload still carries the user's new prompt", promptPreserved);
+
 	checkRealAuthUnchanged(checks, guard);
 
 	if (evidenceSlug) {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,28 @@
 # Builtin compaction extension changes
 
+## OpenAI remote compaction gated on provider capability, not history provenance (2026-07-22)
+
+- `openai-remote-convert.ts` (new, extracted from `openai-remote.ts`): the remote-compaction route no longer
+  requires the entire session branch to be OpenAI Responses-native. The route gate is now provider capability
+  only (current model is `provider "openai"` + `api "openai-responses"`, matching codex's
+  `supports_remote_compaction()`), and branch conversion is total: entries flow through the same
+  `sessionEntryToContextMessages` + `convertToLlm` pipeline the normal context path uses, so foreign-provider
+  assistant messages, bash executions, branch summaries, custom messages, and prior LOCAL compaction entries
+  degrade to their canonical text form instead of forcing a local-summarization fallback. Prior OpenAI remote
+  compaction entries still splice their native `replacementInput` in order.
+- Image-bearing tool results now mirror the Responses payload builder: structured `input_text`/`input_image`
+  parts for image-capable models, `(see attached image)` placeholder otherwise.
+- `rewriteOpenAiPayloadWithRemoteCompaction` no longer silently skips the rewrite when post-compaction history
+  is not OpenAI-native (previously the session then sent the full uncompacted context on the next turn).
+- The `session-not-openai-native` fallback reason is gone; request building can only decline on an empty input
+  (`empty-compaction-input`).
+- Tests: `test/compaction/openai-remote-compaction.test.ts` — degradation cases for mixed providers, bash
+  executions, local compaction entries, branch/custom entries, image tool results, a mixed-history remote run
+  through `runOpenAiRemoteCompaction`, and the post-compaction payload rewrite with a non-native tail.
+
+Expected upstream conflict zones: `builtin/compaction/openai-remote.ts` request building and payload rewrite;
+`builtin/compaction/openai-remote-convert.ts` (new file, no upstream counterpart).
+
 ## Skip placeholder synthesis for errored/aborted assistants (2026-07-22)
 
 - `repair-tool-pairs.ts` no longer synthesizes placeholder tool results for toolCalls declared by

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,19 @@
 # Builtin compaction extension changes
 
+## Preserve the in-flight prompt in remote-compaction payload replay (2026-07-22)
+
+- `index.ts`, `openai-remote.ts`, `openai-remote-convert.ts`: the `before_provider_request` replay after a
+  remote compaction rebuilt the payload from the persisted branch only. The in-flight user prompt is not yet
+  persisted at that point, so the replayed payload silently dropped it — the model never saw the first message
+  after a remote compaction. The `context` handler now stashes the not-yet-persisted tail messages
+  (`pendingProviderMessages`) and the rewrite appends their conversion after the branch-derived items.
+  Pre-existing on main; surfaced by the mixed-history e2e QA scenario.
+- Tests: `test/compaction/openai-remote-compaction.test.ts` (pending-prompt rewrite case) and
+  `.agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs` (asserts the post-compaction payload carries the prompt).
+
+Expected upstream conflict zones: `builtin/compaction/index.ts` context/provider-request handlers,
+`builtin/compaction/openai-remote.ts` payload rewrite.
+
 ## OpenAI remote compaction gated on provider capability, not history provenance (2026-07-22)
 
 - `openai-remote-convert.ts` (new, extracted from `openai-remote.ts`): the remote-compaction route no longer

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -3,7 +3,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Tool } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../../compaction/index.ts";
 import { convertToLlm } from "../../../messages.ts";
-import type { CompactionEntry } from "../../../session-manager.ts";
+import { buildContextEntries, type CompactionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
 import type { ContextUsage, ExtensionAPI, ExtensionContext, SessionBeforeCompactEvent } from "../../types.ts";
 import * as checkpointState from "./checkpoint-state.ts";
 import * as breaker from "./circuit-breaker.ts";
@@ -150,6 +150,10 @@ function createBlockingRemoteCompactionEvent(
 
 export default function compactionExtension(pi: ExtensionAPI): void {
 	let state: CompactionExtensionState = createInitialState();
+	// Messages not yet persisted in the session branch (the in-flight prompt),
+	// captured at context-assembly time so the remote-compaction payload replay
+	// can append them after the branch-derived items.
+	let pendingProviderMessages: AgentMessage[] = [];
 	const degradationState = createDegradationMonitorState();
 	const restorationState = state.restoration ?? restoration.createRestorationTrackerState();
 	state = { ...state, restoration: restorationState };
@@ -476,6 +480,14 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("context", (event, ctx) => {
+		// Messages beyond the persisted branch history are the in-flight prompt;
+		// stash them so the remote-compaction payload replay can append them.
+		const branchEntries = typeof ctx.sessionManager.getBranch === "function" ? ctx.sessionManager.getBranch() : [];
+		const historyMessageCount = buildContextEntries(branchEntries).flatMap((entry) =>
+			sessionEntryToContextMessages(entry),
+		).length;
+		pendingProviderMessages = event.messages.slice(historyMessageCount);
+
 		const usage = ctx.getContextUsage();
 		const contextWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
 		const promptContextWindow = getPromptContextWindow(contextWindow, ctx.model?.maxTokens);
@@ -493,7 +505,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	pi.on("before_provider_request", (event, ctx) => {
 		return rewriteOpenAiPayloadWithRemoteCompaction(
 			event.payload,
-			{ model: ctx.model, branchEntries: ctx.sessionManager.getBranch() },
+			{ model: ctx.model, branchEntries: ctx.sessionManager.getBranch(), pendingMessages: pendingProviderMessages },
 			(data) => pi.events.emit(SENPI_COMPACTION_EVENT, data),
 		);
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
@@ -1,0 +1,317 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, ImageContent, TextContent, ToolCall } from "@earendil-works/pi-ai";
+import type { SessionEntry } from "../../../session-manager.ts";
+import type { ServiceTier } from "../../types.ts";
+
+export const OPENAI_REMOTE_COMPACTION_SCHEMA = "senpi.compaction.openai-remote.v1";
+
+type OpenAiInputText = { type: "input_text"; text: string };
+type OpenAiInputImage = { type: "input_image"; detail: "auto"; image_url: string };
+type OpenAiInputContent = OpenAiInputText | OpenAiInputImage;
+type OpenAiOutputText = { type: "output_text"; text: string; annotations: [] };
+type OpenAiMessageInputItem = {
+	type?: "message";
+	id?: string;
+	role: "user" | "system" | "developer";
+	content: string | OpenAiInputContent[];
+	status?: "in_progress" | "completed" | "incomplete";
+};
+type OpenAiAssistantMessageItem = {
+	type: "message";
+	id: string;
+	role: "assistant";
+	status: "completed";
+	content: OpenAiOutputText[];
+	phase?: "commentary" | "final_answer";
+};
+type OpenAiFunctionCallItem = {
+	type: "function_call";
+	id?: string;
+	call_id: string;
+	name: string;
+	arguments: string;
+};
+type OpenAiFunctionCallOutputItem = {
+	type: "function_call_output";
+	call_id: string;
+	output: string;
+};
+export type OpenAiRemoteTransport = "websocket" | "compact-endpoint";
+type OpenAiCompactionItem = {
+	type: "compaction";
+	encrypted_content: string;
+	id?: string | null;
+	created_by?: string;
+};
+export type OpenAiContextCompactionItem = {
+	type: "context_compaction";
+	encrypted_content: string;
+	id?: string | null;
+	created_by?: string;
+};
+export type OpenAiContextCompactionTriggerItem = {
+	type: "context_compaction";
+};
+type OpenAiProviderNativeItem = Record<string, unknown> & { type: string };
+export type OpenAiRemoteInputItem =
+	| OpenAiMessageInputItem
+	| OpenAiAssistantMessageItem
+	| OpenAiFunctionCallItem
+	| OpenAiFunctionCallOutputItem
+	| OpenAiCompactionItem
+	| OpenAiContextCompactionItem
+	| OpenAiProviderNativeItem;
+
+export type OpenAiCompactBody = {
+	model: string;
+	input: OpenAiRemoteInputItem[];
+	instructions?: string;
+	prompt_cache_key?: string;
+	service_tier?: ServiceTier;
+};
+
+export type OpenAiRemoteCompactionDetails = {
+	schema: typeof OPENAI_REMOTE_COMPACTION_SCHEMA;
+	mode: "openai-remote";
+	provider: "openai";
+	api: "openai-responses";
+	transport: OpenAiRemoteTransport;
+	modelId: string;
+	responseId: string;
+	createdAt: number;
+	requestInputItemCount: number;
+	retainedInputItemCount: number;
+	replacementInput: OpenAiRemoteInputItem[];
+	usage?: Record<string, unknown>;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonRecord(value: string | undefined): Record<string, unknown> | undefined {
+	if (!value?.startsWith("{")) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function parseTextSignature(
+	signature: string | undefined,
+): { id: string; phase?: "commentary" | "final_answer" } | undefined {
+	if (!signature) return undefined;
+	const parsed = parseJsonRecord(signature);
+	if (parsed?.v === 1 && typeof parsed.id === "string") {
+		if (parsed.phase === "commentary" || parsed.phase === "final_answer") {
+			return { id: parsed.id, phase: parsed.phase };
+		}
+		return { id: parsed.id };
+	}
+	return { id: signature };
+}
+
+function toolResultText(content: string | TextContent[] | (TextContent | ImageContent)[]): string | undefined {
+	if (typeof content === "string") return content;
+	const parts: string[] = [];
+	for (const block of content) {
+		if (block.type !== "text") return undefined;
+		parts.push(block.text);
+	}
+	return parts.join("\n");
+}
+
+function convertUserContent(content: string | (TextContent | ImageContent)[]): OpenAiInputContent[] {
+	if (typeof content === "string") return [{ type: "input_text", text: content }];
+	return content.map((block): OpenAiInputContent => {
+		if (block.type === "text") return { type: "input_text", text: block.text };
+		return {
+			type: "input_image",
+			detail: "auto",
+			image_url: `data:${block.mimeType};base64,${block.data}`,
+		};
+	});
+}
+
+export function providerNativeItem(raw: unknown): OpenAiProviderNativeItem | undefined {
+	if (!isRecord(raw) || typeof raw.type !== "string") return undefined;
+	return { ...raw, type: raw.type };
+}
+
+function convertThinking(block: { thinkingSignature?: string }): OpenAiProviderNativeItem | undefined {
+	const parsed = parseJsonRecord(block.thinkingSignature);
+	if (parsed?.type !== "reasoning") return undefined;
+	return { ...parsed, type: "reasoning" };
+}
+
+function convertTextBlock(block: TextContent, messageIndex: number): OpenAiAssistantMessageItem {
+	const signature = parseTextSignature(block.textSignature);
+	const item = {
+		type: "message",
+		role: "assistant",
+		status: "completed",
+		id: signature?.id ?? `msg_${messageIndex}`,
+		content: [{ type: "output_text", text: block.text, annotations: [] }],
+		...(signature?.phase ? { phase: signature.phase } : {}),
+	} satisfies OpenAiAssistantMessageItem;
+	return item;
+}
+
+function convertToolCall(block: ToolCall): OpenAiFunctionCallItem {
+	const [callId = block.id, itemId] = block.id.split("|");
+	return {
+		type: "function_call",
+		// The Responses API rejects item ids not beginning with "fc"; custom tool
+		// calls carry the "<call_id>|custom" sentinel, not a server-issued id.
+		...(itemId?.startsWith("fc") ? { id: itemId } : {}),
+		call_id: callId,
+		name: block.name,
+		arguments: JSON.stringify(block.arguments ?? {}),
+	};
+}
+
+function isSameOpenAiResponsesAssistant(message: AssistantMessage): boolean {
+	return message.provider === "openai" && message.api === "openai-responses";
+}
+
+function convertAssistantMessage(message: AssistantMessage, messageIndex: number): OpenAiRemoteInputItem[] | undefined {
+	if (!isSameOpenAiResponsesAssistant(message)) return undefined;
+
+	const items: OpenAiRemoteInputItem[] = [];
+	for (const block of message.content) {
+		switch (block.type) {
+			case "text":
+				items.push(convertTextBlock(block, messageIndex));
+				break;
+			case "thinking": {
+				const reasoning = convertThinking(block);
+				if (!reasoning) return undefined;
+				items.push(reasoning);
+				break;
+			}
+			case "toolCall":
+				items.push(convertToolCall(block));
+				break;
+			case "providerNative": {
+				const item = providerNativeItem(block.raw);
+				if (!item) return undefined;
+				items.push(item);
+				break;
+			}
+		}
+	}
+	return items.length > 0 ? items : undefined;
+}
+
+function convertAgentMessage(message: AgentMessage, messageIndex: number): OpenAiRemoteInputItem[] | undefined {
+	switch (message.role) {
+		case "user":
+			return [{ role: "user", content: convertUserContent(message.content) }];
+		case "assistant":
+			return convertAssistantMessage(message, messageIndex);
+		case "toolResult": {
+			const [callId = message.toolCallId] = message.toolCallId.split("|");
+			const output = toolResultText(message.content);
+			if (output === undefined) return undefined;
+			return [{ type: "function_call_output", call_id: callId, output }];
+		}
+		case "bashExecution":
+		case "branchSummary":
+		case "compactionSummary":
+		case "custom":
+			return undefined;
+		default: {
+			const exhaustive: never = message;
+			return exhaustive;
+		}
+	}
+}
+
+function detailsFromEntry(entry: SessionEntry): OpenAiRemoteCompactionDetails | undefined {
+	if (entry.type !== "compaction") return undefined;
+	return getOpenAiRemoteCompactionDetails(entry.details);
+}
+
+export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.schema !== OPENAI_REMOTE_COMPACTION_SCHEMA || value.mode !== "openai-remote") return undefined;
+	if (value.provider !== "openai" || value.api !== "openai-responses") return undefined;
+	if (typeof value.modelId !== "string" || typeof value.responseId !== "string") return undefined;
+	if (typeof value.createdAt !== "number") return undefined;
+	if (typeof value.requestInputItemCount !== "number" || typeof value.retainedInputItemCount !== "number") {
+		return undefined;
+	}
+	if (!Array.isArray(value.replacementInput)) return undefined;
+	return {
+		schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
+		mode: "openai-remote",
+		provider: "openai",
+		api: "openai-responses",
+		transport: value.transport === "websocket" ? "websocket" : "compact-endpoint",
+		modelId: value.modelId,
+		responseId: value.responseId,
+		createdAt: value.createdAt,
+		requestInputItemCount: value.requestInputItemCount,
+		retainedInputItemCount: value.retainedInputItemCount,
+		replacementInput: value.replacementInput.filter((item): item is OpenAiRemoteInputItem => isRecord(item)),
+		...(isRecord(value.usage) ? { usage: value.usage } : {}),
+	};
+}
+
+export function convertBranchEntries(entries: SessionEntry[]): OpenAiRemoteInputItem[] | undefined {
+	const items: OpenAiRemoteInputItem[] = [];
+	let messageIndex = 0;
+	for (const entry of entries) {
+		switch (entry.type) {
+			case "message": {
+				const converted = convertAgentMessage(entry.message, messageIndex);
+				if (!converted) return undefined;
+				items.push(...converted);
+				messageIndex++;
+				break;
+			}
+			case "compaction": {
+				const details = detailsFromEntry(entry);
+				if (!details) return undefined;
+				items.push(...details.replacementInput);
+				break;
+			}
+			case "branch_summary":
+			case "custom_message":
+				return undefined;
+			case "thinking_level_change":
+			case "model_change":
+			case "custom":
+			case "label":
+			case "session_info":
+				break;
+		}
+	}
+	return items;
+}
+
+export function isOpenAiCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiCompactionItem {
+	return item.type === "compaction" && typeof item.encrypted_content === "string";
+}
+
+export function isOpenAiContextCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiContextCompactionItem {
+	return item.type === "context_compaction" && typeof item.encrypted_content === "string";
+}
+
+export function isOpenAiRemoteCompactionOutputItem(
+	item: OpenAiRemoteInputItem,
+): item is OpenAiCompactionItem | OpenAiContextCompactionItem {
+	return isOpenAiCompactionItem(item) || isOpenAiContextCompactionItem(item);
+}
+
+export function isRetainedRemoteOutputItem(item: OpenAiRemoteInputItem): boolean {
+	if (isOpenAiRemoteCompactionOutputItem(item)) return true;
+	return item.type === "message" && (item.role === "user" || item.role === "system" || item.role === "developer");
+}
+
+export function isRetainedResponsesStreamInputItem(item: OpenAiRemoteInputItem): boolean {
+	if (item.type === "message") return item.role === "user";
+	return "role" in item && item.role === "user";
+}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
@@ -1,6 +1,16 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent, TextContent, ToolCall } from "@earendil-works/pi-ai";
-import type { SessionEntry } from "../../../session-manager.ts";
+import type {
+	Api,
+	AssistantMessage,
+	ImageContent,
+	Message,
+	Model,
+	TextContent,
+	ToolCall,
+	ToolResultMessage,
+} from "@earendil-works/pi-ai";
+import { convertToLlm } from "../../../messages.ts";
+import { type SessionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
 import type { ServiceTier } from "../../types.ts";
 
 export const OPENAI_REMOTE_COMPACTION_SCHEMA = "senpi.compaction.openai-remote.v1";
@@ -34,7 +44,7 @@ type OpenAiFunctionCallItem = {
 type OpenAiFunctionCallOutputItem = {
 	type: "function_call_output";
 	call_id: string;
-	output: string;
+	output: string | OpenAiInputContent[];
 };
 export type OpenAiRemoteTransport = "websocket" | "compact-endpoint";
 type OpenAiCompactionItem = {
@@ -113,16 +123,6 @@ function parseTextSignature(
 	return { id: signature };
 }
 
-function toolResultText(content: string | TextContent[] | (TextContent | ImageContent)[]): string | undefined {
-	if (typeof content === "string") return content;
-	const parts: string[] = [];
-	for (const block of content) {
-		if (block.type !== "text") return undefined;
-		parts.push(block.text);
-	}
-	return parts.join("\n");
-}
-
 function convertUserContent(content: string | (TextContent | ImageContent)[]): OpenAiInputContent[] {
 	if (typeof content === "string") return [{ type: "input_text", text: content }];
 	return content.map((block): OpenAiInputContent => {
@@ -172,13 +172,14 @@ function convertToolCall(block: ToolCall): OpenAiFunctionCallItem {
 	};
 }
 
-function isSameOpenAiResponsesAssistant(message: AssistantMessage): boolean {
-	return message.provider === "openai" && message.api === "openai-responses";
-}
-
-function convertAssistantMessage(message: AssistantMessage, messageIndex: number): OpenAiRemoteInputItem[] | undefined {
-	if (!isSameOpenAiResponsesAssistant(message)) return undefined;
-
+/**
+ * Convert any assistant message — OpenAI Responses-native or foreign — into
+ * replayable input items. Native text/reasoning/tool-call items are preserved
+ * verbatim; blocks that have no OpenAI Responses representation (foreign
+ * thinking, unknown provider-native payloads) are skipped, mirroring what the
+ * provider would have received for that message in a normal turn.
+ */
+function convertAssistantMessage(message: AssistantMessage, messageIndex: number): OpenAiRemoteInputItem[] {
 	const items: OpenAiRemoteInputItem[] = [];
 	for (const block of message.content) {
 		switch (block.type) {
@@ -187,8 +188,7 @@ function convertAssistantMessage(message: AssistantMessage, messageIndex: number
 				break;
 			case "thinking": {
 				const reasoning = convertThinking(block);
-				if (!reasoning) return undefined;
-				items.push(reasoning);
+				if (reasoning) items.push(reasoning);
 				break;
 			}
 			case "toolCall":
@@ -196,42 +196,53 @@ function convertAssistantMessage(message: AssistantMessage, messageIndex: number
 				break;
 			case "providerNative": {
 				const item = providerNativeItem(block.raw);
-				if (!item) return undefined;
-				items.push(item);
+				if (item) items.push(item);
 				break;
 			}
 		}
 	}
-	return items.length > 0 ? items : undefined;
+	return items;
 }
 
-function convertAgentMessage(message: AgentMessage, messageIndex: number): OpenAiRemoteInputItem[] | undefined {
+/**
+ * Convert a tool result into a function_call_output item, mirroring the
+ * Responses API payload builder: image results stay structured for
+ * image-capable models and degrade to a text placeholder otherwise.
+ */
+function convertToolResultMessage(message: ToolResultMessage, model: Model<Api>): OpenAiRemoteInputItem[] {
+	const [callId = message.toolCallId] = message.toolCallId.split("|");
+	const text = message.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+	const images = message.content.filter((block): block is ImageContent => block.type === "image");
+	let output: string | OpenAiInputContent[];
+	if (images.length > 0 && model.input.includes("image")) {
+		const parts: OpenAiInputContent[] = [];
+		if (text.length > 0) parts.push({ type: "input_text", text });
+		for (const image of images) {
+			parts.push({
+				type: "input_image",
+				detail: "auto",
+				image_url: `data:${image.mimeType};base64,${image.data}`,
+			});
+		}
+		output = parts.length > 0 ? parts : "(no tool output)";
+	} else {
+		output = text.length > 0 ? text : images.length > 0 ? "(see attached image)" : "(no tool output)";
+	}
+	return [{ type: "function_call_output", call_id: callId, output }];
+}
+
+function convertLlmMessage(message: Message, messageIndex: number, model: Model<Api>): OpenAiRemoteInputItem[] {
 	switch (message.role) {
 		case "user":
 			return [{ role: "user", content: convertUserContent(message.content) }];
 		case "assistant":
 			return convertAssistantMessage(message, messageIndex);
-		case "toolResult": {
-			const [callId = message.toolCallId] = message.toolCallId.split("|");
-			const output = toolResultText(message.content);
-			if (output === undefined) return undefined;
-			return [{ type: "function_call_output", call_id: callId, output }];
-		}
-		case "bashExecution":
-		case "branchSummary":
-		case "compactionSummary":
-		case "custom":
-			return undefined;
-		default: {
-			const exhaustive: never = message;
-			return exhaustive;
-		}
+		case "toolResult":
+			return convertToolResultMessage(message, model);
 	}
-}
-
-function detailsFromEntry(entry: SessionEntry): OpenAiRemoteCompactionDetails | undefined {
-	if (entry.type !== "compaction") return undefined;
-	return getOpenAiRemoteCompactionDetails(entry.details);
 }
 
 export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
@@ -260,35 +271,40 @@ export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCo
 	};
 }
 
-export function convertBranchEntries(entries: SessionEntry[]): OpenAiRemoteInputItem[] | undefined {
+/**
+ * Convert session branch entries into OpenAI Responses input items.
+ *
+ * The route gate is provider capability (checked by the caller), not history
+ * provenance: any entry the session can carry is converted through the same
+ * pipeline the normal context path uses (`sessionEntryToContextMessages` +
+ * `convertToLlm`), so foreign-provider messages, bash executions, branch
+ * summaries, and prior local compactions degrade to their canonical text
+ * form instead of disqualifying remote compaction. Prior OpenAI remote
+ * compaction checkpoints splice their native `replacementInput` in order.
+ */
+export function convertBranchEntries(entries: SessionEntry[], model: Model<Api>): OpenAiRemoteInputItem[] {
 	const items: OpenAiRemoteInputItem[] = [];
+	let pendingMessages: AgentMessage[] = [];
 	let messageIndex = 0;
-	for (const entry of entries) {
-		switch (entry.type) {
-			case "message": {
-				const converted = convertAgentMessage(entry.message, messageIndex);
-				if (!converted) return undefined;
-				items.push(...converted);
-				messageIndex++;
-				break;
-			}
-			case "compaction": {
-				const details = detailsFromEntry(entry);
-				if (!details) return undefined;
-				items.push(...details.replacementInput);
-				break;
-			}
-			case "branch_summary":
-			case "custom_message":
-				return undefined;
-			case "thinking_level_change":
-			case "model_change":
-			case "custom":
-			case "label":
-			case "session_info":
-				break;
+	const flush = (): void => {
+		for (const message of convertToLlm(pendingMessages)) {
+			items.push(...convertLlmMessage(message, messageIndex, model));
+			messageIndex++;
 		}
+		pendingMessages = [];
+	};
+	for (const entry of entries) {
+		if (entry.type === "compaction") {
+			const details = getOpenAiRemoteCompactionDetails(entry.details);
+			if (details) {
+				flush();
+				items.push(...details.replacementInput);
+				continue;
+			}
+		}
+		pendingMessages.push(...sessionEntryToContextMessages(entry));
 	}
+	flush();
 	return items;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
@@ -245,6 +245,15 @@ function convertLlmMessage(message: Message, messageIndex: number, model: Model<
 	}
 }
 
+/**
+ * Convert messages that are not yet persisted in the session branch (the
+ * in-flight prompt) into input items, so payload replay can append them after
+ * the branch-derived items.
+ */
+export function convertPendingMessages(messages: AgentMessage[], model: Model<Api>): OpenAiRemoteInputItem[] {
+	return convertToLlm(messages).flatMap((message, index) => convertLlmMessage(message, index, model));
+}
+
 export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
 	if (!isRecord(value)) return undefined;
 	if (value.schema !== OPENAI_REMOTE_COMPACTION_SCHEMA || value.mode !== "openai-remote") return undefined;

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -1,101 +1,35 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type {
-	Api,
-	AssistantMessage,
-	Context,
-	ImageContent,
-	Model,
-	SimpleStreamOptions,
-	TextContent,
-	ToolCall,
-} from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { CompactionResult } from "../../../compaction/index.ts";
 import type { SessionEntry } from "../../../session-manager.ts";
 import type { ServiceTier, SessionBeforeCompactEvent } from "../../types.ts";
+import type {
+	OpenAiCompactBody,
+	OpenAiContextCompactionItem,
+	OpenAiContextCompactionTriggerItem,
+	OpenAiRemoteCompactionDetails,
+	OpenAiRemoteInputItem,
+	OpenAiRemoteTransport,
+} from "./openai-remote-convert.ts";
+import {
+	convertBranchEntries,
+	getOpenAiRemoteCompactionDetails,
+	isOpenAiContextCompactionItem,
+	isOpenAiRemoteCompactionOutputItem,
+	isRecord,
+	isRetainedRemoteOutputItem,
+	isRetainedResponsesStreamInputItem,
+	OPENAI_REMOTE_COMPACTION_SCHEMA,
+	providerNativeItem,
+} from "./openai-remote-convert.ts";
 
-export const OPENAI_REMOTE_COMPACTION_SCHEMA = "senpi.compaction.openai-remote.v1";
+export type {
+	OpenAiRemoteCompactionDetails,
+	OpenAiRemoteInputItem,
+} from "./openai-remote-convert.ts";
+export { getOpenAiRemoteCompactionDetails, OPENAI_REMOTE_COMPACTION_SCHEMA } from "./openai-remote-convert.ts";
+
 export const SENPI_COMPACTION_EVENT = "senpi:compaction";
-
-type OpenAiInputText = { type: "input_text"; text: string };
-type OpenAiInputImage = { type: "input_image"; detail: "auto"; image_url: string };
-type OpenAiInputContent = OpenAiInputText | OpenAiInputImage;
-type OpenAiOutputText = { type: "output_text"; text: string; annotations: [] };
-type OpenAiMessageInputItem = {
-	type?: "message";
-	id?: string;
-	role: "user" | "system" | "developer";
-	content: string | OpenAiInputContent[];
-	status?: "in_progress" | "completed" | "incomplete";
-};
-type OpenAiAssistantMessageItem = {
-	type: "message";
-	id: string;
-	role: "assistant";
-	status: "completed";
-	content: OpenAiOutputText[];
-	phase?: "commentary" | "final_answer";
-};
-type OpenAiFunctionCallItem = {
-	type: "function_call";
-	id?: string;
-	call_id: string;
-	name: string;
-	arguments: string;
-};
-type OpenAiFunctionCallOutputItem = {
-	type: "function_call_output";
-	call_id: string;
-	output: string;
-};
-type OpenAiRemoteTransport = "websocket" | "compact-endpoint";
-type OpenAiCompactionItem = {
-	type: "compaction";
-	encrypted_content: string;
-	id?: string | null;
-	created_by?: string;
-};
-type OpenAiContextCompactionItem = {
-	type: "context_compaction";
-	encrypted_content: string;
-	id?: string | null;
-	created_by?: string;
-};
-type OpenAiContextCompactionTriggerItem = {
-	type: "context_compaction";
-};
-type OpenAiProviderNativeItem = Record<string, unknown> & { type: string };
-export type OpenAiRemoteInputItem =
-	| OpenAiMessageInputItem
-	| OpenAiAssistantMessageItem
-	| OpenAiFunctionCallItem
-	| OpenAiFunctionCallOutputItem
-	| OpenAiCompactionItem
-	| OpenAiContextCompactionItem
-	| OpenAiProviderNativeItem;
-
-type OpenAiCompactBody = {
-	model: string;
-	input: OpenAiRemoteInputItem[];
-	instructions?: string;
-	prompt_cache_key?: string;
-	service_tier?: ServiceTier;
-};
-
-export type OpenAiRemoteCompactionDetails = {
-	schema: typeof OPENAI_REMOTE_COMPACTION_SCHEMA;
-	mode: "openai-remote";
-	provider: "openai";
-	api: "openai-responses";
-	transport: OpenAiRemoteTransport;
-	modelId: string;
-	responseId: string;
-	createdAt: number;
-	requestInputItemCount: number;
-	retainedInputItemCount: number;
-	replacementInput: OpenAiRemoteInputItem[];
-	usage?: Record<string, unknown>;
-};
 
 export type OpenAiRemoteCompactionRequest = {
 	body: OpenAiCompactBody;
@@ -200,34 +134,6 @@ type EmitCompactionEvent = (event: OpenAiRemoteCompactionEvent) => void;
 const OPENAI_REMOTE_COMPACTION_TIMEOUT_MS = 15_000;
 const REMOTE_COMPACTION_TIMEOUT_REASON = "remote-compaction-timeout";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function parseJsonRecord(value: string | undefined): Record<string, unknown> | undefined {
-	if (!value?.startsWith("{")) return undefined;
-	try {
-		const parsed: unknown = JSON.parse(value);
-		return isRecord(parsed) ? parsed : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function parseTextSignature(
-	signature: string | undefined,
-): { id: string; phase?: "commentary" | "final_answer" } | undefined {
-	if (!signature) return undefined;
-	const parsed = parseJsonRecord(signature);
-	if (parsed?.v === 1 && typeof parsed.id === "string") {
-		if (parsed.phase === "commentary" || parsed.phase === "final_answer") {
-			return { id: parsed.id, phase: parsed.phase };
-		}
-		return { id: parsed.id };
-	}
-	return { id: signature };
-}
-
 function isOpenAiResponsesModel(model: Model<Api> | undefined): model is Model<"openai-responses"> {
 	return model?.provider === "openai" && model.api === "openai-responses";
 }
@@ -239,185 +145,6 @@ function supportsOpenAiResponsesWebSocket(model: Model<"openai-responses">): boo
 	} catch {
 		return false;
 	}
-}
-
-function toolResultText(content: string | TextContent[] | (TextContent | ImageContent)[]): string | undefined {
-	if (typeof content === "string") return content;
-	const parts: string[] = [];
-	for (const block of content) {
-		if (block.type !== "text") return undefined;
-		parts.push(block.text);
-	}
-	return parts.join("\n");
-}
-
-function convertUserContent(content: string | (TextContent | ImageContent)[]): OpenAiInputContent[] {
-	if (typeof content === "string") return [{ type: "input_text", text: content }];
-	return content.map((block): OpenAiInputContent => {
-		if (block.type === "text") return { type: "input_text", text: block.text };
-		return {
-			type: "input_image",
-			detail: "auto",
-			image_url: `data:${block.mimeType};base64,${block.data}`,
-		};
-	});
-}
-
-function providerNativeItem(raw: unknown): OpenAiProviderNativeItem | undefined {
-	if (!isRecord(raw) || typeof raw.type !== "string") return undefined;
-	return { ...raw, type: raw.type };
-}
-
-function convertThinking(block: { thinkingSignature?: string }): OpenAiProviderNativeItem | undefined {
-	const parsed = parseJsonRecord(block.thinkingSignature);
-	if (parsed?.type !== "reasoning") return undefined;
-	return { ...parsed, type: "reasoning" };
-}
-
-function convertTextBlock(block: TextContent, messageIndex: number): OpenAiAssistantMessageItem {
-	const signature = parseTextSignature(block.textSignature);
-	const item = {
-		type: "message",
-		role: "assistant",
-		status: "completed",
-		id: signature?.id ?? `msg_${messageIndex}`,
-		content: [{ type: "output_text", text: block.text, annotations: [] }],
-		...(signature?.phase ? { phase: signature.phase } : {}),
-	} satisfies OpenAiAssistantMessageItem;
-	return item;
-}
-
-function convertToolCall(block: ToolCall): OpenAiFunctionCallItem {
-	const [callId = block.id, itemId] = block.id.split("|");
-	return {
-		type: "function_call",
-		// The Responses API rejects item ids not beginning with "fc"; custom tool
-		// calls carry the "<call_id>|custom" sentinel, not a server-issued id.
-		...(itemId?.startsWith("fc") ? { id: itemId } : {}),
-		call_id: callId,
-		name: block.name,
-		arguments: JSON.stringify(block.arguments ?? {}),
-	};
-}
-
-function isSameOpenAiResponsesAssistant(message: AssistantMessage): boolean {
-	return message.provider === "openai" && message.api === "openai-responses";
-}
-
-function convertAssistantMessage(message: AssistantMessage, messageIndex: number): OpenAiRemoteInputItem[] | undefined {
-	if (!isSameOpenAiResponsesAssistant(message)) return undefined;
-
-	const items: OpenAiRemoteInputItem[] = [];
-	for (const block of message.content) {
-		switch (block.type) {
-			case "text":
-				items.push(convertTextBlock(block, messageIndex));
-				break;
-			case "thinking": {
-				const reasoning = convertThinking(block);
-				if (!reasoning) return undefined;
-				items.push(reasoning);
-				break;
-			}
-			case "toolCall":
-				items.push(convertToolCall(block));
-				break;
-			case "providerNative": {
-				const item = providerNativeItem(block.raw);
-				if (!item) return undefined;
-				items.push(item);
-				break;
-			}
-		}
-	}
-	return items.length > 0 ? items : undefined;
-}
-
-function convertAgentMessage(message: AgentMessage, messageIndex: number): OpenAiRemoteInputItem[] | undefined {
-	switch (message.role) {
-		case "user":
-			return [{ role: "user", content: convertUserContent(message.content) }];
-		case "assistant":
-			return convertAssistantMessage(message, messageIndex);
-		case "toolResult": {
-			const [callId = message.toolCallId] = message.toolCallId.split("|");
-			const output = toolResultText(message.content);
-			if (output === undefined) return undefined;
-			return [{ type: "function_call_output", call_id: callId, output }];
-		}
-		case "bashExecution":
-		case "branchSummary":
-		case "compactionSummary":
-		case "custom":
-			return undefined;
-		default: {
-			const exhaustive: never = message;
-			return exhaustive;
-		}
-	}
-}
-
-function detailsFromEntry(entry: SessionEntry): OpenAiRemoteCompactionDetails | undefined {
-	if (entry.type !== "compaction") return undefined;
-	return getOpenAiRemoteCompactionDetails(entry.details);
-}
-
-export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
-	if (!isRecord(value)) return undefined;
-	if (value.schema !== OPENAI_REMOTE_COMPACTION_SCHEMA || value.mode !== "openai-remote") return undefined;
-	if (value.provider !== "openai" || value.api !== "openai-responses") return undefined;
-	if (typeof value.modelId !== "string" || typeof value.responseId !== "string") return undefined;
-	if (typeof value.createdAt !== "number") return undefined;
-	if (typeof value.requestInputItemCount !== "number" || typeof value.retainedInputItemCount !== "number") {
-		return undefined;
-	}
-	if (!Array.isArray(value.replacementInput)) return undefined;
-	return {
-		schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
-		mode: "openai-remote",
-		provider: "openai",
-		api: "openai-responses",
-		transport: value.transport === "websocket" ? "websocket" : "compact-endpoint",
-		modelId: value.modelId,
-		responseId: value.responseId,
-		createdAt: value.createdAt,
-		requestInputItemCount: value.requestInputItemCount,
-		retainedInputItemCount: value.retainedInputItemCount,
-		replacementInput: value.replacementInput.filter((item): item is OpenAiRemoteInputItem => isRecord(item)),
-		...(isRecord(value.usage) ? { usage: value.usage } : {}),
-	};
-}
-
-function convertBranchEntries(entries: SessionEntry[]): OpenAiRemoteInputItem[] | undefined {
-	const items: OpenAiRemoteInputItem[] = [];
-	let messageIndex = 0;
-	for (const entry of entries) {
-		switch (entry.type) {
-			case "message": {
-				const converted = convertAgentMessage(entry.message, messageIndex);
-				if (!converted) return undefined;
-				items.push(...converted);
-				messageIndex++;
-				break;
-			}
-			case "compaction": {
-				const details = detailsFromEntry(entry);
-				if (!details) return undefined;
-				items.push(...details.replacementInput);
-				break;
-			}
-			case "branch_summary":
-			case "custom_message":
-				return undefined;
-			case "thinking_level_change":
-			case "model_change":
-			case "custom":
-			case "label":
-			case "session_info":
-				break;
-		}
-	}
-	return items;
 }
 
 export function createOpenAiRemoteCompactionRequest(options: {
@@ -442,30 +169,6 @@ export function createOpenAiRemoteCompactionRequest(options: {
 		inputItemCount: input.length,
 		tokensBefore: options.tokensBefore,
 	};
-}
-
-function isOpenAiCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiCompactionItem {
-	return item.type === "compaction" && typeof item.encrypted_content === "string";
-}
-
-function isOpenAiContextCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiContextCompactionItem {
-	return item.type === "context_compaction" && typeof item.encrypted_content === "string";
-}
-
-function isOpenAiRemoteCompactionOutputItem(
-	item: OpenAiRemoteInputItem,
-): item is OpenAiCompactionItem | OpenAiContextCompactionItem {
-	return isOpenAiCompactionItem(item) || isOpenAiContextCompactionItem(item);
-}
-
-function isRetainedRemoteOutputItem(item: OpenAiRemoteInputItem): boolean {
-	if (isOpenAiRemoteCompactionOutputItem(item)) return true;
-	return item.type === "message" && (item.role === "user" || item.role === "system" || item.role === "developer");
-}
-
-function isRetainedResponsesStreamInputItem(item: OpenAiRemoteInputItem): boolean {
-	if (item.type === "message") return item.role === "user";
-	return "role" in item && item.role === "user";
 }
 
 function isOpenAiCompactedResponse(value: unknown): value is OpenAiCompactedResponse {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -156,8 +156,8 @@ export function createOpenAiRemoteCompactionRequest(options: {
 	serviceTier?: ServiceTier;
 }): OpenAiRemoteCompactionRequest | undefined {
 	if (!isOpenAiResponsesModel(options.model)) return undefined;
-	const input = convertBranchEntries(options.branchEntries);
-	if (!input || input.length === 0) return undefined;
+	const input = convertBranchEntries(options.branchEntries, options.model);
+	if (input.length === 0) return undefined;
 	return {
 		body: {
 			model: options.model.id,
@@ -569,7 +569,7 @@ export async function runOpenAiRemoteCompaction(
 			route: "builtin.compaction.openai_remote",
 			requestId: event.requestId,
 			modelId: model.id,
-			reason: "session-not-openai-native",
+			reason: "empty-compaction-input",
 		});
 		return undefined;
 	}
@@ -723,8 +723,7 @@ export function rewriteOpenAiPayloadWithRemoteCompaction(
 	const remote = latestRemoteCompaction(options.branchEntries);
 	if (!remote) return undefined;
 
-	const postCompactionItems = convertBranchEntries(options.branchEntries.slice(remote.index + 1));
-	if (!postCompactionItems) return undefined;
+	const postCompactionItems = convertBranchEntries(options.branchEntries.slice(remote.index + 1), options.model);
 
 	const input = [...leadingPromptMessages(payload.input), ...remote.details.replacementInput, ...postCompactionItems];
 	emit?.({

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { CompactionResult } from "../../../compaction/index.ts";
@@ -13,6 +14,7 @@ import type {
 } from "./openai-remote-convert.ts";
 import {
 	convertBranchEntries,
+	convertPendingMessages,
 	getOpenAiRemoteCompactionDetails,
 	isOpenAiContextCompactionItem,
 	isOpenAiRemoteCompactionOutputItem,
@@ -716,7 +718,7 @@ function leadingPromptMessages(input: unknown): OpenAiRemoteInputItem[] {
 
 export function rewriteOpenAiPayloadWithRemoteCompaction(
 	payload: unknown,
-	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[] },
+	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[]; pendingMessages?: AgentMessage[] },
 	emit?: EmitCompactionEvent,
 ): unknown | undefined {
 	if (!isOpenAiResponsesModel(options.model) || !isRecord(payload)) return undefined;
@@ -724,8 +726,16 @@ export function rewriteOpenAiPayloadWithRemoteCompaction(
 	if (!remote) return undefined;
 
 	const postCompactionItems = convertBranchEntries(options.branchEntries.slice(remote.index + 1), options.model);
+	// The in-flight prompt is not yet persisted in the branch at provider-request
+	// time; append it so the replayed payload still carries the user's message.
+	const pendingItems = convertPendingMessages(options.pendingMessages ?? [], options.model);
 
-	const input = [...leadingPromptMessages(payload.input), ...remote.details.replacementInput, ...postCompactionItems];
+	const input = [
+		...leadingPromptMessages(payload.input),
+		...remote.details.replacementInput,
+		...postCompactionItems,
+		...pendingItems,
+	];
 	emit?.({
 		version: 1,
 		action: "remote_payload_rewritten",

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -11,6 +11,12 @@ import {
 	runOpenAiRemoteCompaction,
 } from "../../src/core/extensions/builtin/compaction/openai-remote.ts";
 import type { SessionBeforeCompactEvent } from "../../src/core/extensions/types.ts";
+import {
+	BRANCH_SUMMARY_PREFIX,
+	BRANCH_SUMMARY_SUFFIX,
+	COMPACTION_SUMMARY_PREFIX,
+	COMPACTION_SUMMARY_SUFFIX,
+} from "../../src/core/messages.ts";
 import type { SessionEntry, SessionMessageEntry } from "../../src/core/session-manager.ts";
 
 const OPENAI_MODEL = {
@@ -112,7 +118,7 @@ function compactionEvent(branchEntries: SessionEntry[]): SessionBeforeCompactEve
 }
 
 describe("OpenAI remote compaction", () => {
-	it("builds a compact request only when every context message is OpenAI Responses-compatible", () => {
+	it("builds a compact request from a fully OpenAI-native branch", () => {
 		const request = createOpenAiRemoteCompactionRequest({
 			model: OPENAI_MODEL,
 			systemPrompt: "You are senpi.",
@@ -386,7 +392,243 @@ describe("OpenAI remote compaction", () => {
 		]);
 	});
 
-	it("falls back when a non-OpenAI assistant message is present", () => {
+	it("degrades a non-OpenAI assistant message into replayable input items", () => {
+		const branch = openAiBranch();
+		branch.splice(
+			2,
+			1,
+			messageEntry("anthropic", "u1", {
+				role: "assistant",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-opus-4-7",
+				content: [
+					{ type: "thinking", thinking: "claude reasoned here", thinkingSignature: "sig_anthropic" },
+					{ type: "text", text: "not native" },
+				],
+				usage: {
+					input: 10,
+					output: 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 12,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 2,
+			}),
+		);
+
+		const request = createOpenAiRemoteCompactionRequest({
+			model: OPENAI_MODEL,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+
+		expect(request).toBeDefined();
+		expect(request?.body.input).toContainEqual({
+			type: "message",
+			role: "assistant",
+			status: "completed",
+			id: expect.any(String),
+			content: [{ type: "output_text", text: "not native", annotations: [] }],
+		});
+		// Foreign thinking blocks have no OpenAI reasoning item and are skipped.
+		expect(JSON.stringify(request?.body.input)).not.toContain("claude reasoned here");
+	});
+
+	it("converts bash execution messages to user text instead of bailing", () => {
+		const branch = [
+			...openAiBranch(),
+			messageEntry("bash1", "u2", {
+				role: "bashExecution",
+				command: "ls",
+				output: "file.txt",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+				timestamp: 5,
+			}),
+		];
+
+		const request = createOpenAiRemoteCompactionRequest({
+			model: OPENAI_MODEL,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+
+		expect(request?.body.input).toContainEqual({
+			role: "user",
+			content: [{ type: "input_text", text: "Ran `ls`\n```\nfile.txt\n```" }],
+		});
+	});
+
+	it("degrades a prior local compaction entry into a summary user message", () => {
+		const branch: SessionEntry[] = [
+			...openAiBranch(),
+			{
+				type: "compaction",
+				id: "localcompact",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				summary: "local summary text",
+				firstKeptEntryId: "u2",
+				tokensBefore: 500,
+				fromHook: true,
+			},
+			messageEntry("u3", "localcompact", {
+				role: "user",
+				content: [{ type: "text", text: "after local compaction" }],
+				timestamp: 6,
+			}),
+		];
+
+		const request = createOpenAiRemoteCompactionRequest({
+			model: OPENAI_MODEL,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+
+		expect(request).toBeDefined();
+		expect(request?.body.input).toContainEqual({
+			role: "user",
+			content: [
+				{
+					type: "input_text",
+					text: `${COMPACTION_SUMMARY_PREFIX}local summary text${COMPACTION_SUMMARY_SUFFIX}`,
+				},
+			],
+		});
+		expect(request?.body.input).toContainEqual({
+			role: "user",
+			content: [{ type: "input_text", text: "after local compaction" }],
+		});
+	});
+
+	it("includes branch summary and custom message entries as user text", () => {
+		const branch: SessionEntry[] = [
+			...openAiBranch(),
+			{
+				type: "branch_summary",
+				id: "bs1",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				fromId: "u1",
+				summary: "branch work",
+			},
+			{
+				type: "custom_message",
+				id: "cm1",
+				parentId: "bs1",
+				timestamp: new Date(1_775_000_003_000).toISOString(),
+				customType: "note",
+				content: "remember this",
+				display: false,
+			},
+		];
+
+		const request = createOpenAiRemoteCompactionRequest({
+			model: OPENAI_MODEL,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+
+		expect(request).toBeDefined();
+		expect(request?.body.input).toContainEqual({
+			role: "user",
+			content: [{ type: "input_text", text: `${BRANCH_SUMMARY_PREFIX}branch work${BRANCH_SUMMARY_SUFFIX}` }],
+		});
+		expect(request?.body.input).toContainEqual({
+			role: "user",
+			content: [{ type: "input_text", text: "remember this" }],
+		});
+	});
+
+	it("renders image tool results as structured output for image-capable models and text fallback otherwise", () => {
+		const branch: SessionEntry[] = [
+			{
+				type: "model_change",
+				id: "model",
+				parentId: null,
+				timestamp: new Date(1_775_000_000_000).toISOString(),
+				provider: "openai",
+				modelId: "gpt-5.4",
+			},
+			messageEntry("u1", "model", {
+				role: "user",
+				content: [{ type: "text", text: "look at this" }],
+				timestamp: 1,
+			}),
+			messageEntry("t1", "u1", {
+				role: "toolResult",
+				toolCallId: "call_shot|fc_shot",
+				toolName: "read",
+				content: [
+					{ type: "text", text: "screenshot follows" },
+					{ type: "image", mimeType: "image/png", data: "QUJD" },
+				],
+				isError: false,
+				timestamp: 2,
+			}),
+		];
+
+		const imageCapable = createOpenAiRemoteCompactionRequest({
+			model: OPENAI_MODEL,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+		expect(imageCapable?.body.input).toContainEqual({
+			type: "function_call_output",
+			call_id: "call_shot",
+			output: [
+				{ type: "input_text", text: "screenshot follows" },
+				{ type: "input_image", detail: "auto", image_url: "data:image/png;base64,QUJD" },
+			],
+		});
+
+		const textOnlyModel = { ...OPENAI_MODEL, input: ["text"] } as typeof OPENAI_MODEL;
+		const textOnly = createOpenAiRemoteCompactionRequest({
+			model: textOnlyModel,
+			systemPrompt: "You are senpi.",
+			branchEntries: branch,
+			tokensBefore: 1234,
+		});
+		expect(textOnly?.body.input).toContainEqual({
+			type: "function_call_output",
+			call_id: "call_shot",
+			output: "screenshot follows",
+		});
+
+		const imageOnlyBranch: SessionEntry[] = [
+			branch[0]!,
+			messageEntry("t2", "model", {
+				role: "toolResult",
+				toolCallId: "call_pic|fc_pic",
+				toolName: "read",
+				content: [{ type: "image", mimeType: "image/png", data: "QUJD" }],
+				isError: false,
+				timestamp: 3,
+			}),
+		];
+		const imageOnly = createOpenAiRemoteCompactionRequest({
+			model: textOnlyModel,
+			systemPrompt: "You are senpi.",
+			branchEntries: imageOnlyBranch,
+			tokensBefore: 1234,
+		});
+		expect(imageOnly?.body.input).toContainEqual({
+			type: "function_call_output",
+			call_id: "call_pic",
+			output: "(see attached image)",
+		});
+	});
+
+	it("runs remote compaction for a mixed-provider branch when the current model supports it", async () => {
 		const branch = openAiBranch();
 		branch.splice(
 			2,
@@ -410,14 +652,155 @@ describe("OpenAI remote compaction", () => {
 			}),
 		);
 
-		expect(
-			createOpenAiRemoteCompactionRequest({
-				model: OPENAI_MODEL,
-				systemPrompt: "You are senpi.",
-				branchEntries: branch,
-				tokensBefore: 1234,
+		const emitted: unknown[] = [];
+		const capturedBodies: unknown[] = [];
+		const compactOnlyModel = {
+			...OPENAI_MODEL,
+			baseUrl: "https://ccapi.example.com/v1",
+			compat: { supportsWebSocket: false },
+		} satisfies Model<"openai-responses">;
+		const ctx = {
+			model: compactOnlyModel,
+			serviceTier: undefined,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+			},
+			sessionManager: { getSessionId: () => "session-1" },
+			getSystemPrompt: () => "You are senpi.",
+		};
+
+		const result = await runOpenAiRemoteCompaction(ctx, compactionEvent(branch), (event) => emitted.push(event), {
+			fetch: async (_url, init) => {
+				capturedBodies.push(JSON.parse(String(init?.body)));
+				return new Response(
+					JSON.stringify({
+						id: "resp_compact_mixed",
+						created_at: 1_775_000_002,
+						object: "response.compaction",
+						output: [
+							{
+								type: "message",
+								id: "u1_remote",
+								role: "user",
+								content: [{ type: "input_text", text: "Please inspect the build." }],
+							},
+							{ type: "compaction", id: "cmp_mixed", encrypted_content: "encrypted-mixed" },
+						],
+						usage: { input_tokens: 100, output_tokens: 10, total_tokens: 110 },
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			},
+		});
+
+		expect(result?.details.schema).toBe(OPENAI_REMOTE_COMPACTION_SCHEMA);
+		expect(emitted).toMatchObject([
+			{ action: "remote_started", transport: "compact-endpoint" },
+			{ action: "remote_completed", transport: "compact-endpoint" },
+		]);
+		expect(capturedBodies).toHaveLength(1);
+		expect((capturedBodies[0] as { input: unknown[] }).input).toContainEqual({
+			type: "message",
+			role: "assistant",
+			status: "completed",
+			id: expect.any(String),
+			content: [{ type: "output_text", text: "not native", annotations: [] }],
+		});
+	});
+
+	it("rewrites provider payloads when post-compaction history is not OpenAI-native", () => {
+		const remoteResult = buildOpenAiRemoteCompactionResult({
+			model: OPENAI_MODEL,
+			firstKeptEntryId: "u2",
+			tokensBefore: 1234,
+			requestInputItemCount: 5,
+			response: {
+				id: "resp_compact",
+				created_at: 1_775_000_001,
+				object: "response.compaction",
+				output: [
+					{
+						type: "message",
+						id: "u1_remote",
+						role: "user",
+						content: [{ type: "input_text", text: "Please inspect the build." }],
+					},
+					{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
+				],
+			},
+		});
+		const branchWithMixedTail: SessionEntry[] = [
+			...openAiBranch(),
+			{
+				type: "compaction",
+				id: "compact",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				summary: remoteResult.summary,
+				firstKeptEntryId: remoteResult.firstKeptEntryId,
+				tokensBefore: remoteResult.tokensBefore,
+				details: remoteResult.details,
+				fromHook: true,
+			},
+			messageEntry("bash1", "compact", {
+				role: "bashExecution",
+				command: "git status",
+				output: "clean",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+				timestamp: 5,
 			}),
-		).toBeUndefined();
+			messageEntry("a2", "bash1", {
+				role: "assistant",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-opus-4-7",
+				content: [{ type: "text", text: "switched to claude after compaction" }],
+				usage: {
+					input: 10,
+					output: 2,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 12,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 6,
+			}),
+		];
+
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			{
+				model: "gpt-5.4",
+				input: [{ role: "developer", content: "current system prompt" }],
+				stream: true,
+			},
+			{ model: OPENAI_MODEL, branchEntries: branchWithMixedTail },
+		);
+
+		expect(rewritten).toMatchObject({
+			model: "gpt-5.4",
+			input: [
+				{ role: "developer", content: "current system prompt" },
+				{
+					type: "message",
+					id: "u1_remote",
+					role: "user",
+					content: [{ type: "input_text", text: "Please inspect the build." }],
+				},
+				{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
+				{ role: "user", content: [{ type: "input_text", text: "Ran `git status`\n```\nclean\n```" }] },
+				{
+					type: "message",
+					role: "assistant",
+					status: "completed",
+					id: expect.any(String),
+					content: [{ type: "output_text", text: "switched to claude after compaction", annotations: [] }],
+				},
+			],
+			stream: true,
+		});
 	});
 
 	it("stores remote compaction replacement input in result details for replay", () => {

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -890,6 +890,80 @@ describe("OpenAI remote compaction", () => {
 		]);
 	});
 
+	it("appends the pending prompt that is not yet persisted in the branch", () => {
+		const remoteResult = buildOpenAiRemoteCompactionResult({
+			model: OPENAI_MODEL,
+			firstKeptEntryId: "u2",
+			tokensBefore: 1234,
+			requestInputItemCount: 5,
+			response: {
+				id: "resp_compact",
+				created_at: 1_775_000_001,
+				object: "response.compaction",
+				output: [
+					{
+						type: "message",
+						id: "u1_remote",
+						role: "user",
+						content: [{ type: "input_text", text: "Please inspect the build." }],
+					},
+					{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
+				],
+			},
+		});
+		const branchEndingAtCompaction: SessionEntry[] = [
+			...openAiBranch(),
+			{
+				type: "compaction",
+				id: "compact",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				summary: remoteResult.summary,
+				firstKeptEntryId: remoteResult.firstKeptEntryId,
+				tokensBefore: remoteResult.tokensBefore,
+				details: remoteResult.details,
+				fromHook: true,
+			},
+		];
+
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			{
+				model: "gpt-5.4",
+				input: [
+					{ role: "developer", content: "current system prompt" },
+					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{ role: "user", content: [{ type: "input_text", text: "Turn three: after compaction." }] },
+				],
+				stream: true,
+			},
+			{
+				model: OPENAI_MODEL,
+				branchEntries: branchEndingAtCompaction,
+				pendingMessages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "Turn three: after compaction." }],
+						timestamp: 7,
+					},
+				],
+			},
+		);
+
+		expect(rewritten).toMatchObject({
+			input: [
+				{ role: "developer", content: "current system prompt" },
+				{
+					type: "message",
+					id: "u1_remote",
+					role: "user",
+					content: [{ type: "input_text", text: "Please inspect the build." }],
+				},
+				{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
+				{ role: "user", content: [{ type: "input_text", text: "Turn three: after compaction." }] },
+			],
+		});
+	});
+
 	it("rewrites provider payloads to replay native compacted history plus post-compact messages", () => {
 		const remoteResult = buildOpenAiRemoteCompactionResult({
 			model: OPENAI_MODEL,


### PR DESCRIPTION
## Summary

Senpi's OpenAI remote compaction (`/responses/compact` and the Responses WebSocket `context_compaction` route) previously only ran when the **entire session branch was OpenAI Responses-native** — any foreign-provider assistant message, `!` bash execution, branch summary, custom message, image tool result, or a prior *local* compaction silently forced the route back to local text summarization for the rest of the session. This PR changes the gate to a **provider-capability check only** (current model is `openai` + `openai-responses`, matching codex's `supports_remote_compaction()`), and makes branch-to-input conversion total by degrading non-native entries to their canonical text form via the same `sessionEntryToContextMessages` + `convertToLlm` pipeline the normal context path uses.

It also fixes a pre-existing replay bug surfaced by the new end-to-end QA: after a remote compaction, the next provider request's payload was rebuilt from the persisted branch only, and **the user's in-flight prompt (not yet persisted) was silently dropped** — the model never saw the first message after a remote compaction.

## Changes

- **`compaction/openai-remote-convert.ts`** (extracted from `openai-remote.ts` in a prep refactor): branch conversion is now total. Foreign assistant messages keep text/tool calls and skip unrepresentable thinking/provider-native blocks; bash executions, branch summaries, custom messages, and prior local compaction entries convert to their canonical user-text forms; image-bearing tool results mirror the Responses payload builder (structured `input_text`/`input_image` parts for image-capable models, `(see attached image)` otherwise). Prior remote-compaction checkpoints still splice native `replacementInput` in order.
- **`compaction/openai-remote.ts`**: route gate = capability only; the `session-not-openai-native` fallback reason is gone (only `empty-compaction-input` remains); payload rewrite always applies and now appends the in-flight pending messages after the branch-derived items.
- **`compaction/index.ts`**: the `context` handler stashes the not-yet-persisted tail messages (`pendingProviderMessages`) so the rewrite can include them; computed defensively from `buildContextEntries(branch)` for partial-session-manager contexts.
- **Tests**: `test/compaction/openai-remote-compaction.test.ts` — pure-OpenAI characterization (unchanged expectations), degradation cases (mixed providers, bash executions, local compaction entries, branch/custom entries, image tool results), a mixed-history remote run through `runOpenAiRemoteCompaction`, rewrite with a non-native tail, and pending-prompt preservation.
- **QA**: new senpi-qa channel script `.agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs` — drives the real CLI (`--mode rpc`) against a local mock serving Anthropic Messages, OpenAI Responses, and `/v1/responses/compact`.
- **`compaction/changes.md`**: fork-tracker entries for both changes.

## QA & Evidence

- **What was tested:** unit/integration — `npx vitest run test/compaction/` (22 files, 177 tests) covering every degradation path and both rewrites; static — `npm run check` (biome, tsgo, pinned deps, shrinkwrap, neo) green.
- **Observed result:** all green; pure-OpenAI request building is byte-identical to before (characterization test untouched).
- **What was tested (real surface):** `node .agents/skills/senpi-qa/scripts/compaction-remote-qa.mjs --self-test` — real CLI over RPC: anthropic mock turn → openai mock turn → `compact` → follow-up turn.
- **Observed result:** 6/6 PASS: `/v1/responses/compact` called despite the anthropic turn in history; the anthropic turn reaches OpenAI as a degraded `output_text` item; the RPC `compact` response carries `senpi.compaction.openai-remote.v1` details; the post-compaction `/v1/responses` payload replays the native compaction item **and** still contains the user's new prompt (this last assertion fails without the replay fix); real `~/.senpi` auth untouched.
- **Artifact:** `local-ignore/qa-evidence/20260722-openai-remote-capability-gate/compaction-remote-qa.json` (full request/response capture).
- **Why sufficient:** proves the route decision, the degradation wire format, the persisted compaction details, and the replay path end-to-end on the real binary with zero tokens; the mock-loop `openai-responses` self-test (4/4) confirms no QA-channel regression.

## Risks & Residuals

- **Risk:** degraded (text-form) foreign history is less faithful than native items. **Mitigation:** this is exactly what the provider already receives for such messages in normal turns (same conversion pipeline); OpenAI's compact endpoint summarizes what it sees either way. Accepted.
- **Risk:** pending-message stash counts on `buildContextEntries(branch)` alignment with the context messages; earlier `context`-chain extensions that inject messages could shift the count. **Mitigation:** miscounts bias toward dropping the pending tail (today's behavior), never toward corrupting history; covered by unit + e2e tests. Accepted, noted in `changes.md`.
- **Note:** the pending-prompt drop was pre-existing on main (same rebuild construction); this PR's wider gate makes the remote route far more common, so the fix is a required companion.

## Related Issues

Discord report: senpi fell back to local compaction for GPT sessions whenever history wasn't fully OpenAI-native (mixed-model sessions, `!` commands, prior local compactions).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables OpenAI remote compaction whenever the current model supports it, even with mixed-provider history, by converting non-native entries into faithful text so `/v1/responses/compact` sees the full context. Also fixes a replay bug that dropped the user's first post-compaction message.

- **New Features**
  - Gate remote compaction by capability (`openai` + `openai-responses`), not history provenance.
  - Convert the entire branch via `sessionEntryToContextMessages` + `convertToLlm`; degrade foreign assistant turns, `!` bash, local compactions, branch summaries, and custom messages to canonical text.
  - Mirror image tool results as structured `input_text`/`input_image` parts for image-capable models, or a text placeholder otherwise.
  - Always rewrite the next request payload to replay the native compaction item, even with a non-native tail.

- **Bug Fixes**
  - Preserve the in-flight prompt after remote compaction by appending pending provider messages to the rewritten payload.

<sup>Written for commit 339389ae0a8cd41d8149a68eee9125b69215ca7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

