### PR TITLE
feat(mcp): keep unchanged MCP servers alive across a classic /reload

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -30,6 +30,15 @@
 
 # changes
 
+## Classic MCP reload preservation (2026-07-26)
+
+- `/reload` preserves unchanged MCP servers only in the classic singleton path;
+  the following attach re-syncs configuration and retains the existing
+  connection. Provider-scoped multi-session MCP services still dispose on
+  reload because each re-executed extension factory creates a replacement
+  service, so preserving the old one would orphan its child processes.
+
+
 ## Reload measurement and redundant-work removal (2026-07-26)
 
 - `/reload` records a `reload` timing namespace with one marker per phase

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,20 @@
 # mcp Extension Changes
 
+## Preserve classic MCP servers across reload (2026-07-26)
+
+### What changed
+- `index.ts`: the classic singleton MCP service now survives `/reload`; its next
+  `session_start` re-syncs the configuration, retaining unchanged connections
+  while replacing changed or removed servers. Provider-scoped (multi-session)
+  MCP services still dispose on reload.
+
+### Why
+- A classic reload no longer restarts unchanged stdio MCP servers. A
+  provider-scoped reload does dispose because the re-executed factory creates a
+  replacement service; leaving the previous instance alive would orphan its
+  child processes.
+
+
 ## Raced background registration replays session state (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -149,11 +149,10 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 			wrapAsync(
 				"mcp.session_shutdown",
 				async (event) => {
-					await service.handleSessionShutdown(event);
-					// A classic extension instance can be reused by the test/legacy host
-					// after reload. Its singleton is intentionally refreshed for that next
-					// session; scoped factories keep their closed instance.
-					if (!sessionOwned && event.reason === "reload" && service.isDisposed()) service = getMcpService();
+					// A reload replaces provider-scoped extension factories, each of which owns
+					// a fresh service. Dispose that instance so its MCP child processes are not
+					// orphaned; the classic singleton survives reload and re-syncs on attach.
+					if (sessionOwned || event.reason !== "reload") await service.handleSessionShutdown(event);
 				},
 				sink,
 			),

--- a/packages/coding-agent/test/mcp/extension-load.test.ts
+++ b/packages/coding-agent/test/mcp/extension-load.test.ts
@@ -27,8 +27,8 @@ describe("mcp builtin extension load", () => {
 		expect(extension.handlers.get("session_shutdown")).toHaveLength(1);
 	});
 
-	it("retains the singleton across session switches and disposes only for quit or reload", async () => {
-		for (const reason of ["new", "resume", "fork"] as const) {
+	it("retains the classic singleton across session switches and reload, disposing only for quit", async () => {
+		for (const reason of ["new", "resume", "fork", "reload"] as const) {
 			const extension = await loadMcpBuiltinExtension();
 
 			await emitSessionStart(extension, "startup");
@@ -44,7 +44,7 @@ describe("mcp builtin extension load", () => {
 			resetMcpServiceForTests();
 		}
 
-		for (const reason of ["quit", "reload"] as const) {
+		for (const reason of ["quit"] as const) {
 			const extension = await loadMcpBuiltinExtension();
 
 			await emitSessionStart(extension, "startup");
@@ -65,7 +65,7 @@ describe("mcp builtin extension load", () => {
 		}
 	});
 
-	it("creates a usable singleton for a new session after reload disposal", async () => {
+	it("reuses the classic singleton for a new session after reload", async () => {
 		const extension = await loadMcpBuiltinExtension();
 
 		await emitSessionStart(extension, "startup");
@@ -73,22 +73,22 @@ describe("mcp builtin extension load", () => {
 		await emitSessionShutdown(extension, "reload");
 
 		expect(serviceBeforeReload.getSnapshot()).toMatchObject({
-			disposed: true,
-			disposeCount: 1,
-			lastDisposeReason: "reload",
-			hasSessionContext: false,
+			disposed: false,
+			disposeCount: 0,
+			lastDisposeReason: null,
+			hasSessionContext: true,
 		});
 
 		await emitSessionStart(extension, "reload");
 		const serviceAfterReload = getMcpService();
 
-		expect(serviceAfterReload).not.toBe(serviceBeforeReload);
+		expect(serviceAfterReload).toBe(serviceBeforeReload);
 		expect(serviceAfterReload.getSnapshot()).toMatchObject({
 			disposed: false,
 			disposeCount: 0,
 			lastDisposeReason: null,
 			lastSessionStartReason: "reload",
-			sessionStartCount: 1,
+			sessionStartCount: 2,
 			hasSessionContext: true,
 		});
 	});

--- a/packages/coding-agent/test/mcp/service-lifecycle.test.ts
+++ b/packages/coding-agent/test/mcp/service-lifecycle.test.ts
@@ -1,10 +1,14 @@
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import mcpExtension from "../../src/core/extensions/builtin/mcp/index.ts";
 import {
 	getMcpService,
+	McpService,
 	registerToolsPreservingActiveSet,
 	resetMcpServiceForTests,
 } from "../../src/core/extensions/builtin/mcp/service.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	assertAlive,
 	attach,
@@ -179,6 +183,30 @@ describe("McpService session lifecycle", () => {
 		]);
 	});
 
+	it("reconnects a directly killed stdio server without requiring reload", async () => {
+		const root = makeRoot("manual-reconnect", cleanupTasks);
+		const counterFile = join(root.agentDir, "manual-reconnect-spawns.txt");
+		setConfig(root, {
+			recoverable: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]),
+		});
+		const service = getMcpService();
+
+		await attach(service, root, "startup");
+		await awaitMcpConnected(service, "recoverable");
+		const firstPid = requiredPid(service, "recoverable");
+		expect(await readCounter(counterFile)).toBe(1);
+
+		process.kill(firstPid);
+		await assertProcessDead(firstPid);
+		await service.reconnectServer("recoverable");
+		await awaitMcpConnected(service, "recoverable");
+		const secondPid = requiredPid(service, "recoverable");
+
+		expect(secondPid).not.toBe(firstPid);
+		expect(await readCounter(counterFile)).toBe(2);
+		await assertAlive(secondPid);
+	});
+
 	it("disposes all live fixture processes on quit", async () => {
 		const root = makeRoot("quit", cleanupTasks);
 		const firstCounter = join(root.agentDir, "first-spawns.txt");
@@ -273,6 +301,119 @@ describe("McpService session lifecycle", () => {
 		await assertAlive(pid2);
 	});
 });
+
+describe("MCP extension reload lifecycle", () => {
+	it("keeps the classic singleton's unchanged stdio server through three reload cycles and disposes it on quit", async () => {
+		const root = makeRoot("classic-reload", cleanupTasks);
+		const counterFile = join(root.agentDir, "classic-reload-spawns.txt");
+		writeProjectConfig(root.cwd, {
+			reloadable: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]),
+		});
+		const runtime = createMcpExtensionTestRuntime();
+		const context = contextForRoot(root);
+		mcpExtension(runtime.pi);
+
+		await runtime.emit("session_start", { type: "session_start", reason: "startup" }, context);
+		const service = getMcpService();
+		await awaitMcpConnected(service, "reloadable");
+		const firstPid = requiredPid(service, "reloadable");
+		expect(await readCounter(counterFile)).toBe(1);
+
+		for (let cycle = 0; cycle < 3; cycle++) {
+			await runtime.emit("session_shutdown", { type: "session_shutdown", reason: "reload" }, context);
+
+			expect(service.isDisposed()).toBe(false);
+			expect(getMcpService()).toBe(service);
+			expect(requiredPid(service, "reloadable")).toBe(firstPid);
+			expect(service.getSnapshot().connectionCount).toBe(1);
+			expect(await readCounter(counterFile)).toBe(1);
+			await assertAlive(firstPid);
+
+			await runtime.emit("session_start", { type: "session_start", reason: "reload" }, context);
+			await awaitMcpConnected(service, "reloadable");
+			expect(requiredPid(service, "reloadable")).toBe(firstPid);
+			expect(service.getSnapshot().connectionCount).toBe(1);
+			expect(await readCounter(counterFile)).toBe(1);
+		}
+
+		await runtime.emit("session_shutdown", { type: "session_shutdown", reason: "quit" }, context);
+		expect(service.isDisposed()).toBe(true);
+		await assertProcessDead(firstPid);
+	});
+
+	it("disposes provider-scoped services and their stdio children on reload and quit", async () => {
+		for (const reason of ["reload", "quit"] as const) {
+			const root = makeRoot(`scoped-${reason}`, cleanupTasks);
+			const counterFile = join(root.agentDir, `scoped-${reason}-spawns.txt`);
+			writeProjectConfig(root.cwd, {
+				scoped: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]),
+			});
+			const scope = new ProviderScope();
+			const runtime = createMcpExtensionTestRuntime();
+			const context = contextForRoot(root);
+			const attachSpy = vi.spyOn(McpService.prototype, "attachSession");
+
+			try {
+				await runWithProviderScope(scope, async () => {
+					mcpExtension(runtime.pi);
+					await runtime.emit("session_start", { type: "session_start", reason: "startup" }, context);
+				});
+				const service = attachSpy.mock.instances[0] as McpService | undefined;
+				if (!service) throw new Error("provider-scoped MCP service did not attach");
+				await awaitMcpConnected(service, "scoped");
+				const pid = requiredPid(service, "scoped");
+				expect(await readCounter(counterFile)).toBe(1);
+
+				await runWithProviderScope(scope, () =>
+					runtime.emit("session_shutdown", { type: "session_shutdown", reason }, context),
+				);
+
+				expect(service.getSnapshot()).toMatchObject({
+					disposed: true,
+					disposeCount: 1,
+					lastDisposeReason: reason,
+					connectionCount: 0,
+				});
+				await assertProcessDead(pid);
+			} finally {
+				attachSpy.mockRestore();
+				scope.close();
+			}
+		}
+	});
+});
+
+interface McpExtensionTestRuntime {
+	pi: ExtensionAPI;
+	emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void>;
+}
+
+function createMcpExtensionTestRuntime(): McpExtensionTestRuntime {
+	type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+	const handlers = new Map<string, Handler[]>();
+	const pi = fakePi() as unknown as {
+		on(event: string, handler: Handler): void;
+		registerCommand(...args: unknown[]): void;
+	};
+	pi.on = (event, handler) => {
+		const registered = handlers.get(event) ?? [];
+		registered.push(handler);
+		handlers.set(event, registered);
+	};
+	pi.registerCommand = () => {};
+	return {
+		pi: pi as ExtensionAPI,
+		async emit(event, payload, ctx): Promise<void> {
+			for (const handler of handlers.get(event) ?? []) {
+				await handler(payload, ctx);
+			}
+		},
+	};
+}
+
+function contextForRoot(root: { cwd: string }): ExtensionContext {
+	return { cwd: root.cwd, isProjectTrusted: () => true } as ExtensionContext;
+}
 
 describe("registerToolsPreservingActiveSet", () => {
 	it("restores the intended active tool set synchronously after auto-activating registration", () => {


### PR DESCRIPTION
## Why

`/reload` disposes every MCP connection and the next session respawns every server, even when nothing about their configuration changed. For a setup with several stdio MCP servers that is the bulk of what reload costs, and none of it is necessary: the service already knows how to reconcile.

## What changed

`McpService` keeps a config-hash keyed connection map and `#syncFromConfig` already disposes only changed or removed servers on re-attach — that path ships today for shutdown reason `"new"`. This change lets `/reload` use it too, for the classic singleton: reload no longer disposes, so the surviving instance reconciles on the next attach and unchanged servers keep their process.

**Provider-scoped services still dispose on reload, deliberately.** `mcpExtension` builds `sessionOwned ? new McpService() : getMcpService()`, so under provider scopes (multi-session RPC) every factory execution creates a fresh service, and a reload re-executes factories. Skipping disposal there would orphan the previous instance's child processes. The scope-awareness lives in the extension, not in the service, so core still knows nothing about MCP internals.

This is the narrowed form of a change that was reverted from #370 during review, where removing `"reload"` from `shouldDisposeMcpService` outright would have leaked in the scoped path.

## Evidence

21 tests pass in one run across `service-lifecycle`, `extension-load`, and `mcp-session-isolation`. `npm run check` exits 0.

The scoped-path test is the one that matters: it establishes a real `ProviderScope`, spawns a real stdio child, sends `session_shutdown` with reason `"reload"`, then asserts `disposed: true`, `connectionCount: 0`, and — the actual leak proof — that the child pid is dead.

Other coverage:
- Classic reload keeps the same service object, the same child pid, and a spawn counter of 1; the server is still connected after re-attach.
- Three consecutive classic reload cycles hold `connectionCount` and the spawn counter steady.
- `quit` still disposes in both modes.
- Recovery: kill the stdio child with `process.kill(pid)`, call `reconnectServer`, and assert a new pid with the spawn counter incremented. That is the escape hatch now that reload no longer restarts a wedged server.

## Deliberately flipped assertions

`test/mcp/extension-load.test.ts` pinned the old contract and was updated on purpose, not deleted:
1. The lifecycle matrix now treats `reload` like `new`/`resume`/`fork` for the classic singleton, leaving `quit` as the only disposing reason.
2. The reload-followup test now asserts the same singleton survives with its session context and two session starts, instead of expecting a fresh service.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep unchanged MCP servers alive across a classic `/reload` to avoid needless restarts and speed up reloads. Provider-scoped MCP services still dispose on reload to prevent orphaned child processes.

- **New Features**
  - Classic singleton: `/reload` no longer disposes `McpService`; the next `session_start` reconciles by config hash, keeping unchanged connections and replacing changed or removed servers.
  - Provider-scoped: reload still disposes the service since each factory re-run creates a new instance, ensuring previous stdio children are terminated.
  - Recovery stays the same: use `/mcp reconnect <name>` (or `reconnectServer`) to restart a wedged server without a full reload.

<sup>Written for commit 885e73f45cb4003e17a57a974a281e0605002cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

