### PR TITLE
fix(terminal): keep monitor tools with native bash

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -76,17 +76,18 @@ function shouldStepAside(ctx: ExtensionContext | undefined): boolean {
 
 /**
  * Keep the tool surface consistent with anthropic-bash. When native Anthropic bash is active,
- * the PTY companions are deactivated so none dangle without a usable persistent `bash` (the
- * function `bash` is stripped + replaced by native bash in the provider payload). Otherwise the
- * PTY `bash` + companions are (re)activated. Re-evaluated on session_start AND model_select.
+ * the provider replaces the PTY `bash` function, but the companions stay active because `monitor`
+ * creates its own PTY session and bash_output/input/resize/kill operate on that shared registry.
+ * Otherwise the PTY `bash` + companions are (re)activated. Re-evaluated on session_start AND
+ * model_select.
  */
 function syncToolset(pi: ExtensionAPI, state: TerminalExtensionState): void {
 	const stepAside = shouldStepAside(state.ctx);
 	const active = new Set(pi.getActiveTools());
 	if (stepAside) {
-		for (const companion of TERMINAL_COMPANION_TOOLS) active.delete(companion);
+		for (const companion of TERMINAL_COMPANION_TOOLS) active.add(companion);
 		if (!state.noticeShown) {
-			state.ctx?.ui.notify("native Anthropic bash active — persistent terminal sessions disabled", "info");
+			state.ctx?.ui.notify("native Anthropic bash active — monitor sessions remain available", "info");
 			state.noticeShown = true;
 		}
 	} else {

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -52,19 +52,19 @@ describe("terminal builtin extension — tool surface & mutual exclusion", () =>
 		for (const companion of COMPANIONS) expect(active).toContain(companion);
 	});
 
-	it("steps aside — companions absent — when native Anthropic bash is active", async () => {
+	it("keeps monitor companions active when native Anthropic bash replaces PTY bash", async () => {
 		process.env.PI_ANTHROPIC_BASH = "1";
 		const harness = await anthropicHarness();
 		await harness.session.bindExtensions({});
 		const active = harness.session.getActiveToolNames();
-		for (const companion of COMPANIONS) expect(active).not.toContain(companion);
+		for (const companion of COMPANIONS) expect(active).toContain(companion);
 	});
 
 	it("re-activates companions when native Anthropic bash is disabled on model switch", async () => {
 		process.env.PI_ANTHROPIC_BASH = "1";
 		const harness = await anthropicHarness();
 		await harness.session.bindExtensions({});
-		expect(harness.session.getActiveToolNames()).not.toContain("bash_output");
+		expect(harness.session.getActiveToolNames()).toContain("bash_output");
 
 		delete process.env.PI_ANTHROPIC_BASH;
 		await harness.session.setModel(harness.getModel("claude-test-2")!);


### PR DESCRIPTION
## Summary

Keep the terminal monitor companion surface active when native Anthropic bash replaces the PTY `bash` implementation.

The following tools remain available:

- `monitor`
- `bash_output`
- `bash_input`
- `bash_resize`
- `kill_bash`

## Why

`monitor` creates its own PTY-backed runtime session. Removing all terminal companions under native Anthropic bash made event-driven terminal observation unavailable even though it does not depend on the PTY `bash` tool.

## RED to GREEN

- RED: an Anthropic session exposed only `read`, `bash`, `edit`, and `write`; `bash_output` was the first missing companion
- GREEN: the native-bash and model-switch cases both pass with all five monitor companions active

## Verification

- focused native Anthropic tests: 2 passed
- terminal/monitor regression suite: 34 passed
- `npm run check`
- `npm run build`
- `git diff --check`
- coordinated final reviewer: APPROVE

## Real QA

A live `monitor` command emitted `MONITOR_EVENT_OK` through the notification channel and exited with code 0.

Evidence was recorded under:

`.omo/evidence/20260727-monitor-anthropic/`

No real Anthropic API request or credentials were used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep terminal monitor companions active when native Anthropic bash replaces the PTY `bash`, so monitoring continues to work. Also updates the user notice to reflect this behavior.

- Bug Fixes
  - Preserve `monitor`, `bash_output`, `bash_input`, `bash_resize`, and `kill_bash` when `PI_ANTHROPIC_BASH` is enabled.
  - Update notification to “native Anthropic bash active — monitor sessions remain available” and adjust tests to expect companions present.

<sup>Written for commit f87e92c00c17e4d2b8e8e250a3670ae16094d1ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

