### PR TITLE
fix(config-reload): skip reloads for routine cross-process settings changes

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -236,43 +236,44 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 
 	const processChange = async (change: RealChange): Promise<void> => {
 		if (reloadInFlight || !currentContext) return;
-		const groups = groupChangedPaths(change.changedPaths, activeTargets);
+		// Suppression state (self-write consumption, routine-diff base) is per path,
+		// so it must be resolved before grouping: a path watched by several
+		// registrations would otherwise be classified once per group and reach the
+		// reload flow through the later group.
+		const watchedPaths = excludeSelfWrites(
+			change.changedPaths,
+			engine,
+			agentDir,
+			currentContext.cwd,
+			logger,
+			settingsContents,
+		);
+		const significantPaths = excludeRoutineOnlySettingsChanges(
+			watchedPaths,
+			settingsContents,
+			agentDir,
+			currentContext.cwd,
+			logger,
+		);
+		const groups = groupChangedPaths(significantPaths, activeTargets);
 		const rearmDirectoryWatch = change.created.some((path) =>
 			activeTargets.some((target) => target.rearmOnCreation === resolve(path)),
 		);
 		for (const [registrationId, paths] of groups) {
-			const watchedPaths = excludeSelfWrites(paths, engine, agentDir, currentContext.cwd, logger, settingsContents);
-			if (watchedPaths.length === 0) continue;
-
-			const significantPaths = excludeRoutineOnlySettingsChanges(
-				watchedPaths,
-				settingsContents,
-				agentDir,
-				currentContext.cwd,
-				logger,
-			);
-			if (significantPaths.length === 0) continue;
-
-			const errors = await validateChangedPaths(
-				registrationId,
-				significantPaths,
-				registrations,
-				agentDir,
-				currentContext.cwd,
-			);
+			const errors = await validateChangedPaths(registrationId, paths, registrations, agentDir, currentContext.cwd);
 			if (errors.length > 0) {
-				rejectChange(currentContext, registrationId, significantPaths, errors, logger, pi);
+				rejectChange(currentContext, registrationId, paths, errors, logger, pi);
 				continue;
 			}
 
-			addPending(pending, registrationId, significantPaths);
+			addPending(pending, registrationId, paths);
 			const deferred = !canRequestReload(currentContext);
 			pi.events.emit(CONFIG_WATCH_CHANGED, {
 				registrationId,
-				paths: [...significantPaths],
+				paths: [...paths],
 				deferred,
 			});
-			logger.info("change_detected", { registrationId, paths: significantPaths, deferred });
+			logger.info("change_detected", { registrationId, paths, deferred });
 		}
 		if (rearmDirectoryWatch) rebuildWatchers(currentContext);
 		await flushPending();

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -21,6 +21,13 @@ import {
 	matchesConfigWatchFilter,
 } from "./protocol.ts";
 import {
+	excludeRoutineOnlySettingsChanges,
+	isSettingsPath,
+	joinConfigDir,
+	refreshSettingsContentSnapshots,
+	updateSettingsContentSnapshot,
+} from "./routine-settings.ts";
+import {
 	ConfigReloadWatchEngine,
 	createFsWatchEventSource,
 	type RealChange,
@@ -143,6 +150,8 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	const logger = options.logger ?? createConfigReloadLogger(agentDir);
 	const registrations = new Map<string, ConfigWatchRegistration>();
 	const rejectedRegistrations = new Map<string, string>();
+	/** Last-seen settings.json contents per path; the diff base for routine-key classification. */
+	const settingsContents = new Map<string, string>();
 	const eventUnsubscribes: Array<() => void> = [];
 	const pending = new Map<string, PendingChange>();
 	let engine: ConfigReloadWatchEngine | undefined;
@@ -232,29 +241,38 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 			activeTargets.some((target) => target.rearmOnCreation === resolve(path)),
 		);
 		for (const [registrationId, paths] of groups) {
-			const watchedPaths = excludeSelfWrites(paths, engine, agentDir, currentContext.cwd, logger);
+			const watchedPaths = excludeSelfWrites(paths, engine, agentDir, currentContext.cwd, logger, settingsContents);
 			if (watchedPaths.length === 0) continue;
+
+			const significantPaths = excludeRoutineOnlySettingsChanges(
+				watchedPaths,
+				settingsContents,
+				agentDir,
+				currentContext.cwd,
+				logger,
+			);
+			if (significantPaths.length === 0) continue;
 
 			const errors = await validateChangedPaths(
 				registrationId,
-				watchedPaths,
+				significantPaths,
 				registrations,
 				agentDir,
 				currentContext.cwd,
 			);
 			if (errors.length > 0) {
-				rejectChange(currentContext, registrationId, watchedPaths, errors, logger, pi);
+				rejectChange(currentContext, registrationId, significantPaths, errors, logger, pi);
 				continue;
 			}
 
-			addPending(pending, registrationId, watchedPaths);
+			addPending(pending, registrationId, significantPaths);
 			const deferred = !canRequestReload(currentContext);
 			pi.events.emit(CONFIG_WATCH_CHANGED, {
 				registrationId,
-				paths: [...watchedPaths],
+				paths: [...significantPaths],
 				deferred,
 			});
-			logger.info("change_detected", { registrationId, paths: watchedPaths, deferred });
+			logger.info("change_detected", { registrationId, paths: significantPaths, deferred });
 		}
 		if (rearmDirectoryWatch) rebuildWatchers(currentContext);
 		await flushPending();
@@ -298,6 +316,7 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 				logger.error("watcher_error", { path, message: errorMessage(error) });
 			}),
 		});
+		refreshSettingsContentSnapshots(settingsContents, agentDir, ctx.cwd);
 		logger.info("watcher_started", { targetCount: activeTargets.length });
 		pi.events.emit(CONFIG_WATCH_READY, { enabled: true });
 	};
@@ -701,6 +720,7 @@ function excludeSelfWrites(
 	agentDir: string,
 	cwd: string,
 	logger: ConfigReloadLogger,
+	settingsContents: Map<string, string>,
 ): string[] {
 	const snapshot = engine?.getBaselineSnapshot();
 	return paths.filter((path) => {
@@ -708,6 +728,9 @@ function excludeSelfWrites(
 		const hash = snapshot?.get(path);
 		if (hash === undefined || !wasSelfWrite(path, hash)) return true;
 		logger.debug("self_write_suppressed", { path });
+		// Advance the routine-diff base so a later external change is not
+		// polluted by this session's own just-applied write.
+		updateSettingsContentSnapshot(settingsContents, path);
 		return false;
 	});
 }
@@ -838,17 +861,6 @@ function compareSnapshots(previous: ReadonlyMap<string, string>, next: ReadonlyM
 
 function uniquePaths(paths: readonly string[]): string[] {
 	return [...new Set(paths)].sort();
-}
-
-function joinConfigDir(cwd: string): string {
-	return resolve(cwd, CONFIG_DIR_NAME);
-}
-
-function isSettingsPath(path: string, agentDir: string, cwd: string): boolean {
-	return (
-		resolve(path) === resolve(agentDir, "settings.json") ||
-		resolve(path) === resolve(joinConfigDir(cwd), "settings.json")
-	);
 }
 
 function isWithin(path: string, root: string): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
@@ -13,6 +13,7 @@ export type ConfigReloadLogEvent =
 	| "watcher_started"
 	| "change_detected"
 	| "self_write_suppressed"
+	| "routine_settings_change_suppressed"
 	| "reload_requested"
 	| "reload_completed"
 	| "validation_rejected"
@@ -26,6 +27,7 @@ export interface ConfigReloadLogDetails {
 	watcher_started: { targetCount: number };
 	change_detected: { registrationId: string; paths: readonly string[]; deferred: boolean };
 	self_write_suppressed: { path: string };
+	routine_settings_change_suppressed: { path: string };
 	reload_requested: { reason: string; paths: readonly string[] };
 	reload_completed: { durationMs: number };
 	validation_rejected: { registrationId: string; errorCount: number };

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
@@ -128,6 +128,9 @@ function formatEntry<Event extends ConfigReloadLogEvent>(
 		case "self_write_suppressed":
 			addSafePath(entry, (details as ConfigReloadLogDetails["self_write_suppressed"]).path);
 			break;
+		case "routine_settings_change_suppressed":
+			addSafePath(entry, (details as ConfigReloadLogDetails["routine_settings_change_suppressed"]).path);
+			break;
 		case "reload_requested": {
 			const eventDetails = details as ConfigReloadLogDetails["reload_requested"];
 			entry.reason = safeText(eventDetails.reason);

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { CONFIG_DIR_NAME } from "../../../../config.ts";
+import type { ConfigReloadLogger } from "./log.ts";
+
+/**
+ * Settings keys a running session already applies live (model/thinking picks)
+ * or never reads back (changelog bookkeeping). A settings.json change limited
+ * to these keys — typically /model or a thinking-level change in another
+ * session or a background CLI run — must not hot-reload this session. Any
+ * other key change keeps the full validate-and-reload flow.
+ */
+const ROUTINE_SETTINGS_KEYS: ReadonlySet<string> = new Set([
+	"defaultModel",
+	"defaultProvider",
+	"defaultThinkingLevel",
+	"lastChangelogVersion",
+]);
+
+export function joinConfigDir(cwd: string): string {
+	return resolve(cwd, CONFIG_DIR_NAME);
+}
+
+export function isSettingsPath(path: string, agentDir: string, cwd: string): boolean {
+	return (
+		resolve(path) === resolve(agentDir, "settings.json") ||
+		resolve(path) === resolve(joinConfigDir(cwd), "settings.json")
+	);
+}
+
+function settingsSnapshotKey(path: string): string {
+	return resolve(path);
+}
+
+export function updateSettingsContentSnapshot(contents: Map<string, string>, path: string): void {
+	const key = settingsSnapshotKey(path);
+	try {
+		contents.set(key, readFileSync(path, "utf-8"));
+	} catch {
+		contents.delete(key);
+	}
+}
+
+export function refreshSettingsContentSnapshots(contents: Map<string, string>, agentDir: string, cwd: string): void {
+	contents.clear();
+	updateSettingsContentSnapshot(contents, resolve(agentDir, "settings.json"));
+	updateSettingsContentSnapshot(contents, resolve(joinConfigDir(cwd), "settings.json"));
+}
+
+function parseSettingsObject(content: string): Record<string, unknown> | undefined {
+	try {
+		const parsed: unknown = JSON.parse(content);
+		return isPlainObject(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function changedTopLevelKeys(previous: Record<string, unknown>, next: Record<string, unknown>): string[] {
+	const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+	const changed: string[] = [];
+	for (const key of keys) {
+		if (JSON.stringify(previous[key]) !== JSON.stringify(next[key])) changed.push(key);
+	}
+	return changed.sort();
+}
+
+function isRoutineOnlySettingsChange(previousContent: string | undefined, nextContent: string | undefined): boolean {
+	if (previousContent === undefined || nextContent === undefined) return false;
+	const previous = parseSettingsObject(previousContent);
+	const next = parseSettingsObject(nextContent);
+	if (previous === undefined || next === undefined) return false;
+	const changedKeys = changedTopLevelKeys(previous, next);
+	return changedKeys.length > 0 && changedKeys.every((key) => ROUTINE_SETTINGS_KEYS.has(key));
+}
+
+/**
+ * Drops settings.json changes whose top-level diff is limited to routine keys
+ * (ROUTINE_SETTINGS_KEYS). The content diff works across processes, unlike the
+ * process-local self-write tracker: /model in one session no longer hot-reloads
+ * every other session. The snapshot base advances for every observed settings
+ * path, suppressed or not, so each event is classified against the previous
+ * event's content. Missing or unparseable content is never suppressed.
+ */
+export function excludeRoutineOnlySettingsChanges(
+	paths: readonly string[],
+	contents: Map<string, string>,
+	agentDir: string,
+	cwd: string,
+	logger: ConfigReloadLogger,
+): string[] {
+	return paths.filter((path) => {
+		if (!isSettingsPath(path, agentDir, cwd)) return true;
+		const previousContent = contents.get(settingsSnapshotKey(path));
+		let nextContent: string | undefined;
+		try {
+			nextContent = readFileSync(path, "utf-8");
+		} catch {
+			nextContent = undefined;
+		}
+		updateSettingsContentSnapshot(contents, path);
+		if (!isRoutineOnlySettingsChange(previousContent, nextContent)) return true;
+		logger.debug("routine_settings_change_suppressed", { path });
+		return false;
+	});
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -5,8 +5,8 @@
 ### What changed
 
 - `builtin/config-reload/routine-settings.ts` (new): content-diff classification for watched `settings.json` paths. When a change's top-level key diff is limited to routine, live-applied keys (`defaultModel`, `defaultProvider`, `defaultThinkingLevel`, `lastChangelogVersion`), the change is suppressed before validation and never reaches the notify/reload flow. The extension keeps a per-path content snapshot as the diff base, refreshed on watcher rebuild and advanced on every observed settings change (including self-write-suppressed ones), so each event is classified against the previous event's content. Missing or unparseable content is never suppressed and falls through to the existing validator.
-- `builtin/config-reload/index.ts`: `processChange` applies `excludeRoutineOnlySettingsChanges` after `excludeSelfWrites`; `isSettingsPath`/`joinConfigDir` moved into the new module.
-- `test/suite/config-reload-extension.test.ts`: coverage for idle and busy-deferred routine-only suppression, non-routine/mixed reload preservation with diff-base freshness, consecutive routine writes, and unparseable fall-through.
+- `builtin/config-reload/index.ts`: `processChange` now resolves the self-write and routine-change exclusions once over the change's unique paths before `groupChangedPaths`, then groups the surviving paths for per-registration validation. Suppression state is per path, so classifying inside the registration loop double-processed a path watched by several registrations (external registrations may watch the agent dir; only `auth.json`, `sessions` and `logs` are restricted): the later group saw a consumed self-write marker and an already-advanced diff base and still notified and reloaded. `isSettingsPath`/`joinConfigDir` moved into the new module.
+- `test/suite/config-reload-extension.test.ts`: coverage for idle and busy-deferred routine-only suppression, non-routine/mixed reload preservation with diff-base freshness, consecutive routine writes, unparseable fall-through, and overlapping-registration suppression for both routine external writes and `SettingsManager` self-writes.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,17 @@
 # Core Extensions Changes
 
+## 2026-07-25 - Config-reload skips routine cross-process settings changes
+
+### What changed
+
+- `builtin/config-reload/routine-settings.ts` (new): content-diff classification for watched `settings.json` paths. When a change's top-level key diff is limited to routine, live-applied keys (`defaultModel`, `defaultProvider`, `defaultThinkingLevel`, `lastChangelogVersion`), the change is suppressed before validation and never reaches the notify/reload flow. The extension keeps a per-path content snapshot as the diff base, refreshed on watcher rebuild and advanced on every observed settings change (including self-write-suppressed ones), so each event is classified against the previous event's content. Missing or unparseable content is never suppressed and falls through to the existing validator.
+- `builtin/config-reload/index.ts`: `processChange` applies `excludeRoutineOnlySettingsChanges` after `excludeSelfWrites`; `isSettingsPath`/`joinConfigDir` moved into the new module.
+- `test/suite/config-reload-extension.test.ts`: coverage for idle and busy-deferred routine-only suppression, non-routine/mixed reload preservation with diff-base freshness, consecutive routine writes, and unparseable fall-through.
+
+### Why
+
+The self-write tracker is process-local, so /model or a thinking-level change in one session (or a background CLI run writing the shared global `settings.json`) surfaced in every other session as "Config changed; reloading when idle" followed by a full hot reload. These keys are applied live by the owning session (or never read back), so reloading other sessions buys nothing; structural changes (packages, extensions, retry, …) keep the existing reload behavior.
+
 ## 2026-07-23 - Compaction feedback operation handles
 
 ### What changed

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -293,6 +293,81 @@ describe("config reload builtin extension", () => {
 		expect(fixture.reload).not.toHaveBeenCalled();
 	});
 
+	it("suppresses an external routine-only settings change", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture({ settingsContent: '{"theme":"dark","defaultModel":"m1"}\n' });
+
+		// Another process changed only the default model (e.g. /model in a second session).
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultModel":"m2"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+		expect(fixture.notifications).toEqual([]);
+
+		// Another process changed only the default thinking level.
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultModel":"m2","defaultThinkingLevel":"high"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+		expect(fixture.notifications).toEqual([]);
+	});
+
+	it("does not show the deferred notice for a routine-only change while busy", async () => {
+		vi.useFakeTimers();
+		const started = createDeferred();
+		const release = createDeferred();
+		const fixture = await createFixture();
+		fixture.harness.setResponses([
+			async () => {
+				started.resolve();
+				await release.promise;
+				return fauxAssistantMessage("finished");
+			},
+		]);
+		const prompt = fixture.harness.session.prompt("keep the agent busy");
+		await started.promise;
+
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultModel":"m2"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.notifications).toEqual([]);
+
+		release.resolve();
+		await prompt;
+		expect(fixture.reload).not.toHaveBeenCalled();
+	});
+
+	it("reloads an external settings change that touches non-routine keys", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture({ settingsContent: '{"theme":"dark","defaultModel":"m1"}\n' });
+
+		// Routine write first: suppressed, and must not poison the diff base.
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultModel":"m2"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		// Mixed routine + structural change: reloads.
+		writeFileSync(fixture.settingsPath, '{"theme":"light","defaultModel":"m3"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).toHaveBeenCalledTimes(1);
+	});
+
+	it("suppresses consecutive routine writes and falls through on unparseable content", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture({ settingsContent: '{"theme":"dark"}\n' });
+
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultProvider":"p1"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultProvider":"p1","defaultThinkingLevel":"low"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		// Unparseable content is not suppressed: it reaches the validator and is rejected as before.
+		writeFileSync(fixture.settingsPath, "{nope");
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+		expect(fixture.notifications.some((message) => message.includes("Config change rejected"))).toBe(true);
+	});
+
 	it("rejects a registered target whose validator fails", async () => {
 		vi.useFakeTimers();
 		const fixture = await createFixture();

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -368,6 +368,40 @@ describe("config reload builtin extension", () => {
 		expect(fixture.notifications.some((message) => message.includes("Config change rejected"))).toBe(true);
 	});
 
+	it("suppresses a routine external write when another registration watches the same settings file", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture({ settingsContent: '{"theme":"dark","defaultModel":"m1"}\n' });
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "external-settings",
+			displayName: "External settings watcher",
+			targets: [{ path: fixture.settingsPath, kind: "file" }],
+		});
+
+		writeFileSync(fixture.settingsPath, '{"theme":"dark","defaultModel":"m2"}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+
+		expect(fixture.reload).not.toHaveBeenCalled();
+		expect(fixture.notifications).toEqual([]);
+	});
+
+	it("suppresses a self-write when another registration watches the same settings file", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture();
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "external-settings",
+			displayName: "External settings watcher",
+			targets: [{ path: fixture.settingsPath, kind: "file" }],
+		});
+		const writer = SettingsManager.create(fixture.harness.tempDir, fixture.agentDir, { projectTrusted: true });
+		writer.setTheme("light");
+		await writer.flush();
+
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+
+		expect(fixture.reload).not.toHaveBeenCalled();
+		expect(fixture.notifications).toEqual([]);
+	});
+
 	it("rejects a registered target whose validator fails", async () => {
 		vi.useFakeTimers();
 		const fixture = await createFixture();


### PR DESCRIPTION
## Summary

`/model` in one session (or a background `senpi -p --model … --thinking …` run) writes the shared global `settings.json`. Every *other* running session saw that as an external config change and answered with `Config changed; reloading when idle` followed by a full hot reload. Switching a model or a thinking level is routine, everyday work — it should not reload anything.

The existing suppression is process-local: `wasSelfWrite()` only recognises writes made by the same process. This PR adds a cross-process rule on top of it: classify a watched `settings.json` change by its top-level content diff and skip the reload when the diff is limited to routine, live-applied keys.

Routine keys: `defaultModel`, `defaultProvider`, `defaultThinkingLevel`, `lastChangelogVersion`. Everything else (`packages`, `extensions`, `skills`, `theme`, `retry`, `compaction`, …) keeps today's validate → notify → hot-reload behaviour, including a mixed change that touches one routine key and one structural key.

## Design

- New `builtin/config-reload/routine-settings.ts` owns the classification: a per-path content snapshot is the diff base, refreshed when the watcher rebuilds and advanced on every observed settings change (suppressed or not), so each event is compared against the previous event's content.
- Missing or unparseable content is never suppressed — it falls through to the existing validator, so a malformed `settings.json` is still rejected and a deleted file still counts as a real change.
- `processChange` resolves the self-write and routine exclusions **once over the change's unique paths** before grouping by registration. Both are per-path state, so classifying inside the per-registration loop double-processed any path watched by more than one registration; the second group then saw a consumed self-write marker and an already-advanced diff base and reloaded anyway. That also fixes pre-existing breakage of self-write suppression under overlapping registrations.
- `isSettingsPath` / `joinConfigDir` moved into the new module; the routine-suppression log entry records the path.

## Verification

**Tests** — `packages/coding-agent`, `test/suite/config-reload-extension.test.ts`: 41/41 green. Six new cases, each captured RED first (`expected "vi.fn()" to not be called at all, but actually been called 1 times`):

- routine-only external write (`defaultModel`, then `defaultThinkingLevel`) while idle → no reload, no notice
- routine-only external write while the agent is busy → no `Config changed; reloading when idle` notice
- mixed routine + structural write after a suppressed routine write → reload still fires (diff base stays fresh)
- consecutive routine writes, then unparseable content → not suppressed, validator rejects as before
- routine external write while another registration watches the same file → suppressed
- `SettingsManager` self-write while another registration watches the same file → suppressed

**Static** — root `npm run check` exit 0 (biome, pinned deps, ts imports, shrinkwrap, install-lock, `tsgo --noEmit`, browser smoke, web-ui, neo build+vet+test).

**Manual QA on the real CLI** — live TUI booted from source in tmux (120x36) with a sandboxed `SENPI_CODING_AGENT_DIR` / session dir and `PI_OFFLINE=1`; the real `~/.senpi` was never touched. A second process edited the sandbox `settings.json`:

- routine-only edit (`defaultModel`) → `{"level":"debug","event":"routine_settings_change_suppressed","path":"…/settings.json"}`, zero `reload_requested`, and no notice in the captured pane
- structural edit (`theme`) → `{"event":"reload_requested","reason":"config changed",…}` → `watcher_started` → `{"event":"reload_completed","durationMs":274}`

Evidence (JSONL logs, pane captures, scenario README) saved under `local-ignore/qa-evidence/20260725-routine-config-reload/`; QA tmux session and temp sandboxes were torn down and verified gone.

## Risks & residuals

- **Scope of the exemption**: deliberately narrow — four keys that a running session either applies live or never reads back. A cross-session change to any other key still reloads, so no configuration surface silently stops taking effect.
- **Stale diff base**: the base advances on every observed settings event, including self-write-suppressed ones. A stale base can only ever *add* keys to the computed diff, which biases toward reloading (safe direction), never toward suppressing a structural change.
- **Full package suite**: 17 files fail in a *fresh worktree* with `ERR_MODULE_NOT_FOUND` for unbuilt workspace `dist/` (`@earendil-works/pi-tui`, `pi-ai`) — environmental, unrelated to this change; they pass once the workspace is built. CI builds before testing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip reloads for routine `settings.json` changes from other processes to prevent unnecessary hot reloads when switching model or thinking level. Also fixes overlapping watch registrations that caused accidental reloads.

- **Bug Fixes**
  - Classify `settings.json` changes by top-level diff; suppress when only routine keys change: `defaultModel`, `defaultProvider`, `defaultThinkingLevel`, `lastChangelogVersion`.
  - Track a per-path content snapshot; refresh on watcher start and advance on every observed change.
  - Do not suppress missing or invalid JSON; let validation reject as before.
  - Resolve self-write and routine exclusions once per path before grouping to avoid double-processing across registrations.
  - Log `routine_settings_change_suppressed` with the path; move `isSettingsPath` and `joinConfigDir` into the new module.

<sup>Written for commit 944c5a739237a4d0a96dbd2ba7366db5341b9642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

