### PR TITLE
feat(app-server): project extension-origin injected messages as tracked turns

### DIFF
--- a/packages/coding-agent/src/modes/app-server/runtime.ts
+++ b/packages/coding-agent/src/modes/app-server/runtime.ts
@@ -102,6 +102,7 @@ export function createAppServerRuntime(requestShutdown: (reason: string) => void
 		turnLog,
 		notifications,
 		deferUntilResponded: (connectionId, action) => core.deferUntilResponded(connectionId, action),
+		observeThread: (threadId) => turns.observeThread(threadId),
 		idleUnloadMinutes: 30,
 		replayPendingApprovals: (threadId) => {
 			approvals.replayPendingForThread(threadId);

--- a/packages/coding-agent/src/modes/app-server/threads/handlers.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/handlers.ts
@@ -32,6 +32,7 @@ export interface ThreadLifecycleHandlersOptions {
 	readonly idleUnloadMinutes?: number;
 	readonly replayPendingApprovals?: (threadId: string, connectionId: string) => void;
 	readonly deferUntilResponded?: (connectionId: string, action: () => Promise<void> | void) => boolean;
+	readonly observeThread?: (threadId: string) => void;
 }
 
 type RuntimeThreadResponse = ThreadStartResponse | ThreadResumeResponse | ThreadForkResponse;
@@ -87,6 +88,7 @@ class ThreadLifecycleHandlers {
 		| ((connectionId: string, action: () => Promise<void> | void) => boolean)
 		| undefined;
 	private readonly archiveState: ThreadArchiveState;
+	private readonly observeThread: ((threadId: string) => void) | undefined;
 	private readonly searchCache = new ThreadSearchCache();
 	private readonly idleUnloadMs: number;
 	private readonly idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -98,6 +100,7 @@ class ThreadLifecycleHandlers {
 		this.replayPendingApprovals = options.replayPendingApprovals;
 		this.deferUntilResponded = options.deferUntilResponded;
 		this.archiveState = archiveState;
+		this.observeThread = options.observeThread;
 		this.idleUnloadMs = Math.max(0, options.idleUnloadMinutes ?? DEFAULT_IDLE_UNLOAD_MINUTES) * 60 * 1000;
 	}
 
@@ -448,6 +451,7 @@ class ThreadLifecycleHandlers {
 
 	private attachThread(entry: ThreadEntry): void {
 		this.notifications.addThread(entry);
+		this.observeThread?.(entry.id);
 		this.clearIdleTimer(entry.id);
 	}
 

--- a/packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts
@@ -58,6 +58,7 @@ export interface TurnEngineOptions<Entry extends TurnEngineThreadEntry = TurnEng
 }
 
 export type TurnEngineApi = {
+	readonly observeThread: (threadId: ThreadId) => void;
 	readonly startTurn: (
 		params: TurnStartParams,
 		deferNotifications?: TurnNotificationDeferral,

--- a/packages/coding-agent/src/modes/app-server/threads/turns.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/turns.ts
@@ -1,3 +1,4 @@
+import type { UserMessage } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "../../../core/agent-session.ts";
 import type {
 	JsonValue,
@@ -8,6 +9,7 @@ import type {
 	TurnStartResponse,
 	TurnSteerParams,
 	TurnSteerResponse,
+	UserInput,
 } from "../protocol/index.ts";
 import { EventProjector } from "./projection.ts";
 import type { ProjectedNotification } from "./projection-types.ts";
@@ -71,6 +73,10 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 		this.broadcast = options.broadcast;
 	}
 
+	observeThread(threadId: ThreadId): void {
+		this.ensureSessionSubscription(threadId, this.getLoadedThreadOrThrow(threadId));
+	}
+
 	startTurn(params: TurnStartParams, deferNotifications?: TurnNotificationDeferral): Promise<TurnStartResponse> {
 		this.getLoadedThreadOrThrow(params.threadId);
 
@@ -80,7 +86,7 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 				try {
 					const parsedInput = parseInput(params.input);
 					const entry = this.getLoadedThreadOrThrow(params.threadId);
-					this.ensureSessionSubscription(params.threadId, entry);
+					this.observeThread(params.threadId);
 					const turnId = createTurnId();
 					const startedAtMs = Date.now();
 					const startedAt = new Date(startedAtMs).toISOString();
@@ -297,9 +303,10 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 		} catch {
 			return;
 		}
-		const activeTurn = entry.activeTurn;
+		let activeTurn = entry.activeTurn;
 		if (!activeTurn) {
-			return;
+			activeTurn = this.startExtensionTurn(threadId, entry, event);
+			if (!activeTurn) return;
 		}
 		let state = this.projectorByThreadId.get(threadId);
 		if (!state || state.turnId !== activeTurn.turnId) {
@@ -325,6 +332,43 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 		}
 	}
 
+	private startExtensionTurn(
+		threadId: ThreadId,
+		entry: Entry,
+		event: TurnEngineSessionEvent,
+	): { readonly turnId: string; readonly startedAt: string } | null {
+		const sessionEvent = event as AgentSessionEvent;
+		if (sessionEvent.type !== "message_start" || sessionEvent.message.role !== "user") {
+			return null;
+		}
+
+		const turnId = createTurnId();
+		const startedAtMs = Date.now();
+		const startedAt = new Date(startedAtMs).toISOString();
+		const turn = buildTurn(turnId, "inProgress", startedAtMs, null, []);
+		const userMessage = buildExtensionUserMessage(sessionEvent.message);
+		entry.activeTurn = { turnId, startedAt };
+		entry.status = "active";
+		entry.updatedAt = startedAt;
+		this.turnLog.recordTurn(threadId, { turnId, startedAt, status: "running" });
+		this.pendingByThreadId.set(threadId, {
+			turnId,
+			startedAt,
+			startedAtMs,
+			resolve: () => {},
+			interrupted: false,
+			completed: false,
+			deferTerminalNotifications: undefined,
+		});
+		this.broadcast({
+			method: "thread/status/changed",
+			params: { threadId, status: { type: "active", activeFlags: [] } },
+		});
+		this.emitToThread(threadId, { method: "turn/started", params: { threadId, turn } });
+		this.emitUserMessage(threadId, turnId, startedAtMs, userMessage);
+		return entry.activeTurn;
+	}
+
 	private finalizeProjection(threadId: ThreadId): void {
 		const state = this.projectorByThreadId.get(threadId);
 		if (!state) {
@@ -347,4 +391,16 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 			throw invalidRequest(`Thread not found: ${threadId}`);
 		}
 	}
+}
+
+function buildExtensionUserMessage(message: UserMessage): WireItem {
+	const content: UserInput[] =
+		typeof message.content === "string"
+			? [{ type: "text", text: message.content, text_elements: [] }]
+			: message.content.map((part) =>
+					part.type === "text"
+						? { type: "text", text: part.text, text_elements: [] }
+						: { type: "image", url: `data:${part.mimeType};base64,${part.data}` },
+				);
+	return buildUserMessage(null, content);
 }

--- a/packages/coding-agent/test/suite/app-server-turns.test.ts
+++ b/packages/coding-agent/test/suite/app-server-turns.test.ts
@@ -331,6 +331,41 @@ describe("app-server turn engine", () => {
 		expect(turn.items[1]?.text).toBe("mock answer");
 	});
 
+	it("projects an extension-origin user message as a tracked turn without a client-initiated turn", async () => {
+		// Given: an idle app-server thread subscribed before any client-initiated turn.
+		const { engine, store, notifications, turnLog } = createHarness();
+		const entry = store.add("thread-a");
+		engine.observeThread("thread-a");
+
+		// When: an extension injects a user message while no client turn is active.
+		entry.session.emit({
+			type: "message_start",
+			message: { role: "user", content: [{ type: "text", text: "extension wakeup" }] },
+		} as { type: string });
+		entry.session.emitAgentEnd();
+		await entry.taskQueue;
+
+		// Then: the injected message has a complete, independently tracked app-server turn.
+		expect(notifications.map((notification) => notification.method)).toEqual([
+			"thread/status/changed",
+			"turn/started",
+			"item/started",
+			"item/completed",
+			"thread/status/changed",
+			"turn/completed",
+		]);
+		const started = notifications.find((notification) => notification.method === "turn/started");
+		const completed = notifications.find((notification) => notification.method === "turn/completed");
+		expect(started?.params).toMatchObject({ threadId: "thread-a", turn: { status: "inProgress" } });
+		expect(completed?.params).toMatchObject({
+			threadId: "thread-a",
+			turn: { id: (started?.params as { turn: { id: string } }).turn.id, status: "completed" },
+		});
+		expect(turnLog.readTurns("thread-a")[0]?.items).toMatchObject([
+			{ type: "userMessage", clientId: null, content: [{ type: "text", text: "extension wakeup" }] },
+		]);
+	});
+
 	it("closes dangling tool items before turn/completed when execution never finished", async () => {
 		// Given: a turn whose assistant message requested a tool that never executed.
 		const { engine, store, notifications } = createHarness();

--- a/packages/coding-agent/test/suite/terminal-settings-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-settings-notify.test.ts
@@ -91,11 +91,20 @@ describe("terminal notifier guards", () => {
 		expect(sink[0]?.options).toEqual({ deliverAs: "followUp" });
 	});
 
-	it("never wakes in one-shot print/json runs", () => {
-		const sink: CapturedNotification[] = [];
-		makeNotifier({ sink, ctxMode: "print" }).notifyCompletion("bash_1", exitedRuntime);
-		makeNotifier({ sink, ctxMode: "json" }).notifyCompletion("bash_2", exitedRuntime);
-		expect(sink).toHaveLength(0);
+	it("surfaces extension injections only in interactive modes", () => {
+		const modeMatrix = [
+			{ mode: "tui", surfaces: true },
+			{ mode: "rpc", surfaces: true },
+			{ mode: "app-server", surfaces: true },
+			{ mode: "print", surfaces: false },
+			{ mode: "json", surfaces: false },
+		] as const;
+
+		for (const { mode, surfaces } of modeMatrix) {
+			const sink: CapturedNotification[] = [];
+			makeNotifier({ sink, ctxMode: mode }).notifyCompletion(`bash_${mode}`, exitedRuntime);
+			expect(sink, mode).toHaveLength(surfaces ? 1 : 0);
+		}
 	});
 
 	it("suppresses when notify is off or no model is active", () => {


### PR DESCRIPTION
## Summary

Implements TODO 20 of `.omo/plans/eval-exec-merge-and-injection-wakeup.md`.

Extension-origin `sendUserMessage()` events now create their own app-server tracked lifecycle when a thread is idle: `turn/started`, a projected user-message item, and `turn/completed`. Thread lifecycle attachment subscribes the projection before a client turn begins, so an idle notification is visible to app-server clients. The existing non-interactive notification contract is unchanged: `print` and `json` remain suppressed.

## Why

TODO 20 is the predecessor for the plan's blocking-wait removals. Without an extension-origin tracked turn, app-server clients lose visibility of injected completion notifications once waits are removed.

## Verification

- RED TDD evidence: `local-ignore/qa-evidence/20260726-eval-exec-merge/s0/red-app-server-injected-turns.txt`
- GREEN focused tests (16 passing): `local-ignore/qa-evidence/20260726-eval-exec-merge/s0/scoped-final-tests.txt`
- Root static gate: `local-ignore/qa-evidence/20260726-eval-exec-merge/s0/npm-run-check.txt`
- Sandboxed senpi-qa receipts: `local-ignore/qa-evidence/20260726-eval-exec-merge/s0/{harness-self-check,rpc-self-test,mock-loop-self-test,cli-smoke-self-test}.txt`
- App-server real-client QA: `local-ignore/qa-evidence/20260726-eval-exec-merge/s0/app-server-real-client-qa.txt`

The mode-matrix test covers tui/rpc/app-server delivery and print/json suppression; the app-server regression asserts a notification with no client-initiated turn emits the complete tracked lifecycle.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
App server now creates a full tracked turn when an extension injects a `sendUserMessage()` into an idle thread, projecting the user message and broadcasting the complete lifecycle. Interactive modes surface these notifications; `print` and `json` remain suppressed.

- New Features
  - Subscribes thread projection on attach so idle injections are visible to app-server clients.
  - Starts an extension-origin turn on idle user message: emits thread status active, `turn/started`, projected user-message item, and `turn/completed`, and records in the turn log.
  - Applies only to interactive modes (`tui`, `rpc`, `app-server`); non-interactive modes (`print`, `json`) stay quiet.

<sup>Written for commit d22067816b2b6470e8a5dcd53142817a367f52b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

