### PR TITLE
fix(coding-agent): retry transient session-title failures and clean up runtime error rendering

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -114,6 +114,7 @@ import type {
 	CompactionRejectionCause,
 	ModelSelectSource,
 } from "./extensions/types.ts";
+import { RUNTIME_EXTENSION_PATH } from "./extensions/types.ts";
 import { type BashExecutionMessage, type CustomMessage, filterContextExcludedMessages } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
 import { type AvailableModelsSource, getModelNarrowingPatterns, resolveModelScope } from "./model-resolver.ts";
@@ -131,7 +132,7 @@ import {
 	getLatestCompactionEntry,
 	type SessionHeader,
 } from "./session-manager.ts";
-import { generateSessionTitle, shouldSkipSessionTitle } from "./session-title-generator.ts";
+import { generateSessionTitle, sessionTitleRetryPolicy, shouldSkipSessionTitle } from "./session-title-generator.ts";
 import { SessionWorkBarrier } from "./session-work-barrier.ts";
 import type { SettingsManager } from "./settings-manager.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
@@ -2630,6 +2631,7 @@ export class AgentSession {
 				auth,
 				sessionId: this.sessionId,
 				baseOptions: this._buildSessionTitleBaseOptions(),
+				retry: sessionTitleRetryPolicy(this.settingsManager.getRetrySettings()),
 				signal: abortController.signal,
 				streamFn: this.agent.streamFunction,
 			});
@@ -2645,7 +2647,7 @@ export class AgentSession {
 			}
 			const message = error instanceof Error ? error.message : String(error);
 			this._extensionRunner.emitError({
-				extensionPath: "<runtime>",
+				extensionPath: RUNTIME_EXTENSION_PATH,
 				event: "session_title_generation",
 				error: message,
 			});
@@ -4629,7 +4631,7 @@ export class AgentSession {
 				sendMessage: (message, options) => {
 					this.sendCustomMessage(message, options).catch((err) => {
 						runner.emitError({
-							extensionPath: "<runtime>",
+							extensionPath: RUNTIME_EXTENSION_PATH,
 							event: "send_message",
 							error: err instanceof Error ? err.message : String(err),
 						});
@@ -4638,7 +4640,7 @@ export class AgentSession {
 				sendUserMessage: (content, options) => {
 					this.sendUserMessage(content, options).catch((err) => {
 						runner.emitError({
-							extensionPath: "<runtime>",
+							extensionPath: RUNTIME_EXTENSION_PATH,
 							event: "send_user_message",
 							error: err instanceof Error ? err.message : String(err),
 						});

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## Session-title generation retry + humanized provider errors (2026-07-27)
+
+### What changed
+
+- `session-title-generator.ts`: `generateSessionTitle()` accepts an optional `retry: RetryPolicy` and wraps the
+  title call in `retryAssistantCall`, mirroring `completeSummarization()`. A transient provider error (e.g. an
+  Anthropic 529 `overloaded_error` stream event) no longer fails title generation on the first attempt. Final
+  failures throw `humanizeProviderError(...)` output — a short human-readable line such as
+  `Overloaded (overloaded_error, request req_...)` — instead of the raw provider JSON body.
+- `session-title-generator.ts`: new `sessionTitleRetryPolicy()` narrows the user's `settings.retry` for this
+  cosmetic background call — `enabled` is preserved, `maxRetries` capped at 1 and `baseDelayMs` at 2000ms, and a
+  smaller configured budget is never inflated. The full agent-turn budget would keep hitting an already-overloaded
+  provider for ~14s while the user's real turn competes for the same capacity; a title that still fails is
+  regenerated at the next turn end anyway.
+- `agent-session.ts`: `_generateSessionTitle()` passes `sessionTitleRetryPolicy(settingsManager.getRetrySettings())`.
+  The runtime-emitted extension-error sites now use the shared `RUNTIME_EXTENSION_PATH` sentinel constant.
+
+### Why
+
+- A single transient 529 during background title generation surfaced as `Extension "<runtime>" error: {raw json}`
+  in the TUI and left the session untitled until the next turn end.
+
+### Expected merge conflict zones
+
+- LOW: `session-title-generator.ts` around `generateSessionTitle()`.
+- LOW: `agent-session.ts` `_generateSessionTitle()` and the `emitError` call sites.
+
 ## Composable leading skill commands (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,23 @@
 # Core Extensions Changes
 
+## 2026-07-27 - RUNTIME_EXTENSION_PATH sentinel constant
+
+### What changed
+
+- `types.ts` exports `RUNTIME_EXTENSION_PATH = "<runtime>"`, the sentinel `extensionPath` used when the session
+  runtime itself (not a loaded extension) emits an error through the extension-error channel — e.g. failed
+  background session-title generation. `index.ts` re-exports it.
+- `agent-session.ts` and interactive mode consume the constant instead of repeating the string literal, so the
+  rendering contract ("runtime errors are not extension failures") has one owner.
+
+### Why extension system couldn't handle this alone
+
+- The sentinel is produced by core runtime paths and consumed by the TUI renderer; extensions never emit it.
+
+### Expected merge conflict zones
+
+- LOW: additive export above the `ExtensionError` interface in `types.ts`, and the value-export block in `index.ts`.
+
 ## 2026-07-26 - AgentEndEvent abort payload + goal resume at before_agent_start
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -193,5 +193,6 @@ export {
 	isReadToolResult,
 	isToolCallEventType,
 	isWriteToolResult,
+	RUNTIME_EXTENSION_PATH,
 } from "./types.ts";
 export { wrapRegisteredTool, wrapRegisteredTools } from "./wrapper.ts";

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -2024,6 +2024,13 @@ export interface LoadExtensionsResult {
 // Extension Error
 // ============================================================================
 
+/**
+ * Sentinel `extensionPath` used when the session runtime itself (not a loaded
+ * extension) emits an error through the extension-error channel, e.g. failed
+ * background session-title generation.
+ */
+export const RUNTIME_EXTENSION_PATH = "<runtime>";
+
 export interface ExtensionError {
 	extensionPath: string;
 	event: string;

--- a/packages/coding-agent/src/core/session-title-generator.ts
+++ b/packages/coding-agent/src/core/session-title-generator.ts
@@ -7,7 +7,7 @@ import type {
 	SimpleStreamOptions,
 	TextContent,
 } from "@earendil-works/pi-ai/compat";
-import { completeSimple } from "@earendil-works/pi-ai/compat";
+import { completeSimple, type RetryPolicy, retryAssistantCall } from "@earendil-works/pi-ai/compat";
 
 interface SessionTitleAuth {
 	readonly apiKey?: string;
@@ -24,6 +24,7 @@ interface GenerateSessionTitleOptions {
 	readonly baseOptions?: SimpleStreamOptions;
 	readonly signal?: AbortSignal;
 	readonly streamFn?: StreamFn;
+	readonly retry?: RetryPolicy;
 }
 
 const TITLE_SYSTEM_PROMPT = `Generate a concise title for this coding-agent session.
@@ -51,6 +52,27 @@ const LOW_SIGNAL_PROMPTS = new Set([
 	"nope",
 ]);
 
+const MAX_TITLE_RETRIES = 1;
+const MAX_TITLE_RETRY_DELAY_MS = 2000;
+
+/**
+ * Narrow the user's retry budget for cosmetic background title generation.
+ *
+ * A title is not worth the full agent-turn budget: the default policy would
+ * keep hitting an already-overloaded provider for ~14s while the user's real
+ * turn competes for the same capacity, and a custom `baseDelayMs` could stall
+ * it far longer. One retry recovers the common single-blip case; a title that
+ * still fails is regenerated at the next turn end anyway. `enabled` stays the
+ * user's call, and a smaller configured budget is never inflated.
+ */
+export function sessionTitleRetryPolicy(settings: RetryPolicy): RetryPolicy {
+	return {
+		enabled: settings.enabled,
+		maxRetries: Math.min(settings.maxRetries, MAX_TITLE_RETRIES),
+		baseDelayMs: Math.min(settings.baseDelayMs, MAX_TITLE_RETRY_DELAY_MS),
+	};
+}
+
 export function shouldSkipSessionTitle(text: string): boolean {
 	const normalized = text.replace(/\s+/g, " ").trim().toLowerCase();
 	if (normalized.length === 0) return true;
@@ -63,14 +85,22 @@ export async function generateSessionTitle(options: GenerateSessionTitleOptions)
 		return undefined;
 	}
 
-	const response = await completeTitle(
-		options.model,
-		buildTitleContext(options.firstPrompt),
-		buildTitleOptions(options),
-		options.streamFn,
+	// Titles are cosmetic background work: honor the caller's retry policy so a
+	// single transient provider error (e.g. a 529 overloaded stream) does not
+	// surface as a scary runtime error. Mirrors completeSummarization().
+	const response = await retryAssistantCall(
+		() =>
+			completeTitle(
+				options.model,
+				buildTitleContext(options.firstPrompt),
+				buildTitleOptions(options),
+				options.streamFn,
+			),
+		options.retry,
+		options.signal,
 	);
 	if (response.stopReason === "error") {
-		throw new Error(response.errorMessage ?? "Session title generation failed");
+		throw new Error(humanizeProviderError(response.errorMessage ?? "Session title generation failed"));
 	}
 	return parseSessionTitle(response);
 }
@@ -142,6 +172,62 @@ function parseSessionTitle(message: AssistantMessage): string | undefined {
 		return undefined;
 	}
 	return title;
+}
+
+/**
+ * Reduce a raw provider error payload (e.g. an Anthropic `{"type":"error",...}`
+ * body, optionally prefixed with an HTTP status code) to a short human-readable
+ * line while keeping the error type and request id for follow-up. Non-JSON and
+ * unrecognized payloads pass through unchanged.
+ */
+export function humanizeProviderError(raw: string): string {
+	// `formatProviderError` (packages/ai/src/utils/error-body.ts) emits
+	// `<status>: <body>` or `<prefix> (<status>): <body>`; Anthropic SSE error
+	// events arrive as the bare JSON body.
+	const statusPrefix = raw.trim().match(/^(?:.*?\((\d{3})\)|(\d{3}))\s*:\s*(?=\{)/);
+	const status = statusPrefix?.[1] ?? statusPrefix?.[2];
+	const bodyText = statusPrefix ? raw.trim().slice(statusPrefix[0].length) : raw.trim();
+	if (!bodyText.startsWith("{")) {
+		return raw;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(bodyText);
+	} catch {
+		return raw;
+	}
+	const body = asRecord(parsed);
+	if (!body) {
+		return raw;
+	}
+	const nested = asRecord(body.error);
+	const message = asNonEmptyString(nested?.message) ?? asNonEmptyString(body.message) ?? asNonEmptyString(body.error);
+	if (message === undefined) {
+		return raw;
+	}
+	const details: string[] = [];
+	const errorType = asNonEmptyString(nested?.type) ?? asNonEmptyString(body.type);
+	if (errorType && errorType !== "error") {
+		details.push(errorType);
+	}
+	if (status) {
+		details.push(`HTTP ${status}`);
+	}
+	const requestId = asNonEmptyString(body.request_id);
+	if (requestId) {
+		details.push(`request ${requestId}`);
+	}
+	return details.length > 0 ? `${message} (${details.join(", ")})` : message;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function sanitizeTitle(text: string): string {

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Runtime-error headline rendering (2026-07-27)
+
+### What changed
+
+- `extension-error-format.ts` (new): `formatExtensionErrorHeadline()` renders runtime-emitted errors
+  (`extensionPath === RUNTIME_EXTENSION_PATH`) as `Runtime error (<event>): <message>`; real extensions keep the
+  `Extension "<path>" error: <message>` framing.
+- `extension-error-format.ts` also owns `sanitizeTuiErrorMessage()`, moved out of `interactive-mode.ts`, and the
+  formatter applies it to the message, event name, and extension path. Provider error bodies are JSON-decoded
+  before rendering, so `\u001b` escapes that were previously inert become live OSC/CSI sequences on an
+  ANSI-preserving row; sanitizing inside the formatter means every consumer is protected by default.
+- `interactive-mode.ts`: `showExtensionError()` consumes the full error object and uses the shared formatter, and
+  imports the sanitizer from the format module instead of defining its own copy.
+
+### Why
+
+- Background session-title failures rendered as `Extension "<runtime>" error: {raw provider json}` — misattributed
+  to an extension and unreadable.
+
+### Expected merge conflict zones
+
+- LOW: `showExtensionError()` in `interactive-mode.ts`; the formatter module is additive.
+
 ## grok chrome seam for interactive mode (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/extension-error-format.ts
+++ b/packages/coding-agent/src/modes/interactive/extension-error-format.ts
@@ -1,0 +1,37 @@
+import { RUNTIME_EXTENSION_PATH } from "../../core/extensions/types.ts";
+
+/**
+ * Strip terminal control sequences from text that reaches an ANSI-preserving
+ * chat row. Error text can carry provider-controlled bytes — a JSON error body
+ * may decode `\u001b` escapes into live OSC/CSI sequences — so anything routed
+ * to `Text` is sanitized first.
+ */
+export function sanitizeTuiErrorMessage(value: string): string {
+	return value
+		.replace(/\u001b\][\s\S]*?(?:\u0007|\u001b\\|\u009c|$)/g, "")
+		.replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
+		.replace(/\r\n?/g, "\n")
+		.replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, "")
+		.replace(/[ \t\f\v]+/g, " ");
+}
+
+/**
+ * Headline for an extension-error line in the chat log.
+ *
+ * Errors emitted by the session runtime itself (extensionPath `<runtime>`,
+ * e.g. background session-title generation) are not extension failures, so
+ * they render as runtime errors labeled with the emitting event instead of a
+ * confusing `Extension "<runtime>" error:` attribution.
+ */
+export function formatExtensionErrorHeadline(error: {
+	readonly extensionPath: string;
+	readonly event?: string;
+	readonly error: string;
+}): string {
+	const message = sanitizeTuiErrorMessage(error.error);
+	if (error.extensionPath === RUNTIME_EXTENSION_PATH) {
+		const event = error.event ? sanitizeTuiErrorMessage(error.event) : undefined;
+		return event ? `Runtime error (${event}): ${message}` : `Runtime error: ${message}`;
+	}
+	return `Extension "${sanitizeTuiErrorMessage(error.extensionPath)}" error: ${message}`;
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -157,6 +157,7 @@ import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
 import { UserMessageComponent } from "./components/user-message.ts";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.ts";
+import { formatExtensionErrorHeadline, sanitizeTuiErrorMessage } from "./extension-error-format.ts";
 import { editInExternalEditor } from "./external-editor.ts";
 import { GrokChrome, type InteractiveChrome, type InteractiveFooter } from "./grok/chrome.ts";
 import { restoreInteractiveStderr, takeOverInteractiveStderr } from "./interactive-stderr-guard.ts";
@@ -241,15 +242,6 @@ function formatToolHookTerminalTitle(event: ToolHookStatusStartEvent): string {
 	const hookName = sanitizeWorkingStatusPlainText(event.hookName) || "hook";
 	const statusMessage = sanitizeWorkingStatusPlainText(event.statusMessage);
 	return `${APP_TITLE} - ${hookName}: ${statusMessage}`;
-}
-
-function sanitizeTuiErrorMessage(value: string): string {
-	return value
-		.replace(/\u001b\][\s\S]*?(?:\u0007|\u001b\\|\u009c|$)/g, "")
-		.replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
-		.replace(/\r\n?/g, "\n")
-		.replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, "")
-		.replace(/[ \t\f\v]+/g, " ");
 }
 
 type RenderSessionItem = AgentMessage | Extract<SessionEntry, { type: "custom" }>;
@@ -1939,7 +1931,7 @@ export class InteractiveMode {
 				}
 			},
 			onError: (error) => {
-				this.showExtensionError(error.extensionPath, error.error, error.stack);
+				this.showExtensionError(error);
 			},
 		});
 
@@ -3036,13 +3028,18 @@ export class InteractiveMode {
 	/**
 	 * Show an extension error in the UI.
 	 */
-	private showExtensionError(extensionPath: string, error: string, stack?: string): void {
-		const errorMsg = `Extension "${extensionPath}" error: ${error}`;
+	private showExtensionError(error: {
+		readonly extensionPath: string;
+		readonly event?: string;
+		readonly error: string;
+		readonly stack?: string;
+	}): void {
+		const errorMsg = formatExtensionErrorHeadline(error);
 		const errorText = new Text(theme.fg("error", errorMsg), 1, 0);
 		this.chatContainer.addChild(errorText);
-		if (stack) {
+		if (error.stack) {
 			// Show stack trace in dim color, indented
-			const stackLines = stack
+			const stackLines = error.stack
 				.split("\n")
 				.slice(1) // Skip first line (duplicates error message)
 				.map((line) => theme.fg("dim", `  ${line.trim()}`))

--- a/packages/coding-agent/test/agent-session-auto-title.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-title.test.ts
@@ -11,6 +11,9 @@ import {
 } from "./agent-session-auto-title-helpers.ts";
 import { getAssistantTexts, type Harness } from "./suite/harness.ts";
 
+const RAW_OVERLOADED_ERROR =
+	'{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_011CdRmGPa88udPD5fc8dt8U"}';
+
 describe("agent session auto title", () => {
 	const harnesses: Harness[] = [];
 
@@ -115,6 +118,66 @@ describe("agent session auto title", () => {
 
 		expect(getAssistantTexts(harness)).toEqual(["turn complete"]);
 		await expect(titleError).resolves.toBe("title provider failed");
+		expect(harness.sessionManager.getSessionName()).toBeUndefined();
+	});
+
+	it("retries transient title-generation errors with the configured retry policy", async () => {
+		const harness = await createAutoTitleHarness({
+			settings: { retry: { maxRetries: 2, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		const titleErrors: string[] = [];
+		harness.session.extensionRunner.onError((error) => {
+			if (error.event === "session_title_generation") {
+				titleErrors.push(error.error);
+			}
+		});
+		let titleAttempts = 0;
+		const titleOrTurn: FauxResponseFactory = (context) => {
+			const systemPrompt = Array.isArray(context.systemPrompt)
+				? context.systemPrompt.join("\n")
+				: (context.systemPrompt ?? "");
+			if (!systemPrompt.includes("<title>")) {
+				return fauxAssistantMessage("turn complete");
+			}
+			titleAttempts += 1;
+			if (titleAttempts === 1) {
+				return fauxAssistantMessage("", { stopReason: "error", errorMessage: RAW_OVERLOADED_ERROR });
+			}
+			return fauxAssistantMessage("<title>Fix OAuth Login</title>");
+		};
+		harness.setResponses([titleOrTurn, titleOrTurn, titleOrTurn]);
+
+		const sessionName = waitForSessionName(harness);
+		await harness.session.prompt("fix the OAuth login button on mobile");
+
+		await expect(sessionName).resolves.toBe("Fix OAuth Login");
+		expect(harness.sessionManager.getSessionName()).toBe("Fix OAuth Login");
+		expect(titleAttempts).toBe(2);
+		expect(titleErrors).toEqual([]);
+	});
+
+	it("reports a clean human-readable error once title retries are exhausted", async () => {
+		const harness = await createAutoTitleHarness({
+			settings: { retry: { maxRetries: 1, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		const titleError = waitForTitleError(harness);
+		const titleOrTurn: FauxResponseFactory = (context) => {
+			const systemPrompt = Array.isArray(context.systemPrompt)
+				? context.systemPrompt.join("\n")
+				: (context.systemPrompt ?? "");
+			if (!systemPrompt.includes("<title>")) {
+				return fauxAssistantMessage("turn complete");
+			}
+			return fauxAssistantMessage("", { stopReason: "error", errorMessage: RAW_OVERLOADED_ERROR });
+		};
+		harness.setResponses([titleOrTurn, titleOrTurn, titleOrTurn]);
+
+		await harness.session.prompt("fix the OAuth login button on mobile");
+
+		await expect(titleError).resolves.toBe("Overloaded (overloaded_error, request req_011CdRmGPa88udPD5fc8dt8U)");
+		await waitForCallCount(harness, 3);
 		expect(harness.sessionManager.getSessionName()).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/extension-error-format.test.ts
+++ b/packages/coding-agent/test/extension-error-format.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatExtensionErrorHeadline } from "../src/modes/interactive/extension-error-format.ts";
+
+describe("formatExtensionErrorHeadline", () => {
+	it("renders runtime-emitted errors without the extension framing", () => {
+		expect(
+			formatExtensionErrorHeadline({
+				extensionPath: "<runtime>",
+				event: "session_title_generation",
+				error: "Overloaded (overloaded_error, request req_011CdRmGPa88udPD5fc8dt8U)",
+			}),
+		).toBe(
+			"Runtime error (session_title_generation): Overloaded (overloaded_error, request req_011CdRmGPa88udPD5fc8dt8U)",
+		);
+	});
+
+	it("renders runtime-emitted errors without an event name", () => {
+		expect(formatExtensionErrorHeadline({ extensionPath: "<runtime>", error: "boom" })).toBe("Runtime error: boom");
+	});
+
+	it("strips terminal control sequences a provider can smuggle through the error body", () => {
+		const hostile = [
+			"Overloaded",
+			"\u001b]52;c;Zm9v\u0007",
+			"\u001b]0;pwned\u001b\\",
+			"\u001b]8;;https://evil.example\u0007link\u001b]8;;\u0007",
+			"\u001b[31mred\u001b[0m",
+			"\u009b2Jclear",
+			"tail\u0000\u0008\u007f",
+		].join("");
+		const headline = formatExtensionErrorHeadline({
+			extensionPath: "<runtime>",
+			event: "session_title_generation",
+			error: hostile,
+		});
+
+		expect(headline).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/);
+		expect(headline).toBe("Runtime error (session_title_generation): Overloadedlinkredcleartail");
+	});
+
+	it("strips control sequences smuggled through the event name and extension path", () => {
+		expect(
+			formatExtensionErrorHeadline({
+				extensionPath: "/ext\u001b]52;c;Zm9v\u0007.ts",
+				event: "tool\u001b[31m_call",
+				error: "boom",
+			}),
+		).toBe('Extension "/ext.ts" error: boom');
+	});
+
+	it("keeps the extension framing for real extension paths", () => {
+		expect(
+			formatExtensionErrorHeadline({ extensionPath: "/home/user/ext.ts", event: "tool_call", error: "boom" }),
+		).toBe('Extension "/home/user/ext.ts" error: boom');
+	});
+});

--- a/packages/coding-agent/test/session-title-generator.test.ts
+++ b/packages/coding-agent/test/session-title-generator.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { humanizeProviderError, sessionTitleRetryPolicy } from "../src/core/session-title-generator.ts";
+
+describe("sessionTitleRetryPolicy", () => {
+	it("caps the cosmetic title retry below the full agent-turn budget", () => {
+		expect(sessionTitleRetryPolicy({ enabled: true, maxRetries: 3, baseDelayMs: 2000 })).toEqual({
+			enabled: true,
+			maxRetries: 1,
+			baseDelayMs: 2000,
+		});
+	});
+
+	it("keeps a smaller user budget instead of inflating it", () => {
+		expect(sessionTitleRetryPolicy({ enabled: true, maxRetries: 0, baseDelayMs: 500 })).toEqual({
+			enabled: true,
+			maxRetries: 0,
+			baseDelayMs: 500,
+		});
+	});
+
+	it("caps a long user backoff so a title never stalls for minutes", () => {
+		expect(sessionTitleRetryPolicy({ enabled: true, maxRetries: 5, baseDelayMs: 60_000 })).toEqual({
+			enabled: true,
+			maxRetries: 1,
+			baseDelayMs: 2000,
+		});
+	});
+
+	it("honors a disabled retry policy", () => {
+		expect(sessionTitleRetryPolicy({ enabled: false, maxRetries: 3, baseDelayMs: 2000 })).toEqual({
+			enabled: false,
+			maxRetries: 1,
+			baseDelayMs: 2000,
+		});
+	});
+});
+
+describe("humanizeProviderError", () => {
+	it("extracts message, type, and request id from an Anthropic SSE error body", () => {
+		expect(
+			humanizeProviderError(
+				'{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_011CdRmGPa88udPD5fc8dt8U"}',
+			),
+		).toBe("Overloaded (overloaded_error, request req_011CdRmGPa88udPD5fc8dt8U)");
+	});
+
+	it("parses the `<prefix> (<status>): <body>` shape formatProviderError emits", () => {
+		expect(humanizeProviderError('OpenAI (503): {"error":{"message":"Service unavailable"}}')).toBe(
+			"Service unavailable (HTTP 503)",
+		);
+	});
+
+	it("falls back to the HTTP status when the body carries no error type", () => {
+		expect(humanizeProviderError('529: {"message":"Overloaded"}')).toBe("Overloaded (HTTP 529)");
+	});
+
+	it("keeps a string-valued error body instead of falling back to raw JSON", () => {
+		expect(humanizeProviderError('503: {"error":"blocked by gateway WAF"}')).toBe(
+			"blocked by gateway WAF (HTTP 503)",
+		);
+	});
+
+	it("retains the HTTP status alongside the provider error type", () => {
+		expect(humanizeProviderError('529: {"message":"Overloaded","type":"server_error"}')).toBe(
+			"Overloaded (server_error, HTTP 529)",
+		);
+	});
+
+	it("returns non-JSON messages unchanged", () => {
+		expect(humanizeProviderError("title provider failed")).toBe("title provider failed");
+	});
+
+	it("returns unrecognized JSON unchanged", () => {
+		expect(humanizeProviderError('{"details":"no message here"}')).toBe('{"details":"no message here"}');
+	});
+});


### PR DESCRIPTION
## Problem

A session surfaced this in the TUI:

```
Extension "<runtime>" error: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_011CdRmGPa88udPD5fc8dt8U"}
```

Two separate defects produced that line.

**1. Session-title generation had no retry.** It makes its own LLM call, but unlike the agent turn (`_handleRetryableError`) and compaction (`completeSummarization`, `compaction.ts:661`), it was never wrapped in the retry policy. A single transient provider error — here an Anthropic 529 `overloaded_error` SSE event, thrown raw at `packages/ai/src/api/anthropic-messages.ts:1047` — killed the title permanently. The session stayed untitled until a later turn happened to regenerate it.

**2. Runtime errors were rendered as extension failures.** Errors the session runtime emits through the extension-error channel carry the sentinel `extensionPath` `"<runtime>"`. The TUI rendered them with the generic `Extension "<path>" error:` framing, attributing a core failure to a nonexistent extension, and printed the raw provider JSON body verbatim.

## Change

**Retry** — `generateSessionTitle()` accepts a `RetryPolicy` and wraps its call in `retryAssistantCall()`, mirroring `completeSummarization()`. Aborting mid-backoff still normalizes to an aborted message, so a cancelled title stays silent.

The budget is deliberately narrower than the agent turn's. `sessionTitleRetryPolicy()` preserves the user's `enabled` flag but caps retries at 1 and backoff at 2s, and never inflates a smaller configured budget. The full default budget would keep hitting an already-overloaded provider for ~14s while the user's real turn competes for the same capacity — and a title that still fails is regenerated at the next turn end anyway.

**Readable errors** — `humanizeProviderError()` parses the shapes `formatProviderError` emits (`packages/ai/src/utils/error-body.ts:117`): `<status>: <body>`, `<prefix> (<status>): <body>`, and the bare Anthropic SSE body. It keeps the message, error type, HTTP status, and request id, and passes anything unrecognized through untouched.

**Correct attribution + sanitization** — `formatExtensionErrorHeadline()` renders runtime-emitted errors as `Runtime error (<event>): <message>`, keeping the existing framing for real extension paths. It also sanitizes the message, event name, and extension path: provider error bodies are JSON-decoded before rendering, which turns `\u001b` escapes that were previously inert inside the raw JSON into live OSC/CSI sequences on an ANSI-preserving row. `sanitizeTuiErrorMessage()` moved out of `interactive-mode.ts` into the formatter so every consumer is protected by default rather than by caller discipline.

Net user-visible result:

| | before | after |
|---|---|---|
| transient 529 | title lost permanently | retried once, title lands |
| exhausted retries | `Extension "<runtime>" error: {"type":"error","error":{...},"request_id":"..."}` | `Runtime error (session_title_generation): Overloaded (server_error, HTTP 529)` |

## Verification

**Unit** — 25/25 green across the three touched files: retry-then-success and exhausted-retries-clean-text (`agent-session-auto-title.test.ts`), 8 humanizer + 4 retry-policy cases (`session-title-generator.test.ts`), 5 headline/sanitization cases (`extension-error-format.test.ts`). Every case was captured RED before its fix.

**Full package suite** — green. (An initial 54 failures were traced to a `--ignore-scripts` install leaving `dist/` unbuilt, so subprocess-spawning tests could not resolve workspace packages; they pass after `npm run build`.)

**`npm run check`** — exit 0.

**Real-surface QA** — the actual TUI driven in tmux against a fake model server, isolated sandbox, `PI_OFFLINE=1`, real auth guarded and verified unchanged:

- *recover* (turn → 529 → title ok, maxRetries 2): session named `Retry Title QA`, 3 requests, **no error line rendered**.
- *exhaust* (turn → 529 → 529, maxRetries 1): renders exactly `Runtime error (session_title_generation): Overloaded (server_error, HTTP 529)`, no session name.

This QA caught a real defect the unit tests missed: the first implementation assumed a bare-JSON error shape and still rendered `529: {"message":"Overloaded","type":"server_error"}` on screen. The humanizer and its tests were rewritten against the real wire formats.

Evidence (gitignored): `local-ignore/qa-evidence/20260727-session-title-retry/`. tmux sessions and fake servers torn down and verified gone.

**Review** — oracle review found the sanitization gap above as a blocker plus two notes (retry budget, humanizer coverage); all three are addressed in this PR.

## Notes for reviewers

- `RUNTIME_EXTENSION_PATH` is now an exported constant instead of three string literals, so the "runtime errors are not extension failures" contract has one owner.
- RPC/app-server consumers are unaffected: `extension_error` still carries the structured `extensionPath` / `event` / `error` fields; only TUI presentation changed.
- Fork-mergeability: `changes.md` entries added under `src/core/`, `src/core/extensions/`, and `src/modes/interactive/`, each with expected conflict zones.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient session-title failures and renders runtime errors clearly and safely to avoid lost titles and noisy JSON in the TUI. The retry budget is limited to reduce provider contention.

- **Bug Fixes**
  - Session-title generation now uses `retryAssistantCall()` with `sessionTitleRetryPolicy()` (preserves `enabled`, caps to 1 retry and 2s backoff; never inflates a smaller user budget).
  - Final title failures show `humanizeProviderError()` output (message, error type, HTTP status, request id) instead of raw provider JSON.
  - Runtime errors are labeled as runtime, not extensions, via `RUNTIME_EXTENSION_PATH`; the TUI headline formatter sanitizes message/event/path to strip control sequences.

<sup>Written for commit bbe35e0a0ed2dd7fd28d0c119f56828e866309b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

