### PR TITLE
fix(coding-agent): bound compaction progress preview

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## bounded compaction progress preview (2026-07-24)
+
+### What changed
+
+- Streamed compaction summary progress is normalized and rendered as a single `TruncatedText` row beneath the active
+  compaction indicator.
+- Multiline summary content no longer expands the transient status container or pushes the editor and transcript
+  through repeated terminal viewport remaps.
+
+### Why
+
+- Compaction summaries can contain thousands of characters and many newlines. Rendering that temporary content
+  verbatim above the editor made the composer move with every progress update and pushed prior output into scrollback,
+  which looked like transcript deletion.
+
+### Why extension system couldn't handle this
+
+- Compaction progress events and the status/editor container layout are private interactive-mode rendering surfaces.
+
+### Expected merge conflict zones
+
+- MEDIUM: `interactive-mode.ts` compaction progress event rendering.
+
 ## per-section thinking duration headers (2026-07-22)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3561,11 +3561,13 @@ export class InteractiveMode {
 					event.text !== undefined ? event.text : `${this.autoCompactionProgressText}${event.delta ?? ""}`;
 				if (!nextText) break;
 				this.autoCompactionProgressText = nextText;
-				const preview = nextText.length > 4_000 ? `...${nextText.slice(nextText.length - 4_000)}` : nextText;
+				const previewSource = nextText.length > 4_000 ? `...${nextText.slice(nextText.length - 4_000)}` : nextText;
+				const preview = previewSource.replace(/\s+/g, " ").trim();
+				if (!preview) break;
 				this.statusContainer.clear();
 				this.statusContainer.addChild(this.activeStatusIndicator);
 				this.statusContainer.addChild(new Spacer(1));
-				this.statusContainer.addChild(new Text(theme.fg("muted", preview), 1, 0));
+				this.statusContainer.addChild(new TruncatedText(theme.fg("muted", preview), 1, 0));
 				this.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -83,12 +83,16 @@ describe("InteractiveMode compaction events", () => {
 		await handleEvent.call(fakeThis, {
 			type: "compaction_progress",
 			reason: "extension",
-			delta: "live summary chunk",
+			delta: "live summary\nchunk",
 		});
 
-		const rendered = stripAnsi(statusContainer.children.flatMap((child) => child.render(120)).join("\n"));
-		expect(rendered).toContain("Compacting context");
-		expect(rendered).toContain("live summary chunk");
+		const rendered = statusContainer.children
+			.flatMap((child) => child.render(120))
+			.map((line) => stripAnsi(line))
+			.filter((line) => line.trim().length > 0);
+		expect(rendered).toHaveLength(2);
+		expect(rendered[0]).toContain("Compacting context");
+		expect(rendered[1]).toContain("live summary chunk");
 
 		fakeThis.autoCompactionLoader?.stop();
 	});


### PR DESCRIPTION
## Summary

- keep streamed compaction progress to one transient display row
- preserve the active loader and useful preview text without expanding the status container
- prevent long multiline summaries from pushing the composer and prior transcript through terminal viewport remaps

This PR is deliberately independent and based directly on current `main`. It does not depend on compaction lifecycle
PR #310; the old fork-only stacked PR is superseded by this upstream-facing branch.

## Root cause

`compaction_progress` rendered up to 4,000 characters of accumulated summary text through multiline `Text` inside
`statusContainer`, immediately above the editor. Every streamed newline increased root height, moved the composer, and
made prior output look erased as the terminal viewport remapped.

## Behavior

- normalize whitespace for the transient preview
- show a single bounded line with an ellipsis when needed
- retain the spinner and latest useful preview
- leave completed compaction transcript rendering unchanged

## Verification

- focused interactive compaction regression tests
- coding-agent/root build and static checks
- real source TUI at normal and narrow terminal sizes
- browser-rendered xterm.js screenshot/transcript with viewport-width validation

Fresh validation receipts will be attached to this Draft before it is marked ready.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound streamed compaction progress to a single transient line to stop viewport remaps and composer jumps during auto-compaction. Normalizes whitespace and truncates long previews while keeping the spinner and final compaction transcript unchanged.

- **Bug Fixes**
  - Render progress as one `TruncatedText` row; collapse whitespace and trim.
  - Limit preview source to last 4,000 chars; skip empty previews.
  - Keep the active status indicator; prevent `statusContainer` height growth.
  - Update test to assert two-line status (indicator + preview) and handle newlines.

<sup>Written for commit 6848e71947caf6e096e265a9d2d5d7941214fb10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

