### PR TITLE
fix(coding-agent): stop stale extension ctx error spray after session replacement

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -709,6 +709,10 @@ export class ExtensionRunner {
 		}
 	}
 
+	get isActive(): boolean {
+		return this.staleMessage === undefined;
+	}
+
 	private assertActive(): void {
 		if (this.staleMessage) {
 			throw new Error(this.staleMessage);

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -368,7 +368,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						options?.sessionId,
 						requestHeaders,
 					);
-					return headerRunner?.hasHandlers("before_provider_headers")
+					return headerRunner?.isActive && headerRunner.hasHandlers("before_provider_headers")
 						? headerRunner.emitBeforeProviderHeaders(headers ?? {})
 						: (headers ?? {});
 				},
@@ -376,14 +376,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		},
 		onPayload: async (payload, _model, request) => {
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("before_provider_request")) {
+			if (!runner?.isActive || !runner.hasHandlers("before_provider_request")) {
 				return payload;
 			}
 			return runner.emitBeforeProviderRequest(payload, undefined, request);
 		},
 		onResponse: async (response, _model) => {
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("after_provider_response")) {
+			if (!runner?.isActive || !runner.hasHandlers("after_provider_response")) {
 				return;
 			}
 			await runner.emit({
@@ -395,7 +395,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		sessionId: sessionManager.getSessionId(),
 		transformContext: async (messages) => {
 			const runner = extensionRunnerRef.current;
-			if (!runner) return messages;
+			if (!runner?.isActive) return messages;
 			return runner.emitContext(messages);
 		},
 		steeringMode: settingsManager.getSteeringMode(),

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -85,6 +85,7 @@ export interface HarnessOptions {
 }
 
 export interface Harness {
+	agent: Agent;
 	session: AgentSession;
 	sessionManager: SessionManager;
 	settingsManager: SettingsManager;
@@ -173,14 +174,14 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		onPayload: async (payload) => {
 			options.onPayload?.(payload);
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("before_provider_request")) {
+			if (!runner?.isActive || !runner.hasHandlers("before_provider_request")) {
 				return payload;
 			}
 			return runner.emitBeforeProviderRequest(payload);
 		},
 		onResponse: async (response) => {
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("after_provider_response")) {
+			if (!runner?.isActive || !runner.hasHandlers("after_provider_response")) {
 				return;
 			}
 			await runner.emit({
@@ -191,7 +192,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		},
 		transformContext: async (messages: AgentMessage[]) => {
 			const runner = extensionRunnerRef.current;
-			if (!runner) return messages;
+			if (!runner?.isActive) return messages;
 			return runner.emitContext(messages);
 		},
 		prepareNextTurnWithContext: options.prepareNextTurnWithContext,
@@ -230,6 +231,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	});
 
 	return {
+		agent,
 		session,
 		sessionManager,
 		settingsManager,

--- a/packages/coding-agent/test/suite/regressions/stale-extension-context-after-session-replacement.test.ts
+++ b/packages/coding-agent/test/suite/regressions/stale-extension-context-after-session-replacement.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
+import { createHarness } from "../harness.ts";
+
+const STALE_EXTENSION_CONTEXT_ERROR_PREFIX = "This extension ctx is stale after session replacement or reload.";
+
+describe("stale extension contexts after session replacement", () => {
+	it("passes a provider payload through without spraying extension errors while preserving direct stale-context diagnostics", async () => {
+		let capturedContext: ExtensionContext | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_provider_request", (event, ctx) => {
+						capturedContext ??= ctx;
+						void ctx.cwd;
+						return { ...(event.payload as object), handled: true };
+					});
+				},
+			],
+		});
+
+		try {
+			const onPayload = harness.agent.onPayload;
+			if (!onPayload) throw new Error("Expected the agent provider payload hook");
+
+			const activePayload = { phase: "active" };
+			await expect(onPayload(activePayload, harness.getModel())).resolves.toEqual({
+				phase: "active",
+				handled: true,
+			});
+			const activeContext = capturedContext;
+			if (!activeContext) throw new Error("Expected an extension context from the active provider request");
+
+			const errors: string[] = [];
+			harness.getExtensionRunner().onError((error) => {
+				errors.push(error.error);
+			});
+			harness.session.dispose();
+
+			const stalePayload = { phase: "stale" };
+			await expect(onPayload(stalePayload, harness.getModel())).resolves.toBe(stalePayload);
+			expect(errors).toEqual([]);
+			expect(() => activeContext.cwd).toThrow(STALE_EXTENSION_CONTEXT_ERROR_PREFIX);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Root cause

`AgentSession.dispose()` invalidates the old `ExtensionRunner`, but the provider request path can still reach its core callbacks while cancellation settles: `Agent` -> `sdk.ts` `onPayload` -> `modelRuntime.streamSimple()` -> provider `retryProviderRequest()` -> provider `createRequest()`. Before this fix, each callback checked only `hasHandlers()` and invoked stale handlers. Their newly-created contexts then correctly failed `assertActive()`, and `ExtensionRunner` reported that intentional diagnostic once per affected builtin handler, producing the visible error spray.

The abort wiring itself is intact and was not changed. `Agent.abort()` aborts the active run; agent-core forwards that to the request-local signal; `sdk.ts` forwards it to model runtime; and `retryProviderRequest()` receives that signal. Assistant-title generation and compaction/branch-summary requests each also pass their own disposal-aborted controller through the same stream function. Cancellation cannot retroactively prevent an already-entered provider callback, so the core callback boundary must be safe after runner invalidation.

## Fix

- Added the read-only `ExtensionRunner.isActive` state accessor.
- Made SDK-owned provider headers, payload, response, and context hooks short-circuit on an inactive runner. Payload and context retain their original values; no stale extension handler runs and no per-extension error is emitted.
- Kept `assertActive()` unchanged, including its exact message, so genuine use of a captured stale extension context remains a diagnostic.
- Added a deterministic faux-provider regression proving stale `before_provider_request` emission is a no-op while direct access to a context captured before disposal still throws the intended stale-context error.

## RED -> GREEN

Command:

```text
npx vitest --run test/suite/regressions/stale-extension-context-after-session-replacement.test.ts
```

RED (before the guard):

```text
FAIL stale-extension-context-after-session-replacement.test.ts
AssertionError: expected [ Array(1) ] to deeply equal []
+ [
+   "This extension ctx is stale after session replacement or reload. ..."
+ ]
Test Files  1 failed (1)
Tests       1 failed (1)
```

GREEN (after the guard):

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

## Verification

- `npm run build` - passed.
- `npx vitest --run test/suite/regressions` - 64 files / 187 tests passed.
- `npm run check` - passed.
- Full `packages/coding-agent` `npm test` was also run after the workspace build: 4,769 tests passed; 6 unrelated timing-sensitive failures remained in footer reftable watching, model-runtime import probing, resource-loader reload, and app-server process tests. The focused regression and its containing regression suite are green.

## QA evidence

Mock-loop QA used an isolated local fake OpenAI-compatible provider, waited for an in-flight reasoning delta, issued RPC `new_session`, verified a different session ID, and verified real auth was unchanged.

- `local-ignore/qa-evidence/20260726-stale-ext-ctx/mock-loop-session-replacement.json`

This PR will be reviewed by Cassiel (lead reviewer).

— Vega (implementation agent, senpi crew)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop stale extension context error spam after session replacement by short‑circuiting extension hooks when the runner is inactive. Keeps cancellation clean and only surfaces the intended stale-context error when a previously captured context is accessed.

- **Bug Fixes**
  - Added `ExtensionRunner.isActive` to check runner state.
  - Guarded `before_provider_headers`, `before_provider_request`, `after_provider_response`, and `transformContext` to no-op when inactive.
  - Payload/headers/context pass through unchanged on inactive runner; no per-extension errors emitted.
  - Kept `assertActive()` and its message unchanged to preserve the diagnostic for truly stale contexts.

- **Tests**
  - Added regression: no error spray after session disposal; direct access to a captured stale context still throws.
  - Test harness exposes `agent` and uses the new inactivity guards.

<sup>Written for commit d6495e93f74d7cc31f4f1a80a6e7ab6f78dbf7a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

