### PR TITLE
fix(websearch): render the live search source and refresh native routes

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/external-versions.json
+++ b/packages/coding-agent/src/core/extensions/builtin/external-versions.json
@@ -22,7 +22,7 @@
 		},
 		"websearch": {
 			"packageName": "pi-websearch",
-			"version": "0.2.1",
+			"version": "0.3.0",
 			"source": "../pi-extensions/pi-websearch"
 		},
 		"webfetch": {

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/changes.md
@@ -1,16 +1,19 @@
 # changes.md — websearch (vendored)
 
-Vendored from [`code-yeongyu/pi-websearch`](https://github.com/code-yeongyu/pi-websearch) at `06e3ec457e86d299c20808954e18f20b23cc7a64`.
+Vendored from [`code-yeongyu/pi-websearch`](https://github.com/code-yeongyu/pi-websearch) at `7fb28c31623bafb77f437095d57315c26f202dc2` (0.3.0).
 
 ## Senpi adaptations vs upstream
 
 - Imports rewritten manually for the senpi source tree:
-  - `@mariozechner/pi-tui` -> `@earendil-works/pi-tui`
-  - `@mariozechner/pi-coding-agent` type/tool imports -> senpi local `../../types.ts` / `../../../types.ts`
+  - `@earendil-works/pi-coding-agent` public imports (`defineTool`, `ExtensionAPI`/`ExtensionContext` types) -> senpi-local `../../types.ts` / `../../../types.ts`
   - relative `.js` import suffixes -> `.ts`
-- Senpi forwards the tool `AbortSignal` into native route discovery so cancellation stops waiting for pending authentication before any provider request begins, and canonicalizes one permitted terminal DNS dot in route identity so dotted and undotted aliases share one candidate.
-- Per-attempt search progress: `performSearch` accepts an optional `onAttempt(providerLabel, attempts)` listener fired before each provider attempt; `tool.ts` forwards it to `onUpdate`, and `SearchProgressDetails` gains optional `currentProvider`/`attempts`. The TUI partial renderer shows only the provider currently being tried (`Searching "q" via exa/backup [2/3] (max 10)`, prior attempts as a `route ...` line when expanded) instead of the full configured route; the first pre-loop update keeps upstream's full-route form. Covered by `test/websearch-progress.test.ts` and extended assertions in `test/websearch-native-tool.test.ts`.
+  - the `@earendil-works/pi-tui` import is identical in both trees and needs no rewrite
+- Senpi forwards the tool `AbortSignal` into native route discovery (`buildNativeEntries(model, registry, signal)` and the `configWithNativeRoute` call in `tool.ts`) so cancellation stops waiting for pending authentication before any provider request begins. Not upstream as of 0.3.0.
+- `nativeRouteKey` additionally strips one permitted terminal DNS dot from the hostname before hashing, so `host.` and `host` collapse to one discovered candidate. The hashed `provider|endpoint` route key itself is upstream. Covered by `test/websearch-native-route-dedup.test.ts`.
 - `index.ts` diverges from upstream's provider-name bypass (`provider === "openai" || provider === "anthropic"`): the `provider_native_bypass` state is instead gated on `supportsNativeAnthropicWebSearch` / `supportsNativeOpenAiWebSearch` (+ their enable envs) from the sibling `anthropic-web-search` / `openai-web-search` builtins, and recomputed on `model_select`. Upstream's check disabled the standalone `web_search` tool for any model whose provider id is `anthropic`/`openai`, including proxied baseUrls (ccapi, quotio, …) where the injecting builtins never add the server-side tool — leaving those sessions with no web search at all, and leaving a stale bypass after mid-session model switches. Covered by `test/suite/websearch-extension-bypass.test.ts`.
+- `config.ts` reads senpi's own config dir (`CONFIG_DIR_NAME` from `packages/coding-agent/src/config.ts`, resolved to `.senpi`) ahead of the legacy `.pi` directory, while keeping `.pi` as a fallback so existing users keep loading. Project `.senpi` wins over project `.pi`; both project paths win over anything in the home dir; the legacy `~/websearch.json` keeps its precedence over `~/<config dir>/websearch.json`. Covered by `test/websearch-config-paths.test.ts`.
+
+Per-attempt search progress and the three-state route rendering landed upstream in 0.3.0 (they were previously senpi-only), so the senpi tree now mirrors that logic exactly: one shared `providerEntryLabel` (`provider/id`, discovered native ids collapsed to `provider/native`), resolved `routeLabels` on every progress update, no `[n/m]` step counter, and a `route <label>:<state>` line listing already-tried, currently-running, and pending sources when expanded. Covered by `test/websearch-progress.test.ts` and `test/websearch-native-tool.test.ts`.
 
 ## Conflict zones
 

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/index.ts
@@ -3,6 +3,7 @@ import { isAnthropicWebSearchEnabled, supportsNativeAnthropicWebSearch } from ".
 import { isOpenaiWebSearchEnabled, supportsNativeOpenAiWebSearch } from "../openai-web-search/index.ts";
 
 import { loadWebsearchConfig } from "./websearch/config.ts";
+import { providerEntryLabel } from "./websearch/search.ts";
 import { createWebSearchTool } from "./websearch/tool.ts";
 import type { ConfigLoadResult, WebsearchConfig } from "./websearch/types.ts";
 
@@ -31,12 +32,8 @@ export default function (pi: ExtensionAPI): void {
 		message: "Missing websearch config. Create .pi/websearch.json or ~/.pi/websearch.json before starting pi.",
 	};
 
-	function providerLabel(provider: WebsearchConfig["providers"][number]): string {
-		return provider.id ? `${provider.id}/${provider.provider}` : provider.provider;
-	}
-
 	function providerList(config: WebsearchConfig): string {
-		return config.providers.map(providerLabel).join(", ");
+		return config.providers.map(providerEntryLabel).join(", ");
 	}
 
 	function clearUi(ctx: ExtensionContext): void {

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/config.ts
@@ -2,6 +2,7 @@ import { access, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { CONFIG_DIR_NAME } from "../../../../../config.ts";
 import { isAllowedProviderBaseUrl } from "./provider-endpoints.ts";
 import type {
 	CodexSearchMode,
@@ -260,10 +261,12 @@ async function fileExists(path: string): Promise<boolean> {
 export async function loadWebsearchConfig(options: ConfigLoadOptions): Promise<ConfigLoadResult> {
 	const home = options.homeDir ?? homedir();
 	const paths = [
+		join(options.cwd, CONFIG_DIR_NAME, "websearch.json"),
 		join(options.cwd, ".pi", "websearch.json"),
 		join(home, "websearch.json"),
+		join(home, CONFIG_DIR_NAME, "websearch.json"),
 		join(home, ".pi", "websearch.json"),
-	];
+	].filter((path, index, all) => all.indexOf(path) === index);
 
 	for (const path of paths) {
 		if (!(await fileExists(path))) continue;

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/native.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/native.ts
@@ -29,17 +29,11 @@ interface NativeEntryOptions {
 }
 
 function nativeMapping(model: NativeModelInfo): NativeProviderMapping | null {
-	if (
-		model.provider === "openai" &&
-		(/^(gpt-5\.5(-fast)?|gpt-4\.1(-mini)?)$/.test(model.id) || /^gpt-4o(-mini)?(-\d{4}-\d{2}-\d{2})?$/.test(model.id))
-	) {
+	if (model.provider === "openai" && /^gpt-(4o|4\.1|5)/.test(model.id) && !model.id.includes("codex")) {
 		return { provider: "openai", resource: "responses" };
 	}
 
-	if (
-		model.provider === "anthropic" &&
-		(/^claude-(opus|sonnet)-4(-\d+)?$/.test(model.id) || /^claude-(opus|sonnet)-4-\d+-\d{8}$/.test(model.id))
-	) {
+	if (model.provider === "anthropic" && /^claude-/.test(model.id)) {
 		return { provider: "anthropic", resource: "messages" };
 	}
 

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/renderers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/renderers.ts
@@ -1,5 +1,6 @@
 import { Text } from "@earendil-works/pi-tui";
 
+import { providerEntryLabel } from "./search.ts";
 import type { SearchDetails, SearchErrorDetails, SearchProgressDetails, SearchRenderDetails } from "./types.ts";
 
 interface ThemeLike {
@@ -34,12 +35,22 @@ function durationText(durationMs: number): string {
 function attemptLabel(attempts: SearchDetails["attempts"]): string {
 	return attempts
 		? attempts
-				.map(
-					(attempt) =>
-						`${attempt.entryId ? `${attempt.provider}/${attempt.entryId}` : attempt.provider}:${attempt.error ? "failed" : attempt.resultsCount}`,
-				)
+				.map((attempt) => `${providerEntryLabel(attempt)}:${attempt.error ? "failed" : attempt.resultsCount}`)
 				.join(" -> ")
 		: "";
+}
+
+function routeStateLabel(details: SearchProgressDetails): string {
+	const labels = details.routeLabels ?? details.providerLabels;
+	if (labels.length === 0) return "";
+	const attempts = details.attempts ?? [];
+	return labels
+		.map((label, index) => {
+			const attempt = attempts[index];
+			if (attempt) return `${label}:${attempt.error ? "failed" : attempt.resultsCount}`;
+			return `${label}:${index === attempts.length ? "searching" : "pending"}`;
+		})
+		.join(" -> ");
 }
 
 function isSearchProgressDetails(details: SearchRenderDetails | undefined): details is SearchProgressDetails {
@@ -67,15 +78,12 @@ export function renderSearchResult(
 		const details = result.details;
 		if (isSearchProgressDetails(details)) {
 			if (details.currentProvider) {
-				const total = details.providerLabels.length;
-				const position = Math.min((details.attempts?.length ?? 0) + 1, Math.max(total, 1));
-				const step = total > 1 ? ` [${position}/${total}]` : "";
 				const line = theme.fg(
 					"warning",
-					`Searching "${shorten(details.query, 80)}" via ${details.currentProvider}${step} (max ${details.maxResults})`,
+					`Searching "${shorten(details.query, 80)}" via ${details.currentProvider} (max ${details.maxResults})`,
 				);
-				const attempts = attemptLabel(details.attempts);
-				const rows = options.expanded && attempts ? [line, theme.fg("muted", `route ${attempts}`)] : [line];
+				const route = routeStateLabel(details);
+				const rows = options.expanded && route ? [line, theme.fg("muted", `route ${route}`)] : [line];
 				return new Text(rows.join("\n"), 0, 0);
 			}
 			const route = details.providerLabels.length > 0 ? details.providerLabels.join(" -> ") : "configured providers";
@@ -95,7 +103,7 @@ export function renderSearchResult(
 	if (details.error) return new Text(theme.fg("error", details.error), 0, 0);
 
 	const count = details.results.length;
-	const provider = details.entryId ? `${details.provider}/${details.entryId}` : details.provider;
+	const provider = providerEntryLabel(details);
 	const summary =
 		theme.fg("success", `${count} result${count === 1 ? "" : "s"}`) +
 		theme.fg(

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/search.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/search.ts
@@ -77,7 +77,7 @@ function searchAbortSignal(
 }
 
 function noResultsMessage(config: SearchProviderEntry, request: SearchRequest): string {
-	return `Search provider ${entryLabel(config)} returned no results for "${request.query}".`;
+	return `Search provider ${providerEntryLabel(config)} returned no results for "${request.query}".`;
 }
 
 export interface SearchRoutingState {
@@ -89,10 +89,15 @@ export function createSearchRoutingState(providerCount: number): SearchRoutingSt
 	return { roundRobinCursor: 0, successCounts: Array.from({ length: providerCount }, () => 0) };
 }
 
-function entryLabel(entry: Pick<SearchProviderEntry, "provider" | "id"> | SearchAttempt): string {
-	if ("entryId" in entry && entry.entryId) return `${entry.provider}/${entry.entryId}`;
-	if ("id" in entry && entry.id) return `${entry.provider}/${entry.id}`;
-	return entry.provider;
+export function providerEntryLabel(entry: {
+	readonly provider: string;
+	readonly id?: string;
+	readonly entryId?: string;
+}): string {
+	const id = entry.entryId ?? entry.id;
+	if (!id || id === entry.provider) return entry.provider;
+	const nativePrefix = `native-${entry.provider}-`;
+	return `${entry.provider}/${id.startsWith(nativePrefix) ? "native" : id}`;
 }
 
 function sortedPriorityIndices(providers: SearchProviderEntry[]): number[] {
@@ -244,7 +249,11 @@ function attemptFromDetails(details: SearchDetails): SearchAttempt {
 	return attempt;
 }
 
-export type SearchAttemptListener = (providerLabel: string, attempts: readonly SearchAttempt[]) => void;
+export type SearchAttemptListener = (
+	providerLabel: string,
+	attempts: readonly SearchAttempt[],
+	routeLabels: readonly string[],
+) => void;
 
 export async function performSearch(
 	config: WebsearchConfig,
@@ -257,13 +266,17 @@ export async function performSearch(
 	const state = routingState ?? createSearchRoutingState(config.providers.length);
 	const order = selectOrder(config.strategy, config.providers, state);
 	const attempts: SearchAttempt[] = [];
+	const routeLabels = order.flatMap((index) => {
+		const provider = config.providers[index];
+		return provider ? [providerEntryLabel(provider)] : [];
+	});
 	const collected = new Map<string, SearchDetails["results"][number]>();
 	let selectedDetails: SearchDetails | undefined;
 
 	for (const index of order) {
 		const provider = config.providers[index];
 		if (!provider) continue;
-		onAttempt?.(entryLabel(provider), attempts);
+		onAttempt?.(providerEntryLabel(provider), attempts, routeLabels);
 		const details = await performProviderSearch(provider, request, signal);
 		attempts.push(attemptFromDetails(details));
 
@@ -315,7 +328,7 @@ export async function performSearch(
 		durationMs: Date.now() - startedAt,
 		strategy: config.strategy,
 		attempts,
-		error: `All configured search providers failed: ${attempts.map((attempt) => `${entryLabel(attempt)} ${attempt.error ?? "failed"}`).join("; ")}`,
+		error: `All configured search providers failed: ${attempts.map((attempt) => `${providerEntryLabel(attempt)} ${attempt.error ?? "failed"}`).join("; ")}`,
 	};
 }
 
@@ -324,7 +337,7 @@ export function formatSearchText(details: SearchDetails): string {
 	if (details.results.length === 0) return `No web search results found for "${details.query}".`;
 
 	const route = details.strategy
-		? ` via ${details.entryId ? `${details.provider}/${details.entryId}` : details.provider} (${details.strategy})`
+		? ` via ${providerEntryLabel(details)} (${details.strategy})`
 		: ` via ${details.provider}`;
 	const lines = [`Web search results for "${details.query}"${route}:`, ""];
 	if (details.attempts && details.attempts.length > 0) {
@@ -332,7 +345,7 @@ export function formatSearchText(details: SearchDetails): string {
 			`Routing attempts: ${details.attempts
 				.map(
 					(attempt) =>
-						`${entryLabel(attempt)} ${attempt.error ? `failed: ${attempt.error}` : `${attempt.resultsCount} result${attempt.resultsCount === 1 ? "" : "s"}`}`,
+						`${providerEntryLabel(attempt)} ${attempt.error ? `failed: ${attempt.error}` : `${attempt.resultsCount} result${attempt.resultsCount === 1 ? "" : "s"}`}`,
 				)
 				.join(" -> ")}`,
 			"",

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/tool.ts
@@ -3,12 +3,17 @@ import { defineTool } from "../../../types.ts";
 
 import { buildNativeEntries, type NativeModelInfo, type NativeModelRegistry } from "./native.ts";
 import { renderSearchCall, renderSearchResult } from "./renderers.ts";
-import { createSearchRoutingState, formatSearchText, performSearch, type SearchRoutingState } from "./search.ts";
+import {
+	createSearchRoutingState,
+	formatSearchText,
+	performSearch,
+	providerEntryLabel,
+	type SearchRoutingState,
+} from "./search.ts";
 import type {
 	ConfigLoadResult,
 	SearchErrorDetails,
 	SearchProgressDetails,
-	SearchProviderEntry,
 	SearchRenderDetails,
 	WebsearchConfig,
 } from "./types.ts";
@@ -44,16 +49,9 @@ async function configWithNativeRoute(
 	return nativeEntries.length > 0 ? { ...config, providers: [...nativeEntries, ...config.providers] } : config;
 }
 
-function providerLabel(provider: SearchProviderEntry): string {
-	return provider.id ? `${provider.id}/${provider.provider}` : provider.provider;
-}
-
 function formatSearchProgressText(details: SearchProgressDetails): string {
 	if (details.currentProvider) {
-		const total = details.providerLabels.length;
-		const position = Math.min((details.attempts?.length ?? 0) + 1, Math.max(total, 1));
-		const step = total > 1 ? ` [${position}/${total}]` : "";
-		return `Searching "${details.query}" via ${details.currentProvider}${step} (max ${details.maxResults})`;
+		return `Searching "${details.query}" via ${details.currentProvider} (max ${details.maxResults})`;
 	}
 	const route = details.providerLabels.length > 0 ? details.providerLabels.join(" -> ") : "configured providers";
 	return `Searching "${details.query}" via ${route} (max ${details.maxResults})`;
@@ -92,7 +90,7 @@ export function createWebSearchTool(getConfig: ConfigProvider): WebSearchTool {
 			const progressDetails: SearchProgressDetails = {
 				phase: "searching",
 				query: params.query,
-				providerLabels: config.providers.map(providerLabel),
+				providerLabels: config.providers.map(providerEntryLabel),
 				maxResults,
 				strategy: config.strategy,
 				...(params.allowed_domains ? { allowedDomains: params.allowed_domains } : {}),
@@ -118,17 +116,24 @@ export function createWebSearchTool(getConfig: ConfigProvider): WebSearchTool {
 				...(params.allowed_domains === undefined ? {} : { allowedDomains: params.allowed_domains }),
 				...(params.blocked_domains === undefined ? {} : { blockedDomains: params.blocked_domains }),
 			};
-			const details = await performSearch(config, request, signal, routingState, (providerLabel, attempts) => {
-				const attemptProgress: SearchProgressDetails = {
-					...progressDetails,
-					currentProvider: providerLabel,
-					attempts: [...attempts],
-				};
-				onUpdate?.({
-					content: [{ type: "text", text: formatSearchProgressText(attemptProgress) }],
-					details: attemptProgress,
-				});
-			});
+			const details = await performSearch(
+				config,
+				request,
+				signal,
+				routingState,
+				(providerLabel, attempts, routeLabels) => {
+					const attemptProgress: SearchProgressDetails = {
+						...progressDetails,
+						currentProvider: providerLabel,
+						attempts: [...attempts],
+						routeLabels: [...routeLabels],
+					};
+					onUpdate?.({
+						content: [{ type: "text", text: formatSearchProgressText(attemptProgress) }],
+						details: attemptProgress,
+					});
+				},
+			);
 			return { content: [{ type: "text", text: formatSearchText(details) }], details };
 		},
 		renderCall: (args, theme) => renderSearchCall(args, theme),

--- a/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/websearch/websearch/types.ts
@@ -97,6 +97,7 @@ export interface SearchProgressDetails {
 	maxResults: number;
 	currentProvider?: string;
 	attempts?: SearchAttempt[];
+	routeLabels?: string[];
 	strategy?: RoutingStrategy;
 	allowedDomains?: string[];
 	blockedDomains?: string[];

--- a/packages/coding-agent/test/websearch-config-paths.test.ts
+++ b/packages/coding-agent/test/websearch-config-paths.test.ts
@@ -1,0 +1,83 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadWebsearchConfig } from "../src/core/extensions/builtin/websearch/websearch/config.ts";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function websearchJson(id: string, provider: string): string {
+	return JSON.stringify({ auto: false, providers: [{ id, provider, apiKey: "test-key" }] });
+}
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) await rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("vendored websearch config paths", () => {
+	it("#given a project .senpi config #when loading #then reads <cwd>/.senpi/websearch.json", async () => {
+		// given
+		const cwd = await makeTempDir("websearch-cfg-senpi-");
+		const home = await makeTempDir("websearch-cfg-home-");
+		await mkdir(join(cwd, ".senpi"), { recursive: true });
+		await writeFile(join(cwd, ".senpi", "websearch.json"), websearchJson("project-senpi", "exa"));
+
+		// when
+		const result = await loadWebsearchConfig({ cwd, homeDir: home });
+
+		// then
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.source).toBe(join(cwd, ".senpi", "websearch.json"));
+			expect(result.config.providers[0]?.id).toBe("project-senpi");
+		}
+	});
+
+	it("#given a project without .senpi but with .pi #when loading #then reads <cwd>/.pi/websearch.json", async () => {
+		// given
+		const cwd = await makeTempDir("websearch-cfg-pi-");
+		const home = await makeTempDir("websearch-cfg-home-");
+		await mkdir(join(cwd, ".pi"), { recursive: true });
+		await writeFile(join(cwd, ".pi", "websearch.json"), websearchJson("project-pi", "brave"));
+
+		// when
+		const result = await loadWebsearchConfig({ cwd, homeDir: home });
+
+		// then
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.source).toBe(join(cwd, ".pi", "websearch.json"));
+			expect(result.config.providers[0]?.id).toBe("project-pi");
+		}
+	});
+
+	it("#given a project .senpi config and a home .senpi config #when loading #then the project .senpi wins", async () => {
+		// given
+		const cwd = await makeTempDir("websearch-cfg-cwd-");
+		const home = await makeTempDir("websearch-cfg-home-");
+		await mkdir(join(cwd, ".senpi"), { recursive: true });
+		await writeFile(join(cwd, ".senpi", "websearch.json"), websearchJson("project-senpi", "exa"));
+		await mkdir(join(home, ".senpi"), { recursive: true });
+		await writeFile(join(home, ".senpi", "websearch.json"), websearchJson("home-senpi", "tavily"));
+
+		// when
+		const result = await loadWebsearchConfig({ cwd, homeDir: home });
+
+		// then
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.source).toBe(join(cwd, ".senpi", "websearch.json"));
+			expect(result.config.providers[0]?.id).toBe("project-senpi");
+		}
+	});
+});

--- a/packages/coding-agent/test/websearch-native-model-matrix.test.ts
+++ b/packages/coding-agent/test/websearch-native-model-matrix.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildNativeEntry,
+	type NativeModelInfo,
+	type NativeModelRegistry,
+} from "../src/core/extensions/builtin/websearch/websearch/native.ts";
+
+interface MatrixCase {
+	provider: string;
+	id: string;
+	baseUrl?: string;
+	expected: { provider: string; resource: string } | null;
+}
+
+const registry: NativeModelRegistry = {
+	async getApiKeyAndHeaders() {
+		return { ok: true, apiKey: "native-test" };
+	},
+};
+
+const MATRIX: readonly MatrixCase[] = [
+	// openai mapped -> openai/responses
+	{ provider: "openai", id: "gpt-5.6-sol", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-5.6-terra", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-5.5", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-5.5-fast", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-5.4", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-5-pro", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-5", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-4.1-mini", expected: { provider: "openai", resource: "responses" } },
+	{ provider: "openai", id: "gpt-4o-mini-2026-01-01", expected: { provider: "openai", resource: "responses" } },
+	// openai null (codex variants, legacy 4x, o-series)
+	{ provider: "openai", id: "gpt-5.3-codex", expected: null },
+	{ provider: "openai", id: "gpt-5.3-codex-spark", expected: null },
+	{ provider: "openai", id: "gpt-4-turbo", expected: null },
+	{ provider: "openai", id: "o3", expected: null },
+	// anthropic mapped -> anthropic/messages
+	{ provider: "anthropic", id: "claude-opus-5", expected: { provider: "anthropic", resource: "messages" } },
+	{ provider: "anthropic", id: "claude-sonnet-5", expected: { provider: "anthropic", resource: "messages" } },
+	{ provider: "anthropic", id: "claude-fable-5", expected: { provider: "anthropic", resource: "messages" } },
+	{ provider: "anthropic", id: "claude-haiku-4-5", expected: { provider: "anthropic", resource: "messages" } },
+	{ provider: "anthropic", id: "claude-opus-4-8", expected: { provider: "anthropic", resource: "messages" } },
+	{
+		provider: "anthropic",
+		id: "claude-sonnet-4-5-20250929",
+		expected: { provider: "anthropic", resource: "messages" },
+	},
+	// anthropic null
+	{ provider: "anthropic", id: "not-a-claude-model", expected: null },
+	// xai mapped -> xai/responses
+	{ provider: "xai", id: "grok-4.3", expected: { provider: "xai", resource: "responses" } },
+	// openrouter vendor recursion -> anthropic/messages
+	{
+		provider: "openrouter",
+		id: "anthropic/claude-opus-5",
+		baseUrl: "https://openrouter.example.com/v1",
+		expected: { provider: "anthropic", resource: "messages" },
+	},
+];
+
+describe("vendored websearch native model matrix", () => {
+	for (const testCase of MATRIX) {
+		const label = testCase.expected
+			? `maps to ${testCase.expected.provider}/${testCase.expected.resource}`
+			: "yields no native route";
+		it(`#given ${testCase.provider}/${testCase.id} #when building the native entry #then ${label}`, async () => {
+			// given
+			const model: NativeModelInfo = {
+				provider: testCase.provider,
+				id: testCase.id,
+				baseUrl: testCase.baseUrl ?? "https://gateway.example.com/v1",
+			};
+
+			// when
+			const entry = await buildNativeEntry(model, registry, "native");
+
+			// then
+			if (testCase.expected) {
+				expect(entry).not.toBeNull();
+				expect(entry?.provider).toBe(testCase.expected.provider);
+				expect(entry?.baseUrl).toBe(`${model.baseUrl}/${testCase.expected.resource}`);
+				expect(entry?.model).toBe(testCase.id);
+				expect(entry?.apiKey).toBe("native-test");
+				expect(entry?.priority).toBe(-1);
+			} else {
+				expect(entry).toBeNull();
+			}
+		});
+	}
+});

--- a/packages/coding-agent/test/websearch-native-tool.test.ts
+++ b/packages/coding-agent/test/websearch-native-tool.test.ts
@@ -119,12 +119,12 @@ describe("vendored websearch native tool", () => {
 		expect(progress[1]?.attempts).toEqual([]);
 		const providerLabels = progress[0]?.providerLabels ?? [];
 		expect(providerLabels).toHaveLength(4);
-		expect(providerLabels[0]).toBe("native/openai");
-		expect(providerLabels[1]?.endsWith("/anthropic")).toBe(true);
+		expect(providerLabels[0]).toBe("openai/native");
+		expect(providerLabels[1]?.startsWith("anthropic/")).toBe(true);
 		expect(providerLabels[1]).not.toContain("claude");
-		expect(providerLabels[2]).toBe("configured-first/duckduckgo-html");
-		expect(providerLabels[3]).toBe("configured-second/z-ai");
-		expect(providerLabels.filter((label) => label.endsWith("/openai"))).toEqual(["native/openai"]);
+		expect(providerLabels[2]).toBe("duckduckgo-html/configured-first");
+		expect(providerLabels[3]).toBe("z-ai/configured-second");
+		expect(providerLabels.filter((label) => label.startsWith("openai/"))).toEqual(["openai/native"]);
 		expect(authModels).toEqual(["gpt-5.5", "claude-sonnet-4-20250514"]);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});

--- a/packages/coding-agent/test/websearch-progress.test.ts
+++ b/packages/coding-agent/test/websearch-progress.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
 import { renderSearchResult } from "../src/core/extensions/builtin/websearch/websearch/renderers.ts";
+import { formatSearchText } from "../src/core/extensions/builtin/websearch/websearch/search.ts";
 import { createWebSearchTool } from "../src/core/extensions/builtin/websearch/websearch/tool.ts";
 import type {
+	SearchDetails,
 	SearchProgressDetails,
 	WebsearchConfig,
 } from "../src/core/extensions/builtin/websearch/websearch/types.ts";
@@ -96,11 +98,13 @@ describe("websearch per-attempt progress", () => {
 		// then
 		expect(progress).toHaveLength(3);
 		expect(progress[0]?.currentProvider).toBeUndefined();
+		expect(progress[0]?.providerLabels).toEqual(["exa/primary", "exa/backup"]);
 		expect(progress[1]?.currentProvider).toBe("exa/primary");
 		expect(progress[1]?.attempts).toEqual([]);
 		expect(progress[2]?.currentProvider).toBe("exa/backup");
 		expect(progress[2]?.attempts).toHaveLength(1);
 		expect(progress[2]?.attempts?.[0]?.error).toContain("HTTP 500");
+		expect(progress[2]?.routeLabels).toEqual(["exa/primary", "exa/backup"]);
 		expect(result.details && "provider" in result.details ? result.details.entryId : undefined).toBe("backup");
 	});
 
@@ -110,6 +114,7 @@ describe("websearch per-attempt progress", () => {
 			phase: "searching",
 			query: "attempt progress",
 			providerLabels: ["exa/primary", "exa/backup"],
+			routeLabels: ["exa/primary", "exa/backup"],
 			maxResults: 10,
 			currentProvider: "exa/backup",
 			attempts: [{ provider: "exa", entryId: "primary", durationMs: 12, resultsCount: 0, error: "HTTP 500" }],
@@ -132,8 +137,94 @@ describe("websearch per-attempt progress", () => {
 			.join("\n");
 
 		// then
-		expect(collapsed).toContain('Searching "attempt progress" via exa/backup [2/2] (max 10)');
+		expect(collapsed).toContain('Searching "attempt progress" via exa/backup (max 10)');
+		expect(collapsed).not.toMatch(/\[\d+\/\d+\]/);
 		expect(collapsed).not.toContain("exa/primary ->");
-		expect(expanded).toContain("route exa/primary:failed");
+		expect(expanded).toContain("route exa/primary:failed -> exa/backup:searching");
+	});
+
+	it("#given three providers with the first failed and the second running #when rendering expanded partial output #then shows the three-state route string", () => {
+		// given
+		const details: SearchProgressDetails = {
+			phase: "searching",
+			query: "route render",
+			providerLabels: ["exa/primary", "duckduckgo-html/backup", "brave/extra"],
+			routeLabels: ["exa/primary", "duckduckgo-html/backup", "brave/extra"],
+			maxResults: 10,
+			currentProvider: "duckduckgo-html/backup",
+			attempts: [{ provider: "exa", entryId: "primary", durationMs: 9, resultsCount: 0, error: "HTTP 500" }],
+		};
+
+		// when
+		const collapsed = renderSearchResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{ expanded: false, isPartial: true },
+			passthroughTheme,
+		)
+			.render(200)
+			.join("\n");
+		const expanded = renderSearchResult(
+			{ content: [{ type: "text", text: "" }], details },
+			{ expanded: true, isPartial: true },
+			passthroughTheme,
+		)
+			.render(200)
+			.join("\n");
+
+		// then
+		expect(collapsed).not.toMatch(/\[\d+\/\d+\]/);
+		expect(expanded).toContain("route exa/primary:failed -> duckduckgo-html/backup:searching -> brave/extra:pending");
+	});
+});
+
+describe("websearch native entry label collapse", () => {
+	const nativeDetails: SearchDetails = {
+		provider: "openai",
+		entryId: "native-openai-abc123",
+		query: "native label",
+		results: [{ title: "Native", url: "https://example.com/native", snippet: "snip" }],
+		durationMs: 7,
+		truncated: false,
+		strategy: "priority",
+		attempts: [{ provider: "openai", entryId: "native-openai-abc123", durationMs: 7, resultsCount: 1 }],
+	};
+
+	it("#given finished details with native-openai entryId #when rendering collapsed summary #then collapses to openai/native", () => {
+		// when
+		const rendered = renderSearchResult(
+			{ content: [{ type: "text", text: "ok" }], details: nativeDetails },
+			{ expanded: false },
+			passthroughTheme,
+		)
+			.render(200)
+			.join("\n");
+
+		// then
+		expect(rendered).toContain("via openai/native");
+		expect(rendered).not.toContain("native-openai-abc123");
+	});
+
+	it("#given finished details with native-openai entryId #when rendering expanded route #then collapses route line to openai/native:count", () => {
+		// when
+		const rendered = renderSearchResult(
+			{ content: [{ type: "text", text: "ok" }], details: nativeDetails },
+			{ expanded: true },
+			passthroughTheme,
+		)
+			.render(200)
+			.join("\n");
+
+		// then
+		expect(rendered).toContain("route openai/native:1");
+		expect(rendered).not.toContain("native-openai-abc123");
+	});
+
+	it("#given finished details with native-openai entryId and priority strategy #when formatting text #then route fragment collapses to openai/native", () => {
+		// when
+		const text = formatSearchText(nativeDetails);
+
+		// then
+		expect(text).toContain("via openai/native (priority)");
+		expect(text).not.toContain("native-openai-abc123");
 	});
 });

--- a/packages/coding-agent/test/websearch-status-label.test.ts
+++ b/packages/coding-agent/test/websearch-status-label.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import websearchExtension from "../src/core/extensions/builtin/websearch/index.ts";
+import type { ExtensionAPI } from "../src/core/extensions/types.ts";
+
+const ANTHROPIC_ENABLE_ENV = "PI_ANTHROPIC_WEB_SEARCH";
+const OPENAI_ENABLE_ENV = "PI_OPENAI_WEB_SEARCH";
+
+type CommandHandler = (rawArgs: string, ctx: { ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>;
+type SessionHandler = (event: unknown, ctx: unknown) => Promise<unknown> | unknown;
+
+describe("websearch /websearch status provider labels", () => {
+	let cwd: string;
+
+	beforeEach(async () => {
+		cwd = await mkdtemp(join(tmpdir(), "websearch-status-label-"));
+		await mkdir(join(cwd, ".pi"), { recursive: true });
+		await writeFile(
+			join(cwd, ".pi", "websearch.json"),
+			JSON.stringify({
+				strategy: "priority",
+				fallback: true,
+				auto: true,
+				providers: [
+					{ id: "primary", provider: "exa", apiKey: "test-key" },
+					{ id: "backup", provider: "duckduckgo-html" },
+					{ id: "native-openai-abc123", provider: "openai", apiKey: "test-key" },
+				],
+			}),
+		);
+	});
+
+	afterEach(async () => {
+		delete process.env[ANTHROPIC_ENABLE_ENV];
+		delete process.env[OPENAI_ENABLE_ENV];
+		await rm(cwd, { recursive: true, force: true });
+	});
+
+	it("#given active multi-provider config #when /websearch status runs #then providers render as provider/id and collapse discovered native ids", async () => {
+		// given
+		let sessionStart: SessionHandler | undefined;
+		let statusCommand: CommandHandler | undefined;
+		websearchExtension({
+			registerTool: vi.fn(),
+			registerCommand(_name: string, definition: { handler: CommandHandler }) {
+				statusCommand = definition.handler;
+			},
+			on(eventName: string, handler: unknown) {
+				if (eventName === "session_start") sessionStart = handler as SessionHandler;
+			},
+		} as unknown as ExtensionAPI);
+		await sessionStart?.(
+			{ type: "session_start" },
+			{
+				cwd,
+				model: { provider: "exa", id: "exa-1", api: "openai-completions" },
+				hasUI: false,
+				ui: { notify: vi.fn(), setStatus: vi.fn(), setWidget: vi.fn() },
+			},
+		);
+		const notify = vi.fn();
+
+		// when
+		await statusCommand?.("status", { ui: { notify } });
+
+		// then
+		expect(notify).toHaveBeenCalledTimes(1);
+		const call = notify.mock.calls[0];
+		expect(call?.[1]).toBe("info");
+		expect(call?.[0]).toContain("providers=exa/primary, duckduckgo-html/backup, openai/native");
+		expect(call?.[0]).not.toContain("primary/exa");
+	});
+});


### PR DESCRIPTION
## What

`web_search` now shows **which search source it is actually using** — the one it is about to try, the one running, and the ones already tried — and the misleading `[n/m]` step counter is gone.

Before (real TUI capture, pre-change):

```
Searching "senpi coding agent github" via exa/primary [1/3] (max 5)
route exa/primary:failed
5 results via duckduckgo-html/backup (priority) in 836ms (truncated)
```

After (same harness, post-change):

```
Web search active: strategy=priority, auto=disabled, providers=exa/primary, duckduckgo-html/backup, brave/extra
Searching "senpi coding agent github" via exa/primary (max 5)
route exa/primary:searching -> duckduckgo-html/backup:pending -> brave/extra:pending
Searching "senpi coding agent github" via duckduckgo-html/backup (max 5)
route exa/primary:failed -> duckduckgo-html/backup:searching -> brave/extra:pending
5 results via duckduckgo-html/backup (priority) in 895ms (truncated)
route exa/primary:failed -> duckduckgo-html/backup:5
```

Five defects are fixed:

1. **Bogus step counter.** `[n/m]` was derived from the attempt count against the *configured* provider count and is now removed entirely; the collapsed line names only the source in use.
2. **No route visibility.** The expanded route line listed only completed attempts. It now renders every source in resolved attempt order with its state: `:failed` / `:<count>` (tried), `:searching` (running), `:pending` (not reached). Order comes from `performSearch`, so priority / round-robin / fill-first reordering is reflected honestly.
3. **Two spellings for one source.** `tool.ts` built `id/provider` (`primary/exa`) for the progress route list while `search.ts` built `provider/id` (`exa/primary`) for the current provider, attempts and the finished summary — and `/websearch status` had a third copy. One exported `providerEntryLabel` is now the single spelling everywhere, and a discovered native route renders `openai/native` instead of leaking `native-openai-<fingerprint>`.
4. **Stale provider-native routing.** `nativeMapping()` matched only `gpt-5.5|gpt-4.1|gpt-4o` and `claude-(opus|sonnet)-4*`. Every current model — `gpt-5.6-sol`, `gpt-5.4`, `gpt-5-pro`, `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`, `claude-fable-5` — silently fell through to the DuckDuckGo HTML scraper when the model was reached through a proxied baseUrl. It now matches the families (`/^gpt-(4o|4\.1|5)/` minus codex ids, any `claude-*`). A match whose endpoint rejects the server-side tool just fails that attempt and the configured providers take over (default `fallback: true`).
5. **Config in a directory senpi never reads.** The loader only looked at `.pi/websearch.json`, while senpi's config dir is `.senpi`. It now reads `<cwd>/.senpi/websearch.json` and `~/.senpi/websearch.json` first and keeps every `.pi` path working.

## Upstream

The rendering, label and native-mapping fixes are also released upstream as **pi-websearch 0.3.0** (`code-yeongyu/pi-websearch@7fb28c3`, pushed); `external-versions.json` records 0.3.0 and `changes.md` now lists only what is genuinely senpi-only (AbortSignal forwarding into route discovery, the terminal-DNS-dot canonicalization, the `provider_native_bypass` gating, and the `CONFIG_DIR_NAME` config paths).

## Tests

Test-first; every assertion was captured RED before the change.

- `test/websearch-progress.test.ts` — updated: no `[n/m]`, three-state route line, `providerLabels` spelled like `currentProvider`, `routeLabels` in resolved order, native id collapsing in the finished render and in `formatSearchText`.
- `test/websearch-native-model-matrix.test.ts` — new: 22 parameterized cases over the model matrix incl. the null cases (`gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-4-turbo`, `o3`, non-claude anthropic id).
- `test/websearch-config-paths.test.ts` — new: `.senpi` loads, `.pi` still loads, project `.senpi` beats `~/.senpi`.
- `test/websearch-status-label.test.ts` — new: `/websearch status` prints the shared spelling.
- `test/websearch-native-tool.test.ts` — label expectations updated.

`8 files / 52 tests` green, `npm run check` exits 0, upstream `npm test` 138/138 green with `tsgo` + `biome` clean.

## Manual QA

Real senpi CLI driven from source in an isolated sandbox (`SENPI_CODING_AGENT_DIR` + `PI_OFFLINE=1`, real auth untouched), a local fake model server scripted to call `web_search`, and a three-provider route whose first entry fails (`exa` with an invalid key) and second succeeds (`duckduckgo-html`). RED baseline captured on `main` first, GREEN after, plus a re-run after the review round. Both transcripts (raw pty stream + plain text) are saved under `local-ignore/qa-evidence/20260725-websearch-source-render/`; the RED run also demonstrated the `.senpi` config being ignored (`10 results via duckduckgo-html/default`). All sandboxes, mock servers and TUI sessions were torn down.

Reviewed by the oracle agent: two criterion-cited blockers (`/websearch status` label, cross-repo declaration order) and two doc notes were raised, fixed, and re-reviewed to unconditional approval.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the web search UX by showing the active provider and honest route state, unify provider labels, and fix native routing and config loading for more reliable results. Also vendors `pi-websearch` 0.3.0.

- **Bug Fixes**
  - Show the current provider while searching; remove the `[n/m]` counter. Expanded mode shows `:failed`/`:count`, `:searching`, and `:pending` for each source in resolved order.
  - Use one `providerEntryLabel` (`provider/id`) across progress, summaries, and `/websearch status`; collapse discovered native ids to `openai/native` or `anthropic/native`.
  - Refresh native model mapping to include `gpt-(4o|4.1|5)` (excluding codex) and all `claude-*`; failed native attempts fall back to configured providers.
  - Read configs from `<cwd>/.senpi/websearch.json` and `~/.senpi/websearch.json` before `.pi`; keep legacy paths working.
  - Forward `AbortSignal` into native route discovery so cancellation doesn’t wait on auth.

- **Dependencies**
  - Update `pi-websearch` to `0.3.0` and align rendering/label logic with upstream.

<sup>Written for commit 0cca783eaf44fda9e2737103f0b96d24b2c73fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

