### PR TITLE
fix(codemode): bound eval status history

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Bound each eval cell's retained status history while preserving the newest events and an exact omitted-event count.
+
 ### Removed
 
 ## [2026.7.23] - 2026-07-23

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -74,7 +74,7 @@ Configuration is loaded in this order:
 | `taskTools.output` | `"task_output"` | Registered tool name used by `output()`. |
 | `outputSink.headBytes` | `20480` | Bytes retained from the beginning of a middle-truncated preview; `0` disables it. |
 | `outputSink.maxColumns` | `768` | Maximum rendered output columns; `0` disables column clamping. |
-| `statusEvents` | `true` | Enables kernel status-event forwarding and rendering. |
+| `statusEvents` | `true` | Enables kernel status-event forwarding and rendering. Each cell retains at most 100 status rows; after overflow, one omitted-count row precedes the latest 99 events. |
 
 `SENPI_CODEMODE_PY`, `SENPI_CODEMODE_JS`, `SENPI_CODEMODE_RB`, and
 `SENPI_CODEMODE_JL` override the corresponding file setting. `1` or `true`

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -404,6 +404,9 @@ function formatStatusEvent(event: EvalStatusEvent, theme: Theme | undefined): st
 		case "phase":
 			parts.push(eventString(event.title) ?? "");
 			break;
+		case "status-events-omitted":
+			parts.push(`${eventNumber(event.count)} earlier events omitted`);
+			break;
 		default: {
 			if (event.count !== undefined) parts.push(String(event.count));
 			const path = eventString(event.path);

--- a/packages/senpi-codemode/src/tool/status-events.ts
+++ b/packages/senpi-codemode/src/tool/status-events.ts
@@ -1,12 +1,32 @@
 import type { EvalStatusEvent } from "./types.ts";
 
+export const STATUS_EVENT_HISTORY_LIMIT = 100;
+const OMITTED_STATUS_EVENTS_OP = "status-events-omitted";
+
+function trimStatusHistory(events: EvalStatusEvent[]): void {
+	if (events.length <= STATUS_EVENT_HISTORY_LIMIT) return;
+
+	const first = events[0];
+	if (first?.op === OMITTED_STATUS_EVENTS_OP && typeof first.count === "number") {
+		const removeCount = events.length - STATUS_EVENT_HISTORY_LIMIT;
+		events.splice(1, removeCount);
+		events[0] = { op: OMITTED_STATUS_EVENTS_OP, count: first.count + removeCount };
+		return;
+	}
+
+	const removeCount = events.length - STATUS_EVENT_HISTORY_LIMIT + 1;
+	events.splice(0, removeCount, { op: OMITTED_STATUS_EVENTS_OP, count: removeCount });
+}
+
 export function upsertStatusEvent(events: EvalStatusEvent[], event: EvalStatusEvent): void {
 	if (event.op === "agent" && typeof event.id === "string") {
 		const index = events.findIndex((candidate) => candidate.op === "agent" && candidate.id === event.id);
 		if (index >= 0) {
 			events[index] = event;
+			trimStatusHistory(events);
 			return;
 		}
 	}
 	events.push(event);
+	trimStatusHistory(events);
 }

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -303,6 +303,7 @@ describe("eval renderer", () => {
 						output: "ok",
 						status: "complete",
 						statusEvents: [
+							{ op: "status-events-omitted", count: 26 },
 							{ op: "cat", files: 2, chars: 9 },
 							{ op: "ls", count: 3 },
 							{ op: "env", action: "set", key: "TOKEN", value: "secret" },
@@ -332,6 +333,7 @@ describe("eval renderer", () => {
 
 		// Then
 		for (const summary of [
+			"status-events-omitted 26 earlier events omitted",
 			"cat 2 files · 9 chars",
 			"ls 3 entries",
 			"env set TOKEN=secret",

--- a/packages/senpi-codemode/test/eval-tool-output.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-output.test.ts
@@ -6,6 +6,7 @@ import type { AgentToolResult, AgentToolUpdateCallback } from "@code-yeongyu/sen
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultCodemodeSettings } from "../src/config/settings.ts";
 import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { STATUS_EVENT_HISTORY_LIMIT } from "../src/tool/status-events.ts";
 import type { EvalToolDetails } from "../src/tool/types.ts";
 import { errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
 
@@ -258,5 +259,49 @@ describe("eval tool output pipeline", () => {
 			isError: true,
 			cells: [{ status: "error", output: expect.stringContaining("partial") }],
 		});
+	});
+
+	it("bounds high-volume helper status history in partial and final details", async () => {
+		// Given
+		const totalEvents = STATUS_EVENT_HISTORY_LIMIT + 25;
+		const kernel = new FakeKernel([
+			...Array.from({ length: totalEvents }, (_, index) => ({
+				type: "status" as const,
+				event: {
+					op: "read",
+					path: `/tmp/file-${index}.txt`,
+					preview: "x".repeat(500),
+				},
+			})),
+			result("status-history", "done", 1),
+		]);
+		const tool = createEvalTool({
+			enabledLanguages: { js: true, py: false, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 30,
+			executeTool: vi.fn(),
+		});
+		const partialHistoryLengths: number[] = [];
+		const onUpdate: AgentToolUpdateCallback<EvalToolDetails> = (update) => {
+			const historyLength = update.details.statusEvents?.length;
+			if (historyLength !== undefined) partialHistoryLengths.push(historyLength);
+		};
+
+		// When
+		const toolResult = await tool.execute(
+			"status-history",
+			{ language: "js", code: "for (const path of paths) read(path)" },
+			undefined,
+			onUpdate,
+			fakeExtensionContext(),
+		);
+
+		// Then
+		expect(partialHistoryLengths.length).toBeGreaterThanOrEqual(totalEvents);
+		expect(Math.max(...partialHistoryLengths)).toBe(STATUS_EVENT_HISTORY_LIMIT);
+		expect(partialHistoryLengths.every((length) => length <= STATUS_EVENT_HISTORY_LIMIT)).toBe(true);
+		expect(toolResult.details.statusEvents).toHaveLength(STATUS_EVENT_HISTORY_LIMIT);
+		expect(toolResult.details.statusEvents?.[0]).toEqual({ op: "status-events-omitted", count: 26 });
+		expect(toolResult.details.cells?.[0]?.statusEvents).toEqual(toolResult.details.statusEvents);
 	});
 });

--- a/packages/senpi-codemode/test/status-events.test.ts
+++ b/packages/senpi-codemode/test/status-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { upsertStatusEvent } from "../src/tool/status-events.ts";
+import { STATUS_EVENT_HISTORY_LIMIT, upsertStatusEvent } from "../src/tool/status-events.ts";
 import type { EvalStatusEvent } from "../src/tool/types.ts";
 
 describe("upsertStatusEvent", () => {
@@ -43,5 +43,36 @@ describe("upsertStatusEvent", () => {
 			{ op: "agent", status: "missing-id" },
 			{ op: "agent", status: "missing-id" },
 		]);
+	});
+
+	it("bounds status history while reporting how many earlier events were omitted", () => {
+		const events: EvalStatusEvent[] = [];
+		const totalEvents = STATUS_EVENT_HISTORY_LIMIT + 25;
+
+		for (let index = 0; index < totalEvents; index += 1) {
+			upsertStatusEvent(events, {
+				op: "read",
+				path: `/tmp/file-${index}.txt`,
+				preview: "x".repeat(500),
+			});
+		}
+
+		expect(events).toHaveLength(STATUS_EVENT_HISTORY_LIMIT);
+		expect(events[0]).toEqual({ op: "status-events-omitted", count: 26 });
+		expect(events[1]).toMatchObject({ op: "read", path: "/tmp/file-26.txt" });
+		expect(events.at(-1)).toMatchObject({ op: "read", path: `/tmp/file-${totalEvents - 1}.txt` });
+	});
+
+	it("reserves the omission marker when event 101 arrives", () => {
+		const events: EvalStatusEvent[] = [];
+
+		for (let index = 0; index <= STATUS_EVENT_HISTORY_LIMIT; index += 1) {
+			upsertStatusEvent(events, { op: "read", path: `/tmp/file-${index}.txt` });
+		}
+
+		expect(events).toHaveLength(STATUS_EVENT_HISTORY_LIMIT);
+		expect(events[0]).toEqual({ op: "status-events-omitted", count: 2 });
+		expect(events[1]).toMatchObject({ op: "read", path: "/tmp/file-2.txt" });
+		expect(events.at(-1)).toMatchObject({ op: "read", path: "/tmp/file-100.txt" });
 	});
 });


### PR DESCRIPTION
## Summary

- bound Code Mode eval status history to 100 rows per cell
- reserve one row for an exact omitted-event count after overflow
- retain the newest 99 real events without changing normal small histories or agent-status coalescing
- document the bounded-history contract in the package README and changelog

This is the clean current-`main` replacement for #324, replayed directly onto `upstream/main@38bd3a3cf` with no compaction or TUI dependency.

## Root cause

Each eval cell kept every emitted status event in `state.events`. Read/update-heavy child work could emit thousands of events, and every render rebuilt the full unbounded list. A long session could therefore retain and repeatedly render enough history to drive V8 toward its heap limit.

## Behavior

- at most 100 retained status rows per cell
- after overflow: one synthetic omission row plus the newest 99 events
- exact omitted-event count remains correct as additional events arrive
- small histories and existing agent-status coalescing behavior remain unchanged

## Verification

- focused status/render/tool-output regressions: 3 files, 24 tests passed
- full `senpi-codemode` suite: 54 files / 372 tests passed; 1 file / 12 tests skipped
- root `npm run build`: passed
- root `npm run check`: passed
- real built CLI with a Python eval under `NODE_OPTIONS=--max-old-space-size=256`: 20,000 reads completed, 100 top-level/cell status rows retained, exact omitted count 19,901, auth unchanged
- `git diff --check`: passed

Kept as Draft for maintainer review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound Code Mode eval status history per cell to 100 rows to prevent unbounded growth and reduce memory pressure. Keeps the newest events and shows an exact omitted count.

- **Bug Fixes**
  - On overflow, insert a `status-events-omitted` row and retain the latest 99 events; the omitted count increments as more events arrive.
  - Updated renderer to show "N earlier events omitted"; small histories and agent-status coalescing remain unchanged.
  - Documented the bounded-history contract in `README.md`/`CHANGELOG.md` and added tests for trimming and partial/final details.

<sup>Written for commit 8da0cea07d34488d5d17a1b2f08e3835cb0206d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

