### PR TITLE
fix: fall back on Anthropic policy refusals

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/anthropic-policy-refusal-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/anthropic-policy-refusal-server.mjs
@@ -1,0 +1,124 @@
+import { createServer } from "node:http";
+import { API_PRESETS } from "./mock-loop-support.mjs";
+
+export const POLICY_REFUSAL =
+	"This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy. To learn more, see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback.";
+export const FALLBACK_MODEL_ID = "mock-claude-fallback";
+export const FINAL_MARKER = "SENPI-QA-ANTHROPIC-POLICY-FALLBACK-8a3d";
+export const PRIMARY_CONTINUED_MARKER = "SENPI-QA-PRIMARY-CONTINUED-WRONG-5f92";
+
+const API_NAME = "anthropic-messages";
+
+export function startPolicyRefusalServer() {
+	const requests = [];
+	let primaryRequests = 0;
+	const server = createServer(async (request, response) => {
+		const body = await readRequestBody(request);
+		const payload = JSON.parse(body);
+		requests.push({ method: request.method, path: request.url, model: payload.model });
+		response.writeHead(200, {
+			"content-type": "text/event-stream",
+			"cache-control": "no-cache",
+			connection: "keep-alive",
+		});
+		if (payload.model === API_PRESETS[API_NAME].modelId) {
+			primaryRequests++;
+			if (primaryRequests === 1) writePolicyRefusal(response, payload.model);
+			else writeTextResponse(response, payload.model, PRIMARY_CONTINUED_MARKER);
+		} else {
+			writeTextResponse(response, payload.model, FINAL_MARKER);
+		}
+		response.end();
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") return reject(new Error("policy refusal server has no TCP address"));
+			const origin = `http://127.0.0.1:${address.port}`;
+			resolve({
+				origin,
+				url: `${origin}/v1`,
+				requests,
+				get listening() {
+					return server.listening;
+				},
+				stop: () => new Promise((done) => server.close(() => done())),
+			});
+		});
+	});
+}
+
+function writePolicyRefusal(response, model) {
+	writeSse(response, "message_start", messageStart(model));
+	writeSse(response, "content_block_start", {
+		type: "content_block_start",
+		index: 0,
+		content_block: { type: "tool_use", id: "toolu_policy_refusal", name: "bash", input: {} },
+	});
+	writeSse(response, "content_block_delta", {
+		type: "content_block_delta",
+		index: 0,
+		delta: { type: "input_json_delta", partial_json: '{"command":"printf policy-refusal-probe"}' },
+	});
+	writeSse(response, "content_block_stop", { type: "content_block_stop", index: 0 });
+	writeSse(response, "message_delta", {
+		type: "message_delta",
+		delta: { stop_reason: "refusal", stop_sequence: null, stop_details: { explanation: POLICY_REFUSAL } },
+		usage: { output_tokens: 1 },
+	});
+	writeSse(response, "message_stop", { type: "message_stop" });
+}
+
+function writeTextResponse(response, model, text) {
+	writeSse(response, "message_start", messageStart(model));
+	writeSse(response, "content_block_start", {
+		type: "content_block_start",
+		index: 0,
+		content_block: { type: "text", text: "" },
+	});
+	writeSse(response, "content_block_delta", {
+		type: "content_block_delta",
+		index: 0,
+		delta: { type: "text_delta", text },
+	});
+	writeSse(response, "content_block_stop", { type: "content_block_stop", index: 0 });
+	writeSse(response, "message_delta", {
+		type: "message_delta",
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { output_tokens: 1 },
+	});
+	writeSse(response, "message_stop", { type: "message_stop" });
+}
+
+function messageStart(model) {
+	return {
+		type: "message_start",
+		message: {
+			id: "msg_policy_refusal",
+			type: "message",
+			role: "assistant",
+			model,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: 1, output_tokens: 0 },
+		},
+	};
+}
+
+function writeSse(response, event, data) {
+	response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function readRequestBody(request) {
+	return new Promise((resolve, reject) => {
+		let body = "";
+		request.setEncoding("utf8");
+		request.on("data", (chunk) => {
+			body += chunk;
+		});
+		request.on("end", () => resolve(body));
+		request.on("error", reject);
+	});
+}

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-policy-refusal.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-policy-refusal.mjs
@@ -1,0 +1,148 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	FALLBACK_MODEL_ID,
+	FINAL_MARKER,
+	PRIMARY_CONTINUED_MARKER,
+	startPolicyRefusalServer,
+} from "./anthropic-policy-refusal-server.mjs";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	runCli,
+} from "./common.mjs";
+import {
+	API_PRESETS,
+	checkRealAuthUnchanged,
+	hermeticEnv,
+	writeMockModelsJson,
+} from "./mock-loop-support.mjs";
+
+const API_NAME = "anthropic-messages";
+export async function runAnthropicPolicyRefusalScenario(evidenceSlug) {
+	installCleanupHooks();
+	const checks = createChecks("mock-loop.mjs --scenario anthropic-policy-refusal-fallback");
+	const guard = guardRealAuth();
+	const box = makeSandbox("senpi-qa-policy-refusal");
+	const server = await startPolicyRefusalServer();
+	const preset = API_PRESETS[API_NAME];
+	const evidence = evidenceSlug ? evidenceDir(evidenceSlug) : undefined;
+	let result;
+	let fallbackLog = "";
+	let assistantMessages = [];
+	try {
+		writeMockModelsJson(box.agentDir, server, API_NAME, {}, {
+			models: [{ id: FALLBACK_MODEL_ID }],
+			retry: {
+				enabled: true,
+				maxRetries: 3,
+				baseDelayMs: 0,
+				provider: { maxRetries: 0, maxRetryDelayMs: 60000 },
+				fallbackChains: {
+					[`${preset.provider}/${preset.modelId}`]: [`${preset.provider}/${FALLBACK_MODEL_ID}`],
+				},
+			},
+		});
+		result = await runCli(
+			[
+				"--provider",
+				preset.provider,
+				"--model",
+				preset.modelId,
+				"--print",
+				"--no-extensions",
+				"Trigger the scripted Anthropic policy refusal and return the fallback marker.",
+			],
+			{ env: hermeticEnv(box.env), cwd: box.cwd, timeoutMs: 60000 },
+		);
+		assistantMessages = readAssistantMessages(box.sessionDir);
+		const fallbackLogPath = join(box.agentDir, "logs", "fallback.log");
+		if (existsSync(fallbackLogPath)) fallbackLog = readFileSync(fallbackLogPath, "utf8");
+		const modelSequence = server.requests.map((request) => request.model);
+		const applied = fallbackLog
+			.split(/\r?\n/)
+			.filter(Boolean)
+			.map((line) => JSON.parse(line))
+			.find((entry) => entry.event === "fallback_applied");
+		const markerReturned = `${result.stdout}${result.stderr}`.includes(FINAL_MARKER);
+		const pass =
+			result.code === 0 &&
+			!result.timedOut &&
+			JSON.stringify(modelSequence) === JSON.stringify([preset.modelId, FALLBACK_MODEL_ID]) &&
+			applied?.reason === "refusal" &&
+			markerReturned &&
+			!`${result.stdout}${result.stderr}`.includes(PRIMARY_CONTINUED_MARKER);
+		process.stdout.write(
+			`SENPI_QA_POLICY_REFUSAL_TRANSCRIPT sequence=${modelSequence.join(" -> ") || "none"} reason=${applied?.reason ?? "none"} marker=${markerReturned}\n`,
+		);
+		checks.ok(
+			"Anthropic policy refusal switches immediately to the configured fallback",
+			pass,
+			`code=${result.code} sequence=${modelSequence.join(" -> ") || "none"} reason=${applied?.reason ?? "none"} marker=${markerReturned}`,
+		);
+		checkRealAuthUnchanged(checks, guard);
+		if (evidence) writeEvidence(evidence, result, server.requests, fallbackLog, assistantMessages);
+	} finally {
+		await server.stop();
+		box.cleanup();
+		if (evidence) {
+			writeFileSync(
+				join(evidence, "cleanup.json"),
+				JSON.stringify(
+					{
+						serverListening: server.listening,
+						sandboxExists: existsSync(box.dir),
+						receipt: `server closed; removed ${box.dir}`,
+					},
+					null,
+					2,
+				),
+			);
+		}
+	}
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+function readAssistantMessages(sessionDir) {
+	const messages = [];
+	for (const relativePath of readdirSync(sessionDir, { recursive: true })) {
+		if (typeof relativePath !== "string" || !relativePath.endsWith(".jsonl")) continue;
+		const lines = readFileSync(join(sessionDir, relativePath), "utf8").split(/\r?\n/).filter(Boolean);
+		for (const line of lines) {
+			const event = JSON.parse(line);
+			if (event.type !== "message" || event.message?.role !== "assistant") continue;
+			messages.push({
+				stopReason: event.message.stopReason,
+				errorMessage: event.message.errorMessage,
+				stopDetails: event.message.stopDetails,
+				contentTypes: event.message.content?.map((content) => content.type),
+			});
+		}
+	}
+	return messages;
+}
+
+function writeEvidence(dir, result, requests, fallbackLog, assistantMessages) {
+	writeFileSync(join(dir, "stdout.txt"), result.stdout);
+	writeFileSync(join(dir, "stderr.txt"), result.stderr);
+	writeFileSync(join(dir, "requests.json"), JSON.stringify(requests, null, 2));
+	writeFileSync(join(dir, "assistant-messages.json"), JSON.stringify(assistantMessages, null, 2));
+	writeFileSync(join(dir, "fallback.log"), fallbackLog);
+	writeFileSync(
+		join(dir, "summary.json"),
+		JSON.stringify(
+			{
+				command:
+					"node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario anthropic-policy-refusal-fallback --evidence anthropic-policy-refusal-fallback",
+				exitCode: result.code,
+				timedOut: result.timedOut,
+			},
+			null,
+			2,
+		),
+	);
+	process.stderr.write(`evidence: ${dir}\n`);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
@@ -1,0 +1,108 @@
+import {
+	createChecks,
+	guardRealAuth,
+	installCleanupHooks,
+} from "./common.mjs";
+import {
+	API_PRESETS,
+	checkRealAuthUnchanged,
+} from "./mock-loop-support.mjs";
+
+const STANDARD_RETRY_SCENARIOS = {
+	"transient-recover": {
+		error: { status: 500, message: "overloaded_error" },
+		errorCount: 2,
+		marker: "SENPI-QA-RETRY-TRANSIENT-RECOVER-38cd",
+		primaryAttempts: 3,
+		fallbackAttempts: 0,
+	},
+	"budget-exhaust": {
+		error: { status: 500, message: "overloaded_error" },
+		errorCount: 4,
+		marker: "SENPI-QA-RETRY-BUDGET-EXHAUST-7a16",
+		primaryAttempts: 4,
+		fallbackAttempts: 1,
+	},
+	"long-retry-after": {
+		error: { status: 429, message: "HTTP 429: rate_limit_exceeded - retry after 3600 seconds" },
+		errorCount: 1,
+		marker: "SENPI-QA-RETRY-LONG-RETRY-AFTER-b4e1",
+		primaryAttempts: 1,
+		fallbackAttempts: 1,
+	},
+};
+
+export function retryScenarioNames() {
+	return Object.keys(STANDARD_RETRY_SCENARIOS);
+}
+
+export function isRetryScenario(name) {
+	return retryScenarioNames().includes(name);
+}
+
+export async function checkStandardRetryScenarios(checks, driveTurn) {
+	for (const scenarioName of Object.keys(STANDARD_RETRY_SCENARIOS)) {
+		await checkStandardRetryScenario(checks, scenarioName, "openai-completions", driveTurn);
+	}
+}
+
+export async function runRetryScenario(scenarioName, apiName, driveTurn) {
+	installCleanupHooks();
+	const checks = createChecks(`mock-loop.mjs --scenario ${scenarioName}`);
+	const guard = guardRealAuth();
+	await checkStandardRetryScenario(checks, scenarioName, apiName, driveTurn);
+	checkRealAuthUnchanged(checks, guard);
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+async function checkStandardRetryScenario(checks, scenarioName, apiName, driveTurn) {
+	const scenario = STANDARD_RETRY_SCENARIOS[scenarioName];
+	if (!scenario) throw new Error(`unknown retry scenario ${scenarioName}`);
+	const preset = API_PRESETS[apiName];
+	const fallbackModelId = `${preset.modelId}-fallback`;
+	const expectedModels = [
+		...Array(scenario.primaryAttempts).fill(preset.modelId),
+		...Array(scenario.fallbackAttempts).fill(fallbackModelId),
+	];
+	const { box, server, result } = await driveTurn({
+		apiName,
+		turns: [...Array(scenario.errorCount).fill({ error: scenario.error }), { text: scenario.marker }],
+		prompt: `Return ${scenario.marker} after recovering from the scripted provider error.`,
+		mockModels: [{ id: fallbackModelId }],
+		retry: {
+			enabled: true,
+			maxRetries: 3,
+			baseDelayMs: 0,
+			provider: { maxRetries: 0, maxRetryDelayMs: 60000 },
+			fallbackChains: { [`${preset.provider}/${preset.modelId}`]: [`${preset.provider}/${fallbackModelId}`] },
+		},
+		timeoutMs: 60000,
+	});
+	try {
+		const requests = server.requests.filter((request) => request.url?.includes(preset.path));
+		const modelSequence = requests.map((request) => request.model);
+		const counts = new Map();
+		for (const modelId of modelSequence) counts.set(modelId, (counts.get(modelId) ?? 0) + 1);
+		const transcript = [
+			`scenario=${scenarioName}`,
+			`attempts=${modelSequence.length}`,
+			`sequence=${modelSequence.map((modelId, index) => `${index + 1}:${preset.provider}/${modelId}`).join(",") || "none"}`,
+			`modelAttempts=${[preset.modelId, fallbackModelId].map((modelId) => `${preset.provider}/${modelId}:${counts.get(modelId) ?? 0}`).join(",")}`,
+			`switched=${modelSequence.includes(fallbackModelId) ? "yes" : "no"}`,
+		];
+		process.stdout.write(`SENPI_QA_RETRY_TRANSCRIPT ${transcript.join(" ")}\n`);
+		const markerReturned = `${result.stdout}${result.stderr}`.includes(scenario.marker);
+		const attemptsMatch = JSON.stringify(modelSequence) === JSON.stringify(expectedModels);
+		const pass = result.code === 0 && !result.timedOut && markerReturned && attemptsMatch;
+		checks.ok(
+			`${scenarioName}: scripted provider errors follow the expected retry/fallback path`,
+			pass,
+			`code=${result.code} marker=${markerReturned} expected=${expectedModels.join(" -> ")} actual=${modelSequence.join(" -> ") || "none"}`,
+		);
+		if (!pass) process.stderr.write(`\n--- ${scenarioName} stderr tail ---\n${result.stderr.slice(-1500)}\n`);
+		return pass;
+	} finally {
+		await server.stop();
+		box.cleanup();
+	}
+}

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
@@ -7,6 +7,7 @@ import {
 	API_PRESETS,
 	checkRealAuthUnchanged,
 } from "./mock-loop-support.mjs";
+import { runAnthropicPolicyRefusalScenario } from "./mock-loop-policy-refusal.mjs";
 
 const STANDARD_RETRY_SCENARIOS = {
 	"transient-recover": {
@@ -32,8 +33,10 @@ const STANDARD_RETRY_SCENARIOS = {
 	},
 };
 
+const POLICY_REFUSAL_SCENARIO = "anthropic-policy-refusal-fallback";
+
 export function retryScenarioNames() {
-	return Object.keys(STANDARD_RETRY_SCENARIOS);
+	return [...Object.keys(STANDARD_RETRY_SCENARIOS), POLICY_REFUSAL_SCENARIO];
 }
 
 export function isRetryScenario(name) {
@@ -46,7 +49,14 @@ export async function checkStandardRetryScenarios(checks, driveTurn) {
 	}
 }
 
-export async function runRetryScenario(scenarioName, apiName, driveTurn) {
+export async function runRetryScenario(scenarioName, apiName, driveTurn, evidenceSlug) {
+	if (scenarioName === POLICY_REFUSAL_SCENARIO) {
+		if (apiName !== "anthropic-messages") {
+			throw new Error(`${POLICY_REFUSAL_SCENARIO} requires --api anthropic-messages`);
+		}
+		await runAnthropicPolicyRefusalScenario(evidenceSlug);
+		return;
+	}
 	installCleanupHooks();
 	const checks = createChecks(`mock-loop.mjs --scenario ${scenarioName}`);
 	const guard = guardRealAuth();

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -58,6 +58,7 @@ import {
 	writeToolEvidence,
 } from "./lib/mock-loop-support.mjs";
 import { dispatchExitCode, flagValue, parseToolArgs, positionalAfter } from "./lib/mock-loop-cli.mjs";
+import { checkStandardRetryScenarios, isRetryScenario, retryScenarioNames, runRetryScenario } from "./lib/mock-loop-retry.mjs";
 import {
 	appendTextToolLeakChecks,
 	dispatchTextToolLeakCommand,
@@ -154,91 +155,6 @@ async function checkApi(checks, apiName) {
 	return pass;
 }
 
-const RETRY_SCENARIOS = {
-	"transient-recover": {
-		error: { status: 500, message: "overloaded_error" },
-		errorCount: 2,
-		marker: "SENPI-QA-RETRY-TRANSIENT-RECOVER-38cd",
-		primaryAttempts: 3,
-		fallbackAttempts: 0,
-	},
-	"budget-exhaust": {
-		error: { status: 500, message: "overloaded_error" },
-		errorCount: 4,
-		marker: "SENPI-QA-RETRY-BUDGET-EXHAUST-7a16",
-		primaryAttempts: 4,
-		fallbackAttempts: 1,
-	},
-	"long-retry-after": {
-		error: { status: 429, message: "HTTP 429: rate_limit_exceeded - retry after 3600 seconds" },
-		errorCount: 1,
-		marker: "SENPI-QA-RETRY-LONG-RETRY-AFTER-b4e1",
-		primaryAttempts: 1,
-		fallbackAttempts: 1,
-	},
-};
-
-async function checkRetryScenario(checks, scenarioName, apiName = "openai-completions") {
-	const scenario = RETRY_SCENARIOS[scenarioName];
-	if (!scenario) throw new Error(`unknown retry scenario ${scenarioName}`);
-	const preset = API_PRESETS[apiName];
-	const fallbackModelId = `${preset.modelId}-fallback`;
-	const expectedModels = [
-		...Array(scenario.primaryAttempts).fill(preset.modelId),
-		...Array(scenario.fallbackAttempts).fill(fallbackModelId),
-	];
-	const { box, server, result } = await driveTurn({
-		apiName,
-		turns: [...Array(scenario.errorCount).fill({ error: scenario.error }), { text: scenario.marker }],
-		prompt: `Return ${scenario.marker} after recovering from the scripted provider error.`,
-		mockModels: [{ id: fallbackModelId }],
-		retry: {
-			enabled: true,
-			maxRetries: 3,
-			baseDelayMs: 0,
-			provider: { maxRetries: 0, maxRetryDelayMs: 60000 },
-			fallbackChains: { [`${preset.provider}/${preset.modelId}`]: [`${preset.provider}/${fallbackModelId}`] },
-		},
-		timeoutMs: 60000,
-	});
-	try {
-		const requests = server.requests.filter((request) => request.url?.includes(preset.path));
-		const modelSequence = requests.map((request) => request.model);
-		const counts = new Map();
-		for (const modelId of modelSequence) counts.set(modelId, (counts.get(modelId) ?? 0) + 1);
-		const transcript = [
-			`scenario=${scenarioName}`,
-			`attempts=${modelSequence.length}`,
-			`sequence=${modelSequence.map((modelId, index) => `${index + 1}:${preset.provider}/${modelId}`).join(",") || "none"}`,
-			`modelAttempts=${[preset.modelId, fallbackModelId].map((modelId) => `${preset.provider}/${modelId}:${counts.get(modelId) ?? 0}`).join(",")}`,
-			`switched=${modelSequence.includes(fallbackModelId) ? "yes" : "no"}`,
-		];
-		process.stdout.write(`SENPI_QA_RETRY_TRANSCRIPT ${transcript.join(" ")}\n`);
-		const markerReturned = (result.stdout + result.stderr).includes(scenario.marker);
-		const attemptsMatch = JSON.stringify(modelSequence) === JSON.stringify(expectedModels);
-		const pass = result.code === 0 && !result.timedOut && markerReturned && attemptsMatch;
-		checks.ok(
-			`${scenarioName}: scripted provider errors follow the expected retry/fallback path`,
-			pass,
-			`code=${result.code} marker=${markerReturned} expected=${expectedModels.join(" -> ")} actual=${modelSequence.join(" -> ") || "none"}`,
-		);
-		if (!pass) process.stderr.write(`\n--- ${scenarioName} stderr tail ---\n${result.stderr.slice(-1500)}\n`);
-		return pass;
-	} finally {
-		await server.stop();
-		box.cleanup();
-	}
-}
-
-async function runRetryScenario(scenarioName, apiName) {
-	installCleanupHooks();
-	const checks = createChecks(`mock-loop.mjs --scenario ${scenarioName}`);
-	const guard = guardRealAuth();
-	await checkRetryScenario(checks, scenarioName, apiName);
-	checkRealAuthUnchanged(checks, guard);
-	process.exit(checks.finish() ? 0 : 1);
-}
-
 async function selfTest(onlyApi) {
 	installCleanupHooks();
 	const checks = createChecks("mock-loop.mjs --self-test");
@@ -252,7 +168,7 @@ async function selfTest(onlyApi) {
 		}
 	}
 	if (!onlyApi) {
-		for (const scenarioName of Object.keys(RETRY_SCENARIOS)) await checkRetryScenario(checks, scenarioName);
+		await checkStandardRetryScenarios(checks, driveTurn);
 	}
 	checks.ok("zero real provider calls (only localhost fake hit)", true, "all baseUrls point at 127.0.0.1");
 	checkRealAuthUnchanged(checks, guard);
@@ -580,8 +496,8 @@ if (api && !API_PRESETS[api]) {
 }
 
 const scenario = flagValue(argv, "--scenario");
-if (scenario !== undefined && !RETRY_SCENARIOS[scenario]) {
-	process.stderr.write(`unknown --scenario ${scenario}. valid: ${Object.keys(RETRY_SCENARIOS).join(", ")}\n`);
+if (scenario !== undefined && !isRetryScenario(scenario)) {
+	process.stderr.write(`unknown --scenario ${scenario}. valid: ${retryScenarioNames().join(", ")}\n`);
 	process.exit(2);
 }
 
@@ -596,7 +512,7 @@ if (argv[0] === "--self-test") {
 		process.exit(1);
 	});
 } else if (scenario) {
-	runRetryScenario(scenario, api || "openai-completions").catch((e) => {
+	runRetryScenario(scenario, api || "openai-completions", driveTurn).catch((e) => {
 		process.stderr.write(`${e instanceof Error ? e.stack : String(e)}\n`);
 		process.exit(1);
 	});

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -25,7 +25,7 @@
  *   (the flag is --serve-env, NOT --env-file: Node treats --env-file as a native
  *    startup flag and would try to load the path as a dotenv file before the script runs)
  *   node mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}'
- *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|long-retry-after
+ *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|long-retry-after|anthropic-policy-refusal-fallback
  *   node mock-loop.mjs --run "prompt" [--api ...] [--evidence SLUG]
  */
 
@@ -512,7 +512,7 @@ if (argv[0] === "--self-test") {
 		process.exit(1);
 	});
 } else if (scenario) {
-	runRetryScenario(scenario, api || "openai-completions", driveTurn).catch((e) => {
+	runRetryScenario(scenario, api || (scenario === "anthropic-policy-refusal-fallback" ? "anthropic-messages" : "openai-completions"), driveTurn, flagValue(argv, "--evidence")).catch((e) => {
 		process.stderr.write(`${e instanceof Error ? e.stack : String(e)}\n`);
 		process.exit(1);
 	});
@@ -594,7 +594,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
-			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|long-retry-after> [--api <name>]",
+			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|long-retry-after|anthropic-policy-refusal-fallback> [--api <name>]",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,
 			"",

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -11,6 +11,11 @@ import {
 	type ToolResultMessage,
 	validateToolArguments,
 } from "@earendil-works/pi-ai";
+import {
+	createTerminalFailureAssistantMessage,
+	normalizeTerminalAssistantMessage,
+	shouldTerminateAssistantTurn,
+} from "./assistant-terminal-state.ts";
 import { getDefaultStreamFn } from "./stream-fn.ts";
 import type {
 	AgentContext,
@@ -151,15 +156,6 @@ function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
 	);
 }
 
-const EMPTY_USAGE = {
-	input: 0,
-	output: 0,
-	cacheRead: 0,
-	cacheWrite: 0,
-	totalTokens: 0,
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-} satisfies AssistantMessage["usage"];
-
 class StreamIdleTimeoutError extends Error {
 	constructor(timeoutMs: number) {
 		super(`Idle timeout waiting for provider stream after ${timeoutMs}ms`);
@@ -230,7 +226,7 @@ async function runLoop(
 			const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
 			newMessages.push(message);
 
-			if (message.stopReason === "error" || message.stopReason === "aborted") {
+			if (shouldTerminateAssistantTurn(message)) {
 				await emit({ type: "turn_end", message, toolResults: [] });
 				await emit({ type: "agent_end", messages: newMessages });
 				return;
@@ -692,49 +688,6 @@ type ExecutedToolCallBatch = {
 	messages: ToolResultMessage[];
 	terminate: boolean;
 };
-
-type TerminalAssistantMessageEvent = Extract<AssistantMessageEvent, { type: "done" | "error" }>;
-
-function createTerminalFailureAssistantMessage(
-	model: AgentLoopConfig["model"],
-	reason: Extract<AssistantMessage["stopReason"], "aborted" | "error">,
-	error: unknown,
-	partialMessage: AssistantMessage | null,
-): AssistantMessage {
-	const errorMessage = error instanceof Error ? error.message : String(error);
-	return {
-		role: "assistant",
-		content: partialMessage?.content ?? [{ type: "text", text: "" }],
-		api: partialMessage?.api ?? model.api,
-		provider: partialMessage?.provider ?? model.provider,
-		model: partialMessage?.model ?? model.id,
-		responseModel: partialMessage?.responseModel,
-		responseId: partialMessage?.responseId,
-		diagnostics: partialMessage?.diagnostics,
-		usage: partialMessage?.usage ?? EMPTY_USAGE,
-		stopReason: reason,
-		errorMessage: errorMessage || (reason === "aborted" ? "Request was aborted" : "Error"),
-		timestamp: partialMessage?.timestamp ?? Date.now(),
-	};
-}
-
-function normalizeTerminalAssistantMessage(
-	message: AssistantMessage,
-	event: TerminalAssistantMessageEvent,
-): AssistantMessage {
-	if (event.type === "done") {
-		return message;
-	}
-	const errorMessage = message.errorMessage ?? (event.reason === "aborted" ? "Request was aborted" : "Error");
-	if (message.stopReason === event.reason && message.errorMessage === errorMessage) {
-		return message;
-	}
-	return {
-		...message,
-		stopReason: event.reason,
-		errorMessage,
-	};
-}
 
 async function executeToolCallsSequential(
 	currentContext: AgentContext,

--- a/packages/agent/src/assistant-terminal-state.ts
+++ b/packages/agent/src/assistant-terminal-state.ts
@@ -1,0 +1,50 @@
+import { type AssistantMessage, type AssistantMessageEvent, isClassifierRefusal } from "@earendil-works/pi-ai";
+import type { AgentLoopConfig } from "./types.ts";
+
+const EMPTY_USAGE = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} satisfies AssistantMessage["usage"];
+
+type TerminalAssistantMessageEvent = Extract<AssistantMessageEvent, { type: "done" | "error" }>;
+
+export function shouldTerminateAssistantTurn(message: AssistantMessage): boolean {
+	return message.stopReason === "error" || message.stopReason === "aborted" || isClassifierRefusal(message);
+}
+
+export function createTerminalFailureAssistantMessage(
+	model: AgentLoopConfig["model"],
+	reason: Extract<AssistantMessage["stopReason"], "aborted" | "error">,
+	error: unknown,
+	partialMessage: AssistantMessage | null,
+): AssistantMessage {
+	const errorMessage = error instanceof Error ? error.message : String(error);
+	return {
+		role: "assistant",
+		content: partialMessage?.content ?? [{ type: "text", text: "" }],
+		api: partialMessage?.api ?? model.api,
+		provider: partialMessage?.provider ?? model.provider,
+		model: partialMessage?.model ?? model.id,
+		responseModel: partialMessage?.responseModel,
+		responseId: partialMessage?.responseId,
+		diagnostics: partialMessage?.diagnostics,
+		usage: partialMessage?.usage ?? EMPTY_USAGE,
+		stopReason: reason,
+		errorMessage: errorMessage || (reason === "aborted" ? "Request was aborted" : "Error"),
+		timestamp: partialMessage?.timestamp ?? Date.now(),
+	};
+}
+
+export function normalizeTerminalAssistantMessage(
+	message: AssistantMessage,
+	event: TerminalAssistantMessageEvent,
+): AssistantMessage {
+	if (event.type === "done") return message;
+	const errorMessage = message.errorMessage ?? (event.reason === "aborted" ? "Request was aborted" : "Error");
+	if (message.stopReason === event.reason && message.errorMessage === errorMessage) return message;
+	return { ...message, stopReason: event.reason, errorMessage };
+}

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2026-07-27 - End classifier-refused turns before tool execution
+
+### What changed and why
+
+- `assistant-terminal-state.ts` owns terminal assistant classification, including typed classifier refusals;
+  `agent-loop.ts` now consults it before any partial tool calls are executed. Anthropic can emit a tool call and
+  then finish the same stream with a refusal/sensitive stop; treating the message as ordinary `toolUse` previously
+  ran the refused call and continued on the same model.
+- The terminal `agent_end` lets the coding-agent retry/fallback controller immediately apply its configured pinned
+  refusal fallback.
+
 ## 2026-07-23 - Session-owned post-agent_end queue drain suppression
 
 ### What changed and why

--- a/packages/agent/test/classifier-refusal-tool-loop.test.ts
+++ b/packages/agent/test/classifier-refusal-tool-loop.test.ts
@@ -1,0 +1,48 @@
+import { fauxAssistantMessage, fauxToolCall, registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Agent } from "../src/index.ts";
+import { calculateTool } from "./utils/calculate.ts";
+
+const registrations: Array<ReturnType<typeof registerFauxProvider>> = [];
+const anthropicPolicyRefusal =
+	"This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy. To learn more, see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback.";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const registration of registrations.splice(0)) registration.unregister();
+});
+
+describe("classifier refusal tool-loop termination", () => {
+	it("ends the agent turn without executing a refused tool call", async () => {
+		const registration = registerFauxProvider();
+		registrations.push(registration);
+		registration.setResponses([
+			fauxAssistantMessage([fauxToolCall("calculate", { expression: "123 * 456" }, { id: "refused-tool" })], {
+				stopReason: "toolUse",
+				errorMessage: anthropicPolicyRefusal,
+				stopDetails: { type: "refusal", explanation: anthropicPolicyRefusal },
+			}),
+			fauxAssistantMessage("The primary model continued after the refusal."),
+		]);
+		const execute = vi.spyOn(calculateTool, "execute");
+		const agent = new Agent({
+			streamFn: streamSimple,
+			initialState: {
+				systemPrompt: "Use the calculator when requested.",
+				model: registration.getModel(),
+				thinkingLevel: "off",
+				tools: [calculateTool],
+			},
+		});
+
+		await agent.prompt("Calculate 123 * 456.");
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(agent.state.messages).toHaveLength(2);
+		expect(agent.state.messages[1]).toMatchObject({
+			role: "assistant",
+			stopReason: "toolUse",
+			stopDetails: { type: "refusal" },
+		});
+	});
+});

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,17 @@
 # AI Source Changes
 
+## 2026-07-27 - Treat Anthropic policy blocks as classifier refusals
+
+### What changed and why
+
+- `utils/stop-details.ts`: `isClassifierRefusal()` now accepts typed refusal/sensitive details on mixed
+  `toolUse` stops, matching Anthropic streams that finish with a policy block after emitting a tool call.
+- The same helper recognizes Anthropic's legacy policy-block error text when a gateway omits typed
+  `stopDetails`, while requiring the provider's full restrictions-and-Usage-Policy signature so ordinary
+  policy documentation errors remain non-refusals.
+- This routes both shapes through the existing immediate pinned model-fallback path instead of executing the
+  partial tool call or continuing on the refusing model.
+
 ## 2026-07-26 - Cross-model replay hardening (foreign signatures, id collisions, thinking turn shape)
 
 ### What changed and why

--- a/packages/ai/src/utils/stop-details.ts
+++ b/packages/ai/src/utils/stop-details.ts
@@ -1,9 +1,11 @@
 import type { AssistantMessage } from "../types.ts";
 
-/** Returns true when an assistant error was classified as a refusal or sensitive stop. */
+const ANTHROPIC_POLICY_REFUSAL_PATTERN =
+	/This request triggered restrictions on [\s\S]+? and was blocked under Anthropic's Usage Policy\b/i;
+
+/** Returns true when an assistant response represents a refusal or sensitive stop. */
 export function isClassifierRefusal(message: AssistantMessage): boolean {
-	return (
-		message.stopReason === "error" &&
-		(message.stopDetails?.type === "refusal" || message.stopDetails?.type === "sensitive")
-	);
+	if (message.stopReason !== "error" && message.stopReason !== "toolUse") return false;
+	if (message.stopDetails?.type === "refusal" || message.stopDetails?.type === "sensitive") return true;
+	return message.errorMessage ? ANTHROPIC_POLICY_REFUSAL_PATTERN.test(message.errorMessage) : false;
 }

--- a/packages/ai/test/stop-details.test.ts
+++ b/packages/ai/test/stop-details.test.ts
@@ -51,6 +51,8 @@ async function collectEvents(streamResult: ReturnType<typeof stream>): Promise<A
 }
 
 const context: Context = { messages: [{ role: "user", content: "blocked", timestamp: 1 }] };
+const anthropicPolicyRefusal =
+	"This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy. To learn more, see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback.";
 
 describe("classifier stop details", () => {
 	it("maps Anthropic refusal and sensitive stops to typed error details", async () => {
@@ -89,16 +91,41 @@ describe("classifier stop details", () => {
 		expect(isClassifierRefusal(lengthLimited)).toBe(false);
 	});
 
-	it("recognizes only typed classifier errors", () => {
+	it("recognizes typed classifier details on error and tool-use stops", () => {
 		const classifierRefusal = fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "refusal" } });
 		const classifierSensitive = fauxAssistantMessage("", { stopReason: "error", stopDetails: { type: "sensitive" } });
+		const toolUseRefusal = fauxAssistantMessage("", {
+			stopReason: "toolUse",
+			errorMessage: anthropicPolicyRefusal,
+			stopDetails: { type: "refusal", explanation: anthropicPolicyRefusal },
+		});
 		const nonError = fauxAssistantMessage("", { stopDetails: { type: "refusal" } });
 		const absent = { ...classifierRefusal, stopDetails: undefined };
 
 		expect(isClassifierRefusal(classifierRefusal)).toBe(true);
 		expect(isClassifierRefusal(classifierSensitive)).toBe(true);
+		expect(isClassifierRefusal(toolUseRefusal)).toBe(true);
 		expect(isClassifierRefusal(nonError)).toBe(false);
 		expect(isClassifierRefusal(absent)).toBe(false);
+	});
+
+	it("recognizes the legacy Anthropic policy block when typed details are absent", () => {
+		const refusal = fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage: `${anthropicPolicyRefusal} API integrators: you can reduce refusals for your users by configuring a fallback model.`,
+		});
+
+		expect(isClassifierRefusal(refusal)).toBe(true);
+	});
+
+	it("does not infer refusal from ordinary Anthropic policy documentation errors", () => {
+		const ordinaryPolicyError = fauxAssistantMessage("", {
+			stopReason: "error",
+			errorMessage:
+				"Provider configuration failed. Review Anthropic's Usage Policy at https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback.",
+		});
+
+		expect(isClassifierRefusal(ordinaryPolicyError)).toBe(false);
 	});
 
 	it("passes classifier details through faux error stream events and excludes them from retry", async () => {


### PR DESCRIPTION
## Summary

Senpi now treats Anthropic Usage Policy blocks as classifier refusals even when the stream already emitted a tool call, and it recognizes the legacy provider error text when typed stop details are absent. This prevents refused partial tool calls from executing and lets the existing retry/fallback controller switch immediately to the configured pinned fallback model.

## Changes

- Recognize typed refusal/sensitive details on mixed `toolUse` terminal messages and narrowly match Anthropic's provider-generated policy-block error text.
- End classifier-refused agent turns before executing partial tool calls, then emit `agent_end` so the existing fallback controller can apply its refusal path.
- Add a focused agent-loop regression proving the refused tool is never executed.
- Extract the mock-loop retry scenarios from the oversized QA orchestrator and add a hermetic Anthropic SSE scenario that reproduces the observed error shape through the real Senpi CLI.

## QA & Evidence

- **Classifier RED -> GREEN**
  - Command: `npm --prefix packages/ai test -- stop-details.test.ts`
  - RED: mixed `toolUse` refusal and legacy policy error both classified false.
  - GREEN: 6/6 passed, including the ordinary policy-documentation non-refusal boundary.
  - Local artifact: `local-ignore/qa-evidence/20260726-anthropic-policy-refusal/{c1-red,c1-green}.txt`

- **Agent tool-loop RED -> GREEN**
  - Command: `npm --prefix packages/agent test -- classifier-refusal-tool-loop.test.ts`
  - RED: refused calculator tool executed once.
  - GREEN: 1/1 passed; execution count is zero.
  - Local artifact: `local-ignore/qa-evidence/20260726-anthropic-policy-refusal/c2-agent-red.txt`

- **Real CLI fallback RED -> GREEN**
  - Command: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario anthropic-policy-refusal-fallback --evidence anthropic-policy-refusal-fallback`
  - RED: `mock-claude -> mock-claude`, `reason=none`, `marker=false`.
  - GREEN: `mock-claude -> mock-claude-fallback`, `reason=refusal`, `marker=true`.
  - Cleanup: fake server closed, sandbox removed, real auth unchanged.
  - Local artifact: `local-ignore/qa-evidence/20260727-anthropic-policy-refusal-fallback/`

- **Broader verification**
  - `npm run check`: passed.
  - `npm run build`: passed.
  - Agent package: 291 passed, 1 pre-existing skip.
  - AI package: 1410 passed, 803 pre-existing skips.
  - Coding-agent fallback scope: 28/28 passed.
  - Mock-loop self-test: 41/41 passed.
  - CLI smoke (`--help`, version, model listing, bad input): 8/8 passed.

## Risks & Residuals

- The compatibility matcher requires both Anthropic's `triggered restrictions on ...` wording and `blocked under Anthropic's Usage Policy`, so generic policy/help errors do not become refusals.
- The full local `npm test` run still has four unrelated coding-agent environment/flaky failures: MCP catalog cache invalidation, app-server daemon timeout, local Codex protocol-pin SHA mismatch, and app-server stdio timeout. The affected AI, agent, fallback-controller, build, static, and real CLI scopes are green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Anthropic Usage Policy blocks as classifier refusals, end the agent turn before any tool runs, and immediately fall back to the pinned model. Prevents executing partial tool calls that arrive before a refusal and stops continuing on the refusing model.

- **Bug Fixes**
  - `packages/ai`: `isClassifierRefusal()` now accepts typed `refusal`/`sensitive` on `toolUse` stops and matches Anthropic’s legacy policy-block error text when `stopDetails` are missing.
  - `packages/agent`: added terminal-state guard to end turns on classifier refusals; emits `agent_end` so the retry/fallback controller switches to the configured fallback model.
  - Tests: added a focused tool-loop regression to ensure refused tools never execute; extended stop-details tests.

- **Refactors**
  - Extracted terminal assistant-state helpers to `assistant-terminal-state.ts` and simplified `agent-loop.ts`.
  - QA: pulled mock retry scenarios into `lib/mock-loop-retry.mjs` and added a hermetic Anthropic SSE policy-refusal scenario to the mock loop.

<sup>Written for commit b70af4fbf0998013783e2b4efcac359a3f7a8097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

