### PR TITLE
fix(coding-agent): restore compaction preflight events

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4235,8 +4235,17 @@ export class AgentSession {
 
 			const authResult = await this._modelRuntime.getAuth(this.model);
 			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
+			this._emit({ type: "compaction_start", reason });
+			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
 			if (this.agent.streamFn === streamSimple && !authResult?.auth.apiKey) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
+				this._emit({
+					type: "compaction_end",
+					reason,
+					result: undefined,
+					aborted: false,
+					willRetry: false,
+				});
 				return false;
 			}
 
@@ -4247,10 +4256,16 @@ export class AgentSession {
 			);
 			if (!preparation) {
 				if (reason === "overflow") this._overflowRecoveryAttempted = false;
+				this._emit({
+					type: "compaction_end",
+					reason,
+					result: undefined,
+					aborted: false,
+					willRetry: false,
+				});
 				return false;
 			}
 			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
-			this._emit({ type: "compaction_start", reason });
 
 			const execution = await this._executeCompaction({
 				controller: autoCompactionController,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -8,6 +8,8 @@
   controller at operation start, rejects stale completion/feedback, and retains the terminal result until another
   operation begins. Feedback-only aborts publish one terminal event, and accepted completions publish their terminal
   event before `session_compact` handlers can begin a fresh operation.
+- Owned automatic compaction attempts start before authentication/preparation validation and end when preflight
+  rejects. Ownership is rechecked after start so synchronous listener supersession cannot publish a stale terminal.
 - Durable append now rejects a generation whose message revision or agent-message snapshot changed during preparation
   or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
 - Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -388,6 +388,42 @@ describe("AgentSession compaction characterization", () => {
 		expect(getStreamCallCount()).toBe(1);
 	});
 
+	it("balances auto-compaction events when there is nothing to prepare", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		await runAutoCompaction(harness.session, "threshold", false);
+
+		const compactionEvents = harness.events.filter(
+			(event) => event.type === "compaction_start" || event.type === "compaction_end",
+		);
+		expect(compactionEvents).toEqual([
+			{ type: "compaction_start", reason: "threshold" },
+			expect.objectContaining({
+				type: "compaction_end",
+				reason: "threshold",
+				result: undefined,
+				aborted: false,
+				willRetry: false,
+			}),
+		]);
+	});
+
+	it("does not publish a stale preflight end after a start listener aborts auto-compaction", async () => {
+		const harness = await createHarness({ withConfiguredAuth: false });
+		harnesses.push(harness);
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start" && event.reason === "threshold") {
+				harness.session.abortCompaction();
+			}
+		});
+
+		await runAutoCompaction(harness.session, "threshold", false);
+
+		expect(harness.eventsOfType("compaction_start")).toEqual([{ type: "compaction_start", reason: "threshold" }]);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+	});
+
 	it("does not emit compaction events for a normal response below the threshold", async () => {
 		// given
 		const harness = await createHarness({
@@ -1353,12 +1389,12 @@ describe("AgentSession compaction characterization", () => {
 		await checkCompaction(harness.session, secondOverflow);
 
 		const overflowStarts = harness.eventsOfType("compaction_start").filter((event) => event.reason === "overflow");
-		const terminalOverflowFailures = harness
-			.eventsOfType("compaction_end")
-			.filter((event) =>
-				event.errorMessage?.startsWith("Context overflow recovery failed after one compact-and-retry attempt"),
-			);
+		const overflowEnds = harness.eventsOfType("compaction_end").filter((event) => event.reason === "overflow");
+		const terminalOverflowFailures = overflowEnds.filter((event) =>
+			event.errorMessage?.startsWith("Context overflow recovery failed after one compact-and-retry attempt"),
+		);
 		expect(overflowStarts).toHaveLength(2);
+		expect(overflowEnds).toHaveLength(2);
 		expect(terminalOverflowFailures).toHaveLength(0);
 	});
 


### PR DESCRIPTION
## Summary

- restore observable auto-compaction lifecycle events for auth/preparation preflight failures
- emit a matching non-error terminal event when an owned preflight attempt cannot proceed
- preserve PR #310 stale-controller protection, including synchronous `compaction_start` listener supersession
- strengthen the existing overflow characterization and add no-preparation/reentrant-listener coverage

## Root cause and attribution

Current main inherited the regression from PR #310 commit `b3f643e915`: `_runAutoCompaction()` moved `compaction_start` below auth/preparation validation and removed early terminal events. The existing no-auth characterization consequently observed zero starts instead of two.

The exact owner boundary was reproduced before this change:

- `10a82f30d` (parent of owner commit): PASS
- `b3f643e915` (PR #310 head): FAIL, expected 2 / received 0
- `38bd3a3cf` (merged main baseline): identical FAIL
- PRs #328, #334, and #336: identical inherited failure with byte-identical relevant source/test blobs

This repair is isolated from PR #328 and contains only the three compaction lifecycle files shown in the diff.

## Verification

- Existing focused RED: reproduced `expected [] to have a length of 2 but got +0`
- Focused GREEN: 1/1 passed
- Final compaction domain: 45 files, 366 tests passed
- Full workspace after build:
  - coding-agent: 558 files passed / 4 skipped
  - 4,602 tests passed / 32 skipped
  - all remaining workspace suites passed
- Root `npm run build`: passed
- Root `npm run check`: passed, including Biome, dependency/import/lock checks, `tsgo`, browser smoke, web UI, and Neo build/vet/tests
- Real source CLI isolation/auth self-check: 9/9 passed
- Real source CLI RPC with localhost OpenAI Responses mock: passed
- Real source CLI deterministic mock loop with localhost OpenAI Completions mock: passed
- Independent final read-only review: `PASS - no actionable findings`

## Evidence

Local evidence index:

`local-ignore/qa-evidence/20260724-compaction-preflight-lifecycle/EVIDENCE.md`

Supporting source-CLI artifacts:

- `local-ignore/qa-evidence/20260725-compaction-preflight-rpc/`
- `local-ignore/qa-evidence/20260725-compaction-preflight-mock/`

Original CI attribution:

`local-ignore/qa-evidence/20260724-compaction-progress-live-cdp-final/ci-current-main-attribution/attribution.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores auto-compaction preflight lifecycle events and balances start/end signals around auth/preparation checks. Prevents stale terminal events when a start listener supersedes controller ownership.

- **Bug Fixes**
  - Emit `compaction_start` before auth/prep; on preflight reject, emit a matching non-error `compaction_end`; recheck ownership after start to avoid stale ends.
  - Preserve overflow recovery and controller-ownership safeguards; add tests for no-prep and listener-abort cases; update `changes.md`.

<sup>Written for commit d0272160977d3fb3198251351407510495f52f8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

