### PR TITLE
fix(codemode): stop aborting bridge tool calls on normal request completion

### DIFF
--- a/packages/senpi-codemode/src/bridge/http-server.ts
+++ b/packages/senpi-codemode/src/bridge/http-server.ts
@@ -75,7 +75,12 @@ async function handleRequest(
 	options: BridgeServerOptions,
 ): Promise<void> {
 	const abortController = new AbortController();
-	request.on("close", () => abortController.abort());
+	// IncomingMessage "close" fires on normal message completion in Node >= 16,
+	// so premature disconnect must be detected on the response side instead:
+	// its "close" without a finished response means the connection died mid-call.
+	response.on("close", () => {
+		if (!response.writableFinished) abortController.abort();
+	});
 	if (request.method !== "POST") {
 		sendJson(response, 404, { ok: false, error: transportError("not_found", "Bridge route was not found") });
 		return;

--- a/packages/senpi-codemode/test/bridge-server-signal.test.ts
+++ b/packages/senpi-codemode/test/bridge-server-signal.test.ts
@@ -1,0 +1,106 @@
+import { once } from "node:events";
+import { connect } from "node:net";
+import { describe, expect, it } from "vitest";
+import { startBridgeServer } from "../src/bridge/http-server.ts";
+
+async function postJson(port: number, path: string, token: string, body: unknown): Promise<Response> {
+	return await fetch(`http://127.0.0.1:${port}${path}`, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${token}`,
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+describe("bridge HTTP server call signals", () => {
+	it("keeps the onCall signal live while a normal request is being handled", async () => {
+		const samples: boolean[] = [];
+		const server = await startBridgeServer({
+			token: "test-token",
+			onCall: async (request) => {
+				samples.push(request.signal.aborted);
+				// Let the event loop drain any pending request-lifecycle events
+				// (IncomingMessage "close" fires on message completion in Node >= 16)
+				// before sampling again.
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				samples.push(request.signal.aborted);
+				return "alive";
+			},
+			onEmit: async () => {},
+			onCompletion: async () => "unused",
+		});
+		try {
+			const response = await postJson(server.port, "/call", server.token, {
+				callId: "call-signal-1",
+				toolName: "echo",
+				args: {},
+			});
+			await expect(response.json()).resolves.toEqual({ ok: true, value: "alive" });
+			expect(samples).toEqual([false, false]);
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("keeps the onCompletion signal live while a normal request is being handled", async () => {
+		const samples: boolean[] = [];
+		const server = await startBridgeServer({
+			token: "test-token",
+			onCall: async () => "unused",
+			onEmit: async () => {},
+			onCompletion: async (request) => {
+				samples.push(request.signal.aborted);
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				samples.push(request.signal.aborted);
+				return "alive";
+			},
+		});
+		try {
+			const response = await postJson(server.port, "/completion", server.token, { prompt: "hello" });
+			await expect(response.json()).resolves.toEqual({ ok: true, value: "alive" });
+			expect(samples).toEqual([false, false]);
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("aborts the in-flight onCall signal when the client disconnects prematurely", async () => {
+		let callStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			callStarted = resolve;
+		});
+		let abortObserved: (() => void) | undefined;
+		const aborted = new Promise<void>((resolve) => {
+			abortObserved = resolve;
+		});
+		const server = await startBridgeServer({
+			token: "test-token",
+			onCall: async (request) => {
+				callStarted?.();
+				if (request.signal.aborted) abortObserved?.();
+				else request.signal.addEventListener("abort", () => abortObserved?.(), { once: true });
+				await aborted;
+				return "late";
+			},
+			onEmit: async () => {},
+			onCompletion: async () => "unused",
+		});
+		try {
+			const body = JSON.stringify({ callId: "call-signal-2", toolName: "slow", args: {} });
+			const socket = connect(server.port, "127.0.0.1");
+			await once(socket, "connect");
+			socket.write(
+				`POST /call HTTP/1.1\r\nhost: 127.0.0.1\r\nauthorization: Bearer test-token\r\ncontent-type: application/json\r\ncontent-length: ${Buffer.byteLength(body)}\r\n\r\n${body}`,
+			);
+			await started;
+			socket.destroy();
+			await aborted;
+		} finally {
+			await server.close();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

`tool.<name>()` calls from `eval` cells running on the Python/Ruby/Julia kernels always failed:

- `tool.bash(...)` -> `Command aborted`
- MCP tools (e.g. `tool.mcp_computer_use_get_app_state(...)`) -> `ToolExecError: AbortError: This operation was aborted`

Observed in real session `019f9eaf-fa07-7e8a-bbd7-061b43ccb3aa` ("Browse DCInside Programming Pages") and reproduced live.

## Root cause

`startBridgeServer` wired the per-call `AbortController` to `request.on("close")`. Since Node 16, `IncomingMessage` `"close"` fires when the request message *completes* (body fully consumed), not only on disconnect. Every `/call` and `/completion` therefore executed with an already-aborted signal. The JS kernel path was unaffected (it routes through the cell handler with the cell signal), which is why only py/rb/jl `tool.*` calls broke.

oh-my-pi's bridge (`packages/coding-agent/src/eval/py/tool-bridge.ts`) never derives abort state from the HTTP request lifecycle - parity restored here by only treating a *premature* close as a disconnect.

## Fix

Listen on the response side: a `response` `"close"` with `!response.writableFinished` means the connection died mid-call -> abort. Normal completion leaves the signal live, preserving the documented "aborts work on disconnect" invariant.

## Tests

New `test/bridge-server-signal.test.ts` (captured RED before the fix: signal sampled `[true, true]`):

- `/call` handler observes a live (non-aborted) signal for the whole handler duration
- `/completion` handler observes a live signal
- premature client socket destroy still aborts the in-flight call signal

`packages/senpi-codemode` full suite: 58 files passed / 391 tests. Root `npm run check`: clean.

## QA evidence (`local-ignore/qa-evidence/20260726-codemode-bridge-abort/`)

Real CLI from source, fake model server scripting an `eval` toolCall whose py code runs `tool.bash` (marker only exists as runtime output, never in the request args):

- unfixed main: `FAIL ... marker=false commandAborted=true`
- this branch: `PASS ... marker=true commandAborted=false` - tool result round-tripped to the model: `{'type': 'text', 'text': 'BRIDGE-SIGNAL-OK-5f21'}`


### MCP-style proof (real builtin MCP extension)

Sandbox `agentDir/mcp.json` registers the stdio MCP fixture (`packages/coding-agent/test/mcp/fixtures/stdio-server.ts`) as server `fx`; the scripted eval cell calls both `tool.bash` and `tool.mcp_fx_tool_1` (markers built by runtime concatenation so they can only appear via real execution output):

- unfixed main: `FAIL bashMarker=false mcpMarker=false aborted=true` - requests contain `ToolExecError: AbortError: This operation was aborted` and `Command aborted`, matching the originally reported session
- this branch: `PASS bashMarker=true mcpMarker=true aborted=false` - `fixture tool_1 value=MCP-RT-OK-77aa` round-tripped to the model
