### PR TITLE
feat(codemode): add GPT exec runtime

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,25 +1,24 @@
 # prompt-preset Extension Changes
 
-## Eval-first routing for GPT presets (2026-07-22)
+## GPT Code Mode routing for GPT presets (2026-07-22)
 
 ### What changed
 
-- `gpt-eval-routing.ts` (new): exports the GPT-only
-  `buildGptEvalRoutingTuning()` rule. Each GPT-5.x builder adds
-  that rule, which directs an available `eval` tool to its own live
-  multi-call Tool Guidelines rather than duplicating their model-aware
-  routing details.
-- `test/suite/prompt-presets-gpt-eval-routing.test.ts` (new): verifies every GPT-5
-  preset, including both full-core 5.5/5.6 variants, defers to the actual
-  eval guideline and that Grok does not inherit the GPT-only rule.
+- `gpt-eval-routing.ts`: exports the GPT-only
+  `buildGptEvalRoutingTuning()` rule. Each GPT-5.x builder adds that
+  rule, which selects `exec`/`wait` for bounded JavaScript tool
+  orchestration when those tools are available, while retaining
+  `eval`'s live model-aware guidance as the fallback.
+- `test/suite/prompt-presets-gpt-eval-routing.test.ts`: verifies every GPT-5
+  preset, including both full-core 5.5/5.6 variants, routes both Code Mode
+  surfaces correctly and that Grok does not inherit the GPT-only rule.
 
 ### Why
 
-- The eval extension already provides the cross-model Code Mode surface and
-  model-aware batching guidance. GPT presets need one high-level route to
-  that surface, but repeating a generic direct-call policy conflicts with
-  the family-specific guidance and would leak into Grok through the shared
-  file-operation helper.
+- The persistent eval extension remains the cross-model Code Mode surface and
+  model-aware batching guide. GPT presets need a separate high-level route to
+  the GPT-only public executor without losing eval as the fallback or leaking
+  either policy into Grok through the shared file-operation helper.
 
 ### Expected merge conflict zones
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-eval-routing.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-eval-routing.ts
@@ -1,4 +1,7 @@
 /** GPT-specific bridge to eval's model-aware Tool Guidelines. */
 export function buildGptEvalRoutingTuning(): string {
-	return "When `eval` is available, follow its Tool Guidelines for multi-call work.";
+	return (
+		"When `exec` and `wait` are available, use `exec` for bounded JavaScript orchestration of tool calls " +
+		"and `wait` for yielded cells; otherwise, when `eval` is available, follow its Tool Guidelines for multi-call work."
+	);
 }

--- a/packages/coding-agent/test/suite/prompt-presets-gpt-eval-routing.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-gpt-eval-routing.test.ts
@@ -21,8 +21,8 @@ function createModel(id: string): Model<Api> {
 const GPT_PRESETS = ["gpt-5", "gpt-5.2", "gpt-5.3-codex", "gpt-5.4", "gpt-5.5", "gpt-5.6"] as const;
 
 describe("GPT eval tool routing", () => {
-	it.each(GPT_PRESETS)("%s coordinates eligible tool work through eval", (presetName) => {
-		// Given: a GPT preset with the persistent eval tool registered.
+	it.each(GPT_PRESETS)("%s routes Code Mode orchestration separately from persistent eval work", (presetName) => {
+		// Given: a GPT preset with both Code Mode surfaces registered.
 		const settings: PromptPresetSettings = { promptPreset: presetName };
 		const model = createModel(presetName);
 		const evalGuideline = buildEvalPrompt(
@@ -30,8 +30,12 @@ describe("GPT eval tool routing", () => {
 			{ spawns: false, modelId: presetName },
 		).promptGuidelines[0];
 		const options = {
-			selectedTools: ["eval"],
-			toolSnippets: { eval: "Run one persistent code cell." },
+			selectedTools: ["eval", "exec", "wait"],
+			toolSnippets: {
+				eval: "Run one persistent code cell.",
+				exec: "Execute a bounded JavaScript Code Mode cell.",
+				wait: "Observe a yielded Code Mode cell.",
+			},
 			promptGuidelines: [evalGuideline],
 			contextFiles: [],
 			skills: [],
@@ -40,11 +44,13 @@ describe("GPT eval tool routing", () => {
 		// When: the system prompt is composed for that preset.
 		const preset = resolvePreset(model, settings, options);
 
-		// Then: its GPT-specific rule defers the detailed policy to eval's live tool guideline.
+		// Then: its GPT-specific route prefers the public Code Mode executor for
+		// bounded orchestration while retaining eval's live multi-language policy.
 		if (!preset) {
 			throw new Error(`expected ${presetName} preset to resolve`);
 		}
-		expect(preset.prompt).toContain("When `eval` is available, follow its Tool Guidelines for multi-call work.");
+		expect(preset.prompt).toContain("When `exec` and `wait` are available");
+		expect(preset.prompt).toContain("when `eval` is available, follow its Tool Guidelines");
 		expect(preset.prompt).toContain(evalGuideline);
 	});
 
@@ -68,5 +74,6 @@ describe("GPT eval tool routing", () => {
 		}
 		expect(preset.prompt).not.toContain("When `eval` is available, use it as the default coordinator");
 		expect(preset.prompt).not.toContain("When `eval` is available, follow its Tool Guidelines for multi-call work.");
+		expect(preset.prompt).not.toContain("When `exec` and `wait` are available");
 	});
 });

--- a/packages/senpi-codemode/AGENTS.md
+++ b/packages/senpi-codemode/AGENTS.md
@@ -1,12 +1,14 @@
 # packages/senpi-codemode
 
 `@code-yeongyu/senpi-codemode` is a source-only Senpi extension that registers
-the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia.
+the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia, plus
+the GPT-only `exec`/`wait` JavaScript Code Mode surface.
 
 ## STRUCTURE
 
 ```text
 src/index.ts                     Extension factory: registers baseline eval, re-registers at session_start after runtime resolution, re-registers on model_select when active model changes
+src/codemode/                    GPT exec/wait cell lifecycle, nested-tool bridge, and public schemas
 src/prompt/                      Model-aware eval prompt templates and batching dialect selection
 src/config/                      Settings schema, defaults, env overrides
 src/extension/                   Session generations and kernel ownership
@@ -28,6 +30,9 @@ test/                            Vitest contracts and the omp parity ledger
 
 - `eval` is registered at extension load and re-registered at `session_start`
   after settings, interpreter availability, and active task-tool names resolve.
+- `exec`/`wait` are active only for GPT models. Their short-lived JavaScript
+  workers compose active tools as `tools.<name>(args)` and are independent from
+  eval's persistent language kernels.
 - Eval prompt dialect is selected from the active model id; host/workstation context is explicit; renderer/status semantics are structured.
 - Session generations fence old kernels and callbacks. A retired generation
   must not emit into a newer session.
@@ -54,6 +59,7 @@ test/                            Vitest contracts and the omp parity ledger
 | Task | Path |
 | --- | --- |
 | Register or narrow eval | `src/index.ts`, `src/tool/eval-tool.ts` |
+| GPT Code Mode lifecycle | `src/codemode/runtime.ts`, `src/codemode/tools.ts` |
 | Prompt behavior | `src/prompt/eval-prompt.ts` |
 | Call/result rendering | `src/tool/render.ts` |
 | Cell settlement and output | `src/tool/cell-handler.ts`, `src/output/` |

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -1,9 +1,10 @@
 # @code-yeongyu/senpi-codemode
 
-`@code-yeongyu/senpi-codemode` is Senpi's source-only persistent-kernel
-`eval` extension. It registers `eval`, owns one persistent kernel per enabled
-language, and re-registers the tool at session start after configuration,
-interpreter availability, and active task-tool names are known.
+`@code-yeongyu/senpi-codemode` is Senpi's source-only Code Mode extension. It
+registers persistent-kernel `eval` for every eligible model and GPT-only
+`exec`/`wait` cells for bounded JavaScript orchestration. `eval` owns one
+persistent kernel per enabled language and re-registers at session start after
+configuration, interpreter availability, and active task-tool names are known.
 
 ## Capabilities
 
@@ -19,6 +20,8 @@ interpreter availability, and active task-tool names are known.
   fallbacks.
 - JavaScript import rewriting for supported local modules and package imports
   in the persistent Node.js worker.
+- GPT Code Mode `exec`/`wait` cells use fresh JavaScript workers, can compose
+  active tools through `tools.<name>(args)`, and never replace `eval`.
 
 ## Kernels
 
@@ -93,7 +96,7 @@ options object and asynchronous helpers are `await`-able.
 | `read(path, offset?, limit?)` | Reads text with 1-indexed line slicing. `local://` paths resolve under the session artifact root. |
 | `write(path, content)` | Creates parent directories and writes text. `local://` paths persist in the session artifact root. |
 | `env(key?, value?)` | Reads all kernel environment values, one value, or sets one value. |
-| `tool.<name>(args)` | Invokes an active Senpi tool through the normal `pi.executeTool` pipeline. |
+| `tool.<name>(args)` / `tools.<name>(args)` | Invokes an active Senpi tool through the normal `pi.executeTool` pipeline. `tools` is the GPT Code Mode spelling. |
 | `completion(prompt, model?, system?, schema?)` | Requests a one-shot host completion; `schema` asks the host to parse structured output. |
 | `agent(prompt, ...)` | Delegates to the configured active `taskTools.task` tool. Supports background handles and structured JSON results. |
 | `output(ids, format?, offset?, limit?)` | Delegates transcript retrieval to the configured active `taskTools.output` tool. |
@@ -136,6 +139,12 @@ Session generations fence retired kernels and callbacks; each cell settles once
 across completion, errors, cancellation, timeout, bridge failure, or a kernel
 crash.
 
+GPT Code Mode is not an additional sandbox: it uses the same Node worker trust
+boundary as JavaScript `eval`. Its separate cell lifecycle exists so a yielded
+`exec` can be observed or terminated with `wait` without affecting persistent
+`eval` kernels. `eval`, `exec`, and `wait` are excluded from the nested tool
+namespace to prevent recursive Code Mode execution.
+
 ## Validation
 
 ```bash
@@ -148,5 +157,5 @@ npm run check
 
 Direct real-surface QA drivers live in `scripts/qa-*.ts`: kernel cells
 (`qa-py-cell.ts`, `qa-js-cell.ts`, `qa-rb-cell.ts`, `qa-jl-cell.ts`), end-to-end
-extension execution (`qa-e2e-eval.ts`), and renderer output
+extension execution (`qa-e2e-eval.ts`, `qa-gpt-code-mode.ts`), and renderer output
 (`qa-render-dump.ts`).

--- a/packages/senpi-codemode/scripts/qa-gpt-code-mode.ts
+++ b/packages/senpi-codemode/scripts/qa-gpt-code-mode.ts
@@ -1,0 +1,195 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type AgentToolResult,
+	createAgentSession,
+	DefaultResourceLoader,
+	SessionManager,
+	SettingsManager,
+} from "@code-yeongyu/senpi";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import senpiCodemode from "../src/index.ts";
+import type { CodeModeToolDetails } from "../src/codemode/tools.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+
+class QaScenarioError extends Error {
+	readonly name = "QaScenarioError";
+}
+
+async function main(): Promise<void> {
+	const agentDir = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-agent-"));
+	const cwd = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-"));
+	const evidenceDir = evidenceDirectory();
+	await mkdir(evidenceDir, { recursive: true });
+	await mkdir(join(cwd, ".senpi"), { recursive: true });
+	await writeFile(join(agentDir, "settings.json"), JSON.stringify({ enabledBuiltinExtensions: [] }));
+	await writeFile(join(cwd, "input.txt"), "gpt-code-mode-value\n");
+
+	const settingsManager = SettingsManager.create(cwd, agentDir);
+	const sessionManager = SessionManager.create(cwd, join(agentDir, "sessions"));
+	const resourceLoader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		settingsManager,
+		extensionFactories: [{ name: "senpi-codemode-qa", factory: senpiCodemode }],
+		noExtensions: true,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await resourceLoader.reload();
+	let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+	try {
+		const created = await createAgentSession({
+			cwd,
+			agentDir,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+			model: gptModel(),
+			autoTitleSessions: false,
+		});
+		session = created.session;
+		const extensionErrors: string[] = [];
+		await session.bindExtensions({
+			mode: "print",
+			onError: (error) => extensionErrors.push(`${error.event}: ${error.error}`),
+		});
+		await verifySurface(session, evidenceDir, extensionErrors);
+	} finally {
+		if (session !== undefined) {
+			try {
+				await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+			} finally {
+				session.dispose();
+			}
+		}
+		await rm(cwd, { recursive: true, force: true });
+		await rm(agentDir, { recursive: true, force: true });
+	}
+}
+
+async function verifySurface(
+	session: Awaited<ReturnType<typeof createAgentSession>>["session"],
+	evidenceDir: string,
+	extensionErrors: readonly string[],
+): Promise<void> {
+	const exec = session.getToolDefinition("exec");
+	const wait = session.getToolDefinition("wait");
+	const evalTool = session.getToolDefinition("eval");
+	if (exec === undefined || wait === undefined || evalTool === undefined) {
+		throw new QaScenarioError(
+			`GPT session did not expose eval, exec, and wait together; registered=${session
+				.getAllTools()
+				.map((tool) => tool.name)
+				.join(",")}; active=${session.extensionRunner.getActiveTools().join(",")}; extensionErrors=${extensionErrors.join("|")}`,
+		);
+	}
+
+	const nestedStarted = await session.executeTool<CodeModeToolDetails>("exec", {
+		code: 'const file = await tools.read({ path: "input.txt" }); print(file.text);',
+		yield_time_ms: 1_000,
+	});
+	const nested = await settleCell(session, nestedStarted);
+	const nestedText = textOf(nested);
+	if (!nestedText.includes("gpt-code-mode-value") || nested.details.state !== "result") {
+		throw new QaScenarioError(`nested tool scenario failed: ${nestedText}`);
+	}
+
+	const yielded = await session.executeTool<CodeModeToolDetails>("exec", {
+		code: 'await new Promise((resolve) => setTimeout(resolve, 50)); print("gpt-code-mode-resumed");',
+		yield_time_ms: 1,
+	});
+	if (yielded.details.state !== "yielded") throw new QaScenarioError("exec did not return a yielded cell");
+	const resumed = await session.executeTool<CodeModeToolDetails>("wait", {
+		cell_id: yielded.details.cellId,
+		yield_time_ms: 5_000,
+	});
+	const resumedText = textOf(resumed);
+	if (resumed.details.state !== "result" || !resumedText.includes("gpt-code-mode-resumed")) {
+		throw new QaScenarioError(`wait scenario failed: ${resumedText}`);
+	}
+
+	const evalResult = await session.executeTool<EvalToolDetails>("eval", {
+		language: "js",
+		code: 'print("eval-still-available")',
+	});
+	if (!textOf(evalResult).includes("eval-still-available")) {
+		throw new QaScenarioError("eval did not remain available beside GPT Code Mode");
+	}
+
+	const missing = await session.executeTool<CodeModeToolDetails>("wait", { cell_id: "does-not-exist" });
+	if (missing.details.state !== "missing" || missing.details.isError !== true) {
+		throw new QaScenarioError("wait did not report a missing cell");
+	}
+
+	const receipt = {
+		tools: ["eval", "exec", "wait"],
+		nestedTool: "read",
+		nestedState: nested.details.state,
+		yieldedState: yielded.details.state,
+		resumedState: resumed.details.state,
+		evalState: "available",
+		missingState: missing.details.state,
+	};
+	const evidencePath = join(evidenceDir, "gpt-code-mode.json");
+	await writeFile(evidencePath, `${JSON.stringify(receipt, null, 2)}\n`);
+	console.log(`NESTED: ${nested.details.state}`);
+	console.log(`YIELDED: ${yielded.details.state}`);
+	console.log(`RESUMED: ${resumed.details.state}`);
+	console.log("EVAL: available");
+	console.log(`MISSING: ${missing.details.state}`);
+	console.log(`EVIDENCE: ${evidencePath}`);
+}
+
+async function settleCell(
+	session: Awaited<ReturnType<typeof createAgentSession>>["session"],
+	result: AgentToolResult<CodeModeToolDetails>,
+): Promise<AgentToolResult<CodeModeToolDetails>> {
+	if (result.details.state !== "yielded") return result;
+	return await session.executeTool<CodeModeToolDetails>("wait", {
+		cell_id: result.details.cellId,
+		yield_time_ms: 1_000,
+	});
+}
+
+function gptModel(): Model<Api> {
+	return {
+		id: "gpt-5.6",
+		name: "gpt-5.6",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://mock.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	};
+}
+
+function textOf(result: AgentToolResult<unknown>): string {
+	return result.content
+		.filter((part): part is Extract<(typeof result.content)[number], { type: "text" }> => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function evidenceDirectory(): string {
+	const index = process.argv.indexOf("--evidence-dir");
+	if (index === -1) {
+		return join(process.cwd(), "local-ignore", "qa-evidence", "20260722-gpt-code-mode");
+	}
+	const value = process.argv[index + 1];
+	if (value === undefined) throw new QaScenarioError("--evidence-dir requires a directory");
+	return value;
+}
+
+try {
+	await main();
+} catch (error) {
+	console.error(error instanceof Error ? `${error.name}: ${error.message}` : String(error));
+	process.exitCode = 1;
+}

--- a/packages/senpi-codemode/src/codemode/runtime.ts
+++ b/packages/senpi-codemode/src/codemode/runtime.ts
@@ -1,0 +1,258 @@
+import type { KernelToHostMessage } from "../bridge/protocol.ts";
+import type { AgentExecuteTool } from "../bridges/agent-bridge.ts";
+import { JavaScriptKernel } from "../kernels/js/context-manager.ts";
+import { marshalToolResult } from "../tool/image.ts";
+
+const MAX_ACTIVE_CELLS = 4;
+const MAX_PENDING_OUTPUT_CHARS = 100_000;
+const MAX_TERMINAL_ERROR_CHARS = 4_096;
+const RECURSIVE_TOOLS = new Set(["eval", "exec", "wait"]);
+
+export type CodeModeCellState = "yielded" | "result" | "terminated" | "error" | "missing";
+
+export interface CodeModeObservation {
+	readonly cellId: string;
+	readonly state: CodeModeCellState;
+	readonly output: string;
+	readonly error?: string;
+}
+
+export interface CodeModeRuntimeOptions {
+	readonly sessionId: string;
+	readonly cwd: string;
+	readonly parallelPoolWidth: number;
+	readonly executeTool: AgentExecuteTool;
+}
+
+export class CodeModeCapacityError extends Error {
+	readonly name = "CodeModeCapacityError";
+
+	constructor() {
+		super(`Code Mode supports at most ${MAX_ACTIVE_CELLS} active cells`);
+	}
+}
+
+export class CodeModeSessionRuntime {
+	readonly #options: CodeModeRuntimeOptions;
+	readonly #cells = new Map<string, CodeModeCell>();
+	#nextCell = 0;
+	#disposed = false;
+
+	constructor(options: CodeModeRuntimeOptions) {
+		this.#options = options;
+	}
+
+	async execute(code: string, yieldTimeMs: number, signal: AbortSignal | undefined): Promise<CodeModeObservation> {
+		this.#assertActive();
+		const cellId = `exec-${++this.#nextCell}`;
+		if (signal?.aborted) return { cellId, state: "terminated", output: "" };
+		if (this.#cells.size >= MAX_ACTIVE_CELLS) throw new CodeModeCapacityError();
+		const cell = new CodeModeCell(cellId, this.#options);
+		this.#cells.set(cellId, cell);
+		cell.start(code);
+		const observation = await cell.observe(yieldTimeMs, signal);
+		this.#releaseIfTerminal(observation);
+		return observation;
+	}
+
+	async wait(
+		cellId: string,
+		yieldTimeMs: number,
+		terminate: boolean,
+		signal: AbortSignal | undefined,
+	): Promise<CodeModeObservation> {
+		const cell = this.#cells.get(cellId);
+		if (cell === undefined) return { cellId, state: "missing", output: "" };
+		const observation = terminate ? await cell.terminate() : await cell.observe(yieldTimeMs, signal);
+		this.#releaseIfTerminal(observation);
+		return observation;
+	}
+
+	async dispose(): Promise<void> {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		const cells = [...this.#cells.values()];
+		this.#cells.clear();
+		await Promise.all(cells.map((cell) => cell.terminate()));
+	}
+
+	#releaseIfTerminal(observation: CodeModeObservation): void {
+		if (observation.state !== "yielded") this.#cells.delete(observation.cellId);
+	}
+
+	#assertActive(): void {
+		if (this.#disposed) throw new Error("Code Mode session has been disposed");
+	}
+}
+
+class CodeModeCell {
+	readonly #id: string;
+	readonly #options: CodeModeRuntimeOptions;
+	readonly #kernel: JavaScriptKernel;
+	readonly #abort = new AbortController();
+	#output = "";
+	#outputTruncated = false;
+	#completion: Promise<void> | undefined;
+	#state: "running" | "result" | "terminated" | "error" = "running";
+	#error: string | undefined;
+
+	constructor(id: string, options: CodeModeRuntimeOptions) {
+		this.#id = id;
+		this.#options = options;
+		this.#kernel = new JavaScriptKernel({
+			sessionId: `${options.sessionId}:${id}`,
+			cwd: options.cwd,
+			parallelPoolWidth: options.parallelPoolWidth,
+			onMessage: (message) => this.#handleMessage(message),
+		});
+	}
+
+	start(code: string): void {
+		this.#completion = this.#kernel
+			.run({ cellId: this.#id, code })
+			.then((result) => {
+				if (this.#state !== "running") return;
+				if (result.ok) {
+					this.#state = "result";
+					if (result.valueRepr) this.#appendOutput(`${result.valueRepr}\n`);
+					return;
+				}
+				this.#state = "error";
+				this.#error = truncateTerminalError(result.error.message);
+			})
+			.catch((error: unknown) => {
+				if (this.#state !== "running") return;
+				this.#state = "error";
+				this.#error = truncateTerminalError(error instanceof Error ? error.message : String(error));
+			})
+			.finally(async () => {
+				if (this.#state !== "running") await this.#kernel.close();
+			});
+	}
+
+	async observe(yieldTimeMs: number, signal: AbortSignal | undefined): Promise<CodeModeObservation> {
+		if (signal?.aborted) return await this.terminate();
+		if (this.#state !== "running") return this.#observation();
+		const completion = this.#completion;
+		if (completion === undefined) throw new Error("Code Mode cell has not started");
+		const timeout = Math.max(1, Math.trunc(yieldTimeMs));
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let abortListener: (() => void) | undefined;
+		const timedOut = new Promise<"yielded">((resolve) => {
+			timer = setTimeout(() => resolve("yielded"), timeout);
+		});
+		const completed = completion.then(() => "completed" as const);
+		const aborted = new Promise<"aborted">((resolve) => {
+			if (!signal) return;
+			abortListener = () => resolve("aborted");
+			signal.addEventListener("abort", abortListener, { once: true });
+		});
+		try {
+			const outcome = await Promise.race([completed, timedOut, aborted]);
+			if (outcome === "aborted") return await this.terminate();
+			return this.#observation();
+		} finally {
+			if (timer !== undefined) clearTimeout(timer);
+			if (abortListener && signal) signal.removeEventListener("abort", abortListener);
+		}
+	}
+
+	async terminate(): Promise<CodeModeObservation> {
+		if (this.#state === "terminated") return this.#observation();
+		if (this.#state === "result" || this.#state === "error") return this.#observation();
+		this.#state = "terminated";
+		this.#abort.abort(new Error("Code Mode cell terminated"));
+		try {
+			await this.#kernel.interrupt("Code Mode cell terminated");
+		} finally {
+			await this.#kernel.close();
+		}
+		return this.#observation();
+	}
+
+	#handleMessage(message: KernelToHostMessage): void {
+		if (message.type === "text") {
+			this.#appendOutput(message.data);
+			return;
+		}
+		if (message.type === "display") {
+			this.#appendOutput(`[display ${message.mimeType}]\n`);
+			return;
+		}
+		if (message.type === "tool-call") void this.#invokeTool(message);
+	}
+
+	async #invokeTool(message: Extract<KernelToHostMessage, { type: "tool-call" }>): Promise<void> {
+		if (RECURSIVE_TOOLS.has(message.toolName)) {
+			this.#kernel.deliverToolReply({
+				type: "tool-reply",
+				callId: message.callId,
+				ok: false,
+				error: { message: `recursive Code Mode tool "${message.toolName}" is not allowed` },
+			});
+			return;
+		}
+		if (this.#options.executeTool.isToolAvailable?.(message.toolName) === false) {
+			this.#kernel.deliverToolReply({
+				type: "tool-reply",
+				callId: message.callId,
+				ok: false,
+				error: { message: `nested tool "${message.toolName}" is not active` },
+			});
+			return;
+		}
+		try {
+			const result = await this.#options.executeTool(message.toolName, message.args, { signal: this.#abort.signal });
+			this.#kernel.deliverToolReply({
+				type: "tool-reply",
+				callId: message.callId,
+				ok: true,
+				value: marshalToolResult(result),
+			});
+		} catch (error) {
+			this.#kernel.deliverToolReply({
+				type: "tool-reply",
+				callId: message.callId,
+				ok: false,
+				error: { message: error instanceof Error ? error.message : String(error) },
+			});
+		}
+	}
+
+	#observation(): CodeModeObservation {
+		let output = this.#output;
+		this.#output = "";
+		if (this.#outputTruncated) {
+			output += "\n[output truncated]\n";
+			this.#outputTruncated = false;
+		}
+		if (this.#state === "running") return { cellId: this.#id, state: "yielded", output };
+		if (this.#state === "terminated") return { cellId: this.#id, state: "terminated", output };
+		if (this.#state === "error") {
+			const error = this.#error ?? "Code Mode cell failed";
+			if (output !== "") output += output.endsWith("\n") ? error : `\n${error}`;
+			else output = error;
+			return { cellId: this.#id, state: "error", output, error };
+		}
+		return { cellId: this.#id, state: "result", output };
+	}
+
+	#appendOutput(value: string): void {
+		const remaining = MAX_PENDING_OUTPUT_CHARS - this.#output.length;
+		if (remaining <= 0) {
+			this.#outputTruncated = true;
+			return;
+		}
+		if (value.length > remaining) {
+			this.#output += value.slice(0, remaining);
+			this.#outputTruncated = true;
+			return;
+		}
+		this.#output += value;
+	}
+}
+
+function truncateTerminalError(message: string): string {
+	if (message.length <= MAX_TERMINAL_ERROR_CHARS) return message;
+	return `${message.slice(0, MAX_TERMINAL_ERROR_CHARS)}\n[error truncated]`;
+}

--- a/packages/senpi-codemode/src/codemode/tools.ts
+++ b/packages/senpi-codemode/src/codemode/tools.ts
@@ -1,0 +1,106 @@
+import type { AgentToolResult, ToolDefinition } from "@code-yeongyu/senpi";
+import { type Static, Type } from "typebox";
+import type { CodeModeCellState, CodeModeObservation, CodeModeSessionRuntime } from "./runtime.ts";
+
+const DEFAULT_YIELD_TIME_MS = 10_000;
+
+const execInputSchema = Type.Object({
+	code: Type.String({ minLength: 1, description: "JavaScript program to execute in a dedicated Code Mode cell." }),
+	yield_time_ms: Type.Optional(
+		Type.Integer({ minimum: 1, maximum: 60_000, description: "Return a yielded cell after this many milliseconds." }),
+	),
+});
+
+const waitInputSchema = Type.Object({
+	cell_id: Type.String({ minLength: 1, description: "Code Mode cell id returned by exec." }),
+	yield_time_ms: Type.Optional(
+		Type.Integer({ minimum: 1, maximum: 60_000, description: "Return again after this many milliseconds." }),
+	),
+	terminate: Type.Optional(Type.Boolean({ description: "Interrupt and close the cell instead of waiting." })),
+});
+
+type ExecInput = Static<typeof execInputSchema>;
+type WaitInput = Static<typeof waitInputSchema>;
+
+export interface CodeModeToolDetails {
+	readonly cellId: string;
+	readonly state: CodeModeCellState;
+	readonly isError?: boolean;
+}
+
+export type CodeModeTool =
+	| ToolDefinition<typeof execInputSchema, CodeModeToolDetails>
+	| ToolDefinition<typeof waitInputSchema, CodeModeToolDetails>;
+
+export interface CreateCodeModeToolsOptions {
+	readonly runtime: CodeModeSessionRuntime;
+}
+
+export function createCodeModeTools(options: CreateCodeModeToolsOptions): {
+	readonly exec: ToolDefinition<typeof execInputSchema, CodeModeToolDetails>;
+	readonly wait: ToolDefinition<typeof waitInputSchema, CodeModeToolDetails>;
+} {
+	return {
+		exec: {
+			name: "exec",
+			label: "GPT Code Mode Exec",
+			description:
+				"Run JavaScript in a dedicated GPT Code Mode cell. Call active Senpi tools as `tools.<name>(args)`. " +
+				"If the cell yields, call wait with its cell_id.",
+			promptSnippet: "Execute JavaScript that composes active tools in a dedicated Code Mode cell.",
+			promptGuidelines: [
+				"Use exec for bounded JavaScript composition of active tools; use eval for persistent multi-language analysis.",
+				"Call wait only when exec reports a yielded cell, and terminate abandoned cells with wait({ cell_id, terminate: true }).",
+			],
+			parameters: execInputSchema,
+			executionMode: "sequential",
+			async execute(_toolCallId, params: ExecInput, signal) {
+				return resultFrom(
+					await options.runtime.execute(params.code, params.yield_time_ms ?? DEFAULT_YIELD_TIME_MS, signal),
+				);
+			},
+		},
+		wait: {
+			name: "wait",
+			label: "GPT Code Mode Wait",
+			description: "Observe a yielded GPT Code Mode cell or terminate it.",
+			promptSnippet: "Wait for, or terminate, a yielded GPT Code Mode cell.",
+			parameters: waitInputSchema,
+			executionMode: "sequential",
+			async execute(_toolCallId, params: WaitInput, signal) {
+				return resultFrom(
+					await options.runtime.wait(
+						params.cell_id,
+						params.yield_time_ms ?? DEFAULT_YIELD_TIME_MS,
+						params.terminate ?? false,
+						signal,
+					),
+				);
+			},
+		},
+	};
+}
+
+function resultFrom(observation: CodeModeObservation): AgentToolResult<CodeModeToolDetails> {
+	const text =
+		observation.output ||
+		(observation.state === "yielded"
+			? `Code Mode cell ${observation.cellId} is still running. Call wait with this cell_id.`
+			: observation.state === "missing"
+				? `Code Mode cell ${observation.cellId} does not exist.`
+				: observation.state === "terminated"
+					? `Code Mode cell ${observation.cellId} was terminated.`
+					: (observation.error ?? `Code Mode cell ${observation.cellId} completed.`));
+	return {
+		content: [{ type: "text", text }],
+		details: {
+			cellId: observation.cellId,
+			state: observation.state,
+			...(observation.state === "error" || observation.state === "missing" ? { isError: true } : {}),
+		},
+	};
+}
+
+export function isGptCodeModeModel(modelId: string | undefined): boolean {
+	return modelId !== undefined && /(^|[/.:])gpt[-.]/iu.test(modelId);
+}

--- a/packages/senpi-codemode/src/extension/runtime-factory.ts
+++ b/packages/senpi-codemode/src/extension/runtime-factory.ts
@@ -1,0 +1,114 @@
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { AgentExecuteTool } from "../bridges/agent-bridge.ts";
+import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
+import {
+	type CodemodeSettings,
+	loadCodemodeSettings,
+	type ResolvedCodemodeSettings,
+	resolveEnabledLanguages,
+} from "../config/settings.ts";
+import {
+	createInterpreterDetector,
+	getInterpreterAvailability,
+	type InterpreterAvailability,
+} from "../interpreters/detect.ts";
+import { resolveSessionArtifactsDir } from "../output/streaming-output.ts";
+import type { EnabledEvalLanguages, EvalLanguage } from "../tool/types.ts";
+import {
+	type CodemodeSessionManager,
+	type CreateCodemodeSessionManagerOptions,
+	createCodemodeSessionManager,
+} from "./session-manager.ts";
+
+export interface CodemodeRuntimeAPI {
+	readonly executeTool: AgentExecuteTool;
+	getActiveTools(): string[];
+}
+
+export interface RuntimeFactoryOptions {
+	readonly createSessionManager?: (
+		options: CreateCodemodeSessionManagerOptions,
+	) => CodemodeSessionManager | Promise<CodemodeSessionManager>;
+}
+
+export type SessionRuntime = {
+	readonly sessionId: string;
+	readonly cwd: string;
+	readonly parallelPoolWidth: number;
+	readonly manager: CodemodeSessionManager;
+	readonly enabledLanguages: EnabledEvalLanguages;
+	readonly settings: ResolvedCodemodeSettings;
+	readonly artifactsDir: string;
+	readonly executeTool: AgentExecuteTool;
+	readonly spawns: boolean;
+};
+
+export async function createRuntime(
+	pi: CodemodeRuntimeAPI,
+	ctx: ExtensionContext,
+	event: unknown,
+	complete: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>,
+	options: RuntimeFactoryOptions,
+): Promise<SessionRuntime> {
+	const loaded = await loadCodemodeSettings({ cwd: ctx.cwd });
+	const settings: ResolvedCodemodeSettings = {
+		...loaded.settings,
+		languages: resolveEnabledLanguages(loaded.settings),
+	};
+	const availability = await getInterpreterAvailability(settings, createInterpreterDetector());
+	const enabledLanguages = enabledLanguagesFrom(settings, availability);
+	const artifacts = resolveSessionArtifactsDir(ctx.sessionManager.getSessionFile());
+	const activeTools = new Set(pi.getActiveTools());
+	const executeTool = createExecuteTool(pi, activeTools);
+	const create = options.createSessionManager ?? createCodemodeSessionManager;
+	const sessionId = sessionIdFrom(event);
+	const configuredPoolWidth = settings.parallelPoolWidth;
+	const parallelPoolWidth = Number.isFinite(configuredPoolWidth) ? Math.max(1, Math.trunc(configuredPoolWidth)) : 1;
+	const manager = await create({
+		sessionId,
+		cwd: ctx.cwd,
+		settings,
+		availability,
+		artifactsDir: artifacts.dir,
+		executeTool,
+		complete,
+	});
+	return {
+		sessionId,
+		cwd: ctx.cwd,
+		parallelPoolWidth,
+		manager,
+		enabledLanguages,
+		settings,
+		artifactsDir: artifacts.dir,
+		executeTool,
+		spawns: activeTools.has(settings.taskTools.task),
+	};
+}
+
+export function createExecuteTool(pi: CodemodeRuntimeAPI, activeTools?: ReadonlySet<string>): AgentExecuteTool {
+	const executeTool: AgentExecuteTool = (toolName, params, executeOptions) =>
+		pi.executeTool(toolName, params, executeOptions);
+	return Object.assign(executeTool, {
+		isToolAvailable: (name: string): boolean => activeTools?.has(name) ?? pi.getActiveTools().includes(name),
+	});
+}
+
+function sessionIdFrom(event: unknown): string {
+	if (typeof event === "object" && event !== null && "sessionId" in event && typeof event.sessionId === "string") {
+		return event.sessionId;
+	}
+	return crypto.randomUUID();
+}
+
+export function enabledLanguagesFrom(
+	settings: CodemodeSettings,
+	availability: InterpreterAvailability,
+): Record<EvalLanguage, boolean> {
+	return {
+		py: settings.languages.py && availability.py.detected.ok,
+		js: settings.languages.js && availability.js.detected.ok,
+		rb: settings.languages.rb && availability.rb.detected.ok,
+		jl: settings.languages.jl && availability.jl.detected.ok,
+	};
+}

--- a/packages/senpi-codemode/src/extension/session-manager-proxy.ts
+++ b/packages/senpi-codemode/src/extension/session-manager-proxy.ts
@@ -1,0 +1,116 @@
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { KernelToHostMessage } from "../bridge/protocol.ts";
+import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
+import type { EvalKernel, EvalLanguage } from "../tool/types.ts";
+import {
+	CodemodeSessionDisposedError,
+	type CodemodeSessionManager,
+	type EvalExecutionTracker,
+} from "./session-manager.ts";
+
+type TrackedExecution = {
+	readonly promise: Promise<unknown>;
+	readonly controller: AbortController;
+};
+
+export class CodemodeSessionNotStartedError extends Error {
+	readonly name = "CodemodeSessionNotStartedError";
+
+	constructor() {
+		super("codemode session has not started");
+	}
+}
+
+export class SessionManagerProxy implements CodemodeSessionManager, EvalExecutionTracker {
+	#current: CodemodeSessionManager | undefined;
+	#generation = 0;
+	#started = false;
+	#acceptingExecutions = false;
+	readonly #executions = new Set<TrackedExecution>();
+
+	beginReplacement(): number {
+		this.#generation++;
+		this.#acceptingExecutions = false;
+		this.#abortExecutions();
+		return this.#generation;
+	}
+
+	async replace(generation: number, next: CodemodeSessionManager): Promise<boolean> {
+		if (generation !== this.#generation) {
+			await next.dispose();
+			return false;
+		}
+		await this.#settleExecutions();
+		if (generation !== this.#generation) {
+			await next.dispose();
+			return false;
+		}
+		const current = this.#current;
+		this.#current = undefined;
+		await current?.dispose();
+		if (generation !== this.#generation) {
+			await next.dispose();
+			return false;
+		}
+		this.#current = next;
+		this.#started = true;
+		this.#acceptingExecutions = true;
+		return true;
+	}
+
+	assertEvalExecutionAllowed(): void {
+		if (this.#acceptingExecutions && this.#current !== undefined) return;
+		if (this.#started) throw new CodemodeSessionDisposedError();
+		throw new CodemodeSessionNotStartedError();
+	}
+
+	async trackEvalExecution<Result>(execution: Promise<Result>, controller: AbortController): Promise<Result> {
+		this.assertEvalExecutionAllowed();
+		const tracked: TrackedExecution = { promise: execution, controller };
+		this.#executions.add(tracked);
+		try {
+			return await execution;
+		} finally {
+			this.#executions.delete(tracked);
+		}
+	}
+
+	async getKernel(language: EvalLanguage, onMessage: (message: KernelToHostMessage) => void): Promise<EvalKernel> {
+		this.assertEvalExecutionAllowed();
+		const current = this.#current;
+		if (current === undefined) throw new CodemodeSessionNotStartedError();
+		return await current.getKernel(language, onMessage);
+	}
+
+	async complete(request: CompletionRequest, ctx: ExtensionContext): Promise<CompletionResult> {
+		this.assertEvalExecutionAllowed();
+		const current = this.#current;
+		if (current === undefined) throw new CodemodeSessionNotStartedError();
+		return await current.complete(request, ctx);
+	}
+
+	setContext(ctx: ExtensionContext): void {
+		this.#current?.setContext?.(ctx);
+	}
+
+	async dispose(): Promise<void> {
+		this.#generation++;
+		this.#acceptingExecutions = false;
+		this.#abortExecutions();
+		await this.#settleExecutions();
+		const current = this.#current;
+		this.#current = undefined;
+		await current?.dispose();
+	}
+
+	#abortExecutions(): void {
+		if (this.#executions.size === 0) return;
+		const error = new CodemodeSessionDisposedError();
+		for (const execution of this.#executions) execution.controller.abort(error);
+	}
+
+	async #settleExecutions(): Promise<void> {
+		if (this.#executions.size === 0) return;
+		await Promise.allSettled([...this.#executions].map((execution) => execution.promise));
+	}
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -1,31 +1,20 @@
 import * as os from "node:os";
 import type { ExtensionContext } from "@code-yeongyu/senpi";
-import type { KernelToHostMessage } from "./bridge/protocol.ts";
 import type { AgentExecuteTool } from "./bridges/agent-bridge.ts";
+import { CodeModeSessionRuntime } from "./codemode/runtime.ts";
+import { type CodeModeTool, createCodeModeTools, isGptCodeModeModel } from "./codemode/tools.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
+import { defaultCodemodeSettings } from "./config/settings.ts";
 import {
-	type CodemodeSettings,
-	defaultCodemodeSettings,
-	loadCodemodeSettings,
-	type ResolvedCodemodeSettings,
-	resolveEnabledLanguages,
-} from "./config/settings.ts";
-import {
-	CodemodeSessionDisposedError,
-	type CodemodeSessionManager,
-	type CreateCodemodeSessionManagerOptions,
-	createCodemodeSessionManager,
-	type EvalExecutionTracker,
-} from "./extension/session-manager.ts";
-import {
-	createInterpreterDetector,
-	getInterpreterAvailability,
-	type InterpreterAvailability,
-} from "./interpreters/detect.ts";
-import { resolveSessionArtifactsDir } from "./output/streaming-output.ts";
+	createExecuteTool,
+	createRuntime,
+	enabledLanguagesFrom,
+	type SessionRuntime,
+} from "./extension/runtime-factory.ts";
+import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
+import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
 import { createEvalTool } from "./tool/eval-tool.ts";
 import { renderEvalCall, renderEvalResult } from "./tool/render.ts";
-import type { EnabledEvalLanguages, EvalKernel, EvalLanguage } from "./tool/types.ts";
 
 const SESSION_LIFECYCLE_EVENTS = [
 	"session_start",
@@ -38,25 +27,13 @@ type SessionLifecycleEvent = (typeof SESSION_LIFECYCLE_EVENTS)[number];
 
 type CodemodeEvent = SessionLifecycleEvent | "model_select";
 
-type TrackedExecution = {
-	readonly promise: Promise<unknown>;
-	readonly controller: AbortController;
-};
-
-type SessionRuntime = {
-	readonly manager: CodemodeSessionManager;
-	readonly enabledLanguages: EnabledEvalLanguages;
-	readonly settings: ResolvedCodemodeSettings;
-	readonly artifactsDir: string;
-	readonly executeTool: AgentExecuteTool;
-	readonly spawns: boolean;
-};
-
 export interface CodemodeExtensionAPI {
 	registerTool(tool: ReturnType<typeof createEvalTool>): void;
 	on(event: CodemodeEvent, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void;
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
+	setActiveTools?(toolNames: string[]): void | Promise<void>;
+	getAllTools?(): readonly { readonly name: string }[];
 }
 
 export interface SenpiCodemodeOptions {
@@ -66,19 +43,17 @@ export interface SenpiCodemodeOptions {
 	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
 }
 
-class CodemodeSessionNotStartedError extends Error {
-	readonly name = "CodemodeSessionNotStartedError";
-
-	constructor() {
-		super("codemode session has not started");
-	}
-}
+type DynamicCodeModeExtensionAPI = CodemodeExtensionAPI & {
+	registerTool(tool: CodeModeTool): void;
+	setActiveTools(toolNames: string[]): void | Promise<void>;
+	getAllTools(): readonly { readonly name: string }[];
+};
 
 export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCodemodeOptions = {}): void {
 	const manager = new SessionManagerProxy();
 	const complete = options.complete ?? ((request, ctx) => createCompletionHandler()(ctx)(request));
 	const renderers = { renderCall: renderEvalCall, renderResult: renderEvalResult };
-	let activeRuntime: SessionRuntime | undefined;
+	let activeRuntime: (SessionRuntime & { readonly codeMode?: CodeModeSessionRuntime }) | undefined;
 	let activeModelId: string | undefined;
 	const registerEvalForRuntime = (runtime: SessionRuntime, modelId: string | undefined): void => {
 		pi.registerTool(
@@ -100,9 +75,21 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		);
 	};
 	const dropRuntime = async (): Promise<void> => {
+		const codeMode = activeRuntime?.codeMode;
 		activeRuntime = undefined;
 		activeModelId = undefined;
-		await manager.dispose();
+		await Promise.all([manager.dispose(), codeMode?.dispose()]);
+	};
+	const activateCodeModeTools = async (runtime: CodeModeSessionRuntime): Promise<void> => {
+		if (!isDynamicCodeModeExtensionAPI(pi)) return;
+		const tools = createCodeModeTools({ runtime });
+		pi.registerTool(tools.exec);
+		pi.registerTool(tools.wait);
+		await pi.setActiveTools([...new Set([...pi.getActiveTools(), "exec", "wait"])]);
+	};
+	const deactivateCodeModeTools = async (): Promise<void> => {
+		if (!isDynamicCodeModeExtensionAPI(pi)) return;
+		await pi.setActiveTools(pi.getActiveTools().filter((name) => name !== "exec" && name !== "wait"));
 	};
 	pi.registerTool(
 		createEvalTool({
@@ -119,12 +106,25 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	);
 
 	pi.on("session_start", async (event, ctx) => {
+		const previousCodeMode = activeRuntime?.codeMode;
 		const generation = manager.beginReplacement();
 		const runtime = await createRuntime(pi, ctx, event, complete, options);
-		if (!(await manager.replace(generation, runtime.manager))) return;
-		activeRuntime = runtime;
+		const replaced = await manager.replace(generation, runtime.manager);
+		if (!replaced) return;
+		await previousCodeMode?.dispose();
+		const codeMode = isGptCodeModeModel(ctx.model?.id)
+			? new CodeModeSessionRuntime({
+					sessionId: runtime.sessionId,
+					cwd: runtime.cwd,
+					parallelPoolWidth: runtime.parallelPoolWidth,
+					executeTool: runtime.executeTool,
+				})
+			: undefined;
+		activeRuntime = { ...runtime, ...(codeMode === undefined ? {} : { codeMode }) };
 		activeModelId = ctx.model?.id;
-		registerEvalForRuntime(runtime, activeModelId);
+		registerEvalForRuntime(activeRuntime, activeModelId);
+		if (codeMode) await activateCodeModeTools(codeMode);
+		else await deactivateCodeModeTools();
 	});
 	pi.on("session_shutdown", async () => dropRuntime());
 	pi.on("session_before_switch", async () => dropRuntime());
@@ -136,7 +136,32 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		if (modelId === undefined || modelId === activeModelId) return;
 		activeModelId = modelId;
 		registerEvalForRuntime(runtime, modelId);
+		if (!isGptCodeModeModel(modelId)) {
+			const { codeMode, ...nextRuntime } = runtime;
+			await codeMode?.dispose();
+			activeRuntime = nextRuntime;
+			await deactivateCodeModeTools();
+			return;
+		}
+		if (runtime.codeMode) {
+			if (isDynamicCodeModeExtensionAPI(pi)) {
+				await pi.setActiveTools([...new Set([...pi.getActiveTools(), "exec", "wait"])]);
+			}
+			return;
+		}
+		const codeMode = new CodeModeSessionRuntime({
+			sessionId: runtime.sessionId,
+			cwd: runtime.cwd,
+			parallelPoolWidth: runtime.parallelPoolWidth,
+			executeTool: runtime.executeTool,
+		});
+		activeRuntime = { ...runtime, codeMode };
+		await activateCodeModeTools(codeMode);
 	});
+}
+
+function isDynamicCodeModeExtensionAPI(pi: CodemodeExtensionAPI): pi is DynamicCodeModeExtensionAPI {
+	return typeof pi.setActiveTools === "function" && typeof pi.getAllTools === "function";
 }
 
 function hostLine(): string {
@@ -153,160 +178,4 @@ function modelIdFrom(event: unknown): string | undefined {
 	return typeof model.id === "string" ? model.id : undefined;
 }
 
-class SessionManagerProxy implements CodemodeSessionManager, EvalExecutionTracker {
-	#current: CodemodeSessionManager | undefined;
-	#generation = 0;
-	#started = false;
-	#acceptingExecutions = false;
-	readonly #executions = new Set<TrackedExecution>();
-
-	beginReplacement(): number {
-		this.#generation++;
-		this.#acceptingExecutions = false;
-		this.#abortExecutions();
-		return this.#generation;
-	}
-
-	async replace(generation: number, next: CodemodeSessionManager): Promise<boolean> {
-		if (generation !== this.#generation) {
-			await next.dispose();
-			return false;
-		}
-		await this.#settleExecutions();
-		if (generation !== this.#generation) {
-			await next.dispose();
-			return false;
-		}
-		const current = this.#current;
-		this.#current = undefined;
-		await current?.dispose();
-		if (generation !== this.#generation) {
-			await next.dispose();
-			return false;
-		}
-		this.#current = next;
-		this.#started = true;
-		this.#acceptingExecutions = true;
-		return true;
-	}
-
-	assertEvalExecutionAllowed(): void {
-		if (this.#acceptingExecutions && this.#current !== undefined) return;
-		if (this.#started) throw new CodemodeSessionDisposedError();
-		throw new CodemodeSessionNotStartedError();
-	}
-
-	async trackEvalExecution<Result>(execution: Promise<Result>, controller: AbortController): Promise<Result> {
-		this.assertEvalExecutionAllowed();
-		const tracked: TrackedExecution = { promise: execution, controller };
-		this.#executions.add(tracked);
-		try {
-			return await execution;
-		} finally {
-			this.#executions.delete(tracked);
-		}
-	}
-
-	async getKernel(language: EvalLanguage, onMessage: (message: KernelToHostMessage) => void): Promise<EvalKernel> {
-		this.assertEvalExecutionAllowed();
-		const current = this.#current;
-		if (current === undefined) throw new CodemodeSessionNotStartedError();
-		return await current.getKernel(language, onMessage);
-	}
-
-	async complete(request: CompletionRequest, ctx: ExtensionContext): Promise<CompletionResult> {
-		this.assertEvalExecutionAllowed();
-		const current = this.#current;
-		if (current === undefined) throw new CodemodeSessionNotStartedError();
-		return await current.complete(request, ctx);
-	}
-
-	setContext(ctx: ExtensionContext): void {
-		this.#current?.setContext?.(ctx);
-	}
-
-	async dispose(): Promise<void> {
-		this.#generation++;
-		this.#acceptingExecutions = false;
-		this.#abortExecutions();
-		await this.#settleExecutions();
-		const current = this.#current;
-		this.#current = undefined;
-		await current?.dispose();
-	}
-
-	#abortExecutions(): void {
-		if (this.#executions.size === 0) return;
-		const error = new CodemodeSessionDisposedError();
-		for (const execution of this.#executions) execution.controller.abort(error);
-	}
-
-	async #settleExecutions(): Promise<void> {
-		if (this.#executions.size === 0) return;
-		await Promise.allSettled([...this.#executions].map((execution) => execution.promise));
-	}
-}
-
-async function createRuntime(
-	pi: CodemodeExtensionAPI,
-	ctx: ExtensionContext,
-	event: unknown,
-	complete: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>,
-	options: SenpiCodemodeOptions,
-): Promise<SessionRuntime> {
-	const loaded = await loadCodemodeSettings({ cwd: ctx.cwd });
-	const settings: ResolvedCodemodeSettings = {
-		...loaded.settings,
-		languages: resolveEnabledLanguages(loaded.settings),
-	};
-	const availability = await getInterpreterAvailability(settings, createInterpreterDetector());
-	const enabledLanguages = enabledLanguagesFrom(settings, availability);
-	const artifacts = resolveSessionArtifactsDir(ctx.sessionManager.getSessionFile());
-	const activeTools = new Set(pi.getActiveTools());
-	const executeTool = createExecuteTool(pi, activeTools);
-	const create = options.createSessionManager ?? createCodemodeSessionManager;
-	const manager = await create({
-		sessionId: sessionIdFrom(event),
-		cwd: ctx.cwd,
-		settings,
-		availability,
-		artifactsDir: artifacts.dir,
-		executeTool,
-		complete,
-	});
-	return {
-		manager,
-		enabledLanguages,
-		settings,
-		artifactsDir: artifacts.dir,
-		executeTool,
-		spawns: activeTools.has(settings.taskTools.task),
-	};
-}
-
-function createExecuteTool(pi: CodemodeExtensionAPI, activeTools?: ReadonlySet<string>): AgentExecuteTool {
-	const executeTool: AgentExecuteTool = (toolName, params, executeOptions) =>
-		pi.executeTool(toolName, params, executeOptions);
-	return Object.assign(executeTool, {
-		isToolAvailable: (name: string): boolean => activeTools?.has(name) ?? pi.getActiveTools().includes(name),
-	});
-}
-
-function sessionIdFrom(event: unknown): string {
-	if (typeof event === "object" && event !== null && "sessionId" in event && typeof event.sessionId === "string") {
-		return event.sessionId;
-	}
-	return crypto.randomUUID();
-}
-
-export function enabledLanguagesFrom(
-	settings: CodemodeSettings,
-	availability: InterpreterAvailability,
-): Record<EvalLanguage, boolean> {
-	return {
-		py: settings.languages.py && availability.py.detected.ok,
-		js: settings.languages.js && availability.js.detected.ok,
-		rb: settings.languages.rb && availability.rb.detected.ok,
-		jl: settings.languages.jl && availability.jl.detected.ok,
-	};
-}
+export { enabledLanguagesFrom };

--- a/packages/senpi-codemode/src/kernels/js/worker-runtime.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-runtime.js
@@ -63,6 +63,7 @@ export class JsWorkerRuntime {
 				},
 			},
 		);
+		globalThis.tools = globalThis.tool;
 		const originalLog = console.log.bind(console);
 		const originalError = console.error.bind(console);
 		const originalStdoutWrite = process.stdout.write;

--- a/packages/senpi-codemode/test/codemode/gpt-code-mode.test.ts
+++ b/packages/senpi-codemode/test/codemode/gpt-code-mode.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CodeModeTool } from "../../src/codemode/tools.ts";
+import type { CodemodeSessionManager } from "../../src/extension/session-manager.ts";
+import senpiCodemode, { type CodemodeExtensionAPI } from "../../src/index.ts";
+import type { EvalKernelResult, EvalKernelRunInput } from "../../src/tool/types.ts";
+import { fakeExtensionContext } from "../eval/fakes.ts";
+
+type RegisteredHandler = {
+	readonly event: string;
+	readonly handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void;
+};
+
+type PublicCodeModeTool = {
+	readonly name: "exec" | "wait";
+	readonly execute: (
+		toolCallId: string,
+		params: Record<string, unknown>,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	) => Promise<unknown>;
+};
+
+type RegisteredTool = Parameters<CodemodeExtensionAPI["registerTool"]>[0] | CodeModeTool;
+
+class FakePi {
+	readonly tools: RegisteredTool[] = [];
+	readonly handlers: RegisteredHandler[] = [];
+	readonly nestedCalls: { readonly name: string; readonly args: unknown }[] = [];
+	#activeTools = new Set<string>(["eval", "echo", "hold"]);
+
+	registerTool(tool: RegisteredTool): void {
+		this.tools.push(tool);
+	}
+
+	on(event: string, handler: RegisteredHandler["handler"]): void {
+		this.handlers.push({ event, handler });
+	}
+
+	getActiveTools(): string[] {
+		return [...this.#activeTools];
+	}
+
+	getAllTools(): readonly { readonly name: string }[] {
+		return this.tools.map((tool) => ({ name: tool.name }));
+	}
+
+	setActiveTools(toolNames: string[]): void {
+		this.#activeTools = new Set(toolNames);
+	}
+
+	async executeTool(
+		toolName: string,
+		params: unknown,
+	): Promise<{
+		content: { type: "text"; text: string }[];
+		readonly details: undefined;
+	}> {
+		this.nestedCalls.push({ name: toolName, args: params });
+		if (toolName === "echo") return { content: [{ type: "text", text: "nested result" }], details: undefined };
+		return await new Promise(() => undefined);
+	}
+}
+
+class FakeSessionManager implements CodemodeSessionManager {
+	async getKernel(): Promise<{
+		run(input: EvalKernelRunInput): Promise<EvalKernelResult>;
+		interrupt(): Promise<void>;
+		deliverToolReply(): void;
+		reset(): Promise<void>;
+		close(): Promise<void>;
+	}> {
+		throw new Error("eval kernel was not expected");
+	}
+
+	async complete(): Promise<never> {
+		throw new Error("completion was not expected");
+	}
+
+	async dispose(): Promise<void> {}
+}
+
+function fakeModel(id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "fake-api",
+		provider: "fake",
+		baseUrl: "https://fake.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000,
+		maxTokens: 100,
+	};
+}
+
+function context(cwd: string, modelId: string): ExtensionContext {
+	const base = fakeExtensionContext();
+	return {
+		...base,
+		cwd,
+		model: fakeModel(modelId),
+		sessionManager: {
+			...base.sessionManager,
+			getSessionFile: () => join(cwd, `${crypto.randomUUID()}.jsonl`),
+		},
+	};
+}
+
+async function emit(pi: FakePi, event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
+	for (const entry of pi.handlers.filter((handler) => handler.event === event)) {
+		await entry.handler(payload, ctx);
+	}
+}
+
+function findPublicTool(pi: FakePi, name: PublicCodeModeTool["name"]): PublicCodeModeTool {
+	const candidate = pi.tools.find((tool) => tool.name === name);
+	if (!isPublicCodeModeTool(candidate, name)) throw new Error(`${name} tool was not registered`);
+	return candidate;
+}
+
+function isPublicCodeModeTool(value: unknown, name: PublicCodeModeTool["name"]): value is PublicCodeModeTool {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"name" in value &&
+		value.name === name &&
+		"execute" in value &&
+		typeof value.execute === "function"
+	);
+}
+
+function cellIdFrom(result: unknown): string {
+	if (
+		typeof result !== "object" ||
+		result === null ||
+		!("details" in result) ||
+		typeof result.details !== "object" ||
+		result.details === null ||
+		!("cellId" in result.details) ||
+		typeof result.details.cellId !== "string"
+	) {
+		throw new Error("Code Mode result did not include a cellId");
+	}
+	return result.details.cellId;
+}
+
+describe("GPT Code Mode public tools", () => {
+	afterEach(() => vi.clearAllMocks());
+
+	it("exposes exec and wait for GPT while preserving eval", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-"));
+		const pi = new FakePi();
+		const ctx = context(cwd, "gpt-5.6");
+		senpiCodemode(pi, { createSessionManager: () => new FakeSessionManager() });
+
+		try {
+			await emit(pi, "session_start", { sessionId: "gpt-code-mode-session" }, ctx);
+
+			expect(pi.tools.map((tool) => tool.name)).toContain("eval");
+			expect(pi.tools.map((tool) => tool.name)).toContain("exec");
+			expect(pi.tools.map((tool) => tool.name)).toContain("wait");
+			expect(pi.getActiveTools()).toEqual(expect.arrayContaining(["eval", "exec", "wait"]));
+		} finally {
+			await emit(pi, "session_shutdown", {}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps GPT Code Mode unavailable to non-GPT models", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-"));
+		const pi = new FakePi();
+		const ctx = context(cwd, "claude-sonnet-4-6");
+		senpiCodemode(pi, { createSessionManager: () => new FakeSessionManager() });
+
+		try {
+			await emit(pi, "session_start", { sessionId: "non-gpt-session" }, ctx);
+
+			expect(pi.tools.map((tool) => tool.name)).toContain("eval");
+			expect(pi.getActiveTools()).toContain("eval");
+			expect(pi.getActiveTools()).not.toContain("exec");
+			expect(pi.getActiveTools()).not.toContain("wait");
+		} finally {
+			await emit(pi, "session_shutdown", {}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("runs a nested tool through exec and terminates its yielded cell through wait", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-"));
+		const pi = new FakePi();
+		const ctx = context(cwd, "gpt-5.6");
+		senpiCodemode(pi, { createSessionManager: () => new FakeSessionManager() });
+
+		try {
+			await emit(pi, "session_start", { sessionId: "nested-tool-session" }, ctx);
+			const exec = findPublicTool(pi, "exec");
+			const wait = findPublicTool(pi, "wait");
+
+			const completed = await exec.execute(
+				"nested-tool-call",
+				{ code: 'print(await tools.echo({ value: "nested" }))', yield_time_ms: 100 },
+				undefined,
+				undefined,
+				ctx,
+			);
+
+			expect(pi.nestedCalls).toEqual([{ name: "echo", args: { value: "nested" } }]);
+			expect(completed).toMatchObject({
+				content: [{ type: "text", text: expect.stringContaining("nested result") }],
+				details: { state: "result" },
+			});
+
+			const yielded = await exec.execute(
+				"yielded-cell",
+				{ code: "await tools.hold({});", yield_time_ms: 1 },
+				undefined,
+				undefined,
+				ctx,
+			);
+			const terminated = await wait.execute(
+				"terminate-cell",
+				{ cell_id: cellIdFrom(yielded), terminate: true },
+				undefined,
+				undefined,
+				ctx,
+			);
+
+			expect(terminated).toMatchObject({ details: { state: "terminated" } });
+		} finally {
+			await emit(pi, "session_shutdown", {}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/senpi-codemode/test/codemode/model-lifecycle.test.ts
+++ b/packages/senpi-codemode/test/codemode/model-lifecycle.test.ts
@@ -1,0 +1,224 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import type { CodeModeTool } from "../../src/codemode/tools.ts";
+import type { CodemodeSessionManager } from "../../src/extension/session-manager.ts";
+import senpiCodemode, { type CodemodeExtensionAPI } from "../../src/index.ts";
+import type { EvalKernelResult, EvalKernelRunInput } from "../../src/tool/types.ts";
+import { fakeExtensionContext } from "../eval/fakes.ts";
+
+type RegisteredTool = Parameters<CodemodeExtensionAPI["registerTool"]>[0] | CodeModeTool;
+type ExecTool = {
+	readonly name: "exec";
+	readonly execute: (
+		toolCallId: string,
+		params: Record<string, unknown>,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	) => Promise<unknown>;
+};
+
+class FakePi {
+	readonly tools: RegisteredTool[] = [];
+	readonly handlers: {
+		readonly event: string;
+		readonly handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void;
+	}[] = [];
+	readonly holdStarted = Promise.withResolvers<void>();
+	readonly holdAborted = Promise.withResolvers<void>();
+	#active = new Set<string>(["eval", "hold"]);
+
+	registerTool(tool: RegisteredTool): void {
+		const index = this.tools.findIndex((current) => current.name === tool.name);
+		if (index === -1) this.tools.push(tool);
+		else this.tools[index] = tool;
+	}
+
+	on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void {
+		this.handlers.push({ event, handler });
+	}
+
+	getActiveTools(): string[] {
+		return [...this.#active];
+	}
+
+	getAllTools(): readonly { readonly name: string }[] {
+		return this.tools.map((tool) => ({ name: tool.name }));
+	}
+
+	setActiveTools(names: string[]): void {
+		this.#active = new Set(names);
+	}
+
+	async executeTool(_name: string, _params: unknown, options?: { readonly signal?: AbortSignal }): Promise<never> {
+		this.holdStarted.resolve();
+		const signal = options?.signal;
+		return await new Promise((_, reject) => {
+			signal?.addEventListener(
+				"abort",
+				() => {
+					this.holdAborted.resolve();
+					reject(signal.reason);
+				},
+				{ once: true },
+			);
+		});
+	}
+}
+
+class FakeManager implements CodemodeSessionManager {
+	async getKernel(): Promise<{
+		run(input: EvalKernelRunInput): Promise<EvalKernelResult>;
+		interrupt(): Promise<void>;
+		deliverToolReply(): void;
+		reset(): Promise<void>;
+		close(): Promise<void>;
+	}> {
+		throw new Error("eval was not expected");
+	}
+
+	async complete(): Promise<never> {
+		throw new Error("completion was not expected");
+	}
+
+	async dispose(): Promise<void> {}
+}
+
+function model(id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "fake-api",
+		provider: "fake",
+		baseUrl: "https://fake.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000,
+		maxTokens: 100,
+	};
+}
+
+function context(cwd: string): ExtensionContext {
+	const base = fakeExtensionContext();
+	return {
+		...base,
+		cwd,
+		model: model("gpt-5.6"),
+		sessionManager: { ...base.sessionManager, getSessionFile: () => join(cwd, "session.jsonl") },
+	};
+}
+
+async function emit(pi: FakePi, event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
+	for (const entry of pi.handlers.filter((handler) => handler.event === event)) {
+		await entry.handler(payload, ctx);
+	}
+}
+
+function execTool(pi: FakePi): ExecTool {
+	const tool = pi.tools.find((candidate) => candidate.name === "exec");
+	if (!isExecTool(tool)) throw new Error("exec tool was not registered");
+	return tool;
+}
+
+function isExecTool(tool: RegisteredTool | undefined): tool is RegisteredTool & ExecTool {
+	return tool?.name === "exec";
+}
+
+describe("GPT Code Mode lifecycle", () => {
+	it.each([
+		{
+			name: "switching to a non-GPT model",
+			transition: async (pi: FakePi, ctx: ExtensionContext) =>
+				await emit(pi, "model_select", { model: model("claude-sonnet-4-6") }, ctx),
+		},
+		{
+			name: "replacing the session runtime",
+			transition: async (pi: FakePi, ctx: ExtensionContext) => await emit(pi, "session_start", {}, ctx),
+		},
+		{
+			name: "shutting down the session",
+			transition: async (pi: FakePi, ctx: ExtensionContext) => await emit(pi, "session_shutdown", {}, ctx),
+		},
+		{
+			name: "switching sessions",
+			transition: async (pi: FakePi, ctx: ExtensionContext) => await emit(pi, "session_before_switch", {}, ctx),
+		},
+		{
+			name: "forking the session",
+			transition: async (pi: FakePi, ctx: ExtensionContext) => await emit(pi, "session_before_fork", {}, ctx),
+		},
+	])("terminates yielded cells when $name", async ({ transition }) => {
+		const cwd = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-lifecycle-"));
+		const pi = new FakePi();
+		const ctx = context(cwd);
+		senpiCodemode(pi, { createSessionManager: () => new FakeManager() });
+
+		try {
+			await emit(pi, "session_start", {}, ctx);
+			const execution = execTool(pi).execute(
+				"yielded-cell",
+				{ code: "await tools.hold({})", yield_time_ms: 1_000 },
+				undefined,
+				undefined,
+				ctx,
+			);
+			await expect(pi.holdStarted.promise).resolves.toBeUndefined();
+
+			await transition(pi, ctx);
+
+			await expect(pi.holdAborted.promise).resolves.toBeUndefined();
+			await expect(execution).resolves.toMatchObject({ details: { state: "terminated" } });
+			if (pi.getActiveTools().includes("exec")) {
+				expect(pi.getActiveTools()).toContain("wait");
+			} else {
+				expect(pi.getActiveTools()).not.toEqual(expect.arrayContaining(["exec", "wait"]));
+			}
+		} finally {
+			await emit(pi, "session_shutdown", {}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("creates a fresh executable cell runtime after returning to GPT", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "senpi-gpt-code-mode-lifecycle-"));
+		const pi = new FakePi();
+		const ctx = context(cwd);
+		senpiCodemode(pi, { createSessionManager: () => new FakeManager() });
+
+		try {
+			await emit(pi, "session_start", {}, ctx);
+			const running = execTool(pi).execute(
+				"yielded-cell",
+				{ code: "await tools.hold({})", yield_time_ms: 1_000 },
+				undefined,
+				undefined,
+				ctx,
+			);
+			await expect(pi.holdStarted.promise).resolves.toBeUndefined();
+			await emit(pi, "model_select", { model: model("claude-sonnet-4-6") }, ctx);
+			await expect(running).resolves.toMatchObject({ details: { state: "terminated" } });
+
+			await emit(pi, "model_select", { model: model("gpt-5.6") }, ctx);
+			const fresh = await execTool(pi).execute(
+				"fresh-cell",
+				{ code: 'print("fresh-runtime")', yield_time_ms: 1_000 },
+				undefined,
+				undefined,
+				ctx,
+			);
+
+			expect(fresh).toMatchObject({
+				content: [{ type: "text", text: expect.stringContaining("fresh-runtime") }],
+				details: { state: "result" },
+			});
+		} finally {
+			await emit(pi, "session_shutdown", {}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/senpi-codemode/test/codemode/runtime-lifecycle.test.ts
+++ b/packages/senpi-codemode/test/codemode/runtime-lifecycle.test.ts
@@ -1,0 +1,145 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { describe, expect, it } from "vitest";
+import type { AgentExecuteTool } from "../../src/bridges/agent-bridge.ts";
+import { CodeModeSessionRuntime } from "../../src/codemode/runtime.ts";
+
+function createRuntime(executeTool: AgentExecuteTool): CodeModeSessionRuntime {
+	return new CodeModeSessionRuntime({
+		sessionId: "runtime-lifecycle-test",
+		cwd: process.cwd(),
+		parallelPoolWidth: 1,
+		executeTool,
+	});
+}
+
+function textResult(text: string): AgentToolResult<undefined> {
+	return { content: [{ type: "text", text }], details: undefined };
+}
+
+describe("Code Mode runtime lifecycle", () => {
+	it("does not start a cell for an already-aborted exec signal", async () => {
+		const calls: string[] = [];
+		const executeTool: AgentExecuteTool = async (name) => {
+			calls.push(name);
+			return textResult("unexpected");
+		};
+		const runtime = createRuntime(executeTool);
+		const controller = new AbortController();
+		controller.abort(new Error("cancel before exec"));
+
+		try {
+			const result = await runtime.execute("await tools.echo({})", 1_000, controller.signal);
+
+			expect(result).toMatchObject({ state: "terminated" });
+			expect(calls).toEqual([]);
+		} finally {
+			await runtime.dispose();
+		}
+	});
+
+	it("keeps partial output and the terminal error together", async () => {
+		const runtime = createRuntime(async () => textResult("unused"));
+
+		try {
+			const result = await runtime.execute(
+				'print("partial-output"); throw new Error("terminal-error");',
+				1_000,
+				undefined,
+			);
+
+			expect(result).toMatchObject({ state: "error", output: expect.stringContaining("partial-output") });
+			expect(result.output).toContain("terminal-error");
+		} finally {
+			await runtime.dispose();
+		}
+	});
+
+	it("bounds accumulated output from a noisy cell", async () => {
+		const runtime = createRuntime(async () => textResult("unused"));
+
+		try {
+			const result = await runtime.execute('print("x".repeat(200_000))', 1_000, undefined);
+
+			expect(result.output).toContain("[output truncated]");
+			expect(result.output.length).toBeLessThanOrEqual(100_256);
+		} finally {
+			await runtime.dispose();
+		}
+	});
+
+	it("bounds terminal errors without retaining their full message", async () => {
+		const runtime = createRuntime(async () => textResult("unused"));
+
+		try {
+			const result = await runtime.execute('throw new Error("terminal".repeat(50_000))', 1_000, undefined);
+
+			expect(result).toMatchObject({ state: "error", output: expect.stringContaining("[error truncated]") });
+			expect(result.output.length).toBeLessThanOrEqual(104_512);
+			expect(result.error?.length).toBeLessThanOrEqual(4_128);
+		} finally {
+			await runtime.dispose();
+		}
+	});
+
+	it("rejects recursive and inactive nested tool calls", async () => {
+		const calls: string[] = [];
+		const executeTool: AgentExecuteTool = Object.assign(
+			async (name: string) => {
+				calls.push(name);
+				return textResult("unexpected");
+			},
+			{ isToolAvailable: () => false },
+		);
+		const runtime = createRuntime(executeTool);
+
+		try {
+			const result = await runtime.execute(
+				`for (const name of ["eval", "exec", "wait", "inactive"]) {
+					try {
+						await tools[name]({});
+					} catch (error) {
+						print(error.message);
+					}
+				}`,
+				1_000,
+				undefined,
+			);
+
+			expect(result).toMatchObject({ state: "result" });
+			expect(result.output).toContain('recursive Code Mode tool "eval" is not allowed');
+			expect(result.output).toContain('recursive Code Mode tool "exec" is not allowed');
+			expect(result.output).toContain('recursive Code Mode tool "wait" is not allowed');
+			expect(result.output).toContain('nested tool "inactive" is not active');
+			expect(calls).toEqual([]);
+		} finally {
+			await runtime.dispose();
+		}
+	});
+
+	it("aborts nested tool work when the session runtime is disposed", async () => {
+		const aborted = Promise.withResolvers<void>();
+		const started = Promise.withResolvers<void>();
+		const executeTool: AgentExecuteTool = async (_name, _params, options) => {
+			started.resolve();
+			await new Promise<void>((_resolve, reject) => {
+				options?.signal?.addEventListener(
+					"abort",
+					() => {
+						aborted.resolve();
+						reject(options.signal?.reason);
+					},
+					{ once: true },
+				);
+			});
+			return textResult("unreachable");
+		};
+		const runtime = createRuntime(executeTool);
+
+		const execution = runtime.execute("await tools.hold({})", 1_000, undefined);
+		await expect(started.promise).resolves.toBeUndefined();
+		await runtime.dispose();
+
+		await expect(aborted.promise).resolves.toBeUndefined();
+		await expect(execution).resolves.toMatchObject({ state: "terminated" });
+	});
+});


### PR DESCRIPTION
## Summary

- Add a native GPT-only `exec` / `wait` Code Mode surface alongside persistent `eval`.
- Run each `exec` in its own JavaScript worker, route `tools.<name>(args)` through the existing Senpi tool bridge, and preserve `eval` for every existing model path.
- Bound worker output and terminal errors; terminate cells on abort, session replacement, shutdown, switch, fork, and GPT-to-non-GPT transitions.
- Route GPT presets to `exec` / `wait` for bounded orchestration, with `eval` retained as the fallback.

## Verification

- RED -> GREEN: public tool registration, nested dispatch, output/error bounds, pre-abort, recursive/inactive nested-tool rejection, model switching, and all session lifecycle teardown paths.
- `packages/senpi-codemode`: 375 passed, 6 skipped.
- `packages/coding-agent/test/suite/prompt-presets-gpt-eval-routing.test.ts`: 7 passed.
- `npm run check` and `npm run build`: passed.
- Real isolated AgentSession QA: `exec -> tools.read`, yield -> `wait`, `eval` coexistence, and missing-cell behavior; evidence under `local-ignore/qa-evidence/20260722-gpt-code-mode/`.
- Root `npm test`: 4,450 passed; two unrelated failures remain: a reftable footer watch timing flake and `app-server-protocol-pin`, whose expected Codex SHA differs after the requested `../codex` update.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GPT Code Mode with `exec`/`wait` for bounded JavaScript orchestration while keeping persistent `eval` untouched. GPT presets now prefer `exec`/`wait` and fall back to `eval`.

- New Features
  - `packages/senpi-codemode`: Added per-exec JS worker runtime; compose active tools via `tools.<name>(args)`; bound output and terminal errors; block recursive `eval`/`exec`/`wait`; terminate cells on abort, session replacement, shutdown, switch, fork, and GPT↔non‑GPT transitions.
  - Public tools `exec` and `wait` auto-register only for GPT models and coexist with `eval`; they are deactivated for non‑GPT models.
  - GPT 5.x presets route Code Mode via `exec`/`wait` and retain `eval` as the fallback; Grok unchanged.
  - Added `packages/senpi-codemode/scripts/qa-gpt-code-mode.ts` for end-to-end QA.

- Refactors
  - Extracted runtime factory and session manager proxy (`src/extension/runtime-factory.ts`, `src/extension/session-manager-proxy.ts`) and simplified `src/index.ts`.
  - JS worker now exposes `globalThis.tools` as an alias to `tool` for GPT Code Mode.

<sup>Written for commit 080f553b2162234f233dd32061aed65d33573d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

