### PR TITLE
feat(codemode): detach eval cells on timeout

### DIFF
--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -10,6 +10,10 @@ configuration, interpreter availability, and active task-tool names are known.
 
 - Persistent JavaScript, Python, Ruby, and Julia cells. State survives later
   cells in the same language until reset, restart, or session disposal.
+- Timeout detachment for interactive `eval`: long pure-compute cells return a
+  handle and continue in their existing kernel. Completion is injected with the
+  final value/error and buffered output; use `eval({ action: "peek"|"stop",
+  cell_id })` to inspect or terminate a detached cell.
 - Loopback, bearer-authenticated kernel bridge with bounded JSONL frames.
 - Structured status events for file operations, environment access, phases,
   bridge activity, and delegated task progress.
@@ -68,7 +72,7 @@ Configuration is loaded in this order:
 | Key | Default | Effect |
 | --- | --- | --- |
 | `languages` | `py`/`js` enabled; `rb`/`jl` disabled | Selects desired languages before interpreter detection. |
-| `cellTimeoutSeconds` | `30` | Idle timeout for one cell unless the call supplies `timeout`. |
+| `cellTimeoutSeconds` | `30` | Idle timeout for one cell unless the call supplies `timeout`; interactive calls detach by default and print/json calls error. |
 | `parallelPoolWidth` | `4` | Maximum concurrent `parallel()` thunks. |
 | `taskTools.task` | `"task"` | Registered tool name used by `agent()`. |
 | `taskTools.output` | `"task_output"` | Registered tool name used by `output()`. |
@@ -111,6 +115,22 @@ package. `agent()` delegates through the tool contract, so task-engine
 permissions, progress updates, and transcripts remain owned by that engine.
 `isolated`, `apply`, and `merge` are accepted for compatibility but emit a
 warning because this task-engine integration has no isolation model.
+
+## Detached cells
+
+`eval` accepts `on_timeout: "detach"|"error"`. The default is `"detach"` in
+interactive TUI, RPC, and app-server sessions; print and JSON one-shot runs
+default to `"error"` so their result is never silently detached. A detached
+cell keeps only its own language kernel busy. A new same-language call returns
+a busy error with its cell id and output tail; calls in other languages continue
+normally. Do not re-run the cell.
+
+Use `eval({ action: "peek", cell_id })` for its state and buffered output, or
+`eval({ action: "stop", cell_id })` to cancel it. Python stop interrupts the
+existing kernel and preserves variables. JavaScript stop kills and restarts its
+worker, so JavaScript VM state is lost. Detached completion messages state when
+kernel variables are available to the next eval cell; oversized buffered output
+is written under the session local root and referenced as `local://…`.
 
 ## Output and artifacts
 

--- a/packages/senpi-codemode/src/extension/eval-notifier.ts
+++ b/packages/senpi-codemode/src/extension/eval-notifier.ts
@@ -33,9 +33,8 @@ export class EvalNotifier implements EvalDetachedCellNotifier {
 		const pending = cells.filter((cell) => !this.#notified.has(cell.cellId));
 		if (pending.length === 0) return;
 		for (const cell of pending) this.#notified.add(cell.cellId);
-		this.#deps.sendUserMessage(
-			pending.map((cell) => cell.content).join("\n\n"),
-			{ deliverAs: mode === "wake" ? "steer" : "followUp" },
-		);
+		this.#deps.sendUserMessage(pending.map((cell) => cell.content).join("\n\n"), {
+			deliverAs: mode === "wake" ? "steer" : "followUp",
+		});
 	}
 }

--- a/packages/senpi-codemode/src/extension/eval-notifier.ts
+++ b/packages/senpi-codemode/src/extension/eval-notifier.ts
@@ -1,0 +1,41 @@
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { EvalDetachedCellNotification, EvalDetachedCellNotifier } from "../tool/detached-cell-manager.ts";
+
+const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
+
+export type EvalNotifyMode = "wake" | "next-turn" | "off";
+
+export interface EvalNotifierDeps {
+	readonly sendUserMessage: (content: string, options?: { deliverAs?: "steer" | "followUp" }) => void;
+	readonly getContext: () => ExtensionContext | undefined;
+	readonly getMode: () => EvalNotifyMode;
+}
+
+/** Session-scoped completion injector with the same no-spin guards as terminal notifications. */
+export class EvalNotifier implements EvalDetachedCellNotifier {
+	readonly #deps: EvalNotifierDeps;
+	readonly #notified = new Set<string>();
+
+	constructor(deps: EvalNotifierDeps) {
+		this.#deps = deps;
+	}
+
+	/** Starts a fresh session generation without suppressing reused tool-call ids. */
+	reset(): void {
+		this.#notified.clear();
+	}
+
+	notify(cells: readonly EvalDetachedCellNotification[]): void {
+		const mode = this.#deps.getMode();
+		if (mode === "off") return;
+		const ctx = this.#deps.getContext();
+		if (ctx === undefined || NON_INTERACTIVE_MODES.has(ctx.mode) || ctx.model === undefined) return;
+		const pending = cells.filter((cell) => !this.#notified.has(cell.cellId));
+		if (pending.length === 0) return;
+		for (const cell of pending) this.#notified.add(cell.cellId);
+		this.#deps.sendUserMessage(
+			pending.map((cell) => cell.content).join("\n\n"),
+			{ deliverAs: mode === "wake" ? "steer" : "followUp" },
+		);
+	}
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -5,6 +5,7 @@ import { CodeModeSessionRuntime } from "./codemode/runtime.ts";
 import { type CodeModeTool, createCodeModeTools, isGptCodeModeModel } from "./codemode/tools.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
 import { defaultCodemodeSettings } from "./config/settings.ts";
+import { EvalNotifier } from "./extension/eval-notifier.ts";
 import {
 	createExecuteTool,
 	createRuntime,
@@ -12,7 +13,6 @@ import {
 	type SessionRuntime,
 } from "./extension/runtime-factory.ts";
 import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
-import { EvalNotifier } from "./extension/eval-notifier.ts";
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
 import { EvalDetachedCellManager } from "./tool/detached-cell-manager.ts";
 import { createEvalTool } from "./tool/eval-tool.ts";

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -12,7 +12,9 @@ import {
 	type SessionRuntime,
 } from "./extension/runtime-factory.ts";
 import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
+import { EvalNotifier } from "./extension/eval-notifier.ts";
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
+import { EvalDetachedCellManager } from "./tool/detached-cell-manager.ts";
 import { createEvalTool } from "./tool/eval-tool.ts";
 import { renderEvalCall, renderEvalResult } from "./tool/render.ts";
 
@@ -34,6 +36,7 @@ export interface CodemodeExtensionAPI {
 	getActiveTools(): string[];
 	setActiveTools?(toolNames: string[]): void | Promise<void>;
 	getAllTools?(): readonly { readonly name: string }[];
+	sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
 }
 
 export interface SenpiCodemodeOptions {
@@ -55,7 +58,18 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	const renderers = { renderCall: renderEvalCall, renderResult: renderEvalResult };
 	let activeRuntime: (SessionRuntime & { readonly codeMode?: CodeModeSessionRuntime }) | undefined;
 	let activeModelId: string | undefined;
-	const registerEvalForRuntime = (runtime: SessionRuntime, modelId: string | undefined): void => {
+	let activeContext: ExtensionContext | undefined;
+	let activeCells: EvalDetachedCellManager | undefined;
+	const notifier = new EvalNotifier({
+		sendUserMessage: (content, notifyOptions) => pi.sendUserMessage(content, notifyOptions),
+		getContext: () => activeContext,
+		getMode: () => "wake",
+	});
+	const registerEvalForRuntime = (
+		runtime: SessionRuntime,
+		modelId: string | undefined,
+		cellManager: EvalDetachedCellManager,
+	): void => {
 		pi.registerTool(
 			createEvalTool({
 				enabledLanguages: runtime.enabledLanguages,
@@ -65,6 +79,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				complete,
 				settings: runtime.settings,
 				artifactsDir: runtime.artifactsDir,
+				cellManager,
 				executionTracker: manager,
 				renderers,
 				spawns: runtime.spawns,
@@ -76,8 +91,12 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	};
 	const dropRuntime = async (): Promise<void> => {
 		const codeMode = activeRuntime?.codeMode;
+		const cells = activeCells;
 		activeRuntime = undefined;
 		activeModelId = undefined;
+		activeCells = undefined;
+		await cells?.dispose();
+		activeContext = undefined;
 		await Promise.all([manager.dispose(), codeMode?.dispose()]);
 	};
 	const activateCodeModeTools = async (runtime: CodeModeSessionRuntime): Promise<void> => {
@@ -99,6 +118,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			executeTool: createExecuteTool(pi),
 			complete,
 			settings: defaultCodemodeSettings,
+			cellManager: new EvalDetachedCellManager({ notifier }),
 			executionTracker: manager,
 			renderers,
 			hostLine: hostLine(),
@@ -107,11 +127,18 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 
 	pi.on("session_start", async (event, ctx) => {
 		const previousCodeMode = activeRuntime?.codeMode;
+		const previousCells = activeCells;
+		activeCells = undefined;
+		await previousCells?.dispose();
 		const generation = manager.beginReplacement();
 		const runtime = await createRuntime(pi, ctx, event, complete, options);
 		const replaced = await manager.replace(generation, runtime.manager);
 		if (!replaced) return;
 		await previousCodeMode?.dispose();
+		notifier.reset();
+		activeContext = ctx;
+		const cellManager = new EvalDetachedCellManager({ artifactsDir: runtime.artifactsDir, notifier });
+		activeCells = cellManager;
 		const codeMode = isGptCodeModeModel(ctx.model?.id)
 			? new CodeModeSessionRuntime({
 					sessionId: runtime.sessionId,
@@ -122,20 +149,23 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			: undefined;
 		activeRuntime = { ...runtime, ...(codeMode === undefined ? {} : { codeMode }) };
 		activeModelId = ctx.model?.id;
-		registerEvalForRuntime(activeRuntime, activeModelId);
+		registerEvalForRuntime(activeRuntime, activeModelId, cellManager);
 		if (codeMode) await activateCodeModeTools(codeMode);
 		else await deactivateCodeModeTools();
 	});
 	pi.on("session_shutdown", async () => dropRuntime());
 	pi.on("session_before_switch", async () => dropRuntime());
 	pi.on("session_before_fork", async () => dropRuntime());
-	pi.on("model_select", async (event) => {
+	pi.on("model_select", async (event, ctx) => {
+		activeContext = ctx;
 		const runtime = activeRuntime;
 		if (runtime === undefined) return;
 		const modelId = modelIdFrom(event);
 		if (modelId === undefined || modelId === activeModelId) return;
 		activeModelId = modelId;
-		registerEvalForRuntime(runtime, modelId);
+		const cellManager = activeCells;
+		if (cellManager === undefined) return;
+		registerEvalForRuntime(runtime, modelId, cellManager);
 		if (!isGptCodeModeModel(modelId)) {
 			const { codeMode, ...nextRuntime } = runtime;
 			await codeMode?.dispose();

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -112,7 +112,11 @@ Fields:
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long{{#if spawns}} non-agent{{/if}} tool calls.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
 
 {{#if py}}Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".{{/if}}
 {{#if js}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -136,7 +136,9 @@ export class EvalDetachedCellManager {
 
 	async dispose(): Promise<void> {
 		const detached = [...this.#detachedByLanguage.values()];
-		await Promise.allSettled(detached.map(async (cell) => await this.stop(cell.cellId, "Session ended; detached eval cell cancelled")));
+		await Promise.allSettled(
+			detached.map(async (cell) => await this.stop(cell.cellId, "Session ended; detached eval cell cancelled")),
+		);
 		await this.flushNotifications();
 	}
 
@@ -150,7 +152,8 @@ export class EvalDetachedCellManager {
 		cell.state = next;
 		if (next !== "running" && next !== "detached") cell.terminal.resolve(this.#snapshot(cell));
 		if (cell.wasDetached && next !== "detached") {
-			if (this.#detachedByLanguage.get(cell.input.language) === cell) this.#detachedByLanguage.delete(cell.input.language);
+			if (this.#detachedByLanguage.get(cell.input.language) === cell)
+				this.#detachedByLanguage.delete(cell.input.language);
 			this.#queueNotification(cell);
 		}
 		return true;
@@ -254,7 +257,10 @@ function errorResult(cell: ManagedCell, error: Error): AgentToolResult<EvalToolD
 function notificationBody(cell: EvalDetachedCellSnapshot): string {
 	const outcome = cell.state === "completed" ? "completed" : cell.state === "cancelled" ? "cancelled" : "failed";
 	const resultText =
-		cell.result?.content.filter((part) => part.type === "text").map((part) => part.text).join("\n") ?? cell.outputTail;
+		cell.result?.content
+			.filter((part) => part.type === "text")
+			.map((part) => part.text)
+			.join("\n") ?? cell.outputTail;
 	const stateNote =
 		cell.state === "cancelled" && cell.language === "js"
 			? "JavaScript worker was restarted; VM state was lost."
@@ -271,7 +277,10 @@ function notificationBody(cell: EvalDetachedCellSnapshot): string {
 function notificationPreview(cell: EvalDetachedCellSnapshot): string {
 	const outcome = cell.state === "completed" ? "completed" : cell.state === "cancelled" ? "cancelled" : "failed";
 	const resultText =
-		cell.result?.content.filter((part) => part.type === "text").map((part) => part.text).join("\n") ?? cell.outputTail;
+		cell.result?.content
+			.filter((part) => part.type === "text")
+			.map((part) => part.text)
+			.join("\n") ?? cell.outputTail;
 	const stateNote =
 		cell.state === "cancelled" && cell.language === "js"
 			? "JavaScript worker was restarted; VM state was lost."

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -1,0 +1,305 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import type { EvalKernel, EvalLanguage, EvalToolDetails, EvalToolInput } from "./types.ts";
+
+const NOTIFICATION_TAIL_BYTES = 512;
+
+export type EvalDetachedCellState = "running" | "detached" | "completed" | "failed" | "cancelled";
+
+type ManagedCell = {
+	readonly cellId: string;
+	readonly input: EvalToolInput;
+	readonly spillPath: string | undefined;
+	state: EvalDetachedCellState;
+	canDetach: boolean;
+	wasDetached: boolean;
+	kernel: EvalKernel | undefined;
+	outputTail: (() => string) | undefined;
+	result: AgentToolResult<EvalToolDetails> | undefined;
+	notificationQueued: boolean;
+	readonly terminal: PromiseWithResolvers<EvalDetachedCellSnapshot>;
+};
+
+export interface EvalDetachedCellSnapshot {
+	readonly cellId: string;
+	readonly language: EvalLanguage;
+	readonly state: EvalDetachedCellState;
+	readonly outputTail: string;
+	readonly result: AgentToolResult<EvalToolDetails> | undefined;
+}
+
+export interface EvalDetachedCellNotification {
+	readonly cellId: string;
+	readonly content: string;
+}
+
+export interface EvalDetachedCellNotifier {
+	notify(cells: readonly EvalDetachedCellNotification[]): void;
+}
+
+export interface EvalDetachedCellManagerOptions {
+	readonly artifactsDir?: string;
+	readonly notifier?: EvalDetachedCellNotifier;
+}
+
+/**
+ * Session-owned lifecycle owner for eval cells that outlive their tool call.
+ *
+ * All state changes are synchronous and funnel through #transition. That is the
+ * atomic boundary for timeout, kernel completion, explicit stop, and session
+ * disposal races; exactly one path can release a language's detached busy mark.
+ */
+export class EvalDetachedCellManager {
+	readonly #artifactsDir: string | undefined;
+	readonly #notifier: EvalDetachedCellNotifier | undefined;
+	readonly #cells = new Map<string, ManagedCell>();
+	readonly #detachedByLanguage = new Map<EvalLanguage, ManagedCell>();
+	#notificationQueue: ManagedCell[] = [];
+	#notificationFlush: Promise<void> | undefined;
+
+	constructor(options: EvalDetachedCellManagerOptions = {}) {
+		this.#artifactsDir = options.artifactsDir;
+		this.#notifier = options.notifier;
+	}
+
+	create(cellId: string, input: EvalToolInput): ManagedCell {
+		const existing = this.#cells.get(cellId);
+		if (existing !== undefined) throw new Error(`Eval cell ${cellId} is already managed`);
+		const spillPath =
+			this.#artifactsDir === undefined
+				? undefined
+				: join(this.#artifactsDir, "local", `detached-eval-${safeCellId(cellId)}.log`);
+		const cell: ManagedCell = {
+			cellId,
+			input,
+			spillPath,
+			state: "running",
+			canDetach: false,
+			wasDetached: false,
+			kernel: undefined,
+			outputTail: undefined,
+			result: undefined,
+			notificationQueued: false,
+			terminal: Promise.withResolvers<EvalDetachedCellSnapshot>(),
+		};
+		this.#cells.set(cellId, cell);
+		return cell;
+	}
+
+	markRunning(cell: ManagedCell, kernel: EvalKernel, outputTail: () => string): void {
+		if (cell.state !== "running") return;
+		cell.kernel = kernel;
+		cell.outputTail = outputTail;
+		cell.canDetach = true;
+	}
+
+	detach(cell: ManagedCell): boolean {
+		if (!cell.canDetach || !this.#transition(cell, "detached")) return false;
+		cell.wasDetached = true;
+		this.#detachedByLanguage.set(cell.input.language, cell);
+		return true;
+	}
+
+	complete(cell: ManagedCell, result: AgentToolResult<EvalToolDetails>): boolean {
+		cell.result = result;
+		return this.#transition(cell, result.details.isError === true ? "failed" : "completed");
+	}
+
+	fail(cell: ManagedCell, error: Error): boolean {
+		const result = errorResult(cell, error);
+		cell.result = result;
+		return this.#transition(cell, "failed");
+	}
+
+	async stop(cellId: string, reason = "Stopped detached eval cell"): Promise<EvalDetachedCellSnapshot> {
+		const cell = this.#get(cellId);
+		if (cell.state === "detached" && this.#transition(cell, "cancelled")) {
+			const kernel = cell.kernel;
+			if (kernel !== undefined) await kernel.interrupt(reason);
+		}
+		return this.#snapshot(cell);
+	}
+
+	peek(cellId: string): EvalDetachedCellSnapshot {
+		return this.#snapshot(this.#get(cellId));
+	}
+
+	busyFor(language: EvalLanguage): EvalDetachedCellSnapshot | undefined {
+		const cell = this.#detachedByLanguage.get(language);
+		return cell === undefined ? undefined : this.#snapshot(cell);
+	}
+
+	async waitForTerminal(cellId: string): Promise<EvalDetachedCellSnapshot> {
+		return await this.#get(cellId).terminal.promise;
+	}
+
+	async dispose(): Promise<void> {
+		const detached = [...this.#detachedByLanguage.values()];
+		await Promise.allSettled(detached.map(async (cell) => await this.stop(cell.cellId, "Session ended; detached eval cell cancelled")));
+		await this.flushNotifications();
+	}
+
+	async flushNotifications(): Promise<void> {
+		const flush = this.#notificationFlush;
+		if (flush !== undefined) await flush;
+	}
+
+	#transition(cell: ManagedCell, next: EvalDetachedCellState): boolean {
+		if (!allowsTransition(cell.state, next)) return false;
+		cell.state = next;
+		if (next !== "running" && next !== "detached") cell.terminal.resolve(this.#snapshot(cell));
+		if (cell.wasDetached && next !== "detached") {
+			if (this.#detachedByLanguage.get(cell.input.language) === cell) this.#detachedByLanguage.delete(cell.input.language);
+			this.#queueNotification(cell);
+		}
+		return true;
+	}
+
+	#queueNotification(cell: ManagedCell): void {
+		if (cell.notificationQueued) return;
+		cell.notificationQueued = true;
+		this.#notificationQueue.push(cell);
+		this.#scheduleNotificationFlush();
+	}
+
+	#scheduleNotificationFlush(): void {
+		if (this.#notificationFlush !== undefined) return;
+		const flush = Promise.resolve().then(async () => {
+			const cells = this.#notificationQueue.splice(0);
+			const notifications = await Promise.all(cells.map(async (candidate) => await this.#notification(candidate)));
+			this.#notifier?.notify(notifications);
+		});
+		this.#notificationFlush = flush;
+		void flush.then(
+			() => this.#finishNotificationFlush(flush),
+			() => this.#finishNotificationFlush(flush),
+		);
+	}
+
+	#finishNotificationFlush(flush: Promise<void>): void {
+		if (this.#notificationFlush !== flush) return;
+		this.#notificationFlush = undefined;
+		if (this.#notificationQueue.length > 0) this.#scheduleNotificationFlush();
+	}
+
+	async #notification(cell: ManagedCell): Promise<EvalDetachedCellNotification> {
+		const snapshot = this.#snapshot(cell);
+		const body = notificationBody(snapshot);
+		const overflow = Buffer.byteLength(body, "utf8") > NOTIFICATION_TAIL_BYTES;
+		let spillNotice = "";
+		if (overflow && cell.spillPath !== undefined) {
+			try {
+				await mkdir(dirname(cell.spillPath), { recursive: true });
+				await writeFile(cell.spillPath, body, "utf8");
+				spillNotice = `\nBuffered output overflowed; full output: ${localUri(cell.spillPath, this.#artifactsDir)}`;
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				spillNotice = `\nBuffered output overflow could not be spilled: ${message}`;
+			}
+		}
+		return {
+			cellId: cell.cellId,
+			content: `${overflow ? notificationPreview(snapshot) : body}${overflow ? "\n[…notification tail capped…]" : ""}${spillNotice}`,
+		};
+	}
+
+	#get(cellId: string): ManagedCell {
+		const cell = this.#cells.get(cellId);
+		if (cell === undefined) throw new Error(`Unknown detached eval cell "${cellId}"`);
+		return cell;
+	}
+
+	#snapshot(cell: ManagedCell): EvalDetachedCellSnapshot {
+		return {
+			cellId: cell.cellId,
+			language: cell.input.language,
+			state: cell.state,
+			outputTail: cell.outputTail?.() ?? "",
+			result: cell.result,
+		};
+	}
+}
+
+function allowsTransition(from: EvalDetachedCellState, to: EvalDetachedCellState): boolean {
+	if (from === "running") return to === "detached" || to === "completed" || to === "failed" || to === "cancelled";
+	if (from === "detached") return to === "completed" || to === "failed" || to === "cancelled";
+	return false;
+}
+
+function errorResult(cell: ManagedCell, error: Error): AgentToolResult<EvalToolDetails> {
+	const output = cell.outputTail?.() ?? "";
+	return {
+		content: [{ type: "text", text: output.length > 0 ? `${output}\n${error.message}` : error.message }],
+		details: {
+			language: cell.input.language,
+			languages: [cell.input.language],
+			durationMs: 0,
+			toolCalls: [],
+			truncated: false,
+			isError: true,
+			cells: [
+				{
+					index: 0,
+					code: cell.input.code,
+					language: cell.input.language,
+					output,
+					status: "error",
+				},
+			],
+		},
+	};
+}
+
+function notificationBody(cell: EvalDetachedCellSnapshot): string {
+	const outcome = cell.state === "completed" ? "completed" : cell.state === "cancelled" ? "cancelled" : "failed";
+	const resultText =
+		cell.result?.content.filter((part) => part.type === "text").map((part) => part.text).join("\n") ?? cell.outputTail;
+	const stateNote =
+		cell.state === "cancelled" && cell.language === "js"
+			? "JavaScript worker was restarted; VM state was lost."
+			: cell.state === "cancelled" && cell.language === "py"
+				? "Python kernel was interrupted; its existing variables are preserved."
+				: "Kernel state updated - variables are available to the next eval cell.";
+	return [
+		`<system-reminder>Detached eval cell ${cell.cellId} (${cell.language}) ${outcome}.`,
+		resultText.length === 0 ? "(no output)" : resultText,
+		`${stateNote}</system-reminder>`,
+	].join("\n");
+}
+
+function notificationPreview(cell: EvalDetachedCellSnapshot): string {
+	const outcome = cell.state === "completed" ? "completed" : cell.state === "cancelled" ? "cancelled" : "failed";
+	const resultText =
+		cell.result?.content.filter((part) => part.type === "text").map((part) => part.text).join("\n") ?? cell.outputTail;
+	const stateNote =
+		cell.state === "cancelled" && cell.language === "js"
+			? "JavaScript worker was restarted; VM state was lost."
+			: cell.state === "cancelled" && cell.language === "py"
+				? "Python kernel was interrupted; its existing variables are preserved."
+				: "Kernel state updated - variables are available to the next eval cell.";
+	return [
+		`<system-reminder>Detached eval cell ${cell.cellId} (${cell.language}) ${outcome}.`,
+		"Buffered output tail:",
+		truncateTailUtf8(resultText, NOTIFICATION_TAIL_BYTES),
+		`${stateNote}</system-reminder>`,
+	].join("\n");
+}
+
+function safeCellId(cellId: string): string {
+	return cellId.replace(/[^a-zA-Z0-9_-]/gu, "_");
+}
+
+function localUri(path: string, artifactsDir: string | undefined): string {
+	if (artifactsDir === undefined) return `local://${path}`;
+	const root = join(artifactsDir, "local");
+	return path.startsWith(`${root}/`) ? `local://${path.slice(root.length + 1)}` : `local://${path}`;
+}
+
+function truncateTailUtf8(text: string, maxBytes: number): string {
+	if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+	const bytes = Buffer.from(text, "utf8");
+	let start = bytes.length - maxBytes;
+	while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start++;
+	return bytes.subarray(start).toString("utf8");
+}

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -6,22 +6,30 @@ import { defaultCodemodeSettings, type ResolvedCodemodeSettings } from "../confi
 import type { EvalExecutionTracker } from "../extension/session-manager.ts";
 import { buildEvalPrompt } from "../prompt/eval-prompt.ts";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP } from "../timeouts/bridge-timeout.ts";
-import { IdleTimeout } from "../timeouts/idle-timeout.ts";
+import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
 import { CellHandler, type CellState } from "./cell-handler.ts";
+import { EvalDetachedCellManager, type EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
 import type { EvalImageResizer } from "./image.ts";
 import {
 	createEvalInputSchema,
 	type EnabledEvalLanguages,
+	type EvalCellResult,
+	type EvalControlInput,
 	type EvalInputSchema,
 	type EvalKernel,
 	type EvalKernelManager,
 	type EvalToolDetails,
 	type EvalToolInput,
+	type EvalToolRequest,
 	type ExecuteTool,
 	enabledLanguageList,
 } from "./types.ts";
 
 export type { EnabledEvalLanguages, EvalKernel, EvalKernelManager } from "./types.ts";
+
+export interface EvalTimeoutFactory {
+	create(options: IdleTimeoutOptions): TimeoutPauseHandle & { dispose(): void };
+}
 
 export interface CreateEvalToolOptions {
 	readonly enabledLanguages: EnabledEvalLanguages;
@@ -33,6 +41,8 @@ export interface CreateEvalToolOptions {
 	readonly artifactsDir?: string;
 	readonly imageResizer?: EvalImageResizer;
 	readonly executionTracker?: EvalExecutionTracker;
+	readonly cellManager?: EvalDetachedCellManager;
+	readonly timeoutFactory?: EvalTimeoutFactory;
 	readonly proxyExecutor?: (params: EvalToolInput, signal?: AbortSignal) => Promise<AgentToolResult<EvalToolDetails>>;
 	readonly renderers?: Pick<ToolDefinition<EvalInputSchema, EvalToolDetails>, "renderCall" | "renderResult">;
 	/** Whether the task-tool spawn helpers (agent()/output()/<dag>) are advertised in the prompt. */
@@ -56,18 +66,29 @@ interface EvalCellInvocation {
 interface CellExecutionOptions {
 	readonly callerSignal: AbortSignal;
 	readonly cellId: string;
-	readonly onAbort: (error: Error) => void;
 	readonly timeoutMs: number;
+	readonly timeoutFactory: EvalTimeoutFactory;
+	readonly onTimeout: (error: Error) => void;
+	readonly onAbort: (error: Error) => void;
 }
 
 const INTERRUPT_DELIVERY_GRACE_MS = 100;
+const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
+
+const defaultTimeoutFactory: EvalTimeoutFactory = {
+	create(options): IdleTimeout {
+		return new IdleTimeout(options);
+	},
+};
 
 class CellExecution {
 	readonly #callerSignal: AbortSignal;
 	readonly #onAbort: (error: Error) => void;
 	readonly #abortPromise: Promise<never>;
-	readonly #watchdog: IdleTimeout;
+	readonly #detachedPromise: Promise<void>;
+	readonly #watchdog: TimeoutPauseHandle & { dispose(): void };
 	#rejectAbort: ((reason?: unknown) => void) | undefined;
+	#resolveDetached: (() => void) | undefined;
 	#kernel: EvalKernel | undefined;
 	#interruptDeadline: ReturnType<typeof setTimeout> | undefined;
 	#active = true;
@@ -78,26 +99,44 @@ class CellExecution {
 		this.#abortPromise = new Promise<never>((_resolve, reject) => {
 			this.#rejectAbort = reject;
 		});
-		this.#watchdog = new IdleTimeout({
+		this.#detachedPromise = new Promise<void>((resolve) => {
+			this.#resolveDetached = resolve;
+		});
+		this.#watchdog = options.timeoutFactory.create({
 			cellId: options.cellId,
 			timeoutMs: options.timeoutMs,
-			onTimeout: ({ error }) => this.#abort(error),
+			onTimeout: ({ error }) => options.onTimeout(error),
 		});
 		this.#callerSignal.addEventListener("abort", this.#handleCallerAbort, { once: true });
+	}
+
+	get detached(): Promise<void> {
+		return this.#detachedPromise;
 	}
 
 	pause(): void {
 		this.#watchdog.pause();
 	}
+
 	resume(): void {
 		this.#watchdog.resume();
 	}
+
 	setKernel(kernel: EvalKernel): void {
 		this.#kernel = kernel;
 	}
+
+	detach(): void {
+		if (!this.#active) return;
+		this.#watchdog.dispose();
+		this.#resolveDetached?.();
+		this.#resolveDetached = undefined;
+	}
+
 	cancel(reason: unknown): void {
 		this.#abort(reason);
 	}
+
 	finish(): void {
 		this.#active = false;
 		this.#cleanup();
@@ -128,7 +167,7 @@ class CellExecution {
 		}
 		this.#interruptDeadline = setTimeout(() => this.#settleAbort(error), INTERRUPT_DELIVERY_GRACE_MS);
 		void Promise.resolve()
-			.then(() => kernel.interrupt(error.message))
+			.then(async () => await kernel.interrupt(error.message))
 			.then(
 				() => this.#settleAbort(error),
 				(interruptError: unknown) => this.#settleAbort(interruptError),
@@ -160,6 +199,7 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		...(options.hostLine === undefined ? {} : { hostLine: options.hostLine }),
 	});
 	const languages = enabledLanguageList(options.enabledLanguages);
+	const cellManager = options.cellManager ?? new EvalDetachedCellManager({ artifactsDir: options.artifactsDir });
 	return {
 		name: "eval",
 		label: "Eval",
@@ -171,19 +211,23 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		...(options.renderers?.renderCall === undefined ? {} : { renderCall: options.renderers.renderCall }),
 		...(options.renderers?.renderResult === undefined ? {} : { renderResult: options.renderers.renderResult }),
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
-			if (options.proxyExecutor) return await options.proxyExecutor(params, signal);
-			if (!languages.includes(params.language))
+			const request = requestFrom(params);
+			if (isControlRequest(request)) return await executeControl(cellManager, request);
+			if (options.proxyExecutor) return await options.proxyExecutor(request, signal);
+			if (!languages.includes(request.language))
 				throw new RangeError(
-					`Unsupported eval language "${params.language}". Enabled languages: ${languages.join(", ")}`,
+					`Unsupported eval language "${request.language}". Enabled languages: ${languages.join(", ")}`,
 				);
+			const busy = cellManager.busyFor(request.language);
+			if (busy !== undefined) throw kernelBusyError(busy);
 			options.executionTracker?.assertEvalExecutionAllowed();
 			const lifecycleController = new AbortController();
 			const combinedSignal = signal
 				? AbortSignal.any([signal, lifecycleController.signal])
 				: lifecycleController.signal;
-			const execution = runEvalCell(options, {
+			const execution = runEvalCell(options, cellManager, {
 				cellId: toolCallId,
-				input: params,
+				input: request,
 				signal: combinedSignal,
 				onUpdate,
 				ctx,
@@ -197,10 +241,12 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 
 async function runEvalCell(
 	options: CreateEvalToolOptions,
+	cellManager: EvalDetachedCellManager,
 	invocation: EvalCellInvocation,
 ): Promise<AgentToolResult<EvalToolDetails>> {
 	if (invocation.signal.aborted) throw abortError(invocation.signal.reason);
 	const timeoutMs = Math.floor((invocation.input.timeout ?? options.cellTimeoutSeconds) * 1_000);
+	const timeoutBehavior = timeoutBehaviorFor(invocation.input, invocation.ctx);
 	const bridgeAbortController = new AbortController();
 	const cellSignal = AbortSignal.any([invocation.signal, bridgeAbortController.signal]);
 	const bridgeContext: ExtensionContext = { ...invocation.ctx, signal: cellSignal };
@@ -217,20 +263,63 @@ async function runEvalCell(
 		durationMs: 0,
 		status: "pending",
 	};
-	const execution = new CellExecution({
+	const cell = cellManager.create(invocation.cellId, invocation.input);
+	let handler: CellHandler | undefined;
+	let execution: CellExecution;
+	execution = new CellExecution({
 		callerSignal: invocation.signal,
 		cellId: invocation.cellId,
+		timeoutMs,
+		timeoutFactory: options.timeoutFactory ?? defaultTimeoutFactory,
+		onTimeout: (error) => {
+			if (timeoutBehavior === "detach" && cellManager.detach(cell)) {
+				execution.detach();
+				return;
+			}
+			execution.cancel(error);
+		},
 		onAbort: (error) => {
 			state.active = false;
 			bridgeAbortController.abort(error);
 		},
-		timeoutMs,
 	});
+	const running = executeCell(options, invocation, cellManager, cell, state, execution, bridgeContext, bridgeAbortController, (value) => {
+		handler = value;
+	});
+	const finalized = running.then(
+		(result) => {
+			cellManager.complete(cell, result);
+			return result;
+		},
+		(error: unknown) => {
+			cellManager.fail(cell, error instanceof Error ? error : new Error(String(error)));
+			throw error;
+		},
+	);
+	const outcome = await Promise.race([
+		finalized.then((result) => ({ kind: "result" as const, result })),
+		execution.detached.then(() => ({ kind: "detached" as const })),
+	]);
+	if (outcome.kind === "detached") return detachedResult(cellManager.peek(invocation.cellId), invocation.input);
+	return outcome.result;
+}
+
+async function executeCell(
+	options: CreateEvalToolOptions,
+	invocation: EvalCellInvocation,
+	cellManager: EvalDetachedCellManager,
+	cell: Parameters<EvalDetachedCellManager["markRunning"]>[0],
+	state: CellState,
+	execution: CellExecution,
+	bridgeContext: ExtensionContext,
+	bridgeAbortController: AbortController,
+	setHandler: (handler: CellHandler) => void,
+): Promise<AgentToolResult<EvalToolDetails>> {
 	let handler: CellHandler | undefined;
 	try {
-		const acquired = await execution.wait(
+		const kernel = await execution.wait(
 			options.kernelManager.getKernel(invocation.input.language, (message) => {
-				if (!state.active || !handler) return;
+				if (!state.active || handler === undefined) return;
 				if (message.type === "status") {
 					if (message.event.op === TIMEOUT_PAUSE_OP) {
 						execution.pause();
@@ -245,7 +334,6 @@ async function runEvalCell(
 				void pending.catch((error: unknown) => execution.cancel(error));
 			}),
 		);
-		const kernel = acquired;
 		execution.setKernel(kernel);
 		handler = new CellHandler(kernel, state, {
 			executeTool: options.executeTool,
@@ -257,6 +345,8 @@ async function runEvalCell(
 				: { artifactPath: join(options.artifactsDir, `eval-${randomUUID()}.log`) }),
 			...(options.imageResizer === undefined ? {} : { imageResizer: options.imageResizer }),
 		});
+		setHandler(handler);
+		cellManager.markRunning(cell, kernel, () => state.output);
 		if ("setContext" in options.kernelManager && typeof options.kernelManager.setContext === "function") {
 			options.kernelManager.setContext(bridgeContext);
 		}
@@ -265,9 +355,8 @@ async function runEvalCell(
 		if (result.ok && state.pendingBridgeCalls.length > 0) await execution.wait(Promise.all(state.pendingBridgeCalls));
 		return await handler.finalize(result);
 	} catch (error) {
-		if (handler && error instanceof Error && error.name === "CodemodeSessionDisposedError") {
+		if (handler && error instanceof Error && error.name === "CodemodeSessionDisposedError")
 			return await handler.finalizeCancellation(error);
-		}
 		throw error;
 	} finally {
 		state.active = false;
@@ -275,6 +364,140 @@ async function runEvalCell(
 		execution.finish();
 		if (handler) await handler.flushOutput();
 	}
+}
+
+function requestFrom(params: unknown): EvalToolRequest {
+	if (typeof params !== "object" || params === null) throw new TypeError("eval parameters must be an object");
+	const value = params as Record<string, unknown>;
+	if (value.action === "peek" || value.action === "stop") {
+		if (typeof value.cell_id !== "string" || value.cell_id.length === 0)
+			throw new TypeError(`eval action "${value.action}" requires cell_id`);
+		return { action: value.action, cell_id: value.cell_id };
+	}
+	if (value.action !== undefined && value.action !== "run") throw new TypeError(`Unknown eval action "${String(value.action)}"`);
+	if (!isEvalLanguage(value.language)) throw new TypeError("eval run requires language");
+	if (typeof value.code !== "string") throw new TypeError("eval run requires code");
+	if (value.on_timeout !== undefined && value.on_timeout !== "detach" && value.on_timeout !== "error")
+		throw new TypeError(`Unknown eval on_timeout value "${String(value.on_timeout)}"`);
+	return {
+		language: value.language,
+		code: value.code,
+		...(value.action === "run" ? { action: "run" as const } : {}),
+		...(typeof value.title === "string" ? { title: value.title } : {}),
+		...(typeof value.timeout === "number" ? { timeout: value.timeout } : {}),
+		...(value.on_timeout === "detach" || value.on_timeout === "error" ? { on_timeout: value.on_timeout } : {}),
+		...(typeof value.reset === "boolean" ? { reset: value.reset } : {}),
+	};
+}
+
+function isControlRequest(request: EvalToolRequest): request is EvalControlInput {
+	return request.action === "peek" || request.action === "stop";
+}
+
+function isEvalLanguage(value: unknown): value is EvalToolInput["language"] {
+	return value === "py" || value === "js" || value === "rb" || value === "jl";
+}
+
+async function executeControl(
+	cellManager: EvalDetachedCellManager,
+	request: EvalControlInput,
+): Promise<AgentToolResult<EvalToolDetails>> {
+	const snapshot = request.action === "stop" ? await cellManager.stop(request.cell_id) : cellManager.peek(request.cell_id);
+	return snapshotResult(snapshot);
+}
+
+function detachedResult(snapshot: EvalDetachedCellSnapshot, input: EvalToolInput): AgentToolResult<EvalToolDetails> {
+	return {
+		content: [
+			{
+				type: "text",
+				text: `Eval cell ${snapshot.cellId} detached and is still running in the ${input.language} kernel. Completion will arrive as a notification. Use eval({ action: "peek", cell_id: "${snapshot.cellId}" }) or eval({ action: "stop", cell_id: "${snapshot.cellId}" }).`,
+			},
+		],
+		details: {
+			language: input.language,
+			languages: [input.language],
+			...(input.title === undefined ? {} : { title: input.title }),
+			durationMs: 0,
+			toolCalls: [],
+			truncated: false,
+			statusEvents: [{ op: "detached", cellId: snapshot.cellId }],
+			cells: [
+				{
+					index: 0,
+					...(input.title === undefined ? {} : { title: input.title }),
+					code: input.code,
+					language: input.language,
+					output: snapshot.outputTail,
+					status: "detached",
+					statusEvents: [{ op: "detached", cellId: snapshot.cellId }],
+				},
+			],
+		},
+	};
+}
+
+function snapshotResult(snapshot: EvalDetachedCellSnapshot): AgentToolResult<EvalToolDetails> {
+	const terminationNote =
+		snapshot.state === "cancelled" && snapshot.language === "js"
+			? "JavaScript worker was restarted; VM state was lost."
+			: snapshot.state === "cancelled" && snapshot.language === "py"
+				? "Python kernel was interrupted; its existing variables are preserved."
+				: undefined;
+	const text = [
+		`Eval cell ${snapshot.cellId} (${snapshot.language}) is ${snapshot.state}.`,
+		snapshot.outputTail.length === 0 ? "(no buffered output)" : snapshot.outputTail,
+		...(terminationNote === undefined ? [] : [terminationNote]),
+	].join("\n");
+	return {
+		content: [{ type: "text", text }],
+		details: {
+			language: snapshot.language,
+			languages: [snapshot.language],
+			durationMs: snapshot.result?.details.durationMs ?? 0,
+			toolCalls: snapshot.result?.details.toolCalls ?? [],
+			truncated: snapshot.result?.details.truncated ?? false,
+			...(snapshot.state === "failed" ? { isError: true } : {}),
+			statusEvents: [{ op: snapshot.state, cellId: snapshot.cellId }],
+			cells: [
+				{
+					index: 0,
+					code: "",
+					language: snapshot.language,
+					output: snapshot.outputTail,
+					status: cellStatus(snapshot.state),
+					statusEvents: [{ op: snapshot.state, cellId: snapshot.cellId }],
+				},
+			],
+		},
+	};
+}
+
+function cellStatus(state: EvalDetachedCellSnapshot["state"]): EvalCellResult["status"] {
+	switch (state) {
+		case "running":
+			return "running";
+		case "detached":
+			return "detached";
+		case "completed":
+			return "complete";
+		case "failed":
+			return "error";
+		case "cancelled":
+			return "cancelled";
+	}
+}
+
+function kernelBusyError(snapshot: EvalDetachedCellSnapshot): Error {
+	const tail = snapshot.outputTail.length === 0 ? "(no output yet)" : snapshot.outputTail;
+	return new Error(
+		`The ${snapshot.language} eval kernel is busy running detached cell ${snapshot.cellId}. Do not re-run it; use eval({ action: "peek", cell_id: "${snapshot.cellId}" }). Current output tail:\n${tail}`,
+	);
+}
+
+function timeoutBehaviorFor(input: EvalToolInput, ctx: ExtensionContext): "detach" | "error" {
+	if (input.on_timeout !== undefined) return input.on_timeout;
+	return NON_INTERACTIVE_MODES.has(ctx.mode) ? "error" : "detach";
 }
 
 function abortError(reason: unknown): Error {

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -264,7 +264,6 @@ async function runEvalCell(
 		status: "pending",
 	};
 	const cell = cellManager.create(invocation.cellId, invocation.input);
-	let handler: CellHandler | undefined;
 	let execution: CellExecution;
 	execution = new CellExecution({
 		callerSignal: invocation.signal,
@@ -283,9 +282,16 @@ async function runEvalCell(
 			bridgeAbortController.abort(error);
 		},
 	});
-	const running = executeCell(options, invocation, cellManager, cell, state, execution, bridgeContext, bridgeAbortController, (value) => {
-		handler = value;
-	});
+	const running = executeCell(
+		options,
+		invocation,
+		cellManager,
+		cell,
+		state,
+		execution,
+		bridgeContext,
+		bridgeAbortController,
+	);
 	const finalized = running.then(
 		(result) => {
 			cellManager.complete(cell, result);
@@ -313,7 +319,6 @@ async function executeCell(
 	execution: CellExecution,
 	bridgeContext: ExtensionContext,
 	bridgeAbortController: AbortController,
-	setHandler: (handler: CellHandler) => void,
 ): Promise<AgentToolResult<EvalToolDetails>> {
 	let handler: CellHandler | undefined;
 	try {
@@ -345,7 +350,6 @@ async function executeCell(
 				: { artifactPath: join(options.artifactsDir, `eval-${randomUUID()}.log`) }),
 			...(options.imageResizer === undefined ? {} : { imageResizer: options.imageResizer }),
 		});
-		setHandler(handler);
 		cellManager.markRunning(cell, kernel, () => state.output);
 		if ("setContext" in options.kernelManager && typeof options.kernelManager.setContext === "function") {
 			options.kernelManager.setContext(bridgeContext);
@@ -374,7 +378,8 @@ function requestFrom(params: unknown): EvalToolRequest {
 			throw new TypeError(`eval action "${value.action}" requires cell_id`);
 		return { action: value.action, cell_id: value.cell_id };
 	}
-	if (value.action !== undefined && value.action !== "run") throw new TypeError(`Unknown eval action "${String(value.action)}"`);
+	if (value.action !== undefined && value.action !== "run")
+		throw new TypeError(`Unknown eval action "${String(value.action)}"`);
 	if (!isEvalLanguage(value.language)) throw new TypeError("eval run requires language");
 	if (typeof value.code !== "string") throw new TypeError("eval run requires code");
 	if (value.on_timeout !== undefined && value.on_timeout !== "detach" && value.on_timeout !== "error")
@@ -402,7 +407,8 @@ async function executeControl(
 	cellManager: EvalDetachedCellManager,
 	request: EvalControlInput,
 ): Promise<AgentToolResult<EvalToolDetails>> {
-	const snapshot = request.action === "stop" ? await cellManager.stop(request.cell_id) : cellManager.peek(request.cell_id);
+	const snapshot =
+		request.action === "stop" ? await cellManager.stop(request.cell_id) : cellManager.peek(request.cell_id);
 	return snapshotResult(snapshot);
 }
 

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -26,6 +26,7 @@ import type {
 	EvalStatusEvent,
 	EvalToolDetails,
 	EvalToolInput,
+	EvalToolRequest,
 } from "./types.ts";
 
 type EvalToolDefinition = ToolDefinition<EvalInputSchema, EvalToolDetails>;
@@ -202,7 +203,7 @@ type CellBadges = { readonly reset: boolean; readonly timeout: number | undefine
 type PrefixStyle = { readonly prefix: string; readonly continuation: string; readonly color: ThemeColor };
 type DetailedRenderContext = {
 	readonly environment: RenderEnvironment;
-	readonly args: EvalToolInput;
+	readonly args: EvalToolRequest;
 	readonly showImageFallback: boolean;
 };
 
@@ -253,10 +254,14 @@ function cellPresentation(status: CellStatus, spinnerFrame: number | undefined):
 			return { label: "pending", icon: "○", color: "muted" };
 		case "running":
 			return { label: "running", icon: spinner(spinnerFrame), color: "warning" };
+		case "detached":
+			return { label: "detached", icon: "↗", color: "warning" };
 		case "complete":
 			return { label: "done", icon: "✓", color: "success" };
 		case "error":
 			return { label: "error", icon: "✗", color: "error" };
+		case "cancelled":
+			return { label: "cancelled", icon: "×", color: "error" };
 		default:
 			return assertNever(status);
 	}
@@ -613,9 +618,10 @@ function renderDetailedLines(
 	const lines: string[] = [];
 	const cells = details.cells ?? [];
 	for (const [index, cell] of cells.entries()) {
+		const run = isEvalRunInput(context.args) ? context.args : undefined;
 		const badges = {
-			reset: index === 0 && context.args.reset === true,
-			timeout: index === 0 ? context.args.timeout : undefined,
+			reset: index === 0 && run?.reset === true,
+			timeout: index === 0 ? run?.timeout : undefined,
 		};
 		appendLines(lines, renderCell(cell, context.environment, badges));
 		if (index < cells.length - 1) lines.push("");
@@ -666,6 +672,10 @@ function textOutput(result: AgentToolResult<EvalToolDetails>, showImageFallback:
 		}
 	}
 	return lines.join("\n");
+}
+
+function isEvalRunInput(args: EvalToolRequest): args is EvalToolInput {
+	return args.action !== "peek" && args.action !== "stop";
 }
 
 function toolCallRows(details: EvalToolDetails | undefined): ToolCallRow[] {
@@ -720,7 +730,7 @@ function resultMetadata(
 }
 
 export function renderEvalCall(
-	args: EvalToolInput,
+	args: EvalToolRequest,
 	theme: Theme | undefined,
 	context: RenderContext,
 ): EvalRenderComponent {
@@ -729,6 +739,10 @@ export function renderEvalCall(
 		// The result renderer owns the full pending -> running -> done frame once a result exists.
 		// Rendering the call frame too would stack a duplicate box, so yield to it here.
 		component.setBlocks([]);
+		return component;
+	}
+	if (!isEvalRunInput(args)) {
+		component.setBlocks([{ kind: "text", text: style(theme, "toolTitle", `eval ${args.action} ${args.cell_id}`) }]);
 		return component;
 	}
 	if (theme === undefined && context.spinnerFrame === undefined) {

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, AgentToolUpdateCallback } from "@code-yeongyu/senpi";
-import { Type, type TUnsafe } from "typebox";
+import { type TUnsafe, Type } from "typebox";
 import type { HostToKernelMessage, KernelToHostMessage } from "../bridge/protocol.ts";
 import type { TruncationMeta } from "../output/output-meta.ts";
 
@@ -34,7 +34,9 @@ const fullEvalInputSchema = Type.Object({
 			description: "Defaults to run. peek and stop require cell_id.",
 		}),
 	),
-	language: Type.Optional(Type.Union([Type.Literal("py"), Type.Literal("js"), Type.Literal("rb"), Type.Literal("jl")])),
+	language: Type.Optional(
+		Type.Union([Type.Literal("py"), Type.Literal("js"), Type.Literal("rb"), Type.Literal("jl")]),
+	),
 	code: Type.Optional(Type.String({ description: "Cell body, verbatim." })),
 	title: Type.Optional(Type.String({ description: "Short transcript label." })),
 	timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
@@ -70,7 +72,8 @@ export function createEvalInputSchema(enabled: EnabledEvalLanguages): EvalInputS
 			timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
 			on_timeout: Type.Optional(
 				Type.Union([Type.Literal("detach"), Type.Literal("error")], {
-					description: "Timeout behavior. Interactive sessions detach by default; print/json sessions error by default.",
+					description:
+						"Timeout behavior. Interactive sessions detach by default; print/json sessions error by default.",
 				}),
 			),
 			reset: Type.Optional(Type.Boolean({ description: "Reset this language kernel before running." })),

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, AgentToolUpdateCallback } from "@code-yeongyu/senpi";
-import { Type } from "typebox";
+import { Type, type TUnsafe } from "typebox";
 import type { HostToKernelMessage, KernelToHostMessage } from "../bridge/protocol.ts";
 import type { TruncationMeta } from "../output/output-meta.ts";
 
@@ -11,37 +11,72 @@ export function enabledLanguageList(enabled: EnabledEvalLanguages): EvalLanguage
 	return evalLanguageOrder.filter((language) => enabled[language]);
 }
 
+export interface EvalToolInput {
+	readonly language: EvalLanguage;
+	readonly code: string;
+	readonly action?: "run";
+	readonly title?: string;
+	readonly timeout?: number;
+	readonly on_timeout?: "detach" | "error";
+	readonly reset?: boolean;
+}
+
+export interface EvalControlInput {
+	readonly action: "peek" | "stop";
+	readonly cell_id: string;
+}
+
+export type EvalToolRequest = EvalToolInput | EvalControlInput;
+
 const fullEvalInputSchema = Type.Object({
-	language: Type.Union([Type.Literal("py"), Type.Literal("js"), Type.Literal("rb"), Type.Literal("jl")]),
-	code: Type.String({ description: "Cell body, verbatim." }),
+	action: Type.Optional(
+		Type.Union([Type.Literal("run"), Type.Literal("peek"), Type.Literal("stop")], {
+			description: "Defaults to run. peek and stop require cell_id.",
+		}),
+	),
+	language: Type.Optional(Type.Union([Type.Literal("py"), Type.Literal("js"), Type.Literal("rb"), Type.Literal("jl")])),
+	code: Type.Optional(Type.String({ description: "Cell body, verbatim." })),
 	title: Type.Optional(Type.String({ description: "Short transcript label." })),
 	timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
+	on_timeout: Type.Optional(
+		Type.Union([Type.Literal("detach"), Type.Literal("error")], {
+			description: "Timeout behavior. Interactive sessions detach by default; print/json sessions error by default.",
+		}),
+	),
 	reset: Type.Optional(Type.Boolean({ description: "Reset this language kernel before running." })),
+	cell_id: Type.Optional(Type.String({ description: "Detached eval cell id for peek or stop." })),
 });
 
-export function createEvalInputSchema(enabled: EnabledEvalLanguages): typeof fullEvalInputSchema {
+/** Runtime accepts a discriminated run/control union. */
+export type EvalInputSchema = TUnsafe<EvalToolRequest> & Pick<typeof fullEvalInputSchema, "properties">;
+
+export function createEvalInputSchema(enabled: EnabledEvalLanguages): EvalInputSchema {
 	const languages = enabledLanguageList(enabled);
 	if (languages.length === 0) throw new Error("eval requires at least one enabled language");
 	const languageSchema =
 		languages.length === 1
 			? Type.Union([Type.Literal(languages[0])])
 			: Type.Union(languages.map((item) => Type.Literal(item)));
-	return Type.Object({
-		language: languageSchema,
-		code: Type.String({ description: "Cell body, verbatim." }),
-		title: Type.Optional(Type.String({ description: "Short transcript label." })),
-		timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
-		reset: Type.Optional(Type.Boolean({ description: "Reset this language kernel before running." })),
-	}) as typeof fullEvalInputSchema;
-}
-
-export type EvalInputSchema = typeof fullEvalInputSchema;
-export interface EvalToolInput {
-	readonly language: EvalLanguage;
-	readonly code: string;
-	readonly title?: string;
-	readonly timeout?: number;
-	readonly reset?: boolean;
+	return Type.Unsafe<EvalToolRequest>(
+		Type.Object({
+			action: Type.Optional(
+				Type.Union([Type.Literal("run"), Type.Literal("peek"), Type.Literal("stop")], {
+					description: "Defaults to run. peek and stop require cell_id.",
+				}),
+			),
+			language: Type.Optional(languageSchema),
+			code: Type.Optional(Type.String({ description: "Cell body, verbatim." })),
+			title: Type.Optional(Type.String({ description: "Short transcript label." })),
+			timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
+			on_timeout: Type.Optional(
+				Type.Union([Type.Literal("detach"), Type.Literal("error")], {
+					description: "Timeout behavior. Interactive sessions detach by default; print/json sessions error by default.",
+				}),
+			),
+			reset: Type.Optional(Type.Boolean({ description: "Reset this language kernel before running." })),
+			cell_id: Type.Optional(Type.String({ description: "Detached eval cell id for peek or stop." })),
+		}),
+	) as EvalInputSchema;
 }
 export type EvalKernelResult = Extract<KernelToHostMessage, { type: "result" }>;
 export type EvalToolCallMessage = Extract<KernelToHostMessage, { type: "tool-call" }>;
@@ -90,7 +125,7 @@ export type EvalCellResult = {
 	readonly code: string;
 	readonly language: EvalLanguage;
 	readonly output: string;
-	readonly status: "pending" | "running" | "complete" | "error";
+	readonly status: "pending" | "running" | "detached" | "complete" | "error" | "cancelled";
 	readonly exitCode?: number;
 	readonly durationMs?: number;
 	readonly statusEvents?: readonly EvalStatusEvent[];

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -20,7 +20,11 @@ Fields:
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
@@ -131,7 +135,11 @@ Fields:
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
 
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
@@ -197,7 +205,11 @@ Fields:
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.

--- a/packages/senpi-codemode/test/codemode/gpt-code-mode.test.ts
+++ b/packages/senpi-codemode/test/codemode/gpt-code-mode.test.ts
@@ -54,6 +54,8 @@ class FakePi {
 		this.#activeTools = new Set(toolNames);
 	}
 
+	sendUserMessage(): void {}
+
 	async executeTool(
 		toolName: string,
 		params: unknown,

--- a/packages/senpi-codemode/test/codemode/model-lifecycle.test.ts
+++ b/packages/senpi-codemode/test/codemode/model-lifecycle.test.ts
@@ -54,6 +54,8 @@ class FakePi {
 		this.#active = new Set(names);
 	}
 
+	sendUserMessage(): void {}
+
 	async executeTool(_name: string, _params: unknown, options?: { readonly signal?: AbortSignal }): Promise<never> {
 		this.holdStarted.resolve();
 		const signal = options?.signal;

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -1,0 +1,272 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager, type EvalDetachedCellNotification } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+type TextContent = Extract<AgentToolResult<unknown>["content"][number], { type: "text" }>;
+
+class NotificationRecorder {
+	readonly batches: EvalDetachedCellNotification[][] = [];
+
+	notify(cells: readonly EvalDetachedCellNotification[]): void {
+		this.batches.push([...cells]);
+	}
+
+	get notices(): EvalDetachedCellNotification[] {
+		return this.batches.flat();
+	}
+}
+
+const directories: string[] = [];
+
+afterEach(async () => {
+	vi.useRealTimers();
+	await Promise.all(directories.splice(0).map(async (path) => await rm(path, { recursive: true, force: true })));
+});
+
+function textOf(result: AgentToolResult<unknown>): string {
+	const texts: string[] = [];
+	for (const part of result.content as readonly TextContent[]) {
+		if (part.type === "text") texts.push(part.text);
+	}
+	return texts.join("\n");
+}
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "tui" as const };
+}
+
+function createTool(manager: EvalDetachedCellManager, entries: Array<readonly [string, FakeKernel]>) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: true, rb: false, jl: false },
+		kernelManager: new FakeManager(entries),
+		cellTimeoutSeconds: 1,
+		executeTool: vi.fn(),
+		cellManager: manager,
+	});
+}
+
+async function detach(
+	tool: ReturnType<typeof createTool>,
+	kernel: FakeKernel,
+	cellId: string,
+	language: "js" | "py" = "js",
+): Promise<AgentToolResult<unknown>> {
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		cellId,
+		{ language, code: "await forever", on_timeout: "detach" },
+		undefined,
+		undefined,
+		interactiveContext(),
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	return await execution;
+}
+
+describe("eval detached cells", () => {
+	it("detaches a pure-compute timeout without interrupting the running kernel", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ notifier: recorder });
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		const detached = await detach(tool, kernel, "detached-cell");
+
+		expect(textOf(detached)).toContain("detached-cell");
+		expect(kernel.interrupts).toEqual([]);
+		expect(manager.busyFor("js")).toMatchObject({ cellId: "detached-cell", state: "detached" });
+		await manager.stop("detached-cell");
+		await manager.flushNotifications();
+	});
+
+	it("injects one completion notification with buffered output, final value, and state-persistence guidance", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ notifier: recorder });
+		const kernel = new FakeKernel([{ type: "text", stream: "stdout", data: "buffered print\n" }]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await detach(tool, kernel, "complete-after-detach");
+		expect(manager.busyFor("js")).toMatchObject({ state: "detached" });
+		kernel.completeDeferredRun(result("complete-after-detach", "42"));
+		await manager.waitForTerminal("complete-after-detach");
+		expect(manager.peek("complete-after-detach")).toMatchObject({ state: "completed" });
+		await manager.flushNotifications();
+
+		expect(recorder.batches).toHaveLength(1);
+		expect(recorder.notices).toEqual([
+			expect.objectContaining({
+				cellId: "complete-after-detach",
+				content: expect.stringContaining("buffered print"),
+			}),
+		]);
+		expect(recorder.notices[0]?.content).toContain("42");
+		expect(recorder.notices[0]?.content).toContain("Kernel state updated - variables are available to the next eval cell.");
+		expect(manager.busyFor("js")).toBeUndefined();
+	});
+
+	it("returns a same-language busy error with the detached cell id and output tail while other languages continue", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const js = new FakeKernel([{ type: "text", stream: "stdout", data: "still computing\n" }]);
+		const py = new FakeKernel([result("py-cell", "py-ok")]);
+		const tool = createTool(manager, [
+			["js", js],
+			["py", py],
+		]);
+
+		await detach(tool, js, "busy-js");
+
+		await expect(
+			tool.execute("blocked-js", { language: "js", code: "sideEffect()" }, undefined, undefined, interactiveContext()),
+		).rejects.toThrow(/busy running detached cell busy-js[\s\S]*still computing/u);
+		await expect(
+			tool.execute("py-cell", { language: "py", code: "answer = 42" }, undefined, undefined, interactiveContext()),
+		).resolves.toSatisfy((value: AgentToolResult<unknown>) => textOf(value).includes("py-ok"));
+
+		await manager.stop("busy-js");
+		await manager.flushNotifications();
+	});
+
+	it("supports peek and stop, retaining Python state and reporting JavaScript VM loss", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ notifier: recorder });
+		const py = new FakeKernel([{ type: "text", stream: "stdout", data: "x = 42\n" }]);
+		const js = new FakeKernel([]);
+		const tool = createTool(manager, [
+			["py", py],
+			["js", js],
+		]);
+
+		await detach(tool, py, "py-detached", "py");
+		const peek = await tool.execute("peek-py", { action: "peek", cell_id: "py-detached" }, undefined, undefined, interactiveContext());
+		expect(textOf(peek)).toContain("x = 42");
+		const stoppedPython = await tool.execute(
+			"stop-py",
+			{ action: "stop", cell_id: "py-detached" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		expect(textOf(stoppedPython)).toContain("Python kernel was interrupted; its existing variables are preserved.");
+
+		await detach(tool, js, "js-detached");
+		const stoppedJavaScript = await tool.execute(
+			"stop-js",
+			{ action: "stop", cell_id: "js-detached" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		expect(textOf(stoppedJavaScript)).toContain("JavaScript worker was restarted; VM state was lost.");
+		await manager.flushNotifications();
+		expect(recorder.notices).toHaveLength(2);
+		expect(manager.busyFor("py")).toBeUndefined();
+		expect(manager.busyFor("js")).toBeUndefined();
+	});
+
+	it("uses error timeout semantics by default in print/json modes and on explicit error", async () => {
+		vi.useFakeTimers();
+		const kernel = new FakeKernel([]);
+		const started = kernel.deferNextRun();
+		const tool = createTool(new EvalDetachedCellManager(), [["js", kernel]]);
+		const execution = tool.execute(
+			"print-timeout",
+			{ language: "js", code: "await forever" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+		await started;
+		const outcome = execution.then(
+			() => ({ status: "fulfilled" as const }),
+			(error: unknown) => ({ status: "rejected" as const, error }),
+		);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		await expect(outcome).resolves.toMatchObject({ status: "rejected", error: { name: "TimeoutError" } });
+		expect(kernel.interrupts).toEqual(["Cell timed out after 1000ms"]);
+	});
+
+	it("settles timeout-vs-completion and stop-vs-completion races once with no stranded busy marker", async () => {
+		vi.useFakeTimers();
+		const completionRecorder = new NotificationRecorder();
+		const completionManager = new EvalDetachedCellManager({ notifier: completionRecorder });
+		const completionKernel = new FakeKernel([]);
+		const completionTool = createTool(completionManager, [["js", completionKernel]]);
+		const completionStarted = completionKernel.deferNextRun();
+		const completion = completionTool.execute(
+			"completion-wins",
+			{ language: "js", code: "return 1", on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await completionStarted;
+		completionKernel.completeDeferredRun(result("completion-wins", "1"));
+		await completion;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await completionManager.flushNotifications();
+		expect(completionRecorder.notices).toHaveLength(0);
+		expect(completionManager.busyFor("js")).toBeUndefined();
+
+		const stopRecorder = new NotificationRecorder();
+		const stopManager = new EvalDetachedCellManager({ notifier: stopRecorder });
+		const stopKernel = new FakeKernel([]);
+		const stopTool = createTool(stopManager, [["js", stopKernel]]);
+		await detach(stopTool, stopKernel, "stop-wins");
+		await stopTool.execute("stop", { action: "stop", cell_id: "stop-wins" }, undefined, undefined, interactiveContext());
+		stopKernel.emit(result("stop-wins", "late"));
+		await stopManager.flushNotifications();
+		expect(stopRecorder.notices).toHaveLength(1);
+		expect(stopManager.busyFor("js")).toBeUndefined();
+	});
+
+	it("kills detached cells during session disposal and ignores late kernel messages after terminal state", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ notifier: recorder });
+		const kernel = new FakeKernel([{ type: "text", stream: "stdout", data: "last tail\n" }]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await detach(tool, kernel, "dispose-detached");
+		await manager.dispose();
+		kernel.emit(errorResult("dispose-detached", "late crash"));
+		await manager.flushNotifications();
+
+		expect(recorder.notices).toHaveLength(1);
+		expect(recorder.notices[0]?.content).toContain("last tail");
+		expect(manager.busyFor("js")).toBeUndefined();
+	});
+
+	it("reports detached kernel crashes with the buffered tail and spills oversized notifications to local://", async () => {
+		vi.useFakeTimers();
+		const artifactsDir = await mkdtemp(join(tmpdir(), "senpi-codemode-detach-"));
+		directories.push(artifactsDir);
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ artifactsDir, notifier: recorder });
+		const kernel = new FakeKernel([{ type: "text", stream: "stdout", data: `${"x".repeat(3_000)}\nlast tail\n` }]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await detach(tool, kernel, "crashed-detached");
+		expect(manager.busyFor("js")).toMatchObject({ state: "detached" });
+		kernel.completeDeferredRun(errorResult("crashed-detached", "kernel crashed"));
+		await manager.waitForTerminal("crashed-detached");
+		expect(manager.peek("crashed-detached")).toMatchObject({ state: "failed" });
+		await manager.flushNotifications();
+
+		expect(recorder.notices).toHaveLength(1);
+		expect(recorder.notices[0]?.content).toContain("kernel crashed");
+		expect(recorder.notices[0]?.content).toContain("local://detached-eval-crashed-detached.log");
+		expect(existsSync(join(artifactsDir, "local", "detached-eval-crashed-detached.log"))).toBe(true);
+	});
+});

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -109,7 +109,9 @@ describe("eval detached cells", () => {
 			}),
 		]);
 		expect(recorder.notices[0]?.content).toContain("42");
-		expect(recorder.notices[0]?.content).toContain("Kernel state updated - variables are available to the next eval cell.");
+		expect(recorder.notices[0]?.content).toContain(
+			"Kernel state updated - variables are available to the next eval cell.",
+		);
 		expect(manager.busyFor("js")).toBeUndefined();
 	});
 
@@ -126,7 +128,13 @@ describe("eval detached cells", () => {
 		await detach(tool, js, "busy-js");
 
 		await expect(
-			tool.execute("blocked-js", { language: "js", code: "sideEffect()" }, undefined, undefined, interactiveContext()),
+			tool.execute(
+				"blocked-js",
+				{ language: "js", code: "sideEffect()" },
+				undefined,
+				undefined,
+				interactiveContext(),
+			),
 		).rejects.toThrow(/busy running detached cell busy-js[\s\S]*still computing/u);
 		await expect(
 			tool.execute("py-cell", { language: "py", code: "answer = 42" }, undefined, undefined, interactiveContext()),
@@ -148,7 +156,13 @@ describe("eval detached cells", () => {
 		]);
 
 		await detach(tool, py, "py-detached", "py");
-		const peek = await tool.execute("peek-py", { action: "peek", cell_id: "py-detached" }, undefined, undefined, interactiveContext());
+		const peek = await tool.execute(
+			"peek-py",
+			{ action: "peek", cell_id: "py-detached" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
 		expect(textOf(peek)).toContain("x = 42");
 		const stoppedPython = await tool.execute(
 			"stop-py",
@@ -224,7 +238,13 @@ describe("eval detached cells", () => {
 		const stopKernel = new FakeKernel([]);
 		const stopTool = createTool(stopManager, [["js", stopKernel]]);
 		await detach(stopTool, stopKernel, "stop-wins");
-		await stopTool.execute("stop", { action: "stop", cell_id: "stop-wins" }, undefined, undefined, interactiveContext());
+		await stopTool.execute(
+			"stop",
+			{ action: "stop", cell_id: "stop-wins" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
 		stopKernel.emit(result("stop-wins", "late"));
 		await stopManager.flushNotifications();
 		expect(stopRecorder.notices).toHaveLength(1);

--- a/packages/senpi-codemode/test/eval-notifier.test.ts
+++ b/packages/senpi-codemode/test/eval-notifier.test.ts
@@ -1,0 +1,37 @@
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import { EvalNotifier } from "../src/extension/eval-notifier.ts";
+import { fakeExtensionContext } from "./eval/fakes.ts";
+
+describe("EvalNotifier", () => {
+	it("scopes once-per-cell delivery to one session generation", () => {
+		const messages: string[] = [];
+		const notifier = new EvalNotifier({
+			sendUserMessage: (content) => messages.push(content),
+			getContext: () => ({ ...fakeExtensionContext(), mode: "tui", model: fakeModel() }),
+			getMode: () => "wake",
+		});
+
+		notifier.notify([{ cellId: "reused-cell", content: "first session" }]);
+		notifier.notify([{ cellId: "reused-cell", content: "duplicate in first session" }]);
+		notifier.reset();
+		notifier.notify([{ cellId: "reused-cell", content: "second session" }]);
+
+		expect(messages).toEqual(["first session", "second session"]);
+	});
+});
+
+function fakeModel(): Model<Api> {
+	return {
+		id: "test",
+		name: "test",
+		api: "fake-api",
+		provider: "fake",
+		baseUrl: "https://fake.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000,
+		maxTokens: 100,
+	};
+}

--- a/packages/senpi-codemode/test/eval/fakes.ts
+++ b/packages/senpi-codemode/test/eval/fakes.ts
@@ -46,6 +46,17 @@ export class FakeKernel implements EvalKernel {
 		return started.promise;
 	}
 
+	completeDeferredRun(next: KernelResult): void {
+		const deferred = this.deferredRun;
+		if (!deferred) throw new Error("fake kernel has no deferred run");
+		this.deferredRun = undefined;
+		deferred.result.resolve(next);
+	}
+
+	emit(message: KernelToHostMessage): void {
+		this.onMessage?.(message);
+	}
+
 	async run(input: {
 		cellId: string;
 		code: string;

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -17,6 +17,9 @@ interface RegisteredHandler {
 class FakePi {
 	readonly tools: string[] = [];
 	readonly handlers: RegisteredHandler[] = [];
+	readonly messages: string[] = [];
+	readonly deliveries: Array<{ readonly content: string; readonly deliverAs: "steer" | "followUp" | undefined }> = [];
+	readonly #nextMessage = Promise.withResolvers<string>();
 	readonly activeTools = new Set<string>(["eval"]);
 	registeredTool: Parameters<CodemodeExtensionAPI["registerTool"]>[0] | undefined;
 	registerTool(tool: Parameters<CodemodeExtensionAPI["registerTool"]>[0]): void {
@@ -32,6 +35,14 @@ class FakePi {
 	}
 	async executeTool(): Promise<never> {
 		throw new Error("nested tool execution was not expected");
+	}
+	sendUserMessage(content: string, options?: { readonly deliverAs?: "steer" | "followUp" }): void {
+		this.messages.push(content);
+		this.deliveries.push({ content, deliverAs: options?.deliverAs });
+		this.#nextMessage.resolve(content);
+	}
+	nextMessage(): Promise<string> {
+		return this.#nextMessage.promise;
 	}
 }
 
@@ -144,7 +155,10 @@ async function emit(pi: FakePi, event: string, payload: unknown, ctx: ExtensionC
 }
 
 describe("senpi-codemode extension factory", () => {
-	afterEach(() => vi.clearAllMocks());
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+	});
 
 	it("registers eval exactly once and has no module side effects", () => {
 		const pi = new FakePi();
@@ -367,6 +381,8 @@ describe("senpi-codemode extension factory", () => {
 });
 
 describe("senpi-codemode extension lifecycle", () => {
+	afterEach(() => vi.useRealTimers());
+
 	it("settles a mid-run cell as an error and rejects post-shutdown work", async () => {
 		const pi = new FakePi();
 		const manager = new DisposableManager();
@@ -385,6 +401,37 @@ describe("senpi-codemode extension lifecycle", () => {
 		).rejects.toMatchObject({ name: "CodemodeSessionDisposedError" });
 		expect([manager.disposeCount, manager.getKernelCount]).toEqual([1, 1]);
 		expect(manager.runControllers[0]?.signal.aborted).toBe(true);
+	});
+
+	it("injects one guarded interactive completion notification for a detached cell", async () => {
+		vi.useFakeTimers();
+		const pi = new FakePi();
+		const manager = new DisposableManager();
+		senpiCodemode(pi, { createSessionManager: () => manager });
+		const ctx = { ...extensionContext(), mode: "tui" as const, model: fakeModel("claude-opus-4-8") };
+		await emit(pi, "session_start", { reason: "startup" }, ctx);
+		const tool = pi.registeredTool;
+		if (!tool) throw new Error("eval tool was not registered");
+		const notification = pi.nextMessage();
+		const run = tool.execute(
+			"notified-detached",
+			{ language: "js", code: "await pending()", timeout: 1, on_timeout: "detach" },
+			undefined,
+			undefined,
+			ctx,
+		);
+		await manager.runStarted.promise;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await run;
+
+		manager.runControllers[0]?.abort(new Error("kernel crashed"));
+		const content = await notification;
+
+		expect(pi.deliveries).toEqual([{ content, deliverAs: "steer" }]);
+		expect(content).toContain("notified-detached");
+		expect(content).toContain("kernel disposed");
+		expect(content).toContain("Kernel state updated - variables are available to the next eval cell.");
+		await emit(pi, "session_shutdown", {}, ctx);
 	});
 
 	it("aborts and settles tracked eval work before disposing the session manager", async () => {

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -109,6 +109,15 @@ describe("buildEvalPrompt", () => {
 		}
 	});
 
+	it("documents timeout detachment, busy-kernel discipline, and detached-cell controls", () => {
+		const prompt = fullPrompt({ py: true, js: true, rb: false, jl: false });
+
+		expect(prompt).toContain("`on_timeout`");
+		expect(prompt).toContain('eval({ action: "peek", cell_id })');
+		expect(prompt).toContain('eval({ action: "stop", cell_id })');
+		expect(prompt).toContain("Do not re-run a detached cell");
+	});
+
 	it("keeps eval-specific prompt guidelines stable", () => {
 		// Given: a registered eval tool with no active model id.
 		// When: its prompt metadata is built.


### PR DESCRIPTION
## What
- Detach interactive `eval` cells on timeout instead of interrupting them, with `on_timeout`, `peek`, and `stop` controls.
- Keep one busy detached cell per language kernel, preserve Python interrupt state, restart JavaScript after stop, and render detached/cancelled state.
- Add a session-scoped, guarded completion notifier that coalesces same-idle-edge completions and includes final output/error, tail spill references, and kernel-state guidance.

## Why
Implements TODOs 6 and 7 of `.omo/plans/eval-exec-merge-and-injection-wakeup.md` (lane S3), including B1/B2/B5/B7/B8/B9/B10/B12. This prevents the documented duplicate-side-effect pattern caused by re-running timed-out cells while retaining persistent kernel state.

## Evidence
- TDD RED/GREEN logs: `/tmp/s3-todo6-red.txt`, `/tmp/s3-todo6-prompt-red.txt`, `/tmp/s3-todo7-red.txt`, `/tmp/s3-todo6-green.txt`, `/tmp/s3-todo6-prompt-green.txt`, `/tmp/s3-todo7-green.txt`
- Deterministic race coverage: `packages/senpi-codemode/test/eval-detach.test.ts` (timeout-vs-completion, stop-vs-completion, disposal-mid-detach, late-message terminal fencing).
- Scoped suite: `npm test` in `packages/senpi-codemode` - 386 passed, 6 skipped.
- Root validation: `npm run check` - passed.
- QA receipts: `local-ignore/qa-evidence/20260726-eval-exec-merge/s3/` (harness self-check, mock-loop real CLI tool turn, eval e2e, CLI smoke).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interactive eval cells now detach on timeout, keep running in their kernel, and send a single completion notification with the final value or error. Adds peek/stop controls and a per-language busy gate to prevent duplicate side effects.

- **New Features**
  - `on_timeout`: default is `"detach"` in interactive sessions; `"error"` in print/json. Override per call.
  - Controls: `eval({ action: "peek"|"stop", cell_id })`. Python stop interrupts and preserves variables; JavaScript stop restarts its worker (VM state is lost).
  - One detached cell per language; same-language calls return a busy error with the cell id and output tail. Other languages run normally.
  - Session-scoped notifier injects one completion message with final output/error; oversized tails spill to `local://…`.
  - Updated rendering/prompt/types to show `"detached"`/`"cancelled"` states and support control actions.

- **Migration**
  - Don’t re-run timed-out cells. Use peek/stop, or pass `on_timeout: "error"` for deadline-sensitive work.
  - For print/json one-shots, pass `on_timeout: "detach"` if you want detachment.
  - Expect JS VM state loss after stop; Python variables persist.

<sup>Written for commit f754e987468fdbaac32a7dc04c6f18c4140e6951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

