### PR TITLE
feat(coding-agent): add /exit as an alias of /quit

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -197,7 +197,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/reload` | Reload keybindings, extensions, skills, prompts, themes, and context files |
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/changelog` | Display version history |
-| `/quit` | Quit pi |
+| `/quit`, `/exit` | Quit pi |
 
 ### Keyboard Shortcuts
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -57,7 +57,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/reload` | Reload keybindings, extensions, skills, prompts, themes, and context files |
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/changelog` | Display version history |
-| `/quit` | Quit pi |
+| `/quit`, `/exit` | Quit pi |
 
 ## Message Queue
 

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -39,4 +39,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, themes, and context files" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
+	{ name: "exit", description: `Quit ${APP_NAME} (alias of /quit)` },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3238,7 +3238,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/quit") {
+			if (text === "/quit" || text === "/exit") {
 				this.editor.setText("");
 				await this.shutdown();
 				return;

--- a/packages/coding-agent/test/interactive-mode-exit-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-exit-command.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { APP_NAME } from "../src/config.ts";
+import { BUILTIN_SLASH_COMMANDS } from "../src/core/slash-commands.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+vi.mock("../src/utils/version-check.ts", () => ({
+	checkForNewPiVersion: vi.fn(async () => undefined),
+	getReleaseChangelogUrl: vi.fn((version: string) => `https://example.invalid/releases/${version}`),
+}));
+
+type SubmitContext = {
+	defaultEditor: { onSubmit?: (text: string) => void | Promise<void> };
+	editor: {
+		addToHistory?: (text: string) => void;
+		setText: (text: string) => void;
+	};
+	session: {
+		isCompacting: boolean;
+		isStreaming: boolean;
+		isBashRunning: boolean;
+		prompt: (text: string, options?: unknown) => Promise<void>;
+	};
+	flushPendingBashComponents: () => void;
+	isExtensionCommand: (text: string) => boolean;
+	onInputCallback?: (text: string) => void;
+	pendingUserInputs: string[];
+	shutdown: () => Promise<void>;
+};
+
+type InteractiveModePrivate = {
+	setupEditorSubmitHandler(this: SubmitContext): void;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
+
+function createSubmitContext(): SubmitContext {
+	return {
+		defaultEditor: {},
+		editor: {
+			addToHistory: vi.fn(),
+			setText: vi.fn(),
+		},
+		session: {
+			isCompacting: false,
+			isStreaming: false,
+			isBashRunning: false,
+			prompt: vi.fn(async () => {}),
+		},
+		flushPendingBashComponents: vi.fn(),
+		isExtensionCommand: vi.fn(() => false),
+		pendingUserInputs: [],
+		shutdown: vi.fn(async () => {}),
+	};
+}
+
+describe("BUILTIN_SLASH_COMMANDS exit alias", () => {
+	it("registers an 'exit' builtin next to 'quit'", () => {
+		const names = BUILTIN_SLASH_COMMANDS.map((command) => command.name);
+		expect(names).toContain("exit");
+		expect(names).toContain("quit");
+	});
+
+	it("describes 'exit' as an alias of /quit referencing the app name", () => {
+		const exitCommand = BUILTIN_SLASH_COMMANDS.find((command) => command.name === "exit");
+		expect(exitCommand).toBeDefined();
+		expect(exitCommand?.description).toContain(APP_NAME);
+		expect(exitCommand?.description.toLowerCase()).toContain("alias");
+		expect(exitCommand?.description).toContain("/quit");
+	});
+});
+
+describe("InteractiveMode /exit routing", () => {
+	it("routes /exit to shutdown like /quit and clears the editor", async () => {
+		const context = createSubmitContext();
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+
+		await context.defaultEditor.onSubmit?.("/exit");
+
+		expect(context.shutdown).toHaveBeenCalledTimes(1);
+		expect(context.editor.setText).toHaveBeenCalledWith("");
+		expect(context.pendingUserInputs).toEqual([]);
+		expect(context.session.prompt).not.toHaveBeenCalled();
+	});
+
+	it("still routes /quit to shutdown", async () => {
+		const context = createSubmitContext();
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+
+		await context.defaultEditor.onSubmit?.("/quit");
+
+		expect(context.shutdown).toHaveBeenCalledTimes(1);
+		expect(context.editor.setText).toHaveBeenCalledWith("");
+	});
+
+	it("does not treat /exit-suffixed text as the exit command", async () => {
+		const context = createSubmitContext();
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+
+		await context.defaultEditor.onSubmit?.("/exit-status");
+
+		expect(context.shutdown).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Adds `/exit` as an exact equivalent of `/quit` in the interactive CLI. `/exit` clears the editor and routes to the same `shutdown()` path as `/quit`, so the two commands are interchangeable. The new command is registered as a builtin slash command (so it appears in `/` autocomplete and is conflict-checked against extension commands) and documented alongside `/quit`.

Changes (smallest correct change; erasable TS, no `any`, no new imports):
- `packages/coding-agent/src/core/slash-commands.ts` — add `{ name: "exit", description: \`Quit ${APP_NAME} (alias of /quit)\` }` next to `quit` in `BUILTIN_SLASH_COMMANDS`.
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` — the existing `/quit` branch now accepts `/exit` too: `if (text === "/quit" || text === "/exit")`.
- `packages/coding-agent/docs/usage.md` and `packages/coding-agent/README.md` — document `/exit` next to `/quit` in the slash-command tables.

No keybindings were touched.

## TDD: RED → GREEN

New test: `packages/coding-agent/test/interactive-mode-exit-command.test.ts` (faux-provider-free; uses the `setupEditorSubmitHandler` prototype seam already used by `interactive-mode-startup-input.test.ts`, plus a direct `BUILTIN_SLASH_COMMANDS` assertion).

**RED** (before implementation) — `npx vitest --run test/interactive-mode-exit-command.test.ts`:
```
Test Files  1 failed (1)
Tests       3 failed | 2 passed (5)
```
Failing as expected:
- `BUILTIN_SLASH_COMMANDS exit alias > registers an 'exit' builtin next to 'quit'` — `expected [...] to include 'exit'`
- `BUILTIN_SLASH_COMMANDS exit alias > describes 'exit' as an alias of /quit referencing the app name` — `expected undefined to be defined`
- `InteractiveMode /exit routing > routes /exit to shutdown like /quit and clears the editor` — `expected "vi.fn()" to be called 1 times, but got 0 times`

**GREEN** (after implementation):
```
Test Files  1 passed (1)
Tests       5 passed (5)
```
Covers: `exit` is registered next to `quit`; its description references `APP_NAME`, the word "alias", and `/quit`; `/exit` routes to `shutdown()` and clears the editor; `/quit` still routes to `shutdown()`; `/exit-status` is NOT treated as the exit command.

## Test + check results

- `npm run check` (root): green (exit 0). Includes `biome check`, pinned-deps, ts-imports, shrinkwrap, install-lock, `tsgo --noEmit`, browser-smoke, web-ui check, and `check:neo` (go build+vet+test).
- Scoped test run (`npx vitest --run` from `packages/coding-agent`): **4773 passed, 6 failed, 31 skipped**. The 6 failures are pre-existing environmental flakes, not caused by this change:
  - 5 of them (`footer-data-provider` x2, `omo-local-update`, `app-server-daemon`, `app-server-stdio`) fail identically on a fresh worktree at the base commit `eec85d0af` (built the same way), confirmed by direct comparison.
  - The 6th (`model-runtime-text-toolcall-recovery > does not import the AI compat entrypoint`) passes in isolation on this branch (8/8) and on base; the full-suite failure is test-ordering flakiness. This change adds no imports, so it cannot affect the static import graph that test checks.
  - Full comparison details in `06-preexisting-failures-note.md` (see evidence listing below).
- Adjacent interactive-mode tests (`interactive-mode-exit-command`, `startup-input`, `clone-command`, `import-command`, `status`): 55/55 passed.

## Real CLI QA (Channel 2 — TUI smoke, tmux)

Booted the real CLI from source via `tsx` in an isolated sandbox (`SENPI_CODING_AGENT_DIR`/`SENPI_CODING_AGENT_SESSION_DIR` pointed at a temp dir, `PI_OFFLINE=1`), drove the TUI through tmux, and asserted clean process exit. Real `~/.senpi/agent/auth.json` sha256 asserted unchanged before/after.

```
[PASS] /exit: TUI boots and renders — 13 non-empty lines
[PASS] /exit: command reaches composer
[PASS] /exit: process exits cleanly after Enter — session ended
[PASS] /quit: TUI boots and renders — 4 non-empty lines
[PASS] /quit: command reaches composer
[PASS] /quit: process exits cleanly after Enter — session ended
[PASS] real auth.json unchanged

exit-alias TUI smoke (tmux): 7/7 passed
```

The `/exit` typed capture also shows autocomplete firing with the new entry: `→ exit   Quit senpi (alias of /quit)`, confirming the builtin is surfaced in `/` completion. The post-Enter captures are empty because the process exited and the pane is gone (the clean-exit proof).

## QA evidence (paths only, gitignored under `local-ignore/`)

- `local-ignore/qa-evidence/20260726-exit-alias/01-red-test-output.txt`
- `local-ignore/qa-evidence/20260726-exit-alias/02-green-test-output.txt`
- `local-ignore/qa-evidence/20260726-exit-alias/03-npm-check-output.txt`
- `local-ignore/qa-evidence/20260726-exit-alias/04-scoped-test-output.txt` (pre-build run; many failures due to unbuilt workspace `dist`)
- `local-ignore/qa-evidence/20260726-exit-alias/05-scoped-test-output-built.txt` (post-build run; 4773 passed, 6 pre-existing flakes)
- `local-ignore/qa-evidence/20260726-exit-alias/06-preexisting-failures-note.md` (base-commit comparison)
- `local-ignore/qa-evidence/20260726-exit-alias/07-tui-smoke-output.txt`
- `local-ignore/qa-evidence/20260726-exit-alias/run-exit-qa.mjs` (reproducible QA driver)
- `local-ignore/qa-evidence/20260726-exit-alias/tui-exit-typed.txt`, `tui-exit-after-enter.txt`, `tui-quit-typed.txt`, `tui-quit-after-enter.txt` (pane captures)

— Juno (implementation agent, senpi crew)

Review by Cassiel (lead reviewer) requested.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/exit` as a full alias of `/quit` in interactive mode. Both clear the editor and trigger shutdown, and `/exit` now appears in slash-command autocomplete and docs.

- **New Features**
  - Registered `exit` in `BUILTIN_SLASH_COMMANDS` with description “Quit `APP_NAME` (alias of /quit)”.
  - Routed `/exit` through the same shutdown path as `/quit` in `InteractiveMode`.
  - Updated docs to list `/quit`, `/exit` together in command tables.

<sup>Written for commit 885dda45b221bec998ff04c19af8e12600c3ddf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

