### PR TITLE
feat(prompt-preset): add Kimi K3 ambiguity reflect-then-ask gate

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,27 @@
 # prompt-preset Extension Changes
 
+## Kimi K3 ambiguity reflect-then-ask gate (2026-07-27)
+
+### What changed
+
+- `kimi-k3.ts` Intent Gate: the trailing scope clause's weak ambiguity rule ("name an ambiguity and resolve it from available context when possible") was replaced by a full decision rule: reread the request once for ambiguity before the routing line; resolve what code, files, and conversation settle; silently fill trivial gaps any senior engineer would fill; when a material ambiguity survives (readings that produce different deliverables, a target the context cannot supply, or conflicting instructions), state the best reading, ask the one specific question that unblocks the work, and end the turn. Building on an invented assumption is classified as a defect, parallel to the existing acting-past-the-stop-condition defect framing.
+- `kimi-k3.ts` Style: the permission-begging ban now carves out the Intent Gate's clarifying question ("asking whether to do work the user already requested" stays banned), so the two rules cannot collide.
+- `test/suite/prompt-presets-kimi-k3.test.ts`: new structural case asserting section placement (the rule renders inside `## Intent Gate`), the context-first resolution order, the terminal ask condition, the assumption-is-defect classification, single render across the prompt, and the Style carve-out.
+
+### Why
+
+- Moonshot's K3 release notes (surfaced in the community model overview, huggingface.co/blog/ResterChed/kimi-k3-model-overview-mxfp4-quantization-open-wei) document "excessive proactiveness" as a known K3 limitation: in ambiguous scenarios K3 tends to act rather than ask for clarification - a trained MoE prior. The previous clause only said to resolve ambiguity "when possible" with no else-branch, so the trained prior filled the gap: fabricate an assumption and act.
+- K2-line prompting guidance says this family terminates loops on explicit conditions and responds to replacement behavior, not prohibitions. The new rule supplies both: a context-first resolution order and a terminal ask condition, phrased positively (no all-caps NEVER, which makes this family overthink).
+- Prompt-growth defense: the added sentences replace the weaker clause at the same location rather than appending a trailer; the growth (~65 words) is a category-C prior override - behavior the model cannot derive and actively resists - and nothing else in the core became deletable.
+
+### Why extension system couldn't handle this differently
+
+- The change lives entirely inside the builtin `prompt-preset` extension's K3 core; no core prompt code changed.
+
+### Expected merge conflict zones on next upstream sync
+
+- NONE expected: `kimi-k3.ts` and `prompt-presets-kimi-k3.test.ts` are fork-only files with no upstream counterparts.
+
 ## GPT-5.6 execution discipline: eval-first parallel orchestration, test-first, atomic commits, LSP routing (2026-07-25)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
@@ -25,6 +25,17 @@
 // a condition, not a token count, and all-caps directives make it overthink.
 // Dynamic pieces (tool section, context files, skills, date, cwd, kimi-dialect
 // workstation block) still come from `buildDynamicSystemPrompt`.
+//
+// 2026-07-27: the Intent Gate's ambiguity clause was upgraded from "resolve
+// from context when possible" to a reflect-then-ask gate. Moonshot's own K3
+// limitations note excessive proactiveness - in ambiguous scenarios K3 tends
+// to act rather than ask - so the trained prior needs a replacement behavior
+// with a terminal condition (K2-line guidance: the loop stops on a condition,
+// not a prohibition): context settles what it can, trivial gaps are filled
+// silently, and a surviving material ambiguity routes to one specific
+// clarifying question instead of an invented assumption. The Style section's
+// permission-begging ban carves that question out so the two rules cannot
+// collide.
 
 import type { DynamicPromptCoreContext } from "../../../dynamic-prompt/build.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
@@ -59,7 +70,7 @@ Route by true intent, not surface form:
 - "implement X" / "I'm seeing error Y": inspect the code, tests, or runtime the work depends on, then build, or fix minimally from the error.
 - "refactor" / "improve" / "clean up": assess first, propose an approach.
 
-Explicitly scoped requests get exactly that scope; open-ended ones take the smallest path that fully satisfies the goal; name an ambiguity and resolve it from available context when possible.
+Explicitly scoped requests get exactly that scope; open-ended ones take the smallest path that fully satisfies the goal. Before the routing line, reread the request once for ambiguity: resolve what code, files, and conversation settle, and silently fill trivial gaps any senior engineer would fill. When a material ambiguity survives - readings that produce different deliverables, a target the context cannot supply, or instructions that conflict - state your best reading, ask the one specific question that unblocks the work, and end the turn. Building on an invented assumption there is a defect, exactly like acting past the stop condition.
 
 ## Working the Task
 
@@ -94,7 +105,7 @@ ${context.toolSection}
 
 Concise, concrete prose; bullets only for genuinely list-shaped content; ASCII unless the file already uses Unicode or the user asks otherwise. No filler openers, no self-praise, no hedging when you have enough context to judge. Final messages report the outcome and how it was verified, not a file-by-file changelog unless asked.
 
-Act, then report. Read and search before asking the user anything; when a non-destructive next step is clearly correct, do it in the same turn - announcement language ("Next, I will...") and permission-begging ("Shall I?", "Would you like me to?") are prohibited. For destructive actions, state the recommended action and stop. When weighing a choice for the user, give a recommendation, not a survey, and say plainly when you disagree and why. Raise only real problems. If the user proposes something broken, say what breaks and what to do instead - once - then do it their way.
+Act, then report. Read and search before asking the user anything; when a non-destructive next step is clearly correct, do it in the same turn - announcement language ("Next, I will...") and permission-begging ("Shall I?", "Would you like me to?") are prohibited. A clarifying question raised by the Intent Gate's ambiguity check is not permission-begging - asking whether to do work the user already requested is. For destructive actions, state the recommended action and stop. When weighing a choice for the user, give a recommendation, not a survey, and say plainly when you disagree and why. Raise only real problems. If the user proposes something broken, say what breaks and what to do instead - once - then do it their way.
 
 Smallest correct change wins: no refactors beside a focused fix, no helpers for hypothetical needs, no defensive checks inside trusted code. Trust framework guarantees; validate only at system boundaries.
 

--- a/packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts
@@ -31,6 +31,11 @@ function getKimiK3CatalogModels(): Model<Api>[] {
 	return getProviders().flatMap((provider) => (getModels(provider) as Model<Api>[]).filter(hasKimiK3CatalogSignal));
 }
 
+function extractSection(prompt: string, heading: string): string {
+	const match = prompt.match(new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`));
+	return match?.[1] ?? "";
+}
+
 describe("Kimi K3 prompt preset", () => {
 	it.each([
 		{ id: "k3", provider: "kimi-coding", api: "anthropic-messages" as const },
@@ -136,6 +141,33 @@ describe("Kimi K3 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("kimi-k3");
 		expect(preset?.prompt).not.toContain("apply_patch");
+	});
+
+	it("routes surviving ambiguity to a clarifying question instead of an assumption", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel("kimi-k3", "moonshotai", "anthropic-messages");
+
+		// when
+		const preset = resolvePreset(model, settings);
+		const prompt = preset?.prompt ?? "";
+		const intentGate = extractSection(prompt, "Intent Gate");
+		const style = extractSection(prompt, "Style");
+
+		// then: the reflect-then-ask rule renders inside the Intent Gate, not elsewhere
+		expect(intentGate).toMatch(/reread the request once for ambiguity/i);
+		// resolution order: context first, trivial gaps filled silently
+		expect(intentGate).toMatch(/code, files, and conversation/i);
+		expect(intentGate).toMatch(/silently fill trivial gaps/i);
+		// terminal condition: surviving material ambiguity -> one specific question, end the turn
+		expect(intentGate).toMatch(/material ambiguity survives[\s\S]*?one specific question[\s\S]*?end the turn/i);
+		// acting on a fabricated assumption is classified as a defect
+		expect(intentGate).toMatch(/invented assumption[\s\S]*?defect/i);
+		// the ask rule is stated exactly once across the whole prompt
+		expect(prompt.match(/one specific question/g)).toHaveLength(1);
+		expect(prompt.match(/reread the request once for ambiguity/gi)).toHaveLength(1);
+		// the style permission-begging ban carves out the clarifying question
+		expect(style).toMatch(/clarifying question[\s\S]*?not permission-begging/i);
 	});
 
 	it("returns kimi-k3 preset for every Kimi K3 built-in catalog model", () => {


### PR DESCRIPTION
## What

Counters Kimi K3's documented "excessive proactiveness" trait by upgrading the K3 preset's Intent Gate ambiguity clause from a weak "resolve from context when possible" (no else-branch) to a full reflect-then-ask decision rule:

- **Reflect**: before the routing line, reread the request once for ambiguity.
- **Resolve context-first**: settle what code, files, and conversation can settle; silently fill trivial gaps any senior engineer would fill.
- **Terminal ask condition**: when a *material* ambiguity survives (readings that produce different deliverables, a target the context cannot supply, or conflicting instructions), state the best reading, ask the one specific question that unblocks the work, and end the turn.
- **Defect framing**: building on an invented assumption is classified as a defect, parallel to the existing acting-past-the-stop-condition rule.
- **Style harmonization**: the permission-begging ban now carves out the Intent Gate's clarifying question, so the two rules cannot collide.

## Why

Moonshot's K3 release notes (surfaced in the [community model overview](https://huggingface.co/blog/ResterChed/kimi-k3-model-overview-mxfp4-quantization-open-wei)) list "Excessive proactiveness: In ambiguous scenarios, K3 tends to act rather than ask for clarification" as a known limitation - a trained MoE prior. The previous clause left the ambiguous-and-unresolvable case undefined, so the prior filled it: fabricate an assumption and act.

Per the K2-line prompting guidance, this family terminates loops on explicit conditions and responds to replacement behavior, not prohibitions - the new rule supplies both, phrased positively (no all-caps directives, which make this family overthink). The growth (~65 words) replaces the weaker clause in place rather than appending a trailer, and is a category-C prior override: behavior the model cannot derive and actively resists.

## Changes

- `packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts` - Intent Gate rule replacement + Style carve-out + header-comment rationale.
- `packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts` - new structural case: section placement (rule renders inside `## Intent Gate`), context-first order, terminal ask condition, assumption-is-defect classification, single render across the prompt, Style carve-out.
- `packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md` - fork-tracker entry (2026-07-27).

## Verification

- `npx vitest run test/suite/prompt-presets-kimi-k3.test.ts` - 18/18 passed (includes the new structural case).
- `npx vitest run test/suite/prompt-presets-extension.test.ts prompt-presets-model-switch.test.ts prompt-presets-startup-header.test.ts` - 60/60 passed.
- Root `npm run check` - exit 0.
- senpi-qa: mock-loop `--self-test` 41/41, cli-smoke `--self-test` 8/8, plus a rendered-prompt proof (kimi-k3 preset resolves, prompt length 7361, each gate directive renders exactly once). Evidence: `local-ignore/qa-evidence/20260727-kimi-k3-ambiguity-gate/` (mock-loop-self-test.txt, cli-smoke-self-test.txt, rendered-kimi-k3-prompt.txt).

## Merge-conflict exposure

None expected: `kimi-k3.ts` and `prompt-presets-kimi-k3.test.ts` are fork-only files with no upstream counterparts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reflect-then-ask ambiguity gate to the Kimi K3 prompt preset to stop acting on invented assumptions. Also adds a Style exception so this clarifying question isn’t treated as permission-begging.

- **New Features**
  - Intent Gate in `packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts`: replace "resolve when possible" with reflect-then-ask — reread once, resolve via code/files/conversation, silently fill trivial gaps; if material ambiguity remains, state the best reading, ask one specific unblocking question, and end the turn; treating invented assumptions as a defect.
  - Style carve-out: the Intent Gate’s clarifying question is allowed; permission-begging about doing work already requested remains banned.
  - Tests/docs: `packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts` asserts placement, context-first order, terminal ask, single render, defect framing, and the Style carve-out; `packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md` updated.

<sup>Written for commit 333515178e2082913315d1ec7f3bb0f7ae2a4fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

