### PR TITLE
fix(compaction): sanitize Anthropic tool pairs on summarization requests

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,16 @@
 # Builtin compaction extension changes
 
+## Sanitize Anthropic tool pairs on direct summarization requests (2026-07-23)
+
+- `speculative.ts`: local compaction summarization now applies the existing Anthropic payload sanitizer at the direct
+  `stream()` boundary. Unlike normal agent turns, this side request does not run the extension runner's
+  `before_provider_request` hooks, so an orphan `tool_result` that survived message conversion previously reached
+  Anthropic unchanged and permanently rejected compaction for an over-limit session.
+- Regression: `test/compaction/anthropic-tool-pair-guard.test.ts` drives the real Anthropic wire adapter against a local
+  endpoint that rejects orphan results, proving the summarization request is valid before it leaves senpi.
+
+Expected upstream conflict zones: `builtin/compaction/speculative.ts` direct summary stream options.
+
 ## Support native remote compaction for OpenAI Codex models (2026-07-23)
 
 - `openai-remote-model.ts`, `openai-remote-schema.ts`, `openai-remote.ts`, `openai-remote-convert.ts`,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -24,6 +24,7 @@ import { convertToLlm } from "../../../messages.ts";
 import type { ModelRegistry } from "../../../model-registry.ts";
 import type { ReadonlySessionManager } from "../../../session-manager.ts";
 import type { ApplyCompactionResult, ContextUsage } from "../../types.ts";
+import { sanitizeAnthropicPayload } from "../tool-pair-guard/sanitize-anthropic-payload.ts";
 import { computeEffectiveKeepRecentTokens, computeEffectiveThreshold } from "./policy.ts";
 import { buildPrompt, type MergedCompactionPromptVariant } from "./prompts.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
@@ -165,6 +166,7 @@ async function generateSummaryMessage(options: {
 				apiKey: options.auth.apiKey,
 				headers: options.auth.headers,
 				extraBody: options.auth.extraBody,
+				...(options.snapshot.model.api === "anthropic-messages" ? { onPayload: sanitizeAnthropicPayload } : {}),
 				maxTokens: summaryMaxTokens(options.snapshot.model, options.snapshot.contextWindow),
 				signal: requestController.signal,
 			},

--- a/packages/coding-agent/test/compaction/anthropic-tool-pair-guard.test.ts
+++ b/packages/coding-agent/test/compaction/anthropic-tool-pair-guard.test.ts
@@ -1,0 +1,232 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import {
+	createSpeculativeCompactionSnapshot,
+	runExtensionCompaction,
+	type SpeculativeCompactionContext,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+const PROVIDER = "anthropic-compaction-wire";
+const MODEL_ID = "claude-compaction-wire";
+const ORPHAN_TOOL_USE_ID = "tool_MT8C3KqVPHoD0Xw5GLGvSQBO";
+const SUMMARY_TEXT = "Anthropic compaction summary.";
+
+type AnthropicBlock = {
+	type?: unknown;
+	id?: unknown;
+	tool_use_id?: unknown;
+};
+
+type AnthropicMessage = {
+	role?: unknown;
+	content?: unknown;
+};
+
+type AnthropicRequestBody = {
+	messages?: unknown;
+};
+
+function findOrphanToolResult(body: AnthropicRequestBody): string | undefined {
+	if (!Array.isArray(body.messages)) return undefined;
+	for (let index = 0; index < body.messages.length; index++) {
+		const message = body.messages[index] as AnthropicMessage;
+		if (message.role !== "user" || !Array.isArray(message.content)) continue;
+		const previous = body.messages[index - 1] as AnthropicMessage | undefined;
+		const precedingToolUseIds = new Set(
+			previous?.role === "assistant" && Array.isArray(previous.content)
+				? previous.content.flatMap((block: AnthropicBlock) =>
+						block.type === "tool_use" && typeof block.id === "string" ? [block.id] : [],
+					)
+				: [],
+		);
+		for (const block of message.content as AnthropicBlock[]) {
+			if (block.type !== "tool_result" || typeof block.tool_use_id !== "string") continue;
+			if (!precedingToolUseIds.has(block.tool_use_id)) return block.tool_use_id;
+		}
+	}
+	return undefined;
+}
+
+function writeEvent(response: import("node:http").ServerResponse, event: string, payload: unknown): void {
+	response.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
+
+function writeSummary(response: import("node:http").ServerResponse): void {
+	response.writeHead(200, { "content-type": "text/event-stream" });
+	writeEvent(response, "message_start", {
+		type: "message_start",
+		message: {
+			id: "msg_compaction",
+			usage: { input_tokens: 10, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+		},
+	});
+	writeEvent(response, "content_block_start", {
+		type: "content_block_start",
+		index: 0,
+		content_block: { type: "text", text: "" },
+	});
+	writeEvent(response, "content_block_delta", {
+		type: "content_block_delta",
+		index: 0,
+		delta: { type: "text_delta", text: SUMMARY_TEXT },
+	});
+	writeEvent(response, "content_block_stop", { type: "content_block_stop", index: 0 });
+	writeEvent(response, "message_delta", {
+		type: "message_delta",
+		delta: { stop_reason: "end_turn" },
+		usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+	});
+	writeEvent(response, "message_stop", { type: "message_stop" });
+	response.end();
+}
+
+function startAnthropicServer(): Promise<{
+	readonly url: string;
+	readonly bodies: AnthropicRequestBody[];
+	readonly rejectedToolUseIds: string[];
+	stop(): Promise<void>;
+}> {
+	const bodies: AnthropicRequestBody[] = [];
+	const rejectedToolUseIds: string[] = [];
+	const server: Server = createServer((request, response) => {
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer) => chunks.push(chunk));
+		request.on("end", () => {
+			const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as AnthropicRequestBody;
+			bodies.push(body);
+			const orphanToolUseId = findOrphanToolResult(body);
+			if (orphanToolUseId) {
+				rejectedToolUseIds.push(orphanToolUseId);
+				response.writeHead(400, { "content-type": "application/json" });
+				response.end(
+					JSON.stringify({
+						type: "error",
+						error: {
+							type: "invalid_request_error",
+							message: `unexpected tool_use_id found in tool_result blocks: ${orphanToolUseId}`,
+						},
+					}),
+				);
+				return;
+			}
+			writeSummary(response);
+		});
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address() as AddressInfo;
+			resolve({
+				url: `http://127.0.0.1:${address.port}`,
+				bodies,
+				rejectedToolUseIds,
+				stop: () => new Promise((done) => server.close(() => done())),
+			});
+		});
+	});
+}
+
+function createContext(serverUrl: string): SpeculativeCompactionContext {
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey(PROVIDER, "wire-key");
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	modelRegistry.registerProvider(PROVIDER, {
+		baseUrl: serverUrl,
+		apiKey: "wire-key",
+		api: "anthropic-messages",
+		models: [
+			{
+				id: MODEL_ID,
+				name: "Claude compaction wire",
+				api: "anthropic-messages",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 200_000,
+				maxTokens: 16_384,
+				baseUrl: serverUrl,
+			},
+		],
+	});
+	const model = modelRegistry.find(PROVIDER, MODEL_ID);
+	if (!model) throw new Error("Anthropic compaction wire model registration failed");
+
+	const sessionManager = SessionManager.inMemory();
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "first user ".repeat(12_000) }],
+		timestamp: Date.now() - 3_000,
+	});
+	const interruptedAssistant: AssistantMessage = {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: PROVIDER,
+		model: MODEL_ID,
+		usage: {
+			input: 50_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 50_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		errorMessage: "terminated",
+		timestamp: Date.now() - 2_000,
+	};
+	sessionManager.appendMessage(interruptedAssistant);
+	sessionManager.appendMessage({
+		role: "toolResult",
+		toolCallId: ORPHAN_TOOL_USE_ID,
+		toolName: "task",
+		content: [{ type: "text", text: "orphaned child result" }],
+		isError: false,
+		timestamp: Date.now() - 1_500,
+	});
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "second user ".repeat(12_000) }],
+		timestamp: Date.now() - 1_000,
+	});
+
+	return {
+		model,
+		modelRegistry,
+		sessionManager,
+		getContextUsage: () => ({ tokens: 50_000, contextWindow: 200_000, percent: 25 }),
+		getMessageRevision: () => 1,
+		applyCompaction: async () => ({ applied: true, reason: "ok" }),
+	};
+}
+
+describe("Anthropic compaction tool-pair guard", () => {
+	let server: Awaited<ReturnType<typeof startAnthropicServer>> | undefined;
+
+	afterEach(async () => {
+		await server?.stop();
+		server = undefined;
+	});
+
+	it("removes an orphan tool_result before the summarization request reaches Anthropic", async () => {
+		// Given
+		server = await startAnthropicServer();
+		const context = createContext(server.url);
+		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+		expect(snapshot).toBeDefined();
+		if (!snapshot) return;
+
+		// When
+		const result = await runExtensionCompaction(context, snapshot);
+
+		// Then
+		expect(result?.summary).toBe(SUMMARY_TEXT);
+		expect(server.rejectedToolUseIds).toEqual([]);
+		expect(server.bodies.some((body) => findOrphanToolResult(body) === ORPHAN_TOOL_USE_ID)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

A real over-limit session (`019f82ff-…`) became permanently stuck: every turn died at the output-token limit, and the only recovery path — auto-compaction — itself failed with a hard `400`:

```
messages.280.content.1: unexpected tool_use_id found in tool_result blocks:
tool_MT8C3KqVPHoD0Xw5GLGvSQBO. Each tool_result block must have a
corresponding tool_use block in the previous message.
```

Once compaction 400s repeatedly, the circuit breaker opens and the session bricks (context already `> 1,000,000` tokens).

## Root cause

- The stored transcript does **not** contain an orphan `tool_result`. It has an errored assistant tool call (`stopReason: "error"`, `errorMessage: "terminated"`) at transcript line 556 with no matching result. An older process build synthesized a placeholder result for that dangling call and then dropped the errored assistant, leaving an unconsumed (orphan) `tool_result`.
- Normal agent turns strip such orphans because the provider payload goes through the `before_provider_request` hook chain, which runs `tool-pair-guard`'s `sanitizeAnthropicPayload()`.
- **Compaction summarization calls `stream()` directly** (`speculative.ts`) and does **not** run those hooks, so the orphan reached the Anthropic Messages API unchanged and was rejected — killing the one escape hatch.
- The circuit breaker was secondary: it amplified the repeated 400s but did not create the orphan.

## Fix

Apply the existing Anthropic payload sanitizer at the direct summarization-request boundary, only for `anthropic-messages` models:

```ts
...(options.snapshot.model.api === "anthropic-messages"
    ? { onPayload: sanitizeAnthropicPayload }
    : {}),
```

This adds only the missing tool-pair invariant guard to the side request; it deliberately does not replay the full extension hook chain.

## Tests / verification

- New wire-level regression `test/compaction/anthropic-tool-pair-guard.test.ts` drives the real Anthropic adapter against a local endpoint that rejects orphan/non-adjacent `tool_result` blocks, using the exact rejected id. **Fails before the fix (same 400), passes after.**
- Scoped compaction + tool-pair suites: **50/50 pass**.
- `npm run check`: **pass (exit 0)** — `tsgo --noEmit`, biome, pinned-deps, shrinkwrap, install-lock, web-ui, and Neo build/vet/test all green (one pre-existing info-level `noFlatMapIdentity` note in an unrelated test).
- `npm run build`: **pass** across all packages.
- Real-CLI QA (`.agents/skills/senpi-qa`) self-tests: mock-loop 20/20, rpc 4/4, cli-smoke 7/7, common 9/9 — zero real provider calls, real auth untouched. Evidence under `local-ignore/qa-evidence/20260723-compaction-tool-pair/`.

Pre-existing, unrelated full-suite failures (not touched by this change): `app-server-daemon.test.ts` timeout and `app-server-protocol.test.ts` manifest mismatch.

## Note

A currently running old senpi process must be **restarted** to load this fix; after restart, manual `/compact` bypasses the circuit-breaker cooldown and the summarization request is sanitized before transmission.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Anthropic tool-use/tool-result pairs on compaction summarization requests to prevent 400s from orphan tool_result blocks. This unblocks auto-compaction for over-limit sessions and avoids circuit-breaker lockouts.

- **Bug Fixes**
  - Apply the existing Anthropic payload sanitizer via `onPayload` when the model API is `anthropic-messages`, ensuring no orphan `tool_result` reaches Anthropic during compaction’s direct `stream()` call.
  - Add a wire-level regression test that rejects orphan results and verifies the summarization request is clean.

- **Migration**
  - Restart any running process to load the fix; after restart, manual `/compact` bypasses cooldown and sends a sanitized request.

<sup>Written for commit f7d92c0c68ff6c9e14990496b135f68af94cd02e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

