### PR TITLE
fix(publish): keep platform-constrained natives out of bundleDependencies

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -57,12 +57,20 @@ Manages workspace packages embedded in the published `@code-yeongyu/senpi` tarba
 The publish tarball is fully self-contained: `copyPublishDependencies` stages the ENTIRE
 runtime closure from `publish-deps.lock.json` (all registry deps + transitives, not just the
 workspace closure) into `packages/coding-agent/node_modules`, and `stagePublishManifest`
-rewrites the publish manifest so `bundleDependencies` lists every staged package while all
-`dependencies` edges (including the registry-absent `^2026.x` workspace specs) stay intact.
-npm then needs no registry fetch at install time; the previous partial bundle let arborist
-abort reify mid-flight and drop arbitrary registry deps (ERR_MODULE_NOT_FOUND).
+rewrites the publish manifest so `bundleDependencies` lists every platform-portable staged
+package while all `dependencies` edges (including the registry-absent `^2026.x` workspace
+specs) stay intact. npm then needs no registry fetch at install time; the previous partial
+bundle let arborist abort reify mid-flight and drop arbitrary registry deps
+(ERR_MODULE_NOT_FOUND).
 Staging dirties `packages/coding-agent/package.json`; restore it with `git checkout --`
 after packing/publishing.
+
+`bundleDependencies` deliberately excludes packages that declare `os`/`cpu`/`libc`
+(`isPlatformConstrainedPackage`). npm resolves those fields against the installing machine, but
+the bundle is one artifact shipped to every platform and npm republishes the bundled set as
+required `dependencies` in the registry manifest — so bundling the publish runner's own natives
+(linux-x64, per `publish-npm.yml`) made `npm install @code-yeongyu/senpi` fail with
+EBADPLATFORM everywhere else. They remain optional registry deps, resolved per install target.
 
 ## check-mcp-docs.test.mjs
 

--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -111,10 +111,42 @@ export function listStagedPublishPackageNames(codingAgentNodeModules) {
 	return packageNames.sort((a, b) => a.localeCompare(b));
 }
 
+// npm evaluates `os`/`cpu`/`libc` against the INSTALLING machine, but bundleDependencies ships a
+// single tarball to every platform and npm republishes the bundled set as required `dependencies`
+// in the registry manifest. Bundling a native binary that only matches the publish runner
+// (linux-x64 in publish-npm.yml) therefore aborts `npm install @code-yeongyu/senpi` with
+// EBADPLATFORM on every other platform, before a single file is written. Such packages stay
+// ordinary optional registry deps: npm resolves the binary matching the installing platform, and
+// a failed fetch degrades the feature instead of failing the install.
+export function isPlatformConstrainedPackage(packageDir) {
+	let manifest;
+	try {
+		manifest = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+	} catch {
+		// An unreadable staged package cannot be judged here; leave it bundled so the existing
+		// staging and pack gates report it instead of this filter dropping it silently.
+		return false;
+	}
+	return ["os", "cpu", "libc"].some((field) => {
+		// npm accepts a bare string as well as the documented array form.
+		const constraint = manifest[field];
+		if (typeof constraint === "string") {
+			return constraint.length > 0;
+		}
+		return Array.isArray(constraint) && constraint.length > 0;
+	});
+}
+
+export function bundlablePublishPackageNames(codingAgentNodeModules, packageNames) {
+	return packageNames.filter((name) => !isPlatformConstrainedPackage(join(codingAgentNodeModules, name)));
+}
+
 // The publish tarball must be fully self-contained: every runtime dependency edge in
 // the coding-agent manifest (registry deps AND the 5 vendored workspace packages) is
 // staged into packages/coding-agent/node_modules, and bundleDependencies lists every
-// staged package. npm then never needs the registry at install time. The historical
+// portable staged package (platform-constrained natives are excluded — see
+// isPlatformConstrainedPackage). npm then needs no registry fetch for anything that
+// installs identically on every platform at install time. The historical
 // partial bundle (only the 5 workspace packages + their closure) forced npm to fetch
 // the other runtime deps from the registry, where arborist nondeterministically tried
 // to resolve the registry-absent `^2026.x` workspace specs (ETARGET) and aborted reify
@@ -124,7 +156,8 @@ export function stagePublishManifest(repoRoot) {
 	const codingAgentDir = join(repoRoot, "packages/coding-agent");
 	const manifestPath = join(codingAgentDir, "package.json");
 	const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-	const stagedPackageNames = listStagedPublishPackageNames(join(codingAgentDir, "node_modules"));
+	const codingAgentNodeModules = join(codingAgentDir, "node_modules");
+	const stagedPackageNames = listStagedPublishPackageNames(codingAgentNodeModules);
 	const stagedSet = new Set(stagedPackageNames);
 
 	const runtimeDependencyFields = ["dependencies", "optionalDependencies"];
@@ -147,13 +180,14 @@ export function stagePublishManifest(repoRoot) {
 		);
 	}
 
-	manifest.bundleDependencies = stagedPackageNames;
+	const bundlablePackageNames = bundlablePublishPackageNames(codingAgentNodeModules, stagedPackageNames);
+	manifest.bundleDependencies = bundlablePackageNames;
 	// npm accepts both spellings; the checked-in manifest carries both, so keep them in sync.
 	if (manifest.bundledDependencies !== undefined) {
-		manifest.bundledDependencies = [...stagedPackageNames];
+		manifest.bundledDependencies = [...bundlablePackageNames];
 	}
 	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, "\t")}\n`);
-	return stagedPackageNames;
+	return bundlablePackageNames;
 }
 
 export function copyPublishDependencies(repoRoot) {

--- a/scripts/prepare-senpi-bundled-workspaces.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.test.mjs
@@ -6,9 +6,11 @@ import { afterEach, describe, it } from "node:test";
 import {
 	SUPPORTED_NATIVE_PREBUILD_TARGETS,
 	assertSenpiPackedWorkspaceFiles,
+	bundlablePublishPackageNames,
 	bundledWorkspacePackageChecks,
 	copyPublishDependencies,
 	directNodeModulesPackageName,
+	isPlatformConstrainedPackage,
 	listStagedPublishPackageNames,
 	nativePrebuildFile,
 	nativePrebuildTarget,
@@ -70,6 +72,58 @@ describe("listStagedPublishPackageNames", () => {
 	});
 });
 
+describe("isPlatformConstrainedPackage", () => {
+	function writeStagedPackage(root, name, overrides) {
+		const packageDir = join(root, "node_modules", name);
+		mkdirSync(packageDir, { recursive: true });
+		writeJson(join(packageDir, "package.json"), { name, version: "1.0.0", ...overrides });
+		return packageDir;
+	}
+
+	it("detects os/cpu/libc constraints in both array and bare-string form", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-platform-constraint-"));
+
+		// When / Then
+		assert.equal(isPlatformConstrainedPackage(writeStagedPackage(tempDir, "portable", {})), false);
+		assert.equal(isPlatformConstrainedPackage(writeStagedPackage(tempDir, "os-array", { os: ["linux"] })), true);
+		assert.equal(isPlatformConstrainedPackage(writeStagedPackage(tempDir, "os-negated", { os: ["!win32"] })), true);
+		assert.equal(isPlatformConstrainedPackage(writeStagedPackage(tempDir, "cpu-string", { cpu: "arm64" })), true);
+		assert.equal(isPlatformConstrainedPackage(writeStagedPackage(tempDir, "libc-only", { libc: ["musl"] })), true);
+		// An empty constraint list restricts nothing, so it must not disqualify the package.
+		assert.equal(isPlatformConstrainedPackage(writeStagedPackage(tempDir, "empty", { os: [], cpu: [] })), false);
+	});
+
+	it("leaves an unreadable staged package bundled for the staging and pack gates to report", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-platform-unreadable-"));
+
+		// When / Then
+		assert.equal(isPlatformConstrainedPackage(join(tempDir, "node_modules", "absent")), false);
+	});
+});
+
+describe("bundlablePublishPackageNames", () => {
+	it("drops only the platform-constrained packages and preserves the staged order", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundlable-"));
+		const nodeModules = join(tempDir, "node_modules");
+		writePackage(tempDir, "@scope/native-linux");
+		writeJson(join(nodeModules, "@scope/native-linux", "package.json"), {
+			name: "@scope/native-linux",
+			version: "1.0.0",
+			os: ["linux"],
+			cpu: ["x64"],
+		});
+		writePackage(tempDir, "cross-spawn");
+		writePackage(tempDir, "typebox");
+
+		// When / Then
+		const staged = ["@scope/native-linux", "cross-spawn", "typebox"];
+		assert.deepEqual(bundlablePublishPackageNames(nodeModules, staged), ["cross-spawn", "typebox"]);
+	});
+});
+
 describe("stagePublishManifest", () => {
 	function writeCodingAgentManifest(root, overrides = {}) {
 		writeJson(join(root, "packages", "coding-agent", "package.json"), {
@@ -88,10 +142,10 @@ describe("stagePublishManifest", () => {
 		});
 	}
 
-	function stagePackage(root, name) {
+	function stagePackage(root, name, overrides = {}) {
 		const packageDir = join(root, "packages", "coding-agent", "node_modules", name);
 		mkdirSync(packageDir, { recursive: true });
-		writeJson(join(packageDir, "package.json"), { name, version: "1.0.0" });
+		writeJson(join(packageDir, "package.json"), { name, version: "1.0.0", ...overrides });
 	}
 
 	function stageAllRuntimePackages(root) {
@@ -140,6 +194,30 @@ describe("stagePublishManifest", () => {
 		for (const spec of [...Object.values(manifest.dependencies), ...Object.values(manifest.optionalDependencies)]) {
 			assert.doesNotMatch(spec, /^(file|link|workspace):/);
 		}
+	});
+
+	it("omits platform-constrained natives from bundleDependencies", () => {
+		// Given: the npm-publish job runs on linux-x64, so npm materializes only the linux
+		// clipboard binaries into the staged tree.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-platform-"));
+		writeCodingAgentManifest(tempDir);
+		stageAllRuntimePackages(tempDir);
+		stagePackage(tempDir, "@mariozechner/clipboard-linux-x64-gnu", { os: ["linux"], cpu: ["x64"] });
+		stagePackage(tempDir, "@mariozechner/clipboard-linux-x64-musl", { os: ["linux"], cpu: ["x64"], libc: ["musl"] });
+
+		// When
+		const bundled = stagePublishManifest(tempDir);
+
+		// Then: npm republishes the bundled set as required `dependencies`, so bundling either
+		// native would abort every non-linux-x64 install with EBADPLATFORM. Portable packages
+		// are still bundled, and the optional edge stays so npm resolves the installing
+		// platform's own binary.
+		const expected = ["@earendil-works/pi-ai", "@mariozechner/clipboard", "cross-spawn", "which"];
+		assert.deepEqual(bundled, expected);
+		const manifest = readStagedManifest(tempDir);
+		assert.deepEqual(manifest.bundleDependencies, expected);
+		assert.deepEqual(manifest.bundledDependencies, expected);
+		assert.deepEqual(manifest.optionalDependencies, { "@mariozechner/clipboard": "0.3.9" });
 	});
 
 	it("throws when a declared runtime dependency is not staged", () => {


### PR DESCRIPTION
Fixes #342.

`npm install @code-yeongyu/senpi` has been broken on every non-linux-x64 platform since 2026.7.23.

## What happens

`stagePublishManifest` sets `bundleDependencies` to every package physically present in the staged `packages/coding-agent/node_modules`. npm republishes that bundled set as required `dependencies` in the registry manifest, so the publish runner's own native binaries become hard requirements of the published package. `publish-npm.yml` runs on `ubuntu-latest`, so 2026.7.23 and 2026.7.24 shipped `@mariozechner/clipboard-linux-x64-gnu` and `-musl` as required deps:

```
$ curl -s https://registry.npmjs.org/@code-yeongyu%2Fsenpi \
    | jq '.versions["2026.7.24"] | {deps:(.dependencies|length), bundled:(.bundleDependencies|length)}'
{ "deps": 258, "bundled": 258 }     # the tarball's own package.json declares 39
```

npm then aborts before writing a file:

```
npm error code EBADPLATFORM
npm error notsup Unsupported platform for @mariozechner/clipboard-linux-x64-gnu@0.3.9:
  wanted {"os":"linux","cpu":"x64","libc":"glibc"} (current: {"os":"darwin","cpu":"arm64"})
```

Not a linux quirk — staging on my mac bundles `clipboard-darwin-arm64`/`-universal` instead, which would break linux and Windows the same way.

## The fix

A package that declares `os`/`cpu`/`libc` can never be bundled correctly: npm resolves those fields against the *installing* machine, but the bundle is a single artifact shipped to every platform. So `bundleDependencies` now skips them, and they stay ordinary optional registry deps — npm resolves the binary matching the install target, and a failed fetch degrades clipboard support instead of failing the install.

The filter reads each staged package's own manifest, so it isn't tied to the clipboard dependency; any future native falls out of the bundle automatically.

**What is deliberately unchanged:**

- Direct-dependency validation still runs against the full physically staged set, so nothing weakens there.
- Every portable package stays bundled, so the self-containment that fixed the old arborist `ERR_MODULE_NOT_FOUND` reify problem is intact — 256 of the 258 staged packages still ship in the tarball.
- `@mariozechner/clipboard` itself has no platform fields, so it remains bundled and its `optionalDependencies` edge is untouched.

If a *direct* dependency ever declares platform fields, `validatePack`'s existing "missing vendored runtime dependencies" gate fails the publish loudly rather than shipping a broken tarball. That seemed better than silently widening the exemption.

`scripts/prepare-senpi-bundled-workspaces.mjs` has no upstream counterpart in `badlogic/pi-mono`, so there is no `changes.md` section to add.

## Verification

- **The new `stagePublishManifest` test is a real regression test.** With the one-line filter reverted it fails with exactly the two packages that broke installs:
  ```
  actual:   [..., '@mariozechner/clipboard-linux-x64-gnu', '@mariozechner/clipboard-linux-x64-musl', ...]
  expected: ['@earendil-works/pi-ai', '@mariozechner/clipboard', 'cross-spawn', 'which']
  ```
- **End-to-end on a real checkout** (`copyPublishDependencies` + `stagePublishManifest` against this repo's installed tree, workspace `dist/` stubbed since the filter never reads build output):
  ```
  physically staged: 258 | declared in bundleDependencies: 256
  excluded from the bundle: ["@mariozechner/clipboard-darwin-arm64","@mariozechner/clipboard-darwin-universal"]
  optionalDependencies preserved: {"@mariozechner/clipboard":"0.3.9"}
  ```
  258 is the same count as the broken published manifest, which is what pins the mechanism.
- `npm run test:scripts` — 61 tests, 60 pass, 1 skipped, 0 fail.
- `npm run check` — passes (it also runs as the pre-commit hook for this commit).

  Unrelated flake worth flagging: on my first full run, `check:neo`'s `TestAttachOrSpawn_RaceExactlyOneDaemon` timed out at its 30s budget while `tsgo` was still saturating the machine (`bridge: attach-or-spawn timed out after 30s`). Run on its own it passes in ~0.2-0.3s both with and without this change, and it passed on the re-run, so it looks load-sensitive rather than broken.
- `npm run check:shrinkwrap` / `check:install-lock:coding-agent` / `check:pinned-deps` — all report up to date; the change alters only which staged packages are *declared* bundled, not the dependency graph, so no lockfile regeneration is needed.

I have not run `./pi-test.sh`; this touches no provider code.

Drafted with Claude Code, reviewed and verified by me — every command output above is verbatim from my machine, not inferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude platform-constrained native packages from `bundleDependencies` during publish to stop `npm install @code-yeongyu/senpi` from failing on non‑linux‑x64. Portable packages stay bundled; natives remain optional and resolve per install target. Fixes #342.

- **Bug Fixes**
  - Added `isPlatformConstrainedPackage` and `bundlablePublishPackageNames` to skip packages that declare `os`/`cpu`/`libc` when building `bundleDependencies`.
  - Updated `stagePublishManifest` to write the filtered list to `bundleDependencies`/`bundledDependencies` and return it.
  - Kept full staged-set validation; portable deps still bundle for a self-contained tarball. `@mariozechner/clipboard` remains optional and bundled as the meta package.
  - Updated `scripts/AGENTS.md` and added regression tests to cover the new filter and manifest output.

<sup>Written for commit 8b5685a51b46e4e4f3629566676be00e0f69d25e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

