### PR TITLE
feat(terminal): include exit code and output tail in background completion notifications

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,29 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Payload-rich background completion notifications (2026-07-26)
+
+### What changed
+
+- `notify.ts` `buildNotice()`: the background-session completion notice now embeds the exit
+  status (unchanged) AND the final output tail (sanitized via `sanitizeTerminalOutput`,
+  tail-capped at `NOTICE_TAIL_MAX_CHARS` = 2000 chars, with a truncation note that the full
+  history is still peekable) INSTEAD of the old `Use bash_output({ bash_id: "..." }) to read
+  its output` instruction. Notify modes (`wake`/`next-turn`/`off`) and all guards
+  (non-interactive `print`/`json` suppression, no auth-less turn spin, once per session id)
+  are unchanged. `bash_output` itself is untouched.
+
+### Why
+
+Real session evidence: session `019f79b8-3bec` received the old reminder, dutifully called
+`bash_output`, and got `(no new output)` — a wasted round per background completion. The
+notification is authoritative; receiving it must make a follow-up read unnecessary
+(plan: `.omo/plans/eval-exec-merge-and-injection-wakeup.md`, todo 1 / lane S1).
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `notify.ts` `buildNotice()` body (single function; guards untouched).
+
 ## Model-facing output is sanitized and bounded (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "../../types.ts";
+import { sanitizeTerminalOutput } from "./output-format.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
 import type { NotifyMode } from "./settings.ts";
 import { describeExit } from "./tools/spawn.ts";
@@ -13,11 +14,24 @@ export interface TerminalNotifierDeps {
 	readonly getMode: () => NotifyMode;
 }
 
+/** Max chars of sanitized final output embedded in a completion notification. */
+export const NOTICE_TAIL_MAX_CHARS = 2000;
+
 function buildNotice(id: string, runtime: TerminalRuntimeSession): string {
 	const status = describeExit(runtime) ?? "exited";
 	const code = runtime.exitResult?.exitCode;
 	const codeText = code === null || code === undefined ? "" : ` (exit code ${code})`;
-	return `<system-reminder>Background terminal session ${id} finished: ${status}${codeText}. Use bash_output({ bash_id: "${id}" }) to read its output.</system-reminder>`;
+	const tail = sanitizeTerminalOutput(runtime.fullOutput()).trimEnd();
+	let tailSection = "";
+	if (tail.length > 0) {
+		const truncated = tail.length > NOTICE_TAIL_MAX_CHARS;
+		const shown = truncated ? tail.slice(tail.length - NOTICE_TAIL_MAX_CHARS) : tail;
+		const note = truncated
+			? `\n[Final output truncated to the last ${NOTICE_TAIL_MAX_CHARS} chars; the full history is still peekable.]`
+			: "";
+		tailSection = `\nFinal output:\n${shown}${note}`;
+	}
+	return `<system-reminder>Background terminal session ${id} finished: ${status}${codeText}.${tailSection}</system-reminder>`;
 }
 
 /**

--- a/packages/coding-agent/test/suite/terminal-settings-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-settings-notify.test.ts
@@ -9,6 +9,7 @@ import {
 const exitedRuntime = {
 	exited: true,
 	exitResult: { exitCode: 0, timedOut: false, cancelled: false, signal: null, backend: "native" },
+	fullOutput: () => "done\n",
 } as unknown as TerminalRuntimeSession;
 
 type CapturedNotification = {
@@ -57,6 +58,49 @@ describe("terminal settings resolver", () => {
 		expect(resolved.maxSessions).toBe(32); // 0 is invalid → default
 		expect(resolved.notify).toBe("off");
 		expect(resolved.timeoutAction).toBe("background"); // invalid → default
+	});
+});
+
+describe("terminal notifier completion payload", () => {
+	const exitedWithOutput = (output: string, exitCode = 0) =>
+		({
+			exited: true,
+			exitResult: { exitCode, timedOut: false, cancelled: false, signal: null, backend: "native" },
+			fullOutput: () => output,
+		}) as unknown as TerminalRuntimeSession;
+
+	it("embeds the exit code and final output tail instead of a bash_output instruction", () => {
+		// Given: a finished background session that produced output.
+		const sink: CapturedNotification[] = [];
+		const notifier = makeNotifier({ sink, mode: "wake" });
+
+		// When: the completion notification fires.
+		notifier.notifyCompletion("bash_1", exitedWithOutput("A\nB\nLAST\n", 3));
+
+		// Then: the notice carries the exit code and the output tail, and never tells the
+		// agent to burn a follow-up bash_output call.
+		expect(sink).toHaveLength(1);
+		const content = sink[0]?.content ?? "";
+		expect(content).toContain("exit code 3");
+		expect(content).toContain("LAST");
+		expect(content).not.toContain("Use bash_output");
+	});
+
+	it("caps an oversized tail and notes the full history is still peekable", () => {
+		// Given: a finished session whose retained output far exceeds the notice budget.
+		const sink: CapturedNotification[] = [];
+		const notifier = makeNotifier({ sink, mode: "wake" });
+		const huge = `${"filler\n".repeat(1000)}TAIL_END\n`;
+
+		// When: the completion notification fires.
+		notifier.notifyCompletion("bash_1", exitedWithOutput(huge, 0));
+
+		// Then: the tail is bounded with a truncation note pointing at the peekable history.
+		const content = sink[0]?.content ?? "";
+		expect(content).toContain("TAIL_END");
+		expect(content).toContain("truncat");
+		expect(content.length).toBeLessThan(4000);
+		expect(content).not.toContain("Use bash_output");
 	});
 });
 


### PR DESCRIPTION
## What

Background-terminal completion notifications are now authoritative. `buildNotice()` in `packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts` embeds the exit status (unchanged) **and** the sanitized final output tail (tail-capped at `NOTICE_TAIL_MAX_CHARS` = 2000 chars, with a truncation note that the full history is still peekable) **instead of** the old `Use bash_output({ bash_id: "..." }) to read its output` instruction.

Unchanged, per plan contract:

- Notify modes `wake` / `next-turn` / `off` and the delivery mapping (wake -> steer, next-turn -> followUp)
- All guards: no wake in one-shot `print`/`json` modes, no auth-less turn spin without an active model, at most one notification per session id
- `bash` tool semantics and `bash_output` itself (still available for peeks)

## Why

Plan: `.omo/plans/eval-exec-merge-and-injection-wakeup.md`, todo 1 / lane S1. Real session evidence (session `019f79b8-3bec`): the old reminder told the agent to call `bash_output`, which then returned `(no new output)` — a wasted round trip per background completion. Receiving the notification must make a follow-up read unnecessary.

Example notice now delivered (live QA transcript, failure scenario):

```
<system-reminder>Background terminal session bash_1 finished: exited_3 (exit code 3).
Final output:
ERR-TAIL-9f3a
out</system-reminder>
```

## Verification

- TDD: failing test captured RED before any production change (`embeds the exit code and final output tail instead of a bash_output instruction` + truncation-cap test), then GREEN after the one-function change.
- Scoped tests: `npx vitest run test/suite/terminal-settings-notify.test.ts` — 8/8 pass. Full `packages/coding-agent` suite: 4777 passed; the only failures are load-flaky suites that pass in isolation and are untouched by this diff (verified in isolation: codemode-bridge 4/4, app-server-daemon 4/4, and the remaining 5 files pass standalone).
- `npm run check` at repo root: exit 0.
- senpi-qa real-CLI QA (RPC channel + fake model server, sandboxed, zero real API calls; driver preserved at `local-ignore/qa-evidence/20260726-eval-exec-merge/s1/qa-driver.mjs`):
  - happy: `bash({command:"echo A; echo B; sleep 1; echo LAST", run_in_background:true})` -> injected notice contains `LAST` and `exit code 0`, zero `bash_output` calls in the transcript.
  - failure: stderr tail + `exit 3` -> notice contains the stderr tail and `exit code 3`.
  - 14/14 checks pass (`qa-run.txt`).

## Evidence

- `local-ignore/qa-evidence/20260726-eval-exec-merge/s1/` — `qa-run.txt`, `happy/failure-checks.json`, `happy/failure-requests.json` (recorded model requests carrying the injected notice), `qa-driver.mjs`, `scoped-tests-green.txt`, `npm-run-check-green.log`
- Fork-owned delta recorded in `packages/coding-agent/src/core/extensions/builtin/terminal/changes.md` (upstream-merge discipline).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Background terminal completion notices now include the exit code and the sanitized final output tail, replacing the old reminder to call `bash_output`. This makes the notice authoritative and avoids an extra round trip.

- **New Features**
  - `buildNotice()` now embeds exit status and the final output tail (sanitized via `sanitizeTerminalOutput`).
  - Tail capped at 2000 chars (`NOTICE_TAIL_MAX_CHARS`) with a note that full history is still peekable.
  - Notify modes (`wake`/`next-turn`/`off`), delivery mapping, and all guards remain unchanged.
  - `bash` tool semantics and `bash_output` are unchanged; peeks still supported.

<sup>Written for commit 56f61b191a7f8030b076b9d6920899848a3069dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

