### PR TITLE
fix(coding-agent): stabilize compaction lifecycle

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -171,6 +171,7 @@ type ActiveRun = {
 	promise: Promise<void>;
 	resolve: () => void;
 	abortController: AbortController;
+	suppressQueuedMessageDrain: boolean;
 };
 
 /**
@@ -322,6 +323,16 @@ export class Agent {
 	/** Abort the current run, if one is active. */
 	abort(): void {
 		this.activeRun?.abortController.abort();
+	}
+
+	/**
+	 * Keep queued steering and follow-up messages for an external owner after
+	 * this run reaches agent_end, without changing the active abort signal.
+	 */
+	suppressQueuedMessageDrain(): void {
+		if (this.activeRun) {
+			this.activeRun.suppressQueuedMessageDrain = true;
+		}
 	}
 
 	/**
@@ -505,7 +516,7 @@ export class Agent {
 		const promise = new Promise<void>((resolve) => {
 			resolvePromise = resolve;
 		});
-		this.activeRun = { promise, resolve: resolvePromise, abortController };
+		this.activeRun = { promise, resolve: resolvePromise, abortController, suppressQueuedMessageDrain: false };
 
 		this._state.isStreaming = true;
 		this._state.streamingMessage = undefined;
@@ -513,7 +524,11 @@ export class Agent {
 
 		try {
 			await executor(abortController.signal);
-			while (!abortController.signal.aborted && this.hasQueuedMessages()) {
+			while (
+				!abortController.signal.aborted &&
+				!this.activeRun?.suppressQueuedMessageDrain &&
+				this.hasQueuedMessages()
+			) {
 				await this.runQueuedMessagesAfterAgentEnd(abortController.signal);
 			}
 		} catch (error) {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -368,6 +368,32 @@ export class Agent {
 		await this.runPromptMessages(messages);
 	}
 
+	/** Continue by delivering queued input first when a compaction leaves custom context at the tail. */
+	async continueWithQueuedMessages(): Promise<void> {
+		if (this.activeRun) {
+			throw new Error("Agent is already processing. Wait for completion before continuing.");
+		}
+
+		if (this._state.messages[this._state.messages.length - 1]?.role === "assistant") {
+			await this.continue();
+			return;
+		}
+
+		const queuedSteering = this.steeringQueue.drain();
+		if (queuedSteering.length > 0) {
+			await this.runPromptMessages(queuedSteering, { skipInitialSteeringPoll: true });
+			return;
+		}
+
+		const queuedFollowUps = this.followUpQueue.drain();
+		if (queuedFollowUps.length > 0) {
+			await this.runPromptMessages(queuedFollowUps);
+			return;
+		}
+
+		await this.continue();
+	}
+
 	/** Continue from the current transcript. The last message must be a user or tool-result message. */
 	async continue(): Promise<void> {
 		if (this.activeRun) {

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,27 @@
 # Changes
 
+## 2026-07-23 - Session-owned post-agent_end queue drain suppression
+
+### What changed and why
+
+- `Agent` now exposes `suppressQueuedMessageDrain()` for the active run. It stops only the lifecycle-owned
+  post-`agent_end` steering/follow-up drain, retaining both queues without aborting the run signal.
+- The coding-agent compaction admission gate uses this ownership transfer for required recovery. Real user aborts
+  continue to abort the active signal and retain the normal terminal semantics.
+
+### Files modified
+
+- `agent.ts`
+- `../test/agent.test.ts`
+
+### Why the extension system could not handle this
+
+- Native queue draining and active-run signal ownership occur inside `Agent` after event subscribers return.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `agent.ts` active-run lifecycle and post-`agent_end` queue draining.
+
 ## 2026-07-17 - Truncation-recovery flagged-call failure and proxy payload
 
 ### What changed and why

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -6,8 +6,12 @@
 
 - `Agent` now exposes `suppressQueuedMessageDrain()` for the active run. It stops only the lifecycle-owned
   post-`agent_end` steering/follow-up drain, retaining both queues without aborting the run signal.
+- `Agent` now exposes `continueWithQueuedMessages()` so compaction recovery can deliver retained steer/follow-up input
+  when custom context leaves the transcript tail non-assistant.
 - The coding-agent compaction admission gate uses this ownership transfer for required recovery. Real user aborts
   continue to abort the active signal and retain the normal terminal semantics.
+- Scheduled continuation can revalidate a model changed by `session_compact`, recompact if required, and then deliver
+  retained queues without inventing an empty continuation turn.
 
 ### Files modified
 

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -547,6 +547,42 @@ describe("Agent", () => {
 		expect(() => agent.abort()).not.toThrow();
 	});
 
+	it("retains agent_end queues without aborting when drain suppression is requested", async () => {
+		let providerCalls = 0;
+		let agentEndSignal: AbortSignal | undefined;
+		const agent = new Agent({
+			streamFn: () => {
+				providerCalls++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage(`response ${providerCalls}`),
+					});
+				});
+				return stream;
+			},
+		});
+		agent.subscribe((event, signal) => {
+			if (event.type !== "agent_end" || providerCalls !== 1) return;
+			agentEndSignal = signal;
+			agent.followUp({ role: "user", content: "deferred follow-up", timestamp: Date.now() });
+			agent.suppressQueuedMessageDrain();
+		});
+
+		await agent.prompt("first prompt");
+
+		expect(agentEndSignal?.aborted).toBe(false);
+		expect(agent.hasQueuedMessages()).toBe(true);
+		expect(providerCalls).toBe(1);
+
+		await agent.continue();
+
+		expect(agent.hasQueuedMessages()).toBe(false);
+		expect(providerCalls).toBe(2);
+	});
+
 	it("should throw when prompt() called while streaming", async () => {
 		let abortSignal: AbortSignal | undefined;
 		const agent = new Agent({

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,5 +1,32 @@
 # changes.md — ai
 
+## Carry non-enumerable context provenance through Responses conversion (2026-07-24)
+
+### What changed
+
+- `src/context-provenance.ts`: added request-local, non-enumerable message/item provenance tokens.
+- `src/api/openai-responses-shared.ts`: preserves those tokens while converting messages to Responses input items.
+- `src/types.ts` and `src/index.ts`: expose the typed provenance helpers needed by coding-agent's replay boundary.
+
+### Why
+
+- Provider-wire value equality cannot distinguish duplicated messages after filtering or injection. Replay slicing now
+  requires the exact checkpoint-origin identities to survive the canonical context pipeline.
+
+### Why extension system couldn't handle this
+
+- The provenance must survive conversion inside `packages/ai`, below extension-visible provider payloads.
+
+### Modified upstream files
+
+- `src/api/openai-responses-shared.ts`
+- `src/index.ts`
+- `src/types.ts`
+
+### Expected merge conflict zones
+
+- MEDIUM: Responses message conversion and shared public types.
+
 ## Export canonical OpenAI Responses message conversion (2026-07-24)
 
 ### What changed

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -7,6 +7,8 @@
 - `src/context-provenance.ts`: added request-local, non-enumerable message/item provenance tokens.
 - `src/api/openai-responses-shared.ts`: preserves those tokens while converting messages to Responses input items.
 - `src/types.ts` and `src/index.ts`: expose the typed provenance helpers needed by coding-agent's replay boundary.
+- `src/utils/openai-codex-auth.ts`: centralizes browser-safe ChatGPT account-ID extraction so normal Codex requests
+  and remote compaction canonicalize the same wire tenant across bearer-token refreshes.
 
 ### Why
 
@@ -22,6 +24,7 @@
 - `src/api/openai-responses-shared.ts`
 - `src/index.ts`
 - `src/types.ts`
+- `src/utils/openai-codex-auth.ts`
 
 ### Expected merge conflict zones
 

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,5 +1,29 @@
 # changes.md — ai
 
+## Export canonical OpenAI Responses message conversion (2026-07-24)
+
+### What changed
+
+- `src/index.ts`: exports `convertResponsesMessages` from the browser-safe root so coding-agent remote-compaction
+  replay can locate checkpoint boundaries with the exact conversion semantics used by the real provider pipeline.
+
+### Why
+
+- Counting checkpoint items with a separate converter could drop or duplicate the current prompt when errored/aborted
+  assistants, orphaned tool results, empty users, or provider-native blocks changed item cardinality.
+
+### Why extension system couldn't handle this
+
+- The boundary is defined by the provider wire conversion in `packages/ai`, below the coding-agent extension layer.
+
+### Modified upstream files
+
+- `src/index.ts`
+
+### Expected merge conflict zones
+
+- LOW: root exports if upstream reorganizes OpenAI Responses helpers.
+
 ## Commit generated model catalog data for reproducible builds (2026-07-18)
 
 ### What changed

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -46,6 +46,7 @@ import { formatProviderError, normalizeProviderError } from "../utils/error-body
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
+import { extractOpenAiCodexAccountId } from "../utils/openai-codex-auth.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import {
@@ -60,7 +61,6 @@ import {
 // ============================================================================
 
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
-const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;
 const DEFAULT_MAX_RETRIES = 0;
 const BASE_DELAY_MS = 1000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
@@ -1589,15 +1589,7 @@ async function parseErrorResponse(response: Response): Promise<{ message: string
 // ============================================================================
 
 function extractAccountId(token: string): string | undefined {
-	try {
-		const parts = token.split(".");
-		if (parts.length !== 3) return undefined;
-		const payload = JSON.parse(atob(parts[1]));
-		const accountId = payload?.[JWT_CLAIM_PATH]?.chatgpt_account_id;
-		return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
-	} catch {
-		return undefined;
-	}
+	return extractOpenAiCodexAccountId(token);
 }
 
 function createCodexRequestId(): string {

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -14,6 +14,12 @@ import type {
 	ResponseStreamEvent,
 	ResponseToolSearchOutputItemParam,
 } from "openai/resources/responses/responses.js";
+import {
+	CONTEXT_PROVENANCE_FIELD,
+	type ContextProvenance,
+	contextProvenanceFingerprint,
+	getContextProvenance,
+} from "../context-provenance.ts";
 import { calculateCost } from "../models.ts";
 import type {
 	Api,
@@ -83,6 +89,8 @@ export interface ConvertResponsesMessagesOptions {
 	preserveThinking?: boolean;
 	preserveTextSignatures?: boolean;
 	deferredTools?: ReadonlyMap<string, Tool>;
+	/** Internal request-local provenance sealing pass. Never serialized to provider payloads. */
+	sealContextProvenance?: boolean;
 }
 
 export interface ConvertResponsesToolsOptions {
@@ -123,6 +131,31 @@ function isFreeformToolName(toolName: string, tools: Tool[] | undefined): boolea
 function getFreeformToolInput(argumentsValue: Record<string, unknown>): string {
 	return typeof argumentsValue.input === "string" ? argumentsValue.input : JSON.stringify(argumentsValue);
 }
+
+function contextProvenanceForInput(message: unknown, seal: boolean | undefined): ContextProvenance | undefined {
+	const provenance = getContextProvenance(message);
+	if (!provenance) return undefined;
+	const fingerprint = contextProvenanceFingerprint(message);
+	if (fingerprint === undefined) return undefined;
+	const stored = provenance.integrity;
+	if (stored === undefined && seal) {
+		provenance.integrity = fingerprint;
+		return provenance;
+	}
+	return stored === fingerprint ? provenance : undefined;
+}
+
+function withContextProvenance<T extends object>(item: T, message: unknown, seal: boolean | undefined): T {
+	const provenance = contextProvenanceForInput(message, seal);
+	if (provenance) {
+		Object.defineProperty(item, CONTEXT_PROVENANCE_FIELD, {
+			value: provenance,
+			enumerable: false,
+		});
+	}
+	return item;
+}
+
 // =============================================================================
 // Message conversion
 // =============================================================================
@@ -180,10 +213,16 @@ export function convertResponsesMessages<TApi extends Api>(
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
-				messages.push({
-					role: "user",
-					content: [{ type: "input_text", text: sanitizeSurrogates(msg.content) }],
-				});
+				messages.push(
+					withContextProvenance(
+						{
+							role: "user",
+							content: [{ type: "input_text", text: sanitizeSurrogates(msg.content) }],
+						},
+						msg,
+						options?.sealContextProvenance,
+					),
+				);
 			} else {
 				const content: ResponseInputContent[] = msg.content.map((item): ResponseInputContent => {
 					if (item.type === "text") {
@@ -199,10 +238,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					} satisfies ResponseInputImage;
 				});
 				if (content.length === 0) continue;
-				messages.push({
-					role: "user",
-					content,
-				});
+				messages.push(withContextProvenance({ role: "user", content }, msg, options?.sealContextProvenance));
 			}
 		} else if (msg.role === "assistant") {
 			const output: ResponseInputItem[] = [];
@@ -277,7 +313,7 @@ export function convertResponsesMessages<TApi extends Api>(
 				}
 			}
 			if (output.length === 0) continue;
-			messages.push(...output);
+			messages.push(...output.map((item) => withContextProvenance(item, msg, options?.sealContextProvenance)));
 		} else if (msg.role === "toolResult") {
 			const textResult = msg.content
 				.filter((c): c is TextContent => c.type === "text")
@@ -313,18 +349,26 @@ export function convertResponsesMessages<TApi extends Api>(
 				output = sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : "(no tool output)");
 			}
 			if (isFreeformToolName(msg.toolName, context.tools)) {
-				messages.push({
-					type: "custom_tool_call_output",
-					call_id: callId,
-					name: msg.toolName,
-					output,
-				} satisfies ResponseCustomToolCallOutputItem);
+				messages.push(
+					withContextProvenance(
+						{
+							type: "custom_tool_call_output",
+							call_id: callId,
+							name: msg.toolName,
+							output,
+						} satisfies ResponseCustomToolCallOutputItem,
+						msg,
+						options?.sealContextProvenance,
+					),
+				);
 			} else {
-				messages.push({
-					type: "function_call_output",
-					call_id: callId,
-					output,
-				});
+				messages.push(
+					withContextProvenance(
+						{ type: "function_call_output", call_id: callId, output },
+						msg,
+						options?.sealContextProvenance,
+					),
+				);
 			}
 
 			const deferredTools: Tool[] = [];
@@ -337,20 +381,32 @@ export function convertResponsesMessages<TApi extends Api>(
 			if (deferredTools.length > 0) {
 				const names = deferredTools.map((tool) => tool.name);
 				const searchCallId = `pi_tool_load_${shortHash(`${msg.toolCallId}:${names.join(",")}`)}`;
-				messages.push({
-					type: "tool_search_call",
-					call_id: searchCallId,
-					execution: "client",
-					status: "completed",
-					arguments: { query: names.join(" "), limit: names.length },
-				} satisfies ResponseInputItem);
-				messages.push({
-					type: "tool_search_output",
-					call_id: searchCallId,
-					execution: "client",
-					status: "completed",
-					tools: convertResponsesTools(deferredTools, { deferLoading: true }),
-				} satisfies ResponseToolSearchOutputItemParam);
+				messages.push(
+					withContextProvenance(
+						{
+							type: "tool_search_call",
+							call_id: searchCallId,
+							execution: "client",
+							status: "completed",
+							arguments: { query: names.join(" "), limit: names.length },
+						} satisfies ResponseInputItem,
+						msg,
+						options?.sealContextProvenance,
+					),
+				);
+				messages.push(
+					withContextProvenance(
+						{
+							type: "tool_search_output",
+							call_id: searchCallId,
+							execution: "client",
+							status: "completed",
+							tools: convertResponsesTools(deferredTools, { deferLoading: true }),
+						} satisfies ResponseToolSearchOutputItemParam,
+						msg,
+						options?.sealContextProvenance,
+					),
+				);
 			}
 		}
 		msgIndex++;

--- a/packages/ai/src/auth/oauth/openai-codex.ts
+++ b/packages/ai/src/auth/oauth/openai-codex.ts
@@ -17,6 +17,7 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 	});
 }
 
+import { extractOpenAiCodexAccountId } from "../../utils/openai-codex-auth.ts";
 import { getProviderEnvValue } from "../../utils/provider-env.ts";
 import type { AuthInteraction, OAuthAuth, OAuthCredential } from "../types.ts";
 import { pollOAuthDeviceCodeFlow } from "./device-code.ts";
@@ -36,7 +37,6 @@ const DEVICE_CODE_TIMEOUT_SECONDS = 15 * 60;
 const OPENAI_CODEX_BROWSER_LOGIN_METHOD = "browser";
 const OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD = "device_code";
 const SCOPE = "openid profile email offline_access";
-const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 
 type OAuthToken = { access: string; refresh: string; expires: number };
 type TokenOperation = "exchange" | "refresh";
@@ -54,13 +54,6 @@ type DeviceAuthInfo = {
 type DeviceTokenSuccess = {
 	authorizationCode: string;
 	codeVerifier: string;
-};
-
-type JwtPayload = {
-	[JWT_CLAIM_PATH]?: {
-		chatgpt_account_id?: string;
-	};
-	[key: string]: unknown;
 };
 
 function createState(): string {
@@ -98,18 +91,6 @@ function parseAuthorizationInput(input: string): { code?: string; state?: string
 	}
 
 	return { code: value };
-}
-
-function decodeJwt(token: string): JwtPayload | null {
-	try {
-		const parts = token.split(".");
-		if (parts.length !== 3) return null;
-		const payload = parts[1] ?? "";
-		const decoded = atob(payload);
-		return JSON.parse(decoded) as JwtPayload;
-	} catch {
-		return null;
-	}
 }
 
 async function fetchWithLoginCancellation(input: string, init: RequestInit): Promise<Response> {
@@ -393,10 +374,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 }
 
 function getAccountId(accessToken: string): string | null {
-	const payload = decodeJwt(accessToken);
-	const auth = payload?.[JWT_CLAIM_PATH];
-	const accountId = auth?.chatgpt_account_id;
-	return typeof accountId === "string" && accountId.length > 0 ? accountId : null;
+	return extractOpenAiCodexAccountId(accessToken) ?? null;
 }
 
 function credentialsFromToken(token: OAuthToken): OAuthCredential {

--- a/packages/ai/src/context-provenance.ts
+++ b/packages/ai/src/context-provenance.ts
@@ -1,0 +1,39 @@
+/**
+ * Request-local context provenance. Providers keep this metadata out of their
+ * wire payloads while allowing a context producer to prove that a transformed
+ * input item still represents the same source message.
+ */
+export const CONTEXT_PROVENANCE_FIELD = "__piContextProvenance";
+
+export type ContextProvenance = Record<string, unknown>;
+
+type ContextProvenanceCarrier = {
+	[CONTEXT_PROVENANCE_FIELD]?: ContextProvenance;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function getContextProvenance(value: unknown): ContextProvenance | undefined {
+	if (!isRecord(value)) return undefined;
+	const provenance = value[CONTEXT_PROVENANCE_FIELD];
+	return isRecord(provenance) ? provenance : undefined;
+}
+
+/** Copy request-local provenance across a context representation change. */
+export function copyContextProvenance<T extends object>(source: unknown, target: T): T {
+	const provenance = getContextProvenance(source);
+	return provenance ? Object.assign(target, { [CONTEXT_PROVENANCE_FIELD]: provenance }) : target;
+}
+
+/**
+ * Stable within one request and intentionally never serialized to a provider.
+ * A mismatch is proof that a context hook changed a marked source message.
+ */
+export function contextProvenanceFingerprint(value: unknown): string | undefined {
+	if (!isRecord(value)) return undefined;
+	const clone = { ...value } as ContextProvenanceCarrier;
+	delete clone[CONTEXT_PROVENANCE_FIELD];
+	return JSON.stringify(clone);
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -16,6 +16,7 @@ export type { MistralOptions } from "./api/mistral-conversations.ts";
 export type { OpenAICodexResponsesOptions, OpenAICodexWebSocketDebugStats } from "./api/openai-codex-responses.ts";
 export type { OpenAICompletionsOptions } from "./api/openai-completions.ts";
 export type { OpenAIResponsesOptions } from "./api/openai-responses.ts";
+export { convertResponsesMessages } from "./api/openai-responses-shared.ts";
 export type { PiMessagesEvent, PiMessagesOptions, PiMessagesRewriteImpact } from "./api/pi-messages.ts";
 export { getApiProvider } from "./api-registry.ts";
 export * from "./auth/context.ts";

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -57,6 +57,7 @@ export * from "./types.ts";
 export * from "./utils/diagnostics.ts";
 export * from "./utils/event-stream.ts";
 export * from "./utils/json-parse.ts";
+export { extractOpenAiCodexAccountId } from "./utils/openai-codex-auth.ts";
 export * from "./utils/overflow.ts";
 export * from "./utils/retry.ts";
 export * from "./utils/stop-details.ts";

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -32,6 +32,13 @@ export type {
 	OAuthSelectOption,
 	OAuthSelectPrompt,
 } from "./compat/extension-oauth-types.ts";
+export {
+	CONTEXT_PROVENANCE_FIELD,
+	type ContextProvenance,
+	contextProvenanceFingerprint,
+	copyContextProvenance,
+	getContextProvenance,
+} from "./context-provenance.ts";
 export * from "./env-api-keys.ts";
 export * from "./images-models.ts";
 export * from "./models.ts";

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -109,6 +109,12 @@ export type ProviderEnv = Record<string, string>;
 export type ProviderHeaders = Record<string, string | null>;
 export type SessionAffinityFormat = "openai" | "openai-nosession" | "openrouter";
 
+/** Effective model and fully transformed headers for a request payload hook. */
+export type ProviderRequestMetadata = {
+	model: Model<Api>;
+	headers: ProviderHeaders;
+};
+
 export interface ProviderResponse {
 	status: number;
 	headers: Record<string, string>;
@@ -139,7 +145,11 @@ export interface StreamOptions {
 	 * Optional callback for inspecting or replacing provider payloads before sending.
 	 * Return undefined to keep the payload unchanged.
 	 */
-	onPayload?: (payload: unknown, model: Model<Api>) => unknown | undefined | Promise<unknown | undefined>;
+	onPayload?: (
+		payload: unknown,
+		model: Model<Api>,
+		request?: ProviderRequestMetadata,
+	) => unknown | undefined | Promise<unknown | undefined>;
 	/**
 	 * Optional callback invoked after an HTTP response is received and before
 	 * its body stream is consumed.

--- a/packages/ai/src/utils/openai-codex-auth.ts
+++ b/packages/ai/src/utils/openai-codex-auth.ts
@@ -1,0 +1,26 @@
+/** The JWT claim holding the ChatGPT account that owns a Codex credential. */
+export const OPENAI_CODEX_AUTH_CLAIM_PATH = "https://api.openai.com/auth";
+
+/**
+ * Reads the stable ChatGPT account identifier from a Codex access token.
+ *
+ * This deliberately uses only browser primitives so request code and OAuth
+ * code can share it without pulling Node-only authentication modules into
+ * browser consumers.
+ */
+export function extractOpenAiCodexAccountId(token: string): string | undefined {
+	try {
+		const parts = token.split(".");
+		const encodedPayload = parts.length === 3 ? parts[1] : undefined;
+		if (!encodedPayload) return undefined;
+		const base64 = encodedPayload.replaceAll("-", "+").replaceAll("_", "/");
+		const payload: unknown = JSON.parse(atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")));
+		if (!payload || typeof payload !== "object") return undefined;
+		const auth = Reflect.get(payload, OPENAI_CODEX_AUTH_CLAIM_PATH);
+		if (!auth || typeof auth !== "object") return undefined;
+		const accountId = Reflect.get(auth, "chatgpt_account_id");
+		return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,11 @@
+## Manual compaction keeps agent lifecycle subscription through abort (2026-07-24)
+
+- `core/agent-session.ts`: manual or extension-initiated compaction claims its synchronous admission/barrier first,
+  then aborts and waits for the active agent run while still subscribed. The abort's `agent_end` now clears the
+  active-run and retry state before compaction disconnects for summary generation; all disconnected exits reconnect.
+- Regression: `test/suite/compaction-race.test.ts` covers compaction during a live provider stream and asserts the
+  aborted `agent_end` precedes compaction startup without deadlocking future prompts.
+
 # changes
 
 ## Multi-session RPC mode, session-owned MCP/config-reload state, and back-compat guarantee (2026-07-23)

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -110,6 +110,7 @@ import type {
 	ApplyCompactionResult,
 	CompactionReason,
 	CompactionRejectionCause,
+	ModelSelectSource,
 } from "./extensions/types.ts";
 import { type BashExecutionMessage, type CustomMessage, filterContextExcludedMessages } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
@@ -278,6 +279,7 @@ interface CompactionExecutionRequest {
 	skipAbortedCheck?: boolean;
 	lastAssistantMessage?: AgentMessage;
 	precomputed?: CompactionResult;
+	allowSummaryOnly?: boolean;
 	agentMessagesAtStart?: readonly AgentMessage[];
 }
 
@@ -512,6 +514,12 @@ export class AgentSession {
 	private readonly _sessionWorkBarrier = new SessionWorkBarrier();
 	private _overflowRecoveryAttempted = false;
 	private _requiredCompactionAdmissionError: RequiredCompactionError | undefined;
+	// A retry continuation immediately follows an accepted compaction. Its first
+	// response must not retrigger threshold compaction from stale provider usage.
+	private _skipNextPostRetryCompactionCheck = false;
+	private _blockedPostCompactionAssistant: { assistant: AssistantMessage; revision: number } | undefined;
+	private _skipNextPostCompactionAssistantCheck = false;
+	private readonly _assistantsPendingAtCompaction = new WeakSet<AssistantMessage>();
 	private _messageRevision = 0;
 
 	// Branch summarization state
@@ -612,8 +620,9 @@ export class AgentSession {
 					persistDefault: false,
 					appendSessionEntry: true,
 					entryReason: reason,
-					emitModelSelect: reason === "fallback-revert",
-					invalidateCompaction: false,
+					emitModelSelect: true,
+					modelSelectSource: reason,
+					invalidateCompaction: true,
 					ephemeralThinkingLevel: thinking,
 				});
 			},
@@ -872,6 +881,7 @@ export class AgentSession {
 
 	private _incrementMessageRevision(): void {
 		this._messageRevision++;
+		this._blockedPostCompactionAssistant = undefined;
 	}
 
 	getMessageRevision(): number {
@@ -1057,6 +1067,7 @@ export class AgentSession {
 	 * runs, so only this preflight can transfer required admissions safely.
 	 */
 	private _getRequiredAutoCompactionReason(message: AssistantMessage): "overflow" | "threshold" | undefined {
+		if (this._skipNextPostRetryCompactionCheck) return undefined;
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled || message.stopReason === "aborted") {
 			return undefined;
@@ -1096,7 +1107,7 @@ export class AgentSession {
 			if (
 				compactionEntry &&
 				usageMessage?.role === "assistant" &&
-				usageMessage.timestamp <= new Date(compactionEntry.timestamp).getTime()
+				this._isAssistantFromBeforeLatestCompaction(usageMessage)
 			) {
 				return undefined;
 			}
@@ -1271,8 +1282,9 @@ export class AgentSession {
 			}
 		}
 
-		// Check auto-retry and auto-compaction after agent completes
+		// Check auto-retry and auto-compaction after agent completes.
 		let launchedContinuation = false;
+		let retryContinuationBlocked = false;
 		const userAbortSuppressedQueuedContinuation =
 			event.type === "agent_end" && this._suppressQueuedContinuationAfterUserAbort;
 		if (userAbortSuppressedQueuedContinuation) {
@@ -1285,60 +1297,65 @@ export class AgentSession {
 		if (event.type === "agent_end" && this._lastAssistantMessage) {
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
-			const requiredAutoCompaction = this._getRequiredAutoCompactionReason(msg);
+			const skipPostRetryCompaction = this._skipNextPostRetryCompactionCheck;
+			this._skipNextPostRetryCompactionCheck = false;
+			const requiredAutoCompaction = skipPostRetryCompaction
+				? undefined
+				: this._getRequiredAutoCompactionReason(msg);
 
 			// Retry transient failures normally and eligible hard errors only through a fallback.
 			const retryableError = this._isRetryableError(msg);
 			const hardErrorFallbackEligible = this._isHardErrorFallbackEligible(msg);
 			const retryCanAdmitProvider =
 				this.settingsManager.getRetrySettings().enabled && (retryableError || hardErrorFallbackEligible);
-			let retryCompactionRejected = false;
 			let compactedBeforeRetry = false;
 			if (retryCanAdmitProvider && requiredAutoCompaction) {
-				try {
-					compactedBeforeRetry = await this._enforceCompactionBeforeProvider(msg, true, "threshold", true);
-				} catch (error) {
-					if (error instanceof RequiredCompactionError) {
-						retryCompactionRejected = true;
-					} else {
-						throw error;
-					}
-				}
+				this._retireFailedRetryAssistant(msg);
+				compactedBeforeRetry = await this._runPrePromptCompaction(msg, true, "threshold", true);
+				retryContinuationBlocked = !compactedBeforeRetry;
 			}
 
-			let didRetry = false;
-			if (!retryCompactionRejected) {
+			let retryOutcome: "continued" | "blocked" | "not-handled" = "not-handled";
+			if (!retryContinuationBlocked) {
 				if (retryableError) {
-					didRetry = await this._handleRetryableError(msg);
+					retryOutcome = await this._handleRetryableError(msg);
 				} else if (hardErrorFallbackEligible) {
-					didRetry = await this._handleRetryableError(msg, { hardErrorFallback: true });
+					retryOutcome = await this._handleRetryableError(msg, { hardErrorFallback: true });
 				}
 			}
-			if (didRetry) return; // Retry was initiated, don't proceed to compaction
+			if (retryOutcome === "continued") return;
 
 			this._resolveRetry();
-			if (compactedBeforeRetry && this.agent.hasQueuedMessages()) {
-				this._scheduleContinuationAfterCurrentEvent();
-				launchedContinuation = true;
-			} else if (!retryCompactionRejected) {
-				launchedContinuation = await this._checkCompaction(msg);
-				// _runAutoCompaction() returns false both when recovery was rejected and
-				// when an accepted compaction had no queue to continue. Re-sample after
-				// it settles so only the still-required (rejected) case fails admission.
-				if (
-					requiredAutoCompaction &&
-					!launchedContinuation &&
-					this.agent.hasQueuedMessages() &&
-					this._getRequiredAutoCompactionReason(msg) !== undefined
-				) {
-					this._requiredCompactionAdmissionError = new RequiredCompactionError();
+			retryContinuationBlocked ||= retryOutcome === "blocked";
+			if (!retryContinuationBlocked && !skipPostRetryCompaction) {
+				if (compactedBeforeRetry && this.agent.hasQueuedMessages()) {
+					this._scheduleContinuationAfterCurrentEvent();
+					launchedContinuation = true;
+				} else {
+					launchedContinuation = await this._checkCompaction(msg);
+					// _runAutoCompaction() returns false both when recovery was rejected and
+					// when an accepted compaction had no queue to continue. Re-sample after
+					// it settles so only the still-required (rejected) case fails admission.
+					if (
+						requiredAutoCompaction &&
+						!launchedContinuation &&
+						this.agent.hasQueuedMessages() &&
+						this._getRequiredAutoCompactionReason(msg) !== undefined
+					) {
+						this._requiredCompactionAdmissionError = new RequiredCompactionError();
+					}
 				}
 			}
 		}
 
 		if (event.type === "agent_end") {
 			this._flushPendingBashMessages();
-			if (!launchedContinuation && allowsQueuedContinuation && this.agent.hasQueuedMessages()) {
+			if (
+				!launchedContinuation &&
+				!retryContinuationBlocked &&
+				allowsQueuedContinuation &&
+				this.agent.hasQueuedMessages()
+			) {
 				this._scheduleContinuationAfterCurrentEvent();
 				launchedContinuation = true;
 			}
@@ -1378,9 +1395,47 @@ export class AgentSession {
 		return undefined;
 	}
 
+	/**
+	 * Retry failures stay in append-only history but must not be retained in the
+	 * active context branch. Otherwise split-turn compaction keeps the failed
+	 * assistant response verbatim and cannot make progress before a retry.
+	 */
+	private _retireFailedRetryAssistant(message: AssistantMessage): void {
+		const position = this.sessionManager.getMessageEntryPosition(message);
+		if (!position || this.sessionManager.getLeafId() !== position.entryId) return;
+		const entry = this.sessionManager.getEntry(position.entryId);
+		if (entry?.type !== "message") return;
+
+		if (entry.parentId === null) {
+			this.sessionManager.resetLeaf();
+		} else {
+			this.sessionManager.branch(entry.parentId);
+		}
+		const messageIndex = this.agent.state.messages.lastIndexOf(message);
+		if (messageIndex !== -1) {
+			this.agent.state.messages = this.agent.state.messages.slice(0, messageIndex);
+		}
+		this._incrementMessageRevision();
+	}
+
 	private _isAssistantFromBeforeLatestCompaction(assistantMessage: AssistantMessage): boolean {
 		const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
-		return compactionEntry !== null && assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
+		if (compactionEntry === null) return false;
+
+		// An agent message_end can still be awaiting persistence while compaction
+		// commits. It is necessarily a post-boundary message, even when a provider
+		// supplied an older payload timestamp.
+		if (this._messageEndsAwaitingPersistence.has(assistantMessage)) return false;
+
+		const messagePosition = this.sessionManager.getMessageEntryPosition(assistantMessage);
+		const compactionOrder = this.sessionManager.getEntryOrder(compactionEntry.id);
+		if (messagePosition !== undefined && compactionOrder !== undefined) {
+			return messagePosition.order <= compactionOrder;
+		}
+
+		// Reloaded/reconstructed messages have no runtime identity. Retain the
+		// historical timestamp heuristic only for that compatibility path.
+		return assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
 	}
 
 	private _replaceMessageInPlace(target: AgentMessage, replacement: AgentMessage): void {
@@ -2538,7 +2593,7 @@ export class AgentSession {
 	private async _emitModelSelect(
 		nextModel: Model<any>,
 		previousModel: Model<any> | undefined,
-		source: "set" | "cycle" | "restore",
+		source: ModelSelectSource,
 	): Promise<SystemPromptChangeEvent | undefined> {
 		if (!this._modelSelectionChangesContext(previousModel, nextModel)) return undefined;
 		const result = await this._extensionRunner.emitModelSelect({
@@ -2613,6 +2668,7 @@ export class AgentSession {
 			persistDefault: updateGlobalDefaults,
 			appendSessionEntry: true,
 			emitModelSelect: true,
+			modelSelectSource: "set",
 			invalidateCompaction: true,
 		});
 	}
@@ -2633,6 +2689,7 @@ export class AgentSession {
 			appendSessionEntry: boolean;
 			entryReason?: "fallback" | "fallback-revert";
 			emitModelSelect: boolean;
+			modelSelectSource: ModelSelectSource;
 			invalidateCompaction: boolean;
 			ephemeralThinkingLevel?: ThinkingLevel;
 		},
@@ -2668,7 +2725,7 @@ export class AgentSession {
 		}
 
 		if (!opts.emitModelSelect) return undefined;
-		return await this._emitModelSelect(model, previousModel, "set");
+		return await this._emitModelSelect(model, previousModel, opts.modelSelectSource);
 	}
 
 	private _applyEphemeralThinkingLevel(level: ThinkingLevel): void {
@@ -3076,7 +3133,12 @@ export class AgentSession {
 			let fromExtension = request.precomputed !== undefined;
 
 			if (!compactionResult) {
-				const preparation = prepareCompaction(pathEntries, settings, request.reason === "overflow");
+				const preparation = prepareCompaction(
+					pathEntries,
+					settings,
+					request.reason === "overflow",
+					request.allowSummaryOnly,
+				);
 
 				if (!preparation) {
 					const lastEntry = pathEntries[pathEntries.length - 1];
@@ -3201,6 +3263,12 @@ export class AgentSession {
 				}
 			}
 			const preservedPendingMessages = currentAgentMessages.filter((message) => preservedIdentities.delete(message));
+			this._skipNextPostCompactionAssistantCheck = true;
+			for (const message of preservedPendingMessages) {
+				if (message.role === "assistant") {
+					this._assistantsPendingAtCompaction.add(message);
+				}
+			}
 			this.agent.state.messages = [...sessionContext.messages, ...preservedPendingMessages];
 			compactionResult.estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 			this._incrementMessageRevision();
@@ -3401,6 +3469,20 @@ export class AgentSession {
 		inlineReason: "pre_prompt" | "threshold",
 		retryAfterCompaction = false,
 	): Promise<boolean> {
+		const blockedAdmission = this._blockedPostCompactionAssistant;
+		if (
+			blockedAdmission !== undefined &&
+			blockedAdmission.assistant === assistantMessage &&
+			blockedAdmission.revision === this._messageRevision
+		) {
+			throw new RequiredCompactionError();
+		}
+
+		const settings = this.settingsManager.getCompactionSettings();
+		const model = this.model;
+		const contextTokens = estimateContextTokens(
+			filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
+		).tokens;
 		const compacted = assistantMessage
 			? await this._checkCompaction(assistantMessage, skipAbortedCheck, inlineReason, retryAfterCompaction)
 			: false;
@@ -3408,11 +3490,7 @@ export class AgentSession {
 			return compacted;
 		}
 
-		const settings = this.settingsManager.getCompactionSettings();
-		const contextTokens = estimateContextTokens(
-			filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
-		).tokens;
-		if (!settings.enabled || !this.model || !shouldCompact(contextTokens, this.model.contextWindow, settings)) {
+		if (!settings.enabled || !model || !shouldCompact(contextTokens, model.contextWindow, settings)) {
 			return false;
 		}
 
@@ -3468,6 +3546,15 @@ export class AgentSession {
 		if (this._isAssistantFromBeforeLatestCompaction(assistantMessage)) {
 			return false;
 		}
+		if (this._skipNextPostCompactionAssistantCheck) {
+			this._skipNextPostCompactionAssistantCheck = false;
+			// The first ordinary post-compaction response can still report stale
+			// provider usage. An active overflow recovery is different: its retry
+			// response must be checked so the one-retry cap can terminate it.
+			if (!this._assistantsPendingAtCompaction.has(assistantMessage) && !this._overflowRecoveryAttempted) {
+				return false;
+			}
+		}
 
 		// Case 1: Overflow - LLM returned context overflow error.
 		// If the saved assistant provider differs from the currently selected provider alias,
@@ -3481,7 +3568,18 @@ export class AgentSession {
 			const willRetry = retryAfterCompaction || assistantMessage.stopReason !== "stop";
 
 			if (!willRetry) {
-				return await this._runAutoCompaction("overflow", false);
+				const compacted = await this._runAutoCompaction("overflow", false);
+				if (
+					!compacted &&
+					this._compactionLifecycle.state.status === "failed" &&
+					getLatestCompactionEntry(this.sessionManager.getBranch()) !== null
+				) {
+					this._blockedPostCompactionAssistant = {
+						assistant: assistantMessage,
+						revision: this._messageRevision,
+					};
+				}
+				return compacted;
 			}
 
 			if (this._overflowRecoveryAttempted) {
@@ -3547,7 +3645,7 @@ export class AgentSession {
 				if (
 					compactionEntry &&
 					usageMsg.role === "assistant" &&
-					(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
+					this._isAssistantFromBeforeLatestCompaction(usageMsg)
 				) {
 					return false;
 				}
@@ -3563,7 +3661,18 @@ export class AgentSession {
 					retryAfterCompaction,
 				);
 			} else {
-				return await this._runAutoCompaction("threshold", false);
+				const compacted = await this._runAutoCompaction("threshold", false);
+				if (
+					!compacted &&
+					this._compactionLifecycle.state.status === "failed" &&
+					getLatestCompactionEntry(this.sessionManager.getBranch()) !== null
+				) {
+					this._blockedPostCompactionAssistant = {
+						assistant: assistantMessage,
+						revision: this._messageRevision,
+					};
+				}
+				return compacted;
 			}
 		}
 		return false;
@@ -3574,6 +3683,7 @@ export class AgentSession {
 		skipAbortedCheck: boolean,
 		reason: "pre_prompt" | "overflow" | "threshold" = "pre_prompt",
 		willRetry = false,
+		allowSummaryOnly = false,
 	): Promise<boolean> {
 		this._emit({ type: "compaction_start", reason });
 		const controller = new AbortController();
@@ -3585,6 +3695,7 @@ export class AgentSession {
 				willRetry,
 				lastAssistantMessage,
 				skipAbortedCheck,
+				allowSummaryOnly,
 			});
 			if (!execution.accepted && isContextOverflow(lastAssistantMessage, this.model?.contextWindow ?? 0)) {
 				this._overflowRecoveryAttempted = false;
@@ -4350,16 +4461,16 @@ export class AgentSession {
 
 	/**
 	 * Handle retryable errors with exponential backoff.
-	 * @returns true if retry was initiated, false if max retries exceeded or disabled
+	 * @returns whether retry continuation started, was blocked by compaction, or was not handled
 	 */
 	private async _handleRetryableError(
 		message: AssistantMessage,
 		options: { hardErrorFallback?: boolean } = {},
-	): Promise<boolean> {
+	): Promise<"continued" | "blocked" | "not-handled"> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
 			this._resolveRetry();
-			return false;
+			return "not-handled";
 		}
 
 		// Retry promise is created synchronously in _handleAgentEvent for agent_end.
@@ -4379,7 +4490,7 @@ export class AgentSession {
 			switchedFallback = await this._retryFallback.tryFallback("hard-error", { errorMessage });
 			if (!switchedFallback) {
 				this._resolveRetry();
-				return false;
+				return "not-handled";
 			}
 			// The fallback starts fresh; the failed model's transient attempts do not carry over.
 			this._retryAttempt = 1;
@@ -4388,7 +4499,7 @@ export class AgentSession {
 			// same-model retries or the transient over-budget fallback escape hatch.
 			if (this._retryAttempt + 1 > settings.maxRetries) {
 				this._resolveRetry();
-				return false;
+				return "not-handled";
 			}
 			switchedFallback = await this._retryFallback.tryFallback("refusal", {});
 			if (!switchedFallback) {
@@ -4397,7 +4508,7 @@ export class AgentSession {
 					this._emit({ type: "retry_fallback_exhausted", chainKey: exhaustedChainKey, lastError: errorMessage });
 				}
 				this._resolveRetry();
-				return false;
+				return "not-handled";
 			}
 			this._retryAttempt++;
 		} else {
@@ -4427,7 +4538,7 @@ export class AgentSession {
 					});
 					this._retryAttempt = 0;
 					this._resolveRetry();
-					return false;
+					return "not-handled";
 				}
 			}
 		}
@@ -4443,7 +4554,7 @@ export class AgentSession {
 			});
 			this._retryAttempt = 0;
 			this._resolveRetry();
-			return false;
+			return "not-handled";
 		}
 
 		if (!switchedFallback) {
@@ -4487,13 +4598,41 @@ export class AgentSession {
 				finalError: "Retry cancelled",
 			});
 			this._resolveRetry();
-			return false;
+			return "not-handled";
 		}
 		this._retryAbortController = undefined;
 
 		// Turn boundary: a suppression that expired during the backoff sleep lets
 		// the retry continue on the restored primary instead of the fallback model.
 		await this._maybeRestoreFallbackPrimary();
+
+		// Model fallback (or reversion) can select a smaller context window after
+		// the prior retry checks. Revalidate canonical session context immediately
+		// before the continuation so a rejected compaction never admits that model.
+		const model = this.model;
+		const compactionSettings = this.settingsManager.getCompactionSettings();
+		const contextTokens = estimateContextTokens(
+			filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
+		).tokens;
+		if (
+			compactionSettings.enabled &&
+			model &&
+			shouldCompact(contextTokens, model.contextWindow, compactionSettings)
+		) {
+			if (!(await this._runPrePromptCompaction(message, true, "threshold", true, true))) {
+				const attempt = this._retryAttempt;
+				this._retryAttempt = 0;
+				this._emit({
+					type: "auto_retry_end",
+					success: false,
+					attempt,
+					finalError: new RequiredCompactionError().message,
+				});
+				this._resolveRetry();
+				return "blocked";
+			}
+			this._skipNextPostRetryCompactionCheck = true;
+		}
 
 		// Retry via continue() - use setTimeout to break out of event handler chain
 		setTimeout(() => {
@@ -4502,7 +4641,7 @@ export class AgentSession {
 			});
 		}, 0);
 
-		return true;
+		return "continued";
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -836,8 +836,8 @@ export class AgentSession {
 				...turn,
 				context: { ...turn.context, messages },
 			};
-			const previousSnapshot = await previousPrepareNextTurnWithContext?.(postCompactionTurn, signal);
-			const previousContext = previousSnapshot?.context ?? postCompactionTurn.context;
+			let previousSnapshot = await previousPrepareNextTurnWithContext?.(postCompactionTurn, signal);
+			let previousContext = previousSnapshot?.context ?? postCompactionTurn.context;
 			// The previous callback may await while agent_end extensions enqueue
 			// continuation work. Re-sample after it returns so that work cannot
 			// slip through with the stale provider snapshot it observed on entry.
@@ -845,12 +845,32 @@ export class AgentSession {
 			if (!compactedBeforeCallback) {
 				compactedAfterCallback = await compactBeforeNextAdmission();
 			}
+			if (compactedAfterCallback) {
+				// The callback's first result describes the stale pre-compaction
+				// context. Reapply it once to the compacted context so any host
+				// transformation reaches the provider request. Do not re-sample after
+				// this invocation: one replay is the bounded admission path.
+				const postLateCompactionTurn = {
+					...turn,
+					context: { ...turn.context, messages: this.agent.state.messages.slice() },
+				};
+				const postLateCompactionSnapshot = await previousPrepareNextTurnWithContext?.(
+					postLateCompactionTurn,
+					signal,
+				);
+				previousSnapshot = {
+					...previousSnapshot,
+					...postLateCompactionSnapshot,
+					context: postLateCompactionSnapshot?.context ?? postLateCompactionTurn.context,
+				};
+				previousContext = previousSnapshot.context ?? postLateCompactionTurn.context;
+			}
 
 			return {
 				...previousSnapshot,
 				context: {
 					...previousContext,
-					messages: compactedAfterCallback ? this.agent.state.messages.slice() : previousContext.messages,
+					messages: previousContext.messages,
 					systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
 					tools: this.agent.state.tools.slice(),
 				},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -528,6 +528,7 @@ export class AgentSession {
 	private _retryResolve: (() => void) | undefined = undefined;
 	private _userAbortPromise: Promise<void> | undefined = undefined;
 	private _suppressQueuedContinuationAfterUserAbort = false;
+	private _extensionEventSignal: AbortSignal | undefined = undefined;
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
@@ -794,7 +795,6 @@ export class AgentSession {
 				? async (_turn: PrepareNextTurnContext, signal?: AbortSignal) => await this.agent.prepareNextTurn?.(signal)
 				: undefined);
 		this.agent.prepareNextTurnWithContext = async (turn, signal) => {
-			let compacted = false;
 			// Enforce compaction only when this prepare precedes an actual provider
 			// admission: a tool continuation or queued steer/follow-up messages. A
 			// completed turn with no continuation keeps pre-PR timing, while the
@@ -820,8 +820,8 @@ export class AgentSession {
 				}
 			};
 
-			compacted = await compactBeforeNextAdmission();
-			const messages = compacted ? this.agent.state.messages.slice() : turn.context.messages;
+			const compactedBeforeCallback = await compactBeforeNextAdmission();
+			const messages = compactedBeforeCallback ? this.agent.state.messages.slice() : turn.context.messages;
 
 			const postCompactionTurn = {
 				...turn,
@@ -832,15 +832,16 @@ export class AgentSession {
 			// The previous callback may await while agent_end extensions enqueue
 			// continuation work. Re-sample after it returns so that work cannot
 			// slip through with the stale provider snapshot it observed on entry.
-			if (!compacted) {
-				compacted = await compactBeforeNextAdmission();
+			let compactedAfterCallback = false;
+			if (!compactedBeforeCallback) {
+				compactedAfterCallback = await compactBeforeNextAdmission();
 			}
 
 			return {
 				...previousSnapshot,
 				context: {
 					...previousContext,
-					messages: compacted ? this.agent.state.messages.slice() : previousContext.messages,
+					messages: compactedAfterCallback ? this.agent.state.messages.slice() : previousContext.messages,
 					systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
 					tools: this.agent.state.tools.slice(),
 				},
@@ -973,7 +974,7 @@ export class AgentSession {
 	private _lastAssistantMessage: AssistantMessage | undefined = undefined;
 
 	/** Internal handler for agent events - shared by subscribe and reconnect */
-	private _handleAgentEvent = (event: AgentEvent): void => {
+	private _handleAgentEvent = (event: AgentEvent, signal: AbortSignal): void => {
 		// Agent core drains native steer/follow-up queues immediately after its
 		// final agent_end. This subscriber intentionally processes its own event
 		// queue asynchronously, so a later recovery rejection cannot abort that
@@ -983,7 +984,7 @@ export class AgentSession {
 		if (event.type === "agent_end") {
 			const lastAssistant = this._findLastAssistantInMessages(event.messages);
 			if (lastAssistant && this._getRequiredAutoCompactionReason(lastAssistant)) {
-				this.agent.abort();
+				this.agent.suppressQueuedMessageDrain();
 			}
 		}
 
@@ -1003,8 +1004,8 @@ export class AgentSession {
 		}
 
 		const processing = this._agentEventQueue.then(
-			() => this._processAgentEvent(event),
-			() => this._processAgentEvent(event),
+			() => this._processAgentEvent(event, signal),
+			() => this._processAgentEvent(event, signal),
 		);
 		this._agentEventQueue =
 			pendingMessage !== undefined
@@ -1179,7 +1180,7 @@ export class AgentSession {
 		return providerDelayMs <= this.settingsManager.getProviderRetrySettings().maxRetryDelayMs;
 	}
 
-	private async _processAgentEvent(event: AgentEvent): Promise<void> {
+	private async _processAgentEvent(event: AgentEvent, signal: AbortSignal): Promise<void> {
 		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
 		// This ensures the UI sees the updated queue state
 		if (event.type === "message_start" && event.message.role === "user") {
@@ -1203,8 +1204,14 @@ export class AgentSession {
 			}
 		}
 
-		// Emit to extensions first
-		await this._emitExtensionEvent(event);
+		// Emit to extensions first. Agent event persistence is intentionally
+		// asynchronous, so retain the source run signal while dispatching.
+		this._extensionEventSignal = signal;
+		try {
+			await this._emitExtensionEvent(event);
+		} finally {
+			this._extensionEventSignal = undefined;
+		}
 
 		// Notify all listeners
 		this._emit(
@@ -1282,26 +1289,50 @@ export class AgentSession {
 
 			// Retry transient failures normally and eligible hard errors only through a fallback.
 			const retryableError = this._isRetryableError(msg);
+			const hardErrorFallbackEligible = this._isHardErrorFallbackEligible(msg);
+			const retryCanAdmitProvider =
+				this.settingsManager.getRetrySettings().enabled && (retryableError || hardErrorFallbackEligible);
+			let retryCompactionRejected = false;
+			let compactedBeforeRetry = false;
+			if (retryCanAdmitProvider && requiredAutoCompaction) {
+				try {
+					compactedBeforeRetry = await this._enforceCompactionBeforeProvider(msg, true, "threshold", true);
+				} catch (error) {
+					if (error instanceof RequiredCompactionError) {
+						retryCompactionRejected = true;
+					} else {
+						throw error;
+					}
+				}
+			}
+
 			let didRetry = false;
-			if (retryableError) {
-				didRetry = await this._handleRetryableError(msg);
-			} else if (this._isHardErrorFallbackEligible(msg)) {
-				didRetry = await this._handleRetryableError(msg, { hardErrorFallback: true });
+			if (!retryCompactionRejected) {
+				if (retryableError) {
+					didRetry = await this._handleRetryableError(msg);
+				} else if (hardErrorFallbackEligible) {
+					didRetry = await this._handleRetryableError(msg, { hardErrorFallback: true });
+				}
 			}
 			if (didRetry) return; // Retry was initiated, don't proceed to compaction
 
 			this._resolveRetry();
-			launchedContinuation = await this._checkCompaction(msg);
-			// _runAutoCompaction() returns false both when recovery was rejected and
-			// when an accepted compaction had no queue to continue. Re-sample after
-			// it settles so only the still-required (rejected) case fails admission.
-			if (
-				requiredAutoCompaction &&
-				!launchedContinuation &&
-				this.agent.hasQueuedMessages() &&
-				this._getRequiredAutoCompactionReason(msg) !== undefined
-			) {
-				this._requiredCompactionAdmissionError = new RequiredCompactionError();
+			if (compactedBeforeRetry && this.agent.hasQueuedMessages()) {
+				this._scheduleContinuationAfterCurrentEvent();
+				launchedContinuation = true;
+			} else if (!retryCompactionRejected) {
+				launchedContinuation = await this._checkCompaction(msg);
+				// _runAutoCompaction() returns false both when recovery was rejected and
+				// when an accepted compaction had no queue to continue. Re-sample after
+				// it settles so only the still-required (rejected) case fails admission.
+				if (
+					requiredAutoCompaction &&
+					!launchedContinuation &&
+					this.agent.hasQueuedMessages() &&
+					this._getRequiredAutoCompactionReason(msg) !== undefined
+				) {
+					this._requiredCompactionAdmissionError = new RequiredCompactionError();
+				}
 			}
 		}
 
@@ -1689,11 +1720,18 @@ export class AgentSession {
 				validToolNames.push(name);
 			}
 		}
+		const activeToolNamesChanged =
+			validToolNames.length !== this.agent.state.tools.length ||
+			validToolNames.some((name, index) => name !== this.agent.state.tools[index]?.name);
 		this.agent.state.tools = tools;
 
 		// Rebuild base system prompt with new tool set
 		this._baseSystemPrompt = this._rebuildSystemPrompt(validToolNames);
 		this.agent.state.systemPrompt = this._systemPromptOverride ?? this._baseSystemPrompt;
+		if (activeToolNamesChanged) {
+			this.abortCompaction();
+			this._incrementMessageRevision();
+		}
 	}
 
 	/** Whether compaction or branch summarization is currently running */
@@ -2899,6 +2937,9 @@ export class AgentSession {
 		precomputed: CompactionResult,
 		options: ApplyCompactionOptions,
 	): Promise<ApplyCompactionResult> {
+		if (options.signal !== undefined && options.signal !== this._compactionAbortController?.signal) {
+			return { applied: false, reason: "stale" };
+		}
 		if (options.expectedRevision !== undefined && options.expectedRevision !== this._messageRevision) {
 			return { applied: false, reason: "stale" };
 		}
@@ -3358,11 +3399,12 @@ export class AgentSession {
 		assistantMessage: AssistantMessage | undefined,
 		skipAbortedCheck: boolean,
 		inlineReason: "pre_prompt" | "threshold",
+		retryAfterCompaction = false,
 	): Promise<boolean> {
 		const compacted = assistantMessage
-			? await this._checkCompaction(assistantMessage, skipAbortedCheck, inlineReason)
+			? await this._checkCompaction(assistantMessage, skipAbortedCheck, inlineReason, retryAfterCompaction)
 			: false;
-		if (compacted || (assistantMessage && this._isAssistantFromBeforeLatestCompaction(assistantMessage))) {
+		if (compacted) {
 			return compacted;
 		}
 
@@ -3370,16 +3412,34 @@ export class AgentSession {
 		const contextTokens = estimateContextTokens(
 			filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
 		).tokens;
-		if (settings.enabled && this.model && shouldCompact(contextTokens, this.model.contextWindow, settings)) {
-			throw new RequiredCompactionError();
+		if (!settings.enabled || !this.model || !shouldCompact(contextTokens, this.model.contextWindow, settings)) {
+			return false;
 		}
-		return false;
+
+		const latestCompaction = getLatestCompactionEntry(this.sessionManager.getBranch());
+		const assistantBeforeLatestCompaction =
+			assistantMessage !== undefined && this._isAssistantFromBeforeLatestCompaction(assistantMessage);
+		const hasPostCompactionCustomState =
+			latestCompaction !== null &&
+			this.agent.state.messages.some(
+				(message) =>
+					message.role === "custom" && message.timestamp >= new Date(latestCompaction.timestamp).getTime(),
+			);
+		if (assistantBeforeLatestCompaction && !hasPostCompactionCustomState) {
+			return false;
+		}
+		if (assistantBeforeLatestCompaction && assistantMessage) {
+			const compacted = await this._runPrePromptCompaction(assistantMessage, skipAbortedCheck, inlineReason);
+			if (compacted) return true;
+		}
+		throw new RequiredCompactionError();
 	}
 
 	private async _checkCompaction(
 		assistantMessage: AssistantMessage,
 		skipAbortedCheck = true,
 		inlineReason?: "pre_prompt" | "threshold",
+		retryAfterCompaction = false,
 	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
@@ -3418,7 +3478,7 @@ export class AgentSession {
 			contextUsage.tokens !== null &&
 			shouldCompact(contextUsage.tokens, contextUsage.contextWindow, settings);
 		if (isContextOverflow(assistantMessage, contextWindow) && (sameModel || currentContextNeedsCompaction)) {
-			const willRetry = assistantMessage.stopReason !== "stop";
+			const willRetry = retryAfterCompaction || assistantMessage.stopReason !== "stop";
 
 			if (!willRetry) {
 				return await this._runAutoCompaction("overflow", false);
@@ -3496,7 +3556,12 @@ export class AgentSession {
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			if (inlineReason) {
-				return await this._runPrePromptCompaction(assistantMessage, skipAbortedCheck, inlineReason);
+				return await this._runPrePromptCompaction(
+					assistantMessage,
+					skipAbortedCheck,
+					inlineReason,
+					retryAfterCompaction,
+				);
 			} else {
 				return await this._runAutoCompaction("threshold", false);
 			}
@@ -3888,7 +3953,7 @@ export class AgentSession {
 				getServiceTier: () => this.serviceTier,
 				isIdle: () => this.isIdle,
 				isProjectTrusted: () => this.settingsManager.isProjectTrusted(),
-				getSignal: () => this.agent.signal,
+				getSignal: () => this._extensionEventSignal ?? this.agent.signal,
 				abort: () => {
 					if (this._extensionAbortHandler) {
 						this._extensionAbortHandler();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3225,24 +3225,23 @@ export class AgentSession {
 			// Remove the error message from agent state (it IS saved to session for history,
 			// but we don't want it in context for the retry)
 			const messages = this.agent.state.messages;
+			let removedOverflowAssistant = false;
 			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 				this.agent.state.messages = messages.slice(0, -1);
+				removedOverflowAssistant = true;
 				this._incrementMessageRevision();
 			}
-			if (inlineReason) {
-				const compacted = await this._runPrePromptCompaction(
-					assistantMessage,
-					skipAbortedCheck,
-					"overflow",
-					willRetry,
-				);
-				if (!compacted) {
-					throw new RequiredCompactionError();
-				}
-				return true;
-			} else {
-				return await this._runAutoCompaction("overflow", willRetry);
+			const compacted = inlineReason
+				? await this._runPrePromptCompaction(assistantMessage, skipAbortedCheck, "overflow", willRetry)
+				: await this._runAutoCompaction("overflow", willRetry);
+			if (!compacted && removedOverflowAssistant) {
+				this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+				this._incrementMessageRevision();
 			}
+			if (!compacted && inlineReason) {
+				throw new RequiredCompactionError();
+			}
+			return compacted;
 		}
 
 		// Case 2: Threshold - context is getting large

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -68,13 +68,7 @@ import {
 	prepareCompaction,
 	shouldCompact,
 } from "./compaction/index.ts";
-import {
-	beginCompactionOperation,
-	type CompactionLifecycleState,
-	finishCompactionOperation,
-	initialCompactionLifecycleState,
-	promoteCompactionOperation,
-} from "./compaction/lifecycle.ts";
+import { CompactionLifecycleCoordinator, type CompactionLifecycleState } from "./compaction/lifecycle.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "./dynamic-prompt/index.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
@@ -317,6 +311,8 @@ function describeCompactionRejection(cause: CompactionRejectionCause): string {
 			return "Compaction rejected: the compaction circuit breaker is open after repeated failures. Wait for the cooldown and retry.";
 		case "per-turn-cap":
 			return "Compaction rejected: per-turn compaction cap reached for this turn.";
+		case "stale-revision":
+			return "Compaction rejected: the session changed while the summary was being prepared. Retry compaction against the latest context.";
 	}
 }
 
@@ -455,6 +451,13 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _agentEventQueue: Promise<void> = Promise.resolve();
+	/**
+	 * Exact message objects whose message_end persistence is still queued.
+	 * Agent core appends messages to agent.state.messages before emitting
+	 * message_end; until that event settles on _agentEventQueue, compaction must
+	 * treat these identities as pending persistence, never as stale or droppable.
+	 */
+	private readonly _messageEndsAwaitingPersistence = new Set<AgentMessage>();
 	private _isAgentRunActive = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
@@ -469,11 +472,10 @@ export class AgentSession {
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
-	private _compactionOperationController: AbortController | undefined = undefined;
-	private _compactionFeedbackController: AbortController | undefined = undefined;
-	private _compactionState: CompactionLifecycleState = initialCompactionLifecycleState();
+	private readonly _compactionLifecycle = new CompactionLifecycleCoordinator();
 	private readonly _sessionWorkBarrier = new SessionWorkBarrier();
 	private _overflowRecoveryAttempted = false;
+	private _requiredCompactionAdmissionError: RequiredCompactionError | undefined;
 	private _messageRevision = 0;
 
 	// Branch summarization state
@@ -756,22 +758,24 @@ export class AgentSession {
 				? async (_turn: PrepareNextTurnContext, signal?: AbortSignal) => await this.agent.prepareNextTurn?.(signal)
 				: undefined);
 		this.agent.prepareNextTurnWithContext = async (turn, signal) => {
-			let messages = turn.context.messages;
-			if (turn.toolResults.length > 0) {
+			let compacted = false;
+			// Enforce compaction only when this prepare precedes an actual provider
+			// admission: a tool continuation or queued steer/follow-up messages. A
+			// completed turn with no continuation keeps pre-PR timing, while the
+			// prior prepare callback and context refresh below still run every turn.
+			if (turn.toolResults.length > 0 || this.agent.hasQueuedMessages()) {
 				await this._agentEventQueue;
-				const compacted = await this._checkCompaction(turn.message, true, "threshold");
-				if (compacted) {
-					messages = this.agent.state.messages.slice();
-				} else {
-					const settings = this.settingsManager.getCompactionSettings();
-					const contextTokens = estimateContextTokens(
-						filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
-					).tokens;
-					if (settings.enabled && this.model && shouldCompact(contextTokens, this.model.contextWindow, settings)) {
-						throw new RequiredCompactionError();
+				try {
+					compacted = await this._enforceCompactionBeforeProvider(turn.message, true, "threshold");
+				} catch (error) {
+					if (error instanceof RequiredCompactionError && this.agent.hasQueuedMessages()) {
+						this._requiredCompactionAdmissionError = error;
 					}
+					throw error;
 				}
 			}
+			const messages = compacted ? this.agent.state.messages.slice() : turn.context.messages;
+
 			const postCompactionTurn = {
 				...turn,
 				context: { ...turn.context, messages },
@@ -879,9 +883,29 @@ export class AgentSession {
 
 	private async _promptAgent(messages: AgentMessage | AgentMessage[]): Promise<void> {
 		this._isAgentRunActive = true;
+		this._requiredCompactionAdmissionError = undefined;
 		try {
 			await this.agent.prompt(messages);
+			const requiredCompactionError = this._requiredCompactionAdmissionError;
+			this._requiredCompactionAdmissionError = undefined;
+			if (requiredCompactionError) {
+				throw requiredCompactionError;
+			}
 		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message ===
+					"Agent is already processing a prompt. Use steer() or followUp() to queue messages, or wait for completion."
+			) {
+				const queuedMessages = Array.isArray(messages) ? messages : [messages];
+				for (const message of queuedMessages) this.agent.steer(message);
+				const userMessage = queuedMessages.find((message) => message.role === "user");
+				if (userMessage?.role === "user") {
+					this._steeringMessages.push(this._extractUserMessageText(userMessage.content));
+					this._emitQueueUpdate();
+				}
+				return;
+			}
 			await this._emitAgentSettled();
 			throw error;
 		}
@@ -899,10 +923,24 @@ export class AgentSession {
 		// and waitForRetry() can miss the in-flight retry.
 		this._createRetryPromiseForAgentEnd(event);
 
-		this._agentEventQueue = this._agentEventQueue.then(
+		// The message object is already in agent.state.messages when message_end
+		// fires; track its exact identity until this event's queued processing
+		// settles so compaction can distinguish pending persistence from stale state.
+		const pendingMessage = event.type === "message_end" ? event.message : undefined;
+		if (pendingMessage !== undefined) {
+			this._messageEndsAwaitingPersistence.add(pendingMessage);
+		}
+
+		const processing = this._agentEventQueue.then(
 			() => this._processAgentEvent(event),
 			() => this._processAgentEvent(event),
 		);
+		this._agentEventQueue =
+			pendingMessage !== undefined
+				? processing.finally(() => {
+						this._messageEndsAwaitingPersistence.delete(pendingMessage);
+					})
+				: processing;
 
 		// Keep queue alive if an event handler fails
 		this._agentEventQueue.catch(() => {});
@@ -1520,7 +1558,7 @@ export class AgentSession {
 	/** Whether compaction or branch summarization is currently running */
 	get isCompacting(): boolean {
 		return (
-			this._compactionState.status === "running" ||
+			this._compactionLifecycle.state.status === "running" ||
 			this._autoCompactionAbortController !== undefined ||
 			this._compactionAbortController !== undefined ||
 			this._branchSummaryAbortController !== undefined
@@ -1528,7 +1566,7 @@ export class AgentSession {
 	}
 
 	get compactionState(): Readonly<CompactionLifecycleState> {
-		return this._compactionState;
+		return this._compactionLifecycle.state;
 	}
 
 	/** All messages including custom types like BashExecutionMessage */
@@ -1847,21 +1885,8 @@ export class AgentSession {
 				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
 			}
 
-			// Check if we need to compact before sending (catches aborted responses).
 			// The user's new prompt is sent below, so do not call agent.continue() here.
-			const lastAssistant = this._findLastAssistantMessage();
-			if (lastAssistant) {
-				const compacted = await this._checkCompaction(lastAssistant, false, "pre_prompt");
-				if (!compacted && !this._isAssistantFromBeforeLatestCompaction(lastAssistant)) {
-					const settings = this.settingsManager.getCompactionSettings();
-					const contextTokens = estimateContextTokens(
-						filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
-					).tokens;
-					if (settings.enabled && this.model && shouldCompact(contextTokens, this.model.contextWindow, settings)) {
-						throw new RequiredCompactionError();
-					}
-				}
-			}
+			await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
 
 			// Build messages array (custom message if any, then user message)
 			messages = [];
@@ -2199,6 +2224,7 @@ export class AgentSession {
 				this.agent.steer(appMessage);
 			}
 		} else if (options?.triggerTurn) {
+			await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
 			await this._promptAgent(appMessage);
 		} else {
 			this.agent.state.messages.push(appMessage);
@@ -2718,7 +2744,7 @@ export class AgentSession {
 			});
 			throw error;
 		} finally {
-			if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+			if (this._compactionAbortController === controller && this._compactionLifecycle.state.status !== "running") {
 				this._compactionAbortController = undefined;
 			}
 			this._reconnectToAgent();
@@ -2764,28 +2790,27 @@ export class AgentSession {
 			});
 			return { applied: false, reason: "rejected" };
 		} finally {
-			if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+			if (this._compactionAbortController === controller && this._compactionLifecycle.state.status !== "running") {
 				this._compactionAbortController = undefined;
-			}
-			if (this._compactionFeedbackController === controller && this._compactionState.status !== "running") {
-				this._compactionFeedbackController = undefined;
 			}
 		}
 	}
 
 	private _beginExtensionCompactionFeedback(reason: CompactionReason): AbortSignal {
-		let controller =
-			this._compactionOperationController ?? this._compactionAbortController ?? this._autoCompactionAbortController;
-		if (!controller) {
-			controller = new AbortController();
-			this._compactionAbortController = controller;
-			this._compactionFeedbackController = controller;
-			this._emit({ type: "compaction_start", reason });
-		}
+		const controller = new AbortController();
+		this._compactionAbortController = controller;
 		const model = this.model;
-		if (model) {
-			this._beginCompactionOperation(randomUUID(), reason, model, controller, "feedback");
-		}
+		this._compactionLifecycle.begin(
+			{
+				operationId: randomUUID(),
+				stage: "feedback",
+				reason,
+				model: model ? { provider: model.provider, id: model.id } : undefined,
+				startedRevision: this._messageRevision,
+			},
+			controller,
+		);
+		this._emit({ type: "compaction_start", reason });
 		return controller.signal;
 	}
 
@@ -2795,8 +2820,7 @@ export class AgentSession {
 		delta?: string;
 		text?: string;
 	}): void {
-		if (options.signal && this._compactionOperationController?.signal !== options.signal) return;
-		if (!this._compactionAbortController && !this._autoCompactionAbortController) return;
+		if (!options.signal || !this._compactionLifecycle.hasCurrentSignal(options.signal)) return;
 		this._emit({
 			type: "compaction_progress",
 			reason: options.reason,
@@ -2811,11 +2835,18 @@ export class AgentSession {
 		aborted?: boolean;
 		errorMessage?: string;
 	}): void {
-		const controller =
-			this._compactionOperationController ?? this._compactionAbortController ?? this._autoCompactionAbortController;
-		if (!controller) return;
-		if (options.signal && controller.signal !== options.signal) return;
-		const aborted = options.aborted ?? controller.signal.aborted;
+		if (!options.signal || !this._compactionLifecycle.hasCurrentSignal(options.signal)) return;
+		const operation = this._compactionLifecycle.state;
+		if (operation.status !== "running" || operation.stage !== "feedback") return;
+		const aborted = options.aborted ?? options.signal.aborted;
+		this._compactionLifecycle.finish({
+			operationId: operation.operationId,
+			status: aborted ? "aborted" : "failed",
+			endedRevision: this._messageRevision,
+			...(aborted
+				? { errorMessage: "Compaction cancelled" }
+				: { errorMessage: options.errorMessage ?? "Compaction did not apply" }),
+		});
 		this._emit({
 			type: "compaction_end",
 			reason: options.reason,
@@ -2824,20 +2855,8 @@ export class AgentSession {
 			willRetry: false,
 			errorMessage: aborted ? undefined : options.errorMessage,
 		});
-		if (
-			this._compactionState.status === "running" &&
-			this._compactionOperationController === controller &&
-			this._compactionState.stage === "feedback"
-		) {
-			this._finishCompactionOperation(this._compactionState.operationId, aborted ? "aborted" : "failed", {
-				errorMessage: aborted ? "Compaction cancelled" : (options.errorMessage ?? "Compaction did not apply"),
-			});
-		}
-		if (this._compactionFeedbackController === controller) {
-			this._compactionFeedbackController = undefined;
-			if (this._compactionAbortController === controller) {
-				this._compactionAbortController = undefined;
-			}
+		if (this._compactionAbortController?.signal === options.signal) {
+			this._compactionAbortController = undefined;
 		}
 	}
 
@@ -2848,7 +2867,16 @@ export class AgentSession {
 		const controller = this._compactionAbortController ?? this._autoCompactionAbortController;
 		if (!controller) throw new Error("Compaction abort controller unavailable");
 		const requestId = randomUUID();
-		const operationId = this._beginCompactionOperation(requestId, request.reason, model, controller, "execution");
+		const operationId = this._compactionLifecycle.begin(
+			{
+				operationId: requestId,
+				stage: "execution",
+				reason: request.reason,
+				model: { provider: model.provider, id: model.id },
+				startedRevision: this._messageRevision,
+			},
+			controller,
+		);
 		const finishCompactionWork = this._sessionWorkBarrier.begin();
 		const agentMessagesAtStart = request.agentMessagesAtStart ?? this.agent.state.messages.slice();
 		const signal = controller.signal;
@@ -2860,7 +2888,7 @@ export class AgentSession {
 			let fromExtension = request.precomputed !== undefined;
 
 			if (!compactionResult) {
-				const preparation = prepareCompaction(pathEntries, settings);
+				const preparation = prepareCompaction(pathEntries, settings, request.reason === "overflow");
 
 				if (!preparation) {
 					const lastEntry = pathEntries[pathEntries.length - 1];
@@ -2883,7 +2911,10 @@ export class AgentSession {
 					})) as SessionBeforeCompactResult | undefined;
 
 					if (extensionResult?.cancel) {
-						this._finishCompactionOperation(operationId, "failed", {
+						this._compactionLifecycle.finish({
+							operationId,
+							status: "failed",
+							endedRevision: this._messageRevision,
 							rejectionCause: extensionResult.rejectionCause ?? "cancelled-by-extension",
 							errorMessage: extensionResult.reason,
 						});
@@ -2923,12 +2954,43 @@ export class AgentSession {
 			if (signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
-			if (!this._isCurrentCompactionOperation(operationId, controller)) {
+			if (!this._compactionLifecycle.isCurrent(operationId, controller)) {
 				throw new DOMException("Compaction superseded", "AbortError");
 			}
 
+			const lifecycleState = this._compactionLifecycle.state;
+			const currentMessagesAtCheck = this.agent.state.messages;
+			const startPrefixIntact = agentMessagesAtStart.every(
+				(message, index) => currentMessagesAtCheck[index] === message,
+			);
+			// Appends after the start snapshot are fresh only while they are exact
+			// message_end identities still awaiting persistence. Any revision change,
+			// other append, replacement, or reorder still makes this compaction stale.
+			const onlyPendingPersistenceAppends =
+				startPrefixIntact &&
+				currentMessagesAtCheck
+					.slice(agentMessagesAtStart.length)
+					.every((message) => this._messageEndsAwaitingPersistence.has(message));
+			const sourceChanged =
+				lifecycleState.status !== "running" ||
+				lifecycleState.operationId !== operationId ||
+				lifecycleState.startedRevision !== this._messageRevision ||
+				!onlyPendingPersistenceAppends;
+			if (sourceChanged) {
+				this._compactionLifecycle.finish({
+					operationId,
+					status: "failed",
+					endedRevision: this._messageRevision,
+					rejectionCause: "stale-revision",
+				});
+				return await this._rejectCompaction(request, requestId, "stale-revision", false);
+			}
+
 			if (this._wouldCompactionOverflow(pathEntries, compactionResult, fromExtension, model)) {
-				this._finishCompactionOperation(operationId, "failed", {
+				this._compactionLifecycle.finish({
+					operationId,
+					status: "failed",
+					endedRevision: this._messageRevision,
 					rejectionCause: "would-overflow",
 				});
 				return await this._rejectCompaction(request, requestId, "would-overflow", false);
@@ -2954,19 +3016,24 @@ export class AgentSession {
 			const messagesAppendedDuringCompaction = hasUnchangedPrefix
 				? currentAgentMessages.slice(agentMessagesAtStart.length)
 				: [];
-			this.agent.state.messages = [...sessionContext.messages, ...messagesAppendedDuringCompaction];
+			// Preserve an identity-deduped, agent-ordered union of the append-during-
+			// compaction suffix and exact messages still awaiting persistence. Their
+			// queued message_end owns exactly-once persistence, so they are kept in
+			// agent state only and never persisted here.
+			const preservedIdentities = new Set<AgentMessage>(messagesAppendedDuringCompaction);
+			for (const message of currentAgentMessages) {
+				if (this._messageEndsAwaitingPersistence.has(message)) {
+					preservedIdentities.add(message);
+				}
+			}
+			const preservedPendingMessages = currentAgentMessages.filter((message) => preservedIdentities.delete(message));
+			this.agent.state.messages = [...sessionContext.messages, ...preservedPendingMessages];
 			compactionResult.estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 			this._incrementMessageRevision();
-			this._finishCompactionOperation(operationId, "completed");
-
-			await this._extensionRunner.emit({
-				type: "session_compact",
-				reason: request.reason,
-				requestId,
-				accepted: true,
-				compactionEntry: savedEntry,
-				fromExtension,
-				willRetry: request.willRetry,
+			this._compactionLifecycle.finish({
+				operationId,
+				status: "completed",
+				endedRevision: this._messageRevision,
 			});
 
 			this._emit({
@@ -2979,70 +3046,28 @@ export class AgentSession {
 				accepted: true,
 			});
 
+			await this._extensionRunner.emit({
+				type: "session_compact",
+				reason: request.reason,
+				requestId,
+				accepted: true,
+				compactionEntry: savedEntry,
+				fromExtension,
+				willRetry: request.willRetry,
+			});
+
 			return { accepted: true, requestId, result: compactionResult, compactionEntry: savedEntry, fromExtension };
 		} catch (error) {
 			const aborted = signal.aborted || (error instanceof Error && error.name === "AbortError");
-			this._finishCompactionOperation(operationId, aborted ? "aborted" : "failed", {
+			this._compactionLifecycle.finish({
+				operationId,
+				status: aborted ? "aborted" : "failed",
+				endedRevision: this._messageRevision,
 				errorMessage: error instanceof Error ? error.message : String(error),
 			});
 			throw error;
 		} finally {
 			finishCompactionWork();
-		}
-	}
-
-	private _beginCompactionOperation(
-		operationId: string,
-		reason: CompactionReason,
-		model: Model<Api>,
-		controller: AbortController,
-		stage: "feedback" | "execution",
-	): string {
-		if (this._compactionState.status === "running") {
-			if (this._compactionOperationController === controller) {
-				const currentOperationId = this._compactionState.operationId;
-				if (stage === "execution") {
-					this._compactionState = promoteCompactionOperation(this._compactionState, currentOperationId);
-				}
-				return currentOperationId;
-			}
-			this._compactionOperationController?.abort();
-		}
-		this._compactionOperationController = controller;
-		this._compactionState = beginCompactionOperation(this._compactionState, {
-			operationId,
-			stage,
-			reason,
-			model: { provider: model.provider, id: model.id },
-			startedRevision: this._messageRevision,
-		});
-		return operationId;
-	}
-
-	private _isCurrentCompactionOperation(operationId: string, controller: AbortController): boolean {
-		return (
-			this._compactionState.status === "running" &&
-			this._compactionState.operationId === operationId &&
-			this._compactionOperationController === controller &&
-			!controller.signal.aborted
-		);
-	}
-
-	private _finishCompactionOperation(
-		operationId: string,
-		status: "completed" | "failed" | "aborted",
-		options: { rejectionCause?: CompactionRejectionCause; errorMessage?: string } = {},
-	): void {
-		const previous = this._compactionState;
-		const next = finishCompactionOperation(previous, {
-			operationId,
-			status,
-			endedRevision: this._messageRevision,
-			...options,
-		});
-		this._compactionState = next;
-		if (previous.status === "running" && previous.operationId === operationId && next !== previous) {
-			this._compactionOperationController = undefined;
 		}
 	}
 
@@ -3074,6 +3099,25 @@ export class AgentSession {
 		const contextTokens = estimateMessagesTokens(filterContextExcludedMessages(simulatedMessages));
 		const settings = this.settingsManager.getCompactionSettings();
 		return contextTokens > model.contextWindow - settings.reserveTokens;
+	}
+
+	/**
+	 * Replaces agent state with the canonical session context while keeping exact
+	 * message objects whose message_end persistence is still queued. Identities
+	 * already present in the session context are kept from the context only, so
+	 * nothing is duplicated; the queued message_end still owns exactly-once
+	 * persistence for the rest.
+	 */
+	private _restoreAgentMessagesFromSession(): void {
+		const sessionMessages = this.sessionManager.buildSessionContext().messages;
+		const seen = new Set<AgentMessage>(sessionMessages);
+		const pendingMessages: AgentMessage[] = [];
+		for (const message of this.agent.state.messages) {
+			if (seen.has(message) || !this._messageEndsAwaitingPersistence.has(message)) continue;
+			seen.add(message);
+			pendingMessages.push(message);
+		}
+		this.agent.state.messages = [...sessionMessages, ...pendingMessages];
 	}
 
 	private async _rejectCompaction(
@@ -3121,20 +3165,18 @@ export class AgentSession {
 	 * Cancel in-progress compaction (manual or auto).
 	 */
 	abortCompaction(): void {
-		const feedbackController = this._compactionFeedbackController;
+		const feedbackOperation = this._compactionLifecycle.abort(this._messageRevision);
 		this._compactionAbortController?.abort();
 		this._autoCompactionAbortController?.abort();
-		this._compactionOperationController?.abort();
-		if (this._compactionState.status === "running") {
-			this._finishCompactionOperation(this._compactionState.operationId, "aborted", {
-				errorMessage: "Compaction cancelled",
+		if (feedbackOperation?.stage === "feedback") {
+			this._compactionAbortController = undefined;
+			this._emit({
+				type: "compaction_end",
+				reason: feedbackOperation.reason,
+				result: undefined,
+				aborted: true,
+				willRetry: false,
 			});
-		}
-		if (feedbackController && this._compactionFeedbackController === feedbackController) {
-			this._compactionFeedbackController = undefined;
-			if (this._compactionAbortController === feedbackController) {
-				this._compactionAbortController = undefined;
-			}
 		}
 	}
 
@@ -3156,6 +3198,28 @@ export class AgentSession {
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 */
+	private async _enforceCompactionBeforeProvider(
+		assistantMessage: AssistantMessage | undefined,
+		skipAbortedCheck: boolean,
+		inlineReason: "pre_prompt" | "threshold",
+	): Promise<boolean> {
+		const compacted = assistantMessage
+			? await this._checkCompaction(assistantMessage, skipAbortedCheck, inlineReason)
+			: false;
+		if (compacted || (assistantMessage && this._isAssistantFromBeforeLatestCompaction(assistantMessage))) {
+			return compacted;
+		}
+
+		const settings = this.settingsManager.getCompactionSettings();
+		const contextTokens = estimateContextTokens(
+			filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages),
+		).tokens;
+		if (settings.enabled && this.model && shouldCompact(contextTokens, this.model.contextWindow, settings)) {
+			throw new RequiredCompactionError();
+		}
+		return false;
+	}
+
 	private async _checkCompaction(
 		assistantMessage: AssistantMessage,
 		skipAbortedCheck = true,
@@ -3235,7 +3299,7 @@ export class AgentSession {
 				? await this._runPrePromptCompaction(assistantMessage, skipAbortedCheck, "overflow", willRetry)
 				: await this._runAutoCompaction("overflow", willRetry);
 			if (!compacted && removedOverflowAssistant) {
-				this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+				this._restoreAgentMessagesFromSession();
 				this._incrementMessageRevision();
 			}
 			if (!compacted && inlineReason) {
@@ -3322,7 +3386,7 @@ export class AgentSession {
 			});
 			return false;
 		} finally {
-			if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+			if (this._compactionAbortController === controller && this._compactionLifecycle.state.status !== "running") {
 				this._compactionAbortController = undefined;
 			}
 		}
@@ -3395,6 +3459,7 @@ export class AgentSession {
 			const preparation = prepareCompaction(
 				this.sessionManager.getBranch(),
 				this.settingsManager.getCompactionSettings(),
+				reason === "overflow",
 			);
 			if (!preparation) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
@@ -3754,7 +3819,10 @@ export class AgentSession {
 							const err = error instanceof Error ? error : new Error(String(error));
 							options?.onError?.(err);
 						} finally {
-							if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+							if (
+								this._compactionAbortController === controller &&
+								this._compactionLifecycle.state.status !== "running"
+							) {
 								this._compactionAbortController = undefined;
 							}
 							this._reconnectToAgent();
@@ -4555,9 +4623,8 @@ export class AgentSession {
 				this.sessionManager.appendLabelChange(targetId, label);
 			}
 
-			// Update agent state
-			const sessionContext = this.sessionManager.buildSessionContext();
-			this.agent.state.messages = sessionContext.messages;
+			// Update agent state (preserving exact messages still awaiting persistence)
+			this._restoreAgentMessagesFromSession();
 			this._incrementMessageRevision();
 
 			// Emit session_tree event

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -68,6 +68,13 @@ import {
 	prepareCompaction,
 	shouldCompact,
 } from "./compaction/index.ts";
+import {
+	beginCompactionOperation,
+	type CompactionLifecycleState,
+	finishCompactionOperation,
+	initialCompactionLifecycleState,
+	promoteCompactionOperation,
+} from "./compaction/lifecycle.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "./dynamic-prompt/index.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
@@ -462,6 +469,9 @@ export class AgentSession {
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
+	private _compactionOperationController: AbortController | undefined = undefined;
+	private _compactionFeedbackController: AbortController | undefined = undefined;
+	private _compactionState: CompactionLifecycleState = initialCompactionLifecycleState();
 	private readonly _sessionWorkBarrier = new SessionWorkBarrier();
 	private _overflowRecoveryAttempted = false;
 	private _messageRevision = 0;
@@ -1510,10 +1520,15 @@ export class AgentSession {
 	/** Whether compaction or branch summarization is currently running */
 	get isCompacting(): boolean {
 		return (
+			this._compactionState.status === "running" ||
 			this._autoCompactionAbortController !== undefined ||
 			this._compactionAbortController !== undefined ||
 			this._branchSummaryAbortController !== undefined
 		);
+	}
+
+	get compactionState(): Readonly<CompactionLifecycleState> {
+		return this._compactionState;
 	}
 
 	/** All messages including custom types like BashExecutionMessage */
@@ -2677,7 +2692,8 @@ export class AgentSession {
 	async compact(customInstructions?: string): Promise<CompactionResult> {
 		this._disconnectFromAgent();
 		await this.abort();
-		this._compactionAbortController = new AbortController();
+		const controller = new AbortController();
+		this._compactionAbortController = controller;
 		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
@@ -2702,7 +2718,9 @@ export class AgentSession {
 			});
 			throw error;
 		} finally {
-			this._compactionAbortController = undefined;
+			if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+				this._compactionAbortController = undefined;
+			}
 			this._reconnectToAgent();
 		}
 	}
@@ -2720,6 +2738,8 @@ export class AgentSession {
 			this._compactionAbortController = new AbortController();
 			this._emit({ type: "compaction_start", reason: options.reason });
 		}
+		const controller = this._compactionAbortController;
+		if (!controller) return { applied: false, reason: "rejected" };
 
 		try {
 			const execution = await this._executeCompaction({
@@ -2744,23 +2764,38 @@ export class AgentSession {
 			});
 			return { applied: false, reason: "rejected" };
 		} finally {
-			this._compactionAbortController = undefined;
+			if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+				this._compactionAbortController = undefined;
+			}
+			if (this._compactionFeedbackController === controller && this._compactionState.status !== "running") {
+				this._compactionFeedbackController = undefined;
+			}
 		}
 	}
 
 	private _beginExtensionCompactionFeedback(reason: CompactionReason): AbortSignal {
-		if (!this._compactionAbortController) {
-			this._compactionAbortController = new AbortController();
+		let controller =
+			this._compactionOperationController ?? this._compactionAbortController ?? this._autoCompactionAbortController;
+		if (!controller) {
+			controller = new AbortController();
+			this._compactionAbortController = controller;
+			this._compactionFeedbackController = controller;
 			this._emit({ type: "compaction_start", reason });
 		}
-		return this._compactionAbortController.signal;
+		const model = this.model;
+		if (model) {
+			this._beginCompactionOperation(randomUUID(), reason, model, controller, "feedback");
+		}
+		return controller.signal;
 	}
 
 	private _updateExtensionCompactionFeedback(options: {
 		reason: CompactionReason;
+		signal?: AbortSignal;
 		delta?: string;
 		text?: string;
 	}): void {
+		if (options.signal && this._compactionOperationController?.signal !== options.signal) return;
 		if (!this._compactionAbortController && !this._autoCompactionAbortController) return;
 		this._emit({
 			type: "compaction_progress",
@@ -2772,11 +2807,14 @@ export class AgentSession {
 
 	private _endExtensionCompactionFeedback(options: {
 		reason: CompactionReason;
+		signal?: AbortSignal;
 		aborted?: boolean;
 		errorMessage?: string;
 	}): void {
-		const controller = this._compactionAbortController;
+		const controller =
+			this._compactionOperationController ?? this._compactionAbortController ?? this._autoCompactionAbortController;
 		if (!controller) return;
+		if (options.signal && controller.signal !== options.signal) return;
 		const aborted = options.aborted ?? controller.signal.aborted;
 		this._emit({
 			type: "compaction_end",
@@ -2786,25 +2824,37 @@ export class AgentSession {
 			willRetry: false,
 			errorMessage: aborted ? undefined : options.errorMessage,
 		});
-		this._compactionAbortController = undefined;
+		if (
+			this._compactionState.status === "running" &&
+			this._compactionOperationController === controller &&
+			this._compactionState.stage === "feedback"
+		) {
+			this._finishCompactionOperation(this._compactionState.operationId, aborted ? "aborted" : "failed", {
+				errorMessage: aborted ? "Compaction cancelled" : (options.errorMessage ?? "Compaction did not apply"),
+			});
+		}
+		if (this._compactionFeedbackController === controller) {
+			this._compactionFeedbackController = undefined;
+			if (this._compactionAbortController === controller) {
+				this._compactionAbortController = undefined;
+			}
+		}
 	}
 
 	private async _executeCompaction(request: CompactionExecutionRequest): Promise<CompactionExecutionResult> {
+		const model = this.model;
+		if (!model) throw new Error(formatNoModelSelectedMessage());
+		const thinkingLevel = this.thinkingLevel;
+		const controller = this._compactionAbortController ?? this._autoCompactionAbortController;
+		if (!controller) throw new Error("Compaction abort controller unavailable");
+		const requestId = randomUUID();
+		const operationId = this._beginCompactionOperation(requestId, request.reason, model, controller, "execution");
 		const finishCompactionWork = this._sessionWorkBarrier.begin();
 		const agentMessagesAtStart = request.agentMessagesAtStart ?? this.agent.state.messages.slice();
+		const signal = controller.signal;
 		try {
-			if (!this.model) {
-				throw new Error(formatNoModelSelectedMessage());
-			}
-
-			const requestId = randomUUID();
 			const pathEntries = this.sessionManager.getBranch();
 			const settings = this.settingsManager.getCompactionSettings();
-
-			const signal = this._compactionAbortController?.signal ?? this._autoCompactionAbortController?.signal;
-			if (!signal) {
-				throw new Error("Compaction abort controller unavailable");
-			}
 
 			let compactionResult = request.precomputed;
 			let fromExtension = request.precomputed !== undefined;
@@ -2833,6 +2883,10 @@ export class AgentSession {
 					})) as SessionBeforeCompactResult | undefined;
 
 					if (extensionResult?.cancel) {
+						this._finishCompactionOperation(operationId, "failed", {
+							rejectionCause: extensionResult.rejectionCause ?? "cancelled-by-extension",
+							errorMessage: extensionResult.reason,
+						});
 						return await this._rejectCompaction(
 							request,
 							requestId,
@@ -2849,16 +2903,16 @@ export class AgentSession {
 				}
 
 				if (!compactionResult) {
-					const { apiKey, headers, extraBody, env } = await this._getCompactionRequestAuth(this.model);
+					const { apiKey, headers, extraBody, env } = await this._getCompactionRequestAuth(model);
 					compactionResult = await compact(
 						preparation,
-						this.model,
+						model,
 						apiKey,
 						headers,
 						request.customInstructions,
 						signal,
 						extraBody,
-						this.thinkingLevel,
+						thinkingLevel,
 						this.agent.streamFn,
 						env,
 						this.agent.transformContext,
@@ -2869,8 +2923,14 @@ export class AgentSession {
 			if (signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
+			if (!this._isCurrentCompactionOperation(operationId, controller)) {
+				throw new DOMException("Compaction superseded", "AbortError");
+			}
 
-			if (this._wouldCompactionOverflow(pathEntries, compactionResult, fromExtension)) {
+			if (this._wouldCompactionOverflow(pathEntries, compactionResult, fromExtension, model)) {
+				this._finishCompactionOperation(operationId, "failed", {
+					rejectionCause: "would-overflow",
+				});
 				return await this._rejectCompaction(request, requestId, "would-overflow", false);
 			}
 
@@ -2897,6 +2957,7 @@ export class AgentSession {
 			this.agent.state.messages = [...sessionContext.messages, ...messagesAppendedDuringCompaction];
 			compactionResult.estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 			this._incrementMessageRevision();
+			this._finishCompactionOperation(operationId, "completed");
 
 			await this._extensionRunner.emit({
 				type: "session_compact",
@@ -2919,8 +2980,69 @@ export class AgentSession {
 			});
 
 			return { accepted: true, requestId, result: compactionResult, compactionEntry: savedEntry, fromExtension };
+		} catch (error) {
+			const aborted = signal.aborted || (error instanceof Error && error.name === "AbortError");
+			this._finishCompactionOperation(operationId, aborted ? "aborted" : "failed", {
+				errorMessage: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
 		} finally {
 			finishCompactionWork();
+		}
+	}
+
+	private _beginCompactionOperation(
+		operationId: string,
+		reason: CompactionReason,
+		model: Model<Api>,
+		controller: AbortController,
+		stage: "feedback" | "execution",
+	): string {
+		if (this._compactionState.status === "running") {
+			if (this._compactionOperationController === controller) {
+				const currentOperationId = this._compactionState.operationId;
+				if (stage === "execution") {
+					this._compactionState = promoteCompactionOperation(this._compactionState, currentOperationId);
+				}
+				return currentOperationId;
+			}
+			this._compactionOperationController?.abort();
+		}
+		this._compactionOperationController = controller;
+		this._compactionState = beginCompactionOperation(this._compactionState, {
+			operationId,
+			stage,
+			reason,
+			model: { provider: model.provider, id: model.id },
+			startedRevision: this._messageRevision,
+		});
+		return operationId;
+	}
+
+	private _isCurrentCompactionOperation(operationId: string, controller: AbortController): boolean {
+		return (
+			this._compactionState.status === "running" &&
+			this._compactionState.operationId === operationId &&
+			this._compactionOperationController === controller &&
+			!controller.signal.aborted
+		);
+	}
+
+	private _finishCompactionOperation(
+		operationId: string,
+		status: "completed" | "failed" | "aborted",
+		options: { rejectionCause?: CompactionRejectionCause; errorMessage?: string } = {},
+	): void {
+		const previous = this._compactionState;
+		const next = finishCompactionOperation(previous, {
+			operationId,
+			status,
+			endedRevision: this._messageRevision,
+			...options,
+		});
+		this._compactionState = next;
+		if (previous.status === "running" && previous.operationId === operationId && next !== previous) {
+			this._compactionOperationController = undefined;
 		}
 	}
 
@@ -2928,9 +3050,10 @@ export class AgentSession {
 		pathEntries: SessionEntry[],
 		compactionResult: CompactionResult,
 		fromExtension: boolean,
+		model: Model<Api>,
 	): boolean {
 		const currentLeaf = pathEntries[pathEntries.length - 1];
-		if (!currentLeaf || !this.model) return false;
+		if (!currentLeaf) return false;
 
 		const simulatedCompactionEntry: CompactionEntry = {
 			type: "compaction",
@@ -2950,7 +3073,7 @@ export class AgentSession {
 		).messages;
 		const contextTokens = estimateMessagesTokens(filterContextExcludedMessages(simulatedMessages));
 		const settings = this.settingsManager.getCompactionSettings();
-		return contextTokens > this.model.contextWindow - settings.reserveTokens;
+		return contextTokens > model.contextWindow - settings.reserveTokens;
 	}
 
 	private async _rejectCompaction(
@@ -2998,8 +3121,21 @@ export class AgentSession {
 	 * Cancel in-progress compaction (manual or auto).
 	 */
 	abortCompaction(): void {
+		const feedbackController = this._compactionFeedbackController;
 		this._compactionAbortController?.abort();
 		this._autoCompactionAbortController?.abort();
+		this._compactionOperationController?.abort();
+		if (this._compactionState.status === "running") {
+			this._finishCompactionOperation(this._compactionState.operationId, "aborted", {
+				errorMessage: "Compaction cancelled",
+			});
+		}
+		if (feedbackController && this._compactionFeedbackController === feedbackController) {
+			this._compactionFeedbackController = undefined;
+			if (this._compactionAbortController === feedbackController) {
+				this._compactionAbortController = undefined;
+			}
+		}
 	}
 
 	/**
@@ -3094,7 +3230,16 @@ export class AgentSession {
 				this._incrementMessageRevision();
 			}
 			if (inlineReason) {
-				return await this._runPrePromptCompaction(assistantMessage, skipAbortedCheck, "overflow", willRetry);
+				const compacted = await this._runPrePromptCompaction(
+					assistantMessage,
+					skipAbortedCheck,
+					"overflow",
+					willRetry,
+				);
+				if (!compacted) {
+					throw new RequiredCompactionError();
+				}
+				return true;
 			} else {
 				return await this._runAutoCompaction("overflow", willRetry);
 			}
@@ -3147,7 +3292,8 @@ export class AgentSession {
 		willRetry = false,
 	): Promise<boolean> {
 		this._emit({ type: "compaction_start", reason });
-		this._compactionAbortController = new AbortController();
+		const controller = new AbortController();
+		this._compactionAbortController = controller;
 
 		try {
 			const execution = await this._executeCompaction({
@@ -3177,7 +3323,9 @@ export class AgentSession {
 			});
 			return false;
 		} finally {
-			this._compactionAbortController = undefined;
+			if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+				this._compactionAbortController = undefined;
+			}
 		}
 	}
 
@@ -3577,7 +3725,8 @@ export class AgentSession {
 					void (async () => {
 						this._disconnectFromAgent();
 						await this.abort();
-						this._compactionAbortController = new AbortController();
+						const controller = new AbortController();
+						this._compactionAbortController = controller;
 						this._emit({ type: "compaction_start", reason: "extension" });
 
 						try {
@@ -3606,7 +3755,9 @@ export class AgentSession {
 							const err = error instanceof Error ? error : new Error(String(error));
 							options?.onError?.(err);
 						} finally {
-							this._compactionAbortController = undefined;
+							if (this._compactionAbortController === controller && this._compactionState.status !== "running") {
+								this._compactionAbortController = undefined;
+							}
 							this._reconnectToAgent();
 						}
 					})();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -841,9 +841,11 @@ export class AgentSession {
 				context: {
 					...previousContext,
 					messages: compacted ? this.agent.state.messages.slice() : previousContext.messages,
+					systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
+					tools: this.agent.state.tools.slice(),
 				},
-				model: previousSnapshot?.model ?? this.agent.state.model,
-				thinkingLevel: previousSnapshot?.thinkingLevel ?? this.agent.state.thinkingLevel,
+				model: this.agent.state.model,
+				thinkingLevel: this.agent.state.thinkingLevel,
 			};
 		};
 	}
@@ -976,11 +978,11 @@ export class AgentSession {
 		// final agent_end. This subscriber intentionally processes its own event
 		// queue asynchronously, so a later recovery rejection cannot abort that
 		// drain in time. agent_end itself is still an awaited synchronous boundary
-		// before that drain: transfer provider-confirmed overflow ownership there,
-		// retaining queues until AgentSession accepts recovery.
+		// before that drain: transfer every required overflow or threshold
+		// compaction to AgentSession, retaining queues until recovery is accepted.
 		if (event.type === "agent_end") {
 			const lastAssistant = this._findLastAssistantInMessages(event.messages);
-			if (lastAssistant && this._requiresOverflowRecovery(lastAssistant)) {
+			if (lastAssistant && this._getRequiredAutoCompactionReason(lastAssistant)) {
 				this.agent.abort();
 			}
 		}
@@ -1048,14 +1050,59 @@ export class AgentSession {
 		return undefined;
 	}
 
-	private _requiresOverflowRecovery(message: AssistantMessage): boolean {
+	/**
+	 * Synchronously mirror the auto-compaction decision that _checkCompaction()
+	 * will make after agent_end. Agent core drains queues before that async work
+	 * runs, so only this preflight can transfer required admissions safely.
+	 */
+	private _getRequiredAutoCompactionReason(message: AssistantMessage): "overflow" | "threshold" | undefined {
+		const settings = this.settingsManager.getCompactionSettings();
+		if (!settings.enabled || message.stopReason === "aborted") {
+			return undefined;
+		}
+
 		const model = this.model;
-		return (
-			model !== undefined &&
-			(message.stopReason === "error" || message.stopReason === "length") &&
-			isContextOverflow(message, model.contextWindow) &&
-			isSameOverflowSource(message, model, this._modelRuntime.getCompatibilityRequestConfig(model).upstreamModelId)
+		if (!model || this._isAssistantFromBeforeLatestCompaction(message)) {
+			return undefined;
+		}
+
+		const sameModel = isSameOverflowSource(
+			message,
+			model,
+			this._modelRuntime.getCompatibilityRequestConfig(model).upstreamModelId,
 		);
+		const contextUsage = this.getContextUsage();
+		const currentContextNeedsCompaction =
+			contextUsage !== undefined &&
+			contextUsage.tokens !== null &&
+			shouldCompact(contextUsage.tokens, contextUsage.contextWindow, settings);
+		if (isContextOverflow(message, model.contextWindow) && (sameModel || currentContextNeedsCompaction)) {
+			return "overflow";
+		}
+
+		let contextTokens: number;
+		const directContextTokens = message.usage ? calculateContextTokens(message.usage) : 0;
+		if (message.stopReason !== "error" && directContextTokens !== 0) {
+			contextTokens = directContextTokens;
+		} else {
+			const messages = filterContextExcludedMessages(this.agent.state.messages);
+			const estimate = estimateContextTokens(messages);
+			if (estimate.lastUsageIndex === null) {
+				return undefined;
+			}
+			const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
+			const usageMessage = messages[estimate.lastUsageIndex];
+			if (
+				compactionEntry &&
+				usageMessage?.role === "assistant" &&
+				usageMessage.timestamp <= new Date(compactionEntry.timestamp).getTime()
+			) {
+				return undefined;
+			}
+			contextTokens = estimate.tokens;
+		}
+
+		return shouldCompact(contextTokens, model.contextWindow, settings) ? "threshold" : undefined;
 	}
 
 	private _agentEndAllowsQueuedContinuation(messages: AgentMessage[]): boolean {
@@ -1077,7 +1124,7 @@ export class AgentSession {
 		if (lastAssistant.stopReason === "aborted" || lastAssistant.stopReason === "error") {
 			return false;
 		}
-		if (this._requiresOverflowRecovery(lastAssistant)) {
+		if (this._getRequiredAutoCompactionReason(lastAssistant)) {
 			return false;
 		}
 
@@ -1231,7 +1278,7 @@ export class AgentSession {
 		if (event.type === "agent_end" && this._lastAssistantMessage) {
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
-			const requiredOverflowRecovery = this._requiresOverflowRecovery(msg);
+			const requiredAutoCompaction = this._getRequiredAutoCompactionReason(msg);
 
 			// Retry transient failures normally and eligible hard errors only through a fallback.
 			const retryableError = this._isRetryableError(msg);
@@ -1245,7 +1292,15 @@ export class AgentSession {
 
 			this._resolveRetry();
 			launchedContinuation = await this._checkCompaction(msg);
-			if (requiredOverflowRecovery && !launchedContinuation) {
+			// _runAutoCompaction() returns false both when recovery was rejected and
+			// when an accepted compaction had no queue to continue. Re-sample after
+			// it settles so only the still-required (rejected) case fails admission.
+			if (
+				requiredAutoCompaction &&
+				!launchedContinuation &&
+				this.agent.hasQueuedMessages() &&
+				this._getRequiredAutoCompactionReason(msg) !== undefined
+			) {
 				this._requiredCompactionAdmissionError = new RequiredCompactionError();
 			}
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -330,6 +330,42 @@ class CompactionRejectedError extends Error {
 	}
 }
 
+class CompactionCancelledError extends Error {
+	constructor() {
+		super("Compaction cancelled");
+		this.name = "CompactionCancelledError";
+	}
+}
+
+/**
+ * An execution failure annotated with whether this operation still owns its
+ * terminal transition. Callers must not publish a terminal event for an
+ * operation that a newer compaction generation has superseded.
+ */
+class CompactionExecutionError extends Error {
+	readonly ownsTerminalTransition: boolean;
+	readonly aborted: boolean;
+
+	constructor(error: unknown, ownsTerminalTransition: boolean, aborted: boolean) {
+		super(error instanceof Error ? error.message : String(error));
+		this.name = "CompactionExecutionError";
+		this.ownsTerminalTransition = ownsTerminalTransition;
+		this.aborted = aborted;
+	}
+}
+
+function compactionExecutionOwnsTerminalTransition(error: unknown): boolean {
+	return !(error instanceof CompactionExecutionError) || error.ownsTerminalTransition;
+}
+
+function isCompactionExecutionAborted(error: unknown): boolean {
+	return (
+		(error instanceof CompactionExecutionError && error.aborted) ||
+		error instanceof CompactionCancelledError ||
+		(error instanceof Error && error.name === "AbortError")
+	);
+}
+
 class RequiredCompactionError extends Error {
 	constructor() {
 		super("Context remains above the compaction threshold because compaction did not complete");
@@ -763,17 +799,28 @@ export class AgentSession {
 			// admission: a tool continuation or queued steer/follow-up messages. A
 			// completed turn with no continuation keeps pre-PR timing, while the
 			// prior prepare callback and context refresh below still run every turn.
-			if (turn.toolResults.length > 0 || this.agent.hasQueuedMessages()) {
+			const compactBeforeNextAdmission = async (): Promise<boolean> => {
+				if (turn.toolResults.length === 0 && !this.agent.hasQueuedMessages()) {
+					return false;
+				}
 				await this._agentEventQueue;
+				// A queue can be cleared while waiting for persistence. Re-sample it
+				// immediately before compaction so a completed turn never compacts
+				// merely because it once had a possible continuation.
+				if (turn.toolResults.length === 0 && !this.agent.hasQueuedMessages()) {
+					return false;
+				}
 				try {
-					compacted = await this._enforceCompactionBeforeProvider(turn.message, true, "threshold");
+					return await this._enforceCompactionBeforeProvider(turn.message, true, "threshold");
 				} catch (error) {
 					if (error instanceof RequiredCompactionError && this.agent.hasQueuedMessages()) {
 						this._requiredCompactionAdmissionError = error;
 					}
 					throw error;
 				}
-			}
+			};
+
+			compacted = await compactBeforeNextAdmission();
 			const messages = compacted ? this.agent.state.messages.slice() : turn.context.messages;
 
 			const postCompactionTurn = {
@@ -782,16 +829,21 @@ export class AgentSession {
 			};
 			const previousSnapshot = await previousPrepareNextTurnWithContext?.(postCompactionTurn, signal);
 			const previousContext = previousSnapshot?.context ?? postCompactionTurn.context;
+			// The previous callback may await while agent_end extensions enqueue
+			// continuation work. Re-sample after it returns so that work cannot
+			// slip through with the stale provider snapshot it observed on entry.
+			if (!compacted) {
+				compacted = await compactBeforeNextAdmission();
+			}
 
 			return {
 				...previousSnapshot,
 				context: {
 					...previousContext,
-					systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
-					tools: this.agent.state.tools.slice(),
+					messages: compacted ? this.agent.state.messages.slice() : previousContext.messages,
 				},
-				model: this.agent.state.model,
-				thinkingLevel: this.agent.state.thinkingLevel,
+				model: previousSnapshot?.model ?? this.agent.state.model,
+				thinkingLevel: previousSnapshot?.thinkingLevel ?? this.agent.state.thinkingLevel,
 			};
 		};
 	}
@@ -886,6 +938,10 @@ export class AgentSession {
 		this._requiredCompactionAdmissionError = undefined;
 		try {
 			await this.agent.prompt(messages);
+			// AgentSession's subscriber intentionally queues event work instead of
+			// blocking Agent core. Wait for this run's queued recovery decision
+			// before reporting prompt completion to the caller.
+			await this._agentEventQueue;
 			const requiredCompactionError = this._requiredCompactionAdmissionError;
 			this._requiredCompactionAdmissionError = undefined;
 			if (requiredCompactionError) {
@@ -916,6 +972,19 @@ export class AgentSession {
 
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	private _handleAgentEvent = (event: AgentEvent): void => {
+		// Agent core drains native steer/follow-up queues immediately after its
+		// final agent_end. This subscriber intentionally processes its own event
+		// queue asynchronously, so a later recovery rejection cannot abort that
+		// drain in time. agent_end itself is still an awaited synchronous boundary
+		// before that drain: transfer provider-confirmed overflow ownership there,
+		// retaining queues until AgentSession accepts recovery.
+		if (event.type === "agent_end") {
+			const lastAssistant = this._findLastAssistantInMessages(event.messages);
+			if (lastAssistant && this._requiresOverflowRecovery(lastAssistant)) {
+				this.agent.abort();
+			}
+		}
+
 		// Create retry promise synchronously before queueing async processing.
 		// Agent.emit() calls this handler synchronously, and prompt() calls waitForRetry()
 		// as soon as agent.prompt() resolves. If _retryPromise is created only inside
@@ -979,6 +1048,16 @@ export class AgentSession {
 		return undefined;
 	}
 
+	private _requiresOverflowRecovery(message: AssistantMessage): boolean {
+		const model = this.model;
+		return (
+			model !== undefined &&
+			(message.stopReason === "error" || message.stopReason === "length") &&
+			isContextOverflow(message, model.contextWindow) &&
+			isSameOverflowSource(message, model, this._modelRuntime.getCompatibilityRequestConfig(model).upstreamModelId)
+		);
+	}
+
 	private _agentEndAllowsQueuedContinuation(messages: AgentMessage[]): boolean {
 		let lastAssistantIndex = -1;
 		for (let index = messages.length - 1; index >= 0; index--) {
@@ -996,6 +1075,9 @@ export class AgentSession {
 			return false;
 		}
 		if (lastAssistant.stopReason === "aborted" || lastAssistant.stopReason === "error") {
+			return false;
+		}
+		if (this._requiresOverflowRecovery(lastAssistant)) {
 			return false;
 		}
 
@@ -1149,6 +1231,7 @@ export class AgentSession {
 		if (event.type === "agent_end" && this._lastAssistantMessage) {
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
+			const requiredOverflowRecovery = this._requiresOverflowRecovery(msg);
 
 			// Retry transient failures normally and eligible hard errors only through a fallback.
 			const retryableError = this._isRetryableError(msg);
@@ -1162,6 +1245,9 @@ export class AgentSession {
 
 			this._resolveRetry();
 			launchedContinuation = await this._checkCompaction(msg);
+			if (requiredOverflowRecovery && !launchedContinuation) {
+				this._requiredCompactionAdmissionError = new RequiredCompactionError();
+			}
 		}
 
 		if (event.type === "agent_end") {
@@ -2732,8 +2818,11 @@ export class AgentSession {
 			if (error instanceof CompactionRejectedError) {
 				throw new Error(error.message);
 			}
+			if (!compactionExecutionOwnsTerminalTransition(error)) {
+				throw error;
+			}
 			const message = error instanceof Error ? error.message : String(error);
-			const aborted = message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
+			const aborted = isCompactionExecutionAborted(error);
 			this._emit({
 				type: "compaction_end",
 				reason: "manual",
@@ -2778,8 +2867,11 @@ export class AgentSession {
 			}
 			return { applied: true, reason: "ok" };
 		} catch (error) {
+			if (!compactionExecutionOwnsTerminalTransition(error)) {
+				return { applied: false, reason: "rejected" };
+			}
 			const message = error instanceof Error ? error.message : String(error);
-			const aborted = message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
+			const aborted = isCompactionExecutionAborted(error);
 			this._emit({
 				type: "compaction_end",
 				reason: options.reason,
@@ -2910,17 +3002,15 @@ export class AgentSession {
 						signal,
 					})) as SessionBeforeCompactResult | undefined;
 
+					if (!this._compactionLifecycle.isCurrent(operationId, controller)) {
+						throw new CompactionCancelledError();
+					}
+
 					if (extensionResult?.cancel) {
-						this._compactionLifecycle.finish({
-							operationId,
-							status: "failed",
-							endedRevision: this._messageRevision,
-							rejectionCause: extensionResult.rejectionCause ?? "cancelled-by-extension",
-							errorMessage: extensionResult.reason,
-						});
 						return await this._rejectCompaction(
 							request,
 							requestId,
+							operationId,
 							extensionResult.rejectionCause ?? "cancelled-by-extension",
 							true,
 							extensionResult.reason,
@@ -2952,10 +3042,10 @@ export class AgentSession {
 			}
 
 			if (signal.aborted) {
-				throw new Error("Compaction cancelled");
+				throw new CompactionCancelledError();
 			}
 			if (!this._compactionLifecycle.isCurrent(operationId, controller)) {
-				throw new DOMException("Compaction superseded", "AbortError");
+				throw new CompactionCancelledError();
 			}
 
 			const lifecycleState = this._compactionLifecycle.state;
@@ -2977,23 +3067,11 @@ export class AgentSession {
 				lifecycleState.startedRevision !== this._messageRevision ||
 				!onlyPendingPersistenceAppends;
 			if (sourceChanged) {
-				this._compactionLifecycle.finish({
-					operationId,
-					status: "failed",
-					endedRevision: this._messageRevision,
-					rejectionCause: "stale-revision",
-				});
-				return await this._rejectCompaction(request, requestId, "stale-revision", false);
+				return await this._rejectCompaction(request, requestId, operationId, "stale-revision", false);
 			}
 
 			if (this._wouldCompactionOverflow(pathEntries, compactionResult, fromExtension, model)) {
-				this._compactionLifecycle.finish({
-					operationId,
-					status: "failed",
-					endedRevision: this._messageRevision,
-					rejectionCause: "would-overflow",
-				});
-				return await this._rejectCompaction(request, requestId, "would-overflow", false);
+				return await this._rejectCompaction(request, requestId, operationId, "would-overflow", false);
 			}
 
 			const compactionEntryId = this.sessionManager.appendCompaction(
@@ -3030,11 +3108,15 @@ export class AgentSession {
 			this.agent.state.messages = [...sessionContext.messages, ...preservedPendingMessages];
 			compactionResult.estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 			this._incrementMessageRevision();
-			this._compactionLifecycle.finish({
-				operationId,
-				status: "completed",
-				endedRevision: this._messageRevision,
-			});
+			if (
+				!this._compactionLifecycle.finish({
+					operationId,
+					status: "completed",
+					endedRevision: this._messageRevision,
+				})
+			) {
+				throw new CompactionCancelledError();
+			}
 
 			this._emit({
 				type: "compaction_end",
@@ -3058,14 +3140,21 @@ export class AgentSession {
 
 			return { accepted: true, requestId, result: compactionResult, compactionEntry: savedEntry, fromExtension };
 		} catch (error) {
-			const aborted = signal.aborted || (error instanceof Error && error.name === "AbortError");
-			this._compactionLifecycle.finish({
-				operationId,
-				status: aborted ? "aborted" : "failed",
-				endedRevision: this._messageRevision,
-				errorMessage: error instanceof Error ? error.message : String(error),
-			});
-			throw error;
+			if (error instanceof CompactionExecutionError) {
+				throw error;
+			}
+			const lifecycleState = this._compactionLifecycle.state;
+			const ownsTerminalTransition = lifecycleState.status !== "idle" && lifecycleState.operationId === operationId;
+			const aborted = signal.aborted || isCompactionExecutionAborted(error);
+			if (ownsTerminalTransition && lifecycleState.status === "running") {
+				this._compactionLifecycle.finish({
+					operationId,
+					status: aborted ? "aborted" : "failed",
+					endedRevision: this._messageRevision,
+					errorMessage: error instanceof Error ? error.message : String(error),
+				});
+			}
+			throw new CompactionExecutionError(error, ownsTerminalTransition, aborted);
 		} finally {
 			finishCompactionWork();
 		}
@@ -3123,6 +3212,7 @@ export class AgentSession {
 	private async _rejectCompaction(
 		request: CompactionExecutionRequest,
 		requestId: string,
+		operationId: string,
 		rejectionCause: CompactionRejectionCause,
 		aborted: boolean,
 		extensionReason?: string,
@@ -3138,6 +3228,17 @@ export class AgentSession {
 			? `Compaction rejected: ${trimmedExtensionReason}`
 			: describeCompactionRejection(rejectionCause);
 		const errorMessage = aborted && !trimmedExtensionReason ? undefined : detailedMessage;
+		if (
+			!this._compactionLifecycle.finish({
+				operationId,
+				status: "failed",
+				endedRevision: this._messageRevision,
+				rejectionCause,
+				...(trimmedExtensionReason !== undefined ? { errorMessage: trimmedExtensionReason } : {}),
+			})
+		) {
+			throw new CompactionCancelledError();
+		}
 		this._emit({
 			type: "compaction_end",
 			reason: request.reason,
@@ -3370,12 +3471,14 @@ export class AgentSession {
 			}
 			return execution.accepted;
 		} catch (error) {
+			if (!compactionExecutionOwnsTerminalTransition(error)) {
+				return false;
+			}
 			if (isContextOverflow(lastAssistantMessage, this.model?.contextWindow ?? 0)) {
 				this._overflowRecoveryAttempted = false;
 			}
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
-			const aborted =
-				errorMessage === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
+			const aborted = isCompactionExecutionAborted(error);
 			this._emit({
 				type: "compaction_end",
 				reason,
@@ -3502,10 +3605,12 @@ export class AgentSession {
 
 			return false;
 		} catch (error) {
+			if (!compactionExecutionOwnsTerminalTransition(error)) {
+				return false;
+			}
 			if (reason === "overflow") this._overflowRecoveryAttempted = false;
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
-			const aborted =
-				errorMessage === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
+			const aborted = isCompactionExecutionAborted(error);
 			this._emit({
 				type: "compaction_end",
 				reason,
@@ -3805,9 +3910,11 @@ export class AgentSession {
 								options?.onError?.(new CompactionRejectedError(execution.rejectionCause));
 							}
 						} catch (error) {
+							if (!compactionExecutionOwnsTerminalTransition(error)) {
+								return;
+							}
 							const message = error instanceof Error ? error.message : String(error);
-							const aborted =
-								message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
+							const aborted = isCompactionExecutionAborted(error);
 							this._emit({
 								type: "compaction_end",
 								reason: "extension",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3285,10 +3285,15 @@ export class AgentSession {
 		const admission = this._claimPendingCompactionAdmission();
 		const controller = admission.controller;
 		let outcome: "completed" | "failed" | "aborted" = "failed";
-		this._disconnectFromAgent();
+		let disconnected = false;
 
 		try {
+			// Keep the session subscriber attached until the aborted run emits
+			// agent_end. That event clears the active-run and retry state that
+			// waitForIdle() depends on.
 			await this._abortActiveAgentAndRetry();
+			this._disconnectFromAgent();
+			disconnected = true;
 			this._emit({ type: "compaction_start", reason: "manual" });
 			const execution = await this._executeCompaction({
 				controller,
@@ -3325,7 +3330,7 @@ export class AgentSession {
 				this._compactionAbortController = undefined;
 			}
 			this._releasePendingCompactionAdmission(admission, outcome);
-			if (!this.isCompacting) this._reconnectToAgent();
+			if (disconnected && !this.isCompacting) this._reconnectToAgent();
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -528,6 +528,7 @@ export class AgentSession {
 	private _skipNextPostRetryCompactionCheck = false;
 	private _blockedPostCompactionAssistant: { assistant: AssistantMessage; revision: number } | undefined;
 	private _skipNextPostCompactionAssistantCheck = false;
+	private _scheduledContinuationRecompacted = false;
 	private readonly _assistantsPendingAtCompaction = new WeakSet<AssistantMessage>();
 	private readonly _postCompactionUsageExemptAssistants = new WeakSet<AssistantMessage>();
 	private _messageRevision = 0;
@@ -2627,29 +2628,57 @@ export class AgentSession {
 			details: message.details,
 			timestamp: Date.now(),
 		} satisfies CustomMessage<T>;
-		if (options?.deliverAs === "nextTurn") {
-			this._pendingNextTurnMessages.push(appMessage);
-		} else if (this.isStreaming) {
-			if (options?.deliverAs === "followUp") {
-				this.agent.followUp(appMessage);
-			} else {
-				this.agent.steer(appMessage);
+		const waitForExistingSessionWork =
+			options?.triggerTurn === true &&
+			options.deliverAs !== "nextTurn" &&
+			!this.isStreaming &&
+			this._sessionWorkBarrier.hasActiveWork;
+		const activeCompactionGeneration =
+			this._compactionLifecycle.state.status === "running" ? this._compactionLifecycle.state.generation : undefined;
+		let finishSessionWork: (() => void) | undefined;
+		try {
+			if (waitForExistingSessionWork) {
+				await this._waitForSettledSessionWork();
+				finishSessionWork = this._sessionWorkBarrier.begin();
 			}
-		} else if (options?.triggerTurn) {
-			await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
-			await this._enforceFinalProviderAdmission([appMessage]);
-			await this._promptAgent(appMessage);
-		} else {
-			this.agent.state.messages.push(appMessage);
-			this.sessionManager.appendCustomMessageEntry(
-				message.customType,
-				message.content,
-				message.display,
-				message.details,
-			);
-			this._incrementMessageRevision();
-			this._emit({ type: "message_start", message: appMessage });
-			this._emit({ type: "message_end", message: appMessage });
+
+			if (options?.deliverAs === "nextTurn") {
+				this._pendingNextTurnMessages.push(appMessage);
+			} else if (this.isStreaming) {
+				if (options?.deliverAs === "followUp") {
+					this.agent.followUp(appMessage);
+				} else {
+					this.agent.steer(appMessage);
+				}
+			} else if (
+				options?.triggerTurn === true &&
+				activeCompactionGeneration !== undefined &&
+				this._compactionLifecycle.state.generation === activeCompactionGeneration &&
+				this._compactionLifecycle.state.status !== "completed"
+			) {
+				if (options?.deliverAs === "followUp") {
+					this.agent.followUp(appMessage);
+				} else {
+					this.agent.steer(appMessage);
+				}
+			} else if (options?.triggerTurn) {
+				await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
+				await this._enforceFinalProviderAdmission([appMessage]);
+				await this._promptAgent(appMessage);
+			} else {
+				this.agent.state.messages.push(appMessage);
+				this.sessionManager.appendCustomMessageEntry(
+					message.customType,
+					message.content,
+					message.display,
+					message.details,
+				);
+				this._incrementMessageRevision();
+				this._emit({ type: "message_start", message: appMessage });
+				this._emit({ type: "message_end", message: appMessage });
+			}
+		} finally {
+			finishSessionWork?.();
 		}
 	}
 
@@ -3969,7 +3998,7 @@ export class AgentSession {
 	}
 
 	private async _runPrePromptCompaction(
-		lastAssistantMessage: AssistantMessage,
+		lastAssistantMessage: AssistantMessage | undefined,
 		skipAbortedCheck: boolean,
 		reason: "pre_prompt" | "overflow" | "threshold" = "pre_prompt",
 		willRetry = false,
@@ -3988,7 +4017,11 @@ export class AgentSession {
 				skipAbortedCheck,
 				allowSummaryOnly,
 			});
-			if (!execution.accepted && isContextOverflow(lastAssistantMessage, this.model?.contextWindow ?? 0)) {
+			if (
+				!execution.accepted &&
+				lastAssistantMessage &&
+				isContextOverflow(lastAssistantMessage, this.model?.contextWindow ?? 0)
+			) {
 				this._overflowRecoveryAttempted = false;
 			}
 			return execution.accepted;
@@ -3996,7 +4029,7 @@ export class AgentSession {
 			if (!compactionExecutionOwnsTerminalTransition(error)) {
 				return false;
 			}
-			if (isContextOverflow(lastAssistantMessage, this.model?.contextWindow ?? 0)) {
+			if (lastAssistantMessage && isContextOverflow(lastAssistantMessage, this.model?.contextWindow ?? 0)) {
 				this._overflowRecoveryAttempted = false;
 			}
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
@@ -4017,9 +4050,38 @@ export class AgentSession {
 		}
 	}
 
+	private async _revalidateScheduledContinuationAdmission(): Promise<void> {
+		const model = this.model;
+		const settings = this.settingsManager.getCompactionSettings();
+		if (!model || !settings.enabled) return;
+
+		const canonicalMessages = filterContextExcludedMessages(this.sessionManager.buildSessionContext().messages);
+		const estimate = estimateContextTokens(canonicalMessages);
+		const usageMessage = estimate.lastUsageIndex === null ? undefined : canonicalMessages[estimate.lastUsageIndex];
+		const contextTokens =
+			usageMessage?.role === "assistant" && this._isAssistantFromBeforeLatestCompaction(usageMessage)
+				? estimateMessagesTokens(canonicalMessages)
+				: estimate.tokens;
+		if (!shouldCompact(contextTokens, model.contextWindow, settings)) return;
+
+		const compacted = await this._runPrePromptCompaction(this._findLastAssistantMessage(), true, "pre_prompt");
+		if (!compacted) throw new RequiredCompactionError();
+		this._scheduledContinuationRecompacted = true;
+	}
+
 	private async _continueAgentAfterCurrentRun(): Promise<void> {
 		await this.agent.waitForIdle();
-		await this.agent.continue();
+		await this._revalidateScheduledContinuationAdmission();
+		const useQueuedContinuation = this._scheduledContinuationRecompacted;
+		try {
+			if (useQueuedContinuation) {
+				await this.agent.continueWithQueuedMessages();
+			} else {
+				await this.agent.continue();
+			}
+		} finally {
+			this._scheduledContinuationRecompacted = false;
+		}
 	}
 
 	private _scheduleContinuationAfterCurrentEvent(): void {
@@ -4931,10 +4993,10 @@ export class AgentSession {
 			this._skipNextPostRetryCompactionCheck = true;
 		}
 
-		// Retry via continue() - use setTimeout to break out of event handler chain
+		// Retry via the shared continuation path after the event handler chain settles.
 		setTimeout(() => {
-			this.agent.continue().catch(() => {
-				// Retry failed - will be caught by next agent_end
+			this._continueAgentAfterCurrentRun().catch(() => {
+				// Retry failed - terminal handling remains owned by the next agent_end.
 			});
 		}, 0);
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -274,6 +274,7 @@ type SessionModelEntry = { model: Model<any>; thinkingLevel?: ThinkingLevel; ser
 
 interface CompactionExecutionRequest {
 	controller: AbortController;
+	owner: "auto" | "compaction";
 	reason: CompactionReason;
 	customInstructions?: string;
 	willRetry: boolean;
@@ -3213,6 +3214,15 @@ export class AgentSession {
 		}
 	}
 
+	private _ownsCompactionController(controller: AbortController, owner: "auto" | "compaction"): boolean {
+		return (
+			!controller.signal.aborted &&
+			(owner === "auto"
+				? this._autoCompactionAbortController === controller
+				: this._compactionAbortController === controller)
+		);
+	}
+
 	private _releaseCompactionController(signal: AbortSignal): void {
 		if (this._compactionAbortController?.signal === signal) {
 			this._compactionAbortController = undefined;
@@ -3297,6 +3307,7 @@ export class AgentSession {
 			this._emit({ type: "compaction_start", reason: "manual" });
 			const execution = await this._executeCompaction({
 				controller,
+				owner: "compaction",
 				reason: "manual",
 				customInstructions,
 				willRetry: false,
@@ -3357,6 +3368,7 @@ export class AgentSession {
 		try {
 			const execution = await this._executeCompaction({
 				controller,
+				owner: "compaction",
 				reason: options.reason,
 				willRetry: false,
 				precomputed,
@@ -3458,6 +3470,11 @@ export class AgentSession {
 		if (!model) throw new Error(formatNoModelSelectedMessage());
 		const thinkingLevel = this.thinkingLevel;
 		const controller = request.controller;
+		// Async auth and provider preparation may yield to a newer route. A stale
+		// controller must never promote itself into a lifecycle generation.
+		if (!this._ownsCompactionController(controller, request.owner)) {
+			throw new CompactionExecutionError(new CompactionCancelledError(), false, true);
+		}
 		const requestId = randomUUID();
 		const operationId = this._compactionLifecycle.begin(
 			{
@@ -4104,6 +4121,7 @@ export class AgentSession {
 		try {
 			const execution = await this._executeCompaction({
 				controller,
+				owner: "compaction",
 				reason,
 				willRetry,
 				lastAssistantMessage,
@@ -4208,31 +4226,17 @@ export class AgentSession {
 		const agentMessagesAtStart = this.agent.state.messages.slice();
 		const autoCompactionController = new AbortController();
 		this._claimCompactionController(autoCompactionController, "auto");
-		this._emit({ type: "compaction_start", reason });
 
 		try {
 			if (!this.model) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-				});
 				return false;
 			}
 
 			const authResult = await this._modelRuntime.getAuth(this.model);
+			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
 			if (this.agent.streamFn === streamSimple && !authResult?.auth.apiKey) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-				});
 				return false;
 			}
 
@@ -4243,18 +4247,14 @@ export class AgentSession {
 			);
 			if (!preparation) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
-				this._emit({
-					type: "compaction_end",
-					reason,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-				});
 				return false;
 			}
+			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
+			this._emit({ type: "compaction_start", reason });
 
 			const execution = await this._executeCompaction({
 				controller: autoCompactionController,
+				owner: "auto",
 				reason,
 				willRetry,
 				agentMessagesAtStart,
@@ -4597,6 +4597,7 @@ export class AgentSession {
 							this._emit({ type: "compaction_start", reason: "extension" });
 							const execution = await this._executeCompaction({
 								controller,
+								owner: "compaction",
 								reason: "extension",
 								customInstructions: options?.customInstructions,
 								willRetry: false,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -298,6 +298,20 @@ type CompactionExecutionResult =
 			rejectionCause: CompactionRejectionCause;
 	  };
 
+type PendingCompactionAdmission = {
+	readonly controller: AbortController;
+	readonly finishSessionWork: () => void;
+	outcome?: "completed" | "failed" | "aborted";
+};
+
+function isCompactionOwnedPreCompactDiagnostic(message: AgentMessage, requestId: string): boolean {
+	if (message.role !== "custom" || message.customType !== "senpi.hook") return false;
+	const details = message.details;
+	if (!details || typeof details !== "object") return false;
+	const diagnostic = details as { event?: unknown; compactionRequestId?: unknown };
+	return diagnostic.event === "PreCompact" && diagnostic.compactionRequestId === requestId;
+}
+
 /**
  * Human-readable rejection message paired with a `CompactionRejectionCause`.
  *
@@ -519,6 +533,7 @@ export class AgentSession {
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
+	private _pendingCompactionAdmission: PendingCompactionAdmission | undefined = undefined;
 	private readonly _compactionLifecycle = new CompactionLifecycleCoordinator();
 	private readonly _sessionWorkBarrier = new SessionWorkBarrier();
 	private _overflowRecoveryAttempted = false;
@@ -574,6 +589,7 @@ export class AgentSession {
 	private _extensionShutdownHandler?: ShutdownHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
+	private _extensionBindingPromptReadiness: Set<Promise<void>> | undefined;
 
 	private _modelRuntime: ModelRuntime;
 	private _modelRegistry: ModelRegistry;
@@ -1083,6 +1099,10 @@ export class AgentSession {
 		this._retryPromise = new Promise((resolve) => {
 			this._retryResolve = resolve;
 		});
+		// Agent core normally drains queued input immediately after agent_end.
+		// Retry owns that continuation until its final provider-admission check has
+		// either started it or reported a terminal rejection.
+		this.agent.suppressQueuedMessageDrain();
 	}
 
 	private _findLastAssistantInMessages(messages: AgentMessage[]): AssistantMessage | undefined {
@@ -1880,6 +1900,7 @@ export class AgentSession {
 	/** Whether compaction or branch summarization is currently running */
 	get isCompacting(): boolean {
 		return (
+			this._pendingCompactionAdmission !== undefined ||
 			this._compactionLifecycle.state.status === "running" ||
 			this._autoCompactionAbortController !== undefined ||
 			this._compactionAbortController !== undefined ||
@@ -2073,6 +2094,8 @@ export class AgentSession {
 		// turn must still serialize behind compaction and other session work just
 		// like an interactive prompt does.
 		const shouldWaitForSessionWork = true;
+		const pendingCompactionAdmissionAtExtensionAdmission =
+			options?.source === "extension" ? this._pendingCompactionAdmission : undefined;
 		const compactionGenerationAtExtensionAdmission =
 			options?.source === "extension" &&
 			this._sessionWorkBarrier.hasActiveWork &&
@@ -2228,10 +2251,12 @@ export class AgentSession {
 			// must never overtake a rejected or aborted compaction. Keep its normal
 			// queue ownership instead of attempting another provider admission.
 			if (
-				compactionGenerationAtExtensionAdmission !== undefined &&
-				this._compactionLifecycle.state.generation === compactionGenerationAtExtensionAdmission &&
-				(this._compactionLifecycle.state.status === "failed" ||
-					this._compactionLifecycle.state.status === "aborted")
+				(pendingCompactionAdmissionAtExtensionAdmission !== undefined &&
+					pendingCompactionAdmissionAtExtensionAdmission.outcome !== "completed") ||
+				(compactionGenerationAtExtensionAdmission !== undefined &&
+					this._compactionLifecycle.state.generation === compactionGenerationAtExtensionAdmission &&
+					(this._compactionLifecycle.state.status === "failed" ||
+						this._compactionLifecycle.state.status === "aborted"))
 			) {
 				if (options?.streamingBehavior === "followUp") {
 					await this._queueFollowUp(expandedText, currentImages);
@@ -2633,6 +2658,7 @@ export class AgentSession {
 			options.deliverAs !== "nextTurn" &&
 			!this.isStreaming &&
 			this._sessionWorkBarrier.hasActiveWork;
+		const pendingCompactionAdmission = this._pendingCompactionAdmission;
 		const activeCompactionGeneration =
 			this._compactionLifecycle.state.status === "running" ? this._compactionLifecycle.state.generation : undefined;
 		let finishSessionWork: (() => void) | undefined;
@@ -2652,9 +2678,10 @@ export class AgentSession {
 				}
 			} else if (
 				options?.triggerTurn === true &&
-				activeCompactionGeneration !== undefined &&
-				this._compactionLifecycle.state.generation === activeCompactionGeneration &&
-				this._compactionLifecycle.state.status !== "completed"
+				((pendingCompactionAdmission !== undefined && pendingCompactionAdmission.outcome !== "completed") ||
+					(activeCompactionGeneration !== undefined &&
+						this._compactionLifecycle.state.generation === activeCompactionGeneration &&
+						this._compactionLifecycle.state.status !== "completed"))
 			) {
 				if (options?.deliverAs === "followUp") {
 					this.agent.followUp(appMessage);
@@ -2693,6 +2720,14 @@ export class AgentSession {
 		content: string | (TextContent | ImageContent)[],
 		options?: { deliverAs?: "steer" | "followUp" },
 	): Promise<void> {
+		const bindingPromptReadiness = this._extensionBindingPromptReadiness;
+		let resolveBindingPromptReadiness: (() => void) | undefined;
+		if (bindingPromptReadiness) {
+			const readiness = new Promise<void>((resolve) => {
+				resolveBindingPromptReadiness = resolve;
+			});
+			bindingPromptReadiness.add(readiness);
+		}
 		// Normalize content to text string + optional images
 		let text: string;
 		let images: ImageContent[] | undefined;
@@ -2725,6 +2760,7 @@ export class AgentSession {
 				streamingBehavior: options?.deliverAs,
 				images,
 				source: "extension",
+				promptDisposition: () => resolveBindingPromptReadiness?.(),
 				onSessionWorkReady: waitForExistingSessionWork
 					? () => {
 							finishSessionWork ??= this._sessionWorkBarrier.begin();
@@ -2733,6 +2769,7 @@ export class AgentSession {
 				sessionTitlePrompt: false,
 			});
 		} finally {
+			resolveBindingPromptReadiness?.();
 			finishSessionWork?.();
 		}
 	}
@@ -2780,30 +2817,8 @@ export class AgentSession {
 	 * Abort current operation and wait for agent to become idle.
 	 */
 	async abort(): Promise<void> {
-		this.abortRetry();
 		this.abortCompaction();
-		this.abortBranchSummary();
-		if (this._userAbortPromise) {
-			this.agent.abort();
-			await this._userAbortPromise;
-			return;
-		}
-		if (this.isStreaming) {
-			this._suppressQueuedContinuationAfterUserAbort = true;
-		}
-
-		const abortPromise = (async () => {
-			this.agent.abort();
-			await this.waitForIdle();
-		})();
-		this._userAbortPromise = abortPromise;
-		try {
-			await abortPromise;
-		} finally {
-			if (this._userAbortPromise === abortPromise) {
-				this._userAbortPromise = undefined;
-			}
-		}
+		await this._abortActiveAgentAndRetry();
 	}
 
 	async waitForIdle(): Promise<void> {
@@ -3207,20 +3222,74 @@ export class AgentSession {
 		}
 	}
 
+	private _claimPendingCompactionAdmission(): PendingCompactionAdmission {
+		const priorAdmission = this._pendingCompactionAdmission;
+		if (priorAdmission) {
+			priorAdmission.controller.abort();
+			priorAdmission.outcome = "aborted";
+			priorAdmission.finishSessionWork();
+		}
+
+		const controller = new AbortController();
+		const admission: PendingCompactionAdmission = {
+			controller,
+			finishSessionWork: this._sessionWorkBarrier.begin(),
+		};
+		this._pendingCompactionAdmission = admission;
+		this._claimCompactionController(controller, "compaction");
+		return admission;
+	}
+
+	private _releasePendingCompactionAdmission(
+		admission: PendingCompactionAdmission,
+		outcome: "completed" | "failed" | "aborted",
+	): void {
+		admission.outcome = outcome;
+		if (this._pendingCompactionAdmission !== admission) return;
+		this._pendingCompactionAdmission = undefined;
+		admission.finishSessionWork();
+	}
+
+	private async _abortActiveAgentAndRetry(): Promise<void> {
+		this.abortRetry();
+		this.abortBranchSummary();
+		if (this._userAbortPromise) {
+			this.agent.abort();
+			await this._userAbortPromise;
+			return;
+		}
+		if (this.isStreaming) {
+			this._suppressQueuedContinuationAfterUserAbort = true;
+		}
+
+		const abortPromise = (async () => {
+			this.agent.abort();
+			await this.waitForIdle();
+		})();
+		this._userAbortPromise = abortPromise;
+		try {
+			await abortPromise;
+		} finally {
+			if (this._userAbortPromise === abortPromise) {
+				this._userAbortPromise = undefined;
+			}
+		}
+	}
+
 	/**
 	 * Manually compact the session context.
 	 * Aborts current agent operation first.
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
-		const finishManualCompactionWork = this._sessionWorkBarrier.begin();
+		const admission = this._claimPendingCompactionAdmission();
+		const controller = admission.controller;
+		let outcome: "completed" | "failed" | "aborted" = "failed";
 		this._disconnectFromAgent();
-		await this.abort();
-		const controller = new AbortController();
-		this._claimCompactionController(controller, "compaction");
-		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
+			await this._abortActiveAgentAndRetry();
+			this._emit({ type: "compaction_start", reason: "manual" });
 			const execution = await this._executeCompaction({
 				controller,
 				reason: "manual",
@@ -3230,8 +3299,10 @@ export class AgentSession {
 			if (!execution.accepted) {
 				throw new CompactionRejectedError(execution.rejectionCause);
 			}
+			outcome = "completed";
 			return execution.result;
 		} catch (error) {
+			outcome = isCompactionExecutionAborted(error) ? "aborted" : "failed";
 			if (error instanceof CompactionRejectedError) {
 				throw new Error(error.message);
 			}
@@ -3253,8 +3324,8 @@ export class AgentSession {
 			if (this._compactionAbortController === controller && this._compactionLifecycle.state.status !== "running") {
 				this._compactionAbortController = undefined;
 			}
-			this._reconnectToAgent();
-			finishManualCompactionWork();
+			this._releasePendingCompactionAdmission(admission, outcome);
+			if (!this.isCompacting) this._reconnectToAgent();
 		}
 	}
 
@@ -3395,8 +3466,12 @@ export class AgentSession {
 		);
 		const finishCompactionWork = this._sessionWorkBarrier.begin();
 		const agentMessagesAtStart = request.agentMessagesAtStart ?? this.agent.state.messages.slice();
+		const compactionOwnedDiagnosticMessages = new Set<AgentMessage>();
 		const signal = controller.signal;
 		try {
+			if (signal.aborted) {
+				throw new CompactionCancelledError();
+			}
 			const pathEntries = this.sessionManager.getBranch();
 			const settings = this.settingsManager.getCompactionSettings();
 
@@ -3420,6 +3495,7 @@ export class AgentSession {
 				}
 
 				if (this._extensionRunner.hasHandlers("session_before_compact")) {
+					const messagesBeforeExtension = new Set(this.agent.state.messages);
 					const extensionResult = (await this._extensionRunner.emit({
 						type: "session_before_compact",
 						reason: request.reason,
@@ -3430,6 +3506,14 @@ export class AgentSession {
 						customInstructions: request.customInstructions,
 						signal,
 					})) as SessionBeforeCompactResult | undefined;
+					for (const message of this.agent.state.messages) {
+						if (
+							!messagesBeforeExtension.has(message) &&
+							isCompactionOwnedPreCompactDiagnostic(message, requestId)
+						) {
+							compactionOwnedDiagnosticMessages.add(message);
+						}
+					}
 
 					if (!this._compactionLifecycle.isCurrent(operationId, controller)) {
 						throw new CompactionCancelledError();
@@ -3489,11 +3573,15 @@ export class AgentSession {
 				startPrefixIntact &&
 				currentMessagesAtCheck
 					.slice(agentMessagesAtStart.length)
-					.every((message) => this._messageEndsAwaitingPersistence.has(message));
+					.every(
+						(message) =>
+							this._messageEndsAwaitingPersistence.has(message) ||
+							compactionOwnedDiagnosticMessages.has(message),
+					);
 			const sourceChanged =
 				lifecycleState.status !== "running" ||
 				lifecycleState.operationId !== operationId ||
-				lifecycleState.startedRevision !== this._messageRevision ||
+				lifecycleState.startedRevision + compactionOwnedDiagnosticMessages.size !== this._messageRevision ||
 				!onlyPendingPersistenceAppends;
 			if (sourceChanged) {
 				return await this._rejectCompaction(request, requestId, operationId, "stale-revision", false);
@@ -4234,28 +4322,39 @@ export class AgentSession {
 	}
 
 	async bindExtensions(bindings: ExtensionBindings): Promise<void> {
-		if (bindings.uiContext !== undefined) {
-			this._extensionUIContext = bindings.uiContext;
-		}
-		if (bindings.mode !== undefined) {
-			this._extensionMode = bindings.mode;
-		}
-		if (bindings.commandContextActions !== undefined) {
-			this._extensionCommandContextActions = bindings.commandContextActions;
-		}
-		if (bindings.abortHandler !== undefined) {
-			this._extensionAbortHandler = bindings.abortHandler;
-		}
-		if (bindings.shutdownHandler !== undefined) {
-			this._extensionShutdownHandler = bindings.shutdownHandler;
-		}
-		if (bindings.onError !== undefined) {
-			this._extensionErrorListener = bindings.onError;
-		}
+		const finishBindingWork = this._sessionWorkBarrier.begin();
+		const bindingPromptReadiness = new Set<Promise<void>>();
+		this._extensionBindingPromptReadiness = bindingPromptReadiness;
+		try {
+			if (bindings.uiContext !== undefined) {
+				this._extensionUIContext = bindings.uiContext;
+			}
+			if (bindings.mode !== undefined) {
+				this._extensionMode = bindings.mode;
+			}
+			if (bindings.commandContextActions !== undefined) {
+				this._extensionCommandContextActions = bindings.commandContextActions;
+			}
+			if (bindings.abortHandler !== undefined) {
+				this._extensionAbortHandler = bindings.abortHandler;
+			}
+			if (bindings.shutdownHandler !== undefined) {
+				this._extensionShutdownHandler = bindings.shutdownHandler;
+			}
+			if (bindings.onError !== undefined) {
+				this._extensionErrorListener = bindings.onError;
+			}
 
-		this._applyExtensionBindings(this._extensionRunner);
-		await this._extensionRunner.emit(this._sessionStartEvent);
-		await this.extendResourcesFromExtensions(this._sessionStartEvent.reason === "reload" ? "reload" : "startup");
+			this._applyExtensionBindings(this._extensionRunner);
+			await this._extensionRunner.emit(this._sessionStartEvent);
+			await this.extendResourcesFromExtensions(this._sessionStartEvent.reason === "reload" ? "reload" : "startup");
+		} finally {
+			if (this._extensionBindingPromptReadiness === bindingPromptReadiness) {
+				this._extensionBindingPromptReadiness = undefined;
+			}
+			finishBindingWork();
+		}
+		await Promise.all(bindingPromptReadiness);
 	}
 
 	private async extendResourcesFromExtensions(reason: "startup" | "reload"): Promise<void> {
@@ -4480,14 +4579,15 @@ export class AgentSession {
 					},
 				},
 				compact: (options) => {
+					const admission = this._claimPendingCompactionAdmission();
+					const controller = admission.controller;
 					void (async () => {
+						let outcome: "completed" | "failed" | "aborted" = "failed";
 						this._disconnectFromAgent();
-						await this.abort();
-						const controller = new AbortController();
-						this._claimCompactionController(controller, "compaction");
-						this._emit({ type: "compaction_start", reason: "extension" });
 
 						try {
+							await this._abortActiveAgentAndRetry();
+							this._emit({ type: "compaction_start", reason: "extension" });
 							const execution = await this._executeCompaction({
 								controller,
 								reason: "extension",
@@ -4495,11 +4595,14 @@ export class AgentSession {
 								willRetry: false,
 							});
 							if (execution.accepted) {
+								outcome = "completed";
 								options?.onComplete?.(execution.result);
 							} else {
+								outcome = "failed";
 								options?.onError?.(new CompactionRejectedError(execution.rejectionCause));
 							}
 						} catch (error) {
+							outcome = isCompactionExecutionAborted(error) ? "aborted" : "failed";
 							if (!compactionExecutionOwnsTerminalTransition(error)) {
 								return;
 							}
@@ -4522,7 +4625,8 @@ export class AgentSession {
 							) {
 								this._compactionAbortController = undefined;
 							}
-							this._reconnectToAgent();
+							this._releasePendingCompactionAdmission(admission, outcome);
+							if (!this.isCompacting) this._reconnectToAgent();
 						}
 					})();
 				},
@@ -4994,9 +5098,19 @@ export class AgentSession {
 		}
 
 		// Retry via the shared continuation path after the event handler chain settles.
+		// Agent core would otherwise drain these queues before the continuation
+		// revalidates its provider admission. The scheduled continuation owns them
+		// until it either starts or reports a terminal admission failure.
+		this.agent.suppressQueuedMessageDrain();
 		setTimeout(() => {
-			this._continueAgentAfterCurrentRun().catch(() => {
-				// Retry failed - terminal handling remains owned by the next agent_end.
+			void this._continueAgentAfterCurrentRun().catch(async (error) => {
+				const message = error instanceof Error ? error.message : String(error);
+				this._emit({
+					type: "continuation_error",
+					errorMessage: `Failed to continue queued messages: ${message}`,
+				});
+				await this._emitAgentSettled();
+				this._resolveRetry();
 			});
 		}, 0);
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -411,6 +411,8 @@ export interface PromptOptions {
 	promptDisposition?: (disposition: PromptDisposition) => void;
 	/** Internal cancellation signal for a prompt that has not acquired session-work ownership yet. */
 	signal?: AbortSignal;
+	/** Internal callback used by fire-and-forget extension input to retain session-work ownership after its barrier wait. */
+	onSessionWorkReady?: () => void;
 	sessionTitlePrompt?: string | false;
 }
 
@@ -2065,7 +2067,17 @@ export class AgentSession {
 		const ownsPromptStart =
 			!this.isStreaming && !this._promptStartPending && options?.streamingBehavior === undefined;
 		if (ownsPromptStart) this._promptStartPending = true;
-		const shouldWaitForSessionWork = options?.source !== "extension";
+		// Extension bindings deliberately fire-and-forget sendUserMessage(), so an
+		// extension callback cannot deadlock on this wait. The resulting provider
+		// turn must still serialize behind compaction and other session work just
+		// like an interactive prompt does.
+		const shouldWaitForSessionWork = true;
+		const compactionGenerationAtExtensionAdmission =
+			options?.source === "extension" &&
+			this._sessionWorkBarrier.hasActiveWork &&
+			this._compactionLifecycle.state.status !== "idle"
+				? this._compactionLifecycle.state.generation
+				: undefined;
 		// A steer/followUp submission during an active run can be queued immediately.
 		// Waiting on the session-work barrier here would trap the message inside this
 		// call for the rest of the run whenever a queued continuation (e.g. an active
@@ -2082,6 +2094,7 @@ export class AgentSession {
 		) {
 			await this._waitForSettledSessionWork();
 			throwIfCancelled();
+			options?.onSessionWorkReady?.();
 		}
 
 		// Turn boundary: restore the primary model if the fallback cooldown expired.
@@ -2099,6 +2112,7 @@ export class AgentSession {
 		const promptDisposition = options?.promptDisposition;
 		let messages: AgentMessage[] | undefined;
 		let titlePrompt: string | undefined;
+		let consumedNextTurnMessages: CustomMessage[] | undefined;
 
 		try {
 			// Handle extension commands first (execute immediately, even during streaming)
@@ -2209,6 +2223,25 @@ export class AgentSession {
 				}
 			}
 
+			// A background extension prompt that arrived during a manual compaction
+			// must never overtake a rejected or aborted compaction. Keep its normal
+			// queue ownership instead of attempting another provider admission.
+			if (
+				compactionGenerationAtExtensionAdmission !== undefined &&
+				this._compactionLifecycle.state.generation === compactionGenerationAtExtensionAdmission &&
+				(this._compactionLifecycle.state.status === "failed" ||
+					this._compactionLifecycle.state.status === "aborted")
+			) {
+				if (options?.streamingBehavior === "followUp") {
+					await this._queueFollowUp(expandedText, currentImages);
+				} else {
+					await this._queueSteer(expandedText, currentImages);
+				}
+				promptDisposition?.("queued");
+				preflightResult?.(true);
+				return;
+			}
+
 			// Flush any pending bash messages before the new prompt
 			this._flushPendingBashMessages();
 
@@ -2249,11 +2282,14 @@ export class AgentSession {
 				timestamp: Date.now(),
 			});
 
-			// Inject any pending "nextTurn" messages as context alongside the user message
-			for (const msg of this._pendingNextTurnMessages) {
+			// Consume next-turn messages transactionally: a final admission rejection
+			// restores them in their original order rather than dropping or duplicating
+			// one-shot extension state.
+			consumedNextTurnMessages = this._pendingNextTurnMessages;
+			this._pendingNextTurnMessages = [];
+			for (const msg of consumedNextTurnMessages) {
 				messages.push(msg);
 			}
-			this._pendingNextTurnMessages = [];
 
 			// Emit before_agent_start extension event
 			const result = await this._extensionRunner.emitBeforeAgentStart(
@@ -2285,7 +2321,15 @@ export class AgentSession {
 				this._systemPromptOverride = undefined;
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 			}
+
+			// The preflight above only sees persisted session context. These prompt,
+			// next-turn, and before_agent_start additions are also provider-visible,
+			// so make one final admission decision against the complete request.
+			await this._enforceFinalProviderAdmission(messages);
 		} catch (error) {
+			if (consumedNextTurnMessages && consumedNextTurnMessages.length > 0) {
+				this._pendingNextTurnMessages = [...consumedNextTurnMessages, ...this._pendingNextTurnMessages];
+			}
 			preflightResult?.(false);
 			throw error;
 		} finally {
@@ -2305,7 +2349,13 @@ export class AgentSession {
 		await this._promptAgent(messages);
 		await this.waitForRetry();
 		await this.waitForIdle();
-		if (shouldWaitForSessionWork) {
+		if (options?.onSessionWorkReady) {
+			// This prompt owns a session-work token acquired after waiting for a
+			// prior operation, so waiting for the global barrier here would await
+			// itself. _promptAgent() already drained its event queue; any newly
+			// scheduled continuation retains its own barrier ownership.
+			await this.agent.waitForIdle();
+		} else if (shouldWaitForSessionWork) {
 			await this._waitForSettledSessionWork();
 		} else {
 			await this.agent.waitForIdle();
@@ -2587,6 +2637,7 @@ export class AgentSession {
 			}
 		} else if (options?.triggerTurn) {
 			await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
+			await this._enforceFinalProviderAdmission([appMessage]);
 			await this._promptAgent(appMessage);
 		} else {
 			this.agent.state.messages.push(appMessage);
@@ -2633,14 +2684,28 @@ export class AgentSession {
 			if (images.length === 0) images = undefined;
 		}
 
-		// Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
-		await this.prompt(text, {
-			expandPromptTemplates: false,
-			streamingBehavior: options?.deliverAs,
-			images,
-			source: "extension",
-			sessionTitlePrompt: false,
-		});
+		// An extension binding invokes this method fire-and-forget. When it
+		// arrives during session work, retain a barrier token after the prior work
+		// settles so callers observing session idle cannot race its provider turn.
+		const waitForExistingSessionWork = this._sessionWorkBarrier.hasActiveWork;
+		let finishSessionWork: (() => void) | undefined;
+		try {
+			// Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
+			await this.prompt(text, {
+				expandPromptTemplates: false,
+				streamingBehavior: options?.deliverAs,
+				images,
+				source: "extension",
+				onSessionWorkReady: waitForExistingSessionWork
+					? () => {
+							finishSessionWork ??= this._sessionWorkBarrier.begin();
+						}
+					: undefined,
+				sessionTitlePrompt: false,
+			});
+		} finally {
+			finishSessionWork?.();
+		}
 	}
 
 	/**
@@ -2651,8 +2716,13 @@ export class AgentSession {
 	clearQueue(): { steering: string[]; followUp: string[] } {
 		const steering = [...this._steeringMessages];
 		const followUp = [...this._followUpMessages];
+		// Clear every queue synchronously. Deferred post-compaction messages are
+		// already represented in visible bookkeeping, so they must not be returned
+		// a second time or later resurrected into Agent's native queues.
 		this._steeringMessages = [];
 		this._followUpMessages = [];
+		this._postCompactionDeferredSteeringMessages = [];
+		this._postCompactionDeferredFollowUpMessages = [];
 		this.agent.clearAllQueues();
 		this._emitQueueUpdate();
 		return { steering, followUp };
@@ -3114,6 +3184,7 @@ export class AgentSession {
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
+		const finishManualCompactionWork = this._sessionWorkBarrier.begin();
 		this._disconnectFromAgent();
 		await this.abort();
 		const controller = new AbortController();
@@ -3154,6 +3225,7 @@ export class AgentSession {
 				this._compactionAbortController = undefined;
 			}
 			this._reconnectToAgent();
+			finishManualCompactionWork();
 		}
 	}
 
@@ -3681,6 +3753,49 @@ export class AgentSession {
 			if (compacted) return true;
 		}
 		throw new RequiredCompactionError();
+	}
+
+	/**
+	 * The normal pre-prompt check only estimates persisted session context. This
+	 * final gate also includes turn-local messages which the provider will see:
+	 * the current prompt, next-turn custom messages, and before_agent_start
+	 * additions. Compaction rewrites only session context, so callers retain and
+	 * reapply their already-assembled one-shot additions after it succeeds.
+	 */
+	private async _enforceFinalProviderAdmission(messages: readonly AgentMessage[]): Promise<void> {
+		// Normal user-only prompts keep the established provider-overflow recovery
+		// path. This final gate closes the separate gap introduced by turn-local
+		// custom additions, which the normal pre-prompt check cannot observe.
+		if (!messages.some((message) => message.role === "custom")) return;
+
+		const model = this.model;
+		if (!model) return;
+		const settings = this.settingsManager.getCompactionSettings();
+		const isOversized = (): boolean => {
+			const providerMessages = filterContextExcludedMessages([...this.agent.state.messages, ...messages]);
+			const estimate = estimateContextTokens(providerMessages);
+			const usageMessage = estimate.lastUsageIndex === null ? undefined : providerMessages[estimate.lastUsageIndex];
+			// Kept assistant usage can describe the pre-compaction request. Once a
+			// compaction boundary exists, fall back to byte-derived message estimates
+			// until a provider response refreshes that usage.
+			const contextTokens =
+				usageMessage?.role === "assistant" && this._isAssistantFromBeforeLatestCompaction(usageMessage)
+					? estimateMessagesTokens(providerMessages)
+					: estimate.tokens;
+			return contextTokens > model.contextWindow - settings.reserveTokens;
+		};
+
+		if (!settings.enabled || !isOversized()) return;
+
+		const lastAssistantMessage = this._findLastAssistantMessage();
+		if (!lastAssistantMessage) {
+			throw new RequiredCompactionError();
+		}
+
+		const compacted = await this._runPrePromptCompaction(lastAssistantMessage, false, "pre_prompt");
+		if (!compacted || isOversized()) {
+			throw new RequiredCompactionError();
+		}
 	}
 
 	private async _checkCompaction(

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4588,10 +4588,12 @@ export class AgentSession {
 					const controller = admission.controller;
 					void (async () => {
 						let outcome: "completed" | "failed" | "aborted" = "failed";
-						this._disconnectFromAgent();
+						let disconnected = false;
 
 						try {
 							await this._abortActiveAgentAndRetry();
+							this._disconnectFromAgent();
+							disconnected = true;
 							this._emit({ type: "compaction_start", reason: "extension" });
 							const execution = await this._executeCompaction({
 								controller,
@@ -4631,7 +4633,7 @@ export class AgentSession {
 								this._compactionAbortController = undefined;
 							}
 							this._releasePendingCompactionAdmission(admission, outcome);
-							if (!this.isCompacting) this._reconnectToAgent();
+							if (disconnected && !this.isCompacting) this._reconnectToAgent();
 						}
 					})();
 				},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -273,6 +273,7 @@ export interface AgentSessionConfig {
 type SessionModelEntry = { model: Model<any>; thinkingLevel?: ThinkingLevel; serviceTier?: ServiceTier };
 
 interface CompactionExecutionRequest {
+	controller: AbortController;
 	reason: CompactionReason;
 	customInstructions?: string;
 	willRetry: boolean;
@@ -497,6 +498,7 @@ export class AgentSession {
 	 */
 	private readonly _messageEndsAwaitingPersistence = new Set<AgentMessage>();
 	private _isAgentRunActive = false;
+	private _promptStartPending = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
 
@@ -506,6 +508,11 @@ export class AgentSession {
 	private _followUpMessages: string[] = [];
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
+	// Queues held while the first post-compaction response is classified. Agent
+	// core otherwise drains steering immediately before AgentSession can consume
+	// the stale-usage exemption and schedule the continuation itself.
+	private _postCompactionDeferredSteeringMessages: AgentMessage[] = [];
+	private _postCompactionDeferredFollowUpMessages: AgentMessage[] = [];
 
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
@@ -520,6 +527,7 @@ export class AgentSession {
 	private _blockedPostCompactionAssistant: { assistant: AssistantMessage; revision: number } | undefined;
 	private _skipNextPostCompactionAssistantCheck = false;
 	private readonly _assistantsPendingAtCompaction = new WeakSet<AssistantMessage>();
+	private readonly _postCompactionUsageExemptAssistants = new WeakSet<AssistantMessage>();
 	private _messageRevision = 0;
 
 	// Branch summarization state
@@ -1013,7 +1021,10 @@ export class AgentSession {
 		// compaction to AgentSession, retaining queues until recovery is accepted.
 		if (event.type === "agent_end") {
 			const lastAssistant = this._findLastAssistantInMessages(event.messages);
-			if (lastAssistant && this._getRequiredAutoCompactionReason(lastAssistant)) {
+			const requiredAutoCompaction = lastAssistant
+				? this._getRequiredAutoCompactionReason(lastAssistant)
+				: undefined;
+			if (requiredAutoCompaction) {
 				this.agent.suppressQueuedMessageDrain();
 			}
 		}
@@ -1087,7 +1098,33 @@ export class AgentSession {
 	 * runs, so only this preflight can transfer required admissions safely.
 	 */
 	private _getRequiredAutoCompactionReason(message: AssistantMessage): "overflow" | "threshold" | undefined {
-		if (this._skipNextPostRetryCompactionCheck) return undefined;
+		const reason = this._getAutoCompactionReason(message);
+		// Retry and post-compaction exemptions only cover stale usage estimates.
+		// A provider-confirmed overflow must always retain queue ownership and run
+		// fail-closed recovery.
+		if (
+			reason === "overflow" &&
+			message.stopReason === "stop" &&
+			this._hasPendingPostCompactionUsageExemption(message)
+		) {
+			// A successful post-compaction response can carry stale provider usage.
+			// Retain its queues while the asynchronous check consumes the exemption.
+			return "threshold";
+		}
+		if (reason === "overflow") return reason;
+		// Keep queued continuations under AgentSession ownership while the
+		// asynchronous check consumes this post-compaction usage exemption.
+		if (this._hasPendingPostCompactionUsageExemption(message)) return "threshold";
+		if (
+			reason === "threshold" &&
+			(this._skipNextPostRetryCompactionCheck || this._postCompactionUsageExemptAssistants.has(message))
+		) {
+			return undefined;
+		}
+		return reason;
+	}
+
+	private _getAutoCompactionReason(message: AssistantMessage): "overflow" | "threshold" | undefined {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled || message.stopReason === "aborted") {
 			return undefined;
@@ -1135,6 +1172,28 @@ export class AgentSession {
 		}
 
 		return shouldCompact(contextTokens, model.contextWindow, settings) ? "threshold" : undefined;
+	}
+
+	private _hasPendingPostCompactionUsageExemption(message: AssistantMessage): boolean {
+		return (
+			this._skipNextPostCompactionAssistantCheck &&
+			!this._assistantsPendingAtCompaction.has(message) &&
+			!this._overflowRecoveryAttempted
+		);
+	}
+
+	private _isPostCompactionUsageExempt(message: AssistantMessage): boolean {
+		return (
+			this._postCompactionUsageExemptAssistants.has(message) || this._hasPendingPostCompactionUsageExemption(message)
+		);
+	}
+
+	private _consumePostCompactionUsageExemption(message: AssistantMessage): boolean {
+		if (this._postCompactionUsageExemptAssistants.has(message)) return true;
+		if (!this._isPostCompactionUsageExempt(message)) return false;
+		this._skipNextPostCompactionAssistantCheck = false;
+		this._postCompactionUsageExemptAssistants.add(message);
+		return true;
 	}
 
 	private _agentEndAllowsQueuedContinuation(messages: AgentMessage[]): boolean {
@@ -1305,6 +1364,7 @@ export class AgentSession {
 		// Check auto-retry and auto-compaction after agent completes.
 		let launchedContinuation = false;
 		let retryContinuationBlocked = false;
+		let allowsPostCompactionUsageExemptContinuation = false;
 		const userAbortSuppressedQueuedContinuation =
 			event.type === "agent_end" && this._suppressQueuedContinuationAfterUserAbort;
 		if (userAbortSuppressedQueuedContinuation) {
@@ -1317,11 +1377,8 @@ export class AgentSession {
 		if (event.type === "agent_end" && this._lastAssistantMessage) {
 			const msg = this._lastAssistantMessage;
 			this._lastAssistantMessage = undefined;
-			const skipPostRetryCompaction = this._skipNextPostRetryCompactionCheck;
 			this._skipNextPostRetryCompactionCheck = false;
-			const requiredAutoCompaction = skipPostRetryCompaction
-				? undefined
-				: this._getRequiredAutoCompactionReason(msg);
+			const requiredAutoCompaction = this._getRequiredAutoCompactionReason(msg);
 
 			// Retry transient failures normally and eligible hard errors only through a fallback.
 			const retryableError = this._isRetryableError(msg);
@@ -1329,7 +1386,11 @@ export class AgentSession {
 			const retryCanAdmitProvider =
 				this.settingsManager.getRetrySettings().enabled && (retryableError || hardErrorFallbackEligible);
 			let compactedBeforeRetry = false;
-			if (retryCanAdmitProvider && requiredAutoCompaction) {
+			if (
+				retryCanAdmitProvider &&
+				requiredAutoCompaction &&
+				!(requiredAutoCompaction === "threshold" && this._hasPendingPostCompactionUsageExemption(msg))
+			) {
 				this._retireFailedRetryAssistant(msg);
 				compactedBeforeRetry = await this._runPrePromptCompaction(msg, true, "threshold", true);
 				retryContinuationBlocked = !compactedBeforeRetry;
@@ -1347,12 +1408,16 @@ export class AgentSession {
 
 			this._resolveRetry();
 			retryContinuationBlocked ||= retryOutcome === "blocked";
-			if (!retryContinuationBlocked && !skipPostRetryCompaction) {
+			if (!retryContinuationBlocked) {
 				if (compactedBeforeRetry && this.agent.hasQueuedMessages()) {
 					this._scheduleContinuationAfterCurrentEvent();
 					launchedContinuation = true;
 				} else {
 					launchedContinuation = await this._checkCompaction(msg);
+					allowsPostCompactionUsageExemptContinuation = this._postCompactionUsageExemptAssistants.has(msg);
+					if (allowsPostCompactionUsageExemptContinuation) {
+						this._flushPostCompactionDeferredMessages();
+					}
 					// _runAutoCompaction() returns false both when recovery was rejected and
 					// when an accepted compaction had no queue to continue. Re-sample after
 					// it settles so only the still-required (rejected) case fails admission.
@@ -1373,7 +1438,7 @@ export class AgentSession {
 			if (
 				!launchedContinuation &&
 				!retryContinuationBlocked &&
-				allowsQueuedContinuation &&
+				(allowsQueuedContinuation || allowsPostCompactionUsageExemptContinuation) &&
 				this.agent.hasQueuedMessages()
 			) {
 				this._scheduleContinuationAfterCurrentEvent();
@@ -1997,13 +2062,19 @@ export class AgentSession {
 			await userAbortPromise;
 			throwIfCancelled();
 		}
+		const ownsPromptStart =
+			!this.isStreaming && !this._promptStartPending && options?.streamingBehavior === undefined;
+		if (ownsPromptStart) this._promptStartPending = true;
 		const shouldWaitForSessionWork = options?.source !== "extension";
 		// A steer/followUp submission during an active run can be queued immediately.
 		// Waiting on the session-work barrier here would trap the message inside this
 		// call for the rest of the run whenever a queued continuation (e.g. an active
 		// goal chain) holds the barrier, making typed input invisible until the run
 		// ends or the user aborts.
-		const canQueueWhileStreaming = this.isStreaming && !this.isCompacting && options?.streamingBehavior !== undefined;
+		const canQueueWhileStreaming =
+			(this.isStreaming || this._promptStartPending) &&
+			!this.isCompacting &&
+			options?.streamingBehavior !== undefined;
 		if (
 			shouldWaitForSessionWork &&
 			!canQueueWhileStreaming &&
@@ -2015,7 +2086,12 @@ export class AgentSession {
 
 		// Turn boundary: restore the primary model if the fallback cooldown expired.
 		if (!this.isStreaming) {
-			await this._maybeRestoreFallbackPrimary();
+			try {
+				await this._maybeRestoreFallbackPrimary();
+			} catch (error) {
+				if (ownsPromptStart) this._promptStartPending = false;
+				throw error;
+			}
 		}
 
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
@@ -2079,6 +2155,23 @@ export class AgentSession {
 					throw new Error("Cannot set thinkingLevel on a queued prompt; set it after the current turn completes.");
 				}
 				if (options.streamingBehavior === "followUp") {
+					await this._queueFollowUp(expandedText, currentImages);
+				} else {
+					await this._queueSteer(expandedText, currentImages);
+				}
+				promptDisposition?.("queued");
+				preflightResult?.(true);
+				return;
+			}
+
+			// Input accepted while a run was active remains queued even if that run
+			// ends while extension input handling or template expansion is pending.
+			// Starting a fresh prompt here would let it overtake the held continuation.
+			if (canQueueWhileStreaming && !this.isStreaming) {
+				if (options?.thinkingLevel !== undefined) {
+					throw new Error("Cannot set thinkingLevel on a queued prompt; set it after the current turn completes.");
+				}
+				if (options?.streamingBehavior === "followUp") {
 					await this._queueFollowUp(expandedText, currentImages);
 				} else {
 					await this._queueSteer(expandedText, currentImages);
@@ -2195,6 +2288,8 @@ export class AgentSession {
 		} catch (error) {
 			preflightResult?.(false);
 			throw error;
+		} finally {
+			if (ownsPromptStart) this._promptStartPending = false;
 		}
 
 		if (!messages) {
@@ -2405,11 +2500,12 @@ export class AgentSession {
 		if (images) {
 			content.push(...images);
 		}
-		this.agent.steer({
-			role: "user",
-			content,
-			timestamp: Date.now(),
-		});
+		const message: AgentMessage = { role: "user", content, timestamp: Date.now() };
+		if (this._promptStartPending && this._skipNextPostCompactionAssistantCheck) {
+			this._postCompactionDeferredSteeringMessages.push(message);
+			return;
+		}
+		this.agent.steer(message);
 	}
 
 	/**
@@ -2422,11 +2518,23 @@ export class AgentSession {
 		if (images) {
 			content.push(...images);
 		}
-		this.agent.followUp({
-			role: "user",
-			content,
-			timestamp: Date.now(),
-		});
+		const message: AgentMessage = { role: "user", content, timestamp: Date.now() };
+		if (this._promptStartPending && this._skipNextPostCompactionAssistantCheck) {
+			this._postCompactionDeferredFollowUpMessages.push(message);
+			return;
+		}
+		this.agent.followUp(message);
+	}
+
+	private _flushPostCompactionDeferredMessages(): void {
+		for (const message of this._postCompactionDeferredSteeringMessages) {
+			this.agent.steer(message);
+		}
+		this._postCompactionDeferredSteeringMessages = [];
+		for (const message of this._postCompactionDeferredFollowUpMessages) {
+			this.agent.followUp(message);
+		}
+		this._postCompactionDeferredFollowUpMessages = [];
 	}
 
 	/**
@@ -2966,6 +3074,40 @@ export class AgentSession {
 	// Compaction
 	// =========================================================================
 
+	private _claimCompactionController(controller: AbortController, owner: "auto" | "compaction"): void {
+		const supersedesCurrentOperation =
+			(this._compactionAbortController !== undefined && this._compactionAbortController !== controller) ||
+			(this._autoCompactionAbortController !== undefined && this._autoCompactionAbortController !== controller);
+		if (supersedesCurrentOperation) {
+			// Supersession has no public terminal event: the stale operation no
+			// longer owns the route. Finishing its lifecycle state here prevents a
+			// missing late feedback end from keeping isCompacting true.
+			this._compactionLifecycle.abort(this._messageRevision);
+		}
+		if (this._compactionAbortController && this._compactionAbortController !== controller) {
+			this._compactionAbortController.abort();
+			this._compactionAbortController = undefined;
+		}
+		if (this._autoCompactionAbortController && this._autoCompactionAbortController !== controller) {
+			this._autoCompactionAbortController.abort();
+			this._autoCompactionAbortController = undefined;
+		}
+		if (owner === "auto") {
+			this._autoCompactionAbortController = controller;
+		} else {
+			this._compactionAbortController = controller;
+		}
+	}
+
+	private _releaseCompactionController(signal: AbortSignal): void {
+		if (this._compactionAbortController?.signal === signal) {
+			this._compactionAbortController = undefined;
+		}
+		if (this._autoCompactionAbortController?.signal === signal) {
+			this._autoCompactionAbortController = undefined;
+		}
+	}
+
 	/**
 	 * Manually compact the session context.
 	 * Aborts current agent operation first.
@@ -2975,11 +3117,16 @@ export class AgentSession {
 		this._disconnectFromAgent();
 		await this.abort();
 		const controller = new AbortController();
-		this._compactionAbortController = controller;
+		this._claimCompactionController(controller, "compaction");
 		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
-			const execution = await this._executeCompaction({ reason: "manual", customInstructions, willRetry: false });
+			const execution = await this._executeCompaction({
+				controller,
+				reason: "manual",
+				customInstructions,
+				willRetry: false,
+			});
 			if (!execution.accepted) {
 				throw new CompactionRejectedError(execution.rejectionCause);
 			}
@@ -3023,14 +3170,16 @@ export class AgentSession {
 
 		const ownsController = this._compactionAbortController === undefined;
 		if (ownsController) {
-			this._compactionAbortController = new AbortController();
+			this._claimCompactionController(new AbortController(), "compaction");
 			this._emit({ type: "compaction_start", reason: options.reason });
 		}
 		const controller = this._compactionAbortController;
 		if (!controller) return { applied: false, reason: "rejected" };
+		this._claimCompactionController(controller, "compaction");
 
 		try {
 			const execution = await this._executeCompaction({
+				controller,
 				reason: options.reason,
 				willRetry: false,
 				precomputed,
@@ -3063,7 +3212,7 @@ export class AgentSession {
 
 	private _beginExtensionCompactionFeedback(reason: CompactionReason): AbortSignal {
 		const controller = new AbortController();
-		this._compactionAbortController = controller;
+		this._claimCompactionController(controller, "compaction");
 		const model = this.model;
 		this._compactionLifecycle.begin(
 			{
@@ -3100,7 +3249,11 @@ export class AgentSession {
 		aborted?: boolean;
 		errorMessage?: string;
 	}): void {
-		if (!options.signal || !this._compactionLifecycle.hasCurrentSignal(options.signal)) return;
+		if (!options.signal) return;
+		if (!this._compactionLifecycle.hasCurrentSignal(options.signal)) {
+			this._releaseCompactionController(options.signal);
+			return;
+		}
 		const operation = this._compactionLifecycle.state;
 		if (operation.status !== "running" || operation.stage !== "feedback") return;
 		const aborted = options.aborted ?? options.signal.aborted;
@@ -3120,17 +3273,14 @@ export class AgentSession {
 			willRetry: false,
 			errorMessage: aborted ? undefined : options.errorMessage,
 		});
-		if (this._compactionAbortController?.signal === options.signal) {
-			this._compactionAbortController = undefined;
-		}
+		this._releaseCompactionController(options.signal);
 	}
 
 	private async _executeCompaction(request: CompactionExecutionRequest): Promise<CompactionExecutionResult> {
 		const model = this.model;
 		if (!model) throw new Error(formatNoModelSelectedMessage());
 		const thinkingLevel = this.thinkingLevel;
-		const controller = this._compactionAbortController ?? this._autoCompactionAbortController;
-		if (!controller) throw new Error("Compaction abort controller unavailable");
+		const controller = request.controller;
 		const requestId = randomUUID();
 		const operationId = this._compactionLifecycle.begin(
 			{
@@ -3506,7 +3656,7 @@ export class AgentSession {
 		const compacted = assistantMessage
 			? await this._checkCompaction(assistantMessage, skipAbortedCheck, inlineReason, retryAfterCompaction)
 			: false;
-		if (compacted) {
+		if (compacted || (assistantMessage && this._postCompactionUsageExemptAssistants.has(assistantMessage))) {
 			return compacted;
 		}
 
@@ -3566,16 +3716,6 @@ export class AgentSession {
 		if (this._isAssistantFromBeforeLatestCompaction(assistantMessage)) {
 			return false;
 		}
-		if (this._skipNextPostCompactionAssistantCheck) {
-			this._skipNextPostCompactionAssistantCheck = false;
-			// The first ordinary post-compaction response can still report stale
-			// provider usage. An active overflow recovery is different: its retry
-			// response must be checked so the one-retry cap can terminate it.
-			if (!this._assistantsPendingAtCompaction.has(assistantMessage) && !this._overflowRecoveryAttempted) {
-				return false;
-			}
-		}
-
 		// Case 1: Overflow - LLM returned context overflow error.
 		// If the saved assistant provider differs from the currently selected provider alias,
 		// still recover as overflow when the current context is also at the compaction limit.
@@ -3584,7 +3724,17 @@ export class AgentSession {
 			contextUsage !== undefined &&
 			contextUsage.tokens !== null &&
 			shouldCompact(contextUsage.tokens, contextUsage.contextWindow, settings);
-		if (isContextOverflow(assistantMessage, contextWindow) && (sameModel || currentContextNeedsCompaction)) {
+		const isOverflow =
+			isContextOverflow(assistantMessage, contextWindow) && (sameModel || currentContextNeedsCompaction);
+		if (
+			isOverflow &&
+			assistantMessage.stopReason === "stop" &&
+			this._consumePostCompactionUsageExemption(assistantMessage)
+		) {
+			return false;
+		}
+		if (isOverflow) {
+			this._flushPostCompactionDeferredMessages();
 			const willRetry = retryAfterCompaction || assistantMessage.stopReason !== "stop";
 
 			if (!willRetry) {
@@ -3641,6 +3791,11 @@ export class AgentSession {
 			}
 			return compacted;
 		}
+
+		// The first ordinary response can carry provider usage calculated before
+		// compaction. Consume that exemption only after proving this is not an
+		// overflow, then retain the decision for later admission re-sampling.
+		if (this._consumePostCompactionUsageExemption(assistantMessage)) return false;
 
 		// Case 2: Threshold - context is getting large
 		// For error messages or all-zero usage messages, estimate from the last valid response.
@@ -3705,12 +3860,13 @@ export class AgentSession {
 		willRetry = false,
 		allowSummaryOnly = false,
 	): Promise<boolean> {
-		this._emit({ type: "compaction_start", reason });
 		const controller = new AbortController();
-		this._compactionAbortController = controller;
+		this._claimCompactionController(controller, "compaction");
+		this._emit({ type: "compaction_start", reason });
 
 		try {
 			const execution = await this._executeCompaction({
+				controller,
 				reason,
 				willRetry,
 				lastAssistantMessage,
@@ -3780,9 +3936,9 @@ export class AgentSession {
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
 		const finishCompactionWork = this._sessionWorkBarrier.begin();
 		const agentMessagesAtStart = this.agent.state.messages.slice();
-		this._emit({ type: "compaction_start", reason });
 		const autoCompactionController = new AbortController();
-		this._autoCompactionAbortController = autoCompactionController;
+		this._claimCompactionController(autoCompactionController, "auto");
+		this._emit({ type: "compaction_start", reason });
 
 		try {
 			if (!this.model) {
@@ -3827,7 +3983,12 @@ export class AgentSession {
 				return false;
 			}
 
-			const execution = await this._executeCompaction({ reason, willRetry, agentMessagesAtStart });
+			const execution = await this._executeCompaction({
+				controller: autoCompactionController,
+				reason,
+				willRetry,
+				agentMessagesAtStart,
+			});
 			if (!execution.accepted) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
 				return false;
@@ -4146,11 +4307,12 @@ export class AgentSession {
 						this._disconnectFromAgent();
 						await this.abort();
 						const controller = new AbortController();
-						this._compactionAbortController = controller;
+						this._claimCompactionController(controller, "compaction");
 						this._emit({ type: "compaction_start", reason: "extension" });
 
 						try {
 							const execution = await this._executeCompaction({
+								controller,
 								reason: "extension",
 								customInstructions: options?.customInstructions,
 								willRetry: false,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -27,6 +27,10 @@
   before retrying.
 - Message objects are associated with their persisted session-entry order. Compaction-boundary checks use that order
   (and treat pending `message_end` persistence as post-boundary) instead of relying only on payload timestamps.
+- Session reload materialization restores those message-to-entry associations, so older payload timestamps cannot
+  bypass post-compaction admission after reopening a session.
+- When a late queue triggers compaction after a host `prepareNextTurnWithContext` callback, the callback is replayed
+  once against the compacted context so its message filtering/injection contract reaches the provider request.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -17,6 +17,11 @@
   later prompts cannot bypass the same requirement.
 - Next-turn snapshots reapply the live active tools and effective per-run system prompt after asynchronous preparation,
   so a tool removed during the turn is neither advertised nor executable by the following provider request.
+- Required ownership now suppresses only agent-core's post-`agent_end` queue drain, not the run abort signal. Deferred
+  extension dispatch retains the real source signal, so compaction ownership does not masquerade as user cancellation.
+- Retry and fallback admission resolve required compaction first; rejected recovery retains native queues without
+  dispatching a provider retry. Active-tool changes advance the context revision and abort active core compaction so
+  summaries prepared against a prior tool set cannot apply.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Session-owned compaction lifecycle (2026-07-23)
+
+### What changed
+
+- `agent-session.ts` now owns a monotonic compaction operation state, snapshots the active model and controller at
+  operation start, rejects stale completion/feedback, and retains the terminal result until another operation begins.
+- Provider-confirmed overflow remains fail-closed when required pre-prompt compaction fails, even when the local token
+  estimate is below the configured threshold.
+
+### Why extension system couldn't handle this alone
+
+- Model selection, durable session append, provider-overflow recovery, controller ownership, and prompt admission are
+  private `AgentSession` lifecycle boundaries.
+
+### Expected merge conflict zones
+
+- HIGH: `agent-session.ts` compaction execution, pre-prompt recovery, abort handling, and extension context bindings.
+
 ## Streaming steer/followUp submissions bypass the session-work barrier (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -7,7 +7,8 @@
 - `agent-session.ts` now owns a monotonic compaction operation state, snapshots the active model and controller at
   operation start, rejects stale completion/feedback, and retains the terminal result until another operation begins.
 - Provider-confirmed overflow remains fail-closed when required pre-prompt compaction fails, even when the local token
-  estimate is below the configured threshold.
+  estimate is below the configured threshold; failed recovery restores the overflow context so later prompts cannot
+  bypass the same requirement.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -4,11 +4,15 @@
 
 ### What changed
 
-- `agent-session.ts` now owns a monotonic compaction operation state, snapshots the active model and controller at
-  operation start, rejects stale completion/feedback, and retains the terminal result until another operation begins.
-- Provider-confirmed overflow remains fail-closed when required pre-prompt compaction fails, even when the local token
-  estimate is below the configured threshold; failed recovery restores the overflow context so later prompts cannot
-  bypass the same requirement.
+- `agent-session.ts` now holds a monotonic compaction lifecycle coordinator that snapshots the active model and
+  controller at operation start, rejects stale completion/feedback, and retains the terminal result until another
+  operation begins. Feedback-only aborts publish one terminal event, and accepted completions publish their terminal
+  event before `session_compact` handlers can begin a fresh operation.
+- Durable append now rejects a generation whose message revision or agent-message snapshot changed during preparation
+  or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
+- Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next
+  turn. Provider-confirmed overflow remains fail-closed even when the local token estimate is below the configured
+  threshold; failed recovery restores the overflow context so later prompts cannot bypass the same requirement.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -22,6 +22,11 @@
 - Retry and fallback admission resolve required compaction first; rejected recovery retains native queues without
   dispatching a provider retry. Active-tool changes advance the context revision and abort active core compaction so
   summaries prepared against a prior tool set cannot apply.
+- Fallback apply/revert transitions emit typed model-selection events, rebuild model-scoped tools and prompts, abort
+  compaction prepared for the prior model, and re-run required compaction against the selected model's context window
+  before retrying.
+- Message objects are associated with their persisted session-entry order. Compaction-boundary checks use that order
+  (and treat pending `message_end` persistence as post-boundary) instead of relying only on payload timestamps.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -12,7 +12,9 @@
   or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
 - Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next
   turn. Provider-confirmed overflow remains fail-closed even when the local token estimate is below the configured
-  threshold; failed recovery restores the overflow context so later prompts cannot bypass the same requirement.
+  threshold; `agent_end` synchronously transfers overflow continuation ownership to `AgentSession` before agent-core
+  can drain native queues, and failed recovery restores the overflow context so later prompts cannot bypass the same
+  requirement.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -12,9 +12,11 @@
   or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
 - Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next
   turn. Provider-confirmed overflow remains fail-closed even when the local token estimate is below the configured
-  threshold; `agent_end` synchronously transfers overflow continuation ownership to `AgentSession` before agent-core
-  can drain native queues, and failed recovery restores the overflow context so later prompts cannot bypass the same
-  requirement.
+  threshold; `agent_end` synchronously transfers both silent-overflow and threshold-compaction continuation ownership
+  to `AgentSession` before agent-core can drain native queues, and failed recovery restores the overflow context so
+  later prompts cannot bypass the same requirement.
+- Next-turn snapshots reapply the live active tools and effective per-run system prompt after asynchronous preparation,
+  so a tool removed during the turn is neither advertised nor executable by the following provider request.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -41,6 +41,8 @@
 - Provider admission is checked again after assembling `nextTurn` and `before_agent_start` custom messages. Rejected
   compaction restores one-shot additions transactionally; accepted compaction rebuilds and rechecks the final visible
   request before the provider is called.
+- Request-local context provenance is attached non-enumerably to message identities and removed from persisted/session
+  JSON. Remote replay uses it to prove the exact checkpoint boundary after filtering, injection, or reordering.
 - Trigger-turn custom messages serialize behind manual/extension compaction before they are appended or sent.
   Scheduled continuation revalidates the canonical context against any model selected by `session_compact`, retaining
   queues when the smaller model requires rejected re-compaction.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -44,6 +44,10 @@
 - Trigger-turn custom messages serialize behind manual/extension compaction before they are appended or sent.
   Scheduled continuation revalidates the canonical context against any model selected by `session_compact`, retaining
   queues when the smaller model requires rejected re-compaction.
+- Manual and extension compaction claim a synchronous pending-admission barrier before their first await, closing the
+  same-tick window where a trigger-turn custom message could overtake startup. Retry continuation failures that occur
+  before provider dispatch now settle retry/idle state and retain queues instead of hanging the session.
+- Fire-and-forget `session_start` messages defer past replacement-session work without being discarded as stale.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -36,6 +36,11 @@
   callback never arrives.
 - Post-retry and post-compaction usage exemptions suppress only stale threshold accounting. Provider-confirmed
   overflow always retains queue ownership and runs fail-closed recovery.
+- Extension-originated provider turns now wait behind active session work and manual compaction. `clearQueue()` clears
+  both native and post-compaction deferred ownership layers, preventing canceled steer/follow-up input from resurfacing.
+- Provider admission is checked again after assembling `nextTurn` and `before_agent_start` custom messages. Rejected
+  compaction restores one-shot additions transactionally; accepted compaction rebuilds and rechecks the final visible
+  request before the provider is called.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -41,6 +41,9 @@
 - Provider admission is checked again after assembling `nextTurn` and `before_agent_start` custom messages. Rejected
   compaction restores one-shot additions transactionally; accepted compaction rebuilds and rechecks the final visible
   request before the provider is called.
+- Trigger-turn custom messages serialize behind manual/extension compaction before they are appended or sent.
+  Scheduled continuation revalidates the canonical context against any model selected by `session_compact`, retaining
+  queues when the smaller model requires rejected re-compaction.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -31,6 +31,11 @@
   bypass post-compaction admission after reopening a session.
 - When a late queue triggers compaction after a host `prepareNextTurnWithContext` callback, the callback is replayed
   once against the compacted context so its message filtering/injection contract reaches the provider request.
+- Every compaction execution receives its route-owned controller explicitly. Auto compaction cannot promote unrelated
+  extension feedback, and superseded feedback controller references are released even when their stale terminal
+  callback never arrives.
+- Post-retry and post-compaction usage exemptions suppress only stale threshold accounting. Provider-confirmed
+  overflow always retains queue ownership and runs fail-closed recovery.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,29 @@
 # changes.md — compaction
 
+## Lifecycle ownership and required-admission safety (2026-07-23)
+
+### What changed
+
+- `lifecycle.ts` now owns the active compaction controller together with reducer transitions, so feedback from an older
+  generation cannot progress or terminate a newer one. Feedback-only cancellation emits one terminal
+  `compaction_end`, and accepted compactions emit their terminal event before `session_compact` handlers can start
+  another generation.
+- Extension contexts retain the signal returned by `beginCompaction()` and supply it to legacy `updateCompaction()` /
+  `endCompaction()` calls that omit one. Core accepts feedback mutations only from the current signal.
+- Provider admissions now share one required-compaction gate for prompt preflight, extension-triggered turns, and
+  next turns. Provider-confirmed overflow can force a split-turn preparation when keeping the only oversized prompt
+  would otherwise leave no compactable source.
+- Compaction rejects stale source snapshots with `stale-revision` before the durable entry append.
+
+### Why
+
+A late extension completion could overwrite fresh feedback, and some continuation routes skipped required compaction.
+Compacting a source that changed during summary generation could also append a stale checkpoint over intervening work.
+
+### Expected merge conflict zones
+
+- LOW: `lifecycle.ts` and the compaction admission calls in `agent-session.ts`.
+
 ## Operation lifecycle reducer (2026-07-23)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -15,6 +15,10 @@
   post-`agent_end` queue drain so only an accepted `AgentSession` recovery may resume queued work, and overflow can
   force a split-turn preparation when keeping the only oversized prompt would otherwise leave no compactable source.
 - Compaction rejects stale source snapshots with `stale-revision` before the durable entry append.
+- Retry fallback model changes invalidate prior-model compaction and re-check the selected model's context window.
+  Summary-only re-compaction is allowed only for this retry boundary.
+- Assistant history is classified around the latest compaction by persisted branch order; an older payload timestamp
+  cannot hide a message whose entry was appended after the compaction boundary.
 
 ### Why
 

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,21 @@
 # changes.md — compaction
 
+## Operation lifecycle reducer (2026-07-23)
+
+### What changed
+
+- `lifecycle.ts` adds the pure `idle` / `running` / `completed` / `failed` / `aborted` transition model used by
+  `AgentSession`, including monotonic generations, feedback-to-execution promotion, and stale terminal-event rejection.
+
+### Why
+
+- Compaction completion must remain observable after controllers are released, while delayed work from an older
+  generation must not overwrite the active operation.
+
+### Expected merge conflict zones
+
+- NONE: `lifecycle.ts` is a new fork-owned module.
+
 ## Summarization stream idle watchdog (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -11,9 +11,9 @@
 - Extension contexts retain the signal returned by `beginCompaction()` and supply it to legacy `updateCompaction()` /
   `endCompaction()` calls that omit one. Core accepts feedback mutations only from the current signal.
 - Provider admissions now share one required-compaction gate for prompt preflight, extension-triggered turns, and
-  next turns. Provider-confirmed overflow synchronously stops agent-core's post-`agent_end` queue drain so only an
-  accepted `AgentSession` recovery may resume queued work, and it can force a split-turn preparation when keeping the
-  only oversized prompt would otherwise leave no compactable source.
+  next turns. Silent provider overflow and threshold-required compaction synchronously stop agent-core's
+  post-`agent_end` queue drain so only an accepted `AgentSession` recovery may resume queued work, and overflow can
+  force a split-turn preparation when keeping the only oversized prompt would otherwise leave no compactable source.
 - Compaction rejects stale source snapshots with `stale-revision` before the durable entry append.
 
 ### Why

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -11,8 +11,9 @@
 - Extension contexts retain the signal returned by `beginCompaction()` and supply it to legacy `updateCompaction()` /
   `endCompaction()` calls that omit one. Core accepts feedback mutations only from the current signal.
 - Provider admissions now share one required-compaction gate for prompt preflight, extension-triggered turns, and
-  next turns. Provider-confirmed overflow can force a split-turn preparation when keeping the only oversized prompt
-  would otherwise leave no compactable source.
+  next turns. Provider-confirmed overflow synchronously stops agent-core's post-`agent_end` queue drain so only an
+  accepted `AgentSession` recovery may resume queued work, and it can force a split-turn preparation when keeping the
+  only oversized prompt would otherwise leave no compactable source.
 - Compaction rejects stale source snapshots with `stale-revision` before the durable entry append.
 
 ### Why

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -19,6 +19,10 @@
   Summary-only re-compaction is allowed only for this retry boundary.
 - Assistant history is classified around the latest compaction by persisted branch order; an older payload timestamp
   cannot hide a message whose entry was appended after the compaction boundary.
+- Execution routes pass their own controller into core compaction; an auto request supersedes unrelated feedback
+  instead of inheriting/promoting its controller and leaving outer compaction state stuck.
+- The one-turn post-compaction and post-retry stale-usage exemptions are shared across synchronous queue ownership,
+  asynchronous checking, and admission resampling, while explicit provider overflow is never exempt.
 
 ### Why
 

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -752,6 +752,7 @@ export interface CompactionPreparation {
 export function prepareCompaction(
 	pathEntries: SessionEntry[],
 	settings: CompactionSettings,
+	forceProgress = false,
 ): CompactionPreparation | undefined {
 	if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
 		return undefined;
@@ -779,7 +780,18 @@ export function prepareCompaction(
 		filterContextExcludedMessages(buildSessionContext(pathEntries).messages),
 	).tokens;
 
-	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
+	let cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
+	if (forceProgress && cutPoint.firstKeptEntryIndex === boundaryStart) {
+		const nextCutPoint = findValidCutPoints(pathEntries, boundaryStart + 1, boundaryEnd)[0];
+		if (nextCutPoint !== undefined) {
+			const turnStartIndex = findTurnStartIndex(pathEntries, nextCutPoint, boundaryStart);
+			cutPoint = {
+				firstKeptEntryIndex: nextCutPoint,
+				turnStartIndex,
+				isSplitTurn: turnStartIndex !== -1,
+			};
+		}
+	}
 
 	// Get UUID of first kept entry
 	const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -753,6 +753,7 @@ export function prepareCompaction(
 	pathEntries: SessionEntry[],
 	settings: CompactionSettings,
 	forceProgress = false,
+	allowSummaryOnly = false,
 ): CompactionPreparation | undefined {
 	if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
 		return undefined;
@@ -818,7 +819,10 @@ export function prepareCompaction(
 		}
 	}
 
-	if (messagesToSummarize.length === 0 && turnPrefixMessages.length === 0) {
+	// A model switch can make an existing summary too large even when no new
+	// messages were added. The retry fallback path explicitly opts into
+	// regenerating that summary for its selected model's smaller context window.
+	if (messagesToSummarize.length === 0 && turnPrefixMessages.length === 0 && (!previousSummary || !allowSummaryOnly)) {
 		return undefined;
 	}
 

--- a/packages/coding-agent/src/core/compaction/lifecycle.ts
+++ b/packages/coding-agent/src/core/compaction/lifecycle.ts
@@ -10,7 +10,7 @@ interface CompactionOperation {
 	readonly operationId: string;
 	readonly stage: "feedback" | "execution";
 	readonly reason: CompactionReason;
-	readonly model: CompactionModelRef;
+	readonly model?: CompactionModelRef;
 	readonly startedRevision: number;
 }
 
@@ -37,7 +37,7 @@ export interface BeginCompactionOperation {
 	readonly operationId: string;
 	readonly stage: "feedback" | "execution";
 	readonly reason: CompactionReason;
-	readonly model: CompactionModelRef;
+	readonly model?: CompactionModelRef;
 	readonly startedRevision: number;
 }
 
@@ -104,4 +104,71 @@ export function finishCompactionOperation(
 		rejectionCause: event.rejectionCause,
 		errorMessage: event.errorMessage,
 	};
+}
+
+/**
+ * Couples lifecycle reducer transitions with the controller that owns the
+ * active generation. AgentSession owns event emission and durable work; this
+ * coordinator only protects state transitions from stale callers.
+ */
+export class CompactionLifecycleCoordinator {
+	private _state: CompactionLifecycleState = initialCompactionLifecycleState();
+	private _controller: AbortController | undefined;
+
+	get state(): CompactionLifecycleState {
+		return this._state;
+	}
+
+	begin(operation: BeginCompactionOperation, controller: AbortController): string {
+		if (this._state.status === "running") {
+			if (this._controller === controller) {
+				const runningOperationId = this._state.operationId;
+				if (operation.stage === "execution") {
+					this._state = promoteCompactionOperation(this._state, runningOperationId);
+				}
+				return runningOperationId;
+			}
+			this._controller?.abort();
+		}
+
+		this._controller = controller;
+		this._state = beginCompactionOperation(this._state, operation);
+		return operation.operationId;
+	}
+
+	isCurrent(operationId: string, controller: AbortController): boolean {
+		return (
+			this._state.status === "running" &&
+			this._state.operationId === operationId &&
+			this._controller === controller &&
+			!controller.signal.aborted
+		);
+	}
+
+	hasCurrentSignal(signal: AbortSignal): boolean {
+		return this._state.status === "running" && this._controller?.signal === signal && !signal.aborted;
+	}
+
+	finish(event: FinishCompactionOperation): boolean {
+		const next = finishCompactionOperation(this._state, event);
+		if (next === this._state) return false;
+		this._state = next;
+		this._controller = undefined;
+		return true;
+	}
+
+	abort(
+		endedRevision: number,
+	): { readonly reason: CompactionReason; readonly stage: "feedback" | "execution" } | undefined {
+		if (this._state.status !== "running") return undefined;
+		const { operationId, reason, stage } = this._state;
+		this._controller?.abort();
+		this.finish({
+			operationId,
+			status: "aborted",
+			endedRevision,
+			errorMessage: "Compaction cancelled",
+		});
+		return { reason, stage };
+	}
 }

--- a/packages/coding-agent/src/core/compaction/lifecycle.ts
+++ b/packages/coding-agent/src/core/compaction/lifecycle.ts
@@ -1,0 +1,107 @@
+import type { CompactionReason, CompactionRejectionCause } from "../extensions/types.ts";
+
+export interface CompactionModelRef {
+	readonly provider: string;
+	readonly id: string;
+}
+
+interface CompactionOperation {
+	readonly generation: number;
+	readonly operationId: string;
+	readonly stage: "feedback" | "execution";
+	readonly reason: CompactionReason;
+	readonly model: CompactionModelRef;
+	readonly startedRevision: number;
+}
+
+export type CompactionLifecycleState =
+	| { readonly status: "idle"; readonly generation: 0 }
+	| (CompactionOperation & { readonly status: "running" })
+	| (CompactionOperation & {
+			readonly status: "completed";
+			readonly endedRevision: number;
+	  })
+	| (CompactionOperation & {
+			readonly status: "failed";
+			readonly endedRevision: number;
+			readonly rejectionCause?: CompactionRejectionCause;
+			readonly errorMessage?: string;
+	  })
+	| (CompactionOperation & {
+			readonly status: "aborted";
+			readonly endedRevision: number;
+			readonly errorMessage?: string;
+	  });
+
+export interface BeginCompactionOperation {
+	readonly operationId: string;
+	readonly stage: "feedback" | "execution";
+	readonly reason: CompactionReason;
+	readonly model: CompactionModelRef;
+	readonly startedRevision: number;
+}
+
+export interface FinishCompactionOperation {
+	readonly operationId: string;
+	readonly status: "completed" | "failed" | "aborted";
+	readonly endedRevision: number;
+	readonly rejectionCause?: CompactionRejectionCause;
+	readonly errorMessage?: string;
+}
+
+export function initialCompactionLifecycleState(): CompactionLifecycleState {
+	return { status: "idle", generation: 0 };
+}
+
+export function beginCompactionOperation(
+	state: CompactionLifecycleState,
+	operation: BeginCompactionOperation,
+): CompactionLifecycleState {
+	return {
+		status: "running",
+		generation: state.generation + 1,
+		...operation,
+	};
+}
+
+export function promoteCompactionOperation(
+	state: CompactionLifecycleState,
+	operationId: string,
+): CompactionLifecycleState {
+	if (state.status !== "running" || state.operationId !== operationId || state.stage === "execution") return state;
+	return { ...state, stage: "execution" };
+}
+
+export function finishCompactionOperation(
+	state: CompactionLifecycleState,
+	event: FinishCompactionOperation,
+): CompactionLifecycleState {
+	if (state.status !== "running" || state.operationId !== event.operationId) return state;
+
+	const operation: CompactionOperation = {
+		generation: state.generation,
+		operationId: state.operationId,
+		stage: state.stage,
+		reason: state.reason,
+		model: state.model,
+		startedRevision: state.startedRevision,
+	};
+	if (event.status === "completed") {
+		return { ...operation, status: "completed", endedRevision: event.endedRevision };
+	}
+	if (event.status === "aborted") {
+		return {
+			...operation,
+			status: "aborted",
+			endedRevision: event.endedRevision,
+			errorMessage: event.errorMessage,
+		};
+	}
+	return {
+		...operation,
+		status: "failed",
+		endedRevision: event.endedRevision,
+		rejectionCause: event.rejectionCause,
+		errorMessage: event.errorMessage,
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -11,7 +11,8 @@
 - Stale or duplicate terminal events cannot overwrite a newer compaction operation.
 - Durable append is guarded by the current operation and controller identity.
 - Required compaction remains fail-closed when generation or application fails, including provider-confirmed overflow
-  that the local token estimate places below the configured threshold.
+  that the local token estimate places below the configured threshold; rejected recovery restores the overflow
+  context so a later prompt cannot bypass the same requirement.
 
 Expected upstream conflict zones: `agent-session.ts` around compaction execution, abort handling, and status access;
 `core/compaction/lifecycle.ts`.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,16 @@
 # Builtin compaction extension changes
 
+## Active-tool-only summarization requests (2026-07-23)
+
+- `index.ts`: direct local summarization requests now map the current active tool names to registered definitions.
+  Inactive registered tools, including inactive MCP catalog entries, no longer consume remote compaction payload
+  budget or appear as callable tools to the summarizer.
+- Applied speculative summaries carry their handler's feedback signal, allowing core to reject a superseded apply
+  before durable session mutation.
+
+Expected upstream conflict zones: `builtin/compaction/index.ts` tool snapshot construction and
+`builtin/compaction/speculative.ts` apply path.
+
 ## Session-owned compaction completion state (2026-07-23)
 
 - AgentSession now records compaction as `idle`, `running`, `completed`, `failed`, or `aborted` with a monotonic

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,21 @@
 # Builtin compaction extension changes
 
+## Session-owned compaction completion state (2026-07-23)
+
+- AgentSession now records compaction as `idle`, `running`, `completed`, `failed`, or `aborted` with a monotonic
+  generation and operation identity.
+- Compaction snapshots the current AgentSession model at operation start. If main-thread retry fallback selected a
+  different model, that active model performs compaction; there is no compaction-specific fallback policy.
+- Extension feedback starts the same operation before summary generation and carries its abort signal through
+  progress, application, and terminal feedback.
+- Stale or duplicate terminal events cannot overwrite a newer compaction operation.
+- Durable append is guarded by the current operation and controller identity.
+- Required compaction remains fail-closed when generation or application fails, including provider-confirmed overflow
+  that the local token estimate places below the configured threshold.
+
+Expected upstream conflict zones: `agent-session.ts` around compaction execution, abort handling, and status access;
+`core/compaction/lifecycle.ts`.
+
 ## Sanitize Anthropic tool pairs on direct summarization requests (2026-07-23)
 
 - `speculative.ts`: local compaction summarization now applies the existing Anthropic payload sanitizer at the direct

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,3 +1,13 @@
+## Replay remote checkpoints from final context payloads (2026-07-24)
+
+- `index.ts`, `openai-remote.ts`: remote replay now takes all post-checkpoint items, including the in-flight prompt,
+  directly from the final provider payload after every `context` hook has completed. It retains the persisted remote
+  checkpoint prefix and uses persisted history only to locate that prefix; raw post-checkpoint session content is not
+  reconstructed for the provider request.
+- Regressions: `test/compaction/canonical-routes.test.ts` redacts both persisted post-checkpoint content and the
+  current prompt through later context hooks, while `test/compaction/openai-remote-compaction.test.ts` and the Codex
+  remote-compaction regression exercise final-payload replay in native and mixed-history paths.
+
 # Builtin compaction extension changes
 
 ## Active-tool-only summarization requests (2026-07-23)

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,12 +1,19 @@
 ## Replay remote checkpoints from final context payloads (2026-07-24)
 
-- `index.ts`, `openai-remote.ts`: remote replay now takes all post-checkpoint items, including the in-flight prompt,
-  directly from the final provider payload after every `context` hook has completed. It retains the persisted remote
-  checkpoint prefix and uses persisted history only to locate that prefix; raw post-checkpoint session content is not
-  reconstructed for the provider request.
-- Regressions: `test/compaction/canonical-routes.test.ts` redacts both persisted post-checkpoint content and the
-  current prompt through later context hooks, while `test/compaction/openai-remote-compaction.test.ts` and the Codex
-  remote-compaction regression exercise final-payload replay in native and mixed-history paths.
+- `openai-remote.ts`: replay proves the checkpoint boundary by projecting the compaction-aware session prefix through
+  the same OpenAI Responses converter used by the real provider request, then requiring the final payload prefix to
+  match item-for-item. It only replaces a proven prefix; a context hook that inserts, removes, reorders, or changes a
+  checkpoint item declines native replay and sends the final transformed full payload unchanged. The post-checkpoint
+  suffix, including the in-flight prompt, always comes directly from that final payload and is never reconstructed
+  from persisted raw messages.
+- `openai-remote.ts`: both the direct compact endpoint and WebSocket route validate the final
+  `before_provider_request` replacement as an OpenAI compact body. Invalid replacements emit
+  `remote_fallback` with `invalid-compact-request-payload` and are rejected before transport, never retried with the
+  pre-hook payload.
+- Regressions: `test/compaction/canonical-routes.test.ts` covers a context hook that changes prefix cardinality and
+  confirms final-payload fallback, while `test/compaction/openai-remote-compaction.test.ts` covers invalid downstream
+  compact request replacements, final-payload redaction, and native/mixed-history provenance. The Codex regression
+  exercises the same proven-prefix replay path.
 - Repeated checkpoints project their prefix through the same compaction-aware branch view as normal session context,
   excluding superseded older summaries before canonical Responses conversion.
 - Non-remote summarization runs context hooks on raw `AgentMessage` values before `convertToLlm`, preserving

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -18,6 +18,10 @@
   excluding superseded older summaries before canonical Responses conversion.
 - Non-remote summarization runs context hooks on raw `AgentMessage` values before `convertToLlm`, preserving
   role/customType-based redaction contracts while leaving persisted messages byte-identical.
+- Remote checkpoint provenance now records normalized endpoint/trust-domain identity plus a SHA-256 fingerprint of the
+  effective auth tenant (never raw credentials). Legacy, cross-endpoint, or cross-tenant entries decline replay.
+- Replay boundaries require non-enumerable message/item provenance to survive the canonical context pipeline. Missing,
+  duplicated, reordered, reconstructed, or mutated provenance keeps the final transformed full payload unchanged.
 
 # Builtin compaction extension changes
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,3 +1,10 @@
+## Canonical remote compaction provenance and route ownership (2026-07-24)
+
+- `openai-remote-model.ts`: provenance now hashes the normalized endpoint and every final header by default. The only excluded volatile transport headers are `content-length`, `user-agent`, `request-id`, `x-request-id`, and `x-client-request-id`; raw values are never persisted. This binds non-Codex checkpoints to authorization plus final tenant/workspace routing headers.
+- Codex checkpoints instead bind to the JWT-derived `chatgpt-account-id` and every other final non-volatile header, deliberately excluding only the rotating `authorization` bearer value. Codex remote compaction now applies normal Responses header ordering: extension header transforms first, then configured authorization/account, originator, user agent, beta, and session/cache-affinity fields.
+- `agent-session.ts`: each compaction execution now proves its explicit auto/manual route controller still owns the operation before beginning lifecycle state. An auto compaction superseded during async auth admission publishes no lifecycle events and cannot disturb the newer manual operation.
+- Regressions: `test/compaction/canonical-routes.test.ts`, `test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts`, and `test/suite/compaction-race.test.ts` cover header routing differences, refresh-stable Codex account provenance, canonical override repair, and auth-admission supersession.
+
 ## Replay remote checkpoints from final context payloads (2026-07-24)
 
 - `openai-remote.ts`: replay proves the checkpoint boundary by projecting the compaction-aware session prefix through

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -7,6 +7,10 @@
 - Regressions: `test/compaction/canonical-routes.test.ts` redacts both persisted post-checkpoint content and the
   current prompt through later context hooks, while `test/compaction/openai-remote-compaction.test.ts` and the Codex
   remote-compaction regression exercise final-payload replay in native and mixed-history paths.
+- Repeated checkpoints project their prefix through the same compaction-aware branch view as normal session context,
+  excluding superseded older summaries before canonical Responses conversion.
+- Non-remote summarization runs context hooks on raw `AgentMessage` values before `convertToLlm`, preserving
+  role/customType-based redaction contracts while leaving persisted messages byte-identical.
 
 # Builtin compaction extension changes
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -166,13 +166,13 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	const pendingMetadata = new Map<string, PendingCompactionMetadata>();
 
 	function getSummarizationTools(): Tool[] {
-		if (typeof pi.getAllTools !== "function") return [];
+		if (typeof pi.getAllTools !== "function" || typeof pi.getActiveTools !== "function") return [];
 		try {
-			return pi.getAllTools().map((tool) => ({
-				name: tool.name,
-				description: tool.description,
-				parameters: tool.parameters,
-			}));
+			const definitionsByName = new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
+			return pi.getActiveTools().flatMap((name) => {
+				const tool = definitionsByName.get(name);
+				return tool ? [{ name: tool.name, description: tool.description, parameters: tool.parameters }] : [];
+			});
 		} catch {
 			// Tool registry not bound yet (extension still loading); the summary
 			// request simply goes out without tool definitions.
@@ -254,6 +254,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 							remoteSnapshot,
 							() => speculativeGeneration,
 							remoteCompaction,
+							feedbackSignal,
 						);
 						endCompactionFeedback(ctx, feedbackSignal, result);
 						return result;
@@ -275,6 +276,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 					pendingJob.snapshot,
 					() => speculativeGeneration,
 					compaction,
+					feedbackSignal,
 				);
 				if (result.applied || result.reason === "stale") {
 					speculativeJob = undefined;
@@ -310,7 +312,13 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 				// the session_before_compact route.
 				if (!(error instanceof SummaryGenerationError)) throw error;
 			}
-			const result = await applyGeneratedCompaction(ctx, snapshot, () => speculativeGeneration, compaction);
+			const result = await applyGeneratedCompaction(
+				ctx,
+				snapshot,
+				() => speculativeGeneration,
+				compaction,
+				feedbackSignal,
+			);
 			endCompactionFeedback(ctx, feedbackSignal, result);
 			return result;
 		} catch (error) {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -112,7 +112,7 @@ function endCompactionFeedback(
 	result: SpeculativeCompactionResult,
 ): void {
 	if (shouldEndFeedback(result)) {
-		ctx.endCompaction?.({ reason: "extension", aborted: signal?.aborted });
+		ctx.endCompaction?.({ reason: "extension", signal, aborted: signal?.aborted });
 	}
 }
 
@@ -301,7 +301,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 			let compaction: CompactionResult | undefined;
 			try {
 				compaction = await runExtensionCompaction(ctx, snapshot, feedbackSignal, (delta) =>
-					ctx.updateCompaction?.({ reason: "extension", delta }),
+					ctx.updateCompaction?.({ reason: "extension", signal: feedbackSignal, delta }),
 				);
 			} catch (error) {
 				// Auto-path parity: summary-generation failures (missing credentials,
@@ -317,6 +317,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 			const message = error instanceof Error ? error.message : String(error);
 			ctx.endCompaction?.({
 				reason: "extension",
+				signal: feedbackSignal,
 				aborted: feedbackSignal?.aborted,
 				errorMessage: `Compaction failed: ${message}`,
 			});
@@ -369,7 +370,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 		let compaction: CompactionResult | undefined;
 		try {
 			compaction = await runExtensionCompaction(ctx, snapshot, event.signal, (delta) =>
-				ctx.updateCompaction?.({ reason: event.reason, delta }),
+				ctx.updateCompaction?.({ reason: event.reason, signal: event.signal, delta }),
 			);
 		} catch (error) {
 			// Surface the real provider failure (e.g. a policy refusal or rate

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -3,7 +3,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Tool } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../../compaction/index.ts";
 import { convertToLlm } from "../../../messages.ts";
-import { buildContextEntries, type CompactionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
+import type { CompactionEntry } from "../../../session-manager.ts";
 import type { ContextUsage, ExtensionAPI, ExtensionContext, SessionBeforeCompactEvent } from "../../types.ts";
 import * as checkpointState from "./checkpoint-state.ts";
 import * as breaker from "./circuit-breaker.ts";
@@ -147,10 +147,6 @@ function createBlockingRemoteCompactionEvent(
 
 export default function compactionExtension(pi: ExtensionAPI): void {
 	let state: CompactionExtensionState = createInitialState();
-	// Messages not yet persisted in the session branch (the in-flight prompt),
-	// captured at context-assembly time so the remote-compaction payload replay
-	// can append them after the branch-derived items.
-	let pendingProviderMessages: AgentMessage[] = [];
 	const degradationState = createDegradationMonitorState();
 	const restorationState = state.restoration ?? restoration.createRestorationTrackerState();
 	state = { ...state, restoration: restorationState };
@@ -486,14 +482,6 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("context", (event, ctx) => {
-		// Messages beyond the persisted branch history are the in-flight prompt;
-		// stash them so the remote-compaction payload replay can append them.
-		const branchEntries = typeof ctx.sessionManager.getBranch === "function" ? ctx.sessionManager.getBranch() : [];
-		const historyMessageCount = buildContextEntries(branchEntries).flatMap((entry) =>
-			sessionEntryToContextMessages(entry),
-		).length;
-		pendingProviderMessages = event.messages.slice(historyMessageCount);
-
 		const usage = ctx.getContextUsage();
 		const contextWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
 		const promptContextWindow = getPromptContextWindow(contextWindow, ctx.model?.maxTokens);
@@ -511,7 +499,7 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 	pi.on("before_provider_request", (event, ctx) => {
 		return rewriteOpenAiPayloadWithRemoteCompaction(
 			event.payload,
-			{ model: ctx.model, branchEntries: ctx.sessionManager.getBranch(), pendingMessages: pendingProviderMessages },
+			{ model: ctx.model, branchEntries: ctx.sessionManager.getBranch() },
 			(data) => pi.events.emit(SENPI_COMPACTION_EVENT, data),
 		);
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -518,17 +518,12 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 						...(auth.baseUrl ? { baseUrl: auth.baseUrl } : {}),
 					}
 				: model;
-		const initialHeaders = createOpenAiRemoteCompactionHeaders(
+		const headers = createOpenAiRemoteCompactionHeaders(
 			effectiveModel,
-			auth,
+			{ ...auth, headers: event.headers ?? auth.headers },
 			ctx.sessionManager.getSessionId(),
 		);
-		if (!initialHeaders) return undefined;
-		const headers = new Headers(initialHeaders);
-		for (const [key, value] of Object.entries(event.headers ?? {})) {
-			if (value === null) headers.delete(key);
-			else headers.set(key, value);
-		}
+		if (!headers) return undefined;
 		const origin = openAiRemoteCompactionOrigin(effectiveModel, headers);
 		return rewriteOpenAiPayloadWithRemoteCompaction(
 			event.payload,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -20,11 +20,16 @@ import {
 	resetOnSessionCompact,
 } from "./degradation-monitor.ts";
 import {
+	markOpenAiRemoteReplayBoundary,
 	rewriteOpenAiPayloadWithRemoteCompaction,
 	runOpenAiRemoteCompaction,
 	SENPI_COMPACTION_EVENT,
 } from "./openai-remote.ts";
-import { isOpenAiRemoteCompactionModel } from "./openai-remote-model.ts";
+import {
+	createOpenAiRemoteCompactionHeaders,
+	isOpenAiRemoteCompactionModel,
+	openAiRemoteCompactionOrigin,
+} from "./openai-remote-model.ts";
 import * as cap from "./per-turn-cap.ts";
 import * as policy from "./policy.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
@@ -493,13 +498,41 @@ export default function compactionExtension(pi: ExtensionAPI): void {
 			? reduceContextMessages(event.messages, BUILTIN_CONTEXT_REDUCTION_OPTIONS).messages
 			: event.messages;
 		const emergency = hardLimitEmergencyPrune(sourceMessages, promptContextWindow);
-		return { messages: repairOrphanedToolResults(convertToLlm(emergency.messages)) };
+		const marked = markOpenAiRemoteReplayBoundary(emergency.messages, {
+			model: ctx.model,
+			branchEntries: ctx.sessionManager.getBranch(),
+		});
+		return { messages: repairOrphanedToolResults(convertToLlm(marked)) };
 	});
 
-	pi.on("before_provider_request", (event, ctx) => {
+	pi.on("before_provider_request", async (event, ctx) => {
+		const model = event.model ?? ctx.model;
+		if (!isOpenAiRemoteCompactionModel(model)) return undefined;
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+		if (!auth.ok) return undefined;
+		const effectiveModel =
+			auth.upstreamModelId || auth.baseUrl
+				? {
+						...model,
+						...(auth.upstreamModelId ? { id: auth.upstreamModelId } : {}),
+						...(auth.baseUrl ? { baseUrl: auth.baseUrl } : {}),
+					}
+				: model;
+		const initialHeaders = createOpenAiRemoteCompactionHeaders(
+			effectiveModel,
+			auth,
+			ctx.sessionManager.getSessionId(),
+		);
+		if (!initialHeaders) return undefined;
+		const headers = new Headers(initialHeaders);
+		for (const [key, value] of Object.entries(event.headers ?? {})) {
+			if (value === null) headers.delete(key);
+			else headers.set(key, value);
+		}
+		const origin = openAiRemoteCompactionOrigin(effectiveModel, headers);
 		return rewriteOpenAiPayloadWithRemoteCompaction(
 			event.payload,
-			{ model: ctx.model, branchEntries: ctx.sessionManager.getBranch() },
+			{ model: effectiveModel, branchEntries: ctx.sessionManager.getBranch(), origin },
 			(data) => pi.events.emit(SENPI_COMPACTION_EVENT, data),
 		);
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-model.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-model.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import { arch, platform, release } from "node:os";
+import { type Api, extractOpenAiCodexAccountId, type Model } from "@earendil-works/pi-ai";
 
 export type OpenAiRemoteCompactionModel = Model<"openai-responses"> | Model<"openai-codex-responses">;
 
@@ -16,17 +17,19 @@ export type OpenAiRemoteCompactionOrigin = {
 
 type RemoteCompactionAuth = {
 	apiKey?: string;
-	headers?: Record<string, string>;
+	headers?: Record<string, string | null | undefined>;
 };
 
-const OPENAI_CODEX_INSTALLATION_ID = crypto.randomUUID();
-const AUTH_TENANT_HEADER_NAMES = new Set([
-	"authorization",
-	"api-key",
-	"x-api-key",
-	"chatgpt-account-id",
-	"openai-organization",
-	"openai-project",
+/**
+ * These headers carry request-local transport metadata only. All other final
+ * headers, including routing and security headers, scope replay provenance.
+ */
+const VOLATILE_TRANSPORT_HEADER_NAMES = new Set([
+	"content-length",
+	"user-agent",
+	"request-id",
+	"x-client-request-id",
+	"x-request-id",
 ]);
 
 function defaultOpenAiRemoteCompactionBaseUrl(model: OpenAiRemoteCompactionModel): string {
@@ -110,20 +113,20 @@ export function openAiRemoteCompactionOrigin(
 ): OpenAiRemoteCompactionOrigin | undefined {
 	const endpoint = normalizedOpenAiRemoteCompactionEndpoint(model);
 	if (!endpoint) return undefined;
-	const authHeaders = headers instanceof Headers ? [...headers.entries()] : Object.entries(headers);
-	const tenantMaterial = authHeaders
+	const finalHeaders = headers instanceof Headers ? [...headers.entries()] : Object.entries(headers);
+	const codexAccountId = finalHeaders.find(([name]) => name.toLowerCase() === "chatgpt-account-id")?.[1];
+	if (model.api === "openai-codex-responses" && (typeof codexAccountId !== "string" || !codexAccountId)) {
+		return undefined;
+	}
+
+	const tenantMaterial = finalHeaders
 		.flatMap(([name, value]) => {
 			const normalizedName = name.toLowerCase();
-			if (
-				typeof value !== "string" ||
-				value.length === 0 ||
-				(!AUTH_TENANT_HEADER_NAMES.has(normalizedName) &&
-					!normalizedName.includes("authorization") &&
-					!normalizedName.includes("credential") &&
-					!normalizedName.includes("token"))
-			) {
-				return [];
-			}
+			if (typeof value !== "string" || VOLATILE_TRANSPORT_HEADER_NAMES.has(normalizedName)) return [];
+			// Codex access JWTs rotate frequently. Its account header is stable and
+			// remains in the fingerprint alongside every other final non-volatile
+			// routing or security decision.
+			if (model.api === "openai-codex-responses" && normalizedName === "authorization") return [];
 			return [`${normalizedName}\u0000${value.trim()}`];
 		})
 		.sort();
@@ -134,19 +137,13 @@ export function openAiRemoteCompactionOrigin(
 	};
 }
 
-function extractCodexAccountId(token: string): string | undefined {
-	try {
-		const parts = token.split(".");
-		if (parts.length !== 3 || !parts[1]) return undefined;
-		const base64 = parts[1].replaceAll("-", "+").replaceAll("_", "/");
-		const payload: unknown = JSON.parse(atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")));
-		if (typeof payload !== "object" || payload === null) return undefined;
-		const auth = Reflect.get(payload, "https://api.openai.com/auth");
-		if (typeof auth !== "object" || auth === null) return undefined;
-		const accountId = Reflect.get(auth, "chatgpt_account_id");
-		return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
-	} catch {
-		return undefined;
+function applyHeaders(
+	headers: Headers,
+	additionalHeaders: Record<string, string | null | undefined> | undefined,
+): void {
+	for (const [key, value] of Object.entries(additionalHeaders ?? {})) {
+		if (value === null || value === undefined) headers.delete(key);
+		else headers.set(key, value);
 	}
 }
 
@@ -155,30 +152,30 @@ export function createOpenAiRemoteCompactionHeaders(
 	auth: RemoteCompactionAuth,
 	sessionId?: string,
 ): Headers | undefined {
-	const headers = new Headers(auth.headers);
+	const headers = new Headers(model.headers);
+	applyHeaders(headers, auth.headers);
 	headers.set("content-type", "application/json");
 	if (model.api === "openai-codex-responses" && auth.apiKey) {
+		// This matches the final Codex request contract: header hooks may add
+		// routing headers, but cannot replace configured OAuth identity.
 		headers.set("authorization", `Bearer ${auth.apiKey}`);
+		const accountId = extractOpenAiCodexAccountId(auth.apiKey);
+		if (accountId) headers.set("chatgpt-account-id", accountId);
+		else headers.delete("chatgpt-account-id");
 	} else if (!headers.has("authorization") && auth.apiKey) {
 		headers.set("authorization", `Bearer ${auth.apiKey}`);
 	}
 	if (!headers.has("authorization")) return undefined;
 
 	if (model.api === "openai-codex-responses") {
-		const accountId = auth.apiKey ? extractCodexAccountId(auth.apiKey) : undefined;
-		if (accountId && !headers.has("chatgpt-account-id")) {
-			headers.set("chatgpt-account-id", accountId);
-		}
-		if (sessionId) {
-			headers.set("session_id", sessionId);
-			headers.set("session-id", sessionId);
-			headers.set("thread-id", sessionId);
-			headers.set("x-codex-installation-id", OPENAI_CODEX_INSTALLATION_ID);
-			headers.set("x-codex-window-id", `${sessionId}:0`);
-		}
 		headers.set("originator", "senpi");
-		headers.set("user-agent", "senpi");
+		headers.set("user-agent", `senpi (${platform()} ${release()}; ${arch()})`);
 		headers.set("OpenAI-Beta", "responses=experimental");
+		headers.set("accept", "text/event-stream");
+		if (sessionId) {
+			headers.set("session-id", sessionId);
+			headers.set("x-client-request-id", sessionId);
+		}
 	}
 	return headers;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-model.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-model.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Api, Model } from "@earendil-works/pi-ai";
 
 export type OpenAiRemoteCompactionModel = Model<"openai-responses"> | Model<"openai-codex-responses">;
@@ -6,12 +7,31 @@ export type OpenAiRemoteCompactionIdentity =
 	| { provider: "openai"; api: "openai-responses" }
 	| { provider: "openai-codex"; api: "openai-codex-responses" };
 
+/** Non-secret remote state ownership persisted with a native checkpoint. */
+export type OpenAiRemoteCompactionOrigin = {
+	endpoint: string;
+	trustDomain: string;
+	authTenantFingerprint: string;
+};
+
 type RemoteCompactionAuth = {
 	apiKey?: string;
 	headers?: Record<string, string>;
 };
 
 const OPENAI_CODEX_INSTALLATION_ID = crypto.randomUUID();
+const AUTH_TENANT_HEADER_NAMES = new Set([
+	"authorization",
+	"api-key",
+	"x-api-key",
+	"chatgpt-account-id",
+	"openai-organization",
+	"openai-project",
+]);
+
+function defaultOpenAiRemoteCompactionBaseUrl(model: OpenAiRemoteCompactionModel): string {
+	return model.api === "openai-codex-responses" ? "https://chatgpt.com/backend-api" : "https://api.openai.com/v1";
+}
 
 function isTrustedOpenAiCodexBaseUrl(baseUrl: string | undefined): boolean {
 	try {
@@ -60,13 +80,58 @@ export function openAiRemoteCompactionEndpointPath(model: OpenAiRemoteCompaction
 }
 
 export function openAiRemoteCompactionEndpointUrl(model: OpenAiRemoteCompactionModel): string {
-	const defaultBaseUrl =
-		model.api === "openai-codex-responses" ? "https://chatgpt.com/backend-api" : "https://api.openai.com/v1";
-	const baseUrl = model.baseUrl || defaultBaseUrl;
+	const baseUrl = model.baseUrl || defaultOpenAiRemoteCompactionBaseUrl(model);
 	return new URL(
 		openAiRemoteCompactionEndpointPath(model),
 		baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`,
 	).toString();
+}
+
+function normalizedOpenAiRemoteCompactionEndpoint(
+	model: OpenAiRemoteCompactionModel,
+): { endpoint: string; trustDomain: string } | undefined {
+	try {
+		const url = new URL(model.baseUrl || defaultOpenAiRemoteCompactionBaseUrl(model));
+		url.username = "";
+		url.password = "";
+		url.search = "";
+		url.hash = "";
+		url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+		const endpoint = url.pathname === "/" ? url.origin : url.toString().replace(/\/$/, "");
+		return { endpoint, trustDomain: url.origin };
+	} catch {
+		return undefined;
+	}
+}
+
+export function openAiRemoteCompactionOrigin(
+	model: OpenAiRemoteCompactionModel,
+	headers: Headers | Record<string, string | null | undefined>,
+): OpenAiRemoteCompactionOrigin | undefined {
+	const endpoint = normalizedOpenAiRemoteCompactionEndpoint(model);
+	if (!endpoint) return undefined;
+	const authHeaders = headers instanceof Headers ? [...headers.entries()] : Object.entries(headers);
+	const tenantMaterial = authHeaders
+		.flatMap(([name, value]) => {
+			const normalizedName = name.toLowerCase();
+			if (
+				typeof value !== "string" ||
+				value.length === 0 ||
+				(!AUTH_TENANT_HEADER_NAMES.has(normalizedName) &&
+					!normalizedName.includes("authorization") &&
+					!normalizedName.includes("credential") &&
+					!normalizedName.includes("token"))
+			) {
+				return [];
+			}
+			return [`${normalizedName}\u0000${value.trim()}`];
+		})
+		.sort();
+	if (tenantMaterial.length === 0) return undefined;
+	return {
+		...endpoint,
+		authTenantFingerprint: `sha256:${createHash("sha256").update(tenantMaterial.join("\n")).digest("hex")}`,
+	};
 }
 
 function extractCodexAccountId(token: string): string | undefined {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-schema.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-schema.ts
@@ -1,5 +1,9 @@
 import type { ServiceTier } from "../../types.ts";
-import { type OpenAiRemoteCompactionIdentity, parseOpenAiRemoteCompactionIdentity } from "./openai-remote-model.ts";
+import {
+	type OpenAiRemoteCompactionIdentity,
+	type OpenAiRemoteCompactionOrigin,
+	parseOpenAiRemoteCompactionIdentity,
+} from "./openai-remote-model.ts";
 
 export const OPENAI_REMOTE_COMPACTION_SCHEMA = "senpi.compaction.openai-remote.v1";
 
@@ -78,11 +82,30 @@ export type OpenAiRemoteCompactionDetails = OpenAiRemoteCompactionIdentity & {
 	requestInputItemCount: number;
 	retainedInputItemCount: number;
 	replacementInput: OpenAiRemoteInputItem[];
+	/** Absent in legacy checkpoints, which intentionally cannot use native replay. */
+	origin?: OpenAiRemoteCompactionOrigin;
 	usage?: Record<string, unknown>;
 };
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseOpenAiRemoteCompactionOrigin(value: unknown): OpenAiRemoteCompactionOrigin | undefined {
+	if (!isRecord(value)) return undefined;
+	if (
+		typeof value.endpoint !== "string" ||
+		typeof value.trustDomain !== "string" ||
+		typeof value.authTenantFingerprint !== "string" ||
+		!value.authTenantFingerprint.startsWith("sha256:")
+	) {
+		return undefined;
+	}
+	return {
+		endpoint: value.endpoint,
+		trustDomain: value.trustDomain,
+		authTenantFingerprint: value.authTenantFingerprint,
+	};
 }
 
 export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCompactionDetails | undefined {
@@ -107,6 +130,9 @@ export function getOpenAiRemoteCompactionDetails(value: unknown): OpenAiRemoteCo
 		requestInputItemCount: value.requestInputItemCount,
 		retainedInputItemCount: value.retainedInputItemCount,
 		replacementInput: value.replacementInput.filter((item): item is OpenAiRemoteInputItem => isRecord(item)),
+		...(parseOpenAiRemoteCompactionOrigin(value.origin)
+			? { origin: parseOpenAiRemoteCompactionOrigin(value.origin) }
+			: {}),
 		...(isRecord(value.usage) ? { usage: value.usage } : {}),
 	};
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -1,8 +1,7 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { CompactionResult } from "../../../compaction/index.ts";
-import type { SessionEntry } from "../../../session-manager.ts";
+import { type SessionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
 import type { ServiceTier, SessionBeforeCompactEvent } from "../../types.ts";
 import type {
 	OpenAiCompactBody,
@@ -714,12 +713,12 @@ export async function runOpenAiRemoteCompaction(
 
 function latestRemoteCompaction(
 	entries: SessionEntry[],
-): { entryId: string; index: number; details: OpenAiRemoteCompactionDetails } | undefined {
+): { entryId: string; index: number; firstKeptEntryId: string; details: OpenAiRemoteCompactionDetails } | undefined {
 	for (let index = entries.length - 1; index >= 0; index--) {
 		const entry = entries[index];
 		if (entry?.type !== "compaction") continue;
 		const details = getOpenAiRemoteCompactionDetails(entry.details);
-		if (details) return { entryId: entry.id, index, details };
+		if (details) return { entryId: entry.id, index, firstKeptEntryId: entry.firstKeptEntryId, details };
 		return undefined;
 	}
 	return undefined;
@@ -737,25 +736,50 @@ function leadingPromptMessages(input: unknown): OpenAiRemoteInputItem[] {
 	return result;
 }
 
+function checkpointContextInputItemCount(
+	entries: SessionEntry[],
+	remote: { index: number; firstKeptEntryId: string },
+	model: Model<Api>,
+): number {
+	const compactionEntry = entries[remote.index];
+	if (!compactionEntry) return 0;
+
+	const firstKeptIndex = entries.findIndex((entry) => entry.id === remote.firstKeptEntryId);
+	const checkpointContextEntries = [
+		compactionEntry,
+		...(firstKeptIndex >= 0 && firstKeptIndex < remote.index ? entries.slice(firstKeptIndex, remote.index) : []),
+	];
+	return convertPendingMessages(checkpointContextEntries.flatMap(sessionEntryToContextMessages), model).length;
+}
+
+function postCheckpointPayloadItems(
+	input: unknown,
+	entries: SessionEntry[],
+	remote: { index: number; firstKeptEntryId: string },
+	model: Model<Api>,
+): Record<string, unknown>[] {
+	if (!Array.isArray(input)) return [];
+	const leadingPromptCount = leadingPromptMessages(input).length;
+	const checkpointInputItemCount = checkpointContextInputItemCount(entries, remote, model);
+	return input.slice(leadingPromptCount + checkpointInputItemCount).filter(isRecord);
+}
+
 export function rewriteOpenAiPayloadWithRemoteCompaction(
 	payload: unknown,
-	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[]; pendingMessages?: AgentMessage[] },
+	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[] },
 	emit?: EmitCompactionEvent,
 ): unknown | undefined {
 	if (!isOpenAiRemoteCompactionModel(options.model) || !isRecord(payload)) return undefined;
 	const remote = latestRemoteCompaction(options.branchEntries);
 	if (!remote || !matchesOpenAiRemoteCompactionIdentity(options.model, remote.details)) return undefined;
 
-	const postCompactionItems = convertBranchEntries(options.branchEntries.slice(remote.index + 1), options.model);
-	// The in-flight prompt is not yet persisted in the branch at provider-request
-	// time; append it so the replayed payload still carries the user's message.
-	const pendingItems = convertPendingMessages(options.pendingMessages ?? [], options.model);
-
 	const input = [
 		...leadingPromptMessages(payload.input),
 		...remote.details.replacementInput,
-		...postCompactionItems,
-		...pendingItems,
+		// Context hooks can redact or otherwise transform the live post-checkpoint
+		// messages. Replay only their final provider representation; persisted
+		// history is used solely to locate the checkpoint boundary.
+		...postCheckpointPayloadItems(payload.input, options.branchEntries, remote, options.model),
 	];
 	emit?.({
 		version: 1,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -3,7 +3,9 @@ import {
 	type Api,
 	type AssistantMessage,
 	type Context,
+	type ContextProvenance,
 	convertResponsesMessages,
+	getContextProvenance,
 	type Model,
 	type ProviderHeaders,
 	type SimpleStreamOptions,
@@ -14,6 +16,8 @@ import { convertToLlm } from "../../../messages.ts";
 import {
 	buildContextEntries,
 	buildSessionContext,
+	getSessionContextEntryId,
+	SESSION_CONTEXT_ENTRY_ID,
 	type SessionEntry,
 	sessionEntryToContextMessages,
 } from "../../../session-manager.ts";
@@ -43,9 +47,11 @@ import {
 	isOpenAiRemoteCompactionModel,
 	matchesOpenAiRemoteCompactionIdentity,
 	type OpenAiRemoteCompactionModel,
+	type OpenAiRemoteCompactionOrigin,
 	openAiRemoteCompactionEndpointPath,
 	openAiRemoteCompactionEndpointUrl,
 	openAiRemoteCompactionIdentity,
+	openAiRemoteCompactionOrigin,
 } from "./openai-remote-model.ts";
 
 export type {
@@ -101,6 +107,7 @@ type OpenAiRemoteCompactionContext = {
 					apiKey?: string;
 					headers?: Record<string, string>;
 					extraBody?: Record<string, unknown>;
+					baseUrl?: string;
 					upstreamModelId?: string;
 					serviceTier?: ServiceTier;
 			  }
@@ -160,6 +167,10 @@ type EmitCompactionEvent = (event: OpenAiRemoteCompactionEvent) => void;
 const OPENAI_REMOTE_COMPACTION_TIMEOUT_MS = 15_000;
 const REMOTE_COMPACTION_TIMEOUT_REASON = "remote-compaction-timeout";
 const INVALID_COMPACT_REQUEST_PAYLOAD_REASON = "invalid-compact-request-payload";
+const MISSING_REMOTE_REPLAY_ORIGIN_REASON = "missing-remote-replay-origin-provenance";
+const REMOTE_REPLAY_ORIGIN_MISMATCH_REASON = "remote-replay-origin-mismatch";
+const UNPROVEN_REMOTE_REPLAY_BOUNDARY_REASON = "unproven-remote-replay-boundary";
+const OPENAI_REMOTE_REPLAY_BOUNDARY_SCOPE = "openai-remote-replay";
 const OPENAI_RESPONSES_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 
 function supportsOpenAiResponsesWebSocket(model: OpenAiRemoteCompactionModel): model is Model<"openai-responses"> {
@@ -231,6 +242,7 @@ export function buildOpenAiRemoteCompactionResult(options: {
 	tokensBefore: number;
 	requestInputItemCount: number;
 	response: OpenAiCompactedResponse;
+	origin?: OpenAiRemoteCompactionOrigin;
 }): OpenAiRemoteCompactionResult {
 	const replacementInput = options.response.output.filter(isRetainedRemoteOutputItem);
 	const compactionItem = replacementInput.find(isOpenAiRemoteCompactionOutputItem);
@@ -249,6 +261,7 @@ export function buildOpenAiRemoteCompactionResult(options: {
 		requestInputItemCount: options.requestInputItemCount,
 		retainedInputItemCount: replacementInput.length,
 		replacementInput,
+		...(options.origin ? { origin: options.origin } : {}),
 		...(options.response.usage ? { usage: options.response.usage } : {}),
 	} satisfies OpenAiRemoteCompactionDetails;
 	const endpointPath =
@@ -359,6 +372,7 @@ export function buildOpenAiResponsesStreamCompactionResult(options: {
 	requestInput: OpenAiRemoteInputItem[];
 	response: AssistantMessage;
 	now: () => number;
+	origin?: OpenAiRemoteCompactionOrigin;
 }): OpenAiRemoteCompactionResult {
 	const compactionItem = findResponsesStreamCompactionOutput(options.response);
 	if (!compactionItem) {
@@ -379,6 +393,7 @@ export function buildOpenAiResponsesStreamCompactionResult(options: {
 		requestInputItemCount: options.requestInput.length,
 		retainedInputItemCount: replacementInput.length,
 		replacementInput,
+		...(options.origin ? { origin: options.origin } : {}),
 		usage: usageRecordFromAssistant(options.response),
 	} satisfies OpenAiRemoteCompactionDetails;
 
@@ -405,6 +420,7 @@ async function runOpenAiResponsesStreamCompaction(options: {
 	systemPrompt: string;
 	headers?: ProviderHeaders;
 	providerRequest?: ProviderRequestPreparation;
+	origin: OpenAiRemoteCompactionOrigin;
 }): Promise<OpenAiRemoteCompactionResult | undefined> {
 	const stream = options.streamRunner(
 		options.model,
@@ -443,6 +459,7 @@ async function runOpenAiResponsesStreamCompaction(options: {
 		requestInput: options.request.body.input,
 		response,
 		now: options.now,
+		origin: options.origin,
 	});
 }
 
@@ -456,6 +473,7 @@ async function runOpenAiCompactEndpointCompaction(options: {
 	firstKeptEntryId: string;
 	now: () => number;
 	emit?: EmitCompactionEvent;
+	origin: OpenAiRemoteCompactionOrigin;
 }): Promise<OpenAiRemoteCompactionResult | undefined> {
 	options.emit?.({
 		version: 1,
@@ -544,6 +562,7 @@ async function runOpenAiCompactEndpointCompaction(options: {
 			tokensBefore: options.request.tokensBefore,
 			requestInputItemCount: options.request.inputItemCount,
 			response: compactedResponse,
+			origin: options.origin,
 		});
 	} catch (error) {
 		options.emit?.({
@@ -608,7 +627,14 @@ export async function runOpenAiRemoteCompaction(
 		return undefined;
 	}
 
-	const requestModel = auth.upstreamModelId ? { ...model, id: auth.upstreamModelId } : model;
+	const requestModel: OpenAiRemoteCompactionModel =
+		auth.upstreamModelId || auth.baseUrl
+			? {
+					...model,
+					...(auth.upstreamModelId ? { id: auth.upstreamModelId } : {}),
+					...(auth.baseUrl ? { baseUrl: auth.baseUrl } : {}),
+				}
+			: model;
 	const serviceTier = ctx.serviceTier ?? auth.serviceTier;
 	const providerRequest = await ctx.prepareProviderRequest?.(buildSessionContext(event.branchEntries).messages);
 	const request = createOpenAiRemoteCompactionRequest({
@@ -632,9 +658,41 @@ export async function runOpenAiRemoteCompaction(
 		return undefined;
 	}
 	const remoteTimeoutMs = dependencies.remoteTimeoutMs ?? OPENAI_REMOTE_COMPACTION_TIMEOUT_MS;
+	const headers = createOpenAiRemoteCompactionHeaders(requestModel, auth, request.body.prompt_cache_key);
+	if (!headers) {
+		emit?.({
+			version: 1,
+			action: "remote_fallback",
+			route: "builtin.compaction.openai_remote",
+			requestId: event.requestId,
+			modelId: model.id,
+			reason: "missing-openai-auth",
+		});
+		return undefined;
+	}
+	const transformedHeaders = providerRequest
+		? await providerRequest.transformHeaders(Object.fromEntries(headers.entries()))
+		: undefined;
+	const requestHeaders = transformedHeaders
+		? new Headers(
+				Object.entries(transformedHeaders).flatMap(([key, value]) => (value === null ? [] : [[key, value]])),
+			)
+		: headers;
+	const origin = openAiRemoteCompactionOrigin(requestModel, requestHeaders);
+	if (!origin) {
+		emit?.({
+			version: 1,
+			action: "remote_fallback",
+			route: "builtin.compaction.openai_remote",
+			requestId: event.requestId,
+			modelId: requestModel.id,
+			reason: MISSING_REMOTE_REPLAY_ORIGIN_REASON,
+		});
+		return undefined;
+	}
 
 	if (supportsOpenAiResponsesWebSocket(requestModel)) {
-		const headers = providerRequest ? await providerRequest.transformHeaders(auth.headers ?? {}) : auth.headers;
+		const websocketHeaders = Object.fromEntries(requestHeaders.entries());
 		emit?.({
 			version: 1,
 			action: "remote_started",
@@ -670,8 +728,9 @@ export async function runOpenAiRemoteCompaction(
 							dependencies.streamRunner ??
 							((streamModel, context, options) => streamSimple(streamModel, context, options)),
 						systemPrompt: ctx.getSystemPrompt(),
-						headers,
+						headers: websocketHeaders,
 						providerRequest,
+						origin,
 					}),
 			});
 			if (result) {
@@ -710,18 +769,6 @@ export async function runOpenAiRemoteCompaction(
 		}
 	}
 
-	const headers = createOpenAiRemoteCompactionHeaders(requestModel, auth, request.body.prompt_cache_key);
-	if (!headers) {
-		emit?.({
-			version: 1,
-			action: "remote_fallback",
-			route: "builtin.compaction.openai_remote",
-			requestId: event.requestId,
-			modelId: model.id,
-			reason: "missing-openai-auth",
-		});
-		return undefined;
-	}
 	const transformedPayload = providerRequest ? await providerRequest.transformPayload(request.body) : request.body;
 	if (!isOpenAiCompactBody(transformedPayload)) {
 		emit?.({
@@ -736,14 +783,6 @@ export async function runOpenAiRemoteCompaction(
 		return undefined;
 	}
 	const transformedRequest = { ...request, body: transformedPayload };
-	const transformedHeaders = providerRequest
-		? await providerRequest.transformHeaders(Object.fromEntries(headers.entries()))
-		: undefined;
-	const requestHeaders = transformedHeaders
-		? new Headers(
-				Object.entries(transformedHeaders).flatMap(([key, value]) => (value === null ? [] : [[key, value]])),
-			)
-		: headers;
 
 	return runWithRemoteTimeout({
 		signal: event.signal,
@@ -769,6 +808,7 @@ export async function runOpenAiRemoteCompaction(
 				firstKeptEntryId: event.preparation.firstKeptEntryId,
 				now: dependencies.now ?? Date.now,
 				emit,
+				origin,
 			}),
 	});
 }
@@ -786,14 +826,24 @@ function latestRemoteCompaction(
 	return undefined;
 }
 
-function checkpointContextMessages(
-	entries: SessionEntry[],
-	remote: { index: number; firstKeptEntryId: string },
-): AgentMessage[] {
+type OpenAiRemoteReplayBoundary = ContextProvenance & {
+	scope: typeof OPENAI_REMOTE_REPLAY_BOUNDARY_SCOPE;
+	compactionEntryId: string;
+	ordinal: number;
+	expectedOrdinals: number[];
+	integrity?: string;
+};
+
+type RemoteCompactionCheckpoint = {
+	entryId: string;
+	index: number;
+	firstKeptEntryId: string;
+	details: OpenAiRemoteCompactionDetails;
+};
+
+function checkpointContextEntries(entries: SessionEntry[], remote: RemoteCompactionCheckpoint): SessionEntry[] {
 	const checkpointEntryIds = new Set(entries.slice(0, remote.index + 1).map((entry) => entry.id));
-	return buildContextEntries(entries)
-		.filter((entry) => checkpointEntryIds.has(entry.id))
-		.flatMap(sessionEntryToContextMessages);
+	return buildContextEntries(entries).filter((entry) => checkpointEntryIds.has(entry.id));
 }
 
 function leadingPromptMessages(input: unknown): OpenAiRemoteInputItem[] {
@@ -815,48 +865,169 @@ function replayBoundaryConversionOptions(model: Model<Api>): {
 	return model.api === "openai-codex-responses" ? { includeSystemPrompt: false, preserveTextSignatures: true } : {};
 }
 
-function checkpointProviderInputItems(
-	entries: SessionEntry[],
-	remote: { index: number; firstKeptEntryId: string },
-	model: Model<Api>,
-): unknown[] {
-	const input = convertResponsesMessages(
-		model,
-		{ messages: convertToLlm(checkpointContextMessages(entries, remote)) },
-		OPENAI_RESPONSES_TOOL_CALL_PROVIDERS,
-		replayBoundaryConversionOptions(model),
+function isRemoteReplayBoundary(value: unknown): value is OpenAiRemoteReplayBoundary {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const boundary = value as Record<string, unknown>;
+	return (
+		boundary.scope === OPENAI_REMOTE_REPLAY_BOUNDARY_SCOPE &&
+		typeof boundary.compactionEntryId === "string" &&
+		typeof boundary.ordinal === "number" &&
+		Array.isArray(boundary.expectedOrdinals) &&
+		boundary.expectedOrdinals.every((ordinal) => typeof ordinal === "number") &&
+		typeof boundary.integrity === "string"
 	);
-	return Array.isArray(input) ? input : [];
 }
 
-function hasExactReplayPrefix(input: unknown[], startIndex: number, expected: unknown[]): boolean {
-	if (expected.length === 0 || input.length < startIndex + expected.length) return false;
-	return expected.every((item, index) => JSON.stringify(input[startIndex + index]) === JSON.stringify(item));
+function replayBoundaryForInputItem(value: unknown): OpenAiRemoteReplayBoundary | undefined {
+	const provenance = getContextProvenance(value);
+	return isRemoteReplayBoundary(provenance) ? provenance : undefined;
+}
+
+function sameOrdinals(left: readonly number[], right: readonly number[]): boolean {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function emitReplayFallback(
+	emit: EmitCompactionEvent | undefined,
+	remote: RemoteCompactionCheckpoint,
+	modelId: string,
+	reason: string,
+): void {
+	emit?.({
+		version: 1,
+		action: "remote_fallback",
+		route: "builtin.compaction.openai_remote",
+		requestId: `replay:${remote.entryId}`,
+		modelId,
+		reason,
+	});
+}
+
+function matchingReplayOrigin(
+	persisted: OpenAiRemoteCompactionOrigin | undefined,
+	current: OpenAiRemoteCompactionOrigin | undefined,
+): boolean {
+	return (
+		persisted !== undefined &&
+		current !== undefined &&
+		persisted.endpoint === current.endpoint &&
+		persisted.trustDomain === current.trustDomain &&
+		persisted.authTenantFingerprint === current.authTenantFingerprint
+	);
+}
+
+/**
+ * Mark the exact checkpoint-owned messages before later context hooks run.
+ * The markers carry entry identity, not payload values; the Responses converter
+ * transports them as non-enumerable request-local metadata for final validation.
+ */
+export function markOpenAiRemoteReplayBoundary(
+	messages: AgentMessage[],
+	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[] },
+): AgentMessage[] {
+	if (!isOpenAiRemoteCompactionModel(options.model)) return messages;
+	const remote = latestRemoteCompaction(options.branchEntries);
+	if (!remote?.details.origin || !matchesOpenAiRemoteCompactionIdentity(options.model, remote.details)) {
+		return messages;
+	}
+	const entryIds = checkpointContextEntries(options.branchEntries, remote)
+		.filter((entry) => sessionEntryToContextMessages(entry).length > 0)
+		.map((entry) => entry.id);
+	if (
+		entryIds.length === 0 ||
+		messages.length < entryIds.length ||
+		!entryIds.every((entryId, index) => {
+			const message = messages[index] as AgentMessage & { [SESSION_CONTEXT_ENTRY_ID]?: unknown };
+			return message?.[SESSION_CONTEXT_ENTRY_ID] === entryId || getSessionContextEntryId(message) === entryId;
+		})
+	) {
+		return messages;
+	}
+
+	const expectedOrdinals: number[] = [];
+	const marked = messages.map((message, index) => {
+		if (index >= entryIds.length) return message;
+		const boundary: OpenAiRemoteReplayBoundary = {
+			scope: OPENAI_REMOTE_REPLAY_BOUNDARY_SCOPE,
+			compactionEntryId: remote.entryId,
+			ordinal: index,
+			expectedOrdinals,
+		};
+		return Object.assign({}, message, { __piContextProvenance: boundary }) as AgentMessage;
+	});
+	const baseline = convertResponsesMessages(
+		options.model,
+		{ messages: convertToLlm(marked) },
+		OPENAI_RESPONSES_TOOL_CALL_PROVIDERS,
+		{ ...replayBoundaryConversionOptions(options.model), sealContextProvenance: true },
+	);
+	for (const item of baseline) {
+		const boundary = replayBoundaryForInputItem(item);
+		if (boundary?.compactionEntryId === remote.entryId) expectedOrdinals.push(boundary.ordinal);
+	}
+	return expectedOrdinals.length > 0 ? marked : messages;
 }
 
 export function rewriteOpenAiPayloadWithRemoteCompaction(
 	payload: unknown,
-	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[] },
+	options: {
+		model: Model<Api> | undefined;
+		branchEntries: SessionEntry[];
+		origin?: OpenAiRemoteCompactionOrigin;
+	},
 	emit?: EmitCompactionEvent,
 ): unknown | undefined {
-	if (!isOpenAiRemoteCompactionModel(options.model) || !isRecord(payload) || !Array.isArray(payload.input)) {
+	if (!isOpenAiRemoteCompactionModel(options.model) || !isRecord(payload)) {
 		return undefined;
 	}
+	const payloadInput = payload.input;
+	if (!Array.isArray(payloadInput)) return undefined;
 	const remote = latestRemoteCompaction(options.branchEntries);
-	if (!remote || !matchesOpenAiRemoteCompactionIdentity(options.model, remote.details)) return undefined;
+	if (!remote) return undefined;
+	if (!matchesOpenAiRemoteCompactionIdentity(options.model, remote.details)) {
+		emitReplayFallback(emit, remote, options.model.id, "remote-replay-identity-mismatch");
+		return undefined;
+	}
+	if (!remote.details.origin || !options.origin) {
+		emitReplayFallback(emit, remote, options.model.id, MISSING_REMOTE_REPLAY_ORIGIN_REASON);
+		return undefined;
+	}
+	if (!matchingReplayOrigin(remote.details.origin, options.origin)) {
+		emitReplayFallback(emit, remote, options.model.id, REMOTE_REPLAY_ORIGIN_MISMATCH_REASON);
+		return undefined;
+	}
 
-	const checkpointInput = checkpointProviderInputItems(options.branchEntries, remote, options.model);
-	const checkpointStart = leadingPromptMessages(payload.input).length;
-	// This is a provenance check, not a persisted-item count: use the same
-	// Responses converter as the real provider path, then require every final
-	// prefix item to match exactly. Context changes that insert, remove, reorder,
-	// or alter checkpoint content leave the final payload untouched.
-	if (!hasExactReplayPrefix(payload.input, checkpointStart, checkpointInput)) return undefined;
+	const checkpointStart = leadingPromptMessages(payloadInput).length;
+	const allBoundaries = payloadInput
+		.map(replayBoundaryForInputItem)
+		.filter((boundary): boundary is OpenAiRemoteReplayBoundary => boundary?.compactionEntryId === remote.entryId);
+	const expectedOrdinals = allBoundaries[0]?.expectedOrdinals;
+	if (
+		!expectedOrdinals ||
+		expectedOrdinals.length === 0 ||
+		allBoundaries.length !== expectedOrdinals.length ||
+		payloadInput.length < checkpointStart + expectedOrdinals.length ||
+		!allBoundaries.every(
+			(boundary, index) =>
+				sameOrdinals(boundary.expectedOrdinals, expectedOrdinals) && boundary.ordinal === expectedOrdinals[index],
+		) ||
+		!expectedOrdinals.every((ordinal: number, index: number) => {
+			const boundary = replayBoundaryForInputItem(payloadInput[checkpointStart + index]);
+			return (
+				boundary?.compactionEntryId === remote.entryId &&
+				boundary.ordinal === ordinal &&
+				sameOrdinals(boundary.expectedOrdinals, expectedOrdinals)
+			);
+		})
+	) {
+		emitReplayFallback(emit, remote, options.model.id, UNPROVEN_REMOTE_REPLAY_BOUNDARY_REASON);
+		return undefined;
+	}
 
 	const input = [
-		...payload.input.slice(0, checkpointStart).filter(isRecord),
+		...payloadInput.slice(0, checkpointStart).filter(isRecord),
 		...remote.details.replacementInput,
-		...payload.input.slice(checkpointStart + checkpointInput.length).filter(isRecord),
+		...payloadInput.slice(checkpointStart + expectedOrdinals.length).filter(isRecord),
 	];
 	emit?.({
 		version: 1,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -1,8 +1,18 @@
-import type { Api, AssistantMessage, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import {
+	type Api,
+	type AssistantMessage,
+	type Context,
+	convertResponsesMessages,
+	type Model,
+	type ProviderHeaders,
+	type SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { CompactionResult } from "../../../compaction/index.ts";
-import { type SessionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
-import type { ServiceTier, SessionBeforeCompactEvent } from "../../types.ts";
+import { convertToLlm } from "../../../messages.ts";
+import { buildSessionContext, type SessionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
+import type { ProviderRequestPreparation, ServiceTier, SessionBeforeCompactEvent } from "../../types.ts";
 import type {
 	OpenAiCompactBody,
 	OpenAiContextCompactionItem,
@@ -99,6 +109,7 @@ type OpenAiRemoteCompactionContext = {
 	sessionManager: {
 		getSessionId(): string;
 	};
+	prepareProviderRequest?(messages: AgentMessage[]): Promise<ProviderRequestPreparation>;
 };
 
 type OpenAiRemoteCompactionEvent =
@@ -143,6 +154,7 @@ type EmitCompactionEvent = (event: OpenAiRemoteCompactionEvent) => void;
 
 const OPENAI_REMOTE_COMPACTION_TIMEOUT_MS = 15_000;
 const REMOTE_COMPACTION_TIMEOUT_REASON = "remote-compaction-timeout";
+const OPENAI_RESPONSES_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 
 function supportsOpenAiResponsesWebSocket(model: OpenAiRemoteCompactionModel): model is Model<"openai-responses"> {
 	if (model.provider !== "openai" || model.api !== "openai-responses") return false;
@@ -158,12 +170,15 @@ export function createOpenAiRemoteCompactionRequest(options: {
 	model: Model<Api> | undefined;
 	systemPrompt: string;
 	branchEntries: SessionEntry[];
+	messages?: AgentMessage[];
 	tokensBefore: number;
 	promptCacheKey?: string;
 	serviceTier?: ServiceTier;
 }): OpenAiRemoteCompactionRequest | undefined {
 	if (!isOpenAiRemoteCompactionModel(options.model)) return undefined;
-	const input = convertBranchEntries(options.branchEntries, options.model);
+	const input = options.messages
+		? convertPendingMessages(options.messages, options.model)
+		: convertBranchEntries(options.branchEntries, options.model);
 	if (input.length === 0) return undefined;
 	return {
 		body: {
@@ -382,6 +397,8 @@ async function runOpenAiResponsesStreamCompaction(options: {
 	signal: AbortSignal;
 	streamRunner: OpenAiResponsesStreamRunner;
 	systemPrompt: string;
+	headers?: ProviderHeaders;
+	providerRequest?: ProviderRequestPreparation;
 }): Promise<OpenAiRemoteCompactionResult | undefined> {
 	const stream = options.streamRunner(
 		options.model,
@@ -390,13 +407,13 @@ async function runOpenAiResponsesStreamCompaction(options: {
 			apiKey: options.auth.apiKey,
 			cacheRetention: "short",
 			extraBody: options.auth.extraBody,
-			headers: options.auth.headers,
+			headers: options.headers ?? options.auth.headers,
 			onPayload: (payload) => {
 				const rewritten = createOpenAiResponsesStreamCompactionPayload(payload, options.request);
 				if (!isRecord(rewritten) || !Array.isArray(rewritten.input)) {
 					throw new Error("Unable to build OpenAI Responses stream compaction payload");
 				}
-				return rewritten;
+				return options.providerRequest ? options.providerRequest.transformPayload(rewritten) : rewritten;
 			},
 			sessionId: options.request.body.prompt_cache_key,
 			signal: options.signal,
@@ -541,6 +558,10 @@ async function runOpenAiCompactEndpointCompaction(options: {
 	return result;
 }
 
+function isOpenAiCompactBody(value: unknown): value is OpenAiCompactBody {
+	return isRecord(value) && typeof value.model === "string" && Array.isArray(value.input);
+}
+
 export async function runOpenAiRemoteCompaction(
 	ctx: OpenAiRemoteCompactionContext,
 	event: SessionBeforeCompactEvent,
@@ -575,10 +596,12 @@ export async function runOpenAiRemoteCompaction(
 
 	const requestModel = auth.upstreamModelId ? { ...model, id: auth.upstreamModelId } : model;
 	const serviceTier = ctx.serviceTier ?? auth.serviceTier;
+	const providerRequest = await ctx.prepareProviderRequest?.(buildSessionContext(event.branchEntries).messages);
 	const request = createOpenAiRemoteCompactionRequest({
 		model: requestModel,
 		systemPrompt: ctx.getSystemPrompt(),
 		branchEntries: event.branchEntries,
+		messages: providerRequest?.messages,
 		tokensBefore: event.preparation.tokensBefore,
 		promptCacheKey: ctx.sessionManager.getSessionId(),
 		serviceTier,
@@ -597,6 +620,7 @@ export async function runOpenAiRemoteCompaction(
 	const remoteTimeoutMs = dependencies.remoteTimeoutMs ?? OPENAI_REMOTE_COMPACTION_TIMEOUT_MS;
 
 	if (supportsOpenAiResponsesWebSocket(requestModel)) {
+		const headers = providerRequest ? await providerRequest.transformHeaders(auth.headers ?? {}) : auth.headers;
 		emit?.({
 			version: 1,
 			action: "remote_started",
@@ -632,6 +656,8 @@ export async function runOpenAiRemoteCompaction(
 							dependencies.streamRunner ??
 							((streamModel, context, options) => streamSimple(streamModel, context, options)),
 						systemPrompt: ctx.getSystemPrompt(),
+						headers,
+						providerRequest,
 					}),
 			});
 			if (result) {
@@ -682,6 +708,18 @@ export async function runOpenAiRemoteCompaction(
 		});
 		return undefined;
 	}
+	const transformedPayload = providerRequest ? await providerRequest.transformPayload(request.body) : request.body;
+	const transformedRequest = isOpenAiCompactBody(transformedPayload)
+		? { ...request, body: transformedPayload }
+		: request;
+	const transformedHeaders = providerRequest
+		? await providerRequest.transformHeaders(Object.fromEntries(headers.entries()))
+		: undefined;
+	const requestHeaders = transformedHeaders
+		? new Headers(
+				Object.entries(transformedHeaders).flatMap(([key, value]) => (value === null ? [] : [[key, value]])),
+			)
+		: headers;
 
 	return runWithRemoteTimeout({
 		signal: event.signal,
@@ -699,9 +737,9 @@ export async function runOpenAiRemoteCompaction(
 		run: (signal) =>
 			runOpenAiCompactEndpointCompaction({
 				fetchImpl: dependencies.fetch ?? fetch,
-				headers,
+				headers: requestHeaders,
 				model: requestModel,
-				request,
+				request: transformedRequest,
 				requestId: event.requestId,
 				signal,
 				firstKeptEntryId: event.preparation.firstKeptEntryId,
@@ -749,7 +787,14 @@ function checkpointContextInputItemCount(
 		compactionEntry,
 		...(firstKeptIndex >= 0 && firstKeptIndex < remote.index ? entries.slice(firstKeptIndex, remote.index) : []),
 	];
-	return convertPendingMessages(checkpointContextEntries.flatMap(sessionEntryToContextMessages), model).length;
+	// Match the converter that produced the final Responses payload. In
+	// particular, it drops aborted/error assistants, their orphaned results,
+	// and empty users, so this boundary stays aligned with the live request.
+	return convertResponsesMessages(
+		model,
+		{ messages: convertToLlm(checkpointContextEntries.flatMap(sessionEntryToContextMessages)) },
+		OPENAI_RESPONSES_TOOL_CALL_PROVIDERS,
+	).length;
 }
 
 function postCheckpointPayloadItems(

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -11,7 +11,12 @@ import {
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { CompactionResult } from "../../../compaction/index.ts";
 import { convertToLlm } from "../../../messages.ts";
-import { buildSessionContext, type SessionEntry, sessionEntryToContextMessages } from "../../../session-manager.ts";
+import {
+	buildContextEntries,
+	buildSessionContext,
+	type SessionEntry,
+	sessionEntryToContextMessages,
+} from "../../../session-manager.ts";
 import type { ProviderRequestPreparation, ServiceTier, SessionBeforeCompactEvent } from "../../types.ts";
 import type {
 	OpenAiCompactBody,
@@ -779,14 +784,11 @@ function checkpointContextInputItemCount(
 	remote: { index: number; firstKeptEntryId: string },
 	model: Model<Api>,
 ): number {
-	const compactionEntry = entries[remote.index];
-	if (!compactionEntry) return 0;
-
-	const firstKeptIndex = entries.findIndex((entry) => entry.id === remote.firstKeptEntryId);
-	const checkpointContextEntries = [
-		compactionEntry,
-		...(firstKeptIndex >= 0 && firstKeptIndex < remote.index ? entries.slice(firstKeptIndex, remote.index) : []),
-	];
+	const checkpointEntryIds = new Set(entries.slice(0, remote.index + 1).map((entry) => entry.id));
+	// Project through the same compaction-aware helper as live session context,
+	// then retain only the prefix that existed at this checkpoint. This omits
+	// older summaries superseded by the latest compaction entry.
+	const checkpointContextEntries = buildContextEntries(entries).filter((entry) => checkpointEntryIds.has(entry.id));
 	// Match the converter that produced the final Responses payload. In
 	// particular, it drops aborted/error assistants, their orphaned results,
 	// and empty users, so this boundary stays aligned with the live request.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -658,8 +658,19 @@ export async function runOpenAiRemoteCompaction(
 		return undefined;
 	}
 	const remoteTimeoutMs = dependencies.remoteTimeoutMs ?? OPENAI_REMOTE_COMPACTION_TIMEOUT_MS;
-	const headers = createOpenAiRemoteCompactionHeaders(requestModel, auth, request.body.prompt_cache_key);
-	if (!headers) {
+	// Normal provider requests transform configured headers before the Codex
+	// transport applies its canonical auth/account fields. Mirror that ordering
+	// so extension routing choices are retained but cannot impersonate another
+	// OAuth account on either the wire or persisted provenance.
+	const transformedHeaders = providerRequest
+		? await providerRequest.transformHeaders(auth.headers ?? {})
+		: auth.headers;
+	const requestHeaders = createOpenAiRemoteCompactionHeaders(
+		requestModel,
+		{ ...auth, headers: transformedHeaders },
+		request.body.prompt_cache_key,
+	);
+	if (!requestHeaders) {
 		emit?.({
 			version: 1,
 			action: "remote_fallback",
@@ -670,14 +681,6 @@ export async function runOpenAiRemoteCompaction(
 		});
 		return undefined;
 	}
-	const transformedHeaders = providerRequest
-		? await providerRequest.transformHeaders(Object.fromEntries(headers.entries()))
-		: undefined;
-	const requestHeaders = transformedHeaders
-		? new Headers(
-				Object.entries(transformedHeaders).flatMap(([key, value]) => (value === null ? [] : [[key, value]])),
-			)
-		: headers;
 	const origin = openAiRemoteCompactionOrigin(requestModel, requestHeaders);
 	if (!origin) {
 		emit?.({

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -159,6 +159,7 @@ type EmitCompactionEvent = (event: OpenAiRemoteCompactionEvent) => void;
 
 const OPENAI_REMOTE_COMPACTION_TIMEOUT_MS = 15_000;
 const REMOTE_COMPACTION_TIMEOUT_REASON = "remote-compaction-timeout";
+const INVALID_COMPACT_REQUEST_PAYLOAD_REASON = "invalid-compact-request-payload";
 const OPENAI_RESPONSES_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 
 function supportsOpenAiResponsesWebSocket(model: OpenAiRemoteCompactionModel): model is Model<"openai-responses"> {
@@ -413,12 +414,18 @@ async function runOpenAiResponsesStreamCompaction(options: {
 			cacheRetention: "short",
 			extraBody: options.auth.extraBody,
 			headers: options.headers ?? options.auth.headers,
-			onPayload: (payload) => {
+			onPayload: async (payload) => {
 				const rewritten = createOpenAiResponsesStreamCompactionPayload(payload, options.request);
 				if (!isRecord(rewritten) || !Array.isArray(rewritten.input)) {
 					throw new Error("Unable to build OpenAI Responses stream compaction payload");
 				}
-				return options.providerRequest ? options.providerRequest.transformPayload(rewritten) : rewritten;
+				const transformedPayload = options.providerRequest
+					? await options.providerRequest.transformPayload(rewritten)
+					: rewritten;
+				if (!isOpenAiCompactBody(transformedPayload)) {
+					throw new Error(INVALID_COMPACT_REQUEST_PAYLOAD_REASON);
+				}
+				return transformedPayload;
 			},
 			sessionId: options.request.body.prompt_cache_key,
 			signal: options.signal,
@@ -564,7 +571,9 @@ async function runOpenAiCompactEndpointCompaction(options: {
 }
 
 function isOpenAiCompactBody(value: unknown): value is OpenAiCompactBody {
-	return isRecord(value) && typeof value.model === "string" && Array.isArray(value.input);
+	return (
+		isRecord(value) && typeof value.model === "string" && Array.isArray(value.input) && value.input.every(isRecord)
+	);
 }
 
 export async function runOpenAiRemoteCompaction(
@@ -714,9 +723,19 @@ export async function runOpenAiRemoteCompaction(
 		return undefined;
 	}
 	const transformedPayload = providerRequest ? await providerRequest.transformPayload(request.body) : request.body;
-	const transformedRequest = isOpenAiCompactBody(transformedPayload)
-		? { ...request, body: transformedPayload }
-		: request;
+	if (!isOpenAiCompactBody(transformedPayload)) {
+		emit?.({
+			version: 1,
+			action: "remote_fallback",
+			route: "builtin.compaction.openai_remote",
+			requestId: event.requestId,
+			modelId: requestModel.id,
+			reason: INVALID_COMPACT_REQUEST_PAYLOAD_REASON,
+			transport: "compact-endpoint",
+		});
+		return undefined;
+	}
+	const transformedRequest = { ...request, body: transformedPayload };
 	const transformedHeaders = providerRequest
 		? await providerRequest.transformHeaders(Object.fromEntries(headers.entries()))
 		: undefined;
@@ -767,6 +786,16 @@ function latestRemoteCompaction(
 	return undefined;
 }
 
+function checkpointContextMessages(
+	entries: SessionEntry[],
+	remote: { index: number; firstKeptEntryId: string },
+): AgentMessage[] {
+	const checkpointEntryIds = new Set(entries.slice(0, remote.index + 1).map((entry) => entry.id));
+	return buildContextEntries(entries)
+		.filter((entry) => checkpointEntryIds.has(entry.id))
+		.flatMap(sessionEntryToContextMessages);
+}
+
 function leadingPromptMessages(input: unknown): OpenAiRemoteInputItem[] {
 	if (!Array.isArray(input)) return [];
 	const result: OpenAiRemoteInputItem[] = [];
@@ -779,36 +808,30 @@ function leadingPromptMessages(input: unknown): OpenAiRemoteInputItem[] {
 	return result;
 }
 
-function checkpointContextInputItemCount(
-	entries: SessionEntry[],
-	remote: { index: number; firstKeptEntryId: string },
-	model: Model<Api>,
-): number {
-	const checkpointEntryIds = new Set(entries.slice(0, remote.index + 1).map((entry) => entry.id));
-	// Project through the same compaction-aware helper as live session context,
-	// then retain only the prefix that existed at this checkpoint. This omits
-	// older summaries superseded by the latest compaction entry.
-	const checkpointContextEntries = buildContextEntries(entries).filter((entry) => checkpointEntryIds.has(entry.id));
-	// Match the converter that produced the final Responses payload. In
-	// particular, it drops aborted/error assistants, their orphaned results,
-	// and empty users, so this boundary stays aligned with the live request.
-	return convertResponsesMessages(
-		model,
-		{ messages: convertToLlm(checkpointContextEntries.flatMap(sessionEntryToContextMessages)) },
-		OPENAI_RESPONSES_TOOL_CALL_PROVIDERS,
-	).length;
+function replayBoundaryConversionOptions(model: Model<Api>): {
+	includeSystemPrompt?: boolean;
+	preserveTextSignatures?: boolean;
+} {
+	return model.api === "openai-codex-responses" ? { includeSystemPrompt: false, preserveTextSignatures: true } : {};
 }
 
-function postCheckpointPayloadItems(
-	input: unknown,
+function checkpointProviderInputItems(
 	entries: SessionEntry[],
 	remote: { index: number; firstKeptEntryId: string },
 	model: Model<Api>,
-): Record<string, unknown>[] {
-	if (!Array.isArray(input)) return [];
-	const leadingPromptCount = leadingPromptMessages(input).length;
-	const checkpointInputItemCount = checkpointContextInputItemCount(entries, remote, model);
-	return input.slice(leadingPromptCount + checkpointInputItemCount).filter(isRecord);
+): unknown[] {
+	const input = convertResponsesMessages(
+		model,
+		{ messages: convertToLlm(checkpointContextMessages(entries, remote)) },
+		OPENAI_RESPONSES_TOOL_CALL_PROVIDERS,
+		replayBoundaryConversionOptions(model),
+	);
+	return Array.isArray(input) ? input : [];
+}
+
+function hasExactReplayPrefix(input: unknown[], startIndex: number, expected: unknown[]): boolean {
+	if (expected.length === 0 || input.length < startIndex + expected.length) return false;
+	return expected.every((item, index) => JSON.stringify(input[startIndex + index]) === JSON.stringify(item));
 }
 
 export function rewriteOpenAiPayloadWithRemoteCompaction(
@@ -816,17 +839,24 @@ export function rewriteOpenAiPayloadWithRemoteCompaction(
 	options: { model: Model<Api> | undefined; branchEntries: SessionEntry[] },
 	emit?: EmitCompactionEvent,
 ): unknown | undefined {
-	if (!isOpenAiRemoteCompactionModel(options.model) || !isRecord(payload)) return undefined;
+	if (!isOpenAiRemoteCompactionModel(options.model) || !isRecord(payload) || !Array.isArray(payload.input)) {
+		return undefined;
+	}
 	const remote = latestRemoteCompaction(options.branchEntries);
 	if (!remote || !matchesOpenAiRemoteCompactionIdentity(options.model, remote.details)) return undefined;
 
+	const checkpointInput = checkpointProviderInputItems(options.branchEntries, remote, options.model);
+	const checkpointStart = leadingPromptMessages(payload.input).length;
+	// This is a provenance check, not a persisted-item count: use the same
+	// Responses converter as the real provider path, then require every final
+	// prefix item to match exactly. Context changes that insert, remove, reorder,
+	// or alter checkpoint content leave the final payload untouched.
+	if (!hasExactReplayPrefix(payload.input, checkpointStart, checkpointInput)) return undefined;
+
 	const input = [
-		...leadingPromptMessages(payload.input),
+		...payload.input.slice(0, checkpointStart).filter(isRecord),
 		...remote.details.replacementInput,
-		// Context hooks can redact or otherwise transform the live post-checkpoint
-		// messages. Replay only their final provider representation; persisted
-		// history is used solely to locate the checkpoint boundary.
-		...postCheckpointPayloadItems(payload.input, options.branchEntries, remote, options.model),
+		...payload.input.slice(checkpointStart + checkpointInput.length).filter(isRecord),
 	];
 	emit?.({
 		version: 1,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -49,7 +49,7 @@ export interface SpeculativeCompactionContext {
 	getSystemPrompt?(): string;
 	applyCompaction(
 		precomputed: CompactionResult,
-		options: { reason: "extension"; expectedRevision: number },
+		options: { reason: "extension"; expectedRevision: number; signal?: AbortSignal },
 	): Promise<ApplyCompactionResult>;
 }
 
@@ -466,6 +466,7 @@ export async function applyGeneratedCompaction(
 	snapshot: SpeculativeCompactionSnapshot | undefined,
 	getCurrentGeneration: () => number,
 	compaction: CompactionResult | undefined,
+	signal?: AbortSignal,
 ): Promise<SpeculativeCompactionResult> {
 	if (!snapshot || !compaction) return { applied: false, reason: "unavailable" };
 
@@ -476,6 +477,7 @@ export async function applyGeneratedCompaction(
 	return await context.applyCompaction(compaction, {
 		reason: "extension",
 		expectedRevision: snapshot.expectedRevision,
+		signal,
 	});
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -23,7 +23,7 @@ import {
 import { convertToLlm } from "../../../messages.ts";
 import type { ModelRegistry } from "../../../model-registry.ts";
 import type { ReadonlySessionManager } from "../../../session-manager.ts";
-import type { ApplyCompactionResult, ContextUsage } from "../../types.ts";
+import type { ApplyCompactionResult, ContextUsage, ProviderRequestPreparation } from "../../types.ts";
 import { sanitizeAnthropicPayload } from "../tool-pair-guard/sanitize-anthropic-payload.ts";
 import { computeEffectiveKeepRecentTokens, computeEffectiveThreshold } from "./policy.ts";
 import { buildPrompt, type MergedCompactionPromptVariant } from "./prompts.ts";
@@ -47,6 +47,7 @@ export interface SpeculativeCompactionContext {
 	getCompactionSettings?(): CompactionPreparation["settings"];
 	getMessageRevision(): number;
 	getSystemPrompt?(): string;
+	prepareProviderRequest?(messages: AgentMessage[]): Promise<ProviderRequestPreparation>;
 	applyCompaction(
 		precomputed: CompactionResult,
 		options: { reason: "extension"; expectedRevision: number; signal?: AbortSignal },
@@ -121,6 +122,7 @@ function isAssistantMessage(message: Message): message is AssistantMessage {
 }
 
 async function generateSummaryMessage(options: {
+	context: SpeculativeCompactionContext;
 	messages: AgentMessage[];
 	onProgress?: CompactionProgressCallback;
 	prompt: ReturnType<typeof buildPrompt>;
@@ -148,29 +150,36 @@ async function generateSummaryMessage(options: {
 		else options.signal.addEventListener("abort", onCallerAbort, { once: true });
 	}
 	try {
-		const responseStream = stream(
-			options.snapshot.model,
-			{
-				systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
-				messages: [
-					...conversationMessages,
-					{
-						role: "user",
-						content: [{ type: "text", text: options.prompt.user }],
-						timestamp: Date.now(),
-					},
-				],
-				...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
+		const requestContext = {
+			systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
+			messages: [
+				...conversationMessages,
+				{
+					role: "user" as const,
+					content: [{ type: "text" as const, text: options.prompt.user }],
+					timestamp: Date.now(),
+				},
+			],
+			...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
+		};
+		const providerRequest = await options.context.prepareProviderRequest?.(requestContext.messages);
+		const providerContext = providerRequest
+			? { ...requestContext, messages: convertToLlm(providerRequest.messages) }
+			: requestContext;
+		const headers = providerRequest
+			? await providerRequest.transformHeaders(options.auth.headers ?? {})
+			: options.auth.headers;
+		const responseStream = stream(options.snapshot.model, providerContext, {
+			apiKey: options.auth.apiKey,
+			headers,
+			extraBody: options.auth.extraBody,
+			onPayload: async (payload, model) => {
+				const sanitized = model.api === "anthropic-messages" ? sanitizeAnthropicPayload(payload) : payload;
+				return providerRequest ? await providerRequest.transformPayload(sanitized) : sanitized;
 			},
-			{
-				apiKey: options.auth.apiKey,
-				headers: options.auth.headers,
-				extraBody: options.auth.extraBody,
-				...(options.snapshot.model.api === "anthropic-messages" ? { onPayload: sanitizeAnthropicPayload } : {}),
-				maxTokens: summaryMaxTokens(options.snapshot.model, options.snapshot.contextWindow),
-				signal: requestController.signal,
-			},
-		);
+			maxTokens: summaryMaxTokens(options.snapshot.model, options.snapshot.contextWindow),
+			signal: requestController.signal,
+		});
 		await consumeStreamWithIdleTimeout(responseStream, {
 			idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
 			abort: () => requestController.abort(),
@@ -403,6 +412,7 @@ export async function runExtensionCompaction(
 	while (true) {
 		if (signal?.aborted) return undefined;
 		const response = await generateSummaryMessage({
+			context,
 			messages,
 			onProgress,
 			prompt,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -140,7 +140,6 @@ async function generateSummaryMessage(options: {
 	// deterministically refused by Anthropic's anti-distillation classifier
 	// ("reverse engineering or duplicating model outputs"), while the same
 	// content as native blocks with the agent's system prompt and tools passes.
-	const conversationMessages = repairOrphanedToolResults(convertToLlm(options.messages));
 	// Request-local controller: the idle watchdog must be able to tear down a
 	// stalled summarization request without aborting the caller's own signal.
 	const requestController = new AbortController();
@@ -150,26 +149,24 @@ async function generateSummaryMessage(options: {
 		else options.signal.addEventListener("abort", onCallerAbort, { once: true });
 	}
 	try {
+		const requestMessages: AgentMessage[] = [
+			...options.messages,
+			{
+				role: "user",
+				content: [{ type: "text", text: options.prompt.user }],
+				timestamp: Date.now(),
+			},
+		];
+		const providerRequest = await options.context.prepareProviderRequest?.(requestMessages);
 		const requestContext = {
 			systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
-			messages: [
-				...conversationMessages,
-				{
-					role: "user" as const,
-					content: [{ type: "text" as const, text: options.prompt.user }],
-					timestamp: Date.now(),
-				},
-			],
+			messages: repairOrphanedToolResults(convertToLlm(providerRequest?.messages ?? requestMessages)),
 			...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
 		};
-		const providerRequest = await options.context.prepareProviderRequest?.(requestContext.messages);
-		const providerContext = providerRequest
-			? { ...requestContext, messages: convertToLlm(providerRequest.messages) }
-			: requestContext;
 		const headers = providerRequest
 			? await providerRequest.transformHeaders(options.auth.headers ?? {})
 			: options.auth.headers;
-		const responseStream = stream(options.snapshot.model, providerContext, {
+		const responseStream = stream(options.snapshot.model, requestContext, {
 			apiKey: options.auth.apiKey,
 			headers,
 			extraBody: options.auth.extraBody,

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/index.ts
@@ -229,7 +229,7 @@ export default function hooksExtension(pi: ExtensionAPI): void {
 			trustState: state.trust,
 		});
 		const details = preCompactResultDetails(result);
-		recordLifecycleHookResult(pi, "PreCompact", details);
+		recordLifecycleHookResult(pi, "PreCompact", details, { compactionRequestId: event.requestId });
 		return sessionBeforeCompactResult(details);
 	});
 

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/lifecycle-adapter.ts
@@ -144,6 +144,7 @@ export function recordLifecycleHookResult(
 	pi: Pick<ExtensionAPI, "sendMessage">,
 	event: LifecycleHookEvent,
 	details: LifecycleResultDetails,
+	options?: { compactionRequestId?: string },
 ): void {
 	if (details.contexts.length === 0 && details.diagnostics.length === 0 && details.reason === undefined) return;
 	const content =
@@ -156,6 +157,7 @@ export function recordLifecycleHookResult(
 			details: {
 				event,
 				diagnostics: details.diagnostics.map(safeDiagnosticDetails),
+				...(options?.compactionRequestId === undefined ? {} : { compactionRequestId: options.compactionRequestId }),
 			},
 		},
 		{ triggerTurn: false },

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -6,6 +6,9 @@
 
 - `ExtensionContext` compaction feedback actions now return and accept an optional operation `AbortSignal`, allowing
   progress and terminal feedback from superseded generations to be ignored without breaking existing extensions.
+  A context remembers its `beginCompaction()` signal and supplies it to legacy `updateCompaction()` and
+  `endCompaction()` calls that omit the signal, so an old context cannot end a newer operation.
+- `stale-revision` is a structured compaction rejection cause for a source that changed before durable append.
 - The builtin compaction extension threads that signal through local and remote summary generation and application.
 
 ### Why

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -7,8 +7,8 @@
 - `ExtensionContext` compaction feedback actions now return and accept an optional operation `AbortSignal`, allowing
   progress and terminal feedback from superseded generations to be ignored without breaking existing extensions.
   Each handler invocation receives an isolated context that remembers its own `beginCompaction()` signal and supplies
-  it to legacy `updateCompaction()` and `endCompaction()` calls that omit the signal, so another handler in the same
-  event emission cannot rebind an old completion to a newer operation.
+  it to legacy `updateCompaction()`, `endCompaction()`, and `applyCompaction()` calls that omit the signal, so another
+  handler in the same event emission cannot rebind an old completion or durable apply to a newer operation.
 - `stale-revision` is a structured compaction rejection cause for a source that changed before durable append.
 - The builtin compaction extension threads that signal through local and remote summary generation and application.
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -6,8 +6,9 @@
 
 - `ExtensionContext` compaction feedback actions now return and accept an optional operation `AbortSignal`, allowing
   progress and terminal feedback from superseded generations to be ignored without breaking existing extensions.
-  A context remembers its `beginCompaction()` signal and supplies it to legacy `updateCompaction()` and
-  `endCompaction()` calls that omit the signal, so an old context cannot end a newer operation.
+  Each handler invocation receives an isolated context that remembers its own `beginCompaction()` signal and supplies
+  it to legacy `updateCompaction()` and `endCompaction()` calls that omit the signal, so another handler in the same
+  event emission cannot rebind an old completion to a newer operation.
 - `stale-revision` is a structured compaction rejection cause for a source that changed before durable append.
 - The builtin compaction extension threads that signal through local and remote summary generation and application.
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,18 @@
 # Core Extensions Changes
 
+## 2026-07-23 - Compaction feedback operation handles
+
+### What changed
+
+- `ExtensionContext` compaction feedback actions now return and accept an optional operation `AbortSignal`, allowing
+  progress and terminal feedback from superseded generations to be ignored without breaking existing extensions.
+- The builtin compaction extension threads that signal through local and remote summary generation and application.
+
+### Why
+
+Asynchronous summary feedback can arrive after a newer compaction begins; operation identity prevents stale progress
+or completion from mutating the current session lifecycle.
+
 ## 2026-07-22 - Config-reload rejection loop breaker
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -11,6 +11,8 @@
   handler in the same event emission cannot rebind an old completion or durable apply to a newer operation.
 - `stale-revision` is a structured compaction rejection cause for a source that changed before durable append.
 - The builtin compaction extension threads that signal through local and remote summary generation and application.
+- `model_select` sources now distinguish fallback apply and fallback revert transitions, allowing model-scoped
+  extensions to update prompts and active tools before the retry request.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -15,6 +15,9 @@
   extensions to update prompts and active tools before the retry request.
 - Builtin PreCompact diagnostics carry the active compaction request ID so their own feedback does not falsely trip the
   source-revision guard; unrelated session or tool mutations remain stale-rejected.
+- `ExtensionRunner.prepareProviderRequest()` provides a request-local canonical path for compaction generation:
+  ordered `context` hooks, provider-body transforms, and header transforms run without mutating persisted messages.
+  The originating compaction handler is excluded to avoid recursive re-entry while later redaction hooks still run.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -13,6 +13,8 @@
 - The builtin compaction extension threads that signal through local and remote summary generation and application.
 - `model_select` sources now distinguish fallback apply and fallback revert transitions, allowing model-scoped
   extensions to update prompts and active tools before the retry request.
+- Builtin PreCompact diagnostics carry the active compaction request ID so their own feedback does not falsely trip the
+  source-revision guard; unrelated session or tool mutations remain stale-rejected.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -1011,7 +1011,7 @@ export class ExtensionRunner {
 			},
 			applyCompaction: (precomputed, options) => {
 				runner.assertActive();
-				return runner.applyCompactionFn(precomputed, options);
+				return runner.applyCompactionFn(precomputed, { ...options, signal: options.signal ?? compactionSignal });
 			},
 			getSystemPrompt: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -902,6 +902,7 @@ export class ExtensionRunner {
 		const runner = this;
 		const getModel = this.getModel;
 		const getServiceTier = this.getServiceTier;
+		let compactionSignal: AbortSignal | undefined;
 		return {
 			get ui() {
 				runner.assertActive();
@@ -993,15 +994,16 @@ export class ExtensionRunner {
 			},
 			beginCompaction: (options) => {
 				runner.assertActive();
-				return runner.beginCompactionFn?.(options);
+				compactionSignal = runner.beginCompactionFn?.(options);
+				return compactionSignal;
 			},
 			updateCompaction: (options) => {
 				runner.assertActive();
-				runner.updateCompactionFn?.(options);
+				runner.updateCompactionFn?.({ ...options, signal: options.signal ?? compactionSignal });
 			},
 			endCompaction: (options) => {
 				runner.assertActive();
-				runner.endCompactionFn?.(options);
+				runner.endCompactionFn?.({ ...options, signal: options.signal ?? compactionSignal });
 			},
 			getMessageRevision: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -1077,7 +1077,6 @@ export class ExtensionRunner {
 	}
 
 	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {
-		const ctx = this.createContext();
 		let result: SessionBeforeEventResult | undefined;
 
 		for (const ext of this.extensions) {
@@ -1086,7 +1085,7 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await handler(event, this.createContext());
 
 					if (this.isSessionBeforeEvent(event) && handlerResult) {
 						result = handlerResult as SessionBeforeEventResult;
@@ -1111,7 +1110,6 @@ export class ExtensionRunner {
 	}
 
 	async emitModelSelect(event: ModelSelectEvent): Promise<ModelSelectEventResult | undefined> {
-		const ctx = this.createContext();
 		let result: ModelSelectEventResult | undefined;
 
 		for (const ext of this.extensions) {
@@ -1124,7 +1122,7 @@ export class ExtensionRunner {
 					// the active toolset (gpt-apply-patch) must let later handlers
 					// (prompt-preset) rebuild from the post-swap tools in the same emission.
 					const liveEvent: ModelSelectEvent = { ...event, systemPromptOptions: this.getSystemPromptOptionsFn() };
-					const handlerResult = await handler(liveEvent, ctx);
+					const handlerResult = await handler(liveEvent, this.createContext());
 					if (handlerResult) {
 						const nextResult = handlerResult as ModelSelectEventResult;
 						if (nextResult.systemPrompt !== undefined || nextResult.systemPromptName !== undefined) {
@@ -1159,7 +1157,6 @@ export class ExtensionRunner {
 	}
 
 	async emitMessageEnd(event: MessageEndEvent): Promise<AgentMessage | undefined> {
-		const ctx = this.createContext();
 		let currentMessage = event.message;
 		let modified = false;
 
@@ -1170,7 +1167,9 @@ export class ExtensionRunner {
 			for (const handler of handlers) {
 				try {
 					const currentEvent: MessageEndEvent = { ...event, message: currentMessage };
-					const handlerResult = (await handler(currentEvent, ctx)) as MessageEndEventResult | undefined;
+					const handlerResult = (await handler(currentEvent, this.createContext())) as
+						| MessageEndEventResult
+						| undefined;
 					if (!handlerResult?.message) continue;
 
 					if (handlerResult.message.role !== currentMessage.role) {
@@ -1201,7 +1200,6 @@ export class ExtensionRunner {
 	}
 
 	async emitToolResult(event: ToolResultEvent): Promise<ToolResultEventResult | undefined> {
-		const ctx = this.createContext();
 		const currentEvent: ToolResultEvent = { ...event };
 		let modified = false;
 
@@ -1210,7 +1208,7 @@ export class ExtensionRunner {
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
-				const hookRun = this.beginToolHookRun(ctx, {
+				const hookRun = this.beginToolHookRun(this.createContext(), {
 					hookName: "PostToolUse",
 					toolName: event.toolName,
 					toolCallId: event.toolCallId,
@@ -1265,7 +1263,6 @@ export class ExtensionRunner {
 	}
 
 	async emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
-		const ctx = this.createContext();
 		let result: ToolCallEventResult | undefined;
 
 		for (const ext of this.extensions) {
@@ -1273,7 +1270,7 @@ export class ExtensionRunner {
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
-				const hookRun = this.beginToolHookRun(ctx, {
+				const hookRun = this.beginToolHookRun(this.createContext(), {
 					hookName: "PreToolUse",
 					toolName: event.toolName,
 					toolCallId: event.toolCallId,
@@ -1305,15 +1302,13 @@ export class ExtensionRunner {
 	}
 
 	async emitUserBash(event: UserBashEvent): Promise<UserBashEventResult | undefined> {
-		const ctx = this.createContext();
-
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get("user_bash");
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await handler(event, this.createContext());
 					if (handlerResult) {
 						return handlerResult as UserBashEventResult;
 					}
@@ -1334,7 +1329,6 @@ export class ExtensionRunner {
 	}
 
 	async emitContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
-		const ctx = this.createContext();
 		let currentMessages = cloneJsonValue(messages);
 
 		for (const ext of this.extensions) {
@@ -1344,7 +1338,7 @@ export class ExtensionRunner {
 			for (const handler of handlers) {
 				try {
 					const event: ContextEvent = { type: "context", messages: currentMessages };
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await handler(event, this.createContext());
 
 					if (handlerResult && (handlerResult as ContextEventResult).messages) {
 						currentMessages = (handlerResult as ContextEventResult).messages!;
@@ -1366,7 +1360,6 @@ export class ExtensionRunner {
 	}
 
 	async emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
-		const ctx = this.createContext();
 		let currentPayload = payload;
 
 		for (const ext of this.extensions) {
@@ -1379,7 +1372,7 @@ export class ExtensionRunner {
 						type: "before_provider_request",
 						payload: currentPayload,
 					};
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await handler(event, this.createContext());
 					if (handlerResult !== undefined) {
 						currentPayload = handlerResult;
 					}
@@ -1400,8 +1393,6 @@ export class ExtensionRunner {
 	}
 
 	async emitBeforeProviderHeaders(headers: ProviderHeaders): Promise<ProviderHeaders> {
-		const ctx = this.createContext();
-
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get("before_provider_headers");
 			if (!handlers || handlers.length === 0) continue;
@@ -1413,7 +1404,7 @@ export class ExtensionRunner {
 						type: "before_provider_headers",
 						headers,
 					};
-					await handler(event, ctx);
+					await handler(event, this.createContext());
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					const stack = err instanceof Error ? err.stack : undefined;
@@ -1437,14 +1428,6 @@ export class ExtensionRunner {
 		systemPromptOptions: BuildSystemPromptOptions,
 	): Promise<BeforeAgentStartCombinedResult | undefined> {
 		let currentSystemPrompt = systemPrompt;
-		const ctx = Object.defineProperties(
-			{},
-			Object.getOwnPropertyDescriptors(this.createContext()),
-		) as ExtensionContext;
-		ctx.getSystemPrompt = () => {
-			this.assertActive();
-			return currentSystemPrompt;
-		};
 		const messages: NonNullable<BeforeAgentStartEventResult["message"]>[] = [];
 		let systemPromptModified = false;
 
@@ -1454,6 +1437,16 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
+					// Keep guarded context getters lazy while giving each handler its
+					// own legacy omitted-signal ownership slot.
+					const ctx = Object.defineProperties(
+						{},
+						Object.getOwnPropertyDescriptors(this.createContext()),
+					) as ExtensionContext;
+					ctx.getSystemPrompt = () => {
+						this.assertActive();
+						return currentSystemPrompt;
+					};
 					const event: BeforeAgentStartEvent = {
 						type: "before_agent_start",
 						prompt,
@@ -1505,7 +1498,6 @@ export class ExtensionRunner {
 		themePaths: Array<{ path: string; extensionPath: string }>;
 		hookPaths: Array<{ path: string; extensionPath: string }>;
 	}> {
-		const ctx = this.createContext();
 		const skillPaths: Array<{ path: string; extensionPath: string }> = [];
 		const promptPaths: Array<{ path: string; extensionPath: string }> = [];
 		const themePaths: Array<{ path: string; extensionPath: string }> = [];
@@ -1518,7 +1510,7 @@ export class ExtensionRunner {
 			for (const handler of handlers) {
 				try {
 					const event: ResourcesDiscoverEvent = { type: "resources_discover", cwd, reason };
-					const handlerResult = await handler(event, ctx);
+					const handlerResult = await handler(event, this.createContext());
 					const result = handlerResult as ResourcesDiscoverResult | undefined;
 
 					if (result?.skillPaths?.length) {
@@ -1556,7 +1548,6 @@ export class ExtensionRunner {
 		source: InputSource,
 		streamingBehavior?: "steer" | "followUp",
 	): Promise<InputEventResult> {
-		const ctx = this.createContext();
 		let currentText = text;
 		let currentImages = images;
 
@@ -1570,7 +1561,7 @@ export class ExtensionRunner {
 						source,
 						streamingBehavior,
 					};
-					const result = (await handler(event, ctx)) as InputEventResult | undefined;
+					const result = (await handler(event, this.createContext())) as InputEventResult | undefined;
 					if (result?.action === "handled") return result;
 					if (result?.action === "transform") {
 						currentText = result.text;

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -4,14 +4,14 @@
 
 import { basename } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { ImageContent, Model, Provider, ProviderHeaders } from "@earendil-works/pi-ai";
+import type { Api, ImageContent, Model, Provider, ProviderHeaders } from "@earendil-works/pi-ai";
 import type { KeyId } from "@earendil-works/pi-tui";
 import { type Theme, theme } from "../../modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../../utils/ansi.ts";
 import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
 import type { ModelRegistry } from "../model-registry.ts";
-import type { SessionManager } from "../session-manager.ts";
+import { getSessionContextEntryId, SESSION_CONTEXT_ENTRY_ID, type SessionManager } from "../session-manager.ts";
 import { SettingsManager } from "../settings-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import { drainPendingProviderRegistrations } from "./loader.ts";
@@ -1334,7 +1334,10 @@ export class ExtensionRunner {
 	}
 
 	async emitContext(messages: AgentMessage[], excludeExtensionPath?: string): Promise<AgentMessage[]> {
-		let currentMessages = cloneJsonValue(messages);
+		let currentMessages = cloneJsonValue(messages).map((message, index) => {
+			const entryId = getSessionContextEntryId(messages[index]!);
+			return entryId ? Object.assign(message, { [SESSION_CONTEXT_ENTRY_ID]: entryId }) : message;
+		});
 
 		for (const ext of this.extensions) {
 			if (ext.path === excludeExtensionPath) continue;
@@ -1377,7 +1380,11 @@ export class ExtensionRunner {
 		};
 	}
 
-	async emitBeforeProviderRequest(payload: unknown, excludeExtensionPath?: string): Promise<unknown> {
+	async emitBeforeProviderRequest(
+		payload: unknown,
+		excludeExtensionPath?: string,
+		request?: { model: Model<Api>; headers: ProviderHeaders },
+	): Promise<unknown> {
 		let currentPayload = payload;
 
 		for (const ext of this.extensions) {
@@ -1390,6 +1397,7 @@ export class ExtensionRunner {
 					const event: BeforeProviderRequestEvent = {
 						type: "before_provider_request",
 						payload: currentPayload,
+						...(request ? { model: request.model, headers: request.headers } : {}),
 					};
 					const handlerResult = await handler(event, this.createContext(ext.path));
 					if (handlerResult !== undefined) {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -51,6 +51,7 @@ import type {
 	ProjectTrustEvent,
 	ProjectTrustEventResult,
 	ProviderConfig,
+	ProviderRequestPreparation,
 	RegisteredCommand,
 	RegisteredMcpServerDeclaration,
 	RegisteredTool,
@@ -898,7 +899,7 @@ export class ExtensionRunner {
 	 * Create an ExtensionContext for use in event handlers and tool execution.
 	 * Context values are resolved at call time, so changes via bindCore/bindUI are reflected.
 	 */
-	createContext(): ExtensionContext {
+	createContext(excludeBeforeProviderRequestExtensionPath?: string): ExtensionContext {
 		const runner = this;
 		const getModel = this.getModel;
 		const getServiceTier = this.getServiceTier;
@@ -991,6 +992,10 @@ export class ExtensionRunner {
 			compact: (options) => {
 				runner.assertActive();
 				runner.compactFn(options);
+			},
+			prepareProviderRequest: async (messages) => {
+				runner.assertActive();
+				return runner.prepareProviderRequest(messages, excludeBeforeProviderRequestExtensionPath);
 			},
 			beginCompaction: (options) => {
 				runner.assertActive();
@@ -1085,7 +1090,7 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				try {
-					const handlerResult = await handler(event, this.createContext());
+					const handlerResult = await handler(event, this.createContext(ext.path));
 
 					if (this.isSessionBeforeEvent(event) && handlerResult) {
 						result = handlerResult as SessionBeforeEventResult;
@@ -1122,7 +1127,7 @@ export class ExtensionRunner {
 					// the active toolset (gpt-apply-patch) must let later handlers
 					// (prompt-preset) rebuild from the post-swap tools in the same emission.
 					const liveEvent: ModelSelectEvent = { ...event, systemPromptOptions: this.getSystemPromptOptionsFn() };
-					const handlerResult = await handler(liveEvent, this.createContext());
+					const handlerResult = await handler(liveEvent, this.createContext(ext.path));
 					if (handlerResult) {
 						const nextResult = handlerResult as ModelSelectEventResult;
 						if (nextResult.systemPrompt !== undefined || nextResult.systemPromptName !== undefined) {
@@ -1167,7 +1172,7 @@ export class ExtensionRunner {
 			for (const handler of handlers) {
 				try {
 					const currentEvent: MessageEndEvent = { ...event, message: currentMessage };
-					const handlerResult = (await handler(currentEvent, this.createContext())) as
+					const handlerResult = (await handler(currentEvent, this.createContext(ext.path))) as
 						| MessageEndEventResult
 						| undefined;
 					if (!handlerResult?.message) continue;
@@ -1338,7 +1343,7 @@ export class ExtensionRunner {
 			for (const handler of handlers) {
 				try {
 					const event: ContextEvent = { type: "context", messages: currentMessages };
-					const handlerResult = await handler(event, this.createContext());
+					const handlerResult = await handler(event, this.createContext(ext.path));
 
 					if (handlerResult && (handlerResult as ContextEventResult).messages) {
 						currentMessages = (handlerResult as ContextEventResult).messages!;
@@ -1359,10 +1364,24 @@ export class ExtensionRunner {
 		return currentMessages;
 	}
 
-	async emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
+	async prepareProviderRequest(
+		messages: AgentMessage[],
+		excludeBeforeProviderRequestExtensionPath?: string,
+	): Promise<ProviderRequestPreparation> {
+		const transformedMessages = await this.emitContext(messages);
+		return {
+			messages: transformedMessages,
+			transformPayload: async (payload) =>
+				await this.emitBeforeProviderRequest(payload, excludeBeforeProviderRequestExtensionPath),
+			transformHeaders: async (headers) => await this.emitBeforeProviderHeaders(headers),
+		};
+	}
+
+	async emitBeforeProviderRequest(payload: unknown, excludeExtensionPath?: string): Promise<unknown> {
 		let currentPayload = payload;
 
 		for (const ext of this.extensions) {
+			if (ext.path === excludeExtensionPath) continue;
 			const handlers = ext.handlers.get("before_provider_request");
 			if (!handlers || handlers.length === 0) continue;
 
@@ -1372,7 +1391,7 @@ export class ExtensionRunner {
 						type: "before_provider_request",
 						payload: currentPayload,
 					};
-					const handlerResult = await handler(event, this.createContext());
+					const handlerResult = await handler(event, this.createContext(ext.path));
 					if (handlerResult !== undefined) {
 						currentPayload = handlerResult;
 					}
@@ -1404,7 +1423,7 @@ export class ExtensionRunner {
 						type: "before_provider_headers",
 						headers,
 					};
-					await handler(event, this.createContext());
+					await handler(event, this.createContext(ext.path));
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					const stack = err instanceof Error ? err.stack : undefined;
@@ -1441,7 +1460,7 @@ export class ExtensionRunner {
 					// own legacy omitted-signal ownership slot.
 					const ctx = Object.defineProperties(
 						{},
-						Object.getOwnPropertyDescriptors(this.createContext()),
+						Object.getOwnPropertyDescriptors(this.createContext(ext.path)),
 					) as ExtensionContext;
 					ctx.getSystemPrompt = () => {
 						this.assertActive();
@@ -1510,7 +1529,7 @@ export class ExtensionRunner {
 			for (const handler of handlers) {
 				try {
 					const event: ResourcesDiscoverEvent = { type: "resources_discover", cwd, reason };
-					const handlerResult = await handler(event, this.createContext());
+					const handlerResult = await handler(event, this.createContext(ext.path));
 					const result = handlerResult as ResourcesDiscoverResult | undefined;
 
 					if (result?.skillPaths?.length) {
@@ -1561,7 +1580,7 @@ export class ExtensionRunner {
 						source,
 						streamingBehavior,
 					};
-					const result = (await handler(event, this.createContext())) as InputEventResult | undefined;
+					const result = (await handler(event, this.createContext(ext.path))) as InputEventResult | undefined;
 					if (result?.action === "handled") return result;
 					if (result?.action === "transform") {
 						currentText = result.text;

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -1333,10 +1333,11 @@ export class ExtensionRunner {
 		return undefined;
 	}
 
-	async emitContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
+	async emitContext(messages: AgentMessage[], excludeExtensionPath?: string): Promise<AgentMessage[]> {
 		let currentMessages = cloneJsonValue(messages);
 
 		for (const ext of this.extensions) {
+			if (ext.path === excludeExtensionPath) continue;
 			const handlers = ext.handlers.get("context");
 			if (!handlers || handlers.length === 0) continue;
 
@@ -1366,13 +1367,12 @@ export class ExtensionRunner {
 
 	async prepareProviderRequest(
 		messages: AgentMessage[],
-		excludeBeforeProviderRequestExtensionPath?: string,
+		excludeExtensionPath?: string,
 	): Promise<ProviderRequestPreparation> {
-		const transformedMessages = await this.emitContext(messages);
+		const transformedMessages = await this.emitContext(messages, excludeExtensionPath);
 		return {
 			messages: transformedMessages,
-			transformPayload: async (payload) =>
-				await this.emitBeforeProviderRequest(payload, excludeBeforeProviderRequestExtensionPath),
+			transformPayload: async (payload) => await this.emitBeforeProviderRequest(payload, excludeExtensionPath),
 			transformHeaders: async (headers) => await this.emitBeforeProviderHeaders(headers),
 		};
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -91,7 +91,12 @@ export type { AgentToolResult, AgentToolUpdateCallback, ToolExecutionMode };
 export type ServiceTier = "auto" | "flex" | "priority";
 // biome-ignore format: keep literal union alias consistent with nearby ServiceTier style.
 export type CompactionReason = "manual" | "threshold" | "overflow" | "pre_prompt" | "branch" | "extension";
-export type CompactionRejectionCause = "cancelled-by-extension" | "would-overflow" | "circuit-breaker" | "per-turn-cap";
+export type CompactionRejectionCause =
+	| "cancelled-by-extension"
+	| "would-overflow"
+	| "circuit-breaker"
+	| "per-turn-cap"
+	| "stale-revision";
 
 // ============================================================================
 // UI Context

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -923,7 +923,7 @@ export interface ToolExecutionEndEvent {
 // Model Events
 // ============================================================================
 
-export type ModelSelectSource = "set" | "cycle" | "restore";
+export type ModelSelectSource = "set" | "cycle" | "restore" | "fallback" | "fallback-revert";
 
 /** Fired when a new model is selected */
 export interface ModelSelectEvent {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -341,12 +341,14 @@ export interface BeginCompactionOptions {
 
 export interface UpdateCompactionOptions {
 	reason: CompactionReason;
+	signal?: AbortSignal;
 	delta?: string;
 	text?: string;
 }
 
 export interface EndCompactionOptions {
 	reason: CompactionReason;
+	signal?: AbortSignal;
 	aborted?: boolean;
 	errorMessage?: string;
 }

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -336,6 +336,8 @@ export interface CompactOptions {
 export interface ApplyCompactionOptions {
 	reason: CompactionReason;
 	expectedRevision?: number;
+	/** The feedback operation that owns this apply, when one was begun. */
+	signal?: AbortSignal;
 }
 
 export type ApplyCompactionResult = { applied: true; reason: "ok" } | { applied: false; reason: "stale" | "rejected" };

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -823,6 +823,10 @@ export interface ContextEvent {
 export interface BeforeProviderRequestEvent {
 	type: "before_provider_request";
 	payload: unknown;
+	/** Effective request model after auth/base-url/upstream-model resolution. */
+	model?: Model<Api>;
+	/** Final header transform output for this request. Values are never persisted. */
+	headers?: ProviderHeaders;
 }
 
 /**

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -414,6 +414,11 @@ export interface ExtensionContext {
 	sessionSettings: ExtensionSessionSettings;
 	/** Trigger compaction without awaiting completion. */
 	compact(options?: CompactOptions): void;
+	/**
+	 * Prepare a request-local provider context through the normal extension
+	 * boundary. Persisted session messages are never modified.
+	 */
+	prepareProviderRequest?(messages: AgentMessage[]): Promise<ProviderRequestPreparation>;
 	/** Start user-visible compaction feedback before an extension has a precomputed summary to apply. */
 	beginCompaction?(options: BeginCompactionOptions): AbortSignal | undefined;
 	/** Stream user-visible compaction content while an extension-generated summary is available. */
@@ -437,6 +442,13 @@ export interface ExtensionContext {
 	 * after the handler finished are ignored.
 	 */
 	updateToolHookStatus?(statusMessage: string): void;
+}
+
+/** Request-local transformations shared by normal and compaction provider calls. */
+export interface ProviderRequestPreparation {
+	messages: AgentMessage[];
+	transformPayload(payload: unknown): Promise<unknown>;
+	transformHeaders(headers: ProviderHeaders): Promise<ProviderHeaders>;
 }
 
 /**

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
+import { copyContextProvenance, type ImageContent, type Message, type TextContent } from "@earendil-works/pi-ai";
 
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
 
@@ -156,6 +156,8 @@ export function createCustomMessage(
  * - Custom extensions and tools
  */
 export function convertToLlm(messages: AgentMessage[]): Message[] {
+	const withContextProvenance = <T extends Message>(source: AgentMessage, target: T): T =>
+		copyContextProvenance(source, target);
 	return messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
@@ -164,37 +166,37 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 					if (m.excludeFromContext) {
 						return undefined;
 					}
-					return {
+					return withContextProvenance(m, {
 						role: "user",
 						content: [{ type: "text", text: bashExecutionToText(m) }],
 						timestamp: m.timestamp,
-					};
+					});
 				case "custom": {
 					if (isContextExcludedCustomMessage(m.customType)) {
 						return undefined;
 					}
 
 					const content = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
-					return {
+					return withContextProvenance(m, {
 						role: "user",
 						content,
 						timestamp: m.timestamp,
-					};
+					});
 				}
 				case "branchSummary":
-					return {
+					return withContextProvenance(m, {
 						role: "user",
 						content: [{ type: "text" as const, text: BRANCH_SUMMARY_PREFIX + m.summary + BRANCH_SUMMARY_SUFFIX }],
 						timestamp: m.timestamp,
-					};
+					});
 				case "compactionSummary":
-					return {
+					return withContextProvenance(m, {
 						role: "user",
 						content: [
 							{ type: "text" as const, text: COMPACTION_SUMMARY_PREFIX + m.summary + COMPACTION_SUMMARY_SUFFIX },
 						],
 						timestamp: m.timestamp,
-					};
+					});
 				case "user":
 				case "assistant":
 				case "toolResult":

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -14,6 +14,7 @@ export type ResolvedRequestAuth =
 			apiKey?: string;
 			headers?: Record<string, string>;
 			extraBody?: Record<string, unknown>;
+			baseUrl?: string;
 			upstreamModelId?: string;
 			serviceTier?: "auto" | "flex" | "priority";
 			env?: Record<string, string>;
@@ -119,6 +120,7 @@ export class ModelRegistry {
 				apiKey: resolution.auth.apiKey,
 				headers,
 				extraBody: compatibility.extraBody,
+				baseUrl: resolution.auth.baseUrl,
 				upstreamModelId: compatibility.upstreamModelId,
 				serviceTier: compatibility.serviceTier,
 				env: resolution.env,

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -90,6 +90,16 @@ function mergeHeaders(
 	return merged;
 }
 
+function withPayloadRequestMetadata(options: StreamOptions, model: Model<Api>): StreamOptions {
+	if (!options.onPayload) return options;
+	const onPayload = options.onPayload;
+	return {
+		...options,
+		onPayload: async (payload, providerModel) =>
+			await onPayload(payload, providerModel, { model, headers: options.headers ?? {} }),
+	};
+}
+
 /** Configured pi-ai Models collection used by coding-agent and SDK consumers. */
 export class ModelRuntime implements Models {
 	private readonly models: MutableModels;
@@ -524,7 +534,7 @@ export class ModelRuntime implements Models {
 			const inner = prepared.provider.stream(
 				prepared.model as Model<TApi>,
 				context,
-				prepared.options as ApiStreamOptions<TApi>,
+				withPayloadRequestMetadata(prepared.options, prepared.model) as ApiStreamOptions<TApi>,
 			);
 			return shouldRecoverTextToolCalls(model) && context.tools?.length
 				? wrapStreamWithInvokeRecovery(inner, context.tools)
@@ -542,7 +552,11 @@ export class ModelRuntime implements Models {
 	streamSimple(model: Model<Api>, context: Context, options?: ModelsSimpleStreamOptions): AssistantMessageEventStream {
 		return lazyStream(model, async () => {
 			const prepared = await this.prepareRequest(model, options);
-			const inner = prepared.provider.streamSimple(prepared.model, context, prepared.options as SimpleStreamOptions);
+			const inner = prepared.provider.streamSimple(
+				prepared.model,
+				context,
+				withPayloadRequestMetadata(prepared.options, prepared.model) as SimpleStreamOptions,
+			);
 			return shouldRecoverTextToolCalls(model) && context.tools?.length
 				? wrapStreamWithInvokeRecovery(inner, context.tools)
 				: inner;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -369,12 +369,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				},
 			});
 		},
-		onPayload: async (payload, _model) => {
+		onPayload: async (payload, _model, request) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner?.hasHandlers("before_provider_request")) {
 				return payload;
 			}
-			return runner.emitBeforeProviderRequest(payload);
+			return runner.emitBeforeProviderRequest(payload, undefined, request);
 		},
 		onResponse: async (response, _model) => {
 			const runner = extensionRunnerRef.current;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -486,6 +486,10 @@ export function buildContextEntries(
 	let foundFirstKept = false;
 	for (let i = 0; i < compactionIdx; i++) {
 		const entry = path[i];
+		// The latest summary supersedes every older compaction summary. Older
+		// entries selected by firstKeptEntryId remain verbatim, but nesting a
+		// prior summary here would double-count it in the model context.
+		if (entry.type === "compaction") continue;
 		if (entry.id === compaction.firstKeptEntryId) {
 			foundFirstKept = true;
 		}
@@ -878,6 +882,12 @@ export class SessionManager {
 	private flushed: boolean = false;
 	private fileEntries: FileEntry[] = [];
 	private byId: Map<string, SessionEntry> = new Map();
+	// Runtime-only identity tracking lets AgentSession compare a live message to
+	// a compaction boundary by append order rather than provider timestamps.
+	// Reconstructed messages intentionally have no entry identity and use the
+	// timestamp fallback in AgentSession.
+	private entryOrdersById: Map<string, number> = new Map();
+	private messageEntryPositions = new WeakMap<AgentMessage, { entryId: string; order: number }>();
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
@@ -978,6 +988,8 @@ export class SessionManager {
 		this.fileEntries = [header];
 		this.residentStore.clear();
 		this.byId.clear();
+		this.entryOrdersById.clear();
+		this.messageEntryPositions = new WeakMap();
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
@@ -1002,6 +1014,8 @@ export class SessionManager {
 
 	private _buildIndex(): void {
 		this.byId.clear();
+		this.entryOrdersById.clear();
+		this.messageEntryPositions = new WeakMap();
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
@@ -1014,9 +1028,10 @@ export class SessionManager {
 			cost: 0,
 			latestCacheHitRate: undefined,
 		};
-		for (const entry of this.fileEntries) {
+		for (const [order, entry] of this.fileEntries.entries()) {
 			if (entry.type === "session") continue;
 			this.byId.set(entry.id, entry);
+			this.entryOrdersById.set(entry.id, order);
 			this.leafId = entry.id;
 			this._accumulateUsage(entry);
 			if (entry.type === "session_info") {
@@ -1109,6 +1124,7 @@ export class SessionManager {
 		const residentEntry = this.residentStore.externalize(entry);
 		this.fileEntries.push(residentEntry);
 		this.byId.set(residentEntry.id, residentEntry);
+		this.entryOrdersById.set(residentEntry.id, this.fileEntries.length - 1);
 		this.leafId = residentEntry.id;
 		this._accumulateUsage(residentEntry);
 		this.mutationCount++;
@@ -1158,7 +1174,21 @@ export class SessionManager {
 			message,
 		};
 		this._appendEntry(entry);
+		const order = this.entryOrdersById.get(entry.id);
+		if (order !== undefined) {
+			this.messageEntryPositions.set(message, { entryId: entry.id, order });
+		}
 		return entry.id;
+	}
+
+	/** Runtime append position for this exact persisted message object, if known. */
+	getMessageEntryPosition(message: AgentMessage): Readonly<{ entryId: string; order: number }> | undefined {
+		return this.messageEntryPositions.get(message);
+	}
+
+	/** Runtime/file append position for an entry, used with getMessageEntryPosition(). */
+	getEntryOrder(entryId: string): number | undefined {
+		return this.entryOrdersById.get(entryId);
 	}
 
 	/** Append a thinking level change as child of current leaf, then advance leaf. Returns entry id. */

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -882,10 +882,10 @@ export class SessionManager {
 	private flushed: boolean = false;
 	private fileEntries: FileEntry[] = [];
 	private byId: Map<string, SessionEntry> = new Map();
-	// Runtime-only identity tracking lets AgentSession compare a live message to
-	// a compaction boundary by append order rather than provider timestamps.
-	// Reconstructed messages intentionally have no entry identity and use the
-	// timestamp fallback in AgentSession.
+	// Runtime-only identity tracking lets AgentSession compare messages to a
+	// compaction boundary by append order rather than provider timestamps.
+	// Materialized persisted messages are bound as they are read; only pending
+	// messages that have not reached a session entry use AgentSession's fallback.
 	private entryOrdersById: Map<string, number> = new Map();
 	private messageEntryPositions = new WeakMap<AgentMessage, { entryId: string; order: number }>();
 	private labelsById: Map<string, string> = new Map();
@@ -1131,6 +1131,17 @@ export class SessionManager {
 		this._persist(residentEntry);
 	}
 
+	private _materializeEntry(entry: SessionEntry): SessionEntry {
+		const materialized = this.residentStore.materialize(entry);
+		if (materialized.type === "message") {
+			const order = this.entryOrdersById.get(materialized.id);
+			if (order !== undefined) {
+				this.messageEntryPositions.set(materialized.message, { entryId: materialized.id, order });
+			}
+		}
+		return materialized;
+	}
+
 	/**
 	 * Fold one entry into the running usage totals. Totals iterate ALL entries
 	 * (not branch-scoped), matching the footer hot path's historical semantics.
@@ -1325,12 +1336,12 @@ export class SessionManager {
 
 	getLeafEntry(): SessionEntry | undefined {
 		const entry = this.leafId ? this.byId.get(this.leafId) : undefined;
-		return entry ? this.residentStore.materialize(entry) : undefined;
+		return entry ? this._materializeEntry(entry) : undefined;
 	}
 
 	getEntry(id: string): SessionEntry | undefined {
 		const entry = this.byId.get(id);
-		return entry ? this.residentStore.materialize(entry) : undefined;
+		return entry ? this._materializeEntry(entry) : undefined;
 	}
 
 	/**
@@ -1340,7 +1351,7 @@ export class SessionManager {
 		const children: SessionEntry[] = [];
 		for (const entry of this.byId.values()) {
 			if (entry.parentId === parentId) {
-				children.push(this.residentStore.materialize(entry));
+				children.push(this._materializeEntry(entry));
 			}
 		}
 		return children;
@@ -1401,7 +1412,7 @@ export class SessionManager {
 		const startId = fromId ?? this.leafId;
 		let current = startId ? this.byId.get(startId) : undefined;
 		while (current) {
-			path.unshift(this.residentStore.materialize(current));
+			path.unshift(this._materializeEntry(current));
 			current = current.parentId ? this.byId.get(current.parentId) : undefined;
 		}
 		if (fromId === undefined) {
@@ -1481,7 +1492,7 @@ export class SessionManager {
 		}
 		const entries = this.fileEntries
 			.filter((e): e is SessionEntry => e.type !== "session")
-			.map((entry) => this.residentStore.materialize(entry));
+			.map((entry) => this._materializeEntry(entry));
 		this.entriesCache = { mutation: this.mutationCount, entries };
 		return entries;
 	}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -50,6 +50,21 @@ import {
 	createCustomMessage,
 } from "./messages.ts";
 
+const contextMessageEntryIds = new WeakMap<object, string>();
+
+/** Request-local field carried across context hooks; never persisted or sent to providers. */
+export const SESSION_CONTEXT_ENTRY_ID = "__piSessionContextEntryId";
+
+function withContextEntryId<T extends AgentMessage>(entryId: string, message: T): T {
+	contextMessageEntryIds.set(message, entryId);
+	return message;
+}
+
+/** Entry identity for a transient message projected from session history. */
+export function getSessionContextEntryId(message: AgentMessage): string | undefined {
+	return contextMessageEntryIds.get(message);
+}
+
 export interface UsageTotals {
 	input: number;
 	output: number;
@@ -433,20 +448,28 @@ export function sessionEntryToContextMessages(entry: SessionEntry): AgentMessage
 			(message.role === "user" || message.role === "assistant" || message.role === "toolResult") &&
 			message.content == null
 		) {
-			return [{ ...message, content: [] }];
+			return [withContextEntryId(entry.id, { ...message, content: [] })];
 		}
-		return [message];
+		return [withContextEntryId(entry.id, message)];
 	}
 	if (entry.type === "custom_message") {
 		return [
-			createCustomMessage(entry.customType, entry.content ?? [], entry.display, entry.details, entry.timestamp),
+			withContextEntryId(
+				entry.id,
+				createCustomMessage(entry.customType, entry.content ?? [], entry.display, entry.details, entry.timestamp),
+			),
 		];
 	}
 	if (entry.type === "branch_summary" && entry.summary) {
-		return [createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp)];
+		return [withContextEntryId(entry.id, createBranchSummaryMessage(entry.summary, entry.fromId, entry.timestamp))];
 	}
 	if (entry.type === "compaction") {
-		return [createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp, entry.details)];
+		return [
+			withContextEntryId(
+				entry.id,
+				createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp, entry.details),
+			),
+		];
 	}
 	return [];
 }

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -7,6 +7,8 @@
 - `interactive-mode.ts`: input queued while compaction owns the editor is automatically transferred only after an
   accepted compaction result. Rejected, failed, or aborted compaction retains the input in the editor-owned queue
   instead of resubmitting it through the unchanged required-compaction gate and recursively starting compaction.
+- Consecutive `compaction_start` events share one Escape override. The original editor handler is preserved through
+  supersession and restored exactly once on terminal cleanup, session rebind, invalidation, or TUI stop.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## accepted-only compaction queue transfer (2026-07-24)
+
+### What changed
+
+- `interactive-mode.ts`: input queued while compaction owns the editor is automatically transferred only after an
+  accepted compaction result. Rejected, failed, or aborted compaction retains the input in the editor-owned queue
+  instead of resubmitting it through the unchanged required-compaction gate and recursively starting compaction.
+
+### Why
+
+- Rejection and cancellation do not create a new admissible context. Automatically replaying the same prompt caused an
+  unbounded compaction-start/rejection/restore loop.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-mode.ts` `compaction_end` handling around `flushCompactionQueue()`.
+
 ## per-section thinking duration headers (2026-07-22)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -13,6 +13,8 @@
   summaries and provider/session content remain unchanged.
 - The shared compaction-summary component applies the same display-only sanitization, covering rebuilt chat and
   reopened-session expansion in addition to live `compaction_end` rendering.
+- Provider-derived fallback exhaustion errors are sanitized at the shared `showError()` render boundary; raw retry
+  events and persisted/provider error content remain unchanged.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -9,6 +9,8 @@
   instead of resubmitting it through the unchanged required-compaction gate and recursively starting compaction.
 - Consecutive `compaction_start` events share one Escape override. The original editor handler is preserved through
   supersession and restored exactly once on terminal cleanup, session rebind, invalidation, or TUI stop.
+- Compaction progress, errors, and summaries are stripped of terminal control sequences only when rendered. Persisted
+  summaries and provider/session content remain unchanged.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -11,6 +11,8 @@
   supersession and restored exactly once on terminal cleanup, session rebind, invalidation, or TUI stop.
 - Compaction progress, errors, and summaries are stripped of terminal control sequences only when rendered. Persisted
   summaries and provider/session content remain unchanged.
+- The shared compaction-summary component applies the same display-only sanitization, covering rebuilt chat and
+  reopened-session expansion in addition to live `compaction_end` rendering.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-summary-message.ts
@@ -3,6 +3,16 @@ import type { CompactionSummaryMessage } from "../../../core/messages.ts";
 import { getMarkdownTheme, theme } from "../theme/theme.ts";
 import { keyText } from "./keybinding-hints.ts";
 
+const TERMINAL_ESCAPE_SEQUENCE =
+	/(?:\u001B\]|\u009D)[\s\S]*?(?:\u0007|\u001B\\|\u009C)|(?:\u001B\[|\u009B)[0-?]*[ -/]*[@-~]/g;
+
+function sanitizeCompactionSummary(summary: string): string {
+	return summary
+		.replace(TERMINAL_ESCAPE_SEQUENCE, "")
+		.replace(/\r\n?/g, "\n")
+		.replace(/[\u0000-\u0009\u000B-\u001F\u007F-\u009F]/g, "");
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -58,7 +68,7 @@ export class CompactionSummaryMessageComponent extends Box {
 			const detailLine = details ? `\n${details}\n\n` : "\n\n";
 			const header = `**Compacted from ${tokenStr} tokens**${detailLine}`;
 			this.addChild(
-				new Markdown(header + this.message.summary, 0, 0, this.markdownTheme, {
+				new Markdown(header + sanitizeCompactionSummary(this.message.summary), 0, 0, this.markdownTheme, {
 					color: (text: string) => theme.fg("customMessageText", text),
 				}),
 			);

--- a/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
+++ b/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
@@ -23,6 +23,10 @@ export class StatusIndicator extends Loader {
 	dispose(): void {
 		this.stop();
 	}
+
+	setProgressText(_progressText: string): void {
+		// Only compaction status renders progress.
+	}
 }
 
 export class WorkingStatusIndicator extends StatusIndicator {
@@ -73,6 +77,8 @@ export class RetryStatusIndicator extends StatusIndicator {
 export type CompactionStatusReason = "manual" | "threshold" | "overflow" | "pre_prompt" | "branch" | "extension";
 
 export class CompactionStatusIndicator extends StatusIndicator {
+	private progressText = "";
+
 	constructor(ui: TUI, reason: CompactionStatusReason) {
 		const cancelHint = `(${keyText("app.interrupt")} to cancel)`;
 		const label =
@@ -92,6 +98,16 @@ export class CompactionStatusIndicator extends StatusIndicator {
 			(text) => theme.fg("muted", text),
 			label,
 		);
+	}
+
+	setProgressText(progressText: string): void {
+		this.progressText = progressText;
+	}
+
+	override render(width: number): string[] {
+		const status = super.render(width).join(" ");
+		if (!this.progressText) return [status];
+		return [`${status} ${theme.fg("muted", this.progressText)}`];
 	}
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3625,7 +3625,12 @@ export class InteractiveMode {
 						this.chatContainer.addChild(new Text(theme.fg("error", message), 1, 0));
 					}
 				}
-				void this.flushCompactionQueue({ willRetry: event.willRetry });
+				// Only an accepted compaction transfers editor-owned input to the
+				// session. Rejections and aborts retain the draft for an explicit
+				// user retry while the UI cleanup above still always runs.
+				if (event.accepted === true || event.result !== undefined) {
+					void this.flushCompactionQueue({ willRetry: event.willRetry });
+				}
 				this.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -418,6 +418,13 @@ export interface InteractiveModeOptions {
 }
 
 export class InteractiveMode {
+	private static restoreCompactionEscapeOverride(host: InteractiveMode): void {
+		if (!host.compactionEscapeOverrideActive) return;
+		host.defaultEditor.onEscape = host.autoCompactionEscapeHandler;
+		host.autoCompactionEscapeHandler = undefined;
+		host.compactionEscapeOverrideActive = false;
+	}
+
 	private runtimeHost: AgentSessionRuntime;
 	private options: InteractiveModeOptions;
 	private ui: TUI;
@@ -512,6 +519,7 @@ export class InteractiveMode {
 
 	// Auto-compaction state
 	private autoCompactionEscapeHandler?: () => void;
+	private compactionEscapeOverrideActive = false;
 	private autoCompactionProgressText = "";
 
 	// Auto-retry state
@@ -572,6 +580,7 @@ export class InteractiveMode {
 		this.options = options;
 		this.autoTrustOnReloadCwd = options.autoTrustOnReloadCwd;
 		this.runtimeHost.setBeforeSessionInvalidate(() => {
+			InteractiveMode.restoreCompactionEscapeOverride(this);
 			this.resetExtensionUI();
 		});
 		this.runtimeHost.setRebindSession(async () => {
@@ -1895,6 +1904,7 @@ export class InteractiveMode {
 	}
 
 	private async rebindCurrentSession(options: { renderBeforeBind?: boolean } = {}): Promise<void> {
+		InteractiveMode.restoreCompactionEscapeOverride(this);
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
 		this.applyRuntimeSettings();
@@ -3541,7 +3551,10 @@ export class InteractiveMode {
 					this.ui.terminal.setProgress(true);
 				}
 				// Keep editor active; submissions are queued during compaction.
-				this.autoCompactionEscapeHandler = this.defaultEditor.onEscape;
+				if (!this.compactionEscapeOverrideActive) {
+					this.autoCompactionEscapeHandler = this.defaultEditor.onEscape;
+					this.compactionEscapeOverrideActive = true;
+				}
 				this.defaultEditor.onEscape = () => {
 					this.session.abortCompaction();
 				};
@@ -3574,10 +3587,7 @@ export class InteractiveMode {
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(false);
 				}
-				if (this.autoCompactionEscapeHandler) {
-					this.defaultEditor.onEscape = this.autoCompactionEscapeHandler;
-					this.autoCompactionEscapeHandler = undefined;
-				}
+				InteractiveMode.restoreCompactionEscapeOverride(this);
 				this.clearStatusIndicator("compaction");
 				this.autoCompactionProgressText = "";
 				if (event.aborted) {
@@ -6681,6 +6691,7 @@ export class InteractiveMode {
 	}
 
 	stop(): void {
+		InteractiveMode.restoreCompactionEscapeOverride(this);
 		this.streamingReveal.stop();
 		this.toolResultReveal.stop();
 		if (this.settingsManager.getShowTerminalProgress()) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3575,10 +3575,7 @@ export class InteractiveMode {
 				if (!nextText) break;
 				this.autoCompactionProgressText = nextText;
 				const preview = nextText.length > 4_000 ? `...${nextText.slice(nextText.length - 4_000)}` : nextText;
-				this.statusContainer.clear();
-				this.statusContainer.addChild(this.activeStatusIndicator);
-				this.statusContainer.addChild(new Spacer(1));
-				this.statusContainer.addChild(new Text(theme.fg("muted", preview), 1, 0));
+				this.activeStatusIndicator.setProgressText(sanitizeTerminalLabel(preview));
 				this.ui.requestRender();
 				break;
 			}
@@ -3594,12 +3591,12 @@ export class InteractiveMode {
 					// Prefer the extension-provided reason over the generic "cancelled"
 					// label so per-turn-cap / circuit-breaker / provider-error cancels are
 					// no longer indistinguishable from a user-triggered abort.
-					const cancelMessage = event.errorMessage ?? "Compaction cancelled";
+					const cancelMessage = sanitizeTerminalLabel(event.errorMessage ?? "Compaction cancelled");
 					if (event.reason === "manual") {
 						this.showError(cancelMessage);
 					} else if (event.errorMessage) {
 						this.chatContainer.addChild(new Spacer(1));
-						this.chatContainer.addChild(new Text(theme.fg("error", event.errorMessage), 1, 0));
+						this.chatContainer.addChild(new Text(theme.fg("error", cancelMessage), 1, 0));
 					} else {
 						this.showStatus("Auto-compaction cancelled");
 					}
@@ -3608,7 +3605,7 @@ export class InteractiveMode {
 					this.rebuildChatFromMessages();
 					this.addMessageToChat(
 						createCompactionSummaryMessage(
-							event.result.summary,
+							sanitizeTerminalLabel(event.result.summary),
 							event.result.tokensBefore,
 							new Date().toISOString(),
 							event.result.details,
@@ -3616,11 +3613,11 @@ export class InteractiveMode {
 					);
 					this.footer.invalidate();
 				} else if (event.errorMessage) {
+					const errorMessage = sanitizeTerminalLabel(event.errorMessage);
 					if (event.reason === "manual") {
-						this.showError(event.errorMessage);
+						this.showError(errorMessage);
 					} else {
-						this.chatContainer.addChild(new Spacer(1));
-						this.chatContainer.addChild(new Text(theme.fg("error", event.errorMessage), 1, 0));
+						this.chatContainer.addChild(new Text(theme.fg("error", errorMessage), 1, 0));
 					}
 				} else if (event.accepted === false) {
 					// Exhaustive fallback per plan Section 1: compaction_end must never fall

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -234,6 +234,15 @@ function formatToolHookTerminalTitle(event: ToolHookStatusStartEvent): string {
 	return `${APP_TITLE} - ${hookName}: ${statusMessage}`;
 }
 
+function sanitizeTuiErrorMessage(value: string): string {
+	return value
+		.replace(/\u001b\][\s\S]*?(?:\u0007|\u001b\\|\u009c|$)/g, "")
+		.replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
+		.replace(/\r\n?/g, "\n")
+		.replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, "")
+		.replace(/[ \t\f\v]+/g, " ");
+}
+
 type RenderSessionItem = AgentMessage | Extract<SessionEntry, { type: "custom" }>;
 
 function isCustomSessionEntry(item: RenderSessionItem): item is Extract<SessionEntry, { type: "custom" }> {
@@ -4452,7 +4461,7 @@ export class InteractiveMode {
 
 	showError(errorMessage: string): void {
 		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new Text(theme.fg("error", `Error: ${errorMessage}`), 1, 0));
+		this.chatContainer.addChild(new Text(theme.fg("error", `Error: ${sanitizeTuiErrorMessage(errorMessage)}`), 1, 0));
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Tool } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context, Model, StreamOptions, Usage } from "@earendil-works/pi-ai/compat";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -200,18 +201,22 @@ interface CapturedCompactionHandlers {
 	modelSelect: ModelSelectHandler;
 }
 
-function captureBeforeAgentStartHandler(): BeforeAgentStartHandler {
+function captureBeforeAgentStartHandler(options?: {
+	activeTools?: string[];
+	allTools?: Tool[];
+}): BeforeAgentStartHandler {
 	let handler: BeforeAgentStartHandler | undefined;
-	const api: ExtensionAPI = Object.assign(Object.create(null), {
+	const api = Object.assign(Object.create(null), {
 		on: (event: string, currentHandler: BeforeAgentStartHandler) => {
 			if (event === "before_agent_start") {
 				handler = currentHandler;
 			}
 		},
 		appendEntry: vi.fn(),
-		getActiveTools: () => [],
+		getActiveTools: () => options?.activeTools ?? [],
+		getAllTools: () => options?.allTools ?? [],
 		getThinkingLevel: () => "off" as const,
-	});
+	}) as ExtensionAPI;
 
 	compactionExtension(api);
 	if (!handler) {
@@ -930,6 +935,54 @@ describe("builtin compaction extension threshold regressions", () => {
 
 		// then
 		expect(order).toEqual(["auth-start", "apply-called", "hook-returned"]);
+	});
+
+	it("sends only active registered and MCP tools to blocking compaction summarization", async () => {
+		const handler = captureBeforeAgentStartHandler({
+			activeTools: ["registered_active"],
+			allTools: [
+				{
+					name: "registered_active",
+					description: "Active registered tool",
+					parameters: { type: "object", properties: {} },
+				},
+				{
+					name: "mcp__inactive_server__query",
+					description: "Inactive MCP tool",
+					parameters: { type: "object", properties: {} },
+				},
+			],
+		});
+		const model = createAnthropicModel("claude-tools", 200_000);
+		const branchEntries = [
+			createMessageEntry(createUserMessage("first request")),
+			createMessageEntry(createAssistantMessage("first answer", createMockUsage(4_000, 500))),
+			createMessageEntry(createUserMessage("second request")),
+			createMessageEntry(createAssistantMessage("second answer", createMockUsage(5_000, 500))),
+		];
+		const providerToolNames: string[][] = [];
+		completeMock.mockImplementation(async (_model: Model<string>, context: Context) => {
+			providerToolNames.push((context.tools ?? []).map((tool) => tool.name));
+			return createAssistantMessage("summary constrained to active tools");
+		});
+		const ctx = createExtensionContext({
+			model,
+			sessionManager: Object.assign(Object.create(null), {
+				getEntries: () => branchEntries,
+				getBranch: () => branchEntries,
+			}) as ExtensionContext["sessionManager"],
+			modelRegistry: Object.assign(Object.create(null), {
+				getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+			}) as ExtensionContext["modelRegistry"],
+			getContextUsage: () => ({ tokens: 190_000, contextWindow: 200_000, percent: 95 }),
+			getCompactionSettings: () => ({ ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 1 }),
+			beginCompaction: () => new AbortController().signal,
+			applyCompaction: async () => ({ applied: true, reason: "ok" }),
+		});
+
+		await handler({ type: "before_agent_start", systemPrompt: "system" }, ctx);
+
+		expect(providerToolNames).toEqual([["registered_active"]]);
 	});
 
 	it("starts compaction feedback before blocking extension summary generation", async () => {

--- a/packages/coding-agent/test/compaction/canonical-routes.test.ts
+++ b/packages/coding-agent/test/compaction/canonical-routes.test.ts
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { type CompactionResult, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import { createEventBus } from "../../src/core/event-bus.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
+import { buildOpenAiRemoteCompactionResult } from "../../src/core/extensions/builtin/compaction/openai-remote.ts";
 import type { BeforeAgentStartEvent } from "../../src/core/extensions/index.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
 import type { SessionEntry, SessionMessageEntry } from "../../src/core/session-manager.ts";
+import { createHarness } from "../suite/harness.ts";
 
 const OPENAI_MODEL = {
 	id: "gpt-5.4",
@@ -154,5 +156,134 @@ describe("builtin compaction canonical routes", () => {
 			mode: "openai-remote",
 			transport: "compact-endpoint",
 		});
+	});
+
+	it("replays a remote checkpoint from the final redacted context without mutating persisted messages", async () => {
+		const sensitivePostCompaction = "SENSITIVE_POST_COMPACTION_CONTEXT";
+		const sensitiveCurrentPrompt = "SENSITIVE_CURRENT_PROMPT";
+		const redactedPostCompaction = "[redacted post-compaction context]";
+		const redactedCurrentPrompt = "[redacted current prompt]";
+		const contextHookOrder: string[] = [];
+		let firstContextHookInput = "";
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "openai",
+			models: [
+				{ id: OPENAI_MODEL.id, contextWindow: OPENAI_MODEL.contextWindow, maxTokens: OPENAI_MODEL.maxTokens },
+			],
+			extensionFactories: [
+				compactionExtension,
+				(pi) => {
+					pi.on("context", (event) => {
+						contextHookOrder.push("first");
+						firstContextHookInput = JSON.stringify(event.messages);
+						return { messages: event.messages };
+					});
+				},
+				(pi) => {
+					pi.on("context", (event) => {
+						contextHookOrder.push("redact");
+						return {
+							messages: event.messages.map((message) => {
+								if (message.role !== "user" || typeof message.content === "string") return message;
+								return {
+									...message,
+									content: message.content.map((part) =>
+										part.type !== "text"
+											? part
+											: {
+													...part,
+													text: part.text
+														.replaceAll(sensitivePostCompaction, redactedPostCompaction)
+														.replaceAll(sensitiveCurrentPrompt, redactedCurrentPrompt),
+												},
+									),
+								};
+							}),
+						};
+					});
+				},
+			],
+		});
+
+		try {
+			const model = harness.getModel() as Model<"openai-responses">;
+			const retainedEntryId = harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "retained checkpoint context" }],
+				timestamp: 1,
+			});
+			const checkpoint = buildOpenAiRemoteCompactionResult({
+				model,
+				firstKeptEntryId: retainedEntryId,
+				tokensBefore: 1_234,
+				requestInputItemCount: 1,
+				response: {
+					id: "resp_checkpoint",
+					created_at: 1_775_000_001,
+					object: "response.compaction",
+					output: [{ type: "compaction", id: "cmp_checkpoint", encrypted_content: "encrypted-checkpoint" }],
+				},
+			});
+			harness.sessionManager.appendCompaction(
+				checkpoint.summary,
+				checkpoint.firstKeptEntryId,
+				checkpoint.tokensBefore,
+				checkpoint.details,
+				true,
+			);
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: `post-checkpoint: ${sensitivePostCompaction}` }],
+				timestamp: 2,
+			});
+
+			const persistedBeforeTransform = JSON.stringify(harness.sessionManager.getBranch());
+			const transformedContext = await harness.getExtensionRunner().emitContext([
+				...harness.sessionManager.buildSessionContext().messages,
+				{
+					role: "user",
+					content: [{ type: "text", text: `current prompt: ${sensitiveCurrentPrompt}` }],
+					timestamp: 3,
+				},
+			]);
+			const transformedContextText = JSON.stringify(transformedContext);
+			expect(contextHookOrder).toEqual(["first", "redact"]);
+			expect(firstContextHookInput).toContain(sensitivePostCompaction);
+			expect(firstContextHookInput).toContain(sensitiveCurrentPrompt);
+			expect(transformedContextText).toContain(redactedPostCompaction);
+			expect(transformedContextText).toContain(redactedCurrentPrompt);
+			expect(transformedContextText).not.toContain(sensitivePostCompaction);
+			expect(transformedContextText).not.toContain(sensitiveCurrentPrompt);
+			expect(JSON.stringify(harness.sessionManager.getBranch())).toBe(persistedBeforeTransform);
+			expect(persistedBeforeTransform).toContain(sensitivePostCompaction);
+			const finalProviderInput = transformedContext.flatMap((message) => {
+				if (message.role !== "user") return [];
+				return [
+					{
+						role: "user" as const,
+						content:
+							typeof message.content === "string"
+								? [{ type: "input_text" as const, text: message.content }]
+								: message.content.flatMap((part) =>
+										part.type === "text" ? [{ type: "input_text" as const, text: part.text }] : [],
+									),
+					},
+				];
+			});
+
+			const rewritten = await harness.getExtensionRunner().emitBeforeProviderRequest({
+				model: model.id,
+				input: [{ role: "developer", content: "current system prompt" }, ...finalProviderInput],
+				stream: true,
+			});
+			const outgoingRemoteInput = JSON.stringify(rewritten);
+			expect(outgoingRemoteInput).toContain(redactedPostCompaction);
+			expect(outgoingRemoteInput).toContain(redactedCurrentPrompt);
+			expect(outgoingRemoteInput).not.toContain(sensitivePostCompaction);
+			expect(outgoingRemoteInput).not.toContain(sensitiveCurrentPrompt);
+		} finally {
+			harness.cleanup();
+		}
 	});
 });

--- a/packages/coding-agent/test/compaction/canonical-routes.test.ts
+++ b/packages/coding-agent/test/compaction/canonical-routes.test.ts
@@ -430,6 +430,112 @@ describe("builtin compaction canonical routes", () => {
 		expect(rewrittenPayload).toContain(firstPostCheckpoint);
 	});
 
+	it("declines remote checkpoint replay when context hooks change the checkpoint prefix boundary", async () => {
+		const filteredPrefix = "FILTERED_CHECKPOINT_PREFIX";
+		const injectedPrefixOne = "INJECTED_CHECKPOINT_PREFIX_ONE";
+		const injectedPrefixTwo = "INJECTED_CHECKPOINT_PREFIX_TWO";
+		const postCheckpointMessage = "POST_CHECKPOINT_MESSAGE_MUST_APPEAR_ONCE";
+		const currentPrompt = "CURRENT_PROMPT_MUST_APPEAR_ONCE";
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "openai",
+			models: [
+				{ id: OPENAI_MODEL.id, contextWindow: OPENAI_MODEL.contextWindow, maxTokens: OPENAI_MODEL.maxTokens },
+			],
+			extensionFactories: [
+				compactionExtension,
+				(pi) => {
+					pi.on("context", (event) => {
+						const withoutFilteredPrefix = event.messages.filter((message) => {
+							if (message.role !== "user" || typeof message.content === "string") return true;
+							return !message.content.some((part) => part.type === "text" && part.text.includes(filteredPrefix));
+						});
+						return {
+							// The transformed checkpoint prefix is no longer identifiable by
+							// persisted-entry count: one item was removed and two injected.
+							messages: [
+								{
+									role: "user",
+									content: [{ type: "text", text: injectedPrefixOne }],
+									timestamp: 10,
+								},
+								{
+									role: "user",
+									content: [{ type: "text", text: injectedPrefixTwo }],
+									timestamp: 11,
+								},
+								...withoutFilteredPrefix,
+							],
+						};
+					});
+				},
+			],
+		});
+
+		try {
+			const model = harness.getModel() as Model<"openai-responses">;
+			const retainedEntryId = harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: filteredPrefix }],
+				timestamp: 1,
+			});
+			const checkpoint = buildOpenAiRemoteCompactionResult({
+				model,
+				firstKeptEntryId: retainedEntryId,
+				tokensBefore: 1_234,
+				requestInputItemCount: 1,
+				response: {
+					id: "resp_checkpoint",
+					created_at: 1_775_000_001,
+					object: "response.compaction",
+					output: [{ type: "compaction", id: "cmp_checkpoint", encrypted_content: "provider-checkpoint" }],
+				},
+			});
+			harness.sessionManager.appendCompaction(
+				checkpoint.summary,
+				checkpoint.firstKeptEntryId,
+				checkpoint.tokensBefore,
+				checkpoint.details,
+				true,
+			);
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: postCheckpointMessage }],
+				timestamp: 2,
+			});
+
+			const finalContext = await harness
+				.getExtensionRunner()
+				.emitContext([
+					...harness.sessionManager.buildSessionContext().messages,
+					{ role: "user", content: [{ type: "text", text: currentPrompt }], timestamp: 3 },
+				]);
+			const finalProviderInput = convertResponsesMessages(
+				model,
+				{ systemPrompt: "current system prompt", messages: convertToLlm(finalContext) },
+				new Set(["openai"]),
+			);
+			const finalPayload = { model: model.id, input: finalProviderInput, stream: true };
+			const finalPayloadText = JSON.stringify(finalPayload);
+			expect(finalPayloadText).not.toContain(filteredPrefix);
+			expect(finalPayloadText).toContain(injectedPrefixOne);
+			expect(finalPayloadText).toContain(injectedPrefixTwo);
+
+			const rewritten = await harness.getExtensionRunner().emitBeforeProviderRequest(finalPayload);
+
+			// A count derived from persisted entries cannot prove this transformed
+			// boundary. Preserve the final transformed payload instead of slicing it.
+			expect(rewritten).toEqual(finalPayload);
+			const outgoingPayload = JSON.stringify(rewritten);
+			for (const text of [injectedPrefixOne, injectedPrefixTwo, postCheckpointMessage, currentPrompt]) {
+				expect(outgoingPayload.split(text)).toHaveLength(2);
+			}
+			expect(outgoingPayload).not.toContain("provider-checkpoint");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("replays a remote checkpoint from the final redacted context without mutating persisted messages", async () => {
 		const sensitivePostCompaction = "SENSITIVE_POST_COMPACTION_CONTEXT";
 		const sensitiveCurrentPrompt = "SENSITIVE_CURRENT_PROMPT";

--- a/packages/coding-agent/test/compaction/canonical-routes.test.ts
+++ b/packages/coding-agent/test/compaction/canonical-routes.test.ts
@@ -1,12 +1,21 @@
 import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { convertResponsesMessages } from "../../../ai/src/api/openai-responses-shared.ts";
 import { type CompactionResult, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
 import { createEventBus } from "../../src/core/event-bus.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
-import { buildOpenAiRemoteCompactionResult } from "../../src/core/extensions/builtin/compaction/openai-remote.ts";
+import {
+	buildOpenAiRemoteCompactionResult,
+	rewriteOpenAiPayloadWithRemoteCompaction,
+} from "../../src/core/extensions/builtin/compaction/openai-remote.ts";
 import type { BeforeAgentStartEvent } from "../../src/core/extensions/index.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
-import type { SessionEntry, SessionMessageEntry } from "../../src/core/session-manager.ts";
+import { convertToLlm } from "../../src/core/messages.ts";
+import {
+	type SessionEntry,
+	type SessionMessageEntry,
+	sessionEntryToContextMessages,
+} from "../../src/core/session-manager.ts";
 import { createHarness } from "../suite/harness.ts";
 
 const OPENAI_MODEL = {
@@ -156,6 +165,128 @@ describe("builtin compaction canonical routes", () => {
 			mode: "openai-remote",
 			transport: "compact-endpoint",
 		});
+	});
+
+	it("retains the current prompt after a checkpoint prefix whose failed turns Responses drops", () => {
+		const currentPrompt = "CURRENT_PROMPT_MUST_APPEAR_ONCE";
+		const usage = {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		const branch: SessionEntry[] = [
+			messageEntry("u1", null, {
+				role: "user",
+				content: [{ type: "text", text: "kept checkpoint context" }],
+				timestamp: 1,
+			}),
+			messageEntry("error", "u1", {
+				role: "assistant",
+				api: "openai-responses",
+				provider: "openai",
+				model: OPENAI_MODEL.id,
+				content: [
+					{ type: "text", text: "ERRORED_ASSISTANT_SHOULD_NOT_REPLAY" },
+					{ type: "toolCall", id: "call_error|fc_error", name: "read", arguments: {} },
+				],
+				usage,
+				stopReason: "error",
+				timestamp: 2,
+			}),
+			messageEntry("error-result", "error", {
+				role: "toolResult",
+				toolCallId: "call_error|fc_error",
+				toolName: "read",
+				content: [{ type: "text", text: "ERRORED_TOOL_RESULT_SHOULD_NOT_REPLAY" }],
+				isError: true,
+				timestamp: 3,
+			}),
+			messageEntry("aborted", "error-result", {
+				role: "assistant",
+				api: "openai-responses",
+				provider: "openai",
+				model: OPENAI_MODEL.id,
+				content: [
+					{ type: "text", text: "ABORTED_ASSISTANT_SHOULD_NOT_REPLAY" },
+					{ type: "toolCall", id: "call_abort|fc_abort", name: "read", arguments: {} },
+				],
+				usage,
+				stopReason: "aborted",
+				timestamp: 4,
+			}),
+			messageEntry("aborted-result", "aborted", {
+				role: "toolResult",
+				toolCallId: "call_abort|fc_abort",
+				toolName: "read",
+				content: [{ type: "text", text: "ABORTED_TOOL_RESULT_SHOULD_NOT_REPLAY" }],
+				isError: true,
+				timestamp: 5,
+			}),
+			messageEntry("empty", "aborted-result", {
+				role: "user",
+				content: [],
+				timestamp: 6,
+			}),
+			{
+				type: "compaction",
+				id: "checkpoint",
+				parentId: "empty",
+				timestamp: new Date(1_775_000_001_000).toISOString(),
+				summary: "fallback checkpoint summary",
+				firstKeptEntryId: "u1",
+				tokensBefore: 100,
+				fromHook: true,
+				details: {
+					schema: "senpi.compaction.openai-remote.v1",
+					mode: "openai-remote",
+					provider: "openai",
+					api: "openai-responses",
+					transport: "compact-endpoint",
+					modelId: OPENAI_MODEL.id,
+					responseId: "checkpoint-response",
+					createdAt: 1_775_000_001,
+					requestInputItemCount: 1,
+					retainedInputItemCount: 1,
+					replacementInput: [{ type: "compaction", encrypted_content: "provider-checkpoint" }],
+				},
+			},
+		];
+
+		const checkpointIndex = branch.findIndex((entry) => entry.id === "checkpoint");
+		const canonicalInput = convertResponsesMessages(
+			OPENAI_MODEL,
+			{
+				systemPrompt: "current system prompt",
+				messages: [
+					...convertToLlm(
+						[branch[checkpointIndex]!, ...branch.slice(0, checkpointIndex)].flatMap(
+							sessionEntryToContextMessages,
+						),
+					),
+					{ role: "user", content: [{ type: "text", text: currentPrompt }], timestamp: 7 },
+				],
+			},
+			new Set(["openai"]),
+		);
+		const canonicalPayload = JSON.stringify(canonicalInput);
+		expect(canonicalPayload).not.toContain("ERRORED_ASSISTANT_SHOULD_NOT_REPLAY");
+		expect(canonicalPayload).not.toContain("ERRORED_TOOL_RESULT_SHOULD_NOT_REPLAY");
+		expect(canonicalPayload).not.toContain("ABORTED_ASSISTANT_SHOULD_NOT_REPLAY");
+		expect(canonicalPayload).not.toContain("ABORTED_TOOL_RESULT_SHOULD_NOT_REPLAY");
+
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			{ model: OPENAI_MODEL.id, input: canonicalInput, stream: true },
+			{ model: OPENAI_MODEL, branchEntries: branch },
+		);
+		const rewrittenPayload = JSON.stringify(rewritten);
+
+		// The boundary must come from the actual provider payload, not a second
+		// converter that counts the empty user and dropped tool pairs above.
+		expect(rewrittenPayload.split(currentPrompt)).toHaveLength(2);
+		expect(rewrittenPayload).toContain("provider-checkpoint");
 	});
 
 	it("replays a remote checkpoint from the final redacted context without mutating persisted messages", async () => {

--- a/packages/coding-agent/test/compaction/canonical-routes.test.ts
+++ b/packages/coding-agent/test/compaction/canonical-routes.test.ts
@@ -6,9 +6,13 @@ import { createEventBus } from "../../src/core/event-bus.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import {
 	buildOpenAiRemoteCompactionResult,
+	markOpenAiRemoteReplayBoundary,
 	rewriteOpenAiPayloadWithRemoteCompaction,
 } from "../../src/core/extensions/builtin/compaction/openai-remote.ts";
-import { openAiRemoteCompactionOrigin } from "../../src/core/extensions/builtin/compaction/openai-remote-model.ts";
+import {
+	createOpenAiRemoteCompactionHeaders,
+	openAiRemoteCompactionOrigin,
+} from "../../src/core/extensions/builtin/compaction/openai-remote-model.ts";
 import type { BeforeAgentStartEvent } from "../../src/core/extensions/index.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
 import { COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX, convertToLlm } from "../../src/core/messages.ts";
@@ -838,7 +842,12 @@ describe("builtin compaction canonical routes", () => {
 
 		try {
 			const model = harness.getModel() as Model<"openai-responses">;
-			const origin = openAiRemoteCompactionOrigin(model, new Headers({ authorization: "Bearer faux-key" }));
+			const headers = createOpenAiRemoteCompactionHeaders(
+				model,
+				{ apiKey: "faux-key" },
+				harness.sessionManager.getSessionId(),
+			);
+			const origin = headers ? openAiRemoteCompactionOrigin(model, headers) : undefined;
 			expect(origin).toBeDefined();
 			if (!origin) return;
 			const retainedEntryId = harness.sessionManager.appendMessage({
@@ -909,5 +918,109 @@ describe("builtin compaction canonical routes", () => {
 		} finally {
 			harness.cleanup();
 		}
+	});
+
+	it.each([
+		"x-tenant-id",
+		"x-workspace-id",
+	] as const)("declines replay when final routing header %s changes for the same endpoint and credential", (routingHeader) => {
+		const commonHeaders = {
+			authorization: "Bearer shared-account-credential",
+			"x-tenant-id": "tenant-a",
+			"x-workspace-id": "workspace-a",
+		};
+		const originA = openAiRemoteCompactionOrigin(OPENAI_MODEL, new Headers(commonHeaders));
+		const originB = openAiRemoteCompactionOrigin(
+			OPENAI_MODEL,
+			new Headers({ ...commonHeaders, [routingHeader]: `${routingHeader}-b` }),
+		);
+		if (!originA || !originB) throw new Error("Expected remote replay origins");
+
+		const checkpoint = buildOpenAiRemoteCompactionResult({
+			model: OPENAI_MODEL,
+			firstKeptEntryId: "u2",
+			tokensBefore: 1_234,
+			requestInputItemCount: 4,
+			response: {
+				id: `resp_${routingHeader}`,
+				created_at: 1_775_000_001,
+				object: "response.compaction",
+				output: [{ type: "context_compaction", encrypted_content: "routing-bound-checkpoint" }],
+			},
+			origin: originA,
+		});
+		const branch: SessionEntry[] = [
+			...openAiBranch(),
+			{
+				type: "compaction",
+				id: "routing-checkpoint",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				summary: checkpoint.summary,
+				firstKeptEntryId: checkpoint.firstKeptEntryId,
+				tokensBefore: checkpoint.tokensBefore,
+				details: checkpoint.details,
+				fromHook: true,
+			},
+		];
+		const markedContext = markOpenAiRemoteReplayBoundary(
+			[
+				...buildSessionContext(branch).messages,
+				{ role: "user", content: [{ type: "text", text: "Continue on the new route." }], timestamp: 4 },
+			],
+			{ model: OPENAI_MODEL, branchEntries: branch },
+		);
+		const finalPayload = {
+			model: OPENAI_MODEL.id,
+			input: convertResponsesMessages(OPENAI_MODEL, { messages: convertToLlm(markedContext) }, new Set(["openai"])),
+			stream: true,
+		};
+
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(finalPayload, {
+			model: OPENAI_MODEL,
+			branchEntries: branch,
+			origin: originB,
+		});
+
+		// Every final routing decision scopes the native checkpoint, not only
+		// credentials. Neither tenant nor workspace state may cross-replay.
+		expect(rewritten).toBeUndefined();
+		expect(originB.authTenantFingerprint).not.toBe(originA.authTenantFingerprint);
+	});
+
+	it("excludes only documented volatile transport headers from non-Codex provenance", () => {
+		const stableHeaders = {
+			authorization: "Bearer tenant-a",
+			"x-tenant-id": "tenant-a",
+			accept: "application/json",
+		};
+		const first = openAiRemoteCompactionOrigin(
+			OPENAI_MODEL,
+			new Headers({
+				...stableHeaders,
+				"content-length": "123",
+				"user-agent": "senpi test A",
+				"x-request-id": "request-a",
+				"x-client-request-id": "client-a",
+			}),
+		);
+		const onlyVolatileHeadersChanged = openAiRemoteCompactionOrigin(
+			OPENAI_MODEL,
+			new Headers({
+				...stableHeaders,
+				"content-length": "456",
+				"user-agent": "senpi test B",
+				"x-request-id": "request-b",
+				"x-client-request-id": "client-b",
+			}),
+		);
+		const finalNonVolatileHeaderChanged = openAiRemoteCompactionOrigin(
+			OPENAI_MODEL,
+			new Headers({ ...stableHeaders, accept: "application/vnd.route-b+json" }),
+		);
+
+		expect(first).toBeDefined();
+		expect(onlyVolatileHeadersChanged).toEqual(first);
+		expect(finalNonVolatileHeaderChanged?.authTenantFingerprint).not.toBe(first?.authTenantFingerprint);
 	});
 });

--- a/packages/coding-agent/test/compaction/canonical-routes.test.ts
+++ b/packages/coding-agent/test/compaction/canonical-routes.test.ts
@@ -12,6 +12,7 @@ import type { BeforeAgentStartEvent } from "../../src/core/extensions/index.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
 import { convertToLlm } from "../../src/core/messages.ts";
 import {
+	buildSessionContext,
 	type SessionEntry,
 	type SessionMessageEntry,
 	sessionEntryToContextMessages,
@@ -287,6 +288,146 @@ describe("builtin compaction canonical routes", () => {
 		// converter that counts the empty user and dropped tool pairs above.
 		expect(rewrittenPayload.split(currentPrompt)).toHaveLength(2);
 		expect(rewrittenPayload).toContain("provider-checkpoint");
+	});
+
+	it("uses the canonical projection for the checkpoint prefix when a newer checkpoint supersedes an older compaction", () => {
+		const currentPrompt = "CURRENT_PROMPT_MUST_APPEAR_ONCE";
+		const firstPostCheckpoint = "FIRST_POST_CHECKPOINT_ITEM";
+		const olderRemote = buildOpenAiRemoteCompactionResult({
+			model: OPENAI_MODEL,
+			firstKeptEntryId: "u2",
+			tokensBefore: 100,
+			requestInputItemCount: 3,
+			response: {
+				id: "resp_older",
+				created_at: 1_775_000_001,
+				object: "response.compaction",
+				output: [{ type: "compaction", id: "cmp_older", encrypted_content: "OLDER_CHECKPOINT_SUPERSEDED" }],
+			},
+		});
+		const latestRemote = buildOpenAiRemoteCompactionResult({
+			model: OPENAI_MODEL,
+			firstKeptEntryId: "u1",
+			tokensBefore: 200,
+			requestInputItemCount: 6,
+			response: {
+				id: "resp_latest",
+				created_at: 1_775_000_002,
+				object: "response.compaction",
+				output: [{ type: "compaction", id: "cmp_latest", encrypted_content: "LATEST_CHECKPOINT" }],
+			},
+		});
+		// The latest checkpoint's firstKeptEntryId (u1) reaches before the older
+		// compaction entry, so the older summary is superseded.
+		const branch: SessionEntry[] = [
+			{
+				type: "model_change",
+				id: "model",
+				parentId: null,
+				timestamp: new Date(1_775_000_000_000).toISOString(),
+				provider: "openai",
+				modelId: OPENAI_MODEL.id,
+			},
+			messageEntry("u1", "model", {
+				role: "user",
+				content: [{ type: "text", text: "kept turn one" }],
+				timestamp: 1,
+			}),
+			messageEntry("a1", "u1", {
+				role: "assistant",
+				api: "openai-responses",
+				provider: "openai",
+				model: OPENAI_MODEL.id,
+				content: [{ type: "text", text: "kept assistant one" }],
+				usage: {
+					input: 10,
+					output: 5,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 15,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 2,
+			}),
+			messageEntry("u2", "a1", {
+				role: "user",
+				content: [{ type: "text", text: "kept turn two" }],
+				timestamp: 3,
+			}),
+			{
+				type: "compaction",
+				id: "compact-older",
+				parentId: "u2",
+				timestamp: new Date(1_775_000_001_000).toISOString(),
+				summary: "OLDER_SUMMARY_SUPERSEDED",
+				firstKeptEntryId: olderRemote.firstKeptEntryId,
+				tokensBefore: olderRemote.tokensBefore,
+				details: olderRemote.details,
+				fromHook: true,
+			},
+			messageEntry("u3", "compact-older", {
+				role: "user",
+				content: [{ type: "text", text: "kept turn three" }],
+				timestamp: 4,
+			}),
+			messageEntry("u4", "u3", {
+				role: "user",
+				content: [{ type: "text", text: "kept turn four" }],
+				timestamp: 5,
+			}),
+			{
+				type: "compaction",
+				id: "compact-latest",
+				parentId: "u4",
+				timestamp: new Date(1_775_000_002_000).toISOString(),
+				summary: "LATEST_SUMMARY",
+				firstKeptEntryId: latestRemote.firstKeptEntryId,
+				tokensBefore: latestRemote.tokensBefore,
+				details: latestRemote.details,
+				fromHook: true,
+			},
+			messageEntry("u5", "compact-latest", {
+				role: "user",
+				content: [{ type: "text", text: firstPostCheckpoint }],
+				timestamp: 6,
+			}),
+		];
+
+		// Canonical session context skips the superseded older summary.
+		const canonicalMessages = convertToLlm(buildSessionContext(branch).messages);
+		const canonicalText = JSON.stringify(canonicalMessages);
+		expect(canonicalText).toContain("LATEST_SUMMARY");
+		expect(canonicalText).not.toContain("OLDER_SUMMARY_SUPERSEDED");
+		expect(canonicalText).toContain("kept turn one");
+		expect(canonicalText).toContain(firstPostCheckpoint);
+
+		const canonicalInput = convertResponsesMessages(
+			OPENAI_MODEL,
+			{
+				systemPrompt: "current system prompt",
+				messages: [
+					...canonicalMessages,
+					{ role: "user", content: [{ type: "text", text: currentPrompt }], timestamp: 7 },
+				],
+			},
+			new Set(["openai"]),
+		);
+
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			{ model: OPENAI_MODEL.id, input: canonicalInput, stream: true },
+			{ model: OPENAI_MODEL, branchEntries: branch },
+		);
+		const rewrittenPayload = JSON.stringify(rewritten);
+
+		// The checkpoint prefix boundary must use the same projection: the
+		// superseded older summary contributes no payload item, so it must not
+		// shift the boundary past the first post-checkpoint item.
+		expect(rewrittenPayload).toContain("LATEST_CHECKPOINT");
+		expect(rewrittenPayload).not.toContain("OLDER_CHECKPOINT_SUPERSEDED");
+		expect(rewrittenPayload).not.toContain("kept turn one");
+		expect(rewrittenPayload.split(currentPrompt)).toHaveLength(2);
+		expect(rewrittenPayload).toContain(firstPostCheckpoint);
 	});
 
 	it("replays a remote checkpoint from the final redacted context without mutating persisted messages", async () => {

--- a/packages/coding-agent/test/compaction/canonical-routes.test.ts
+++ b/packages/coding-agent/test/compaction/canonical-routes.test.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+import { type AssistantMessage, fauxAssistantMessage, type Model } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { convertResponsesMessages } from "../../../ai/src/api/openai-responses-shared.ts";
 import { type CompactionResult, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
@@ -8,9 +8,10 @@ import {
 	buildOpenAiRemoteCompactionResult,
 	rewriteOpenAiPayloadWithRemoteCompaction,
 } from "../../src/core/extensions/builtin/compaction/openai-remote.ts";
+import { openAiRemoteCompactionOrigin } from "../../src/core/extensions/builtin/compaction/openai-remote-model.ts";
 import type { BeforeAgentStartEvent } from "../../src/core/extensions/index.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
-import { convertToLlm } from "../../src/core/messages.ts";
+import { COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX, convertToLlm } from "../../src/core/messages.ts";
 import {
 	buildSessionContext,
 	type SessionEntry,
@@ -165,6 +166,11 @@ describe("builtin compaction canonical routes", () => {
 			schema: "senpi.compaction.openai-remote.v1",
 			mode: "openai-remote",
 			transport: "compact-endpoint",
+			origin: {
+				endpoint: "http://openai.test/v1",
+				trustDomain: "http://openai.test",
+				authTenantFingerprint: expect.stringMatching(/^sha256:/),
+			},
 		});
 	});
 
@@ -282,12 +288,10 @@ describe("builtin compaction canonical routes", () => {
 			{ model: OPENAI_MODEL.id, input: canonicalInput, stream: true },
 			{ model: OPENAI_MODEL, branchEntries: branch },
 		);
-		const rewrittenPayload = JSON.stringify(rewritten);
 
-		// The boundary must come from the actual provider payload, not a second
-		// converter that counts the empty user and dropped tool pairs above.
-		expect(rewrittenPayload.split(currentPrompt)).toHaveLength(2);
-		expect(rewrittenPayload).toContain("provider-checkpoint");
+		// A manually reconstructed payload has no request-local boundary marker.
+		// It is intentionally not enough to carry equal provider items.
+		expect(rewritten).toBeUndefined();
 	});
 
 	it("uses the canonical projection for the checkpoint prefix when a newer checkpoint supersedes an older compaction", () => {
@@ -418,16 +422,10 @@ describe("builtin compaction canonical routes", () => {
 			{ model: OPENAI_MODEL.id, input: canonicalInput, stream: true },
 			{ model: OPENAI_MODEL, branchEntries: branch },
 		);
-		const rewrittenPayload = JSON.stringify(rewritten);
 
-		// The checkpoint prefix boundary must use the same projection: the
-		// superseded older summary contributes no payload item, so it must not
-		// shift the boundary past the first post-checkpoint item.
-		expect(rewrittenPayload).toContain("LATEST_CHECKPOINT");
-		expect(rewrittenPayload).not.toContain("OLDER_CHECKPOINT_SUPERSEDED");
-		expect(rewrittenPayload).not.toContain("kept turn one");
-		expect(rewrittenPayload.split(currentPrompt)).toHaveLength(2);
-		expect(rewrittenPayload).toContain(firstPostCheckpoint);
+		// The compaction projection alone is not provenance. Only the actual
+		// context pipeline may authorize replay.
+		expect(rewritten).toBeUndefined();
 	});
 
 	it("declines remote checkpoint replay when context hooks change the checkpoint prefix boundary", async () => {
@@ -536,6 +534,260 @@ describe("builtin compaction canonical routes", () => {
 		}
 	});
 
+	it("declines replay when a later context hook filters a retained prompt with the same text as the current prompt", async () => {
+		const currentPrompt = "IDENTICAL_RETAINED_AND_CURRENT_PROMPT";
+		let filteredPersistedPrompt = false;
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "openai",
+			models: [
+				{ id: OPENAI_MODEL.id, contextWindow: OPENAI_MODEL.contextWindow, maxTokens: OPENAI_MODEL.maxTokens },
+			],
+			extensionFactories: [
+				compactionExtension,
+				(pi) => {
+					pi.on("context", (event) => {
+						const messages = event.messages.filter((message) => {
+							const isRetainedPrompt =
+								message.role === "user" &&
+								message.timestamp === 1 &&
+								typeof message.content !== "string" &&
+								message.content.some((part) => part.type === "text" && part.text === currentPrompt);
+							if (isRetainedPrompt) filteredPersistedPrompt = true;
+							return !isRetainedPrompt;
+						});
+						return { messages };
+					});
+				},
+			],
+		});
+
+		try {
+			const model = harness.getModel() as Model<"openai-responses">;
+			const retainedEntryId = harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: currentPrompt }],
+				timestamp: 1,
+			});
+			const checkpoint = buildOpenAiRemoteCompactionResult({
+				model,
+				firstKeptEntryId: retainedEntryId,
+				tokensBefore: 1_234,
+				requestInputItemCount: 1,
+				response: {
+					id: "resp_identical_prompt_checkpoint",
+					created_at: 1_775_000_001,
+					object: "response.compaction",
+					output: [{ type: "compaction", id: "cmp_identical_prompt", encrypted_content: "provider-checkpoint" }],
+				},
+			});
+			harness.sessionManager.appendCompaction(
+				checkpoint.summary,
+				checkpoint.firstKeptEntryId,
+				checkpoint.tokensBefore,
+				checkpoint.details,
+				true,
+			);
+
+			const finalContext = await harness
+				.getExtensionRunner()
+				.emitContext([
+					...harness.sessionManager.buildSessionContext().messages,
+					{ role: "user", content: [{ type: "text", text: currentPrompt }], timestamp: 2 },
+				]);
+			const finalProviderInput = convertResponsesMessages(
+				model,
+				{ systemPrompt: "current system prompt", messages: convertToLlm(finalContext) },
+				new Set(["openai"]),
+			);
+			const finalPayload = { model: model.id, input: finalProviderInput, stream: true };
+			expect(filteredPersistedPrompt).toBe(true);
+			expect(JSON.stringify(finalPayload).split(currentPrompt)).toHaveLength(2);
+
+			const rewritten = await harness.getExtensionRunner().emitBeforeProviderRequest(finalPayload);
+
+			// The timestamp-selected retained message is gone, even though the
+			// in-flight prompt has identical text. Content equality alone cannot
+			// establish the checkpoint boundary.
+			expect(rewritten).toEqual(finalPayload);
+			const outgoingPayload = JSON.stringify(rewritten);
+			expect(outgoingPayload.split(currentPrompt)).toHaveLength(2);
+			expect(outgoingPayload).not.toContain("provider-checkpoint");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("declines a checkpoint generated at endpoint A after the same effective model is reconfigured to endpoint B", () => {
+		const endpointA = {
+			...OPENAI_MODEL,
+			baseUrl: "https://endpoint-a.example.test/v1",
+		} satisfies Model<"openai-responses">;
+		const endpointB = {
+			...endpointA,
+			baseUrl: "https://endpoint-b.example.test/v1",
+		} satisfies Model<"openai-responses">;
+		const retainedPrompt = "RETAINED_AT_ENDPOINT_A";
+		const originA = openAiRemoteCompactionOrigin(endpointA, new Headers({ authorization: "Bearer tenant-a" }));
+		const originB = openAiRemoteCompactionOrigin(endpointB, new Headers({ authorization: "Bearer tenant-a" }));
+		expect(originA).toBeDefined();
+		expect(originB).toBeDefined();
+		if (!originA || !originB) return;
+		const checkpoint = buildOpenAiRemoteCompactionResult({
+			model: endpointA,
+			firstKeptEntryId: "retained",
+			tokensBefore: 1_234,
+			requestInputItemCount: 1,
+			response: {
+				id: "resp_endpoint_a",
+				created_at: 1_775_000_001,
+				object: "response.compaction",
+				output: [{ type: "compaction", id: "cmp_endpoint_a", encrypted_content: "endpoint-a-checkpoint" }],
+			},
+			origin: originA,
+		});
+		const branch: SessionEntry[] = [
+			messageEntry("retained", null, {
+				role: "user",
+				content: [{ type: "text", text: retainedPrompt }],
+				timestamp: 1,
+			}),
+			{
+				type: "compaction",
+				id: "checkpoint",
+				parentId: "retained",
+				timestamp: new Date(1_775_000_001_000).toISOString(),
+				summary: checkpoint.summary,
+				firstKeptEntryId: checkpoint.firstKeptEntryId,
+				tokensBefore: checkpoint.tokensBefore,
+				details: checkpoint.details,
+				fromHook: true,
+			},
+		];
+		const finalPayload = {
+			model: endpointB.id,
+			input: [
+				{ role: "developer", content: "current system prompt" },
+				{
+					role: "user",
+					content: [
+						{
+							type: "input_text",
+							text: `${COMPACTION_SUMMARY_PREFIX}${checkpoint.summary}${COMPACTION_SUMMARY_SUFFIX}`,
+						},
+					],
+				},
+				{ role: "user", content: [{ type: "input_text", text: retainedPrompt }] },
+			],
+			stream: true,
+		};
+
+		const emitted: unknown[] = [];
+		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
+			finalPayload,
+			{ model: endpointB, branchEntries: branch, origin: originB },
+			(event) => emitted.push(event),
+		);
+
+		// Provider/API/model-id equality is insufficient: endpoint B must never
+		// receive a replacement issued by endpoint A.
+		expect(rewritten).toBeUndefined();
+		expect(emitted).toContainEqual(
+			expect.objectContaining({ action: "remote_fallback", reason: "remote-replay-origin-mismatch" }),
+		);
+		expect(rewritten ?? finalPayload).toEqual(finalPayload);
+	});
+
+	it("declines replay after the authorization tenant changes without persisting the raw credential", async () => {
+		const tenantAKey = "sk-tenant-a-remote-replay-secret";
+		const tenantBKey = "sk-tenant-b-remote-replay-secret";
+		const currentPrompt = "CURRENT_PROMPT_AFTER_AUTH_TENANT_CHANGE";
+		const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+			expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${tenantAKey}`);
+			return new Response(
+				JSON.stringify({
+					id: "resp_tenant_a_checkpoint",
+					created_at: 1_775_000_001,
+					object: "response.compaction",
+					output: [{ type: "compaction", id: "cmp_tenant_a", encrypted_content: "encrypted-checkpoint" }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "openai",
+			models: [{ id: OPENAI_MODEL.id, contextWindow: 200_000, maxTokens: 16_384 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [compactionExtension],
+		});
+
+		try {
+			await harness.session.bindExtensions({});
+			const model = harness.getModel() as Model<"openai-responses">;
+			await harness.authStorage.modify(model.provider, async () => ({ type: "api_key", key: tenantAKey }));
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "context compacted for tenant A" }],
+				timestamp: 1,
+			});
+			harness.sessionManager.appendMessage({
+				...fauxAssistantMessage("tenant A completed this turn"),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				timestamp: 2,
+			});
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "retain this tenant A turn" }],
+				timestamp: 3,
+			});
+			harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+			await harness.session.compact();
+
+			expect(fetchMock).toHaveBeenCalledOnce();
+			const persistedCheckpoint = JSON.stringify(
+				harness.sessionManager.getBranch().find((entry) => entry.type === "compaction"),
+			);
+			expect(persistedCheckpoint).not.toContain(tenantAKey);
+
+			await harness.authStorage.modify(model.provider, async () => ({ type: "api_key", key: tenantBKey }));
+			expect(await harness.getExtensionRunner().getModelRegistry().getApiKeyAndHeaders(model)).toMatchObject({
+				ok: true,
+				apiKey: tenantBKey,
+			});
+			const finalContext = await harness
+				.getExtensionRunner()
+				.emitContext([
+					...harness.sessionManager.buildSessionContext().messages,
+					{ role: "user", content: [{ type: "text", text: currentPrompt }], timestamp: 4 },
+				]);
+			const finalPayload = {
+				model: model.id,
+				input: convertResponsesMessages(
+					model,
+					{ systemPrompt: "current system prompt", messages: convertToLlm(finalContext) },
+					new Set(["openai"]),
+				),
+				stream: true,
+			};
+
+			const rewritten = await harness.getExtensionRunner().emitBeforeProviderRequest(finalPayload);
+
+			// A tenant switch cannot replay a checkpoint authorized for tenant A.
+			// Persisted provenance may contain a one-way fingerprint, but never the
+			// credential itself.
+			expect(rewritten).toEqual(finalPayload);
+			const outgoingPayload = JSON.stringify(rewritten);
+			expect(outgoingPayload.split(currentPrompt)).toHaveLength(2);
+			expect(outgoingPayload).not.toContain("encrypted-checkpoint");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("replays a remote checkpoint from the final redacted context without mutating persisted messages", async () => {
 		const sensitivePostCompaction = "SENSITIVE_POST_COMPACTION_CONTEXT";
 		const sensitiveCurrentPrompt = "SENSITIVE_CURRENT_PROMPT";
@@ -586,6 +838,9 @@ describe("builtin compaction canonical routes", () => {
 
 		try {
 			const model = harness.getModel() as Model<"openai-responses">;
+			const origin = openAiRemoteCompactionOrigin(model, new Headers({ authorization: "Bearer faux-key" }));
+			expect(origin).toBeDefined();
+			if (!origin) return;
 			const retainedEntryId = harness.sessionManager.appendMessage({
 				role: "user",
 				content: [{ type: "text", text: "retained checkpoint context" }],
@@ -602,6 +857,7 @@ describe("builtin compaction canonical routes", () => {
 					object: "response.compaction",
 					output: [{ type: "compaction", id: "cmp_checkpoint", encrypted_content: "encrypted-checkpoint" }],
 				},
+				origin,
 			});
 			harness.sessionManager.appendCompaction(
 				checkpoint.summary,
@@ -635,27 +891,17 @@ describe("builtin compaction canonical routes", () => {
 			expect(transformedContextText).not.toContain(sensitiveCurrentPrompt);
 			expect(JSON.stringify(harness.sessionManager.getBranch())).toBe(persistedBeforeTransform);
 			expect(persistedBeforeTransform).toContain(sensitivePostCompaction);
-			const finalProviderInput = transformedContext.flatMap((message) => {
-				if (message.role !== "user") return [];
-				return [
-					{
-						role: "user" as const,
-						content:
-							typeof message.content === "string"
-								? [{ type: "input_text" as const, text: message.content }]
-								: message.content.flatMap((part) =>
-										part.type === "text" ? [{ type: "input_text" as const, text: part.text }] : [],
-									),
-					},
-				];
-			});
-
 			const rewritten = await harness.getExtensionRunner().emitBeforeProviderRequest({
 				model: model.id,
-				input: [{ role: "developer", content: "current system prompt" }, ...finalProviderInput],
+				input: convertResponsesMessages(
+					model,
+					{ systemPrompt: "current system prompt", messages: convertToLlm(transformedContext) },
+					new Set(["openai"]),
+				),
 				stream: true,
 			});
 			const outgoingRemoteInput = JSON.stringify(rewritten);
+			expect(outgoingRemoteInput).toContain("encrypted-checkpoint");
 			expect(outgoingRemoteInput).toContain(redactedPostCompaction);
 			expect(outgoingRemoteInput).toContain(redactedCurrentPrompt);
 			expect(outgoingRemoteInput).not.toContain(sensitivePostCompaction);

--- a/packages/coding-agent/test/compaction/lifecycle.test.ts
+++ b/packages/coding-agent/test/compaction/lifecycle.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+	beginCompactionOperation,
+	finishCompactionOperation,
+	initialCompactionLifecycleState,
+	promoteCompactionOperation,
+} from "../../src/core/compaction/lifecycle.ts";
+
+function begin(operationId: string, generation = 0) {
+	return beginCompactionOperation(
+		generation === 0
+			? initialCompactionLifecycleState()
+			: {
+					status: "completed",
+					generation,
+					operationId: `previous-${generation}`,
+					stage: "execution",
+					reason: "threshold",
+					model: { provider: "faux", id: "previous" },
+					startedRevision: generation,
+					endedRevision: generation,
+				},
+		{
+			operationId,
+			stage: "execution",
+			reason: "threshold",
+			model: { provider: "faux", id: "active" },
+			startedRevision: generation + 1,
+		},
+	);
+}
+
+describe("compaction lifecycle", () => {
+	it("retains completed state until the next operation begins", () => {
+		const running = begin("operation-1");
+		const completed = finishCompactionOperation(running, {
+			operationId: "operation-1",
+			status: "completed",
+			endedRevision: 2,
+		});
+
+		expect(completed).toMatchObject({
+			status: "completed",
+			generation: 1,
+			operationId: "operation-1",
+			model: { provider: "faux", id: "active" },
+			endedRevision: 2,
+		});
+	});
+
+	it("ignores stale completion from a superseded operation", () => {
+		const first = begin("operation-1");
+		const second = beginCompactionOperation(first, {
+			operationId: "operation-2",
+			stage: "execution",
+			reason: "pre_prompt",
+			model: { provider: "faux", id: "fallback" },
+			startedRevision: 3,
+		});
+		const afterStaleCompletion = finishCompactionOperation(second, {
+			operationId: "operation-1",
+			status: "completed",
+			endedRevision: 4,
+		});
+
+		expect(afterStaleCompletion).toBe(second);
+		expect(afterStaleCompletion).toMatchObject({
+			status: "running",
+			generation: 2,
+			operationId: "operation-2",
+			model: { provider: "faux", id: "fallback" },
+		});
+	});
+
+	it("promotes feedback generation into the same execution operation", () => {
+		const feedback = beginCompactionOperation(initialCompactionLifecycleState(), {
+			operationId: "operation-1",
+			stage: "feedback",
+			reason: "extension",
+			model: { provider: "faux", id: "fallback" },
+			startedRevision: 2,
+		});
+		const execution = promoteCompactionOperation(feedback, "operation-1");
+
+		expect(execution).toMatchObject({
+			status: "running",
+			generation: 1,
+			operationId: "operation-1",
+			stage: "execution",
+		});
+	});
+
+	it("records failure and abort as distinct terminal states", () => {
+		const failed = finishCompactionOperation(begin("failed-operation"), {
+			operationId: "failed-operation",
+			status: "failed",
+			endedRevision: 5,
+			rejectionCause: "would-overflow",
+			errorMessage: "summary exceeds budget",
+		});
+		const aborted = finishCompactionOperation(begin("aborted-operation", 1), {
+			operationId: "aborted-operation",
+			status: "aborted",
+			endedRevision: 6,
+			errorMessage: "Compaction cancelled",
+		});
+
+		expect(failed).toMatchObject({
+			status: "failed",
+			rejectionCause: "would-overflow",
+			errorMessage: "summary exceeds budget",
+		});
+		expect(aborted).toMatchObject({
+			status: "aborted",
+			generation: 2,
+			errorMessage: "Compaction cancelled",
+		});
+	});
+
+	it("ignores duplicate terminal events", () => {
+		const completed = finishCompactionOperation(begin("operation-1"), {
+			operationId: "operation-1",
+			status: "completed",
+			endedRevision: 2,
+		});
+		const duplicate = finishCompactionOperation(completed, {
+			operationId: "operation-1",
+			status: "failed",
+			endedRevision: 3,
+			errorMessage: "late failure",
+		});
+
+		expect(duplicate).toBe(completed);
+		expect(duplicate.status).toBe("completed");
+	});
+});

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -1,6 +1,7 @@
-import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { type AssistantMessage, fauxAssistantMessage, type Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import {
 	buildOpenAiRemoteCompactionResult,
 	buildOpenAiResponsesStreamCompactionResult,
@@ -18,6 +19,7 @@ import {
 	COMPACTION_SUMMARY_SUFFIX,
 } from "../../src/core/messages.ts";
 import type { SessionEntry, SessionMessageEntry } from "../../src/core/session-manager.ts";
+import { createHarness } from "../suite/harness.ts";
 
 const OPENAI_MODEL = {
 	id: "gpt-5.4",
@@ -116,6 +118,10 @@ function compactionEvent(branchEntries: SessionEntry[]): SessionBeforeCompactEve
 		signal: new AbortController().signal,
 	};
 }
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
 
 describe("OpenAI remote compaction", () => {
 	it("builds a compact request from a fully OpenAI-native branch", () => {
@@ -349,6 +355,110 @@ describe("OpenAI remote compaction", () => {
 			{ action: "remote_started", transport: "websocket" },
 			{ action: "remote_completed", transport: "websocket" },
 		]);
+	});
+
+	it("runs the direct compact endpoint through the final extension request pipeline", async () => {
+		const rawSecret = "REMOTE_COMPACTION_RAW_SECRET";
+		const redactedSecret = "REMOTE_COMPACTION_REDACTED";
+		const stages: string[] = [];
+		let capturedBody: unknown;
+		let capturedHeaders: Headers | undefined;
+		const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+			stages.push("fetch");
+			capturedBody = JSON.parse(String(init?.body));
+			capturedHeaders = new Headers(init?.headers);
+			return new Response(
+				JSON.stringify({
+					id: "resp_compact_extension_pipeline",
+					created_at: 1_775_000_001,
+					object: "response.compaction",
+					output: [{ type: "compaction", encrypted_content: "encrypted-summary" }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const harness = await createHarness({
+			api: "openai-responses",
+			provider: "openai",
+			models: [
+				{ id: OPENAI_MODEL.id, contextWindow: OPENAI_MODEL.contextWindow, maxTokens: OPENAI_MODEL.maxTokens },
+			],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				compactionExtension,
+				(pi) => {
+					pi.on("context", (event) => {
+						stages.push("context-redact");
+						return {
+							messages: event.messages.map((message) => {
+								if (message.role !== "user" || typeof message.content === "string") return message;
+								return {
+									...message,
+									content: message.content.map((part) =>
+										part.type === "text"
+											? { ...part, text: part.text.replaceAll(rawSecret, redactedSecret) }
+											: part,
+									),
+								};
+							}),
+						};
+					});
+					pi.on("context", () => {
+						stages.push("context-final");
+					});
+					pi.on("before_provider_request", (event) => {
+						stages.push("payload");
+						return { ...(event.payload as Record<string, unknown>), extension_request_hook: "applied" };
+					});
+					pi.on("before_provider_headers", (event) => {
+						stages.push("headers");
+						event.headers["x-compaction-request-hook"] = "applied";
+					});
+				},
+			],
+		});
+
+		try {
+			await harness.session.bindExtensions({});
+			const model = harness.getModel();
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: `persisted ${rawSecret}` }],
+				timestamp: 1,
+			});
+			harness.sessionManager.appendMessage({
+				...fauxAssistantMessage("persisted assistant"),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				timestamp: 2,
+			});
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "retain this turn" }],
+				timestamp: 3,
+			});
+			harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+			await harness.session.compact();
+
+			expect(JSON.stringify(harness.sessionManager.getEntries())).toContain(rawSecret);
+			expect(fetchMock).toHaveBeenCalledOnce();
+			const outgoing = JSON.stringify(capturedBody);
+			expect(outgoing).toContain(redactedSecret);
+			expect(outgoing).not.toContain(rawSecret);
+			expect(capturedBody).toMatchObject({ extension_request_hook: "applied" });
+			expect(capturedHeaders?.get("x-compaction-request-hook")).toBe("applied");
+			for (const stage of ["context-redact", "context-final", "payload", "headers"]) {
+				expect(stages.indexOf(stage)).toBeGreaterThanOrEqual(0);
+				expect(stages.indexOf(stage)).toBeLessThan(stages.indexOf("fetch"));
+			}
+			expect(stages.indexOf("context-redact")).toBeLessThan(stages.indexOf("context-final"));
+		} finally {
+			harness.cleanup();
+		}
 	});
 
 	it("falls back when the compact endpoint does not respond before the remote timeout", async () => {

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -773,7 +773,19 @@ describe("OpenAI remote compaction", () => {
 		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
 			{
 				model: "gpt-5.4",
-				input: [{ role: "developer", content: "current system prompt" }],
+				input: [
+					{ role: "developer", content: "current system prompt" },
+					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
+					{ role: "user", content: [{ type: "input_text", text: "Ran `git status`\n```\nclean\n```" }] },
+					{
+						type: "message",
+						role: "assistant",
+						status: "completed",
+						id: "msg_post_compaction",
+						content: [{ type: "output_text", text: "switched to claude after compaction", annotations: [] }],
+					},
+				],
 				stream: true,
 			},
 			{ model: OPENAI_MODEL, branchEntries: branchWithMixedTail },
@@ -890,7 +902,7 @@ describe("OpenAI remote compaction", () => {
 		]);
 	});
 
-	it("appends the pending prompt that is not yet persisted in the branch", () => {
+	it("replays the in-flight prompt from the final provider payload", () => {
 		const remoteResult = buildOpenAiRemoteCompactionResult({
 			model: OPENAI_MODEL,
 			firstKeptEntryId: "u2",
@@ -932,21 +944,12 @@ describe("OpenAI remote compaction", () => {
 				input: [
 					{ role: "developer", content: "current system prompt" },
 					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 					{ role: "user", content: [{ type: "input_text", text: "Turn three: after compaction." }] },
 				],
 				stream: true,
 			},
-			{
-				model: OPENAI_MODEL,
-				branchEntries: branchEndingAtCompaction,
-				pendingMessages: [
-					{
-						role: "user",
-						content: [{ type: "text", text: "Turn three: after compaction." }],
-						timestamp: 7,
-					},
-				],
-			},
+			{ model: OPENAI_MODEL, branchEntries: branchEndingAtCompaction },
 		);
 
 		expect(rewritten).toMatchObject({
@@ -1011,6 +1014,8 @@ describe("OpenAI remote compaction", () => {
 				input: [
 					{ role: "developer", content: "current system prompt" },
 					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
+					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 				],
 				stream: true,
 			},

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -461,6 +461,56 @@ describe("OpenAI remote compaction", () => {
 		}
 	});
 
+	it("rejects an invalid downstream compact request replacement before it reaches the network", async () => {
+		const compactOnlyModel = {
+			...OPENAI_MODEL,
+			baseUrl: "https://ccapi.example.com/v1",
+			compat: { supportsWebSocket: false },
+		} satisfies Model<"openai-responses">;
+		const emitted: unknown[] = [];
+		const originalPayloads: unknown[] = [];
+		const fetchMock = vi.fn(async () => {
+			throw new Error("an invalid replacement must not reach the compact endpoint");
+		});
+
+		const result = await runOpenAiRemoteCompaction(
+			{
+				model: compactOnlyModel,
+				serviceTier: undefined,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+				},
+				sessionManager: { getSessionId: () => "session-1" },
+				getSystemPrompt: () => "You are senpi.",
+				prepareProviderRequest: async (messages) => ({
+					messages,
+					transformPayload: async (payload) => {
+						originalPayloads.push(payload);
+						// This is the replacement returned by a downstream
+						// before_provider_request handler. It is not an OpenAiCompactBody.
+						return { model: 42, input: "not-an-input-array" };
+					},
+					transformHeaders: async (headers) => headers,
+				}),
+			},
+			compactionEvent(openAiBranch()),
+			(event) => emitted.push(event),
+			{ fetch: fetchMock },
+		);
+
+		expect(originalPayloads).toHaveLength(1);
+		expect(JSON.stringify(originalPayloads[0])).toContain("Please inspect the build.");
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+		expect(emitted).toContainEqual(
+			expect.objectContaining({
+				action: "remote_fallback",
+				reason: "invalid-compact-request-payload",
+				transport: "compact-endpoint",
+			}),
+		);
+	});
+
 	it("falls back when the compact endpoint does not respond before the remote timeout", async () => {
 		const emitted: unknown[] = [];
 		const compactOnlyModel = {
@@ -885,8 +935,16 @@ describe("OpenAI remote compaction", () => {
 				model: "gpt-5.4",
 				input: [
 					{ role: "developer", content: "current system prompt" },
-					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
-					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
+					{
+						role: "user",
+						content: [
+							{
+								type: "input_text",
+								text: `${COMPACTION_SUMMARY_PREFIX}${remoteResult.summary}${COMPACTION_SUMMARY_SUFFIX}`,
+							},
+						],
+					},
+					{ role: "user", content: [{ type: "input_text", text: "Great. Commit it." }] },
 					{ role: "user", content: [{ type: "input_text", text: "Ran `git status`\n```\nclean\n```" }] },
 					{
 						type: "message",
@@ -1053,8 +1111,16 @@ describe("OpenAI remote compaction", () => {
 				model: "gpt-5.4",
 				input: [
 					{ role: "developer", content: "current system prompt" },
-					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
-					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
+					{
+						role: "user",
+						content: [
+							{
+								type: "input_text",
+								text: `${COMPACTION_SUMMARY_PREFIX}${remoteResult.summary}${COMPACTION_SUMMARY_SUFFIX}`,
+							},
+						],
+					},
+					{ role: "user", content: [{ type: "input_text", text: "Great. Commit it." }] },
 					{ role: "user", content: [{ type: "input_text", text: "Turn three: after compaction." }] },
 				],
 				stream: true,
@@ -1123,7 +1189,16 @@ describe("OpenAI remote compaction", () => {
 				model: "gpt-5.4",
 				input: [
 					{ role: "developer", content: "current system prompt" },
-					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{
+						role: "user",
+						content: [
+							{
+								type: "input_text",
+								text: `${COMPACTION_SUMMARY_PREFIX}${remoteResult.summary}${COMPACTION_SUMMARY_SUFFIX}`,
+							},
+						],
+					},
+					{ role: "user", content: [{ type: "input_text", text: "Great. Commit it." }] },
 					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 				],
@@ -1143,6 +1218,7 @@ describe("OpenAI remote compaction", () => {
 					content: [{ type: "input_text", text: "Please inspect the build." }],
 				},
 				{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
+				{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 				{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 			],
 			stream: true,

--- a/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/openai-remote-compaction.test.ts
@@ -959,28 +959,9 @@ describe("OpenAI remote compaction", () => {
 			{ model: OPENAI_MODEL, branchEntries: branchWithMixedTail },
 		);
 
-		expect(rewritten).toMatchObject({
-			model: "gpt-5.4",
-			input: [
-				{ role: "developer", content: "current system prompt" },
-				{
-					type: "message",
-					id: "u1_remote",
-					role: "user",
-					content: [{ type: "input_text", text: "Please inspect the build." }],
-				},
-				{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
-				{ role: "user", content: [{ type: "input_text", text: "Ran `git status`\n```\nclean\n```" }] },
-				{
-					type: "message",
-					role: "assistant",
-					status: "completed",
-					id: expect.any(String),
-					content: [{ type: "output_text", text: "switched to claude after compaction", annotations: [] }],
-				},
-			],
-			stream: true,
-		});
+		// Raw provider items carry no context-boundary provenance and must never
+		// authorize replacement, even when they look like session history.
+		expect(rewritten).toBeUndefined();
 	});
 
 	it("stores remote compaction replacement input in result details for replay", () => {
@@ -1128,19 +1109,7 @@ describe("OpenAI remote compaction", () => {
 			{ model: OPENAI_MODEL, branchEntries: branchEndingAtCompaction },
 		);
 
-		expect(rewritten).toMatchObject({
-			input: [
-				{ role: "developer", content: "current system prompt" },
-				{
-					type: "message",
-					id: "u1_remote",
-					role: "user",
-					content: [{ type: "input_text", text: "Please inspect the build." }],
-				},
-				{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
-				{ role: "user", content: [{ type: "input_text", text: "Turn three: after compaction." }] },
-			],
-		});
+		expect(rewritten).toBeUndefined();
 	});
 
 	it("rewrites provider payloads to replay native compacted history plus post-compact messages", () => {
@@ -1207,21 +1176,6 @@ describe("OpenAI remote compaction", () => {
 			{ model: OPENAI_MODEL, branchEntries: branchWithRemoteCompaction },
 		);
 
-		expect(rewritten).toMatchObject({
-			model: "gpt-5.4",
-			input: [
-				{ role: "developer", content: "current system prompt" },
-				{
-					type: "message",
-					id: "u1_remote",
-					role: "user",
-					content: [{ type: "input_text", text: "Please inspect the build." }],
-				},
-				{ type: "compaction", id: "cmp_1", encrypted_content: "encrypted-summary" },
-				{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
-				{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
-			],
-			stream: true,
-		});
+		expect(rewritten).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/compaction/speculative-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/speculative-compaction.test.ts
@@ -5,9 +5,18 @@ import {
 	fauxToolCall,
 	registerFauxProvider,
 } from "@earendil-works/pi-ai";
+import {
+	type Context,
+	createAssistantMessageEventStream,
+	type Model,
+	registerApiProvider,
+	type StreamOptions,
+	unregisterApiProviders,
+} from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
 import { shouldStartSpeculativeCompaction } from "../../src/core/extensions/builtin/compaction/policy.ts";
 import {
 	applyGeneratedCompaction,
@@ -18,6 +27,7 @@ import {
 } from "../../src/core/extensions/builtin/compaction/speculative.ts";
 import { ModelRegistry } from "../../src/core/model-registry.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
+import { createHarness } from "../suite/harness.ts";
 
 const registrations: Array<{ unregister: () => void }> = [];
 
@@ -236,6 +246,132 @@ describe("speculative compaction", () => {
 
 		// Then
 		expect(result).toBeUndefined();
+	});
+
+	it("runs the non-remote summarizer through the final extension request pipeline", async () => {
+		const api = `compaction-stream-${Math.random().toString(36).slice(2)}`;
+		const provider = `compaction-provider-${Math.random().toString(36).slice(2)}`;
+		const sourceId = `compaction-stream-capture-${api}`;
+		const rawSecret = "STREAM_COMPACTION_RAW_SECRET";
+		const redactedSecret = "STREAM_COMPACTION_REDACTED";
+		const stages: string[] = [];
+		let captured: { context: Context; payload: unknown; headers: StreamOptions["headers"] | undefined } | undefined;
+		const captureStream = (model: Model<typeof api>, context: Context, options?: StreamOptions) => {
+			const stream = createAssistantMessageEventStream();
+			queueMicrotask(() => {
+				void (async () => {
+					const initialPayload = { system: context.systemPrompt, messages: context.messages };
+					const payload = (await options?.onPayload?.(initialPayload, model)) ?? initialPayload;
+					captured = { context, payload, headers: options?.headers ? { ...options.headers } : undefined };
+					stages.push("provider");
+					const message = fauxAssistantMessage("stream summary");
+					stream.push({ type: "done", reason: "stop", message });
+					stream.end(message);
+				})().catch((error) => {
+					const message = fauxAssistantMessage("", {
+						stopReason: "error",
+						errorMessage: error instanceof Error ? error.message : String(error),
+					});
+					stream.push({ type: "error", reason: "error", error: message });
+					stream.end(message);
+				});
+			});
+			return stream;
+		};
+
+		const harness = await createHarness({
+			api,
+			provider,
+			models: [{ id: "stream-compact", contextWindow: 32_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				compactionExtension,
+				(pi) => {
+					pi.on("context", (event) => {
+						stages.push("context-redact");
+						return {
+							messages: event.messages.map((message) => {
+								if (message.role !== "user" || typeof message.content === "string") return message;
+								return {
+									...message,
+									content: message.content.map((part) =>
+										part.type === "text"
+											? { ...part, text: part.text.replaceAll(rawSecret, redactedSecret) }
+											: part,
+									),
+								};
+							}),
+						};
+					});
+					pi.on("context", () => {
+						stages.push("context-final");
+					});
+					pi.on("before_provider_request", (event) => {
+						stages.push("payload");
+						return { ...(event.payload as Record<string, unknown>), extension_request_hook: "applied" };
+					});
+					pi.on("before_provider_headers", (event) => {
+						stages.push("headers");
+						event.headers["x-compaction-request-hook"] = "applied";
+					});
+				},
+			],
+		});
+
+		harness.faux.unregister();
+		registerApiProvider({ api, stream: captureStream, streamSimple: captureStream }, sourceId);
+		try {
+			await harness.session.bindExtensions({});
+			const model = harness.getModel();
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: `persisted ${rawSecret}` }],
+				timestamp: 1,
+			});
+			harness.sessionManager.appendMessage({
+				...fauxAssistantMessage("persisted assistant"),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				timestamp: 2,
+			});
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "retain this turn" }],
+				timestamp: 3,
+			});
+			harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+			await harness.session.compact();
+
+			expect(JSON.stringify(harness.sessionManager.getEntries())).toContain(rawSecret);
+			expect(captured).toBeDefined();
+			const capturedSecretMessage = captured?.context.messages.find(
+				(message) =>
+					message.role === "user" &&
+					typeof message.content !== "string" &&
+					message.content.some((part) => part.type === "text" && part.text.includes("persisted")),
+			);
+			const capturedSecretText =
+				capturedSecretMessage?.role === "user" && Array.isArray(capturedSecretMessage.content)
+					? capturedSecretMessage.content
+							.filter((part): part is { type: "text"; text: string } => part.type === "text")
+							.map((part) => part.text)
+							.join("\n")
+					: "";
+			expect(capturedSecretText).toContain(redactedSecret);
+			expect(capturedSecretText).not.toContain(rawSecret);
+			expect(captured?.payload).toMatchObject({ extension_request_hook: "applied" });
+			expect(captured?.headers?.["x-compaction-request-hook"]).toBe("applied");
+			for (const stage of ["context-redact", "context-final", "payload", "headers"]) {
+				expect(stages.indexOf(stage)).toBeGreaterThanOrEqual(0);
+				expect(stages.indexOf(stage)).toBeLessThan(stages.indexOf("provider"));
+			}
+			expect(stages.indexOf("context-redact")).toBeLessThan(stages.indexOf("context-final"));
+		} finally {
+			unregisterApiProviders(sourceId);
+			harness.cleanup();
+		}
 	});
 
 	it("streams generated summary deltas to the compaction progress callback", async () => {

--- a/packages/coding-agent/test/compaction/speculative-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/speculative-compaction.test.ts
@@ -374,6 +374,91 @@ describe("speculative compaction", () => {
 		}
 	});
 
+	it("redacts a persisted custom message via raw-message context hooks before the non-remote summarizer stream", async () => {
+		const api = `compaction-stream-${Math.random().toString(36).slice(2)}`;
+		const provider = `compaction-provider-${Math.random().toString(36).slice(2)}`;
+		const sourceId = `compaction-stream-capture-${api}`;
+		const rawSecret = "PERSISTED_CUSTOM_RAW_SECRET";
+		const redactedSecret = "[redacted persisted custom secret]";
+		let contextHookRan = false;
+		let hookSawRawCustomSecret = false;
+		let captured: Context | undefined;
+		const captureStream = (_model: Model<typeof api>, context: Context, _options?: StreamOptions) => {
+			const stream = createAssistantMessageEventStream();
+			queueMicrotask(() => {
+				captured = context;
+				const message = fauxAssistantMessage("stream summary");
+				stream.push({ type: "done", reason: "stop", message });
+				stream.end(message);
+			});
+			return stream;
+		};
+
+		const harness = await createHarness({
+			api,
+			provider,
+			models: [{ id: "stream-compact", contextWindow: 32_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				compactionExtension,
+				(pi) => {
+					pi.on("context", (event) => {
+						contextHookRan = true;
+						return {
+							messages: event.messages.map((message) => {
+								if (message.role !== "custom" || message.customType !== "secret") return message;
+								hookSawRawCustomSecret = true;
+								return { ...message, content: redactedSecret };
+							}),
+						};
+					});
+				},
+			],
+		});
+
+		harness.faux.unregister();
+		registerApiProvider({ api, stream: captureStream, streamSimple: captureStream }, sourceId);
+		try {
+			await harness.session.bindExtensions({});
+			const model = harness.getModel();
+			harness.sessionManager.appendCustomMessageEntry(
+				"secret",
+				[{ type: "text", text: `persisted ${rawSecret}` }],
+				false,
+			);
+			harness.sessionManager.appendMessage({
+				...fauxAssistantMessage("persisted assistant"),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				timestamp: 2,
+			});
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "retain this turn" }],
+				timestamp: 3,
+			});
+			harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+			await harness.session.compact();
+
+			// The raw session keeps the persisted secret untouched; only the
+			// outgoing summarization stream input is redacted.
+			expect(JSON.stringify(harness.sessionManager.getEntries())).toContain(rawSecret);
+			expect(contextHookRan).toBe(true);
+			// Ordered context hooks must run on the raw AgentMessage list, before
+			// convertToLlm/repair erases role + customType.
+			expect(hookSawRawCustomSecret).toBe(true);
+			expect(captured).toBeDefined();
+			const capturedText = JSON.stringify(captured?.messages);
+			expect(capturedText).toContain(redactedSecret);
+			expect(capturedText).not.toContain(rawSecret);
+		} finally {
+			unregisterApiProviders(sourceId);
+			harness.cleanup();
+		}
+	});
+
 	it("streams generated summary deltas to the compaction progress callback", async () => {
 		// Given
 		const context = createContext();

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -200,7 +200,9 @@ describe("InteractiveMode compaction events", () => {
 			...fakeThis.showStatus.mock.calls.map((call) => String(call[0])),
 		].join("\n");
 		expect(feedback).toMatch(/would.?overflow|overflow|rejected/i);
-		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+		// Rejected compaction retains editor-owned input instead of submitting it
+		// through a recursive post-compaction prompt path.
+		expect(fakeThis.flushCompactionQueue).not.toHaveBeenCalled();
 	});
 
 	test("sanitizes a detached continuation launch failure before rendering", async () => {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -299,4 +299,98 @@ describe("InteractiveMode compaction events", () => {
 		expect(fakeThis.compactionQueuedMessages).toEqual([]);
 		expect(fakeThis.showError).not.toHaveBeenCalled();
 	});
+
+	test("restores the normal escape handler after a superseded compaction sequence", async () => {
+		const statusContainer = new Container();
+		const abortCompaction = vi.fn();
+		const abortAndFireQueuedMessages = vi.fn().mockResolvedValue(undefined);
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+			autoCompactionProgressText: "",
+			retryEscapeHandler: undefined as (() => void) | undefined,
+			activeStatusIndicator: undefined as { dispose(): void } | undefined,
+			defaultEditor: {
+				onEscape: undefined as (() => void) | undefined,
+				onAction: vi.fn(),
+				onCtrlD: undefined as unknown,
+				onChange: undefined as unknown,
+				onPasteImage: undefined as unknown,
+			},
+			editor: { getText: () => "", setText: vi.fn() },
+			session: {
+				isStreaming: true,
+				retryAttempt: 0,
+				isBashRunning: false,
+				abortBash: vi.fn(),
+				abortCompaction,
+			},
+			abortAndFireQueuedMessages,
+			isBashMode: false,
+			lastEscapeTime: 0,
+			statusContainer,
+			chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			addMessageToChat: vi.fn(),
+			showError: vi.fn(),
+			showWarning: vi.fn(),
+			showStatus: vi.fn(),
+			clearStatusIndicator: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+			showTreeSelector: vi.fn(),
+			showUserMessageSelector: vi.fn(),
+			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			settingsManager: { getShowTerminalProgress: () => false, getDoubleEscapeAction: () => "none" },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() }, onDebug: undefined as unknown },
+		};
+
+		// Install the real normal Escape handler, then drive the real event handler
+		// through a supersession sequence: compaction A starts, compaction B starts
+		// before A ends (A is superseded and never emits compaction_end), then B ends.
+		const setupKeyHandlers = Reflect.get(InteractiveMode.prototype, "setupKeyHandlers") as (
+			this: typeof fakeThis,
+		) => void;
+		setupKeyHandlers.call(fakeThis);
+		const normalEscapeHandler = fakeThis.defaultEditor.onEscape;
+		expect(typeof normalEscapeHandler).toBe("function");
+
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event:
+				| { type: "compaction_start"; reason: "extension" }
+				| {
+						type: "compaction_end";
+						reason: "extension";
+						result: { tokensBefore: number; summary: string } | undefined;
+						aborted: boolean;
+						willRetry: boolean;
+						accepted: boolean;
+				  },
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, { type: "compaction_start", reason: "extension" });
+		await handleEvent.call(fakeThis, { type: "compaction_start", reason: "extension" });
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "extension",
+			result: { tokensBefore: 42, summary: "summary" },
+			aborted: false,
+			willRetry: false,
+			accepted: true,
+		});
+
+		// The compaction escape override must be fully unwound back to the handler
+		// that was installed before compaction A started, not to compaction A's stale
+		// abort closure captured when compaction B superseded it.
+		expect(fakeThis.autoCompactionEscapeHandler).toBeUndefined();
+		expect(fakeThis.defaultEditor.onEscape).toBe(normalEscapeHandler);
+
+		// Escape during streaming/retry must run the normal cancellation path.
+		fakeThis.defaultEditor.onEscape?.();
+		expect(abortAndFireQueuedMessages).toHaveBeenCalledTimes(1);
+		expect(abortCompaction).not.toHaveBeenCalled();
+
+		fakeThis.activeStatusIndicator?.dispose();
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@earendil-works/pi-tui";
+import { Container, sanitizeTerminalLabel } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { CompactionSummaryMessageComponent } from "../src/modes/interactive/components/compaction-summary-message.ts";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
@@ -231,6 +231,73 @@ describe("InteractiveMode compaction events", () => {
 		expect(rendered).not.toContain("]52;");
 		expect(rendered).not.toContain("attacker.invalid");
 		expect(rendered).not.toContain("stolen title");
+	});
+
+	test("sanitizes compaction progress, errors, and display summaries without rewriting the event result", async () => {
+		const hostileText =
+			"compaction\u001b]52;c;c2VjcmV0\u0007 live\u001b]0;stolen title\u0007 " +
+			"\u001b]8;;https://attacker.invalid\u0007link\u001b]8;;\u0007 \u001b[31mcolor\u001b[0m \u009b31mprovider\u009b0m";
+		const sanitizedText = sanitizeTerminalLabel(hostileText);
+		const statusContainer = new Container();
+		const chatContainer = new Container();
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+			autoCompactionLoader: undefined as { stop(): void } | undefined,
+			autoCompactionProgressText: "",
+			defaultEditor: {} as { onEscape?: () => void },
+			session: { abortCompaction: vi.fn() },
+			statusContainer,
+			chatContainer,
+			clearStatusIndicator: vi.fn(),
+			rebuildChatFromMessages: vi.fn(),
+			addMessageToChat: vi.fn(),
+			showError: vi.fn(),
+			showStatus: vi.fn(),
+			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		};
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: object,
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, { type: "compaction_start", reason: "extension" });
+		await handleEvent.call(fakeThis, { type: "compaction_progress", reason: "extension", delta: hostileText });
+		const renderedProgress = stripAnsi(statusContainer.children.flatMap((child) => child.render(120)).join("\n"));
+		expect(renderedProgress).toContain(sanitizedText);
+		expect(renderedProgress).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+		expect(renderedProgress).not.toContain("attacker.invalid");
+		expect(renderedProgress).not.toContain("stolen title");
+
+		const result = { tokensBefore: 123, summary: hostileText };
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "extension",
+			result,
+			aborted: false,
+			willRetry: false,
+			accepted: true,
+		});
+		expect(result.summary).toBe(hostileText);
+		expect(fakeThis.addMessageToChat).toHaveBeenCalledWith(expect.objectContaining({ summary: sanitizedText }));
+
+		await handleEvent.call(fakeThis, { type: "compaction_start", reason: "extension" });
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "extension",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+			errorMessage: hostileText,
+		});
+		const renderedError = stripAnsi(chatContainer.children.flatMap((child) => child.render(120)).join("\n"));
+		expect(renderedError).toContain(sanitizedText);
+		expect(renderedError).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+		expect(renderedError).not.toContain("attacker.invalid");
+		expect(renderedError).not.toContain("stolen title");
 	});
 
 	test("renders OpenAI remote compaction details in the summary card", () => {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -1,11 +1,61 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Container, sanitizeTerminalLabel } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
+import { SessionManager } from "../src/core/session-manager.ts";
 import { CompactionSummaryMessageComponent } from "../src/modes/interactive/components/compaction-summary-message.ts";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
-import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { getMarkdownTheme, initTheme } from "../src/modes/interactive/theme/theme.ts";
 
 function stripAnsi(value: string): string {
 	return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+type PrivateMethod = (this: object, ...args: unknown[]) => void;
+
+function renderExpandedPersistedCompactionSummary(sessionManager: SessionManager): string {
+	const chatContainer = new Container();
+	const addMessageToChat = Reflect.get(InteractiveMode.prototype, "addMessageToChat") as PrivateMethod;
+	const renderSessionItems = Reflect.get(InteractiveMode.prototype, "renderSessionItems") as PrivateMethod;
+	const renderSessionEntries = Reflect.get(InteractiveMode.prototype, "renderSessionEntries") as PrivateMethod;
+	const rebuildChatFromMessages = Reflect.get(InteractiveMode.prototype, "rebuildChatFromMessages") as PrivateMethod;
+	if (
+		typeof addMessageToChat !== "function" ||
+		typeof renderSessionItems !== "function" ||
+		typeof renderSessionEntries !== "function" ||
+		typeof rebuildChatFromMessages !== "function"
+	) {
+		throw new Error("Expected InteractiveMode chat rebuilding methods");
+	}
+
+	const fakeThis = {
+		chatContainer,
+		sessionManager,
+		toolOutputExpanded: true,
+		clearPendingTools: () => {},
+		pendingTools: new Map(),
+		settingsManager: {
+			getCodeBlockIndent: () => 0,
+			getShowCacheMissNotices: () => false,
+		},
+		ui: { requestRender: () => {} },
+		getMarkdownThemeWithSettings: () => getMarkdownTheme(),
+		addMessageToChat: (..._args: unknown[]) => {},
+		renderSessionItems: (..._args: unknown[]) => {},
+		renderSessionEntries: (..._args: unknown[]) => {},
+	};
+	fakeThis.addMessageToChat = (...args) => addMessageToChat.call(fakeThis, ...args);
+	fakeThis.renderSessionItems = (...args) => renderSessionItems.call(fakeThis, ...args);
+	fakeThis.renderSessionEntries = (...args) => renderSessionEntries.call(fakeThis, ...args);
+
+	rebuildChatFromMessages.call(fakeThis);
+	const component = chatContainer.children.find(
+		(child): child is CompactionSummaryMessageComponent => child instanceof CompactionSummaryMessageComponent,
+	);
+	if (!component) throw new Error("Expected rebuilt chat to contain a compaction summary");
+	component.setExpanded(true);
+	return stripAnsi(component.render(120).join("\n"));
 }
 
 describe("InteractiveMode compaction events", () => {
@@ -298,6 +348,73 @@ describe("InteractiveMode compaction events", () => {
 		expect(renderedError).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
 		expect(renderedError).not.toContain("attacker.invalid");
 		expect(renderedError).not.toContain("stolen title");
+	});
+
+	test("renders persisted hostile summaries safely after a chat rebuild and session reopen", () => {
+		const hostileSummary =
+			"persisted\u001b]52;c;c2VjcmV0\u0007 summary\u001b]0;stolen title\u0007 " +
+			"\u001b]8;;https://attacker.invalid\u0007link\u001b]8;;\u0007 \u001b[31mcolor\u001b[0m \u0000\u0001\u007f\u0085\u009b31mprovider\u009b0m";
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-hostile-compaction-summary-"));
+
+		try {
+			const sessionManager = SessionManager.create(tempDir, join(tempDir, "sessions"));
+			sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "context that was compacted" }],
+				timestamp: 1,
+			});
+			const firstKeptEntryId = sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "message retained after compaction" }],
+				api: "test",
+				provider: "test",
+				model: "test",
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 2,
+			});
+			sessionManager.appendCompaction(hostileSummary, firstKeptEntryId, 1234);
+
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) throw new Error("Expected a persisted session file");
+			const persistedEntry = sessionManager.getEntries().find((entry) => entry.type === "compaction");
+			if (persistedEntry?.type !== "compaction") {
+				throw new Error("Expected a persisted compaction entry");
+			}
+			expect(Buffer.from(persistedEntry.summary)).toEqual(Buffer.from(hostileSummary));
+			const onDiskEntry = readFileSync(sessionFile, "utf8")
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line) as { type: string; summary?: string })
+				.find((entry) => entry.type === "compaction");
+			expect(Buffer.from(onDiskEntry?.summary ?? "")).toEqual(Buffer.from(hostileSummary));
+
+			expect(sessionManager.buildSessionContext().messages[0]).toMatchObject({
+				role: "compactionSummary",
+				summary: hostileSummary,
+			});
+			const rebuiltOutput = renderExpandedPersistedCompactionSummary(sessionManager);
+			expect(rebuiltOutput).not.toMatch(/[\u0000-\u0009\u000B-\u001F\u007f-\u009f]/);
+			expect(rebuiltOutput).not.toContain("attacker.invalid");
+			expect(rebuiltOutput).not.toContain("stolen title");
+
+			const reloaded = SessionManager.open(sessionFile);
+			const reloadedSummary = reloaded.buildSessionContext().messages[0];
+			expect(reloadedSummary).toMatchObject({ role: "compactionSummary", summary: hostileSummary });
+			const reloadedOutput = renderExpandedPersistedCompactionSummary(reloaded);
+			expect(reloadedOutput).not.toMatch(/[\u0000-\u0009\u000B-\u001F\u007f-\u009f]/);
+			expect(reloadedOutput).not.toContain("attacker.invalid");
+			expect(reloadedOutput).not.toContain("stolen title");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	test("renders OpenAI remote compaction details in the summary card", () => {

--- a/packages/coding-agent/test/interactive-mode-fallback-error-sanitization.test.ts
+++ b/packages/coding-agent/test/interactive-mode-fallback-error-sanitization.test.ts
@@ -1,0 +1,92 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { Container } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { createHarness } from "./suite/harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+type FallbackErrorFixture = {
+	isInitialized: true;
+	footer: { invalidate: () => void };
+	fallbackAppliedBeforeRetryStart: boolean;
+	showWarning: (message: string) => void;
+	showStatus: (message: string) => void;
+	showError: (message: string) => void;
+	setExtensionStatus: (key: string, text: string | undefined) => void;
+	chatContainer: Container;
+	ui: { requestRender: () => void };
+};
+
+type InteractiveEventHandler = {
+	handleEvent(this: FallbackErrorFixture, event: AgentSessionEvent): Promise<void>;
+};
+
+function stripSgr(value: string): string {
+	return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+describe("InteractiveMode fallback exhaustion errors", () => {
+	it("renders a provider-derived exhausted fallback error safely without mutating the raw event", async () => {
+		initTheme("dark");
+		const rawProviderError =
+			"fallback failed \u001b]52;c;c2VjcmV0\u0007 with \u001b]0;owned title\u0007 " +
+			"\u001b]8;;https://attacker.invalid\u0007hyperlink\u001b]8;;\u0007 \u001b[31mCSI\u001b[0m " +
+			"\u0000\u0001\u007f\u0085\u009b31mC1\u009b0m";
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 2, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		try {
+			harness.setResponses([
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "primary classifier refusal",
+					stopDetails: { type: "refusal" },
+				}),
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: rawProviderError,
+					stopDetails: { type: "refusal" },
+				}),
+			]);
+			await harness.session.prompt("exhaust fallback chain");
+			const exhausted = harness.eventsOfType("retry_fallback_exhausted").at(-1);
+			if (!exhausted) throw new Error("Expected retry_fallback_exhausted event");
+			expect(exhausted.lastError).toBe(rawProviderError);
+			expect(harness.session.messages.at(-1)).toMatchObject({ errorMessage: rawProviderError });
+
+			const fixture: FallbackErrorFixture = {
+				isInitialized: true,
+				footer: { invalidate: vi.fn() },
+				fallbackAppliedBeforeRetryStart: false,
+				showWarning: vi.fn(),
+				showStatus: vi.fn(),
+				showError(message) {
+					InteractiveMode.prototype.showError.call(fixture, message);
+				},
+				setExtensionStatus: vi.fn(),
+				chatContainer: new Container(),
+				ui: { requestRender: vi.fn() },
+			};
+			const handleEvent = (InteractiveMode.prototype as unknown as InteractiveEventHandler).handleEvent;
+			await handleEvent.call(fixture, exhausted);
+
+			const rendered = stripSgr(fixture.chatContainer.children.flatMap((child) => child.render(320)).join(" "));
+			expect(rendered).toContain(
+				"Error: Fallback chain exhausted for faux/faux-1: fallback failed with hyperlink CSI C1",
+			);
+			expect(rendered).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+			expect(rendered).not.toContain("c2VjcmV0");
+			expect(rendered).not.toContain("owned title");
+			expect(rendered).not.toContain("attacker.invalid");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-apply-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-apply-compaction.test.ts
@@ -125,6 +125,8 @@ describe("AgentSession applyCompaction", () => {
 
 	it("emits one compaction start while an extension prepares and applies a summary", async () => {
 		// given
+		const observedCompactionStates: string[] = [];
+		let harness: Harness;
 		const extension = (pi: ExtensionAPI): void => {
 			pi.on("before_agent_start", async (_event, ctx) => {
 				const entries = ctx.sessionManager.getEntries();
@@ -134,6 +136,7 @@ describe("AgentSession applyCompaction", () => {
 				}
 
 				ctx.beginCompaction?.({ reason: "extension" });
+				observedCompactionStates.push(harness.session.compactionState.status);
 				await ctx.applyCompaction(
 					{
 						summary: "extension feedback summary",
@@ -145,7 +148,7 @@ describe("AgentSession applyCompaction", () => {
 				return undefined;
 			});
 		};
-		const harness = await createHarness({ extensionFactories: [extension] });
+		harness = await createHarness({ extensionFactories: [extension] });
 		harnesses.push(harness);
 		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
 		await harness.session.prompt("one");
@@ -165,5 +168,6 @@ describe("AgentSession applyCompaction", () => {
 			reason: "extension",
 			aborted: false,
 		});
+		expect(observedCompactionStates).toEqual(["running"]);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, PrepareNextTurnContext } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
 	createAssistantMessageEventStream,
@@ -71,6 +71,49 @@ function createUsage(totalTokens: number) {
 		totalTokens,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function bypassFirstPrePromptCompaction(harness: Harness): void {
+	const original = Reflect.get(harness.session, "_enforceCompactionBeforeProvider");
+	if (typeof original !== "function") {
+		throw new Error("AgentSession._enforceCompactionBeforeProvider is not available for retry characterization");
+	}
+	let bypassed = false;
+	Reflect.set(harness.session, "_enforceCompactionBeforeProvider", async (...args: unknown[]) => {
+		if (!bypassed) {
+			bypassed = true;
+			return false;
+		}
+		return await original.apply(harness.session, args);
+	});
+}
+
+function seedSuccessfulContextAboveThreshold(harness: Harness): void {
+	const model = harness.getModel();
+	const timestamp = Date.now() - 1_000;
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "successful context seed" }],
+		timestamp: timestamp - 1,
+	});
+	harness.sessionManager.appendMessage(
+		createAssistant(harness, {
+			text: "successful response before retryable failure",
+			stopReason: "stop",
+			totalTokens: (model.contextWindow ?? 10_000) - 999,
+			timestamp,
+		}),
+	);
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
 }
 
 function createAssistant(
@@ -605,6 +648,70 @@ describe("AgentSession compaction characterization", () => {
 		expect(callbackContexts[0]).not.toContain("callback prior context ");
 	});
 
+	it("retains a constructor next-turn context transform in the provider request after compaction", async () => {
+		const largeToolResult = "transformed callback tool output ".repeat(300);
+		const compactionSummary = "transform-before-next-turn summary";
+		const injectedMarker = "INJECTED_NEXT_TURN_CONTEXT";
+		const callbackInputs: string[] = [];
+		let continuationRequest = "";
+		const prepareNextTurnWithContext = vi.fn(async (turn: PrepareNextTurnContext) => {
+			callbackInputs.push(JSON.stringify(turn.context.messages));
+			return {
+				context: {
+					...turn.context,
+					messages: [
+						{
+							role: "user" as const,
+							content: [{ type: "text" as const, text: injectedMarker }],
+							timestamp: Date.now(),
+						},
+						...turn.context.messages.filter((message) => message.role !== "compactionSummary").reverse(),
+					],
+				},
+			};
+		});
+		const harness = await createHarness({
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 },
+				retry: { enabled: false },
+			},
+			models: [{ id: "faux-1", contextWindow: 5_000 }],
+			extensionFactories: [createResultToolExtension(largeToolResult, compactionSummary)],
+			prepareNextTurnWithContext,
+		});
+		harnesses.push(harness);
+		const timestamp = Date.now() - 2_000;
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "transform prior context ".repeat(220) }],
+			timestamp,
+		});
+		harness.sessionManager.appendMessage(
+			createAssistant(harness, {
+				text: "prior response",
+				stopReason: "stop",
+				totalTokens: 700,
+				timestamp: timestamp + 1_000,
+			}),
+		);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("large_result", {}), { stopReason: "toolUse" }),
+			(context) => {
+				continuationRequest = JSON.stringify(context.messages);
+				return fauxAssistantMessage("done after transformed callback");
+			},
+		]);
+
+		await harness.session.prompt("run the transformed callback result tool");
+
+		expect(prepareNextTurnWithContext).toHaveBeenCalled();
+		expect(callbackInputs).toContainEqual(expect.stringContaining(compactionSummary));
+		expect(continuationRequest).toContain(injectedMarker);
+		expect(continuationRequest).not.toContain(compactionSummary);
+		expect(continuationRequest.indexOf(injectedMarker)).toBeLessThan(continuationRequest.indexOf(largeToolResult));
+	});
+
 	it("applies the provider context transform to inline compaction summarization", async () => {
 		// given
 		const sensitiveToolOutput = "SENSITIVE_TOOL_OUTPUT";
@@ -968,6 +1075,100 @@ describe("AgentSession compaction characterization", () => {
 		await vi.advanceTimersByTimeAsync(100);
 
 		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("compacts a retryable zero-usage error before retrying when the prior context is above threshold", async () => {
+		let acceptedCompactionsAtRetryProviderCall = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 },
+				retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 },
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "retry threshold summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedSuccessfulContextAboveThreshold(harness);
+		bypassFirstPrePromptCompaction(harness);
+		harness.setResponses([
+			createAssistant(harness, { stopReason: "error", errorMessage: "overloaded_error", totalTokens: 0 }),
+			() => {
+				acceptedCompactionsAtRetryProviderCall = harness
+					.eventsOfType("compaction_end")
+					.filter((event) => event.reason === "threshold" && event.accepted).length;
+				return fauxAssistantMessage("retry succeeded after compaction");
+			},
+		]);
+
+		await harness.session.prompt("trigger zero-usage retryable failure");
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(acceptedCompactionsAtRetryProviderCall).toBe(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+	});
+
+	it("retains queues and skips the retry provider call when required retry compaction is rejected", async () => {
+		const providerStarted = createDeferred();
+		const releaseError = createDeferred();
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 },
+				retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 },
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "retry compaction rejected",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedSuccessfulContextAboveThreshold(harness);
+		bypassFirstPrePromptCompaction(harness);
+		harness.setResponses([
+			async () => {
+				providerStarted.resolve();
+				await releaseError.promise;
+				return createAssistant(harness, {
+					stopReason: "error",
+					errorMessage: "overloaded_error",
+					totalTokens: 0,
+				});
+			},
+			fauxAssistantMessage("retry provider must not run"),
+		]);
+
+		const prompt = harness.session.prompt("trigger rejected retry compaction");
+		await providerStarted.promise;
+		await harness.session.followUp("retain retry follow-up");
+		releaseError.resolve();
+		await prompt;
+
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "threshold",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain retry follow-up"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
 	});
 
 	it("does not retry overflow recovery more than once", async () => {

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -712,6 +712,104 @@ describe("AgentSession compaction characterization", () => {
 		expect(continuationRequest.indexOf(injectedMarker)).toBeLessThan(continuationRequest.indexOf(largeToolResult));
 	});
 
+	it("reapplies a late constructor next-turn transform to the post-compaction provider request", async () => {
+		// given a constructor callback that suspends mid-turn and transforms the
+		// context (inject + redact + reorder), and a queue that arrives while the
+		// callback is suspended so the second admission sample compacts.
+		const callbackStarted = createDeferred();
+		const releaseCallback = createDeferred();
+		const injectedMarker = "INJECTED_LATE_CALLBACK_CONTEXT";
+		const compactionSummary = "late callback compaction summary";
+		const queuedText = "queued while the next-turn callback is suspended";
+		let continuationRequest = "";
+		const prepareNextTurnWithContext = vi.fn(async (turn: PrepareNextTurnContext) => {
+			callbackStarted.resolve();
+			await releaseCallback.promise;
+			return {
+				context: {
+					...turn.context,
+					messages: [
+						{
+							role: "user" as const,
+							content: [{ type: "text" as const, text: injectedMarker }],
+							timestamp: Date.now(),
+						},
+						...turn.context.messages.filter((message) => message.role !== "compactionSummary").reverse(),
+					],
+				},
+			};
+		});
+		const harness = await createHarness({
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 },
+				retry: { enabled: false },
+			},
+			models: [{ id: "faux-1", contextWindow: 5_000 }],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: compactionSummary,
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+			prepareNextTurnWithContext,
+		});
+		harnesses.push(harness);
+		const seedTimestamp = Date.now() - 2_000;
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "late callback prior context ".repeat(220) }],
+			timestamp: seedTimestamp,
+		});
+		harness.sessionManager.appendMessage(
+			createAssistant(harness, {
+				text: "prior response",
+				stopReason: "stop",
+				totalTokens: 700,
+				timestamp: seedTimestamp + 1_000,
+			}),
+		);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		const model = harness.getModel();
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("first response before the queued admission"),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: createUsage(4_500),
+			},
+			(context) => {
+				continuationRequest = JSON.stringify(context.messages);
+				return fauxAssistantMessage("response after the queued admission");
+			},
+		]);
+
+		// when the first turn completes, the callback suspends, a queue arrives, and
+		// the second admission sample compacts before the continuation request.
+		const promptPromise = harness.session.prompt("trigger the late next-turn callback");
+		void promptPromise.catch(() => undefined);
+		await callbackStarted.promise;
+		await harness.session.steer(queuedText);
+		releaseCallback.resolve();
+		await promptPromise;
+
+		// then the queued admission did compact exactly once, and the provider
+		// request for the drained queue still respects the host transformation
+		// (reapplied on the post-compaction context), not the raw compacted state.
+		expect(prepareNextTurnWithContext).toHaveBeenCalled();
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+		expect(continuationRequest).toContain(injectedMarker);
+		expect(continuationRequest).not.toContain(compactionSummary);
+		expect(continuationRequest.indexOf(injectedMarker)).toBeGreaterThanOrEqual(0);
+		expect(continuationRequest.indexOf(injectedMarker)).toBeLessThan(continuationRequest.indexOf(queuedText));
+	});
+
 	it("applies the provider context transform to inline compaction summarization", async () => {
 		// given
 		const sensitiveToolOutput = "SENSITIVE_TOOL_OUTPUT";

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -5,6 +5,32 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { BuildSystemPromptOptions, ExtensionAPI } from "../../src/index.ts";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
 
+function seedBelowThresholdCompactionContext(harness: Harness): void {
+	const timestamp = Date.now() - 1_000;
+	const model = harness.getModel();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "preflight context ".repeat(120) }],
+		timestamp: timestamp - 1,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("preflight response"),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 1_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 1_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp,
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
 describe("AgentSession model and extension characterization", () => {
 	const harnesses: Harness[] = [];
 
@@ -448,6 +474,75 @@ describe("AgentSession model and extension characterization", () => {
 		expect(seenOptions[0]?.cwd).toBe(harness.tempDir);
 		expect(seenOptions[0]?.selectedTools).toContain("read");
 		expect(seenOptions[1]?.selectedTools).toContain("mutated_tool");
+	});
+
+	it.each([
+		{
+			label: "next-turn and before_agent_start custom state on a normal prompt",
+			beforeAgentStartCalls: 1,
+			admit: async (harness: Harness, oversized: string) => {
+				await harness.session.sendCustomMessage(
+					{ customType: "oversized-next-turn", content: oversized, display: false },
+					{ deliverAs: "nextTurn" },
+				);
+				return await harness.session.prompt("normal prompt after initial preflight");
+			},
+		},
+		{
+			label: "trigger-turn custom state",
+			beforeAgentStartCalls: 0,
+			admit: async (harness: Harness, oversized: string) =>
+				await harness.session.sendCustomMessage(
+					{ customType: "oversized-trigger-turn", content: oversized, display: false },
+					{ triggerTurn: true },
+				),
+		},
+	])("rejects a fully assembled oversized request for $label before its provider call", async (scenario) => {
+		const oversized = "final request content ".repeat(4_000);
+		let beforeAgentStartCalls = 0;
+		let compactionRequests = 0;
+		const harness = await createHarness({
+			models: [{ id: "final-request-preflight", contextWindow: 5_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", () => {
+						beforeAgentStartCalls += 1;
+						return {
+							message: {
+								customType: "oversized-before-agent-start",
+								content: oversized,
+								display: false,
+							},
+						};
+					});
+					pi.on("session_before_compact", () => {
+						compactionRequests += 1;
+						return {
+							cancel: true,
+							rejectionCause: "cancelled-by-extension",
+							reason: "final assembled request must not reach the provider",
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedBelowThresholdCompactionContext(harness);
+		harness.setResponses([fauxAssistantMessage("provider must not receive the oversized request")]);
+
+		const error = await scenario.admit(harness, oversized).then(
+			() => undefined,
+			(reason: unknown) => reason,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		expect(beforeAgentStartCalls).toBe(scenario.beforeAgentStartCalls);
+		expect(compactionRequests).toBe(1);
+		expect(harness.faux.state.callCount).toBe(0);
 	});
 
 	it("allows before_agent_start handlers to inject custom messages and modify the system prompt", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -1,4 +1,4 @@
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
@@ -252,6 +252,99 @@ describe("AgentSession queue characterization", () => {
 		expect(barrierStatesAtExtensionAdmission[0]).toBe(true);
 		expect(harness.faux.state.callCount).toBe(1);
 		expect(harness.session.getFollowUpMessages()).toEqual([marker]);
+	});
+
+	it.each([
+		"accepted",
+		"rejected",
+		"aborted",
+	] as const)("keeps pi.sendMessage({ triggerTurn: true }) behind the %s manual compaction boundary", async (outcome) => {
+		const marker = `custom trigger-turn during ${outcome} manual compaction`;
+		let beforeCompactCalls = 0;
+		let resolveBeforeCompact: (() => void) | undefined;
+		const beforeCompact = new Promise<void>((resolve) => {
+			resolveBeforeCompact = resolve;
+		});
+		const providerContexts: AgentMessage[][] = [];
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						beforeCompactCalls++;
+						pi.sendMessage(
+							{
+								customType: "compaction-trigger-turn",
+								content: marker,
+								display: false,
+							},
+							{ triggerTurn: true },
+						);
+						resolveBeforeCompact?.();
+
+						if (outcome === "accepted") {
+							return {
+								compaction: {
+									summary: `accepted summary before ${marker}`,
+									firstKeptEntryId: event.preparation.firstKeptEntryId,
+									tokensBefore: event.preparation.tokensBefore,
+								},
+							};
+						}
+						if (outcome === "rejected") {
+							return { cancel: true, rejectionCause: "cancelled-by-extension" as const };
+						}
+						return await new Promise<{ cancel: true }>((resolve) => {
+							event.signal.addEventListener("abort", () => resolve({ cancel: true }), { once: true });
+						});
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed manual compaction context");
+		harness.setResponses([
+			(context) => {
+				providerContexts.push(context.messages);
+				return fauxAssistantMessage("custom trigger-turn handled");
+			},
+		]);
+
+		const compact = harness.session.compact();
+		await beforeCompact;
+		if (outcome === "aborted") harness.session.abortCompaction();
+		if (outcome === "accepted") {
+			await compact;
+		} else {
+			await compact.catch(() => undefined);
+		}
+		await harness.session.waitForSettledSessionWork();
+		await harness.session.agent.waitForIdle();
+
+		expect(beforeCompactCalls).toBe(1);
+		if (outcome === "accepted") {
+			expect(harness.faux.state.callCount).toBe(2);
+			expect(providerContexts).toHaveLength(1);
+			const providerContext = providerContexts[0] ?? [];
+			const summaryIndex = providerContext.findIndex(
+				(message) => message.role === "user" && getMessageText(message).includes("accepted summary"),
+			);
+			const customIndex = providerContext.findIndex(
+				(message) => message.role === "user" && getMessageText(message) === marker,
+			);
+			expect(summaryIndex).toBeGreaterThanOrEqual(0);
+			expect(customIndex).toBeGreaterThan(summaryIndex);
+			expect(
+				harness.sessionManager
+					.getEntries()
+					.filter((entry) => entry.type === "custom_message" && entry.content === marker),
+			).toHaveLength(1);
+		} else {
+			expect(harness.faux.state.callCount).toBe(1);
+			expect(providerContexts).toEqual([]);
+			expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		}
 	});
 
 	it("delivers follow-up messages only after the current run finishes", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -57,6 +57,20 @@ async function createWaitingHarness(options: Pick<HarnessOptions, "extensionFact
 	};
 }
 
+function getWaitForSettledSessionWork(harness: Harness) {
+	const wait = Reflect.get(harness.session, "_waitForSettledSessionWork");
+	if (typeof wait !== "function") throw new Error("Expected AgentSession._waitForSettledSessionWork");
+	return (): Promise<void> => Promise.resolve(wait.call(harness.session));
+}
+
+function getSessionWorkBarrier(harness: Harness): { readonly hasActiveWork: boolean } {
+	const barrier = Reflect.get(harness.session, "_sessionWorkBarrier");
+	if (!barrier || typeof barrier !== "object" || !("hasActiveWork" in barrier)) {
+		throw new Error("Expected AgentSession._sessionWorkBarrier");
+	}
+	return barrier as { readonly hasActiveWork: boolean };
+}
+
 describe("AgentSession queue characterization", () => {
 	const harnesses: Harness[] = [];
 
@@ -120,6 +134,124 @@ describe("AgentSession queue characterization", () => {
 
 		expect(getUserTexts(harness)).toEqual(["start", "steer now"]);
 		expect(getAssistantTexts(harness)).toContain("saw steer");
+	});
+
+	it("waits for manual compaction before admitting a background extension prompt", async () => {
+		const marker = "background extension prompt";
+		const summary = "manual compaction summary before extension admission";
+		let extensionApi: ExtensionAPI | undefined;
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					extensionApi = pi;
+					pi.on("session_before_compact", (event) => {
+						queueMicrotask(() => {
+							pi.sendUserMessage(marker, { deliverAs: "followUp" });
+						});
+						return {
+							compaction: {
+								summary,
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed manual compaction context");
+
+		const waitForSettledSessionWork = getWaitForSettledSessionWork(harness);
+		const barrier = getSessionWorkBarrier(harness);
+		const barrierStatesAtExtensionAdmission: boolean[] = [];
+		Reflect.set(harness.session, "_waitForSettledSessionWork", async () => {
+			barrierStatesAtExtensionAdmission.push(barrier.hasActiveWork);
+			await waitForSettledSessionWork();
+		});
+		let providerCallsAtAcceptedCompaction: number | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.accepted) {
+				providerCallsAtAcceptedCompaction = harness.faux.state.callCount;
+			}
+		});
+		let extensionRequest = "";
+		harness.setResponses([
+			(context) => {
+				extensionRequest = JSON.stringify(context.messages);
+				return fauxAssistantMessage("extension prompt handled");
+			},
+		]);
+
+		await harness.session.compact();
+		await harness.session.waitForSettledSessionWork();
+
+		expect(extensionApi).toBeDefined();
+		expect(barrierStatesAtExtensionAdmission[0]).toBe(true);
+		expect(providerCallsAtAcceptedCompaction).toBe(1);
+		expect(extensionRequest).toContain(summary);
+		expect(getUserTexts(harness).filter((text) => text === marker)).toHaveLength(1);
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it.each([
+		"rejected",
+		"aborted",
+	] as const)("keeps a background extension follow-up fail-closed after a %s manual compaction", async (outcome) => {
+		const marker = `retain extension follow-up after ${outcome} compaction`;
+		let compactionAttempt = 0;
+		let resolveFirstCompactionStart: (() => void) | undefined;
+		const firstCompactionStarted = new Promise<void>((resolve) => {
+			resolveFirstCompactionStart = resolve;
+		});
+		const harness = await createHarness({
+			models: [{ id: `extension-${outcome}-compaction`, contextWindow: 5_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: false, keepRecentTokens: 1, reserveTokens: 1_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						compactionAttempt += 1;
+						if (compactionAttempt === 1) {
+							queueMicrotask(() => {
+								pi.sendUserMessage(marker, { deliverAs: "followUp" });
+							});
+							resolveFirstCompactionStart?.();
+						}
+						if (outcome === "rejected" || compactionAttempt > 1) {
+							return { cancel: true, rejectionCause: "cancelled-by-extension" };
+						}
+						return await new Promise<{ cancel: true }>((resolve) => {
+							event.signal.addEventListener("abort", () => resolve({ cancel: true }), { once: true });
+						});
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("pre-compaction context ".repeat(1_600));
+		harness.settingsManager.applyOverrides({
+			compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 },
+		});
+
+		const waitForSettledSessionWork = getWaitForSettledSessionWork(harness);
+		const barrier = getSessionWorkBarrier(harness);
+		const barrierStatesAtExtensionAdmission: boolean[] = [];
+		Reflect.set(harness.session, "_waitForSettledSessionWork", async () => {
+			barrierStatesAtExtensionAdmission.push(barrier.hasActiveWork);
+			await waitForSettledSessionWork();
+		});
+		const compact = harness.session.compact();
+		await firstCompactionStarted;
+		if (outcome === "aborted") harness.session.abortCompaction();
+		await compact.catch(() => undefined);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(barrierStatesAtExtensionAdmission[0]).toBe(true);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getFollowUpMessages()).toEqual([marker]);
 	});
 
 	it("delivers follow-up messages only after the current run finishes", async () => {

--- a/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
@@ -1,5 +1,7 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import type { CompactionReason } from "../../src/core/extensions/types.ts";
+import type { ExtensionAPI } from "../../src/core/extensions/index.ts";
+import type { CompactionReason, ExtensionContext } from "../../src/core/extensions/types.ts";
 import { createHarness, type Harness } from "./harness.ts";
 
 type BeginFeedback = (reason: CompactionReason) => AbortSignal;
@@ -15,6 +17,42 @@ type EndFeedback = (options: {
 	aborted?: boolean;
 	errorMessage?: string;
 }) => void;
+
+interface PostApplyFeedbackCapture {
+	firstContext?: ExtensionContext;
+	firstSignal?: AbortSignal;
+	secondSignal?: AbortSignal;
+}
+
+/**
+ * Drives the real extension surface: feedback begun in before_agent_start is
+ * applied, and the accepted session_compact handler immediately begins the
+ * next feedback operation (the builtin speculative path does this).
+ */
+function createPostApplyFeedbackExtension(capture: PostApplyFeedbackCapture) {
+	return (pi: ExtensionAPI): void => {
+		pi.on("before_agent_start", async (_event, ctx) => {
+			if (capture.firstSignal) return undefined;
+			const firstEntry = ctx.sessionManager.getEntries()[0];
+			if (!firstEntry) return undefined;
+			capture.firstSignal = ctx.beginCompaction?.({ reason: "extension" });
+			capture.firstContext = ctx;
+			await ctx.applyCompaction(
+				{
+					summary: "applied before the next feedback operation",
+					firstKeptEntryId: firstEntry.id,
+					tokensBefore: 42,
+				},
+				{ reason: "extension", expectedRevision: ctx.getMessageRevision() },
+			);
+			return undefined;
+		});
+		pi.on("session_compact", (event, ctx) => {
+			if (!event.accepted) return;
+			capture.secondSignal = ctx.beginCompaction?.({ reason: "extension" });
+		});
+	};
+}
 
 describe("compaction feedback lifecycle", () => {
 	const harnesses: Harness[] = [];
@@ -114,5 +152,140 @@ describe("compaction feedback lifecycle", () => {
 			signal: freshSignal,
 			errorMessage: "current failure",
 		});
+	});
+
+	it("emits exactly one aborted compaction_end when abortCompaction cancels feedback-only compaction", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const begin = Reflect.get(harness.session, "_beginExtensionCompactionFeedback");
+		const end = Reflect.get(harness.session, "_endExtensionCompactionFeedback");
+		if (typeof begin !== "function" || typeof end !== "function") {
+			throw new Error("Compaction feedback lifecycle methods unavailable");
+		}
+
+		const signal = (begin as BeginFeedback).call(harness.session, "extension");
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 1,
+			stage: "feedback",
+		});
+
+		harness.session.abortCompaction();
+
+		expect(signal.aborted).toBe(true);
+		expect(harness.session.compactionState).toMatchObject({ status: "aborted", generation: 1 });
+		expect(harness.session.isCompacting).toBe(false);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "extension", aborted: true }),
+		]);
+
+		// The owning extension's late end after the abort must not emit a second public end.
+		(end as EndFeedback).call(harness.session, { reason: "extension", signal, aborted: true });
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(1);
+	});
+
+	it("gives feedback begun from session_compact a distinct controller and its own compaction_start", async () => {
+		const capture: PostApplyFeedbackCapture = {};
+		const harness = await createHarness({ extensionFactories: [createPostApplyFeedbackExtension(capture)] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		expect(capture.secondSignal).toBeDefined();
+		expect(capture.secondSignal?.aborted).toBe(false);
+		expect(capture.secondSignal).not.toBe(capture.firstSignal);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 2,
+			stage: "feedback",
+		});
+		expect(harness.session.isCompacting).toBe(true);
+	});
+
+	it("keeps post-apply feedback running when the superseded operation ends", async () => {
+		const capture: PostApplyFeedbackCapture = {};
+		const harness = await createHarness({ extensionFactories: [createPostApplyFeedbackExtension(capture)] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("one");
+		await harness.session.prompt("two");
+
+		expect(capture.secondSignal).toBeDefined();
+		expect(harness.session.compactionState).toMatchObject({ status: "running", generation: 2 });
+		const endCountBeforeLateEnd = harness.eventsOfType("compaction_end").length;
+
+		// The old operation's terminal end must not terminate the newer feedback operation.
+		capture.firstContext?.endCompaction?.({
+			reason: "extension",
+			signal: capture.firstSignal,
+			errorMessage: "superseded operation ended late",
+		});
+
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 2,
+			stage: "feedback",
+		});
+		expect(harness.session.isCompacting).toBe(true);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(endCountBeforeLateEnd);
+	});
+
+	it("binds an omitted endCompaction signal to the operation begun by the same context", async () => {
+		const contexts: ExtensionContext[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("agent_settled", (_event, ctx) => {
+						contexts.push(ctx);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+
+		await runner.emit({ type: "agent_settled" });
+		const legacyContext = contexts[0];
+		if (!legacyContext) throw new Error("Expected legacy extension context");
+		const legacySignal = legacyContext.beginCompaction?.({ reason: "extension" });
+		expect(legacySignal?.aborted).toBe(false);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 1,
+			stage: "feedback",
+		});
+
+		legacyContext.endCompaction?.({
+			reason: "extension",
+			signal: legacySignal,
+			errorMessage: "legacy work finished",
+		});
+		expect(harness.session.compactionState).toMatchObject({ status: "failed", generation: 1 });
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(1);
+
+		await runner.emit({ type: "agent_settled" });
+		const newerContext = contexts[1];
+		if (!newerContext) throw new Error("Expected newer extension context");
+		const newerSignal = newerContext.beginCompaction?.({ reason: "extension" });
+		expect(newerSignal?.aborted).toBe(false);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 2,
+			stage: "feedback",
+		});
+
+		// Legacy context ends without an explicit signal; it must not terminate the newer operation.
+		legacyContext.endCompaction?.({ reason: "extension" });
+
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 2,
+			stage: "feedback",
+		});
+		expect(harness.session.isCompacting).toBe(true);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { CompactionReason } from "../../src/core/extensions/types.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+type BeginFeedback = (reason: CompactionReason) => AbortSignal;
+type UpdateFeedback = (options: {
+	reason: CompactionReason;
+	signal?: AbortSignal;
+	delta?: string;
+	text?: string;
+}) => void;
+type EndFeedback = (options: {
+	reason: CompactionReason;
+	signal?: AbortSignal;
+	aborted?: boolean;
+	errorMessage?: string;
+}) => void;
+
+describe("compaction feedback lifecycle", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("ignores stale feedback completion after a newer operation begins", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const begin = Reflect.get(harness.session, "_beginExtensionCompactionFeedback");
+		const update = Reflect.get(harness.session, "_updateExtensionCompactionFeedback");
+		const end = Reflect.get(harness.session, "_endExtensionCompactionFeedback");
+		if (typeof begin !== "function" || typeof update !== "function" || typeof end !== "function") {
+			throw new Error("Compaction feedback lifecycle methods unavailable");
+		}
+
+		const oldSignal = (begin as BeginFeedback).call(harness.session, "extension");
+		(end as EndFeedback).call(harness.session, {
+			reason: "extension",
+			signal: oldSignal,
+			aborted: true,
+		});
+		const freshSignal = (begin as BeginFeedback).call(harness.session, "extension");
+		const freshState = harness.session.compactionState;
+		const progressBeforeStaleUpdate = harness.eventsOfType("compaction_progress").length;
+		(update as UpdateFeedback).call(harness.session, {
+			reason: "extension",
+			signal: oldSignal,
+			delta: "late progress",
+		});
+		(end as EndFeedback).call(harness.session, {
+			reason: "extension",
+			signal: oldSignal,
+			errorMessage: "late failure",
+		});
+
+		expect(harness.session.compactionState).toBe(freshState);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 2,
+			stage: "feedback",
+		});
+		expect(harness.session.isCompacting).toBe(true);
+		expect(harness.eventsOfType("compaction_progress")).toHaveLength(progressBeforeStaleUpdate);
+
+		(update as UpdateFeedback).call(harness.session, {
+			reason: "extension",
+			signal: freshSignal,
+			delta: "current progress",
+		});
+		expect(harness.eventsOfType("compaction_progress").at(-1)).toMatchObject({
+			reason: "extension",
+			delta: "current progress",
+		});
+
+		(end as EndFeedback).call(harness.session, {
+			reason: "extension",
+			signal: freshSignal,
+			errorMessage: "current failure",
+		});
+		expect(harness.session.compactionState).toMatchObject({
+			status: "failed",
+			generation: 2,
+			errorMessage: "current failure",
+		});
+		expect(harness.session.isCompacting).toBe(false);
+	});
+
+	it("clears feedback ownership on abort before a later operation begins", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const begin = Reflect.get(harness.session, "_beginExtensionCompactionFeedback");
+		const end = Reflect.get(harness.session, "_endExtensionCompactionFeedback");
+		if (typeof begin !== "function" || typeof end !== "function") {
+			throw new Error("Compaction feedback lifecycle methods unavailable");
+		}
+
+		const abortedSignal = (begin as BeginFeedback).call(harness.session, "extension");
+		harness.session.abortCompaction();
+
+		expect(abortedSignal.aborted).toBe(true);
+		expect(harness.session.compactionState.status).toBe("aborted");
+		expect(harness.session.isCompacting).toBe(false);
+
+		const freshSignal = (begin as BeginFeedback).call(harness.session, "extension");
+		expect(freshSignal.aborted).toBe(false);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 2,
+			stage: "feedback",
+		});
+
+		(end as EndFeedback).call(harness.session, {
+			reason: "extension",
+			signal: freshSignal,
+			errorMessage: "current failure",
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
@@ -419,4 +419,67 @@ describe("compaction feedback lifecycle", () => {
 			expect.objectContaining({ reason: "extension", errorMessage: "B ended itself" }),
 		]);
 	});
+
+	it("rejects A's stale apply after B supersedes feedback from the same emission", async () => {
+		let captureContexts = false;
+		let contextA: ExtensionContext | undefined;
+		let contextB: ExtensionContext | undefined;
+		let signalA: AbortSignal | undefined;
+		let signalB: AbortSignal | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_settled", (_event, ctx) => {
+						if (!captureContexts) return;
+						contextA = ctx;
+						signalA = ctx.beginCompaction?.({ reason: "extension" });
+					});
+					pi.on("agent_settled", (_event, ctx) => {
+						if (!captureContexts) return;
+						contextB = ctx;
+						signalB = ctx.beginCompaction?.({ reason: "extension" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed context");
+
+		const firstEntry = harness.sessionManager.getEntries()[0];
+		if (!firstEntry) throw new Error("Expected a persisted entry for precomputed compaction");
+		const expectedRevision = harness.session.getMessageRevision();
+		const precomputed = {
+			summary: "summary prepared by A before B superseded it",
+			firstKeptEntryId: firstEntry.id,
+			tokensBefore: 42,
+		};
+		captureContexts = true;
+		await harness.getExtensionRunner().emit({ type: "agent_settled" });
+		if (!contextA || !contextB || !signalA || !signalB) {
+			throw new Error("Expected both same-emission extension contexts to begin feedback");
+		}
+
+		try {
+			expect(signalA.aborted).toBe(true);
+			expect(signalB.aborted).toBe(false);
+			const staleResult = await contextA.applyCompaction(precomputed, {
+				reason: "extension",
+				expectedRevision,
+			});
+			expect(staleResult).toEqual({ applied: false, reason: "stale" });
+			expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+			expect(harness.session.compactionState).toMatchObject({ status: "running", generation: 2, stage: "feedback" });
+
+			const freshResult = await contextB.applyCompaction(precomputed, {
+				reason: "extension",
+				expectedRevision,
+			});
+			expect(freshResult).toEqual({ applied: true, reason: "ok" });
+			expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+			expect(harness.session.compactionState).toMatchObject({ status: "completed" });
+		} finally {
+			contextB.endCompaction?.({ reason: "extension", signal: signalB });
+		}
+	});
 });

--- a/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/compaction-feedback-lifecycle.test.ts
@@ -24,6 +24,25 @@ interface PostApplyFeedbackCapture {
 	secondSignal?: AbortSignal;
 }
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function createManualCompactionResult(harness: Harness, summary: string) {
+	const firstEntry = harness.sessionManager.getEntries()[0];
+	if (!firstEntry) throw new Error("Expected a session entry before compaction");
+	return {
+		summary,
+		firstKeptEntryId: firstEntry.id,
+		tokensBefore: 42,
+	};
+}
+
 /**
  * Drives the real extension surface: feedback begun in before_agent_start is
  * applied, and the accepted session_compact handler immediately begins the
@@ -287,5 +306,117 @@ describe("compaction feedback lifecycle", () => {
 		});
 		expect(harness.session.isCompacting).toBe(true);
 		expect(harness.eventsOfType("compaction_end")).toHaveLength(1);
+	});
+
+	it("does not emit an execution terminal from A after B supersedes it", async () => {
+		const firstExecutionStarted = createDeferred();
+		const releaseFirstExecution = createDeferred();
+		const secondExecutionStarted = createDeferred();
+		const releaseSecondExecution = createDeferred();
+		let executionCount = 0;
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => {
+						executionCount++;
+						if (executionCount === 1) {
+							firstExecutionStarted.resolve();
+							await releaseFirstExecution.promise;
+						} else {
+							secondExecutionStarted.resolve();
+							await releaseSecondExecution.promise;
+						}
+						return { compaction: createManualCompactionResult(harness, `manual summary ${executionCount}`) };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed context ".repeat(40));
+		harness.events.length = 0;
+
+		const operationA = harness.session.compact();
+		await firstExecutionStarted.promise;
+		const operationB = harness.session.compact();
+		await secondExecutionStarted.promise;
+
+		try {
+			releaseFirstExecution.resolve();
+			await expect(operationA).rejects.toThrow("Compaction cancelled");
+			expect(
+				harness.events
+					.filter((event) => event.type === "compaction_start" || event.type === "compaction_end")
+					.map((event) => event.type),
+			).toEqual(["compaction_start", "compaction_start"]);
+			expect(harness.session.compactionState).toMatchObject({
+				status: "running",
+				generation: 2,
+				stage: "execution",
+			});
+			expect(harness.session.isCompacting).toBe(true);
+		} finally {
+			releaseSecondExecution.resolve();
+			await expect(operationB).resolves.toBeDefined();
+		}
+	});
+
+	it.each([
+		["two extensions", true],
+		["two handlers in one extension", false],
+	])("keeps feedback ownership isolated across %s in one emission", async (_label, splitExtensions) => {
+		let firstContext: ExtensionContext | undefined;
+		let secondContext: ExtensionContext | undefined;
+		let firstSignal: AbortSignal | undefined;
+		let secondSignal: AbortSignal | undefined;
+		const firstHandler = (_event: { type: "agent_settled" }, ctx: ExtensionContext) => {
+			firstContext = ctx;
+			firstSignal = ctx.beginCompaction?.({ reason: "extension" });
+		};
+		const secondHandler = (_event: { type: "agent_settled" }, ctx: ExtensionContext) => {
+			secondContext = ctx;
+			secondSignal = ctx.beginCompaction?.({ reason: "extension" });
+		};
+		const harness = await createHarness({
+			extensionFactories: splitExtensions
+				? [(pi) => pi.on("agent_settled", firstHandler), (pi) => pi.on("agent_settled", secondHandler)]
+				: [
+						(pi) => {
+							pi.on("agent_settled", firstHandler);
+							pi.on("agent_settled", secondHandler);
+						},
+					],
+		});
+		harnesses.push(harness);
+
+		await harness.getExtensionRunner().emit({ type: "agent_settled" });
+		if (!firstContext || !secondContext || !firstSignal || !secondSignal) {
+			throw new Error("Expected both handlers to retain their feedback context");
+		}
+		expect(firstSignal.aborted).toBe(true);
+		expect(secondSignal.aborted).toBe(false);
+		expect(harness.session.compactionState).toMatchObject({ status: "running", generation: 2 });
+
+		try {
+			firstContext.endCompaction?.({ reason: "extension", errorMessage: "A ended late" });
+			expect(harness.session.compactionState).toMatchObject({
+				status: "running",
+				generation: 2,
+				stage: "feedback",
+			});
+			expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+		} finally {
+			secondContext.endCompaction?.({ reason: "extension", errorMessage: "B ended itself" });
+		}
+
+		expect(harness.session.compactionState).toMatchObject({
+			status: "failed",
+			generation: 2,
+			errorMessage: "B ended itself",
+		});
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "extension", errorMessage: "B ended itself" }),
+		]);
 	});
 });

--- a/packages/coding-agent/test/suite/compaction-race.test.ts
+++ b/packages/coding-agent/test/suite/compaction-race.test.ts
@@ -1,7 +1,7 @@
 import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import type { ExtensionAPI } from "../../src/core/extensions/index.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/index.ts";
 import { COMPACTION_SUMMARY_PREFIX } from "../../src/core/messages.ts";
 import { createHarness, getUserTexts, type Harness } from "./harness.ts";
 
@@ -334,6 +334,78 @@ describe("AgentSession compaction race handling", () => {
 		harness.setResponses([fauxAssistantMessage("later prompt succeeded")]);
 		await harness.session.prompt("later prompt after manual compaction");
 		expect(getUserTexts(harness).at(-1)).toBe("later prompt after manual compaction");
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.session.isCompacting).toBe(false);
+	});
+
+	it("settles an active stream before extension-context compaction starts", async () => {
+		const eventOrder: string[] = [];
+		const extensionCompactionEnded = createDeferred();
+		let extensionContext: ExtensionContext | undefined;
+		let resolveStreamingUpdate: (() => void) | undefined;
+		const streamingUpdate = new Promise<void>((resolve) => {
+			resolveStreamingUpdate = resolve;
+		});
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						extensionContext = ctx;
+					});
+					pi.on("session_before_compact", (event) => ({
+						compaction: {
+							summary: "extension-context compaction after active abort",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		if (!extensionContext) throw new Error("Expected session_start extension context");
+
+		harness.setResponses([
+			fauxAssistantMessage("first seed response"),
+			fauxAssistantMessage("second seed response"),
+			fauxAssistantMessage("streaming response ".repeat(4_000)),
+		]);
+		await harness.session.prompt("first seed prompt");
+		await harness.session.prompt("second seed prompt");
+
+		harness.session.subscribe((event) => {
+			if (event.type === "message_update" && event.message.role === "assistant") {
+				resolveStreamingUpdate?.();
+				resolveStreamingUpdate = undefined;
+			}
+			if (event.type === "agent_end") eventOrder.push("agent_end");
+			if (event.type === "compaction_start") eventOrder.push("compaction_start");
+			if (event.type === "compaction_end" && event.reason === "extension") extensionCompactionEnded.resolve();
+		});
+
+		const activePrompt = harness.session.prompt("prompt whose provider stream is active");
+		await streamingUpdate;
+		expect(harness.session.isStreaming).toBe(true);
+
+		// Exercise the actual ctx.compact() binding rather than AgentSession.compact().
+		extensionContext.compact();
+		const settled = await settlesWithin(Promise.allSettled([activePrompt, extensionCompactionEnded.promise]), 1_000);
+		expect(settled, "extension compaction must not deadlock behind an aborted active run").toBe(true);
+		if (!settled) return;
+		await harness.session.waitForSettledSessionWork();
+
+		const activeAgentEnd = harness.eventsOfType("agent_end").at(-1);
+		expect(activeAgentEnd?.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+		expect(eventOrder.indexOf("agent_end")).toBeGreaterThanOrEqual(0);
+		expect(eventOrder.indexOf("compaction_start")).toBeGreaterThan(eventOrder.indexOf("agent_end"));
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.session.isCompacting).toBe(false);
+
+		harness.setResponses([fauxAssistantMessage("later prompt succeeded")]);
+		await harness.session.prompt("later prompt after extension compaction");
+		expect(getUserTexts(harness).at(-1)).toBe("later prompt after extension compaction");
 		expect(harness.session.isStreaming).toBe(false);
 		expect(harness.session.isCompacting).toBe(false);
 	});

--- a/packages/coding-agent/test/suite/compaction-race.test.ts
+++ b/packages/coding-agent/test/suite/compaction-race.test.ts
@@ -1,6 +1,6 @@
 import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/index.ts";
 import { COMPACTION_SUMMARY_PREFIX } from "../../src/core/messages.ts";
 import { createHarness, getUserTexts, type Harness } from "./harness.ts";
@@ -475,6 +475,62 @@ describe("AgentSession compaction race handling", () => {
 		expect(harness.eventsOfType("compaction_end")).toEqual([
 			expect.objectContaining({ reason: "threshold", accepted: true, aborted: false }),
 		]);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+	});
+
+	it("does not let an auto-compaction admitted before auth supersede a manual compaction", async () => {
+		const autoAuthStarted = createDeferred();
+		const releaseAutoAuth = createDeferred();
+		const harness = await createHarness({
+			models: [{ id: "auto-auth-race", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => ({
+						compaction: {
+							summary: "manual wins auto-auth race",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed context ".repeat(40));
+		harness.events.length = 0;
+
+		const lifecycle = Reflect.get(harness.session, "_compactionLifecycle") as {
+			begin: (...args: never[]) => unknown;
+		};
+		const lifecycleBegin = vi.spyOn(lifecycle, "begin");
+		const modelRuntime = Reflect.get(harness.session, "_modelRuntime") as {
+			getAuth: (...args: unknown[]) => Promise<unknown>;
+		};
+		const originalGetAuth = modelRuntime.getAuth.bind(modelRuntime);
+		vi.spyOn(modelRuntime, "getAuth").mockImplementation(async (...args) => {
+			autoAuthStarted.resolve();
+			await releaseAutoAuth.promise;
+			return await originalGetAuth(...args);
+		});
+
+		const autoCompaction = getRunAutoCompaction(harness)("threshold", false);
+		await autoAuthStarted.promise;
+		const manualCompaction = harness.session.compact();
+		await manualCompaction;
+		releaseAutoAuth.resolve();
+		expect(await autoCompaction).toBe(false);
+		await harness.session.waitForSettledSessionWork();
+
+		// The auto attempt was superseded while auth was pending. It owns no
+		// lifecycle transition or public events; the manual operation completes once.
+		expect(lifecycleBegin).toHaveBeenCalledTimes(1);
+		expect(harness.eventsOfType("compaction_start")).toEqual([expect.objectContaining({ reason: "manual" })]);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "manual", accepted: true, aborted: false }),
+		]);
+		expect(harness.session.compactionState).toMatchObject({ status: "completed" });
 		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/suite/compaction-race.test.ts
+++ b/packages/coding-agent/test/suite/compaction-race.test.ts
@@ -55,6 +55,20 @@ async function waitForCompactionStart(deferred: Deferred): Promise<void> {
 	}
 }
 
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(() => true),
+			new Promise<boolean>((resolve) => {
+				timeout = setTimeout(() => resolve(false), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
+}
+
 function getRunAutoCompaction(harness: Harness) {
 	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
 	if (typeof runAutoCompaction !== "function") {
@@ -261,6 +275,67 @@ describe("AgentSession compaction race handling", () => {
 		).toBe(true);
 		expect(secondCall?.context.messages.some((message) => contextHasText(message, initialPrompt))).toBe(false);
 		expect(getUserTexts(harness)).toEqual(["after compaction prompt"]);
+	});
+
+	it("aborts an active run before manual compaction disconnects the agent-event subscription", async () => {
+		const eventOrder: string[] = [];
+		let resolveStreamingUpdate: (() => void) | undefined;
+		const streamingUpdate = new Promise<void>((resolve) => {
+			resolveStreamingUpdate = resolve;
+		});
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => ({
+						compaction: {
+							summary: "manual compaction after active abort",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("first seed response"),
+			fauxAssistantMessage("second seed response"),
+			fauxAssistantMessage("streaming response ".repeat(4_000)),
+		]);
+		await harness.session.prompt("first seed prompt");
+		await harness.session.prompt("second seed prompt");
+
+		harness.session.subscribe((event) => {
+			if (event.type === "message_update" && event.message.role === "assistant") {
+				resolveStreamingUpdate?.();
+				resolveStreamingUpdate = undefined;
+			}
+			if (event.type === "agent_end") eventOrder.push("agent_end");
+			if (event.type === "compaction_start") eventOrder.push("compaction_start");
+		});
+
+		const activePrompt = harness.session.prompt("prompt whose provider stream is active");
+		await streamingUpdate;
+		expect(harness.session.isStreaming).toBe(true);
+
+		const manualCompaction = harness.session.compact();
+		const settled = await settlesWithin(Promise.allSettled([activePrompt, manualCompaction]), 1_000);
+		expect(settled, "manual compaction must not deadlock behind an aborted active run").toBe(true);
+		if (!settled) return;
+
+		const activeAgentEnd = harness.eventsOfType("agent_end").at(-1);
+		expect(activeAgentEnd?.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+		expect(eventOrder).toEqual(expect.arrayContaining(["agent_end", "compaction_start"]));
+		expect(eventOrder.indexOf("agent_end")).toBeLessThan(eventOrder.indexOf("compaction_start"));
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.session.isCompacting).toBe(false);
+
+		harness.setResponses([fauxAssistantMessage("later prompt succeeded")]);
+		await harness.session.prompt("later prompt after manual compaction");
+		expect(getUserTexts(harness).at(-1)).toBe("later prompt after manual compaction");
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.session.isCompacting).toBe(false);
 	});
 
 	it("auto compaction supersedes unrelated extension feedback without promoting it", async () => {

--- a/packages/coding-agent/test/suite/compaction-race.test.ts
+++ b/packages/coding-agent/test/suite/compaction-race.test.ts
@@ -10,6 +10,14 @@ type Deferred = {
 	readonly resolve: () => void;
 };
 
+type BeginFeedback = (reason: "extension") => AbortSignal;
+type EndFeedback = (options: {
+	reason: "extension";
+	signal?: AbortSignal;
+	aborted?: boolean;
+	errorMessage?: string;
+}) => void;
+
 type TextBlock = {
 	readonly type: "text";
 	readonly text?: string;
@@ -45,6 +53,15 @@ async function waitForCompactionStart(deferred: Deferred): Promise<void> {
 			clearTimeout(timeout);
 		}
 	}
+}
+
+function getRunAutoCompaction(harness: Harness) {
+	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof runAutoCompaction !== "function") {
+		throw new Error("Expected AgentSession._runAutoCompaction");
+	}
+	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
+		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
 }
 
 function createBlockingCompactionExtension(started: Deferred, release: Deferred, summary: string) {
@@ -244,5 +261,73 @@ describe("AgentSession compaction race handling", () => {
 		).toBe(true);
 		expect(secondCall?.context.messages.some((message) => contextHasText(message, initialPrompt))).toBe(false);
 		expect(getUserTexts(harness)).toEqual(["after compaction prompt"]);
+	});
+
+	it("auto compaction supersedes unrelated extension feedback without promoting it", async () => {
+		// RED 1: an active extension feedback operation owns neither the auto
+		// compaction that starts underneath it nor the final terminal event. The
+		// auto operation must supersede/abort the stale feedback operation instead
+		// of promoting or reusing its controller: the stale feedback end must not
+		// publish a terminal, the matching outer controller must still clear, and
+		// the auto compaction must complete exactly once.
+		const compactionStarted = createDeferred();
+		const releaseCompaction = createDeferred();
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 16_384 } },
+			extensionFactories: [
+				createBlockingCompactionExtension(compactionStarted, releaseCompaction, "auto threshold summary"),
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed context ".repeat(40));
+		harness.events.length = 0;
+
+		const begin = Reflect.get(harness.session, "_beginExtensionCompactionFeedback");
+		const end = Reflect.get(harness.session, "_endExtensionCompactionFeedback");
+		if (typeof begin !== "function" || typeof end !== "function") {
+			throw new Error("Compaction feedback lifecycle methods unavailable");
+		}
+
+		const staleFeedbackSignal = (begin as BeginFeedback).call(harness.session, "extension");
+		expect(harness.session.isCompacting).toBe(true);
+		expect(harness.session.compactionState).toMatchObject({
+			status: "running",
+			generation: 1,
+			stage: "feedback",
+		});
+
+		const autoCompaction = getRunAutoCompaction(harness)("threshold", false);
+		await compactionStarted.promise;
+		try {
+			// The auto compaction runs on its own controller: it supersedes the
+			// unrelated feedback operation rather than promoting or reusing it.
+			expect(staleFeedbackSignal.aborted).toBe(true);
+			expect(harness.session.compactionState).toMatchObject({
+				status: "running",
+				generation: 2,
+				stage: "execution",
+			});
+		} finally {
+			releaseCompaction.resolve();
+		}
+		await autoCompaction;
+		await harness.session.waitForSettledSessionWork();
+
+		// The stale feedback end publishes no terminal of its own: the auto
+		// completion is the final lifecycle terminal, with no duplicate
+		// compaction entry appended and no duplicate terminal event.
+		(end as EndFeedback).call(harness.session, {
+			reason: "extension",
+			signal: staleFeedbackSignal,
+			errorMessage: "stale feedback ended after auto compaction",
+		});
+		expect(harness.session.compactionState).toMatchObject({ status: "completed", generation: 2 });
+		expect(harness.session.isCompacting).toBe(false);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "threshold", accepted: true, aborted: false }),
+		]);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/6162-extension-active-tools-next-turn.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6162-extension-active-tools-next-turn.test.ts
@@ -1,6 +1,7 @@
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
 import type { ExtensionFactory } from "../../../src/index.ts";
 import { createHarness } from "../harness.ts";
 
@@ -186,6 +187,61 @@ describe("extension active tools next-turn refresh", () => {
 			expect(providerSystemPrompts[0]).toContain("keep this run override");
 			expect(providerSystemPrompts[1]).toContain("keep this run override");
 		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("stale-rejects an in-flight extension compaction after a tool is revoked", async () => {
+		let capturedContext: ExtensionContext | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerTool({
+						name: "active_compaction_tool",
+						label: "Active Compaction Tool",
+						description: "Remains active while compaction is prepared",
+						parameters: Type.Object({}),
+						execute: async () => ({ content: [{ type: "text", text: "active" }], details: {} }),
+					});
+					pi.registerTool({
+						name: "mcp__revoked_server__tool",
+						label: "Revoked MCP Tool",
+						description: "Is revoked before its summary can apply",
+						parameters: Type.Object({}),
+						execute: async () => ({ content: [{ type: "text", text: "revoked" }], details: {} }),
+					});
+					pi.on("agent_settled", (_event, ctx) => {
+						capturedContext = ctx;
+					});
+				},
+			],
+		});
+
+		try {
+			harness.session.setActiveToolsByName(["active_compaction_tool", "mcp__revoked_server__tool"]);
+			harness.setResponses([fauxAssistantMessage("seed response")]);
+			await harness.session.prompt("seed in-flight compaction context");
+			if (!capturedContext) throw new Error("Expected an ExtensionContext from agent_settled");
+			const firstEntry = harness.sessionManager.getEntries()[0];
+			if (!firstEntry) throw new Error("Expected a persisted source entry");
+			const expectedRevision = capturedContext.getMessageRevision();
+			const signal = capturedContext.beginCompaction?.({ reason: "extension" });
+			if (!signal) throw new Error("Expected compaction feedback signal");
+
+			harness.session.setActiveToolsByName(["active_compaction_tool"]);
+			const result = await capturedContext.applyCompaction(
+				{
+					summary: "summary prepared with mcp__revoked_server__tool",
+					firstKeptEntryId: firstEntry.id,
+					tokensBefore: 42,
+				},
+				{ reason: "extension", expectedRevision },
+			);
+
+			expect(result).toEqual({ applied: false, reason: "stale" });
+			expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		} finally {
+			capturedContext?.endCompaction?.({ reason: "extension" });
 			harness.cleanup();
 		}
 	});

--- a/packages/coding-agent/test/suite/regressions/compaction-current-model-state.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-current-model-state.test.ts
@@ -1,0 +1,109 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import type { Context, FauxResponseFactory } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import compactionExtension from "../../../src/core/extensions/builtin/compaction/index.ts";
+import { createHarness, getAssistantTexts, getMessageText, type Harness } from "../harness.ts";
+
+function lastUserText(context: Context): string {
+	for (let index = context.messages.length - 1; index >= 0; index--) {
+		const message = context.messages[index];
+		if (message?.role === "user") return getMessageText(message);
+	}
+	return "";
+}
+
+function seedLargeContext(harness: Harness): void {
+	const model = harness.getModel("faux-1");
+	if (!model) throw new Error("Primary model was not registered");
+	const now = Date.now();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "history ".repeat(22_000) }],
+		timestamp: now - 1000,
+	});
+	harness.sessionManager.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: "result ".repeat(200) }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 19_900,
+			output: 100,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 20_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: now - 500,
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
+describe("Regression: compaction state during model fallback", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("uses the active main-thread fallback model for compaction", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 50_000, maxTokens: 2048 },
+				{ id: "faux-2", contextWindow: 50_000, maxTokens: 2048 },
+			],
+			settings: {
+				compaction: {
+					enabled: true,
+					reserveTokens: 5000,
+					keepRecentTokens: 32,
+					speculativeEnabled: false,
+				},
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { "faux/faux-1": ["faux/faux-2"] },
+				},
+			},
+			extensionFactories: [compactionExtension],
+		});
+		harnesses.push(harness);
+		seedLargeContext(harness);
+
+		const response: FauxResponseFactory = async (context, _options, _state, model) => {
+			const prompt = lastUserText(context);
+			if (prompt === "trigger fallback") {
+				if (model.id === "faux-1") {
+					return fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" });
+				}
+				return fauxAssistantMessage("fallback answer");
+			}
+			if (prompt === "prompt after compaction") return fauxAssistantMessage("next answer");
+			return fauxAssistantMessage("compacted on active fallback");
+		};
+		harness.setResponses([response, response, response, response]);
+
+		await harness.session.prompt("trigger fallback");
+		const compactionModels = harness.faux
+			.getCallLog()
+			.filter((entry) => !["trigger fallback", "prompt after compaction"].includes(lastUserText(entry.context)))
+			.map((entry) => entry.modelId);
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: "faux/faux-1", to: "faux/faux-2" },
+		]);
+		expect(compactionModels).toEqual(["faux-2"]);
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(Reflect.get(harness.session, "compactionState")).toMatchObject({
+			status: "completed",
+			generation: 1,
+			model: { provider: "faux", id: "faux-2" },
+		});
+
+		await harness.session.prompt("prompt after compaction");
+		expect(getAssistantTexts(harness)).toContain("next answer");
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/compaction-current-model-state.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-current-model-state.test.ts
@@ -12,6 +12,12 @@ function lastUserText(context: Context): string {
 	return "";
 }
 
+function runAutoCompaction(harness: Harness, reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+	const run = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof run !== "function") throw new Error("Expected AgentSession._runAutoCompaction");
+	return Promise.resolve(run.call(harness.session, reason, willRetry));
+}
+
 function seedLargeContext(harness: Harness): void {
 	const model = harness.getModel("faux-1");
 	if (!model) throw new Error("Primary model was not registered");
@@ -105,5 +111,126 @@ describe("Regression: compaction state during model fallback", () => {
 		await harness.session.prompt("prompt after compaction");
 		expect(getAssistantTexts(harness)).toContain("next answer");
 		expect(harness.session.model?.id).toBe("faux-2");
+	});
+
+	it.each([
+		"rejected",
+		"accepted",
+	] as const)("revalidates the model selected by a delayed session_compact handler before queued continuation when re-compaction is %s", async (secondCompaction) => {
+		const continuationMarker = `queued continuation after ${secondCompaction} smaller-model revalidation`;
+		const firstSummary = "large-window summary ".repeat(80);
+		let compactionRequests = 0;
+		let smallerModel: Harness["models"][number] | undefined;
+		let resolveFirstCompactionEnd: (() => void) | undefined;
+		const firstCompactionEnd = new Promise<void>((resolve) => {
+			resolveFirstCompactionEnd = resolve;
+		});
+		const compactionEndModels: string[] = [];
+		const providerCompactionCounts: number[] = [];
+		let switchedToSmallerModel = false;
+		const harness = await createHarness({
+			models: [
+				{ id: "large", contextWindow: 1_000, maxTokens: 64 },
+				{ id: "small", contextWindow: 100, maxTokens: 64 },
+			],
+			settings: { compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => {
+						compactionRequests++;
+						if (compactionRequests === 2 && secondCompaction === "rejected") {
+							return {
+								cancel: true,
+								rejectionCause: "cancelled-by-extension" as const,
+								reason: "smaller model requires a rejected second compaction",
+							};
+						}
+						return {
+							compaction: {
+								summary: compactionRequests === 1 ? firstSummary : "small-window replacement summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
+					pi.on("session_compact", async (event) => {
+						if (!event.accepted || switchedToSmallerModel) return;
+						await firstCompactionEnd;
+						pi.sendMessage({
+							customType: "post-compaction-state",
+							content: "first post-compaction state",
+							display: false,
+						});
+						pi.sendMessage({
+							customType: "post-compaction-state",
+							content: "second post-compaction state",
+							display: false,
+						});
+						if (!smallerModel) throw new Error("Expected smaller model");
+						switchedToSmallerModel = await pi.setModel(smallerModel);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		smallerModel = harness.getModel("small");
+		if (!smallerModel) throw new Error("Expected smaller model");
+		const largeModel = harness.getModel("large");
+		if (!largeModel) throw new Error("Expected large model");
+		const timestamp = Date.now();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "large context before compaction ".repeat(120) }],
+			timestamp: timestamp - 1,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("large context response"),
+			api: largeModel.api,
+			provider: largeModel.provider,
+			model: largeModel.id,
+			usage: {
+				input: 900,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 900,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			() => {
+				providerCompactionCounts.push(
+					harness.eventsOfType("compaction_end").filter((event) => event.accepted === true).length,
+				);
+				return fauxAssistantMessage("queued continuation handled");
+			},
+		]);
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.accepted && event.reason === "threshold") {
+				compactionEndModels.push(harness.session.model?.id ?? "none");
+				resolveFirstCompactionEnd?.();
+			}
+		});
+		await harness.session.followUp(continuationMarker);
+
+		await runAutoCompaction(harness, "threshold", false);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(compactionEndModels[0]).toBe("large");
+		expect(switchedToSmallerModel).toBe(true);
+		expect(harness.session.model?.id).toBe("small");
+		if (secondCompaction === "rejected") {
+			expect(harness.faux.state.callCount).toBe(0);
+			expect(providerCompactionCounts).toEqual([]);
+			expect(compactionRequests).toBe(2);
+			expect(harness.session.getFollowUpMessages()).toEqual([continuationMarker]);
+			expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		} else {
+			expect(compactionRequests).toBe(2);
+			expect(providerCompactionCounts).toEqual([2]);
+			expect(harness.faux.state.callCount).toBe(1);
+		}
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/compaction-generation-stale-revision.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-generation-stale-revision.test.ts
@@ -1,0 +1,110 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import { createHarness, getMessageText, type Harness } from "../harness.ts";
+
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function compactionEntryCount(harness: Harness): number {
+	return harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length;
+}
+
+function agentMessagesContaining(harness: Harness, text: string): number {
+	return harness.session.messages.filter((message) => getMessageText(message).includes(text)).length;
+}
+
+async function appendMidCompactionMessage(harness: Harness): Promise<void> {
+	await harness.session.sendCustomMessage({
+		customType: "mid-compaction-note",
+		content: "arrived mid-compaction",
+		display: true,
+	});
+}
+
+describe("Regression: stale compaction generation after a revision change", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("rejects stale compaction when the session changes during extension preparation", async () => {
+		const preparationStarted = createDeferred();
+		const releasePreparation = createDeferred();
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", async (event) => {
+						preparationStarted.resolve();
+						await releasePreparation.promise;
+						return {
+							compaction: {
+								summary: "summary generated from a stale branch",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("initial assistant")]);
+		await harness.session.prompt("initial prompt ".repeat(40));
+
+		const compactPromise = harness.session.compact();
+		await preparationStarted.promise;
+		await appendMidCompactionMessage(harness);
+		releasePreparation.resolve();
+
+		await expect(compactPromise).rejects.toThrow();
+		expect(compactionEntryCount(harness)).toBe(0);
+		expect(agentMessagesContaining(harness, "arrived mid-compaction")).toBe(1);
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === true)).toHaveLength(0);
+	});
+
+	it("rejects stale compaction when the session changes during summary generation", async () => {
+		const generationStarted = createDeferred();
+		const releaseGeneration = createDeferred();
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("initial assistant"),
+			async () => {
+				generationStarted.resolve();
+				await releaseGeneration.promise;
+				return fauxAssistantMessage("provider generated summary");
+			},
+		]);
+		await harness.session.prompt("initial prompt ".repeat(40));
+
+		const compactPromise = harness.session.compact();
+		await generationStarted.promise;
+		await appendMidCompactionMessage(harness);
+		releaseGeneration.resolve();
+
+		await expect(compactPromise).rejects.toThrow();
+		expect(compactionEntryCount(harness)).toBe(0);
+		expect(agentMessagesContaining(harness, "arrived mid-compaction")).toBe(1);
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === true)).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/compaction-generation-stale-revision.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-generation-stale-revision.test.ts
@@ -107,4 +107,96 @@ describe("Regression: stale compaction generation after a revision change", () =
 		expect(agentMessagesContaining(harness, "arrived mid-compaction")).toBe(1);
 		expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === true)).toHaveLength(0);
 	});
+
+	it("keeps a delayed assistant message_end post-compaction despite its earlier payload timestamp", async () => {
+		const assistantEndStarted = createDeferred();
+		const releaseAssistantEnd = createDeferred();
+		const payloadTimestamp = Date.now() - 10_000;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 1_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("message_end", async (event) => {
+						if (
+							event.message.role !== "assistant" ||
+							!getMessageText(event.message).includes("delayed assistant payload")
+						)
+							return;
+						assistantEndStarted.resolve();
+						await releaseAssistantEnd.promise;
+					});
+					pi.on("session_before_compact", () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "subsequent admission must remain blocked",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "seed pending persistence boundary" }],
+			timestamp: payloadTimestamp - 1,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("delayed assistant payload"),
+				timestamp: payloadTimestamp,
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 1_200,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 1_200,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+			fauxAssistantMessage("must not reach the next provider admission"),
+		]);
+		const delayedPrompt = harness.session.prompt("produce a delayed assistant");
+		void delayedPrompt.catch(() => undefined);
+		await assistantEndStarted.promise;
+		const firstEntry = harness.sessionManager.getEntries()[0];
+		if (!firstEntry) throw new Error("Expected a persisted entry before compaction");
+
+		const applied = await harness.session.applyCompaction(
+			{
+				summary: "summary that fits the original context window",
+				firstKeptEntryId: firstEntry.id,
+				tokensBefore: 42,
+			},
+			{ reason: "extension" },
+		);
+		expect(applied).toEqual({ applied: true, reason: "ok" });
+		expect(agentMessagesContaining(harness, "delayed assistant payload")).toBe(1);
+
+		releaseAssistantEnd.resolve();
+		await delayedPrompt;
+		const branch = harness.sessionManager.getBranch();
+		const compactionIndex = branch.findIndex((entry) => entry.type === "compaction");
+		const delayedAssistantIndex = branch.findIndex(
+			(entry) => entry.type === "message" && getMessageText(entry.message).includes("delayed assistant payload"),
+		);
+		expect(compactionIndex).toBeGreaterThanOrEqual(0);
+		expect(delayedAssistantIndex).toBeGreaterThan(compactionIndex);
+		const delayedAssistant = branch[delayedAssistantIndex];
+		if (delayedAssistant?.type !== "message" || delayedAssistant.message.role !== "assistant") {
+			throw new Error("Expected the delayed assistant entry after compaction");
+		}
+		expect(delayedAssistant.message.timestamp).toBe(payloadTimestamp);
+		expect(new Date(branch[compactionIndex]!.timestamp).getTime()).toBeGreaterThan(payloadTimestamp);
+
+		await expect(harness.session.prompt("subsequent admission")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/compaction-generation-stale-revision.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-generation-stale-revision.test.ts
@@ -1,6 +1,19 @@
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import { AgentSession, type AgentSessionEvent } from "../../../src/core/agent-session.ts";
+import type { ExtensionAPI, ExtensionRunner } from "../../../src/core/extensions/index.ts";
+import { convertToLlm } from "../../../src/core/messages.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { type Settings, SettingsManager } from "../../../src/core/settings-manager.ts";
+import type { InlineExtension } from "../../../src/index.ts";
+import { createInMemoryModelRegistry, getModelRuntime } from "../../model-runtime-test-utils.ts";
+import {
+	type CreateTestExtensionsResultInput,
+	createTestExtensionsResult,
+	createTestResourceLoader,
+} from "../../utilities.ts";
 import { createHarness, getMessageText, type Harness } from "../harness.ts";
 
 type Deferred = {
@@ -23,6 +36,79 @@ function compactionEntryCount(harness: Harness): number {
 
 function agentMessagesContaining(harness: Harness, text: string): number {
 	return harness.session.messages.filter((message) => getMessageText(message).includes(text)).length;
+}
+
+interface ReloadedHarness {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	events: AgentSessionEvent[];
+}
+
+/**
+ * Rebuild the full SessionManager/AgentSession stack from the source harness's
+ * persisted session file, mirroring a close/reopen cycle. Reloaded messages are
+ * new object identities with no runtime position bookkeeping, exactly like a
+ * process restart.
+ */
+async function reloadHarnessFromSessionFile(
+	source: Harness,
+	options: {
+		settings?: Partial<Settings>;
+		extensionFactories?: Array<InlineExtension | CreateTestExtensionsResultInput>;
+	} = {},
+): Promise<ReloadedHarness> {
+	const sessionFile = source.sessionManager.getSessionFile();
+	if (!sessionFile) throw new Error("Expected the source harness to persist its session file");
+	const sessionManager = SessionManager.open(sessionFile);
+	const settingsManager = SettingsManager.inMemory(options.settings);
+	const model = source.getModel();
+	const modelRegistry = await createInMemoryModelRegistry(source.authStorage);
+	modelRegistry.registerProvider(model.provider, {
+		baseUrl: model.baseUrl,
+		apiKey: "faux-key",
+		api: source.faux.api,
+		models: source.models.map((registeredModel) => ({
+			id: registeredModel.id,
+			name: registeredModel.name,
+			api: registeredModel.api,
+			reasoning: registeredModel.reasoning,
+			input: registeredModel.input,
+			cost: registeredModel.cost,
+			contextWindow: registeredModel.contextWindow,
+			maxTokens: registeredModel.maxTokens,
+			baseUrl: registeredModel.baseUrl,
+		})),
+	});
+	const extensionRunnerRef: { current?: ExtensionRunner } = {};
+	const agent = new Agent({
+		getApiKey: () => "faux-key",
+		initialState: {
+			model,
+			systemPrompt: "You are a test assistant.",
+			tools: [],
+		},
+		convertToLlm,
+	});
+	const extensionsResult = options.extensionFactories
+		? await createTestExtensionsResult(options.extensionFactories, source.tempDir)
+		: undefined;
+	const resourceLoader = createTestResourceLoader(extensionsResult ? { extensionsResult } : undefined);
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settingsManager,
+		cwd: source.tempDir,
+		agentDir: join(source.tempDir, "agent-reload"),
+		modelRuntime: getModelRuntime(modelRegistry),
+		resourceLoader,
+		extensionRunnerRef,
+	});
+	const events: AgentSessionEvent[] = [];
+	session.subscribe((event) => {
+		events.push(event);
+	});
+	session.agent.state.messages = sessionManager.buildSessionContext().messages;
+	return { session, sessionManager, events };
 }
 
 async function appendMidCompactionMessage(harness: Harness): Promise<void> {
@@ -198,5 +284,126 @@ describe("Regression: stale compaction generation after a revision change", () =
 		);
 		expect(harness.faux.state.callCount).toBe(1);
 		expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
+	});
+
+	it("keeps a reloaded delayed assistant post-compaction without falling back to payload timestamps", async () => {
+		const assistantEndStarted = createDeferred();
+		const releaseAssistantEnd = createDeferred();
+		const payloadTimestamp = Date.now() - 10_000;
+		const harness = await createHarness({
+			persistSession: true,
+			models: [{ id: "faux-1", contextWindow: 1_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("message_end", async (event) => {
+						if (
+							event.message.role !== "assistant" ||
+							!getMessageText(event.message).includes("delayed assistant payload")
+						)
+							return;
+						assistantEndStarted.resolve();
+						await releaseAssistantEnd.promise;
+					});
+					pi.on("session_before_compact", () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "post-reload admission must compact or block",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "seed pending persistence boundary" }],
+			timestamp: payloadTimestamp - 1,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("delayed assistant payload"),
+				timestamp: payloadTimestamp,
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 1_200,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 1_200,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+			fauxAssistantMessage("reloaded session must not reach the provider"),
+		]);
+		const delayedPrompt = harness.session.prompt("produce a delayed assistant");
+		void delayedPrompt.catch(() => undefined);
+		await assistantEndStarted.promise;
+		const firstEntry = harness.sessionManager.getEntries()[0];
+		if (!firstEntry) throw new Error("Expected a persisted entry before compaction");
+
+		const applied = await harness.session.applyCompaction(
+			{
+				summary: "summary that fits the original context window",
+				firstKeptEntryId: firstEntry.id,
+				tokensBefore: 42,
+			},
+			{ reason: "extension" },
+		);
+		expect(applied).toEqual({ applied: true, reason: "ok" });
+
+		releaseAssistantEnd.resolve();
+		await delayedPrompt;
+
+		// Close the live session, then reopen the persisted file through a fresh
+		// SessionManager/AgentSession stack, exactly like a process restart.
+		harness.session.dispose();
+		const reloaded = await reloadHarnessFromSessionFile(harness, {
+			settings: { compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "post-reload admission must compact or block",
+					}));
+				},
+			],
+		});
+
+		try {
+			const branch = reloaded.sessionManager.getBranch();
+			const compactionIndex = branch.findIndex((entry) => entry.type === "compaction");
+			const delayedAssistantIndex = branch.findIndex(
+				(entry) => entry.type === "message" && getMessageText(entry.message).includes("delayed assistant payload"),
+			);
+			expect(compactionIndex).toBeGreaterThanOrEqual(0);
+			expect(delayedAssistantIndex).toBeGreaterThan(compactionIndex);
+			const compactionEntry = branch[compactionIndex]!;
+			const delayedAssistantEntry = branch[delayedAssistantIndex]!;
+			if (delayedAssistantEntry.type !== "message" || delayedAssistantEntry.message.role !== "assistant") {
+				throw new Error("Expected the delayed assistant entry after compaction");
+			}
+			// The persisted branch orders the assistant after the compaction entry even
+			// though its provider-supplied payload timestamp is older.
+			expect(delayedAssistantEntry.message.timestamp).toBe(payloadTimestamp);
+			expect(new Date(compactionEntry.timestamp).getTime()).toBeGreaterThan(payloadTimestamp);
+
+			// The reloaded context is still above threshold (usage 1200 > window 1000),
+			// so the next admission must compact (cancelled here) or block entirely. It
+			// must not classify the assistant as pre-compaction via the timestamp
+			// fallback and wave the prompt through to the provider.
+			const providerCallsBefore = harness.faux.state.callCount;
+			await expect(reloaded.session.prompt("subsequent admission after reload")).rejects.toThrow(
+				"Context remains above the compaction threshold because compaction did not complete",
+			);
+			expect(harness.faux.state.callCount).toBe(providerCallsBefore);
+			expect(reloaded.events.filter((event) => event.type === "compaction_start")).toHaveLength(1);
+		} finally {
+			reloaded.session.dispose();
+		}
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/compaction-synchronous-admission.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-synchronous-admission.test.ts
@@ -1,0 +1,150 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "../../../src/core/extensions/index.ts";
+import { createHarness, getMessageText, type Harness } from "../harness.ts";
+
+type Deferred = {
+	promise: Promise<void>;
+	resolve: () => void;
+};
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function customMessageEntries(harness: Harness, content: string) {
+	return harness.sessionManager
+		.getEntries()
+		.filter((entry) => entry.type === "custom_message" && entry.content === content);
+}
+
+describe("synchronous manual compaction admission ownership", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it.each([
+		{ origin: "session", outcome: "accepted" },
+		{ origin: "session", outcome: "rejected" },
+		{ origin: "session", outcome: "aborted" },
+		{ origin: "extension", outcome: "accepted" },
+		{ origin: "extension", outcome: "rejected" },
+		{ origin: "extension", outcome: "aborted" },
+	] as const)("claims admission synchronously when $origin compaction and a trigger-turn custom message share a tick ($outcome)", async ({
+		origin,
+		outcome,
+	}) => {
+		const marker = `${origin} trigger-turn after ${outcome} compaction`;
+		const summary = `${origin} accepted compaction summary`;
+		let extensionApi: ExtensionAPI | undefined;
+		let extensionContext: ExtensionContext | undefined;
+		const compactionStarted = createDeferred();
+		const compactionFinished = createDeferred();
+		const providerContexts: AgentMessage[][] = [];
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					extensionApi = pi;
+					pi.on("session_start", (_event, ctx) => {
+						extensionContext = ctx;
+					});
+					pi.on("session_before_compact", async (event) => {
+						if (outcome === "accepted") {
+							return {
+								compaction: {
+									summary,
+									firstKeptEntryId: event.preparation.firstKeptEntryId,
+									tokensBefore: event.preparation.tokensBefore,
+								},
+							};
+						}
+						if (outcome === "rejected") {
+							return { cancel: true, rejectionCause: "cancelled-by-extension" as const };
+						}
+						return await new Promise<{ cancel: true }>((resolve) => {
+							event.signal.addEventListener("abort", () => resolve({ cancel: true }), { once: true });
+						});
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		if (!extensionApi || !extensionContext) throw new Error("Expected extension API and context");
+
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed manual compaction context");
+		harness.setResponses([
+			(context) => {
+				providerContexts.push(context.messages);
+				return fauxAssistantMessage("custom trigger-turn handled");
+			},
+		]);
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start") compactionStarted.resolve();
+			if (event.type === "compaction_end") compactionFinished.resolve();
+		});
+
+		const sessionCompact =
+			origin === "session"
+				? harness.session.compact().then(
+						() => undefined,
+						() => undefined,
+					)
+				: undefined;
+		if (origin === "extension") extensionContext.compact();
+		const claimedAdmissionSynchronously = harness.session.isCompacting;
+		const customTurn =
+			origin === "session"
+				? harness.session.sendCustomMessage(
+						{ customType: "same-tick-compaction", content: marker, display: false },
+						{ triggerTurn: true },
+					)
+				: undefined;
+		if (origin === "extension") {
+			extensionApi.sendMessage(
+				{ customType: "same-tick-compaction", content: marker, display: false },
+				{ triggerTurn: true },
+			);
+		}
+
+		await compactionStarted.promise;
+		if (outcome === "aborted") harness.session.abortCompaction();
+		await compactionFinished.promise;
+		await Promise.allSettled([sessionCompact ?? Promise.resolve(), customTurn ?? Promise.resolve()]);
+		await harness.session.waitForSettledSessionWork();
+		await harness.session.agent.waitForIdle();
+
+		// Neither compaction entry point may yield before claiming the lifecycle;
+		// otherwise same-tick trigger-turn messages race past the compaction boundary.
+		expect(claimedAdmissionSynchronously).toBe(true);
+		if (outcome === "accepted") {
+			expect(harness.faux.state.callCount).toBe(2);
+			expect(providerContexts).toHaveLength(1);
+			const providerContext = providerContexts[0] ?? [];
+			const summaryIndex = providerContext.findIndex(
+				(message) => message.role === "user" && getMessageText(message).includes(summary),
+			);
+			const customIndex = providerContext.findIndex(
+				(message) => message.role === "user" && getMessageText(message) === marker,
+			);
+			expect(summaryIndex).toBeGreaterThanOrEqual(0);
+			expect(customIndex).toBeGreaterThan(summaryIndex);
+			expect(customMessageEntries(harness, marker)).toHaveLength(1);
+		} else {
+			expect(harness.faux.state.callCount).toBe(1);
+			expect(providerContexts).toEqual([]);
+			expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+			expect(customMessageEntries(harness, marker)).toHaveLength(0);
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction-boundaries.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction-boundaries.test.ts
@@ -105,7 +105,7 @@ describe("issue #296 remote compaction boundaries", () => {
 	])("does not replay $persistedProvider state through $current.provider", ({ current, persistedProvider }) => {
 		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
 			{ model: current.id, input: [], stream: true },
-			{ model: current, branchEntries: compactedBranch(persistedProvider), pendingMessages: [] },
+			{ model: current, branchEntries: compactedBranch(persistedProvider) },
 		);
 
 		expect(rewritten).toBeUndefined();

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
@@ -1,4 +1,3 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../../src/core/compaction/index.ts";
@@ -191,16 +190,18 @@ describe("issue #296 OpenAI Codex remote compaction", () => {
 				fromHook: true,
 			},
 		];
-		const pendingMessages = [
-			{
-				role: "user",
-				content: [{ type: "text", text: "Continue after compaction." }],
-				timestamp: 4,
-			},
-		] satisfies AgentMessage[];
 		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
-			{ model: CODEX_MODEL.id, input: [{ role: "developer", content: "Current prompt." }], stream: true },
-			{ model: CODEX_MODEL, branchEntries: compactedBranch, pendingMessages },
+			{
+				model: CODEX_MODEL.id,
+				input: [
+					{ role: "developer", content: "Current prompt." },
+					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{ role: "user", content: [{ type: "input_text", text: "Keep the diagnosis." }] },
+					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
+				],
+				stream: true,
+			},
+			{ model: CODEX_MODEL, branchEntries: compactedBranch },
 		) as { input?: unknown[] } | undefined;
 
 		expect(rewritten?.input).toContainEqual({

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
@@ -1,3 +1,4 @@
+import { arch, platform, release } from "node:os";
 import { type Api, type AssistantMessage, convertResponsesMessages, type Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../../src/core/compaction/index.ts";
@@ -7,9 +8,14 @@ import {
 	rewriteOpenAiPayloadWithRemoteCompaction,
 	runOpenAiRemoteCompaction,
 } from "../../../src/core/extensions/builtin/compaction/openai-remote.ts";
+import {
+	createOpenAiRemoteCompactionHeaders,
+	openAiRemoteCompactionOrigin,
+} from "../../../src/core/extensions/builtin/compaction/openai-remote-model.ts";
 import type { SessionBeforeCompactEvent } from "../../../src/core/extensions/types.ts";
 import { convertToLlm } from "../../../src/core/messages.ts";
 import { buildSessionContext, type SessionEntry, type SessionMessageEntry } from "../../../src/core/session-manager.ts";
+import { createHarness } from "../harness.ts";
 
 const CODEX_MODEL = {
 	id: "gpt-5.4-codex",
@@ -107,13 +113,61 @@ function compactionEvent(model: Api, branchEntries: SessionEntry[]): SessionBefo
 	};
 }
 
-function codexToken(): string {
+function codexToken(accountId = "account_issue_296", nonce = "initial"): string {
 	const payload = Buffer.from(
 		JSON.stringify({
-			"https://api.openai.com/auth": { chatgpt_account_id: "account_issue_296" },
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+			nonce,
 		}),
 	).toString("base64url");
 	return `header.${payload}.signature`;
+}
+
+function codexReplayOrigin(token: string) {
+	const headers = createOpenAiRemoteCompactionHeaders(CODEX_MODEL, { apiKey: token }, "stable-account-session");
+	const origin = headers ? openAiRemoteCompactionOrigin(CODEX_MODEL, headers) : undefined;
+	if (!origin) throw new Error("Expected a canonical Codex replay origin");
+	return origin;
+}
+
+function branchWithRemoteCheckpoint(
+	branch: SessionEntry[],
+	result: NonNullable<Awaited<ReturnType<typeof runOpenAiRemoteCompaction>>>,
+): SessionEntry[] {
+	return [
+		...branch,
+		{
+			type: "compaction",
+			id: "remote-checkpoint",
+			parentId: "u2",
+			timestamp: new Date(1_775_000_002_000).toISOString(),
+			summary: result.summary,
+			firstKeptEntryId: result.firstKeptEntryId,
+			tokensBefore: result.tokensBefore,
+			details: result.details,
+			fromHook: true,
+		},
+	];
+}
+
+function finalCodexReplayPayload(branchEntries: SessionEntry[]) {
+	const markedContext = markOpenAiRemoteReplayBoundary(
+		[
+			...buildSessionContext(branchEntries).messages,
+			{ role: "user", content: [{ type: "text", text: "Continue after compaction." }], timestamp: 4 },
+		],
+		{ model: CODEX_MODEL, branchEntries },
+	);
+	return {
+		model: CODEX_MODEL.id,
+		input: convertResponsesMessages(
+			CODEX_MODEL,
+			{ messages: convertToLlm(markedContext) },
+			new Set(["openai-codex"]),
+			{ includeSystemPrompt: false, preserveTextSignatures: true },
+		),
+		stream: true,
+	};
 }
 
 describe("issue #296 OpenAI Codex remote compaction", () => {
@@ -162,15 +216,14 @@ describe("issue #296 OpenAI Codex remote compaction", () => {
 		expect(calls[0]?.headers.get("chatgpt-account-id")).toBe("account_issue_296");
 		expect(calls[0]?.headers.get("originator")).toBe("senpi");
 		expect(calls[0]?.headers.get("openai-beta")).toBe("responses=experimental");
-		expect(calls[0]?.headers.get("session_id")).toBe("issue-296-session");
+		expect(calls[0]?.headers.has("session_id")).toBe(false);
 		expect(calls[0]?.headers.get("session-id")).toBe("issue-296-session");
-		expect(calls[0]?.headers.get("thread-id")).toBe("issue-296-session");
-		expect(calls[0]?.headers.get("x-codex-installation-id")).toMatch(
-			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
-		);
-		expect(calls[0]?.headers.get("x-codex-installation-id")).not.toBe("issue-296-session");
-		expect(calls[0]?.headers.get("x-codex-window-id")).toBe("issue-296-session:0");
-		expect(calls[0]?.headers.get("user-agent")).toBe("senpi");
+		expect(calls[0]?.headers.get("x-client-request-id")).toBe("issue-296-session");
+		expect(calls[0]?.headers.has("thread-id")).toBe(false);
+		expect(calls[0]?.headers.has("x-codex-installation-id")).toBe(false);
+		expect(calls[0]?.headers.has("x-codex-window-id")).toBe(false);
+		expect(calls[0]?.headers.get("accept")).toBe("text/event-stream");
+		expect(calls[0]?.headers.get("user-agent")).toBe(`senpi (${platform()} ${release()}; ${arch()})`);
 		expect(result.details).toMatchObject({
 			schema: OPENAI_REMOTE_COMPACTION_SCHEMA,
 			provider: "openai-codex",
@@ -250,5 +303,155 @@ describe("issue #296 OpenAI Codex remote compaction", () => {
 
 		expect(result).toBeUndefined();
 		expect(compactCalls).toBe(0);
+	});
+
+	it("replays a Codex checkpoint across refreshed JWTs for only the same ChatGPT account", async () => {
+		const accountA = "account-stable";
+		const tokenA = codexToken(accountA, "issued-a");
+		const tokenB = codexToken(accountA, "refreshed-b");
+		const tokenC = codexToken("account-other", "issued-c");
+		const branch = codexBranch();
+		const result = await runOpenAiRemoteCompaction(
+			{
+				model: CODEX_MODEL,
+				serviceTier: undefined,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: tokenA }),
+				},
+				sessionManager: { getSessionId: () => "stable-account-session" },
+				getSystemPrompt: () => "You are Senpi.",
+			},
+			compactionEvent(CODEX_MODEL.api, branch),
+			undefined,
+			{
+				fetch: async () =>
+					new Response(
+						JSON.stringify({
+							output: [
+								{
+									type: "message",
+									id: "retained",
+									role: "user",
+									content: [{ type: "input_text", text: "keep" }],
+								},
+								{ type: "compaction", id: "cmp_stable_account", encrypted_content: "stable-account-state" },
+							],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+			},
+		);
+		if (!result) throw new Error("Expected Codex remote compaction result");
+
+		const persistedDetails = JSON.stringify(result.details);
+		expect(persistedDetails).not.toContain(tokenA);
+		expect(persistedDetails).not.toContain(tokenB);
+		expect(persistedDetails).not.toContain(tokenC);
+
+		const compactedBranch = branchWithRemoteCheckpoint(branch, result);
+		const payload = finalCodexReplayPayload(compactedBranch);
+		const replayedWithRefreshedToken = rewriteOpenAiPayloadWithRemoteCompaction(payload, {
+			model: CODEX_MODEL,
+			branchEntries: compactedBranch,
+			origin: codexReplayOrigin(tokenB),
+		}) as { input?: unknown[] } | undefined;
+		expect(replayedWithRefreshedToken?.input).toEqual(
+			expect.arrayContaining([
+				{
+					type: "compaction",
+					id: "cmp_stable_account",
+					encrypted_content: "stable-account-state",
+				},
+			]),
+		);
+
+		const replayedWithDifferentAccount = rewriteOpenAiPayloadWithRemoteCompaction(payload, {
+			model: CODEX_MODEL,
+			branchEntries: compactedBranch,
+			origin: codexReplayOrigin(tokenC),
+		});
+		expect(replayedWithDifferentAccount).toBeUndefined();
+	});
+
+	it("keeps Codex compaction wire auth and replay provenance canonical when header hooks try to override them", async () => {
+		const accountA = "account-wire-a";
+		const accountB = "account-wire-b";
+		const tokenA = codexToken(accountA, "wire-a");
+		const tokenB = codexToken(accountB, "hook-b");
+		const calls: Headers[] = [];
+		const branch = codexBranch();
+		const headerHookHarness = await createHarness({
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			models: [{ id: CODEX_MODEL.id, contextWindow: CODEX_MODEL.contextWindow, maxTokens: CODEX_MODEL.maxTokens }],
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_provider_headers", (event) => {
+						event.headers.authorization = `Bearer ${tokenB}`;
+						event.headers["chatgpt-account-id"] = accountB;
+					});
+				},
+			],
+		});
+
+		try {
+			await headerHookHarness.session.bindExtensions({});
+			const result = await runOpenAiRemoteCompaction(
+				{
+					model: CODEX_MODEL,
+					serviceTier: undefined,
+					modelRegistry: {
+						getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: tokenA }),
+					},
+					sessionManager: { getSessionId: () => "canonical-wire-session" },
+					getSystemPrompt: () => "You are Senpi.",
+					prepareProviderRequest: async (messages) =>
+						await headerHookHarness.getExtensionRunner().prepareProviderRequest(messages),
+				},
+				compactionEvent(CODEX_MODEL.api, branch),
+				undefined,
+				{
+					fetch: async (_url, init) => {
+						calls.push(new Headers(init?.headers));
+						return new Response(
+							JSON.stringify({
+								output: [
+									{
+										type: "message",
+										id: "retained",
+										role: "user",
+										content: [{ type: "input_text", text: "keep" }],
+									},
+									{ type: "compaction", id: "cmp_canonical_wire", encrypted_content: "canonical-wire-state" },
+								],
+							}),
+							{ status: 200, headers: { "content-type": "application/json" } },
+						);
+					},
+				},
+			);
+			if (!result) throw new Error("Expected Codex remote compaction result");
+
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.get("authorization")).toBe(`Bearer ${tokenA}`);
+			expect(calls[0]?.get("chatgpt-account-id")).toBe(accountA);
+			const wireOrigin = openAiRemoteCompactionOrigin(CODEX_MODEL, calls[0]!);
+			expect(result.details.origin).toEqual(wireOrigin);
+			expect(JSON.stringify(result.details)).not.toContain(tokenB);
+
+			const compactedBranch = branchWithRemoteCheckpoint(branch, result);
+			const replayed = rewriteOpenAiPayloadWithRemoteCompaction(finalCodexReplayPayload(compactedBranch), {
+				model: CODEX_MODEL,
+				branchEntries: compactedBranch,
+				origin: wireOrigin,
+			}) as { input?: unknown[] } | undefined;
+			expect(replayed?.input).toContainEqual({
+				type: "compaction",
+				id: "cmp_canonical_wire",
+				encrypted_content: "canonical-wire-state",
+			});
+		} finally {
+			headerHookHarness.cleanup();
+		}
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
@@ -7,6 +7,7 @@ import {
 	runOpenAiRemoteCompaction,
 } from "../../../src/core/extensions/builtin/compaction/openai-remote.ts";
 import type { SessionBeforeCompactEvent } from "../../../src/core/extensions/types.ts";
+import { COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX } from "../../../src/core/messages.ts";
 import type { SessionEntry, SessionMessageEntry } from "../../../src/core/session-manager.ts";
 
 const CODEX_MODEL = {
@@ -195,7 +196,15 @@ describe("issue #296 OpenAI Codex remote compaction", () => {
 				model: CODEX_MODEL.id,
 				input: [
 					{ role: "developer", content: "Current prompt." },
-					{ role: "user", content: [{ type: "input_text", text: "fallback compact summary" }] },
+					{
+						role: "user",
+						content: [
+							{
+								type: "input_text",
+								text: `${COMPACTION_SUMMARY_PREFIX}${result.summary}${COMPACTION_SUMMARY_SUFFIX}`,
+							},
+						],
+					},
 					{ role: "user", content: [{ type: "input_text", text: "Keep the diagnosis." }] },
 					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
 				],

--- a/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-296-openai-codex-remote-compaction.test.ts
@@ -1,14 +1,15 @@
-import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
+import { type Api, type AssistantMessage, convertResponsesMessages, type Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_COMPACTION_SETTINGS } from "../../../src/core/compaction/index.ts";
 import {
+	markOpenAiRemoteReplayBoundary,
 	OPENAI_REMOTE_COMPACTION_SCHEMA,
 	rewriteOpenAiPayloadWithRemoteCompaction,
 	runOpenAiRemoteCompaction,
 } from "../../../src/core/extensions/builtin/compaction/openai-remote.ts";
 import type { SessionBeforeCompactEvent } from "../../../src/core/extensions/types.ts";
-import { COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX } from "../../../src/core/messages.ts";
-import type { SessionEntry, SessionMessageEntry } from "../../../src/core/session-manager.ts";
+import { convertToLlm } from "../../../src/core/messages.ts";
+import { buildSessionContext, type SessionEntry, type SessionMessageEntry } from "../../../src/core/session-manager.ts";
 
 const CODEX_MODEL = {
 	id: "gpt-5.4-codex",
@@ -191,26 +192,25 @@ describe("issue #296 OpenAI Codex remote compaction", () => {
 				fromHook: true,
 			},
 		];
+		const markedContext = markOpenAiRemoteReplayBoundary(
+			[
+				...buildSessionContext(compactedBranch).messages,
+				{ role: "user", content: [{ type: "text", text: "Continue after compaction." }], timestamp: 4 },
+			],
+			{ model: CODEX_MODEL, branchEntries: compactedBranch },
+		);
 		const rewritten = rewriteOpenAiPayloadWithRemoteCompaction(
 			{
 				model: CODEX_MODEL.id,
-				input: [
-					{ role: "developer", content: "Current prompt." },
-					{
-						role: "user",
-						content: [
-							{
-								type: "input_text",
-								text: `${COMPACTION_SUMMARY_PREFIX}${result.summary}${COMPACTION_SUMMARY_SUFFIX}`,
-							},
-						],
-					},
-					{ role: "user", content: [{ type: "input_text", text: "Keep the diagnosis." }] },
-					{ role: "user", content: [{ type: "input_text", text: "Continue after compaction." }] },
-				],
+				input: convertResponsesMessages(
+					CODEX_MODEL,
+					{ messages: convertToLlm(markedContext) },
+					new Set(["openai-codex"]),
+					{ includeSystemPrompt: false, preserveTextSignatures: true },
+				),
 				stream: true,
 			},
-			{ model: CODEX_MODEL, branchEntries: compactedBranch },
+			{ model: CODEX_MODEL, branchEntries: compactedBranch, origin: result.details.origin },
 		) as { input?: unknown[] } | undefined;
 
 		expect(rewritten?.input).toContainEqual({

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
 import { type AssistantMessage, type FauxResponseFactory, fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
 import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
 import { createHarness, getUserTexts, type Harness } from "../harness.ts";
 
 type Deferred<T> = {
@@ -49,6 +50,19 @@ function getFlushCompactionQueue() {
 		Promise.resolve(flush.call(context, options));
 }
 
+function getHandleEvent() {
+	const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent");
+	if (typeof handleEvent !== "function") throw new Error("Expected InteractiveMode.handleEvent");
+	return (context: object, event: object): Promise<void> => Promise.resolve(handleEvent.call(context, event));
+}
+
+function getRunAutoCompaction(harness: Harness) {
+	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof runAutoCompaction !== "function") throw new Error("Expected AgentSession._runAutoCompaction");
+	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
+		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
 function createTuiQueueContext(harness: Harness) {
 	return {
 		compactionQueuedMessages: [] as QueuedMessage[],
@@ -61,6 +75,49 @@ function createTuiQueueContext(harness: Harness) {
 		updatePendingMessagesDisplay: () => {},
 		session: harness.session,
 	};
+}
+
+function createTuiCompactionEventContext(harness: Harness) {
+	const context = createTuiQueueContext(harness) as ReturnType<typeof createTuiQueueContext> & {
+		isInitialized: boolean;
+		footer: { invalidate: () => void };
+		autoCompactionEscapeHandler: (() => void) | undefined;
+		autoCompactionProgressText: string;
+		defaultEditor: { onEscape?: () => void };
+		statusContainer: { clear: () => void };
+		chatContainer: { clear: () => void; addChild: () => void };
+		clearStatusIndicator: () => void;
+		rebuildChatFromMessages: () => void;
+		addMessageToChat: () => void;
+		showStatus: () => void;
+		ui: { requestRender: () => void; terminal: { setProgress: () => void } };
+		settingsManager: { getShowTerminalProgress: () => boolean };
+		flushCompactionQueue: (options: { willRetry: boolean }) => Promise<void>;
+		flushes: Promise<void>[];
+	};
+	const flushes: Promise<void>[] = [];
+	Object.assign(context, {
+		isInitialized: true,
+		footer: { invalidate: () => {} },
+		autoCompactionEscapeHandler: undefined,
+		autoCompactionProgressText: "",
+		defaultEditor: {},
+		statusContainer: { clear: () => {} },
+		chatContainer: { clear: () => {}, addChild: () => {} },
+		clearStatusIndicator: () => {},
+		rebuildChatFromMessages: () => {},
+		addMessageToChat: () => {},
+		showStatus: () => {},
+		ui: { requestRender: () => {}, terminal: { setProgress: () => {} } },
+		settingsManager: { getShowTerminalProgress: () => false },
+		flushes,
+		flushCompactionQueue(options: { willRetry: boolean }) {
+			const flush = getFlushCompactionQueue()(context, options);
+			flushes.push(flush);
+			return flush;
+		},
+	});
+	return context;
 }
 
 async function submitLikeTui(harness: Harness, context: ReturnType<typeof createTuiQueueContext>, text: string) {
@@ -90,6 +147,10 @@ function createOverflowResponse(harness: Harness): AssistantMessage {
 }
 
 describe("post-compaction queued input recovery", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
 	const harnesses: Harness[] = [];
 
 	afterEach(() => {
@@ -221,5 +282,88 @@ describe("post-compaction queued input recovery", () => {
 		expect(countInPersistedSession(harness, USER_MARKER)).toBe(1);
 		expect(countInPersistedSession(harness, OMO_MARKER)).toBe(1);
 		expect(countInPersistedSession(harness, GOAL_MARKER)).toBe(1);
+	});
+
+	it.each([
+		["rejected overflow", "overflow" as const, true, "reject" as const],
+		["rejected threshold", "threshold" as const, false, "reject" as const],
+		["feedback-only abort", undefined, false, "abort" as const],
+	])("keeps queued TUI input owned by the editor after a %s compaction_end", async (_label, reason, willRetry, outcome) => {
+		const marker = `[TUI queue remains ${outcome}]`;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories:
+				outcome === "reject"
+					? [
+							(pi: ExtensionAPI) => {
+								pi.on("session_before_compact", () => ({
+									cancel: true,
+									rejectionCause: "cancelled-by-extension",
+									reason: "test rejection",
+								}));
+							},
+						]
+					: [],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed handled"), fauxAssistantMessage("must not execute")]);
+		await harness.session.prompt("seed context ".repeat(40));
+		const providerCallsBeforeCompaction = harness.faux.state.callCount;
+		const context = createTuiCompactionEventContext(harness);
+		context.compactionQueuedMessages.push({ text: marker, mode: "steer" });
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end") {
+				void getHandleEvent()(context, event);
+			}
+		});
+
+		if (outcome === "abort") {
+			const beginFeedback = Reflect.get(harness.session, "_beginExtensionCompactionFeedback");
+			const endFeedback = Reflect.get(harness.session, "_endExtensionCompactionFeedback");
+			if (typeof beginFeedback !== "function" || typeof endFeedback !== "function") {
+				throw new Error("Expected extension compaction feedback lifecycle methods");
+			}
+			const signal = beginFeedback.call(harness.session, "extension") as AbortSignal;
+			endFeedback.call(harness.session, { reason: "extension", signal, aborted: true });
+		} else {
+			await getRunAutoCompaction(harness)(reason!, willRetry);
+		}
+		await Promise.all(context.flushes);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(context.compactionQueuedMessages).toEqual([{ text: marker, mode: "steer" }]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(getUserTexts(harness)).not.toContain(marker);
+		expect(harness.faux.state.callCount).toBe(providerCallsBeforeCompaction);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+	});
+
+	it("flushes accepted compaction input once through the real compaction_end handler", async () => {
+		const marker = "[TUI queue flushes once]";
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [createAcceptedCompactionExtension()],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed handled"), fauxAssistantMessage("queued marker handled")]);
+		await harness.session.prompt("seed context ".repeat(40));
+		const context = createTuiCompactionEventContext(harness);
+		context.compactionQueuedMessages.push({ text: marker, mode: "steer" });
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end") {
+				void getHandleEvent()(context, event);
+			}
+		});
+
+		await getRunAutoCompaction(harness)("threshold", false);
+		await Promise.all(context.flushes);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(getUserTexts(harness).filter((text) => text === marker)).toHaveLength(1);
+		expect(harness.faux.state.callCount).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/post-compaction-stale-usage-queue-exemption.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-stale-usage-queue-exemption.test.ts
@@ -1,6 +1,7 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
 import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
 
 const STALE_USAGE_TOTAL_TOKENS = 127_500;
@@ -36,6 +37,18 @@ function getRunAutoCompaction(harness: Harness) {
 	}
 	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
 		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
+function getClearAllQueues() {
+	const clearAllQueues = Reflect.get(InteractiveMode.prototype, "clearAllQueues");
+	if (typeof clearAllQueues !== "function") throw new Error("Expected InteractiveMode.clearAllQueues");
+	return (context: object): { steering: string[]; followUp: string[] } => clearAllQueues.call(context);
+}
+
+function getAbortAndFireQueuedMessages() {
+	const abortAndFire = Reflect.get(InteractiveMode.prototype, "abortAndFireQueuedMessages");
+	if (typeof abortAndFire !== "function") throw new Error("Expected InteractiveMode.abortAndFireQueuedMessages");
+	return (context: object): Promise<number> => Promise.resolve(abortAndFire.call(context));
 }
 
 function createPostCompactionExemptionHarness() {
@@ -156,5 +169,97 @@ describe("post-compaction queued continuation exemption", () => {
 		expect(harness.session.getSteeringMessages()).toEqual([]);
 		expect(harness.session.getFollowUpMessages()).toEqual([]);
 		expect(harness.session.isCompacting).toBe(false);
+	});
+
+	it.each([
+		{
+			label: "the public session queue clear",
+			clear: (harness: Harness) => harness.session.clearQueue(),
+		},
+		{
+			label: "the InteractiveMode queue clear",
+			clear: (harness: Harness) =>
+				getClearAllQueues()({
+					compactionQueuedMessages: [],
+					compactionInFlightMessages: [],
+					compactionTransferAbortControllers: new Map(),
+					session: harness.session,
+				}),
+		},
+	])("does not resurrect deferred post-compaction work after $label", async ({ clear }) => {
+		const steerMarker = "clear deferred post-compaction steer";
+		const followUpMarker = "clear deferred post-compaction follow-up";
+		const harness = await createPostCompactionExemptionHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed clear-deferred context ".repeat(40));
+		await getRunAutoCompaction(harness)("threshold", false);
+		harness.events.length = 0;
+
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("stale response before queue clear"),
+				usage: staleHighUsage(),
+			},
+			fauxAssistantMessage("deferred steer must not reach provider"),
+			fauxAssistantMessage("deferred follow-up must not reach provider"),
+		]);
+		const prompt = harness.session.prompt("first prompt after accepted compaction");
+		await harness.session.waitForIdle();
+		await harness.session.prompt(steerMarker, { streamingBehavior: "steer" });
+		await harness.session.followUp(followUpMarker);
+
+		const cleared = clear(harness);
+		expect(cleared).toEqual({ steering: [steerMarker], followUp: [followUpMarker] });
+		expect(cleared.steering.filter((text) => text === steerMarker)).toHaveLength(1);
+		expect(cleared.followUp.filter((text) => text === followUpMarker)).toHaveLength(1);
+
+		await prompt;
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(getAssistantTexts(harness)).not.toContain("deferred steer must not reach provider");
+		expect(getAssistantTexts(harness)).not.toContain("deferred follow-up must not reach provider");
+	});
+
+	it("does not resurrect deferred work after InteractiveMode abort clears the visible queue", async () => {
+		const steerMarker = "abort deferred post-compaction steer";
+		const followUpMarker = "abort deferred post-compaction follow-up";
+		const harness = await createPostCompactionExemptionHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed abort-deferred context ".repeat(40));
+		await getRunAutoCompaction(harness)("threshold", false);
+		harness.setResponses([
+			{ ...fauxAssistantMessage("stale response before abort"), usage: staleHighUsage() },
+			fauxAssistantMessage("aborted deferred steer must not reach provider"),
+			fauxAssistantMessage("aborted deferred follow-up must not reach provider"),
+		]);
+		const prompt = harness.session.prompt("first prompt before queue abort");
+		await harness.session.waitForIdle();
+		await harness.session.prompt(steerMarker, { streamingBehavior: "steer" });
+		await harness.session.followUp(followUpMarker);
+
+		const setText = vi.fn<(text: string) => void>();
+		const context = {
+			compactionQueuedMessages: [],
+			compactionInFlightMessages: [],
+			compactionTransferAbortControllers: new Map(),
+			session: harness.session,
+			updatePendingMessagesDisplay: vi.fn(),
+			editor: { getText: () => "draft", setText },
+			clearAllQueues: () => getClearAllQueues()(context),
+		};
+		const restored = await getAbortAndFireQueuedMessages()(context);
+		expect(restored).toBe(2);
+		expect(setText).toHaveBeenCalledWith(`${steerMarker}\n\n${followUpMarker}\n\ndraft`);
+
+		await prompt;
+		await harness.session.waitForSettledSessionWork();
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(getAssistantTexts(harness)).not.toContain("aborted deferred steer must not reach provider");
+		expect(getAssistantTexts(harness)).not.toContain("aborted deferred follow-up must not reach provider");
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/post-compaction-stale-usage-queue-exemption.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-stale-usage-queue-exemption.test.ts
@@ -1,0 +1,160 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
+
+const STALE_USAGE_TOTAL_TOKENS = 127_500;
+const STALE_USAGE_INPUT_TOKENS = 127_300;
+const STALE_USAGE_OUTPUT_TOKENS = 200;
+
+function zeroUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function staleHighUsage() {
+	return {
+		input: STALE_USAGE_INPUT_TOKENS,
+		output: STALE_USAGE_OUTPUT_TOKENS,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: STALE_USAGE_TOTAL_TOKENS,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function getRunAutoCompaction(harness: Harness) {
+	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof runAutoCompaction !== "function") {
+		throw new Error("Expected AgentSession._runAutoCompaction");
+	}
+	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
+		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
+function createPostCompactionExemptionHarness() {
+	return createHarness({
+		models: [{ id: "post-compaction-stale-usage", contextWindow: 128_000, maxTokens: 64 }],
+		settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+		extensionFactories: [
+			(pi: ExtensionAPI) => {
+				pi.on("session_before_compact", (event) => ({
+					compaction: {
+						summary: "accepted post-compaction exemption summary",
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+					},
+				}));
+			},
+		],
+	});
+}
+
+describe("post-compaction queued continuation exemption", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("lets the queued continuation reach the provider after stale-usage compaction without recompacting", async () => {
+		// RED 2: the accepted auto compaction arms the post-compaction exemption
+		// exactly once. The first ordinary response still reports the stale high
+		// provider usage from before the compaction, and its agent_end queues
+		// steer/followUp work. The exemption must be shared by the synchronous
+		// drain classification (queued drain is not suppressed) and the async
+		// _checkCompaction (no second compaction, no RequiredCompactionError):
+		// the queued continuation reaches the provider once.
+		const harness = await createPostCompactionExemptionHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed exemption context ".repeat(40));
+
+		await getRunAutoCompaction(harness)("threshold", false);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "threshold", accepted: true }),
+		]);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		harness.events.length = 0;
+
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("ordinary post-compaction response"),
+				usage: staleHighUsage(),
+			},
+			fauxAssistantMessage("queued steer handled"),
+			fauxAssistantMessage("queued follow-up handled"),
+		]);
+		const prompt = harness.session.prompt("first ordinary prompt after compaction");
+		await harness.session.waitForIdle();
+		// agent_end must see the queued work before the exemption is consumed so
+		// the drain classification under test decides its fate.
+		await harness.session.prompt("queued steer after stale usage", { streamingBehavior: "steer" });
+		await harness.session.followUp("queued follow-up after stale usage");
+		await prompt;
+		await harness.session.waitForIdle();
+		await harness.session.waitForSettledSessionWork();
+
+		// One accepted compaction from the setup and exactly one assistant
+		// appended per provider call: the exempted response never triggers a
+		// second compaction, a duplicate append, or a duplicate terminal event.
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(getAssistantTexts(harness).filter((text) => text === "ordinary post-compaction response")).toHaveLength(1);
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(harness.session.isCompacting).toBe(false);
+	});
+
+	it("consumes the exemption exactly once when a stale-usage agent_end queues continuation", async () => {
+		// Companion boundary for RED 2: after the exempted stale-usage response,
+		// its queued follow-up drains to the provider with zero usage. That
+		// follow-up's agent_end must not consume a second exemption: the
+		// estimate path sees only kept pre-compaction usage plus the exempted
+		// (already before-boundary) response, so no further compaction runs.
+		const harness = await createPostCompactionExemptionHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed response")]);
+		await harness.session.prompt("seed single-exemption context ".repeat(40));
+
+		await getRunAutoCompaction(harness)("threshold", false);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({ reason: "threshold", accepted: true }),
+		]);
+		harness.events.length = 0;
+
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("stale usage response"),
+				usage: staleHighUsage(),
+			},
+			{ ...fauxAssistantMessage("zero-usage follow-up handled"), usage: zeroUsage() },
+		]);
+		const prompt = harness.session.prompt("first single-exemption prompt after compaction");
+		await harness.session.waitForIdle();
+		await harness.session.followUp("single follow-up after stale usage");
+		await prompt;
+		await harness.session.waitForIdle();
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(getAssistantTexts(harness)).toEqual([
+			"seed response",
+			"stale usage response",
+			"zero-usage follow-up handled",
+		]);
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(harness.session.isCompacting).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -126,9 +126,14 @@ describe("pre-prompt compaction regression", () => {
 		await expect(harness.session.prompt("next prompt")).rejects.toThrow(
 			"Context remains above the compaction threshold because compaction did not complete",
 		);
+		await expect(harness.session.prompt("retry prompt")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
 
 		expect(harness.faux.state.callCount).toBe(0);
 		expect(getUserTexts(harness)).not.toContain("next prompt");
+		expect(getUserTexts(harness)).not.toContain("retry prompt");
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === false)).toHaveLength(2);
 		expect(harness.eventsOfType("compaction_end")).toContainEqual(
 			expect.objectContaining({
 				reason: "overflow",

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -723,4 +723,192 @@ describe("pre-prompt compaction regression", () => {
 		).rejects.toThrow("Context remains above the compaction threshold because compaction did not complete");
 		expect(harness.faux.state.callCount).toBe(1);
 	});
+
+	it.each([
+		{
+			label: "silent overflow",
+			contextWindow: 10_000,
+			reserveTokens: 0,
+			prompt: "x".repeat(44_000),
+			reason: "overflow",
+		},
+		{
+			label: "threshold",
+			contextWindow: 13_000,
+			reserveTokens: 3_000,
+			prompt: "x".repeat(38_000),
+			reason: "threshold",
+		},
+	])("keeps the agent signal live for a signal-aware $label agent_end continuation", async (scenario) => {
+		const observedAbortStates: boolean[] = [];
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: scenario.contextWindow, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: scenario.reserveTokens } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: `${scenario.label} signal summary`,
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+				(pi) => {
+					let queued = false;
+					pi.on("agent_end", (_event, ctx) => {
+						observedAbortStates.push(ctx.signal?.aborted ?? false);
+						if (queued || ctx.signal?.aborted) return;
+						queued = true;
+						pi.sendUserMessage("signal-aware continuation", { deliverAs: "followUp" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(`${scenario.label} answer`),
+			fauxAssistantMessage("continuation answer"),
+		]);
+
+		await harness.session.prompt(scenario.prompt);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(observedAbortStates[0]).toBe(false);
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({ reason: scenario.reason, accepted: true }),
+		);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(getUserTexts(harness)).toContain("signal-aware continuation");
+		expect(getAssistantTexts(harness)).toContain("continuation answer");
+	});
+
+	it("still exposes genuine user cancellation to an agent_end handler", async () => {
+		const providerStarted = createDeferred();
+		const releaseProvider = createDeferred();
+		const observedAbortStates: boolean[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_end", (_event, ctx) => {
+						observedAbortStates.push(ctx.signal?.aborted ?? false);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			async () => {
+				providerStarted.resolve();
+				await releaseProvider.promise;
+				return fauxAssistantMessage("cancelled response");
+			},
+		]);
+
+		const prompt = harness.session.prompt("wait for cancellation");
+		await providerStarted.promise;
+		const abort = harness.session.abort();
+		releaseProvider.resolve();
+		await abort;
+		await prompt;
+		await harness.session.waitForSettledSessionWork();
+
+		expect(observedAbortStates).toContain(true);
+	});
+
+	it("rejects both normal and custom admissions after an oversized custom message follows accepted compaction", async () => {
+		let compactionRequests = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 5_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => {
+						compactionRequests++;
+						return {
+							cancel: true,
+							rejectionCause: "cancelled-by-extension",
+							reason: "reject follow-up compaction",
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "context before compaction" }],
+			timestamp: now - 1_000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("retained assistant", { timestamp: now - 500 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(100),
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		const retainedAssistant = harness.sessionManager.getEntries().at(-1);
+		if (retainedAssistant?.type !== "message") {
+			throw new Error("Expected an assistant entry to retain after compaction");
+		}
+
+		await expect(
+			harness.session.applyCompaction(
+				{
+					summary: "accepted baseline summary",
+					firstKeptEntryId: retainedAssistant.id,
+					tokensBefore: 100,
+				},
+				{ reason: "extension", expectedRevision: harness.session.getMessageRevision() },
+			),
+		).resolves.toEqual({ applied: true, reason: "ok" });
+
+		const oversizedCustomContent = "oversized custom state ".repeat(2_000);
+		await harness.session.sendCustomMessage({
+			customType: "oversized-post-compaction-state",
+			content: oversizedCustomContent,
+			display: true,
+		});
+		harness.setResponses([
+			fauxAssistantMessage("normal provider must not run"),
+			fauxAssistantMessage("custom provider must not run"),
+		]);
+
+		const normalError = await harness.session.prompt("normal admission").then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		const customError = await harness.session
+			.sendCustomMessage(
+				{ customType: "custom-trigger", content: "custom admission", display: true },
+				{ triggerTurn: true },
+			)
+			.then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+
+		expect(normalError).toBeInstanceOf(Error);
+		expect((normalError as Error).message).toContain(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		expect(customError).toBeInstanceOf(Error);
+		expect((customError as Error).message).toContain(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		expect(compactionRequests).toBe(2);
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(harness.session.messages).toContainEqual(
+			expect.objectContaining({
+				role: "custom",
+				customType: "oversized-post-compaction-state",
+				content: oversizedCustomContent,
+			}),
+		);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -13,6 +13,15 @@ function createUsage(totalTokens: number) {
 	};
 }
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
 describe("pre-prompt compaction regression", () => {
 	const harnesses: Harness[] = [];
 
@@ -212,5 +221,122 @@ describe("pre-prompt compaction regression", () => {
 		});
 		expect(getUserTexts(harness)).toContain(".");
 		expect(harness.faux.state.callCount).toBe(1);
+	});
+
+	it("blocks a queued steer continuation when overflow compaction is rejected", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "forced rejection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const firstTurnStarted = createDeferred();
+		const releaseFirstTurn = createDeferred();
+		harness.setResponses([
+			async () => {
+				firstTurnStarted.resolve();
+				await releaseFirstTurn.promise;
+				// Provider-confirmed overflow: native length stop with zero output and
+				// a full context window (the 40_000-char prompt fills the 10_000 window).
+				return fauxAssistantMessage("", { stopReason: "length" });
+			},
+			fauxAssistantMessage("must not reach provider"),
+		]);
+
+		const promptPromise = harness.session.prompt("x".repeat(40_000));
+		await firstTurnStarted.promise;
+		const steerPromise = harness.session.prompt("steered follow-up", { streamingBehavior: "steer" });
+		releaseFirstTurn.resolve();
+
+		// The steered continuation must reject at turn admission instead of
+		// reaching the provider with the still-overflowing context.
+		await expect(promptPromise).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		await steerPromise;
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "overflow",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+	});
+
+	it("blocks sendCustomMessage triggerTurn when overflow compaction is rejected below the local threshold", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "forced rejection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier prompt" }],
+			timestamp: now - 3000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("earlier response", { timestamp: now - 2000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(50),
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "previous prompt" }],
+			timestamp: now - 1000,
+		});
+		const overflowAssistant: AssistantMessage = {
+			...fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "context_length_exceeded",
+				timestamp: now - 500,
+			}),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(100),
+		};
+		harness.sessionManager.appendMessage(overflowAssistant);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([fauxAssistantMessage("must not reach provider")]);
+
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "extension-note", content: "trigger a turn", display: true },
+				{ triggerTurn: true },
+			),
+		).rejects.toThrow("Context remains above the compaction threshold because compaction did not complete");
+
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "overflow",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -73,6 +73,71 @@ describe("pre-prompt compaction regression", () => {
 		expect(harness.faux.state.callCount).toBe(1);
 	});
 
+	it("blocks the next provider call when required overflow compaction is rejected below the local threshold", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "forced rejection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier prompt" }],
+			timestamp: now - 3000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("earlier response", { timestamp: now - 2000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(50),
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "previous prompt" }],
+			timestamp: now - 1000,
+		});
+		const overflowAssistant: AssistantMessage = {
+			...fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "context_length_exceeded",
+				timestamp: now - 500,
+			}),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(100),
+		};
+		harness.sessionManager.appendMessage(overflowAssistant);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([fauxAssistantMessage("must not reach provider")]);
+
+		await expect(harness.session.prompt("next prompt")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(getUserTexts(harness)).not.toContain("next prompt");
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "overflow",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+	});
+
 	it("compacts upstream model alias overflow before a dot retry", async () => {
 		const harness = await createHarness({
 			api: "openai-responses",
@@ -97,6 +162,18 @@ describe("pre-prompt compaction regression", () => {
 
 		const now = Date.now();
 		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier prompt" }],
+			timestamp: now - 3000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("earlier response", { timestamp: now - 2000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(50),
+		});
 		harness.sessionManager.appendMessage({
 			role: "user",
 			content: [{ type: "text", text: "read /tmp/h2.jpg" }],
@@ -126,6 +203,7 @@ describe("pre-prompt compaction regression", () => {
 			reason: "overflow",
 			aborted: false,
 			willRetry: true,
+			accepted: true,
 		});
 		expect(getUserTexts(harness)).toContain(".");
 		expect(harness.faux.state.callCount).toBe(1);

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -273,6 +273,136 @@ describe("pre-prompt compaction regression", () => {
 		);
 	});
 
+	it("retains native steer and follow-up queues after an error-terminal overflow recovery is rejected", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "required recovery rejected",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const providerStarted = createDeferred();
+		const releaseProvider = createDeferred();
+		harness.setResponses([
+			async () => {
+				providerStarted.resolve();
+				await releaseProvider.promise;
+				return fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "context_length_exceeded",
+				});
+			},
+			fauxAssistantMessage("must not reach provider"),
+		]);
+
+		const initialPrompt = harness.session.prompt("x".repeat(40_000));
+		await providerStarted.promise;
+		await harness.session.prompt("retain native steer", { streamingBehavior: "steer" });
+		await harness.session.followUp("retain native follow-up");
+		releaseProvider.resolve();
+
+		await expect(initialPrompt).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain native steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain native follow-up"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		await expect(harness.session.prompt("later normal admission")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "extension-note", content: "later custom admission", display: true },
+				{ triggerTurn: true },
+			),
+		).rejects.toThrow("Context remains above the compaction threshold because compaction did not complete");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain native steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain native follow-up"]);
+	});
+
+	it("does not admit agent_end queues that arrive after the first next-turn compaction sample", async () => {
+		const firstPrepareSampled = createDeferred();
+		const releaseFirstPrepare = createDeferred();
+		let prepareCount = 0;
+		let queuedAtAgentEnd = false;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			prepareNextTurnWithContext: async () => {
+				prepareCount++;
+				if (prepareCount === 1) {
+					firstPrepareSampled.resolve();
+					await releaseFirstPrepare.promise;
+				}
+				return undefined;
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "late queue recovery rejected",
+					}));
+				},
+				(pi) => {
+					pi.on("agent_end", () => {
+						if (queuedAtAgentEnd) return;
+						queuedAtAgentEnd = true;
+						pi.sendUserMessage("late native follow-up", { deliverAs: "followUp" });
+						pi.sendUserMessage("late native steer", { deliverAs: "steer" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const model = harness.getModel();
+		harness.setResponses([
+			{
+				...fauxAssistantMessage("", { stopReason: "length" }),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: createUsage(10_000),
+			},
+			fauxAssistantMessage("must not reach provider"),
+			fauxAssistantMessage("must not reach provider either"),
+		]);
+
+		const prompt = harness.session.prompt("x".repeat(40_000));
+		await firstPrepareSampled.promise;
+		expect(harness.session.pendingMessageCount).toBe(0);
+		releaseFirstPrepare.resolve();
+		await expect(prompt).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "overflow",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getSteeringMessages()).toEqual(["late native steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["late native follow-up"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+	});
+
 	it("blocks sendCustomMessage triggerTurn when overflow compaction is rejected below the local threshold", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -1,6 +1,6 @@
 import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.ts";
 
 function createUsage(totalTokens: number) {
 	return {
@@ -468,5 +468,259 @@ describe("pre-prompt compaction regression", () => {
 				rejectionCause: "cancelled-by-extension",
 			}),
 		);
+	});
+
+	it("retains native steer and follow-up queues when a silent successful overflow recovery is rejected", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "silent overflow recovery rejected",
+					}));
+				},
+				(pi) => {
+					let queuedAtAgentEnd = false;
+					pi.on("agent_end", () => {
+						if (queuedAtAgentEnd) return;
+						queuedAtAgentEnd = true;
+						pi.sendUserMessage("retain silent steer", { deliverAs: "steer" });
+						pi.sendUserMessage("retain silent follow-up", { deliverAs: "followUp" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier prompt" }],
+			timestamp: now - 2000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("earlier response", { timestamp: now - 1000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(50),
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			// Silent successful overflow (z.ai style): the provider answers with
+			// stopReason "stop" while the faux-simulated usage.input + cacheRead
+			// exceeds the 10_000 context window (the 44_000-char prompt fills it),
+			// so isContextOverflow() is true without any error or length signal.
+			fauxAssistantMessage("silent overflow answer", { stopReason: "stop" }),
+			fauxAssistantMessage("must not reach provider"),
+			fauxAssistantMessage("must not reach provider either"),
+		]);
+
+		// The follow-up fix owns whether the already-completed prompt itself
+		// rejects; the fail-closed admission contract below is what this RED pins.
+		await harness.session.prompt("x".repeat(44_000)).then(
+			() => undefined,
+			() => undefined,
+		);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "overflow",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain silent steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain silent follow-up"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		await expect(harness.session.prompt("later normal admission")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "extension-note", content: "later custom admission", display: true },
+				{ triggerTurn: true },
+			),
+		).rejects.toThrow("Context remains above the compaction threshold because compaction did not complete");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain silent steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain silent follow-up"]);
+	});
+
+	it("drains retained agent_end queues only after an accepted silent-overflow compaction", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "silent overflow summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+				(pi) => {
+					let queuedAtAgentEnd = false;
+					pi.on("agent_end", () => {
+						if (queuedAtAgentEnd) return;
+						queuedAtAgentEnd = true;
+						pi.sendUserMessage("silent steer", { deliverAs: "steer" });
+						pi.sendUserMessage("silent follow-up", { deliverAs: "followUp" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		let callCountAtAcceptedCompaction: number | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.accepted === true) {
+				callCountAtAcceptedCompaction = harness.faux.state.callCount;
+			}
+		});
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier prompt" }],
+			timestamp: now - 2000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("earlier response", { timestamp: now - 1000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(50),
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			fauxAssistantMessage("silent overflow answer", { stopReason: "stop" }),
+			fauxAssistantMessage("silent steer answer"),
+			fauxAssistantMessage("silent follow-up answer"),
+		]);
+
+		await expect(harness.session.prompt("x".repeat(44_000))).resolves.toBeUndefined();
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({ reason: "overflow", accepted: true }),
+		);
+		// Compaction completed while only the overflow turn had reached the
+		// provider, so the retained queues drained strictly after recovery.
+		expect(callCountAtAcceptedCompaction).toBe(1);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(getAssistantTexts(harness)).toContain("silent steer answer");
+		expect(getAssistantTexts(harness)).toContain("silent follow-up answer");
+	});
+
+	it("does not continue agent_end queues above the compaction threshold when late recovery is rejected", async () => {
+		const firstPrepareSampled = createDeferred();
+		const releaseFirstPrepare = createDeferred();
+		let prepareCount = 0;
+		let queuedAtAgentEnd = false;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 13_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 3_000 } },
+			prepareNextTurnWithContext: async () => {
+				prepareCount++;
+				if (prepareCount === 1) {
+					firstPrepareSampled.resolve();
+					await releaseFirstPrepare.promise;
+				}
+				return undefined;
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "late threshold recovery rejected",
+					}));
+				},
+				(pi) => {
+					pi.on("agent_end", () => {
+						if (queuedAtAgentEnd) return;
+						queuedAtAgentEnd = true;
+						pi.sendUserMessage("late threshold follow-up", { deliverAs: "followUp" });
+						pi.sendUserMessage("late threshold steer", { deliverAs: "steer" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier prompt" }],
+			timestamp: now - 2000,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("earlier response", { timestamp: now - 1000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(50),
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			// Faux-simulated usage lands above the configured threshold
+			// (13_000 - 3_000 = 10_000) without any provider-confirmed overflow
+			// signal: the 38_000-char prompt yields ~12_100 input tokens (default
+			// tool schemas included), below the 13_000 context window.
+			fauxAssistantMessage("threshold answer", { stopReason: "stop" }),
+			fauxAssistantMessage("must not reach provider"),
+			fauxAssistantMessage("must not reach provider either"),
+		]);
+
+		const prompt = harness.session.prompt("x".repeat(38_000));
+		await firstPrepareSampled.promise;
+		expect(harness.session.pendingMessageCount).toBe(0);
+		releaseFirstPrepare.resolve();
+		// The follow-up fix owns whether the already-completed prompt itself
+		// rejects; the fail-closed admission contract below is what this RED pins.
+		await prompt.then(
+			() => undefined,
+			() => undefined,
+		);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "threshold",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.getSteeringMessages()).toEqual(["late threshold steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["late threshold follow-up"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		await expect(harness.session.prompt("later normal admission")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "extension-note", content: "later custom admission", display: true },
+				{ triggerTurn: true },
+			),
+		).rejects.toThrow("Context remains above the compaction threshold because compaction did not complete");
+		expect(harness.faux.state.callCount).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/retry-fallback-continuation-revalidation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/retry-fallback-continuation-revalidation.test.ts
@@ -1,0 +1,99 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+type Deferred = {
+	promise: Promise<void>;
+	resolve: () => void;
+};
+
+type ContinuationInternals = {
+	_isAgentRunActive: boolean;
+	_retryPromise: Promise<void> | undefined;
+	_revalidateScheduledContinuationAdmission(): Promise<void>;
+};
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const timeoutFailure = new Promise<never>((_resolve, reject) => {
+		timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), 1_000);
+	});
+	try {
+		return await Promise.race([promise, timeoutFailure]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+describe("retry fallback continuation revalidation", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("settles a fallback retry when continuation admission rejects before agent.continue", async () => {
+		const providerStarted = createDeferred();
+		const releaseProvider = createDeferred();
+		const revalidationError = new Error("fallback model/context admission rejected");
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		const internals = harness.session as unknown as ContinuationInternals;
+		const revalidate = vi
+			.spyOn(internals, "_revalidateScheduledContinuationAdmission")
+			.mockRejectedValue(revalidationError);
+		const continueSpy = vi.spyOn(harness.session.agent, "continue");
+		const continuationError = new Promise<string>((resolve) => {
+			harness.session.subscribe((event) => {
+				if (event.type === "continuation_error") resolve(event.errorMessage);
+			});
+		});
+		harness.setResponses([
+			async () => {
+				providerStarted.resolve();
+				await releaseProvider.promise;
+				return fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" });
+			},
+			fauxAssistantMessage("fallback provider must not run"),
+		]);
+
+		const prompt = harness.session.prompt("retry fallback continuation admission");
+		await providerStarted.promise;
+		await harness.session.followUp("retain queued fallback continuation");
+		releaseProvider.resolve();
+
+		const [promptResult, terminalError] = await settleWithin(
+			Promise.all([prompt, continuationError]),
+			"fallback continuation terminal settlement",
+		);
+
+		expect(promptResult).toBeUndefined();
+		expect(revalidate).toHaveBeenCalledTimes(1);
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(terminalError).toBe("Failed to continue queued messages: fallback model/context admission rejected");
+		expect(internals._isAgentRunActive).toBe(false);
+		expect(internals._retryPromise).toBeUndefined();
+		expect(harness.session.isRetrying).toBe(false);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain queued fallback continuation"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -94,79 +94,222 @@ describe("retry fallback engine", () => {
 		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, false]);
 	});
 
-	it("removes only the failed assistant while preserving state across a fallback switch", async () => {
-		const snapshotTool: AgentTool = {
-			name: "snapshot",
-			label: "Snapshot",
-			description: "Provides stable tool state for fallback assertions.",
+	it("rebuilds model-scoped prompt and tools through an explicit fallback model_select", async () => {
+		const primaryPrivilegedTool: AgentTool = {
+			name: "primary_privileged",
+			label: "Primary Privileged",
+			description: "Must never remain active after a fallback switch.",
 			parameters: Type.Object({}),
-			execute: async () => ({
-				content: [{ type: "text", text: "snapshot" }],
-				details: {},
-			}),
+			execute: async () => ({ content: [{ type: "text", text: "primary" }], details: {} }),
 		};
+		const fallbackPresetTool: AgentTool = {
+			name: "fallback_preset",
+			label: "Fallback Preset",
+			description: "Only available through the fallback model preset.",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "fallback" }], details: {} }),
+		};
+		const modelSelectSources: string[] = [];
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
-			tools: [snapshotTool],
-			settings: {
-				retry: {
-					enabled: true,
-					baseDelayMs: 1,
-					fallbackChains: { [primary]: [fallback] },
+			tools: [primaryPrivilegedTool, fallbackPresetTool],
+			initialActiveToolNames: ["primary_privileged"],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("model_select", (event) => {
+						modelSelectSources.push(`${event.previousModel?.id ?? "none"}->${event.model.id}:${event.source}`);
+						if (event.model.id !== "faux-2") return undefined;
+						pi.setActiveTools(["fallback_preset"]);
+						return { systemPrompt: "fallback preset system prompt", systemPromptName: "fallback-preset" };
+					});
 				},
-			},
+			],
 		});
 		harnesses.push(harness);
-		harness.setResponses([
-			fauxAssistantMessage("first"),
-			fauxAssistantMessage("", {
-				stopReason: "error",
-				errorMessage: "overloaded_error",
-			}),
-			fauxAssistantMessage("recovered"),
-		]);
+		harness.setResponses([fauxAssistantMessage("first")]);
 		await harness.session.prompt("first turn");
 
 		let stateBeforeFailedAssistant: typeof harness.session.state.messages | undefined;
-		let systemPromptBeforeFailedAssistant: string | undefined;
-		let toolsBeforeFailedAssistant: unknown;
 		let fallbackRequestMessages: unknown;
 		let stateAtFallbackRequest: typeof harness.session.state.messages | undefined;
+		let fallbackRequestSystemPrompt: string | undefined;
+		let fallbackRequestToolNames: string[] | undefined;
 		harness.session.subscribe((event) => {
-			if (event.type === "auto_retry_start") {
+			if (event.type === "auto_retry_start")
 				stateBeforeFailedAssistant = structuredClone(harness.session.state.messages);
-				systemPromptBeforeFailedAssistant = harness.session.state.systemPrompt;
-				toolsBeforeFailedAssistant = JSON.parse(JSON.stringify(harness.session.state.tools));
-			}
 		});
 		harness.setResponses([
-			fauxAssistantMessage("", {
-				stopReason: "error",
-				errorMessage: "overloaded_error",
-			}),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
 			(context) => {
 				fallbackRequestMessages = structuredClone(context.messages);
 				stateAtFallbackRequest = structuredClone(harness.session.state.messages);
+				fallbackRequestSystemPrompt = context.systemPrompt;
+				fallbackRequestToolNames = (context.tools ?? []).map((tool) => tool.name);
 				return fauxAssistantMessage("recovered");
 			},
 		]);
 
 		await harness.session.prompt("second turn");
 
-		if (
-			!stateBeforeFailedAssistant ||
-			systemPromptBeforeFailedAssistant === undefined ||
-			!toolsBeforeFailedAssistant
-		) {
-			throw new Error("Missing pre-error fallback snapshot");
-		}
+		if (!stateBeforeFailedAssistant) throw new Error("Missing pre-error fallback snapshot");
 		expect(stateAtFallbackRequest).toEqual(stateBeforeFailedAssistant.slice(0, -1));
 		expect(fallbackRequestMessages).toEqual(stateBeforeFailedAssistant.slice(0, -1));
-		expect(harness.session.state.systemPrompt).toBe(systemPromptBeforeFailedAssistant);
-		expect(JSON.stringify(harness.session.state.systemPrompt)).toBe(
-			JSON.stringify(systemPromptBeforeFailedAssistant),
-		);
-		expect(JSON.stringify(harness.session.state.tools)).toBe(JSON.stringify(toolsBeforeFailedAssistant));
+		expect(modelSelectSources).toEqual(["faux-1->faux-2:fallback"]);
+		expect(fallbackRequestSystemPrompt).toBe("fallback preset system prompt");
+		expect(fallbackRequestToolNames).toEqual(["fallback_preset"]);
+		expect(harness.session.systemPrompt).toBe("fallback preset system prompt");
+		expect(harness.session.getActiveToolNames()).toEqual(["fallback_preset"]);
+		expect(harness.session.getActiveToolNames()).not.toContain("primary_privileged");
+	});
+
+	it("invalidates an in-flight compaction when retry fallback changes the model", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed")]);
+		await harness.session.prompt("seed fallback compaction state");
+		const firstEntry = harness.sessionManager.getEntries()[0];
+		if (!firstEntry) throw new Error("Expected a persisted seed entry");
+		const beginFeedback = Reflect.get(harness.session, "_beginExtensionCompactionFeedback");
+		if (typeof beginFeedback !== "function") throw new Error("Expected extension compaction feedback lifecycle");
+		const signal = beginFeedback.call(harness.session, "extension") as AbortSignal;
+		let oldApply: Promise<unknown> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type !== "auto_retry_start" || event.delayMs !== 0) return;
+			oldApply = harness.session.applyCompaction(
+				{ summary: "must not apply after fallback selection", firstKeptEntryId: firstEntry.id, tokensBefore: 42 },
+				{ reason: "extension", signal },
+			);
+		});
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("trigger fallback while compaction is pending");
+
+		if (!oldApply) throw new Error("Expected fallback retry to attempt the stale apply");
+		await expect(oldApply).resolves.toEqual({ applied: false, reason: "stale" });
+		expect(signal.aborted).toBe(true);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+	});
+
+	it.each([
+		["rejects", true],
+		["accepts", false],
+	])("revalidates the smaller fallback context window immediately before a retry (%s second compaction)", async (_label, rejectSecondCompaction) => {
+		let compactionCount = 0;
+		let releasePrimaryError: (() => void) | undefined;
+		const primaryErrorReady = new Promise<void>((resolve) => {
+			releasePrimaryError = resolve;
+		});
+		let primaryProviderStarted: (() => void) | undefined;
+		const primaryStarted = new Promise<void>((resolve) => {
+			primaryProviderStarted = resolve;
+		});
+		const fallbackCompactionEndsAtCall: number[] = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 1_000, maxTokens: 64 },
+				{ id: "faux-2", contextWindow: 100, maxTokens: 64 },
+			],
+			settings: {
+				compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 0 },
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => {
+						compactionCount++;
+						if (compactionCount === 2 && rejectSecondCompaction) {
+							return {
+								cancel: true,
+								rejectionCause: "cancelled-by-extension" as const,
+								reason: "fallback window requires a rejected second compaction",
+							};
+						}
+						return {
+							compaction: {
+								summary: compactionCount === 1 ? "p".repeat(480) : "fallback summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const primaryModel = harness.getModel("faux-1");
+		if (!primaryModel) throw new Error("Expected primary fallback model");
+		const historyTimestamp = Date.now() - 1_000;
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "history before retry fallback" }],
+			timestamp: historyTimestamp,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("history response", { timestamp: historyTimestamp + 1 }),
+			api: primaryModel.api,
+			provider: primaryModel.provider,
+			model: primaryModel.id,
+			usage: {
+				input: 900,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 900,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([
+			async (_context, _options, _state, model) => {
+				if (model.id === "faux-1") {
+					primaryProviderStarted?.();
+					await primaryErrorReady;
+					return fauxAssistantMessage("context ".repeat(900), {
+						stopReason: "error",
+						errorMessage: "overloaded_error",
+					});
+				}
+				fallbackCompactionEndsAtCall.push(
+					harness.eventsOfType("compaction_end").filter((event) => event.accepted === true).length,
+				);
+				return fauxAssistantMessage("fallback answer");
+			},
+			(_context, _options, _state, model) => {
+				fallbackCompactionEndsAtCall.push(
+					harness.eventsOfType("compaction_end").filter((event) => event.accepted === true).length,
+				);
+				expect(model.id).toBe("faux-2");
+				return fauxAssistantMessage("fallback answer");
+			},
+			fauxAssistantMessage("queued continuation answer"),
+		]);
+
+		const prompt = harness.session.prompt("trigger fallback window revalidation");
+		await primaryStarted;
+		if (rejectSecondCompaction) {
+			await harness.session.followUp("queued until fallback context is safe");
+		}
+		releasePrimaryError?.();
+		await prompt;
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([{ from: primary, to: fallback }]);
+		if (rejectSecondCompaction) {
+			expect(fallbackCompactionEndsAtCall).toEqual([]);
+			expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+			expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
+			expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({ accepted: false });
+		} else {
+			expect(fallbackCompactionEndsAtCall).toEqual([2]);
+			expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
+			expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === true)).toHaveLength(2);
+		}
 	});
 
 	it("submits a complete fallback request rather than reusing primary continuation state", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -57,6 +57,15 @@ function retryTranscript(events: Harness["events"]): EventTranscriptEntry[] {
 	});
 }
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
 describe("retry fallback engine", () => {
 	const harnesses: Harness[] = [];
 	afterEach(() => {
@@ -310,6 +319,142 @@ describe("retry fallback engine", () => {
 			expect(harness.eventsOfType("compaction_start")).toHaveLength(2);
 			expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === true)).toHaveLength(2);
 		}
+	});
+
+	it("owns a provider-confirmed fallback retry overflow despite the post-retry compaction skip", async () => {
+		// Composition: a retryable primary error selects the smaller fallback window,
+		// the required fallback-window compaction succeeds (arming
+		// _skipNextPostRetryCompactionCheck), and the fallback retry itself then
+		// returns provider-confirmed overflow. The skip flag may still suppress a
+		// threshold-only stale-usage check, but it must never suppress overflow
+		// ownership: the overflow needs its own required compaction (rejected here,
+		// so recovery fails closed) while queued steer/follow-up messages are
+		// retained instead of draining into the provider.
+		let compactionRequests = 0;
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 1_000, maxTokens: 64 },
+				{ id: "faux-2", contextWindow: 100, maxTokens: 64 },
+			],
+			settings: {
+				compaction: { enabled: true, reserveTokens: 0, keepRecentTokens: 0 },
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+					fallbackRevertPolicy: "never",
+				},
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => {
+						compactionRequests++;
+						if (compactionRequests > 2) {
+							return {
+								cancel: true,
+								rejectionCause: "cancelled-by-extension" as const,
+								reason: "fallback overflow recovery rejected",
+							};
+						}
+						return {
+							compaction: {
+								summary: compactionRequests === 1 ? "p".repeat(480) : "fallback summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const primaryModel = harness.getModel("faux-1");
+		if (!primaryModel) throw new Error("Expected primary fallback model");
+		const historyTimestamp = Date.now() - 1_000;
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "history before retry fallback" }],
+			timestamp: historyTimestamp,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("history response", { timestamp: historyTimestamp + 1 }),
+			api: primaryModel.api,
+			provider: primaryModel.provider,
+			model: primaryModel.id,
+			usage: {
+				input: 900,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 900,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const fallbackStarted = createDeferred();
+		const releaseFallback = createDeferred();
+		harness.setResponses([
+			async (_context, _options, _state, model) => {
+				expect(model.id).toBe("faux-1");
+				return fauxAssistantMessage("context ".repeat(900), {
+					stopReason: "error",
+					errorMessage: "overloaded_error",
+				});
+			},
+			async (_context, _options, _state, model) => {
+				expect(model.id).toBe("faux-2");
+				fallbackStarted.resolve();
+				await releaseFallback.promise;
+				// Provider-confirmed overflow from the fallback model itself.
+				return fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "context_length_exceeded",
+				});
+			},
+			fauxAssistantMessage("must not reach provider"),
+			fauxAssistantMessage("must not reach provider either"),
+		]);
+
+		const prompt = harness.session.prompt("trigger fallback overflow ownership");
+		await fallbackStarted.promise;
+		await harness.session.prompt("retain fallback steer", { streamingBehavior: "steer" });
+		await harness.session.followUp("retain fallback follow-up");
+		releaseFallback.resolve();
+		// The follow-up fix owns whether the already-completed prompt itself
+		// rejects; the fail-closed admission contract below is what this RED pins.
+		await prompt.then(
+			() => undefined,
+			() => undefined,
+		);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([{ from: primary, to: fallback }]);
+		// The required fallback-window compaction succeeded before the retry,
+		// which is what arms the post-retry skip flag under test.
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({ reason: "threshold", accepted: true }),
+		);
+		// RED: the skip flag must not suppress overflow ownership of the fallback
+		// retry response, so a second required compaction runs and fails closed.
+		expect(harness.eventsOfType("compaction_end")).toContainEqual(
+			expect.objectContaining({
+				reason: "overflow",
+				accepted: false,
+				rejectionCause: "cancelled-by-extension",
+			}),
+		);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain fallback steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain fallback follow-up"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.faux.state.callCount).toBe(2);
+
+		await expect(harness.session.prompt("later normal admission")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain fallback steer"]);
+		expect(harness.session.getFollowUpMessages()).toEqual(["retain fallback follow-up"]);
 	});
 
 	it("submits a complete fallback request rather than reusing primary continuation state", async () => {


### PR DESCRIPTION
## Summary

- move compaction completion tracking into an `AgentSession`-owned monotonic lifecycle
- snapshot the active fallback model and bind durable apply/abort/feedback to the current operation
- retain terminal compaction state while rejecting stale or duplicate progress/completion
- keep provider-confirmed overflow recovery fail-closed, including repeated prompts after rejected compaction

## Problem

Compaction could observe construction-time or stale model/controller state after main-thread fallback selected another
model. Completion state disappeared when controllers were released, and delayed feedback from a superseded operation
could affect the active operation. Provider-confirmed overflow also needed to remain authoritative when local token
estimation undercounted the context.

## Implementation

- add a pure `idle` / `running` / `completed` / `failed` / `aborted` lifecycle reducer with monotonic generations
- snapshot the current `AgentSession` model at compaction operation start
- thread operation signals through builtin compaction feedback and ignore stale signals
- guard durable compaction append with operation/controller identity
- expose retained read-only compaction state for session observers
- rebuild live context from the canonical `SessionManager` after failed overflow recovery so later prompts cannot bypass
  the same required compaction

## Tests

- `npm test -- test/compaction test/suite/*compaction*.test.ts test/suite/regressions/*compaction*.test.ts test/suite/regressions/pre-prompt-compaction-no-continue.test.ts`
  - 42 files, 299 tests passed
- `npm run check`
  - passed
- `git diff --check`
  - passed

Added coverage for:

- fallback-selected current-model compaction and the next successful prompt
- lifecycle terminal retention, generation increments, and stale/duplicate events
- stale progress and terminal feedback signals
- precomputed apply state and model-switch invalidation
- rejected provider-overflow compaction below the local threshold
- repeated prompts after rejected required compaction, with zero provider calls

## Manual QA

- bug-specific fallback driver:
  - fallback switched `faux-1` to `faux-2`
  - compaction ran on `faux-2`
  - lifecycle retained `completed`
  - the next prompt succeeded
- repeated-overflow driver:
  - 2 prompts blocked
  - 0 provider calls
  - 2 rejected compactions
  - overflow assistant restored
- real source CLI mock-loop: 38/38 checks passed across all three wire formats
- CLI smoke: 7/7 checks passed
- RPC smoke: 4/4 checks passed

QA receipts are stored locally under:

- `local-ignore/qa-evidence/20260723-compaction-completion-fsm-final-turn/`
- `local-ignore/qa-evidence/20260723-compaction-completion-fsm-final-review/`

## Review

Five independent lanes reviewed goal compliance, hands-on QA, code quality, security, and repository/GitHub context.
The first goal review found a repeated-prompt fail-open path after rejected overflow recovery. The follow-up commit fixes
that path and adds a regression. Focused goal, QA, code-quality, security, and repository-context re-reviews all passed
against the follow-up delta.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the compaction lifecycle and admission so only the active operation can mutate state, closing races across retries, fallback, and continuations. Adds safe queue handoff after compaction, canonicalizes remote compaction provenance, and keeps provider-confirmed overflow fail-closed.

- **New Features**
  - Session-owned compaction lifecycle with monotonic generations; snapshots model/controller; exposes read-only `compactionState` and `isCompacting`; feedback APIs accept an operation `AbortSignal`.
  - `Agent` queue control: `suppressQueuedMessageDrain()` and `continueWithQueuedMessages()` enable required recovery to deliver retained steer/follow-up input without inventing empty turns.
  - `@pi-ai`: carries non-enumerable context provenance through Responses conversion; adds `ProviderRequestMetadata` to `onPayload`.
  - Remote compaction provenance: canonical tenant/workspace identity for OpenAI and Codex (JWT-derived for Codex), explicit replay boundary markers, and provider hooks applied to compaction requests.

- **Bug Fixes**
  - Closed lifecycle races: ignore stale progress/terminal events, retain terminal state, and serialize compaction continuations.
  - Compaction uses the active fallback model and preserves retry compaction ownership across model switches.
  - Gated overflow continuations and queue transfer: provider-confirmed overflow stays fail-closed; rejected required compaction blocks prompts and retains queues.
  - Preserved compaction boundaries and redaction; reject `stale-revision` generations; closed final provider boundaries.
  - Interactive mode: sanitized compaction progress/errors for display and stabilized Escape handling across consecutive compactions.

<sup>Written for commit b3f643e915667bb27cb1e432a0ff8398ebe67795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

