### PR TITLE
fix(codemode): tell the truth about eval kernel state on interrupt

### DIFF
--- a/packages/senpi-codemode/scripts/qa-timeout-state.ts
+++ b/packages/senpi-codemode/scripts/qa-timeout-state.ts
@@ -1,0 +1,62 @@
+import { startBridgeServer } from "../src/bridge/http-server.ts";
+import { createInterpreterDetector } from "../src/interpreters/detect.ts";
+import { PythonKernel } from "../src/kernels/py/kernel.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+
+class QaScenarioError extends Error {
+	readonly name = "QaScenarioError";
+}
+
+const detected = await createInterpreterDetector().detect("py");
+if (!detected.ok) throw new QaScenarioError("no python interpreter");
+const server = await startBridgeServer({
+	onCall: async () => {
+		throw new QaScenarioError("no bridge tools in qa");
+	},
+	onEmit: async () => {},
+	onCompletion: async () => {
+		throw new QaScenarioError("no completion in qa");
+	},
+});
+try {
+	const kernel = await PythonKernel.start({
+		interpreterPath: detected.path,
+		sessionId: "qa-timeout-state-" + crypto.randomUUID(),
+		cwd: process.cwd(),
+		connection: { port: server.port, token: server.token },
+	});
+	try {
+		const tool = createEvalTool({
+			enabledLanguages: { js: false, py: true, rb: false, jl: false },
+			kernelManager: { getKernel: async () => kernel },
+			cellTimeoutSeconds: 1,
+			executeTool: (async () => {
+				throw new QaScenarioError("no executeTool in qa");
+			}) as never,
+		});
+		const ctx = { mode: "print" } as unknown as ExtensionContext;
+
+		// Cooperative interrupt: the runner answers SIGINT, so state must survive and
+		// the timeout message must say the kernel remains running.
+		const cooperative = await tool
+			.execute("qa-coop", { language: "py", code: "x=42\nimport time\ntime.sleep(30)", on_timeout: "error", timeout: 1 }, undefined, undefined, ctx)
+			.then(() => "UNEXPECTED-SUCCESS", (error: Error) => `${error.name}: ${error.message}`);
+		console.log(`COOPERATIVE_TIMEOUT: ${cooperative}`);
+
+		// Assert on the kernel's own readback so output-capture formatting cannot
+		// mask whether the interrupted kernel actually kept its variables.
+		const readback = await kernel.run({ cellId: "qa-readback", code: "x", timeoutMs: 5_000 });
+		console.log(`STATE_READBACK: ${JSON.stringify(readback)}`);
+
+		if (!cooperative.includes("TimeoutError")) throw new QaScenarioError(`expected TimeoutError: ${cooperative}`);
+		if (!/remains running|preserved/i.test(cooperative))
+			throw new QaScenarioError(`timeout message did not name preserved state: ${cooperative}`);
+		if (!readback.ok || readback.valueRepr !== "42")
+			throw new QaScenarioError(`python state did not survive timeout: ${JSON.stringify(readback)}`);
+	} finally {
+		await kernel.close();
+	}
+} finally {
+	await server.close();
+}

--- a/packages/senpi-codemode/src/kernels/js/context-manager.ts
+++ b/packages/senpi-codemode/src/kernels/js/context-manager.ts
@@ -1,4 +1,5 @@
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { KernelInterruptHandle } from "../../tool/types.ts";
 import { createInlineWorker, type WorkerLike } from "./inline-worker.ts";
 import {
 	assertJavaScriptKernelOpen,
@@ -48,14 +49,16 @@ export class JavaScriptKernel {
 		return await promise;
 	}
 
-	async interrupt(reason = "interrupted"): Promise<void> {
+	async interrupt(reason = "interrupted"): Promise<KernelInterruptHandle> {
 		assertJavaScriptKernelOpen(this.#lifecycle, "interrupt");
 		const active = this.#runs.active;
 		const target = this.#runs.takeInterruptTarget();
-		if (!target) return;
+		if (!target) return { stateRetained: Promise.resolve(true) };
 		if (target === active) this.#clearTimeout();
 		this.#runs.settle(target, stoppedResult(target.input.cellId, `JS cell interrupted: ${reason}`));
 		await this.#restartAfterStop();
+		// A restart always replaces the worker VM, so no user global survives.
+		return { stateRetained: Promise.resolve(false) };
 	}
 
 	async reset(): Promise<void> {

--- a/packages/senpi-codemode/src/kernels/py/kernel-contract.ts
+++ b/packages/senpi-codemode/src/kernels/py/kernel-contract.ts
@@ -29,4 +29,6 @@ export interface PendingRun {
 	timeoutTimer: NodeJS.Timeout | null;
 	escalationTimer?: NodeJS.Timeout;
 	interruptReason?: string;
+	/** Set while an interrupt outcome is pending; resolved once the kernel knows whether state survived. */
+	resolveStateRetained?: (retained: boolean) => void;
 }

--- a/packages/senpi-codemode/src/kernels/py/kernel.ts
+++ b/packages/senpi-codemode/src/kernels/py/kernel.ts
@@ -1,3 +1,4 @@
+import type { KernelInterruptHandle } from "../../tool/types.ts";
 import type { PendingRun, PythonKernelRunOptions, PythonKernelStartOptions, ResultMessage } from "./kernel-contract.ts";
 import { failedPythonResult, PythonKernelTransport } from "./transport.ts";
 
@@ -41,7 +42,7 @@ export class PythonKernel {
 		});
 	}
 
-	async interrupt(reason = "interrupted"): Promise<void> {
+	async interrupt(reason = "interrupted"): Promise<KernelInterruptHandle> {
 		if (this.#failure) throw this.#failure;
 		for (const pending of [...this.#queue]) {
 			pending.interruptReason = reason;
@@ -49,7 +50,8 @@ export class PythonKernel {
 		}
 		const active = this.#active;
 		const transport = this.#transport;
-		if (!active || !transport || active.interruptReason !== undefined) return;
+		if (!active || !transport || active.interruptReason !== undefined)
+			return { stateRetained: Promise.resolve(true) };
 		active.interruptReason = reason;
 		if (active.timeoutTimer) clearTimeout(active.timeoutTimer);
 		active.timeoutTimer = null;
@@ -57,7 +59,11 @@ export class PythonKernel {
 			() => void this.#escalateInterruptedRun(active).catch(() => undefined),
 			interruptEscalationMs,
 		);
+		const stateRetained = new Promise<boolean>((resolve) => {
+			active.resolveStateRetained = resolve;
+		});
 		transport.interrupt(reason);
+		return { stateRetained };
 	}
 
 	async reset(): Promise<void> {
@@ -187,13 +193,18 @@ export class PythonKernel {
 		if (this.#transport !== transport) return;
 		const pending = this.#pending.get(result.cellId);
 		if (pending) this.#settleRun(pending, result);
+		// A result frame from the live runner proves the process survived the interrupt.
+		if (pending?.resolveStateRetained) pending.resolveStateRetained(true);
 	}
 
 	#onExit(transport: PythonKernelTransport, error: Error): void {
 		if (this.#transport !== transport) return;
 		this.#transport = null;
 		const active = this.#active;
-		if (active) this.#settleRun(active, failedPythonResult(active.input.cellId, "Python kernel died", error.message));
+		if (active) {
+			if (active.resolveStateRetained) active.resolveStateRetained(false);
+			this.#settleRun(active, failedPythonResult(active.input.cellId, "Python kernel died", error.message));
+		}
 		this.#startNext();
 	}
 
@@ -209,7 +220,10 @@ export class PythonKernel {
 			},
 		);
 		const active = this.#active;
-		if (active) this.#settleRun(active, failedPythonResult(active.input.cellId, "Python kernel died", error.message));
+		if (active) {
+			if (active.resolveStateRetained) active.resolveStateRetained(false);
+			this.#settleRun(active, failedPythonResult(active.input.cellId, "Python kernel died", error.message));
+		}
 	}
 
 	#settleRun(pending: PendingRun, result: ResultMessage): void {
@@ -258,6 +272,7 @@ export class PythonKernel {
 	async #escalateInterruptedRun(pending: PendingRun): Promise<void> {
 		if (this.#active !== pending || pending.interruptReason === undefined) return;
 		const transport = this.#transport;
+		if (pending.resolveStateRetained) pending.resolveStateRetained(false);
 		if (transport) await this.#beginRetirement(transport);
 		if (this.#pending.has(pending.input.cellId))
 			this.#settleRun(pending, failedPythonResult(pending.input.cellId, "Eval interrupted"));

--- a/packages/senpi-codemode/src/kernels/py/prelude.py
+++ b/packages/senpi-codemode/src/kernels/py/prelude.py
@@ -12,6 +12,7 @@ import json
 import locale
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -886,6 +887,9 @@ def run_cell(cell_id: str, code: str) -> None:
     start = time.monotonic()
     stdout = io.StringIO()
     stderr = io.StringIO()
+    # SIGINT must interrupt user code here; the idle baseline (set between
+    # cells) ignores it so a late signal cannot kill the stdin-read loop.
+    signal.signal(signal.SIGINT, signal.default_int_handler)
     try:
         with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
             body, expression = compile_cell(code)
@@ -914,6 +918,8 @@ def run_cell(cell_id: str, code: str) -> None:
                 "durationMs": elapsed(start),
             }
         )
+    finally:
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
 def elapsed(start: float) -> int:
@@ -942,6 +948,7 @@ def handle(message: dict[str, Any]) -> bool:
 
 
 def main() -> None:
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     for raw in sys.stdin:
         try:
             if not handle(json.loads(raw)):

--- a/packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts
+++ b/packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts
@@ -1,5 +1,6 @@
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
 import { decodeBridgeFrame, encodeBridgeFrame, isKernelToHostMessage } from "../../bridge/protocol.ts";
+import type { KernelInterruptHandle } from "../../tool/types.ts";
 import type { KernelResult, KernelRunInput, SubprocessKernelOptions, ToolCallMessage } from "./subprocess-contract.ts";
 import { type SubprocessLike, SubprocessProcess, type SubprocessSpawn, spawnSubprocess } from "./subprocess-process.ts";
 import { SubprocessRunQueue } from "./subprocess-queue.ts";
@@ -44,24 +45,26 @@ export class SubprocessKernel {
 		return run;
 	}
 
-	async interrupt(reason = "interrupted"): Promise<void> {
-		if (this.closed) return;
+	async interrupt(reason = "interrupted"): Promise<KernelInterruptHandle> {
+		if (this.closed) return { stateRetained: Promise.resolve(true) };
 		if (!this.runs.active) {
-			if (!this.retirementPromise) return;
+			if (!this.retirementPromise) return { stateRetained: Promise.resolve(true) };
 			const queued = this.runs.takeWaiting();
 			if (queued) this.runs.settle(queued, failureResult(queued, new CellInterruptedError(reason)));
-			return;
+			return { stateRetained: Promise.resolve(true) };
 		}
 		const process = this.process;
 		process?.retire();
 		this.runs.clearToolCalls();
 		const run = this.runs.active;
-		if (!run) return;
+		if (!run) return { stateRetained: Promise.resolve(true) };
 		this.runs.releaseActive(run);
 		this.runs.settle(run, failureResult(run, new CellInterruptedError(reason)));
 		const signal = globalThis.process.platform === "win32" ? "SIGTERM" : "SIGINT";
 		await this.restartProcess(process, signal, 5_000);
 		if (this.failure) throw this.failure;
+		// Restart always spawns a fresh interpreter, so no user global survives.
+		return { stateRetained: Promise.resolve(false) };
 	}
 
 	nextToolCall(): Promise<ToolCallMessage> {

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -128,13 +128,13 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 {{#if py}}Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".{{/if}}
 {{#if js}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}
 {{#if rb}}Ruby: synchronous; helper options are keyword args{{#if spawns}} (e.g. \`output("id", limit: 2)\`){{/if}}; the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).{{/if}}
 {{#if jl}}Julia: synchronous; helper options are standard keyword args{{#if spawns}} (e.g. \`output("id", limit=2)\`){{/if}}; the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).{{/if}}
-On error, fix and re-run only the failing step — prior calls' state survives.
+On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
 </instruction>
 
 <prelude>

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -29,6 +29,7 @@ export interface EvalDetachedCellSnapshot {
 	readonly state: EvalDetachedCellState;
 	readonly outputTail: string;
 	readonly result: AgentToolResult<EvalToolDetails> | undefined;
+	readonly stateRetained: boolean | undefined;
 }
 
 export interface EvalDetachedCellNotification {

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -15,6 +15,8 @@ type ManagedCell = {
 	canDetach: boolean;
 	wasDetached: boolean;
 	kernel: EvalKernel | undefined;
+	/** Set after an interrupt-driven stop; undefined until the kernel reports its fate. */
+	stateRetained: boolean | undefined;
 	outputTail: (() => string) | undefined;
 	result: AgentToolResult<EvalToolDetails> | undefined;
 	notificationQueued: boolean;
@@ -78,6 +80,7 @@ export class EvalDetachedCellManager {
 			canDetach: false,
 			wasDetached: false,
 			kernel: undefined,
+			stateRetained: undefined,
 			outputTail: undefined,
 			result: undefined,
 			notificationQueued: false,
@@ -116,7 +119,10 @@ export class EvalDetachedCellManager {
 		const cell = this.#get(cellId);
 		if (cell.state === "detached" && this.#transition(cell, "cancelled")) {
 			const kernel = cell.kernel;
-			if (kernel !== undefined) await kernel.interrupt(reason);
+			if (kernel !== undefined) {
+				const handle = await kernel.interrupt(reason);
+				cell.stateRetained = await handle.stateRetained;
+			}
 		}
 		return this.#snapshot(cell);
 	}
@@ -220,6 +226,7 @@ export class EvalDetachedCellManager {
 			state: cell.state,
 			outputTail: cell.outputTail?.() ?? "",
 			result: cell.result,
+			stateRetained: cell.stateRetained,
 		};
 	}
 }

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -8,7 +8,7 @@ import { buildEvalPrompt } from "../prompt/eval-prompt.ts";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP } from "../timeouts/bridge-timeout.ts";
 import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
 import { CellHandler, type CellState } from "./cell-handler.ts";
-import { interruptionStateNote } from "./interrupt-note.ts";
+import { describeTimeoutState, interruptionStateNote } from "./interrupt-note.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
 import type { EvalImageResizer } from "./image.ts";
 import {
@@ -155,6 +155,9 @@ class CellExecution {
 		this.#abort(this.#callerSignal.reason);
 	};
 
+	/** Outcome of the most recent interrupt, when a kernel was interrupted. */
+	interruptStateRetained: Promise<boolean> | undefined;
+
 	#abort(reason: unknown): void {
 		if (!this.#active) return;
 		this.#active = false;
@@ -168,7 +171,10 @@ class CellExecution {
 		}
 		this.#interruptDeadline = setTimeout(() => this.#settleAbort(error), INTERRUPT_DELIVERY_GRACE_MS);
 		void Promise.resolve()
-			.then(async () => await kernel.interrupt(error.message))
+			.then(async () => {
+				const handle = await kernel.interrupt(error.message);
+				this.interruptStateRetained = handle.stateRetained;
+			})
 			.then(
 				() => this.#settleAbort(error),
 				(interruptError: unknown) => this.#settleAbort(interruptError),
@@ -362,6 +368,7 @@ async function executeCell(
 	} catch (error) {
 		if (handler && error instanceof Error && error.name === "CodemodeSessionDisposedError")
 			return await handler.finalizeCancellation(error);
+		if (error instanceof Error && error.name === "TimeoutError") throw await describeTimeoutState(error, execution);
 		throw error;
 	} finally {
 		state.active = false;

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -8,9 +8,9 @@ import { buildEvalPrompt } from "../prompt/eval-prompt.ts";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP } from "../timeouts/bridge-timeout.ts";
 import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
 import { CellHandler, type CellState } from "./cell-handler.ts";
-import { describeTimeoutState, interruptionStateNote } from "./interrupt-note.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
 import type { EvalImageResizer } from "./image.ts";
+import { describeTimeoutState, interruptionStateNote } from "./interrupt-note.ts";
 import {
 	createEvalInputSchema,
 	type EnabledEvalLanguages,
@@ -455,9 +455,7 @@ function detachedResult(snapshot: EvalDetachedCellSnapshot, input: EvalToolInput
 
 function snapshotResult(snapshot: EvalDetachedCellSnapshot): AgentToolResult<EvalToolDetails> {
 	const terminationNote =
-		snapshot.state === "cancelled"
-			? interruptionStateNote(snapshot.language, snapshot.stateRetained)
-			: undefined;
+		snapshot.state === "cancelled" ? interruptionStateNote(snapshot.language, snapshot.stateRetained) : undefined;
 	const text = [
 		`Eval cell ${snapshot.cellId} (${snapshot.language}) is ${snapshot.state}.`,
 		snapshot.outputTail.length === 0 ? "(no buffered output)" : snapshot.outputTail,

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -8,6 +8,7 @@ import { buildEvalPrompt } from "../prompt/eval-prompt.ts";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP } from "../timeouts/bridge-timeout.ts";
 import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
 import { CellHandler, type CellState } from "./cell-handler.ts";
+import { interruptionStateNote } from "./interrupt-note.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
 import type { EvalImageResizer } from "./image.ts";
 import {
@@ -445,11 +446,9 @@ function detachedResult(snapshot: EvalDetachedCellSnapshot, input: EvalToolInput
 
 function snapshotResult(snapshot: EvalDetachedCellSnapshot): AgentToolResult<EvalToolDetails> {
 	const terminationNote =
-		snapshot.state === "cancelled" && snapshot.language === "js"
-			? "JavaScript worker was restarted; VM state was lost."
-			: snapshot.state === "cancelled" && snapshot.language === "py"
-				? "Python kernel was interrupted; its existing variables are preserved."
-				: undefined;
+		snapshot.state === "cancelled"
+			? interruptionStateNote(snapshot.language, snapshot.stateRetained)
+			: undefined;
 	const text = [
 		`Eval cell ${snapshot.cellId} (${snapshot.language}) is ${snapshot.state}.`,
 		snapshot.outputTail.length === 0 ? "(no buffered output)" : snapshot.outputTail,

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -173,7 +173,9 @@ class CellExecution {
 		void Promise.resolve()
 			.then(async () => {
 				const handle = await kernel.interrupt(error.message);
-				this.interruptStateRetained = handle.stateRetained;
+				// Kernels predating the interrupt-outcome contract resolve void; leave
+				// the outcome undefined so callers report an honest unknown state.
+				this.interruptStateRetained = handle?.stateRetained;
 			})
 			.then(
 				() => this.#settleAbort(error),

--- a/packages/senpi-codemode/src/tool/interrupt-note.ts
+++ b/packages/senpi-codemode/src/tool/interrupt-note.ts
@@ -1,0 +1,25 @@
+import type { EvalLanguage } from "./types.ts";
+
+const LANGUAGE_LABEL: Record<EvalLanguage, string> = {
+	py: "Python kernel",
+	js: "JavaScript worker",
+	rb: "Ruby kernel",
+	jl: "Julia kernel",
+};
+
+/**
+ * Composes the user-facing note for a cancelled eval cell from the interrupt
+ * outcome the kernel actually reported — never a per-language assumption.
+ *
+ * Returns undefined when there is nothing truthful to add (no interrupt ran).
+ */
+export function interruptionStateNote(
+	language: EvalLanguage,
+	stateRetained: boolean | undefined,
+): string | undefined {
+	if (stateRetained === undefined) return undefined;
+	const label = LANGUAGE_LABEL[language];
+	if (stateRetained)
+		return `${label} was interrupted and remains running; its existing variables are preserved.`;
+	return `${label} was unresponsive to interrupt and was restarted; variables from earlier cells are lost.`;
+}

--- a/packages/senpi-codemode/src/tool/interrupt-note.ts
+++ b/packages/senpi-codemode/src/tool/interrupt-note.ts
@@ -1,5 +1,41 @@
 import type { EvalLanguage } from "./types.ts";
 
+const TIMEOUT_STATE_GRACE_MS = 5_500;
+
+function fallbackTimeoutMessage(base: string): string {
+	return `${base} Kernel state may have been lost; re-establish any variables the next cell needs.`;
+}
+
+/**
+ * Appends the kernel's actual post-timeout state to a TimeoutError, waiting a
+ * bounded window for the interrupt outcome so the model knows whether its
+ * variables survived. Falls back to an honest unknown when no outcome arrives.
+ */
+export async function describeTimeoutState(
+	error: Error,
+	execution: { readonly interruptStateRetained: Promise<boolean> | undefined },
+): Promise<Error> {
+	const outcome = execution.interruptStateRetained;
+	if (outcome === undefined) {
+		error.message = fallbackTimeoutMessage(error.message);
+		return error;
+	}
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const retained = await Promise.race([
+		outcome,
+		new Promise<boolean | undefined>((resolve) => {
+			timer = setTimeout(() => resolve(undefined), TIMEOUT_STATE_GRACE_MS);
+		}),
+	]).finally(() => {
+		if (timer !== undefined) clearTimeout(timer);
+	});
+	if (retained === undefined) error.message = fallbackTimeoutMessage(error.message);
+	else if (retained)
+		error.message = `${error.message} The kernel remains running; its existing variables are preserved.`;
+	else error.message = `${error.message} The kernel was unresponsive and restarted; variables from earlier cells are lost.`;
+	return error;
+}
+
 const LANGUAGE_LABEL: Record<EvalLanguage, string> = {
 	py: "Python kernel",
 	js: "JavaScript worker",

--- a/packages/senpi-codemode/src/tool/interrupt-note.ts
+++ b/packages/senpi-codemode/src/tool/interrupt-note.ts
@@ -32,7 +32,8 @@ export async function describeTimeoutState(
 	if (retained === undefined) error.message = fallbackTimeoutMessage(error.message);
 	else if (retained)
 		error.message = `${error.message} The kernel remains running; its existing variables are preserved.`;
-	else error.message = `${error.message} The kernel was unresponsive and restarted; variables from earlier cells are lost.`;
+	else
+		error.message = `${error.message} The kernel was unresponsive and restarted; variables from earlier cells are lost.`;
 	return error;
 }
 
@@ -49,13 +50,9 @@ const LANGUAGE_LABEL: Record<EvalLanguage, string> = {
  *
  * Returns undefined when there is nothing truthful to add (no interrupt ran).
  */
-export function interruptionStateNote(
-	language: EvalLanguage,
-	stateRetained: boolean | undefined,
-): string | undefined {
+export function interruptionStateNote(language: EvalLanguage, stateRetained: boolean | undefined): string | undefined {
 	if (stateRetained === undefined) return undefined;
 	const label = LANGUAGE_LABEL[language];
-	if (stateRetained)
-		return `${label} was interrupted and remains running; its existing variables are preserved.`;
+	if (stateRetained) return `${label} was interrupted and remains running; its existing variables are preserved.`;
 	return `${label} was unresponsive to interrupt and was restarted; variables from earlier cells are lost.`;
 }

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -90,9 +90,14 @@ export interface EvalKernelRunInput {
 	readonly timeoutMs?: number;
 }
 
+export interface KernelInterruptHandle {
+	/** Resolves once the kernel knows whether user state survived the interrupt. */
+	readonly stateRetained: Promise<boolean>;
+}
+
 export interface EvalKernel {
 	run(input: EvalKernelRunInput): Promise<EvalKernelResult>;
-	interrupt(reason?: string): Promise<void>;
+	interrupt(reason?: string): Promise<KernelInterruptHandle>;
 	deliverToolReply(message: Extract<HostToKernelMessage, { type: "tool-reply" }>): void;
 	reset(): Promise<void>;
 	close(): Promise<void>;

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -24,13 +24,13 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 Ruby: synchronous; helper options are keyword args (e.g. \`output("id", limit: 2)\`); the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).
 Julia: synchronous; helper options are standard keyword args (e.g. \`output("id", limit=2)\`); the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).
-On error, fix and re-run only the failing step — prior calls' state survives.
+On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
 </instruction>
 
 <prelude>
@@ -139,11 +139,11 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
-On error, fix and re-run only the failing step — prior calls' state survives.
+On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
 </instruction>
 
 <prelude>
@@ -209,12 +209,12 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Python stop interrupts while preserving kernel state; JavaScript stop restarts a fresh worker, so its VM state is lost.
+A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
-On error, fix and re-run only the failing step — prior calls' state survives.
+On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
 </instruction>
 
 <prelude>

--- a/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
+++ b/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
@@ -151,7 +151,7 @@ describe("eval bridge finalization", () => {
 
 		await expect(outcome).resolves.toMatchObject({
 			status: "rejected",
-			reason: { name: "TimeoutError", message: "Cell timed out after 1000ms" },
+			reason: { name: "TimeoutError", message: expect.stringContaining("Cell timed out after 1000ms") },
 		});
 		expect(kernel.interrupts).toEqual(["Cell timed out after 1000ms"]);
 		bridgeResult.resolve({ content: [{ type: "text", text: "late bridge value" }], details: {} });

--- a/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
+++ b/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
@@ -2,7 +2,13 @@ import type { AgentToolResult } from "@code-yeongyu/senpi";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HostToKernelMessage, KernelToHostMessage } from "../src/bridge/protocol.ts";
 import { createEvalTool } from "../src/tool/eval-tool.ts";
-import type { EvalKernel, EvalKernelManager, EvalKernelRunInput, ExecuteTool, KernelInterruptHandle } from "../src/tool/types.ts";
+import type {
+	EvalKernel,
+	EvalKernelManager,
+	EvalKernelRunInput,
+	ExecuteTool,
+	KernelInterruptHandle,
+} from "../src/tool/types.ts";
 import { Deferred, fakeExtensionContext } from "./eval/fakes.ts";
 
 type EvalResult = Extract<KernelToHostMessage, { type: "result" }>;

--- a/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
+++ b/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
@@ -2,7 +2,7 @@ import type { AgentToolResult } from "@code-yeongyu/senpi";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HostToKernelMessage, KernelToHostMessage } from "../src/bridge/protocol.ts";
 import { createEvalTool } from "../src/tool/eval-tool.ts";
-import type { EvalKernel, EvalKernelManager, EvalKernelRunInput, ExecuteTool } from "../src/tool/types.ts";
+import type { EvalKernel, EvalKernelManager, EvalKernelRunInput, ExecuteTool, KernelInterruptHandle } from "../src/tool/types.ts";
 import { Deferred, fakeExtensionContext } from "./eval/fakes.ts";
 
 type EvalResult = Extract<KernelToHostMessage, { type: "result" }>;
@@ -25,8 +25,9 @@ class BridgeKernel implements EvalKernel {
 		return await new Promise<EvalResult>(() => {});
 	}
 
-	async interrupt(reason?: string): Promise<void> {
+	async interrupt(reason?: string): Promise<KernelInterruptHandle> {
 		this.interrupts.push(reason);
+		return { stateRetained: Promise.resolve(true) };
 	}
 
 	deliverToolReply(message: Extract<HostToKernelMessage, { type: "tool-reply" }>): void {

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -150,6 +150,7 @@ describe("eval detached cells", () => {
 		const manager = new EvalDetachedCellManager({ notifier: recorder });
 		const py = new FakeKernel([{ type: "text", stream: "stdout", data: "x = 42\n" }]);
 		const js = new FakeKernel([]);
+		js.stateRetainedOnInterrupt = false;
 		const tool = createTool(manager, [
 			["py", py],
 			["js", js],
@@ -171,7 +172,7 @@ describe("eval detached cells", () => {
 			undefined,
 			interactiveContext(),
 		);
-		expect(textOf(stoppedPython)).toContain("Python kernel was interrupted; its existing variables are preserved.");
+		expect(textOf(stoppedPython)).toContain("remains running; its existing variables are preserved.");
 
 		await detach(tool, js, "js-detached");
 		const stoppedJavaScript = await tool.execute(
@@ -181,7 +182,8 @@ describe("eval detached cells", () => {
 			undefined,
 			interactiveContext(),
 		);
-		expect(textOf(stoppedJavaScript)).toContain("JavaScript worker was restarted; VM state was lost.");
+		expect(textOf(stoppedJavaScript)).toContain("was restarted");
+		expect(textOf(stoppedJavaScript)).toContain("lost");
 		await manager.flushNotifications();
 		expect(recorder.notices).toHaveLength(2);
 		expect(manager.busyFor("py")).toBeUndefined();

--- a/packages/senpi-codemode/test/eval-stop-state-note.test.ts
+++ b/packages/senpi-codemode/test/eval-stop-state-note.test.ts
@@ -1,0 +1,120 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+type TextContent = Extract<AgentToolResult<unknown>["content"][number], { type: "text" }>;
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function textOf(result: AgentToolResult<unknown>): string {
+	const texts: string[] = [];
+	for (const part of result.content as readonly TextContent[]) {
+		if (part.type === "text") texts.push(part.text);
+	}
+	return texts.join("\n");
+}
+
+function createTool(manager: EvalDetachedCellManager, entries: Array<readonly [string, FakeKernel]>) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: true, rb: false, jl: false },
+		kernelManager: new FakeManager(entries),
+		cellTimeoutSeconds: 1,
+		executeTool: vi.fn(),
+		cellManager: manager,
+	});
+}
+
+async function detachPyCell(
+	tool: ReturnType<typeof createTool>,
+	kernel: FakeKernel,
+	cellId: string,
+): Promise<AgentToolResult<unknown>> {
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		cellId,
+		{ language: "py", code: "await forever", on_timeout: "detach" },
+		undefined,
+		undefined,
+		{ ...fakeExtensionContext(), mode: "tui" as const },
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	return await execution;
+}
+
+describe("eval stop reports true kernel state", () => {
+	it("says Python state survived when the runner answered the stop interrupt", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		kernel.stateRetainedOnInterrupt = true;
+		const tool = createTool(manager, [["py", kernel]]);
+
+		await detachPyCell(tool, kernel, "stop-cooperative-cell");
+		const stopped = await tool.execute(
+			"stop-call-1",
+			{ action: "stop", cell_id: "stop-cooperative-cell" },
+			undefined,
+			undefined,
+			{ ...fakeExtensionContext(), mode: "tui" as const },
+		);
+
+		expect(textOf(stopped)).toContain("preserved");
+	});
+
+	it("says Python state was lost when the kernel had to be killed, never claiming preserved", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		kernel.stateRetainedOnInterrupt = false;
+		const tool = createTool(manager, [["py", kernel]]);
+
+		await detachPyCell(tool, kernel, "stop-killed-cell");
+		const stopped = await tool.execute(
+			"stop-call-2",
+			{ action: "stop", cell_id: "stop-killed-cell" },
+			undefined,
+			undefined,
+			{ ...fakeExtensionContext(), mode: "tui" as const },
+		);
+
+		const text = textOf(stopped);
+		expect(text).not.toContain("preserved");
+		expect(text).toMatch(/lost|gone|restart|recreated/i);
+	});
+
+	it("says JavaScript state was lost when the worker is restarted by stop", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		kernel.stateRetainedOnInterrupt = false;
+		const tool = createTool(manager, [["js", kernel]]);
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"stop-js-cell",
+			{ language: "js", code: "await forever", on_timeout: "detach" },
+			undefined,
+			undefined,
+			{ ...fakeExtensionContext(), mode: "tui" as const },
+		);
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+
+		const stopped = await tool.execute(
+			"stop-call-3",
+			{ action: "stop", cell_id: "stop-js-cell" },
+			undefined,
+			undefined,
+			{ ...fakeExtensionContext(), mode: "tui" as const },
+		);
+
+		const text = textOf(stopped);
+		expect(text).not.toContain("preserved");
+		expect(text).toMatch(/lost|restarted/i);
+	});
+});

--- a/packages/senpi-codemode/test/eval-tool-interrupt.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-interrupt.test.ts
@@ -86,7 +86,7 @@ describe("createEvalTool interrupt handling", () => {
 
 		await expect(outcome).resolves.toMatchObject({
 			status: "rejected",
-			reason: { name: "TimeoutError", message: "Cell timed out after 1000ms" },
+			reason: { name: "TimeoutError", message: expect.stringContaining("Cell timed out after 1000ms") },
 		});
 		expect(kernel.interrupts).toEqual(["Cell timed out after 1000ms"]);
 		expect(kernel.runs).toEqual([]);

--- a/packages/senpi-codemode/test/eval-tool-timeout-state.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-timeout-state.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function createTool(entries: Array<readonly [string, FakeKernel]>) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: true, rb: false, jl: false },
+		kernelManager: new FakeManager(entries),
+		cellTimeoutSeconds: 1,
+		executeTool: vi.fn(),
+	});
+}
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "print" as const };
+}
+
+async function runTimedOutCell(
+	tool: ReturnType<typeof createTool>,
+	kernel: FakeKernel,
+	language: "js" | "py",
+): Promise<{ status: string; reason?: Error }> {
+	kernel.deferNextRun();
+	const outcome = tool
+		.execute(
+			"timeout-cell",
+			{ language, code: "await forever", on_timeout: "error", timeout: 1 },
+			undefined,
+			undefined,
+			interactiveContext(),
+		)
+		.then(
+			() => ({ status: "fulfilled" }),
+			(reason: Error) => ({ status: "rejected", reason }),
+		);
+	await vi.advanceTimersByTimeAsync(1_000);
+	return await outcome;
+}
+
+describe("eval error-mode timeout names kernel state", () => {
+	it("says the kernel remains running and state survived when the interrupt was cooperative", async () => {
+		vi.useFakeTimers();
+		const kernel = new FakeKernel([]);
+		kernel.stateRetainedOnInterrupt = true;
+		const tool = createTool([["py", kernel]]);
+
+		const outcome = await runTimedOutCell(tool, kernel, "py");
+
+		expect(outcome.status).toBe("rejected");
+		expect(outcome.reason?.name).toBe("TimeoutError");
+		expect(outcome.reason?.message).toContain("Cell timed out after 1000ms");
+		expect(outcome.reason?.message).toMatch(/remains running|preserved|survived/i);
+		expect(outcome.reason?.message).not.toMatch(/lost/i);
+	});
+
+	it("says state was lost when the kernel had to be restarted after the timeout", async () => {
+		vi.useFakeTimers();
+		const kernel = new FakeKernel([]);
+		kernel.stateRetainedOnInterrupt = false;
+		const tool = createTool([["js", kernel]]);
+
+		const outcome = await runTimedOutCell(tool, kernel, "js");
+
+		expect(outcome.status).toBe("rejected");
+		expect(outcome.reason?.name).toBe("TimeoutError");
+		expect(outcome.reason?.message).toContain("Cell timed out after 1000ms");
+		expect(outcome.reason?.message).toMatch(/lost|restarted|recreated/i);
+		expect(outcome.reason?.message).not.toMatch(/preserved|remains running/i);
+	});
+});

--- a/packages/senpi-codemode/test/eval/fakes.ts
+++ b/packages/senpi-codemode/test/eval/fakes.ts
@@ -29,6 +29,8 @@ export class FakeKernel implements EvalKernel {
 	readonly interrupts: Array<string | undefined> = [];
 	resetCount = 0;
 	closeCount = 0;
+	/** Outcome reported by interrupt(); tests flip to false to simulate a killed kernel. */
+	stateRetainedOnInterrupt = true;
 	private readonly messages: KernelToHostMessage[];
 	private deferredRun: { readonly started: Deferred<void>; readonly result: Deferred<KernelResult> } | undefined;
 
@@ -90,7 +92,7 @@ export class FakeKernel implements EvalKernel {
 			error: { message: reason ?? "Eval interrupted" },
 			durationMs: 0,
 		});
-		return { stateRetained: Promise.resolve(true) };
+		return { stateRetained: Promise.resolve(this.stateRetainedOnInterrupt) };
 	}
 
 	deliverToolReply(message: unknown): void {

--- a/packages/senpi-codemode/test/eval/fakes.ts
+++ b/packages/senpi-codemode/test/eval/fakes.ts
@@ -2,7 +2,7 @@ import { DEFAULT_COMPACTION_SETTINGS, type ExtensionContext } from "@code-yeongy
 import { createInMemoryExtensionSessionSettings } from "../../../coding-agent/test/helpers/extension-session-settings.ts";
 import type { KernelToHostMessage } from "../../src/bridge/protocol.ts";
 import type { EvalKernel, EvalKernelManager } from "../../src/tool/eval-tool.ts";
-import type { EvalKernelRunInput } from "../../src/tool/types.ts";
+import type { EvalKernelRunInput, KernelInterruptHandle } from "../../src/tool/types.ts";
 
 type KernelResult = Extract<KernelToHostMessage, { type: "result" }>;
 

--- a/packages/senpi-codemode/test/eval/fakes.ts
+++ b/packages/senpi-codemode/test/eval/fakes.ts
@@ -77,11 +77,11 @@ export class FakeKernel implements EvalKernel {
 		return result;
 	}
 
-	async interrupt(reason?: string): Promise<void> {
+	async interrupt(reason?: string): Promise<KernelInterruptHandle> {
 		this.interrupts.push(reason);
 		const deferredRun = this.deferredRun;
 		const activeRun = this.runs.at(-1);
-		if (!deferredRun || !activeRun) return;
+		if (!deferredRun || !activeRun) return { stateRetained: Promise.resolve(true) };
 		this.deferredRun = undefined;
 		deferredRun.result.resolve({
 			type: "result",
@@ -90,6 +90,7 @@ export class FakeKernel implements EvalKernel {
 			error: { message: reason ?? "Eval interrupted" },
 			durationMs: 0,
 		});
+		return { stateRetained: Promise.resolve(true) };
 	}
 
 	deliverToolReply(message: unknown): void {
@@ -154,10 +155,11 @@ export class PendingInterruptKernel implements EvalKernel {
 		return await this.runResult.promise;
 	}
 
-	async interrupt(reason?: string): Promise<void> {
+	async interrupt(reason?: string): Promise<KernelInterruptHandle> {
 		this.interrupts.push(reason);
 		this.interruptStarted.resolve(undefined);
 		await this.interruptResult.promise;
+		return { stateRetained: Promise.resolve(true) };
 	}
 
 	deliverToolReply(): void {}
@@ -188,8 +190,9 @@ export class KernelOwnedTimeoutKernel implements EvalKernel {
 		});
 	}
 
-	async interrupt(reason?: string): Promise<void> {
+	async interrupt(reason?: string): Promise<KernelInterruptHandle> {
 		this.interrupts.push(reason);
+		return { stateRetained: Promise.resolve(true) };
 	}
 
 	deliverToolReply(): void {}

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -6,7 +6,7 @@ import type { Api, Model } from "@earendil-works/pi-ai/compat";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import type { CodemodeSessionManager } from "../src/extension/session-manager.ts";
 import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
-import type { EvalKernelResult, EvalKernelRunInput } from "../src/tool/types.ts";
+import type { EvalKernelResult, EvalKernelRunInput, KernelInterruptHandle } from "../src/tool/types.ts";
 import { fakeExtensionContext } from "./eval/fakes.ts";
 
 interface RegisteredHandler {
@@ -72,7 +72,7 @@ class DisposableManager implements CodemodeSessionManager {
 
 	async getKernel(): Promise<{
 		run(input: EvalKernelRunInput): Promise<EvalKernelResult>;
-		interrupt(reason?: string): Promise<void>;
+		interrupt(reason?: string): Promise<KernelInterruptHandle>;
 		deliverToolReply(): void;
 		reset(): Promise<void>;
 		close(): Promise<void>;
@@ -102,6 +102,7 @@ class DisposableManager implements CodemodeSessionManager {
 			interrupt: async (reason) => {
 				this.events.push("interrupt");
 				controller.abort(reason);
+				return { stateRetained: Promise.resolve(true) };
 			},
 			deliverToolReply: () => undefined,
 			reset: async () => undefined,

--- a/packages/senpi-codemode/test/py-kernel-interrupt-outcome.test.ts
+++ b/packages/senpi-codemode/test/py-kernel-interrupt-outcome.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeChild, startFakeKernel } from "./py-kernel/fixtures.ts";
+
+const interruptSignal = process.platform === "win32" ? "SIGTERM" : "SIGINT";
+
+describe("PythonKernel interrupt outcome", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports retained state when the runner answers the interrupt", async () => {
+		vi.useFakeTimers();
+		const child = new FakeChild({ autoReady: false, autoRun: false, remainAliveOnInterrupt: true });
+		const kernel = await startFakeKernel(child, "outcome-cooperative-session");
+		const pending = kernel.run({ cellId: "cooperative-cell", code: "while True: pass", timeoutMs: 60_000 });
+		await vi.advanceTimersByTimeAsync(0);
+
+		const handle = await kernel.interrupt("manual stop");
+		child.emitMessage({
+			type: "result",
+			cellId: "cooperative-cell",
+			ok: false,
+			error: { message: "Eval interrupted" },
+			durationMs: 1,
+		});
+		await pending;
+
+		await expect(handle.stateRetained).resolves.toBe(true);
+		expect(child.killSignals).toEqual([interruptSignal]);
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(child.killSignals).toEqual([interruptSignal]);
+	});
+
+	it("reports lost state when the unresponsive runner is killed after the escalation window", async () => {
+		vi.useFakeTimers();
+		const child = new FakeChild({ autoReady: false, autoRun: false, remainAliveOnInterrupt: true });
+		const kernel = await startFakeKernel(child, "outcome-escalation-session");
+		const pending = kernel.run({ cellId: "escalated-cell", code: "while True: pass", timeoutMs: 60_000 });
+		await vi.advanceTimersByTimeAsync(0);
+
+		const handle = await kernel.interrupt("manual stop");
+		await vi.advanceTimersByTimeAsync(5_000);
+		await pending;
+
+		await expect(handle.stateRetained).resolves.toBe(false);
+		expect(child.killSignals).toEqual([interruptSignal, "SIGKILL"]);
+	});
+
+	it("reports retained state when there is nothing to interrupt", async () => {
+		vi.useFakeTimers();
+		const child = new FakeChild({ autoReady: false, autoRun: false });
+		const kernel = await startFakeKernel(child, "outcome-idle-session");
+
+		const handle = await kernel.interrupt("manual stop");
+
+		await expect(handle.stateRetained).resolves.toBe(true);
+		expect(child.killSignals).toEqual([]);
+	});
+
+	it("reports lost state when the interrupted runner dies", async () => {
+		vi.useFakeTimers();
+		const child = new FakeChild({ autoReady: false, autoRun: false, remainAliveOnInterrupt: true });
+		const kernel = await startFakeKernel(child, "outcome-death-session");
+		const pending = kernel.run({ cellId: "dying-cell", code: "while True: pass", timeoutMs: 60_000 });
+		await vi.advanceTimersByTimeAsync(0);
+
+		const handle = await kernel.interrupt("manual stop");
+		child.finish(null, interruptSignal);
+		await pending;
+
+		await expect(handle.stateRetained).resolves.toBe(false);
+	});
+});

--- a/packages/senpi-codemode/test/py-prelude-idle-sigint.test.ts
+++ b/packages/senpi-codemode/test/py-prelude-idle-sigint.test.ts
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { hasPython3 } from "./py-kernel/fixtures.ts";
+
+const preludePath = join(dirname(fileURLToPath(import.meta.url)), "../src/kernels/py/prelude.py");
+
+function sendFrame(child: ReturnType<typeof spawn>, message: unknown): void {
+	child.stdin?.write(`${JSON.stringify(message)}\n`);
+}
+
+async function readFrame(child: ReturnType<typeof spawn>): Promise<Record<string, unknown>> {
+	const [chunk] = (await once(child.stdout!, "data")) as [Buffer];
+	const line = chunk.toString("utf8").split("\n").find(Boolean);
+	if (line === undefined) throw new Error("no prelude frame");
+	return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe.skipIf(!(await hasPython3()))("Python prelude idle SIGINT guard", () => {
+	it("keeps the runner alive when SIGINT arrives while it is idle on stdin", async () => {
+		const child = spawn("python3", [preludePath], { stdio: ["pipe", "pipe", "inherit"] });
+		try {
+			sendFrame(child, {
+				type: "init",
+				sessionId: "idle-sigint",
+				connection: { port: 1, token: "t", parallelPoolWidth: 2 },
+			});
+			const ready = await readFrame(child);
+			expect(ready.type).toBe("ready");
+
+			sendFrame(child, { type: "run", cellId: "cell-1", code: "marker = 'alive'\nresult = 1 + 1" });
+			const first = await readFrame(child);
+			expect(first).toMatchObject({ type: "result", cellId: "cell-1", ok: true });
+
+			// The cell finished and the runner is back in its stdin-read loop. A stray
+			// SIGINT (a late or duplicated interrupt) must not kill it here.
+			child.kill("SIGINT");
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			expect(child.exitCode, "idle runner must survive a stray SIGINT").toBeNull();
+			expect(child.signalCode, "idle runner must not be signalled to death").toBeNull();
+
+			sendFrame(child, { type: "run", cellId: "cell-2", code: "result = marker" });
+			const second = await readFrame(child);
+			expect(second).toMatchObject({ type: "result", cellId: "cell-2", ok: true });
+		} finally {
+			child.kill("SIGKILL");
+		}
+	});
+
+	it("still interrupts a running cell when SIGINT arrives mid-execution", async () => {
+		const child = spawn("python3", [preludePath], { stdio: ["pipe", "pipe", "inherit"] });
+		try {
+			sendFrame(child, {
+				type: "init",
+				sessionId: "exec-sigint",
+				connection: { port: 1, token: "t", parallelPoolWidth: 2 },
+			});
+			const ready = await readFrame(child);
+			expect(ready.type).toBe("ready");
+
+			sendFrame(child, { type: "run", cellId: "cell-3", code: "while True:\n    pass" });
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			child.kill("SIGINT");
+
+			const interrupted = await readFrame(child);
+			expect(interrupted).toMatchObject({ type: "result", cellId: "cell-3", ok: false });
+			expect(child.exitCode).toBeNull();
+		} finally {
+			child.kill("SIGKILL");
+		}
+	});
+});

--- a/packages/senpi-codemode/test/session-manager-lifecycle.test.ts
+++ b/packages/senpi-codemode/test/session-manager-lifecycle.test.ts
@@ -7,7 +7,7 @@ import { defaultCodemodeSettings } from "../src/config/settings.ts";
 import { type CodemodeSessionManager, createCodemodeSessionManager } from "../src/extension/session-manager.ts";
 import type { InterpreterAvailability } from "../src/interpreters/detect.ts";
 import type { PythonKernelStartOptions } from "../src/kernels/py/kernel.ts";
-import type { EvalKernel, EvalKernelRunInput } from "../src/tool/types.ts";
+import type { EvalKernel, EvalKernelRunInput, KernelInterruptHandle } from "../src/tool/types.ts";
 import { fakeExtensionContext } from "./eval/fakes.ts";
 
 interface SessionManagerHarness {
@@ -42,7 +42,9 @@ class FakeKernel implements EvalKernel {
 		return { type: "result", cellId: input.cellId, ok: true, durationMs: 0 };
 	}
 
-	async interrupt(): Promise<void> {}
+	async interrupt(): Promise<KernelInterruptHandle> {
+		return { stateRetained: Promise.resolve(true) };
+	}
 
 	deliverToolReply(): void {}
 


### PR DESCRIPTION
## Ideal state

After **any** interrupt of an eval kernel — the `stop` action, a timeout in `error` mode (print/json), or session disposal — the model is told the **truth** about kernel state, derived from what actually happened, never a hardcoded per-language guess. Python state is preserved whenever the runner can answer a cooperative SIGINT, and the window where a stray signal kills an idle runner is closed. The eval prompt never promises survival it cannot guarantee.

This builds on #371 (`feat/eval-detach`), which made interactive timeouts detach instead of interrupt. The remaining gap was that every *interrupt* path still reported state by language assumption, and one of those assumptions was false.

## The lie this fixes

`EvalDetachedCellManager`'s stop/peek snapshot hardcoded `"Python kernel was interrupted; its existing variables are preserved."` for **every** cancelled Python cell. When a stopped Python kernel is unresponsive to SIGINT and must be killed after the 5 s escalation window, its state is gone — but the model was told its variables survived, and only learned otherwise from the next cell's `NameError`. The eval prompt made the same promise ("Python stop interrupts while preserving kernel state", "prior calls' state survives").

## Changes

- **`EvalKernel.interrupt()` returns a `KernelInterruptHandle`** carrying `stateRetained: Promise<boolean>`. The Python kernel reports `retained` only when the live runner answers the interrupt, and `lost` when the run escalates to a hard kill or the process dies. JavaScript and the shared subprocess kernels report deterministically from their restart semantics. Kernels predating the contract resolve `void`; the host tolerates that and reports an honest unknown rather than crashing.
- **Stop/peek snapshot reports the real outcome.** A preserved kernel says it "remains running; its existing variables are preserved"; a killed kernel says it "was restarted; variables from earlier cells are lost." Composed in a new `src/tool/interrupt-note.ts` (the timeout/stop message concept) rather than grown inside `eval-tool.ts`.
- **Error-mode timeouts name the state.** The tool waits a bounded window for the interrupt outcome and appends whether the kernel remains running, was restarted, or could not be determined — instead of returning a bare `Cell timed out after Nms`.
- **Idle SIGINT guard in the Python prelude.** The runner's `main()` loop iterated `sys.stdin` outside the `try`, so a late or duplicated SIGINT arriving after a cell settled raised `KeyboardInterrupt` in the blocking read and killed the kernel, wiping state. The runner now installs `SIG_IGN` as the idle baseline and `default_int_handler` only while user code executes inside `run_cell`.
- **Prompt honesty.** The prompt now says stop/timeout results *state whether* the kernel survived, and directs the model to verify a sentinel before rebuilding instead of blindly re-running side effects.

## Verification (TDD, failing-first per change)

Each change was captured RED before the production edit:

- `test/py-kernel-interrupt-outcome.test.ts` — cooperative interrupt → `stateRetained: true`; escalation → `false` (RED: `Cannot read properties of undefined (reading 'stateRetained')`).
- `test/eval-stop-state-note.test.ts` — stopped-but-killed Python kernel must not claim "preserved" (RED: hardcoded lie printed).
- `test/py-prelude-idle-sigint.test.ts` — SIGINT while idle must not kill the runner; SIGINT mid-cell still interrupts (RED: idle runner died, follow-up cell hung).
- `test/eval-tool-timeout-state.test.ts` — error-mode timeout message names preserved vs lost (RED: bare `Cell timed out after Nms`).

Gates:

- Package suite: **60 passed, 397 tests, 0 failed** in one run.
- `npm run check` from repo root: **exit 0**.
- Real-surface QA (`scripts/qa-e2e-eval.ts`, `scripts/qa-timeout-state.ts`): a real Python kernel interrupted in error mode returns `"... The kernel remains running; its existing variables are preserved."` **and** a direct kernel readback confirms `x=42` survived. Evidence under `local-ignore/qa-evidence/<date>-eval-timeout-state/`.

## Out of scope

Ruby/Julia cooperative-preservation (their shared subprocess path still restarts unconditionally) — needs live signal characterization per language before it can be done safely; tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report the real kernel state after eval interrupts and timeouts, and stop claiming Python state is always preserved. Timeout/stop messages now state whether variables survived or were lost, and Python no longer dies on stray idle SIGINT.

- **Bug Fixes**
  - Stop/timeout now report true kernel state: Python marks preserved only if the runner answered SIGINT; JS and shared-subprocess kernels report restart with state lost. The tool waits briefly for the outcome and falls back to an honest unknown.
  - Detached cell stop/peek uses the kernel’s outcome instead of language guesses; the prompt no longer promises survival and suggests checking a sentinel before rebuilding state.
  - Python prelude ignores SIGINT while idle and enables it only during `run_cell`, preventing late/duplicate SIGINT from killing the runner while still interrupting running code.

- **Migration**
  - `EvalKernel.interrupt()` now returns `{ stateRetained: Promise<boolean> }`. Update custom kernels to return this handle. Legacy kernels that return `void` continue to work at runtime, but timeout/stop notes may say the state is unknown until you implement the handle.

<sup>Written for commit a50a2caad10bdec45ba830f0c1896bf53859798d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

