### PR TITLE
feat(mcp): keep unchanged MCP servers alive across a classic /reload

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -21,6 +21,13 @@
 - Root cause of the omo `team_wait` starvation forensics: member self-poller injections via `pi.sendUserMessage(..., { deliverAs: "followUp" })` vanished without a trace when the fresh-prompt path threw, leaving no record in the session JSONL while RPC-path `steer`/`follow_up` commands (which bypass `prompt()`) landed normally.
 - Interactive `prompt()` behavior is unchanged: a rejected interactive prompt still drops the input and surfaces the error to the user (pinned by `test/suite/regressions/pre-prompt-compaction-no-continue.test.ts`).
 - Coverage: `test/suite/agent-session-extension-injection.test.ts` pins retention for followUp and steer injections, exact-once delivery after recovery through the post-run drain, and no double-queueing on the streaming accept path.
+
+## Reload-safe MCP preservation and extension-removal lifecycle event (2026-07-26)
+
+- `session_extensions_removed` is emitted on the old extension runner when a `/reload` or a session replacement (`/new`, `/resume`, `/fork`, import) rebuilds the extension set. Its payload is `{ type: "session_extensions_removed", reason: SessionShutdownEvent["reason"], removed: Array<{ path, resolvedPath }> }`, allowing an extension that did not survive the rebuild to release resources after the new settings and active builtin set are known.
+- Unchanged MCP servers now survive a classic `/reload`: the shared service reattaches and reconciles by config hash, preserving live connections while replacing changed servers and disposing removed ones. Provider-scoped MCP services still dispose on reload because their factory creates a replacement instance.
+- If the MCP builtin itself is disabled during a reload or replacement, its removal event disposes the preserved classic service so stdio children cannot leak. For an otherwise wedged server, use `/mcp reconnect <name>` to force a fresh connection.
+
 ## Same-model-first transient retries and capped server waits (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -9,7 +9,7 @@ import type {
 	SessionShutdownEvent,
 	SessionStartEvent,
 } from "./extensions/index.ts";
-import { emitSessionShutdownEvent } from "./extensions/runner.ts";
+import { type ExtensionRunner, emitSessionShutdownEvent } from "./extensions/runner.ts";
 import type { CreateAgentSessionResult } from "./sdk.ts";
 import { assertSessionCwdExists } from "./session-cwd.ts";
 import { SessionManager } from "./session-manager.ts";
@@ -89,6 +89,11 @@ export class AgentSessionRuntime {
 	private _diagnostics: AgentSessionRuntimeDiagnostic[];
 	private _modelFallbackMessage?: string;
 	private readonly _launchProfile?: Readonly<AgentSessionLaunchProfile>;
+	private _removedOnReplacement?: {
+		oldRunner: ExtensionRunner;
+		oldIdentities: Array<{ path: string; resolvedPath: string }>;
+		reason: SessionShutdownEvent["reason"];
+	};
 
 	constructor(
 		_session: AgentSession,
@@ -181,7 +186,13 @@ export class AgentSessionRuntime {
 	}
 
 	private async teardownCurrent(reason: SessionShutdownEvent["reason"], targetSessionFile?: string): Promise<void> {
-		await emitSessionShutdownEvent(this.session.extensionRunner, {
+		const oldRunner = this.session.extensionRunner;
+		this._removedOnReplacement = {
+			oldRunner,
+			oldIdentities: oldRunner.getExtensionIdentities(),
+			reason,
+		};
+		await emitSessionShutdownEvent(oldRunner, {
 			type: "session_shutdown",
 			reason,
 			targetSessionFile,
@@ -190,11 +201,24 @@ export class AgentSessionRuntime {
 		this.session.dispose();
 	}
 
-	private apply(result: CreateAgentSessionRuntimeResult): void {
+	private async reportRemovedExtensions(): Promise<void> {
+		const pending = this._removedOnReplacement;
+		this._removedOnReplacement = undefined;
+		if (!pending) return;
+		const newResolvedPaths = new Set(
+			this.session.extensionRunner.getExtensionIdentities().map((extension) => extension.resolvedPath),
+		);
+		const removed = pending.oldIdentities.filter((extension) => !newResolvedPaths.has(extension.resolvedPath));
+		if (removed.length === 0) return;
+		await pending.oldRunner.emit({ type: "session_extensions_removed", reason: pending.reason, removed });
+	}
+
+	private async apply(result: CreateAgentSessionRuntimeResult): Promise<void> {
 		this._session = result.session;
 		this._services = result.services;
 		this._diagnostics = result.diagnostics;
 		this._modelFallbackMessage = result.modelFallbackMessage;
+		await this.reportRemovedExtensions();
 	}
 
 	private async finishSessionReplacement(withSession?: (ctx: ReplacedSessionContext) => Promise<void>): Promise<void> {
@@ -223,7 +247,7 @@ export class AgentSessionRuntime {
 		const sessionManager = SessionManager.open(sessionPath, undefined, options?.cwdOverride);
 		assertSessionCwdExists(sessionManager, this.cwd);
 		await this.teardownCurrent("resume", sessionManager.getSessionFile());
-		this.apply(
+		await this.apply(
 			await this.createRuntime({
 				cwd: sessionManager.getCwd(),
 				agentDir: this.services.agentDir,
@@ -257,7 +281,7 @@ export class AgentSessionRuntime {
 		}
 
 		await this.teardownCurrent("new", sessionManager.getSessionFile());
-		this.apply(
+		await this.apply(
 			await this.createRuntime({
 				cwd: this.cwd,
 				agentDir: this.services.agentDir,
@@ -312,7 +336,7 @@ export class AgentSessionRuntime {
 				const sessionManager = SessionManager.create(this.cwd, sessionDir);
 				sessionManager.newSession({ parentSession: currentSessionFile });
 				await this.teardownCurrent("fork", sessionManager.getSessionFile());
-				this.apply(
+				await this.apply(
 					await this.createRuntime({
 						cwd: this.cwd,
 						agentDir: this.services.agentDir,
@@ -336,7 +360,7 @@ export class AgentSessionRuntime {
 				throw new Error("Failed to create forked session");
 			}
 			await this.teardownCurrent("fork", sessionManager.getSessionFile());
-			this.apply(
+			await this.apply(
 				await this.createRuntime({
 					cwd: sessionManager.getCwd(),
 					agentDir: this.services.agentDir,
@@ -356,7 +380,7 @@ export class AgentSessionRuntime {
 			sessionManager.createBranchedSession(targetLeafId);
 		}
 		await this.teardownCurrent("fork", sessionManager.getSessionFile());
-		this.apply(
+		await this.apply(
 			await this.createRuntime({
 				cwd: this.cwd,
 				agentDir: this.services.agentDir,
@@ -401,7 +425,7 @@ export class AgentSessionRuntime {
 		const sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride);
 		assertSessionCwdExists(sessionManager, this.cwd);
 		await this.teardownCurrent("resume", sessionManager.getSessionFile());
-		this.apply(
+		await this.apply(
 			await this.createRuntime({
 				cwd: sessionManager.getCwd(),
 				agentDir: this.services.agentDir,

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -187,11 +187,15 @@ export class AgentSessionRuntime {
 
 	private async teardownCurrent(reason: SessionShutdownEvent["reason"], targetSessionFile?: string): Promise<void> {
 		const oldRunner = this.session.extensionRunner;
-		this._removedOnReplacement = {
-			oldRunner,
-			oldIdentities: oldRunner.getExtensionIdentities(),
-			reason,
-		};
+		// Test hosts and partial runner implementations may lack identity introspection;
+		// skip removal reporting there rather than break the replacement itself.
+		if (typeof oldRunner.getExtensionIdentities === "function") {
+			this._removedOnReplacement = {
+				oldRunner,
+				oldIdentities: oldRunner.getExtensionIdentities(),
+				reason,
+			};
+		}
 		await emitSessionShutdownEvent(oldRunner, {
 			type: "session_shutdown",
 			reason,
@@ -205,8 +209,10 @@ export class AgentSessionRuntime {
 		const pending = this._removedOnReplacement;
 		this._removedOnReplacement = undefined;
 		if (!pending) return;
+		const newRunner = this.session.extensionRunner;
+		if (typeof newRunner.getExtensionIdentities !== "function") return;
 		const newResolvedPaths = new Set(
-			this.session.extensionRunner.getExtensionIdentities().map((extension) => extension.resolvedPath),
+			newRunner.getExtensionIdentities().map((extension) => extension.resolvedPath),
 		);
 		const removed = pending.oldIdentities.filter((extension) => !newResolvedPaths.has(extension.resolvedPath));
 		if (removed.length === 0) return;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4976,8 +4976,10 @@ export class AgentSession {
 
 	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void> {
 		resetTimings("reload");
-		const previousFlagValues = this._extensionRunner.getFlagValues();
-		await emitSessionShutdownEvent(this._extensionRunner, { type: "session_shutdown", reason: "reload" });
+		const oldExtensionRunner = this._extensionRunner;
+		const oldExtensionIdentities = oldExtensionRunner.getExtensionIdentities();
+		const previousFlagValues = oldExtensionRunner.getFlagValues();
+		await emitSessionShutdownEvent(oldExtensionRunner, { type: "session_shutdown", reason: "reload" });
 		time("shutdown", "reload");
 		await this.settingsManager.reload();
 		this.syncQueueModesFromSettings();
@@ -5008,6 +5010,15 @@ export class AgentSession {
 			flagValues: previousFlagValues,
 			includeAllExtensionTools: true,
 		});
+		const newExtensionResolvedPaths = new Set(
+			this._extensionRunner.getExtensionIdentities().map((extension) => extension.resolvedPath),
+		);
+		const removed = oldExtensionIdentities.filter(
+			(extension) => !newExtensionResolvedPaths.has(extension.resolvedPath),
+		);
+		if (removed.length > 0) {
+			await oldExtensionRunner.emit({ type: "session_extensions_removed", reason: "reload", removed });
+		}
 		time("runtime", "reload");
 
 		const hasBindings =

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5005,21 +5005,27 @@ export class AgentSession {
 		time("models", "reload");
 		await this._resourceLoader.reload({ settingsAlreadyReloadedFor: this.settingsManager });
 		time("resources", "reload");
-		this._buildRuntime({
-			activeToolNames: this.getActiveToolNames(),
-			flagValues: previousFlagValues,
-			includeAllExtensionTools: true,
-		});
-		const newExtensionResolvedPaths = new Set(
-			this._extensionRunner.getExtensionIdentities().map((extension) => extension.resolvedPath),
-		);
-		const removed = oldExtensionIdentities.filter(
-			(extension) => !newExtensionResolvedPaths.has(extension.resolvedPath),
-		);
-		if (removed.length > 0) {
-			await oldExtensionRunner.emit({ type: "session_extensions_removed", reason: "reload", removed });
+		try {
+			this._buildRuntime({
+				activeToolNames: this.getActiveToolNames(),
+				flagValues: previousFlagValues,
+				includeAllExtensionTools: true,
+			});
+		} finally {
+			// An extension removed by this reload must be told even if the rebuild throws
+			// (e.g. _refreshToolRegistry rejecting an extension's tool metadata): the new
+			// runner is already installed without it, so nothing else would dispose it.
+			const newExtensionResolvedPaths = new Set(
+				this._extensionRunner.getExtensionIdentities().map((extension) => extension.resolvedPath),
+			);
+			const removed = oldExtensionIdentities.filter(
+				(extension) => !newExtensionResolvedPaths.has(extension.resolvedPath),
+			);
+			if (removed.length > 0) {
+				await oldExtensionRunner.emit({ type: "session_extensions_removed", reason: "reload", removed });
+			}
+			time("runtime", "reload");
 		}
-		time("runtime", "reload");
 
 		const hasBindings =
 			this._extensionUIContext ||

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,22 @@
 # mcp Extension Changes
 
+## Classic reload preserves unchanged MCP servers (2026-07-26)
+
+### What changed
+- Classic (non-provider-scoped) MCP reloads keep the shared `McpService` alive. The reload-time `session_start` reattaches it and its existing config-hash reconciliation preserves unchanged servers while replacing changed definitions and disposing removed definitions.
+- Provider-scoped MCP services still dispose on `reload`, because rebuilding an extension factory creates a new scoped instance and preserving the old one would orphan its child processes.
+- Core now emits `{ type: "session_extensions_removed", reason: "reload", removed: Array<{ path, resolvedPath }> }` on the old runner after it knows the rebuilt extension set. MCP matches its builtin identity (`<builtin:mcp>`) in that event and disposes the preserved classic service when MCP is disabled during a reload.
+- `/mcp reconnect <name>` remains the explicit escape hatch for a server that is connected but wedged: it renews that server without requiring a full reload.
+
+### Why
+- Spawning every MCP server again on every classic reload adds a fixed process startup cost even when config is unchanged. Preserving and reconciling retains healthy children, while the removal event closes the only gap where the preserved singleton otherwise loses its owning extension.
+
+### Why extension system couldn't handle this alone
+- The core alone can identify removed extension entries but must remain resource-agnostic; MCP alone cannot know the post-reload builtin set at `session_shutdown`. The core event provides the lifecycle boundary and MCP owns the service-specific disposal.
+
+### Expected merge conflict zones
+- LOW: `index.ts` lifecycle handlers; `service.ts` remains the config-hash reconciliation owner.
+
 ## Raced background registration replays session state (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -16,6 +16,8 @@ import {
 } from "./skills.ts";
 import { reportMcpAsyncError, wrapAsync } from "./wrap.ts";
 
+const MCP_BUILTIN_EXTENSION_PATH = "<builtin:mcp>";
+
 export function createMcpExtension(service: McpService, sessionOwned = true): ExtensionFactory {
 	return (pi: ExtensionAPI): void => {
 		let attachPromise: Promise<void> | undefined;
@@ -149,11 +151,20 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 			wrapAsync(
 				"mcp.session_shutdown",
 				async (event) => {
+					if (event.reason === "reload" && !sessionOwned) return;
 					await service.handleSessionShutdown(event);
-					// A classic extension instance can be reused by the test/legacy host
-					// after reload. Its singleton is intentionally refreshed for that next
-					// session; scoped factories keep their closed instance.
-					if (!sessionOwned && event.reason === "reload" && service.isDisposed()) service = getMcpService();
+				},
+				sink,
+			),
+		);
+		pi.on(
+			"session_extensions_removed",
+			wrapAsync(
+				"mcp.session_extensions_removed",
+				async (event) => {
+					if (event.removed.some((extension) => extension.path === MCP_BUILTIN_EXTENSION_PATH)) {
+						await service.dispose("reload");
+					}
 				},
 				sink,
 			),

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -591,6 +591,10 @@ export class ExtensionRunner {
 		return this.extensions.map((e) => e.path);
 	}
 
+	getExtensionIdentities(): Array<{ path: string; resolvedPath: string }> {
+		return this.extensions.map(({ path, resolvedPath }) => ({ path, resolvedPath }));
+	}
+
 	/**
 	 * Get all registered tools from all extensions. The first registration within a source tier
 	 * wins, while a non-builtin extension may override a builtin extension tool.

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -773,6 +773,13 @@ export interface SessionShutdownEvent {
 	targetSessionFile?: string;
 }
 
+/** Fired on the old extension runner after reload when one or more extensions are absent from the rebuilt runner. */
+export interface SessionExtensionsRemovedEvent {
+	type: "session_extensions_removed";
+	reason: "reload";
+	removed: Array<{ path: string; resolvedPath: string }>;
+}
+
 /** Preparation data for tree navigation */
 export interface TreePreparation {
 	targetId: string;
@@ -812,6 +819,7 @@ export type SessionEvent =
 	| SessionBeforeCompactEvent
 	| SessionCompactEvent
 	| SessionShutdownEvent
+	| SessionExtensionsRemovedEvent
 	| SessionBeforeTreeEvent
 	| SessionTreeEvent;
 
@@ -1401,6 +1409,7 @@ export interface ExtensionAPI {
 	): void;
 	on(event: "session_compact", handler: ExtensionHandler<SessionCompactEvent>): void;
 	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
+	on(event: "session_extensions_removed", handler: ExtensionHandler<SessionExtensionsRemovedEvent>): void;
 	on(event: "session_before_tree", handler: ExtensionHandler<SessionBeforeTreeEvent, SessionBeforeTreeResult>): void;
 	on(event: "session_tree", handler: ExtensionHandler<SessionTreeEvent>): void;
 	on(event: "context", handler: ExtensionHandler<ContextEvent, ContextEventResult>): void;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -773,7 +773,7 @@ export interface SessionShutdownEvent {
 	targetSessionFile?: string;
 }
 
-/** Fired on the old extension runner after reload when one or more extensions are absent from the rebuilt runner. */
+/** Fired on the old extension runner when a reload or session replacement rebuilds the runner and one or more extensions are absent from it. */
 export interface SessionExtensionsRemovedEvent {
 	type: "session_extensions_removed";
 	reason: SessionShutdownEvent["reason"];

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -776,7 +776,7 @@ export interface SessionShutdownEvent {
 /** Fired on the old extension runner after reload when one or more extensions are absent from the rebuilt runner. */
 export interface SessionExtensionsRemovedEvent {
 	type: "session_extensions_removed";
-	reason: "reload";
+	reason: SessionShutdownEvent["reason"];
 	removed: Array<{ path: string; resolvedPath: string }>;
 }
 

--- a/packages/coding-agent/test/mcp/extension-load.test.ts
+++ b/packages/coding-agent/test/mcp/extension-load.test.ts
@@ -1,16 +1,45 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { ProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../../src/config.ts";
 import { createEventBus } from "../../src/core/event-bus.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
-import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import { createMcpExtension } from "../../src/core/extensions/builtin/mcp/index.ts";
+import { getMcpService, McpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
 import type { Extension, SessionShutdownEvent, SessionStartEvent } from "../../src/core/extensions/types.ts";
 import { awaitMcpToolRegistration } from "./fixtures/register-call.ts";
-import { fakePi } from "./fixtures/service-lifecycle.ts";
-import { stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
+import {
+	awaitMcpConnected,
+	cleanupRoots,
+	fakePi,
+	makeRoot,
+	readCounter,
+	requiredPid,
+	setConfig,
+	stdioServer,
+	type TestRoot,
+} from "./fixtures/service-lifecycle.ts";
+import { assertProcessDead, stdioFixtureCommand } from "./fixtures/spawn-fixture.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+const scopedServices: McpService[] = [];
+const originalAgentDir = process.env[ENV_AGENT_DIR];
 
 describe("mcp builtin extension load", () => {
 	beforeEach(() => {
 		resetMcpServiceForTests();
+	});
+
+	afterEach(async () => {
+		await Promise.all(scopedServices.splice(0).map((service) => service.dispose("quit")));
+		await getMcpService().dispose("quit");
+		resetMcpServiceForTests();
+		if (originalAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = originalAgentDir;
+		}
+		await cleanupRoots(cleanupTasks);
 	});
 
 	it("registers the mcp builtin factory", () => {
@@ -25,10 +54,11 @@ describe("mcp builtin extension load", () => {
 		expect(extension.flags.size).toBe(0);
 		expect(extension.handlers.get("session_start")).toHaveLength(1);
 		expect(extension.handlers.get("session_shutdown")).toHaveLength(1);
+		expect(extension.handlers.get("session_extensions_removed")).toHaveLength(1);
 	});
 
-	it("retains the singleton across session switches and disposes only for quit or reload", async () => {
-		for (const reason of ["new", "resume", "fork"] as const) {
+	it("retains the singleton across session switches and classic reloads, disposing only for quit", async () => {
+		for (const reason of ["new", "resume", "fork", "reload"] as const) {
 			const extension = await loadMcpBuiltinExtension();
 
 			await emitSessionStart(extension, "startup");
@@ -44,53 +74,154 @@ describe("mcp builtin extension load", () => {
 			resetMcpServiceForTests();
 		}
 
-		for (const reason of ["quit", "reload"] as const) {
-			const extension = await loadMcpBuiltinExtension();
+		const extension = await loadMcpBuiltinExtension();
 
-			await emitSessionStart(extension, "startup");
-			await emitSessionStart(extension, "resume");
-			const serviceBeforeShutdown = getMcpService();
-			await emitSessionShutdown(extension, reason);
-			await emitSessionShutdown(extension, reason);
+		await emitSessionStart(extension, "startup");
+		await emitSessionStart(extension, "resume");
+		const serviceBeforeShutdown = getMcpService();
+		await emitSessionShutdown(extension, "quit");
+		await emitSessionShutdown(extension, "quit");
 
-			expect(serviceBeforeShutdown.getSnapshot()).toMatchObject({
-				disposed: true,
-				disposeCount: 1,
-				lastDisposeReason: reason,
-				lastSessionStartReason: "resume",
-				sessionStartCount: 2,
-				hasSessionContext: false,
-			});
-			resetMcpServiceForTests();
-		}
+		expect(serviceBeforeShutdown.getSnapshot()).toMatchObject({
+			disposed: true,
+			disposeCount: 1,
+			lastDisposeReason: "quit",
+			lastSessionStartReason: "resume",
+			sessionStartCount: 2,
+			hasSessionContext: false,
+		});
 	});
 
-	it("creates a usable singleton for a new session after reload disposal", async () => {
+	it("keeps the same classic singleton alive across reload shutdown and start", async () => {
 		const extension = await loadMcpBuiltinExtension();
 
 		await emitSessionStart(extension, "startup");
 		const serviceBeforeReload = getMcpService();
 		await emitSessionShutdown(extension, "reload");
 
+		expect(getMcpService()).toBe(serviceBeforeReload);
 		expect(serviceBeforeReload.getSnapshot()).toMatchObject({
-			disposed: true,
-			disposeCount: 1,
-			lastDisposeReason: "reload",
-			hasSessionContext: false,
+			disposed: false,
+			disposeCount: 0,
+			lastSessionStartReason: "startup",
+			sessionStartCount: 1,
+			hasSessionContext: true,
 		});
 
 		await emitSessionStart(extension, "reload");
-		const serviceAfterReload = getMcpService();
 
-		expect(serviceAfterReload).not.toBe(serviceBeforeReload);
-		expect(serviceAfterReload.getSnapshot()).toMatchObject({
+		expect(getMcpService()).toBe(serviceBeforeReload);
+		expect(serviceBeforeReload.getSnapshot()).toMatchObject({
 			disposed: false,
 			disposeCount: 0,
 			lastDisposeReason: null,
 			lastSessionStartReason: "reload",
-			sessionStartCount: 1,
+			sessionStartCount: 2,
 			hasSessionContext: true,
 		});
+	});
+
+	it("preserves a classic stdio child across reload", async () => {
+		const root = makeMcpRoot("classic-reload");
+		const counterFile = `${root.agentDir}/classic-reload-spawns.txt`;
+		setConfig(root, { fixture: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]) });
+		const extension = await loadMcpBuiltinExtension();
+		const ctx = mcpContext(root);
+
+		await emitSessionStart(extension, "startup", ctx);
+		const service = getMcpService();
+		await awaitMcpConnected(service, "fixture");
+		const pid = requiredPid(service, "fixture");
+		await emitSessionShutdown(extension, "reload", ctx);
+
+		expect(getMcpService()).toBe(service);
+		expect(service.isDisposed()).toBe(false);
+		await emitSessionStart(extension, "reload", ctx);
+		await awaitMcpConnected(service, "fixture");
+
+		expect(requiredPid(service, "fixture")).toBe(pid);
+		expect(await readCounter(counterFile)).toBe(1);
+		expect(service.getConnection("fixture")?.state).toBe("connected");
+	});
+
+	it("disposes the preserved classic singleton when the MCP builtin is removed during reload", async () => {
+		const root = makeMcpRoot("removed-on-reload");
+		const counterFile = `${root.agentDir}/removed-on-reload-spawns.txt`;
+		setConfig(root, { fixture: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]) });
+		const extension = await loadMcpBuiltinExtension();
+		const ctx = mcpContext(root);
+
+		await emitSessionStart(extension, "startup", ctx);
+		const service = getMcpService();
+		await awaitMcpConnected(service, "fixture");
+		const pid = requiredPid(service, "fixture");
+		await emitSessionShutdown(extension, "reload", ctx);
+
+		expect(service.isDisposed()).toBe(false);
+		await emit(extension, "session_extensions_removed", {
+			type: "session_extensions_removed",
+			reason: "reload",
+			removed: [{ path: "<builtin:mcp>", resolvedPath: "<builtin:mcp>" }],
+		});
+
+		expect(service.isDisposed()).toBe(true);
+		await assertProcessDead(pid);
+	});
+
+	it("keeps one child and connection inventory through three consecutive classic reloads", async () => {
+		const root = makeMcpRoot("three-classic-reloads");
+		const counterFile = `${root.agentDir}/three-classic-reload-spawns.txt`;
+		setConfig(root, { fixture: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]) });
+		const extension = await loadMcpBuiltinExtension();
+		const ctx = mcpContext(root);
+
+		await emitSessionStart(extension, "startup", ctx);
+		const service = getMcpService();
+		await awaitMcpConnected(service, "fixture");
+		const pid = requiredPid(service, "fixture");
+
+		for (let reload = 0; reload < 3; reload++) {
+			await emitSessionShutdown(extension, "reload", ctx);
+			await emitSessionStart(extension, "reload", ctx);
+			await awaitMcpConnected(service, "fixture");
+			expect(service.getSnapshot().connectionCount).toBe(1);
+			expect(requiredPid(service, "fixture")).toBe(pid);
+			expect(await readCounter(counterFile)).toBe(1);
+		}
+	});
+
+	it("disposes provider-scoped services on reload and quit", async () => {
+		for (const reason of ["reload", "quit"] as const) {
+			const root = makeMcpRoot(`scoped-${reason}`);
+			const counterFile = `${root.agentDir}/scoped-${reason}-spawns.txt`;
+			setConfig(root, { fixture: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]) });
+			const scope = new ProviderScope();
+			const service = new McpService();
+			scopedServices.push(service);
+			const extension = await runWithProviderScope(scope, () =>
+				loadExtensionFromFactory(
+					createMcpExtension(service, true),
+					root.cwd,
+					createEventBus(),
+					createExtensionRuntime(),
+					"<builtin:mcp>",
+				),
+			);
+			const ctx = mcpContext(root);
+
+			await emitSessionStart(extension, "startup", ctx);
+			await awaitMcpConnected(service, "fixture");
+			const pid = requiredPid(service, "fixture");
+			await emitSessionShutdown(extension, reason, ctx);
+
+			expect(service.getSnapshot()).toMatchObject({
+				disposed: true,
+				disposeCount: 1,
+				lastDisposeReason: reason,
+			});
+			await assertProcessDead(pid);
+			scope.close();
+		}
 	});
 
 	it("registers tools from an extension-declared MCP server with source=extension", async () => {
@@ -146,18 +277,36 @@ function loadMcpBuiltinExtension(): Promise<Extension> {
 	);
 }
 
-async function emitSessionStart(extension: Extension, reason: SessionStartEvent["reason"]): Promise<void> {
+function makeMcpRoot(slug: string): TestRoot {
+	const root = makeRoot(`extension-load-${slug}`, cleanupTasks);
+	process.env[ENV_AGENT_DIR] = root.agentDir;
+	return root;
+}
+
+function mcpContext(root: TestRoot) {
+	return { cwd: root.cwd, isProjectTrusted: () => true };
+}
+
+async function emitSessionStart(
+	extension: Extension,
+	reason: SessionStartEvent["reason"],
+	ctx: unknown = {},
+): Promise<void> {
 	const event: SessionStartEvent = { type: "session_start", reason };
-	await emit(extension, "session_start", event);
+	await emit(extension, "session_start", event, ctx);
 }
 
-async function emitSessionShutdown(extension: Extension, reason: SessionShutdownEvent["reason"]): Promise<void> {
+async function emitSessionShutdown(
+	extension: Extension,
+	reason: SessionShutdownEvent["reason"],
+	ctx: unknown = {},
+): Promise<void> {
 	const event: SessionShutdownEvent = { type: "session_shutdown", reason };
-	await emit(extension, "session_shutdown", event);
+	await emit(extension, "session_shutdown", event, ctx);
 }
 
-async function emit(extension: Extension, name: string, event: unknown): Promise<void> {
+async function emit(extension: Extension, name: string, event: unknown, ctx: unknown = {}): Promise<void> {
 	for (const handler of extension.handlers.get(name) ?? []) {
-		await handler(event, {});
+		await handler(event, ctx);
 	}
 }

--- a/packages/coding-agent/test/mcp/service-lifecycle.test.ts
+++ b/packages/coding-agent/test/mcp/service-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ServerConnection, ServerConnectionState } from "../../src/core/extensions/builtin/mcp/connection.ts";
 import {
 	getMcpService,
 	registerToolsPreservingActiveSet,
@@ -56,6 +57,32 @@ describe("McpService session lifecycle", () => {
 		expect(service.getServerSnapshots()).toMatchObject([
 			{ name: "shared", lifecycleState: "connected", pid: firstPid, configState: "enabled" },
 		]);
+	});
+
+	it("recovers a killed stdio child through manual reconnect", async () => {
+		const root = makeRoot("manual-reconnect", cleanupTasks);
+		const counterFile = join(root.agentDir, "manual-reconnect-spawns.txt");
+		setConfig(root, {
+			recoverable: stdioServer(["--tools", "1", "--spawn-counter-file", counterFile]),
+		});
+		const service = getMcpService();
+
+		await attach(service, root, "startup");
+		await awaitMcpConnected(service, "recoverable");
+		const firstPid = requiredPid(service, "recoverable");
+		const connection = service.getConnection("recoverable");
+		if (connection === undefined) throw new Error("missing recoverable connection");
+		const degraded = awaitConnectionState(connection, "degraded");
+		process.kill(firstPid, "SIGTERM");
+		await degraded;
+
+		await service.reconnectServer("recoverable");
+		await awaitMcpConnected(service, "recoverable");
+		const secondPid = requiredPid(service, "recoverable");
+
+		expect(secondPid).not.toBe(firstPid);
+		expect(await readCounter(counterFile)).toBe(2);
+		expect(service.getConnection("recoverable")?.state).toBe("connected");
 	});
 
 	it("disposes on reload and a subsequent session respawns the server", async () => {
@@ -273,6 +300,27 @@ describe("McpService session lifecycle", () => {
 		await assertAlive(pid2);
 	});
 });
+
+function awaitConnectionState(connection: ServerConnection, expected: ServerConnectionState): Promise<void> {
+	if (connection.state === expected) return Promise.resolve();
+	return new Promise<void>((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			unsubscribe();
+			reject(new Error(`${connection.serverName} did not reach ${expected}`));
+		}, 10_000);
+		const unsubscribe = connection.onStateChange((event) => {
+			if (event.state !== expected) return;
+			clearTimeout(timeout);
+			unsubscribe();
+			resolve();
+		});
+		if (connection.state === expected) {
+			clearTimeout(timeout);
+			unsubscribe();
+			resolve();
+		}
+	});
+}
 
 describe("registerToolsPreservingActiveSet", () => {
 	it("restores the intended active tool set synchronously after auto-activating registration", () => {

--- a/packages/coding-agent/test/suite/reload-efficiency.test.ts
+++ b/packages/coding-agent/test/suite/reload-efficiency.test.ts
@@ -10,6 +10,12 @@ import {
 	createAgentSessionServices,
 } from "../../src/core/agent-session-runtime.ts";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
+import type {
+	ExtensionAPI,
+	InlineExtension,
+	LoadExtensionsResult,
+	SessionExtensionsRemovedEvent,
+} from "../../src/core/extensions/types.ts";
 import { ModelConfig } from "../../src/core/model-config.ts";
 import { ModelRuntime } from "../../src/core/model-runtime.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
@@ -17,7 +23,12 @@ import { SettingsManager } from "../../src/core/settings-manager.ts";
 
 const cleanups: Array<() => void> = [];
 
-async function createReloadSession() {
+async function createReloadSession(
+	options: {
+		extensionFactories?: InlineExtension[];
+		extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
+	} = {},
+) {
 	const tempDir = join(tmpdir(), `pi-reload-eff-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	const agentDir = join(tempDir, "agent");
 	mkdirSync(agentDir, { recursive: true });
@@ -36,6 +47,7 @@ async function createReloadSession() {
 			agentDir,
 			modelRuntime,
 			resourceLoaderOptions: {
+				extensionsOverride: options.extensionsOverride,
 				extensionFactories: [
 					(pi) => {
 						pi.registerProvider(faux.getModel().provider, {
@@ -54,6 +66,7 @@ async function createReloadSession() {
 							})),
 						});
 					},
+					...(options.extensionFactories ?? []),
 				],
 			},
 		});
@@ -141,5 +154,38 @@ describe("reload does redundant work only once", () => {
 		await runtime.services.resourceLoader.reload({ settingsAlreadyReloadedFor: unrelatedManager });
 
 		expect(settingsReload).toHaveBeenCalledTimes(1);
+	});
+
+	it("notifies extensions removed from the rebuilt runner during reload", async () => {
+		const removedEvents: SessionExtensionsRemovedEvent[] = [];
+		let removeProbe = false;
+		const probePath = "<inline:reload-removal-probe>";
+		const { runtime } = await createReloadSession({
+			extensionFactories: [
+				{
+					name: "reload-removal-probe",
+					factory: (pi: ExtensionAPI) => {
+						pi.on("session_extensions_removed", (event: SessionExtensionsRemovedEvent) => {
+							removedEvents.push(event);
+						});
+					},
+				},
+			],
+			extensionsOverride: (base) =>
+				removeProbe
+					? { ...base, extensions: base.extensions.filter((extension) => extension.path !== probePath) }
+					: base,
+		});
+		removeProbe = true;
+
+		await runtime.session.reload();
+
+		expect(removedEvents).toEqual([
+			{
+				type: "session_extensions_removed",
+				reason: "reload",
+				removed: [{ path: probePath, resolvedPath: probePath }],
+			},
+		]);
 	});
 });

--- a/packages/coding-agent/test/suite/session-replacement-removal.test.ts
+++ b/packages/coding-agent/test/suite/session-replacement-removal.test.ts
@@ -1,0 +1,121 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionFromServices,
+	createAgentSessionRuntime,
+	createAgentSessionServices,
+} from "../../src/core/agent-session-runtime.ts";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import type {
+	ExtensionAPI,
+	LoadExtensionsResult,
+	SessionExtensionsRemovedEvent,
+} from "../../src/core/extensions/types.ts";
+import { ModelRuntime } from "../../src/core/model-runtime.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+const cleanups: Array<() => void> = [];
+
+async function createReplacingSession(removeProbe: () => boolean) {
+	const tempDir = join(tmpdir(), `pi-sr-removal-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const agentDir = join(tempDir, "agent");
+	mkdirSync(agentDir, { recursive: true });
+
+	const faux = registerFauxProvider({ models: [{ id: "faux-1", reasoning: false }] });
+	const authStorage = AuthStorage.inMemory();
+	await authStorage.modify(faux.getModel().provider, async () => ({ type: "api_key", key: "faux-key" }));
+	const modelRuntime = await ModelRuntime.create({
+		credentials: authStorage,
+		modelsPath: join(agentDir, "models.json"),
+	});
+
+	const removedEvents: SessionExtensionsRemovedEvent[] = [];
+	const probePath = "<inline:removal-probe>";
+
+	const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+		const services = await createAgentSessionServices({
+			cwd,
+			agentDir,
+			modelRuntime,
+			resourceLoaderOptions: {
+				extensionsOverride: (base: LoadExtensionsResult) =>
+					removeProbe()
+						? { ...base, extensions: base.extensions.filter((extension) => extension.path !== probePath) }
+						: base,
+				extensionFactories: [
+					(pi) => {
+						pi.registerProvider(faux.getModel().provider, {
+							baseUrl: faux.getModel().baseUrl,
+							apiKey: "faux-key",
+							api: faux.api,
+							models: faux.models.map((m) => ({
+								id: m.id,
+								name: m.name,
+								api: m.api,
+								reasoning: m.reasoning,
+								input: m.input,
+								cost: m.cost,
+								contextWindow: m.contextWindow,
+								maxTokens: m.maxTokens,
+							})),
+						});
+					},
+					{
+						name: "removal-probe",
+						factory: (pi: ExtensionAPI) => {
+							pi.on("session_extensions_removed", (event: SessionExtensionsRemovedEvent) => {
+								removedEvents.push(event);
+							});
+						},
+					},
+				],
+			},
+		});
+		return {
+			...(await createAgentSessionFromServices({
+				services,
+				sessionManager,
+				sessionStartEvent,
+				model: faux.getModel(),
+			})),
+			services,
+			diagnostics: services.diagnostics,
+		};
+	};
+
+	const runtime = await createAgentSessionRuntime(createRuntime, {
+		cwd: tempDir,
+		agentDir,
+		sessionManager: SessionManager.create(tempDir),
+	});
+
+	cleanups.push(() => {
+		runtime.session.dispose();
+		faux.unregister();
+		if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	return { runtime, removedEvents, probePath };
+}
+
+describe("extension removal notification on session replacement", () => {
+	afterEach(() => {
+		while (cleanups.length > 0) cleanups.pop()?.();
+	});
+
+	it("notifies an extension dropped from the new runtime during /new", async () => {
+		let drop = false;
+		const { runtime, removedEvents, probePath } = await createReplacingSession(() => drop);
+		drop = true;
+
+		await runtime.newSession();
+
+		expect(removedEvents).toEqual([
+			{ type: "session_extensions_removed", reason: "new", removed: [{ path: probePath, resolvedPath: probePath }] },
+		]);
+	});
+});


### PR DESCRIPTION
## Why

`/reload` disposes every MCP connection and the next session respawns every server, even when nothing about their configuration changed. Measured on real stdio children:

| | p50 | p95 |
|---|---:|---:|
| Dispose + respawn (current `/reload`) | 411 ms | 419 ms |
| Preserve + reconcile | 0.76 ms | 0.82 ms |

The cost is a roughly constant ~400 ms floor per reload (independent of server count — 2 vs 5 servers barely moves it), against a total reload of ~477 ms. It is the single largest remaining reload cost, and it is entirely self-inflicted: the service already has config-hash reconciliation (`#syncFromConfig`, keyed `name\0configHash`) that disposes only changed or removed servers. That path ships today for shutdown reason `"new"` — `/reload` just never used it.

## What changed

**Classic reload preserves the MCP singleton.** The next attach re-enters reconciliation: unchanged servers keep their process, changed ones reconnect, removed ones are disposed. `quit` still disposes.

**Provider-scoped services still dispose on reload, deliberately.** `mcpExtension` builds `sessionOwned ? new McpService() : getMcpService()`, so under provider scopes (multi-session RPC) every factory execution creates a fresh service, and reload re-executes factories. Skipping disposal there would orphan the previous instance's child processes.

**Core now tells an extension it was removed by a reload.** After the runtime is rebuilt, `AgentSession` compares old vs new extension identities and emits `session_extensions_removed` to any extension present in the old runner but absent in the new one. This is the part that makes preservation safe: if the MCP builtin is *disabled* during that same reload, shutdown alone would skip disposal and nothing would ever re-attach, leaking the preserved connections. MCP subscribes and disposes when its own `<builtin:mcp>` entry is removed. The mechanism is extension-agnostic — core knows nothing about MCP.

This closes both leak vectors the earlier attempts hit. Removing `"reload"` from `shouldDisposeMcpService` outright leaked provider-scoped services; making that scope-aware alone then leaked when MCP was disabled mid-reload. Each is now covered by a dedicated test.

`/mcp reconnect <name>` remains the wedged-server escape hatch, covered by a kill-the-child-then-reconnect test.

## Evidence

58 tests pass in one run across the MCP and reload suites; 127 pass across the 16 affected suites. `npm run check` exits 0. The cost table above is from a dedicated A/B probe using the existing fixtures (`local-ignore/mcp-reload-cost.mts`, `reason "reload"` vs `reason "new"`, real stdio children, 6 cycles).

The leak-guard tests that matter:
- Classic reload keeps the same service object, same child pid, spawn counter 1, still connected.
- Disable MCP during a classic reload: the preserved singleton is disposed and its child pid is dead (this is the second-round leak, now guarded).
- Provider-scoped reload: real `ProviderScope`, real stdio child, asserts the child pid is dead (the first-round leak, guarded).
- `quit` disposes in both modes; three consecutive classic reloads hold connection and spawn counts steady.
- Core: an extension removed from the rebuilt runner receives `session_extensions_removed`.

## Deliberately flipped assertions

`test/mcp/extension-load.test.ts` pinned the old always-dispose contract and was updated on purpose: reload moved from the disposal set to the retained-session set; the reload-followup test now asserts the same singleton survives with two session starts instead of expecting a fresh service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classic `/reload` now preserves unchanged MCP servers by reusing the shared `McpService`, cutting reloads by ~400ms. Core reports `session_extensions_removed` on the old runner for all session replacements and even if a reload rebuild fails, so disabling the MCP builtin cleanly disposes preserved servers.

- **New Features**
  - Keep the classic `McpService` alive across `/reload`; unchanged servers keep their process, changed reconnect, removed dispose.
  - Provider-scoped MCP services still dispose on reload.
  - `/mcp reconnect <name>` remains the manual recovery path for wedged servers.

- **Bug Fixes**
  - Emit `session_extensions_removed` on the old runner for all replacements (`/new`, `/resume`, `/fork`, imports, cross-cwd`) and in a `finally` for `/reload`; MCP listens and disposes when `"<builtin:mcp>"` is removed.
  - Skip removal reporting when runners don’t expose `getExtensionIdentities`, avoiding crashes in partial test hosts.

<sup>Written for commit 996222223968f4e2c42d41e09f1444a95533622a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

