### PR TITLE
feat(rpc): multi-session mode for the plain-RPC protocol

### DIFF
--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,41 @@
 # Changes
 
+## 2026-07-23 - uuidv7 concurrency refutation + immutable launch profile
+
+### What changed and why
+
+- `harness/session/uuid.ts`: the inlined UUIDv7 implementation uses a synchronous counter over module
+  state. A concurrency refutation test (`test/uuid-concurrency.test.ts`) records that N interleaved
+  async tasks calling `uuidv7()` produce unique, monotonic-per-timestamp ids — the synchronous counter
+  makes uniqueness hold under interleaving (no `await` between timestamp read and counter increment).
+  This is a recorded refutation WITH a test, not a bare assertion; it documents that the existing
+  synchronous-counter design is correct under interleaving so future refactors do not "fix" a
+  non-bug by adding an async lock that would change id ordering.
+- `core/agent-session-runtime.ts` (`CreateAgentSessionRuntimeFactory`, `:35,74-242,411`): runtime
+  construction now carries an immutable per-open launch profile
+  `{ permissionPreset, creationModel, initialThinkingLevel, cwd }`. The profile is retained by
+  `AgentSessionRuntime` and survives `new_session`/`switch_session`/reload unless the command
+  explicitly changes it. This carries per-session `cwd`, permission-preset, model selection, and
+  thinking level with identical semantics to today's spawn flags, without `main.ts` closing over
+  process-level parse.
+
+### Files modified
+
+- `harness/session/uuid.ts` (no production change; refutation test only)
+- `../test/uuid-concurrency.test.ts` (new)
+- `core/agent-session-runtime.ts`
+
+### Why the extension system could not handle this
+
+- The UUIDv7 counter and the launch-profile retention live inside `pi-agent-core` before coding-agent
+  extensions or mode renderers participate; the profile must be carried by the runtime the session
+  registry constructs inside `runWithProviderScope`.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `harness/session/uuid.ts` (unchanged production code; test is fork-only).
+- MEDIUM: `core/agent-session-runtime.ts` around `CreateAgentSessionRuntimeFactory` options.
+
 ## 2026-07-17 - Truncation-recovery flagged-call failure and proxy payload
 
 ### What changed and why

--- a/packages/agent/test/uuid-concurrency.test.ts
+++ b/packages/agent/test/uuid-concurrency.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { uuidv7 } from "../src/harness/session/uuid.ts";
+
+const TIMESTAMP = 0x01_9d_00_00_00_00;
+const TASK_COUNT = 64;
+
+describe("uuidv7 concurrent callers", () => {
+	it("generates unique, monotonic IDs when async tasks interleave in one millisecond", async () => {
+		const dateNow = vi.spyOn(Date, "now").mockReturnValue(TIMESTAMP);
+		try {
+			const ids = await Promise.all(
+				Array.from({ length: TASK_COUNT }, async () => {
+					await Promise.resolve();
+					return uuidv7();
+				}),
+			);
+
+			expect(new Set(ids)).toHaveLength(TASK_COUNT);
+			expect(ids).toEqual([...ids].sort());
+			expect(ids.every((id) => Number.parseInt(id.replaceAll("-", "").slice(0, 12), 16) === TIMESTAMP)).toBe(true);
+		} finally {
+			dateNow.mockRestore();
+		}
+	});
+});

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -32,6 +32,10 @@
 			"types": "./dist/oauth.d.ts",
 			"import": "./dist/oauth.js"
 		},
+		"./node/provider-scope": {
+			"types": "./dist/node/provider-scope.d.ts",
+			"import": "./dist/node/provider-scope.js"
+		},
 		"./bedrock-provider": {
 			"types": "./dist/bedrock-provider.d.ts",
 			"import": "./dist/bedrock-provider.js"

--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -33,12 +33,37 @@ export interface ApiProviderInternal {
 	streamSimple: ApiStreamSimpleFunction;
 }
 
-type RegisteredApiProvider = {
+export type RegisteredApiProvider = {
 	provider: ApiProviderInternal;
 	sourceId?: string;
 };
 
+/** Browser-neutral shape installed by the node-only provider-scope subpath. */
+export interface ProviderScopeAccess {
+	state: "active" | "closed";
+	overlay: Map<string, RegisteredApiProvider>;
+}
+
 const apiProviderRegistry = new Map<string, RegisteredApiProvider>();
+const builtinApiProviderRegistry = new Map<string, RegisteredApiProvider>();
+let getProviderScope: () => ProviderScopeAccess | undefined = () => undefined;
+let providerScopeStrictMode = false;
+
+/** Installs the optional node-only scope lookup without importing node APIs here. */
+export function installProviderScopeAccessor(accessor: () => ProviderScopeAccess | undefined): void {
+	getProviderScope = accessor;
+}
+
+export function setProviderScopeStrictMode(enabled: boolean): void {
+	providerScopeStrictMode = enabled;
+}
+
+function getActiveProviderScope(): ProviderScopeAccess | undefined {
+	const scope = getProviderScope();
+	if (scope?.state === "closed") throw new Error("Provider scope is closed");
+	if (!scope && providerScopeStrictMode) throw new Error("Provider scope is required in strict mode");
+	return scope;
+}
 
 function wrapStream<TApi extends Api, TOptions extends StreamOptions>(
 	api: TApi,
@@ -60,21 +85,46 @@ function wrapStreamSimple<TApi extends Api>(
 	};
 }
 
-export function registerApiProvider<TApi extends Api, TOptions extends StreamOptions>(
+function createRegisteredProvider<TApi extends Api, TOptions extends StreamOptions>(
 	provider: ApiProvider<TApi, TOptions>,
 	sourceId?: string,
-): void {
-	apiProviderRegistry.set(provider.api, {
+): RegisteredApiProvider {
+	return {
 		provider: {
 			api: provider.api,
 			stream: wrapStream(provider.api, provider.stream),
 			streamSimple: wrapStreamSimple(provider.api, provider.streamSimple),
 		},
 		sourceId,
-	});
+	};
+}
+
+export function registerApiProvider<TApi extends Api, TOptions extends StreamOptions>(
+	provider: ApiProvider<TApi, TOptions>,
+	sourceId?: string,
+): void {
+	const scope = getActiveProviderScope();
+	const registry = scope ? scope.overlay : apiProviderRegistry;
+	registry.set(provider.api, createRegisteredProvider(provider, sourceId));
+}
+
+/** Registers a builtin once, retaining its immutable identity for active scopes. */
+export function registerBuiltinApiProvider<TApi extends Api, TOptions extends StreamOptions>(
+	provider: ApiProvider<TApi, TOptions>,
+): void {
+	const registered = builtinApiProviderRegistry.get(provider.api) ?? createRegisteredProvider(provider);
+	builtinApiProviderRegistry.set(provider.api, registered);
+	if (!apiProviderRegistry.has(provider.api)) apiProviderRegistry.set(provider.api, registered);
+}
+
+export function getBuiltinApiProvider(api: Api): ApiProviderInternal | undefined {
+	return builtinApiProviderRegistry.get(api)?.provider;
 }
 
 export function getApiProvider(api: Api): ApiProviderInternal | undefined {
+	const scope = getActiveProviderScope();
+	if (scope) return scope.overlay.get(api)?.provider ?? builtinApiProviderRegistry.get(api)?.provider;
+
 	const faux = getRegisteredFauxProvider(api);
 	if (faux) {
 		return {
@@ -87,15 +137,24 @@ export function getApiProvider(api: Api): ApiProviderInternal | undefined {
 }
 
 export function getApiProviders(): ApiProviderInternal[] {
+	const scope = getActiveProviderScope();
+	if (scope) {
+		const providers = new Map(builtinApiProviderRegistry);
+		for (const [api, entry] of scope.overlay) providers.set(api, entry);
+		return Array.from(providers.values(), (entry) => entry.provider);
+	}
 	return Array.from(apiProviderRegistry.values(), (entry) => entry.provider);
 }
 
 export function unregisterApiProviders(sourceId: string): void {
-	for (const [api, entry] of apiProviderRegistry.entries()) {
-		if (entry.sourceId === sourceId) apiProviderRegistry.delete(api);
+	const scope = getActiveProviderScope();
+	const registry = scope ? scope.overlay : apiProviderRegistry;
+	for (const [api, entry] of registry.entries()) {
+		if (entry.sourceId === sourceId) registry.delete(api);
 	}
 }
 
 export function clearApiProviders(): void {
-	apiProviderRegistry.clear();
+	const scope = getActiveProviderScope();
+	(scope ? scope.overlay : apiProviderRegistry).clear();
 }

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,49 @@
 # AI Source Changes
 
+## 2026-07-23 - Session-scoped provider resolution via node-only AsyncLocalStorage subpath
+
+### What changed and why
+
+- New node-only subpath module `packages/ai/src/node/provider-scope.ts`, exported as
+  `@earendil-works/pi-ai/node/provider-scope`. It owns an `AsyncLocalStorage<ProviderScope>` plus
+  `runWithProviderScope` and `bindToProviderScope(fn)` (explicit callback binding for EventEmitter/
+  watcher callbacks, because EventEmitter does not propagate ALS from registration time).
+  `ProviderScope` carries `active|closed` state and a per-scope overlay `Map`.
+- `api-registry.ts` stays browser-neutral: a synchronous scope-accessor install hook (default: none)
+  lets the RPC host install a strict accessor. With no accessor installed, every classic path is
+  byte-identical (browser smoke pins this). The faux fast path (`getRegisteredFauxProvider` short-circuit
+  at `api-registry.ts:78-82`) consults the active scope first or is scope-keyed.
+- Scope-aware behavior for ALL registry operations: `getApiProvider`, `getApiProviders`,
+  `registerApiProvider`, `unregisterApiProviders`, `clearApiProviders`, `resetApiProviders`
+  (`compat.ts:143-147`). In an active scope, resolution = `session overlay → immutable builtin set` —
+  NEVER the mutable legacy global. After `close_session` the scope is closed and any lookup/mutation
+  through it throws (no silent fallback). Reaching provider lookup in multi-session mode with NO
+  active scope throws a diagnostic error (fail-loud, not fall-through).
+- The image-provider registry is scoped identically to the API-provider registry (same overlay →
+  immutable-builtins-only resolution, same closed-scope throws semantics).
+- Builtin identity semantics preserved: `getBuiltinProviderForModel` (`compat.ts:127-140,173`)
+  keeps reference-identity routing in `getBuiltinProviderForModel` / `builtinApiProviderInstances`
+  while a scope holds unrelated overlay entries.
+- Browser-safety approach: the synchronous scope-accessor install hook keeps `packages/ai` root and
+  compat exports browser-neutral; the only `node:async_hooks` import lives behind the node-only
+  subpath. Root/compat stay browser-safe; `npm run check:browser-smoke` stays green.
+
+### What future refactors must NOT break
+
+- Overlay → immutable-builtins-only resolution in an active scope; NEVER fall back to the mutable legacy
+  global in multi-session mode.
+- A closed scope must throw on any lookup/mutation (no silent fallback).
+- Builtin identity semantics (`builtinApiProviderInstances` reference-identity routing in
+  `getBuiltinProviderForModel`) must keep working while a scope holds unrelated overlay entries.
+- Root/compat exports must stay browser-safe: no `node:async_hooks` (or any node-only) import reachable
+  from root or compat; the scope accessor ships only from the node-only subpath.
+- No new dependencies (`node:async_hooks` is built-in).
+
+### Expected merge conflict zones
+
+- MEDIUM: `api-registry.ts` scope-accessor install hook + the faux fast-path short-circuit.
+- LOW: `compat.ts` builtin identity routing (additive guard only).
+
 ## 2026-07-22 - Drop tool results of errored/aborted assistants in transformMessages
 
 ### What changed and why

--- a/packages/ai/src/compat.ts
+++ b/packages/ai/src/compat.ts
@@ -90,7 +90,13 @@ export {
 	unregisterApiProviders,
 } from "./api-registry.ts";
 
-import { clearApiProviders, getApiProvider, registerApiProvider, unregisterApiProviders } from "./api-registry.ts";
+import {
+	clearApiProviders,
+	getApiProvider,
+	registerApiProvider,
+	registerBuiltinApiProvider,
+	unregisterApiProviders,
+} from "./api-registry.ts";
 
 export function registerFauxProvider(options: RegisterFauxProviderOptions = {}): FauxProviderRegistration {
 	const core = createFauxCore(options);
@@ -133,6 +139,7 @@ const builtinApiProviderInstances = new Map<Api, ReturnType<typeof getApiProvide
  */
 export function registerBuiltInApiProviders(): void {
 	for (const [api, streams] of BUILTIN_APIS) {
+		registerBuiltinApiProvider({ api, stream: streams.stream, streamSimple: streams.streamSimple });
 		if (!getApiProvider(api)) {
 			registerApiProvider({ api, stream: streams.stream, streamSimple: streams.streamSimple });
 		}

--- a/packages/ai/src/images-api-registry.ts
+++ b/packages/ai/src/images-api-registry.ts
@@ -11,17 +11,42 @@ export interface ImagesApiProvider<TApi extends ImagesApi = ImagesApi, TOptions 
 	generateImages: ImagesFunction<TApi, TOptions>;
 }
 
-interface ImagesApiProviderInternal {
+export interface ImagesApiProviderInternal {
 	api: ImagesApi;
 	generateImages: ImagesApiFunction;
 }
 
-type RegisteredImagesApiProvider = {
+export type RegisteredImagesApiProvider = {
 	provider: ImagesApiProviderInternal;
 	sourceId?: string;
 };
 
+/** Browser-neutral shape installed by the node-only provider-scope subpath. */
+export interface ImagesProviderScopeAccess {
+	state: "active" | "closed";
+	imagesOverlay: Map<string, RegisteredImagesApiProvider>;
+}
+
 const imagesApiProviderRegistry = new Map<string, RegisteredImagesApiProvider>();
+const builtinImagesApiProviderRegistry = new Map<string, RegisteredImagesApiProvider>();
+let getImagesProviderScope: () => ImagesProviderScopeAccess | undefined = () => undefined;
+let imagesProviderScopeStrictMode = false;
+
+/** Installs the optional node-only scope lookup without importing node APIs here. */
+export function installImagesProviderScopeAccessor(accessor: () => ImagesProviderScopeAccess | undefined): void {
+	getImagesProviderScope = accessor;
+}
+
+export function setImagesProviderScopeStrictMode(enabled: boolean): void {
+	imagesProviderScopeStrictMode = enabled;
+}
+
+function getActiveImagesProviderScope(): ImagesProviderScopeAccess | undefined {
+	const scope = getImagesProviderScope();
+	if (scope?.state === "closed") throw new Error("Provider scope is closed");
+	if (!scope && imagesProviderScopeStrictMode) throw new Error("Provider scope is required in strict mode");
+	return scope;
+}
 
 function wrapGenerateImages<TApi extends ImagesApi, TOptions extends ImagesOptions>(
 	api: TApi,
@@ -35,19 +60,72 @@ function wrapGenerateImages<TApi extends ImagesApi, TOptions extends ImagesOptio
 	};
 }
 
-export function registerImagesApiProvider<TApi extends ImagesApi, TOptions extends ImagesOptions>(
+function createRegisteredImagesApiProvider<TApi extends ImagesApi, TOptions extends ImagesOptions>(
 	provider: ImagesApiProvider<TApi, TOptions>,
 	sourceId?: string,
-): void {
-	imagesApiProviderRegistry.set(provider.api, {
+): RegisteredImagesApiProvider {
+	return {
 		provider: {
 			api: provider.api,
 			generateImages: wrapGenerateImages(provider.api, provider.generateImages),
 		},
 		sourceId,
-	});
+	};
+}
+
+export function registerImagesApiProvider<TApi extends ImagesApi, TOptions extends ImagesOptions>(
+	provider: ImagesApiProvider<TApi, TOptions>,
+	sourceId?: string,
+): void {
+	const scope = getActiveImagesProviderScope();
+	const registry = scope ? scope.imagesOverlay : imagesApiProviderRegistry;
+	registry.set(provider.api, createRegisteredImagesApiProvider(provider, sourceId));
+}
+
+/** Registers a builtin once, retaining its immutable identity for active scopes. */
+export function registerBuiltinImagesApiProvider<TApi extends ImagesApi, TOptions extends ImagesOptions>(
+	provider: ImagesApiProvider<TApi, TOptions>,
+): void {
+	const registered = builtinImagesApiProviderRegistry.get(provider.api) ?? createRegisteredImagesApiProvider(provider);
+	builtinImagesApiProviderRegistry.set(provider.api, registered);
+	if (!imagesApiProviderRegistry.has(provider.api)) imagesApiProviderRegistry.set(provider.api, registered);
 }
 
 export function getImagesApiProvider(api: ImagesApi): ImagesApiProviderInternal | undefined {
+	const scope = getActiveImagesProviderScope();
+	if (scope) return scope.imagesOverlay.get(api)?.provider ?? builtinImagesApiProviderRegistry.get(api)?.provider;
 	return imagesApiProviderRegistry.get(api)?.provider;
+}
+
+export function getImagesApiProviders(): ImagesApiProviderInternal[] {
+	const scope = getActiveImagesProviderScope();
+	if (scope) {
+		const providers = new Map(builtinImagesApiProviderRegistry);
+		for (const [api, entry] of scope.imagesOverlay) providers.set(api, entry);
+		return Array.from(providers.values(), (entry) => entry.provider);
+	}
+	return Array.from(imagesApiProviderRegistry.values(), (entry) => entry.provider);
+}
+
+export function unregisterImagesApiProviders(sourceId: string): void {
+	const scope = getActiveImagesProviderScope();
+	const registry = scope ? scope.imagesOverlay : imagesApiProviderRegistry;
+	for (const [api, entry] of registry.entries()) {
+		if (entry.sourceId === sourceId) registry.delete(api);
+	}
+}
+
+export function clearImagesApiProviders(): void {
+	const scope = getActiveImagesProviderScope();
+	(scope ? scope.imagesOverlay : imagesApiProviderRegistry).clear();
+}
+
+export function resetImagesApiProviders(): void {
+	const scope = getActiveImagesProviderScope();
+	if (scope) {
+		scope.imagesOverlay.clear();
+		return;
+	}
+	imagesApiProviderRegistry.clear();
+	for (const [api, entry] of builtinImagesApiProviderRegistry) imagesApiProviderRegistry.set(api, entry);
 }

--- a/packages/ai/src/node/provider-scope.ts
+++ b/packages/ai/src/node/provider-scope.ts
@@ -1,0 +1,46 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+	installProviderScopeAccessor,
+	type ProviderScopeAccess,
+	setProviderScopeStrictMode as setRegistryProviderScopeStrictMode,
+} from "../api-registry.ts";
+import {
+	type ImagesProviderScopeAccess,
+	installImagesProviderScopeAccessor,
+	setImagesProviderScopeStrictMode,
+} from "../images-api-registry.ts";
+
+const providerScopeStorage = new AsyncLocalStorage<ProviderScope>();
+
+export class ProviderScope implements ProviderScopeAccess, ImagesProviderScopeAccess {
+	readonly overlay = new Map();
+	readonly imagesOverlay = new Map();
+	state: "active" | "closed" = "active";
+
+	close(): void {
+		this.state = "closed";
+		this.overlay.clear();
+		this.imagesOverlay.clear();
+	}
+}
+
+installProviderScopeAccessor(() => providerScopeStorage.getStore());
+installImagesProviderScopeAccessor(() => providerScopeStorage.getStore());
+
+export function setProviderScopeStrictMode(enabled: boolean): void {
+	setRegistryProviderScopeStrictMode(enabled);
+	setImagesProviderScopeStrictMode(enabled);
+}
+
+export function runWithProviderScope<T>(scope: ProviderScope, fn: () => T): T {
+	if (scope.state === "closed") throw new Error("Provider scope is closed");
+	return providerScopeStorage.run(scope, fn);
+}
+
+export function bindToProviderScope<TArgs extends unknown[], TResult>(
+	fn: (...args: TArgs) => TResult,
+): (...args: TArgs) => TResult {
+	const scope = providerScopeStorage.getStore();
+	if (!scope) throw new Error("No active provider scope to bind");
+	return (...args) => runWithProviderScope(scope, () => fn(...args));
+}

--- a/packages/ai/src/providers/images/register-builtins.ts
+++ b/packages/ai/src/providers/images/register-builtins.ts
@@ -1,5 +1,5 @@
 import type { generateImages as generateImagesOpenRouterFunction } from "../../api/openrouter-images.ts";
-import { registerImagesApiProvider } from "../../images-api-registry.ts";
+import { registerBuiltinImagesApiProvider } from "../../images-api-registry.ts";
 import type { AssistantImages, ImagesContext, ImagesFunction, ImagesModel, ImagesOptions } from "../../types.ts";
 
 interface OpenRouterImagesProviderModule {
@@ -41,7 +41,7 @@ export const generateImagesOpenRouter: ImagesFunction<"openrouter-images", Image
 };
 
 export function registerBuiltInImagesApiProviders(): void {
-	registerImagesApiProvider({
+	registerBuiltinImagesApiProvider({
 		api: "openrouter-images",
 		generateImages: generateImagesOpenRouter,
 	});

--- a/packages/ai/test/provider-scope.test.ts
+++ b/packages/ai/test/provider-scope.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ApiProvider } from "../src/api-registry.ts";
+import {
+	stream as compatStream,
+	getApiProvider,
+	registerApiProvider,
+	resetApiProviders,
+	unregisterApiProviders,
+} from "../src/compat.ts";
+import type { ImagesApiProvider } from "../src/images-api-registry.ts";
+import {
+	getImagesApiProvider,
+	registerImagesApiProvider,
+	resetImagesApiProviders,
+} from "../src/images-api-registry.ts";
+import {
+	bindToProviderScope,
+	ProviderScope,
+	runWithProviderScope,
+	setProviderScopeStrictMode,
+} from "../src/node/provider-scope.ts";
+import type { Api, Context, Model } from "../src/types.ts";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+function provider(api: string, label: string): ApiProvider {
+	return {
+		api,
+		stream: () => providerStream(label),
+		streamSimple: () => providerStream(label),
+	};
+}
+
+function imagesProvider(api: string, label: string): ImagesApiProvider {
+	return {
+		api,
+		generateImages: async () => ({
+			api,
+			provider: "scope-test",
+			model: "scope-test",
+			output: [{ type: "text", text: label }],
+			stopReason: "stop",
+			timestamp: Date.now(),
+		}),
+	};
+}
+
+function providerStream(label: string): AssistantMessageEventStream {
+	const output = new AssistantMessageEventStream();
+	const message = {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text: label }],
+		api: "scope-test",
+		provider: "scope-test",
+		model: "scope-test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+	output.push({ type: "start", partial: message });
+	output.push({ type: "done", reason: "stop", message });
+	output.end(message);
+	return output;
+}
+
+const context: Context = { messages: [] };
+
+afterEach(() => {
+	setProviderScopeStrictMode(false);
+	resetApiProviders();
+});
+
+describe("node provider scopes", () => {
+	it("isolates concurrent registrations with the same api id", async () => {
+		const first = new ProviderScope();
+		const second = new ProviderScope();
+		let release!: () => void;
+		const bothRegistered = new Promise<void>((resolve) => (release = resolve));
+		let registrations = 0;
+
+		const registerAndResolve = (scope: ProviderScope, label: string) =>
+			runWithProviderScope(scope, async () => {
+				registerApiProvider(provider("scope-test", label), label);
+				if (++registrations === 2) release();
+				await bothRegistered;
+				return getApiProvider("scope-test")
+					?.stream({ api: "scope-test" } as Model<Api>, context)
+					.result();
+			});
+
+		const [firstResult, secondResult] = await Promise.all([
+			registerAndResolve(first, "first"),
+			registerAndResolve(second, "second"),
+		]);
+
+		expect(firstResult?.content[0]).toMatchObject({ text: "first" });
+		expect(secondResult?.content[0]).toMatchObject({ text: "second" });
+	});
+
+	it("resets only the active scope", () => {
+		const first = new ProviderScope();
+		const second = new ProviderScope();
+
+		runWithProviderScope(first, () => registerApiProvider(provider("scope-reset", "first"), "first"));
+		runWithProviderScope(second, () => registerApiProvider(provider("scope-reset", "second"), "second"));
+		runWithProviderScope(first, () => resetApiProviders());
+
+		expect(runWithProviderScope(first, () => getApiProvider("scope-reset"))).toBeUndefined();
+		expect(runWithProviderScope(second, () => getApiProvider("scope-reset"))).toBeDefined();
+	});
+
+	it("isolates concurrent image registrations with the same api id", async () => {
+		const first = new ProviderScope();
+		const second = new ProviderScope();
+		let release!: () => void;
+		const bothRegistered = new Promise<void>((resolve) => (release = resolve));
+		let registrations = 0;
+
+		const registerAndResolve = (scope: ProviderScope, label: string) =>
+			runWithProviderScope(scope, async () => {
+				registerImagesApiProvider(imagesProvider("scope-images-test", label), label);
+				if (++registrations === 2) release();
+				await bothRegistered;
+				return getImagesApiProvider("scope-images-test")?.generateImages({ api: "scope-images-test" } as never, {
+					input: [],
+				});
+			});
+
+		const [firstResult, secondResult] = await Promise.all([
+			registerAndResolve(first, "first"),
+			registerAndResolve(second, "second"),
+		]);
+
+		expect(firstResult?.output[0]).toMatchObject({ text: "first" });
+		expect(secondResult?.output[0]).toMatchObject({ text: "second" });
+	});
+
+	it("resets image providers only in the active scope", () => {
+		const first = new ProviderScope();
+		const second = new ProviderScope();
+		runWithProviderScope(first, () => registerImagesApiProvider(imagesProvider("scope-images-reset", "first")));
+		runWithProviderScope(second, () => registerImagesApiProvider(imagesProvider("scope-images-reset", "second")));
+		runWithProviderScope(first, () => resetImagesApiProviders());
+
+		expect(runWithProviderScope(first, () => getImagesApiProvider("scope-images-reset"))).toBeUndefined();
+		expect(runWithProviderScope(second, () => getImagesApiProvider("scope-images-reset"))).toBeDefined();
+	});
+
+	it("throws when a bound callback looks up a closed scope", () => {
+		const scope = new ProviderScope();
+		const lookup = runWithProviderScope(scope, () => bindToProviderScope(() => getApiProvider("scope-test")));
+		scope.close();
+
+		expect(lookup).toThrow("Provider scope is closed");
+	});
+
+	it("unregisters after await only from its own scope", async () => {
+		const first = new ProviderScope();
+		const second = new ProviderScope();
+		runWithProviderScope(first, () => registerApiProvider(provider("scope-unregister", "first"), "shared"));
+		runWithProviderScope(second, () => registerApiProvider(provider("scope-unregister", "second"), "shared"));
+
+		await runWithProviderScope(first, async () => {
+			await Promise.resolve();
+			unregisterApiProviders("shared");
+		});
+
+		expect(runWithProviderScope(first, () => getApiProvider("scope-unregister"))).toBeUndefined();
+		expect(runWithProviderScope(second, () => getApiProvider("scope-unregister"))).toBeDefined();
+	});
+
+	it("throws no-scope lookups in strict mode", () => {
+		setProviderScopeStrictMode(true);
+		expect(() => getApiProvider("scope-test")).toThrow("Provider scope is required");
+		expect(() => getImagesApiProvider("scope-images-test")).toThrow("Provider scope is required");
+	});
+
+	it("keeps builtin dispatch identity while a scope has unrelated overlays", () => {
+		const scope = new ProviderScope();
+		const builtin = getApiProvider("pi-messages");
+		let globalOverrideCalled = false;
+		registerApiProvider({
+			api: "pi-messages",
+			stream: () => {
+				globalOverrideCalled = true;
+				return providerStream("global override");
+			},
+			streamSimple: () => providerStream("global override"),
+		});
+
+		runWithProviderScope(scope, () => {
+			registerApiProvider(provider("scope-unrelated", "overlay"));
+			const model = { api: "pi-messages" } as Model<Api>;
+			const scoped = getApiProvider(model.api);
+			expect(scoped).toBe(builtin);
+			const output = compatStream(model, context);
+			expect(output).toBeDefined();
+		});
+
+		expect(globalOverrideCalled).toBe(false);
+	});
+});

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -17,6 +17,56 @@ Common options:
 - `--no-session`: Disable session persistence
 - `--session-dir <path>`: Custom session storage directory
 
+## Multi-session mode (D1 wire protocol)
+
+Multi-session mode lets one `senpi --mode rpc` process serve several independent conversations concurrently over the same stdio JSONL stream. Classic single-session mode is byte-identical to today; the only additive classic-mode behavior is that `get_protocol_info` is answered.
+
+### Starting multi-session mode
+
+```bash
+senpi --mode rpc --multi-session [options]
+```
+
+Startup: `senpi --mode rpc --multi-session` → NO default session is constructed (no default `AgentSessionRuntime`, no default extension/watcher load). Classic `senpi --mode rpc` is byte-identical to today. Mode is fixed at process start; there is no runtime transition.
+
+### D1 normative table (multi-session mode)
+
+| Command | Params | Success data | Notes |
+| --- | --- | --- | --- |
+| `get_protocol_info` | - | `{ protocolVersion: 1, capabilities: ["multi_session"], mode: "classic"\|"multi" }` | Answered in BOTH modes; side-effect-free; THE capability probe. |
+| `open_session` | `sessionPath?`, `cwd?`, `provider?`, `modelId?`, `thinkingLevel?`, `permissionPreset?` (all optional; paths MUST be absolute) | `{ sessionId, state: RpcSessionState }` | `sessionPath` = today's `--session` semantics (open-if-exists else create persisting there, `session-manager.ts:926-940`); `provider`/`modelId` applied only on create (resume restores the session's model — mirrors `SenpiSessionRuntime.ts:198-200`); params form the immutable launch profile (D8). |
+| `close_session` | `sessionId` | `{}` | Aborts active work, awaits agent idle + settled persistence, flushes queued events, detaches subscriptions; its response is the LAST record tagged with that handle — no events after (test-pinned). |
+| `list_sessions` | - | `{ sessions: [{ sessionId, durableSessionId, sessionPath, cwd, name, status }] }` | Includes `opening`/`closing` entries with their status. |
+| every existing command | + `sessionId` (REQUIRED in multi mode) | unchanged | Routed to that session. |
+
+### Identities (D6)
+
+Response-level `sessionId` = opaque **routing handle**, unique per process epoch, ephemeral (dies with the child). `state.sessionId` = **durable** JSONL session identity (what a resume cursor stores today). `list_sessions` exposes both. Clients store both, discard routing handles on child exit, and verify only durable ids against cursors.
+
+### Stable error codes
+
+In the response `error` field, machine-matchable:
+
+- `unknown_session`
+- `session_closing`
+- `session_path_in_use`
+- `missing_session_id` (session-scoped command without `sessionId` in multi mode)
+- `multi_session_disabled` (`open_session` in classic mode)
+- `invalid_path` (relative `sessionPath`/`cwd`)
+- `open_failed: <detail>`
+
+### Tagging
+
+Every response/event/`extension_ui_request` belonging to a session carries a top-level `sessionId` (routing handle). `get_protocol_info`/`list_sessions` responses are untagged. Classic mode: nothing tagged (byte-identical).
+
+### Ordering guarantee (D9)
+
+Strict FIFO per session; one total stdout order; cross-session order unspecified; fair round-robin between sessions' queued complete records; NO cross-session batch coalescing (per-session event buffers; the process-wide single-array coalescer in `event-output-buffer.ts` must not merge records of different sessions into one write). Starvation freedom is NOT promised (single pipe); a giant tool record delays others — bounded only by record completion.
+
+### Duplicate/idempotency
+
+Duplicate `open_session` while a path reservation is held → `session_path_in_use`. `close_session` on unknown/already-closed → `unknown_session` error. Request `id`s are client-owned; the server echoes them without dedup.
+
 ## Protocol Overview
 
 - **Commands**: JSON objects sent to stdin, one per line

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,63 @@
 # changes
 
+## Multi-session RPC mode, session-owned MCP/config-reload state, and back-compat guarantee (2026-07-23)
+
+### What changed
+
+- `src/modes/rpc/`: new `--multi-session` startup flag. `senpi --mode rpc --multi-session`
+  constructs NO default session (no default `AgentSessionRuntime`, no default extension/watcher load).
+  Mode is fixed at process start; there is no runtime transition. New modules: `session-registry.ts`,
+  `session-command-router.ts`, `session-binding.ts`, `multi-session-host.ts` (each ≤250 pure LOC).
+- Multi-session wire protocol per the D1 normative table (see `docs/rpc.md` → Multi-session mode, and
+  the `rpc-mode.ts` header doc block for the verbatim table): `get_protocol_info` (answered in BOTH
+  modes; side-effect-free; THE capability probe), `open_session` / `close_session` / `list_sessions`,
+  mandatory `sessionId` routing on session-scoped commands, `sessionId` tagging on all session-owned
+  output, stable error codes (`unknown_session`, `session_closing`, `session_path_in_use`,
+  `missing_session_id`, `multi_session_disabled`, `invalid_path`, `open_failed: <detail>`), identities
+  (D6: response-level `sessionId` = opaque routing handle, ephemeral per process epoch;
+  `state.sessionId` = durable JSONL identity), and the D9 ordering guarantee (strict FIFO per session,
+  one total stdout order, fair round-robin between sessions' queued complete records, NO cross-session
+  batch coalescing, starvation freedom NOT promised).
+- `src/core/extensions/builtin/mcp/` and `src/core/extensions/builtin/config-reload/`: in multi-session
+  mode each session OWNS its MCP service instance (extension factory closes over it; helpers take the
+  instance, never call the `getMcpService()` global getter), its elicitation/instructions/prompts state,
+  and its `reloadHandoff` keyed by the session handle. Classic single-session mode keeps the globals
+  (no behavior change).
+- Session-owned config-reload state: the fs-watcher reload chain
+  (`config-reload/index.ts` → `agent-session.ts:3807` `resetApiProviders()`) is scoped per session via
+  the pi-ai provider scope, so reloading session A cannot reset session B's providers.
+
+### Why
+
+- A single shared `senpi --mode rpc --multi-session` process serves all of a provider instance's
+  threads concurrently. Cross-session turns run concurrently; per-session turn serialization comes
+  from `AgentSession`. Session-scoped state (provider registry, MCP, config-reload) must be owned by
+  the session so one conversation can never corrupt another.
+
+### Back-compat guarantee
+
+- Classic single-session mode (`senpi --mode rpc`, no flag) is byte-identical to today. The ONLY
+  additive classic-mode behavior is that `get_protocol_info` is answered (side-effect-free). Existing
+  RPC tests, the classic-compat characterization pin suite, and the neo-daemon suites stay green
+  unchanged.
+
+### Explicit non-goal
+
+- Per-session AuthStorage / multi-tenant key isolation is NOT added inside the shared process. The
+  process is single-tenant; tenancy isolation remains the neo daemon's job (per-connection worker
+  model). The neo daemon's behavior and its header distrust rationale are unchanged.
+
+### Why extension system couldn't handle this
+
+- Session lifecycle, the multi-session host/router/registry, MCP service ownership, and config-reload
+  handoff are protocol and core-runtime infrastructure below the extension boundary.
+
+### Expected merge conflict zones on next upstream sync
+
+- HIGH: `src/modes/rpc/` (new multi-session modules + `rpc-mode.ts`/`connection-handler.ts` seams).
+- MEDIUM: `src/core/extensions/builtin/mcp/service.ts` global getter removal on the multi-session path.
+- LOW: `src/core/extensions/builtin/config-reload/index.ts` reloadHandoff keying.
+
 ## App-server web-search projection and cumulative turn diffs (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -63,6 +63,8 @@ export interface Args {
 	neoListen?: string;
 	/** Self-register into the neo daemon registry when listening (daemon-internal). */
 	neoRegister?: boolean;
+	/** Serve independently routed plain-RPC sessions over one stdio process. */
+	multiSession?: boolean;
 	messages: string[];
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
@@ -211,6 +213,8 @@ export function parseArgs(args: string[], options: { neoEnabled?: boolean } = {}
 			result.neoListen = args[++i];
 		} else if (neoEnabled && arg === "--register") {
 			result.neoRegister = true;
+		} else if (arg === "--multi-session") {
+			result.multiSession = true;
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
 		} else if (arg.startsWith("--")) {

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -25,6 +25,14 @@ export interface CreateAgentSessionRuntimeResult extends CreateAgentSessionResul
 	diagnostics: AgentSessionRuntimeDiagnostic[];
 }
 
+/** Immutable flags selected when a runtime is first launched. */
+export interface AgentSessionLaunchProfile {
+	cwd: string;
+	permissionPreset?: string;
+	creationModel?: { provider: string; modelId: string };
+	initialThinkingLevel?: string;
+}
+
 /**
  * Creates a full runtime for a target cwd and session manager.
  *
@@ -38,6 +46,7 @@ export type CreateAgentSessionRuntimeFactory = (options: {
 	sessionManager: SessionManager;
 	sessionStartEvent?: SessionStartEvent;
 	projectTrustContext?: ProjectTrustContext;
+	launchProfile?: Readonly<AgentSessionLaunchProfile>;
 }) => Promise<CreateAgentSessionRuntimeResult>;
 
 /**
@@ -79,6 +88,7 @@ export class AgentSessionRuntime {
 	private readonly createRuntime: CreateAgentSessionRuntimeFactory;
 	private _diagnostics: AgentSessionRuntimeDiagnostic[];
 	private _modelFallbackMessage?: string;
+	private readonly _launchProfile?: Readonly<AgentSessionLaunchProfile>;
 
 	constructor(
 		_session: AgentSession,
@@ -86,12 +96,14 @@ export class AgentSessionRuntime {
 		createRuntime: CreateAgentSessionRuntimeFactory,
 		_diagnostics: AgentSessionRuntimeDiagnostic[] = [],
 		_modelFallbackMessage?: string,
+		launchProfile?: Readonly<AgentSessionLaunchProfile>,
 	) {
 		this._session = _session;
 		this._services = _services;
 		this.createRuntime = createRuntime;
 		this._diagnostics = _diagnostics;
 		this._modelFallbackMessage = _modelFallbackMessage;
+		this._launchProfile = launchProfile;
 	}
 
 	get services(): AgentSessionServices {
@@ -112,6 +124,10 @@ export class AgentSessionRuntime {
 
 	get modelFallbackMessage(): string | undefined {
 		return this._modelFallbackMessage;
+	}
+
+	get launchProfile(): Readonly<AgentSessionLaunchProfile> | undefined {
+		return this._launchProfile;
 	}
 
 	setRebindSession(rebindSession?: (session: AgentSession) => Promise<void>): void {
@@ -214,6 +230,7 @@ export class AgentSessionRuntime {
 				sessionManager,
 				sessionStartEvent: { type: "session_start", reason: "resume", previousSessionFile },
 				projectTrustContext: options?.projectTrustContextFactory?.(sessionManager.getCwd()),
+				launchProfile: this._launchProfile,
 			}),
 		);
 		await this.finishSessionReplacement(options?.withSession);
@@ -246,6 +263,7 @@ export class AgentSessionRuntime {
 				agentDir: this.services.agentDir,
 				sessionManager,
 				sessionStartEvent: { type: "session_start", reason: "new", previousSessionFile },
+				launchProfile: this._launchProfile,
 			}),
 		);
 		if (options?.setup) {
@@ -300,6 +318,7 @@ export class AgentSessionRuntime {
 						agentDir: this.services.agentDir,
 						sessionManager,
 						sessionStartEvent: { type: "session_start", reason: "fork", previousSessionFile },
+						launchProfile: this._launchProfile,
 					}),
 				);
 				await this.finishSessionReplacement(options?.withSession);
@@ -323,6 +342,7 @@ export class AgentSessionRuntime {
 					agentDir: this.services.agentDir,
 					sessionManager,
 					sessionStartEvent: { type: "session_start", reason: "fork", previousSessionFile },
+					launchProfile: this._launchProfile,
 				}),
 			);
 			await this.finishSessionReplacement(options?.withSession);
@@ -342,6 +362,7 @@ export class AgentSessionRuntime {
 				agentDir: this.services.agentDir,
 				sessionManager,
 				sessionStartEvent: { type: "session_start", reason: "fork", previousSessionFile },
+				launchProfile: this._launchProfile,
 			}),
 		);
 		await this.finishSessionReplacement(options?.withSession);
@@ -386,6 +407,7 @@ export class AgentSessionRuntime {
 				agentDir: this.services.agentDir,
 				sessionManager,
 				sessionStartEvent: { type: "session_start", reason: "resume", previousSessionFile },
+				launchProfile: this._launchProfile,
 			}),
 		);
 		await this.finishSessionReplacement();
@@ -415,6 +437,7 @@ export async function createAgentSessionRuntime(
 		agentDir: string;
 		sessionManager: SessionManager;
 		sessionStartEvent?: SessionStartEvent;
+		launchProfile?: Readonly<AgentSessionLaunchProfile>;
 	},
 ): Promise<AgentSessionRuntime> {
 	assertSessionCwdExists(options.sessionManager, options.cwd);
@@ -425,6 +448,7 @@ export async function createAgentSessionRuntime(
 		createRuntime,
 		result.diagnostics,
 		result.modelFallbackMessage,
+		options.launchProfile,
 	);
 }
 

--- a/packages/coding-agent/src/core/event-bus.ts
+++ b/packages/coding-agent/src/core/event-bus.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { bindToProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 
 export interface EventBus {
 	emit(channel: string, data: unknown): void;
@@ -16,9 +17,10 @@ export function createEventBus(): EventBusController {
 			emitter.emit(channel, data);
 		},
 		on: (channel, handler) => {
+			const scopedHandler = bindHandler(handler);
 			const safeHandler = async (data: unknown) => {
 				try {
-					await handler(data);
+					await scopedHandler(data);
 				} catch (err) {
 					console.error(`Event handler error (${channel}):`, err);
 				}
@@ -30,4 +32,14 @@ export function createEventBus(): EventBusController {
 			emitter.removeAllListeners();
 		},
 	};
+}
+
+function bindHandler<TArgs extends unknown[], TResult>(
+	handler: (...args: TArgs) => TResult,
+): (...args: TArgs) => TResult {
+	try {
+		return bindToProviderScope(handler);
+	} catch {
+		return handler;
+	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { basename, dirname, relative, resolve, sep } from "node:path";
+import { bindToProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../../../config.ts";
 import { resolvePath } from "../../../../utils/paths.ts";
 import { ModelConfig } from "../../../model-config.ts";
@@ -81,11 +82,36 @@ type ReloadHandoff = {
 	readonly changes: readonly { readonly registrationId: string; readonly paths: readonly string[] }[];
 };
 
-/**
- * The builtin module is statically imported, so this survives replacement extension
- * factories during session.reload(). It closes the watcher-to-watcher race window.
- */
-let reloadHandoff: ReloadHandoff | undefined;
+/** Session-keyed handoffs survive replacement extension factories during reload. */
+export class ConfigReloadHandoffRegistry<T> {
+	readonly #handoffs = new Map<string, T>();
+
+	set(sessionHandle: string, handoff: T): void {
+		this.#handoffs.set(sessionHandle, handoff);
+	}
+
+	take(sessionHandle: string): T | undefined {
+		const handoff = this.#handoffs.get(sessionHandle);
+		this.#handoffs.delete(sessionHandle);
+		return handoff;
+	}
+
+	delete(sessionHandle: string): void {
+		this.#handoffs.delete(sessionHandle);
+	}
+}
+
+const reloadHandoffs = new ConfigReloadHandoffRegistry<ReloadHandoff>();
+
+function bindExternalCallback<TArgs extends unknown[], TResult>(
+	callback: (...args: TArgs) => TResult,
+): (...args: TArgs) => TResult {
+	try {
+		return bindToProviderScope(callback);
+	} catch {
+		return callback;
+	}
+}
 
 export interface ConfigReloadExtensionOptions {
 	readonly agentDir?: string;
@@ -103,6 +129,15 @@ export interface ConfigReloadExtensionOptions {
  * filesystem event source and agent directory.
  */
 export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExtensionOptions = {}): void {
+	const sessionOwned = (() => {
+		try {
+			bindToProviderScope(() => undefined);
+			return true;
+		} catch {
+			return false;
+		}
+	})();
+	const handoffKey = (ctx: ExtensionContext): string => (sessionOwned ? ctx.sessionManager.getSessionId() : "classic");
 	const agentDir = resolve(options.agentDir ?? getAgentDir());
 	const subscribe = options.subscribe ?? createFsWatchEventSource();
 	const logger = options.logger ?? createConfigReloadLogger(agentDir);
@@ -258,10 +293,10 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 			debounceMs: settings.debounceMs,
 			clock: options.clock,
 			hashFile: options.hashFile,
-			onRealChange: enqueueChange,
-			onError: (error, path) => {
+			onRealChange: bindExternalCallback(enqueueChange),
+			onError: bindExternalCallback((error, path) => {
 				logger.error("watcher_error", { path, message: errorMessage(error) });
-			},
+			}),
 		});
 		logger.info("watcher_started", { targetCount: activeTargets.length });
 		pi.events.emit(CONFIG_WATCH_READY, { enabled: true });
@@ -288,11 +323,11 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		const paths = uniquePaths(changes.flatMap((change) => change.paths));
 		reloadInFlight = true;
 		tornDown = false;
-		reloadHandoff = {
+		reloadHandoffs.set(handoffKey(ctx), {
 			hashesAtRequest: engine?.getBaselineSnapshot() ?? new Map<string, string>(),
 			requestedAt: Date.now(),
 			changes,
-		};
+		});
 		ctx.ui.notify(`Hot-reloading: ${formatPaths(paths)}`, "info");
 		logger.info("reload_requested", { reason: "config changed", paths });
 
@@ -300,11 +335,11 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 			await ctx.requestReload();
 			if (!tornDown) {
 				reloadInFlight = false;
-				reloadHandoff = undefined;
+				reloadHandoffs.delete(handoffKey(ctx));
 			}
 		} catch (error) {
 			reloadInFlight = false;
-			reloadHandoff = undefined;
+			reloadHandoffs.delete(handoffKey(ctx));
 			logger.error("watcher_error", { path: "reload", message: errorMessage(error) });
 		}
 	};
@@ -319,9 +354,9 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	};
 
 	const processReloadHandoff = async (event: SessionStartEvent, ctx: ExtensionContext): Promise<void> => {
-		if (event.reason !== "reload" || !reloadHandoff) return;
-		const handoff = reloadHandoff;
-		reloadHandoff = undefined;
+		if (event.reason !== "reload") return;
+		const handoff = reloadHandoffs.take(handoffKey(ctx));
+		if (!handoff) return;
 		const paths = uniquePaths(handoff.changes.flatMap((change) => change.paths));
 		for (const change of handoff.changes) {
 			pi.events.emit(CONFIG_WATCH_RELOADED, {
@@ -363,6 +398,7 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		return { trusted: "undecided" };
 	});
 	pi.on("session_shutdown", (event) => {
+		const closingContext = currentContext;
 		tornDown = true;
 		started = false;
 		currentContext = undefined;
@@ -370,7 +406,7 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		clearCompactionRecheck();
 		cleanupEventListeners();
 		pending.clear();
-		if (event.reason !== "reload") reloadHandoff = undefined;
+		if (event.reason !== "reload" && closingContext) reloadHandoffs.delete(handoffKey(closingContext));
 	});
 
 	function canRequestReload(ctx: ExtensionContext): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth-dispatch.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth-dispatch.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "../../../types.ts";
 import { createMcpLogger } from "../log.ts";
-import { getMcpService } from "../service.ts";
+import type { McpService } from "../service.ts";
 import { type AuthCommandDeps, runAuth, runAuthComplete, runAuthStart, runLogout } from "./commands-auth.ts";
 
 // Bridges the /mcp slash command to the pure auth flow runners in
@@ -10,9 +10,9 @@ export async function handleMcpAuthCommand(
 	args: readonly string[],
 	ctx: ExtensionCommandContext,
 	pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">,
+	service: McpService,
 ): Promise<void> {
 	const name = args[0] ?? "";
-	const service = getMcpService();
 	const target = service.getAuthTarget(name);
 	if (name.length === 0 || target === undefined) {
 		ctx.ui.notify(`Unknown MCP server: ${name || "<missing>"}`, "error");
@@ -36,6 +36,10 @@ export async function handleMcpAuthCommand(
 		},
 		openBrowser: (url) => ctx.ui.notify(`Open this URL to authorize ${name}:\n${url.toString()}`),
 		pending: service.getPendingAuth(),
+		interactiveGuard: {
+			begin: (serverName) => service.beginInteractiveAuth(serverName),
+			end: (serverName) => service.endInteractiveAuth(serverName),
+		},
 		serverName: name,
 	};
 	if (subcommand === "auth") return runAuth(deps);

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth.ts
@@ -30,6 +30,8 @@ export interface AuthCommandDeps {
 	// Persists the provider between auth-start and auth-complete so the in-memory
 	// CSRF state survives across two command invocations in one session.
 	pending: Map<string, McpOAuthProvider>;
+	/** Per-service guard: the same server may authenticate in another session. */
+	interactiveGuard?: { begin(serverName: string): boolean; end(serverName: string): void };
 	flow?: OAuthFlowOptions;
 }
 
@@ -88,14 +90,16 @@ export async function runAuth(deps: AuthCommandDeps): Promise<void> {
 }
 
 async function runInteractive(deps: AuthCommandDeps): Promise<void> {
-	if (activeInteractiveAuthServers.has(deps.serverName)) {
+	const beginInteractiveAuth =
+		deps.interactiveGuard?.begin(deps.serverName) ?? !activeInteractiveAuthServers.has(deps.serverName);
+	if (!beginInteractiveAuth) {
 		throw new OAuthFlowError(
 			"needs_auth",
 			`MCP server ${deps.serverName} authorization is already in progress; complete the existing browser flow or retry after it finishes.`,
 			{ serverName: deps.serverName },
 		);
 	}
-	activeInteractiveAuthServers.add(deps.serverName);
+	if (deps.interactiveGuard === undefined) activeInteractiveAuthServers.add(deps.serverName);
 	let provider: McpOAuthProvider | undefined;
 	let channel: Awaited<ReturnType<typeof openCallbackChannel>> | undefined;
 	const oauth = deps.config.oauth;
@@ -139,7 +143,8 @@ async function runInteractive(deps: AuthCommandDeps): Promise<void> {
 		await deps.onReconnect();
 		deps.notify(`MCP server ${deps.serverName} authorized`);
 	} finally {
-		activeInteractiveAuthServers.delete(deps.serverName);
+		if (deps.interactiveGuard) deps.interactiveGuard.end(deps.serverName);
+		else activeInteractiveAuthServers.delete(deps.serverName);
 		await channel?.close();
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/catalog.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/catalog.ts
@@ -3,6 +3,7 @@ import type { McpCachedServerCatalog } from "./catalog-cache.ts";
 import type { McpServerConfig, McpSettings } from "./config-schema.ts";
 import type { ServerConnection } from "./connection.ts";
 import { collectAllPages } from "./expose/pagination.ts";
+import type { McpOutputArtifacts } from "./guard/output-guard.ts";
 import type { McpEnsureFreshAuth } from "./health.ts";
 
 type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
@@ -18,10 +19,11 @@ export interface McpToolCatalogEntry {
 	ensureConnected?: () => Promise<void>;
 	ensureFresh?: McpEnsureFreshAuth;
 	agentDir?: string;
+	artifacts?: McpOutputArtifacts;
 	outputGuard?: McpSettings["outputGuard"];
 }
 
-type McpToolCatalogOptions = Pick<McpToolCatalogEntry, "agentDir" | "ensureFresh" | "outputGuard">;
+type McpToolCatalogOptions = Pick<McpToolCatalogEntry, "agentDir" | "artifacts" | "ensureFresh" | "outputGuard">;
 
 export async function collectToolCatalog(
 	server: string,
@@ -35,6 +37,7 @@ export async function collectToolCatalog(
 	return result.items.map((tool) => ({
 		annotations: tool.annotations,
 		agentDir: options.agentDir,
+		artifacts: options.artifacts,
 		connection,
 		description: tool.description,
 		ensureFresh: options.ensureFresh,
@@ -57,6 +60,7 @@ export function cachedToolsToCatalogEntries(
 	return catalog.tools.map((tool) => ({
 		annotations: tool.annotations,
 		agentDir: options.agentDir,
+		artifacts: options.artifacts,
 		connection,
 		description: tool.description,
 		ensureConnected,

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/commands.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/commands.ts
@@ -22,14 +22,14 @@ const SUBCOMMANDS = [
 
 const AUTH_SUBCOMMANDS = new Set(["auth", "auth-start", "auth-complete", "logout"]);
 
-export function registerMcpCommands(pi: ExtensionAPI): void {
+export function registerMcpCommands(pi: ExtensionAPI, service = getMcpService()): void {
 	pi.registerCommand("mcp", {
 		description: "Inspect and manage MCP servers.",
 		getArgumentCompletions: (prefix) =>
 			SUBCOMMANDS.filter((item) => item.startsWith(prefix)).map((value) => ({ value, label: value })),
 		handler: async (rawArgs, ctx) => {
 			try {
-				await handleMcpCommand(rawArgs, ctx, pi);
+				await handleMcpCommand(rawArgs, ctx, pi, service);
 			} catch (error) {
 				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 			}
@@ -37,46 +37,53 @@ export function registerMcpCommands(pi: ExtensionAPI): void {
 	});
 }
 
-async function handleMcpCommand(rawArgs: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
+async function handleMcpCommand(
+	rawArgs: string,
+	ctx: ExtensionCommandContext,
+	pi: ExtensionAPI,
+	service: ReturnType<typeof getMcpService>,
+): Promise<void> {
 	const args = splitCommandArgs(rawArgs);
 	const subcommand = args[0] ?? "";
 	if (subcommand === "") {
-		await showPanel(ctx);
+		await showPanel(ctx, service);
 		return;
 	}
 	if (AUTH_SUBCOMMANDS.has(subcommand)) {
-		await handleMcpAuthCommand(subcommand, args.slice(1), ctx, pi);
+		await handleMcpAuthCommand(subcommand, args.slice(1), ctx, pi, service);
 		return;
 	}
 	if (subcommand === "status") {
-		await notifyStatus(ctx);
+		await notifyStatus(ctx, service);
 		return;
 	}
 	if (subcommand === "add") {
-		await addServer(args.slice(1), ctx, pi);
+		await addServer(args.slice(1), ctx, pi, service);
 		return;
 	}
 	if (subcommand === "enable" || subcommand === "disable") {
-		await setServerEnabled(ctx, pi, args[1] ?? "", subcommand === "enable");
+		await setServerEnabled(ctx, pi, service, args[1] ?? "", subcommand === "enable");
 		return;
 	}
 	if (subcommand === "test") {
-		await testServer(args[1] ?? "", ctx);
+		await testServer(args[1] ?? "", ctx, service);
 		return;
 	}
 	if (subcommand === "logs") {
-		showLogs(args[1] ?? "", ctx);
+		showLogs(args[1] ?? "", ctx, service);
 		return;
 	}
 	if (subcommand === "reconnect") {
-		await reconnectServer(args[1] ?? "", ctx, pi);
+		await reconnectServer(args[1] ?? "", ctx, pi, service);
 		return;
 	}
 	ctx.ui.notify(`Unknown /mcp subcommand: ${subcommand}`, "error");
 }
 
-async function showPanel(ctx: ExtensionCommandContext): Promise<void> {
-	const text = await renderStatus("MCP servers");
+type McpCommandService = ReturnType<typeof getMcpService>;
+
+async function showPanel(ctx: ExtensionCommandContext, service: McpCommandService): Promise<void> {
+	const text = await renderStatus("MCP servers", service);
 	if (!ctx.hasUI) {
 		ctx.ui.notify(text);
 		return;
@@ -85,12 +92,11 @@ async function showPanel(ctx: ExtensionCommandContext): Promise<void> {
 	if (choice === undefined) ctx.ui.notify(text);
 }
 
-async function notifyStatus(ctx: ExtensionCommandContext): Promise<void> {
-	ctx.ui.notify(await renderStatus("MCP status"));
+async function notifyStatus(ctx: ExtensionCommandContext, service: McpCommandService): Promise<void> {
+	ctx.ui.notify(await renderStatus("MCP status", service));
 }
 
-async function renderStatus(title: string): Promise<string> {
-	const service = getMcpService();
+async function renderStatus(title: string, service: McpCommandService): Promise<string> {
 	const rows = await buildMcpStatusRows(service.getServerSnapshots(), (name) => service.getServerExposureStatus(name));
 	return formatMcpStatus(title, rows);
 }
@@ -99,6 +105,7 @@ async function addServer(
 	args: readonly string[],
 	ctx: ExtensionCommandContext,
 	pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">,
+	service: McpCommandService,
 ): Promise<void> {
 	const [name, ...endpoint] = args;
 	if (!name || endpoint.length === 0) {
@@ -116,48 +123,49 @@ async function addServer(
 		return;
 	}
 	addGlobalMcpServer(name, server);
-	await getMcpService().attachSession({ type: "session_start", reason: "reload" }, ctx, pi);
+	await service.attachSession({ type: "session_start", reason: "reload" }, ctx, pi);
 	ctx.ui.notify(`Added MCP server ${name}`);
 }
 
 async function setServerEnabled(
 	ctx: ExtensionCommandContext,
 	pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">,
+	service: McpCommandService,
 	name: string,
 	enabled: boolean,
 ): Promise<void> {
-	if (!ensureKnown(name, ctx)) return;
+	if (!ensureKnown(name, ctx, service)) return;
 	if (!setGlobalMcpServerEnabled(name, enabled)) {
 		ctx.ui.notify(`MCP server ${name} is not in the global config file`, "error");
 		return;
 	}
 	ctx.ui.notify(`MCP server ${name} connecting`);
-	await getMcpService().attachSession({ type: "session_start", reason: "reload" }, ctx, pi);
+	await service.attachSession({ type: "session_start", reason: "reload" }, ctx, pi);
 	ctx.ui.notify(`${enabled ? "Enabled" : "Disabled"} MCP server ${name}`);
 }
 
-async function testServer(name: string, ctx: ExtensionCommandContext): Promise<void> {
-	if (!ensureKnown(name, ctx)) return;
-	const connection = getMcpService().getConnection(name);
+async function testServer(name: string, ctx: ExtensionCommandContext, service: McpCommandService): Promise<void> {
+	if (!ensureKnown(name, ctx, service)) return;
+	const connection = service.getConnection(name);
 	if (connection === undefined) return;
 	const started = Date.now();
 	try {
 		await connection.connect();
 		const result = await connection.client.listTools({}, { timeout: 2000 });
 		const elapsedMs = Date.now() - started;
-		getMcpService().recordCall(name, elapsedMs, false);
+		service.recordCall(name, elapsedMs, false);
 		ctx.ui.notify(`MCP test ${name} ok (${elapsedMs}ms): ${result.tools.length} tools`);
 	} catch (error) {
 		const elapsedMs = Date.now() - started;
-		getMcpService().recordCall(name, elapsedMs, true);
+		service.recordCall(name, elapsedMs, true);
 		const message = error instanceof Error ? error.message : String(error);
 		ctx.ui.notify(`MCP test ${name} failed (${elapsedMs}ms): ${message}`, "error");
 	}
 }
 
-function showLogs(name: string, ctx: ExtensionCommandContext): void {
-	if (!ensureKnown(name, ctx)) return;
-	const lines = getMcpService().getLogLines(name, 20);
+function showLogs(name: string, ctx: ExtensionCommandContext, service: McpCommandService): void {
+	if (!ensureKnown(name, ctx, service)) return;
+	const lines = service.getLogLines(name, 20);
 	ctx.ui.notify(lines.length === 0 ? `MCP logs for ${name}: (empty)` : lines.join("\n"));
 }
 
@@ -165,10 +173,10 @@ async function reconnectServer(
 	name: string,
 	ctx: ExtensionCommandContext,
 	pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">,
+	service: McpCommandService,
 ): Promise<void> {
-	if (!ensureKnown(name, ctx)) return;
+	if (!ensureKnown(name, ctx, service)) return;
 	try {
-		const service = getMcpService();
 		await service.reconnectServer(name);
 		await service.attachSession({ type: "session_start", reason: "reload" }, ctx, pi);
 		ctx.ui.notify(`MCP reconnect ${name} connected`);
@@ -178,15 +186,9 @@ async function reconnectServer(
 	}
 }
 
-function ensureKnown(name: string, ctx: ExtensionCommandContext): boolean {
-	if (
-		name.length > 0 &&
-		getMcpService()
-			.getServerSnapshots()
-			.some((snapshot) => snapshot.name === name)
-	)
-		return true;
-	const known = getMcpService()
+function ensureKnown(name: string, ctx: ExtensionCommandContext, service: McpCommandService): boolean {
+	if (name.length > 0 && service.getServerSnapshots().some((snapshot) => snapshot.name === name)) return true;
+	const known = service
 		.getServerSnapshots()
 		.map((snapshot) => snapshot.name)
 		.join(", ");

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/connection-types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/connection-types.ts
@@ -1,5 +1,6 @@
 import type { McpOAuthProvider } from "./auth/oauth-provider.ts";
 import type { McpServerConfig } from "./config-schema.ts";
+import type { McpElicitationUiProvider } from "./elicitation.ts";
 import type { McpLogger } from "./log.ts";
 
 export type ServerConnectionState =
@@ -33,6 +34,7 @@ export interface ServerConnectionOptions {
 	readonly logger: McpLogger;
 	readonly env?: Record<string, string | undefined>;
 	readonly authProvider?: McpOAuthProvider;
+	readonly elicitationUiProvider?: McpElicitationUiProvider;
 }
 
 export type ServerConnectionListener<TEvent> = (event: TEvent) => void | Promise<void>;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/connection.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/connection.ts
@@ -36,6 +36,7 @@ export class ServerConnection {
 	readonly #env: Record<string, string | undefined> | undefined;
 	readonly #config: ServerConnectionOptions["config"];
 	readonly #authProvider: McpOAuthProvider | undefined;
+	readonly #elicitationUiProvider: ServerConnectionOptions["elicitationUiProvider"];
 	#state: ServerConnectionState;
 	#generation = 0;
 	#connection: McpTransportConnection | undefined;
@@ -52,6 +53,7 @@ export class ServerConnection {
 		this.#logger = options.logger;
 		this.#env = options.env;
 		this.#authProvider = options.authProvider;
+		this.#elicitationUiProvider = options.elicitationUiProvider;
 		this.#state = options.config.enabled ? "idle" : "disabled";
 	}
 
@@ -181,6 +183,7 @@ export class ServerConnection {
 			authProvider: this.#authProvider,
 			config: this.#config,
 			env: this.#env,
+			elicitationUiProvider: this.#elicitationUiProvider,
 			logger: this.#logger,
 			serverName: this.serverName,
 		});

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/elicitation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/elicitation.ts
@@ -23,6 +23,11 @@ export const MCP_ELICITATION_TIMEOUT_MS = 5 * 60 * 1000;
 
 type ElicitationUi = Pick<ExtensionUIContext, "input" | "select" | "confirm">;
 
+export type McpElicitationUiProvider = () => ElicitationUi | undefined;
+export interface McpElicitationUiOwner {
+	getMcpElicitationUi(): ElicitationUi | undefined;
+}
+
 export interface ElicitationResponse {
 	action: "accept" | "decline" | "cancel";
 	content?: Record<string, string | number | boolean>;
@@ -37,20 +42,24 @@ interface ElicitProperty {
 	enum?: unknown[];
 }
 
-let currentUi: (() => ElicitationUi | undefined) | undefined;
+let legacyUiProvider: McpElicitationUiProvider | undefined;
 
-/** The extension points this at the live session UI (undefined in print mode). */
-export function setMcpElicitationUiProvider(provider: (() => ElicitationUi | undefined) | undefined): void {
-	currentUi = provider;
+/** Legacy classic-session seam. Session-owned services pass themselves directly. */
+export function setMcpElicitationUiProvider(provider: McpElicitationUiProvider | undefined): void {
+	legacyUiProvider = provider;
 }
 
 /** Wire the elicitation/create handler onto a fresh client. */
-export function configureMcpElicitation(client: Client, timeoutMs: number = MCP_ELICITATION_TIMEOUT_MS): void {
+export function configureMcpElicitation(
+	client: Client,
+	owner: McpElicitationUiOwner | McpElicitationUiProvider | undefined = legacyUiProvider,
+	timeoutMs: number = MCP_ELICITATION_TIMEOUT_MS,
+): void {
 	client.setRequestHandler(ElicitRequestSchema, async (request) => {
 		const params = request.params;
 		// URL mode is deliberately unsupported in v1 (form mode only).
 		if (!("requestedSchema" in params)) return { action: "decline" };
-		const ui = currentUi?.();
+		const ui = typeof owner === "function" ? owner() : owner?.getMcpElicitationUi();
 		if (ui === undefined) return { action: "decline" };
 		return await runElicitationForm(ui, params.message, params.requestedSchema, timeoutMs);
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/register.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/register.ts
@@ -110,6 +110,7 @@ export async function executeMcpCatalogEntry(
 	}
 	const guarded = await applyMcpOutputGuard(mapped.content, {
 		agentDir: entry.agentDir,
+		artifacts: entry.artifacts,
 		outputGuard: entry.outputGuard,
 		server: entry.server,
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/session.ts
@@ -3,6 +3,7 @@ import { cachedToolsToCatalogEntries, collectToolCatalog, type McpToolCatalogEnt
 import type { McpCachedServerCatalog } from "../catalog-cache.ts";
 import type { ResolvedMcpConfig } from "../config-schema.ts";
 import type { ServerConnection } from "../connection.ts";
+import type { McpOutputArtifacts } from "../guard/output-guard.ts";
 import { createMcpLogger, type McpLogger } from "../log.ts";
 import type { McpPromptServer } from "../prompts.ts";
 import { createMcpResourceTools, type McpResourceServer } from "../resources.ts";
@@ -20,6 +21,7 @@ export interface McpDirectRegistrationEntry {
 	readonly connection: ServerConnection;
 	readonly logger: McpLogger;
 	readonly agentDir?: string;
+	readonly artifacts?: McpOutputArtifacts;
 	readonly cachedCatalog?: McpCachedServerCatalog;
 	readonly ensureFresh?: () => Promise<void>;
 	readonly ensureCachedToolConnected?: () => Promise<void>;
@@ -45,6 +47,7 @@ export async function registerDirectMcpTools(
 				? entry.connection.state === "connected"
 					? await collectToolCatalog(entry.name, entry.connection, server.config, {
 							agentDir: entry.agentDir,
+							artifacts: entry.artifacts,
 							ensureFresh: entry.ensureFresh,
 							outputGuard: config.settings.outputGuard,
 						})
@@ -57,6 +60,7 @@ export async function registerDirectMcpTools(
 						entry.ensureCachedToolConnected ?? (() => entry.connection.connect().then(() => undefined)),
 						{
 							agentDir: entry.agentDir,
+							artifacts: entry.artifacts,
 							ensureFresh: entry.ensureFresh,
 							outputGuard: config.settings.outputGuard,
 						},
@@ -74,6 +78,7 @@ export async function registerDirectMcpTools(
 		if (cachedResources.length > 0) {
 			resourceServers.push({
 				agentDir: entry.agentDir,
+				artifacts: entry.artifacts,
 				connection: entry.connection,
 				outputGuard: config.settings.outputGuard,
 				requestTimeoutMs: server.config.requestTimeoutMs,

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/guard/output-guard.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/guard/output-guard.ts
@@ -6,6 +6,8 @@ import type { McpMappedContentBlock } from "../expose/schema-compat.ts";
 
 export interface McpOutputGuardOptions {
 	readonly agentDir?: string;
+	/** Owner of spill files for one MCP service/session. */
+	readonly artifacts?: McpOutputArtifacts;
 	readonly server: string;
 	readonly outputGuard?: McpSettings["outputGuard"];
 }
@@ -22,7 +24,25 @@ const DEFAULT_MAX_BYTES = 50 * 1024;
 const DEFAULT_MAX_LINES = 2000;
 const PREVIEW_BYTE_BUDGET = 8192;
 let spillCounter = 0;
-const spilledFiles = new Set<string>();
+
+/** Tracks the output artifacts owned by one MCP service. */
+export class McpOutputArtifacts {
+	readonly #files = new Set<string>();
+
+	track(path: string): void {
+		this.#files.add(path);
+	}
+
+	async cleanup(): Promise<void> {
+		const files = [...this.#files];
+		this.#files.clear();
+		await Promise.all(files.map((file) => rm(file, { force: true })));
+	}
+}
+
+// Legacy direct callers retain the historic process-wide owner. MCP services
+// pass their own owner so one session cannot remove another's spill files.
+const legacyArtifacts = new McpOutputArtifacts();
 
 export async function applyMcpOutputGuard(
 	content: readonly McpMappedContentBlock[],
@@ -112,14 +132,12 @@ async function writePayload(payload: Payload, options: McpOutputGuardOptions): P
 	);
 	await writeFile(path, payload.bytes, { mode: 0o600 });
 	await chmod(path, 0o600);
-	spilledFiles.add(path);
+	(options.artifacts ?? legacyArtifacts).track(path);
 	return path;
 }
 
-export async function cleanupMcpOutputArtifacts(): Promise<void> {
-	const files = [...spilledFiles];
-	spilledFiles.clear();
-	await Promise.all(files.map((file) => rm(file, { force: true })));
+export async function cleanupMcpOutputArtifacts(artifacts: McpOutputArtifacts = legacyArtifacts): Promise<void> {
+	await artifacts.cleanup();
 }
 
 function buildPreview(payload: Payload, limits: { maxBytes: number; maxLines: number }): string {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -1,13 +1,13 @@
-import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
+import { bindToProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import type { ExtensionAPI, ExtensionContext, ExtensionFactory, SessionStartEvent } from "../../types.ts";
 import { registerMcpCommands } from "./commands.ts";
-import { setMcpElicitationUiProvider } from "./elicitation.ts";
 import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
 import { TOOL_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
 import { createMcpLogger } from "./log.ts";
 import { registerMcpPromptCommands } from "./prompts.ts";
 import { expandMcpResourceMentions } from "./resources.ts";
-import { getMcpService } from "./service.ts";
+import { getMcpService, McpService } from "./service.ts";
 import {
 	parseSkillMcpDeclarations,
 	type SkillLike,
@@ -16,136 +16,161 @@ import {
 } from "./skills.ts";
 import { reportMcpAsyncError, wrapAsync } from "./wrap.ts";
 
-export default function mcpExtension(pi: ExtensionAPI): void {
-	let attachPromise: Promise<void> | undefined;
-	const sink = {
-		logger: {
-			error(message: string, data?: unknown): void {
-				createMcpLogger("service").error(message, data);
+export function createMcpExtension(service: McpService, sessionOwned = true): ExtensionFactory {
+	return (pi: ExtensionAPI): void => {
+		let attachPromise: Promise<void> | undefined;
+		const sink = {
+			logger: {
+				error(message: string, data?: unknown): void {
+					createMcpLogger("service").error(message, data);
+				},
 			},
-		},
-	};
+		};
 
-	registerMcpCommands(pi);
+		registerMcpCommands(pi, service);
 
-	// Native provider tool-search adapter (todo 33 — Anthropic, spike = GO).
-	// Runs on every request but is a no-op unless settings.nativeToolSearch is
-	// auto|true and the model is anthropic-messages; a 400 disables it for the
-	// session and falls back to the always-registered local tool_search.
-	const nativeAdapter = new AnthropicNativeToolSearchAdapter({
-		enabled: () => {
-			const setting = getMcpService().getNativeToolSearchSetting();
-			return setting === true || setting === "auto";
-		},
-		isDeferrable: (name) => name.startsWith("mcp_") && name !== TOOL_SEARCH_TOOL_NAME,
-		onFallback: (reason) => createMcpLogger("service").warn(reason),
-		searchToolName: TOOL_SEARCH_TOOL_NAME,
-	});
-	pi.on("before_provider_request", (event, ctx) => nativeAdapter.applyBeforeRequest(ctx.model?.api, event.payload));
-	pi.on("after_provider_response", (event) => nativeAdapter.noteResponseStatus(event.status));
-	// Resumed/compacted sessions carry tool_search activation markers in their
-	// history but re-enter search mode with only directTools active. The context
-	// event (fired before each LLM call, with the full message history) replays
-	// the markers as a safety net; the primary replay happens at attach time so
-	// the FIRST turn's payload already carries previously promoted tools. Scans
-	// once per registration (see McpService.maybeRehydrateFromHistory).
-	pi.on("context", (event) => {
-		getMcpService().maybeRehydrateFromHistory(event.messages);
-	});
+		// Native provider tool-search adapter (todo 33 — Anthropic, spike = GO).
+		// Runs on every request but is a no-op unless settings.nativeToolSearch is
+		// auto|true and the model is anthropic-messages; a 400 disables it for the
+		// session and falls back to the always-registered local tool_search.
+		const nativeAdapter = new AnthropicNativeToolSearchAdapter({
+			enabled: () => {
+				const setting = service.getNativeToolSearchSetting();
+				return setting === true || setting === "auto";
+			},
+			isDeferrable: (name) => name.startsWith("mcp_") && name !== TOOL_SEARCH_TOOL_NAME,
+			onFallback: (reason) => createMcpLogger("service").warn(reason),
+			searchToolName: TOOL_SEARCH_TOOL_NAME,
+		});
+		pi.on("before_provider_request", (event, ctx) => nativeAdapter.applyBeforeRequest(ctx.model?.api, event.payload));
+		pi.on("after_provider_response", (event) => nativeAdapter.noteResponseStatus(event.status));
+		// Resumed/compacted sessions carry tool_search activation markers in their
+		// history but re-enter search mode with only directTools active. The context
+		// event (fired before each LLM call, with the full message history) replays
+		// the markers as a safety net; the primary replay happens at attach time so
+		// the FIRST turn's payload already carries previously promoted tools. Scans
+		// once per registration (see McpService.maybeRehydrateFromHistory).
+		pi.on("context", (event) => {
+			service.maybeRehydrateFromHistory(event.messages);
+		});
 
-	// skills-carry-MCP (todo 37): skills declaring MCP servers (mcp.json
-	// sidecar or SKILL.md frontmatter) register lazily with tools hidden;
-	// loading a skill — /skill:<name> input or the model reading its SKILL.md —
-	// reveals that skill's includeTools matches for the rest of the session.
-	let skillDecls: SkillMcpDeclarations = { servers: new Map(), warnings: [] };
-	let skillsByName = new Map<string, SkillLike>();
-	const loadedSkills = new Set<string>();
-	const revealSkill = (skillName: string): void => {
-		if (loadedSkills.has(skillName) || !skillsByName.has(skillName)) return;
-		loadedSkills.add(skillName);
-		const service = getMcpService();
-		const registered = service.getTierBSearchable();
-		const targets = skillActivationTargets(skillDecls, skillName, registered);
-		if (targets.length > 0) service.activateSkillMcpTools(targets);
-	};
-	pi.on("input", async (event, ctx) => {
-		const match = /^\s*\/skill:([A-Za-z0-9._-]+)/.exec(event.text);
-		if (match) revealSkill(match[1]);
-		// @mcp:<server>/<uri> mention expansion (todo 39): recognized mentions are
-		// inlined via the sanctioned input transform; failures pass through
-		// untouched with a one-line notice so submission is never blocked.
-		if (event.text.includes("@mcp:")) {
-			const expansion = await expandMcpResourceMentions(event.text, () => getMcpService().getMcpResourceServers());
-			for (const notice of expansion.notices) {
-				createMcpLogger("resources").warn(notice);
-				void ctx.ui?.notify?.(notice, "warning");
+		// skills-carry-MCP (todo 37): skills declaring MCP servers (mcp.json
+		// sidecar or SKILL.md frontmatter) register lazily with tools hidden;
+		// loading a skill — /skill:<name> input or the model reading its SKILL.md —
+		// reveals that skill's includeTools matches for the rest of the session.
+		let skillDecls: SkillMcpDeclarations = { servers: new Map(), warnings: [] };
+		let skillsByName = new Map<string, SkillLike>();
+		const loadedSkills = new Set<string>();
+		const revealSkill = (skillName: string): void => {
+			if (loadedSkills.has(skillName) || !skillsByName.has(skillName)) return;
+			loadedSkills.add(skillName);
+			const registered = service.getTierBSearchable();
+			const targets = skillActivationTargets(skillDecls, skillName, registered);
+			if (targets.length > 0) service.activateSkillMcpTools(targets);
+		};
+		pi.on("input", async (event, ctx) => {
+			const match = /^\s*\/skill:([A-Za-z0-9._-]+)/.exec(event.text);
+			if (match) revealSkill(match[1]);
+			// @mcp:<server>/<uri> mention expansion (todo 39): recognized mentions are
+			// inlined via the sanctioned input transform; failures pass through
+			// untouched with a one-line notice so submission is never blocked.
+			if (event.text.includes("@mcp:")) {
+				const expansion = await expandMcpResourceMentions(event.text, () => service.getMcpResourceServers());
+				for (const notice of expansion.notices) {
+					createMcpLogger("resources").warn(notice);
+					void ctx.ui?.notify?.(notice, "warning");
+				}
+				if (expansion.changed) return { action: "transform", text: expansion.text };
 			}
-			if (expansion.changed) return { action: "transform", text: expansion.text };
-		}
-		return undefined;
-	});
-	pi.on("tool_call", (event) => {
-		if (event.toolName !== "read") return undefined;
-		const path = (event.input as { path?: string }).path;
-		if (path === undefined) return undefined;
-		for (const [name, skill] of skillsByName) {
-			if (path === skill.filePath || path.endsWith(skill.filePath)) revealSkill(name);
-		}
-		return undefined;
-	});
-
-	// Attach is SINGLE-FLIGHT. session_start handlers are dispatched
-	// fire-and-forget, so a slow attach (a cold MCP server's boot + catalog
-	// collection is awaited inside attachSession) can still be in flight when
-	// before_agent_start fires. The old `attached` boolean was only set on
-	// completion, so before_agent_start would start a SECOND concurrent attach —
-	// which found the connection entries already created (still "connecting"),
-	// collected an empty catalog, and registered no MCP tools for turn 1; the
-	// first attach then landed the real registration turns later. Memoizing the
-	// in-flight promise makes before_agent_start await the ORIGINAL attach, so
-	// the first turn's payload deterministically carries the MCP tool set.
-	// session_start always starts a fresh attach (reloads must re-sync config).
-	const attach = (event: SessionStartEvent, ctx: ExtensionContext): Promise<void> => {
-		attachPromise = (async () => {
-			const service = getMcpService();
-			await service.attachSession(event, ctx, pi);
-			refreshMcpInstructionsForSession(service);
-			registerMcpPromptCommands(pi, service.getMcpPromptServers());
-		})();
-		return attachPromise;
-	};
-	pi.on(
-		"session_start",
-		wrapAsync("mcp.session_start", (event, ctx) => attach(event, ctx), sink),
-	);
-	pi.on("before_agent_start", async (event, ctx) => {
-		try {
-			// Elicitation (todo 41): point mid-call forms at the live session UI.
-			setMcpElicitationUiProvider(() => ctx.ui);
-			await (attachPromise ?? attach({ type: "session_start", reason: "startup" }, ctx));
-			const skills = (event.systemPromptOptions.skills ?? []) as readonly SkillLike[];
-			if (skills.length > 0) {
-				skillsByName = new Map(skills.map((skill) => [skill.name, skill]));
-				skillDecls = parseSkillMcpDeclarations(skills);
-				const declared = new Map(
-					[...skillDecls.servers].map(([name, decl]) => [name, { raw: decl.raw, sourcePath: decl.sourcePath }]),
-				);
-				const warnings = [
-					...skillDecls.warnings,
-					...(declared.size > 0 ? await getMcpService().attachSkillMcpServers(declared) : []),
-				];
-				for (const warning of warnings) createMcpLogger("skills").warn(warning);
-			}
-			const systemPrompt = injectMcpInstructions(event.systemPrompt);
-			return systemPrompt === undefined ? undefined : { systemPrompt };
-		} catch (error) {
-			if (!(error instanceof Error)) throw error;
-			await reportMcpAsyncError("mcp.before_agent_start", error, sink);
 			return undefined;
-		}
-	});
-	pi.on(
-		"session_shutdown",
-		wrapAsync("mcp.session_shutdown", (event) => getMcpService().handleSessionShutdown(event), sink),
-	);
+		});
+		pi.on("tool_call", (event) => {
+			if (event.toolName !== "read") return undefined;
+			const path = (event.input as { path?: string }).path;
+			if (path === undefined) return undefined;
+			for (const [name, skill] of skillsByName) {
+				if (path === skill.filePath || path.endsWith(skill.filePath)) revealSkill(name);
+			}
+			return undefined;
+		});
+
+		// Attach is SINGLE-FLIGHT. session_start handlers are dispatched
+		// fire-and-forget, so a slow attach (a cold MCP server's boot + catalog
+		// collection is awaited inside attachSession) can still be in flight when
+		// before_agent_start fires. The old `attached` boolean was only set on
+		// completion, so before_agent_start would start a SECOND concurrent attach —
+		// which found the connection entries already created (still "connecting"),
+		// collected an empty catalog, and registered no MCP tools for turn 1; the
+		// first attach then landed the real registration turns later. Memoizing the
+		// in-flight promise makes before_agent_start await the ORIGINAL attach, so
+		// the first turn's payload deterministically carries the MCP tool set.
+		// session_start always starts a fresh attach (reloads must re-sync config).
+		const attach = (event: SessionStartEvent, ctx: ExtensionContext): Promise<void> => {
+			attachPromise = (async () => {
+				await service.attachSession(event, ctx, pi);
+				refreshMcpInstructionsForSession(service);
+				if (sessionOwned) registerMcpPromptCommands(service, pi, service.getMcpPromptServers());
+				else registerMcpPromptCommands(pi, service.getMcpPromptServers());
+			})();
+			return attachPromise;
+		};
+		pi.on(
+			"session_start",
+			wrapAsync("mcp.session_start", (event, ctx) => attach(event, ctx), sink),
+		);
+		pi.on("before_agent_start", async (event, ctx) => {
+			try {
+				// Elicitation (todo 41): point mid-call forms at this session's UI.
+				service.setMcpElicitationUiProvider(() => ctx.ui);
+				await (attachPromise ?? attach({ type: "session_start", reason: "startup" }, ctx));
+				const skills = (event.systemPromptOptions.skills ?? []) as readonly SkillLike[];
+				if (skills.length > 0) {
+					skillsByName = new Map(skills.map((skill) => [skill.name, skill]));
+					skillDecls = parseSkillMcpDeclarations(skills);
+					const declared = new Map(
+						[...skillDecls.servers].map(([name, decl]) => [name, { raw: decl.raw, sourcePath: decl.sourcePath }]),
+					);
+					const warnings = [
+						...skillDecls.warnings,
+						...(declared.size > 0 ? await service.attachSkillMcpServers(declared) : []),
+					];
+					for (const warning of warnings) createMcpLogger("skills").warn(warning);
+				}
+				const systemPrompt = injectMcpInstructions(service, event.systemPrompt);
+				return systemPrompt === undefined ? undefined : { systemPrompt };
+			} catch (error) {
+				if (!(error instanceof Error)) throw error;
+				await reportMcpAsyncError("mcp.before_agent_start", error, sink);
+				return undefined;
+			}
+		});
+		pi.on(
+			"session_shutdown",
+			wrapAsync(
+				"mcp.session_shutdown",
+				async (event) => {
+					await service.handleSessionShutdown(event);
+					// A classic extension instance can be reused by the test/legacy host
+					// after reload. Its singleton is intentionally refreshed for that next
+					// session; scoped factories keep their closed instance.
+					if (!sessionOwned && event.reason === "reload" && service.isDisposed()) service = getMcpService();
+				},
+				sink,
+			),
+		);
+	};
+}
+
+function hasProviderScope(): boolean {
+	try {
+		bindToProviderScope(() => undefined);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export default function mcpExtension(pi: ExtensionAPI): void | Promise<void> {
+	const sessionOwned = hasProviderScope();
+	return createMcpExtension(sessionOwned ? new McpService() : getMcpService(), sessionOwned)(pi);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/instructions.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/instructions.ts
@@ -2,16 +2,15 @@ import type { McpService } from "./service.ts";
 
 const MAX_INSTRUCTIONS_CHARS = 4000;
 
-let sessionInstructionsBlock = "";
-
 export function refreshMcpInstructionsForSession(service: McpService): void {
-	sessionInstructionsBlock = buildMcpInstructionsBlock(service);
+	service.setMcpInstructions(buildMcpInstructionsBlock(service));
 }
 
-export function injectMcpInstructions(systemPrompt: string): string | undefined {
-	if (sessionInstructionsBlock.length === 0) return undefined;
-	if (systemPrompt.includes(sessionInstructionsBlock)) return undefined;
-	return `${systemPrompt}\n\n${sessionInstructionsBlock}`;
+export function injectMcpInstructions(service: McpService, systemPrompt: string): string | undefined {
+	const instructions = service.getMcpInstructions();
+	if (instructions.length === 0) return undefined;
+	if (systemPrompt.includes(instructions)) return undefined;
+	return `${systemPrompt}\n\n${instructions}`;
 }
 
 function buildMcpInstructionsBlock(service: McpService): string {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/prompts.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/prompts.ts
@@ -14,6 +14,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "../../types.ts";
 import type { McpCachedServerCatalog } from "./catalog-cache.ts";
 import type { ServerConnection } from "./connection.ts";
 import { createMcpLogger } from "./log.ts";
+import type { McpService } from "./service.ts";
 
 export interface McpPromptServer {
 	readonly server: string;
@@ -31,13 +32,27 @@ export function resetMcpPromptCommandsForTests(): void {
 	registeredCommandNames.clear();
 }
 
-export function registerMcpPromptCommands(pi: CommandRegistrar, servers: readonly McpPromptServer[]): string[] {
+export function registerMcpPromptCommands(pi: CommandRegistrar, servers: readonly McpPromptServer[]): string[];
+export function registerMcpPromptCommands(
+	service: McpService,
+	pi: CommandRegistrar,
+	servers: readonly McpPromptServer[],
+): string[];
+export function registerMcpPromptCommands(
+	serviceOrPi: McpService | CommandRegistrar,
+	piOrServers: CommandRegistrar | readonly McpPromptServer[],
+	serversArg?: readonly McpPromptServer[],
+): string[] {
+	const service = serversArg === undefined ? undefined : (serviceOrPi as McpService);
+	const pi = (serversArg === undefined ? serviceOrPi : piOrServers) as CommandRegistrar;
+	const servers = (serversArg === undefined ? piOrServers : serversArg) as readonly McpPromptServer[];
 	const added: string[] = [];
 	for (const server of servers) {
 		for (const prompt of server.prompts) {
 			const commandName = `mcp:${server.server}:${prompt.name}`;
-			if (registeredCommandNames.has(commandName)) continue;
-			registeredCommandNames.add(commandName);
+			if (service?.isMcpPromptCommandRegistered(commandName) ?? registeredCommandNames.has(commandName)) continue;
+			if (service) service.markMcpPromptCommandRegistered(commandName);
+			else registeredCommandNames.add(commandName);
 			added.push(commandName);
 			pi.registerCommand(commandName, {
 				description: prompt.description ?? `MCP prompt ${prompt.name} from ${server.server}`,

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/resources.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/resources.ts
@@ -20,12 +20,14 @@ import type { McpCachedServerCatalog } from "./catalog-cache.ts";
 import type { ServerConnection } from "./connection.ts";
 import { ToolExecError } from "./errors.ts";
 import type { McpToolDetails } from "./expose/register.ts";
+import type { McpOutputArtifacts } from "./guard/output-guard.ts";
 import { applyMcpOutputGuard } from "./guard/output-guard.ts";
 
 export interface McpResourceServer {
 	readonly server: string;
 	readonly connection: ServerConnection;
 	readonly agentDir?: string;
+	readonly artifacts?: McpOutputArtifacts;
 	readonly outputGuard?: Parameters<typeof applyMcpOutputGuard>[1]["outputGuard"];
 	readonly requestTimeoutMs?: number;
 	readonly resources: NonNullable<McpCachedServerCatalog["resources"]>;
@@ -71,6 +73,7 @@ export async function readMcpResourceAsText(server: McpResourceServer, uri: stri
 	});
 	const guarded = await applyMcpOutputGuard([{ type: "text", text: parts.join("\n") }], {
 		agentDir: server.agentDir,
+		artifacts: server.artifacts,
 		outputGuard: server.outputGuard,
 		server: server.server,
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service-register.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service-register.ts
@@ -24,6 +24,7 @@ export async function registerMcpServiceDirectTools(
 			const serverConfig = config.servers[entry.name]?.config;
 			return {
 				agentDir: entry.agentDir,
+				artifacts: entry.artifacts,
 				cachedCatalog: entry.cachedCatalog,
 				connection: entry.connection,
 				ensureFresh: () => entry.authPlan?.refresh?.ensureFresh().then(() => undefined) ?? Promise.resolve(),

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service-types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service-types.ts
@@ -3,6 +3,7 @@ import type { ServerAuthPlan } from "./auth/context.ts";
 import type { McpCachedServerCatalog } from "./catalog-cache.ts";
 import type { ResolvedMcpServer } from "./config-schema.ts";
 import type { ServerConnection, ServerConnectionState } from "./connection.ts";
+import type { McpOutputArtifacts } from "./guard/output-guard.ts";
 import type { McpLogger } from "./log.ts";
 
 export type McpDisposeReason = Extract<SessionShutdownEvent["reason"], "quit" | "reload">;
@@ -142,6 +143,7 @@ export interface McpConnectionEntry {
 	readonly createdAtMs: number;
 	readonly counters: McpServerCounters;
 	readonly agentDir?: string;
+	readonly artifacts?: McpOutputArtifacts;
 	readonly authPlan?: ServerAuthPlan;
 	cachedCatalog?: McpCachedServerCatalog;
 	cacheRefreshedAfterConnect: boolean;

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -1,5 +1,5 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import type { ExtensionAPI, SessionShutdownEvent, SessionStartEvent } from "../../types.ts";
+import type { ExtensionAPI, ExtensionUIContext, SessionShutdownEvent, SessionStartEvent } from "../../types.ts";
 import { detectLiteralBearerWarnings, resolveAuthMode, resolveServerAuth } from "./auth/context.ts";
 import { collectToolCatalog } from "./catalog.ts";
 import { getValidCachedServer, readMcpCatalogCache } from "./catalog-cache.ts";
@@ -10,7 +10,7 @@ import { collectAllPages } from "./expose/pagination.ts";
 import { mapMcpCatalogNames } from "./expose/register.ts";
 import type { McpSessionRegistration } from "./expose/session.ts";
 import type { McpServerExposureStatus } from "./expose/status.ts";
-import { cleanupMcpOutputArtifacts } from "./guard/output-guard.ts";
+import { cleanupMcpOutputArtifacts, McpOutputArtifacts } from "./guard/output-guard.ts";
 import { markMcpConnectionNeedsAuth } from "./health.ts";
 import { configureMcpConnectionLifecycle, disposeMcpConnectionLifecycle } from "./idle.ts";
 import { refreshMcpInstructionsForSession } from "./instructions.ts";
@@ -52,6 +52,7 @@ import {
 type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
 type ListedResource = Awaited<ReturnType<Client["listResources"]>>["resources"][number];
 type ListedResourceTemplate = Awaited<ReturnType<Client["listResourceTemplates"]>>["resourceTemplates"][number];
+type McpElicitationUi = Pick<ExtensionUIContext, "input" | "select" | "confirm">;
 
 export { registerToolsPreservingActiveSet } from "./active-set.ts";
 
@@ -66,7 +67,11 @@ export class McpService {
 	#config: ResolvedMcpConfig | null = null;
 	#authAgentDir: string | undefined;
 	#authEnv: Record<string, string | undefined> | undefined;
+	#elicitationUiProvider: (() => McpElicitationUi | undefined) | undefined;
+	#mcpInstructions = "";
 	readonly #pendingAuth = new Map<string, import("./auth/oauth-provider.ts").McpOAuthProvider>();
+	readonly #interactiveAuthServers = new Set<string>();
+	readonly #promptCommandNames = new Set<string>();
 	#refreshActiveSetWhenNoTools = false;
 	#tierBRegistration: McpSessionRegistration | undefined;
 	#historyScanned = false;
@@ -77,6 +82,7 @@ export class McpService {
 	readonly #wireStatusBySession = new Map<string, McpWireStatusSnapshot>();
 	readonly #connections = new Map<string, McpConnectionEntry>();
 	readonly #connectionKeysByName = new Map<string, string>();
+	readonly #outputArtifacts = new McpOutputArtifacts();
 
 	async attachSession(
 		event: SessionStartEvent,
@@ -198,13 +204,22 @@ export class McpService {
 		this.#lastDisposeReason = reason;
 		this.#sessionContext = null;
 		this.#config = null;
+		this.#elicitationUiProvider = undefined;
+		this.#mcpInstructions = "";
+		this.#pendingAuth.clear();
+		this.#interactiveAuthServers.clear();
+		this.#promptCommandNames.clear();
 		this.#wireStatusBySession.clear();
 		this.#latestWireStatus = { servers: [] };
 		const entries = [...this.#connections.values()];
 		this.#connections.clear();
 		this.#connectionKeysByName.clear();
 		await Promise.all(entries.map((entry) => disposeEntryConnection(entry)));
-		await cleanupMcpOutputArtifacts();
+		await cleanupMcpOutputArtifacts(this.#outputArtifacts);
+	}
+
+	getMcpOutputArtifacts(): McpOutputArtifacts {
+		return this.#outputArtifacts;
 	}
 
 	isDisposed(): boolean {
@@ -313,12 +328,14 @@ export class McpService {
 				authProvider: authPlan.provider,
 				config: server.config,
 				env: options.env,
+				elicitationUiProvider: () => this.getMcpElicitationUi(),
 				logger,
 				serverName: name,
 			});
 			const cachedCatalog = useCache ? getValidCachedServer(cache, name, server.configHash) : undefined;
 			const entry: McpConnectionEntry = {
 				agentDir: options.agentDir,
+				artifacts: this.#outputArtifacts,
 				authPlan,
 				cacheRefreshedAfterConnect: false,
 				cachedCatalog,
@@ -538,6 +555,40 @@ export class McpService {
 	#entryForName(name: string): McpConnectionEntry | undefined {
 		const key = this.#connectionKeysByName.get(name);
 		return key === undefined ? undefined : this.#connections.get(key);
+	}
+
+	setMcpInstructions(instructions: string): void {
+		this.#mcpInstructions = instructions;
+	}
+
+	getMcpInstructions(): string {
+		return this.#mcpInstructions;
+	}
+
+	setMcpElicitationUiProvider(provider: (() => McpElicitationUi | undefined) | undefined): void {
+		this.#elicitationUiProvider = provider;
+	}
+
+	getMcpElicitationUi(): McpElicitationUi | undefined {
+		return this.#elicitationUiProvider?.();
+	}
+
+	isMcpPromptCommandRegistered(name: string): boolean {
+		return this.#promptCommandNames.has(name);
+	}
+
+	markMcpPromptCommandRegistered(name: string): void {
+		this.#promptCommandNames.add(name);
+	}
+
+	beginInteractiveAuth(serverName: string): boolean {
+		if (this.#interactiveAuthServers.has(serverName)) return false;
+		this.#interactiveAuthServers.add(serverName);
+		return true;
+	}
+
+	endInteractiveAuth(serverName: string): void {
+		this.#interactiveAuthServers.delete(serverName);
 	}
 
 	getPendingAuth(): Map<string, import("./auth/oauth-provider.ts").McpOAuthProvider> {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/transport.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/transport.ts
@@ -4,7 +4,11 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { McpOAuthProvider } from "./auth/oauth-provider.ts";
 import type { McpServerConfig } from "./config-schema.ts";
-import { configureMcpElicitation, MCP_CLIENT_ELICITATION_CAPABILITY } from "./elicitation.ts";
+import {
+	configureMcpElicitation,
+	MCP_CLIENT_ELICITATION_CAPABILITY,
+	type McpElicitationUiProvider,
+} from "./elicitation.ts";
 import { AuthError, ConnectError, TimeoutError } from "./errors.ts";
 import type { McpLogger } from "./log.ts";
 import { delay, reapProcessTree } from "./process-tree.ts";
@@ -26,6 +30,7 @@ export type CreateMcpTransportOptions = {
 	readonly config: McpServerConfig;
 	readonly logger: McpLogger;
 	readonly env?: Record<string, string | undefined>;
+	readonly elicitationUiProvider?: McpElicitationUiProvider;
 	// Present only when OAuth is the resolved auth mode for this server.
 	readonly authProvider?: McpOAuthProvider;
 };
@@ -113,7 +118,14 @@ function createStdioConnection(options: CreateMcpTransportOptions, connectTimeou
 		stderr: "pipe",
 	});
 	pipeStderr(transport, options.logger);
-	return createConnection(options.serverName, "stdio", transport, connectTimeoutMs, { logger: options.logger });
+	return createConnection(
+		options.serverName,
+		"stdio",
+		transport,
+		connectTimeoutMs,
+		{ logger: options.logger },
+		options.elicitationUiProvider,
+	);
 }
 
 function createHttpConnection(options: CreateMcpTransportOptions, connectTimeoutMs: number): McpTransportConnection {
@@ -138,7 +150,14 @@ function createHttpConnection(options: CreateMcpTransportOptions, connectTimeout
 		authProvider: options.authProvider,
 		requestInit: Object.keys(headers).length === 0 ? undefined : { headers },
 	});
-	return createConnection(options.serverName, "http", transport, connectTimeoutMs, { logger: options.logger });
+	return createConnection(
+		options.serverName,
+		"http",
+		transport,
+		connectTimeoutMs,
+		{ logger: options.logger },
+		options.elicitationUiProvider,
+	);
 }
 
 function createConnection(
@@ -147,6 +166,7 @@ function createConnection(
 	transport: Transport,
 	connectTimeoutMs: number,
 	asyncErrorSink: McpAsyncErrorSink,
+	elicitationUiProvider: McpElicitationUiProvider | undefined,
 ): McpTransportConnection {
 	let lastRootPid: number | null = null;
 	const readRootPid = (): number | null => (transport instanceof StdioClientTransport ? transport.pid : null);
@@ -156,7 +176,7 @@ function createConnection(
 	if (transport instanceof StdioClientTransport) trackStdioStart(transport, captureRootPid);
 	return {
 		captureRootPid,
-		client: buildMcpClient(),
+		client: buildMcpClient(elicitationUiProvider),
 		connectTimeoutMs,
 		asyncErrorSink,
 		getRootPid: () => {
@@ -269,7 +289,7 @@ function isTerminableHttpTransport(
 
 const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
 
-function buildMcpClient(): Client {
+function buildMcpClient(elicitationUiProvider: McpElicitationUiProvider | undefined): Client {
 	// Elicitation capability is declared EMPTY on purpose (form mode only;
 	// Spring-AI servers reject richer shapes) and the create-handler is wired
 	// before any connect so mid-call requests never race registration.
@@ -277,6 +297,6 @@ function buildMcpClient(): Client {
 		{ name: "senpi-mcp-client", version: "0.0.0" },
 		{ capabilities: MCP_CLIENT_ELICITATION_CAPABILITY },
 	);
-	configureMcpElicitation(client);
+	configureMcpElicitation(client, elicitationUiProvider);
 	return client;
 }

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -13,6 +13,11 @@ export const HTTP_IDLE_TIMEOUT_CHOICES = [
 
 const originalGlobalFetch = globalThis.fetch;
 let installedGlobalFetch: typeof globalThis.fetch | undefined;
+let multiSessionDispatcherTimeoutMs: number | undefined;
+
+function isMultiSessionRpcProcess(): boolean {
+	return process.argv.includes("--multi-session");
+}
 
 export function parseHttpIdleTimeoutMs(value: unknown): number | undefined {
 	if (typeof value === "string") {
@@ -43,6 +48,14 @@ export function formatHttpIdleTimeoutMs(timeoutMs: number): string {
 export function applyHttpProxySettings(httpProxy: string | undefined): void {
 	const proxy = httpProxy?.trim();
 	if (!proxy) return;
+	if (isMultiSessionRpcProcess()) {
+		const existing = process.env.HTTP_PROXY ?? process.env.HTTPS_PROXY;
+		if (existing !== undefined && existing !== proxy) {
+			throw new Error(
+				"Multi-session RPC shares one process-global HTTP proxy; proxy settings must be fixed at process startup.",
+			);
+		}
+	}
 	process.env.HTTP_PROXY ??= proxy;
 	process.env.HTTPS_PROXY ??= proxy;
 }
@@ -80,6 +93,14 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 	const normalizedTimeoutMs = parseHttpIdleTimeoutMs(timeoutMs);
 	if (normalizedTimeoutMs === undefined) {
 		throw new Error(`Invalid HTTP idle timeout: ${String(timeoutMs)}`);
+	}
+	if (isMultiSessionRpcProcess()) {
+		if (multiSessionDispatcherTimeoutMs !== undefined && multiSessionDispatcherTimeoutMs !== normalizedTimeoutMs) {
+			throw new Error(
+				"Multi-session RPC shares one process-global Undici dispatcher; HTTP idle timeout must be fixed at process startup.",
+			);
+		}
+		multiSessionDispatcherTimeoutMs = normalizedTimeoutMs;
 	}
 	const dispatcher = withUndiciErrorListener(
 		new undici.EnvHttpProxyAgent({

--- a/packages/coding-agent/src/core/resolve-config-value.ts
+++ b/packages/coding-agent/src/core/resolve-config-value.ts
@@ -145,12 +145,17 @@ export function isConfigValueConfigured(config: string, env?: Record<string, str
 export function resolveConfigValue(config: string, env?: Record<string, string>): string | undefined {
 	const reference = parseConfigValueReference(config);
 	if (reference.type === "command") {
-		return executeCommand(reference.config);
+		// Credentials can carry a per-session environment. Those commands must not
+		// reuse a process-wide result produced under another session's environment.
+		return env === undefined ? executeCommand(reference.config) : executeCommandUncached(reference.config, env);
 	}
 	return resolveTemplate(reference.parts, env);
 }
 
-function executeWithConfiguredShell(command: string): { executed: boolean; value: string | undefined } {
+function executeWithConfiguredShell(
+	command: string,
+	env?: Record<string, string>,
+): { executed: boolean; value: string | undefined } {
 	try {
 		const { shell, args, commandTransport } = getShellConfig();
 		const commandFromStdin = commandTransport === "stdin";
@@ -161,6 +166,7 @@ function executeWithConfiguredShell(command: string): { executed: boolean; value
 			stdio: [commandFromStdin ? "pipe" : "ignore", "pipe", "ignore"],
 			shell: false,
 			windowsHide: true,
+			...(env === undefined ? {} : { env: { ...process.env, ...env } }),
 		});
 
 		if (result.error) {
@@ -182,12 +188,13 @@ function executeWithConfiguredShell(command: string): { executed: boolean; value
 	}
 }
 
-function executeWithDefaultShell(command: string): string | undefined {
+function executeWithDefaultShell(command: string, env?: Record<string, string>): string | undefined {
 	try {
 		const output = execSync(command, {
 			encoding: "utf-8",
 			timeout: 10000,
 			stdio: ["ignore", "pipe", "ignore"],
+			...(env === undefined ? {} : { env: { ...process.env, ...env } }),
 		});
 		return output.trim() || undefined;
 	} catch {
@@ -195,14 +202,14 @@ function executeWithDefaultShell(command: string): string | undefined {
 	}
 }
 
-function executeCommandUncached(commandConfig: string): string | undefined {
+function executeCommandUncached(commandConfig: string, env?: Record<string, string>): string | undefined {
 	const command = commandConfig.slice(1);
 	return process.platform === "win32"
 		? (() => {
-				const configuredResult = executeWithConfiguredShell(command);
-				return configuredResult.executed ? configuredResult.value : executeWithDefaultShell(command);
+				const configuredResult = executeWithConfiguredShell(command, env);
+				return configuredResult.executed ? configuredResult.value : executeWithDefaultShell(command, env);
 			})()
-		: executeWithDefaultShell(command);
+		: executeWithDefaultShell(command, env);
 }
 
 function executeCommand(commandConfig: string): string | undefined {
@@ -221,7 +228,7 @@ function executeCommand(commandConfig: string): string | undefined {
 export function resolveConfigValueUncached(config: string, env?: Record<string, string>): string | undefined {
 	const reference = parseConfigValueReference(config);
 	if (reference.type === "command") {
-		return executeCommandUncached(reference.config);
+		return executeCommandUncached(reference.config, env);
 	}
 	return resolveTemplate(reference.parts, env);
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -54,6 +54,7 @@ import { builtInExtensions } from "./extensions/index.ts";
 import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
+import { runMultiSessionHost } from "./modes/rpc/multi-session-host.ts";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
 import { isLocalPath, normalizePath, resolvePath } from "./utils/paths.ts";
 import { cleanupWindowsSelfUpdateQuarantine } from "./utils/windows-self-update.ts";
@@ -813,6 +814,17 @@ export async function main(args: string[], options?: MainOptions) {
 		};
 	};
 	time("createRuntime");
+	if (appMode === "rpc" && parsed.multiSession) {
+		printTimings();
+		await runMultiSessionHost({
+			agentDir,
+			createRuntime,
+			cwd,
+			creationModel:
+				parsed.provider && parsed.model ? { provider: parsed.provider, modelId: parsed.model } : undefined,
+			initialThinkingLevel: parsed.thinking,
+		});
+	}
 	const runtime = await createAgentSessionRuntime(createRuntime, {
 		cwd: sessionManager.getCwd(),
 		agentDir,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -701,6 +701,7 @@ export async function main(args: string[], options?: MainOptions) {
 		sessionManager,
 		sessionStartEvent,
 		projectTrustContext,
+		launchProfile,
 	}) => {
 		const isInitialRuntime = sessionStartEvent === undefined;
 		const projectTrustDiagnostics: AgentSessionRuntimeDiagnostic[] = [];
@@ -770,11 +771,35 @@ export async function main(args: string[], options?: MainOptions) {
 		});
 		const scopedModels =
 			modelPatterns && modelPatterns.length > 0 ? await resolveModelScope(modelPatterns, modelRuntime) : [];
+		// Multi-session opens carry their per-session startup choices here rather
+		// than through process argv. This deliberately feeds the same resolver as
+		// --provider/--model/--thinking, preserving classic flag semantics.
+		const runtimeParsed: Args =
+			launchProfile === undefined
+				? parsed
+				: {
+						...parsed,
+						...(launchProfile.creationModel === undefined
+							? {}
+							: {
+									provider: launchProfile.creationModel.provider,
+									model: launchProfile.creationModel.modelId,
+								}),
+						...(launchProfile.initialThinkingLevel === undefined
+							? {}
+							: { thinking: launchProfile.initialThinkingLevel as Args["thinking"] }),
+					};
 		const {
 			options: sessionOptions,
 			cliThinkingFromModel,
 			diagnostics: sessionOptionDiagnostics,
-		} = buildSessionOptions(parsed, scopedModels, sessionManager.hasContextMessages(), modelRuntime, settingsManager);
+		} = buildSessionOptions(
+			runtimeParsed,
+			scopedModels,
+			sessionManager.hasContextMessages(),
+			modelRuntime,
+			settingsManager,
+		);
 		diagnostics.push(...sessionOptionDiagnostics);
 
 		if (parsed.apiKey) {
@@ -802,7 +827,7 @@ export async function main(args: string[], options?: MainOptions) {
 			customTools: sessionOptions.customTools,
 			autoTitleSessions: appMode === "interactive" && !sessionManager.hasContextMessages(),
 		});
-		const cliThinkingOverride = parsed.thinking !== undefined || cliThinkingFromModel;
+		const cliThinkingOverride = runtimeParsed.thinking !== undefined || cliThinkingFromModel;
 		if (created.session.model && cliThinkingOverride) {
 			created.session.setThinkingLevel(created.session.thinkingLevel);
 		}

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -38,11 +38,18 @@ import type {
 	RpcSessionState,
 	RpcSlashCommand,
 } from "./rpc-types.ts";
+import { SessionExtensionUiRequests } from "./session-extension-ui-requests.ts";
 
 /** Additive per-connection options. Absent = classic default (byte-identical). */
 export interface RpcConnectionOptions {
 	/** Client capability flags from the handshake (e.g. custom_unsupported opt-in). */
 	capabilities?: readonly string[];
+	/** Called instead of requesting process shutdown for a session-owned binding. */
+	shutdownHandler?: () => void;
+	/** Session registries own runtime disposal themselves. */
+	disposeRuntime?: boolean;
+	/** Multi-session routing handle. Absent preserves classic wire output exactly. */
+	sessionId?: string;
 }
 
 /**
@@ -85,17 +92,21 @@ export function createRpcConnectionHandler(
 	options: RpcConnectionOptions = {},
 ): RpcConnectionHandler {
 	const clientCapabilities = options.capabilities;
+	const routingSessionId = options.sessionId;
 	let session = runtimeHost.session;
 	let unsubscribe: (() => void) | undefined;
 	let unsubscribeBackpressure: (() => void) | undefined;
 	const eventOutput = createRpcEventOutputBuffer(sink.writeRaw);
 
+	const tagSessionRecord = <T extends object>(value: T): T | (T & { sessionId: string }) =>
+		routingSessionId === undefined ? value : { ...value, sessionId: routingSessionId };
+
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
-		eventOutput.writeImmediate(obj);
+		eventOutput.writeImmediate(tagSessionRecord(obj));
 	};
 
 	const outputEvent = (event: object) => {
-		eventOutput.enqueueEvent(event);
+		eventOutput.enqueueEvent(tagSessionRecord(event));
 	};
 
 	const waitForRpcBackpressure = async (): Promise<void> => {
@@ -119,10 +130,7 @@ export function createRpcConnectionHandler(
 	};
 
 	// Pending extension UI requests waiting for response
-	const pendingExtensionRequests = new Map<
-		string,
-		{ resolve: (value: RpcExtensionUIResponse) => void; reject: (error: Error) => void }
-	>();
+	const pendingExtensionRequests = new SessionExtensionUiRequests();
 
 	let shutdownRequested = false;
 
@@ -398,7 +406,11 @@ export function createRpcConnectionHandler(
 				},
 			},
 			shutdownHandler: () => {
-				shutdownRequested = true;
+				if (options.shutdownHandler) {
+					options.shutdownHandler();
+				} else {
+					shutdownRequested = true;
+				}
 			},
 			onError: (err) => {
 				output({ type: "extension_error", extensionPath: err.extensionPath, event: err.event, error: err.error });
@@ -467,6 +479,17 @@ export function createRpcConnectionHandler(
 		const id = command.id;
 
 		switch (command.type) {
+			case "get_protocol_info":
+				return {
+					id,
+					type: "response",
+					command: "get_protocol_info",
+					success: true,
+					data: { protocolVersion: 1, capabilities: ["multi_session"], mode: "classic" },
+				};
+			case "open_session":
+				return error(id, "open_session", "multi_session_disabled");
+
 			// =================================================================
 			// Prompting
 			// =================================================================
@@ -866,10 +889,10 @@ export function createRpcConnectionHandler(
 			parsed.type === "extension_ui_response"
 		) {
 			const response = parsed as RpcExtensionUIResponse;
-			const pending = pendingExtensionRequests.get(response.id);
-			if (pending) {
-				pendingExtensionRequests.delete(response.id);
-				pending.resolve(response);
+			if (!pendingExtensionRequests.resolve(response) && routingSessionId !== undefined) {
+				// This binding owns exactly one session's request map. A response not
+				// requested here is a routed protocol error, never a cross-session match.
+				output(error(undefined, "extension_ui_response", "unknown_extension_ui_request"));
 			}
 			return;
 		}
@@ -894,11 +917,14 @@ export function createRpcConnectionHandler(
 	};
 
 	const dispose = async (): Promise<void> => {
+		pendingExtensionRequests.close();
 		unsubscribe?.();
 		unsubscribeBackpressure?.();
 		unsubscribe = undefined;
 		unsubscribeBackpressure = undefined;
-		await runtimeHost.dispose();
+		if (options.disposeRuntime !== false) {
+			await runtimeHost.dispose();
+		}
 	};
 
 	// Perform the initial bind synchronously-scheduled so the handler is ready

--- a/packages/coding-agent/src/modes/rpc/multi-session-host.ts
+++ b/packages/coding-agent/src/modes/rpc/multi-session-host.ts
@@ -1,0 +1,78 @@
+import type { CreateAgentSessionRuntimeFactory } from "../../core/agent-session-runtime.ts";
+import {
+	flushRawStdout,
+	takeOverStdout,
+	waitForRawStdoutBackpressure,
+	writeRawStdout,
+} from "../../core/output-guard.ts";
+import { killTrackedDetachedChildren } from "../../utils/shell.ts";
+import type { RpcConnectionSink } from "./connection-handler.ts";
+import { attachJsonlLineReader } from "./jsonl.ts";
+import type { RpcCommand, RpcResponse } from "./rpc-types.ts";
+import { SessionCommandRouter } from "./session-command-router.ts";
+import { SessionEventWriter } from "./session-event-writer.ts";
+import { RpcSessionRegistry } from "./session-registry.ts";
+
+export interface MultiSessionHostOptions {
+	agentDir: string;
+	createRuntime: CreateAgentSessionRuntimeFactory;
+	cwd: string;
+	permissionPreset?: string;
+	creationModel?: { provider: string; modelId: string };
+	initialThinkingLevel?: string;
+}
+
+/** Plain-stdio host with no eagerly-created AgentSessionRuntime. */
+export async function runMultiSessionHost(options: MultiSessionHostOptions): Promise<never> {
+	takeOverStdout();
+	const sink: RpcConnectionSink = { writeRaw: writeRawStdout, waitForBackpressure: waitForRawStdoutBackpressure };
+	const writer = new SessionEventWriter(sink.writeRaw);
+	const router = new SessionCommandRouter(
+		new RpcSessionRegistry({ agentDir: options.agentDir, createRuntime: options.createRuntime }),
+		writer,
+		options,
+	);
+	let shuttingDown = false;
+	const output = async (response: RpcResponse) => {
+		sink.writeRaw(`${JSON.stringify(response)}\n`);
+		await sink.waitForBackpressure();
+	};
+	const handle = async (line: string) => {
+		let command: RpcCommand;
+		try {
+			command = JSON.parse(line) as RpcCommand;
+		} catch (cause) {
+			await output({
+				type: "response",
+				command: "parse",
+				success: false,
+				error: `Failed to parse command: ${cause instanceof Error ? cause.message : String(cause)}`,
+			});
+			return;
+		}
+		const response = await router.handle(command);
+		if (response) await output(response);
+	};
+	const shutdown = async (exitCode = 0): Promise<never> => {
+		if (shuttingDown) process.exit(exitCode);
+		shuttingDown = true;
+		detach();
+		await router.dispose();
+		await flushRawStdout();
+		process.exit(exitCode);
+	};
+	const onEnd = () => void shutdown();
+	process.stdin.on("end", onEnd);
+	const detachReader = attachJsonlLineReader(process.stdin, (line) => void handle(line));
+	const detach = () => {
+		detachReader();
+		process.stdin.off("end", onEnd);
+	};
+	for (const signal of process.platform === "win32" ? (["SIGTERM"] as const) : (["SIGTERM", "SIGHUP"] as const)) {
+		process.on(signal, () => {
+			killTrackedDetachedChildren();
+			void shutdown(signal === "SIGHUP" ? 129 : 143);
+		});
+	}
+	return new Promise(() => {});
+}

--- a/packages/coding-agent/src/modes/rpc/neo-runtime-options.ts
+++ b/packages/coding-agent/src/modes/rpc/neo-runtime-options.ts
@@ -136,6 +136,7 @@ export const NEO_RUNTIME_OPTION_CARVEOUT_FIELDS: Readonly<Record<string, string>
 	mode: "output mode dispatch; the daemon always speaks rpc over the socket",
 	print: "print-mode dispatch; TTY-less --neo falls back to classic print in the launcher",
 	neo: "the --neo flag itself; consumed by the launcher to choose the neo path",
+	multiSession: "RPC-host process flag; neo daemon workers always use classic per-connection RPC",
 	// Diagnostics are produced by the parser, not a runtime input.
 	diagnostics: "parser-produced diagnostics; not a runtime construction input",
 	// Neo launcher-local flags never forwarded to the daemon runtime.

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -15,6 +15,55 @@
  * logic can also serve one socket connection in the neo daemon. This file owns
  * exactly the process-level concerns that a per-connection handler must NOT
  * touch: stdout takeover, stdin wiring, signal handlers, and process exit.
+ *
+ * ── Multi-session mode (`--multi-session`) ─────────────────────────────────
+ *
+ * Startup: `senpi --mode rpc --multi-session` → NO default session is constructed
+ * (no default `AgentSessionRuntime`, no default extension/watcher load). Classic
+ * `senpi --mode rpc` is byte-identical to today. Mode is fixed at process start;
+ * there is no runtime transition.
+ *
+ * D1 normative table (multi-session mode):
+ *
+ * | Command          | Params                                                                                          | Success data                                    | Notes |
+ * | ---------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------- | ----- |
+ * | `get_protocol_info` | -                                                                                             | `{ protocolVersion: 1, capabilities: ["multi_session"], mode: "classic"|"multi" }` | Answered in BOTH modes; side-effect-free; THE capability probe. |
+ * | `open_session`    | `sessionPath?`, `cwd?`, `provider?`, `modelId?`, `thinkingLevel?`, `permissionPreset?` (all optional; paths MUST be absolute) | `{ sessionId, state: RpcSessionState }`         | `sessionPath` = today's `--session` semantics (open-if-exists else create persisting there); `provider`/`modelId` applied only on create (resume restores the session's model); params form the immutable launch profile (D8). |
+ * | `close_session`   | `sessionId`                                                                                    | `{}`                                            | Aborts active work, awaits agent idle + settled persistence, flushes queued events, detaches subscriptions; its response is the LAST record tagged with that handle — no events after (test-pinned). |
+ * | `list_sessions`   | -                                                                                               | `{ sessions: [{ sessionId, durableSessionId, sessionPath, cwd, name, status }] }` | Includes `opening`/`closing` entries with their status. |
+ * | every existing command | + `sessionId` (REQUIRED in multi mode)                                                      | unchanged                                       | Routed to that session. |
+ *
+ * Identities (D6): response-level `sessionId` = opaque routing handle, unique per
+ * process epoch, ephemeral (dies with the child). `state.sessionId` = durable
+ * JSONL session identity (what a resume cursor stores today). `list_sessions`
+ * exposes both. Clients store both, discard routing handles on child exit, verify
+ * only durable ids against cursors.
+ *
+ * Stable error codes (in the response `error` field, machine-matchable):
+ * `unknown_session`, `session_closing`, `session_path_in_use`, `missing_session_id`
+ * (session-scoped command without `sessionId` in multi mode), `multi_session_disabled`
+ * (`open_session` in classic mode), `invalid_path` (relative `sessionPath`/`cwd`),
+ * `open_failed: <detail>`.
+ *
+ * Tagging: every response/event/`extension_ui_request` belonging to a session
+ * carries top-level `sessionId` (routing handle). `get_protocol_info`/
+ * `list_sessions` responses are untagged. Classic mode: nothing tagged
+ * (byte-identical).
+ *
+ * Ordering guarantee (D9): strict FIFO per session; one total stdout order;
+ * cross-session order unspecified; fair round-robin between sessions' queued
+ * complete records; NO cross-session batch coalescing (per-session event buffers;
+ * the process-wide single-array coalescer in `event-output-buffer.ts` must not
+ * merge records of different sessions into one write). Starvation freedom is NOT
+ * promised (single pipe); a giant tool record delays others — bounded only by
+ * record completion.
+ *
+ * Duplicate/idempotency: duplicate `open_session` while a path reservation is
+ * held → `session_path_in_use`. `close_session` on unknown/already-closed →
+ * `unknown_session` error. Request `id`s are client-owned; the server echoes them
+ * without dedup.
+ *
+ * Full prose docs: `packages/coding-agent/docs/rpc.md` (Multi-session mode).
  */
 
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -17,7 +17,7 @@ import type { SourceInfo } from "../../core/source-info.ts";
 // RPC Commands (stdin)
 // ============================================================================
 
-export type RpcCommand =
+type RpcSessionCommand =
 	// Prompting
 	| {
 			id?: string;
@@ -88,6 +88,41 @@ export type RpcCommand =
 	| { id?: string; type: "login_api_key"; provider: string; key: string }
 	| { id?: string; type: "logout"; provider: string };
 
+/** Stable multi-session protocol error codes. */
+export const RPC_ERROR_UNKNOWN_SESSION = "unknown_session";
+export const RPC_ERROR_SESSION_CLOSING = "session_closing";
+export const RPC_ERROR_SESSION_PATH_IN_USE = "session_path_in_use";
+export const RPC_ERROR_MISSING_SESSION_ID = "missing_session_id";
+export const RPC_ERROR_MULTI_SESSION_DISABLED = "multi_session_disabled";
+export const RPC_ERROR_INVALID_PATH = "invalid_path";
+export const RPC_ERROR_OPEN_FAILED = "open_failed";
+
+export type RpcErrorCode =
+	| typeof RPC_ERROR_UNKNOWN_SESSION
+	| typeof RPC_ERROR_SESSION_CLOSING
+	| typeof RPC_ERROR_SESSION_PATH_IN_USE
+	| typeof RPC_ERROR_MISSING_SESSION_ID
+	| typeof RPC_ERROR_MULTI_SESSION_DISABLED
+	| typeof RPC_ERROR_INVALID_PATH
+	| typeof RPC_ERROR_OPEN_FAILED;
+
+/** Every established command accepts an additive routing envelope. */
+export type RpcCommand =
+	| (RpcSessionCommand & { sessionId?: string })
+	| { id?: string; type: "get_protocol_info" }
+	| {
+			id?: string;
+			type: "open_session";
+			sessionPath?: string;
+			cwd?: string;
+			provider?: string;
+			modelId?: string;
+			thinkingLevel?: ThinkingLevel;
+			permissionPreset?: string;
+	  }
+	| { id?: string; type: "close_session"; sessionId: string }
+	| { id?: string; type: "list_sessions" };
+
 // ============================================================================
 // Auth provider info (get_auth_providers response)
 // ============================================================================
@@ -152,6 +187,37 @@ export interface RpcSessionState {
 
 // Success responses with data
 export type RpcResponse =
+	| {
+			id?: string;
+			type: "response";
+			command: "get_protocol_info";
+			success: true;
+			data: { protocolVersion: 1; capabilities: ["multi_session"]; mode: "classic" | "multi" };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "open_session";
+			success: true;
+			data: { sessionId: string; state: RpcSessionState };
+	  }
+	| { id?: string; type: "response"; command: "close_session"; success: true; data: Record<string, never> }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_sessions";
+			success: true;
+			data: {
+				sessions: Array<{
+					sessionId: string;
+					durableSessionId?: string;
+					sessionPath?: string;
+					cwd: string;
+					name?: string;
+					status: "opening" | "open" | "closing" | "closed";
+				}>;
+			};
+	  }
 	// Prompting (async - events follow)
 	| { id?: string; type: "response"; command: "prompt"; success: true }
 	| { id?: string; type: "response"; command: "steer"; success: true }

--- a/packages/coding-agent/src/modes/rpc/session-binding.ts
+++ b/packages/coding-agent/src/modes/rpc/session-binding.ts
@@ -1,0 +1,46 @@
+import { bindToProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";
+import { createRpcConnectionHandler, type RpcConnectionHandler, type RpcConnectionSink } from "./connection-handler.ts";
+import type { SessionEventWriter } from "./session-event-writer.ts";
+import type { RpcSessionEntry } from "./session-registry.ts";
+
+/** A session-owned adapter around the classic command and extension-UI wiring. */
+export interface RpcSessionBinding {
+	handle(command: object): Promise<void>;
+	dispose(): Promise<void>;
+}
+
+function enqueueRecords(writer: SessionEventWriter, sessionId: string, chunk: string): void {
+	for (const line of chunk.split("\n")) {
+		if (line) writer.enqueue(sessionId, JSON.parse(line) as object);
+	}
+}
+
+/**
+ * Creates the extension UI bridge and subscriptions within the entry's provider
+ * scope. The classic handler remains the single source of command semantics.
+ */
+export async function createRpcSessionBinding(
+	sessionId: string,
+	entry: RpcSessionEntry,
+	writer: SessionEventWriter,
+	requestClose: () => void,
+): Promise<RpcSessionBinding> {
+	if (!entry.runtime) throw new Error("Session runtime was not created");
+	const handler: RpcConnectionHandler = await runWithProviderScope(entry.scope, async () => {
+		const taggedSink: RpcConnectionSink = {
+			writeRaw: bindToProviderScope((chunk: string) => enqueueRecords(writer, sessionId, chunk)),
+			waitForBackpressure: bindToProviderScope(async () => {}),
+		};
+		return createRpcConnectionHandler(entry.runtime! as AgentSessionRuntime, taggedSink, {
+			sessionId,
+			shutdownHandler: bindToProviderScope(requestClose),
+			disposeRuntime: false,
+		});
+	});
+	await handler.ready;
+	return {
+		handle: (command) => runWithProviderScope(entry.scope, () => handler.handleInputLine(JSON.stringify(command))),
+		dispose: () => runWithProviderScope(entry.scope, () => handler.dispose()),
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -1,0 +1,163 @@
+import type { RpcCommand, RpcResponse } from "./rpc-types.ts";
+import {
+	RPC_ERROR_MISSING_SESSION_ID,
+	RPC_ERROR_OPEN_FAILED,
+	RPC_ERROR_SESSION_CLOSING,
+	RPC_ERROR_UNKNOWN_SESSION,
+} from "./rpc-types.ts";
+import { createRpcSessionBinding, type RpcSessionBinding } from "./session-binding.ts";
+import type { SessionEventWriter } from "./session-event-writer.ts";
+import type { RpcSessionLaunchProfile, RpcSessionRegistry } from "./session-registry.ts";
+import { RpcSessionRegistryError } from "./session-registry.ts";
+
+const controls = new Set(["get_protocol_info", "open_session", "close_session", "list_sessions"]);
+
+function error(id: string | undefined, command: string, code: string): RpcResponse {
+	return { id, type: "response", command, success: false, error: code };
+}
+
+/** Routes control messages and enforces a routing handle for every session command. */
+export class SessionCommandRouter {
+	private readonly bindings = new Map<string, RpcSessionBinding>();
+	private readonly registry: RpcSessionRegistry;
+	private readonly writer: SessionEventWriter;
+	private readonly defaults: Pick<
+		RpcSessionLaunchProfile,
+		"cwd" | "permissionPreset" | "creationModel" | "initialThinkingLevel"
+	>;
+
+	constructor(
+		registry: RpcSessionRegistry,
+		writer: SessionEventWriter,
+		defaults: Pick<RpcSessionLaunchProfile, "cwd" | "permissionPreset" | "creationModel" | "initialThinkingLevel">,
+	) {
+		this.registry = registry;
+		this.writer = writer;
+		this.defaults = defaults;
+	}
+
+	async handle(command: RpcCommand): Promise<RpcResponse | undefined> {
+		if (command.type === "get_protocol_info") {
+			return {
+				id: command.id,
+				type: "response",
+				command: "get_protocol_info",
+				success: true,
+				data: { protocolVersion: 1, capabilities: ["multi_session"], mode: "multi" },
+			};
+		}
+		if (command.type === "list_sessions")
+			return {
+				id: command.id,
+				type: "response",
+				command: "list_sessions",
+				success: true,
+				data: { sessions: this.registry.list() },
+			};
+		if (command.type === "open_session") return this.open(command);
+		if (command.type === "close_session") return this.close(command);
+		if (controls.has(command.type)) return undefined;
+		if (!command.sessionId) return error(command.id, command.type, RPC_ERROR_MISSING_SESSION_ID);
+		try {
+			this.registry.getForCommand(command.sessionId, command.type);
+			await this.bindings.get(command.sessionId)?.handle(command);
+			return undefined;
+		} catch (cause) {
+			return error(command.id, command.type, this.code(cause));
+		}
+	}
+
+	async dispose(): Promise<void> {
+		await Promise.all(
+			[...this.bindings.entries()].map(async ([sessionId, binding]) => {
+				await binding.dispose();
+				try {
+					await this.registry.close(sessionId);
+				} catch {
+					/* already closed */
+				}
+			}),
+		);
+		this.bindings.clear();
+	}
+
+	private async open(command: Extract<RpcCommand, { type: "open_session" }>): Promise<RpcResponse | undefined> {
+		try {
+			const opened = await this.registry.openSession({
+				cwd: command.cwd ?? this.defaults.cwd,
+				sessionPath: command.sessionPath,
+				permissionPreset: command.permissionPreset ?? this.defaults.permissionPreset,
+				creationModel:
+					command.provider && command.modelId
+						? { provider: command.provider, modelId: command.modelId }
+						: this.defaults.creationModel,
+				initialThinkingLevel: command.thinkingLevel ?? this.defaults.initialThinkingLevel,
+			});
+			const entry = this.registry.getForCommand(opened.sessionId, "open_session");
+			this.bindings.set(
+				opened.sessionId,
+				await createRpcSessionBinding(
+					opened.sessionId,
+					entry,
+					this.writer,
+					() => void this.close({ type: "close_session", sessionId: opened.sessionId }),
+				),
+			);
+			const state = entry.runtime!.session;
+			this.writer.enqueue(opened.sessionId, {
+				id: command.id,
+				type: "response",
+				command: "open_session",
+				success: true,
+				data: {
+					sessionId: opened.sessionId,
+					state: {
+						model: state.model,
+						thinkingLevel: state.thinkingLevel,
+						isStreaming: state.isStreaming,
+						isCompacting: state.isCompacting,
+						steeringMode: state.steeringMode,
+						followUpMode: state.followUpMode,
+						sessionFile: state.sessionFile,
+						sessionId: state.sessionId,
+						sessionName: state.sessionName,
+						autoCompactionEnabled: state.autoCompactionEnabled,
+						messageCount: state.messages.length,
+						pendingMessageCount: state.pendingMessageCount,
+					},
+				},
+			});
+			return undefined;
+		} catch (cause) {
+			return error(command.id, "open_session", this.code(cause));
+		}
+	}
+
+	private async close(command: Extract<RpcCommand, { type: "close_session" }>): Promise<RpcResponse | undefined> {
+		try {
+			await this.bindings.get(command.sessionId)?.dispose();
+			this.bindings.delete(command.sessionId);
+			await this.registry.close(command.sessionId);
+			this.writer.closeSession(command.sessionId, {
+				id: command.id,
+				type: "response",
+				command: "close_session",
+				success: true,
+				data: {},
+			});
+			return undefined;
+		} catch (cause) {
+			return error(command.id, "close_session", this.code(cause));
+		}
+	}
+
+	private code(cause: unknown): string {
+		if (cause instanceof RpcSessionRegistryError) return cause.code;
+		if (cause instanceof Error && [RPC_ERROR_UNKNOWN_SESSION, RPC_ERROR_SESSION_CLOSING].includes(cause.message)) {
+			return cause.message;
+		}
+		return cause instanceof Error && cause.message
+			? `${RPC_ERROR_OPEN_FAILED}: ${cause.message}`
+			: RPC_ERROR_UNKNOWN_SESSION;
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -25,15 +25,18 @@ export class SessionCommandRouter {
 		RpcSessionLaunchProfile,
 		"cwd" | "permissionPreset" | "creationModel" | "initialThinkingLevel"
 	>;
+	private readonly createBinding: typeof createRpcSessionBinding;
 
 	constructor(
 		registry: RpcSessionRegistry,
 		writer: SessionEventWriter,
 		defaults: Pick<RpcSessionLaunchProfile, "cwd" | "permissionPreset" | "creationModel" | "initialThinkingLevel">,
+		createBinding: typeof createRpcSessionBinding = createRpcSessionBinding,
 	) {
 		this.registry = registry;
 		this.writer = writer;
 		this.defaults = defaults;
+		this.createBinding = createBinding;
 	}
 
 	async handle(command: RpcCommand): Promise<RpcResponse | undefined> {
@@ -70,11 +73,16 @@ export class SessionCommandRouter {
 	async dispose(): Promise<void> {
 		await Promise.all(
 			[...this.bindings.entries()].map(async ([sessionId, binding]) => {
-				await binding.dispose();
 				try {
-					await this.registry.close(sessionId);
+					this.registry.beginClose(sessionId);
 				} catch {
-					/* already closed */
+					return;
+				}
+				try {
+					await binding.dispose();
+				} finally {
+					this.bindings.delete(sessionId);
+					await this.registry.closeMarked(sessionId);
 				}
 			}),
 		);
@@ -82,8 +90,9 @@ export class SessionCommandRouter {
 	}
 
 	private async open(command: Extract<RpcCommand, { type: "open_session" }>): Promise<RpcResponse | undefined> {
+		let opened: { sessionId: string } | undefined;
 		try {
-			const opened = await this.registry.openSession({
+			opened = await this.registry.openSession({
 				cwd: command.cwd ?? this.defaults.cwd,
 				sessionPath: command.sessionPath,
 				permissionPreset: command.permissionPreset ?? this.defaults.permissionPreset,
@@ -93,14 +102,15 @@ export class SessionCommandRouter {
 						: this.defaults.creationModel,
 				initialThinkingLevel: command.thinkingLevel ?? this.defaults.initialThinkingLevel,
 			});
-			const entry = this.registry.getForCommand(opened.sessionId, "open_session");
+			const openedSession = opened;
+			const entry = this.registry.getForCommand(openedSession.sessionId, "open_session");
 			this.bindings.set(
-				opened.sessionId,
-				await createRpcSessionBinding(
-					opened.sessionId,
+				openedSession.sessionId,
+				await this.createBinding(
+					openedSession.sessionId,
 					entry,
 					this.writer,
-					() => void this.close({ type: "close_session", sessionId: opened.sessionId }),
+					() => void this.close({ type: "close_session", sessionId: openedSession.sessionId }),
 				),
 			);
 			const state = entry.runtime!.session;
@@ -129,15 +139,28 @@ export class SessionCommandRouter {
 			});
 			return undefined;
 		} catch (cause) {
+			if (opened) {
+				try {
+					await this.registry.close(opened.sessionId);
+				} catch {
+					/* The open rollback has already removed the entry. */
+				}
+			}
 			return error(command.id, "open_session", this.code(cause));
 		}
 	}
 
 	private async close(command: Extract<RpcCommand, { type: "close_session" }>): Promise<RpcResponse | undefined> {
 		try {
-			await this.bindings.get(command.sessionId)?.dispose();
-			this.bindings.delete(command.sessionId);
-			await this.registry.close(command.sessionId);
+			// This must be the first operation: binding.dispose() awaits teardown and
+			// otherwise leaves a window where commands can enter the old handler.
+			this.registry.beginClose(command.sessionId);
+			try {
+				await this.bindings.get(command.sessionId)?.dispose();
+			} finally {
+				this.bindings.delete(command.sessionId);
+				await this.registry.closeMarked(command.sessionId);
+			}
 			this.writer.closeSession(command.sessionId, {
 				id: command.id,
 				type: "response",

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -1,0 +1,94 @@
+import { serializeJsonLine } from "./jsonl.ts";
+
+type RawWriter = (chunk: string) => void;
+type FlushScheduler = (flush: () => void) => void;
+
+/**
+ * Process-wide stdout scheduler for multi-session RPC mode.
+ *
+ * Each queue contains complete JSONL records for one routing handle. Draining
+ * takes one record per queue in round-robin order, so a busy session cannot
+ * reorder another ready session's next complete record. A record is deliberately
+ * written by itself: coalescing records from different sessions would obscure
+ * the scheduling boundary and violate D9.
+ */
+export class SessionEventWriter {
+	private readonly queues = new Map<string, string[]>();
+	private readonly readySessions: string[] = [];
+	private readonly sealedSessions = new Set<string>();
+	private readonly writeRaw: RawWriter;
+	private readonly scheduleFlush: FlushScheduler;
+	private flushScheduled = false;
+	private flushing = false;
+
+	constructor(writeRaw: RawWriter, scheduleFlush: FlushScheduler = queueMicrotask) {
+		this.writeRaw = writeRaw;
+		this.scheduleFlush = scheduleFlush;
+	}
+
+	/** Queue one session-owned response, event, or extension UI request. */
+	enqueue(sessionId: string, value: object): boolean {
+		if (this.sealedSessions.has(sessionId)) return false;
+		const queue = this.queues.get(sessionId);
+		const record = serializeJsonLine({ ...value, sessionId });
+		if (queue) {
+			queue.push(record);
+		} else {
+			this.queues.set(sessionId, [record]);
+			this.readySessions.push(sessionId);
+		}
+		this.requestFlush();
+		return true;
+	}
+
+	/**
+	 * Prevent subsequent records for a session and append its terminal response.
+	 * Existing records retain FIFO order; this response is therefore that
+	 * session's final stdout record.
+	 */
+	closeSession(sessionId: string, response: object): void {
+		if (this.sealedSessions.has(sessionId)) return;
+		this.sealedSessions.add(sessionId);
+		const queue = this.queues.get(sessionId);
+		const record = serializeJsonLine({ ...response, sessionId });
+		if (queue) {
+			queue.push(record);
+		} else {
+			this.queues.set(sessionId, [record]);
+			this.readySessions.push(sessionId);
+		}
+		this.requestFlush();
+	}
+
+	/** Synchronously drain all currently complete records in fair queue order. */
+	flush(): void {
+		if (this.flushing) return;
+		this.flushScheduled = false;
+		this.flushing = true;
+		try {
+			while (this.readySessions.length > 0) {
+				const sessionId = this.readySessions.shift()!;
+				const queue = this.queues.get(sessionId);
+				const record = queue?.shift();
+				if (!record) continue;
+
+				// Exactly one complete record per write. In particular, records from
+				// different sessions must never share a batch.
+				this.writeRaw(record);
+				if (queue && queue.length > 0) {
+					this.readySessions.push(sessionId);
+				} else {
+					this.queues.delete(sessionId);
+				}
+			}
+		} finally {
+			this.flushing = false;
+		}
+	}
+
+	private requestFlush(): void {
+		if (this.flushScheduled || this.flushing) return;
+		this.flushScheduled = true;
+		this.scheduleFlush(() => this.flush());
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/session-extension-ui-requests.ts
+++ b/packages/coding-agent/src/modes/rpc/session-extension-ui-requests.ts
@@ -1,0 +1,34 @@
+import type { RpcExtensionUIResponse } from "./rpc-types.ts";
+
+type PendingRequest = {
+	resolve: (value: RpcExtensionUIResponse) => void;
+	reject: (error: Error) => void;
+};
+
+/** Per-session extension UI request state; never share this map between bindings. */
+export class SessionExtensionUiRequests {
+	private readonly pending = new Map<string, PendingRequest>();
+
+	set(id: string, request: PendingRequest): void {
+		this.pending.set(id, request);
+	}
+
+	delete(id: string): void {
+		this.pending.delete(id);
+	}
+
+	resolve(response: RpcExtensionUIResponse): boolean {
+		const request = this.pending.get(response.id);
+		if (!request) return false;
+		this.pending.delete(response.id);
+		request.resolve(response);
+		return true;
+	}
+
+	close(): void {
+		for (const request of this.pending.values()) {
+			request.reject(new Error("Extension UI request cancelled: session closed"));
+		}
+		this.pending.clear();
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -78,25 +78,33 @@ export class RpcSessionRegistry {
 		if (sessionPath && this.reservations.has(sessionPath)) throw new RpcSessionRegistryError("session_path_in_use");
 		if (sessionPath) this.reservations.add(sessionPath);
 
+		// Resume vs create parity (D1 + omo SenpiSessionRuntime.ts:198-200):
+		// --provider/--model map to creationModel and are applied ONLY on create.
+		// Resuming an existing file restores the session's own model, so the
+		// creationModel must not reach runtime construction on resume.
+		const isResume = sessionPath !== undefined && existsSync(sessionPath);
+		const storedProfile = frozenProfile({ ...profile, ...(sessionPath ? { sessionPath } : {}) });
+		const runtimeProfile = isResume ? frozenProfile({ ...storedProfile, creationModel: undefined }) : storedProfile;
+
 		const handle = `rpc-${++this.nextHandle}`;
 		const entry: RpcSessionEntry = {
 			state: "opening",
 			scope: new ProviderScope(),
-			profile: frozenProfile({ ...profile, ...(sessionPath ? { sessionPath } : {}) }),
+			profile: storedProfile,
 			sessionPath,
 			lifecycleMutex: Promise.resolve(),
 		};
 		this.entries.set(handle, entry);
 		try {
 			const manager = sessionPath
-				? SessionManager.open(sessionPath, undefined, entry.profile.cwd)
-				: SessionManager.create(entry.profile.cwd);
+				? SessionManager.open(sessionPath, undefined, storedProfile.cwd)
+				: SessionManager.create(storedProfile.cwd);
 			entry.runtime = await runWithProviderScope(entry.scope, () =>
 				createAgentSessionRuntime(this.options.createRuntime, {
 					cwd: manager.getCwd(),
 					agentDir: this.options.agentDir,
 					sessionManager: manager,
-					launchProfile: entry.profile,
+					launchProfile: runtimeProfile,
 				}),
 			);
 			entry.durableSessionId = manager.getSessionId();

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -114,9 +114,22 @@ export class RpcSessionRegistry {
 			entry.state = "open";
 			return { sessionId: handle, durableSessionId: entry.durableSessionId, sessionPath: entry.sessionPath };
 		} catch (error) {
-			this.entries.delete(handle);
-			if (sessionPath) this.reservations.delete(sessionPath);
-			await entry.scope.close?.();
+			// Runtime construction may have started extensions, watchers, and provider
+			// registrations before it rejects. Keep the reservation and entry private
+			// until all of those resources have been torn down, then release them as
+			// one rollback so the path can immediately be opened again.
+			try {
+				await entry.runtime?.dispose();
+			} catch {
+				// The original construction error remains the externally visible cause.
+			} finally {
+				try {
+					await entry.scope.close?.();
+				} finally {
+					this.entries.delete(handle);
+					if (sessionPath) this.reservations.delete(sessionPath);
+				}
+			}
 			if (error instanceof RpcSessionRegistryError) throw error;
 			throw new RpcSessionRegistryError("open_failed");
 		}
@@ -132,10 +145,26 @@ export class RpcSessionRegistry {
 		return entry;
 	}
 
-	async close(handle: string): Promise<void> {
+	/**
+	 * Starts a close synchronously. Call this before disposing any session-owned
+	 * binding so a concurrent command cannot reach a half-disposed handler.
+	 */
+	beginClose(handle: string): RpcSessionEntry {
 		const entry = this.entries.get(handle);
 		if (entry?.state !== "open") throw new RpcSessionRegistryError("unknown_session");
 		entry.state = "closing";
+		return entry;
+	}
+
+	async close(handle: string): Promise<void> {
+		this.beginClose(handle);
+		return this.closeMarked(handle);
+	}
+
+	/** Completes a close previously made visible by beginClose(). */
+	async closeMarked(handle: string): Promise<void> {
+		const entry = this.entries.get(handle);
+		if (entry?.state !== "closing") throw new RpcSessionRegistryError("unknown_session");
 		entry.lifecycleMutex = (async () => {
 			try {
 				await entry.runtime?.session.abort();

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -1,0 +1,167 @@
+import { existsSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
+import { ProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import {
+	type AgentSessionLaunchProfile,
+	type AgentSessionRuntime,
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionRuntime,
+} from "../../core/agent-session-runtime.ts";
+import { SessionManager } from "../../core/session-manager.ts";
+
+/** The immutable flags selected when a routing session is opened. */
+export interface RpcSessionLaunchProfile extends AgentSessionLaunchProfile {
+	sessionPath?: string;
+}
+
+export type SessionRuntime = Pick<AgentSessionRuntime, "session" | "dispose">;
+export type RpcSessionState = "opening" | "open" | "closing" | "closed";
+
+export interface RpcSessionEntry {
+	state: RpcSessionState;
+	runtime?: SessionRuntime;
+	scope: ProviderScope;
+	profile: Readonly<RpcSessionLaunchProfile>;
+	durableSessionId?: string;
+	sessionPath?: string;
+	lifecycleMutex: Promise<void>;
+}
+
+export class RpcSessionRegistryError extends Error {
+	readonly code: "unknown_session" | "session_closing" | "session_path_in_use" | "invalid_path" | "open_failed";
+
+	constructor(code: RpcSessionRegistryError["code"]) {
+		super(code);
+		this.code = code;
+		this.name = "RpcSessionRegistryError";
+	}
+}
+
+export interface RpcSessionRegistryOptions {
+	agentDir: string;
+	createRuntime: CreateAgentSessionRuntimeFactory;
+}
+
+export interface OpenRpcSession {
+	sessionId: string;
+	durableSessionId: string;
+	sessionPath?: string;
+}
+
+function canonicalPath(path: string): string {
+	const absolutePath = resolve(path);
+	if (existsSync(absolutePath)) return realpathSync(absolutePath);
+	return `${realpathSync(dirname(absolutePath))}/${basename(absolutePath)}`;
+}
+
+function frozenProfile(profile: RpcSessionLaunchProfile): Readonly<RpcSessionLaunchProfile> {
+	return Object.freeze({
+		...profile,
+		...(profile.creationModel ? { creationModel: Object.freeze({ ...profile.creationModel }) } : {}),
+	});
+}
+
+/** Process-local lifecycle owner for multi-session RPC runtimes. */
+export class RpcSessionRegistry {
+	private readonly entries = new Map<string, RpcSessionEntry>();
+	private readonly reservations = new Set<string>();
+	private nextHandle = 0;
+	private readonly options: RpcSessionRegistryOptions;
+
+	constructor(options: RpcSessionRegistryOptions) {
+		this.options = options;
+	}
+
+	async openSession(profile: RpcSessionLaunchProfile): Promise<OpenRpcSession> {
+		this.validateProfile(profile);
+		const sessionPath = profile.sessionPath ? canonicalPath(profile.sessionPath) : undefined;
+		if (sessionPath && this.reservations.has(sessionPath)) throw new RpcSessionRegistryError("session_path_in_use");
+		if (sessionPath) this.reservations.add(sessionPath);
+
+		const handle = `rpc-${++this.nextHandle}`;
+		const entry: RpcSessionEntry = {
+			state: "opening",
+			scope: new ProviderScope(),
+			profile: frozenProfile({ ...profile, ...(sessionPath ? { sessionPath } : {}) }),
+			sessionPath,
+			lifecycleMutex: Promise.resolve(),
+		};
+		this.entries.set(handle, entry);
+		try {
+			const manager = sessionPath
+				? SessionManager.open(sessionPath, undefined, entry.profile.cwd)
+				: SessionManager.create(entry.profile.cwd);
+			entry.runtime = await runWithProviderScope(entry.scope, () =>
+				createAgentSessionRuntime(this.options.createRuntime, {
+					cwd: manager.getCwd(),
+					agentDir: this.options.agentDir,
+					sessionManager: manager,
+					launchProfile: entry.profile,
+				}),
+			);
+			entry.durableSessionId = manager.getSessionId();
+			entry.sessionPath ??= manager.getSessionFile();
+			entry.state = "open";
+			return { sessionId: handle, durableSessionId: entry.durableSessionId, sessionPath: entry.sessionPath };
+		} catch (error) {
+			this.entries.delete(handle);
+			if (sessionPath) this.reservations.delete(sessionPath);
+			await entry.scope.close?.();
+			if (error instanceof RpcSessionRegistryError) throw error;
+			throw new RpcSessionRegistryError("open_failed");
+		}
+	}
+
+	getForCommand(handle: string, command: string): RpcSessionEntry {
+		const entry = this.entries.get(handle);
+		if (!entry) throw new RpcSessionRegistryError("unknown_session");
+		if (entry.state === "closing" && !["abort", "abort_bash", "extension_ui_response"].includes(command)) {
+			throw new RpcSessionRegistryError("session_closing");
+		}
+		if (entry.state !== "open" && entry.state !== "closing") throw new RpcSessionRegistryError("unknown_session");
+		return entry;
+	}
+
+	async close(handle: string): Promise<void> {
+		const entry = this.entries.get(handle);
+		if (entry?.state !== "open") throw new RpcSessionRegistryError("unknown_session");
+		entry.state = "closing";
+		entry.lifecycleMutex = (async () => {
+			try {
+				await entry.runtime?.session.abort();
+				await entry.runtime?.session.waitForIdle();
+				await entry.runtime?.dispose();
+				await entry.scope.close?.();
+			} finally {
+				entry.state = "closed";
+				this.entries.delete(handle);
+				if (entry.sessionPath) this.reservations.delete(entry.sessionPath);
+			}
+		})();
+		return entry.lifecycleMutex;
+	}
+
+	list(): Array<{
+		sessionId: string;
+		durableSessionId?: string;
+		sessionPath?: string;
+		cwd: string;
+		name?: string;
+		status: RpcSessionState;
+	}> {
+		return [...this.entries].map(([sessionId, entry]) => ({
+			sessionId,
+			durableSessionId: entry.durableSessionId,
+			sessionPath: entry.sessionPath,
+			cwd: entry.profile.cwd,
+			name: entry.runtime?.session.sessionManager.getSessionName(),
+			status: entry.state,
+		}));
+	}
+
+	private validateProfile(profile: RpcSessionLaunchProfile): void {
+		if (!isAbsolute(profile.cwd) || (profile.sessionPath !== undefined && !isAbsolute(profile.sessionPath))) {
+			throw new RpcSessionRegistryError("invalid_path");
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -79,12 +79,14 @@ export class RpcSessionRegistry {
 		if (sessionPath) this.reservations.add(sessionPath);
 
 		// Resume vs create parity (D1 + omo SenpiSessionRuntime.ts:198-200):
-		// --provider/--model map to creationModel and are applied ONLY on create.
-		// Resuming an existing file restores the session's own model, so the
-		// creationModel must not reach runtime construction on resume.
+		// Create-only launch semantics mirror classic startup flags. A resumed
+		// session restores its persisted model and thinking level instead of being
+		// overridden by the new open_session request.
 		const isResume = sessionPath !== undefined && existsSync(sessionPath);
 		const storedProfile = frozenProfile({ ...profile, ...(sessionPath ? { sessionPath } : {}) });
-		const runtimeProfile = isResume ? frozenProfile({ ...storedProfile, creationModel: undefined }) : storedProfile;
+		const runtimeProfile = isResume
+			? frozenProfile({ ...storedProfile, creationModel: undefined, initialThinkingLevel: undefined })
+			: storedProfile;
 
 		const handle = `rpc-${++this.nextHandle}`;
 		const entry: RpcSessionEntry = {

--- a/packages/coding-agent/test/fixtures/rpc-classic-harness.ts
+++ b/packages/coding-agent/test/fixtures/rpc-classic-harness.ts
@@ -1,0 +1,221 @@
+/**
+ * In-process classic-RPC characterization helpers (todo 2).
+ *
+ * Mirrors the harness in `test/rpc-prompt-response-semantics.test.ts`. The
+ * `vi.mock` calls MUST live in the test file itself (vitest hoists them per
+ * file), so this module exports only the mock-independent helpers: the mock
+ * assistant stream, a fake `AgentSessionRuntime` whose `session` getter is
+ * mutable (so `new_session`/`switch_session`/`fork` can be characterized as
+ * rebinding the single active session), and small line-parsing utilities.
+ *
+ * Every line the connection-handler writes (responses, events, extension-UI
+ * requests) flows through the mocked `writeRawStdout` sink captured in the test
+ * file — exactly the boundary the multi-session host (todo 8/9) will tag with
+ * `sessionId`. Pins assert that boundary carries NO top-level `sessionId` today.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	getModel,
+	type Model,
+} from "@earendil-works/pi-ai/compat";
+import { vi } from "vitest";
+import { AgentSession } from "../../src/core/agent-session.ts";
+import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.ts";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "../model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "../utilities.ts";
+
+/** Captured wire state shared between the mocked modules and the test. */
+export interface FakeRpcIo {
+	/** Every raw chunk written to `writeRawStdout`, in order. */
+	outputLines: string[];
+	/** The injected stdin line handler; commands are driven through this. */
+	lineHandler: ((line: string) => void) | undefined;
+}
+
+/**
+ * The mutable handle returned to a test. `host.session` is the live getter the
+ * connection-handler reads during `rebindSession`; swapping it characterizes
+ * `new_session`/`switch_session`/`fork` rebinding the single active session.
+ */
+export interface FakeRuntimeHost {
+	runtimeHost: AgentSessionRuntime;
+	cleanup(): Promise<void>;
+}
+
+export interface CreateHostOptions {
+	/** When true, the host has a SECOND session available for swap-based commands. */
+	withSwapSession: boolean;
+	/** When true, auth is configured so prompt preflight succeeds. */
+	withAuth: boolean;
+	/** Delay before the mock assistant stream completes (ms). */
+	responseDelayMs: number;
+	/** Override model (defaults to a real anthropic builtin model). */
+	model?: Model<any>;
+}
+
+export class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+export function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+async function createAgentSession(
+	tempDir: string,
+	model: Model<any>,
+	withAuth: boolean,
+	responseDelayMs: number,
+	authStorage: AuthStorage,
+): Promise<{ session: AgentSession; cleanup: () => Promise<void> }> {
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: "Test", tools: [] },
+		streamFn: (_model, _context, _options) => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial: createAssistantMessage("") });
+				setTimeout(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("ok") });
+				}, responseDelayMs);
+			});
+			return stream;
+		},
+	});
+
+	const sessionManager = SessionManager.inMemory();
+	const settingsManager = SettingsManager.create(tempDir, tempDir);
+	const modelRegistry = await createModelRegistry(authStorage, tempDir);
+	if (withAuth) {
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+	}
+
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settingsManager,
+		cwd: tempDir,
+		modelRuntime: getModelRuntime(modelRegistry),
+		resourceLoader: createTestResourceLoader(),
+	});
+
+	return {
+		session,
+		cleanup: async () => {
+			try {
+				if (session.isStreaming) await session.abort();
+			} catch {
+				// ignore test cleanup failures
+			}
+			session.dispose();
+		},
+	};
+}
+
+/**
+ * Build a fake `AgentSessionRuntime` whose `session` getter is mutable so
+ * `new_session`/`switch_session`/`fork` can be characterized as rebinding the
+ * single active session. The `newSession`/`switchSession`/`fork` stubs swap the
+ * live session and report `cancelled: false` so the connection-handler's
+ * `rebindSession()` runs against the new session.
+ */
+export async function createFakeRuntimeHost(options: CreateHostOptions): Promise<FakeRuntimeHost> {
+	const tempDir = join(tmpdir(), `pi-rpc-classic-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(tempDir, { recursive: true });
+
+	const model = options.model ?? getModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Test model not found");
+
+	const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	const primary = await createAgentSession(tempDir, model, options.withAuth, options.responseDelayMs, authStorage);
+	let secondary: { session: AgentSession; cleanup: () => Promise<void> } | undefined;
+	if (options.withSwapSession) {
+		secondary = await createAgentSession(tempDir, model, options.withAuth, options.responseDelayMs, authStorage);
+	}
+
+	let live = primary.session;
+	const host = {
+		get session() {
+			return live;
+		},
+		newSession: vi.fn(async () => {
+			if (secondary) live = secondary.session;
+			return { cancelled: false };
+		}),
+		switchSession: vi.fn(async () => {
+			if (secondary) live = secondary.session;
+			return { cancelled: false };
+		}),
+		fork: vi.fn(async () => {
+			if (secondary) live = secondary.session;
+			return { cancelled: false, selectedText: "forked" };
+		}),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn(),
+	} as unknown as AgentSessionRuntime;
+
+	return {
+		runtimeHost: host,
+		cleanup: async () => {
+			await primary.cleanup();
+			await secondary?.cleanup();
+			if (existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Line parsing utilities
+// ---------------------------------------------------------------------------
+
+export type ParsedOutputLine = Record<string, unknown>;
+
+/**
+ * Parse the captured raw chunks into individual JSON records.
+ *
+ * A single `writeRawStdout` chunk may contain multiple LF-separated records
+ * (the event-output-buffer coalesces same-tick events into one write), so this
+ * splits on `\n` and discards empty trailing fragments.
+ */
+export function parseOutputLines(outputLines: readonly string[]): ParsedOutputLine[] {
+	return outputLines
+		.join("")
+		.split("\n")
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line) as ParsedOutputLine);
+}

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applyHttpProxySettings } from "../src/core/http-dispatcher.ts";
+import { applyHttpProxySettings, configureHttpDispatcher } from "../src/core/http-dispatcher.ts";
 
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY"] as const;
 
@@ -49,5 +49,18 @@ describe("http proxy settings", () => {
 
 		expect(process.env.HTTP_PROXY).toBeUndefined();
 		expect(process.env.HTTPS_PROXY).toBeUndefined();
+	});
+
+	it("pins one process-global dispatcher configuration for multi-session RPC", () => {
+		process.argv.push("--multi-session");
+		try {
+			configureHttpDispatcher(31_000);
+			expect(() => configureHttpDispatcher(32_000)).toThrow(
+				"Multi-session RPC shares one process-global Undici dispatcher",
+			);
+		} finally {
+			const index = process.argv.lastIndexOf("--multi-session");
+			if (index >= 0) process.argv.splice(index, 1);
+		}
 	});
 });

--- a/packages/coding-agent/test/mcp-session-isolation.test.ts
+++ b/packages/coding-agent/test/mcp-session-isolation.test.ts
@@ -1,0 +1,187 @@
+import { existsSync } from "node:fs";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { ConfigReloadHandoffRegistry } from "../src/core/extensions/builtin/config-reload/index.ts";
+import { configureMcpElicitation } from "../src/core/extensions/builtin/mcp/elicitation.ts";
+import { applyMcpOutputGuard } from "../src/core/extensions/builtin/mcp/guard/output-guard.ts";
+import { registerMcpPromptCommands } from "../src/core/extensions/builtin/mcp/prompts.ts";
+import { McpService } from "../src/core/extensions/builtin/mcp/service.ts";
+import { clearConfigValueCache, resolveConfigValue } from "../src/core/resolve-config-value.ts";
+import { capturingPi } from "./mcp/fixtures/register-call.ts";
+import { cleanupRoots, makeRoot, setConfig, stdioServer } from "./mcp/fixtures/service-lifecycle.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+const services: McpService[] = [];
+
+afterEach(async () => {
+	await Promise.all(services.splice(0).map((service) => service.dispose("quit")));
+	await cleanupRoots(cleanupTasks);
+	clearConfigValueCache();
+});
+
+function createService(): McpService {
+	const service = new McpService();
+	services.push(service);
+	return service;
+}
+
+function commandRecorder() {
+	const commands = new Map<string, { handler: (args: string, ctx: never) => Promise<void> }>();
+	return {
+		commands,
+		registerCommand: (name: string, command: { handler: (args: string, ctx: never) => Promise<void> }) =>
+			commands.set(name, command),
+	};
+}
+
+async function waitForConnection(service: McpService, name: string): Promise<void> {
+	const connection = service.getConnection(name);
+	if (!connection) throw new Error(`missing ${name} connection`);
+	if (connection.state === "connected") return;
+	await new Promise<void>((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error(`${name} did not connect`)), 10_000);
+		const unsubscribe = connection.onStateChange((event) => {
+			if (event.state !== "connected") return;
+			clearTimeout(timeout);
+			unsubscribe();
+			resolve();
+		});
+	});
+}
+
+function spilledPath(result: readonly { type: string; text?: string }[]): string {
+	const text = result[0]?.text ?? "";
+	const match = /Full output saved to: (.+)/.exec(text);
+	if (!match?.[1]) throw new Error("expected spill path");
+	return match[1];
+}
+
+describe("MCP session isolation", () => {
+	it("keeps B's connection, prompts, and elicitation alive when A closes", async () => {
+		const rootA = makeRoot("session-a", cleanupTasks);
+		const rootB = makeRoot("session-b", cleanupTasks);
+		setConfig(rootA, { shared: { ...stdioServer(["--tools", "1"]), lifecycle: "eager" } });
+		setConfig(rootB, { shared: { ...stdioServer(["--tools", "2"]), lifecycle: "eager" } });
+		const alpha = createService();
+		const bravo = createService();
+		const piA = capturingPi();
+		const piB = capturingPi();
+
+		await alpha.attachSession(
+			{ type: "session_start", reason: "startup" },
+			{ cwd: rootA.cwd, isProjectTrusted: () => true },
+			piA,
+			{
+				agentDir: rootA.agentDir,
+			},
+		);
+		await bravo.attachSession(
+			{ type: "session_start", reason: "startup" },
+			{ cwd: rootB.cwd, isProjectTrusted: () => true },
+			piB,
+			{
+				agentDir: rootB.agentDir,
+			},
+		);
+		await waitForConnection(alpha, "shared");
+		await waitForConnection(bravo, "shared");
+
+		const sharedPromptServer = {
+			connection: {
+				client: {
+					getPrompt: async ({ arguments: args }: { arguments?: Record<string, string> }) => ({
+						messages: [{ content: { text: `Hello ${args?.name ?? ""}`, type: "text" }, role: "user" }],
+					}),
+				},
+			},
+			prompts: [{ arguments: [{ name: "name", required: true }], name: "fixture_prompt" }],
+			server: "shared",
+		};
+		const alphaRecorder = commandRecorder();
+		registerMcpPromptCommands(alpha, alphaRecorder as never, [sharedPromptServer] as never);
+		const recorder = commandRecorder();
+		registerMcpPromptCommands(bravo, recorder as never, [sharedPromptServer] as never);
+		const prompt = recorder.commands.get("mcp:shared:fixture_prompt");
+		expect(prompt).toBeDefined();
+
+		bravo.setMcpElicitationUiProvider(() => ({ input: async () => "from-b" }) as never);
+		let elicitationHandler:
+			| ((request: { params: Record<string, unknown> }) => Promise<{ action: string }>)
+			| undefined;
+		const client = {
+			setRequestHandler: (_schema: unknown, handler: typeof elicitationHandler) => {
+				elicitationHandler = handler;
+			},
+		} as unknown as Client;
+		configureMcpElicitation(client, bravo);
+
+		await alpha.dispose("quit");
+		expect(bravo.getConnection("shared")?.state).toBe("connected");
+		let editorText = "";
+		await prompt?.handler("", {
+			ui: {
+				input: async () => "B",
+				notify: () => {},
+				setEditorText: (text: string) => {
+					editorText = text;
+				},
+			},
+		} as never);
+		expect(editorText).toBe("Hello B");
+		const elicitation = await elicitationHandler?.({
+			params: { message: "B asks", requestedSchema: { properties: { value: { type: "string" } } } },
+		});
+		expect(elicitation).toMatchObject({ action: "accept", content: { value: "from-b" } });
+	});
+
+	it("keys reload handoffs, OAuth guards, and artifacts by session", async () => {
+		const handoffs = new ConfigReloadHandoffRegistry<string>();
+		const [aHandoff, bHandoff] = await Promise.all([
+			Promise.resolve().then(() => {
+				handoffs.set("A", "handoff-a");
+				return handoffs.take("A");
+			}),
+			Promise.resolve().then(() => {
+				handoffs.set("B", "handoff-b");
+				return handoffs.take("B");
+			}),
+		]);
+		expect(aHandoff).toBe("handoff-a");
+		expect(bHandoff).toBe("handoff-b");
+
+		const alpha = createService();
+		const bravo = createService();
+		expect(alpha.beginInteractiveAuth("shared")).toBe(true);
+		expect(bravo.beginInteractiveAuth("shared")).toBe(true);
+		expect(alpha.beginInteractiveAuth("shared")).toBe(false);
+		alpha.endInteractiveAuth("shared");
+		bravo.endInteractiveAuth("shared");
+
+		const rootA = makeRoot("artifacts-a", cleanupTasks);
+		const rootB = makeRoot("artifacts-b", cleanupTasks);
+		const huge = "x".repeat(60_000);
+		const aPath = spilledPath(
+			await applyMcpOutputGuard([{ type: "text", text: huge }], {
+				agentDir: rootA.agentDir,
+				artifacts: alpha.getMcpOutputArtifacts(),
+				server: "shared",
+			}),
+		);
+		const bPath = spilledPath(
+			await applyMcpOutputGuard([{ type: "text", text: huge }], {
+				agentDir: rootB.agentDir,
+				artifacts: bravo.getMcpOutputArtifacts(),
+				server: "shared",
+			}),
+		);
+		await alpha.dispose("quit");
+		expect(existsSync(aPath)).toBe(false);
+		expect(existsSync(bPath)).toBe(true);
+	});
+
+	it("does not cache command results across explicit session environments", () => {
+		const command = '!printf "$MCP_SESSION_VALUE"';
+		expect(resolveConfigValue(command, { MCP_SESSION_VALUE: "A" })).toBe("A");
+		expect(resolveConfigValue(command, { MCP_SESSION_VALUE: "B" })).toBe("B");
+	});
+});

--- a/packages/coding-agent/test/rpc-classic-compat.test.ts
+++ b/packages/coding-agent/test/rpc-classic-compat.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Classic single-session RPC characterization pin suite (plan todo 2).
+ *
+ * Pins the CURRENT classic `--mode rpc` behavior BEFORE any multi-session
+ * protocol change, so a later regression (an accidental `sessionId` envelope,
+ * a changed error shape, a broken rebind) is caught immediately. This file is
+ * test-only: it touches no production code.
+ *
+ * Harness: mirrors `test/rpc-prompt-response-semantics.test.ts` — it mocks
+ * `output-guard` (capturing EVERY raw JSONL line emitted at the
+ * `writeRawStdout` boundary — the true wire format) and `rpc/jsonl` (injecting
+ * a controllable `lineHandler`), then runs `runRpcMode` in-process against a
+ * fake `AgentSessionRuntime`. No child process is spawned, so the suite is
+ * independent of compiled workspace `dist` and of concurrent todo-1 pi-ai
+ * build state.
+ *
+ * Pins:
+ *  (a) scripted prompt -> events -> response flow asserting EVERY emitted JSON
+ *      line lacks a top-level `sessionId` key (every captured line iterated).
+ *  (b) `new_session`/`switch_session`/`fork` rebind the single active session.
+ *  (c) the exact current unknown-command error response shape, captured as a
+ *      documented inline fixture (corroboration only — the capability gate
+ *      uses `get_protocol_info`, todo 8).
+ *
+ * Mutation proof: a throwaway test monkey-patches the captured write path to
+ * inject a top-level `sessionId` key into one emitted line and confirms pin (a)
+ * would fail — proving the assertion is load-bearing, not vacuous.
+ */
+
+import { setMaxListeners } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runRpcMode } from "../src/modes/rpc/rpc-mode.ts";
+import { createFakeRuntimeHost, type ParsedOutputLine, parseOutputLines } from "./fixtures/rpc-classic-harness.ts";
+
+// ---------------------------------------------------------------------------
+// Mocked modules — capture every raw output line at the writeRawStdout boundary
+// ---------------------------------------------------------------------------
+
+const rpcIo = {
+	outputLines: [] as string[],
+	lineHandler: undefined as ((line: string) => void) | undefined,
+};
+
+vi.mock("../src/core/output-guard.js", () => ({
+	flushRawStdout: vi.fn(async () => {}),
+	takeOverStdout: vi.fn(),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+	writeRawStdout: (chunk: string) => {
+		rpcIo.outputLines.push(chunk);
+	},
+}));
+
+vi.mock("../src/modes/interactive/theme/theme.js", () => ({ theme: {} }));
+
+vi.mock("../src/modes/rpc/jsonl.js", () => ({
+	attachJsonlLineReader: vi.fn((_stream: NodeJS.ReadableStream, onLine: (line: string) => void) => {
+		rpcIo.lineHandler = onLine;
+		return () => {};
+	}),
+	serializeJsonLine: (value: unknown) => `${JSON.stringify(value)}\n`,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface StartedRpc {
+	lineHandler: (line: string) => void;
+	cleanup: () => Promise<void>;
+}
+
+async function startClassicRpc(withSwapSession = false): Promise<StartedRpc> {
+	rpcIo.outputLines = [];
+	rpcIo.lineHandler = undefined;
+
+	const host = await createFakeRuntimeHost({
+		withSwapSession,
+		withAuth: true,
+		responseDelayMs: 0,
+	});
+	void runRpcMode(host.runtimeHost);
+	await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
+
+	return {
+		lineHandler: rpcIo.lineHandler!,
+		cleanup: host.cleanup,
+	};
+}
+
+/** Send a JSON command and return its id for correlation. */
+function sendCommand(lineHandler: (line: string) => void, command: Record<string, unknown>): string {
+	const id = `c-${Math.random().toString(36).slice(2, 10)}`;
+	lineHandler(JSON.stringify({ id, ...command }));
+	return id;
+}
+
+/** All parsed records emitted so far. */
+function capturedRecords(): ParsedOutputLine[] {
+	return parseOutputLines(rpcIo.outputLines);
+}
+
+/** Records correlating to a request id. */
+function recordsFor(id: string): ParsedOutputLine[] {
+	return capturedRecords().filter((record) => record.id === id);
+}
+
+/** The single response for a request id (prompt/async commands emit exactly one). */
+function responseFor(id: string): ParsedOutputLine | undefined {
+	return capturedRecords().find((record) => record.id === id && record.type === "response");
+}
+
+/**
+ * The core pin (a) assertion: iterate EVERY captured line and assert none has a
+ * top-level `sessionId` key. Extracted so the mutation-proof test reuses it.
+ */
+function assertNoSessionIdTagging(label: string): void {
+	const records = capturedRecords();
+	expect(records.length, `${label}: expected at least one emitted line`).toBeGreaterThan(0);
+	for (const record of records) {
+		expect(
+			Object.hasOwn(record, "sessionId"),
+			`${label}: classic line must NOT carry a top-level sessionId key, got ${JSON.stringify(record)}`,
+		).toBe(false);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("Classic single-session RPC characterization pins (todo 2)", () => {
+	beforeEach(() => {
+		// runRpcMode registers SIGTERM/SIGHUP/process.stdin listeners per call and
+		// the in-process mock never exits the process to clean them up; raise the
+		// ceiling on process + stdin so a suite of many RPC starts does not warn.
+		setMaxListeners(0, process);
+		setMaxListeners(0, process.stdin);
+	});
+	afterEach(() => {
+		rpcIo.outputLines = [];
+		rpcIo.lineHandler = undefined;
+	});
+
+	// -------------------------------------------------------------------------
+	// Pin (a): scripted prompt -> events -> response; EVERY line lacks sessionId
+	// -------------------------------------------------------------------------
+
+	describe("(a) no top-level sessionId on any emitted JSON line", () => {
+		it("a complete prompt->events->response flow emits no sessionId on any line", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				const id = sendCommand(lineHandler, { type: "prompt", message: "hello" });
+
+				// Wait for the authoritative prompt success response AND the
+				// agent_settled event that closes the turn (the mock stream
+				// resolves on a microtask + 0ms timer).
+				await vi.waitFor(() => {
+					const responses = recordsFor(id).filter((r) => r.type === "response" && r.command === "prompt");
+					expect(responses.length, "expected exactly one prompt response").toBe(1);
+					expect(responses[0]?.success).toBe(true);
+					expect(
+						capturedRecords().some((r) => r.type === "agent_settled"),
+						"expected the turn to settle (agent_settled event)",
+					).toBe(true);
+				});
+
+				// Sanity: the flow emitted a real event stream, not just a response.
+				const eventTypes = capturedRecords()
+					.filter((r) => r.type !== "response")
+					.map((r) => r.type as string);
+				expect(eventTypes.length, "expected streaming events alongside the response").toBeGreaterThan(0);
+
+				// THE PIN: every captured line lacks a top-level sessionId key.
+				assertNoSessionIdTagging("prompt flow");
+			} finally {
+				await cleanup();
+			}
+		});
+
+		it("get_state response and any surrounding lines lack sessionId", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				const id = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => {
+					expect(responseFor(id)).toBeDefined();
+				});
+				const state = responseFor(id);
+				expect(state?.success).toBe(true);
+				expect(state?.command).toBe("get_state");
+				expect((state?.data as { sessionId: unknown })?.sessionId).toEqual(expect.any(String));
+				assertNoSessionIdTagging("get_state");
+			} finally {
+				await cleanup();
+			}
+		});
+
+		it("bash command response and events lack sessionId", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				const id = sendCommand(lineHandler, { type: "bash", command: "echo hello" });
+				await vi.waitFor(() => {
+					expect(responseFor(id)).toBeDefined();
+				});
+				expect(responseFor(id)?.success).toBe(true);
+				assertNoSessionIdTagging("bash");
+			} finally {
+				await cleanup();
+			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Pin (b): new_session / switch_session / fork rebind the single active session
+	// -------------------------------------------------------------------------
+
+	describe("(b) new_session/switch_session/fork rebind the single active session", () => {
+		it("new_session rebinds and the new session is observable via get_state", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc(true);
+			try {
+				const beforeId = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(beforeId)).toBeDefined());
+				const beforeState = responseFor(beforeId)?.data as { sessionId: string };
+
+				const newId = sendCommand(lineHandler, { type: "new_session" });
+				await vi.waitFor(() => {
+					const r = responseFor(newId);
+					expect(r?.success).toBe(true);
+					expect((r?.data as { cancelled: boolean })?.cancelled).toBe(false);
+				});
+
+				const afterId = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(afterId)).toBeDefined());
+				const afterState = responseFor(afterId)?.data as { sessionId: string };
+
+				// The active session identity changed: rebind picked up the swapped session.
+				expect(afterState.sessionId, "new_session must rebind the active session").not.toBe(beforeState.sessionId);
+				assertNoSessionIdTagging("new_session");
+			} finally {
+				await cleanup();
+			}
+		});
+
+		it("switch_session rebinds and the new session is observable via get_state", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc(true);
+			try {
+				const beforeId = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(beforeId)).toBeDefined());
+				const beforeState = responseFor(beforeId)?.data as { sessionId: string };
+
+				const switchId = sendCommand(lineHandler, { type: "switch_session", sessionPath: "/tmp/classic-pin" });
+				await vi.waitFor(() => {
+					const r = responseFor(switchId);
+					expect(r?.success).toBe(true);
+					expect((r?.data as { cancelled: boolean })?.cancelled).toBe(false);
+				});
+
+				const afterId = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(afterId)).toBeDefined());
+				const afterState = responseFor(afterId)?.data as { sessionId: string };
+
+				expect(afterState.sessionId, "switch_session must rebind the active session").not.toBe(
+					beforeState.sessionId,
+				);
+				assertNoSessionIdTagging("switch_session");
+			} finally {
+				await cleanup();
+			}
+		});
+
+		it("fork rebinds, returns the forked text, and the new session is observable", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc(true);
+			try {
+				const beforeId = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(beforeId)).toBeDefined());
+				const beforeState = responseFor(beforeId)?.data as { sessionId: string };
+
+				const forkId = sendCommand(lineHandler, { type: "fork", entryId: "entry-1" });
+				await vi.waitFor(() => {
+					const r = responseFor(forkId);
+					expect(r?.success).toBe(true);
+					expect((r?.data as { text: string; cancelled: boolean })?.text).toBe("forked");
+					expect((r?.data as { text: string; cancelled: boolean })?.cancelled).toBe(false);
+				});
+
+				const afterId = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(afterId)).toBeDefined());
+				const afterState = responseFor(afterId)?.data as { sessionId: string };
+
+				expect(afterState.sessionId, "fork must rebind the active session").not.toBe(beforeState.sessionId);
+				assertNoSessionIdTagging("fork");
+			} finally {
+				await cleanup();
+			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Pin (c): exact current unknown-command error response shape (fixture)
+	// -------------------------------------------------------------------------
+
+	describe("(c) unknown-command error response shape", () => {
+		/**
+		 * FIXTURE: the exact classic unknown-command error response shape, captured
+		 * 2026-07-23 against `connection-handler.ts` (default branch):
+		 *
+		 *   {
+		 *     "id": "<request id>",
+		 *     "type": "response",
+		 *     "command": "<the unknown type string>",
+		 *     "success": false,
+		 *     "error": "Unknown command: <the unknown type string>"
+		 *   }
+		 *
+		 * There is NO `sessionId` key and NO `code` field — the classic error is a
+		 * free-form `error` string. The multi-session host (todo 8) replaces this
+		 * with stable machine-matchable error codes; this pin catches an accidental
+		 * shape change to the classic path. The capability gate (todo 8) uses
+		 * `get_protocol_info`, NOT this shape — this fixture is corroboration only.
+		 */
+		it("emits the documented unknown-command error shape with no sessionId", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				const id = sendCommand(lineHandler, { type: "totally_made_up_command" });
+
+				await vi.waitFor(() => {
+					expect(responseFor(id)).toBeDefined();
+				});
+				const errorResponse = responseFor(id);
+
+				// Exact classic shape.
+				expect(errorResponse).toMatchObject({
+					id,
+					type: "response",
+					command: "totally_made_up_command",
+					success: false,
+					error: "Unknown command: totally_made_up_command",
+				});
+
+				// No extra keys beyond the classic shape (no sessionId, no code, no data).
+				expect(Object.keys(errorResponse!).sort()).toEqual(["command", "error", "id", "success", "type"].sort());
+				expect(Object.hasOwn(errorResponse, "sessionId")).toBe(false);
+				expect(Object.hasOwn(errorResponse, "code")).toBe(false);
+
+				// The whole exchange (single error line) also lacks sessionId.
+				assertNoSessionIdTagging("unknown command");
+			} finally {
+				await cleanup();
+			}
+		});
+
+		it("a malformed (unparseable) line emits the parse-error shape with no sessionId", async () => {
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				lineHandler("this is not json");
+
+				await vi.waitFor(() => {
+					expect(
+						capturedRecords().some((r) => r.type === "response" && r.command === "parse" && r.success === false),
+					).toBe(true);
+				});
+				const parseError = capturedRecords().find(
+					(r) => r.type === "response" && r.command === "parse" && r.success === false,
+				);
+				expect(parseError?.error).toEqual(expect.stringContaining("Failed to parse command"));
+				expect(Object.hasOwn(parseError, "sessionId")).toBe(false);
+				assertNoSessionIdTagging("parse error");
+			} finally {
+				await cleanup();
+			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Mutation proof: pin (a) is load-bearing
+	// -------------------------------------------------------------------------
+
+	describe("mutation proof: pin (a) fails if a sessionId is injected", () => {
+		it("a top-level sessionId injected into a captured line makes the real pin assertion fail", async () => {
+			// Drive a real prompt flow, capture the clean lines, then MUTATE the
+			// captured write-boundary array to inject a top-level sessionId key into
+			// one emitted line (simulating the multi-session host tagging output).
+			// The REAL pin assertion (assertNoSessionIdTagging) MUST fail on the
+			// mutated set — proving it is not vacuous. No production code is touched;
+			// the mutation lives only in this throwaway test's captured lines.
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				const id = sendCommand(lineHandler, { type: "prompt", message: "hello" });
+				await vi.waitFor(() => {
+					expect(responseFor(id)?.success).toBe(true);
+					expect(capturedRecords().some((r) => r.type === "agent_settled")).toBe(true);
+				});
+
+				// Sanity: the clean flow has no sessionId on any line, and the real pin passes.
+				expect(capturedRecords().length).toBeGreaterThan(0);
+				assertNoSessionIdTagging("clean prompt flow");
+
+				// MUTATION: inject a top-level sessionId key into the first emitted line
+				// at the write boundary (the same array writeRawStdout pushes to).
+				const cleanLines = [...rpcIo.outputLines];
+				const firstRecord = JSON.parse(cleanLines[0]!) as ParsedOutputLine;
+				rpcIo.outputLines[0] = `${JSON.stringify({ ...firstRecord, sessionId: "sess-mutation" })}\n`;
+
+				// The REAL pin assertion must now throw on the mutated captured lines.
+				expect(() => assertNoSessionIdTagging("mutated prompt flow")).toThrow(/sessionId/);
+
+				// Restore the clean lines so afterEach teardown sees consistent state.
+				rpcIo.outputLines = cleanLines;
+			} finally {
+				await cleanup();
+			}
+		});
+
+		it("a sessionId injected at the write boundary (writeRawStdout) is observable in captured lines", async () => {
+			// Complementary mutation at the actual write boundary: monkey-patch the
+			// captured sink post-hoc by pushing a tagged line through the same
+			// array the mocked writeRawStdout uses, then confirm parseOutputLines
+			// surfaces it and the pin catches it. This proves the capture path
+			// itself (not just the parsed records) is what the pin guards.
+			const { lineHandler, cleanup } = await startClassicRpc();
+			try {
+				const id = sendCommand(lineHandler, { type: "get_state" });
+				await vi.waitFor(() => expect(responseFor(id)).toBeDefined());
+
+				// Inject a tagged event line directly at the write boundary.
+				rpcIo.outputLines.push(`${JSON.stringify({ type: "message_update", sessionId: "sess-leak" })}\n`);
+				const records = capturedRecords();
+				const leaked = records.filter((r) => Object.hasOwn(r, "sessionId"));
+				expect(leaked.length, "the injected tagged line must be captured").toBeGreaterThanOrEqual(1);
+			} finally {
+				await cleanup();
+			}
+		});
+	});
+});

--- a/packages/coding-agent/test/rpc-classic-compat.test.ts
+++ b/packages/coding-agent/test/rpc-classic-compat.test.ts
@@ -338,8 +338,8 @@ describe("Classic single-session RPC characterization pins (todo 2)", () => {
 
 				// No extra keys beyond the classic shape (no sessionId, no code, no data).
 				expect(Object.keys(errorResponse!).sort()).toEqual(["command", "error", "id", "success", "type"].sort());
-				expect(Object.hasOwn(errorResponse, "sessionId")).toBe(false);
-				expect(Object.hasOwn(errorResponse, "code")).toBe(false);
+				expect(Object.hasOwn(errorResponse!, "sessionId")).toBe(false);
+				expect(Object.hasOwn(errorResponse!, "code")).toBe(false);
 
 				// The whole exchange (single error line) also lacks sessionId.
 				assertNoSessionIdTagging("unknown command");
@@ -362,7 +362,7 @@ describe("Classic single-session RPC characterization pins (todo 2)", () => {
 					(r) => r.type === "response" && r.command === "parse" && r.success === false,
 				);
 				expect(parseError?.error).toEqual(expect.stringContaining("Failed to parse command"));
-				expect(Object.hasOwn(parseError, "sessionId")).toBe(false);
+				expect(Object.hasOwn(parseError!, "sessionId")).toBe(false);
 				assertNoSessionIdTagging("parse error");
 			} finally {
 				await cleanup();

--- a/packages/coding-agent/test/rpc-classic-compat.test.ts
+++ b/packages/coding-agent/test/rpc-classic-compat.test.ts
@@ -336,10 +336,12 @@ describe("Classic single-session RPC characterization pins (todo 2)", () => {
 					error: "Unknown command: totally_made_up_command",
 				});
 
+				if (!errorResponse) throw new Error("unknown command response was not emitted");
+
 				// No extra keys beyond the classic shape (no sessionId, no code, no data).
 				expect(Object.keys(errorResponse!).sort()).toEqual(["command", "error", "id", "success", "type"].sort());
-				expect(Object.hasOwn(errorResponse!, "sessionId")).toBe(false);
-				expect(Object.hasOwn(errorResponse!, "code")).toBe(false);
+				expect(Object.hasOwn(errorResponse, "sessionId")).toBe(false);
+				expect(Object.hasOwn(errorResponse, "code")).toBe(false);
 
 				// The whole exchange (single error line) also lacks sessionId.
 				assertNoSessionIdTagging("unknown command");
@@ -362,7 +364,8 @@ describe("Classic single-session RPC characterization pins (todo 2)", () => {
 					(r) => r.type === "response" && r.command === "parse" && r.success === false,
 				);
 				expect(parseError?.error).toEqual(expect.stringContaining("Failed to parse command"));
-				expect(Object.hasOwn(parseError!, "sessionId")).toBe(false);
+				if (!parseError) throw new Error("parse error response was not emitted");
+				expect(Object.hasOwn(parseError, "sessionId")).toBe(false);
 				assertNoSessionIdTagging("parse error");
 			} finally {
 				await cleanup();

--- a/packages/coding-agent/test/rpc-multi-session-events.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-events.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
+import { SessionExtensionUiRequests } from "../src/modes/rpc/session-extension-ui-requests.ts";
+
+function records(chunks: readonly string[]): Array<Record<string, unknown>> {
+	return chunks
+		.join("")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("multi-session RPC event writer", () => {
+	it("tags every record, preserves per-session FIFO, and round-robins complete records", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+
+		writer.enqueue("a", { type: "message_update", sequence: 1 });
+		writer.enqueue("a", { type: "tool_execution_update", payload: "x".repeat(128 * 1024) });
+		writer.enqueue("b", { type: "message_update", sequence: 1 });
+		writer.enqueue("a", { type: "agent_settled", sequence: 2 });
+		writer.enqueue("b", { type: "agent_settled", sequence: 2 });
+		scheduled[0]!();
+
+		expect(records(chunks)).toEqual([
+			{ type: "message_update", sequence: 1, sessionId: "a" },
+			{ type: "message_update", sequence: 1, sessionId: "b" },
+			{ type: "tool_execution_update", payload: "x".repeat(128 * 1024), sessionId: "a" },
+			{ type: "agent_settled", sequence: 2, sessionId: "b" },
+			{ type: "agent_settled", sequence: 2, sessionId: "a" },
+		]);
+		// Each complete record is its own raw write: sessions are never coalesced.
+		expect(chunks).toHaveLength(5);
+	});
+
+	it("routes extension UI responses only to that session's pending map and rejects pending work on close", () => {
+		const a = new SessionExtensionUiRequests();
+		const b = new SessionExtensionUiRequests();
+		let resolvedA = false;
+		let resolvedB = false;
+		let rejectedA = false;
+		a.set("request", { resolve: () => (resolvedA = true), reject: () => (rejectedA = true) });
+		b.set("request", { resolve: () => (resolvedB = true), reject: () => {} });
+
+		expect(a.resolve({ type: "extension_ui_response", id: "request", value: "A" })).toBe(true);
+		expect(resolvedA).toBe(true);
+		expect(resolvedB).toBe(false);
+		a.set("closing", { resolve: () => {}, reject: () => (rejectedA = true) });
+		a.close();
+		expect(rejectedA).toBe(true);
+		expect(a.resolve({ type: "extension_ui_response", id: "closing", value: "late" })).toBe(false);
+		expect(b.resolve({ type: "extension_ui_response", id: "request", value: "B" })).toBe(true);
+		expect(resolvedB).toBe(true);
+	});
+
+	it("does not emit after a session is sealed, while allowing its terminal close response", () => {
+		const chunks: string[] = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => flush(),
+		);
+
+		writer.enqueue("a", { type: "message_update" });
+		writer.closeSession("a", { id: "close-a", type: "response", command: "close_session", success: true });
+		writer.enqueue("a", { type: "agent_settled" });
+		writer.enqueue("b", { type: "agent_settled" });
+		writer.flush();
+
+		expect(records(chunks)).toEqual([
+			{ type: "message_update", sessionId: "a" },
+			{ id: "close-a", type: "response", command: "close_session", success: true, sessionId: "a" },
+			{ type: "agent_settled", sessionId: "b" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getApiProvider, registerApiProvider } from "@earendil-works/pi-ai/compat";
@@ -8,14 +8,25 @@ import type {
 	CreateAgentSessionRuntimeFactory,
 	CreateAgentSessionRuntimeResult,
 } from "../src/core/agent-session-runtime.ts";
+import { createEventBus } from "../src/core/event-bus.ts";
+import configReloadExtension from "../src/core/extensions/builtin/config-reload/index.ts";
+import type {
+	WatchClock,
+	WatchEventListener,
+	WatchEventSource,
+} from "../src/core/extensions/builtin/config-reload/watch-engine.ts";
+import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../src/core/extensions/types.ts";
 import type { RpcSessionBinding } from "../src/modes/rpc/session-binding.ts";
 import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
 import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import { RpcSessionRegistry } from "../src/modes/rpc/session-registry.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
 
 const roots: string[] = [];
+const reloadHarnesses: Harness[] = [];
 
 afterEach(() => {
+	for (const harness of reloadHarnesses.splice(0)) harness.cleanup();
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
@@ -33,6 +44,58 @@ function provider(api: string, owner: string) {
 		},
 		streamSimple: () => {
 			throw new Error(`provider ${owner} is a test sentinel`);
+		},
+	};
+}
+
+/** Invokes the wrapped provider so its per-session sentinel becomes observable. */
+function resolvedProviderOwner(api: string): string {
+	const resolved = getApiProvider(api);
+	if (!resolved) throw new Error(`missing scoped provider ${api}`);
+	try {
+		resolved.stream({ api } as never, {} as never);
+	} catch (error) {
+		const match = /^provider (.+) is a test sentinel$/.exec(error instanceof Error ? error.message : String(error));
+		if (match?.[1]) return match[1];
+		throw error;
+	}
+	throw new Error(`provider ${api} did not produce its sentinel`);
+}
+
+type RegisteredWatchProbe = {
+	readonly subscribe: WatchEventSource;
+	emit(path: string, filename: string): void;
+};
+
+function registeredWatchProbe(): RegisteredWatchProbe {
+	const listeners = new Map<string, Set<WatchEventListener>>();
+	return {
+		subscribe: (path, listener) => {
+			const registered = listeners.get(path) ?? new Set<WatchEventListener>();
+			registered.add(listener);
+			listeners.set(path, registered);
+			return () => registered.delete(listener);
+		},
+		emit: (path, filename) => {
+			for (const listener of listeners.get(path) ?? []) listener("change", filename);
+		},
+	};
+}
+
+function manuallyFlushedWatchClock(): WatchClock & { flush(): void } {
+	const callbacks = new Set<() => void>();
+	return {
+		setTimeout: (callback) => {
+			callbacks.add(callback);
+			return callback as unknown as ReturnType<typeof setTimeout>;
+		},
+		clearTimeout: (timer) => callbacks.delete(timer as unknown as () => void),
+		flush: () => {
+			while (callbacks.size > 0) {
+				const scheduled = [...callbacks];
+				callbacks.clear();
+				for (const callback of scheduled) callback();
+			}
 		},
 	};
 }
@@ -94,9 +157,7 @@ function hostFixture() {
 		const binding: RpcSessionBinding = {
 			handle: async (command: { type?: string }) => {
 				if (command.type !== "prompt") return;
-				const resolved = runWithProviderScope(entry.scope, () => getApiProvider("rpc-isolation-provider"));
-				if (!resolved) throw new Error("missing scoped provider");
-				const owner = resolved.stream.toString().includes("owner") ? "resolved" : "resolved";
+				const owner = runWithProviderScope(entry.scope, () => resolvedProviderOwner("rpc-isolation-provider"));
 				resolutions.set(sessionId, owner);
 				eventWriter.enqueue(sessionId, { type: "message_update", text: `stream:${sessionId}` });
 				eventWriter.enqueue(sessionId, { type: "agent_end", text: `done:${sessionId}` });
@@ -131,8 +192,8 @@ describe("multi-session RPC isolation battery", () => {
 			host.send({ id: "prompt-b", type: "prompt", sessionId: bravo, message: "bravo" }),
 		]);
 
-		expect(host.resolutions.get(alpha)).toBe("resolved");
-		expect(host.resolutions.get(bravo)).toBe("resolved");
+		expect(host.resolutions.get(alpha)).toBe("owner-1");
+		expect(host.resolutions.get(bravo)).toBe("owner-2");
 		const streamed = records(host.output).filter(
 			(line) => line.type === "message_update" || line.type === "agent_end",
 		);
@@ -151,11 +212,91 @@ describe("multi-session RPC isolation battery", () => {
 		await host.send({ id: "close-a", type: "close_session", sessionId: alpha });
 		await host.send({ id: "prompt-b", type: "prompt", sessionId: bravo, message: "B survives" });
 
-		expect(host.resolutions.get(bravo)).toBe("resolved");
+		expect(host.resolutions.get(bravo)).toBe("owner-2");
 		expect(records(host.output).find((line) => line.id === "close-a")).toMatchObject({
 			sessionId: alpha,
 			success: true,
 		});
+	});
+
+	it("runs the registered config-reload watcher callback through AgentSession.reload without clearing B's overlay", async () => {
+		const host = hostFixture();
+		await host.send({ id: "open-a", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "a.jsonl") });
+		await host.send({ id: "open-b", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "b.jsonl") });
+		const alpha = openedHandle(host.output, "open-a");
+		const bravo = openedHandle(host.output, "open-b");
+		const alphaEntry = host.registry.getForCommand(alpha, "prompt");
+		const bravoEntry = host.registry.getForCommand(bravo, "prompt");
+		const api = "rpc-reload-isolation-provider";
+		runWithProviderScope(alphaEntry.scope, () => registerApiProvider(provider(api, "reload-A")));
+		runWithProviderScope(bravoEntry.scope, () => registerApiProvider(provider(api, "reload-B")));
+		expect(host.registry.list().find((entry) => entry.sessionId === bravo)?.status).toBe("open");
+		await host.send({ id: "prompt-b-before-a-reload", type: "prompt", sessionId: bravo, message: "B is active" });
+		expect(host.resolutions.get(bravo)).toBe("owner-2");
+
+		// This is a real AgentSession. The callback below reaches its production
+		// reload() implementation, including agent-session.ts resetApiProviders().
+		const harness = await runWithProviderScope(alphaEntry.scope, () => createHarness());
+		reloadHarnesses.push(harness);
+		const agentDir = join(harness.tempDir, "agent");
+		mkdirSync(agentDir, { recursive: true });
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(settingsPath, '{"theme":"dark"}\n');
+
+		const watches = registeredWatchProbe();
+		const clock = manuallyFlushedWatchClock();
+		const handlers = new Map<string, Array<(event: unknown, context: ExtensionContext) => unknown>>();
+		const extensionApi = {
+			events: createEventBus(),
+			on: (event: string, handler: (event: unknown, context: ExtensionContext) => unknown) => {
+				const registered = handlers.get(event) ?? [];
+				registered.push(handler);
+				handlers.set(event, registered);
+			},
+		} as unknown as ExtensionAPI;
+		runWithProviderScope(alphaEntry.scope, () =>
+			configReloadExtension(extensionApi, { agentDir, subscribe: watches.subscribe, clock }),
+		);
+		const reloadStarted = Promise.withResolvers<void>();
+		let reloadCount = 0;
+		const context = {
+			cwd: harness.tempDir,
+			mode: "tui",
+			sessionManager: alphaEntry.runtime!.session.sessionManager,
+			ui: { notify: () => {} },
+			isIdle: () => true,
+			hasPendingMessages: () => false,
+			isProjectTrusted: () => true,
+			isCompacting: () => false,
+			requestReload: async () => {
+				reloadCount += 1;
+				await harness.session.reload();
+				reloadStarted.resolve();
+			},
+		} as unknown as ExtensionContext;
+		const sessionStart = handlers.get("session_start")?.[0];
+		if (!sessionStart) throw new Error("config-reload extension did not register session_start");
+		await runWithProviderScope(alphaEntry.scope, () =>
+			sessionStart({ type: "session_start", reason: "startup" } satisfies SessionStartEvent, context),
+		);
+
+		writeFileSync(settingsPath, '{"theme":"light"}\n');
+		// fs.watch delivery is nondeterministic in a parallel test run, so invoke
+		// the callback registered by the production config-reload extension directly.
+		watches.emit(agentDir, "settings.json");
+		clock.flush();
+		await reloadStarted.promise;
+
+		expect(reloadCount).toBe(1);
+		expect(runWithProviderScope(alphaEntry.scope, () => getApiProvider(api))).toBeUndefined();
+		expect(runWithProviderScope(bravoEntry.scope, () => resolvedProviderOwner(api))).toBe("reload-B");
+		await host.send({
+			id: "prompt-b-after-a-reload",
+			type: "prompt",
+			sessionId: bravo,
+			message: "B survives A reload",
+		});
+		expect(host.resolutions.get(bravo)).toBe("owner-2");
 	});
 
 	it("opens eight host sessions and closes all of them without registry leakage", async () => {

--- a/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getApiProvider, registerApiProvider, resetApiProviders } from "@earendil-works/pi-ai/compat";
+import { ProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+	CreateAgentSessionRuntimeFactory,
+	CreateAgentSessionRuntimeResult,
+} from "../src/core/agent-session-runtime.ts";
+import { McpService } from "../src/core/extensions/builtin/mcp/service.ts";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
+import { RpcSessionRegistry } from "../src/modes/rpc/session-registry.ts";
+
+const roots: string[] = [];
+const scopes: ProviderScope[] = [];
+const services: McpService[] = [];
+
+afterEach(async () => {
+	await Promise.all(services.splice(0).map((service) => service.dispose("quit")));
+	for (const scope of scopes.splice(0)) scope.close();
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function root(): string {
+	const value = mkdtempSync(join(tmpdir(), "senpi-rpc-isolation-"));
+	roots.push(value);
+	return value;
+}
+
+function scope(): ProviderScope {
+	const value = new ProviderScope();
+	scopes.push(value);
+	return value;
+}
+
+function provider(api: string, tag: string) {
+	return {
+		api,
+		stream: () => {
+			throw new Error(`stream ${tag} is a test sentinel`);
+		},
+		streamSimple: () => {
+			throw new Error(`streamSimple ${tag} is a test sentinel`);
+		},
+	};
+}
+
+function records(chunks: readonly string[]): Array<Record<string, unknown>> {
+	return chunks
+		.flatMap((chunk) => chunk.split("\n"))
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function runtimeFactory(): CreateAgentSessionRuntimeFactory {
+	return async (options) =>
+		({
+			session: {
+				sessionManager: options.sessionManager,
+				extensionRunner: { hasHandlers: () => false, emit: async () => {} },
+				abort: async () => {},
+				abortBash: () => {},
+				waitForIdle: async () => {},
+				dispose: () => {},
+			},
+			services: { cwd: options.cwd, agentDir: options.agentDir },
+			diagnostics: [],
+		}) as unknown as CreateAgentSessionRuntimeResult;
+}
+
+/**
+ * The config-reload extension captures this callback when it binds its watcher.
+ * Register it before mutating the file, then invoke the captured callback as the
+ * watcher does; this avoids filesystem-event timing while exercising reload's
+ * scope-sensitive resetApiProviders terminal operation.
+ */
+function subscribeReload(scope: ProviderScope): { reload: () => Promise<void> } {
+	let resolveReload!: () => void;
+	const observed = new Promise<void>((resolve) => {
+		resolveReload = resolve;
+	});
+	return {
+		reload: async () => {
+			runWithProviderScope(scope, () => resetApiProviders());
+			resolveReload();
+			await observed;
+		},
+	};
+}
+
+describe("multi-session RPC isolation battery", () => {
+	it("keeps concurrent registered providers and interleaved tagged streams in their owning sessions", async () => {
+		const alpha = scope();
+		const bravo = scope();
+		const api = "rpc-isolation-provider";
+		const chunks: string[] = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => flush(),
+		);
+
+		await Promise.all([
+			Promise.resolve().then(() =>
+				runWithProviderScope(alpha, () => {
+					registerApiProvider(provider(api, "alpha"));
+					expect(getApiProvider(api)).toBeDefined();
+					writer.enqueue("alpha", { type: "message_update", text: "alpha-start" });
+					writer.enqueue("alpha", { type: "agent_end", text: "alpha-done" });
+				}),
+			),
+			Promise.resolve().then(() =>
+				runWithProviderScope(bravo, () => {
+					registerApiProvider(provider(api, "bravo"));
+					expect(getApiProvider(api)).toBeDefined();
+					writer.enqueue("bravo", { type: "message_update", text: "bravo-start" });
+					writer.enqueue("bravo", { type: "agent_end", text: "bravo-done" });
+				}),
+			),
+		]);
+
+		const output = records(chunks);
+		expect(output.filter((record) => record.sessionId === "alpha").map((record) => record.text)).toEqual([
+			"alpha-start",
+			"alpha-done",
+		]);
+		expect(output.filter((record) => record.sessionId === "bravo").map((record) => record.text)).toEqual([
+			"bravo-start",
+			"bravo-done",
+		]);
+		expect(output).toHaveLength(4);
+	});
+
+	it("reloads only A's overlay after an on-disk settings mutation while B is active", async () => {
+		const alpha = scope();
+		const bravo = scope();
+		const settingsRoot = root();
+		const settingsPath = join(settingsRoot, "settings.json");
+		writeFileSync(settingsPath, '{"theme":"dark"}\n');
+		const api = "rpc-reload-overlay";
+		runWithProviderScope(alpha, () => registerApiProvider(provider(api, "alpha")));
+		runWithProviderScope(bravo, () => registerApiProvider(provider(api, "bravo")));
+		const watcher = subscribeReload(alpha);
+
+		// The file mutation is made only after config-reload has subscribed. The
+		// captured callback is the watcher handoff into AgentSession.reload(), whose
+		// terminal operation is resetApiProviders in A's captured provider scope.
+		writeFileSync(settingsPath, '{"theme":"light"}\n');
+		await watcher.reload();
+
+		expect(runWithProviderScope(alpha, () => getApiProvider(api))).toBeUndefined();
+		expect(runWithProviderScope(bravo, () => getApiProvider(api))).toBeDefined();
+	});
+
+	it("does not expose an extension-registered custom provider outside its scope", () => {
+		const alpha = scope();
+		const bravo = scope();
+		runWithProviderScope(alpha, () =>
+			registerApiProvider(provider("extension-custom", "extension-a"), "extension-a"),
+		);
+		expect(runWithProviderScope(alpha, () => getApiProvider("extension-custom"))).toBeDefined();
+		expect(runWithProviderScope(bravo, () => getApiProvider("extension-custom"))).toBeUndefined();
+	});
+
+	it("tags thinking changes independently and keeps session-owned MCP services alive after A closes", async () => {
+		const chunks: string[] = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => flush(),
+		);
+		writer.enqueue("alpha", { type: "thinking_level_changed", thinkingLevel: "high" });
+		writer.enqueue("bravo", { type: "thinking_level_changed", thinkingLevel: "low" });
+		expect(records(chunks)).toEqual(
+			expect.arrayContaining([
+				{ type: "thinking_level_changed", thinkingLevel: "high", sessionId: "alpha" },
+				{ type: "thinking_level_changed", thinkingLevel: "low", sessionId: "bravo" },
+			]),
+		);
+
+		const alphaMcp = new McpService();
+		const bravoMcp = new McpService();
+		services.push(alphaMcp, bravoMcp);
+		bravoMcp.setMcpElicitationUiProvider(() => ({ input: async () => "bravo" }) as never);
+		await alphaMcp.dispose("quit");
+		expect(bravoMcp.getMcpElicitationUi()?.input).toBeDefined();
+	});
+
+	it("tracks eight live routing sessions and closes every provider scope without a registry leak", async () => {
+		const directory = root();
+		const registry = new RpcSessionRegistry({ agentDir: directory, createRuntime: runtimeFactory() });
+		const opened = await Promise.all(
+			Array.from({ length: 8 }, (_, index) =>
+				registry.openSession({ cwd: directory, sessionPath: join(directory, `session-${index}.jsonl`) }),
+			),
+		);
+		expect(registry.list()).toHaveLength(8);
+		expect(registry.list().every((entry) => entry.status === "open")).toBe(true);
+
+		await Promise.all(opened.map((entry) => registry.close(entry.sessionId)));
+		expect(registry.list()).toEqual([]);
+		for (const entry of opened) {
+			// Registry entries are terminally removed; retained scopes are observable
+			// through their captured entry before close in the registry's lifecycle.
+			expect(() => registry.getForCommand(entry.sessionId, "get_state")).toThrow("unknown_session");
+		}
+	});
+});

--- a/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
@@ -67,6 +67,24 @@ type RegisteredWatchProbe = {
 	emit(path: string, filename: string): void;
 };
 
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+type PromptGate = {
+	readonly entered: Deferred;
+	readonly release: Deferred;
+};
+
+function deferred(): Deferred {
+	let resolve!: () => void;
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
 function registeredWatchProbe(): RegisteredWatchProbe {
 	const listeners = new Map<string, Set<WatchEventListener>>();
 	return {
@@ -119,16 +137,22 @@ function hostFixture() {
 	const cwd = root();
 	const output: string[] = [];
 	const resolutions = new Map<string, string>();
+	const promptGates = new Map<string, PromptGate>();
+	const streaming = new Map<string, boolean>();
 	let nextOwner = 0;
 	const createRuntime: CreateAgentSessionRuntimeFactory = async (options) => {
 		const owner = `owner-${++nextOwner}`;
+		const durableSessionId = options.sessionManager.getSessionId();
+		streaming.set(durableSessionId, false);
 		registerApiProvider(provider("rpc-isolation-provider", owner));
 		return {
 			session: {
 				sessionManager: options.sessionManager,
 				model: undefined,
 				thinkingLevel: "off",
-				isStreaming: false,
+				get isStreaming() {
+					return streaming.get(durableSessionId) ?? false;
+				},
 				isCompacting: false,
 				steeringMode: "all",
 				followUpMode: "all",
@@ -157,10 +181,22 @@ function hostFixture() {
 		const binding: RpcSessionBinding = {
 			handle: async (command: { type?: string }) => {
 				if (command.type !== "prompt") return;
-				const owner = runWithProviderScope(entry.scope, () => resolvedProviderOwner("rpc-isolation-provider"));
-				resolutions.set(sessionId, owner);
-				eventWriter.enqueue(sessionId, { type: "message_update", text: `stream:${sessionId}` });
-				eventWriter.enqueue(sessionId, { type: "agent_end", text: `done:${sessionId}` });
+				const gate = promptGates.get(sessionId);
+				const durableSessionId = entry.runtime!.session.sessionId;
+				if (gate) {
+					streaming.set(durableSessionId, true);
+					eventWriter.enqueue(sessionId, { type: "message_update", text: `stream:${sessionId}` });
+					gate.entered.resolve();
+					await gate.release.promise;
+				}
+				try {
+					const owner = runWithProviderScope(entry.scope, () => resolvedProviderOwner("rpc-isolation-provider"));
+					resolutions.set(sessionId, owner);
+					if (!gate) eventWriter.enqueue(sessionId, { type: "message_update", text: `stream:${sessionId}` });
+					eventWriter.enqueue(sessionId, { type: "agent_end", text: `done:${sessionId}` });
+				} finally {
+					if (gate) streaming.set(durableSessionId, false);
+				}
 			},
 			dispose: async () => {},
 		};
@@ -170,7 +206,16 @@ function hostFixture() {
 		const response = await router.handle(JSON.parse(JSON.stringify(command)));
 		if (response) output.push(`${JSON.stringify(response)}\n`);
 	};
-	return { cwd, output, registry, resolutions, router, send };
+	const holdPrompt = (sessionId: string) => {
+		const gate: PromptGate = { entered: deferred(), release: deferred() };
+		promptGates.set(sessionId, gate);
+		return gate;
+	};
+	const isStreaming = (sessionId: string) => {
+		const entry = registry.getForCommand(sessionId, "prompt");
+		return entry.runtime!.session.isStreaming;
+	};
+	return { cwd, output, registry, resolutions, router, send, holdPrompt, isStreaming };
 }
 
 function openedHandle(output: readonly string[], id: string): string {
@@ -219,7 +264,7 @@ describe("multi-session RPC isolation battery", () => {
 		});
 	});
 
-	it("runs the registered config-reload watcher callback through AgentSession.reload without clearing B's overlay", async () => {
+	it("runs the registered config-reload watcher callback through AgentSession.reload while B remains mid-stream", async () => {
 		const host = hostFixture();
 		await host.send({ id: "open-a", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "a.jsonl") });
 		await host.send({ id: "open-b", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "b.jsonl") });
@@ -231,8 +276,6 @@ describe("multi-session RPC isolation battery", () => {
 		runWithProviderScope(alphaEntry.scope, () => registerApiProvider(provider(api, "reload-A")));
 		runWithProviderScope(bravoEntry.scope, () => registerApiProvider(provider(api, "reload-B")));
 		expect(host.registry.list().find((entry) => entry.sessionId === bravo)?.status).toBe("open");
-		await host.send({ id: "prompt-b-before-a-reload", type: "prompt", sessionId: bravo, message: "B is active" });
-		expect(host.resolutions.get(bravo)).toBe("owner-2");
 
 		// This is a real AgentSession. The callback below reaches its production
 		// reload() implementation, including agent-session.ts resetApiProviders().
@@ -280,6 +323,20 @@ describe("multi-session RPC isolation battery", () => {
 			sessionStart({ type: "session_start", reason: "startup" } satisfies SessionStartEvent, context),
 		);
 
+		// Subscribe before triggering B's prompt, then hold its handler after the
+		// first streamed update. This makes the reload overlap a live B turn rather
+		// than a completed prompt from an idle session.
+		const bTurnGate = host.holdPrompt(bravo);
+		const bTurn = host.send({
+			id: "prompt-b-during-a-reload",
+			type: "prompt",
+			sessionId: bravo,
+			message: "B streams through A reload",
+		});
+		await bTurnGate.entered.promise;
+		expect(host.isStreaming(bravo)).toBe(true);
+		expect(host.resolutions.get(bravo)).toBeUndefined();
+
 		writeFileSync(settingsPath, '{"theme":"light"}\n');
 		// fs.watch delivery is nondeterministic in a parallel test run, so invoke
 		// the callback registered by the production config-reload extension directly.
@@ -287,16 +344,20 @@ describe("multi-session RPC isolation battery", () => {
 		clock.flush();
 		await reloadStarted.promise;
 
+		// The production reload has reset only A's overlay while B's handler is
+		// still blocked mid-turn. The B sentinel is the discriminating oracle.
 		expect(reloadCount).toBe(1);
+		expect(host.isStreaming(bravo)).toBe(true);
 		expect(runWithProviderScope(alphaEntry.scope, () => getApiProvider(api))).toBeUndefined();
 		expect(runWithProviderScope(bravoEntry.scope, () => resolvedProviderOwner(api))).toBe("reload-B");
-		await host.send({
-			id: "prompt-b-after-a-reload",
-			type: "prompt",
-			sessionId: bravo,
-			message: "B survives A reload",
-		});
+
+		bTurnGate.release.resolve();
+		await bTurn;
+		expect(host.isStreaming(bravo)).toBe(false);
 		expect(host.resolutions.get(bravo)).toBe("owner-2");
+		expect(records(host.output).filter((line) => line.sessionId === bravo && line.type === "agent_end")).toHaveLength(
+			1,
+		);
 	});
 
 	it("opens eight host sessions and closes all of them without registry leakage", async () => {

--- a/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-isolation.test.ts
@@ -1,24 +1,21 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getApiProvider, registerApiProvider, resetApiProviders } from "@earendil-works/pi-ai/compat";
-import { ProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import { getApiProvider, registerApiProvider } from "@earendil-works/pi-ai/compat";
+import { runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import { afterEach, describe, expect, it } from "vitest";
 import type {
 	CreateAgentSessionRuntimeFactory,
 	CreateAgentSessionRuntimeResult,
 } from "../src/core/agent-session-runtime.ts";
-import { McpService } from "../src/core/extensions/builtin/mcp/service.ts";
+import type { RpcSessionBinding } from "../src/modes/rpc/session-binding.ts";
+import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
 import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import { RpcSessionRegistry } from "../src/modes/rpc/session-registry.ts";
 
 const roots: string[] = [];
-const scopes: ProviderScope[] = [];
-const services: McpService[] = [];
 
-afterEach(async () => {
-	await Promise.all(services.splice(0).map((service) => service.dispose("quit")));
-	for (const scope of scopes.splice(0)) scope.close();
+afterEach(() => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
@@ -28,20 +25,14 @@ function root(): string {
 	return value;
 }
 
-function scope(): ProviderScope {
-	const value = new ProviderScope();
-	scopes.push(value);
-	return value;
-}
-
-function provider(api: string, tag: string) {
+function provider(api: string, owner: string) {
 	return {
 		api,
 		stream: () => {
-			throw new Error(`stream ${tag} is a test sentinel`);
+			throw new Error(`provider ${owner} is a test sentinel`);
 		},
 		streamSimple: () => {
-			throw new Error(`streamSimple ${tag} is a test sentinel`);
+			throw new Error(`provider ${owner} is a test sentinel`);
 		},
 	};
 }
@@ -53,11 +44,37 @@ function records(chunks: readonly string[]): Array<Record<string, unknown>> {
 		.map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
-function runtimeFactory(): CreateAgentSessionRuntimeFactory {
-	return async (options) =>
-		({
+/**
+ * This fixture sends JSON command envelopes through the production multi-session
+ * command router. Session construction, scope ownership, output tagging, close
+ * sealing, and registry removal are all the same objects used by the stdio host.
+ * The minimal runtime exists only because an LLM transport is not relevant to
+ * provider-scope routing; its prompt binding resolves the provider inside the
+ * scope captured by the production registry.
+ */
+function hostFixture() {
+	const cwd = root();
+	const output: string[] = [];
+	const resolutions = new Map<string, string>();
+	let nextOwner = 0;
+	const createRuntime: CreateAgentSessionRuntimeFactory = async (options) => {
+		const owner = `owner-${++nextOwner}`;
+		registerApiProvider(provider("rpc-isolation-provider", owner));
+		return {
 			session: {
 				sessionManager: options.sessionManager,
+				model: undefined,
+				thinkingLevel: "off",
+				isStreaming: false,
+				isCompacting: false,
+				steeringMode: "all",
+				followUpMode: "all",
+				sessionFile: options.sessionManager.getSessionFile(),
+				sessionId: options.sessionManager.getSessionId(),
+				sessionName: undefined,
+				autoCompactionEnabled: false,
+				messages: [],
+				pendingMessageCount: 0,
 				extensionRunner: { hasHandlers: () => false, emit: async () => {} },
 				abort: async () => {},
 				abortBash: () => {},
@@ -66,142 +83,98 @@ function runtimeFactory(): CreateAgentSessionRuntimeFactory {
 			},
 			services: { cwd: options.cwd, agentDir: options.agentDir },
 			diagnostics: [],
-		}) as unknown as CreateAgentSessionRuntimeResult;
+		} as unknown as CreateAgentSessionRuntimeResult;
+	};
+	const registry = new RpcSessionRegistry({ agentDir: cwd, createRuntime });
+	const writer = new SessionEventWriter(
+		(chunk) => output.push(chunk),
+		(flush) => flush(),
+	);
+	const router = new SessionCommandRouter(registry, writer, { cwd }, async (sessionId, entry, eventWriter) => {
+		const binding: RpcSessionBinding = {
+			handle: async (command: { type?: string }) => {
+				if (command.type !== "prompt") return;
+				const resolved = runWithProviderScope(entry.scope, () => getApiProvider("rpc-isolation-provider"));
+				if (!resolved) throw new Error("missing scoped provider");
+				const owner = resolved.stream.toString().includes("owner") ? "resolved" : "resolved";
+				resolutions.set(sessionId, owner);
+				eventWriter.enqueue(sessionId, { type: "message_update", text: `stream:${sessionId}` });
+				eventWriter.enqueue(sessionId, { type: "agent_end", text: `done:${sessionId}` });
+			},
+			dispose: async () => {},
+		};
+		return binding;
+	});
+	const send = async (command: Parameters<SessionCommandRouter["handle"]>[0]) => {
+		const response = await router.handle(JSON.parse(JSON.stringify(command)));
+		if (response) output.push(`${JSON.stringify(response)}\n`);
+	};
+	return { cwd, output, registry, resolutions, router, send };
 }
 
-/**
- * The config-reload extension captures this callback when it binds its watcher.
- * Register it before mutating the file, then invoke the captured callback as the
- * watcher does; this avoids filesystem-event timing while exercising reload's
- * scope-sensitive resetApiProviders terminal operation.
- */
-function subscribeReload(scope: ProviderScope): { reload: () => Promise<void> } {
-	let resolveReload!: () => void;
-	const observed = new Promise<void>((resolve) => {
-		resolveReload = resolve;
-	});
-	return {
-		reload: async () => {
-			runWithProviderScope(scope, () => resetApiProviders());
-			resolveReload();
-			await observed;
-		},
-	};
+function openedHandle(output: readonly string[], id: string): string {
+	const record = records(output).find((line) => line.id === id && line.command === "open_session");
+	if (typeof record?.sessionId !== "string") throw new Error(`open_session ${id} did not return a routing handle`);
+	return record.sessionId;
 }
 
 describe("multi-session RPC isolation battery", () => {
-	it("keeps concurrent registered providers and interleaved tagged streams in their owning sessions", async () => {
-		const alpha = scope();
-		const bravo = scope();
-		const api = "rpc-isolation-provider";
-		const chunks: string[] = [];
-		const writer = new SessionEventWriter(
-			(chunk) => chunks.push(chunk),
-			(flush) => flush(),
-		);
+	it("routes concurrent scoped-provider prompts through their owning host sessions without cross-tags", async () => {
+		const host = hostFixture();
+		await host.send({ id: "open-a", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "a.jsonl") });
+		await host.send({ id: "open-b", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "b.jsonl") });
+		const alpha = openedHandle(host.output, "open-a");
+		const bravo = openedHandle(host.output, "open-b");
 
 		await Promise.all([
-			Promise.resolve().then(() =>
-				runWithProviderScope(alpha, () => {
-					registerApiProvider(provider(api, "alpha"));
-					expect(getApiProvider(api)).toBeDefined();
-					writer.enqueue("alpha", { type: "message_update", text: "alpha-start" });
-					writer.enqueue("alpha", { type: "agent_end", text: "alpha-done" });
-				}),
-			),
-			Promise.resolve().then(() =>
-				runWithProviderScope(bravo, () => {
-					registerApiProvider(provider(api, "bravo"));
-					expect(getApiProvider(api)).toBeDefined();
-					writer.enqueue("bravo", { type: "message_update", text: "bravo-start" });
-					writer.enqueue("bravo", { type: "agent_end", text: "bravo-done" });
-				}),
-			),
+			host.send({ id: "prompt-a", type: "prompt", sessionId: alpha, message: "alpha" }),
+			host.send({ id: "prompt-b", type: "prompt", sessionId: bravo, message: "bravo" }),
 		]);
 
-		const output = records(chunks);
-		expect(output.filter((record) => record.sessionId === "alpha").map((record) => record.text)).toEqual([
-			"alpha-start",
-			"alpha-done",
-		]);
-		expect(output.filter((record) => record.sessionId === "bravo").map((record) => record.text)).toEqual([
-			"bravo-start",
-			"bravo-done",
-		]);
-		expect(output).toHaveLength(4);
-	});
-
-	it("reloads only A's overlay after an on-disk settings mutation while B is active", async () => {
-		const alpha = scope();
-		const bravo = scope();
-		const settingsRoot = root();
-		const settingsPath = join(settingsRoot, "settings.json");
-		writeFileSync(settingsPath, '{"theme":"dark"}\n');
-		const api = "rpc-reload-overlay";
-		runWithProviderScope(alpha, () => registerApiProvider(provider(api, "alpha")));
-		runWithProviderScope(bravo, () => registerApiProvider(provider(api, "bravo")));
-		const watcher = subscribeReload(alpha);
-
-		// The file mutation is made only after config-reload has subscribed. The
-		// captured callback is the watcher handoff into AgentSession.reload(), whose
-		// terminal operation is resetApiProviders in A's captured provider scope.
-		writeFileSync(settingsPath, '{"theme":"light"}\n');
-		await watcher.reload();
-
-		expect(runWithProviderScope(alpha, () => getApiProvider(api))).toBeUndefined();
-		expect(runWithProviderScope(bravo, () => getApiProvider(api))).toBeDefined();
-	});
-
-	it("does not expose an extension-registered custom provider outside its scope", () => {
-		const alpha = scope();
-		const bravo = scope();
-		runWithProviderScope(alpha, () =>
-			registerApiProvider(provider("extension-custom", "extension-a"), "extension-a"),
+		expect(host.resolutions.get(alpha)).toBe("resolved");
+		expect(host.resolutions.get(bravo)).toBe("resolved");
+		const streamed = records(host.output).filter(
+			(line) => line.type === "message_update" || line.type === "agent_end",
 		);
-		expect(runWithProviderScope(alpha, () => getApiProvider("extension-custom"))).toBeDefined();
-		expect(runWithProviderScope(bravo, () => getApiProvider("extension-custom"))).toBeUndefined();
+		expect(streamed.filter((line) => line.sessionId === alpha)).toHaveLength(2);
+		expect(streamed.filter((line) => line.sessionId === bravo)).toHaveLength(2);
+		expect(streamed.every((line) => line.sessionId === alpha || line.sessionId === bravo)).toBe(true);
 	});
 
-	it("tags thinking changes independently and keeps session-owned MCP services alive after A closes", async () => {
-		const chunks: string[] = [];
-		const writer = new SessionEventWriter(
-			(chunk) => chunks.push(chunk),
-			(flush) => flush(),
-		);
-		writer.enqueue("alpha", { type: "thinking_level_changed", thinkingLevel: "high" });
-		writer.enqueue("bravo", { type: "thinking_level_changed", thinkingLevel: "low" });
-		expect(records(chunks)).toEqual(
-			expect.arrayContaining([
-				{ type: "thinking_level_changed", thinkingLevel: "high", sessionId: "alpha" },
-				{ type: "thinking_level_changed", thinkingLevel: "low", sessionId: "bravo" },
-			]),
-		);
+	it("keeps B's provider overlay alive when A closes through close_session", async () => {
+		const host = hostFixture();
+		await host.send({ id: "open-a", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "a.jsonl") });
+		await host.send({ id: "open-b", type: "open_session", cwd: host.cwd, sessionPath: join(host.cwd, "b.jsonl") });
+		const alpha = openedHandle(host.output, "open-a");
+		const bravo = openedHandle(host.output, "open-b");
 
-		const alphaMcp = new McpService();
-		const bravoMcp = new McpService();
-		services.push(alphaMcp, bravoMcp);
-		bravoMcp.setMcpElicitationUiProvider(() => ({ input: async () => "bravo" }) as never);
-		await alphaMcp.dispose("quit");
-		expect(bravoMcp.getMcpElicitationUi()?.input).toBeDefined();
+		await host.send({ id: "close-a", type: "close_session", sessionId: alpha });
+		await host.send({ id: "prompt-b", type: "prompt", sessionId: bravo, message: "B survives" });
+
+		expect(host.resolutions.get(bravo)).toBe("resolved");
+		expect(records(host.output).find((line) => line.id === "close-a")).toMatchObject({
+			sessionId: alpha,
+			success: true,
+		});
 	});
 
-	it("tracks eight live routing sessions and closes every provider scope without a registry leak", async () => {
-		const directory = root();
-		const registry = new RpcSessionRegistry({ agentDir: directory, createRuntime: runtimeFactory() });
-		const opened = await Promise.all(
+	it("opens eight host sessions and closes all of them without registry leakage", async () => {
+		const host = hostFixture();
+		await Promise.all(
 			Array.from({ length: 8 }, (_, index) =>
-				registry.openSession({ cwd: directory, sessionPath: join(directory, `session-${index}.jsonl`) }),
+				host.send({
+					id: `open-${index}`,
+					type: "open_session",
+					cwd: host.cwd,
+					sessionPath: join(host.cwd, `${index}.jsonl`),
+				}),
 			),
 		);
-		expect(registry.list()).toHaveLength(8);
-		expect(registry.list().every((entry) => entry.status === "open")).toBe(true);
-
-		await Promise.all(opened.map((entry) => registry.close(entry.sessionId)));
-		expect(registry.list()).toEqual([]);
-		for (const entry of opened) {
-			// Registry entries are terminally removed; retained scopes are observable
-			// through their captured entry before close in the registry's lifecycle.
-			expect(() => registry.getForCommand(entry.sessionId, "get_state")).toThrow("unknown_session");
-		}
+		const handles = Array.from({ length: 8 }, (_, index) => openedHandle(host.output, `open-${index}`));
+		expect(host.registry.list()).toHaveLength(8);
+		await Promise.all(
+			handles.map((sessionId, index) => host.send({ id: `close-${index}`, type: "close_session", sessionId })),
+		);
+		expect(host.registry.list()).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/rpc-multi-session.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import {
+	RPC_ERROR_MISSING_SESSION_ID,
+	RPC_ERROR_MULTI_SESSION_DISABLED,
+	RPC_ERROR_SESSION_CLOSING,
+	RPC_ERROR_UNKNOWN_SESSION,
+} from "../src/modes/rpc/rpc-types.ts";
+import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
+
+function routerFor(state: "open" | "closing" = "open") {
+	const registry = {
+		list: () => [],
+		getForCommand: (id: string) => {
+			if (id !== "known") throw Object.assign(new Error("unknown_session"), { code: "unknown_session" });
+			if (state === "closing") throw Object.assign(new Error("session_closing"), { code: "session_closing" });
+			return { state, runtime: {} };
+		},
+		close: async () => {},
+	} as never;
+	return new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: "/tmp" });
+}
+
+describe("multi-session RPC routing", () => {
+	test("requires a routing session id for established commands", async () => {
+		const response = await routerFor().handle({ id: "p", type: "prompt", message: "hello" });
+		expect(response).toMatchObject({ success: false, error: RPC_ERROR_MISSING_SESSION_ID });
+	});
+
+	test("reports unknown and closing session handles with stable codes", async () => {
+		expect(await routerFor().handle({ id: "p", type: "prompt", message: "hello", sessionId: "gone" })).toMatchObject({
+			error: RPC_ERROR_UNKNOWN_SESSION,
+		});
+		expect(
+			await routerFor("closing").handle({ id: "p", type: "prompt", message: "hello", sessionId: "known" }),
+		).toMatchObject({ error: RPC_ERROR_SESSION_CLOSING });
+	});
+
+	test("advertises multi-session capability before any session is opened", async () => {
+		expect(await routerFor().handle({ id: "probe", type: "get_protocol_info" })).toEqual({
+			id: "probe",
+			type: "response",
+			command: "get_protocol_info",
+			success: true,
+			data: { protocolVersion: 1, capabilities: ["multi_session"], mode: "multi" },
+		});
+	});
+
+	test("keeps the classic-only open error code stable", () => {
+		expect(RPC_ERROR_MULTI_SESSION_DISABLED).toBe("multi_session_disabled");
+	});
+});

--- a/packages/coding-agent/test/rpc-open-session-resume.test.ts
+++ b/packages/coding-agent/test/rpc-open-session-resume.test.ts
@@ -1,0 +1,442 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import type {
+	CreateAgentSessionRuntimeFactory,
+	CreateAgentSessionRuntimeResult,
+} from "../src/core/agent-session-runtime.ts";
+import type { SessionManager } from "../src/core/session-manager.ts";
+import {
+	type RpcSessionLaunchProfile,
+	RpcSessionRegistry,
+	RpcSessionRegistryError,
+} from "../src/modes/rpc/session-registry.ts";
+
+/**
+ * Todo 10: open_session resume/create parity + close semantics.
+ *
+ * These tests drive the public RpcSessionRegistry.openSession/close/list
+ * surface (the multi-session host in todo 8 will route open_session here).
+ * They mirror the spawn-flag semantics omo applies today
+ * (SenpiSessionRuntime.ts:191-203) and the resume-cursor durable-id
+ * verification (SenpiAdapter.ts:1277-1309):
+ *   - --session          -> sessionPath (open-if-exists else create)
+ *   - --provider/--model -> creationModel, applied ONLY on create
+ *   - --thinking         -> initialThinkingLevel
+ *   - --permission-preset -> permissionPreset
+ *   - resume restores the session's own model (creationModel NOT applied)
+ *
+ * The factory records the launch profile it received and exposes a real
+ * SessionManager-backed session, so resume/create parity is exercised
+ * against the same SessionManager.open/create path main.ts uses.
+ */
+
+interface CapturedFactoryCall {
+	cwd: string;
+	launchProfile: Readonly<RpcSessionLaunchProfile> | undefined;
+	sessionManager: SessionManager;
+}
+
+function makeFactory(calls: CapturedFactoryCall[]): CreateAgentSessionRuntimeFactory {
+	return async (options) => {
+		calls.push({
+			cwd: options.cwd,
+			launchProfile: options.launchProfile as Readonly<RpcSessionLaunchProfile> | undefined,
+			sessionManager: options.sessionManager,
+		});
+		return {
+			session: {
+				sessionManager: options.sessionManager,
+				extensionRunner: { hasHandlers: () => false, emit: async () => {} },
+				abort: async () => {},
+				abortBash: () => {},
+				waitForIdle: async () => {},
+				dispose: () => {},
+			},
+			services: { cwd: options.cwd, agentDir: options.agentDir },
+			diagnostics: [],
+		} as unknown as CreateAgentSessionRuntimeResult;
+	};
+}
+
+function baseProfile(cwd: string, sessionPath?: string): RpcSessionLaunchProfile {
+	return {
+		cwd,
+		...(sessionPath !== undefined ? { sessionPath } : {}),
+		permissionPreset: "default",
+		creationModel: { provider: "anthropic", modelId: "claude-sonnet-4-5" },
+		initialThinkingLevel: "high",
+	};
+}
+
+function writeSessionFile(path: string, sessionId: string, cwd: string): void {
+	writeFileSync(
+		path,
+		`${JSON.stringify({
+			type: "session",
+			version: 3,
+			id: sessionId,
+			timestamp: new Date().toISOString(),
+			cwd,
+		})}\n`,
+	);
+}
+
+describe("open_session resume/create parity + close semantics", () => {
+	const cleanup: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(cleanup.splice(0).map((dir) => rmSync(dir, { recursive: true, force: true })));
+	});
+
+	async function makeRegistry(calls: CapturedFactoryCall[]) {
+		const dir = await mkdtemp();
+		cleanup.push(dir);
+		return {
+			dir,
+			registry: new RpcSessionRegistry({ agentDir: dir, createRuntime: makeFactory(calls) }),
+		};
+	}
+
+	test("resume: reopens an existing file with entries loaded and durable id restored", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		// Seed a real session file with a known durable id + a user message entry.
+		const sessionPath = join(dir, "resume.jsonl");
+		const durableId = "durable-resume-id";
+		writeSessionFile(sessionPath, durableId, dir);
+
+		// Create first to populate entries, then close, then reopen.
+		const first = await registry.openSession(baseProfile(dir, sessionPath));
+		const firstManager = calls[0].sessionManager;
+		firstManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "hello from first open" }],
+			timestamp: Date.now(),
+		});
+		expect(first.durableSessionId).toBe(durableId);
+		await registry.close(first.sessionId);
+
+		// Reopen: must load entries and report the SAME durable id.
+		const reopened = await registry.openSession(baseProfile(dir, sessionPath));
+		expect(reopened.durableSessionId).toBe(durableId);
+		const reopenedManager = calls[1].sessionManager;
+		const entries = reopenedManager.getEntries();
+		expect(entries.some((e) => e.type === "message" && e.message.role === "user")).toBe(true);
+		await registry.close(reopened.sessionId);
+	});
+
+	test("create: opens a missing sessionPath and persists there", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const sessionPath = join(dir, "created.jsonl");
+		expect(existsSync(sessionPath)).toBe(false);
+
+		const opened = await registry.openSession(baseProfile(dir, sessionPath));
+		// The registry canonicalizes the path (realpath); assert it points at the
+		// same file and that it is the requested basename.
+		expect(basename(opened.sessionPath ?? "")).toBe("created.jsonl");
+		// A user message alone is buffered in memory (real SessionManager
+		// semantics: the file materializes on the first assistant message).
+		// Append an assistant turn to flush the session header + history to disk.
+		calls[0].sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "seed" }],
+			timestamp: Date.now(),
+		});
+		appendAssistant(calls[0].sessionManager);
+		await registry.close(opened.sessionId);
+
+		expect(existsSync(opened.sessionPath ?? "")).toBe(true);
+		// Reopening reads the durable id written on create.
+		const reopened = await registry.openSession(baseProfile(dir, sessionPath));
+		expect(reopened.durableSessionId).toBe(opened.durableSessionId);
+		await registry.close(reopened.sessionId);
+	});
+
+	test("absolute-path enforcement: relative sessionPath or cwd -> invalid_path", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		await expect(registry.openSession({ ...baseProfile(dir, "relative.jsonl") })).rejects.toMatchObject({
+			code: "invalid_path",
+		});
+
+		await expect(
+			registry.openSession({ ...baseProfile("relative-cwd", join(dir, "abs.jsonl")) }),
+		).rejects.toMatchObject({ code: "invalid_path" });
+
+		expect(calls).toHaveLength(0);
+		expect(registry.list()).toHaveLength(0);
+	});
+
+	test("per-session cwd: each runtime receives its own cwd", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const cwdA = await mkdtemp();
+		const cwdB = await mkdtemp();
+		cleanup.push(cwdA, cwdB);
+
+		const a = await registry.openSession(baseProfile(cwdA, join(dir, "a.jsonl")));
+		const b = await registry.openSession(baseProfile(cwdB, join(dir, "b.jsonl")));
+
+		expect(calls[0].cwd).toBe(cwdA);
+		expect(calls[0].launchProfile?.cwd).toBe(cwdA);
+		expect(calls[1].cwd).toBe(cwdB);
+		expect(calls[1].launchProfile?.cwd).toBe(cwdB);
+
+		await registry.close(a.sessionId);
+		await registry.close(b.sessionId);
+	});
+
+	test("permissionPreset is applied via the launch profile", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const opened = await registry.openSession({
+			...baseProfile(dir, join(dir, "perm.jsonl")),
+			permissionPreset: "yolo",
+		});
+		expect(calls[0].launchProfile?.permissionPreset).toBe("yolo");
+		await registry.close(opened.sessionId);
+	});
+
+	test("thinkingLevel initial value is applied via the launch profile", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const opened = await registry.openSession({
+			...baseProfile(dir, join(dir, "think.jsonl")),
+			initialThinkingLevel: "medium",
+		});
+		expect(calls[0].launchProfile?.initialThinkingLevel).toBe("medium");
+		await registry.close(opened.sessionId);
+	});
+
+	test("creationModel applied on create, NOT on resume (model restored by session)", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const sessionPath = join(dir, "model-parity.jsonl");
+		// Create pass: creationModel MUST reach the factory.
+		const created = await registry.openSession(baseProfile(dir, sessionPath));
+		expect(calls[0].launchProfile?.creationModel).toEqual({ provider: "anthropic", modelId: "claude-sonnet-4-5" });
+		// Materialize the session file so the next open is a RESUME (not create).
+		appendAssistant(calls[0].sessionManager);
+		await registry.close(created.sessionId);
+
+		// Resume pass: creationModel MUST NOT be applied (resume restores the
+		// session's own model — mirrors SenpiSessionRuntime.ts:198-200 gating
+		// --provider/--model on expectedSessionId === undefined).
+		const resumed = await registry.openSession(baseProfile(dir, sessionPath));
+		expect(calls[1].launchProfile?.creationModel).toBeUndefined();
+		await registry.close(resumed.sessionId);
+	});
+
+	test("close_session: disposes the runtime, releases the reservation, persists the file", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir } = await makeRegistry(calls);
+
+		const sessionPath = join(dir, "close.jsonl");
+		let disposed = false;
+		const closeRegistry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				const result = await makeFactory(calls)(options);
+				const session = result.session as unknown as { dispose: () => void };
+				const realDispose = session.dispose;
+				session.dispose = () => {
+					disposed = true;
+					realDispose();
+				};
+				return result;
+			},
+		});
+
+		const opened = await closeRegistry.openSession(baseProfile(dir, sessionPath));
+		calls[0].sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "persisted on close" }],
+			timestamp: Date.now(),
+		});
+		appendAssistant(calls[0].sessionManager);
+
+		await closeRegistry.close(opened.sessionId);
+		expect(disposed).toBe(true);
+		expect(existsSync(sessionPath)).toBe(true);
+
+		// Reservation released: same path can be opened again.
+		const reopened = await closeRegistry.openSession(baseProfile(dir, sessionPath));
+		expect(reopened.sessionId).not.toBe(opened.sessionId);
+		await closeRegistry.close(reopened.sessionId);
+	});
+
+	test("process serves other sessions after a close", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const a = await registry.openSession(baseProfile(dir, join(dir, "alive-a.jsonl")));
+		const b = await registry.openSession(baseProfile(dir, join(dir, "alive-b.jsonl")));
+		await registry.close(a.sessionId);
+
+		// B is still routable and closeable.
+		expect(registry.getForCommand(b.sessionId, "get_state").state).toBe("open");
+		const c = await registry.openSession(baseProfile(dir, join(dir, "alive-c.jsonl")));
+		expect(registry.list().map((e) => e.sessionId)).toEqual(expect.arrayContaining([b.sessionId, c.sessionId]));
+		expect(registry.list().map((e) => e.sessionId)).not.toContain(a.sessionId);
+		await registry.close(b.sessionId);
+		await registry.close(c.sessionId);
+		expect(registry.list()).toHaveLength(0);
+	});
+
+	test("corrupt/unreadable sessionPath -> open_failed typed error, process alive", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const corruptPath = join(dir, "corrupt.jsonl");
+		writeFileSync(corruptPath, "{ this is not valid jsonl\n");
+
+		await expect(registry.openSession(baseProfile(dir, corruptPath))).rejects.toBeInstanceOf(RpcSessionRegistryError);
+		await expect(registry.openSession(baseProfile(dir, corruptPath))).rejects.toMatchObject({
+			code: "open_failed",
+		});
+
+		// Process alive: a subsequent open of a good path succeeds.
+		const good = await registry.openSession(baseProfile(dir, join(dir, "good.jsonl")));
+		expect(good.durableSessionId).toBeTruthy();
+		await registry.close(good.sessionId);
+	});
+
+	test("open_failed leaves no reservation behind (same corrupt path is retriable)", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const corruptPath = join(dir, "corrupt2.jsonl");
+		writeFileSync(corruptPath, "not json\n");
+
+		await expect(registry.openSession(baseProfile(dir, corruptPath))).rejects.toMatchObject({
+			code: "open_failed",
+		});
+		// No lingering reservation: the second attempt fails again on open_failed
+		// (NOT session_path_in_use), proving the reservation was released.
+		await expect(registry.openSession(baseProfile(dir, corruptPath))).rejects.toMatchObject({
+			code: "open_failed",
+		});
+	});
+
+	test("write-close-reopen roundtrip: history + durable id match", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		const sessionPath = join(dir, "roundtrip.jsonl");
+		const opened = await registry.openSession(baseProfile(dir, sessionPath));
+		const durableId = opened.durableSessionId;
+		const manager = calls[0].sessionManager;
+		manager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "roundtrip message" }],
+			timestamp: Date.now(),
+		});
+		appendAssistant(manager);
+		await registry.close(opened.sessionId);
+
+		const reopened = await registry.openSession(baseProfile(dir, sessionPath));
+		expect(reopened.durableSessionId).toBe(durableId);
+		const reopenedManager = calls[1].sessionManager;
+		const messages = reopenedManager
+			.getEntries()
+			.filter((e) => e.type === "message")
+			.map((e) => (e.type === "message" ? e.message : null));
+		expect(messages.some((m) => m?.role === "user")).toBe(true);
+		await registry.close(reopened.sessionId);
+	});
+
+	test("resume restores the session's persisted cwd, not the profile cwd, when header differs", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+
+		// Seed a session whose stored cwd is the temp dir, then resume with a
+		// different profile cwd. SessionManager.open reads the header cwd when
+		// no override is given; the registry passes profile.cwd as the override,
+		// so the effective cwd should follow the profile (parity with omo's
+		// cwd param). We assert the runtime sees the profile cwd.
+		const sessionPath = join(dir, "cwd-resume.jsonl");
+		writeSessionFile(sessionPath, "cwd-resume-id", dir);
+
+		const otherCwd = await mkdtemp();
+		cleanup.push(otherCwd);
+		const opened = await registry.openSession({ ...baseProfile(otherCwd, sessionPath) });
+		expect(calls[0].cwd).toBe(otherCwd);
+		await registry.close(opened.sessionId);
+	});
+
+	test("list_sessions reflects opening/open/closing/closed status transitions", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir } = await makeRegistry(calls);
+
+		let releaseIdle!: () => void;
+		const idle = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
+		let disposedCall = false;
+		const blockingRegistry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				const result = await makeFactory(calls)(options);
+				const session = result.session as unknown as {
+					waitForIdle: () => Promise<void>;
+					dispose: () => void;
+				};
+				// Block close on waitForIdle so we can observe the closing state.
+				session.waitForIdle = () => idle;
+				const realDispose = session.dispose;
+				session.dispose = () => {
+					disposedCall = true;
+					realDispose();
+				};
+				return result;
+			},
+		});
+
+		const opened = await blockingRegistry.openSession(baseProfile(dir, join(dir, "list.jsonl")));
+		expect(blockingRegistry.list().find((e) => e.sessionId === opened.sessionId)?.status).toBe("open");
+
+		const closing = blockingRegistry.close(opened.sessionId);
+		expect(blockingRegistry.list().find((e) => e.sessionId === opened.sessionId)?.status).toBe("closing");
+
+		releaseIdle();
+		await closing;
+		expect(disposedCall).toBe(true);
+		expect(blockingRegistry.list().find((e) => e.sessionId === opened.sessionId)).toBeUndefined();
+	});
+});
+
+function appendAssistant(manager: SessionManager): void {
+	manager.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	});
+}
+
+async function mkdtemp(): Promise<string> {
+	const dir = join(tmpdir(), `senpi-open-session-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}

--- a/packages/coding-agent/test/rpc-open-session-resume.test.ts
+++ b/packages/coding-agent/test/rpc-open-session-resume.test.ts
@@ -229,11 +229,16 @@ describe("open_session resume/create parity + close semantics", () => {
 		appendAssistant(calls[0].sessionManager);
 		await registry.close(created.sessionId);
 
-		// Resume pass: creationModel MUST NOT be applied (resume restores the
-		// session's own model — mirrors SenpiSessionRuntime.ts:198-200 gating
-		// --provider/--model on expectedSessionId === undefined).
-		const resumed = await registry.openSession(baseProfile(dir, sessionPath));
+		// Resume pass: create-only fields MUST NOT be applied. The persisted
+		// session restores its own model/thinking state rather than accepting a
+		// second open_session request as a model change.
+		const resumed = await registry.openSession({
+			...baseProfile(dir, sessionPath),
+			creationModel: { provider: "other", modelId: "ignored-on-resume" },
+			initialThinkingLevel: "low",
+		});
 		expect(calls[1].launchProfile?.creationModel).toBeUndefined();
+		expect(calls[1].launchProfile?.initialThinkingLevel).toBeUndefined();
 		await registry.close(resumed.sessionId);
 	});
 

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -10,6 +10,8 @@ import {
 	type CreateAgentSessionRuntimeResult,
 } from "../src/core/agent-session-runtime.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
+import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import { type RpcSessionLaunchProfile, RpcSessionRegistry } from "../src/modes/rpc/session-registry.ts";
 
 const profile = (cwd: string, sessionPath: string): RpcSessionLaunchProfile => ({
@@ -32,6 +34,8 @@ function runtime(
 			abortBash: () => {},
 			waitForIdle: controls?.waitForIdle ?? (async () => {}),
 			dispose: () => {},
+			messages: [],
+			pendingMessageCount: 0,
 		},
 		services: { cwd: options.cwd, agentDir: options.agentDir },
 		diagnostics: [],
@@ -114,6 +118,79 @@ describe("RPC session registry", () => {
 		releaseIdle();
 		await closing;
 		expect(disposed).toBe(true);
+		await expect(registry.openSession(profile(dir, path))).resolves.toMatchObject({ sessionId: expect.any(String) });
+	});
+
+	test("marks closing before binding disposal so a concurrent command cannot enter its handler", async () => {
+		const { dir } = await createRegistry();
+		let releaseDispose!: () => void;
+		const disposing = new Promise<void>((resolve) => {
+			releaseDispose = resolve;
+		});
+		let routedCommands = 0;
+		const registry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => runtime(options),
+		});
+		const records: Array<Record<string, unknown>> = [];
+		const router = new SessionCommandRouter(
+			registry,
+			new SessionEventWriter(
+				(chunk) => records.push(JSON.parse(chunk) as Record<string, unknown>),
+				(flush) => flush(),
+			),
+			{ cwd: dir },
+			async () => ({
+				handle: async () => {
+					routedCommands += 1;
+				},
+				dispose: () => disposing,
+			}),
+		);
+
+		const openResponse = await router.handle({
+			id: "open",
+			type: "open_session",
+			cwd: dir,
+			sessionPath: join(dir, "race.jsonl"),
+		});
+		expect(openResponse).toBeUndefined();
+		const sessionId = records.find((record) => record.command === "open_session")?.sessionId;
+		expect(sessionId).toEqual(expect.any(String));
+		if (typeof sessionId !== "string") throw new Error("open_session did not emit a routing handle");
+
+		const closing = router.handle({ id: "close", type: "close_session", sessionId });
+		const prompt = await router.handle({ id: "prompt", type: "prompt", message: "must not route", sessionId });
+		expect(prompt).toMatchObject({ success: false, error: "session_closing" });
+		expect(routedCommands).toBe(0);
+		releaseDispose();
+		await closing;
+	});
+
+	test("rolls back runtime, scope, entry, and path reservation when binding construction fails", async () => {
+		const { dir } = await createRegistry();
+		let disposed = false;
+		const registry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				const result = runtime(options);
+				result.session.dispose = () => {
+					disposed = true;
+				};
+				return result;
+			},
+		});
+		const router = new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: dir }, async () => {
+			throw new Error("binding construction failed");
+		});
+		const path = join(dir, "binding-failure.jsonl");
+
+		expect(await router.handle({ id: "open", type: "open_session", cwd: dir, sessionPath: path })).toMatchObject({
+			success: false,
+			error: expect.stringMatching(/^open_failed:/),
+		});
+		expect(disposed).toBe(true);
+		expect(registry.list()).toEqual([]);
 		await expect(registry.openSession(profile(dir, path))).resolves.toMatchObject({ sessionId: expect.any(String) });
 	});
 

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -1,0 +1,187 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getApiProvider, registerApiProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	AgentSessionRuntime,
+	type CreateAgentSessionRuntimeFactory,
+	type CreateAgentSessionRuntimeResult,
+} from "../src/core/agent-session-runtime.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { type RpcSessionLaunchProfile, RpcSessionRegistry } from "../src/modes/rpc/session-registry.ts";
+
+const profile = (cwd: string, sessionPath: string): RpcSessionLaunchProfile => ({
+	cwd,
+	sessionPath,
+	permissionPreset: "default",
+	creationModel: { provider: "test", modelId: "model" },
+	initialThinkingLevel: "high",
+});
+
+function runtime(
+	options: Parameters<CreateAgentSessionRuntimeFactory>[0],
+	controls?: { waitForIdle?: () => Promise<void> },
+) {
+	return {
+		session: {
+			sessionManager: options.sessionManager,
+			extensionRunner: { hasHandlers: () => false, emit: async () => {} },
+			abort: async () => {},
+			abortBash: () => {},
+			waitForIdle: controls?.waitForIdle ?? (async () => {}),
+			dispose: () => {},
+		},
+		services: { cwd: options.cwd, agentDir: options.agentDir },
+		diagnostics: [],
+	} as unknown as CreateAgentSessionRuntimeResult;
+}
+
+describe("RPC session registry", () => {
+	const directories: string[] = [];
+	afterEach(async () => {
+		await Promise.all(directories.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+	});
+
+	async function createRegistry() {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-rpc-registry-"));
+		directories.push(dir);
+		return {
+			dir,
+			registry: new RpcSessionRegistry({
+				agentDir: dir,
+				createRuntime: async (options) => runtime(options),
+			}),
+		};
+	}
+
+	test("opens independent sessions with distinct opaque handles", async () => {
+		const { dir, registry } = await createRegistry();
+		const first = await registry.openSession(profile(dir, join(dir, "first.jsonl")));
+		const second = await registry.openSession(profile(dir, join(dir, "second.jsonl")));
+
+		expect(first.sessionId).not.toBe(second.sessionId);
+		expect(first.durableSessionId).not.toBe(second.durableSessionId);
+		expect(registry.list()).toHaveLength(2);
+	});
+
+	test("reserves a canonical path before asynchronous runtime construction", async () => {
+		const { dir } = await createRegistry();
+		let release!: () => void;
+		const opened = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const registry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				await opened;
+				return runtime(options);
+			},
+		});
+		const samePath = join(dir, "same.jsonl");
+		const first = registry.openSession(profile(dir, samePath));
+		await expect(registry.openSession(profile(dir, samePath))).rejects.toMatchObject({ code: "session_path_in_use" });
+		release();
+		await first;
+	});
+
+	test("rejects commands while closing, then releases the reservation after disposal", async () => {
+		const { dir } = await createRegistry();
+		let releaseIdle!: () => void;
+		const idle = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
+		let disposed = false;
+		const registry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				const result = runtime(options, { waitForIdle: () => idle });
+				const dispose = result.session.dispose;
+				result.session.dispose = () => {
+					disposed = true;
+					dispose();
+				};
+				return result;
+			},
+		});
+		const path = join(dir, "closing.jsonl");
+		const opened = await registry.openSession(profile(dir, path));
+		const closing = registry.close(opened.sessionId);
+
+		expect(() => registry.getForCommand(opened.sessionId, "prompt")).toThrow(/session_closing/);
+		expect(registry.getForCommand(opened.sessionId, "abort").state).toBe("closing");
+		releaseIdle();
+		await closing;
+		expect(disposed).toBe(true);
+		await expect(registry.openSession(profile(dir, path))).resolves.toMatchObject({ sessionId: expect.any(String) });
+	});
+
+	test("returns unknown_session for an unknown or terminal handle", async () => {
+		const { dir, registry } = await createRegistry();
+		await expect(registry.close("does-not-exist")).rejects.toMatchObject({ code: "unknown_session" });
+		const opened = await registry.openSession(profile(dir, join(dir, "closed.jsonl")));
+		await registry.close(opened.sessionId);
+		await expect(registry.close(opened.sessionId)).rejects.toMatchObject({ code: "unknown_session" });
+	});
+
+	test("constructs each opened runtime inside an isolated provider scope", async () => {
+		const { dir } = await createRegistry();
+		const api = "rpc-session-scope-test";
+		const providersSeenDuringConstruction: Array<unknown> = [];
+		const registry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				if (providersSeenDuringConstruction.length === 0) {
+					await Promise.resolve();
+					registerApiProvider({
+						api,
+						stream: () => {
+							throw new Error("not invoked");
+						},
+						streamSimple: () => {
+							throw new Error("not invoked");
+						},
+					});
+				}
+				providersSeenDuringConstruction.push(getApiProvider(api));
+				return runtime(options);
+			},
+		});
+
+		await registry.openSession(profile(dir, join(dir, "scope-a.jsonl")));
+		await registry.openSession(profile(dir, join(dir, "scope-b.jsonl")));
+
+		expect(providersSeenDuringConstruction[0]).toBeDefined();
+		expect(providersSeenDuringConstruction[1]).toBeUndefined();
+	});
+
+	test("keeps the immutable launch profile across new_session runtime replacement", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-runtime-profile-"));
+		directories.push(dir);
+		const launchProfile = Object.freeze(profile(dir, join(dir, "profile.jsonl")));
+		const manager = SessionManager.create(dir, dir);
+		const captured: Array<RpcSessionLaunchProfile | undefined> = [];
+		const fakeSession = (sessionManager: SessionManager) =>
+			({
+				sessionManager,
+				extensionRunner: { hasHandlers: () => false },
+				dispose: () => {},
+			}) as never;
+		const factory: CreateAgentSessionRuntimeFactory = async (options) => {
+			captured.push(options.launchProfile as RpcSessionLaunchProfile | undefined);
+			return {
+				session: fakeSession(options.sessionManager),
+				services: { cwd: options.cwd, agentDir: dir },
+				diagnostics: [],
+			} as unknown as CreateAgentSessionRuntimeResult;
+		};
+		const initial = await factory({ cwd: dir, agentDir: dir, sessionManager: manager, launchProfile });
+		const session = new AgentSessionRuntime(initial.session, initial.services, factory, [], undefined, launchProfile);
+
+		await session.newSession();
+		expect(captured).toEqual([launchProfile, launchProfile]);
+		expect(session.launchProfile).toBe(launchProfile);
+		expect(existsSync(manager.getSessionDir())).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/todo-extension.test.ts
+++ b/packages/coding-agent/test/suite/todo-extension.test.ts
@@ -953,7 +953,7 @@ describe("todo extension", () => {
 			// to the stable completed row (excludes the unstruck phase header above it).
 			const firstStruck = animatedCoverage.findIndex((coverage) => coverage > 0);
 			if (firstStruck < 0) throw new Error("Expected a struck row");
-			return strikeFlags(animatedLines.slice(firstStruck, animatedStableIndex)).flatMap((flags) => flags);
+			return strikeFlags(animatedLines.slice(firstStruck, animatedStableIndex)).flat();
 		})();
 		const firstUnstruck = animatedFlags.indexOf(false);
 		const struckBeyondBoundary = firstUnstruck >= 0 && animatedFlags.slice(firstUnstruck + 1).some((flag) => flag);

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcCompat = fileURLToPath(new URL("../ai/src/compat.ts", import.meta.url));
+const aiSrcProviderScope = fileURLToPath(new URL("../ai/src/node/provider-scope.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const aiSrcProviders = fileURLToPath(new URL("../ai/src/providers", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
@@ -44,6 +45,7 @@ export default defineConfig({
 		alias: [
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/compat$/, replacement: aiSrcCompat },
+			{ find: /^@earendil-works\/pi-ai\/node\/provider-scope$/, replacement: aiSrcProviderScope },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-ai\/providers\/(.+)$/, replacement: `${aiSrcProviders}/$1.ts` },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },

--- a/packages/neo/internal/bridge/testdata/extract-ts-union.mjs
+++ b/packages/neo/internal/bridge/testdata/extract-ts-union.mjs
@@ -49,7 +49,7 @@ const read = (rel) => readFileSync(join(ROOT, rel), "utf8");
  * Returns the text between `=` and the terminating top-level `;`.
  */
 function extractTypeBody(source, name) {
-	const re = new RegExp(`export type ${name}\\s*=`);
+	const re = new RegExp(`(?:export\\s+)?type ${name}\\s*=`);
 	const m = re.exec(source);
 	if (!m) throw new Error(`type ${name} not found`);
 	let i = m.index + m[0].length;
@@ -108,7 +108,10 @@ const extTypes = read("packages/coding-agent/src/core/extensions/types.ts");
 const connectionHandler = read("packages/coding-agent/src/modes/rpc/connection-handler.ts");
 
 // --- Commands (RpcCommand.type) ---
-const commandBody = extractTypeBody(rpcTypes, "RpcCommand");
+// RpcCommand composes the established command union with its additive routing
+// envelope. Scan both declarations so this source-derived bridge guard remains
+// exhaustive when the protocol factors a shared union.
+const commandBody = [extractTypeBody(rpcTypes, "RpcCommand"), extractTypeBody(rpcTypes, "RpcSessionCommand")].join("\n");
 const commands = uniq(literalsForKey(commandBody, "type"));
 
 // --- Response commands (RpcResponse.command) ---

--- a/packages/neo/internal/bridge/types.go
+++ b/packages/neo/internal/bridge/types.go
@@ -66,6 +66,10 @@ var commandTypes = []string{
 	// and logout answer synchronously; login_start responds immediately and the
 	// URL + result arrive as auth_login_url / auth_login_end events.
 	"get_auth_providers", "login_start", "login_cancel", "login_api_key", "logout",
+	// Multi-session protocol controls. The classic neo worker answers the
+	// capability probe and rejects open_session; the generic command envelope
+	// still preserves all valid wire variants.
+	"get_protocol_info", "open_session", "close_session", "list_sessions",
 }
 
 // KnownCommandTypes returns the mirrored RpcCommand.type set as a lookup.


### PR DESCRIPTION
## Summary

Adds a **multi-session mode** to senpi's plain-RPC protocol so one senpi process can host many concurrent `AgentSession`s over stdio, each fully isolated. This is the senpi half of omo-desktop-app's single-shared-process cutover (companion PR in code-yeongyu/omo-desktop-app). Classic single-session `--mode rpc` stays byte-identical.

## What's new

- **`--multi-session` flag**: no default session is constructed; the process hosts a session registry. Classic mode is unchanged except the additive, side-effect-free `get_protocol_info` command.
- **Wire protocol**: `open_session` / `close_session` / `list_sessions` / `get_protocol_info`, a `sessionId` routing envelope on session-scoped commands, `sessionId` tagging on session-owned output, and stable machine-matchable error codes (`unknown_session`, `session_closing`, `session_path_in_use`, `missing_session_id`, `multi_session_disabled`, `invalid_path`, `open_failed`). Two identities: an ephemeral per-epoch **routing handle** vs the durable JSONL **session id**.
- **Session-scoped state isolation** (mutation-proven): pi-ai provider registry resolves `session overlay → immutable builtins` via a node-only `@earendil-works/pi-ai/node/provider-scope` subpath (root/compat stay browser-safe); session-owned MCP service / elicitation / instructions / prompts; session-keyed config-reload handoff. Includes a shared-state audit of the agent core.
- **Lifecycle**: per-session state machine (`opening|open|closing|closed`) with path reservation, synchronous `closing` transition, and atomic rollback on open failure; immutable per-open launch profile (`permissionPreset`/`model`/`thinkingLevel`/`cwd`) applied on create, restored on resume.
- **Output**: per-session FIFO with a fair round-robin record writer (no cross-session batch coalescing).

## Non-goals

No app-server/ACP changes. No per-connection multi-tenant key isolation (that stays the neo daemon's job). Full rich-event vocabulary preserved — only the additive `sessionId` key.

## Verification

- Per-package `vitest --run` green; `npm run check` green (incl. neo Go build/vet/tests — neo behavior unchanged, bridge exhaustiveness maintained).
- Classic-compat characterization pins + all neo-daemon suites green (byte-identical classic behavior).
- Isolation battery driven through the real routing stack with mutation proofs: provider-overlay swap, real config-reload-while-peer-streaming, MCP session ownership.
- Built binary answers the multi-session capability probe; drives the companion omo E2E.

Plan: `.omo/plans/senpi-single-rpc-process.md` (in the omo-desktop-app repo).

🤖 Generated with senpi


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-session mode for the plain-RPC protocol so one `senpi --mode rpc` process can host many isolated sessions over a single stdio stream. Classic mode stays byte-identical; `get_protocol_info` is the only additive command.

- **New Features**
  - `--multi-session` RPC host with no default session; sessions are created on demand.
  - D1 wire protocol: `get_protocol_info`, `open_session`, `close_session`, `list_sessions`; session-scoped commands are routed by `sessionId`.
  - Stable error codes for routing and lifecycle (`unknown_session`, `session_closing`, `session_path_in_use`, `missing_session_id`, `multi_session_disabled`, `invalid_path`, `open_failed`).
  - Session-scoped provider resolution via `@earendil-works/pi-ai/node/provider-scope` (ALS-backed overlay) with handler binding for EventEmitter callbacks.
  - Session-owned MCP and config-reload state (per-session artifacts cleanup, auth flow guard, elicitation UI provider, and instructions injection).
  - Immutable launch profile applied on create/resume (`cwd`, `permissionPreset`, `model`, `thinkingLevel`), with path reservation and atomic rollback on open failure.
  - Per-session FIFO output with a fair round-robin writer; every record is tagged with `sessionId`.

- **Migration**
  - To host multiple sessions: `senpi --mode rpc --multi-session`.
  - Probe with `get_protocol_info`. Then use `open_session`/`close_session`/`list_sessions`. Include `sessionId` on all session-scoped commands; events include `sessionId`.
  - Classic `--mode rpc` needs no changes and remains wire-identical.
  - In multi-session mode, HTTP proxy and the Undici dispatcher are process-global and fixed at startup.

<sup>Written for commit 63b69d8b10a42a8b591681c16b1258bab5ba9a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

