### PR TITLE
fix(coding-agent): preserve compaction preflight ownership

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4329,12 +4329,17 @@ export class AgentSession {
 			if (reason === "overflow" && this._autoCompactionAbortController === autoCompactionController) {
 				this._overflowRecoveryAttempted = false;
 			}
-			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
+			// A synchronous compaction_start listener can supersede this controller with a new
+			// operation, which then owns its own start/end lifecycle; publishing another terminal
+			// event here would be stale. A listener can instead abort this very controller, and
+			// that still needs a terminal event: consumers open UI state on compaction_start and
+			// close it only on compaction_end.
+			if (this._autoCompactionAbortController !== autoCompactionController) return false;
 			this._emit({
 				type: "compaction_end",
 				reason,
 				result: undefined,
-				aborted: false,
+				aborted: autoCompactionController.signal.aborted,
 				willRetry: false,
 			});
 			return false;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4326,8 +4326,10 @@ export class AgentSession {
 		this._claimCompactionController(autoCompactionController, "auto");
 		const endBeforeExecution = (): false => {
 			this._emit({ type: "compaction_start", reason });
+			if (reason === "overflow" && this._autoCompactionAbortController === autoCompactionController) {
+				this._overflowRecoveryAttempted = false;
+			}
 			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
-			if (reason === "overflow") this._overflowRecoveryAttempted = false;
 			this._emit({
 				type: "compaction_end",
 				reason,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4326,6 +4326,7 @@ export class AgentSession {
 		this._claimCompactionController(autoCompactionController, "auto");
 		const endBeforeExecution = (): false => {
 			this._emit({ type: "compaction_start", reason });
+			if (!this._ownsCompactionController(autoCompactionController, "auto")) return false;
 			if (reason === "overflow") this._overflowRecoveryAttempted = false;
 			this._emit({
 				type: "compaction_end",

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -66,7 +66,9 @@ Skill commands are resource-loader entries rather than extension commands, and t
   operation begins. Feedback-only aborts publish one terminal event, and accepted completions publish their terminal
   event before `session_compact` handlers can begin a fresh operation.
 - Owned automatic compaction attempts publish balanced start/end events when execution cannot begin. Ownership is
-  rechecked after start so synchronous listener supersession cannot publish a stale terminal event.
+  rechecked after start: a synchronous listener that supersedes the controller with a new operation silences the stale
+  terminal event (the new owner publishes its own lifecycle), while a listener that aborts the same controller still
+  receives an `aborted` terminal event so UI state opened on `compaction_start` is always closed.
 - Durable append now rejects a generation whose message revision or agent-message snapshot changed during preparation
   or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
 - Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -65,6 +65,8 @@ Skill commands are resource-loader entries rather than extension commands, and t
   controller at operation start, rejects stale completion/feedback, and retains the terminal result until another
   operation begins. Feedback-only aborts publish one terminal event, and accepted completions publish their terminal
   event before `session_compact` handlers can begin a fresh operation.
+- Owned automatic compaction attempts publish balanced start/end events when execution cannot begin. Ownership is
+  rechecked after start so synchronous listener supersession cannot publish a stale terminal event.
 - Durable append now rejects a generation whose message revision or agent-message snapshot changed during preparation
   or summary generation (`stale-revision`), preserving intervening context without duplicate replay.
 - Required compaction uses one provider-admission gate for normal prompts, extension-triggered turns, and every next

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -481,7 +481,7 @@ describe("AgentSession compaction characterization", () => {
 		]);
 	});
 
-	it("does not publish a stale preflight end after a start listener aborts auto-compaction", async () => {
+	it("publishes an aborted preflight end after a start listener aborts auto-compaction", async () => {
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
 		harness.session.subscribe((event) => {
@@ -492,8 +492,18 @@ describe("AgentSession compaction characterization", () => {
 
 		await runAutoCompaction(harness.session, "threshold", false);
 
+		// Consumers open UI state (progress indicator, Escape override) on compaction_start and
+		// close it only on compaction_end, so a same-controller abort must stay balanced.
 		expect(harness.eventsOfType("compaction_start")).toEqual([{ type: "compaction_start", reason: "threshold" }]);
-		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({
+				type: "compaction_end",
+				reason: "threshold",
+				result: undefined,
+				aborted: true,
+				willRetry: false,
+			}),
+		]);
 	});
 
 	it("does not consume overflow recovery when a start listener aborts preflight auto-compaction", async () => {
@@ -529,7 +539,10 @@ describe("AgentSession compaction characterization", () => {
 		const overflowStarts = harness.eventsOfType("compaction_start").filter((event) => event.reason === "overflow");
 		const overflowEnds = harness.eventsOfType("compaction_end").filter((event) => event.reason === "overflow");
 		expect(overflowStarts).toHaveLength(2);
-		expect(overflowEnds).toHaveLength(0);
+		expect(overflowEnds).toEqual([
+			expect.objectContaining({ result: undefined, aborted: true, willRetry: false }),
+			expect.objectContaining({ result: undefined, aborted: true, willRetry: false }),
+		]);
 		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -496,6 +496,84 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
 	});
 
+	it("does not consume overflow recovery when a start listener aborts preflight auto-compaction", async () => {
+		const harness = await createHarness({ withConfiguredAuth: false });
+		harnesses.push(harness);
+		const timestamp = Date.now();
+		const firstOverflow = createAssistant(harness, {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			timestamp,
+		});
+		const secondOverflow = createAssistant(harness, {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			timestamp: timestamp + 1,
+		});
+		const userMessage = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "continue" }],
+			timestamp: timestamp - 1,
+		};
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start" && event.reason === "overflow") {
+				harness.session.abortCompaction();
+			}
+		});
+
+		harness.session.agent.state.messages = [userMessage, firstOverflow];
+		await checkCompaction(harness.session, firstOverflow);
+		harness.session.agent.state.messages = [userMessage, secondOverflow];
+		await checkCompaction(harness.session, secondOverflow);
+
+		const overflowStarts = harness.eventsOfType("compaction_start").filter((event) => event.reason === "overflow");
+		const overflowEnds = harness.eventsOfType("compaction_end").filter((event) => event.reason === "overflow");
+		expect(overflowStarts).toHaveLength(2);
+		expect(overflowEnds).toHaveLength(0);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+	});
+
+	it("retains overflow retry exhaustion when a start listener supersedes preflight auto-compaction", async () => {
+		const harness = await createHarness({ withConfiguredAuth: false });
+		harnesses.push(harness);
+		const timestamp = Date.now();
+		const firstOverflow = createAssistant(harness, {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			timestamp,
+		});
+		const secondOverflow = createAssistant(harness, {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			timestamp: timestamp + 1,
+		});
+		const userMessage = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "continue" }],
+			timestamp: timestamp - 1,
+		};
+		let supersedingCompaction: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start" && event.reason === "overflow" && !supersedingCompaction) {
+				supersedingCompaction = runAutoCompaction(harness.session, "threshold", false);
+			}
+		});
+
+		harness.session.agent.state.messages = [userMessage, firstOverflow];
+		await checkCompaction(harness.session, firstOverflow);
+		if (!supersedingCompaction) throw new Error("Expected the listener to supersede overflow compaction");
+		await supersedingCompaction;
+		harness.session.agent.state.messages = [userMessage, secondOverflow];
+		await checkCompaction(harness.session, secondOverflow);
+
+		const terminalOverflowFailures = harness
+			.eventsOfType("compaction_end")
+			.filter((event) =>
+				event.errorMessage?.startsWith("Context overflow recovery failed after one compact-and-retry attempt"),
+			);
+		expect(terminalOverflowFailures).toHaveLength(1);
+	});
+
 	it("does not emit compaction events for a normal response below the threshold", async () => {
 		// given
 		const harness = await createHarness({

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -460,6 +460,42 @@ describe("AgentSession compaction characterization", () => {
 		expect(getStreamCallCount()).toBe(1);
 	});
 
+	it("balances auto-compaction events when there is nothing to prepare", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		await runAutoCompaction(harness.session, "threshold", false);
+
+		const compactionEvents = harness.events.filter(
+			(event) => event.type === "compaction_start" || event.type === "compaction_end",
+		);
+		expect(compactionEvents).toEqual([
+			{ type: "compaction_start", reason: "threshold" },
+			expect.objectContaining({
+				type: "compaction_end",
+				reason: "threshold",
+				result: undefined,
+				aborted: false,
+				willRetry: false,
+			}),
+		]);
+	});
+
+	it("does not publish a stale preflight end after a start listener aborts auto-compaction", async () => {
+		const harness = await createHarness({ withConfiguredAuth: false });
+		harnesses.push(harness);
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start" && event.reason === "threshold") {
+				harness.session.abortCompaction();
+			}
+		});
+
+		await runAutoCompaction(harness.session, "threshold", false);
+
+		expect(harness.eventsOfType("compaction_start")).toEqual([{ type: "compaction_start", reason: "threshold" }]);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+	});
+
 	it("does not emit compaction events for a normal response below the threshold", async () => {
 		// given
 		const harness = await createHarness({
@@ -1425,12 +1461,12 @@ describe("AgentSession compaction characterization", () => {
 		await checkCompaction(harness.session, secondOverflow);
 
 		const overflowStarts = harness.eventsOfType("compaction_start").filter((event) => event.reason === "overflow");
-		const terminalOverflowFailures = harness
-			.eventsOfType("compaction_end")
-			.filter((event) =>
-				event.errorMessage?.startsWith("Context overflow recovery failed after one compact-and-retry attempt"),
-			);
+		const overflowEnds = harness.eventsOfType("compaction_end").filter((event) => event.reason === "overflow");
+		const terminalOverflowFailures = overflowEnds.filter((event) =>
+			event.errorMessage?.startsWith("Context overflow recovery failed after one compact-and-retry attempt"),
+		);
 		expect(overflowStarts).toHaveLength(2);
+		expect(overflowEnds).toHaveLength(2);
 		expect(terminalOverflowFailures).toHaveLength(0);
 	});
 


### PR DESCRIPTION
## Summary
Fixes the current-main compaction lifecycle ownership regression: a synchronous listener can supersede the controller during compaction_start, and stale preflight terminals must not emit afterward.

## Verification
- focused lifecycle: 3 passed
- compaction domain: 51 files / 400 tests passed
- root build and root check passed
- real CLI QA: isolation 9/9, RPC 4/4, mock loop 38/38, smoke 7/7

Evidence directory: local-ignore/qa-evidence/20260724-compaction-contract-current-st_019f9584/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction preflight ownership in `coding-agent` to prevent stale `compaction_end` and keep UI state balanced. Auto-compaction now emits an aborted `compaction_end` when the same controller is aborted, and stays silent only when superseded.

- **Bug Fixes**
  - Recheck ownership right after `compaction_start`; publish `compaction_end` with `aborted: true` for same-controller aborts; skip terminal when superseded; reset overflow-recovery only if the same controller still owns the run.
  - Added tests for balanced start/end when there’s no work, aborted end after a start-listener abort, no overflow-retry use on abort, and exhaustion preserved when superseded.

<sup>Written for commit 99802927689802a20f69904f1f5dff0288fd0568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

