### PR TITLE
fix(coding-agent): expose failed compaction attempts

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4232,6 +4232,8 @@ export class AgentSession {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
 				return false;
 			}
+			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
+			this._emit({ type: "compaction_start", reason });
 
 			const authResult = await this._modelRuntime.getAuth(this.model);
 			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
@@ -4250,7 +4252,6 @@ export class AgentSession {
 				return false;
 			}
 			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
-			this._emit({ type: "compaction_start", reason });
 
 			const execution = await this._executeCompaction({
 				controller: autoCompactionController,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -8,6 +8,8 @@
   controller at operation start, rejects stale completion/feedback, and retains the terminal result until another
   operation begins. Feedback-only aborts publish one terminal event, and accepted completions publish their terminal
   event before `session_compact` handlers can begin a fresh operation.
+- Owned automatic compaction attempts publish `compaction_start` before authentication/preparation so an early
+  preparation failure does not invisibly consume the one overflow retry attempt.
 - Durable append now rejects a generation whose message revision or agent-message snapshot changed during preparation
   or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
 - Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next


### PR DESCRIPTION
## Summary

- publish `compaction_start` once an automatic compaction owns its model/controller
- do so before authentication/preparation can fail
- preserve the one-overflow-retry attempt when preparation fails before a provider retry

This is a one-commit follow-up to merged PR #310, based directly on its merge result.

## Root cause

The final #310 controller-supersession fix moved `compaction_start` after authentication and request preparation. An
overflow compaction that failed during those early preparation steps therefore consumed/released internal attempt
state without publishing the attempt. The next prompt could not prove that the overflow recovery had been retried,
and the established no-auth regression observed zero starts instead of two independent attempts.

The event now emits after model/controller ownership is proven but before fallible authentication/preparation. A
superseded controller still cannot emit; a valid owned attempt remains observable even when preparation returns early.

## RED -> GREEN

- RED on exact merged `main`:
  - `does not consume the overflow compact-and-retry attempt when compaction fails before retrying`
  - expected two `compaction_start` events, received zero
- GREEN:
  - exact target 1/1
  - agent-session compaction + controller lifecycle group 42/42
  - full compaction/retry/hook matrix 14 files / 121 tests

## Verification

- root build: passed
- root `npm run check`: passed
- real source CLI mock loop: exit 0, one localhost request, expected assistant text, auth unchanged
- built CLI `--help`: exit 0
- built CLI invalid `install` input: exit 1 with usage

The broader coding-agent full suite has unrelated load-sensitive MCP/app-server/temporary-filesystem failures which
pass directly; no compaction test remains failing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `compaction_start` as soon as an automatic compaction owns its model/controller, before auth and preparation. This makes early preparation failures visible and preserves the single overflow retry attempt.

<sup>Written for commit 62354c272c81623155829e573dbf0294ed047d15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

