### PR TITLE
fix(compaction): degrade transient blocking-compaction failures cleanly

### DIFF
--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -47,6 +47,19 @@
 - LOW: `utils/tool-call-id.ts`, the three adapter imports/call sites, and the thinking-config block of
   `api/anthropic-messages.ts` `buildParams()`.
 
+## 2026-07-27 - Export string-based transient-error classifier
+
+### What changed and why
+
+- `utils/retry.ts` now exports `isRetryableErrorMessage(errorMessage: string)` and `isRetryableAssistantError`
+  delegates to it. Callers that hold a thrown `Error` instead of an `AssistantMessage` (the compaction
+  extension's blocking summarization path) need the same transient-vs-terminal classification to decide
+  between degrading gracefully and surfacing loudly. No pattern changes; classification behavior is identical.
+
+### Expected merge conflict zones
+
+- LOW: `utils/retry.ts` around `isRetryableAssistantError`.
+
 ## 2026-07-26 - Retry transient Codex upstream websocket failures
 
 ### What changed and why

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -239,7 +239,17 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
 	) {
 		return false;
 	}
-	const errorMessage = message.errorMessage;
+	return isRetryableErrorMessage(message.errorMessage);
+}
+
+/**
+ * Classifies a raw error-message string with the same transient-vs-terminal
+ * rules as {@link isRetryableAssistantError}, for callers that hold a thrown
+ * `Error` instead of an `AssistantMessage` (e.g. compaction summarization
+ * failures that must decide between degrading and surfacing loudly).
+ */
+export function isRetryableErrorMessage(errorMessage: string): boolean {
+	if (!errorMessage) return false;
 	if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) return false;
 	return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -48,9 +48,18 @@
 - `index.ts` `before_agent_start`: while the breaker cools down, the proactive blocking route and speculative
   warm start are skipped so an offline session does not pay a doomed summarization request on every prompt.
   The hard-limit emergency route still attempts unconditionally.
+- Review hardening: transient failures now return `{ applied: false, reason: "failed" }` (new
+  `SpeculativeCompactionResult` member) so `degradation-monitor.ts` can suppress the recovery notification
+  for a failure that already surfaced its own compaction_end errorMessage; `unavailable` results keep
+  notifying. The `model_select` window-shrink route also skips speculative warm starts while the breaker
+  cools down. Provider `error` stops throw `SummaryRequestError` carrying `isRetryableAssistantError`'s
+  metadata-aware verdict, so a refusal whose text looks retryable still surfaces loudly instead of being
+  string-classified as transient.
 - Tests: `test/compaction/blocking-compaction-network-degrade.test.ts` (transient degrade with a single clean
   errorMessage surface, breaker skip during cooldown, non-transient loud rethrow pin, credential-failure
-  degrade pin).
+  degrade pin) and `test/compaction/blocking-compaction-review-hardening.test.ts` (refusal metadata, breaker
+  gating of model_select warm starts, blocking abort/empty-summary pins, recovery-notification suppression),
+  sharing `test/helpers/blocking-compaction-harness.ts`.
 
 Expected upstream conflict zones: `builtin/compaction/index.ts` around the `applyBlockingCompaction` catch
 block and the `before_agent_start` route selection; LOW on `packages/ai/src/utils/retry.ts` exports.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -32,6 +32,29 @@
 
 # Builtin compaction extension changes
 
+## Degrade transient blocking-compaction failures instead of erroring the turn (2026-07-27)
+
+- `index.ts` `applyBlockingCompaction()`: when the summarization request fails with a transient
+  transport/provider error (classified by `isRetryableErrorMessage` from `@earendil-works/pi-ai`), the catch
+  no longer rethrows. It still ends compaction feedback with `Compaction failed: <message>`, then records a
+  circuit-breaker failure and returns `{ applied: false, reason: "unavailable" }`. Previously a network drop
+  during blocking compaction (`before_agent_start` hard-limit/proactive routes, degradation-monitor recovery)
+  escaped to the ExtensionRunner, which printed `Extension "<builtin:compaction>" error: Connection error.`
+  plus a raw stack on top of the compaction_end message - two surfaces for one outage - while the turn's own
+  provider request was about to report the same outage a third time through the normal retry path. Matches
+  Claude Code (swallow + consecutive-failure breaker), Codex (single structured error event, session stays
+  usable), and oh-my-pi (emit errorMessage, no rethrow). Non-transient failures (policy refusals, real bugs)
+  still rethrow; `SummaryGenerationError` and user-abort paths are unchanged.
+- `index.ts` `before_agent_start`: while the breaker cools down, the proactive blocking route and speculative
+  warm start are skipped so an offline session does not pay a doomed summarization request on every prompt.
+  The hard-limit emergency route still attempts unconditionally.
+- Tests: `test/compaction/blocking-compaction-network-degrade.test.ts` (transient degrade with a single clean
+  errorMessage surface, breaker skip during cooldown, non-transient loud rethrow pin, credential-failure
+  degrade pin).
+
+Expected upstream conflict zones: `builtin/compaction/index.ts` around the `applyBlockingCompaction` catch
+block and the `before_agent_start` route selection; LOW on `packages/ai/src/utils/retry.ts` exports.
+
 ## Reasoning-free summarization + shrink warm start (2026-07-26)
 
 - `speculative.ts` `generateSummaryMessage` now merges `summarizationReasoningOptions(model)` into the stream

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/degradation-monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/degradation-monitor.ts
@@ -119,8 +119,12 @@ export async function handleMessageEnd(
 	state.recoveryAttempts += 1;
 	state.noTextCounter = 0;
 
-	await context.applyCompaction({ customInstructions: RECOVERY_INSTRUCTIONS });
-	context.notify(RECOVERY_NOTIFICATION);
+	const result = await context.applyCompaction({ customInstructions: RECOVERY_INSTRUCTIONS });
+	// A "failed" result already surfaced its own compaction_end errorMessage;
+	// notifying again would stack a second surface on the same failure.
+	if (result.applied || result.reason !== "failed") {
+		context.notify(RECOVERY_NOTIFICATION);
+	}
 }
 
 export function handleTurnEnd(state: DegradationMonitorState): void {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { Tool } from "@earendil-works/pi-ai";
+import { isRetryableErrorMessage, type Tool } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../../compaction/index.ts";
 import { convertToLlm } from "../../../messages.ts";
 import type { CompactionEntry } from "../../../session-manager.ts";
@@ -335,6 +335,16 @@ export default function compactionExtension(
 				aborted: feedbackSignal?.aborted,
 				errorMessage: `Compaction failed: ${message}`,
 			});
+			// Transient transport failures (network drop, timeout, provider blip)
+			// must not escape as extension errors: the runner would print a raw
+			// stack on top of the compaction_end message above, while the turn's
+			// own provider request surfaces the same outage once through the
+			// normal retry path. Count the failure so the circuit breaker halts
+			// repeated doomed attempts; everything else stays loud.
+			if (isRetryableErrorMessage(message)) {
+				state = breaker.recordFailure(state, Date.now(), { route: "extension" });
+				return { applied: false, reason: "unavailable" };
+			}
 			throw error;
 		}
 	}
@@ -498,14 +508,20 @@ export default function compactionExtension(
 		const settings = ctx.getCompactionSettings();
 		const pendingPromptTokens = estimatePendingPromptTokens(event);
 		const usageWithPendingPrompt = usage ? withAdditionalTokens(usage, pendingPromptTokens) : undefined;
+		// Proactive routes back off while the breaker cools down after repeated
+		// failures (e.g. summarization attempts during a network outage); only
+		// the hard-limit emergency still tries unconditionally.
+		const breakerCoolingDown = breaker.isTripped(state, Date.now());
 		if (usage && policy.isAtHardLimit(usage, contextWindow, settings.reserveTokens, pendingPromptTokens)) {
 			await applyBlockingCompaction(ctx, EMERGENCY_COMPACTION_INSTRUCTIONS);
 		} else if (
+			!breakerCoolingDown &&
 			usageWithPendingPrompt &&
 			policy.shouldTriggerCompaction(usageWithPendingPrompt, contextWindow, settings, state.lastYield ?? undefined)
 		) {
 			await applyBlockingCompaction(ctx, PROACTIVE_COMPACTION_INSTRUCTIONS);
 		} else if (
+			!breakerCoolingDown &&
 			usageWithPendingPrompt &&
 			policy.shouldStartSpeculativeCompaction(
 				usageWithPendingPrompt,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -44,6 +44,7 @@ import {
 	type SpeculativeCompactionResult,
 	type SpeculativeCompactionSnapshot,
 	SummaryGenerationError,
+	SummaryRequestError,
 } from "./speculative.ts";
 import { type CompactionExtensionState, createInitialState, resetTurnCounter } from "./state.ts";
 import * as todoBridge from "./todo-bridge.ts";
@@ -339,11 +340,14 @@ export default function compactionExtension(
 			// must not escape as extension errors: the runner would print a raw
 			// stack on top of the compaction_end message above, while the turn's
 			// own provider request surfaces the same outage once through the
-			// normal retry path. Count the failure so the circuit breaker halts
-			// repeated doomed attempts; everything else stays loud.
-			if (isRetryableErrorMessage(message)) {
+			// normal retry path. Provider `error` stops carry metadata-aware
+			// classification (a refusal with retryable-looking text stays loud);
+			// bare transport throws fall back to the message classifier. Count
+			// the failure so the circuit breaker halts repeated doomed attempts.
+			const transient = error instanceof SummaryRequestError ? error.transient : isRetryableErrorMessage(message);
+			if (transient) {
 				state = breaker.recordFailure(state, Date.now(), { route: "extension" });
-				return { applied: false, reason: "unavailable" };
+				return { applied: false, reason: "failed" };
 			}
 			throw error;
 		}
@@ -454,6 +458,7 @@ export default function compactionExtension(
 		// smaller window: this is the overflow risk the warm start must absorb.
 		const usage = ctx.getContextUsage();
 		if (!usage) return;
+		if (breaker.isTripped(state, Date.now())) return;
 		const settings = ctx.getCompactionSettings();
 		if (policy.shouldStartSpeculativeCompaction(usage, contextWindow, settings, state.lastYield ?? undefined)) {
 			startSpeculativeCompaction(ctx, PROACTIVE_COMPACTION_INSTRUCTIONS);

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
 	isContextOverflow,
+	isRetryableAssistantError,
 	type Message,
 	type Model,
 	type TextContent,
@@ -68,7 +69,7 @@ export interface SpeculativeCompactionSnapshot {
 	tools?: Tool[];
 }
 
-export type SpeculativeCompactionResult = ApplyCompactionResult | { applied: false; reason: "unavailable" };
+export type SpeculativeCompactionResult = ApplyCompactionResult | { applied: false; reason: "unavailable" | "failed" };
 
 function approxTokens(text: string): number {
 	return Math.ceil(text.length / 4);
@@ -79,6 +80,22 @@ function approxTokens(text: string): number {
  * user abort (which resolves `undefined`): callers surface `message` on the
  * manual route and degrade to "unavailable" on automatic routes.
  */
+/**
+ * Provider `error` stop during summarization, carrying the metadata-aware
+ * transient classification from the full assistant message. A refusal whose
+ * text happens to look retryable must still surface loudly; the message
+ * string alone cannot encode that.
+ */
+export class SummaryRequestError extends Error {
+	readonly transient: boolean;
+
+	constructor(message: string, transient: boolean) {
+		super(message);
+		this.name = "SummaryRequestError";
+		this.transient = transient;
+	}
+}
+
 export class SummaryGenerationError extends Error {
 	readonly kind: "auth" | "empty-summary";
 
@@ -468,7 +485,10 @@ export async function runExtensionCompaction(
 		if (isAssistantMessage(response) && response.stopReason === "error") {
 			// Surface the real provider failure instead of silently degrading
 			// into a generic "Compaction cancelled".
-			throw new Error(response.errorMessage || "Compaction summary request failed");
+			throw new SummaryRequestError(
+				response.errorMessage || "Compaction summary request failed",
+				isRetryableAssistantError(response),
+			);
 		}
 
 		const summary = getSummaryText(response);

--- a/packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts
@@ -1,0 +1,197 @@
+import { fauxAssistantMessage, registerFauxProvider, type UserMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
+import type {
+	BeforeAgentStartEvent,
+	BeforeAgentStartEventResult,
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionHandler,
+} from "../../src/core/extensions/index.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+function userMessage(text: string, timestamp: number): UserMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function createBeforeAgentStartHandler(): ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult> {
+	let beforeAgentStartHandler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult> | undefined;
+	const api = {
+		on: (event: string, handler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>) => {
+			if (event === "before_agent_start") beforeAgentStartHandler = handler;
+		},
+	} as ExtensionAPI;
+	compactionExtension(api);
+	expect(beforeAgentStartHandler).toBeDefined();
+	return beforeAgentStartHandler as ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>;
+}
+
+interface BlockingHarness {
+	ctx: ExtensionContext;
+	endCompaction: ReturnType<typeof vi.fn>;
+	registration: ReturnType<typeof registerFauxProvider>;
+}
+
+function createBlockingContext(options: { usageTokens: number; withAuth?: boolean }): BlockingHarness {
+	const registration = registerFauxProvider();
+	registrations.push(registration);
+	const model = registration.getModel();
+	const sessionManager = SessionManager.inMemory();
+	sessionManager.appendMessage(userMessage("Summarize old context", 1));
+	sessionManager.appendMessage({
+		...fauxAssistantMessage("Old assistant context ".repeat(6_000), { timestamp: 2 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 30_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 30_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	});
+	sessionManager.appendMessage(userMessage("Keep latest request", 3));
+	const modelRegistry = Object.create(null) as ExtensionContext["modelRegistry"];
+	modelRegistry.getApiKeyAndHeaders =
+		options.withAuth === false
+			? async () => ({ ok: false, error: "no API key configured" })
+			: async () => ({ ok: true, apiKey: "test-key" });
+	const endCompaction = vi.fn();
+	const ctx = {
+		hasUI: false,
+		mode: "print",
+		ui: Object.create(null) as ExtensionContext["ui"],
+		cwd: process.cwd(),
+		isProjectTrusted: () => true,
+		sessionManager,
+		modelRegistry,
+		model,
+		serviceTier: undefined,
+		isIdle: () => true,
+		signal: undefined,
+		abort: vi.fn(),
+		hasPendingMessages: () => false,
+		shutdown: vi.fn(),
+		getContextUsage: () => ({
+			tokens: options.usageTokens,
+			contextWindow: 10_000,
+			percent: (options.usageTokens / 10_000) * 100,
+		}),
+		getCompactionSettings: () => ({ enabled: true, reserveTokens: 100, keepRecentTokens: 2_000 }),
+		getLookAtSettings: () => ({ enabled: true, models: undefined }),
+		getImageSettings: () => ({ autoResize: true, blockImages: false }),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
+		compact: vi.fn(),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: true as const, reason: "ok" as const })),
+		beginCompaction: () => undefined,
+		endCompaction,
+		getSystemPrompt: () => "",
+	} as unknown as ExtensionContext;
+	return { ctx, endCompaction, registration };
+}
+
+function createEvent(): BeforeAgentStartEvent {
+	return {
+		type: "before_agent_start",
+		prompt: "continue",
+		systemPrompt: "system",
+		systemPromptOptions: Object.create(null) as BeforeAgentStartEvent["systemPromptOptions"],
+	};
+}
+
+function connectionErrorResponse() {
+	return fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." });
+}
+
+describe("blocking compaction network-failure degradation", () => {
+	describe("Given the provider connection drops during emergency blocking compaction", () => {
+		it("Then before_agent_start degrades cleanly instead of erroring the turn", async () => {
+			// Given: usage at the hard limit forces blocking compaction, and the
+			// summarization request fails with a transient connection error.
+			const handler = createBeforeAgentStartHandler();
+			const harness = createBlockingContext({ usageTokens: 9_950 });
+			harness.registration.setResponses([connectionErrorResponse()]);
+
+			// When / Then: the handler resolves (no extension-error stack surface)…
+			await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+
+			// …and the single clean surface is compaction_end's errorMessage.
+			expect(harness.endCompaction).toHaveBeenCalledWith(
+				expect.objectContaining({ errorMessage: "Compaction failed: Connection error." }),
+			);
+		});
+	});
+
+	describe("Given repeated transient blocking-compaction failures", () => {
+		it("Then the circuit breaker skips further proactive attempts during cooldown", async () => {
+			// Given: usage above the proactive threshold (45% of 10k) but below the
+			// hard limit, so the proactive blocking route is taken each prompt.
+			const handler = createBeforeAgentStartHandler();
+			const harness = createBlockingContext({ usageTokens: 6_000 });
+			harness.registration.setResponses([
+				connectionErrorResponse(),
+				connectionErrorResponse(),
+				connectionErrorResponse(),
+			]);
+
+			// When: three consecutive prompts fail on connection errors.
+			for (let attempt = 0; attempt < 3; attempt++) {
+				await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+			}
+			const callsAfterTrip = harness.registration.state.callCount;
+			await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+
+			// Then: the tripped breaker stops the fourth prompt from paying for
+			// another doomed summarization request.
+			expect(callsAfterTrip).toBe(3);
+			expect(harness.registration.state.callCount).toBe(callsAfterTrip);
+		});
+	});
+
+	describe("Given a non-transient summarization failure", () => {
+		it("Then the failure still surfaces loudly as an extension error", async () => {
+			// Given: a deterministic provider rejection that retrying cannot fix.
+			const handler = createBeforeAgentStartHandler();
+			const harness = createBlockingContext({ usageTokens: 9_950 });
+			harness.registration.setResponses([
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "request blocked by provider policy",
+				}),
+			]);
+
+			// When / Then: unchanged behavior — real bugs and policy rejections
+			// keep propagating so they stay visible.
+			await expect(handler(createEvent(), harness.ctx)).rejects.toThrow("request blocked by provider policy");
+		});
+	});
+
+	describe("Given summarization credentials are unavailable", () => {
+		it("Then blocking compaction degrades silently as before", async () => {
+			// Given
+			const handler = createBeforeAgentStartHandler();
+			const harness = createBlockingContext({ usageTokens: 9_950, withAuth: false });
+			harness.registration.setResponses([fauxAssistantMessage("never reached")]);
+
+			// When / Then: SummaryGenerationError keeps its degrade-to-unavailable
+			// contract, with no error message on the compaction feedback.
+			await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+			const callsWithError = harness.endCompaction.mock.calls.filter(
+				(call) => typeof call[0]?.errorMessage === "string",
+			);
+			expect(callsWithError).toHaveLength(0);
+		});
+	});
+});

--- a/packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts
@@ -1,15 +1,11 @@
-import { fauxAssistantMessage, registerFauxProvider, type UserMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
-import type {
-	BeforeAgentStartEvent,
-	BeforeAgentStartEventResult,
-	ExtensionAPI,
-	ExtensionContext,
-	ExtensionHandler,
-} from "../../src/core/extensions/index.ts";
-import { SessionManager } from "../../src/core/session-manager.ts";
-import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	connectionErrorResponse,
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+	createCompactionHandlers,
+} from "../helpers/blocking-compaction-harness.ts";
 
 const registrations: Array<{ unregister: () => void }> = [];
 
@@ -19,113 +15,18 @@ afterEach(() => {
 	}
 });
 
-function userMessage(text: string, timestamp: number): UserMessage {
-	return { role: "user", content: [{ type: "text", text }], timestamp };
-}
-
-function createBeforeAgentStartHandler(): ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult> {
-	let beforeAgentStartHandler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult> | undefined;
-	const api = {
-		on: (event: string, handler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>) => {
-			if (event === "before_agent_start") beforeAgentStartHandler = handler;
-		},
-	} as ExtensionAPI;
-	compactionExtension(api);
-	expect(beforeAgentStartHandler).toBeDefined();
-	return beforeAgentStartHandler as ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>;
-}
-
-interface BlockingHarness {
-	ctx: ExtensionContext;
-	endCompaction: ReturnType<typeof vi.fn>;
-	registration: ReturnType<typeof registerFauxProvider>;
-}
-
-function createBlockingContext(options: { usageTokens: number; withAuth?: boolean }): BlockingHarness {
-	const registration = registerFauxProvider();
-	registrations.push(registration);
-	const model = registration.getModel();
-	const sessionManager = SessionManager.inMemory();
-	sessionManager.appendMessage(userMessage("Summarize old context", 1));
-	sessionManager.appendMessage({
-		...fauxAssistantMessage("Old assistant context ".repeat(6_000), { timestamp: 2 }),
-		api: model.api,
-		provider: model.provider,
-		model: model.id,
-		usage: {
-			input: 30_000,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 30_000,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-	});
-	sessionManager.appendMessage(userMessage("Keep latest request", 3));
-	const modelRegistry = Object.create(null) as ExtensionContext["modelRegistry"];
-	modelRegistry.getApiKeyAndHeaders =
-		options.withAuth === false
-			? async () => ({ ok: false, error: "no API key configured" })
-			: async () => ({ ok: true, apiKey: "test-key" });
-	const endCompaction = vi.fn();
-	const ctx = {
-		hasUI: false,
-		mode: "print",
-		ui: Object.create(null) as ExtensionContext["ui"],
-		cwd: process.cwd(),
-		isProjectTrusted: () => true,
-		sessionManager,
-		modelRegistry,
-		model,
-		serviceTier: undefined,
-		isIdle: () => true,
-		signal: undefined,
-		abort: vi.fn(),
-		hasPendingMessages: () => false,
-		shutdown: vi.fn(),
-		getContextUsage: () => ({
-			tokens: options.usageTokens,
-			contextWindow: 10_000,
-			percent: (options.usageTokens / 10_000) * 100,
-		}),
-		getCompactionSettings: () => ({ enabled: true, reserveTokens: 100, keepRecentTokens: 2_000 }),
-		getLookAtSettings: () => ({ enabled: true, models: undefined }),
-		getImageSettings: () => ({ autoResize: true, blockImages: false }),
-		sessionSettings: createInMemoryExtensionSessionSettings(),
-		compact: vi.fn(),
-		getMessageRevision: () => 1,
-		applyCompaction: vi.fn(async () => ({ applied: true as const, reason: "ok" as const })),
-		beginCompaction: () => undefined,
-		endCompaction,
-		getSystemPrompt: () => "",
-	} as unknown as ExtensionContext;
-	return { ctx, endCompaction, registration };
-}
-
-function createEvent(): BeforeAgentStartEvent {
-	return {
-		type: "before_agent_start",
-		prompt: "continue",
-		systemPrompt: "system",
-		systemPromptOptions: Object.create(null) as BeforeAgentStartEvent["systemPromptOptions"],
-	};
-}
-
-function connectionErrorResponse() {
-	return fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." });
-}
-
 describe("blocking compaction network-failure degradation", () => {
 	describe("Given the provider connection drops during emergency blocking compaction", () => {
 		it("Then before_agent_start degrades cleanly instead of erroring the turn", async () => {
 			// Given: usage at the hard limit forces blocking compaction, and the
 			// summarization request fails with a transient connection error.
-			const handler = createBeforeAgentStartHandler();
+			const { beforeAgentStart } = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 9_950 });
+			registrations.push(harness.registration);
 			harness.registration.setResponses([connectionErrorResponse()]);
 
 			// When / Then: the handler resolves (no extension-error stack surface)…
-			await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
 
 			// …and the single clean surface is compaction_end's errorMessage.
 			expect(harness.endCompaction).toHaveBeenCalledWith(
@@ -138,8 +39,9 @@ describe("blocking compaction network-failure degradation", () => {
 		it("Then the circuit breaker skips further proactive attempts during cooldown", async () => {
 			// Given: usage above the proactive threshold (45% of 10k) but below the
 			// hard limit, so the proactive blocking route is taken each prompt.
-			const handler = createBeforeAgentStartHandler();
+			const { beforeAgentStart } = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 6_000 });
+			registrations.push(harness.registration);
 			harness.registration.setResponses([
 				connectionErrorResponse(),
 				connectionErrorResponse(),
@@ -148,10 +50,10 @@ describe("blocking compaction network-failure degradation", () => {
 
 			// When: three consecutive prompts fail on connection errors.
 			for (let attempt = 0; attempt < 3; attempt++) {
-				await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+				await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
 			}
 			const callsAfterTrip = harness.registration.state.callCount;
-			await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
 
 			// Then: the tripped breaker stops the fourth prompt from paying for
 			// another doomed summarization request.
@@ -163,8 +65,9 @@ describe("blocking compaction network-failure degradation", () => {
 	describe("Given a non-transient summarization failure", () => {
 		it("Then the failure still surfaces loudly as an extension error", async () => {
 			// Given: a deterministic provider rejection that retrying cannot fix.
-			const handler = createBeforeAgentStartHandler();
+			const { beforeAgentStart } = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 9_950 });
+			registrations.push(harness.registration);
 			harness.registration.setResponses([
 				fauxAssistantMessage("", {
 					stopReason: "error",
@@ -174,20 +77,23 @@ describe("blocking compaction network-failure degradation", () => {
 
 			// When / Then: unchanged behavior — real bugs and policy rejections
 			// keep propagating so they stay visible.
-			await expect(handler(createEvent(), harness.ctx)).rejects.toThrow("request blocked by provider policy");
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).rejects.toThrow(
+				"request blocked by provider policy",
+			);
 		});
 	});
 
 	describe("Given summarization credentials are unavailable", () => {
 		it("Then blocking compaction degrades silently as before", async () => {
 			// Given
-			const handler = createBeforeAgentStartHandler();
+			const { beforeAgentStart } = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 9_950, withAuth: false });
+			registrations.push(harness.registration);
 			harness.registration.setResponses([fauxAssistantMessage("never reached")]);
 
 			// When / Then: SummaryGenerationError keeps its degrade-to-unavailable
 			// contract, with no error message on the compaction feedback.
-			await expect(handler(createEvent(), harness.ctx)).resolves.toBeUndefined();
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
 			const callsWithError = harness.endCompaction.mock.calls.filter(
 				(call) => typeof call[0]?.errorMessage === "string",
 			);

--- a/packages/coding-agent/test/compaction/blocking-compaction-review-hardening.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-review-hardening.test.ts
@@ -1,0 +1,176 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createDegradationMonitorState,
+	handleMessageEnd,
+	RECOVERY_INSTRUCTIONS,
+} from "../../src/core/extensions/builtin/compaction/degradation-monitor.ts";
+import type { ModelSelectEvent } from "../../src/core/extensions/index.ts";
+import {
+	connectionErrorResponse,
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+	createCompactionHandlers,
+} from "../helpers/blocking-compaction-harness.ts";
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+function noTextAssistantEvent() {
+	return { message: { role: "assistant", content: [{ type: "toolCall" }] } };
+}
+
+async function driveRecovery(applyResult: { applied: boolean; reason: string }): Promise<string[]> {
+	const state = createDegradationMonitorState();
+	state.postCompactionTurnsRemaining = 5;
+	const notifications: string[] = [];
+	const context = {
+		applyCompaction: async (options: { customInstructions: string }) => {
+			expect(options.customInstructions).toBe(RECOVERY_INSTRUCTIONS);
+			return applyResult;
+		},
+		notify: (message: string) => {
+			notifications.push(message);
+		},
+	};
+	for (let i = 0; i < 3; i++) {
+		await handleMessageEnd(state, noTextAssistantEvent(), context);
+	}
+	return notifications;
+}
+
+describe("blocking compaction review hardening", () => {
+	describe("Given a provider refusal whose text looks transient", () => {
+		it("Then blocking compaction still surfaces it loudly", async () => {
+			// Given: refusal metadata must win over retryable-looking message text.
+			const { beforeAgentStart } = createCompactionHandlers();
+			const harness = createBlockingContext({ usageTokens: 9_950 });
+			registrations.push(harness.registration);
+			harness.registration.setResponses([
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "Refused. You can retry your request with different content.",
+					stopDetails: { type: "refusal" },
+				}),
+			]);
+
+			// When / Then
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).rejects.toThrow(
+				"retry your request",
+			);
+		});
+	});
+
+	describe("Given the breaker tripped from repeated transient failures", () => {
+		it("Then a window-shrink model_select does not start a speculative summary", async () => {
+			// Given: three transient blocking failures trip the breaker.
+			const handlers = createCompactionHandlers();
+			const harness = createBlockingContext({ usageTokens: 6_000 });
+			registrations.push(harness.registration);
+			harness.registration.setResponses([
+				connectionErrorResponse(),
+				connectionErrorResponse(),
+				connectionErrorResponse(),
+			]);
+			for (let attempt = 0; attempt < 3; attempt++) {
+				await expect(
+					handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx),
+				).resolves.toBeUndefined();
+			}
+			harness.getApiKeyAndHeaders.mockClear();
+			harness.setUsageTokens(120_000);
+
+			// When: the model window shrinks while cooling down.
+			await handlers.modelSelect(shrinkEvent(harness.ctx.model), harness.ctx);
+
+			// Then: no summarization credentials are even resolved.
+			expect(harness.getApiKeyAndHeaders).not.toHaveBeenCalled();
+		});
+
+		it("Then a window-shrink model_select still warms up when the breaker is closed", async () => {
+			// Given
+			const handlers = createCompactionHandlers();
+			const harness = createBlockingContext({ usageTokens: 120_000 });
+			registrations.push(harness.registration);
+			harness.registration.setResponses([fauxAssistantMessage("warm summary")]);
+
+			// When
+			await handlers.modelSelect(shrinkEvent(harness.ctx.model), harness.ctx);
+
+			// Then
+			expect(harness.getApiKeyAndHeaders).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("Given blocking compaction is aborted by its feedback signal", () => {
+		it("Then it degrades silently with no error message", async () => {
+			// Given
+			const { beforeAgentStart } = createCompactionHandlers();
+			const controller = new AbortController();
+			controller.abort();
+			const harness = createBlockingContext({ usageTokens: 9_950, beginCompaction: () => controller.signal });
+			registrations.push(harness.registration);
+			harness.registration.setResponses([fauxAssistantMessage("never used")]);
+
+			// When / Then
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
+			expect(errorMessages(harness.endCompaction)).toHaveLength(0);
+		});
+	});
+
+	describe("Given the summarization response has no text", () => {
+		it("Then blocking compaction degrades silently as before", async () => {
+			// Given
+			const { beforeAgentStart } = createCompactionHandlers();
+			const harness = createBlockingContext({ usageTokens: 9_950 });
+			registrations.push(harness.registration);
+			harness.registration.setResponses([fauxAssistantMessage("", { stopReason: "stop" })]);
+
+			// When / Then
+			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
+			expect(errorMessages(harness.endCompaction)).toHaveLength(0);
+		});
+	});
+
+	describe("Given degradation recovery hits a transient compaction failure", () => {
+		it("Then no recovery notification stacks on the compaction error surface", async () => {
+			// When: recovery compaction reports a failed (already-surfaced) result.
+			const notifications = await driveRecovery({ applied: false, reason: "failed" });
+
+			// Then: compaction_end's errorMessage stays the single surface.
+			expect(notifications).toHaveLength(0);
+		});
+
+		it("Then unavailable results keep notifying as before", async () => {
+			// When
+			const notifications = await driveRecovery({ applied: false, reason: "unavailable" });
+
+			// Then
+			expect(notifications).toHaveLength(1);
+		});
+	});
+});
+
+function shrinkEvent(model: ModelSelectEvent["model"] | undefined): ModelSelectEvent {
+	if (!model) throw new Error("harness model missing");
+	return {
+		type: "model_select",
+		model,
+		previousModel: { ...model, contextWindow: 1_000_000 },
+		source: "set",
+		systemPrompt: "system",
+		systemPromptOptions: Object.create(null) as ModelSelectEvent["systemPromptOptions"],
+	};
+}
+
+function errorMessages(endCompaction: { mock: { calls: unknown[][] } }): unknown[] {
+	return endCompaction.mock.calls.filter((call) => {
+		const first = call[0];
+		return typeof first === "object" && first !== null && typeof Reflect.get(first, "errorMessage") === "string";
+	});
+}

--- a/packages/coding-agent/test/helpers/blocking-compaction-harness.ts
+++ b/packages/coding-agent/test/helpers/blocking-compaction-harness.ts
@@ -1,0 +1,141 @@
+import { fauxAssistantMessage, registerFauxProvider, type UserMessage } from "@earendil-works/pi-ai";
+import { expect, vi } from "vitest";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
+import type {
+	BeforeAgentStartEvent,
+	BeforeAgentStartEventResult,
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionHandler,
+	ModelSelectEvent,
+	ModelSelectEventResult,
+} from "../../src/core/extensions/index.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "./extension-session-settings.ts";
+
+export interface CompactionHandlers {
+	beforeAgentStart: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>;
+	modelSelect: ExtensionHandler<ModelSelectEvent, ModelSelectEventResult>;
+}
+
+export function createCompactionHandlers(): CompactionHandlers {
+	let beforeAgentStart: CompactionHandlers["beforeAgentStart"] | undefined;
+	let modelSelect: CompactionHandlers["modelSelect"] | undefined;
+	const api = {
+		on: (event: string, handler: unknown) => {
+			if (event === "before_agent_start") {
+				beforeAgentStart = handler as CompactionHandlers["beforeAgentStart"];
+			}
+			if (event === "model_select") {
+				modelSelect = handler as CompactionHandlers["modelSelect"];
+			}
+		},
+	} as ExtensionAPI;
+	compactionExtension(api);
+	expect(beforeAgentStart).toBeDefined();
+	expect(modelSelect).toBeDefined();
+	return {
+		beforeAgentStart: beforeAgentStart as CompactionHandlers["beforeAgentStart"],
+		modelSelect: modelSelect as CompactionHandlers["modelSelect"],
+	};
+}
+
+export interface BlockingHarness {
+	ctx: ExtensionContext;
+	endCompaction: ReturnType<typeof vi.fn>;
+	getApiKeyAndHeaders: ReturnType<typeof vi.fn>;
+	registration: ReturnType<typeof registerFauxProvider>;
+	setUsageTokens: (tokens: number) => void;
+}
+
+function userMessage(text: string, timestamp: number): UserMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+export function createBlockingContext(options: {
+	usageTokens: number;
+	withAuth?: boolean;
+	beginCompaction?: () => AbortSignal | undefined;
+}): BlockingHarness {
+	const registration = registerFauxProvider();
+	const model = registration.getModel();
+	const sessionManager = SessionManager.inMemory();
+	sessionManager.appendMessage(userMessage("Summarize old context", 1));
+	sessionManager.appendMessage({
+		...fauxAssistantMessage("Old assistant context ".repeat(6_000), { timestamp: 2 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 30_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 30_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	});
+	sessionManager.appendMessage(userMessage("Keep latest request", 3));
+	const modelRegistry = Object.create(null) as ExtensionContext["modelRegistry"];
+	const getApiKeyAndHeaders = vi.fn(
+		options.withAuth === false
+			? async () => ({ ok: false as const, error: "no API key configured" })
+			: async () => ({ ok: true as const, apiKey: "test-key" }),
+	);
+	modelRegistry.getApiKeyAndHeaders = getApiKeyAndHeaders as ExtensionContext["modelRegistry"]["getApiKeyAndHeaders"];
+	const endCompaction = vi.fn();
+	let usageTokens = options.usageTokens;
+	const ctx = {
+		hasUI: false,
+		mode: "print",
+		ui: Object.create(null) as ExtensionContext["ui"],
+		cwd: process.cwd(),
+		isProjectTrusted: () => true,
+		sessionManager,
+		modelRegistry,
+		model,
+		serviceTier: undefined,
+		isIdle: () => true,
+		signal: undefined,
+		abort: vi.fn(),
+		hasPendingMessages: () => false,
+		shutdown: vi.fn(),
+		getContextUsage: () => ({
+			tokens: usageTokens,
+			contextWindow: 10_000,
+			percent: (usageTokens / 10_000) * 100,
+		}),
+		getCompactionSettings: () => ({ enabled: true, reserveTokens: 100, keepRecentTokens: 2_000 }),
+		getLookAtSettings: () => ({ enabled: true, models: undefined }),
+		getImageSettings: () => ({ autoResize: true, blockImages: false }),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
+		compact: vi.fn(),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: true as const, reason: "ok" as const })),
+		beginCompaction: options.beginCompaction ?? (() => undefined),
+		endCompaction,
+		getSystemPrompt: () => "",
+	} as unknown as ExtensionContext;
+	return {
+		ctx,
+		endCompaction,
+		getApiKeyAndHeaders,
+		registration,
+		setUsageTokens: (tokens: number) => {
+			usageTokens = tokens;
+		},
+	};
+}
+
+export function createBeforeAgentStartEvent(): BeforeAgentStartEvent {
+	return {
+		type: "before_agent_start",
+		prompt: "continue",
+		systemPrompt: "system",
+		systemPromptOptions: Object.create(null) as BeforeAgentStartEvent["systemPromptOptions"],
+	};
+}
+
+export function connectionErrorResponse() {
+	return fauxAssistantMessage("", { stopReason: "error", errorMessage: "Connection error." });
+}


### PR DESCRIPTION
## Summary

When a network drop coincides with blocking compaction (the `before_agent_start` hard-limit/proactive routes or degradation recovery), senpi currently re-throws the provider connection error out of the compaction extension. The runner then prints `Extension "<builtin:compaction>" error: Connection error.` with a raw stack **on top of** the `Compaction failed: Connection error.` feedback, while the turn's own provider request surfaces the same outage a third time through the retry path. After this PR, transient transport failures degrade cleanly: one `Compaction failed: <msg>` surface, a circuit-breaker failure recorded, and the turn proceeds so the outage is reported once through the normal retry path. While the breaker cools down, proactive blocking compaction and speculative warm starts are skipped so an offline session stops paying a doomed summarization request on every prompt.

The design mirrors the three reference implementations surveyed for this fix: Claude Code (swallows auto-compact failures, counts consecutive failures, 3-strike breaker skips further attempts), Codex (single structured error event, session stays usable), and oh-my-pi (emit `errorMessage`, no rethrow).

## Changes

- **`packages/ai/src/utils/retry.ts`** — exports `isRetryableErrorMessage(message)`; `isRetryableAssistantError` delegates to it. No pattern/behavior change; the classification is now reusable for thrown `Error`s.
- **`packages/coding-agent/src/core/extensions/builtin/compaction/index.ts`** — `applyBlockingCompaction`'s catch still ends compaction feedback with `Compaction failed: <msg>`, then, for transient errors only, records a breaker failure and returns `{ applied: false, reason: "unavailable" }` instead of re-throwing. `before_agent_start` skips the proactive blocking route and speculative starts while the breaker cools down; the hard-limit emergency route still attempts unconditionally. Non-transient failures, `SummaryGenerationError`, and user aborts keep their exact previous behavior.
- **`packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts`** — new: transient degrade (captured RED before the fix), breaker cooldown skip, plus pins for non-transient loud rethrow and credential-failure silent degrade.
- **`changes.md`** fork trackers updated in both packages with expected merge-conflict zones.

## QA & Evidence

- **What was tested:** RED→GREEN unit proof — new test rejected with `Error: Connection error.` from `applyBlockingCompaction` on unchanged code, 4/4 green after the fix. **Artifact:** `packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts` (vitest). **Why sufficient:** covers criteria happy path + breaker + both behavior pins.
- **What was tested:** regression scope — `test/compaction/` 27 files / 209 tests green; `packages/ai` `retry.test.ts` 22 green; root `npm run check` exit 0.
- **What was tested:** real CLI end-to-end (senpi-qa RPC channel + mock provider scripting per-turn reported usage, provider killed between turns to force blocking compaction against a dead network). **Observed result:** *before* (main): events contain `{"type":"extension_error","extensionPath":"<builtin:compaction>","event":"before_agent_start","error":"Connection error."}`; *after* (this branch): only `{"type":"compaction_end",...,"errorMessage":"Compaction failed: Connection error."}`, session still answers `get_state`; *control* (live server): the same flow applies a real summary, proving the QA arms the actual summarization request. **Artifact:** `local-ignore/qa-evidence/20260727-compaction-network-drop/{before,after,control}/` (gitignored evidence; verdict.json + rpc-events.jsonl + cli-stderr.txt).
- **What was tested:** `senpi-qa` mock-loop `--self-test` 41/41 (all three wire formats, retry scenarios, zero real provider calls, real auth untouched). **Artifact:** `local-ignore/qa-evidence/20260727-compaction-network-drop/mock-loop-self-test.txt`.

## Risks & Residuals

- Misclassifying a permanent failure as transient would hide a real bug behind a clean message: mitigated by reusing the long-standing `isRetryableAssistantError` pattern set unchanged, and pinned by the non-transient loud-rethrow test.
- The breaker gate could starve compaction while degraded: scoped to proactive/speculative routes only — the hard-limit emergency route always attempts — and cooldown (60s) matches existing breaker semantics on the `session_before_compact` route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blocking compaction to degrade transient network/provider failures cleanly. Prevents duplicate error surfaces, keeps the turn running, and backs off with a circuit breaker; recovery and window‑shrink warm starts follow the same rules.

- **Bug Fixes**
  - Transient blocking‑compaction failures now end with a single “Compaction failed: <msg>” and do not bubble as extension errors; a breaker failure is recorded and the turn proceeds.
  - While the breaker is tripped, proactive blocking compaction and speculative warm starts—including `model_select` window‑shrink warmups—are skipped; the hard‑limit emergency route still attempts.
  - Degradation recovery no longer stacks a second surface: transient failures return `reason: "failed"` and suppress the recovery notification; `unavailable` results keep notifying.
  - Reused the retryable classifier by exporting `isRetryableErrorMessage` in `@earendil-works/pi-ai`; provider error stops throw `SummaryRequestError` with metadata‑aware `isRetryableAssistantError` so refusals still surface loudly.
  - Added tests for recovery‑notification suppression, `model_select` breaker gating, refusal metadata, and abort/empty‑summary pins; includes a shared blocking‑compaction harness.

<sup>Written for commit afd4ba1e580c55bacf47ded002619b0609b338c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

