### PR TITLE
fix(release): authenticate protected main pushes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,7 @@ name: Release
         default: false
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 concurrency:
@@ -36,8 +36,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Configure git identity
         run: |
@@ -68,9 +67,14 @@ jobs:
       - name: Run release
         if: inputs.publish-only != true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.UPSTREAM_AUTOMATION_TOKEN }}
           SENPI_SKIP_PM_VERIFY: '1'
         run: |
+          test -n "$GH_TOKEN" || {
+            echo "::error::UPSTREAM_AUTOMATION_TOKEN is required to push release commits and tags through branch protection."
+            exit 1
+          }
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           ARGS=()
           if [ -n "${{ inputs.version }}" ]; then
             ARGS+=(--version "${{ inputs.version }}")

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed npm installs on non-Linux x64 platforms by keeping platform-constrained native packages out of bundled dependencies ([#343](https://github.com/code-yeongyu/senpi/pull/343) by [@realsigridjin](https://github.com/realsigridjin)).
+
 ### Removed
 
 ## [2026.7.24] - 2026-07-24


### PR DESCRIPTION
## Summary

The manual Release workflow could prepare the CalVer commit and tag, but its push was rejected by protected `main` because it used the repository-scoped `GITHUB_TOKEN`.

This change keeps branch protection intact and routes only release pushes through the existing dedicated automation PAT already used by the upstream merge-and-release workflow.

## Changes

- Keep the workflow's default `GITHUB_TOKEN` at `contents: read`.
- Stop persisting checkout credentials.
- Require `UPSTREAM_AUTOMATION_TOKEN` for the live release path and authenticate the release commit/tag pushes with it.
- Add the missing user-facing changelog entry for the cross-platform npm installation fix in #343.

## QA & Evidence

- **What was tested:** `actionlint .github/workflows/publish-npm.yml`
  - **Observed result:** passed with no findings.
  - **Artifact:** `local-ignore/qa-evidence/20260725-release-protected-main/pre-pr-validation.md`
  - **Why sufficient:** validates workflow syntax, expressions, and shell blocks before dispatch.
- **What was tested:** `git diff --check`
  - **Observed result:** passed with no findings.
  - **Artifact:** `local-ignore/qa-evidence/20260725-release-protected-main/pre-pr-validation.md`
  - **Why sufficient:** validates the committed patch has no whitespace errors.

The real-surface QA will be the live Release workflow after merge: it must push through protected `main`, create the CalVer tag, and complete publishing successfully.

## Risks & Residuals

- The dedicated PAT is exposed only to the release step and is not persisted by checkout.
- Branch protection remains unchanged; no generic GitHub Actions bypass is added.
- The live release run is intentionally deferred until this PR lands because the workflow file must be present on `main`.

## Related Issues

- Follow-up to #342 and #343.
- Failed release run: https://github.com/code-yeongyu/senpi/actions/runs/30153260858


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the manual Release workflow so CalVer commits and tags can push to protected `main` using a dedicated PAT, without weakening branch protection. Also adds a missing changelog item for the cross-platform npm install fix.

- **Bug Fixes**
  - Route release commits/tags through `UPSTREAM_AUTOMATION_TOKEN` instead of `GITHUB_TOKEN`.
  - Set workflow permissions to `contents: read` and stop persisting checkout credentials.

- **Migration**
  - Ensure the `UPSTREAM_AUTOMATION_TOKEN` secret exists and has push access to `main`.

<sup>Written for commit 20773be0df3ea4335452bc1227c374470dd23f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

