### PR TITLE
fix(codemode): bound eval status history on current main

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Fixed
 
-- Bound each eval cell's retained status history while preserving the newest events and an exact omitted-event count.
-
 ### Removed
 
 ## [2026.7.25-2] - 2026-07-25

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Bound each eval cell's retained status history while preserving the newest events and an exact omitted-event count.
+
 ### Removed
 
 ## [2026.7.25-2] - 2026-07-25

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -78,7 +78,7 @@ Configuration is loaded in this order:
 | `taskTools.output` | `"task_output"` | Registered tool name used by `output()`. |
 | `outputSink.headBytes` | `20480` | Bytes retained from the beginning of a middle-truncated preview; `0` disables it. |
 | `outputSink.maxColumns` | `768` | Maximum rendered output columns; `0` disables column clamping. |
-| `statusEvents` | `true` | Enables kernel status-event forwarding and rendering. |
+| `statusEvents` | `true` | Enables kernel status-event forwarding and rendering. Each cell retains at most 100 status rows; after overflow, one omitted-count row precedes the latest 99 events. |
 
 `SENPI_CODEMODE_PY`, `SENPI_CODEMODE_JS`, `SENPI_CODEMODE_RB`, and
 `SENPI_CODEMODE_JL` override the corresponding file setting. `1` or `true`

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -409,6 +409,9 @@ function formatStatusEvent(event: EvalStatusEvent, theme: Theme | undefined): st
 		case "phase":
 			parts.push(eventString(event.title) ?? "");
 			break;
+		case "status-events-omitted":
+			parts.push(`${eventNumber(event.count)} earlier events omitted`);
+			break;
 		default: {
 			if (event.count !== undefined) parts.push(String(event.count));
 			const path = eventString(event.path);

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -423,8 +423,13 @@ function formatStatusEvent(event: EvalStatusEvent, theme: Theme | undefined): st
 }
 
 function renderStatusEvents(events: readonly EvalStatusEvent[], environment: RenderEnvironment): string[] {
-	const retained = environment.expanded ? events : events.slice(-STATUS_PREVIEW_COUNT);
-	const skipped = events.length - retained.length;
+	// A bounded history stores its exact omission count in a leading marker event; fold that
+	// count into the summary line so collapsing the preview can never understate omissions.
+	const first = events[0];
+	const omittedByBound = first?.op === "status-events-omitted" && typeof first.count === "number" ? first.count : 0;
+	const visible = omittedByBound > 0 ? events.slice(1) : events;
+	const retained = environment.expanded ? visible : visible.slice(-STATUS_PREVIEW_COUNT);
+	const skipped = visible.length - retained.length + omittedByBound;
 	const lines: string[] = [];
 	if (skipped > 0) lines.push(style(environment.theme, "dim", `├ … ${skipped} earlier status events`));
 	for (const [index, event] of retained.entries()) {

--- a/packages/senpi-codemode/src/tool/status-events.ts
+++ b/packages/senpi-codemode/src/tool/status-events.ts
@@ -1,12 +1,32 @@
 import type { EvalStatusEvent } from "./types.ts";
 
+export const STATUS_EVENT_HISTORY_LIMIT = 100;
+const OMITTED_STATUS_EVENTS_OP = "status-events-omitted";
+
+function trimStatusHistory(events: EvalStatusEvent[]): void {
+	if (events.length <= STATUS_EVENT_HISTORY_LIMIT) return;
+
+	const first = events[0];
+	if (first?.op === OMITTED_STATUS_EVENTS_OP && typeof first.count === "number") {
+		const removeCount = events.length - STATUS_EVENT_HISTORY_LIMIT;
+		events.splice(1, removeCount);
+		events[0] = { op: OMITTED_STATUS_EVENTS_OP, count: first.count + removeCount };
+		return;
+	}
+
+	const removeCount = events.length - STATUS_EVENT_HISTORY_LIMIT + 1;
+	events.splice(0, removeCount, { op: OMITTED_STATUS_EVENTS_OP, count: removeCount });
+}
+
 export function upsertStatusEvent(events: EvalStatusEvent[], event: EvalStatusEvent): void {
 	if (event.op === "agent" && typeof event.id === "string") {
 		const index = events.findIndex((candidate) => candidate.op === "agent" && candidate.id === event.id);
 		if (index >= 0) {
 			events[index] = event;
+			trimStatusHistory(events);
 			return;
 		}
 	}
 	events.push(event);
+	trimStatusHistory(events);
 }

--- a/packages/senpi-codemode/test/eval-render-preview.test.ts
+++ b/packages/senpi-codemode/test/eval-render-preview.test.ts
@@ -335,4 +335,59 @@ describe("eval renderer preview", () => {
 		for (const outputLine of outputLines) expect.soft(expandedText).toContain(outputLine);
 		expect.soft(expandedText).not.toContain("earlier status events");
 	});
+
+	it("Given a bounded status history when collapsed and expanded then the exact omission count survives", () => {
+		// Given: a history that overflowed the retention bound, e.g. 19,906 events kept as one
+		// marker plus the newest five real events.
+		const statusEvents = [
+			{ op: "status-events-omitted", count: 19_901 },
+			...Array.from({ length: 5 }, (_, index) => ({ op: "log", message: `status-${index + 1}` })),
+		];
+		const givenResult = evalResult(
+			{
+				language: "js",
+				durationMs: 1,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "run()",
+						language: "js",
+						output: "ok",
+						status: "complete",
+						statusEvents,
+					},
+				],
+			},
+			"",
+		);
+
+		// When
+		const collapsedText = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext(),
+		)
+			.render(80)
+			.join("\n");
+		const expandedText = renderEvalResult(
+			givenResult,
+			{ expanded: true, isPartial: false },
+			undefined,
+			resultContext({ expanded: true }),
+		)
+			.render(80)
+			.join("\n");
+
+		// Then: collapsing keeps the newest three rows and reports 19,901 + 2 sliced omissions,
+		// while expanding shows every retained row above the exact marker count.
+		expect.soft(collapsedText).toContain("19903 earlier status events");
+		for (const visibleStatus of ["status-3", "status-4", "status-5"])
+			expect.soft(collapsedText).toContain(visibleStatus);
+		expect.soft(expandedText).toContain("19901 earlier status events");
+		for (let index = 1; index <= 5; index++) expect.soft(expandedText).toContain(`status-${index}`);
+		expect.soft(expandedText).not.toContain("status-events-omitted");
+	});
 });

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -332,8 +332,10 @@ describe("eval renderer", () => {
 			.join("\n");
 
 		// Then
+		// The bound marker is folded into the omission summary line instead of rendering as its own row.
+		expect(text).toContain("26 earlier status events");
+		expect(text).not.toContain("status-events-omitted");
 		for (const summary of [
-			"status-events-omitted 26 earlier events omitted",
 			"cat 2 files · 9 chars",
 			"ls 3 entries",
 			"env set TOKEN=secret",

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -303,6 +303,7 @@ describe("eval renderer", () => {
 						output: "ok",
 						status: "complete",
 						statusEvents: [
+							{ op: "status-events-omitted", count: 26 },
 							{ op: "cat", files: 2, chars: 9 },
 							{ op: "ls", count: 3 },
 							{ op: "env", action: "set", key: "TOKEN", value: "secret" },
@@ -332,6 +333,7 @@ describe("eval renderer", () => {
 
 		// Then
 		for (const summary of [
+			"status-events-omitted 26 earlier events omitted",
 			"cat 2 files · 9 chars",
 			"ls 3 entries",
 			"env set TOKEN=secret",

--- a/packages/senpi-codemode/test/eval-tool-output.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-output.test.ts
@@ -6,6 +6,7 @@ import type { AgentToolResult, AgentToolUpdateCallback } from "@code-yeongyu/sen
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultCodemodeSettings } from "../src/config/settings.ts";
 import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { STATUS_EVENT_HISTORY_LIMIT } from "../src/tool/status-events.ts";
 import type { EvalToolDetails } from "../src/tool/types.ts";
 import { errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
 
@@ -258,5 +259,49 @@ describe("eval tool output pipeline", () => {
 			isError: true,
 			cells: [{ status: "error", output: expect.stringContaining("partial") }],
 		});
+	});
+
+	it("bounds high-volume helper status history in partial and final details", async () => {
+		// Given
+		const totalEvents = STATUS_EVENT_HISTORY_LIMIT + 25;
+		const kernel = new FakeKernel([
+			...Array.from({ length: totalEvents }, (_, index) => ({
+				type: "status" as const,
+				event: {
+					op: "read",
+					path: `/tmp/file-${index}.txt`,
+					preview: "x".repeat(500),
+				},
+			})),
+			result("status-history", "done", 1),
+		]);
+		const tool = createEvalTool({
+			enabledLanguages: { js: true, py: false, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 30,
+			executeTool: vi.fn(),
+		});
+		const partialHistoryLengths: number[] = [];
+		const onUpdate: AgentToolUpdateCallback<EvalToolDetails> = (update) => {
+			const historyLength = update.details.statusEvents?.length;
+			if (historyLength !== undefined) partialHistoryLengths.push(historyLength);
+		};
+
+		// When
+		const toolResult = await tool.execute(
+			"status-history",
+			{ language: "js", code: "for (const path of paths) read(path)" },
+			undefined,
+			onUpdate,
+			fakeExtensionContext(),
+		);
+
+		// Then
+		expect(partialHistoryLengths.length).toBeGreaterThanOrEqual(totalEvents);
+		expect(Math.max(...partialHistoryLengths)).toBe(STATUS_EVENT_HISTORY_LIMIT);
+		expect(partialHistoryLengths.every((length) => length <= STATUS_EVENT_HISTORY_LIMIT)).toBe(true);
+		expect(toolResult.details.statusEvents).toHaveLength(STATUS_EVENT_HISTORY_LIMIT);
+		expect(toolResult.details.statusEvents?.[0]).toEqual({ op: "status-events-omitted", count: 26 });
+		expect(toolResult.details.cells?.[0]?.statusEvents).toEqual(toolResult.details.statusEvents);
 	});
 });

--- a/packages/senpi-codemode/test/status-events.test.ts
+++ b/packages/senpi-codemode/test/status-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { upsertStatusEvent } from "../src/tool/status-events.ts";
+import { STATUS_EVENT_HISTORY_LIMIT, upsertStatusEvent } from "../src/tool/status-events.ts";
 import type { EvalStatusEvent } from "../src/tool/types.ts";
 
 describe("upsertStatusEvent", () => {
@@ -43,5 +43,36 @@ describe("upsertStatusEvent", () => {
 			{ op: "agent", status: "missing-id" },
 			{ op: "agent", status: "missing-id" },
 		]);
+	});
+
+	it("bounds status history while reporting how many earlier events were omitted", () => {
+		const events: EvalStatusEvent[] = [];
+		const totalEvents = STATUS_EVENT_HISTORY_LIMIT + 25;
+
+		for (let index = 0; index < totalEvents; index += 1) {
+			upsertStatusEvent(events, {
+				op: "read",
+				path: `/tmp/file-${index}.txt`,
+				preview: "x".repeat(500),
+			});
+		}
+
+		expect(events).toHaveLength(STATUS_EVENT_HISTORY_LIMIT);
+		expect(events[0]).toEqual({ op: "status-events-omitted", count: 26 });
+		expect(events[1]).toMatchObject({ op: "read", path: "/tmp/file-26.txt" });
+		expect(events.at(-1)).toMatchObject({ op: "read", path: `/tmp/file-${totalEvents - 1}.txt` });
+	});
+
+	it("reserves the omission marker when event 101 arrives", () => {
+		const events: EvalStatusEvent[] = [];
+
+		for (let index = 0; index <= STATUS_EVENT_HISTORY_LIMIT; index += 1) {
+			upsertStatusEvent(events, { op: "read", path: `/tmp/file-${index}.txt` });
+		}
+
+		expect(events).toHaveLength(STATUS_EVENT_HISTORY_LIMIT);
+		expect(events[0]).toEqual({ op: "status-events-omitted", count: 2 });
+		expect(events[1]).toMatchObject({ op: "read", path: "/tmp/file-2.txt" });
+		expect(events.at(-1)).toMatchObject({ op: "read", path: "/tmp/file-100.txt" });
 	});
 });


### PR DESCRIPTION
## Summary

- bound each Code Mode eval cell's retained status history to 100 rows
- after overflow, retain one exact omitted-event count plus the newest 99 real events
- preserve small histories and existing in-window agent-status coalescing
- render and document the omission row

## Root cause

Each eval cell retained every status event, including a path and preview for every `read()`. Every partial update then copied the entire unbounded history into both top-level and cell details. Read-heavy child work could therefore exhaust V8's heap before eval completed.

## Current-main replacement

This Draft is based directly on `upstream/main@38bd3a3cf` and contains patch-identical ports of the two focused commits from #324. No current-main source file touched by the fix diverged from #324's old base.

Supersedes #324, which was 21 main commits behind and did not contain current `main` in its ancestry.

## Verification

- root `npm run build`: passed
- focused status/output/render source tests: 3 files / 24 tests passed
- full `@code-yeongyu/senpi-codemode` source suite: 54 files / 372 tests passed; 1 file / 12 tests capability-skipped
- CI Code Mode suite: 55 files / 384 tests passed
- required root `npm run check`: passed
- changed-file LSP diagnostics, no-excuse audit, and `git diff --check`: passed

## Exact 256 MB source CLI QA

Run from the PR worktree root through the Senpi QA harness and real source CLI (`runCli`/`tsx`) with a hermetic localhost fake-model provider:

```sh
NODE_OPTIONS=--max-old-space-size=256 node local-ignore/qa-evidence/20260724-eval-status-history-current-main/eval-memory-cli-qa.mjs 125
NODE_OPTIONS=--max-old-space-size=256 node local-ignore/qa-evidence/20260724-eval-status-history-current-main/eval-memory-cli-qa.mjs 20000
```

Results:

- 125 Python `read()` events: PASS in 5.232 s; 100 top-level rows; 100 cell rows; exact omitted count 26
- 20,000 Python `read()` events: PASS in 7.735 s; 100 top-level rows; 100 cell rows; exact omitted count 19,901
- both runs completed two model turns, observed the completion marker, kept real auth unchanged, and removed the QA sandbox

## Red `Check and test` classification

The historical check remains red and is not represented as passing. Its two `packages/coding-agent` failures were compared against fresh `upstream/main@38bd3a3cf`, which is still the PR's exact base:

- `git diff --stat upstream/main...HEAD -- packages/coding-agent` is empty; the failing tests, Vitest config, and `src/main.ts` have identical hashes at PR head and base.
- **Compaction assertion:** current-main CI run `30089381490` has the same test, `expected [] to have a length of 2 but got +0` assertion, and line 1361 as PR run `30110526214`. Fresh focused runs fail identically at both PR head and a clean detached base worktree; fresh serialized `CI=1 npm test` runs fail it on both revisions. Classification: pre-existing current-main failure.
- **List-model 30 s timeout:** the exact failed test passes focused at PR head (7.50 s) and base (7.32 s), and does not time out in either fresh serialized full-package run. Classification: non-reproducing suite/runner timeout with no PR source delta, not a PR regression.

No unrelated `coding-agent` fix is included in this scoped Code Mode OOM PR.

Local evidence: `local-ignore/qa-evidence/20260724-eval-status-history-current-main/INDEX.md` and `ci-failure-classification.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound each eval cell’s status history to 100 rows and folded the omission marker into the summary line to prevent heap bloat while showing the exact number of earlier events. Newest events stay intact.

- **Bug Fixes**
  - Trim history in `status-events.ts` with `STATUS_EVENT_HISTORY_LIMIT = 100`; keep the latest 99 events plus a `{ op: "status-events-omitted", count }` marker; apply on inserts and updates; per‑cell and top‑level histories remain bounded; preserve `agent` coalescing.
  - In `render.ts`, hide the marker row and fold its count into the omission summary so collapsed previews report the exact total and expanded views show all retained rows without the marker.
  - Updated `README` and tests in `@code-yeongyu/senpi-codemode` to document and verify bounded history and the folded summary behavior.

<sup>Written for commit c0d48145e25ede51e696e5bcbece69560ce786f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

