### PR TITLE
feat(coding-agent): auto-correct malformed todo tool calls and surface real errors

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -131,3 +131,77 @@
   `renderResult` call site).
 - LOW: the shared `modes/interactive/components/todo-strike.ts` module
   (fork-only).
+
+## 2026-07-26 - Auto-correct malformed todo calls and surface real errors
+
+### Source
+
+- Fork-local change set (no upstream port). Motivated by session mining:
+  17 failures across 2,435 recorded todo calls, concentrated in kimi/glm
+  models; the replay contract lives in
+  `packages/coding-agent/test/fixtures/todo-arg-correction.fixtures.json`.
+
+### What changed
+
+- `TODO_PARAMS_SCHEMA.op` is now `Type.Optional(...)` so calls that omit the
+  operation reach `execute` and can be rescued; the advertised description
+  still states the operation is required ("Operation to perform. Required —
+  always pass it explicitly.") and auto-correction is never advertised.
+- `normalize.ts` (new): argument normalization runs before any state
+  application, in strict rule order — R0 blank-target guard (a
+  provided-but-blank `task`/`phase` on start/done/drop/rm errors instead of
+  silently widening into a bulk operation; a blank sibling of a non-blank
+  target is dropped quietly), R1 explicit-init preservation
+  (`{"op":"init","list":[]}` keeps its clear-the-list semantics), R-VIEW
+  short-circuit (`op:"view"` ignores every other field), R2 alias
+  canonicalization (`init`/`append` keys folded into effective `items`
+  BEFORE conflict detection so an alias can never bypass it), R3 conflict
+  detection + op inference (non-empty `list` plus non-empty effective
+  `items` errors as conflicting shapes; a missing `op` is inferred from the
+  payload shape or rejected with both canonical forms), R4 per-op
+  field-compatibility matrix (non-empty unrelated fields error as
+  conflicting shapes instead of passing through silently).
+- `fuzzy-match.ts` (new): task/phase resolution ladder with a conservatism
+  rule — auto-apply ONLY on unique exact or unique `sanitizeTodoText`
+  normalized (casefold) equality; containment and char-bigram Dice
+  (score >= 0.5) matches are suggestion-only (`Did you mean ...?`), because
+  containment can select a negated sibling ("Do not deploy X" contains
+  "Deploy X"). Uniqueness is enforced only on the corrections-present
+  model-tool path (`resolveTaskOrError`/`resolvePhaseOrError` invoked with a
+  `corrections` array); the omitted-corrections legacy path keeps
+  first-match semantics for `commands.ts` and `index.ts` consumers.
+- Throw-on-error: `execute` now THROWS on unrecoverable errors instead of
+  returning a result carrying `isError: true`, because
+  `packages/agent/src/agent-loop.ts` `executeToolCall`
+  (`executePreparedToolCall`) returns `{ result, isError: false }` for ANY
+  non-throwing execute — a tool-returned `isError` field is silently
+  dropped, so state-level errors reached providers flagged as success.
+  Throwing routes through the loop's error path and records
+  `isError: true`; the thrown message keeps the full remaining-items echo
+  models rely on for recovery. The dead `TodoToolResult.isError` field and
+  `isTodoToolError` helper were removed; `renderResult` now depends solely
+  on `context.isError`.
+- Init duplicate merging: duplicate phase names in an init list merge into
+  the first occurrence (items concatenated in order) and duplicate task
+  contents keep the first occurrence, each with an `[auto-corrected]`
+  correction; the empty-phase init error is preserved.
+- Append `phase` is now optional with the default chain active-task phase
+  -> last existing phase -> `DEFAULT_INIT_PHASE`, emitting
+  `[auto-corrected] append had no phase; used "<name>"`.
+- Prompt/schema guidance: a canonical init example line directly under the
+  Operations table, `phase?` in the append row, a verbatim-copy rule
+  ("done/start/drop take the task's EXACT text — copy it verbatim from the
+  latest todo result, never re-type from memory."), and sharpened schema
+  field descriptions on `op`, `task`, `phase`, and `items`.
+- Correction notices ride in plain tool-result `content` text (prepended to
+  the summary) and in `details.corrections`, so they need NO RPC/app-server
+  or web-ui rendering seam — every surface renders them generically.
+
+### Expected merge conflict zones
+
+- HIGH: `tools/todo.ts` — the schema (optional `op`, field descriptions) and
+  `execute` (normalization call, corrections threading, throw-on-error);
+  `state.ts` — `resolveTaskOrError`/`resolvePhaseOrError` signatures and
+  ladder integration, `initPhases` merge, `appendItems` default chain.
+- MEDIUM: `prompt.ts` (guidance text) and the fork-only `normalize.ts` /
+  `fuzzy-match.ts` modules if upstream ships similar correction logic.

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/fuzzy-match.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/fuzzy-match.ts
@@ -1,0 +1,92 @@
+import { sanitizeTodoText, type TodoItem, type TodoPhase } from "./state.ts";
+
+type TaskHit = {
+	task: TodoItem;
+	phase: TodoPhase;
+};
+
+export type FuzzyTaskResolution = {
+	hit?: TaskHit;
+	corrected: boolean;
+	suggestion?: string;
+};
+
+export type FuzzyPhaseResolution = {
+	hit?: TodoPhase;
+	corrected: boolean;
+	suggestion?: string;
+};
+
+function normalized(text: string): string {
+	return sanitizeTodoText(text).toLowerCase();
+}
+
+function diceCoefficient(left: string, right: string): number {
+	if (left === right) return 1;
+	if (left.length < 2 || right.length < 2) return 0;
+	const pairs = new Map<string, number>();
+	for (let index = 0; index < left.length - 1; index += 1) {
+		const pair = left.slice(index, index + 2);
+		pairs.set(pair, (pairs.get(pair) ?? 0) + 1);
+	}
+	let overlap = 0;
+	for (let index = 0; index < right.length - 1; index += 1) {
+		const pair = right.slice(index, index + 2);
+		const count = pairs.get(pair) ?? 0;
+		if (count > 0) {
+			overlap += 1;
+			pairs.set(pair, count - 1);
+		}
+	}
+	return (2 * overlap) / (left.length + right.length - 2);
+}
+
+function suggestionFor<T>(
+	candidates: readonly T[],
+	query: string,
+	contentOf: (candidate: T) => string,
+): string | undefined {
+	const normalizedQuery = normalized(query);
+	if (!normalizedQuery) return undefined;
+	let suggestion: string | undefined;
+	let bestScore = 0;
+	for (const candidate of candidates) {
+		const content = contentOf(candidate);
+		const normalizedContent = normalized(content);
+		if (!normalizedContent) continue;
+		const score =
+			normalizedContent.includes(normalizedQuery) || normalizedQuery.includes(normalizedContent)
+				? 1
+				: diceCoefficient(normalizedContent, normalizedQuery);
+		if (score >= 0.5 && score > bestScore) {
+			bestScore = score;
+			suggestion = content;
+		}
+	}
+	return suggestion;
+}
+
+export function fuzzyResolveTask(phases: readonly TodoPhase[], query: string): FuzzyTaskResolution {
+	const candidates = phases.flatMap((phase) => phase.tasks.map((task) => ({ task, phase })));
+	const exactMatches = candidates.filter(({ task }) => task.content === query);
+	if (exactMatches.length === 1) return { hit: exactMatches[0], corrected: false };
+
+	const normalizedQuery = normalized(query);
+	const normalizedMatches = candidates.filter(({ task }) => normalized(task.content) === normalizedQuery);
+	if (normalizedMatches.length === 1) return { hit: normalizedMatches[0], corrected: true };
+
+	const suggestion = suggestionFor(candidates, query, ({ task }) => task.content);
+	return suggestion ? { corrected: false, suggestion } : { corrected: false };
+}
+
+export function fuzzyResolvePhase(phases: readonly TodoPhase[], name: string): FuzzyPhaseResolution {
+	const exactMatches = phases.filter((phase) => phase.name === name);
+	if (exactMatches.length === 1) return { hit: exactMatches[0], corrected: false };
+
+	const normalizedName = normalized(name);
+	const normalizedMatches = phases.filter((phase) => normalized(phase.name) === normalizedName);
+	if (normalizedMatches.length === 1) return { hit: normalizedMatches[0], corrected: true };
+
+	const suggestion = suggestionFor(phases, name, (phase) => phase.name);
+	return suggestion ? { corrected: false, suggestion } : { corrected: false };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/normalize.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/normalize.ts
@@ -1,0 +1,189 @@
+import type { TodoOpEntry, TodoOperation, TodoPhase } from "./state.ts";
+
+export type TodoNormalization = {
+	entry?: TodoOpEntry;
+	corrections: string[];
+	error?: string;
+};
+
+type Alias = "init" | "append";
+
+const CONFLICTING_SHAPES =
+	'conflicting shapes. Use {"op":"init","list":[...]} to replace the list or {"op":"append","phase":"<active phase>","items":[...]} to add tasks.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isOperation(value: unknown): value is TodoOperation {
+	switch (value) {
+		case "init":
+		case "start":
+		case "done":
+		case "rm":
+		case "drop":
+		case "append":
+		case "view":
+			return true;
+		default:
+			return false;
+	}
+}
+
+function strings(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const parsed: string[] = [];
+	for (const item of value) {
+		if (typeof item !== "string") return undefined;
+		parsed.push(item);
+	}
+	return parsed;
+}
+
+function list(value: unknown): TodoOpEntry["list"] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const parsed: NonNullable<TodoOpEntry["list"]> = [];
+	for (const item of value) {
+		if (!isRecord(item) || typeof item.phase !== "string") return undefined;
+		const items = strings(item.items);
+		if (!items) return undefined;
+		parsed.push({ phase: item.phase, items });
+	}
+	return parsed;
+}
+
+function nonBlank(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function isBlank(value: unknown): boolean {
+	return typeof value === "string" && value.trim() === "";
+}
+
+function error(message: string): TodoNormalization {
+	return { corrections: [], error: message };
+}
+
+function aliasCorrection(alias: Alias, inferred: boolean): string {
+	const form =
+		alias === "init" ? '{"op":"init","items":[...]}' : '{"op":"append","phase":"<active phase>","items":[...]}';
+	if (inferred) {
+		return `[auto-corrected] "op" was missing; interpreted as "${alias}" because "${alias}" was provided as an items alias. Always pass op explicitly: ${form}`;
+	}
+	return `[auto-corrected] "${alias}" was used as an items alias and folded into "items". Use: ${form}`;
+}
+
+function inferredCorrection(op: "init" | "append", reason: string, form: string): string {
+	return `[auto-corrected] "op" was missing; interpreted as "${op}" because ${reason}. Always pass op explicitly: ${form}`;
+}
+
+function hasTasks(phases: readonly TodoPhase[]): boolean {
+	return phases.some((phase) => phase.tasks.length > 0);
+}
+
+export function normalizeTodoParams(
+	raw: Record<string, unknown>,
+	currentPhases: readonly TodoPhase[],
+): TodoNormalization {
+	const rawOp = raw.op;
+	if (rawOp === "view") return { entry: { op: "view" }, corrections: [] };
+	if (rawOp !== undefined && !isOperation(rawOp)) return error('Invalid "op".');
+
+	const op = isOperation(rawOp) ? rawOp : undefined;
+	const task = nonBlank(raw.task);
+	const phase = nonBlank(raw.phase);
+	if (op === "start" || op === "done" || op === "drop" || op === "rm") {
+		if (isBlank(raw.task) && !phase) {
+			return error('Blank "task" — pass the exact task text, or omit the field entirely for a bulk operation.');
+		}
+		if (isBlank(raw.phase) && !task) {
+			return error('Blank "phase" — pass the exact phase text, or omit the field entirely for a bulk operation.');
+		}
+	}
+
+	const rawItems = strings(raw.items);
+	const aliases: Array<{ name: Alias; items: string[] }> = [];
+	for (const name of ["init", "append"] as const) {
+		const items = strings(raw[name]);
+		if (items && items.length > 0) aliases.push({ name, items });
+	}
+	if (aliases.length > 1) return error(CONFLICTING_SHAPES);
+	if (aliases.length === 1 && rawItems && rawItems.length > 0) return error(CONFLICTING_SHAPES);
+
+	const alias = aliases[0];
+	let effectiveItems = rawItems && rawItems.length > 0 ? rawItems : undefined;
+	let candidate: Alias | undefined;
+	const corrections: string[] = [];
+	if (alias) {
+		if (op && op !== alias.name) return error(CONFLICTING_SHAPES);
+		effectiveItems = alias.items;
+		candidate = op ? undefined : alias.name;
+		corrections.push(aliasCorrection(alias.name, !op));
+	}
+
+	const effectiveList = list(raw.list);
+	const hasList = Boolean(effectiveList && effectiveList.length > 0);
+	const hasItems = Boolean(effectiveItems && effectiveItems.length > 0);
+	if (hasList && hasItems) return error(CONFLICTING_SHAPES);
+
+	let effectiveOp = op;
+	if (!effectiveOp) {
+		if (candidate) {
+			effectiveOp = candidate;
+		} else if (hasList) {
+			effectiveOp = "init";
+			corrections.push(inferredCorrection("init", '"list" was provided', '{"op":"init","list":[...]}'));
+		} else if (hasItems && phase) {
+			effectiveOp = "append";
+			corrections.push(
+				inferredCorrection(
+					"append",
+					'"items" and "phase" were provided',
+					'{"op":"append","phase":"<active phase>","items":[...]}',
+				),
+			);
+		} else if (hasItems && !hasTasks(currentPhases)) {
+			effectiveOp = "init";
+			corrections.push(
+				inferredCorrection("init", '"items" was provided to an empty todo list', '{"op":"init","items":[...]}'),
+			);
+		} else if (hasItems) {
+			return error(
+				'Missing "op": use {"op":"init","list":[...]} to replace the list, or {"op":"append","phase":"<active phase>","items":[...]} to add tasks.',
+			);
+		} else {
+			return error('Missing "op". Example: {"op":"init","list":[{"phase":"Setup","items":["..."]}]}');
+		}
+	}
+
+	switch (effectiveOp) {
+		case "init": {
+			if (task || (effectiveList && effectiveList.length === 0 && hasItems)) return error(CONFLICTING_SHAPES);
+			const entry: TodoOpEntry = { op: "init" };
+			if (effectiveList) entry.list = effectiveList;
+			if (effectiveItems) entry.items = effectiveItems;
+			if (phase) entry.phase = phase;
+			return { entry, corrections };
+		}
+		case "start":
+			if (phase || hasList || hasItems) return error(CONFLICTING_SHAPES);
+			return { entry: task ? { op: "start", task } : { op: "start" }, corrections };
+		case "done":
+		case "drop":
+		case "rm": {
+			if (hasList || hasItems) return error(CONFLICTING_SHAPES);
+			const entry: TodoOpEntry = { op: effectiveOp };
+			if (task) entry.task = task;
+			if (phase) entry.phase = phase;
+			return { entry, corrections };
+		}
+		case "append":
+			if (task || hasList) return error(CONFLICTING_SHAPES);
+			return {
+				entry: { op: "append", ...(phase ? { phase } : {}), ...(effectiveItems ? { items: effectiveItems } : {}) },
+				corrections,
+			};
+		case "view":
+			return { entry: { op: "view" }, corrections: [] };
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/prompt.ts
@@ -18,8 +18,10 @@ Completing tasks out of phase order can move this pointer **back** to an earlier
 | done | task or phase | Mark completed |
 | drop | task or phase | Mark abandoned |
 | rm | task or phase (optional) | Remove task or phase; omit both to clear |
-| append | phase, items: string[] | Append tasks to phase; lazily creates phase |
+| append | phase?, items: string[] | Append tasks to phase; lazily creates phase |
 | view | — | Read-only: echo list |
+
+Example: {"op":"init","list":[{"phase":"Setup","items":["Survey code","Write tests"]}]}
 
 ## Anatomy
 - **Task content**: 5–10 words; what, not how. Unique identifier.
@@ -30,7 +32,7 @@ Completing tasks out of phase order can move this pointer **back** to an earlier
 - NEVER make a todo call your turn's only tool call — batch it with the real work: init with the first reads/edits, each done/start with the next action. Solo todo turns waste a round trip.
 - Blocked? append a task to the active phase, or drop.
 - Keep task/phase strings stable once introduced.
-- Lost the exact task text? view echoes the list — NEVER guess from memory.
+- Lost the exact task text? view echoes the list — NEVER guess from memory. done/start/drop take the task's EXACT text — copy it verbatim from the latest todo result, never re-type from memory.
 
 ## When to create a list
 - Task requires 3+ distinct steps

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/state.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/state.ts
@@ -5,6 +5,7 @@
 
 import { stripAnsi } from "../../../../utils/ansi.ts";
 import type { SessionEntry } from "../../../session-manager.ts";
+import { fuzzyResolvePhase, fuzzyResolveTask } from "./fuzzy-match.ts";
 
 export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned";
 
@@ -196,53 +197,115 @@ export function resolveTaskOrError(
 	phases: TodoPhase[],
 	content: string | undefined,
 	errors: string[],
+	corrections?: string[],
 ): TaskHit | undefined {
 	if (!content) {
 		errors.push("Missing task content");
 		return undefined;
 	}
-	const hit = findTaskByContent(phases, content);
-	if (!hit) {
-		if (/^task-\d+$/.test(content)) {
-			errors.push(
-				`Task "${content}" not found. Tasks are referenced by content, not by IDs — pass the task's full text from the previous result.`,
-			);
-		} else {
-			const totalTasks = phases.reduce((sum, phase) => sum + phase.tasks.length, 0);
-			const hint = totalTasks === 0 ? " (todo list is empty — was it replaced or not yet created?)" : "";
-			errors.push(`Task "${content}" not found${hint}`);
+	if (!corrections) {
+		const hit = findTaskByContent(phases, content);
+		if (!hit) {
+			if (/^task-\d+$/.test(content)) {
+				errors.push(
+					`Task "${content}" not found. Tasks are referenced by content, not by IDs — pass the task's full text from the previous result.`,
+				);
+			} else {
+				const totalTasks = phases.reduce((sum, phase) => sum + phase.tasks.length, 0);
+				const hint = totalTasks === 0 ? " (todo list is empty — was it replaced or not yet created?)" : "";
+				errors.push(`Task "${content}" not found${hint}`);
+			}
 		}
+		return hit;
 	}
-	return hit;
+
+	const resolution = fuzzyResolveTask(phases, content);
+	if (resolution.hit) {
+		if (resolution.corrected) {
+			corrections.push(
+				`[auto-matched] task "${content}" -> "${resolution.hit.task.content}" — pass the exact text from the previous todo result next time`,
+			);
+		}
+		return resolution.hit;
+	}
+
+	const exactMatches = phases.flatMap((phase) =>
+		phase.tasks.filter((task) => task.content === content).map((task) => ({ task, phase })),
+	);
+	if (exactMatches.length > 1) {
+		const phaseNames = [...new Set(exactMatches.map((match) => match.phase.name))].map((name) => `"${name}"`);
+		errors.push(
+			`Task "${content}" is ambiguous: duplicate task text exists in phases ${phaseNames.join(", ")}. Use /todo edit to make the task text unique.`,
+		);
+		return undefined;
+	}
+	if (/^task-\d+$/.test(content)) {
+		errors.push(
+			`Task "${content}" not found. Tasks are referenced by content, not by IDs — pass the task's full text from the previous result.`,
+		);
+		return undefined;
+	}
+	const totalTasks = phases.reduce((sum, phase) => sum + phase.tasks.length, 0);
+	const hint = totalTasks === 0 ? " (todo list is empty — was it replaced or not yet created?)" : "";
+	const suggestion = resolution.suggestion ? ` Did you mean "${resolution.suggestion}"?` : "";
+	errors.push(`Task "${content}" not found${hint}${suggestion}`);
+	return undefined;
 }
 
 export function resolvePhaseOrError(
 	phases: TodoPhase[],
 	name: string | undefined,
 	errors: string[],
+	corrections?: string[],
 ): TodoPhase | undefined {
 	if (!name) {
 		errors.push("Missing phase name");
 		return undefined;
 	}
-	const phase = findPhaseByName(phases, name);
-	if (!phase) errors.push(`Phase "${name}" not found`);
-	return phase;
+	if (!corrections) {
+		const phase = findPhaseByName(phases, name);
+		if (!phase) errors.push(`Phase "${name}" not found`);
+		return phase;
+	}
+
+	const resolution = fuzzyResolvePhase(phases, name);
+	if (resolution.hit) {
+		if (resolution.corrected) {
+			corrections.push(
+				`[auto-matched] phase "${name}" -> "${resolution.hit.name}" — pass the exact text from the previous todo result next time`,
+			);
+		}
+		return resolution.hit;
+	}
+	if (phases.filter((phase) => phase.name === name).length > 1) {
+		errors.push(
+			`Phase "${name}" is ambiguous: duplicate phase names exist. Use /todo edit to make the phase name unique.`,
+		);
+		return undefined;
+	}
+	const suggestion = resolution.suggestion ? ` Did you mean "${resolution.suggestion}"?` : "";
+	errors.push(`Phase "${name}" not found${suggestion}`);
+	return undefined;
 }
 
-export function getTaskTargets(phases: TodoPhase[], entry: TodoOpEntry, errors: string[]): TodoItem[] {
+export function getTaskTargets(
+	phases: TodoPhase[],
+	entry: TodoOpEntry,
+	errors: string[],
+	corrections?: string[],
+): TodoItem[] {
 	if (entry.task) {
-		const hit = resolveTaskOrError(phases, entry.task, errors);
+		const hit = resolveTaskOrError(phases, entry.task, errors, corrections);
 		return hit ? [hit.task] : [];
 	}
 	if (entry.phase) {
-		const phase = resolvePhaseOrError(phases, entry.phase, errors);
+		const phase = resolvePhaseOrError(phases, entry.phase, errors, corrections);
 		return phase ? [...phase.tasks] : [];
 	}
 	return phases.flatMap((phase) => phase.tasks);
 }
 
-export function initPhases(entry: TodoOpEntry, errors: string[]): TodoPhase[] {
+export function initPhases(entry: TodoOpEntry, errors: string[], corrections?: string[]): TodoPhase[] {
 	const list =
 		entry.list ??
 		(entry.items && entry.items.length > 0
@@ -253,29 +316,38 @@ export function initPhases(entry: TodoOpEntry, errors: string[]): TodoPhase[] {
 		return [];
 	}
 
-	const seenPhases = new Set<string>();
+	const phases: TodoPhase[] = [];
+	const phasesByName = new Map<string, TodoPhase>();
 	const seenTasks = new Set<string>();
 	for (const listEntry of list) {
-		if (seenPhases.has(listEntry.phase)) errors.push(`Duplicate phase "${listEntry.phase}" in init list`);
-		seenPhases.add(listEntry.phase);
 		if (listEntry.items.length === 0) errors.push(`Phase "${listEntry.phase}" has no tasks in init list`);
+		let phase = phasesByName.get(listEntry.phase);
+		if (phase) {
+			corrections?.push(`[auto-corrected] merged duplicate phase "${listEntry.phase}" in init list`);
+		} else {
+			phase = { name: listEntry.phase, tasks: [] };
+			phasesByName.set(listEntry.phase, phase);
+			phases.push(phase);
+		}
 		for (const content of listEntry.items) {
-			if (seenTasks.has(content)) errors.push(`Duplicate task "${content}" in init list`);
+			if (seenTasks.has(content)) {
+				corrections?.push(`[auto-corrected] kept first duplicate task "${content}" in init list`);
+				continue;
+			}
 			seenTasks.add(content);
+			phase.tasks.push({ content, status: "pending" });
 		}
 	}
 
-	return list.map((listEntry) => ({
-		name: listEntry.phase,
-		tasks: listEntry.items.map((content) => ({ content, status: "pending" })),
-	}));
+	return phases;
 }
 
-export function appendItems(phases: TodoPhase[], entry: TodoOpEntry, errors: string[]): TodoPhase[] {
-	if (!entry.phase) {
-		errors.push("Missing phase name for append operation");
-		return phases;
-	}
+export function appendItems(
+	phases: TodoPhase[],
+	entry: TodoOpEntry,
+	errors: string[],
+	corrections?: string[],
+): TodoPhase[] {
 	if (!entry.items || entry.items.length === 0) {
 		errors.push("Missing items for append operation");
 		return phases;
@@ -292,9 +364,17 @@ export function appendItems(phases: TodoPhase[], entry: TodoOpEntry, errors: str
 	}
 	if (hasDuplicate) return phases;
 
-	let phase = findPhaseByName(phases, entry.phase);
+	let phaseName = entry.phase;
+	if (!phaseName) {
+		const activeTask = nextActionableTask(phases);
+		const activePhase = activeTask ? phases.find((phase) => phase.tasks.includes(activeTask)) : undefined;
+		phaseName = activePhase?.name ?? phases[phases.length - 1]?.name ?? DEFAULT_INIT_PHASE;
+		corrections?.push(`[auto-corrected] append had no phase; used "${phaseName}"`);
+	}
+
+	let phase = findPhaseByName(phases, phaseName);
 	if (!phase) {
-		phase = { name: entry.phase, tasks: [] };
+		phase = { name: phaseName, tasks: [] };
 		phases.push(phase);
 	}
 
@@ -302,15 +382,20 @@ export function appendItems(phases: TodoPhase[], entry: TodoOpEntry, errors: str
 	return phases;
 }
 
-export function removeTasks(phases: TodoPhase[], entry: TodoOpEntry, errors: string[]): TodoPhase[] {
+export function removeTasks(
+	phases: TodoPhase[],
+	entry: TodoOpEntry,
+	errors: string[],
+	corrections?: string[],
+): TodoPhase[] {
 	if (entry.task) {
-		const hit = resolveTaskOrError(phases, entry.task, errors);
+		const hit = resolveTaskOrError(phases, entry.task, errors, corrections);
 		if (!hit) return phases;
 		hit.phase.tasks = hit.phase.tasks.filter((candidate) => candidate !== hit.task);
 		return phases;
 	}
 	if (entry.phase) {
-		const phase = resolvePhaseOrError(phases, entry.phase, errors);
+		const phase = resolvePhaseOrError(phases, entry.phase, errors, corrections);
 		if (!phase) return phases;
 		phase.tasks = [];
 		return phases;
@@ -319,12 +404,17 @@ export function removeTasks(phases: TodoPhase[], entry: TodoOpEntry, errors: str
 	return phases;
 }
 
-export function applyEntry(phases: TodoPhase[], entry: TodoOpEntry, errors: string[]): TodoPhase[] {
+export function applyEntry(
+	phases: TodoPhase[],
+	entry: TodoOpEntry,
+	errors: string[],
+	corrections?: string[],
+): TodoPhase[] {
 	switch (entry.op) {
 		case "init":
-			return initPhases(entry, errors);
+			return initPhases(entry, errors, corrections);
 		case "start": {
-			const hit = resolveTaskOrError(phases, entry.task, errors);
+			const hit = resolveTaskOrError(phases, entry.task, errors, corrections);
 			if (!hit) return phases;
 			for (const phase of phases) {
 				for (const candidate of phase.tasks) {
@@ -335,25 +425,29 @@ export function applyEntry(phases: TodoPhase[], entry: TodoOpEntry, errors: stri
 			return phases;
 		}
 		case "done":
-			for (const task of getTaskTargets(phases, entry, errors)) task.status = "completed";
+			for (const task of getTaskTargets(phases, entry, errors, corrections)) task.status = "completed";
 			return phases;
 		case "drop":
-			for (const task of getTaskTargets(phases, entry, errors)) task.status = "abandoned";
+			for (const task of getTaskTargets(phases, entry, errors, corrections)) task.status = "abandoned";
 			return phases;
 		case "rm":
-			return removeTasks(phases, entry, errors);
+			return removeTasks(phases, entry, errors, corrections);
 		case "append":
-			return appendItems(phases, entry, errors);
+			return appendItems(phases, entry, errors, corrections);
 		case "view":
 			return phases;
 	}
 }
 
-export function applyParams(phases: TodoPhase[], params: TodoOpEntry): { phases: TodoPhase[]; errors: string[] } {
+export function applyParams(
+	phases: TodoPhase[],
+	params: TodoOpEntry,
+	corrections?: string[],
+): { phases: TodoPhase[]; errors: string[] } {
 	if (params.op === "view") return { phases, errors: [] };
 	const original = clonePhases(phases);
 	const errors: string[] = [];
-	const next = applyEntry(phases, params, errors);
+	const next = applyEntry(phases, params, errors, corrections);
 	if (errors.length > 0) return { phases: original, errors };
 	normalizeInProgressTask(next);
 	return { phases: next, errors };

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/state.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/state.ts
@@ -30,6 +30,7 @@ export type TodoToolDetails = {
 	op?: TodoOperation;
 	phases: TodoPhase[];
 	storage: "session" | "memory";
+	corrections?: string[];
 	completedTasks?: TodoCompletionTransition[];
 };
 

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
@@ -109,7 +109,10 @@ function renderCallLabel(params: TodoParams): string {
 			return `todo rm: ${sanitizeTodoText(params.task ?? params.phase ?? "all") || "all"}`;
 		case "view":
 			return "todo view";
-		default:
+		// Normalization can rescue a call that omitted `op`; label it generically until
+		// execute resolves the effective operation. Listing `undefined` explicitly (instead
+		// of `default`) keeps this switch exhaustive, so a new TodoOperation fails typecheck.
+		case undefined:
 			return "todo";
 	}
 }
@@ -194,16 +197,32 @@ function computeTouchedPhases(
 		if (activePhase) touched.add(activePhase.name);
 	}
 	for (const transition of completedTasks) touched.add(transition.phase);
-	if (operation === "init") {
-		for (const phase of phases) touched.add(phase.name);
-	} else {
-		if (args.phase) {
-			const phase = phases.find((candidate) => candidate.name === args.phase);
-			if (phase) touched.add(phase.name);
+	// Exhaustive over TodoOperation | undefined so adding an operation is a typecheck
+	// failure here rather than a silent fall-through into target-scoped highlighting.
+	switch (operation) {
+		case "init":
+			for (const phase of phases) touched.add(phase.name);
+			break;
+		case "start":
+		case "done":
+		case "drop":
+		case "rm":
+		case "append":
+		case "view":
+		case undefined: {
+			if (args.phase) {
+				const phase = phases.find((candidate) => candidate.name === args.phase);
+				if (phase) touched.add(phase.name);
+			}
+			if (args.task) {
+				const hit = findTaskByContent([...phases], args.task);
+				if (hit) touched.add(hit.phase.name);
+			}
+			break;
 		}
-		if (args.task) {
-			const hit = findTaskByContent([...phases], args.task);
-			if (hit) touched.add(hit.phase.name);
+		default: {
+			const _exhaustive: never = operation;
+			return touched.size > 0 ? touched : null;
 		}
 	}
 	return touched.size > 0 ? touched : null;

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
@@ -15,6 +15,7 @@ import type {
 	ToolRenderContext,
 	ToolRenderResultOptions,
 } from "../../../types.ts";
+import { normalizeTodoParams } from "../normalize.ts";
 import { TODO_TOOL_DESCRIPTION } from "../prompt.ts";
 import {
 	applyParams,
@@ -27,20 +28,24 @@ import {
 	sanitizeTodoText,
 	TODO_STATE_ENTRY_TYPE,
 	type TodoCompletionTransition,
+	type TodoOperation,
 	type TodoPhase,
 	type TodoStateEntry,
 	type TodoToolDetails,
 } from "../state.ts";
 
-const TodoOperationSchema = Type.Union([
-	Type.Literal("init"),
-	Type.Literal("start"),
-	Type.Literal("done"),
-	Type.Literal("rm"),
-	Type.Literal("drop"),
-	Type.Literal("append"),
-	Type.Literal("view"),
-]);
+const TodoOperationSchema = Type.Union(
+	[
+		Type.Literal("init"),
+		Type.Literal("start"),
+		Type.Literal("done"),
+		Type.Literal("rm"),
+		Type.Literal("drop"),
+		Type.Literal("append"),
+		Type.Literal("view"),
+	],
+	{ description: "Operation to perform. Required — always pass it explicitly." },
+);
 
 const TodoPhaseInputSchema = Type.Object({
 	phase: Type.String({ description: "Phase name" }),
@@ -51,13 +56,15 @@ const TodoPhaseInputSchema = Type.Object({
 });
 
 export const TODO_PARAMS_SCHEMA = Type.Object({
-	op: TodoOperationSchema,
+	op: Type.Optional(TodoOperationSchema),
 	list: Type.Optional(Type.Array(TodoPhaseInputSchema, { description: "Phased task list for init" })),
-	task: Type.Optional(Type.String({ description: "Task content" })),
-	phase: Type.Optional(Type.String({ description: "Phase name" })),
+	task: Type.Optional(Type.String({ description: "Exact task text copied from the previous todo result" })),
+	phase: Type.Optional(Type.String({ description: "Exact phase name copied from the previous todo result" })),
 	// Keep this unconstrained at the schema boundary. init and append return
 	// operation-specific errors, while unrelated operations may ignore it.
-	items: Type.Optional(Type.Array(Type.String({ description: "Task content" }), { description: "Tasks to append" })),
+	items: Type.Optional(
+		Type.Array(Type.String({ description: "Task content" }), { description: "Task texts to append" }),
+	),
 });
 
 type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
@@ -66,10 +73,6 @@ type TodoAccessors = {
 	getCurrentPhases: () => TodoPhase[];
 	setCurrentPhases: (phases: TodoPhase[]) => void;
 	syncWidget: (ctx: ExtensionContext) => void;
-};
-
-type TodoToolResult = AgentToolResult<TodoToolDetails> & {
-	isError?: boolean;
 };
 
 function countInitItems(params: TodoParams): { phases: number; tasks: number } {
@@ -106,6 +109,8 @@ function renderCallLabel(params: TodoParams): string {
 			return `todo rm: ${sanitizeTodoText(params.task ?? params.phase ?? "all") || "all"}`;
 		case "view":
 			return "todo view";
+		default:
+			return "todo";
 	}
 }
 
@@ -178,6 +183,7 @@ function formatTaskLine(
 
 function computeTouchedPhases(
 	args: TodoParams,
+	operation: TodoOperation | undefined,
 	phases: readonly TodoPhase[],
 	completedTasks: readonly TodoCompletionTransition[],
 ): Set<string> | null {
@@ -188,7 +194,7 @@ function computeTouchedPhases(
 		if (activePhase) touched.add(activePhase.name);
 	}
 	for (const transition of completedTasks) touched.add(transition.phase);
-	if (args.op === "init") {
+	if (operation === "init") {
 		for (const phase of phases) touched.add(phase.name);
 	} else {
 		if (args.phase) {
@@ -210,6 +216,7 @@ function renderTodoPhases(
 	completedTasks: readonly TodoCompletionTransition[],
 	options: ToolRenderResultOptions,
 	args: TodoParams,
+	operation: TodoOperation | undefined,
 	theme: Theme,
 	frame: number | undefined,
 ): string {
@@ -217,7 +224,9 @@ function renderTodoPhases(
 	if (visiblePhases.length === 0) return "";
 
 	const touched =
-		options.expanded || visiblePhases.length === 1 ? null : computeTouchedPhases(args, visiblePhases, completedTasks);
+		options.expanded || visiblePhases.length === 1
+			? null
+			: computeTouchedPhases(args, operation, visiblePhases, completedTasks);
 	const completionKeysByPhase = new Map<string, Set<string>>();
 	for (const transition of completedTasks) {
 		let completionKeys = completionKeysByPhase.get(transition.phase);
@@ -265,16 +274,23 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 		],
 		parameters: TODO_PARAMS_SCHEMA,
 		executionMode: "sequential",
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<TodoToolResult> {
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<TodoToolDetails>> {
 			const previousPhases = clonePhases(accessors.getCurrentPhases());
-			const readOnly = params.op === "view";
+			const normalized = normalizeTodoParams(params as Record<string, unknown>, previousPhases);
+			if (normalized.error || !normalized.entry) {
+				const error =
+					normalized.error ?? 'Missing "op". Example: {"op":"init","list":[{"phase":"Setup","items":["..."]}]}';
+				throw new Error(`${error}\n\n${formatSummary(previousPhases, [], true)}`);
+			}
+			const entry = normalized.entry;
+			const corrections = normalized.corrections;
+			const readOnly = entry.op === "view";
 			const applied = readOnly
 				? { phases: previousPhases, errors: [] as string[] }
-				: applyParams(clonePhases(previousPhases), params);
-			const failed = applied.errors.length > 0;
-			const effective = failed ? previousPhases : applied.phases;
-			const completedTasks = readOnly || failed ? [] : getCompletionTransitions(previousPhases, applied.phases);
-			if (!readOnly && !failed) {
+				: applyParams(clonePhases(previousPhases), entry, corrections);
+			if (applied.errors.length > 0) throw new Error(formatSummary(previousPhases, applied.errors, readOnly));
+			const completedTasks = readOnly ? [] : getCompletionTransitions(previousPhases, applied.phases);
+			if (!readOnly) {
 				pi.appendEntry(TODO_STATE_ENTRY_TYPE, {
 					schema: "v2",
 					phases: clonePhases(applied.phases),
@@ -284,23 +300,22 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 			}
 
 			const details: TodoToolDetails = {
-				op: params.op,
-				phases: clonePhases(effective),
+				op: entry.op,
+				phases: clonePhases(applied.phases),
 				storage: ctx.sessionManager.getSessionFile() ? "session" : "memory",
 			};
+			if (corrections.length > 0) details.corrections = corrections;
 			if (completedTasks.length > 0) details.completedTasks = completedTasks;
+			const summary = formatSummary(applied.phases, [], readOnly);
+			const text = corrections.length > 0 ? `${corrections.join("\n")}\n\n${summary}` : summary;
 
-			return {
-				content: [{ type: "text", text: formatSummary(effective, applied.errors, readOnly) }],
-				details,
-				isError: failed ? true : undefined,
-			};
+			return { content: [{ type: "text", text }], details };
 		},
 		renderCall(args, theme) {
 			return new Text(theme.fg("toolTitle", theme.bold(renderCallLabel(args))), 0, 0);
 		},
 		renderResult(result, options, theme, context: ToolRenderContext<unknown, TodoParams>) {
-			if (isTodoToolError(result) || context.isError) {
+			if (context.isError) {
 				return new Text(theme.fg("toolOutput", getTextContent(result)), 0, 0);
 			}
 			const phases = result.details?.phases ?? [];
@@ -309,6 +324,7 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 				result.details?.completedTasks ?? [],
 				options,
 				context.args,
+				result.details?.op,
 				theme,
 				context.spinnerFrame,
 			);
@@ -318,8 +334,4 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 	};
 
 	pi.registerTool(tool);
-}
-
-function isTodoToolError(result: AgentToolResult<TodoToolDetails>): result is TodoToolResult {
-	return "isError" in result && result.isError === true;
 }

--- a/packages/coding-agent/test/fixtures/todo-arg-correction.fixtures.json
+++ b/packages/coding-agent/test/fixtures/todo-arg-correction.fixtures.json
@@ -1,0 +1,626 @@
+{
+ "description": "Sanitized regression fixtures for the todo-tool-correction plan. raw_args are VERBATIM tool-call arguments mined from ~/.senpi/agent/sessions (2026-07-20..07-25). starting_state entries marked reconstructed=true are representative reconstructions from the error-echo text (exact pre-call state was not persisted); behavior class, not exact wording, is the contract for those. No secrets present (scanned).",
+ "mined": {
+  "total_todo_calls": 2435,
+  "failures": 17,
+  "window": "2026-07-19..2026-07-26"
+ },
+ "rules_version": "r2-conservative (unique-normalized-equality auto-match only; containment/similarity suggestion-only)",
+ "fixtures": [
+  {
+   "id": "fx01",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "state-level",
+   "raw_args": {
+    "op": "done",
+    "task": "synthesize non-overlapping findings and current status"
+   },
+   "starting_state": [
+    {
+     "name": "Acquire",
+     "tasks": [
+      {
+       "content": "fetch stall-analysis artifacts",
+       "status": "completed"
+      },
+      {
+       "content": "collect harness logs",
+       "status": "completed"
+      }
+     ]
+    },
+    {
+     "name": "Report",
+     "tasks": [
+      {
+       "content": "synthesize findings and write current-status report",
+       "status": "completed"
+      }
+     ]
+    }
+   ],
+   "starting_state_reconstructed": true,
+   "expected_behavior_after_fix": "throw: task not found; suggestion (did-you-mean) for the closest task; isError=true; state unchanged",
+   "observed_error_text_excerpt": "Errors: Task \"synthesize non-overlapping findings and current status\" not found\nRemaining items: none.\nOverall: 6/6 done, 0 open.\nActive phase 3/3 \"Report\" (1/1).\n  Acquire:\n    - [X] fetch 병현 stall-analysis markdown\n    - [X] locate sglang source repo/version used\n  Critical rev"
+  },
+  {
+   "id": "fx02",
+   "source_model": "apitopia/kimi-k3-unlocked",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "items": [
+     "Wave1: DNS/WHOIS/TLS/HTTP/crt.sh fingerprint via eval — verify outputs in notepad",
+     "Wave2: fetch ydtour50.sbs content Tier1 engine, escalate CloakBrowser if blocked — verify captured text+screenshot",
+     "Wave3: enumerate >=3 sibling mirror domains — verify list with sources",
+     "Synthesize final report with evidence refs — verify all criteria PASS"
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (items-only, empty current list); [auto-corrected] notice; list initialized under DEFAULT_INIT_PHASE",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"items\": [\n    \"Wave1: DNS/WHOIS/TLS/HTTP/crt.sh fingerprint via eval — verify outputs in notepad\",\n    \"Wave2: fetch ydtour50.sbs content Tier1 engine, escalate CloakBrowser if b"
+  },
+  {
+   "id": "fx03",
+   "source_model": "quotio-openai/gpt-5.6-sol-fast",
+   "observed_error_kind": "state-level",
+   "raw_args": {
+    "op": "done",
+    "list": [],
+    "task": "Confirm temporary 13773 server is offline",
+    "phase": "",
+    "items": []
+   },
+   "starting_state": [
+    {
+     "name": "Migration",
+     "tasks": [
+      {
+       "content": "Capture current 13773 server config",
+       "status": "completed"
+      },
+      {
+       "content": "Migrate service to new port",
+       "status": "completed"
+      },
+      {
+       "content": "Verify new server healthy",
+       "status": "completed"
+      },
+      {
+       "content": "Confirm the temporary server on 13773 is offline",
+       "status": "completed"
+      }
+     ]
+    }
+   ],
+   "starting_state_reconstructed": true,
+   "expected_behavior_after_fix": "placeholder stripping: list=[]/phase=''/items=[] treated as absent (no notice); task non-blank but not an exact/unique-normalized match -> throw with did-you-mean; isError=true; state unchanged",
+   "observed_error_text_excerpt": "Errors: Task \"Confirm temporary 13773 server is offline\" not found\nRemaining items: none.\nOverall: 4/4 done, 0 open.\nActive phase 1/1 \"Migration\" (4/4).\n  Migration:\n    - [X] Capture current 13773 server command and health\n    - [X] Terminate stale Senpi and CUA process tree\n   "
+  },
+  {
+   "id": "fx04",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "items": [
+       "W1-A: migration 0016 + drizzle schema + repos types/mapping + inline test DDL sweep — verify tsc + full bun test green",
+       "W1-B: src/lib/cost-limits.ts + unit tests RED→GREEN — verify bun test tests/unit/cost-limits.test.ts",
+       "W1 review: diff both lanes against plan D1-D4/D6 — verify checklist items"
+      ],
+      "phase": "Foundation"
+     },
+     {
+      "items": [
+       "W2-C: auth.ts enforcement + integration 429 tests RED→GREEN",
+       "W2-D: logUsage counter UPDATE + usage counter tests RED→GREEN",
+       "W2-E: admin PATCH/reset/list-enrich + integration tests RED→GREEN",
+       "W2 review: diff all three lanes, run full suite + typecheck"
+      ],
+      "phase": "Enforcement"
+     },
+     {
+      "items": [
+       "AGENTS.md doc row + section, openapi.json regen if committed",
+       "Oracle reviewer gate: submit diff+criteria+evidence, resolve blockers to unconditional approval",
+       "Final local gate: bun test + tsc --noEmit + biome check all green"
+      ],
+      "phase": "Review"
+     },
+     {
+      "items": [
+       "Prod D1 migration first — verify PRAGMA table_info shows 5 new columns",
+       "Commit + push main, watch deploy.yml to green",
+       "C6 live chain: insert test key limit=1µ¢, 200→429 evidence, counters SELECT, no-limit key 200, limit cleared 200",
+       "Cleanup: DELETE test key rows, verify count 0, receipt in notepad",
+       "Final report + update_goal complete"
+      ],
+      "phase": "Ship"
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"items\": [\n        \"W1-A: migration 0016 + drizzle schema + repos types/mapping + inline test DDL sweep — verify tsc + full bun test green\",\n        \"W1-B: s"
+  },
+  {
+   "id": "fx05",
+   "source_model": "opengateway/z-ai/glm-5.2-ultrafast",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "op": "Study kimi-k3-unlocked full implementation"
+   },
+   "starting_state": null,
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "loop-level validation error (op not in enum) — unchanged by design; assert validateToolArguments throws the enum message",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must be equal to constant\n  - op: must be equal to constant\n  - op: must be equal to constant\n  - op: must be equal to constant\n  - op: must be equal to constant\n  - op: must be equal to constant\n  - op: must be equal to constant\n  - op:"
+  },
+  {
+   "id": "fx06",
+   "source_model": "opengateway/z-ai/glm-5.2-ultrafast",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "phase": "Build",
+      "items": [
+       "Build Galaga-style game with HTML5 Canvas",
+       "Add AI auto-pilot demo mode",
+       "Add wave system, enemies, shooting, scoring",
+       "Verify game runs in browser"
+      ]
+     },
+     {
+      "phase": "Record",
+      "items": [
+       "Open game in browser",
+       "Record screen during gameplay to MP4",
+       "Verify MP4 file is valid"
+      ]
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"phase\": \"Build\",\n      \"items\": [\n        \"Build Galaga-style game with HTML5 Canvas\",\n        \"Add AI auto-pilot demo mode\",\n        \"Add wave system, enem"
+  },
+  {
+   "id": "fx07",
+   "source_model": "apitopia/kimi-k3-unlocked",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "phase": "Bootstrap",
+      "items": [
+       "Clone and survey reference repo structure",
+       "Extract physics constants and level data format from reference",
+       "Write decision-complete plan file to .omo/plans/mario-port.md",
+       "Record tier triage and skills in notepad"
+      ]
+     },
+     {
+      "phase": "Foundation",
+      "items": [
+       "Scaffold git+bun+vite+strict tsconfig+biome",
+       "RED: first failing physics constants test",
+       "GREEN: constants module flips test, commit foundation"
+      ]
+     },
+     {
+      "phase": "Simulation Core",
+      "items": [
+       "TDD fixed-point math and physics constants parity",
+       "TDD level format and converter from reference data",
+       "TDD tilemap collision and player movement physics",
+       "TDD camera scrolling rules, commit sim core"
+      ]
+     },
+     {
+      "phase": "Entities",
+      "items": [
+       "TDD Goomba and Koopa behaviors",
+       "TDD question/brick blocks, coins, powerups",
+       "TDD pipes, flagpole, scoring, timer, lives",
+       "Commit entities slice"
+      ]
+     },
+     {
+      "phase": "Presentation",
+      "items": [
+       "Extract sprite atlas from reference assets",
+       "Canvas 256x240 renderer with integer scaling",
+       "HUD, title screen, level transitions, input map",
+       "Commit presentation slice"
+      ]
+     },
+     {
+      "phase": "Parity and QA",
+      "items": [
+       "Dev server up, agent-browser captures title and gameplay evidence",
+       "Run parity checklist against reference, fix diffs",
+       "Full suite+typecheck+build green, final commit, cleanup receipts"
+      ]
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"phase\": \"Bootstrap\",\n      \"items\": [\n        \"Clone and survey reference repo structure\",\n        \"Extract physics constants and level data format from ref"
+  },
+  {
+   "id": "fx08",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "items": [
+     "Boulder state + worktrees created",
+     "Wave1: T1 SessionManager mutation-counter cache (PR-1)",
+     "Wave1: T4 MCP startup race all lifecycles (PR-2)",
+     "Wave1: T5 port group-liveness cleanup to main (PR-2)",
+     "Wave1: T6 omo codegraph eager lifecycle (PR-3)",
+     "Wave1: T7 task8 teardown on feat/app-server-parity",
+     "Wave2: T2 incremental usage totals + footer (PR-1)",
+     "Wave3: T3 manual perf QA Bug A evidence",
+     "F1 senpi full gates on PR-1/PR-2 branches",
+     "F2 cross-fix live QA in ~/local-workspaces",
+     "F3 orphan reap to zero + probe recount",
+     "F4 PR hygiene, CI green, merge all PRs"
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"items\": [\n    \"Boulder state + worktrees created\",\n    \"Wave1: T1 SessionManager mutation-counter cache (PR-1)\",\n    \"Wave1: T4 MCP startup race all lifecycles (PR-2)\",\n    \"Wave"
+  },
+  {
+   "id": "fx09",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "items": [
+       "Survey skills, fire discovery wave, open notepad",
+       "Record tier triage and detailed plan"
+      ],
+      "phase": "Bootstrap"
+     },
+     {
+      "items": [
+       "Create isolated PR worktree and branch"
+      ],
+      "phase": "Worktree"
+     },
+     {
+      "items": [
+       "Design and write senpi ulw-research skill",
+       "Wire team-mode default and debate flow"
+      ],
+      "phase": "ulw-research"
+     },
+     {
+      "items": [
+       "Rewrite senpi ultrawork prompt with eval-parallel directive"
+      ],
+      "phase": "ultrawork"
+     },
+     {
+      "items": [
+       "Run scoped tests and QA, capture evidence"
+      ],
+      "phase": "QA"
+     },
+     {
+      "items": [
+       "Open PR, pass CI, merge"
+      ],
+      "phase": "PR"
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"items\": [\n        \"Survey skills, fire discovery wave, open notepad\",\n        \"Record tier triage and detailed plan\"\n      ],\n      \"phase\": \"Bootstrap\"\n   "
+  },
+  {
+   "id": "fx10",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "phase": "Research",
+      "items": [
+       "Read GLM prompt reference + builtin category appends + senpi tool surface",
+       "Inspect ~/.senpi install layout for task + omo-senpi update path"
+      ]
+     },
+     {
+      "phase": "Prompt",
+      "items": [
+       "Write GLM-5.2-tuned eval-parallel prompt_append",
+       "Wire prompt_append into ~/.config/omo/omo.jsonc ultrafast categories"
+      ]
+     },
+     {
+      "phase": "Update",
+      "items": [
+       "Update task + omo-senpi to latest version"
+      ]
+     },
+     {
+      "phase": "Verify",
+      "items": [
+       "Validate omo.jsonc parses against schema",
+       "Verify updated installs work"
+      ]
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"phase\": \"Research\",\n      \"items\": [\n        \"Read GLM prompt reference + builtin category appends + senpi tool surface\",\n        \"Inspect ~/.senpi install "
+  },
+  {
+   "id": "fx11",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "items": [
+       "Map senpi adapter, orchestration stream path, web render path — verify by file:line map in notepad",
+       "Dump state.sqlite events for thread 39587eea — verify by event-type/timestamp dump",
+       "Run senpi CLI directly, timestamp stdout chunks — verify by timing log",
+       "Write root cause + fix plan to notepad — verify by cited diagnosis complete"
+      ],
+      "phase": "Discovery"
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"items\": [\n        \"Map senpi adapter, orchestration stream path, web render path — verify by file:line map in notepad\",\n        \"Dump state.sqlite events fo"
+  },
+  {
+   "id": "fx12",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "state-level",
+   "raw_args": {
+    "append": [
+     "Fix oracle blocker 2 via Agent A: reasoning terminal-path flush + regression — verify by tests green",
+     "Fix oracle blocker 1 via Agent B: empty-delta throttle accounting + regression — verify by tests green",
+     "Re-review blocker fixes + re-run focused tests + gates — verify exit 0",
+     "Re-submit delta to same oracle — verify by APPROVE"
+    ],
+    "op": "append",
+    "phase": "Tasks"
+   },
+   "starting_state": [
+    {
+     "name": "Tasks",
+     "tasks": [
+      {
+       "content": "Review Agent B diff, run focused tests — verify by diff read + tests green",
+       "status": "in_progress"
+      },
+      {
+       "content": "Integration gates: vp check + vp run typecheck — verify exit 0",
+       "status": "pending"
+      },
+      {
+       "content": "Oracle review of integrated diff (HEAVY gate)",
+       "status": "pending"
+      }
+     ]
+    }
+   ],
+   "starting_state_reconstructed": true,
+   "expected_behavior_after_fix": "auto-correct: op-named key alias — 'append' key holds string[] while items is absent and op=='append'; use it as items; append 4 tasks to phase 'Tasks'; [auto-corrected] notice",
+   "observed_error_text_excerpt": "Errors: Missing items for append operation\nRemaining items (6):\n  - Review Agent B diff, run focused tests — verify by diff read + tests green [in_progress] (Tasks)\n  - Integration gates: vp check + vp run typecheck — verify exit 0 [pending] (Tasks)\n  - Oracle review of integrate"
+  },
+  {
+   "id": "fx13",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "phase": "Setup",
+      "items": [
+       "Create worktree branch for footer notation change"
+      ]
+     },
+     {
+      "phase": "TDD",
+      "items": [
+       "Write failing formatTokens abbreviation test",
+       "Implement oh-my-pi-style formatTokens GREEN"
+      ]
+     },
+     {
+      "phase": "Verify",
+      "items": [
+       "Run scoped tests and npm run check",
+       "Real CLI QA evidence via senpi-qa"
+      ]
+     },
+     {
+      "phase": "Ship",
+      "items": [
+       "Commit, open PR, merge, cleanup worktree"
+      ]
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"phase\": \"Setup\",\n      \"items\": [\n        \"Create worktree branch for footer notation change\"\n      ]\n    },\n    {\n      \"phase\": \"TDD\",\n      \"items\": [\n  "
+  },
+  {
+   "id": "fx14",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "items": [
+     "Setup worktrees, branches, deps, boulder state",
+     "W1-T1 watch engine hash gating (senpi)",
+     "W1-T2 settings self-write hash seam (senpi)",
+     "W1-T3 requestReload+isCompacting seam (senpi)",
+     "W1-T4 config-watch events protocol (senpi)",
+     "W1-T5 JSONL logger (senpi)",
+     "W1 verify+commit senpi todos 1-5",
+     "W2-T6 builtin extension core (senpi)",
+     "W2-T7 builtin registration+docs (senpi)",
+     "W2-T8 mode-matrix hardening (senpi)",
+     "W2 verify+commit senpi todos 6-8",
+     "W3-T9 omo path resolution+validate (omo)",
+     "W3-T10 omo config-watch component (omo)",
+     "W3-T11 omo compose wiring+flag (omo)",
+     "W3 verify+commit omo todos 9-11",
+     "W4-T12 senpi e2e QA via senpi-qa",
+     "W4-T13 omo e2e QA cross-repo",
+     "F1 plan compliance audit",
+     "F2 code quality review both repos",
+     "F3 fresh real manual QA re-run",
+     "F4 scope fidelity check",
+     "Push branches, open PRs, merge both repos",
+     "Cleanup worktrees, boulder, final receipts"
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"items\": [\n    \"Setup worktrees, branches, deps, boulder state\",\n    \"W1-T1 watch engine hash gating (senpi)\",\n    \"W1-T2 settings self-write hash seam (senpi)\",\n    \"W1-T3 reques"
+  },
+  {
+   "id": "fx15",
+   "source_model": "apitopia/kimi-k3",
+   "observed_error_kind": "loop-validation",
+   "raw_args": {
+    "list": [
+     {
+      "phase": "Setup",
+      "items": [
+       "Create worktree + branch off origin/main",
+       "Install deps in worktree"
+      ]
+     },
+     {
+      "phase": "RED",
+      "items": [
+       "RED ai: convertResponsesMessages omits invalid non-fc item id",
+       "RED coding-agent: openai-remote convertToolCall omits invalid id",
+       "RED coding-agent: wire-level compaction replay rejects poisoned id"
+      ]
+     },
+     {
+      "phase": "GREEN",
+      "items": [
+       "Fix convertResponsesMessages id omission",
+       "Fix openai-remote convertToolCall id omission",
+       "All three tests GREEN"
+      ]
+     },
+     {
+      "phase": "Verify",
+      "items": [
+       "Scoped test suites green + npm run check",
+       "Full npm test",
+       "senpi-qa CLI evidence (mock loop + rpc + smoke)",
+       "changes.md entries both packages",
+       "Reviewer loop approval (HEAVY gate)"
+      ]
+     },
+     {
+      "phase": "Ship",
+      "items": [
+       "Atomic commits + push",
+       "Open PR to main",
+       "CI + Cubic gates green",
+       "Merge with merge commit, wait MERGED",
+       "Worktree cleanup + final report"
+      ]
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: op inferred as init (list provided without op); [auto-corrected] notice; list initialized",
+   "observed_error_text_excerpt": "Validation failed for tool \"todo\":\n  - op: must have required properties op\n\nReceived arguments:\n{\n  \"list\": [\n    {\n      \"phase\": \"Setup\",\n      \"items\": [\n        \"Create worktree + branch off origin/main\",\n        \"Install deps in worktree\"\n      ]\n    },\n    {\n      \"phase\":"
+  },
+  {
+   "id": "fx16",
+   "source_model": "apitopia/z-ai/glm-5.2-ultrafast-unlocked",
+   "observed_error_kind": "state-level",
+   "raw_args": {
+    "op": "start",
+    "task": "Investigate and fix compaction test #2 regression"
+   },
+   "starting_state": [
+    {
+     "name": "Release",
+     "tasks": [
+      {
+       "content": "Execute release.mjs --version 2026.7.24 (check build test commit tag push)",
+       "status": "in_progress"
+      },
+      {
+       "content": "Investigate compaction test regression #2 and fix",
+       "status": "pending"
+      }
+     ]
+    }
+   ],
+   "starting_state_reconstructed": true,
+   "expected_behavior_after_fix": "throw: task not found; did-you-mean suggests the near-miss compaction task; isError=true; NO auto-apply (containment/similarity is suggestion-only)",
+   "observed_error_text_excerpt": "Errors: Task \"Investigate and fix compaction test #2 regression\" not found\nRemaining items (5):\n  - Execute release.mjs --version 2026.7.24 (check build test commit tag push) [in_progress] (Release)\n  - Poll npm view until 2026.7.24 is published by CI [pending] (Publish)\n  - Inst"
+  },
+  {
+   "id": "fx17",
+   "source_model": "opengateway/z-ai/glm-5.2-ultrafast",
+   "observed_error_kind": "state-level",
+   "raw_args": {
+    "op": "init",
+    "list": [
+     {
+      "phase": "Dockerfile",
+      "items": [
+       "Dockerfile secret 제거 + 가드 반전 GREEN"
+      ]
+     },
+     {
+      "phase": "Ship",
+      "items": [
+       "커밋 + push + PR 생성",
+       "CI green + 머지(사용자 사전 승인: 이 작업 병합)",
+       "deploy-dev 트리거 관찰: Build Succeeded?"
+      ],
+      "phase2": "Verify"
+     },
+     {
+      "phase": "Dockerfile",
+      "items": [
+       "dev uptime 리셋 + memory 활성화 확인"
+      ],
+      "items2": []
+     }
+    ]
+   },
+   "starting_state": [],
+   "starting_state_reconstructed": false,
+   "expected_behavior_after_fix": "auto-correct: duplicate phase 'Dockerfile' in init list merged into first occurrence; [auto-corrected] notice; init succeeds",
+   "observed_error_text_excerpt": "Errors: Duplicate phase \"Dockerfile\" in init list\nRemaining items (3):\n  - Delegate lanes to unspecified-low parallel [in_progress] (ArbiterFix)\n  - Review worker PRs + adversarial verify [pending] (ArbiterFix)\n  - Merge arbiter env-respect PR [pending] (ArbiterFix)\nOverall: 4/7 "
+  }
+ ]
+}

--- a/packages/coding-agent/test/suite/fixtures/task-management-section.txt
+++ b/packages/coding-agent/test/suite/fixtures/task-management-section.txt
@@ -19,8 +19,10 @@ Completing tasks out of phase order can move this pointer **back** to an earlier
 | done | task or phase | Mark completed |
 | drop | task or phase | Mark abandoned |
 | rm | task or phase (optional) | Remove task or phase; omit both to clear |
-| append | phase, items: string[] | Append tasks to phase; lazily creates phase |
+| append | phase?, items: string[] | Append tasks to phase; lazily creates phase |
 | view | — | Read-only: echo list |
+
+Example: {"op":"init","list":[{"phase":"Setup","items":["Survey code","Write tests"]}]}
 
 ## Anatomy
 - **Task content**: 5–10 words; what, not how. Unique identifier.
@@ -31,7 +33,7 @@ Completing tasks out of phase order can move this pointer **back** to an earlier
 - NEVER make a todo call your turn's only tool call — batch it with the real work: init with the first reads/edits, each done/start with the next action. Solo todo turns waste a round trip.
 - Blocked? append a task to the active phase, or drop.
 - Keep task/phase strings stable once introduced.
-- Lost the exact task text? view echoes the list — NEVER guess from memory.
+- Lost the exact task text? view echoes the list — NEVER guess from memory. done/start/drop take the task's EXACT text — copy it verbatim from the latest todo result, never re-type from memory.
 
 ## When to create a list
 - Task requires 3+ distinct steps

--- a/packages/coding-agent/test/suite/todo-arg-correction.test.ts
+++ b/packages/coding-agent/test/suite/todo-arg-correction.test.ts
@@ -3,7 +3,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { validateToolArguments, type Tool } from "@earendil-works/pi-ai";
+import { type Tool, validateToolArguments } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { describe, expect, it } from "vitest";
 import {
@@ -13,7 +13,12 @@ import {
 	type TodoToolDetails,
 } from "../../src/core/extensions/builtin/todotools/state.ts";
 import { registerTodoTool, TODO_PARAMS_SCHEMA } from "../../src/core/extensions/builtin/todotools/tools/todo.ts";
-import type { AgentToolResult, ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
+import type {
+	AgentToolResult,
+	ExtensionAPI,
+	ExtensionContext,
+	ToolDefinition,
+} from "../../src/core/extensions/types.ts";
 
 type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
 type RegisteredTodoTool = ToolDefinition<typeof TODO_PARAMS_SCHEMA, TodoToolDetails, unknown>;
@@ -191,7 +196,9 @@ describe("todo argument correction fixture replay", () => {
 			const text = resultText(result);
 
 			expect(result.details.op).toBe("init");
-			expect(text).toContain('[auto-corrected] "op" was missing; interpreted as "init" because "list" was provided.');
+			expect(text).toContain(
+				'[auto-corrected] "op" was missing; interpreted as "init" because "list" was provided.',
+			);
 			expect(text).toContain('Always pass op explicitly: {"op":"init","list":[...]}');
 			expect(captured.getCurrentPhases()).toEqual(expectedInitializedPhases(fixture.raw_args));
 			expect(captured.getAppendCalls()).toBe(1);
@@ -204,7 +211,9 @@ describe("todo argument correction fixture replay", () => {
 			const text = resultText(result);
 
 			expect(result.details.op).toBe("init");
-			expect(text).toContain('[auto-corrected] "op" was missing; interpreted as "init" because "items" was provided to an empty todo list.');
+			expect(text).toContain(
+				'[auto-corrected] "op" was missing; interpreted as "init" because "items" was provided to an empty todo list.',
+			);
 			expect(text).toContain('Always pass op explicitly: {"op":"init","items":[...]}');
 			expect(captured.getCurrentPhases()).toEqual(expectedInitializedPhases(fixture.raw_args));
 			expect(captured.getAppendCalls()).toBe(1);
@@ -219,7 +228,9 @@ describe("todo argument correction fixture replay", () => {
 
 			expect(result.details.op).toBe("append");
 			expect(text).toContain('[auto-corrected] "append" was used as an items alias and folded into "items".');
-			expect(captured.getCurrentPhases()).toEqual(expectedAliasedAppendState(fixture.starting_state, fixture.raw_args));
+			expect(captured.getCurrentPhases()).toEqual(
+				expectedAliasedAppendState(fixture.starting_state, fixture.raw_args),
+			);
 			expect(captured.getCurrentPhases()[0]?.tasks).toHaveLength(7);
 			expect(captured.getAppendCalls()).toBe(1);
 			return;

--- a/packages/coding-agent/test/suite/todo-arg-correction.test.ts
+++ b/packages/coding-agent/test/suite/todo-arg-correction.test.ts
@@ -1,0 +1,284 @@
+// Fixture provenance: .omo/plans/todo-tool-correction.fixtures.json
+// SHA-256: 5d12183155fcbe8ecb7df5d24a0eb72cc07c58c15de7d876a39f2e04b91dd9b4
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { validateToolArguments, type Tool } from "@earendil-works/pi-ai";
+import type { Static } from "typebox";
+import { describe, expect, it } from "vitest";
+import {
+	clonePhases,
+	DEFAULT_INIT_PHASE,
+	type TodoPhase,
+	type TodoToolDetails,
+} from "../../src/core/extensions/builtin/todotools/state.ts";
+import { registerTodoTool, TODO_PARAMS_SCHEMA } from "../../src/core/extensions/builtin/todotools/tools/todo.ts";
+import type { AgentToolResult, ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
+
+type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
+type RegisteredTodoTool = ToolDefinition<typeof TODO_PARAMS_SCHEMA, TodoToolDetails, unknown>;
+
+type FixtureListEntry = {
+	phase: string;
+	items: string[];
+};
+
+type FixtureRawArgs = Record<string, unknown> & {
+	op?: string;
+	task?: string;
+	phase?: string;
+	list?: FixtureListEntry[];
+	items?: string[];
+	append?: string[];
+};
+
+type TodoFixture = {
+	id: string;
+	source_model: string;
+	raw_args: FixtureRawArgs;
+	starting_state: TodoPhase[] | null;
+	starting_state_reconstructed: boolean;
+	expected_behavior_after_fix: string;
+};
+
+type FixtureDocument = {
+	fixtures: TodoFixture[];
+};
+
+const fixturePath = join(process.cwd(), "test/fixtures/todo-arg-correction.fixtures.json");
+const fixtureDocument = JSON.parse(readFileSync(fixturePath, "utf8")) as FixtureDocument;
+const fixtures = fixtureDocument.fixtures;
+const validationTool = {
+	name: "todo",
+	description: "Todo fixture validation tool",
+	parameters: TODO_PARAMS_SCHEMA,
+} satisfies Tool;
+
+const inferredListFixtureIds = new Set(["fx04", "fx06", "fx07", "fx09", "fx10", "fx11", "fx13", "fx15"]);
+const inferredItemsFixtureIds = new Set(["fx02", "fx08", "fx14"]);
+const notFoundFixtureIds = new Set(["fx01", "fx03", "fx16"]);
+
+function expectedInitializedPhases(rawArgs: FixtureRawArgs): TodoPhase[] {
+	const list = rawArgs.list ?? (rawArgs.items ? [{ phase: DEFAULT_INIT_PHASE, items: rawArgs.items }] : undefined);
+	if (!list) throw new Error("Expected an init fixture list or items payload");
+
+	const phases: TodoPhase[] = [];
+	const phasesByName = new Map<string, TodoPhase>();
+	const seenTasks = new Set<string>();
+	for (const entry of list) {
+		let phase = phasesByName.get(entry.phase);
+		if (!phase) {
+			phase = { name: entry.phase, tasks: [] };
+			phasesByName.set(entry.phase, phase);
+			phases.push(phase);
+		}
+		for (const content of entry.items) {
+			if (seenTasks.has(content)) continue;
+			seenTasks.add(content);
+			phase.tasks.push({ content, status: "pending" });
+		}
+	}
+
+	const firstTask = phases.flatMap((phase) => phase.tasks)[0];
+	if (firstTask) firstTask.status = "in_progress";
+	return phases;
+}
+
+function expectedAliasedAppendState(initialPhases: readonly TodoPhase[], rawArgs: FixtureRawArgs): TodoPhase[] {
+	const items = rawArgs.append;
+	const phaseName = rawArgs.phase;
+	if (!items || !phaseName) throw new Error("Expected an append-alias fixture payload");
+
+	const phases = clonePhases(initialPhases);
+	const phase = phases.find((candidate) => candidate.name === phaseName);
+	if (!phase) throw new Error(`Expected initial phase "${phaseName}"`);
+	phase.tasks.push(...items.map((content) => ({ content, status: "pending" as const })));
+	return phases;
+}
+
+function captureTodoTool(initialPhases: readonly TodoPhase[]) {
+	let capturedTool: RegisteredTodoTool | undefined;
+	let currentPhases = clonePhases(initialPhases);
+	let appendCalls = 0;
+	const pi = {
+		registerTool(tool: RegisteredTodoTool) {
+			capturedTool = tool;
+		},
+		appendEntry() {
+			appendCalls += 1;
+		},
+	} as Pick<ExtensionAPI, "registerTool" | "appendEntry"> as ExtensionAPI;
+	registerTodoTool(pi, {
+		getCurrentPhases: () => clonePhases(currentPhases),
+		setCurrentPhases: (phases) => {
+			currentPhases = clonePhases(phases);
+		},
+		syncWidget: () => {},
+	});
+	if (!capturedTool) throw new Error("Expected todo tool to be registered");
+
+	return {
+		tool: capturedTool,
+		getCurrentPhases: () => clonePhases(currentPhases),
+		getAppendCalls: () => appendCalls,
+		context: { sessionManager: { getSessionFile: () => undefined } } as unknown as ExtensionContext,
+	};
+}
+
+async function executeTodo(
+	tool: RegisteredTodoTool,
+	rawArgs: FixtureRawArgs,
+	context: ExtensionContext,
+): Promise<AgentToolResult<TodoToolDetails>> {
+	if (!tool.execute) throw new Error("Expected todo execute");
+	return tool.execute("todo-arg-correction", rawArgs as TodoParams, undefined, undefined, context);
+}
+
+async function executeError(
+	tool: RegisteredTodoTool,
+	rawArgs: FixtureRawArgs,
+	context: ExtensionContext,
+): Promise<Error> {
+	try {
+		await executeTodo(tool, rawArgs, context);
+	} catch (error) {
+		if (error instanceof Error) return error;
+		throw error;
+	}
+	throw new Error("Expected todo execute to throw");
+}
+
+function resultText(result: AgentToolResult<TodoToolDetails>): string {
+	return result.content
+		.filter((content): content is { type: "text"; text: string } => content.type === "text")
+		.map((content) => content.text)
+		.join("\n");
+}
+
+function requiredTask(rawArgs: FixtureRawArgs): string {
+	if (typeof rawArgs.task !== "string") throw new Error("Expected fixture task text");
+	return rawArgs.task;
+}
+
+describe("todo argument correction fixture replay", () => {
+	it("loads all 17 tracked observed-failure fixtures", () => {
+		expect(fixtures).toHaveLength(17);
+		expect(fixtures.map((fixture) => fixture.id)).toEqual([
+			"fx01",
+			"fx02",
+			"fx03",
+			"fx04",
+			"fx05",
+			"fx06",
+			"fx07",
+			"fx08",
+			"fx09",
+			"fx10",
+			"fx11",
+			"fx12",
+			"fx13",
+			"fx14",
+			"fx15",
+			"fx16",
+			"fx17",
+		]);
+	});
+
+	it.each(fixtures)("replays $id from $source_model through registered todo execute", async (fixture) => {
+		if (inferredListFixtureIds.has(fixture.id)) {
+			const captured = captureTodoTool([]);
+			const result = await executeTodo(captured.tool, fixture.raw_args, captured.context);
+			const text = resultText(result);
+
+			expect(result.details.op).toBe("init");
+			expect(text).toContain('[auto-corrected] "op" was missing; interpreted as "init" because "list" was provided.');
+			expect(text).toContain('Always pass op explicitly: {"op":"init","list":[...]}');
+			expect(captured.getCurrentPhases()).toEqual(expectedInitializedPhases(fixture.raw_args));
+			expect(captured.getAppendCalls()).toBe(1);
+			return;
+		}
+
+		if (inferredItemsFixtureIds.has(fixture.id)) {
+			const captured = captureTodoTool([]);
+			const result = await executeTodo(captured.tool, fixture.raw_args, captured.context);
+			const text = resultText(result);
+
+			expect(result.details.op).toBe("init");
+			expect(text).toContain('[auto-corrected] "op" was missing; interpreted as "init" because "items" was provided to an empty todo list.');
+			expect(text).toContain('Always pass op explicitly: {"op":"init","items":[...]}');
+			expect(captured.getCurrentPhases()).toEqual(expectedInitializedPhases(fixture.raw_args));
+			expect(captured.getAppendCalls()).toBe(1);
+			return;
+		}
+
+		if (fixture.id === "fx12") {
+			if (!fixture.starting_state) throw new Error("Expected fx12 starting state");
+			const captured = captureTodoTool(fixture.starting_state);
+			const result = await executeTodo(captured.tool, fixture.raw_args, captured.context);
+			const text = resultText(result);
+
+			expect(result.details.op).toBe("append");
+			expect(text).toContain('[auto-corrected] "append" was used as an items alias and folded into "items".');
+			expect(captured.getCurrentPhases()).toEqual(expectedAliasedAppendState(fixture.starting_state, fixture.raw_args));
+			expect(captured.getCurrentPhases()[0]?.tasks).toHaveLength(7);
+			expect(captured.getAppendCalls()).toBe(1);
+			return;
+		}
+
+		if (fixture.id === "fx17") {
+			const captured = captureTodoTool([]);
+			const result = await executeTodo(captured.tool, fixture.raw_args, captured.context);
+
+			expect(result.details.op).toBe("init");
+			expect(resultText(result)).toContain('[auto-corrected] merged duplicate phase "Dockerfile" in init list');
+			expect(captured.getCurrentPhases()).toEqual(expectedInitializedPhases(fixture.raw_args));
+			expect(captured.getAppendCalls()).toBe(1);
+			return;
+		}
+
+		if (notFoundFixtureIds.has(fixture.id)) {
+			if (!fixture.starting_state) throw new Error(`Expected ${fixture.id} starting state`);
+			const captured = captureTodoTool(fixture.starting_state);
+			const error = await executeError(captured.tool, fixture.raw_args, captured.context);
+
+			expect(error.message).toContain(`Task "${requiredTask(fixture.raw_args)}" not found`);
+			expect(error.message).toContain("Did you mean");
+			if (fixture.id === "fx03") expect(error.message).not.toContain("[auto-corrected]");
+			expect(captured.getCurrentPhases()).toEqual(fixture.starting_state);
+			expect(captured.getAppendCalls()).toBe(0);
+			return;
+		}
+
+		if (fixture.id === "fx05") {
+			const captured = captureTodoTool([]);
+
+			expect(() =>
+				validateToolArguments(validationTool, {
+					type: "toolCall",
+					id: fixture.id,
+					name: "todo",
+					arguments: fixture.raw_args,
+				}),
+			).toThrow("op: must be equal to constant");
+			expect(captured.getCurrentPhases()).toEqual([]);
+			expect(captured.getAppendCalls()).toBe(0);
+			return;
+		}
+
+		throw new Error(`Unhandled fixture ${fixture.id}`);
+	});
+
+	it("preserves task-N errors through registered todo execute", async () => {
+		const initialPhases: TodoPhase[] = [
+			{ name: "Tasks", tasks: [{ content: "Build release", status: "in_progress" }] },
+		];
+		const captured = captureTodoTool(initialPhases);
+		const error = await executeError(captured.tool, { op: "done", task: "task-12" }, captured.context);
+
+		expect(error.message).toContain(
+			'Task "task-12" not found. Tasks are referenced by content, not by IDs — pass the task\'s full text from the previous result.',
+		);
+		expect(captured.getCurrentPhases()).toEqual(initialPhases);
+		expect(captured.getAppendCalls()).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/suite/todo-correction-wiring.test.ts
+++ b/packages/coding-agent/test/suite/todo-correction-wiring.test.ts
@@ -1,0 +1,278 @@
+import { fileURLToPath } from "node:url";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import type { Static } from "typebox";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+	clonePhases,
+	getLatestPhasesFromBranchEntries,
+	getTodoWidgetLines,
+	type TodoPhase,
+	type TodoToolDetails,
+} from "../../src/core/extensions/builtin/todotools/state.ts";
+import { registerTodoTool, TODO_PARAMS_SCHEMA } from "../../src/core/extensions/builtin/todotools/tools/todo.ts";
+import { discoverAndLoadExtensions } from "../../src/core/extensions/loader.ts";
+import type {
+	AgentToolResult,
+	ExtensionAPI,
+	ExtensionContext,
+	ToolDefinition,
+	ToolRenderContext,
+} from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../src/utils/ansi.ts";
+import { createTestResourceLoader } from "../utilities.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+const TODO_EXTENSION_PATH = fileURLToPath(
+	new URL("../../src/core/extensions/builtin/todotools/index.ts", import.meta.url),
+);
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
+
+beforeAll(() => initTheme("dark"));
+
+async function createHarnessWithTodoExtension(): Promise<Harness> {
+	const extensionsResult = await discoverAndLoadExtensions([TODO_EXTENSION_PATH], REPO_ROOT, REPO_ROOT);
+	return createHarness({ resourceLoader: createTestResourceLoader({ extensionsResult }) });
+}
+
+function getLatestTodoResult(harness: Harness) {
+	const results = harness.session.messages.filter(
+		(message) => message.role === "toolResult" && message.toolName === "todo",
+	);
+	const result = results[results.length - 1];
+	if (result?.role !== "toolResult") throw new Error("Expected a todo tool result");
+	return result;
+}
+
+function responsesForTodo(params: Record<string, unknown>, finalText = "done") {
+	return [
+		fauxAssistantMessage([fauxToolCall("todo", params)], { stopReason: "toolUse" }),
+		fauxAssistantMessage(finalText),
+	];
+}
+
+async function captureTodoTool(initialPhases: TodoPhase[] = []) {
+	let capturedTool: ToolDefinition<typeof TODO_PARAMS_SCHEMA> | undefined;
+	let currentPhases = clonePhases(initialPhases);
+	const mockPi = {
+		registerTool(tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA>) {
+			capturedTool = tool;
+		},
+		appendEntry() {},
+	} as Pick<ExtensionAPI, "registerTool" | "appendEntry"> as ExtensionAPI;
+	registerTodoTool(mockPi, {
+		getCurrentPhases: () => clonePhases(currentPhases),
+		setCurrentPhases: (phases) => {
+			currentPhases = clonePhases(phases);
+		},
+		syncWidget: () => {},
+	});
+	if (!capturedTool) throw new Error("Expected todo tool to be registered");
+	return {
+		tool: capturedTool,
+		getCurrentPhases: () => clonePhases(currentPhases),
+		context: { sessionManager: { getSessionFile: () => undefined } } as unknown as ExtensionContext,
+	};
+}
+
+function schemaDescription(schema: unknown): string | undefined {
+	if (typeof schema !== "object" || schema === null || !("description" in schema)) return undefined;
+	return typeof schema.description === "string" ? schema.description : undefined;
+}
+
+function renderContext(args: TodoParams, isError = false): ToolRenderContext<unknown, TodoParams> {
+	return {
+		args,
+		toolCallId: "todo-correction-render",
+		invalidate: () => {},
+		lastComponent: undefined,
+		state: undefined,
+		cwd: REPO_ROOT,
+		executionStarted: true,
+		argsComplete: true,
+		isPartial: false,
+		expanded: false,
+		showImages: false,
+		isError,
+		spinnerFrame: undefined,
+	};
+}
+
+describe("todo correction wiring", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("advertises explicit operation and exact-reference schema guidance without auto-correction", () => {
+		expect(schemaDescription(TODO_PARAMS_SCHEMA.properties.op)).toBe(
+			"Operation to perform. Required — always pass it explicitly.",
+		);
+		expect(schemaDescription(TODO_PARAMS_SCHEMA.properties.list)).toBe("Phased task list for init");
+		expect(schemaDescription(TODO_PARAMS_SCHEMA.properties.task)).toBe(
+			"Exact task text copied from the previous todo result",
+		);
+		expect(schemaDescription(TODO_PARAMS_SCHEMA.properties.phase)).toBe(
+			"Exact phase name copied from the previous todo result",
+		);
+		expect(schemaDescription(TODO_PARAMS_SCHEMA.properties.items)).toBe("Task texts to append");
+		expect(JSON.stringify(TODO_PARAMS_SCHEMA).toLowerCase()).not.toContain("auto-correct");
+	});
+
+	it("normalizes omitted init and append aliases through the agent loop", async () => {
+		const harness = await createHarnessWithTodoExtension();
+		harnesses.push(harness);
+		harness.setResponses([
+			...responsesForTodo({
+				list: [
+					{ phase: "Foundation", items: ["Survey code"] },
+					{ phase: "Verification", items: ["Run checks"] },
+				],
+			}),
+			...responsesForTodo({ op: "append", phase: "Foundation", append: ["Write tests"] }),
+		]);
+
+		await harness.session.prompt("initialize");
+		const initResult = getLatestTodoResult(harness);
+		const initDetails = initResult.details as TodoToolDetails;
+		expect(initResult.isError).not.toBe(true);
+		expect(getMessageText(initResult).startsWith('[auto-corrected] "op" was missing; interpreted as "init"')).toBe(
+			true,
+		);
+		expect(initDetails.op).toBe("init");
+		expect(initDetails.corrections).toHaveLength(1);
+		expect(initDetails.phases).toEqual([
+			{ name: "Foundation", tasks: [{ content: "Survey code", status: "in_progress" }] },
+			{ name: "Verification", tasks: [{ content: "Run checks", status: "pending" }] },
+		]);
+
+		await harness.session.prompt("append");
+		const appendResult = getLatestTodoResult(harness);
+		expect(getMessageText(appendResult).startsWith('[auto-corrected] "append" was used as an items alias')).toBe(
+			true,
+		);
+		expect((appendResult.details as TodoToolDetails).phases[0]?.tasks).toEqual([
+			{ content: "Survey code", status: "in_progress" },
+			{ content: "Write tests", status: "pending" },
+		]);
+	});
+
+	it("throws unrecoverable errors through the loop while preserving the current state and rendered recovery text", async () => {
+		const harness = await createHarnessWithTodoExtension();
+		harnesses.push(harness);
+		harness.setResponses([
+			...responsesForTodo({ op: "init", items: ["Do not deploy API to production"] }),
+			...responsesForTodo({ op: "done", task: "Deploy API to production" }),
+		]);
+
+		await harness.session.prompt("initialize");
+		const currentPhases = getLatestPhasesFromBranchEntries(harness.sessionManager.getBranch());
+		await harness.session.prompt("complete paraphrase");
+
+		const result = getLatestTodoResult(harness);
+		const text = getMessageText(result);
+		expect(result.isError).toBe(true);
+		expect(text).toContain('Task "Deploy API to production" not found');
+		expect(text).toContain('Did you mean "Do not deploy API to production"?');
+		expect(text).toContain("Remaining items (1):");
+		expect(getLatestPhasesFromBranchEntries(harness.sessionManager.getBranch())).toEqual(currentPhases);
+
+		const { tool } = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const errorResult = {
+			content: [{ type: "text" as const, text }],
+			details: {},
+		} as unknown as AgentToolResult<TodoToolDetails>;
+		const rendered = stripAnsi(
+			tool
+				.renderResult(
+					errorResult,
+					{ expanded: false, isPartial: false },
+					theme,
+					renderContext({ op: "done", task: "Deploy API to production" }, true),
+				)
+				.render(160)
+				.join("\n"),
+		);
+		expect(rendered).toContain('Task "Deploy API to production" not found');
+	});
+
+	it("throws normalization errors without changing the accessor state", async () => {
+		const initialPhases: TodoPhase[] = [
+			{ name: "Tasks", tasks: [{ content: "Stable task", status: "in_progress" }] },
+		];
+		const { tool, getCurrentPhases, context } = await captureTodoTool(initialPhases);
+		if (!tool.execute) throw new Error("Expected todo execute");
+
+		await expect(
+			tool.execute("blank-target", { op: "done", task: " " } as TodoParams, undefined, undefined, context),
+		).rejects.toThrow('Blank "task" — pass the exact task text, or omit the field entirely for a bulk operation.');
+		expect(getCurrentPhases()).toEqual(initialPhases);
+	});
+
+	it("renders all corrected-init phases while the widget remains limited to the active phase", async () => {
+		const { tool } = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const phases: TodoPhase[] = [
+			{ name: "Foundation", tasks: [{ content: "Survey code", status: "in_progress" }] },
+			{ name: "Verification", tasks: [{ content: "Run checks", status: "pending" }] },
+		];
+		const result = {
+			content: [{ type: "text" as const, text: "summary" }],
+			details: { op: "init" as const, phases, storage: "memory" as const },
+		} satisfies { content: { type: "text"; text: string }[]; details: TodoToolDetails };
+		const args = {
+			list: [
+				{ phase: "Foundation", items: ["Survey code"] },
+				{ phase: "Verification", items: ["Run checks"] },
+			],
+		} as TodoParams;
+
+		const rendered = stripAnsi(
+			tool
+				.renderResult(result, { expanded: false, isPartial: false }, theme, renderContext(args))
+				.render(160)
+				.join("\n"),
+		);
+		expect(rendered).toContain("I. Foundation");
+		expect(rendered).toContain("II. Verification");
+		expect(rendered).toContain("[ ] Run checks");
+		expect(getTodoWidgetLines(phases)).toEqual(["Todo", "Foundation", "[•] Survey code"]);
+	});
+
+	it("renders fuzzy-corrected drops when the raw task text no longer literally exists", async () => {
+		const { tool } = await captureTodoTool();
+		if (!tool.renderResult) throw new Error("Expected todo result renderer");
+		const result = {
+			content: [{ type: "text" as const, text: "summary" }],
+			details: {
+				op: "drop" as const,
+				phases: [
+					{ name: "Planning", tasks: [{ content: "Deploy API", status: "abandoned" as const }] },
+					{ name: "Verification", tasks: [{ content: "Continue", status: "in_progress" as const }] },
+				],
+				storage: "memory" as const,
+				corrections: [
+					'[auto-matched] task " deploy api " -> "Deploy API" — pass the exact text from the previous todo result next time',
+				],
+			},
+		} satisfies { content: { type: "text"; text: string }[]; details: TodoToolDetails };
+
+		const rendered = stripAnsi(
+			tool
+				.renderResult(
+					result,
+					{ expanded: false, isPartial: false },
+					theme,
+					renderContext({ op: "drop", task: " deploy api " }),
+				)
+				.render(160)
+				.join("\n"),
+		);
+		expect(rendered).toContain("I. Planning");
+		expect(rendered).toContain("II. Verification");
+		expect(rendered).toContain("[•] Continue");
+	});
+});

--- a/packages/coding-agent/test/suite/todo-extension.test.ts
+++ b/packages/coding-agent/test/suite/todo-extension.test.ts
@@ -335,7 +335,7 @@ describe("todo extension", () => {
 		// Then the result is an error and both memory and session state stay unchanged
 		const result = getLatestTodoResult(harness);
 		expect(result.content.some((content) => content.type === "text" && content.text.includes("Errors:"))).toBe(true);
-		expect(phasesFromResult(result)).toEqual([
+		expect(getLatestPhasesFromBranchEntries(harness.sessionManager.getBranch())).toEqual([
 			{ name: "Tasks", tasks: [{ content: "Stable task", status: "in_progress" }] },
 		]);
 		expect(

--- a/packages/coding-agent/test/suite/todo-fuzzy-match.test.ts
+++ b/packages/coding-agent/test/suite/todo-fuzzy-match.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyResolvePhase, fuzzyResolveTask } from "../../src/core/extensions/builtin/todotools/fuzzy-match.ts";
+import {
+	applyParams,
+	resolvePhaseOrError,
+	resolveTaskOrError,
+	type TodoPhase,
+} from "../../src/core/extensions/builtin/todotools/state.ts";
+
+function phasesWithTasks(...contents: string[]): TodoPhase[] {
+	return [{ name: "Tasks", tasks: contents.map((content) => ({ content, status: "pending" as const })) }];
+}
+
+describe("todo model-path fuzzy resolution", () => {
+	it("returns a unique exact task hit without a correction", () => {
+		const phases = phasesWithTasks("Deploy API");
+		const corrections: string[] = [];
+		const errors: string[] = [];
+
+		const hit = resolveTaskOrError(phases, "Deploy API", errors, corrections);
+
+		expect(hit).toEqual({ task: phases[0].tasks[0], phase: phases[0] });
+		expect(errors).toEqual([]);
+		expect(corrections).toEqual([]);
+		expect(fuzzyResolveTask(phases, "Deploy API")).toMatchObject({ hit, corrected: false });
+	});
+
+	it("auto-matches one normalized task and phase with a correction", () => {
+		const phases: TodoPhase[] = [
+			{
+				name: "Verification",
+				tasks: [{ content: "\u001b[31mDeploy   API\u001b[0m", status: "pending" }],
+			},
+		];
+		const taskCorrections: string[] = [];
+		const phaseCorrections: string[] = [];
+		const taskErrors: string[] = [];
+		const phaseErrors: string[] = [];
+
+		const task = resolveTaskOrError(phases, " deploy api ", taskErrors, taskCorrections);
+		const phase = resolvePhaseOrError(phases, " verification ", phaseErrors, phaseCorrections);
+
+		expect(task).toEqual({ task: phases[0].tasks[0], phase: phases[0] });
+		expect(phase).toBe(phases[0]);
+		expect(fuzzyResolveTask(phases, " deploy api ")).toMatchObject({ hit: task, corrected: true });
+		expect(fuzzyResolvePhase(phases, " verification ")).toMatchObject({ hit: phases[0], corrected: true });
+		expect(taskCorrections).toEqual([
+			'[auto-matched] task " deploy api " -> "\u001b[31mDeploy   API\u001b[0m" — pass the exact text from the previous todo result next time',
+		]);
+		expect(phaseCorrections).toEqual([
+			'[auto-matched] phase " verification " -> "Verification" — pass the exact text from the previous todo result next time',
+		]);
+	});
+
+	it("does not auto-match duplicate normalized task text and offers a suggestion", () => {
+		const phases: TodoPhase[] = [
+			{ name: "One", tasks: [{ content: "Deploy API", status: "pending" }] },
+			{ name: "Two", tasks: [{ content: " deploy   api ", status: "pending" }] },
+		];
+		const corrections: string[] = [];
+		const errors: string[] = [];
+
+		const result = fuzzyResolveTask(phases, "DEPLOY API");
+		const hit = resolveTaskOrError(phases, "DEPLOY API", errors, corrections);
+
+		expect(result).toEqual({ corrected: false, suggestion: "Deploy API" });
+		expect(hit).toBeUndefined();
+		expect(corrections).toEqual([]);
+		expect(errors).toEqual(['Task "DEPLOY API" not found Did you mean "Deploy API"?']);
+	});
+
+	it("keeps containment matches as suggestions so a negated sibling cannot be mutated", () => {
+		const phases = phasesWithTasks("Do not deploy API to production");
+		const corrections: string[] = [];
+
+		const fuzzy = fuzzyResolveTask(phases, "Deploy API to production");
+		const applied = applyParams(phases, { op: "done", task: "Deploy API to production" }, corrections);
+
+		expect(fuzzy).toEqual({ corrected: false, suggestion: "Do not deploy API to production" });
+		expect(applied.errors).toEqual([
+			'Task "Deploy API to production" not found Did you mean "Do not deploy API to production"?',
+		]);
+		expect(applied.phases[0].tasks[0].status).toBe("pending");
+		expect(corrections).toEqual([]);
+	});
+
+	it("keeps paraphrase-like Dice matches as suggestions", () => {
+		const phases = phasesWithTasks("Synthesize non-overlapping findings and current status");
+
+		const fuzzy = fuzzyResolveTask(phases, "Synthesize findings and current status");
+
+		expect(fuzzy).toEqual({
+			corrected: false,
+			suggestion: "Synthesize non-overlapping findings and current status",
+		});
+	});
+
+	it("reports duplicate exact content across phases on the model path", () => {
+		const phases: TodoPhase[] = [
+			{ name: "Planning", tasks: [{ content: "Duplicate", status: "pending" }] },
+			{ name: "Delivery", tasks: [{ content: "Duplicate", status: "pending" }] },
+		];
+		const errors: string[] = [];
+
+		const hit = resolveTaskOrError(phases, "Duplicate", errors, []);
+
+		expect(hit).toBeUndefined();
+		expect(errors).toEqual([
+			'Task "Duplicate" is ambiguous: duplicate task text exists in phases "Planning", "Delivery". Use /todo edit to make the task text unique.',
+		]);
+	});
+
+	it("preserves legacy first-match resolution when corrections are omitted", () => {
+		const phases: TodoPhase[] = [
+			{ name: "Planning", tasks: [{ content: "Duplicate", status: "pending" }] },
+			{ name: "Delivery", tasks: [{ content: "Duplicate", status: "pending" }] },
+		];
+		const errors: string[] = [];
+
+		const hit = resolveTaskOrError(phases, "Duplicate", errors);
+
+		expect(hit).toEqual({ task: phases[0].tasks[0], phase: phases[0] });
+		expect(errors).toEqual([]);
+	});
+
+	it("preserves the task-ID error text verbatim", () => {
+		const errors: string[] = [];
+
+		resolveTaskOrError(phasesWithTasks("Build release"), "task-12", errors, []);
+
+		expect(errors).toEqual([
+			'Task "task-12" not found. Tasks are referenced by content, not by IDs — pass the task\'s full text from the previous result.',
+		]);
+	});
+
+	it("preserves the empty-list hint verbatim", () => {
+		const errors: string[] = [];
+
+		resolveTaskOrError([], "Unknown task", errors, []);
+
+		expect(errors).toEqual([
+			'Task "Unknown task" not found (todo list is empty — was it replaced or not yet created?)',
+		]);
+	});
+
+	it.each(["done", "drop"] as const)("threads auto-match corrections through %s task targeting", (op) => {
+		const corrections: string[] = [];
+		const applied = applyParams(phasesWithTasks("Deploy API"), { op, task: " deploy api " }, corrections);
+
+		expect(applied.errors).toEqual([]);
+		expect(applied.phases[0].tasks[0].status).toBe(op === "done" ? "completed" : "abandoned");
+		expect(corrections).toEqual([
+			'[auto-matched] task " deploy api " -> "Deploy API" — pass the exact text from the previous todo result next time',
+		]);
+	});
+
+	it("threads auto-match corrections through rm task targeting", () => {
+		const corrections: string[] = [];
+		const applied = applyParams(phasesWithTasks("Deploy API"), { op: "rm", task: " deploy api " }, corrections);
+
+		expect(applied.errors).toEqual([]);
+		expect(applied.phases[0].tasks).toEqual([]);
+		expect(corrections).toEqual([
+			'[auto-matched] task " deploy api " -> "Deploy API" — pass the exact text from the previous todo result next time',
+		]);
+	});
+});

--- a/packages/coding-agent/test/suite/todo-init-merge.test.ts
+++ b/packages/coding-agent/test/suite/todo-init-merge.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendItems,
+	DEFAULT_INIT_PHASE,
+	initPhases,
+	type TodoPhase,
+} from "../../src/core/extensions/builtin/todotools/state.ts";
+
+describe("todo init duplicate correction", () => {
+	it("merges duplicate phases into their first occurrence without reordering items", () => {
+		const errors: string[] = [];
+		const corrections: string[] = [];
+
+		const phases = initPhases(
+			{
+				op: "init",
+				list: [
+					{ phase: "Dockerfile", items: ["Create base image"] },
+					{ phase: "Tests", items: ["Add coverage"] },
+					{ phase: "Dockerfile", items: ["Install runtime"] },
+				],
+			},
+			errors,
+			corrections,
+		);
+
+		expect(errors).toEqual([]);
+		expect(phases).toEqual([
+			{
+				name: "Dockerfile",
+				tasks: [
+					{ content: "Create base image", status: "pending" },
+					{ content: "Install runtime", status: "pending" },
+				],
+			},
+			{ name: "Tests", tasks: [{ content: "Add coverage", status: "pending" }] },
+		]);
+		expect(corrections).toEqual(['[auto-corrected] merged duplicate phase "Dockerfile" in init list']);
+	});
+
+	it("keeps the first duplicate task in an init list and records a correction", () => {
+		const errors: string[] = [];
+		const corrections: string[] = [];
+
+		const phases = initPhases(
+			{
+				op: "init",
+				list: [
+					{ phase: "One", items: ["Keep first"] },
+					{ phase: "Two", items: ["Keep first", "Keep second"] },
+				],
+			},
+			errors,
+			corrections,
+		);
+
+		expect(errors).toEqual([]);
+		expect(phases).toEqual([
+			{ name: "One", tasks: [{ content: "Keep first", status: "pending" }] },
+			{ name: "Two", tasks: [{ content: "Keep second", status: "pending" }] },
+		]);
+		expect(corrections).toEqual(['[auto-corrected] kept first duplicate task "Keep first" in init list']);
+	});
+
+	it("retains the empty-phase init error", () => {
+		const errors: string[] = [];
+
+		initPhases({ op: "init", list: [{ phase: "Empty", items: [] }] }, errors, []);
+
+		expect(errors).toEqual(['Phase "Empty" has no tasks in init list']);
+	});
+});
+
+describe("todo append phase defaults", () => {
+	it("uses the active task's phase when append omits phase", () => {
+		const phases: TodoPhase[] = [
+			{ name: "Active", tasks: [{ content: "Work now", status: "in_progress" }] },
+			{ name: "Later", tasks: [{ content: "Work later", status: "pending" }] },
+		];
+		const errors: string[] = [];
+		const corrections: string[] = [];
+
+		appendItems(phases, { op: "append", items: ["New task"] }, errors, corrections);
+
+		expect(errors).toEqual([]);
+		expect(phases[0].tasks.map((task) => task.content)).toEqual(["Work now", "New task"]);
+		expect(phases[1].tasks.map((task) => task.content)).toEqual(["Work later"]);
+		expect(corrections).toEqual(['[auto-corrected] append had no phase; used "Active"']);
+	});
+
+	it("uses the last phase when all existing tasks are terminal", () => {
+		const phases: TodoPhase[] = [
+			{ name: "Completed", tasks: [{ content: "Done", status: "completed" }] },
+			{ name: "Abandoned", tasks: [{ content: "Dropped", status: "abandoned" }] },
+		];
+		const errors: string[] = [];
+		const corrections: string[] = [];
+
+		appendItems(phases, { op: "append", items: ["Follow up"] }, errors, corrections);
+
+		expect(errors).toEqual([]);
+		expect(phases[0].tasks.map((task) => task.content)).toEqual(["Done"]);
+		expect(phases[1].tasks.map((task) => task.content)).toEqual(["Dropped", "Follow up"]);
+		expect(corrections).toEqual(['[auto-corrected] append had no phase; used "Abandoned"']);
+	});
+
+	it("creates the default phase when append omits phase on an empty list", () => {
+		const phases: TodoPhase[] = [];
+		const errors: string[] = [];
+		const corrections: string[] = [];
+
+		appendItems(phases, { op: "append", items: ["First task"] }, errors, corrections);
+
+		expect(errors).toEqual([]);
+		expect(phases).toEqual([{ name: DEFAULT_INIT_PHASE, tasks: [{ content: "First task", status: "pending" }] }]);
+		expect(corrections).toEqual([`[auto-corrected] append had no phase; used "${DEFAULT_INIT_PHASE}"`]);
+	});
+
+	it("keeps duplicate-task append failures as errors", () => {
+		const phases = [{ name: "Tasks", tasks: [{ content: "Already exists", status: "pending" as const }] }];
+		const errors: string[] = [];
+
+		appendItems(phases, { op: "append", items: ["Already exists"] }, errors, []);
+
+		expect(errors).toEqual(['Task "Already exists" already exists']);
+		expect(phases[0].tasks).toEqual([{ content: "Already exists", status: "pending" }]);
+	});
+});

--- a/packages/coding-agent/test/suite/todo-normalize.test.ts
+++ b/packages/coding-agent/test/suite/todo-normalize.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTodoParams } from "../../src/core/extensions/builtin/todotools/normalize.ts";
+import type { TodoPhase } from "../../src/core/extensions/builtin/todotools/state.ts";
+
+const emptyPhases: TodoPhase[] = [];
+const populatedPhases: TodoPhase[] = [
+	{
+		name: "Tasks",
+		tasks: [{ content: "Existing task", status: "in_progress" }],
+	},
+];
+
+function expectError(raw: Record<string, unknown>, phases: readonly TodoPhase[] = emptyPhases): string {
+	const result = normalizeTodoParams(raw, phases);
+	expect(result.entry).toBeUndefined();
+	expect(result.error).toBeTypeOf("string");
+	return result.error ?? "";
+}
+
+describe("normalizeTodoParams", () => {
+	describe("R0 blank-target guard", () => {
+		it.each([
+			["start", "task"],
+			["start", "phase"],
+			["done", "task"],
+			["done", "phase"],
+			["drop", "task"],
+			["drop", "phase"],
+			["rm", "task"],
+			["rm", "phase"],
+		] as const)("rejects a blank %s %s target", (op, field) => {
+			const raw: Record<string, unknown> = { op, [field]: " \t " };
+			expect(expectError(raw)).toBe(
+				`Blank "${field}" — pass the exact ${field} text, or omit the field entirely for a bulk operation.`,
+			);
+		});
+
+		it("drops a blank task when a real phase makes the target unambiguous", () => {
+			const result = normalizeTodoParams({ op: "done", task: " ", phase: "Tasks" }, populatedPhases);
+			expect(result).toEqual({ entry: { op: "done", phase: "Tasks" }, corrections: [] });
+		});
+
+		it("drops fx03's blank phase padding when a real task is present", () => {
+			const raw = {
+				op: "done",
+				list: [],
+				task: "Confirm temporary 13773 server is offline",
+				phase: "",
+				items: [],
+			};
+			const result = normalizeTodoParams(raw, populatedPhases);
+			expect(result).toEqual({
+				entry: { op: "done", task: "Confirm temporary 13773 server is offline" },
+				corrections: [],
+			});
+			expect(raw).toEqual({
+				op: "done",
+				list: [],
+				task: "Confirm temporary 13773 server is offline",
+				phase: "",
+				items: [],
+			});
+		});
+	});
+
+	describe("R1 and R-VIEW", () => {
+		it("preserves explicit init list=[] clear semantics", () => {
+			expect(normalizeTodoParams({ op: "init", list: [] }, populatedPhases)).toEqual({
+				entry: { op: "init", list: [] },
+				corrections: [],
+			});
+		});
+
+		it("ignores empty placeholders on operations that do not read them", () => {
+			expect(
+				normalizeTodoParams(
+					{ op: "start", task: "Existing task", list: [], items: [], phase: "" },
+					populatedPhases,
+				),
+			).toEqual({ entry: { op: "start", task: "Existing task" }, corrections: [] });
+		});
+
+		it("short-circuits view and ignores every other field", () => {
+			expect(
+				normalizeTodoParams({ op: "view", append: ["x"], task: " ", list: [{ bad: true }] }, populatedPhases),
+			).toEqual({
+				entry: { op: "view" },
+				corrections: [],
+			});
+		});
+	});
+
+	describe("R2 alias canonicalization", () => {
+		it("folds fx12's op-named append alias into items", () => {
+			const result = normalizeTodoParams(
+				{
+					append: [
+						"Fix oracle blocker 2 via Agent A: reasoning terminal-path flush + regression — verify by tests green",
+						"Fix oracle blocker 1 via Agent B: empty-delta throttle accounting + regression — verify by tests green",
+						"Re-review blocker fixes + re-run focused tests + gates — verify exit 0",
+						"Re-submit delta to same oracle — verify by APPROVE",
+					],
+					op: "append",
+					phase: "Tasks",
+				},
+				populatedPhases,
+			);
+			expect(result.entry).toEqual({
+				op: "append",
+				phase: "Tasks",
+				items: [
+					"Fix oracle blocker 2 via Agent A: reasoning terminal-path flush + regression — verify by tests green",
+					"Fix oracle blocker 1 via Agent B: empty-delta throttle accounting + regression — verify by tests green",
+					"Re-review blocker fixes + re-run focused tests + gates — verify exit 0",
+					"Re-submit delta to same oracle — verify by APPROVE",
+				],
+			});
+			expect(result.corrections).toHaveLength(1);
+			expect(result.corrections[0]).toContain('"append"');
+		});
+
+		it("uses an alias as the missing-op candidate", () => {
+			const result = normalizeTodoParams({ init: ["First task"] }, emptyPhases);
+			expect(result.entry).toEqual({ op: "init", items: ["First task"] });
+			expect(result.corrections).toHaveLength(1);
+		});
+
+		it("rejects a conflicting alias operation", () => {
+			expect(expectError({ op: "init", append: ["x"] })).toContain("conflicting shapes");
+		});
+
+		it("rejects alias and items shapes together", () => {
+			expect(expectError({ op: "append", append: ["x"], items: ["y"] })).toContain("conflicting shapes");
+		});
+
+		it("rejects two non-empty aliases at once", () => {
+			expect(expectError({ init: ["x"], append: ["y"] })).toContain("conflicting shapes");
+		});
+	});
+
+	describe("R3 op inference and conflicts", () => {
+		it("infers init from the verbatim fx04-shaped list payload", () => {
+			const raw = {
+				list: [
+					{
+						items: [
+							"W1-A: migration 0016 + drizzle schema + repos types/mapping + inline test DDL sweep — verify tsc + full bun test green",
+							"W1-B: src/lib/cost-limits.ts + unit tests RED→GREEN — verify bun test tests/unit/cost-limits.test.ts",
+						],
+						phase: "Foundation",
+					},
+				],
+			};
+			const result = normalizeTodoParams(raw, emptyPhases);
+			expect(result.entry).toEqual({ op: "init", list: raw.list });
+			expect(result.corrections[0]).toContain('interpreted as "init"');
+			expect(result.corrections[0]).toContain('{"op":"init","list":[...]}');
+		});
+
+		it("infers init from the verbatim fx02 items-only payload on an empty list", () => {
+			const raw = {
+				items: [
+					"Wave1: DNS/WHOIS/TLS/HTTP/crt.sh fingerprint via eval — verify outputs in notepad",
+					"Wave2: fetch ydtour50.sbs content Tier1 engine, escalate CloakBrowser if blocked — verify captured text+screenshot",
+					"Wave3: enumerate >=3 sibling mirror domains — verify list with sources",
+					"Synthesize final report with evidence refs — verify all criteria PASS",
+				],
+			};
+			const result = normalizeTodoParams(raw, emptyPhases);
+			expect(result.entry).toEqual({ op: "init", items: raw.items });
+			expect(result.corrections[0]).toContain('interpreted as "init"');
+		});
+
+		it("infers append from items and a non-blank phase", () => {
+			const result = normalizeTodoParams({ items: ["x"], phase: "Later" }, emptyPhases);
+			expect(result.entry).toEqual({ op: "append", phase: "Later", items: ["x"] });
+			expect(result.corrections[0]).toContain('interpreted as "append"');
+		});
+
+		it("does not guess init versus append on a populated list", () => {
+			const error = expectError({ items: ["x"] }, populatedPhases);
+			expect(error).toContain('{"op":"init","list":[...]}');
+			expect(error).toContain('{"op":"append","phase":"<active phase>","items":[...]}');
+		});
+
+		it("rejects list plus items before alias inference can choose a priority", () => {
+			expect(expectError({ list: [{ phase: "A", items: ["x"] }], append: ["y"] })).toContain("conflicting shapes");
+		});
+
+		it("rejects direct list and items conflicts", () => {
+			expect(expectError({ list: [{ phase: "A", items: ["x"] }], items: ["y"] })).toContain("conflicting shapes");
+		});
+
+		it("rejects missing-op calls without a non-empty signal", () => {
+			expect(expectError({ list: [], items: [], phase: " " })).toBe(
+				'Missing "op". Example: {"op":"init","list":[{"phase":"Setup","items":["..."]}]}',
+			);
+		});
+	});
+
+	describe("R4 field compatibility", () => {
+		it("rejects an invalid op from fx05", () => {
+			expect(expectError({ op: "Study kimi-k3-unlocked full implementation" })).toContain('Invalid "op"');
+		});
+
+		it("rejects TodoWrite residue on done before it can bulk-complete", () => {
+			expect(expectError({ op: "done", list: [{ phase: "A", items: ["x"] }] }, populatedPhases)).toContain(
+				"conflicting shapes",
+			);
+		});
+
+		it("rejects explicit init clear combined with items", () => {
+			expect(expectError({ op: "init", list: [], items: ["x"] })).toContain("conflicting shapes");
+		});
+
+		it("passes fx17's duplicate-phase init shape through for the merge layer", () => {
+			const raw = {
+				op: "init",
+				list: [
+					{ phase: "Dockerfile", items: ["Dockerfile secret 제거 + 가드 반전 GREEN"] },
+					{
+						phase: "Ship",
+						items: [
+							"커밋 + push + PR 생성",
+							"CI green + 머지(사용자 사전 승인: 이 작업 병합)",
+							"deploy-dev 트리거 관찰: Build Succeeded?",
+						],
+						phase2: "Verify",
+					},
+					{ phase: "Dockerfile", items: ["dev uptime 리셋 + memory 활성화 확인"], items2: [] },
+				],
+			};
+			expect(normalizeTodoParams(raw, emptyPhases)).toEqual({
+				entry: {
+					op: "init",
+					list: [
+						{ phase: "Dockerfile", items: ["Dockerfile secret 제거 + 가드 반전 GREEN"] },
+						{
+							phase: "Ship",
+							items: [
+								"커밋 + push + PR 생성",
+								"CI green + 머지(사용자 사전 승인: 이 작업 병합)",
+								"deploy-dev 트리거 관찰: Build Succeeded?",
+							],
+						},
+						{ phase: "Dockerfile", items: ["dev uptime 리셋 + memory 활성화 확인"] },
+					],
+				},
+				corrections: [],
+			});
+		});
+
+		it("canonicalizes alias append with a blank phase to an absent phase", () => {
+			const result = normalizeTodoParams({ op: "append", append: ["x"], phase: " \n " }, emptyPhases);
+			expect(result.entry).toEqual({ op: "append", items: ["x"] });
+			expect(result.corrections).toHaveLength(1);
+		});
+
+		it("keeps task precedence when done receives both targets", () => {
+			expect(normalizeTodoParams({ op: "done", task: "Existing task", phase: "Tasks" }, populatedPhases)).toEqual({
+				entry: { op: "done", task: "Existing task", phase: "Tasks" },
+				corrections: [],
+			});
+		});
+
+		it.each([
+			[{ op: "init", task: "x" }, "init"],
+			[{ op: "start", phase: "Tasks" }, "start"],
+			[{ op: "start", list: [{ phase: "A", items: ["x"] }] }, "start"],
+			[{ op: "drop", items: ["x"] }, "drop"],
+			[{ op: "rm", list: [{ phase: "A", items: ["x"] }] }, "rm"],
+			[{ op: "append", list: [{ phase: "A", items: ["x"] }] }, "append"],
+			[{ op: "append", task: "x", items: ["y"] }, "append"],
+		])("rejects incoherent %s fields", (raw, _op) => {
+			expect(expectError(raw)).toContain("conflicting shapes");
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/todo-prompt-guidance.test.ts
+++ b/packages/coding-agent/test/suite/todo-prompt-guidance.test.ts
@@ -1,0 +1,46 @@
+import { Value } from "typebox/value";
+import { describe, expect, it } from "vitest";
+import { TODO_TOOL_DESCRIPTION } from "../../src/core/extensions/builtin/todotools/prompt.ts";
+import { TODO_PARAMS_SCHEMA } from "../../src/core/extensions/builtin/todotools/tools/todo.ts";
+
+// Behavioral guards for the TODO_TOOL_DESCRIPTION guidance additions (plan
+// todo 6). Assertions target structure/parseability, never full sentences.
+
+const lines = TODO_TOOL_DESCRIPTION.split("\n");
+
+const exampleLine = lines.find((line) => line.startsWith("Example:"));
+const exampleJson = exampleLine ? exampleLine.slice("Example:".length).trim() : "";
+
+let parsed: unknown = null;
+let parseError: string | null = null;
+if (exampleJson) {
+	try {
+		parsed = JSON.parse(exampleJson);
+	} catch (err) {
+		parseError = err instanceof Error ? err.message : String(err);
+	}
+}
+
+describe("todo prompt guidance", () => {
+	it("exposes a canonical Example: line directly under the Operations table", () => {
+		expect(exampleLine, "TODO_TOOL_DESCRIPTION must contain an 'Example:' line").toBeDefined();
+	});
+
+	it("the Example line is valid JSON", () => {
+		expect(parseError, `Example JSON did not parse: ${parseError ?? ""}`).toBeNull();
+	});
+
+	it("the Example payload validates against TODO_PARAMS_SCHEMA", () => {
+		expect(Value.Check(TODO_PARAMS_SCHEMA, parsed), "Example payload must satisfy TODO_PARAMS_SCHEMA").toBe(true);
+	});
+
+	it("the append Operations row marks phase as optional (phase?)", () => {
+		const appendRow = lines.find((line) => line.startsWith("| append |"));
+		expect(appendRow, "append row must exist in the Operations table").toBeDefined();
+		expect(appendRow ?? "", "append phase must be marked optional").toContain("phase?");
+	});
+
+	it("does not advertise auto-correction in the description", () => {
+		expect(TODO_TOOL_DESCRIPTION.toLowerCase()).not.toContain("auto-correct");
+	});
+});


### PR DESCRIPTION
## Why

Senpi's `todo` tool is op-based (`init/start/done/rm/drop/append/view`, tasks referenced by verbatim content string). Every model was trained on the classic `TodoWrite` full-list schema (`{todos:[{content,status,...}]}`), and some keep making the same small mistakes against ours.

Mining **881 local session transcripts** (`~/.senpi/agent/sessions`, window 2026-07-19..07-26) found **17 failures across 2,435 `todo` calls (0.7%)**, concentrated in two cheap-to-fix classes and almost entirely in one model family:

| model | calls | failures | rate |
|---|---|---|---|
| `kimi-k3` / `kimi-k3-unlocked` | 605 | 12 | 1.8–4.2% |
| `glm-5.2-ultrafast` (+unlocked) | 160 | 4 | 2.4–2.5% |
| `gpt-5.6-terra-fast` / `sol-fast` | 984 | 1 | 0–0.3% |
| `claude-opus-*` / `claude-fable-5` | 675 | 0 | 0% |

Failure classes: **11×** missing `op` on an init-shaped call, **3×** task-not-found from paraphrased/stale task text, **1×** op-named alias key (`{"append":[...]}`) instead of `items`, **1×** task content placed in `op`, **1×** duplicate phase in an init list, plus gpt-style placeholder padding (`list:[]`, `phase:""`, `items:[]`).

15 of 17 recovered on the next call — but each burned a round trip, and init retries re-sent the entire list. One session abandoned todo tracking entirely; another wiped its list via re-init. All of this happened **under the current prompt**, so guidance alone was proven insufficient for kimi/glm.

## What this does

Unambiguous mistakes are corrected inside the tool, the intended operation runs, and the result **tells the model what was corrected and the canonical form to send next time**. Genuinely ambiguous calls fail — and now fail *correctly*.

- **`normalize.ts` (new, 189 LOC)** — argument normalization in strict rule order: `R0` blank-target guard, `R1` explicit-init preservation, `R-VIEW` short-circuit, `R2` alias canonicalization *before* conflict detection, `R3` conflict detection + op inference, `R4` per-op field-compatibility matrix.
- **`fuzzy-match.ts` (new, 92 LOC)** — task/phase resolution ladder. Auto-applies **only** on unique exact or unique normalized (casefold/whitespace/ANSI) equality; containment and char-bigram Dice are **suggestion-only** (`Did you mean "…"?`).
- **Init duplicate merging** and **optional append `phase`** (default chain: active-task phase → last existing phase → `DEFAULT_INIT_PHASE`).
- **Real errors.** `execute` now **throws** on unrecoverable errors. `packages/agent/src/agent-loop.ts` `executeToolCall` returns `isError: false` for *any* non-throwing execute, so the tool's own returned `isError` was being silently dropped — all 5 observed state-level errors reached providers **flagged as success**. Throwing routes through the loop's error path and records `isError: true`, while the thrown message keeps the remaining-items echo models need to recover. Fixed extension-locally; `packages/agent` and `packages/ai` are untouched.
- **Guidance hardening** — canonical init example under the operations table, `phase?` in the append row, an explicit verbatim-copy rule, and sharpened schema field descriptions. The advertised text never mentions auto-correction (a test guards this, so we don't teach sloppiness).

### Deliberately NOT done: cache-breaking history rewrite

Force-correcting the *recorded* tool-call arguments was considered and **rejected**: rewriting a prior tool call invalidates the cached prefix from that segment onward until it is rebuilt. For a 0.7% failure rate that trade is bad, and the loop's assistant messages are immutable by design anyway. The correction notice rides in the new tool result — same teaching effect, zero cache cost. `F4` audited the diff to confirm no session-history mutation exists.

## Verification

| Gate | Result |
|---|---|
| Todo suites (9 files) | **136 passed** |
| `npm run check` (root) | **exit 0** |
| `npm run build` | **exit 0** |
| `npm test` (full workspace, CI parity) | **exit 0** |
| Real-CLI QA (senpi-qa mock-loop, RPC channel) | **15/15 checks, exit 0** |
| CLI smoke | **7/7, exit 0** |
| Real `~/.senpi/agent/auth.json` | sha256 **unchanged** (guard receipt before+after) |

**Regression lock:** all **17 mined payloads** are committed verbatim as `packages/coding-agent/test/fixtures/todo-arg-correction.fixtures.json` (byte-identical to the plan companion, sha256 `5d121831…`, provenance in the test header) and replayed end-to-end through the registered tool by `test/suite/todo-arg-correction.test.ts`, plus a synthetic `task-N` case. A mutation check confirmed the suite actually bites: breaking rule `R0` turned `fx03` red, and reverting restored green.

**Real-CLI QA** drove the CLI from source against a local fake model server (zero tokens, isolated sandbox) through a scripted 4-turn conversation and asserted, in-script:
1. `{"list":[…]}` with **no `op`** → executed as `init`, result text carries `[auto-corrected]`, both tasks landed under `Setup`.
2. `"  alpha   TASK "` → **auto-matched** `"Alpha task"` with `[auto-matched]`; the intended task completed, sibling untouched.
3. An unresolvable paraphrase → recorded with **`isError: true`** and `Did you mean "Alpha task"?` (the pre-fix bug would have recorded this as success).
4. All 3 notices verifiably reached the model on the wire in later requests.

Compatibility, base-anchored at `dc4ee0c8d`: `todo-command.test.ts` and the compaction tests have **zero diff**; `packages/agent` + `packages/ai` have **zero diff**; `todo-extension.test.ts` has **exactly one** `-` line — the plan-authorized assertion swap (`details.phases` → persisted-branch state check), forced because the loop's `createErrorToolResult` yields `details: {}` on a throw.

## Reviewer notes

- **Commit granularity:** the plan specified one commit per todo; todos 2+5 and 3+4 are each combined because they own the same file (`state.ts`, `tools/todo.ts` respectively) and the plan itself mandated a single worker for that reason. 6 commits for 8 committable todos.
- **Pre-existing file-size smell:** `tools/todo.ts` 295→309 and `state.ts` 446→537 pure LOC — both were already over the 250 ceiling at the base commit. All new logic went into the two new files (189 / 92 LOC, both under). A split of those two files is reasonable follow-up, deliberately out of scope here to keep the fork diff mergeable.
- `changes.md` documents every behavior change plus the expected upstream merge-conflict zones (`tools/todo.ts` schema+execute, `state.ts` resolvers/init/append).
- Correction notices ride in plain tool-result `content` text, so no RPC/app-server/web-ui rendering seam was needed.

Planned with a dual high-accuracy review (5 rounds, `momus` + independent oracle, both APPROVED) and executed by parallel subagents in an isolated worktree; QA evidence under `local-ignore/qa-evidence/20260726-todo-arg-correction/` (gitignored, not committed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-corrects malformed `todo` tool calls, throws on unrecoverable errors so the agent records `isError: true`, and makes render paths exhaustive. This cuts round trips and teaches models the canonical payload via clear correction notices.

- **New Features**
  - Argument normalization with strict rules: preserve explicit init, short-circuit `view`, canonicalize aliases, infer `op`, detect conflicts, and reject blank targets.
  - Conservative fuzzy matching: apply only unique exact/normalized hits; otherwise emit “Did you mean …?” suggestions.
  - Init merges duplicate phases/tasks; `append` `phase` is optional with a safe default chain.
  - Tool results include correction notices in text and `details.corrections`; prompt adds a canonical `init` example and marks `append` `phase?`.

- **Bug Fixes**
  - Unrecoverable errors now throw, ensuring the loop records `isError: true` instead of silently succeeding.
  - Schema accepts missing `op` to enable rescue, while the description still instructs models to pass it explicitly.
  - Render paths (labels and touched phases) now enumerate every `op` (including undefined) with a `never` guard to prevent silent generic fallbacks.
  - Synced the task-management prompt snapshot fixture to reflect the guidance changes (append `phase?`, canonical `init` example).

<sup>Written for commit 0c21b85840abb7948daa8fa012765c97f0179a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

