### PR TITLE
fix(coding-agent): retain extension-injected user messages on prompt-path rejection

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,10 @@
+## Extension user-message injections are retained when the prompt path rejects (2026-07-26)
+
+- `core/agent-session.ts`: `sendUserMessage()` now tracks the prompt disposition. When `prompt()` rejects before the message reaches a queue or a turn (e.g. a required compaction that cannot complete, auth/model validation, or provider admission), the message is queued for later delivery (`deliverAs: "steer"` goes to the steering queue, otherwise the followUp queue) instead of being silently dropped. The rejection still propagates, so fire-and-forget extension bindings keep emitting their `send_user_message` error event.
+- Root cause of the omo `team_wait` starvation forensics: member self-poller injections via `pi.sendUserMessage(..., { deliverAs: "followUp" })` vanished without a trace when the fresh-prompt path threw, leaving no record in the session JSONL while RPC-path `steer`/`follow_up` commands (which bypass `prompt()`) landed normally.
+- Interactive `prompt()` behavior is unchanged: a rejected interactive prompt still drops the input and surfaces the error to the user (pinned by `test/suite/regressions/pre-prompt-compaction-no-continue.test.ts`).
+- Coverage: `test/suite/agent-session-extension-injection.test.ts` pins retention for followUp and steer injections, exact-once delivery after recovery through the post-run drain, and no double-queueing on the streaming accept path.
+
 ## Same-model-first transient retries and capped server waits (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2808,6 +2808,9 @@ export class AgentSession {
 	/**
 	 * Send a user message to the agent. Always triggers a turn.
 	 * When the agent is streaming, use deliverAs to specify how to queue the message.
+	 * If the prompt path rejects before the message reaches a queue or a turn
+	 * (e.g. a required compaction that cannot complete), the message is retained
+	 * in the steering/followUp queue for later delivery and the error still propagates.
 	 *
 	 * @param content User message content (string or content array)
 	 * @param options.deliverAs Delivery mode when streaming: "steer" or "followUp"
@@ -2849,6 +2852,7 @@ export class AgentSession {
 		// settles so callers observing session idle cannot race its provider turn.
 		const waitForExistingSessionWork = this._sessionWorkBarrier.hasActiveWork;
 		let finishSessionWork: (() => void) | undefined;
+		let disposition: PromptDisposition | undefined;
 		try {
 			// Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
 			await this.prompt(text, {
@@ -2856,7 +2860,10 @@ export class AgentSession {
 				streamingBehavior: options?.deliverAs,
 				images,
 				source: "extension",
-				promptDisposition: () => resolveBindingPromptReadiness?.(),
+				promptDisposition: (nextDisposition) => {
+					disposition = nextDisposition;
+					resolveBindingPromptReadiness?.();
+				},
 				onSessionWorkReady: waitForExistingSessionWork
 					? () => {
 							finishSessionWork ??= this._sessionWorkBarrier.begin();
@@ -2864,6 +2871,17 @@ export class AgentSession {
 					: undefined,
 				sessionTitlePrompt: false,
 			});
+		} catch (error) {
+			// Extension bindings invoke this method fire-and-forget, so a rejection
+			// before prompt() accepted the message must not silently drop it.
+			if (disposition === undefined) {
+				if (options?.deliverAs === "steer") {
+					await this._queueSteer(text, images);
+				} else {
+					await this._queueFollowUp(text, images);
+				}
+			}
+			throw error;
 		} finally {
 			resolveBindingPromptReadiness?.();
 			finishSessionWork?.();

--- a/packages/coding-agent/test/suite/agent-session-extension-injection.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-extension-injection.test.ts
@@ -1,0 +1,180 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getUserTexts, type Harness } from "./harness.ts";
+
+function createUsage(totalTokens: number) {
+	return {
+		input: totalTokens,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+const COMPACTION_REJECTION = "Context remains above the compaction threshold because compaction did not complete";
+
+async function createCompactionGatedHarness(gate: { reject: boolean }): Promise<Harness> {
+	const harness = await createHarness({
+		models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+		settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 } },
+		extensionFactories: [
+			(pi) => {
+				pi.on("session_before_compact", async (event) => {
+					if (gate.reject) {
+						return {
+							cancel: true,
+							rejectionCause: "cancelled-by-extension",
+							reason: "forced rejection",
+						};
+					}
+					return {
+						compaction: {
+							summary: "recovered summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					};
+				});
+			},
+		],
+	});
+
+	const now = Date.now();
+	const model = harness.getModel();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "earlier prompt" }],
+		timestamp: now - 3000,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("earlier response", { timestamp: now - 2000 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: createUsage(50),
+	});
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "previous prompt" }],
+		timestamp: now - 1000,
+	});
+	const overflowAssistant: AssistantMessage = {
+		...fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: "context_length_exceeded",
+			timestamp: now - 500,
+		}),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: createUsage(100),
+	};
+	harness.sessionManager.appendMessage(overflowAssistant);
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+	return harness;
+}
+
+describe("AgentSession extension injection retention", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("retains a followUp injection when the prompt path rejects, and delivers it after recovery", async () => {
+		const gate = { reject: true };
+		const harness = await createCompactionGatedHarness(gate);
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("must not reach provider yet")]);
+
+		await expect(harness.session.sendUserMessage("lead-brief-c62b6acb", { deliverAs: "followUp" })).rejects.toThrow(
+			COMPACTION_REJECTION,
+		);
+		expect(harness.faux.state.callCount).toBe(0);
+
+		expect(harness.session.getFollowUpMessages()).toContain("lead-brief-c62b6acb");
+
+		gate.reject = false;
+		harness.setResponses([fauxAssistantMessage("compacted reply"), fauxAssistantMessage("followup reply")]);
+		await expect(harness.session.prompt("next prompt")).resolves.toBeUndefined();
+
+		const userTexts = getUserTexts(harness);
+		expect(userTexts).toContain("next prompt");
+		expect(userTexts.filter((text) => text.includes("lead-brief-c62b6acb"))).toHaveLength(1);
+		expect(harness.session.getFollowUpMessages()).toHaveLength(0);
+	});
+
+	it("retains a steer injection when the prompt path rejects, and delivers it after recovery", async () => {
+		const gate = { reject: true };
+		const harness = await createCompactionGatedHarness(gate);
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("must not reach provider yet")]);
+
+		await expect(harness.session.sendUserMessage("steer-brief-32e080cf", { deliverAs: "steer" })).rejects.toThrow(
+			COMPACTION_REJECTION,
+		);
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(harness.session.getSteeringMessages()).toContain("steer-brief-32e080cf");
+
+		gate.reject = false;
+		harness.setResponses([fauxAssistantMessage("steered reply")]);
+		await expect(harness.session.prompt("next prompt")).resolves.toBeUndefined();
+
+		const userTexts = getUserTexts(harness);
+		expect(userTexts.filter((text) => text.includes("steer-brief-32e080cf"))).toHaveLength(1);
+		expect(harness.session.getSteeringMessages()).toHaveLength(0);
+	});
+
+	it("does not double-queue a followUp that the streaming path already accepted", async () => {
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("tool done"),
+			fauxAssistantMessage("queued followup reply"),
+		]);
+
+		const waitForToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start" && event.toolName === "wait") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("start");
+		await waitForToolStart;
+
+		await expect(harness.session.sendUserMessage("queued-brief", { deliverAs: "followUp" })).resolves.toBeUndefined();
+		expect(harness.session.getFollowUpMessages()).toEqual(["queued-brief"]);
+
+		releaseToolExecution?.();
+		await promptPromise;
+
+		const userTexts = getUserTexts(harness);
+		expect(userTexts.filter((text) => text.includes("queued-brief"))).toHaveLength(1);
+		expect(harness.session.getFollowUpMessages()).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

`pi.sendUserMessage()` extension bindings are fire-and-forget. When `prompt()` rejects **before** the message reaches any queue or turn — a required compaction that cannot complete, auth/model validation, final provider admission, or a streaming↔idle race — the injected user message silently vanished: never persisted to the session JSONL, never delivered, with only an error event as its trace.

This was the root cause left over from the omo `team_wait` starvation forensics (team `df1f4ed0`): member self-poller injections via `pi.sendUserMessage(..., { deliverAs: "followUp" })` never landed in the member session JSONL, while RPC-path `steer`/`follow_up` commands — which bypass `prompt()` entirely and call `session.steer()`/`session.followUp()` directly — landed fine.

## Fix

`AgentSession.sendUserMessage()` now tracks the prompt disposition. On a pre-acceptance rejection the message is retained in the requested queue (`deliverAs: "steer"` → steering queue, otherwise followUp queue) and delivered at the next opportunity (post-run drain / next run boundary). The rejection still propagates, so bindings keep emitting their `send_user_message` error event.

Interactive `prompt()` behavior is intentionally unchanged: a rejected interactive prompt still drops input and surfaces the error to the user (pinned by `test/suite/regressions/pre-prompt-compaction-no-continue.test.ts`).

Non-goal (documented): `sendCustomMessage`'s `triggerTurn` path shares the failure class but has different retention semantics; durable persistence of queued-but-undelivered messages across process restarts stays with the caller's reservation layer (omo-side, already fixed).

## Evidence

- **RED→GREEN**: `test/suite/agent-session-extension-injection.test.ts` — followUp retention, steer retention, exact-once delivery after recovery through the post-run drain, and no double-queueing on the streaming accept path. RED captured before the fix (`expected [] to include 'lead-brief-c62b6acb'`), GREEN after (3/3).
- **Suite**: `test/suite` 1517 pass; 7 failures in 5 files (app-server/codemode/fswatch) proven **pre-existing** by re-running them with this change stashed (same failures).
- **Static**: root `npm run check` passes.
- **Real CLI QA (senpi-qa Channel 1, RPC)**: sandboxed extension injects a followUp while idle → forced compaction rejection → message retained (`queue_update`) → later prompt settles → post-run drain delivers → injected user message persisted **exactly once** in the real session JSONL and produced its assistant reply. 10/10 checks; artifacts in `local-ignore/qa-evidence/20260726-extension-injection-retention/` (`session.jsonl`, `rpc-events.json`, `verdict.txt`).

## Smell disclosure

`agent-session.ts` is a large upstream-fork file; this adds ~15 lines in place rather than splitting, to preserve upstream mergeability per the repo guide. A structural split of that file is out of scope here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains extension-injected user messages when the prompt path rejects, queuing them for later delivery instead of dropping them. Fixes lost follow-up/steer messages from `pi.sendUserMessage()` and ensures exactly-once delivery.

- **Bug Fixes**
  - `AgentSession.sendUserMessage()` now tracks prompt disposition; if `prompt()` rejects before acceptance, messages are queued (`deliverAs: "steer"` → steering, else follow-up) and delivered on the next run. The rejection still propagates.
  - Interactive `prompt()` behavior is unchanged; rejected interactive input is still dropped.
  - Adds `test/suite/agent-session-extension-injection.test.ts` to pin follow-up/steer retention, post-run drain delivery, and no double-queueing.

<sup>Written for commit 1285f9eff5b411d44016b4e4df127ee0e9f45ae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

