### PR TITLE
fix(ai): retry upstream availability failures

### DIFF
--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,13 @@
 # AI Source Changes
 
+## 2026-07-24 - Retry Codex upstream availability failures
+
+### What changed and why
+
+- Treat the exact `upstream_unavailable` provider error code as a transient retry candidate.
+- This covers Codex proxy WebSocket failures such as `ConnectionClosedOK` while preserving the existing
+  non-retryable quota/billing override and bounded retry policy.
+
 ## 2026-07-23 - Session-scoped provider resolution via node-only AsyncLocalStorage subpath
 
 ### What changed and why

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -35,6 +35,7 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 	"504",
 	"524",
 	"service.?unavailable",
+	"\\bupstream_unavailable\\b",
 	"server.?error",
 	"internal.?error",
 

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -10,6 +10,8 @@ const nvidiaNIMResourceExhaustedMessage = "ResourceExhausted: Worker local total
 const bunFetchSocketClosedMessage =
 	"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
 const openAIResponsesEarlyEofMessage = "OpenAI Responses stream ended before a terminal response event";
+const codexUpstreamUnavailableMessage =
+	"Error: upstream_unavailable: Codex upstream websocket send failed via proxy endpoint unknown: ConnectionClosedOK";
 
 describe("provider retry classification", () => {
 	it("matches explicit provider retry guidance", () => {
@@ -56,6 +58,14 @@ describe("provider retry classification", () => {
 		expect(
 			isRetryableAssistantError(
 				fauxAssistantMessage("", { stopReason: "error", errorMessage: openAIResponsesEarlyEofMessage }),
+			),
+		).toBe(true);
+	});
+
+	it("classifies Codex upstream websocket availability failures as retryable", () => {
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: codexUpstreamUnavailableMessage }),
 			),
 		).toBe(true);
 	});

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -6,6 +6,8 @@ import { createHarness, type Harness } from "./harness.ts";
 
 const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
+const codexUpstreamUnavailableMessage =
+	"Error: upstream_unavailable: Codex upstream websocket send failed via proxy endpoint unknown: ConnectionClosedOK";
 
 type EventTranscriptEntry =
 	| { type: "message_start" | "message_end"; role: string }
@@ -92,6 +94,34 @@ describe("retry fallback engine", () => {
 		expect(harness.eventsOfType("retry_fallback_succeeded")).toMatchObject([{ model: fallback, chainKey: primary }]);
 		expect(harness.faux.state.callCount).toBe(2);
 		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, false]);
+	});
+
+	it("retries Codex upstream websocket availability failures without a fallback chain", async () => {
+		const harness = await createHarness({
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: codexUpstreamUnavailableMessage,
+			}),
+			fauxAssistantMessage("fallback recovered"),
+		]);
+
+		await harness.session.prompt("recover the upstream websocket");
+
+		expect(harness.eventsOfType("auto_retry_start")).toMatchObject([
+			{ attempt: 1, delayMs: 1, errorMessage: codexUpstreamUnavailableMessage },
+		]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, false]);
+		expect(harness.faux.state.callCount).toBe(2);
 	});
 
 	it("removes only the failed assistant while preserving state across a fallback switch", async () => {


### PR DESCRIPTION
## Summary

- classify the exact `upstream_unavailable` provider code as transient and retryable
- keep context overflow, refusals, sensitive output, quota, billing, and generic unknown errors excluded
- prove both the provider-neutral classifier and the no-fallback same-model AgentSession path

This is an independent PR based directly on current `main`.

## Reported failure

```text
Error: upstream_unavailable: Codex upstream websocket send failed via proxy endpoint unknown: ConnectionClosedOK
```

The existing classifier covered HTTP 503, service-unavailable text, network errors, and narrow WebSocket close
wording, but not the structured `upstream_unavailable` code. Without a configured fallback chain the turn therefore
settled immediately instead of entering the bounded same-model retry policy.

## RED -> GREEN

- RED classifier: expected retryable `true`, received `false`
- RED AgentSession: expected one `auto_retry_start`, received none; one provider call only
- GREEN: exact token `\bupstream_unavailable\b` admitted
- GREEN classifier: 7/7
- GREEN retry/fallback engine: 7/7
- full AI package suite: 1,191 passed / 761 skipped

## Real-surface QA

A local OpenAI Responses server emitted the exact `response.failed` code/message once, then a successful response.
The real source CLI:

- exited 0
- made exactly two provider requests
- printed the recovery marker
- used only localhost and a dummy local key
- left the real auth file unchanged
- removed its sandbox and closed its server

Root build and `npm run check` also passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies the exact `upstream_unavailable` provider error as transient and retryable, so Codex upstream WebSocket send failures trigger the bounded same-model retry policy instead of failing immediately. Non-retryable cases (quota/billing, context overflow, refusals, sensitive output, and generic unknowns) remain excluded; tests validate the provider-neutral classifier and the no-fallback AgentSession path.

<sup>Written for commit 8b9d28a42be124de520fca78b7eb995b177b2557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

