### PR TITLE
feat(coding-agent): beta omo local plugin auto-update on bare senpi update

### DIFF
--- a/packages/coding-agent/src/beta/omo-local-update.ts
+++ b/packages/coding-agent/src/beta/omo-local-update.ts
@@ -1,0 +1,311 @@
+// BETA(omo-local-update): removable beta module - delete this file, all test/omo-local-update*
+// files, and the two marked touch points in src/package-manager-cli.ts to drop the feature.
+//
+// Beta: on bare `senpi update`, sync a locally-installed OMO plugin checkout (omo-senpi +
+// senpi-task) to origin/dev, rebuild the plugin bundle, and notify - before senpi updates
+// itself. See .omo/plans/senpi-update-omo-local-beta.md.
+//
+// Export policy: `runOmoLocalUpdateBeta` is the ONLY production API and the only symbol the
+// CLI may import. Every other export in this module is /** exported for tests only */ so the
+// single test file (test/omo-local-update.test.ts) can exercise helpers directly - no
+// CLI-side helper imports, no logic duplication.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { PackageSource } from "../core/settings-manager.ts";
+import { spawnProcess, waitForChildProcess } from "../utils/child-process.ts";
+import { canonicalizePath, isLocalPath, resolvePath } from "../utils/paths.ts";
+import { killProcessTree } from "../utils/shell.ts";
+
+/** Result of one spawned command, with output captured and timeout enforced. */
+export interface OmoLocalRunResult {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+	timedOut: boolean;
+}
+
+export interface OmoLocalRunOptions {
+	cwd?: string;
+	timeoutMs?: number;
+	/** Merged over process.env (callers inject the isolated git env from the fixture contract). */
+	env?: Record<string, string | undefined>;
+}
+
+/** exported for tests only */
+export type OmoLocalRun = (command: string, args: string[], options: OmoLocalRunOptions) => Promise<OmoLocalRunResult>;
+
+/**
+ * exported for tests only
+ *
+ * Shared process seam for the whole module. spawnProcess/waitForChildProcess neither capture
+ * output nor enforce timeouts; this adds both. The child is spawned detached on POSIX so it
+ * owns a process group, and the timeout kill goes through killProcessTree (SIGKILL to the
+ * whole group) - without that, bun/git descendants would keep mutating the checkout after
+ * the direct child died.
+ */
+export async function defaultRun(
+	command: string,
+	args: string[],
+	options: OmoLocalRunOptions,
+): Promise<OmoLocalRunResult> {
+	const child = spawnProcess(command, args, {
+		cwd: options.cwd,
+		stdio: ["ignore", "pipe", "pipe"],
+		env: { ...process.env, ...options.env },
+		detached: process.platform !== "win32",
+		windowsHide: true,
+	});
+	let stdout = "";
+	let stderr = "";
+	child.stdout.on("data", (chunk: Buffer) => {
+		stdout += chunk.toString();
+	});
+	child.stderr.on("data", (chunk: Buffer) => {
+		stderr += chunk.toString();
+	});
+	const abort = new AbortController();
+	let timedOut = false;
+	const pid = child.pid;
+	const timer =
+		options.timeoutMs === undefined
+			? undefined
+			: setTimeout(() => {
+					timedOut = true;
+					if (pid !== undefined) {
+						killProcessTree(pid);
+					}
+					abort.abort();
+				}, options.timeoutMs);
+	try {
+		const code = await waitForChildProcess(child, { signal: abort.signal });
+		return { code, stdout, stderr, timedOut };
+	} finally {
+		if (timer !== undefined) {
+			clearTimeout(timer);
+		}
+	}
+}
+
+/** exported for tests only */
+export function isKillSwitched(env: Record<string, string | undefined>): boolean {
+	return env.SENPI_OMO_LOCAL_UPDATE === "0";
+}
+
+/** A detected locally-installed OMO plugin and its enclosing omo monorepo checkout. */
+export interface OmoLocalInstall {
+	pluginPath: string;
+	repoRoot: string;
+}
+
+/** exported for tests only */
+export interface DetectOmoLocalInstallOptions {
+	packages: PackageSource[] | undefined;
+	agentDir: string;
+	run: OmoLocalRun;
+	readJson?: (path: string) => unknown;
+	exists?: (path: string) => boolean;
+}
+
+function defaultReadJson(path: string): unknown {
+	try {
+		return JSON.parse(readFileSync(path, "utf-8"));
+	} catch {
+		return undefined;
+	}
+}
+
+function packageNameOf(json: unknown): string | undefined {
+	if (typeof json !== "object" || json === null) {
+		return undefined;
+	}
+	const name = (json as { name?: unknown }).name;
+	return typeof name === "string" ? name : undefined;
+}
+
+/** Same semantics as package-manager.ts's private getHomeDir (HOME env wins over os.homedir). */
+function homeDir(): string {
+	return process.env.HOME || homedir();
+}
+
+/**
+ * exported for tests only
+ *
+ * Three-part detection gate (ALL must hold, else silent no-op):
+ * 1. A global settings `packages` entry (string or object form) is a local path whose resolved
+ *    dir's package.json name is `@code-yeongyu/omo-senpi`.
+ * 2. The derived repo root (pluginPath/../../..) contains both workspace packages
+ *    `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task`.
+ * 3. `git -C <repoRoot> rev-parse --show-toplevel` succeeds AND its canonicalized output equals
+ *    the canonicalized repo root - a mismatched toplevel would let later `git add -A` stage an
+ *    enclosing repo's files.
+ */
+export async function detectOmoLocalInstall(
+	options: DetectOmoLocalInstallOptions,
+): Promise<OmoLocalInstall | undefined> {
+	const readJson = options.readJson ?? defaultReadJson;
+	const exists = options.exists ?? existsSync;
+	if (!options.packages) {
+		return undefined;
+	}
+	for (const entry of options.packages) {
+		const source = typeof entry === "string" ? entry : entry.source;
+		if (!isLocalPath(source)) {
+			continue;
+		}
+		const pluginPath = resolvePath(source, options.agentDir, { homeDir: homeDir(), trim: true });
+		if (packageNameOf(readJson(join(pluginPath, "package.json"))) !== "@code-yeongyu/omo-senpi") {
+			continue;
+		}
+		const repoRoot = resolve(pluginPath, "..", "..", "..");
+		const omoSenpiPkgPath = join(repoRoot, "packages", "omo-senpi", "package.json");
+		const senpiTaskPkgPath = join(repoRoot, "packages", "senpi-task", "package.json");
+		if (!exists(omoSenpiPkgPath) || packageNameOf(readJson(omoSenpiPkgPath)) !== "@oh-my-opencode/omo-senpi") {
+			continue;
+		}
+		if (!exists(senpiTaskPkgPath) || packageNameOf(readJson(senpiTaskPkgPath)) !== "@oh-my-opencode/senpi-task") {
+			continue;
+		}
+		let topLevel: string;
+		try {
+			const result = await options.run("git", ["-C", repoRoot, "rev-parse", "--show-toplevel"], {});
+			if (result.code !== 0) {
+				continue;
+			}
+			topLevel = result.stdout.trim();
+		} catch {
+			continue;
+		}
+		if (topLevel === "" || canonicalizePath(topLevel) !== canonicalizePath(repoRoot)) {
+			continue;
+		}
+		return { pluginPath, repoRoot };
+	}
+	return undefined;
+}
+
+/** Skip-stamp written after a successful build: `<agentDir>/omo-local-update-state.json`. */
+export interface OmoLocalUpdateStamp {
+	repoRoot: string;
+	builtSha: string;
+	builtAt: string;
+	/** Post-build inventory: relative paths of every built artifact present at stamp time. */
+	artifacts: string[];
+}
+
+/** exported for tests only */
+export function omoLocalUpdateStampPath(agentDir: string): string {
+	return join(agentDir, "omo-local-update-state.json");
+}
+
+/** exported for tests only */
+export function readStamp(agentDir: string): OmoLocalUpdateStamp | undefined {
+	const json = defaultReadJson(omoLocalUpdateStampPath(agentDir));
+	if (typeof json !== "object" || json === null) {
+		return undefined;
+	}
+	const candidate = json as { repoRoot?: unknown; builtSha?: unknown; builtAt?: unknown; artifacts?: unknown };
+	if (
+		typeof candidate.repoRoot !== "string" ||
+		typeof candidate.builtSha !== "string" ||
+		typeof candidate.builtAt !== "string" ||
+		!Array.isArray(candidate.artifacts)
+	) {
+		return undefined;
+	}
+	const artifacts: string[] = [];
+	for (const artifact of candidate.artifacts as unknown[]) {
+		if (typeof artifact !== "string") {
+			return undefined;
+		}
+		artifacts.push(artifact);
+	}
+	return {
+		repoRoot: candidate.repoRoot,
+		builtSha: candidate.builtSha,
+		builtAt: candidate.builtAt,
+		artifacts,
+	};
+}
+
+/** exported for tests only */
+export function writeStamp(agentDir: string, stamp: OmoLocalUpdateStamp): void {
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(omoLocalUpdateStampPath(agentDir), `${JSON.stringify(stamp, null, 2)}\n`, "utf-8");
+}
+
+/** exported for tests only */
+export interface ShouldSkipBuildOptions {
+	stamp: OmoLocalUpdateStamp | undefined;
+	repoRoot: string;
+	targetSha: string;
+	/** True only when every path recorded in stamp.artifacts still exists on disk. */
+	stampArtifactsExist: boolean;
+	force: boolean;
+}
+
+/**
+ * exported for tests only
+ *
+ * Skip decision (taken BEFORE any worktree mutation): skip only when the stamp belongs to this
+ * repo root, was built at the frozen target sha, recorded a non-empty artifact inventory, and
+ * every inventoried path still exists. A repoRoot mismatch always rebuilds; an empty/absent
+ * inventory never skips.
+ */
+export function shouldSkipBuild(options: ShouldSkipBuildOptions): boolean {
+	if (options.force) {
+		return false;
+	}
+	const stamp = options.stamp;
+	if (!stamp) {
+		return false;
+	}
+	if (stamp.repoRoot !== options.repoRoot) {
+		return false;
+	}
+	if (stamp.builtSha !== options.targetSha) {
+		return false;
+	}
+	if (stamp.artifacts.length === 0) {
+		return false;
+	}
+	return options.stampArtifactsExist;
+}
+
+export interface RunOmoLocalUpdateBetaOptions {
+	env: Record<string, string | undefined>;
+	agentDir: string;
+	settings?: { packages?: PackageSource[] };
+	force?: boolean;
+	log?: (message: string) => void;
+	run?: OmoLocalRun;
+}
+
+/**
+ * Beta hook entry point, called from bare `senpi update` before the self-update.
+ *
+ * STUB (todo 1): gate chain only - kill-switch, then detection. The ordered state machine
+ * (lock -> fetch -> skip decision -> sync -> install/build -> stamp -> notify) lands in todo 4.
+ * This hook NEVER throws and NEVER sets process.exitCode: any failure downgrades to a warning
+ * so the senpi self-update continues untouched.
+ */
+export async function runOmoLocalUpdateBeta(options: RunOmoLocalUpdateBetaOptions): Promise<void> {
+	try {
+		if (isKillSwitched(options.env)) {
+			return;
+		}
+		const install = await detectOmoLocalInstall({
+			packages: options.settings?.packages,
+			agentDir: options.agentDir,
+			run: options.run ?? defaultRun,
+		});
+		if (!install) {
+			return;
+		}
+		// todo 4: acquire lock -> fetch origin/dev -> skip decision -> syncToOriginDev ->
+		// bun install -> bun run build:senpi-plugin -> completeness check -> write stamp -> notify.
+	} catch {
+		// Beta failures are never fatal; todo 4 renders the yellow failure line + manual hint.
+	}
+}

--- a/packages/coding-agent/src/beta/omo-local-update.ts
+++ b/packages/coding-agent/src/beta/omo-local-update.ts
@@ -10,9 +10,10 @@
 // single test file (test/omo-local-update.test.ts) can exercise helpers directly - no
 // CLI-side helper imports, no logic duplication.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import chalk from "chalk";
 import type { PackageSource } from "../core/settings-manager.ts";
 import { spawnProcess, waitForChildProcess } from "../utils/child-process.ts";
 import { canonicalizePath, isLocalPath, resolvePath } from "../utils/paths.ts";
@@ -271,6 +272,341 @@ export function shouldSkipBuild(options: ShouldSkipBuildOptions): boolean {
 		return false;
 	}
 	return options.stampArtifactsExist;
+}
+
+/** One parsed entry of `git status --porcelain=v1 -z` output. */
+export interface OmoDirtEntry {
+	/** The path git reports (for renames: the rename TARGET). */
+	path: string;
+	/** Rename source path, present only for R/C records. */
+	origPath?: string;
+	/** True for `??` untracked records. */
+	untracked: boolean;
+}
+
+/** exported for tests only */
+export interface OmoDirtClassification {
+	generated: OmoDirtEntry[];
+	source: OmoDirtEntry[];
+}
+
+const GENERATED_DIR_PREFIXES = [
+	"packages/omo-senpi/plugin/extensions/",
+	"packages/omo-senpi/plugin/skills/",
+	"packages/omo-senpi/plugin/runtime/",
+] as const;
+
+const GENERATED_FILE_PATHS = new Set(["packages/omo-senpi/plugin/scripts/install.mjs"]);
+
+function isGeneratedPath(path: string): boolean {
+	if (GENERATED_FILE_PATHS.has(path)) {
+		return true;
+	}
+	for (const prefix of GENERATED_DIR_PREFIXES) {
+		if (path.startsWith(prefix)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * exported for tests only
+ *
+ * Parse `git status --porcelain=v1 -z` into GENERATED vs SOURCE dirt. With -z each record is
+ * `XY <path>` NUL-terminated; rename/copy records carry a SECOND NUL-separated field holding
+ * the ORIGINAL path (order: new then old, no arrow, no quoting). Rename rule (Scope): if
+ * EITHER half of a rename lies outside the GENERATED prefixes, the whole rename is SOURCE.
+ */
+export function classifyDirt(porcelainZ: string): OmoDirtClassification {
+	const fields = porcelainZ.split("\0");
+	const generated: OmoDirtEntry[] = [];
+	const source: OmoDirtEntry[] = [];
+	let index = 0;
+	while (index < fields.length) {
+		const record = fields[index];
+		index += 1;
+		if (record === "") {
+			continue;
+		}
+		const code = record.slice(0, 2);
+		const entry: OmoDirtEntry = { path: record.slice(3), untracked: code === "??" };
+		if (code.includes("R") || code.includes("C")) {
+			const origPath = fields[index];
+			index += 1;
+			if (origPath !== undefined && origPath !== "") {
+				entry.origPath = origPath;
+			}
+		}
+		const isGenerated =
+			isGeneratedPath(entry.path) && (entry.origPath === undefined || isGeneratedPath(entry.origPath));
+		(isGenerated ? generated : source).push(entry);
+	}
+	return { generated, source };
+}
+
+function firstErrorLine(result: OmoLocalRunResult): string {
+	for (const text of [result.stderr, result.stdout]) {
+		for (const line of text.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed !== "") {
+				return trimmed;
+			}
+		}
+	}
+	return "unknown error";
+}
+
+/** `YYYYMMDD-HHMMSSZ` in UTC, for `backup/senpi-update-<stamp>` branch names. */
+function formatBackupTimestamp(date: Date): string {
+	const iso = date.toISOString();
+	return `${iso.slice(0, 10).replaceAll("-", "")}-${iso.slice(11, 19).replaceAll(":", "")}Z`;
+}
+
+/**
+ * exported for tests only
+ *
+ * Sync failure carrying the state-machine stage ("classify" | "backup" | "discard" | "sync")
+ * so the orchestrator can render `OMO local plugin update failed (<stage>): <first line>`.
+ */
+export class OmoLocalSyncError extends Error {
+	readonly stage: string;
+	constructor(stage: string, message: string) {
+		super(message);
+		this.name = "OmoLocalSyncError";
+		this.stage = stage;
+	}
+}
+
+/** exported for tests only */
+export interface SyncToOriginDevReport {
+	/** `git log -1 --format=%s <targetSha>` - read from the FROZEN sha, never the mutable ref. */
+	subject: string;
+	/** Restoration handle for later-stage failures: pre-sync branch name, or detached HEAD sha. */
+	prevRef: string;
+	backupBranch?: string;
+	backupPushed?: boolean;
+	/** True when local dev was ahead/diverged and the build happens detached at the target. */
+	detached?: boolean;
+	discardedPaths: string[];
+}
+
+/** exported for tests only */
+export interface SyncToOriginDevOptions {
+	repoRoot: string;
+	/** Frozen origin/dev sha resolved ONCE by the orchestrator; every git op takes this literal. */
+	targetSha: string;
+	run: OmoLocalRun;
+	log: (message: string) => void;
+}
+
+/**
+ * exported for tests only
+ *
+ * Post-skip MUTATION HELPER (Scope ownership split): NEVER fetches, locks, skips, or stamps -
+ * the orchestrator owns those and passes the frozen targetSha. Flow: capture prevRef ->
+ * classify dirt -> back up SOURCE dirt to a pushed (or local-fallback) backup branch ->
+ * discard GENERATED dirt -> branch triage under the FROZEN-SHA RULE -> mandatory
+ * HEAD===targetSha postcondition. Forbidden git ops (reset --hard / clean -fd / stash /
+ * force-push) are never used.
+ */
+export async function syncToOriginDev(options: SyncToOriginDevOptions): Promise<SyncToOriginDevReport> {
+	const { repoRoot, targetSha, run, log } = options;
+	const git = (args: string[]) => run("git", args, { cwd: repoRoot });
+	const requireOk = async (stage: string, args: string[]): Promise<OmoLocalRunResult> => {
+		const result = await git(args);
+		if (result.code !== 0) {
+			throw new OmoLocalSyncError(stage, `git ${args.join(" ")}: ${firstErrorLine(result)}`);
+		}
+		return result;
+	};
+	const discardGenerated = async (entries: OmoDirtEntry[]): Promise<boolean> => {
+		const checkoutPaths: string[] = [];
+		for (const entry of entries) {
+			if (entry.untracked) {
+				// Untracked files inside generated dirs: targeted fs.rm only.
+				rmSync(join(repoRoot, entry.path), { recursive: true, force: true });
+				continue;
+			}
+			// `checkout HEAD --` (not bare `checkout --`) so staged generated dirt resets from
+			// HEAD too instead of being restored out of the index. For renames the TARGET path
+			// is not in HEAD, so the SOURCE path is the checkout pathspec and the target file
+			// is removed directly.
+			if (entry.origPath !== undefined) {
+				rmSync(join(repoRoot, entry.path), { recursive: true, force: true });
+				checkoutPaths.push(entry.origPath);
+			} else {
+				checkoutPaths.push(entry.path);
+			}
+		}
+		if (checkoutPaths.length === 0) {
+			return true;
+		}
+		const result = await git(["checkout", "HEAD", "--", ...checkoutPaths]);
+		return result.code === 0;
+	};
+
+	// Restoration handle: current branch name, or the detached HEAD sha.
+	const symref = await git(["symbolic-ref", "--short", "-q", "HEAD"]);
+	const prevRef =
+		symref.code === 0 && symref.stdout.trim() !== ""
+			? symref.stdout.trim()
+			: (await requireOk("classify", ["rev-parse", "HEAD"])).stdout.trim();
+
+	const status = await requireOk("classify", ["status", "--porcelain=v1", "-z"]);
+	const dirt = classifyDirt(status.stdout);
+	const discardedPaths = dirt.generated.map((entry) => entry.path);
+
+	let backupBranch: string | undefined;
+	let backupPushed: boolean | undefined;
+
+	if (dirt.source.length > 0) {
+		// SOURCE dirt is preserved via an auto backup branch created at current HEAD. `git add -A`
+		// runs with cwd = repoRoot only and never stages ignored files, so the snapshot is all
+		// tracked modifications + untracked non-ignored files (generated dirt included, for
+		// snapshot fidelity).
+		backupBranch = `backup/senpi-update-${formatBackupTimestamp(new Date())}`;
+		await requireOk("backup", ["checkout", "-b", backupBranch]);
+		await requireOk("backup", ["add", "-A"]);
+		const commit = await git(["commit", "-m", `backup(senpi-update): auto snapshot from ${prevRef}`]);
+		if (commit.code !== 0) {
+			// Backup-COMMIT failure: roll back (restore prevRef, delete the empty backup branch)
+			// and abort the sync. The pre-existing dirt rides along with the checkout - it is
+			// never destroyed without a successful backup commit.
+			const back = await git(["checkout", prevRef]);
+			if (back.code !== 0) {
+				log(
+					chalk.yellow(
+						`OMO local plugin update: backup commit failed AND restoring ${prevRef} failed: ${firstErrorLine(back)}`,
+					),
+				);
+			}
+			const del = await git(["branch", "-D", backupBranch]);
+			if (del.code !== 0) {
+				log(
+					chalk.yellow(
+						`OMO local plugin update: could not delete empty backup branch ${backupBranch}: ${firstErrorLine(del)}`,
+					),
+				);
+			}
+			throw new OmoLocalSyncError("backup", `git commit: ${firstErrorLine(commit)}`);
+		}
+		const push = await git(["push", "-u", "origin", backupBranch]);
+		backupPushed = push.code === 0;
+		if (!backupPushed) {
+			// Push failure alone does NOT abort: the work is preserved in the snapshot commit.
+			log(
+				chalk.yellow(
+					`OMO local plugin update: backup branch ${backupBranch} could not be pushed (kept locally only); your work is preserved in the snapshot commit.`,
+				),
+			);
+		}
+		// Everything (generated dirt included) is now committed on the backup branch, so the
+		// worktree is fully clean: no explicit discard is needed on this path - the branch-triage
+		// checkout resets generated files to the frozen target's versions.
+	} else if (dirt.generated.length > 0) {
+		if (!(await discardGenerated(dirt.generated))) {
+			throw new OmoLocalSyncError("discard", "could not discard generated build-output dirt");
+		}
+	}
+
+	const restoreAfterBackup = async (): Promise<void> => {
+		// RESTORATION PROCEDURE (Scope): reclassify fresh, discard GENERATED-set entries only,
+		// then checkout prevRef. Post-failure SOURCE dirt is never overwritten: leave the
+		// worktree untouched, keep the backup ref, and warn explicitly.
+		const keepNote = `your work is preserved on ${backupBranch ?? "the backup branch"}`;
+		const fresh = await git(["status", "--porcelain=v1", "-z"]);
+		if (fresh.code !== 0) {
+			log(chalk.yellow(`OMO local plugin update: could not restore ${prevRef} (git status failed); ${keepNote}.`));
+			return;
+		}
+		const freshDirt = classifyDirt(fresh.stdout);
+		if (freshDirt.source.length > 0) {
+			log(
+				chalk.yellow(
+					`OMO local plugin update: could not restore ${prevRef} - uncommitted source changes would be overwritten; leaving the worktree untouched (${keepNote}).`,
+				),
+			);
+			return;
+		}
+		if (!(await discardGenerated(freshDirt.generated))) {
+			log(
+				chalk.yellow(
+					`OMO local plugin update: could not restore ${prevRef} (generated-dirt discard failed); ${keepNote}.`,
+				),
+			);
+			return;
+		}
+		const back = await git(["checkout", prevRef]);
+		if (back.code !== 0) {
+			log(
+				chalk.yellow(
+					`OMO local plugin update: could not restore ${prevRef}: ${firstErrorLine(back)} (${keepNote}).`,
+				),
+			);
+		}
+	};
+
+	try {
+		// Branch triage - FROZEN-SHA RULE: every ancestry/merge/detach/subject op below takes
+		// the targetSha literal, never the mutable origin/dev ref.
+		let detached = false;
+		const devRes = await git(["rev-parse", "dev"]);
+		if (devRes.code !== 0) {
+			// Absent local dev: create FROM THE FROZEN COMMIT - never a DWIM checkout, which
+			// would read the mutable origin/dev ref.
+			await requireOk("sync", ["branch", "dev", targetSha]);
+			await requireOk("sync", ["branch", "--set-upstream-to=origin/dev", "dev"]);
+			await requireOk("sync", ["checkout", "dev"]);
+		} else if (devRes.stdout.trim() === targetSha) {
+			await requireOk("sync", ["checkout", "dev"]);
+		} else {
+			const ancestor = await git(["merge-base", "--is-ancestor", "dev", targetSha]);
+			if (ancestor.code === 0) {
+				// Strictly behind: plain fast-forward.
+				await requireOk("sync", ["checkout", "dev"]);
+				await requireOk("sync", ["merge", "--ff-only", targetSha]);
+			} else if (ancestor.code === 1) {
+				// AHEAD of or DIVERGED from the frozen target: never destroy or build local
+				// commits - warn and build detached at the frozen sha.
+				log(
+					chalk.yellow(
+						`OMO local plugin update: local dev has commits not on origin/dev; leaving them intact and building detached at origin/dev @${targetSha.slice(0, 7)}.`,
+					),
+				);
+				await requireOk("sync", ["checkout", "--detach", targetSha]);
+				detached = true;
+			} else {
+				throw new OmoLocalSyncError("sync", `git merge-base --is-ancestor: ${firstErrorLine(ancestor)}`);
+			}
+		}
+		const subject = (await requireOk("sync", ["log", "-1", "--format=%s", targetSha])).stdout.trim();
+		const head = (await requireOk("sync", ["rev-parse", "HEAD"])).stdout.trim();
+		if (head !== targetSha) {
+			throw new OmoLocalSyncError(
+				"sync",
+				`postcondition failed: HEAD is ${head.slice(0, 7)}, expected ${targetSha.slice(0, 7)}`,
+			);
+		}
+		const report: SyncToOriginDevReport = { subject, prevRef, discardedPaths };
+		if (backupBranch !== undefined) {
+			report.backupBranch = backupBranch;
+		}
+		if (backupPushed !== undefined) {
+			report.backupPushed = backupPushed;
+		}
+		if (detached) {
+			report.detached = true;
+		}
+		return report;
+	} catch (error) {
+		// Any other git failure in the sequence: abort; if a backup commit already succeeded,
+		// restore prevRef first while KEEPING the backup ref.
+		if (backupBranch !== undefined) {
+			await restoreAfterBackup();
+		}
+		throw error;
+	}
 }
 
 export interface RunOmoLocalUpdateBetaOptions {

--- a/packages/coding-agent/src/beta/omo-local-update.ts
+++ b/packages/coding-agent/src/beta/omo-local-update.ts
@@ -10,9 +10,10 @@
 // single test file (test/omo-local-update.test.ts) can exercise helpers directly - no
 // CLI-side helper imports, no logic duplication.
 
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { type Dirent, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import chalk from "chalk";
 import type { PackageSource } from "../core/settings-manager.ts";
 import { spawnProcess, waitForChildProcess } from "../utils/child-process.ts";
@@ -400,6 +401,84 @@ export interface SyncToOriginDevOptions {
 	log: (message: string) => void;
 }
 
+type OmoGitRunner = (args: string[]) => Promise<OmoLocalRunResult>;
+
+/**
+ * Discard GENERATED-set dirt: untracked entries via targeted fs.rm; tracked entries via
+ * `git checkout HEAD -- <pathspec...>` (not bare `checkout --`, so staged generated dirt
+ * resets from HEAD too instead of being restored out of the index). For renames the
+ * TARGET path is not in HEAD, so the target file is removed directly and the SOURCE path
+ * is the checkout pathspec.
+ */
+async function discardGeneratedDirt(git: OmoGitRunner, repoRoot: string, entries: OmoDirtEntry[]): Promise<boolean> {
+	const checkoutPaths: string[] = [];
+	for (const entry of entries) {
+		if (entry.untracked) {
+			// Untracked files inside generated dirs: targeted fs.rm only.
+			rmSync(join(repoRoot, entry.path), { recursive: true, force: true });
+			continue;
+		}
+		if (entry.origPath !== undefined) {
+			rmSync(join(repoRoot, entry.path), { recursive: true, force: true });
+			checkoutPaths.push(entry.origPath);
+		} else {
+			checkoutPaths.push(entry.path);
+		}
+	}
+	if (checkoutPaths.length === 0) {
+		return true;
+	}
+	const result = await git(["checkout", "HEAD", "--", ...checkoutPaths]);
+	return result.code === 0;
+}
+
+/**
+ * RESTORATION PROCEDURE (Scope): reclassify dirt fresh, discard GENERATED-set entries
+ * only, then `git checkout <prevRef>`. Post-failure SOURCE dirt is NEVER overwritten:
+ * leave the worktree as-is, keep the backup ref, and emit an explicit restoration-failed
+ * warning naming prevRef. Used by syncToOriginDev (sync-stage failures after a backup)
+ * and by the orchestrator (install/build/completeness/stamp failures after a backup).
+ */
+async function restorePrevRefAfterFailure(options: {
+	repoRoot: string;
+	prevRef: string;
+	backupBranch?: string;
+	run: OmoLocalRun;
+	log: (message: string) => void;
+}): Promise<void> {
+	const { repoRoot, prevRef, backupBranch, run, log } = options;
+	const git: OmoGitRunner = (args) => run("git", args, { cwd: repoRoot });
+	const keepNote = `your work is preserved on ${backupBranch ?? "the backup branch"}`;
+	const fresh = await git(["status", "--porcelain=v1", "-z"]);
+	if (fresh.code !== 0) {
+		log(chalk.yellow(`OMO local plugin update: could not restore ${prevRef} (git status failed); ${keepNote}.`));
+		return;
+	}
+	const freshDirt = classifyDirt(fresh.stdout);
+	if (freshDirt.source.length > 0) {
+		log(
+			chalk.yellow(
+				`OMO local plugin update: could not restore ${prevRef} - uncommitted source changes would be overwritten; leaving the worktree untouched (${keepNote}).`,
+			),
+		);
+		return;
+	}
+	if (!(await discardGeneratedDirt(git, repoRoot, freshDirt.generated))) {
+		log(
+			chalk.yellow(
+				`OMO local plugin update: could not restore ${prevRef} (generated-dirt discard failed); ${keepNote}.`,
+			),
+		);
+		return;
+	}
+	const back = await git(["checkout", prevRef]);
+	if (back.code !== 0) {
+		log(
+			chalk.yellow(`OMO local plugin update: could not restore ${prevRef}: ${firstErrorLine(back)} (${keepNote}).`),
+		);
+	}
+}
+
 /**
  * exported for tests only
  *
@@ -420,32 +499,6 @@ export async function syncToOriginDev(options: SyncToOriginDevOptions): Promise<
 		}
 		return result;
 	};
-	const discardGenerated = async (entries: OmoDirtEntry[]): Promise<boolean> => {
-		const checkoutPaths: string[] = [];
-		for (const entry of entries) {
-			if (entry.untracked) {
-				// Untracked files inside generated dirs: targeted fs.rm only.
-				rmSync(join(repoRoot, entry.path), { recursive: true, force: true });
-				continue;
-			}
-			// `checkout HEAD --` (not bare `checkout --`) so staged generated dirt resets from
-			// HEAD too instead of being restored out of the index. For renames the TARGET path
-			// is not in HEAD, so the SOURCE path is the checkout pathspec and the target file
-			// is removed directly.
-			if (entry.origPath !== undefined) {
-				rmSync(join(repoRoot, entry.path), { recursive: true, force: true });
-				checkoutPaths.push(entry.origPath);
-			} else {
-				checkoutPaths.push(entry.path);
-			}
-		}
-		if (checkoutPaths.length === 0) {
-			return true;
-		}
-		const result = await git(["checkout", "HEAD", "--", ...checkoutPaths]);
-		return result.code === 0;
-	};
-
 	// Restoration handle: current branch name, or the detached HEAD sha.
 	const symref = await git(["symbolic-ref", "--short", "-q", "HEAD"]);
 	const prevRef =
@@ -505,47 +558,10 @@ export async function syncToOriginDev(options: SyncToOriginDevOptions): Promise<
 		// worktree is fully clean: no explicit discard is needed on this path - the branch-triage
 		// checkout resets generated files to the frozen target's versions.
 	} else if (dirt.generated.length > 0) {
-		if (!(await discardGenerated(dirt.generated))) {
+		if (!(await discardGeneratedDirt(git, repoRoot, dirt.generated))) {
 			throw new OmoLocalSyncError("discard", "could not discard generated build-output dirt");
 		}
 	}
-
-	const restoreAfterBackup = async (): Promise<void> => {
-		// RESTORATION PROCEDURE (Scope): reclassify fresh, discard GENERATED-set entries only,
-		// then checkout prevRef. Post-failure SOURCE dirt is never overwritten: leave the
-		// worktree untouched, keep the backup ref, and warn explicitly.
-		const keepNote = `your work is preserved on ${backupBranch ?? "the backup branch"}`;
-		const fresh = await git(["status", "--porcelain=v1", "-z"]);
-		if (fresh.code !== 0) {
-			log(chalk.yellow(`OMO local plugin update: could not restore ${prevRef} (git status failed); ${keepNote}.`));
-			return;
-		}
-		const freshDirt = classifyDirt(fresh.stdout);
-		if (freshDirt.source.length > 0) {
-			log(
-				chalk.yellow(
-					`OMO local plugin update: could not restore ${prevRef} - uncommitted source changes would be overwritten; leaving the worktree untouched (${keepNote}).`,
-				),
-			);
-			return;
-		}
-		if (!(await discardGenerated(freshDirt.generated))) {
-			log(
-				chalk.yellow(
-					`OMO local plugin update: could not restore ${prevRef} (generated-dirt discard failed); ${keepNote}.`,
-				),
-			);
-			return;
-		}
-		const back = await git(["checkout", prevRef]);
-		if (back.code !== 0) {
-			log(
-				chalk.yellow(
-					`OMO local plugin update: could not restore ${prevRef}: ${firstErrorLine(back)} (${keepNote}).`,
-				),
-			);
-		}
-	};
 
 	try {
 		// Branch triage - FROZEN-SHA RULE: every ancestry/merge/detach/subject op below takes
@@ -603,7 +619,7 @@ export async function syncToOriginDev(options: SyncToOriginDevOptions): Promise<
 		// Any other git failure in the sequence: abort; if a backup commit already succeeded,
 		// restore prevRef first while KEEPING the backup ref.
 		if (backupBranch !== undefined) {
-			await restoreAfterBackup();
+			await restorePrevRefAfterFailure({ repoRoot, prevRef, backupBranch, run, log });
 		}
 		throw error;
 	}
@@ -619,14 +635,285 @@ export interface RunOmoLocalUpdateBetaOptions {
 }
 
 /**
+ * Failure of one orchestrator-owned step (fetch/install/build/artifacts/stamp). The stage
+ * feeds `OMO local plugin update failed (<stage>): ...`; `output` (combined stdout+stderr
+ * of the failed step) is echoed dim, last 40 lines.
+ */
+class OmoLocalStepError extends Error {
+	readonly stage: string;
+	readonly output: string | undefined;
+	constructor(stage: string, message: string, output?: string) {
+		super(message);
+		this.name = "OmoLocalStepError";
+		this.stage = stage;
+		this.output = output;
+	}
+}
+
+/** Marker error: the bun binary is missing from PATH (spawn ENOENT). */
+class OmoLocalBunMissingError extends Error {
+	constructor() {
+		super("bun not found on PATH");
+		this.name = "OmoLocalBunMissingError";
+	}
+}
+
+/** exported for tests only */
+export function omoLocalUpdateLockPath(agentDir: string): string {
+	return join(agentDir, "omo-local-update.lock");
+}
+
+interface OmoLocalLock {
+	path: string;
+	pid: number;
+	nonce: string;
+}
+
+function readLockFile(path: string): { pid: number; nonce: string } | undefined {
+	try {
+		const json = JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown; nonce?: unknown };
+		if (typeof json.pid !== "number" || typeof json.nonce !== "string") {
+			return undefined;
+		}
+		return { pid: json.pid, nonce: json.nonce };
+	} catch {
+		return undefined;
+	}
+}
+
+function pidIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		// EPERM: the process exists but belongs to another user.
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/**
+ * Atomic lock acquisition (Scope concurrency guard): `wx` create writing {pid, nonce,
+ * startedAt}. On EEXIST: a LIVE pid wins unconditionally - dim line, NEVER take over
+ * regardless of age. A dead pid (or an unreadable lock) is unlinked and the `wx` create
+ * retried ONCE; a concurrent winner's fresh lock then loses us the retry, which is
+ * correct. Synchronous throughout, so in-process contenders cannot interleave mid-check.
+ */
+function acquireOmoLocalLock(agentDir: string, log: (message: string) => void): OmoLocalLock | undefined {
+	mkdirSync(agentDir, { recursive: true });
+	const path = omoLocalUpdateLockPath(agentDir);
+	const lock: OmoLocalLock = { path, pid: process.pid, nonce: randomUUID() };
+	const payload = JSON.stringify({ pid: lock.pid, nonce: lock.nonce, startedAt: new Date().toISOString() });
+	const tryCreate = (): boolean => {
+		try {
+			writeFileSync(path, payload, { flag: "wx" });
+			return true;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+				return false;
+			}
+			throw error;
+		}
+	};
+	const reportBusy = (): undefined => {
+		const existing = readLockFile(path);
+		log(chalk.dim(`OMO local plugin update already running (pid ${existing?.pid ?? "unknown"}); skipping.`));
+		return undefined;
+	};
+	if (tryCreate()) {
+		return lock;
+	}
+	const existing = readLockFile(path);
+	if (existing !== undefined && pidIsAlive(existing.pid)) {
+		log(chalk.dim(`OMO local plugin update already running (pid ${existing.pid}); skipping.`));
+		return undefined;
+	}
+	try {
+		rmSync(path);
+	} catch {
+		// Another process reclaimed first; the single retry below loses correctly.
+	}
+	if (tryCreate()) {
+		return lock;
+	}
+	return reportBusy();
+}
+
+/** Owner-checked unlink: re-read and match our own pid+nonce before deleting. */
+function releaseOmoLocalLock(lock: OmoLocalLock): void {
+	try {
+		const existing = readLockFile(lock.path);
+		if (existing !== undefined && existing.pid === lock.pid && existing.nonce === lock.nonce) {
+			rmSync(lock.path);
+		}
+	} catch {
+		// Lock release must never throw.
+	}
+}
+
+/** Post-build completeness set (Scope): five files plus a non-empty skills glob. */
+const REQUIRED_BUILD_ARTIFACTS = [
+	"extensions/omo.js",
+	"runtime/lsp-daemon/dist/cli.js",
+	"runtime/lsp-daemon/dist/index.js",
+	"runtime/lsp-daemon/dist/.omo-runtime-manifest.json",
+	"scripts/install.mjs",
+] as const;
+
+function walkFiles(rootDir: string): string[] {
+	const files: string[] = [];
+	const pending = [rootDir];
+	while (pending.length > 0) {
+		const dir = pending.pop();
+		if (dir === undefined) {
+			continue;
+		}
+		let entries: Dirent[];
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				pending.push(full);
+			} else if (entry.isFile()) {
+				files.push(full);
+			}
+		}
+	}
+	return files;
+}
+
+/**
+ * Post-build inventory for the stamp (Scope): every file under plugin/extensions/ and
+ * plugin/runtime/lsp-daemon/dist/, every SKILL.md under plugin/skills/, plus
+ * plugin/scripts/install.mjs - paths relative to the plugin dir, posix-separated, sorted.
+ */
+function collectArtifactInventory(pluginPath: string): string[] {
+	const inventory: string[] = [];
+	const collectUnder = (relativeDir: string, filter?: (posixPath: string) => boolean): void => {
+		for (const filePath of walkFiles(join(pluginPath, relativeDir))) {
+			const posixPath = relative(pluginPath, filePath).split(sep).join("/");
+			if (filter === undefined || filter(posixPath)) {
+				inventory.push(posixPath);
+			}
+		}
+	};
+	collectUnder("extensions");
+	collectUnder(join("runtime", "lsp-daemon", "dist"));
+	collectUnder("skills", (posixPath) => posixPath.endsWith("/SKILL.md"));
+	if (existsSync(join(pluginPath, "scripts", "install.mjs"))) {
+		inventory.push("scripts/install.mjs");
+	}
+	inventory.sort();
+	return inventory;
+}
+
+/** Scope post-build completeness check: the five required files + >=1 skills/<name>/SKILL.md. */
+function findMissingBuildArtifacts(pluginPath: string): string[] {
+	const missing: string[] = [];
+	for (const required of REQUIRED_BUILD_ARTIFACTS) {
+		if (!existsSync(join(pluginPath, required))) {
+			missing.push(required);
+		}
+	}
+	let skillCount = 0;
+	try {
+		for (const entry of readdirSync(join(pluginPath, "skills"), { withFileTypes: true })) {
+			if (entry.isDirectory() && existsSync(join(pluginPath, "skills", entry.name, "SKILL.md"))) {
+				skillCount++;
+			}
+		}
+	} catch {
+		// A missing skills dir counts as zero skills.
+	}
+	if (skillCount === 0) {
+		missing.push("skills/*/SKILL.md");
+	}
+	return missing;
+}
+
+/**
+ * One bun step through the shared run seam. A missing binary (spawn ENOENT) gets the
+ * dedicated marker so the orchestrator can render the single yellow bun warning; any
+ * other failed start, non-zero exit, or timeout becomes an OmoLocalStepError carrying
+ * the combined output for the dim 40-line dump.
+ */
+async function runBunStep(
+	stage: "install" | "build",
+	args: string[],
+	repoRoot: string,
+	run: OmoLocalRun,
+	timeoutMs: number,
+): Promise<void> {
+	let result: OmoLocalRunResult;
+	try {
+		result = await run("bun", args, { cwd: repoRoot, timeoutMs });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			throw new OmoLocalBunMissingError();
+		}
+		throw new OmoLocalStepError(
+			stage,
+			`bun ${args.join(" ")} failed to start: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const output = `${result.stdout}${result.stderr}`;
+	if (result.timedOut) {
+		throw new OmoLocalStepError(
+			stage,
+			`bun ${args.join(" ")} timed out after ${Math.round(timeoutMs / 1000)}s`,
+			output,
+		);
+	}
+	if (result.code !== 0) {
+		throw new OmoLocalStepError(stage, `bun ${args.join(" ")} exited with code ${result.code ?? "unknown"}`, output);
+	}
+}
+
+function firstLine(text: string): string {
+	for (const line of text.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed !== "") {
+			return trimmed;
+		}
+	}
+	return "unknown error";
+}
+
+function lastNonEmptyLines(text: string, count: number): string[] {
+	const lines: string[] = [];
+	for (const line of text.split("\n")) {
+		if (line.trim() !== "") {
+			lines.push(line);
+		}
+	}
+	return lines.slice(-count);
+}
+
+/**
  * Beta hook entry point, called from bare `senpi update` before the self-update.
  *
- * STUB (todo 1): gate chain only - kill-switch, then detection. The ordered state machine
- * (lock -> fetch -> skip decision -> sync -> install/build -> stamp -> notify) lands in todo 4.
- * This hook NEVER throws and NEVER sets process.exitCode: any failure downgrades to a warning
- * so the senpi self-update continues untouched.
+ * SINGLE owner of the Scope ORDERED state machine: gate chain (kill-switch -> detection)
+ * -> atomic lock acquisition (held through fetch, sync, build, stamp AND notify;
+ * owner-checked unlink in `finally`) -> ONE `git fetch origin dev` (120s) -> freeze
+ * targetSha -> skip decision BEFORE any worktree mutation -> syncToOriginDev (which never
+ * fetches, locks, skips, or stamps) -> `bun install` (600s) -> `bun run
+ * build:senpi-plugin` (900s) -> post-build artifact completeness check -> writeStamp
+ * (post-build inventory) -> notify. On ANY failure after sync returned a backup branch,
+ * the Scope RESTORATION PROCEDURE runs BEFORE the failure warning. This hook NEVER throws
+ * and NEVER sets process.exitCode: every failure downgrades to a yellow warning + dim
+ * manual hint so the senpi self-update continues untouched.
  */
 export async function runOmoLocalUpdateBeta(options: RunOmoLocalUpdateBetaOptions): Promise<void> {
+	const log =
+		options.log ??
+		((message: string) => {
+			console.log(message);
+		});
+	const run = options.run ?? defaultRun;
+	let repoRoot: string | undefined;
 	try {
 		if (isKillSwitched(options.env)) {
 			return;
@@ -634,14 +921,129 @@ export async function runOmoLocalUpdateBeta(options: RunOmoLocalUpdateBetaOption
 		const install = await detectOmoLocalInstall({
 			packages: options.settings?.packages,
 			agentDir: options.agentDir,
-			run: options.run ?? defaultRun,
+			run,
 		});
 		if (!install) {
 			return;
 		}
-		// todo 4: acquire lock -> fetch origin/dev -> skip decision -> syncToOriginDev ->
-		// bun install -> bun run build:senpi-plugin -> completeness check -> write stamp -> notify.
-	} catch {
-		// Beta failures are never fatal; todo 4 renders the yellow failure line + manual hint.
+		repoRoot = install.repoRoot;
+		const { pluginPath } = install;
+
+		const lock = acquireOmoLocalLock(options.agentDir, log);
+		if (lock === undefined) {
+			return;
+		}
+		try {
+			// ONE fetch; the target is frozen immediately so a concurrent re-fetch by another
+			// process can never move it between the skip decision and the mutation.
+			log(chalk.dim("Updating OMO local plugins: fetching origin/dev..."));
+			const fetch = await run("git", ["fetch", "origin", "dev"], { cwd: repoRoot, timeoutMs: 120_000 });
+			if (fetch.timedOut) {
+				throw new OmoLocalStepError("fetch", "git fetch origin dev timed out after 120s");
+			}
+			if (fetch.code !== 0) {
+				throw new OmoLocalStepError(
+					"fetch",
+					`git fetch origin dev: ${firstErrorLine(fetch)}`,
+					`${fetch.stdout}${fetch.stderr}`,
+				);
+			}
+			const shaResult = await run("git", ["rev-parse", "origin/dev"], { cwd: repoRoot });
+			const targetSha = shaResult.code === 0 ? shaResult.stdout.trim() : "";
+			if (targetSha === "") {
+				throw new OmoLocalStepError("fetch", `git rev-parse origin/dev: ${firstErrorLine(shaResult)}`);
+			}
+
+			// Skip decision FIRST: a skip touches NOTHING (no classify, discard, or sync).
+			const stamp = readStamp(options.agentDir);
+			const stampArtifactsExist =
+				stamp?.artifacts.every((artifact) => existsSync(join(pluginPath, artifact))) ?? false;
+			if (shouldSkipBuild({ stamp, repoRoot, targetSha, stampArtifactsExist, force: options.force ?? false })) {
+				log(chalk.dim(`OMO local plugins already at origin/dev @${targetSha.slice(0, 7)}; skipping rebuild.`));
+				return;
+			}
+
+			const report = await syncToOriginDev({ repoRoot, targetSha, run, log });
+			if (report.backupBranch !== undefined) {
+				log(
+					chalk.yellow(
+						`OMO local plugin update: uncommitted changes backed up to ${report.backupBranch} (${report.backupPushed === true ? "pushed to origin" : "kept locally only"}).`,
+					),
+				);
+			}
+
+			try {
+				log(chalk.dim("Updating OMO local plugins: installing deps..."));
+				await runBunStep("install", ["install"], repoRoot, run, 600_000);
+				log(chalk.dim("Updating OMO local plugins: building plugin..."));
+				await runBunStep("build", ["run", "build:senpi-plugin"], repoRoot, run, 900_000);
+				const missing = findMissingBuildArtifacts(pluginPath);
+				if (missing.length > 0) {
+					throw new OmoLocalStepError("artifacts", `build incomplete - missing: ${missing.join(", ")}`);
+				}
+				writeStamp(options.agentDir, {
+					repoRoot,
+					builtSha: targetSha,
+					builtAt: new Date().toISOString(),
+					artifacts: collectArtifactInventory(pluginPath),
+				});
+			} catch (stepError) {
+				// RESTORATION PROCEDURE before any warning when a backup branch exists.
+				if (report.backupBranch !== undefined) {
+					await restorePrevRefAfterFailure({
+						repoRoot,
+						prevRef: report.prevRef,
+						backupBranch: report.backupBranch,
+						run,
+						log,
+					});
+				}
+				if (stepError instanceof OmoLocalBunMissingError) {
+					log(
+						chalk.yellow(
+							"OMO local plugin update skipped: bun is required to install and build the plugin but was not found on PATH. Install bun and re-run `senpi update`.",
+						),
+					);
+					return;
+				}
+				throw stepError;
+			}
+
+			const short = targetSha.slice(0, 7);
+			if (report.detached === true) {
+				log(
+					chalk.green(
+						`Built OMO local plugins (omo-senpi + senpi-task) from origin/dev @${short} - ${report.subject} (detached HEAD)`,
+					),
+				);
+			} else {
+				log(
+					chalk.green(
+						`Updated OMO local plugins (omo-senpi + senpi-task) to origin/dev @${short} - ${report.subject}`,
+					),
+				);
+			}
+		} finally {
+			releaseOmoLocalLock(lock);
+		}
+	} catch (error) {
+		// The hook NEVER throws and NEVER sets process.exitCode: render the yellow failure
+		// line (+ dim failed-step output tail + dim manual hint) and let the senpi
+		// self-update continue.
+		const stage = error instanceof OmoLocalSyncError || error instanceof OmoLocalStepError ? error.stage : "unknown";
+		const message = error instanceof Error ? error.message : String(error);
+		log(chalk.yellow(`OMO local plugin update failed (${stage}): ${firstLine(message)}`));
+		if (error instanceof OmoLocalStepError && error.output !== undefined) {
+			for (const line of lastNonEmptyLines(error.output, 40)) {
+				log(chalk.dim(line));
+			}
+		}
+		if (repoRoot !== undefined) {
+			log(
+				chalk.dim(
+					`To update manually: git -C ${repoRoot} pull origin dev && bun install && bun run build:senpi-plugin`,
+				),
+			);
+		}
 	}
 }

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,9 @@
+## Beta: bare `senpi update` syncs and rebuilds a local OMO plugin checkout (2026-07-25)
+
+- `src/beta/omo-local-update.ts` (removable beta module): on a bare `senpi update` — the no-flags invocation that also prints the extensions-skipped note — the CLI now runs a beta hook BEFORE any self-update work. The hook detects a locally-installed OMO plugin checkout (`@code-yeongyu/omo-senpi` plugin plus the `@oh-my-opencode/omo-senpi` / `@oh-my-opencode/senpi-task` workspace packages in one git repo), fast-forwards it to `origin/dev` (source dirt is first snapshotted onto a pushed `backup/senpi-update-*` branch; diverged local work is never reset), then rebuilds via `bun install` + `bun run build:senpi-plugin` and prints a green success line with the short sha and commit subject. A skip-stamp short-circuits when the checkout is already current; `--force` rebuilds anyway. The hook never throws and never sets `process.exitCode` — every failure degrades to a yellow warning so the senpi self-update continues untouched.
+- Kill-switch: `SENPI_OMO_LOCAL_UPDATE=0` disables the hook entirely (zero beta output, zero side effects).
+- Removal (3 steps): delete `src/beta/omo-local-update.ts`; delete all `test/omo-local-update*` files; delete the two BETA-marked touch points in `src/package-manager-cli.ts` (the top-of-file import and the marked block inside `case "update":`).
+
 ## App-server daemon launch diagnostics and hermetic lifecycle coverage (2026-07-24)
 
 - The daemon launcher now classifies websocket listener occupancy before spawn: a compatible app-server answers `initialize` and attaches, while any other TCP listener fails immediately with an `EADDRINUSE` diagnostic instead of consuming the child readiness budget. Child-process startup stderr still accompanies actual post-spawn failures, and each launch replaces stale diagnostics.

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1,6 +1,8 @@
 import { join } from "node:path";
 import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
 import chalk from "chalk";
+// BETA(omo-local-update): removable beta import - delete with src/beta/omo-local-update.ts
+import { runOmoLocalUpdateBeta } from "./beta/omo-local-update.ts";
 import { selectConfig } from "./cli/config-selector.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import {
@@ -817,6 +819,15 @@ export async function handlePackageCommand(
 
 			case "update": {
 				const target = options.updateTarget ?? { type: "self" };
+				// BETA(omo-local-update): remove this block, src/beta/omo-local-update.ts and all test/omo-local-update* files to drop the feature.
+				if (options.showExtensionsSkippedNote) {
+					await runOmoLocalUpdateBeta({
+						env: process.env,
+						agentDir,
+						settings: settingsManager.getGlobalSettings(),
+						force: options.force,
+					});
+				}
 				if (options.showExtensionsSkippedNote) {
 					console.log(
 						chalk.dim(`Extensions are skipped. Run ${APP_NAME} update --extensions to update extensions.`),

--- a/packages/coding-agent/test/omo-local-update-fixture.ts
+++ b/packages/coding-agent/test/omo-local-update-fixture.ts
@@ -1,0 +1,275 @@
+/**
+ * Fake omo repo factory for omo-local-update tests and QA.
+ *
+ * Builds a fully local git fixture (bare origin + clone) under a caller-provided
+ * tmpDir: the clone carries a stub `build:senpi-plugin` script that writes the
+ * FULL artifact completeness set, the three omo package manifests with their
+ * real names, and seed source files - all committed on `dev` and pushed.
+ *
+ * Determinism contract: no network, everything under the passed tmpDir, and
+ * every git invocation runs with GIT_CONFIG_GLOBAL pointed at an empty file,
+ * GIT_CONFIG_NOSYSTEM=1, and fixed GIT_AUTHOR_* / GIT_COMMITTER_* identity
+ * and dates, so ambient host git config can never change an outcome.
+ *
+ * This is a non-test helper module: it stays dependency-free and must NOT
+ * import src/beta/omo-local-update.ts.
+ */
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface OmoFixture {
+	/** Working clone of the fake omo repo (checked out on dev, tracking origin/dev). */
+	repoRoot: string;
+	/** Bare origin repository the clone pushes to and fetches from. */
+	originDir: string;
+	/** The local-path plugin dir a settings `packages` entry would point at. */
+	pluginPath: string;
+}
+
+/** Artifact completeness set written by the stub build, relative to pluginPath. */
+export const FIXTURE_PLUGIN_ARTIFACTS = [
+	"extensions/omo.js",
+	"runtime/lsp-daemon/dist/cli.js",
+	"runtime/lsp-daemon/dist/index.js",
+	"runtime/lsp-daemon/dist/.omo-runtime-manifest.json",
+	"scripts/install.mjs",
+	"skills/alpha/SKILL.md",
+	"skills/beta/SKILL.md",
+] as const;
+
+const GENERATED_OMO_JS = "packages/omo-senpi/plugin/extensions/omo.js";
+const SOURCE_INDEX_TS = "packages/omo-senpi/src/index.ts";
+
+const BUILD_SCRIPT = `import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const pluginRoot = join(repoRoot, "packages", "omo-senpi", "plugin");
+const artifacts = {
+	"extensions/omo.js": "// omo extension bundle (fixture stub)\\nexport {};\\n",
+	"runtime/lsp-daemon/dist/cli.js": "// lsp daemon cli (fixture stub)\\n",
+	"runtime/lsp-daemon/dist/index.js": "// lsp daemon index (fixture stub)\\n",
+	"runtime/lsp-daemon/dist/.omo-runtime-manifest.json": JSON.stringify({ fixture: true, schema: 1 }) + "\\n",
+	"scripts/install.mjs": "// install script (fixture stub)\\n",
+	"skills/alpha/SKILL.md": "# alpha skill (fixture stub)\\n",
+	"skills/beta/SKILL.md": "# beta skill (fixture stub)\\n",
+};
+for (const [relativePath, content] of Object.entries(artifacts)) {
+	const target = join(pluginRoot, relativePath);
+	mkdirSync(dirname(target), { recursive: true });
+	writeFileSync(target, content);
+}
+console.log("fixture build:senpi-plugin wrote " + Object.keys(artifacts).length + " artifacts");
+`;
+
+function gitDirFor(anchorDir: string): string {
+	const dotGit = join(anchorDir, ".git");
+	return existsSync(dotGit) ? dotGit : anchorDir;
+}
+
+function ensureConfig(anchorDir: string): string {
+	const configPath = join(gitDirFor(anchorDir), "fixture-gitconfig");
+	if (!existsSync(configPath)) writeFileSync(configPath, "");
+	return configPath;
+}
+
+function gitEnv(configPath: string): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		GIT_CONFIG_GLOBAL: configPath,
+		GIT_CONFIG_NOSYSTEM: "1",
+		GIT_AUTHOR_NAME: "OMO Fixture",
+		GIT_AUTHOR_EMAIL: "omo-fixture@example.invalid",
+		GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+		GIT_COMMITTER_NAME: "OMO Fixture",
+		GIT_COMMITTER_EMAIL: "omo-fixture@example.invalid",
+		GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
+	};
+}
+
+/**
+ * Environment for git invocations against a fixture repo, honoring the
+ * determinism contract. `anchorDir` is a fixture repoRoot or originDir.
+ * Exported so tests can run their own git assertions under the same isolation.
+ */
+export function fixtureGitEnv(anchorDir: string): NodeJS.ProcessEnv {
+	return gitEnv(ensureConfig(anchorDir));
+}
+
+function runGit(args: string[], cwd: string, configPath: string): string {
+	return execFileSync("git", args, {
+		cwd,
+		env: gitEnv(configPath),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
+}
+
+function writeSeedFile(repoRoot: string, relativePath: string, content: string): void {
+	const target = join(repoRoot, relativePath);
+	mkdirSync(dirname(target), { recursive: true });
+	writeFileSync(target, content);
+}
+
+function writeSeedJson(repoRoot: string, relativePath: string, value: Record<string, unknown>): void {
+	writeSeedFile(repoRoot, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/**
+ * Build the fake omo repo: bare origin + clone, stub build writing the full
+ * artifact completeness set, all three omo package manifests, committed on
+ * `dev` and pushed, origin URL set to the local bare path.
+ */
+export function createOmoFixture(tmpDir: string): OmoFixture {
+	mkdirSync(tmpDir, { recursive: true });
+	const originDir = join(tmpDir, "origin.git");
+	const repoRoot = join(tmpDir, "repo");
+	const pluginPath = join(repoRoot, "packages", "omo-senpi", "plugin");
+	const configPath = join(tmpDir, "fixture-gitconfig");
+	writeFileSync(configPath, "");
+
+	runGit(["init", "--bare", "-b", "dev", originDir], tmpDir, configPath);
+	runGit(["clone", originDir, repoRoot], tmpDir, configPath);
+	runGit(["symbolic-ref", "HEAD", "refs/heads/dev"], repoRoot, configPath);
+
+	writeSeedJson(repoRoot, "package.json", {
+		name: "omo-fixture",
+		private: true,
+		version: "0.0.0",
+		scripts: { "build:senpi-plugin": "node scripts/build-senpi-plugin.mjs" },
+	});
+	writeSeedFile(repoRoot, "scripts/build-senpi-plugin.mjs", BUILD_SCRIPT);
+	writeSeedFile(repoRoot, ".gitignore", "node_modules/\n");
+	writeSeedJson(repoRoot, "packages/omo-senpi/package.json", {
+		name: "@oh-my-opencode/omo-senpi",
+		private: true,
+		version: "0.0.0",
+	});
+	writeSeedJson(repoRoot, "packages/omo-senpi/plugin/package.json", {
+		name: "@code-yeongyu/omo-senpi",
+		private: true,
+		version: "0.0.0",
+	});
+	writeSeedJson(repoRoot, "packages/senpi-task/package.json", {
+		name: "@oh-my-opencode/senpi-task",
+		private: true,
+		version: "0.0.0",
+	});
+	writeSeedFile(repoRoot, SOURCE_INDEX_TS, "// omo-senpi fixture source\nexport {};\n");
+	writeSeedFile(repoRoot, "packages/senpi-task/src/index.ts", "// senpi-task fixture source\nexport {};\n");
+
+	// Run the stub build once so the generated artifacts are TRACKED (matching
+	// the real omo checkout, where plugin/extensions/omo.js etc. are committed).
+	execFileSync(process.execPath, [join(repoRoot, "scripts", "build-senpi-plugin.mjs")], {
+		cwd: repoRoot,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	runGit(["add", "-A"], repoRoot, configPath);
+	runGit(["commit", "-m", "fixture: seed fake omo repo"], repoRoot, configPath);
+	runGit(["push", "-u", "origin", "dev"], repoRoot, configPath);
+	runGit(["remote", "set-url", "origin", originDir], repoRoot, configPath);
+
+	return { repoRoot, originDir, pluginPath };
+}
+
+/** Modify a tracked SOURCE-set file (outside every generated prefix). */
+export function dirtySource(repoRoot: string): string {
+	appendFileSync(join(repoRoot, SOURCE_INDEX_TS), "// fixture source dirt\n");
+	return SOURCE_INDEX_TS;
+}
+
+/** Modify a tracked GENERATED-set file (under plugin/extensions/). */
+export function dirtyGenerated(repoRoot: string): string {
+	appendFileSync(join(repoRoot, GENERATED_OMO_JS), "// fixture generated dirt\n");
+	return GENERATED_OMO_JS;
+}
+
+/**
+ * `git mv` a generated file to a source path, producing a porcelain rename
+ * whose halves straddle the GENERATED/SOURCE boundary.
+ */
+export function dirtyRenameAcrossSets(repoRoot: string): { from: string; to: string } {
+	const from = "packages/omo-senpi/plugin/skills/alpha/SKILL.md";
+	const to = "packages/omo-senpi/src/alpha-skill.md";
+	runGit(["mv", from, to], repoRoot, ensureConfig(repoRoot));
+	return { from, to };
+}
+
+function commitOnLocalDev(repoRoot: string, label: string): string {
+	const configPath = ensureConfig(repoRoot);
+	const n = Number(runGit(["rev-list", "--count", "HEAD"], repoRoot, configPath)) + 1;
+	writeSeedFile(repoRoot, `local-dev-${n}.txt`, `${label} ${n}\n`);
+	runGit(["add", "-A"], repoRoot, configPath);
+	runGit(["commit", "-m", `${label} ${n}`], repoRoot, configPath);
+	return runGit(["rev-parse", "HEAD"], repoRoot, configPath);
+}
+
+/**
+ * Advance origin/dev by committing in a second temporary clone of the bare
+ * origin. Returns the new origin/dev sha. The fixture clone is NOT fetched.
+ */
+export function advanceOriginDev(originDir: string): string {
+	const configPath = ensureConfig(originDir);
+	const n = Number(runGit(["rev-list", "--count", "dev"], originDir, configPath)) + 1;
+	const workDir = join(dirname(originDir), "origin-advance-work");
+	rmSync(workDir, { recursive: true, force: true });
+	try {
+		runGit(["clone", originDir, workDir], dirname(originDir), configPath);
+		writeSeedFile(workDir, `origin-dev-${n}.txt`, `origin dev commit ${n}\n`);
+		runGit(["add", "-A"], workDir, configPath);
+		runGit(["commit", "-m", `origin dev commit ${n}`], workDir, configPath);
+		runGit(["push", "origin", "dev"], workDir, configPath);
+		return runGit(["rev-parse", "dev"], originDir, configPath);
+	} finally {
+		rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+/** Commit on the fixture's local dev WITHOUT pushing (local-only commit). */
+export function advanceLocalDevOnly(repoRoot: string): string {
+	return commitOnLocalDev(repoRoot, "local dev commit");
+}
+
+/**
+ * Commit locally on dev without pushing AND advance origin/dev, leaving the
+ * two diverged (one commit each side after the fixture fetches).
+ */
+export function divergeLocalDev(repoRoot: string): { localSha: string; originSha: string } {
+	const configPath = ensureConfig(repoRoot);
+	const localSha = commitOnLocalDev(repoRoot, "local dev commit");
+	const originDir = runGit(["remote", "get-url", "origin"], repoRoot, configPath);
+	const originSha = advanceOriginDev(originDir);
+	runGit(["fetch", "origin", "dev"], repoRoot, configPath);
+	return { localSha, originSha };
+}
+
+/** Check out a side branch and delete the local dev branch. */
+export function deleteLocalDev(repoRoot: string): void {
+	const configPath = ensureConfig(repoRoot);
+	runGit(["checkout", "-B", "fixture-side"], repoRoot, configPath);
+	runGit(["branch", "-D", "dev"], repoRoot, configPath);
+}
+
+/**
+ * Install an executable pre-receive hook exiting 1 in the bare origin, so
+ * pushes deterministically fail while fetches keep working.
+ */
+export function blockPushes(originDir: string): void {
+	const hookPath = join(originDir, "hooks", "pre-receive");
+	writeFileSync(hookPath, "#!/bin/sh\nexit 1\n");
+	chmodSync(hookPath, 0o755);
+}
+
+/**
+ * Install an executable pre-commit hook exiting 1 in the fixture clone, so
+ * `git commit` deterministically fails (regardless of identity env).
+ */
+export function blockCommits(repoRoot: string): void {
+	const hookPath = join(repoRoot, ".git", "hooks", "pre-commit");
+	writeFileSync(hookPath, "#!/bin/sh\nexit 1\n");
+	chmodSync(hookPath, 0o755);
+}

--- a/packages/coding-agent/test/omo-local-update.test.ts
+++ b/packages/coding-agent/test/omo-local-update.test.ts
@@ -1,7 +1,7 @@
-import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, relative, resolve } from "node:path";
+import { delimiter, join, relative, resolve } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
 	classifyDirt,
@@ -11,6 +11,7 @@ import {
 	type OmoLocalRun,
 	OmoLocalSyncError,
 	type OmoLocalUpdateStamp,
+	omoLocalUpdateLockPath,
 	omoLocalUpdateStampPath,
 	readStamp,
 	runOmoLocalUpdateBeta,
@@ -29,6 +30,7 @@ import {
 	dirtyRenameAcrossSets,
 	dirtySource,
 	divergeLocalDev,
+	FIXTURE_PLUGIN_ARTIFACTS,
 } from "./omo-local-update-fixture.ts";
 
 // Git determinism: isolate every git invocation in this file (test-side AND
@@ -734,5 +736,505 @@ describe("syncToOriginDev", () => {
 		expect(report.backupPushed).toBe(true);
 		expect(headSha(fixture.repoRoot)).toBe(targetSha);
 		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+	});
+});
+
+function makeSpyRun(): { calls: string[][]; run: OmoLocalRun } {
+	const calls: string[][] = [];
+	return {
+		calls,
+		run: (command, args, options) => {
+			calls.push([command, ...args]);
+			return defaultRun(command, args, options);
+		},
+	};
+}
+
+/**
+ * Executable `bun` stand-in for orchestrator tests: `bun install` succeeds quietly;
+ * `bun run build:senpi-plugin` runs the fixture's real stub build. FAKE_BUN_BUILD_FAIL
+ * makes the build exit 1 after writing artifacts; FAKE_BUN_SOURCE_LEFTOVER additionally
+ * drops a NEW source-path file (post-failure SOURCE dirt).
+ */
+function installFakeBun(binDir: string): void {
+	mkdirSync(binDir, { recursive: true });
+	const script = [
+		"#!/bin/sh",
+		'if [ "$1" = "install" ]; then',
+		'  echo "fake bun install: ok"',
+		"  exit 0",
+		"fi",
+		'if [ "$1" = "run" ] && [ "$2" = "build:senpi-plugin" ]; then',
+		"  node scripts/build-senpi-plugin.mjs",
+		"  build_status=$?",
+		'  if [ -n "$FAKE_BUN_SOURCE_LEFTOVER" ]; then',
+		'    echo "leftover" > packages/omo-senpi/src/build-leftover.txt',
+		"  fi",
+		'  if [ -n "$FAKE_BUN_BUILD_FAIL" ]; then',
+		'    echo "// failed build leftover" >> packages/omo-senpi/plugin/extensions/omo.js',
+		'    echo "fake bun: simulated build failure" >&2',
+		"    exit 1",
+		"  fi",
+		"  exit $build_status",
+		"fi",
+		'echo "fake bun: unexpected argv: $*" >&2',
+		"exit 1",
+		"",
+	].join("\n");
+	const bunPath = join(binDir, "bun");
+	writeFileSync(bunPath, script);
+	chmodSync(bunPath, 0o755);
+}
+
+/** Prepend binDir to PATH; returns a restore function. */
+function withPrependedPath(binDir: string): () => void {
+	const originalPath = process.env.PATH;
+	process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`;
+	return () => {
+		if (originalPath === undefined) {
+			delete process.env.PATH;
+		} else {
+			process.env.PATH = originalPath;
+		}
+	};
+}
+
+describe("runOmoLocalUpdateBeta orchestrator", () => {
+	function makeAgentDir(root: string): string {
+		const agentDir = join(root, "agent");
+		mkdirSync(agentDir, { recursive: true });
+		return agentDir;
+	}
+
+	it("runs the full happy path: fetch, sync, bun install/build via the real run seam, stamp, notify", {
+		timeout: 60000,
+	}, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		const { calls, run } = makeSpyRun();
+		const { lines, log } = makeLogCollector();
+		try {
+			await expect(
+				runOmoLocalUpdateBeta({
+					env: {},
+					agentDir,
+					settings: { packages: [fixture.pluginPath] },
+					log,
+					run,
+				}),
+			).resolves.toBeUndefined();
+		} finally {
+			restorePath();
+		}
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const short = targetSha.slice(0, 7);
+		// Green success line with the short sha + subject of the FROZEN commit.
+		expect(lines).toContain(
+			`Updated OMO local plugins (omo-senpi + senpi-task) to origin/dev @${short} - fixture: seed fake omo repo`,
+		);
+		// Dim progress lines for fetch/install/build.
+		expect(lines.some((line) => line.includes("Updating OMO local plugins: fetching origin/dev..."))).toBe(true);
+		expect(lines.some((line) => line.includes("Updating OMO local plugins: installing deps..."))).toBe(true);
+		expect(lines.some((line) => line.includes("Updating OMO local plugins: building plugin..."))).toBe(true);
+		// The REAL run seam received the exact bun argv.
+		expect(calls).toContainEqual(["bun", "install"]);
+		expect(calls).toContainEqual(["bun", "run", "build:senpi-plugin"]);
+		// The stub build wrote the full artifact set; the stamp records the post-build inventory.
+		for (const artifact of FIXTURE_PLUGIN_ARTIFACTS) {
+			expect(existsSync(join(fixture.pluginPath, artifact))).toBe(true);
+		}
+		const stamp = readStamp(agentDir);
+		expect(stamp?.repoRoot).toBe(fixture.repoRoot);
+		expect(stamp?.builtSha).toBe(targetSha);
+		expect(stamp?.artifacts).toEqual([...FIXTURE_PLUGIN_ARTIFACTS].sort());
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		// Lock released by the finally.
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
+	});
+
+	it("emits the detached-build success variant when local dev has diverged", { timeout: 60000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		const { localSha, originSha } = divergeLocalDev(fixture.repoRoot);
+		const { lines, log } = makeLogCollector();
+		try {
+			await runOmoLocalUpdateBeta({
+				env: {},
+				agentDir,
+				settings: { packages: [fixture.pluginPath] },
+				log,
+				run: defaultRun,
+			});
+		} finally {
+			restorePath();
+		}
+		const short = originSha.slice(0, 7);
+		expect(
+			lines.some((line) => line.includes("local dev has commits not on origin/dev") && line.includes("detached")),
+		).toBe(true);
+		expect(lines).toContain(
+			`Built OMO local plugins (omo-senpi + senpi-task) from origin/dev @${short} - origin dev commit 2 (detached HEAD)`,
+		);
+		expect(headSha(fixture.repoRoot)).toBe(originSha);
+		expect(currentBranch(fixture.repoRoot)).toBeUndefined();
+		expect(git(["rev-parse", "dev"], fixture.repoRoot)).toBe(localSha);
+		expect(readStamp(agentDir)?.builtSha).toBe(originSha);
+	});
+
+	it("skips the rebuild on a second run, and declines the skip when a stamped skills file is deleted", {
+		timeout: 90000,
+	}, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		const { calls, run } = makeSpyRun();
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const short = targetSha.slice(0, 7);
+		const base = { env: {}, agentDir, settings: { packages: [fixture.pluginPath] }, run };
+		try {
+			const first = makeLogCollector();
+			await runOmoLocalUpdateBeta({ ...base, log: first.log });
+			expect(first.lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(true);
+
+			// Second run: dim skip line, and the skip touches NOTHING (no bun, no classify/sync git calls).
+			calls.length = 0;
+			const second = makeLogCollector();
+			await runOmoLocalUpdateBeta({ ...base, log: second.log });
+			expect(second.lines.some((line) => line.includes(`already at origin/dev @${short}`))).toBe(true);
+			expect(second.lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(false);
+			expect(calls.some(([command]) => command === "bun")).toBe(false);
+			expect(
+				calls.some(([, ...args]) => args.includes("status") || args.includes("checkout") || args.includes("merge")),
+			).toBe(false);
+			expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+
+			// Deleting one stamped skills file declines the skip -> full rebuild.
+			const stampedSkill = join(fixture.pluginPath, "skills", "alpha", "SKILL.md");
+			expect(readStamp(agentDir)?.artifacts).toContain("skills/alpha/SKILL.md");
+			rmSync(stampedSkill);
+			calls.length = 0;
+			const third = makeLogCollector();
+			await runOmoLocalUpdateBeta({ ...base, log: third.log });
+			expect(third.lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(true);
+			expect(calls).toContainEqual(["bun", "install"]);
+			expect(calls).toContainEqual(["bun", "run", "build:senpi-plugin"]);
+			expect(existsSync(stampedSkill)).toBe(true);
+		} finally {
+			restorePath();
+		}
+	});
+
+	it("rebuilds when force is set even with a matching stamp", { timeout: 90000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		const { calls, run } = makeSpyRun();
+		const base = { env: {}, agentDir, settings: { packages: [fixture.pluginPath] }, run };
+		try {
+			const first = makeLogCollector();
+			await runOmoLocalUpdateBeta({ ...base, log: first.log });
+			expect(first.lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(true);
+			calls.length = 0;
+			const second = makeLogCollector();
+			await runOmoLocalUpdateBeta({ ...base, force: true, log: second.log });
+			expect(second.lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(true);
+			expect(second.lines.some((line) => line.includes("already at origin/dev"))).toBe(false);
+			expect(calls).toContainEqual(["bun", "install"]);
+			expect(calls).toContainEqual(["bun", "run", "build:senpi-plugin"]);
+		} finally {
+			restorePath();
+		}
+	});
+
+	it("warns once and skips when the bun binary is missing", { timeout: 60000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const noBun: OmoLocalRun = async (command, args, runOptions) => {
+			if (command === "bun") {
+				throw Object.assign(new Error("spawn bun ENOENT"), { code: "ENOENT" });
+			}
+			return defaultRun(command, args, runOptions);
+		};
+		const { lines, log } = makeLogCollector();
+		await expect(
+			runOmoLocalUpdateBeta({
+				env: {},
+				agentDir,
+				settings: { packages: [fixture.pluginPath] },
+				log,
+				run: noBun,
+			}),
+		).resolves.toBeUndefined();
+		expect(lines.filter((line) => line.includes("bun is required"))).toHaveLength(1);
+		expect(lines.some((line) => line.includes("OMO local plugin update failed"))).toBe(false);
+		expect(lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(false);
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+
+	it("reports a build failure (yellow line, dim output tail, manual hint), writes no stamp, never throws", {
+		timeout: 60000,
+	}, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		process.env.FAKE_BUN_BUILD_FAIL = "1";
+		const { lines, log } = makeLogCollector();
+		try {
+			await expect(
+				runOmoLocalUpdateBeta({
+					env: {},
+					agentDir,
+					settings: { packages: [fixture.pluginPath] },
+					log,
+					run: defaultRun,
+				}),
+			).resolves.toBeUndefined();
+		} finally {
+			restorePath();
+			delete process.env.FAKE_BUN_BUILD_FAIL;
+		}
+		expect(lines.some((line) => line.includes("OMO local plugin update failed (build):"))).toBe(true);
+		// The failed step's output tail is echoed (the stub wrote artifacts before exiting 1).
+		expect(lines.some((line) => line.includes("fixture build:senpi-plugin wrote"))).toBe(true);
+		expect(
+			lines.some((line) =>
+				line.includes(`git -C ${fixture.repoRoot} pull origin dev && bun install && bun run build:senpi-plugin`),
+			),
+		).toBe(true);
+		expect(lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(false);
+		expect(readStamp(agentDir)).toBeUndefined();
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
+		// No backup branch existed, so no restoration runs: the partial build state stays.
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toContain("packages/omo-senpi/plugin/extensions/omo.js");
+	});
+
+	it("restores prevRef and keeps the backup ref when the build fails after a source-dirt backup", {
+		timeout: 60000,
+	}, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		dirtySource(fixture.repoRoot);
+		process.env.FAKE_BUN_BUILD_FAIL = "1";
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const { lines, log } = makeLogCollector();
+		try {
+			await runOmoLocalUpdateBeta({
+				env: {},
+				agentDir,
+				settings: { packages: [fixture.pluginPath] },
+				log,
+				run: defaultRun,
+			});
+		} finally {
+			restorePath();
+			delete process.env.FAKE_BUN_BUILD_FAIL;
+		}
+		expect(lines.some((line) => line.includes("OMO local plugin update failed (build):"))).toBe(true);
+		expect(lines.some((line) => line.includes("backed up to backup/senpi-update-"))).toBe(true);
+		// RESTORATION PROCEDURE ran: generated build leftovers discarded, prevRef checked out,
+		// worktree clean, backup ref retained, no stamp.
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(git(["branch", "--list", "backup/*"], fixture.repoRoot)).not.toBe("");
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+
+	it("preserves the worktree untouched and warns when post-failure SOURCE dirt blocks restoration", {
+		timeout: 60000,
+	}, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		dirtySource(fixture.repoRoot);
+		process.env.FAKE_BUN_BUILD_FAIL = "1";
+		process.env.FAKE_BUN_SOURCE_LEFTOVER = "1";
+		const { lines, log } = makeLogCollector();
+		try {
+			await runOmoLocalUpdateBeta({
+				env: {},
+				agentDir,
+				settings: { packages: [fixture.pluginPath] },
+				log,
+				run: defaultRun,
+			});
+		} finally {
+			restorePath();
+			delete process.env.FAKE_BUN_BUILD_FAIL;
+			delete process.env.FAKE_BUN_SOURCE_LEFTOVER;
+		}
+		// Restoration-failed warning (naming prevRef) comes BEFORE the failure warning.
+		const restoreIndex = lines.findIndex((line) => line.includes("could not restore dev"));
+		const failureIndex = lines.findIndex((line) => line.includes("OMO local plugin update failed (build):"));
+		expect(restoreIndex).toBeGreaterThanOrEqual(0);
+		expect(failureIndex).toBeGreaterThan(restoreIndex);
+		// Worktree preserved untouched: the new source-path file AND the generated leftovers
+		// are all still there; the backup ref is kept; no stamp.
+		expect(existsSync(join(fixture.repoRoot, "packages", "omo-senpi", "src", "build-leftover.txt"))).toBe(true);
+		const status = git(["status", "--porcelain"], fixture.repoRoot);
+		expect(status).toContain("build-leftover.txt");
+		expect(status).toContain("packages/omo-senpi/plugin/extensions/omo.js");
+		expect(git(["branch", "--list", "backup/*"], fixture.repoRoot)).not.toBe("");
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+
+	it("downgrades a fetch failure to a yellow warning and leaves the repo untouched", {
+		timeout: 60000,
+	}, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		git(["remote", "set-url", "origin", join(root, "does-not-exist.git")], fixture.repoRoot);
+		const headBefore = headSha(fixture.repoRoot);
+		const { lines, log } = makeLogCollector();
+		await expect(
+			runOmoLocalUpdateBeta({
+				env: {},
+				agentDir,
+				settings: { packages: [fixture.pluginPath] },
+				log,
+				run: defaultRun,
+			}),
+		).resolves.toBeUndefined();
+		expect(lines.some((line) => line.includes("OMO local plugin update failed (fetch):"))).toBe(true);
+		expect(lines.some((line) => line.includes(`git -C ${fixture.repoRoot} pull origin dev`))).toBe(true);
+		expect(headSha(fixture.repoRoot)).toBe(headBefore);
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		expect(readStamp(agentDir)).toBeUndefined();
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
+	});
+
+	it("allows exactly one of two simultaneous runs to proceed", { timeout: 90000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		const { lines, log } = makeLogCollector();
+		const options = {
+			env: {},
+			agentDir,
+			settings: { packages: [fixture.pluginPath] },
+			log,
+			run: defaultRun,
+		};
+		try {
+			await expect(Promise.all([runOmoLocalUpdateBeta(options), runOmoLocalUpdateBeta(options)])).resolves.toEqual([
+				undefined,
+				undefined,
+			]);
+		} finally {
+			restorePath();
+		}
+		expect(lines.filter((line) => line.includes("Updated OMO local plugins"))).toHaveLength(1);
+		expect(lines.filter((line) => line.includes("already running (pid"))).toHaveLength(1);
+		expect(readStamp(agentDir)).toBeDefined();
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
+	});
+
+	it("reclaims the lock from a dead pid and proceeds", { timeout: 60000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const binDir = join(root, "bin");
+		installFakeBun(binDir);
+		const restorePath = withPrependedPath(binDir);
+		const deadPid = spawnSync(process.execPath, ["-e", ""]).pid;
+		if (deadPid === undefined) throw new Error("expected a child pid");
+		writeFileSync(
+			omoLocalUpdateLockPath(agentDir),
+			JSON.stringify({ pid: deadPid, nonce: "stale", startedAt: "2020-01-01T00:00:00.000Z" }),
+		);
+		const { lines, log } = makeLogCollector();
+		try {
+			await runOmoLocalUpdateBeta({
+				env: {},
+				agentDir,
+				settings: { packages: [fixture.pluginPath] },
+				log,
+				run: defaultRun,
+			});
+		} finally {
+			restorePath();
+		}
+		expect(lines.some((line) => line.includes("Updated OMO local plugins"))).toBe(true);
+		expect(readStamp(agentDir)).toBeDefined();
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
+	});
+
+	it("never takes over a live pid's lock, regardless of age", { timeout: 60000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		writeFileSync(
+			omoLocalUpdateLockPath(agentDir),
+			JSON.stringify({ pid: process.pid, nonce: "someone-else", startedAt: "2020-01-01T00:00:00.000Z" }),
+		);
+		const { calls, run } = makeSpyRun();
+		const { lines, log } = makeLogCollector();
+		await runOmoLocalUpdateBeta({
+			env: {},
+			agentDir,
+			settings: { packages: [fixture.pluginPath] },
+			log,
+			run,
+		});
+		expect(lines.some((line) => line.includes(`already running (pid ${process.pid})`))).toBe(true);
+		// No fetch, no sync, no build - nothing but detection ran.
+		expect(calls.some(([, ...args]) => args.includes("fetch"))).toBe(false);
+		expect(calls.some(([command]) => command === "bun")).toBe(false);
+		expect(readStamp(agentDir)).toBeUndefined();
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		// The other owner's lock is left in place.
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(true);
+	});
+
+	it("kill-switch run has zero fs/git side effects", { timeout: 60000 }, async () => {
+		const root = makeTempRoot();
+		const fixture = createOmoFixture(root);
+		const agentDir = makeAgentDir(root);
+		const headBefore = headSha(fixture.repoRoot);
+		const { calls, run } = makeSpyRun();
+		const { lines, log } = makeLogCollector();
+		await runOmoLocalUpdateBeta({
+			env: { SENPI_OMO_LOCAL_UPDATE: "0" },
+			agentDir,
+			settings: { packages: [fixture.pluginPath] },
+			log,
+			run,
+		});
+		expect(lines).toEqual([]);
+		expect(calls).toEqual([]);
+		expect(headSha(fixture.repoRoot)).toBe(headBefore);
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		expect(readStamp(agentDir)).toBeUndefined();
+		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/omo-local-update.test.ts
+++ b/packages/coding-agent/test/omo-local-update.test.ts
@@ -1,0 +1,397 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, resolve } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+	defaultRun,
+	detectOmoLocalInstall,
+	isKillSwitched,
+	type OmoLocalUpdateStamp,
+	omoLocalUpdateStampPath,
+	readStamp,
+	runOmoLocalUpdateBeta,
+	shouldSkipBuild,
+	writeStamp,
+} from "../src/beta/omo-local-update.ts";
+
+// Git determinism: isolate every git invocation in this file (test-side AND
+// engine-side through the inherited process.env) from ambient host config.
+const gitConfigDir = mkdtempSync(join(tmpdir(), "omo-local-update-gitcfg-"));
+const emptyGitConfig = join(gitConfigDir, "config");
+writeFileSync(emptyGitConfig, "");
+process.env.GIT_CONFIG_NOSYSTEM = "1";
+process.env.GIT_CONFIG_GLOBAL = emptyGitConfig;
+process.env.GIT_AUTHOR_NAME = "senpi-test";
+process.env.GIT_AUTHOR_EMAIL = "senpi-test@example.com";
+process.env.GIT_COMMITTER_NAME = "senpi-test";
+process.env.GIT_COMMITTER_EMAIL = "senpi-test@example.com";
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "omo-local-update-test-"));
+	tempRoots.push(root);
+	return root;
+}
+
+afterAll(() => {
+	for (const root of tempRoots) {
+		rmSync(root, { recursive: true, force: true });
+	}
+	rmSync(gitConfigDir, { recursive: true, force: true });
+});
+
+function git(args: string[], cwd: string): string {
+	return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+interface LayoutOptions {
+	pluginPkgName?: string;
+	withOmoSenpiWorkspace?: boolean;
+	withSenpiTask?: boolean;
+	gitInit?: boolean;
+}
+
+function makeOmoLayout(
+	root: string,
+	options: LayoutOptions = {},
+): { repoRoot: string; pluginPath: string; agentDir: string } {
+	const repoRoot = join(root, "omo");
+	const pluginPath = join(repoRoot, "packages", "omo-senpi", "plugin");
+	const agentDir = join(root, "agent");
+	mkdirSync(pluginPath, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(
+		join(pluginPath, "package.json"),
+		JSON.stringify({ name: options.pluginPkgName ?? "@code-yeongyu/omo-senpi" }),
+	);
+	if (options.withOmoSenpiWorkspace ?? true) {
+		writeFileSync(
+			join(repoRoot, "packages", "omo-senpi", "package.json"),
+			JSON.stringify({ name: "@oh-my-opencode/omo-senpi" }),
+		);
+	}
+	if (options.withSenpiTask ?? true) {
+		mkdirSync(join(repoRoot, "packages", "senpi-task"), { recursive: true });
+		writeFileSync(
+			join(repoRoot, "packages", "senpi-task", "package.json"),
+			JSON.stringify({ name: "@oh-my-opencode/senpi-task" }),
+		);
+	}
+	if (options.gitInit ?? true) {
+		git(["-c", "init.defaultBranch=main", "init"], repoRoot);
+	}
+	return { repoRoot, pluginPath, agentDir };
+}
+
+function pidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function expectPidDead(pid: number): Promise<void> {
+	const deadline = Date.now() + 5000;
+	while (Date.now() < deadline) {
+		if (!pidAlive(pid)) return;
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+	}
+	expect(pidAlive(pid)).toBe(false);
+}
+
+describe("isKillSwitched", () => {
+	it("returns true only for the literal '0'", () => {
+		expect(isKillSwitched({ SENPI_OMO_LOCAL_UPDATE: "0" })).toBe(true);
+		expect(isKillSwitched({ SENPI_OMO_LOCAL_UPDATE: "1" })).toBe(false);
+		expect(isKillSwitched({ SENPI_OMO_LOCAL_UPDATE: "" })).toBe(false);
+		expect(isKillSwitched({})).toBe(false);
+	});
+});
+
+describe("defaultRun process seam", () => {
+	it("captures stdout and stderr and resolves the exit code", async () => {
+		const result = await defaultRun(
+			process.execPath,
+			["-e", 'process.stdout.write("out"); process.stderr.write("err"); process.exit(3);'],
+			{},
+		);
+		expect(result.code).toBe(3);
+		expect(result.stdout).toBe("out");
+		expect(result.stderr).toBe("err");
+		expect(result.timedOut).toBe(false);
+	});
+
+	it("merges options.env over process.env", async () => {
+		process.env.OMO_LOCAL_UPDATE_SEAM_AMBIENT = "base";
+		const result = await defaultRun(
+			process.execPath,
+			[
+				"-e",
+				"console.log(JSON.stringify({ injected: process.env.OMO_LOCAL_UPDATE_SEAM_TEST ?? null, overridden: process.env.OMO_LOCAL_UPDATE_SEAM_AMBIENT ?? null, hasPath: Boolean(process.env.PATH) }));",
+			],
+			{ env: { OMO_LOCAL_UPDATE_SEAM_TEST: "hello", OMO_LOCAL_UPDATE_SEAM_AMBIENT: "override" } },
+		);
+		const printed = JSON.parse(result.stdout.trim()) as {
+			injected: string | null;
+			overridden: string | null;
+			hasPath: boolean;
+		};
+		expect(printed.injected).toBe("hello");
+		expect(printed.overridden).toBe("override");
+		expect(printed.hasPath).toBe(true);
+	});
+
+	it("kills the whole process tree and reports timedOut on timeout", async () => {
+		const script = [
+			'const { spawn } = require("node:child_process");',
+			'const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
+			"console.log(JSON.stringify({ self: process.pid, grandchild: grandchild.pid }));",
+			"setInterval(() => {}, 1000);",
+		].join("\n");
+		const result = await defaultRun(process.execPath, ["-e", script], { timeoutMs: 2000 });
+		expect(result.timedOut).toBe(true);
+		const pids = JSON.parse(result.stdout.trim()) as { self: number; grandchild: number };
+		await expectPidDead(pids.self);
+		await expectPidDead(pids.grandchild);
+	});
+});
+
+describe("detectOmoLocalInstall", () => {
+	it("returns undefined when the packages key is absent", async () => {
+		const root = makeTempRoot();
+		const { agentDir } = makeOmoLayout(root);
+		expect(await detectOmoLocalInstall({ packages: undefined, agentDir, run: defaultRun })).toBeUndefined();
+	});
+
+	it("returns undefined for npm-only and git-only entries", async () => {
+		const root = makeTempRoot();
+		const { agentDir } = makeOmoLayout(root);
+		expect(
+			await detectOmoLocalInstall({
+				packages: ["npm:@code-yeongyu/omo-senpi", "git:https://example.com/omo.git"],
+				agentDir,
+				run: defaultRun,
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the plugin package name does not match", async () => {
+		const root = makeTempRoot();
+		const { pluginPath, agentDir } = makeOmoLayout(root, { pluginPkgName: "@code-yeongyu/not-omo" });
+		expect(await detectOmoLocalInstall({ packages: [pluginPath], agentDir, run: defaultRun })).toBeUndefined();
+	});
+
+	it("returns undefined when the senpi-task workspace package is missing", async () => {
+		const root = makeTempRoot();
+		const { pluginPath, agentDir } = makeOmoLayout(root, { withSenpiTask: false });
+		expect(await detectOmoLocalInstall({ packages: [pluginPath], agentDir, run: defaultRun })).toBeUndefined();
+	});
+
+	it("returns undefined when the omo-senpi workspace package is missing", async () => {
+		const root = makeTempRoot();
+		const { pluginPath, agentDir } = makeOmoLayout(root, { withOmoSenpiWorkspace: false });
+		expect(await detectOmoLocalInstall({ packages: [pluginPath], agentDir, run: defaultRun })).toBeUndefined();
+	});
+
+	it("returns undefined when the derived repo root is not a git repository", async () => {
+		const root = makeTempRoot();
+		const { pluginPath, agentDir } = makeOmoLayout(root, { gitInit: false });
+		expect(await detectOmoLocalInstall({ packages: [pluginPath], agentDir, run: defaultRun })).toBeUndefined();
+	});
+
+	it("returns undefined when the git toplevel is an enclosing repository", async () => {
+		const root = makeTempRoot();
+		git(["-c", "init.defaultBranch=main", "init"], root);
+		const { pluginPath, agentDir } = makeOmoLayout(root, { gitInit: false });
+		expect(await detectOmoLocalInstall({ packages: [pluginPath], agentDir, run: defaultRun })).toBeUndefined();
+	});
+
+	it("resolves pluginPath and repoRoot for an absolute settings entry", async () => {
+		const root = makeTempRoot();
+		const { repoRoot, pluginPath, agentDir } = makeOmoLayout(root);
+		const install = await detectOmoLocalInstall({ packages: [pluginPath], agentDir, run: defaultRun });
+		expect(install).toEqual({ pluginPath: resolve(pluginPath), repoRoot: resolve(repoRoot) });
+	});
+
+	it("resolves a relative settings entry against agentDir", async () => {
+		const root = makeTempRoot();
+		const { repoRoot, pluginPath, agentDir } = makeOmoLayout(root);
+		const relativeEntry = relative(agentDir, pluginPath);
+		const install = await detectOmoLocalInstall({ packages: [relativeEntry], agentDir, run: defaultRun });
+		expect(install).toEqual({ pluginPath: resolve(pluginPath), repoRoot: resolve(repoRoot) });
+	});
+
+	it("expands a ~-prefixed settings entry against the home directory", async () => {
+		const root = makeTempRoot();
+		const { repoRoot, pluginPath, agentDir } = makeOmoLayout(root);
+		const originalHome = process.env.HOME;
+		process.env.HOME = root;
+		try {
+			const install = await detectOmoLocalInstall({
+				packages: ["~/omo/packages/omo-senpi/plugin"],
+				agentDir,
+				run: defaultRun,
+			});
+			expect(install).toEqual({ pluginPath: resolve(pluginPath), repoRoot: resolve(repoRoot) });
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = originalHome;
+			}
+		}
+	});
+
+	it("accepts object-form PackageSource entries", async () => {
+		const root = makeTempRoot();
+		const { repoRoot, pluginPath, agentDir } = makeOmoLayout(root);
+		const install = await detectOmoLocalInstall({
+			packages: [{ source: pluginPath, autoload: true }],
+			agentDir,
+			run: defaultRun,
+		});
+		expect(install).toEqual({ pluginPath: resolve(pluginPath), repoRoot: resolve(repoRoot) });
+	});
+
+	it("skips non-matching entries and finds a later matching one", async () => {
+		const root = makeTempRoot();
+		const { repoRoot, pluginPath, agentDir } = makeOmoLayout(root);
+		const install = await detectOmoLocalInstall({
+			packages: ["npm:@scope/other", join(root, "does-not-exist"), { source: pluginPath }],
+			agentDir,
+			run: defaultRun,
+		});
+		expect(install).toEqual({ pluginPath: resolve(pluginPath), repoRoot: resolve(repoRoot) });
+	});
+
+	it("honors injected readJson, exists and run seams", async () => {
+		const pluginPath = join("/virtual", "omo", "packages", "omo-senpi", "plugin");
+		const repoRoot = join("/virtual", "omo");
+		const names = new Map<string, string>([
+			[join(pluginPath, "package.json"), "@code-yeongyu/omo-senpi"],
+			[join(repoRoot, "packages", "omo-senpi", "package.json"), "@oh-my-opencode/omo-senpi"],
+			[join(repoRoot, "packages", "senpi-task", "package.json"), "@oh-my-opencode/senpi-task"],
+		]);
+		const install = await detectOmoLocalInstall({
+			packages: [pluginPath],
+			agentDir: "/virtual/agent",
+			readJson: (path) => {
+				const name = names.get(path);
+				return name === undefined ? undefined : { name };
+			},
+			exists: (path) => names.has(path),
+			run: async () => ({ code: 0, stdout: `${realpathSync("/")}virtual${"/"}omo\n`, stderr: "", timedOut: false }),
+		});
+		expect(install).toEqual({ pluginPath, repoRoot });
+	});
+});
+
+describe("readStamp/writeStamp", () => {
+	const stamp: OmoLocalUpdateStamp = {
+		repoRoot: "/some/repo",
+		builtSha: "0123456789abcdef",
+		builtAt: "2026-07-25T00:00:00.000Z",
+		artifacts: ["plugin/extensions/omo.js", "plugin/scripts/install.mjs"],
+	};
+
+	it("round-trips a stamp through the agent dir state file", () => {
+		const agentDir = join(makeTempRoot(), "agent");
+		writeStamp(agentDir, stamp);
+		expect(readStamp(agentDir)).toEqual(stamp);
+	});
+
+	it("returns undefined when no stamp file exists", () => {
+		const agentDir = join(makeTempRoot(), "agent");
+		mkdirSync(agentDir, { recursive: true });
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+
+	it("returns undefined for a corrupt stamp file", () => {
+		const agentDir = join(makeTempRoot(), "agent");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(omoLocalUpdateStampPath(agentDir), "{ not json");
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+
+	it("returns undefined for a stamp with an invalid shape", () => {
+		const agentDir = join(makeTempRoot(), "agent");
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			omoLocalUpdateStampPath(agentDir),
+			JSON.stringify({ repoRoot: "/some/repo", builtSha: 42, builtAt: "now", artifacts: "nope" }),
+		);
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+});
+
+describe("shouldSkipBuild", () => {
+	const stamp: OmoLocalUpdateStamp = {
+		repoRoot: "/repo",
+		builtSha: "abc123",
+		builtAt: "2026-07-25T00:00:00.000Z",
+		artifacts: ["plugin/extensions/omo.js"],
+	};
+	const base = {
+		stamp,
+		repoRoot: "/repo",
+		targetSha: "abc123",
+		stampArtifactsExist: true,
+		force: false,
+	};
+
+	it("skips when the stamp matches, the full inventory exists, and force is off", () => {
+		expect(shouldSkipBuild(base)).toBe(true);
+	});
+
+	it("builds when force is set", () => {
+		expect(shouldSkipBuild({ ...base, force: true })).toBe(false);
+	});
+
+	it("builds when the target sha moved", () => {
+		expect(shouldSkipBuild({ ...base, targetSha: "def456" })).toBe(false);
+	});
+
+	it("builds when any inventoried artifact is missing", () => {
+		expect(shouldSkipBuild({ ...base, stampArtifactsExist: false })).toBe(false);
+	});
+
+	it("builds when the inventory is empty", () => {
+		expect(shouldSkipBuild({ ...base, stamp: { ...stamp, artifacts: [] } })).toBe(false);
+	});
+
+	it("builds when no stamp exists at all", () => {
+		expect(shouldSkipBuild({ ...base, stamp: undefined })).toBe(false);
+	});
+
+	it("builds when the stamp belongs to a different repo root", () => {
+		expect(shouldSkipBuild({ ...base, repoRoot: "/other/repo" })).toBe(false);
+	});
+});
+
+describe("runOmoLocalUpdateBeta stub", () => {
+	it("no-ops under the kill-switch", async () => {
+		const root = makeTempRoot();
+		const { pluginPath, agentDir } = makeOmoLayout(root);
+		await expect(
+			runOmoLocalUpdateBeta({
+				env: { SENPI_OMO_LOCAL_UPDATE: "0" },
+				agentDir,
+				settings: { packages: [pluginPath] },
+			}),
+		).resolves.toBeUndefined();
+		expect(readStamp(agentDir)).toBeUndefined();
+	});
+
+	it("no-ops when nothing is detected", async () => {
+		const root = makeTempRoot();
+		const agentDir = join(root, "agent");
+		mkdirSync(agentDir, { recursive: true });
+		await expect(
+			runOmoLocalUpdateBeta({ env: {}, agentDir, settings: { packages: ["npm:@scope/other"] } }),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/omo-local-update.test.ts
+++ b/packages/coding-agent/test/omo-local-update.test.ts
@@ -4,16 +4,32 @@ import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+	classifyDirt,
 	defaultRun,
 	detectOmoLocalInstall,
 	isKillSwitched,
+	type OmoLocalRun,
+	OmoLocalSyncError,
 	type OmoLocalUpdateStamp,
 	omoLocalUpdateStampPath,
 	readStamp,
 	runOmoLocalUpdateBeta,
 	shouldSkipBuild,
+	syncToOriginDev,
 	writeStamp,
 } from "../src/beta/omo-local-update.ts";
+import {
+	advanceLocalDevOnly,
+	advanceOriginDev,
+	blockCommits,
+	blockPushes,
+	createOmoFixture,
+	deleteLocalDev,
+	dirtyGenerated,
+	dirtyRenameAcrossSets,
+	dirtySource,
+	divergeLocalDev,
+} from "./omo-local-update-fixture.ts";
 
 // Git determinism: isolate every git invocation in this file (test-side AND
 // engine-side through the inherited process.env) from ambient host config.
@@ -393,5 +409,330 @@ describe("runOmoLocalUpdateBeta stub", () => {
 		await expect(
 			runOmoLocalUpdateBeta({ env: {}, agentDir, settings: { packages: ["npm:@scope/other"] } }),
 		).resolves.toBeUndefined();
+	});
+});
+
+function headSha(cwd: string): string {
+	return git(["rev-parse", "HEAD"], cwd);
+}
+
+function currentBranch(cwd: string): string | undefined {
+	try {
+		return git(["symbolic-ref", "--short", "-q", "HEAD"], cwd) || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function makeLogCollector(): { lines: string[]; log: (message: string) => void } {
+	const lines: string[] = [];
+	return {
+		lines,
+		log: (message: string) => {
+			lines.push(message);
+		},
+	};
+}
+
+/** Fetch origin/dev in the fixture clone (the orchestrator's job) and return the frozen sha. */
+function fetchTargetSha(repoRoot: string): string {
+	git(["fetch", "origin", "dev"], repoRoot);
+	return git(["rev-parse", "origin/dev"], repoRoot);
+}
+
+async function captureFailure(promise: Promise<unknown>): Promise<unknown> {
+	try {
+		await promise;
+		return undefined;
+	} catch (error) {
+		return error;
+	}
+}
+
+describe("classifyDirt", () => {
+	it("classifies tracked modifications under every generated prefix as generated", () => {
+		const porcelain =
+			[
+				" M packages/omo-senpi/plugin/extensions/omo.js",
+				" M packages/omo-senpi/plugin/skills/alpha/SKILL.md",
+				" M packages/omo-senpi/plugin/runtime/lsp-daemon/dist/cli.js",
+				" M packages/omo-senpi/plugin/scripts/install.mjs",
+			].join("\0") + "\0";
+		const dirt = classifyDirt(porcelain);
+		expect(dirt.source).toEqual([]);
+		expect(dirt.generated.map((entry) => entry.path)).toEqual([
+			"packages/omo-senpi/plugin/extensions/omo.js",
+			"packages/omo-senpi/plugin/skills/alpha/SKILL.md",
+			"packages/omo-senpi/plugin/runtime/lsp-daemon/dist/cli.js",
+			"packages/omo-senpi/plugin/scripts/install.mjs",
+		]);
+	});
+
+	it("classifies untracked entries by path and marks them untracked", () => {
+		const porcelain =
+			["?? packages/omo-senpi/plugin/skills/newskill/", "?? packages/omo-senpi/src/new-file.ts"].join("\0") + "\0";
+		const dirt = classifyDirt(porcelain);
+		expect(dirt.generated).toEqual([{ path: "packages/omo-senpi/plugin/skills/newskill/", untracked: true }]);
+		expect(dirt.source).toEqual([{ path: "packages/omo-senpi/src/new-file.ts", untracked: true }]);
+	});
+
+	it("treats files merely NEAR the generated prefixes as source", () => {
+		const porcelain =
+			[
+				" M packages/omo-senpi/plugin/scripts/other.mjs",
+				" M packages/omo-senpi/plugin/extensions.json",
+				" M packages/omo-senpi/plugin/package.json",
+			].join("\0") + "\0";
+		const dirt = classifyDirt(porcelain);
+		expect(dirt.generated).toEqual([]);
+		expect(dirt.source).toHaveLength(3);
+	});
+
+	it("keeps a rename fully inside the generated prefixes generated, recording the source path", () => {
+		const porcelain =
+			"R  packages/omo-senpi/plugin/skills/beta/SKILL.md\0packages/omo-senpi/plugin/skills/alpha/SKILL.md\0";
+		const dirt = classifyDirt(porcelain);
+		expect(dirt.source).toEqual([]);
+		expect(dirt.generated).toEqual([
+			{
+				path: "packages/omo-senpi/plugin/skills/beta/SKILL.md",
+				origPath: "packages/omo-senpi/plugin/skills/alpha/SKILL.md",
+				untracked: false,
+			},
+		]);
+	});
+
+	it("classifies a rename as source when EITHER half leaves the generated prefixes", () => {
+		const generatedToSource =
+			"R  packages/omo-senpi/src/alpha-skill.md\0packages/omo-senpi/plugin/skills/alpha/SKILL.md\0";
+		const sourceToGenerated =
+			"R  packages/omo-senpi/plugin/skills/alpha/SKILL.md\0packages/omo-senpi/src/alpha-skill.md\0";
+		for (const porcelain of [generatedToSource, sourceToGenerated]) {
+			const dirt = classifyDirt(porcelain);
+			expect(dirt.generated).toEqual([]);
+			expect(dirt.source).toHaveLength(1);
+			expect(dirt.source[0]?.origPath).toBeDefined();
+		}
+	});
+
+	it("handles an empty status and mixed streams", () => {
+		expect(classifyDirt("")).toEqual({ generated: [], source: [] });
+		const porcelain =
+			[
+				" M packages/omo-senpi/plugin/extensions/omo.js",
+				" M packages/omo-senpi/src/index.ts",
+				"?? packages/omo-senpi/plugin/runtime/extra.js",
+			].join("\0") + "\0";
+		const dirt = classifyDirt(porcelain);
+		expect(dirt.generated).toHaveLength(2);
+		expect(dirt.source).toHaveLength(1);
+	});
+});
+
+describe("syncToOriginDev", () => {
+	it("fast-forwards a clean checkout to the frozen origin/dev sha", { timeout: 30000 }, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		advanceOriginDev(fixture.originDir);
+		const targetSha = fetchTargetSha(fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		expect(git(["rev-parse", "dev"], fixture.repoRoot)).toBe(targetSha);
+		expect(report.prevRef).toBe("dev");
+		expect(report.subject).toBe("origin dev commit 2");
+		expect(report.backupBranch).toBeUndefined();
+		expect(report.detached).toBeUndefined();
+		expect(report.discardedPaths).toEqual([]);
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+	});
+
+	it("discards generated-only dirt (tracked and untracked) without any backup branch", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		const generatedPath = dirtyGenerated(fixture.repoRoot);
+		const untrackedDir = join(fixture.repoRoot, "packages", "omo-senpi", "plugin", "skills", "newskill");
+		mkdirSync(untrackedDir, { recursive: true });
+		writeFileSync(join(untrackedDir, "SKILL.md"), "# junk\n");
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		expect(report.backupBranch).toBeUndefined();
+		expect(git(["branch", "--list", "backup/*"], fixture.repoRoot)).toBe("");
+		expect(report.discardedPaths).toContain(generatedPath);
+		expect(report.discardedPaths).toContain("packages/omo-senpi/plugin/skills/newskill/");
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+	});
+
+	it("backs up source dirt to a PUSHED backup branch, then syncs dev to the target", { timeout: 30000 }, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		dirtySource(fixture.repoRoot);
+		advanceOriginDev(fixture.originDir);
+		const targetSha = fetchTargetSha(fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		if (report.backupBranch === undefined) throw new Error("expected a backup branch");
+		expect(report.backupBranch).toMatch(/^backup\/senpi-update-\d{8}-\d{6}Z$/);
+		expect(report.backupPushed).toBe(true);
+		// The backup branch exists on the bare origin and carries exactly the snapshot commit.
+		expect(git(["-C", fixture.originDir, "branch", "--list", report.backupBranch], ".")).not.toBe("");
+		const ahead = git(["log", `origin/dev..${report.backupBranch}`, "--oneline"], fixture.repoRoot);
+		expect(ahead.split("\n")).toHaveLength(1);
+		const snapshot = git(["show", `${report.backupBranch}:packages/omo-senpi/src/index.ts`], fixture.repoRoot);
+		expect(snapshot).toContain("fixture source dirt");
+		// Worktree clean, dev synced, previous branch ref unchanged.
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		expect(git(["rev-parse", "dev"], fixture.repoRoot)).toBe(targetSha);
+		expect(report.prevRef).toBe("dev");
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+	});
+
+	it("keeps the backup branch locally (with a warning) when the push is rejected", { timeout: 30000 }, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		dirtySource(fixture.repoRoot);
+		blockPushes(fixture.originDir);
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const { lines, log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		if (report.backupBranch === undefined) throw new Error("expected a backup branch");
+		expect(report.backupPushed).toBe(false);
+		// Local branch retains the snapshot; origin rejected it.
+		expect(git(["rev-parse", report.backupBranch], fixture.repoRoot)).not.toBe("");
+		expect(git(["-C", fixture.originDir, "branch", "--list", "backup/*"], ".")).toBe("");
+		const snapshot = git(["show", `${report.backupBranch}:packages/omo-senpi/src/index.ts`], fixture.repoRoot);
+		expect(snapshot).toContain("fixture source dirt");
+		expect(lines.some((line) => line.includes(report.backupBranch ?? "\0") && line.includes("locally"))).toBe(true);
+		// Sync still completes.
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+	});
+
+	it("detaches at the frozen target when local dev has diverged, leaving local commits intact", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		const { localSha, originSha } = divergeLocalDev(fixture.repoRoot);
+		const { lines, log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha: originSha, run: defaultRun, log });
+		expect(report.detached).toBe(true);
+		expect(headSha(fixture.repoRoot)).toBe(originSha);
+		expect(currentBranch(fixture.repoRoot)).toBeUndefined();
+		expect(git(["rev-parse", "dev"], fixture.repoRoot)).toBe(localSha);
+		expect(lines.some((line) => line.includes("detached"))).toBe(true);
+	});
+
+	it("detaches at the frozen target when local dev is AHEAD of origin (never builds local-only commits)", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		const localSha = advanceLocalDevOnly(fixture.repoRoot);
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		expect(localSha).not.toBe(targetSha);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		expect(report.detached).toBe(true);
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(git(["rev-parse", "dev"], fixture.repoRoot)).toBe(localSha);
+		expect(report.prevRef).toBe("dev");
+	});
+
+	it("creates an absent local dev AT the frozen target with upstream set, then checks it out", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		deleteLocalDev(fixture.repoRoot);
+		advanceOriginDev(fixture.originDir);
+		const targetSha = fetchTargetSha(fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		expect(report.prevRef).toBe("fixture-side");
+		expect(git(["rev-parse", "dev"], fixture.repoRoot)).toBe(targetSha);
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		expect(git(["rev-parse", "--abbrev-ref", "dev@{upstream}"], fixture.repoRoot)).toBe("origin/dev");
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+	});
+
+	it("treats a rename across the generated/source boundary as source and snapshots it", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		dirtyRenameAcrossSets(fixture.repoRoot);
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		if (report.backupBranch === undefined) throw new Error("expected a backup branch");
+		const snapshot = git(["show", `${report.backupBranch}:packages/omo-senpi/src/alpha-skill.md`], fixture.repoRoot);
+		expect(snapshot).toContain("alpha skill");
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toBe("");
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+	});
+
+	it("rolls back and aborts when the backup COMMIT fails (dirt preserved, empty branch deleted)", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		dirtySource(fixture.repoRoot);
+		blockCommits(fixture.repoRoot);
+		const devShaBefore = headSha(fixture.repoRoot);
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const failure = await captureFailure(
+			syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log }),
+		);
+		expect(failure).toBeInstanceOf(OmoLocalSyncError);
+		expect((failure as OmoLocalSyncError).stage).toBe("backup");
+		// prevRef restored, empty backup branch deleted, source dirt never destroyed.
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		expect(headSha(fixture.repoRoot)).toBe(devShaBefore);
+		expect(git(["branch", "--list", "backup/*"], fixture.repoRoot)).toBe("");
+		expect(git(["status", "--porcelain"], fixture.repoRoot)).toContain("packages/omo-senpi/src/index.ts");
+	});
+
+	it("restores prevRef but KEEPS the backup ref when a later sync stage fails after a successful backup", {
+		timeout: 30000,
+	}, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		dirtySource(fixture.repoRoot);
+		const devShaBefore = headSha(fixture.repoRoot);
+		advanceOriginDev(fixture.originDir);
+		const targetSha = fetchTargetSha(fixture.repoRoot);
+		let failedOnce = false;
+		const failFirstCheckoutDev: OmoLocalRun = async (command, args, options) => {
+			if (!failedOnce && command === "git" && args[0] === "checkout" && args.includes("dev")) {
+				failedOnce = true;
+				return { code: 1, stdout: "", stderr: "error: simulated checkout refusal", timedOut: false };
+			}
+			return defaultRun(command, args, options);
+		};
+		const { log } = makeLogCollector();
+		const failure = await captureFailure(
+			syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: failFirstCheckoutDev, log }),
+		);
+		expect(failure).toBeInstanceOf(OmoLocalSyncError);
+		expect((failure as OmoLocalSyncError).stage).toBe("sync");
+		// prevRef restored to its exact pre-sync commit; the snapshot backup ref is retained.
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
+		expect(headSha(fixture.repoRoot)).toBe(devShaBefore);
+		expect(git(["branch", "--list", "backup/*"], fixture.repoRoot)).not.toBe("");
+	});
+
+	it("reports prevRef as the detached HEAD sha when starting detached", { timeout: 30000 }, async () => {
+		const fixture = createOmoFixture(makeTempRoot());
+		git(["checkout", "--detach", "HEAD"], fixture.repoRoot);
+		const detachedSha = headSha(fixture.repoRoot);
+		dirtySource(fixture.repoRoot);
+		const targetSha = git(["rev-parse", "origin/dev"], fixture.repoRoot);
+		const { log } = makeLogCollector();
+		const report = await syncToOriginDev({ repoRoot: fixture.repoRoot, targetSha, run: defaultRun, log });
+		expect(report.prevRef).toBe(detachedSha);
+		expect(report.backupBranch).toBeDefined();
+		expect(report.backupPushed).toBe(true);
+		expect(headSha(fixture.repoRoot)).toBe(targetSha);
+		expect(currentBranch(fixture.repoRoot)).toBe("dev");
 	});
 });


### PR DESCRIPTION
## What

Beta, easily-removable hook in bare `senpi update`: when a locally-installed OMO plugin checkout is present (the `@code-yeongyu/omo-senpi` local path package, with both `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task` in the repo), the CLI syncs that checkout to `origin/dev` and rebuilds the plugin bundle **before** senpi self-update runs — then tells the user exactly what it did.

Plan: `.omo/plans/senpi-update-omo-local-beta.md` (decision-complete, dual high-accuracy reviewed: metis + momus/oracle, 5 rounds).

## How it works

- **Trigger:** bare `senpi update` only (the verified discriminant `options.showExtensionsSkippedNote`), before any self-update work. Flagged invocations (`--self/--all/--extensions/--models`, source args) are untouched; `SENPI_OMO_LOCAL_UPDATE=0` disables everything silently.
- **Detection:** settings packages (string|object normalized, `isLocalPath`/`resolvePath` reuse) → plugin name check → both workspace packages present → `git rev-parse --show-toplevel` + realpath equality (never mutates an enclosing repo).
- **Sync (single-owner ordered state machine):** atomic `wx` lock (no live-pid takeover, owner-checked unlink) → one fetch → frozen `targetSha` (all ancestry/merge/detach/subject ops use the SHA literal, never the mutable ref) → skip decision *before* any worktree mutation (stamp + post-build artifact inventory) → dirt triage: generated artifacts discarded, **source dirt committed to a pushed `backup/senpi-update-*` branch first** (work is never lost; diverged local `dev` is never reset — builds detached at the target) → `bun install` + `bun run build:senpi-plugin` → stamp → notify.
- **Safety:** the hook never throws and never sets `process.exitCode`; every failure is a yellow warning with a manual-fix hint. Post-backup failures restore the previous checkout (generated-only discard first; post-failure source dirt is preserved with an explicit warning).

## Removability (beta contract)

Three deletions remove the feature with zero dangling references (proven by execution in a scratch worktree): delete `src/beta/omo-local-update.ts`, delete all `test/omo-local-update*` files, delete the two `BETA(omo-local-update)`-marked touch points in `package-manager-cli.ts`. Documented in `src/changes.md`.

## Evidence

- Scoped tests: `npx vitest --run test/omo-local-update.test.ts` — **60/60** (RED-first transcripts for every phase in `.omo/evidence/task-{1,3,4}-*.txt`).
- `npm run check` — exit 0 (baseline and at HEAD).
- senpi-qa real-CLI QA — 5/5 scenarios (happy / source-dirty backup / skip / kill-switch / no-op gate), 24/24 checks: `local-ignore/qa-evidence/20260725-omo-local-update/`.
- Real-surface run on the actual `../omo` checkout: ff-synced `c155fa863 → d5a277e5`, real `bun run build:senpi-plugin`, second run skips; auth store untouched (sha256 verified).
- Final verification wave: F1 plan-compliance audit, F2 code quality + executed removability proof, F3 real manual QA, F4 scope fidelity — all APPROVE (evidence under `.omo/evidence/task-F{1..4}-*.txt`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a beta hook to bare `senpi update` that, when a local `@code-yeongyu/omo-senpi` checkout is installed with `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task`, fast-forwards it to `origin/dev` and rebuilds the plugin before senpi self-update. Keeps local dev plugin builds current with safe backups and clear messaging.

- **New Features**
  - Runs only on bare `senpi update`; flagged updates are unchanged.
  - Detects a local-path plugin with both workspace packages in the same git repo.
  - Safely syncs to `origin/dev`: single-owner lock, pinned SHA, backs up local source changes to `backup/senpi-update-*`, never hard-resets diverged `dev`.
  - Rebuilds via `bun install` + `bun run build:senpi-plugin`; prints a success line with short SHA. Uses a skip-stamp to avoid no-op rebuilds; `--force` rebuilds. Failures degrade to warnings and never set an error exit.

- **Migration**
  - No action needed.
  - Disable with `SENPI_OMO_LOCAL_UPDATE=0`.
  - To remove the beta: delete `src/beta/omo-local-update.ts`, all `test/omo-local-update*`, and the two `BETA(omo-local-update)` touch points in `src/package-manager-cli.ts`.

<sup>Written for commit c9e07bbe60aa0f69030de919ead14dbc97a68bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

