### PR TITLE
feat(compaction): support OpenAI Codex remote compaction

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,24 @@
 # Builtin compaction extension changes
 
+## Support native remote compaction for OpenAI Codex models (2026-07-23)
+
+- `openai-remote-model.ts`, `openai-remote-schema.ts`, `openai-remote.ts`, `openai-remote-convert.ts`,
+  `index.ts`: native remote compaction now treats `openai-codex` / `openai-codex-responses` as a supported
+  provider capability.
+  Codex compaction uses the ChatGPT backend's `/codex/responses/compact` route with OAuth Bearer auth,
+  the JWT-derived `chatgpt-account-id`, Codex session/window identity headers, the Responses beta flag,
+  and `originator: senpi`. The compact parser accepts Codex's output-only JSON response while retaining
+  strict direct-OpenAI response validation.
+- Codex OAuth remote compaction is restricted to the canonical ChatGPT origin and loopback QA/proxy
+  origins, preventing OAuth bearer tokens and conversation history from being sent to arbitrary remote
+  custom URLs. Persisted replacement history is replayed only when its provider/API identity exactly
+  matches the current model family.
+- Persisted remote-compaction details retain the paired provider/API identity so the next Codex request
+  replays the encrypted compaction item and in-flight prompt through the existing payload rewrite hook.
+  Direct `openai` / `openai-responses` endpoint and WebSocket behavior remains unchanged.
+- Regressions: `test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts` and
+  `test/suite/regressions/issue-296-openai-codex-remote-compaction-boundaries.test.ts`.
+
 ## Preserve the in-flight prompt in remote-compaction payload replay (2026-07-22)
 
 - `index.ts`, `openai-remote.ts`, `openai-remote-convert.ts`: the `before_provider_request` replay after a

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -24,6 +24,7 @@ import {
 	runOpenAiRemoteCompaction,
 	SENPI_COMPACTION_EVENT,
 } from "./openai-remote.ts";
+import { isOpenAiRemoteCompactionModel } from "./openai-remote-model.ts";
 import * as cap from "./per-turn-cap.ts";
 import * as policy from "./policy.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
@@ -56,10 +57,6 @@ interface PendingCompactionMetadata {
 
 function approxTokens(text: string): number {
 	return Math.ceil(text.length / 4);
-}
-
-function isOpenAiResponsesModel(model: ExtensionContext["model"]): boolean {
-	return model?.provider === "openai" && model.api === "openai-responses";
 }
 
 function estimatePendingPromptTokens(event: { prompt?: string; images?: readonly unknown[] }): number {
@@ -230,7 +227,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	): Promise<SpeculativeCompactionResult> {
 		let feedbackSignal = ctx.beginCompaction?.({ reason: "extension" });
 		try {
-			if (isOpenAiResponsesModel(ctx.model)) {
+			if (isOpenAiRemoteCompactionModel(ctx.model)) {
 				const remoteGeneration = speculativeGeneration + 1;
 				const remoteSnapshot = createSpeculativeCompactionSnapshot(ctx, {
 					generation: remoteGeneration,
@@ -494,7 +491,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 		const sourceMessages = shouldApplyContextReduction({
 			usageTokens: usage?.tokens ?? null,
 			contextWindow,
-			isProviderNativeCompactionPath: isOpenAiResponsesModel(ctx.model),
+			isProviderNativeCompactionPath: isOpenAiRemoteCompactionModel(ctx.model),
 		})
 			? reduceContextMessages(event.messages, BUILTIN_CONTEXT_REDUCTION_OPTIONS).messages
 			: event.messages;

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
@@ -11,93 +11,33 @@ import type {
 } from "@earendil-works/pi-ai";
 import { convertToLlm } from "../../../messages.ts";
 import { type SessionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
-import type { ServiceTier } from "../../types.ts";
+import {
+	getOpenAiRemoteCompactionDetails,
+	isRecord,
+	type OpenAiAssistantMessageItem,
+	type OpenAiFunctionCallItem,
+	type OpenAiInputContent,
+	type OpenAiProviderNativeItem,
+	type OpenAiRemoteInputItem,
+} from "./openai-remote-schema.ts";
 
-export const OPENAI_REMOTE_COMPACTION_SCHEMA = "senpi.compaction.openai-remote.v1";
-
-type OpenAiInputText = { type: "input_text"; text: string };
-type OpenAiInputImage = { type: "input_image"; detail: "auto"; image_url: string };
-type OpenAiInputContent = OpenAiInputText | OpenAiInputImage;
-type OpenAiOutputText = { type: "output_text"; text: string; annotations: [] };
-type OpenAiMessageInputItem = {
-	type?: "message";
-	id?: string;
-	role: "user" | "system" | "developer";
-	content: string | OpenAiInputContent[];
-	status?: "in_progress" | "completed" | "incomplete";
-};
-type OpenAiAssistantMessageItem = {
-	type: "message";
-	id: string;
-	role: "assistant";
-	status: "completed";
-	content: OpenAiOutputText[];
-	phase?: "commentary" | "final_answer";
-};
-type OpenAiFunctionCallItem = {
-	type: "function_call";
-	id?: string;
-	call_id: string;
-	name: string;
-	arguments: string;
-};
-type OpenAiFunctionCallOutputItem = {
-	type: "function_call_output";
-	call_id: string;
-	output: string | OpenAiInputContent[];
-};
-export type OpenAiRemoteTransport = "websocket" | "compact-endpoint";
-type OpenAiCompactionItem = {
-	type: "compaction";
-	encrypted_content: string;
-	id?: string | null;
-	created_by?: string;
-};
-export type OpenAiContextCompactionItem = {
-	type: "context_compaction";
-	encrypted_content: string;
-	id?: string | null;
-	created_by?: string;
-};
-export type OpenAiContextCompactionTriggerItem = {
-	type: "context_compaction";
-};
-type OpenAiProviderNativeItem = Record<string, unknown> & { type: string };
-export type OpenAiRemoteInputItem =
-	| OpenAiMessageInputItem
-	| OpenAiAssistantMessageItem
-	| OpenAiFunctionCallItem
-	| OpenAiFunctionCallOutputItem
-	| OpenAiCompactionItem
-	| OpenAiContextCompactionItem
-	| OpenAiProviderNativeItem;
-
-export type OpenAiCompactBody = {
-	model: string;
-	input: OpenAiRemoteInputItem[];
-	instructions?: string;
-	prompt_cache_key?: string;
-	service_tier?: ServiceTier;
-};
-
-export type OpenAiRemoteCompactionDetails = {
-	schema: typeof OPENAI_REMOTE_COMPACTION_SCHEMA;
-	mode: "openai-remote";
-	provider: "openai";
-	api: "openai-responses";
-	transport: OpenAiRemoteTransport;
-	modelId: string;
-	responseId: string;
-	createdAt: number;
-	requestInputItemCount: number;
-	retainedInputItemCount: number;
-	replacementInput: OpenAiRemoteInputItem[];
-	usage?: Record<string, unknown>;
-};
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+export type {
+	OpenAiCompactBody,
+	OpenAiContextCompactionItem,
+	OpenAiContextCompactionTriggerItem,
+	OpenAiRemoteCompactionDetails,
+	OpenAiRemoteInputItem,
+	OpenAiRemoteTransport,
+} from "./openai-remote-schema.ts";
+export {
+	getOpenAiRemoteCompactionDetails,
+	isOpenAiContextCompactionItem,
+	isOpenAiRemoteCompactionOutputItem,
+	isRecord,
+	isRetainedRemoteOutputItem,
+	isRetainedResponsesStreamInputItem,
+	OPENAI_REMOTE_COMPACTION_SCHEMA,
+} from "./openai-remote-schema.ts";
 
 function parseJsonRecord(value: string | undefined): Record<string, unknown> | undefined {
 	if (!value?.startsWith("{")) return undefined;
@@ -254,32 +194,6 @@ export function convertPendingMessages(messages: AgentMessage[], model: Model<Ap
 	return convertToLlm(messages).flatMap((message, index) => convertLlmMessage(message, index, model));
 }
 
-export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
-	if (!isRecord(value)) return undefined;
-	if (value.schema !== OPENAI_REMOTE_COMPACTION_SCHEMA || value.mode !== "openai-remote") return undefined;
-	if (value.provider !== "openai" || value.api !== "openai-responses") return undefined;
-	if (typeof value.modelId !== "string" || typeof value.responseId !== "string") return undefined;
-	if (typeof value.createdAt !== "number") return undefined;
-	if (typeof value.requestInputItemCount !== "number" || typeof value.retainedInputItemCount !== "number") {
-		return undefined;
-	}
-	if (!Array.isArray(value.replacementInput)) return undefined;
-	return {
-		schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
-		mode: "openai-remote",
-		provider: "openai",
-		api: "openai-responses",
-		transport: value.transport === "websocket" ? "websocket" : "compact-endpoint",
-		modelId: value.modelId,
-		responseId: value.responseId,
-		createdAt: value.createdAt,
-		requestInputItemCount: value.requestInputItemCount,
-		retainedInputItemCount: value.retainedInputItemCount,
-		replacementInput: value.replacementInput.filter((item): item is OpenAiRemoteInputItem => isRecord(item)),
-		...(isRecord(value.usage) ? { usage: value.usage } : {}),
-	};
-}
-
 /**
  * Convert session branch entries into OpenAI Responses input items.
  *
@@ -315,28 +229,4 @@ export function convertBranchEntries(entries: SessionEntry[], model: Model<Api>)
 	}
 	flush();
 	return items;
-}
-
-export function isOpenAiCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiCompactionItem {
-	return item.type === "compaction" && typeof item.encrypted_content === "string";
-}
-
-export function isOpenAiContextCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiContextCompactionItem {
-	return item.type === "context_compaction" && typeof item.encrypted_content === "string";
-}
-
-export function isOpenAiRemoteCompactionOutputItem(
-	item: OpenAiRemoteInputItem,
-): item is OpenAiCompactionItem | OpenAiContextCompactionItem {
-	return isOpenAiCompactionItem(item) || isOpenAiContextCompactionItem(item);
-}
-
-export function isRetainedRemoteOutputItem(item: OpenAiRemoteInputItem): boolean {
-	if (isOpenAiRemoteCompactionOutputItem(item)) return true;
-	return item.type === "message" && (item.role === "user" || item.role === "system" || item.role === "developer");
-}
-
-export function isRetainedResponsesStreamInputItem(item: OpenAiRemoteInputItem): boolean {
-	if (item.type === "message") return item.role === "user";
-	return "role" in item && item.role === "user";
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-model.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-model.ts
@@ -1,0 +1,119 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+export type OpenAiRemoteCompactionModel = Model<"openai-responses"> | Model<"openai-codex-responses">;
+
+export type OpenAiRemoteCompactionIdentity =
+	| { provider: "openai"; api: "openai-responses" }
+	| { provider: "openai-codex"; api: "openai-codex-responses" };
+
+type RemoteCompactionAuth = {
+	apiKey?: string;
+	headers?: Record<string, string>;
+};
+
+const OPENAI_CODEX_INSTALLATION_ID = crypto.randomUUID();
+
+function isTrustedOpenAiCodexBaseUrl(baseUrl: string | undefined): boolean {
+	try {
+		const url = new URL(baseUrl || "https://chatgpt.com/backend-api");
+		if (url.protocol === "https:" && url.hostname === "chatgpt.com") return true;
+		return ["127.0.0.1", "[::1]", "localhost"].includes(url.hostname);
+	} catch {
+		return false;
+	}
+}
+
+export function parseOpenAiRemoteCompactionIdentity(
+	provider: unknown,
+	api: unknown,
+): OpenAiRemoteCompactionIdentity | undefined {
+	if (provider === "openai" && api === "openai-responses") {
+		return { provider, api };
+	}
+	if (provider === "openai-codex" && api === "openai-codex-responses") {
+		return { provider, api };
+	}
+	return undefined;
+}
+
+export function isOpenAiRemoteCompactionModel(model: Model<Api> | undefined): model is OpenAiRemoteCompactionModel {
+	const identity = parseOpenAiRemoteCompactionIdentity(model?.provider, model?.api);
+	if (!identity || !model) return false;
+	return identity.api !== "openai-codex-responses" || isTrustedOpenAiCodexBaseUrl(model.baseUrl);
+}
+
+export function matchesOpenAiRemoteCompactionIdentity(
+	model: OpenAiRemoteCompactionModel,
+	identity: OpenAiRemoteCompactionIdentity,
+): boolean {
+	return model.provider === identity.provider && model.api === identity.api;
+}
+
+export function openAiRemoteCompactionIdentity(model: OpenAiRemoteCompactionModel): OpenAiRemoteCompactionIdentity {
+	return model.api === "openai-codex-responses"
+		? { provider: "openai-codex", api: "openai-codex-responses" }
+		: { provider: "openai", api: "openai-responses" };
+}
+
+export function openAiRemoteCompactionEndpointPath(model: OpenAiRemoteCompactionModel): string {
+	return model.api === "openai-codex-responses" ? "codex/responses/compact" : "responses/compact";
+}
+
+export function openAiRemoteCompactionEndpointUrl(model: OpenAiRemoteCompactionModel): string {
+	const defaultBaseUrl =
+		model.api === "openai-codex-responses" ? "https://chatgpt.com/backend-api" : "https://api.openai.com/v1";
+	const baseUrl = model.baseUrl || defaultBaseUrl;
+	return new URL(
+		openAiRemoteCompactionEndpointPath(model),
+		baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`,
+	).toString();
+}
+
+function extractCodexAccountId(token: string): string | undefined {
+	try {
+		const parts = token.split(".");
+		if (parts.length !== 3 || !parts[1]) return undefined;
+		const base64 = parts[1].replaceAll("-", "+").replaceAll("_", "/");
+		const payload: unknown = JSON.parse(atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")));
+		if (typeof payload !== "object" || payload === null) return undefined;
+		const auth = Reflect.get(payload, "https://api.openai.com/auth");
+		if (typeof auth !== "object" || auth === null) return undefined;
+		const accountId = Reflect.get(auth, "chatgpt_account_id");
+		return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function createOpenAiRemoteCompactionHeaders(
+	model: OpenAiRemoteCompactionModel,
+	auth: RemoteCompactionAuth,
+	sessionId?: string,
+): Headers | undefined {
+	const headers = new Headers(auth.headers);
+	headers.set("content-type", "application/json");
+	if (model.api === "openai-codex-responses" && auth.apiKey) {
+		headers.set("authorization", `Bearer ${auth.apiKey}`);
+	} else if (!headers.has("authorization") && auth.apiKey) {
+		headers.set("authorization", `Bearer ${auth.apiKey}`);
+	}
+	if (!headers.has("authorization")) return undefined;
+
+	if (model.api === "openai-codex-responses") {
+		const accountId = auth.apiKey ? extractCodexAccountId(auth.apiKey) : undefined;
+		if (accountId && !headers.has("chatgpt-account-id")) {
+			headers.set("chatgpt-account-id", accountId);
+		}
+		if (sessionId) {
+			headers.set("session_id", sessionId);
+			headers.set("session-id", sessionId);
+			headers.set("thread-id", sessionId);
+			headers.set("x-codex-installation-id", OPENAI_CODEX_INSTALLATION_ID);
+			headers.set("x-codex-window-id", `${sessionId}:0`);
+		}
+		headers.set("originator", "senpi");
+		headers.set("user-agent", "senpi");
+		headers.set("OpenAI-Beta", "responses=experimental");
+	}
+	return headers;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-schema.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-schema.ts
@@ -1,0 +1,136 @@
+import type { ServiceTier } from "../../types.ts";
+import { type OpenAiRemoteCompactionIdentity, parseOpenAiRemoteCompactionIdentity } from "./openai-remote-model.ts";
+
+export const OPENAI_REMOTE_COMPACTION_SCHEMA = "senpi.compaction.openai-remote.v1";
+
+export type OpenAiInputText = { type: "input_text"; text: string };
+export type OpenAiInputImage = { type: "input_image"; detail: "auto"; image_url: string };
+export type OpenAiInputContent = OpenAiInputText | OpenAiInputImage;
+export type OpenAiOutputText = { type: "output_text"; text: string; annotations: [] };
+export type OpenAiMessageInputItem = {
+	type?: "message";
+	id?: string;
+	role: "user" | "system" | "developer";
+	content: string | OpenAiInputContent[];
+	status?: "in_progress" | "completed" | "incomplete";
+};
+export type OpenAiAssistantMessageItem = {
+	type: "message";
+	id: string;
+	role: "assistant";
+	status: "completed";
+	content: OpenAiOutputText[];
+	phase?: "commentary" | "final_answer";
+};
+export type OpenAiFunctionCallItem = {
+	type: "function_call";
+	id?: string;
+	call_id: string;
+	name: string;
+	arguments: string;
+};
+export type OpenAiFunctionCallOutputItem = {
+	type: "function_call_output";
+	call_id: string;
+	output: string | OpenAiInputContent[];
+};
+export type OpenAiRemoteTransport = "websocket" | "compact-endpoint";
+export type OpenAiCompactionItem = {
+	type: "compaction";
+	encrypted_content: string;
+	id?: string | null;
+	created_by?: string;
+};
+export type OpenAiContextCompactionItem = {
+	type: "context_compaction";
+	encrypted_content: string;
+	id?: string | null;
+	created_by?: string;
+};
+export type OpenAiContextCompactionTriggerItem = {
+	type: "context_compaction";
+};
+export type OpenAiProviderNativeItem = Record<string, unknown> & { type: string };
+export type OpenAiRemoteInputItem =
+	| OpenAiMessageInputItem
+	| OpenAiAssistantMessageItem
+	| OpenAiFunctionCallItem
+	| OpenAiFunctionCallOutputItem
+	| OpenAiCompactionItem
+	| OpenAiContextCompactionItem
+	| OpenAiProviderNativeItem;
+
+export type OpenAiCompactBody = {
+	model: string;
+	input: OpenAiRemoteInputItem[];
+	instructions?: string;
+	prompt_cache_key?: string;
+	service_tier?: ServiceTier;
+};
+
+export type OpenAiRemoteCompactionDetails = OpenAiRemoteCompactionIdentity & {
+	schema: typeof OPENAI_REMOTE_COMPACTION_SCHEMA;
+	mode: "openai-remote";
+	transport: OpenAiRemoteTransport;
+	modelId: string;
+	responseId: string;
+	createdAt: number;
+	requestInputItemCount: number;
+	retainedInputItemCount: number;
+	replacementInput: OpenAiRemoteInputItem[];
+	usage?: Record<string, unknown>;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.schema !== OPENAI_REMOTE_COMPACTION_SCHEMA || value.mode !== "openai-remote") return undefined;
+	const identity = parseOpenAiRemoteCompactionIdentity(value.provider, value.api);
+	if (!identity) return undefined;
+	if (typeof value.modelId !== "string" || typeof value.responseId !== "string") return undefined;
+	if (typeof value.createdAt !== "number") return undefined;
+	if (typeof value.requestInputItemCount !== "number" || typeof value.retainedInputItemCount !== "number") {
+		return undefined;
+	}
+	if (!Array.isArray(value.replacementInput)) return undefined;
+	return {
+		schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
+		mode: "openai-remote",
+		...identity,
+		transport: value.transport === "websocket" ? "websocket" : "compact-endpoint",
+		modelId: value.modelId,
+		responseId: value.responseId,
+		createdAt: value.createdAt,
+		requestInputItemCount: value.requestInputItemCount,
+		retainedInputItemCount: value.retainedInputItemCount,
+		replacementInput: value.replacementInput.filter((item): item is OpenAiRemoteInputItem => isRecord(item)),
+		...(isRecord(value.usage) ? { usage: value.usage } : {}),
+	};
+}
+
+export function isOpenAiCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiCompactionItem {
+	return item.type === "compaction" && typeof item.encrypted_content === "string";
+}
+
+export function isOpenAiContextCompactionItem(item: OpenAiRemoteInputItem): item is OpenAiContextCompactionItem {
+	return item.type === "context_compaction" && typeof item.encrypted_content === "string";
+}
+
+export function isOpenAiRemoteCompactionOutputItem(
+	item: OpenAiRemoteInputItem,
+): item is OpenAiCompactionItem | OpenAiContextCompactionItem {
+	return isOpenAiCompactionItem(item) || isOpenAiContextCompactionItem(item);
+}
+
+export function isRetainedRemoteOutputItem(item: OpenAiRemoteInputItem): boolean {
+	if (isOpenAiRemoteCompactionOutputItem(item)) return true;
+	return item.type === "message" && (item.role === "user" || item.role === "system" || item.role === "developer");
+}
+
+export function isRetainedResponsesStreamInputItem(item: OpenAiRemoteInputItem): boolean {
+	if (item.type === "message") return item.role === "user";
+	return "role" in item && item.role === "user";
+}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -24,6 +24,15 @@ import {
 	OPENAI_REMOTE_COMPACTION_SCHEMA,
 	providerNativeItem,
 } from "./openai-remote-convert.ts";
+import {
+	createOpenAiRemoteCompactionHeaders,
+	isOpenAiRemoteCompactionModel,
+	matchesOpenAiRemoteCompactionIdentity,
+	type OpenAiRemoteCompactionModel,
+	openAiRemoteCompactionEndpointPath,
+	openAiRemoteCompactionEndpointUrl,
+	openAiRemoteCompactionIdentity,
+} from "./openai-remote-model.ts";
 
 export type {
 	OpenAiRemoteCompactionDetails,
@@ -136,11 +145,8 @@ type EmitCompactionEvent = (event: OpenAiRemoteCompactionEvent) => void;
 const OPENAI_REMOTE_COMPACTION_TIMEOUT_MS = 15_000;
 const REMOTE_COMPACTION_TIMEOUT_REASON = "remote-compaction-timeout";
 
-function isOpenAiResponsesModel(model: Model<Api> | undefined): model is Model<"openai-responses"> {
-	return model?.provider === "openai" && model.api === "openai-responses";
-}
-
-function supportsOpenAiResponsesWebSocket(model: Model<"openai-responses">): boolean {
+function supportsOpenAiResponsesWebSocket(model: OpenAiRemoteCompactionModel): model is Model<"openai-responses"> {
+	if (model.provider !== "openai" || model.api !== "openai-responses") return false;
 	if (model.compat?.supportsWebSocket !== undefined) return model.compat.supportsWebSocket;
 	try {
 		return new URL(model.baseUrl || "https://api.openai.com/v1").hostname === "api.openai.com";
@@ -157,7 +163,7 @@ export function createOpenAiRemoteCompactionRequest(options: {
 	promptCacheKey?: string;
 	serviceTier?: ServiceTier;
 }): OpenAiRemoteCompactionRequest | undefined {
-	if (!isOpenAiResponsesModel(options.model)) return undefined;
+	if (!isOpenAiRemoteCompactionModel(options.model)) return undefined;
 	const input = convertBranchEntries(options.branchEntries, options.model);
 	if (input.length === 0) return undefined;
 	return {
@@ -173,16 +179,34 @@ export function createOpenAiRemoteCompactionRequest(options: {
 	};
 }
 
-function isOpenAiCompactedResponse(value: unknown): value is OpenAiCompactedResponse {
-	if (!isRecord(value)) return false;
-	if (value.object !== "response.compaction" || typeof value.id !== "string" || typeof value.created_at !== "number") {
-		return false;
+function parseOpenAiCompactedResponse(options: {
+	value: unknown;
+	model: OpenAiRemoteCompactionModel;
+	requestId: string;
+	now: () => number;
+}): OpenAiCompactedResponse | undefined {
+	if (!isRecord(options.value) || !Array.isArray(options.value.output)) return undefined;
+	if (options.model.api === "openai-responses") {
+		if (
+			options.value.object !== "response.compaction" ||
+			typeof options.value.id !== "string" ||
+			typeof options.value.created_at !== "number"
+		) {
+			return undefined;
+		}
 	}
-	return Array.isArray(value.output);
+	return {
+		id: typeof options.value.id === "string" ? options.value.id : `codex-compact:${options.requestId}`,
+		created_at:
+			typeof options.value.created_at === "number" ? options.value.created_at : Math.floor(options.now() / 1000),
+		object: "response.compaction",
+		output: options.value.output.filter((item): item is OpenAiRemoteInputItem => isRecord(item)),
+		...(isRecord(options.value.usage) ? { usage: options.value.usage } : {}),
+	};
 }
 
 export function buildOpenAiRemoteCompactionResult(options: {
-	model: Model<"openai-responses">;
+	model: OpenAiRemoteCompactionModel;
 	firstKeptEntryId: string;
 	tokensBefore: number;
 	requestInputItemCount: number;
@@ -197,8 +221,7 @@ export function buildOpenAiRemoteCompactionResult(options: {
 	const details = {
 		schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
 		mode: "openai-remote",
-		provider: "openai",
-		api: "openai-responses",
+		...openAiRemoteCompactionIdentity(options.model),
 		transport: "compact-endpoint",
 		modelId: options.model.id,
 		responseId: options.response.id,
@@ -208,31 +231,21 @@ export function buildOpenAiRemoteCompactionResult(options: {
 		replacementInput,
 		...(options.response.usage ? { usage: options.response.usage } : {}),
 	} satisfies OpenAiRemoteCompactionDetails;
+	const endpointPath =
+		options.model.api === "openai-codex-responses"
+			? `/${openAiRemoteCompactionEndpointPath(options.model)}`
+			: "/v1/responses/compact";
 
 	return {
 		summary: [
 			"OpenAI remote compaction checkpoint.",
-			`Native /v1/responses/compact replay is active for ${replacementInput.length.toLocaleString()} retained item(s).`,
+			`Native ${endpointPath} replay is active for ${replacementInput.length.toLocaleString()} retained item(s).`,
 			`Original OpenAI input items compacted: ${options.requestInputItemCount.toLocaleString()}.`,
 		].join("\n"),
 		firstKeptEntryId: options.firstKeptEntryId,
 		tokensBefore: options.tokensBefore,
 		details,
 	};
-}
-
-function compactEndpointUrl(model: Model<"openai-responses">): string {
-	const baseUrl = model.baseUrl || "https://api.openai.com/v1";
-	return new URL("responses/compact", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).toString();
-}
-
-function createHeaders(auth: { apiKey?: string; headers?: Record<string, string> }): Headers | undefined {
-	const headers = new Headers(auth.headers);
-	headers.set("content-type", "application/json");
-	if (!headers.has("authorization") && auth.apiKey) {
-		headers.set("authorization", `Bearer ${auth.apiKey}`);
-	}
-	return headers.has("authorization") ? headers : undefined;
 }
 
 async function runWithRemoteTimeout<T>(options: {
@@ -408,11 +421,12 @@ async function runOpenAiResponsesStreamCompaction(options: {
 async function runOpenAiCompactEndpointCompaction(options: {
 	fetchImpl: typeof fetch;
 	headers: Headers;
-	model: Model<"openai-responses">;
+	model: OpenAiRemoteCompactionModel;
 	request: OpenAiRemoteCompactionRequest;
 	requestId: string;
 	signal: AbortSignal;
 	firstKeptEntryId: string;
+	now: () => number;
 	emit?: EmitCompactionEvent;
 }): Promise<OpenAiRemoteCompactionResult | undefined> {
 	options.emit?.({
@@ -427,7 +441,7 @@ async function runOpenAiCompactEndpointCompaction(options: {
 
 	let response: Response;
 	try {
-		response = await options.fetchImpl(compactEndpointUrl(options.model), {
+		response = await options.fetchImpl(openAiRemoteCompactionEndpointUrl(options.model), {
 			method: "POST",
 			headers: options.headers,
 			body: JSON.stringify(options.request.body),
@@ -475,7 +489,13 @@ async function runOpenAiCompactEndpointCompaction(options: {
 		});
 		return undefined;
 	}
-	if (!isOpenAiCompactedResponse(payload)) {
+	const compactedResponse = parseOpenAiCompactedResponse({
+		value: payload,
+		model: options.model,
+		requestId: options.requestId,
+		now: options.now,
+	});
+	if (!compactedResponse) {
 		options.emit?.({
 			version: 1,
 			action: "remote_fallback",
@@ -495,7 +515,7 @@ async function runOpenAiCompactEndpointCompaction(options: {
 			firstKeptEntryId: options.firstKeptEntryId,
 			tokensBefore: options.request.tokensBefore,
 			requestInputItemCount: options.request.inputItemCount,
-			response: payload,
+			response: compactedResponse,
 		});
 	} catch (error) {
 		options.emit?.({
@@ -515,7 +535,7 @@ async function runOpenAiCompactEndpointCompaction(options: {
 		route: "builtin.compaction.openai_remote",
 		requestId: options.requestId,
 		modelId: options.model.id,
-		responseId: payload.id,
+		responseId: compactedResponse.id,
 		retainedInputItemCount: result.details.retainedInputItemCount,
 		transport: "compact-endpoint",
 	});
@@ -529,7 +549,7 @@ export async function runOpenAiRemoteCompaction(
 	dependencies: OpenAiRemoteCompactionDependencies = {},
 ): Promise<OpenAiRemoteCompactionResult | undefined> {
 	const model = ctx.model;
-	if (!isOpenAiResponsesModel(model) || event.reason === "branch") {
+	if (!isOpenAiRemoteCompactionModel(model) || event.reason === "branch") {
 		emit?.({
 			version: 1,
 			action: "remote_fallback",
@@ -651,7 +671,7 @@ export async function runOpenAiRemoteCompaction(
 		}
 	}
 
-	const headers = createHeaders(auth);
+	const headers = createOpenAiRemoteCompactionHeaders(requestModel, auth, request.body.prompt_cache_key);
 	if (!headers) {
 		emit?.({
 			version: 1,
@@ -686,6 +706,7 @@ export async function runOpenAiRemoteCompaction(
 				requestId: event.requestId,
 				signal,
 				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				now: dependencies.now ?? Date.now,
 				emit,
 			}),
 	});
@@ -721,9 +742,9 @@ export function rewriteOpenAiPayloadWithRemoteCompaction(
 	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[]; pendingMessages?: AgentMessage[] },
 	emit?: EmitCompactionEvent,
 ): unknown | undefined {
-	if (!isOpenAiResponsesModel(options.model) || !isRecord(payload)) return undefined;
+	if (!isOpenAiRemoteCompactionModel(options.model) || !isRecord(payload)) return undefined;
 	const remote = latestRemoteCompaction(options.branchEntries);
-	if (!remote) return undefined;
+	if (!remote || !matchesOpenAiRemoteCompactionIdentity(options.model, remote.details)) return undefined;
 
 	const postCompactionItems = convertBranchEntries(options.branchEntries.slice(remote.index + 1), options.model);
 	// The in-flight prompt is not yet persisted in the branch at provider-request

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction-boundaries.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction-boundaries.test.ts
@@ -1,0 +1,137 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_COMPACTION_SETTINGS } from "../../../src/core/compaction/index.ts";
+import {
+	OPENAI_REMOTE_COMPACTION_SCHEMA,
+	rewriteOpenAiPayloadWithRemoteCompaction,
+	runOpenAiRemoteCompaction,
+} from "../../../src/core/extensions/builtin/compaction/openai-remote.ts";
+import type { SessionBeforeCompactEvent } from "../../../src/core/extensions/types.ts";
+import type { SessionEntry } from "../../../src/core/session-manager.ts";
+
+const OPENAI_MODEL = {
+	id: "gpt-5.4",
+	name: "GPT-5.4",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 16_384,
+} satisfies Model<"openai-responses">;
+
+const CODEX_MODEL = {
+	...OPENAI_MODEL,
+	id: "gpt-5.4-codex",
+	name: "GPT-5.4 Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+} satisfies Model<"openai-codex-responses">;
+
+function compactedBranch(provider: "openai" | "openai-codex"): SessionEntry[] {
+	const isCodex = provider === "openai-codex";
+	return [
+		{
+			type: "message",
+			id: "u1",
+			parentId: null,
+			timestamp: new Date(1_775_000_000_000).toISOString(),
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "History before compaction." }],
+				timestamp: 1,
+			},
+		},
+		{
+			type: "compaction",
+			id: "compact",
+			parentId: "u1",
+			timestamp: new Date(1_775_000_001_000).toISOString(),
+			summary: "Remote checkpoint.",
+			firstKeptEntryId: "u1",
+			tokensBefore: 100,
+			fromHook: true,
+			details: {
+				schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
+				mode: "openai-remote",
+				provider,
+				api: isCodex ? "openai-codex-responses" : "openai-responses",
+				transport: "compact-endpoint",
+				modelId: isCodex ? CODEX_MODEL.id : OPENAI_MODEL.id,
+				responseId: "remote-compact",
+				createdAt: 1_775_000_001,
+				requestInputItemCount: 1,
+				retainedInputItemCount: 1,
+				replacementInput: [{ type: "compaction", encrypted_content: "provider-owned-state" }],
+			},
+		},
+	];
+}
+
+function event(branchEntries: SessionEntry[]): SessionBeforeCompactEvent {
+	return {
+		type: "session_before_compact",
+		reason: "threshold",
+		willRetry: true,
+		requestId: "issue-296-boundary",
+		preparation: {
+			firstKeptEntryId: "u1",
+			messagesToSummarize: [],
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: DEFAULT_COMPACTION_SETTINGS,
+		},
+		branchEntries,
+		signal: new AbortController().signal,
+	};
+}
+
+function codexToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "account_issue_296" } }),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("issue #296 remote compaction boundaries", () => {
+	it.each([
+		{ current: CODEX_MODEL, persistedProvider: "openai" as const },
+		{ current: OPENAI_MODEL, persistedProvider: "openai-codex" as const },
+	])("does not replay $persistedProvider state through $current.provider", ({ current, persistedProvider }) => {
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			{ model: current.id, input: [], stream: true },
+			{ model: current, branchEntries: compactedBranch(persistedProvider), pendingMessages: [] },
+		);
+
+		expect(rewritten).toBeUndefined();
+	});
+
+	it("does not send Codex OAuth compaction to an untrusted remote base URL", async () => {
+		const model = { ...CODEX_MODEL, baseUrl: "https://attacker.example/backend-api" };
+		let fetchCalls = 0;
+		const ctx = {
+			model,
+			serviceTier: undefined,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: codexToken() }),
+			},
+			sessionManager: { getSessionId: () => "issue-296-untrusted-origin" },
+			getSystemPrompt: () => "Sensitive system prompt.",
+		};
+
+		const result = await runOpenAiRemoteCompaction(ctx, event(compactedBranch("openai-codex")), undefined, {
+			fetch: async () => {
+				fetchCalls += 1;
+				return new Response("unexpected", { status: 500 });
+			},
+		});
+
+		expect(result).toBeUndefined();
+		expect(fetchCalls).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
@@ -1,0 +1,244 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_COMPACTION_SETTINGS } from "../../../src/core/compaction/index.ts";
+import {
+	OPENAI_REMOTE_COMPACTION_SCHEMA,
+	rewriteOpenAiPayloadWithRemoteCompaction,
+	runOpenAiRemoteCompaction,
+} from "../../../src/core/extensions/builtin/compaction/openai-remote.ts";
+import type { SessionBeforeCompactEvent } from "../../../src/core/extensions/types.ts";
+import type { SessionEntry, SessionMessageEntry } from "../../../src/core/session-manager.ts";
+
+const CODEX_MODEL = {
+	id: "gpt-5.4-codex",
+	name: "GPT-5.4 Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 16_384,
+} satisfies Model<"openai-codex-responses">;
+
+const ANTHROPIC_MODEL = {
+	id: "claude-sonnet-4-6",
+	name: "Claude Sonnet 4.6",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 16_384,
+} satisfies Model<"anthropic-messages">;
+
+function messageEntry(id: string, parentId: string | null, message: SessionMessageEntry["message"]): SessionEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date(1_775_000_000_000 + id.length).toISOString(),
+		message,
+	};
+}
+
+function codexBranch(): SessionEntry[] {
+	return [
+		{
+			type: "model_change",
+			id: "model",
+			parentId: null,
+			timestamp: new Date(1_775_000_000_000).toISOString(),
+			provider: "openai-codex",
+			modelId: CODEX_MODEL.id,
+		},
+		messageEntry("u1", "model", {
+			role: "user",
+			content: [{ type: "text", text: "Inspect the failing build." }],
+			timestamp: 1,
+		}),
+		messageEntry("a1", "u1", {
+			role: "assistant",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			model: CODEX_MODEL.id,
+			content: [{ type: "text", text: "I found the failure." }],
+			usage: {
+				input: 100,
+				output: 20,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 120,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 2,
+		} satisfies AssistantMessage),
+		messageEntry("u2", "a1", {
+			role: "user",
+			content: [{ type: "text", text: "Keep the diagnosis." }],
+			timestamp: 3,
+		}),
+	];
+}
+
+function compactionEvent(model: Api, branchEntries: SessionEntry[]): SessionBeforeCompactEvent {
+	return {
+		type: "session_before_compact",
+		reason: "threshold",
+		willRetry: true,
+		requestId: `issue-296-${model}`,
+		preparation: {
+			firstKeptEntryId: "u2",
+			messagesToSummarize: [],
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 1234,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: DEFAULT_COMPACTION_SETTINGS,
+		},
+		branchEntries,
+		signal: new AbortController().signal,
+	};
+}
+
+function codexToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: "account_issue_296" },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+describe("issue #296 OpenAI Codex remote compaction", () => {
+	it("compacts through the Codex endpoint and replays retained history on the next request", async () => {
+		const branch = codexBranch();
+		const calls: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
+		const ctx = {
+			model: CODEX_MODEL,
+			serviceTier: undefined,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: codexToken() }),
+			},
+			sessionManager: { getSessionId: () => "issue-296-session" },
+			getSystemPrompt: () => "You are Senpi.",
+		};
+
+		const result = await runOpenAiRemoteCompaction(ctx, compactionEvent(CODEX_MODEL.api, branch), undefined, {
+			fetch: async (url, init) => {
+				calls.push({
+					url: String(url),
+					headers: new Headers(init?.headers),
+					body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+				});
+				return new Response(
+					JSON.stringify({
+						output: [
+							{
+								type: "message",
+								id: "u1_remote",
+								role: "user",
+								content: [{ type: "input_text", text: "Inspect the failing build." }],
+							},
+							{ type: "compaction", id: "cmp_codex", encrypted_content: "encrypted-codex-summary" },
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			},
+		});
+
+		expect(result, "Codex models must use native remote compaction").toBeDefined();
+		if (!result) return;
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe("https://chatgpt.com/backend-api/codex/responses/compact");
+		expect(calls[0]?.headers.get("authorization")).toBe(`Bearer ${codexToken()}`);
+		expect(calls[0]?.headers.get("chatgpt-account-id")).toBe("account_issue_296");
+		expect(calls[0]?.headers.get("originator")).toBe("senpi");
+		expect(calls[0]?.headers.get("openai-beta")).toBe("responses=experimental");
+		expect(calls[0]?.headers.get("session_id")).toBe("issue-296-session");
+		expect(calls[0]?.headers.get("session-id")).toBe("issue-296-session");
+		expect(calls[0]?.headers.get("thread-id")).toBe("issue-296-session");
+		expect(calls[0]?.headers.get("x-codex-installation-id")).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+		expect(calls[0]?.headers.get("x-codex-installation-id")).not.toBe("issue-296-session");
+		expect(calls[0]?.headers.get("x-codex-window-id")).toBe("issue-296-session:0");
+		expect(calls[0]?.headers.get("user-agent")).toBe("senpi");
+		expect(result.details).toMatchObject({
+			schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+			transport: "compact-endpoint",
+		});
+
+		const compactedBranch: SessionEntry[] = [
+			...branch,
+			{
+				type: "compaction",
+				id: "compact",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				summary: result.summary,
+				firstKeptEntryId: result.firstKeptEntryId,
+				tokensBefore: result.tokensBefore,
+				details: result.details,
+				fromHook: true,
+			},
+		];
+		const pendingMessages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "Continue after compaction." }],
+				timestamp: 4,
+			},
+		] satisfies AgentMessage[];
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			{ model: CODEX_MODEL.id, input: [{ role: "developer", content: "Current prompt." }], stream: true },
+			{ model: CODEX_MODEL, branchEntries: compactedBranch, pendingMessages },
+		) as { input?: unknown[] } | undefined;
+
+		expect(rewritten?.input).toContainEqual({
+			type: "compaction",
+			id: "cmp_codex",
+			encrypted_content: "encrypted-codex-summary",
+		});
+		expect(rewritten?.input).toContainEqual({
+			role: "user",
+			content: [{ type: "input_text", text: "Continue after compaction." }],
+		});
+	});
+
+	it("keeps unsupported providers outside native remote compaction", async () => {
+		let compactCalls = 0;
+		const ctx = {
+			model: ANTHROPIC_MODEL,
+			serviceTier: undefined,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "unused" }),
+			},
+			sessionManager: { getSessionId: () => "issue-296-anthropic" },
+			getSystemPrompt: () => "You are Senpi.",
+		};
+
+		const result = await runOpenAiRemoteCompaction(
+			ctx,
+			compactionEvent(ANTHROPIC_MODEL.api, codexBranch()),
+			undefined,
+			{
+				fetch: async () => {
+					compactCalls += 1;
+					throw new Error("unsupported provider must not reach the compact endpoint");
+				},
+			},
+		);
+
+		expect(result).toBeUndefined();
+		expect(compactCalls).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

- enable builtin native remote compaction for `openai-codex` / `openai-codex-responses`
- send Codex compaction to the official ChatGPT `/codex/responses/compact` route with paired OAuth/account and Codex session identity headers
- accept Codex's output-only compact response while preserving strict direct-OpenAI parsing
- persist the provider/API identity and replay encrypted compacted history only through the matching model family
- block Codex OAuth compaction to untrusted remote custom origins while retaining loopback QA/proxy support
- preserve the existing direct `openai` / `openai-responses` endpoint and WebSocket behavior

Closes #296

## RED -> GREEN

- initial issue regression failed because Codex returned `undefined` before fetch
- Codex output-only response regression failed until the parser normalized that official response shape
- provider-family boundary tests failed in both directions until replay required exact provider/API identity
- untrusted-origin regression reached `fetch` once until the trusted-origin gate was added
- official header parity regression failed until `session-id`, `thread-id`, and a process-stable installation UUID were added

## Verification

- `npm run check` - passed
- `npm run build` - passed
- `npm test -- test/compaction/ test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts test/suite/regressions/issue-296-openai-codex-remote-compaction-boundaries.test.ts` - 24 files, 182 tests passed
- source CLI Codex RPC QA - 10/10 passed
- direct OpenAI remote compaction QA - 6/6 passed
- CLI smoke (`--help`, version, list-models, bad input) - 7/7 passed
- five-lane goal, quality, security, hands-on QA, and context review - PASS

QA receipts:

- `local-ignore/qa-evidence/20260723-openai-codex-remote-compaction/`
- `local-ignore/qa-evidence/20260723-openai-codex-direct-regression/`

The local full workspace `npm test` additionally exposed unrelated machine-state tests: the checked-out sibling Codex repository does not match this repo's pinned commit; the app-server daemon port test and the intentional MCP OAuth race control case pass in isolation but can fail in the full parallel run. No production or test suppression changes were made for those pre-existing conditions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native remote compaction for `openai-codex` models via ChatGPT’s `codex/responses/compact`. This enables server-side compaction with identity-locked replay while keeping existing `openai` behavior unchanged.

- New Features
  - Native remote compaction for `openai-codex`/`openai-codex-responses`.
  - Uses ChatGPT `codex/responses/compact` with OAuth and Codex session headers; accepts Codex’s output-only response.
  - Persists provider/API identity and replays only within the same model family; `openai`/`openai-responses` keeps current endpoint/WebSocket behavior.

- Bug Fixes
  - Normalizes parser for Codex’s output-only shape and avoids early undefined responses.
  - Restricts Codex OAuth compaction to trusted origins (chatgpt.com and loopback).
  - Adds required session/thread/installation headers and blocks cross-provider replay between `openai` and `openai-codex`.

<sup>Written for commit 60d4376d13497bef43749ee1a7bb9f85bf7b9b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

