### PR TITLE
fix(config-reload): stop reloading on extension runtime state and unrelated subtrees

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/extension-watch-scope.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/extension-watch-scope.ts
@@ -1,0 +1,29 @@
+import { sep } from "node:path";
+
+const SUBDIRECTORY_ENTRY_NAMES = ["index.ts", "index.js", "package.json"] as const;
+
+function isExtensionSource(name: string): boolean {
+	return name.endsWith(".ts") || name.endsWith(".js");
+}
+
+/**
+ * Mirrors `discoverExtensionsInDir` in `../../loader.ts`, which never recurses
+ * past one level. Anything deeper is extension runtime state, not configuration:
+ * the goal extension persists `extensions/goal/<scope>/<id>.json`, and watching
+ * it turned every goal tool call into a full session reload.
+ */
+export function isLoadableExtensionEntry(relativePath: string): boolean {
+	const segments = relativePath.split(sep).filter((segment) => segment !== "");
+	const [first, second] = segments;
+	if (first === undefined) return false;
+	if (segments.length === 1) return isExtensionSource(first);
+	if (segments.length === 2) {
+		return SUBDIRECTORY_ENTRY_NAMES.some((entryName) => entryName === second);
+	}
+	return false;
+}
+
+export function isScannableExtensionDirectory(relativePath: string): boolean {
+	if (relativePath === "") return true;
+	return !relativePath.includes(sep);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/extension-watch-scope.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/extension-watch-scope.ts
@@ -1,4 +1,5 @@
-import { sep } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
 
 const SUBDIRECTORY_ENTRY_NAMES = ["index.ts", "index.js", "package.json"] as const;
 
@@ -6,24 +7,65 @@ function isExtensionSource(name: string): boolean {
 	return name.endsWith(".ts") || name.endsWith(".js");
 }
 
+function isWithinPackage(relativePath: string): boolean {
+	return relativePath !== "" && !relativePath.startsWith("..") && !relativePath.startsWith(sep);
+}
+
+/**
+ * Paths a one-level extension package declares through `pi.extensions`, which
+ * `resolveExtensionEntries` in `../../loader.ts` resolves relative to the
+ * package directory and at any depth.
+ */
+function manifestEntryPaths(extensionsDir: string, packageName: string): string[] {
+	const packageDir = join(extensionsDir, packageName);
+	const packageJsonPath = join(packageDir, "package.json");
+	if (!existsSync(packageJsonPath)) return [];
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+		if (typeof parsed !== "object" || parsed === null) return [];
+		const pi: unknown = (parsed as { pi?: unknown }).pi;
+		if (typeof pi !== "object" || pi === null) return [];
+		const declared: unknown = (pi as { extensions?: unknown }).extensions;
+		if (!Array.isArray(declared)) return [];
+		return declared
+			.filter((entry): entry is string => typeof entry === "string")
+			.map((entry) => relative(extensionsDir, resolve(packageDir, entry)))
+			.filter(isWithinPackage);
+	} catch {
+		return [];
+	}
+}
+
 /**
  * Mirrors `discoverExtensionsInDir` in `../../loader.ts`, which never recurses
- * past one level. Anything deeper is extension runtime state, not configuration:
- * the goal extension persists `extensions/goal/<scope>/<id>.json`, and watching
- * it turned every goal tool call into a full session reload.
+ * past one level except through a package manifest. Anything else is extension
+ * runtime state, not configuration: the goal extension persists
+ * `extensions/goal/<scope>/<id>.json`, and watching it turned every goal tool
+ * call into a full session reload.
  */
-export function isLoadableExtensionEntry(relativePath: string): boolean {
+export function isLoadableExtensionEntry(extensionsDir: string, relativePath: string): boolean {
 	const segments = relativePath.split(sep).filter((segment) => segment !== "");
 	const [first, second] = segments;
 	if (first === undefined) return false;
 	if (segments.length === 1) return isExtensionSource(first);
-	if (segments.length === 2) {
-		return SUBDIRECTORY_ENTRY_NAMES.some((entryName) => entryName === second);
+	if (segments.length === 2 && SUBDIRECTORY_ENTRY_NAMES.some((entryName) => entryName === second)) {
+		return true;
 	}
-	return false;
+	return manifestEntryPaths(extensionsDir, first).includes(relativePath);
 }
 
-export function isScannableExtensionDirectory(relativePath: string): boolean {
+/**
+ * Directories worth descending into while scanning. A manifest can declare an
+ * entry at any depth, so every directory inside a package that declares one
+ * stays scannable.
+ */
+export function isScannableExtensionDirectory(extensionsDir: string, relativePath: string): boolean {
 	if (relativePath === "") return true;
-	return !relativePath.includes(sep);
+	const segments = relativePath.split(sep).filter((segment) => segment !== "");
+	const [first] = segments;
+	if (first === undefined) return false;
+	if (segments.length === 1) return true;
+	return manifestEntryPaths(extensionsDir, first).some(
+		(entryPath) => entryPath === relativePath || entryPath.startsWith(`${relativePath}${sep}`),
+	);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -689,9 +689,11 @@ function externalTargetToWatchTarget(
 
 function literalFilterNames(filterGlobs: readonly string[] | undefined): string[] | undefined {
 	if (!filterGlobs) return undefined;
-	const literalNames = filterGlobs.filter(
-		(filterGlob) => !filterGlob.includes("*") && !filterGlob.includes("/") && !filterGlob.includes("\\\\"),
-	);
+	// A root-anchored glob names a literal path relative to the watch root, so
+	// strip the anchor before the separator check rejects it.
+	const literalNames = filterGlobs
+		.map((filterGlob) => (filterGlob.startsWith("/") ? filterGlob.slice(1) : filterGlob))
+		.filter((filterGlob) => !filterGlob.includes("*") && !filterGlob.includes("/") && !filterGlob.includes("\\\\"));
 	return literalNames.length > 0 ? literalNames : undefined;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -6,6 +6,7 @@ import { resolvePath } from "../../../../utils/paths.ts";
 import { ModelConfig } from "../../../model-config.ts";
 import { type Settings, SettingsManager, wasSelfWrite } from "../../../settings-manager.ts";
 import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
+import { isLoadableExtensionEntry, isScannableExtensionDirectory } from "./extension-watch-scope.ts";
 import { type ConfigReloadLogger, createConfigReloadLogger } from "./log.ts";
 import {
 	CONFIG_WATCH_CHANGED,
@@ -40,6 +41,13 @@ const BUILTIN_REGISTRATION_ID = "builtin";
 const DEFAULT_DEBOUNCE_MS = 200;
 const COMPACTION_RECHECK_MS = 250;
 const CONFIG_FILE_NAMES = ["settings.json", "models.json", "keybindings.json"] as const;
+
+/**
+ * The engine applies one predicate to both file gating and directory descent, so
+ * this must admit immediate subdirectories in order to reach their entry files.
+ */
+const extensionWatchFilter = (relPath: string): boolean =>
+	isLoadableExtensionEntry(relPath) || isScannableExtensionDirectory(relPath);
 
 type ConfigReloadWatchSettings = {
 	readonly settings?: boolean;
@@ -530,10 +538,15 @@ function buildWatchTargets(options: {
 	const addBuiltin = (id: string, target: WatchTargetInput, rearmOnCreation?: string): void => {
 		targets.push({ registrationId: BUILTIN_REGISTRATION_ID, target: { ...target, id }, rearmOnCreation });
 	};
-	const addBuiltinDirectory = (id: string, path: string): void => {
+	const addBuiltinDirectory = (id: string, path: string, filter?: (relPath: string) => boolean): void => {
 		const resourcePath = resolve(path);
 		if (isExistingDirectory(resourcePath)) {
-			addBuiltin(id, { kind: "dir-recursive", path: resourcePath });
+			addBuiltin(
+				id,
+				filter
+					? { kind: "dir-recursive", path: resourcePath, filter }
+					: { kind: "dir-recursive", path: resourcePath },
+			);
 			return;
 		}
 		const watchPath = nearestExistingDirectory(dirname(resourcePath));
@@ -564,7 +577,7 @@ function buildWatchTargets(options: {
 		addBuiltinDirectory("builtin-global-prompts", resolve(agentDir, "prompts"));
 	}
 	if (settings.watch.extensions) {
-		addBuiltinDirectory("builtin-global-extensions", resolve(agentDir, "extensions"));
+		addBuiltinDirectory("builtin-global-extensions", resolve(agentDir, "extensions"), extensionWatchFilter);
 	}
 	if (settings.watch.skills) {
 		for (const [index, skillPath] of options.skillPaths.entries()) {
@@ -602,7 +615,7 @@ function buildWatchTargets(options: {
 				addBuiltinDirectory("builtin-project-skills", resolve(projectDir, "skills"));
 			}
 			if (settings.watch.extensions) {
-				addBuiltinDirectory("builtin-project-extensions", resolve(projectDir, "extensions"));
+				addBuiltinDirectory("builtin-project-extensions", resolve(projectDir, "extensions"), extensionWatchFilter);
 			}
 		}
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -44,10 +44,12 @@ const CONFIG_FILE_NAMES = ["settings.json", "models.json", "keybindings.json"] a
 
 /**
  * The engine applies one predicate to both file gating and directory descent, so
- * this must admit immediate subdirectories in order to reach their entry files.
+ * this must admit scannable directories in order to reach their entry files.
  */
-const extensionWatchFilter = (relPath: string): boolean =>
-	isLoadableExtensionEntry(relPath) || isScannableExtensionDirectory(relPath);
+const extensionWatchFilter =
+	(extensionsDir: string) =>
+	(relPath: string): boolean =>
+		isLoadableExtensionEntry(extensionsDir, relPath) || isScannableExtensionDirectory(extensionsDir, relPath);
 
 type ConfigReloadWatchSettings = {
 	readonly settings?: boolean;
@@ -577,7 +579,8 @@ function buildWatchTargets(options: {
 		addBuiltinDirectory("builtin-global-prompts", resolve(agentDir, "prompts"));
 	}
 	if (settings.watch.extensions) {
-		addBuiltinDirectory("builtin-global-extensions", resolve(agentDir, "extensions"), extensionWatchFilter);
+		const globalExtensionsDir = resolve(agentDir, "extensions");
+		addBuiltinDirectory("builtin-global-extensions", globalExtensionsDir, extensionWatchFilter(globalExtensionsDir));
 	}
 	if (settings.watch.skills) {
 		for (const [index, skillPath] of options.skillPaths.entries()) {
@@ -615,7 +618,12 @@ function buildWatchTargets(options: {
 				addBuiltinDirectory("builtin-project-skills", resolve(projectDir, "skills"));
 			}
 			if (settings.watch.extensions) {
-				addBuiltinDirectory("builtin-project-extensions", resolve(projectDir, "extensions"), extensionWatchFilter);
+				const projectExtensionsDir = resolve(projectDir, "extensions");
+				addBuiltinDirectory(
+					"builtin-project-extensions",
+					projectExtensionsDir,
+					extensionWatchFilter(projectExtensionsDir),
+				);
 			}
 		}
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/protocol.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/protocol.ts
@@ -121,6 +121,11 @@ export function isConfigWatchRejected(value: unknown): value is ConfigWatchRejec
 /**
  * Matches plain file names, path suffixes, and a leading-star suffix pattern.
  * This intentionally does not implement a full glob language.
+ *
+ * A leading `/` anchors the glob to the watch root, which is the only way to
+ * express "this immediate child" for a recursive target. Without it a bare
+ * `.omo` glob on an ancestor watch matches every `.omo` directory in the whole
+ * subtree.
  */
 export function matchesConfigWatchFilter(path: string, filterGlobs: readonly string[] | undefined): boolean {
 	if (filterGlobs === undefined || filterGlobs.length === 0) return true;
@@ -128,6 +133,7 @@ export function matchesConfigWatchFilter(path: string, filterGlobs: readonly str
 	const normalizedPath = path.replaceAll("\\", "/");
 	const basename = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
 	return filterGlobs.some((filterGlob) => {
+		if (filterGlob.startsWith("/")) return normalizedPath === filterGlob.slice(1);
 		if (filterGlob.startsWith("*")) return normalizedPath.endsWith(filterGlob.slice(1));
 		return basename === filterGlob || normalizedPath.endsWith(`/${filterGlob}`);
 	});

--- a/packages/coding-agent/test/config-reload-extension-watch-scope.test.ts
+++ b/packages/coding-agent/test/config-reload-extension-watch-scope.test.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	isLoadableExtensionEntry,
+	isScannableExtensionDirectory,
+} from "../src/core/extensions/builtin/config-reload/extension-watch-scope.ts";
+
+describe("config reload extension watch scope", () => {
+	describe("#given a direct entry in the extensions directory", () => {
+		it("#then treats extension sources as loadable", () => {
+			expect(isLoadableExtensionEntry("diff.js")).toBe(true);
+			expect(isLoadableExtensionEntry("tps.ts")).toBe(true);
+		});
+
+		it("#then ignores non-source files", () => {
+			expect(isLoadableExtensionEntry("notes.md")).toBe(false);
+			expect(isLoadableExtensionEntry("state.json")).toBe(false);
+		});
+	});
+
+	describe("#given a subdirectory extension", () => {
+		it("#then treats its discovery entry points as loadable", () => {
+			expect(isLoadableExtensionEntry(join("my-ext", "index.ts"))).toBe(true);
+			expect(isLoadableExtensionEntry(join("my-ext", "index.js"))).toBe(true);
+			expect(isLoadableExtensionEntry(join("my-ext", "package.json"))).toBe(true);
+		});
+
+		it("#then ignores files the loader never discovers", () => {
+			expect(isLoadableExtensionEntry(join("my-ext", "helper.ts"))).toBe(false);
+			expect(isLoadableExtensionEntry(join("my-ext", "src", "index.ts"))).toBe(false);
+		});
+	});
+
+	describe("#given extension runtime state written below the discovery depth", () => {
+		it("#then never treats it as a loadable entry", () => {
+			const goalState = join(
+				"goal",
+				"no-session",
+				"2fca6eb7d09fc68d11abc56e",
+				"019fa192-1633-7803-9770-f2c76bd91ca3.json",
+			);
+			expect(isLoadableExtensionEntry(goalState)).toBe(false);
+			expect(isScannableExtensionDirectory(join("goal", "no-session"))).toBe(false);
+		});
+	});
+
+	describe("#given directory descent during a scan", () => {
+		it("#then descends into the root and immediate children only", () => {
+			expect(isScannableExtensionDirectory("")).toBe(true);
+			expect(isScannableExtensionDirectory("goal")).toBe(true);
+			expect(isScannableExtensionDirectory(join("goal", "no-session"))).toBe(false);
+		});
+	});
+});

--- a/packages/coding-agent/test/config-reload-extension-watch-scope.test.ts
+++ b/packages/coding-agent/test/config-reload-extension-watch-scope.test.ts
@@ -1,33 +1,48 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
 	isLoadableExtensionEntry,
 	isScannableExtensionDirectory,
 } from "../src/core/extensions/builtin/config-reload/extension-watch-scope.ts";
 
+const scopeRoots: string[] = [];
+
+function extensionsRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "senpi-extension-watch-scope-"));
+	scopeRoots.push(root);
+	return root;
+}
+
+afterEach(() => {
+	for (const root of scopeRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
 describe("config reload extension watch scope", () => {
+	const dir = extensionsRoot();
 	describe("#given a direct entry in the extensions directory", () => {
 		it("#then treats extension sources as loadable", () => {
-			expect(isLoadableExtensionEntry("diff.js")).toBe(true);
-			expect(isLoadableExtensionEntry("tps.ts")).toBe(true);
+			expect(isLoadableExtensionEntry(dir, "diff.js")).toBe(true);
+			expect(isLoadableExtensionEntry(dir, "tps.ts")).toBe(true);
 		});
 
 		it("#then ignores non-source files", () => {
-			expect(isLoadableExtensionEntry("notes.md")).toBe(false);
-			expect(isLoadableExtensionEntry("state.json")).toBe(false);
+			expect(isLoadableExtensionEntry(dir, "notes.md")).toBe(false);
+			expect(isLoadableExtensionEntry(dir, "state.json")).toBe(false);
 		});
 	});
 
 	describe("#given a subdirectory extension", () => {
 		it("#then treats its discovery entry points as loadable", () => {
-			expect(isLoadableExtensionEntry(join("my-ext", "index.ts"))).toBe(true);
-			expect(isLoadableExtensionEntry(join("my-ext", "index.js"))).toBe(true);
-			expect(isLoadableExtensionEntry(join("my-ext", "package.json"))).toBe(true);
+			expect(isLoadableExtensionEntry(dir, join("my-ext", "index.ts"))).toBe(true);
+			expect(isLoadableExtensionEntry(dir, join("my-ext", "index.js"))).toBe(true);
+			expect(isLoadableExtensionEntry(dir, join("my-ext", "package.json"))).toBe(true);
 		});
 
 		it("#then ignores files the loader never discovers", () => {
-			expect(isLoadableExtensionEntry(join("my-ext", "helper.ts"))).toBe(false);
-			expect(isLoadableExtensionEntry(join("my-ext", "src", "index.ts"))).toBe(false);
+			expect(isLoadableExtensionEntry(dir, join("my-ext", "helper.ts"))).toBe(false);
+			expect(isLoadableExtensionEntry(dir, join("my-ext", "src", "index.ts"))).toBe(false);
 		});
 	});
 
@@ -39,16 +54,39 @@ describe("config reload extension watch scope", () => {
 				"2fca6eb7d09fc68d11abc56e",
 				"019fa192-1633-7803-9770-f2c76bd91ca3.json",
 			);
-			expect(isLoadableExtensionEntry(goalState)).toBe(false);
-			expect(isScannableExtensionDirectory(join("goal", "no-session"))).toBe(false);
+			expect(isLoadableExtensionEntry(dir, goalState)).toBe(false);
+			expect(isScannableExtensionDirectory(dir, join("goal", "no-session"))).toBe(false);
 		});
 	});
 
 	describe("#given directory descent during a scan", () => {
 		it("#then descends into the root and immediate children only", () => {
-			expect(isScannableExtensionDirectory("")).toBe(true);
-			expect(isScannableExtensionDirectory("goal")).toBe(true);
-			expect(isScannableExtensionDirectory(join("goal", "no-session"))).toBe(false);
+			expect(isScannableExtensionDirectory(dir, "")).toBe(true);
+			expect(isScannableExtensionDirectory(dir, "goal")).toBe(true);
+			expect(isScannableExtensionDirectory(dir, join("goal", "no-session"))).toBe(false);
+		});
+	});
+
+	describe("#given a package manifest declaring a nested entry", () => {
+		it("#then the declared entry and the directories leading to it stay watched", () => {
+			const root = extensionsRoot();
+			mkdirSync(join(root, "my-ext", "dist"), { recursive: true });
+			writeFileSync(
+				join(root, "my-ext", "package.json"),
+				JSON.stringify({ name: "my-ext", pi: { extensions: ["dist/index.js"] } }),
+			);
+
+			expect(isLoadableExtensionEntry(root, join("my-ext", "dist", "index.js"))).toBe(true);
+			expect(isScannableExtensionDirectory(root, join("my-ext", "dist"))).toBe(true);
+			expect(isLoadableExtensionEntry(root, join("my-ext", "dist", "state.json"))).toBe(false);
+		});
+
+		it("#then a package without a manifest entry keeps runtime state unwatched", () => {
+			const root = extensionsRoot();
+			mkdirSync(join(root, "goal", "no-session", "hash"), { recursive: true });
+
+			expect(isScannableExtensionDirectory(root, join("goal", "no-session"))).toBe(false);
+			expect(isLoadableExtensionEntry(root, join("goal", "no-session", "hash", "id.json"))).toBe(false);
 		});
 	});
 });

--- a/packages/coding-agent/test/config-reload-extension-watch-scope.test.ts
+++ b/packages/coding-agent/test/config-reload-extension-watch-scope.test.ts
@@ -89,4 +89,39 @@ describe("config reload extension watch scope", () => {
 			expect(isLoadableExtensionEntry(root, join("goal", "no-session", "hash", "id.json"))).toBe(false);
 		});
 	});
+
+	describe("#given the manifest shape used by extension discovery", () => {
+		it("#then resolves dot-prefixed sibling entries", () => {
+			const root = extensionsRoot();
+			mkdirSync(join(root, "my-package"), { recursive: true });
+			writeFileSync(
+				join(root, "my-package", "package.json"),
+				JSON.stringify({ name: "my-package", pi: { extensions: ["./ext1.ts", "./ext2.ts"] } }),
+			);
+
+			expect(isLoadableExtensionEntry(root, join("my-package", "ext1.ts"))).toBe(true);
+			expect(isLoadableExtensionEntry(root, join("my-package", "ext2.ts"))).toBe(true);
+			expect(isLoadableExtensionEntry(root, join("my-package", "ext3.ts"))).toBe(false);
+		});
+
+		it("#then a manifest entry escaping its package is ignored", () => {
+			const root = extensionsRoot();
+			mkdirSync(join(root, "escaping"), { recursive: true });
+			writeFileSync(
+				join(root, "escaping", "package.json"),
+				JSON.stringify({ pi: { extensions: ["../../outside.js"] } }),
+			);
+
+			expect(isLoadableExtensionEntry(root, join("escaping", "..", "..", "outside.js"))).toBe(false);
+		});
+
+		it("#then a malformed manifest degrades without throwing", () => {
+			const root = extensionsRoot();
+			mkdirSync(join(root, "broken"), { recursive: true });
+			writeFileSync(join(root, "broken", "package.json"), "{ not json");
+
+			expect(isLoadableExtensionEntry(root, join("broken", "dist", "index.js"))).toBe(false);
+			expect(isLoadableExtensionEntry(root, join("broken", "package.json"))).toBe(true);
+		});
+	});
 });

--- a/packages/coding-agent/test/config-reload-protocol.test.ts
+++ b/packages/coding-agent/test/config-reload-protocol.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -83,6 +84,25 @@ describe("config-watch protocol", () => {
 			changed: "config-watch:changed",
 			reloaded: "config-watch:reloaded",
 			rejected: "config-watch:rejected",
+		});
+	});
+
+	describe("#given a root-anchored filter glob", () => {
+		it("#then matches only the immediate child of the watch root", () => {
+			expect(matchesConfigWatchFilter(".omo", ["/.omo"])).toBe(true);
+			expect(matchesConfigWatchFilter(join("nested", ".omo"), ["/.omo"])).toBe(false);
+			expect(matchesConfigWatchFilter(join("a", "b", ".omo"), ["/.omo"])).toBe(false);
+		});
+
+		it("#then matches a nested path anchored at the watch root", () => {
+			expect(matchesConfigWatchFilter(join(".omo", "omo.jsonc"), ["/.omo/omo.jsonc"])).toBe(true);
+			expect(matchesConfigWatchFilter(join("worktree", ".omo", "omo.jsonc"), ["/.omo/omo.jsonc"])).toBe(false);
+		});
+
+		it("#then leaves unanchored suffix matching unchanged", () => {
+			expect(matchesConfigWatchFilter(join("nested", ".omo"), [".omo"])).toBe(true);
+			expect(matchesConfigWatchFilter("settings.json", ["settings.json"])).toBe(true);
+			expect(matchesConfigWatchFilter("theme.js", ["*.js"])).toBe(true);
 		});
 	});
 });

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1219,4 +1219,40 @@ describe("config reload builtin extension", () => {
 
 		expect(fixture.reload).not.toHaveBeenCalled();
 	});
+
+	it("reloads when a manifest-declared nested extension entry changes", async () => {
+		vi.useFakeTimers();
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-manifest-entry-"));
+		agentDirs.push(agentDir);
+		writeFileSync(join(agentDir, "settings.json"), '{"theme":"dark"}\n', "utf-8");
+		const packageDir = join(agentDir, "extensions", "my-ext");
+		const distDir = join(packageDir, "dist");
+		mkdirSync(distDir, { recursive: true });
+		writeFileSync(
+			join(packageDir, "package.json"),
+			`${JSON.stringify({ name: "my-ext", pi: { extensions: ["dist/index.js"] } })}\n`,
+			"utf-8",
+		);
+		const entryPath = join(distDir, "index.js");
+		writeFileSync(entryPath, "export default () => {};\n", "utf-8");
+
+		const watches = createWatchProbe();
+		const reload = vi.fn(async () => {});
+		const extension = createManualExtension(createEventBus());
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir, requestReload: reload }),
+		);
+
+		writeFileSync(entryPath, "export default () => { /* changed */ };\n", "utf-8");
+		watches.emit(join(agentDir, "extensions"), join("my-ext", "dist", "index.js"));
+		await vi.advanceTimersByTimeAsync(200);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(reload).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1181,4 +1181,42 @@ describe("config reload builtin extension", () => {
 
 		expect(reload).toHaveBeenCalledTimes(1);
 	});
+
+	it("detects an anchored external dot directory when it is created", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture();
+		const ancestorDir = join(fixture.harness.tempDir, "anchored-ancestor");
+		mkdirSync(ancestorDir);
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-anchored",
+			displayName: ".omo anchored",
+			targets: [{ path: ancestorDir, kind: "dir", filterGlobs: ["/.omo"] }],
+		});
+		const omoDir = join(ancestorDir, ".omo");
+		mkdirSync(omoDir);
+
+		await settleChange(fixture, ancestorDir, ".omo");
+
+		expect(fixture.reload).toHaveBeenCalledTimes(1);
+		expect(fixture.notifications.some((message) => message.includes(omoDir))).toBe(true);
+	});
+
+	it("ignores unrelated nested dot directories under an anchored external target", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture();
+		const ancestorDir = join(fixture.harness.tempDir, "anchored-scope");
+		const unrelatedDir = join(ancestorDir, "other-repo", "worktrees", "scratch");
+		mkdirSync(unrelatedDir, { recursive: true });
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-anchored-scope",
+			displayName: ".omo anchored scope",
+			targets: [{ path: ancestorDir, kind: "dir", filterGlobs: ["/.omo"] }],
+		});
+		fixture.reload.mockClear();
+
+		mkdirSync(join(unrelatedDir, ".omo"));
+		await settleChange(fixture, ancestorDir, join("other-repo", "worktrees", "scratch", ".omo"));
+
+		expect(fixture.reload).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1115,4 +1115,70 @@ describe("config reload builtin extension", () => {
 			}),
 		).toBe(true);
 	});
+
+	it("ignores extension runtime state writes under the watched extensions directory", async () => {
+		vi.useFakeTimers();
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-ext-state-"));
+		agentDirs.push(agentDir);
+		writeFileSync(join(agentDir, "settings.json"), '{"theme":"dark"}\n', "utf-8");
+		const extensionsDir = join(agentDir, "extensions");
+		mkdirSync(extensionsDir, { recursive: true });
+		writeFileSync(join(extensionsDir, "diff.js"), "export default () => {};\n", "utf-8");
+		const goalStateDir = join(extensionsDir, "goal", "no-session", "2fca6eb7d09fc68d11abc56e");
+		mkdirSync(goalStateDir, { recursive: true });
+		const goalStatePath = join(goalStateDir, "019fa192-1633-7803-9770-f2c76bd91ca3.json");
+		writeFileSync(goalStatePath, '{"status":"active"}\n', "utf-8");
+
+		const watches = createWatchProbe();
+		const reload = vi.fn(async () => {});
+		const extension = createManualExtension(createEventBus());
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir, requestReload: reload }),
+		);
+
+		writeFileSync(goalStatePath, '{"status":"complete"}\n', "utf-8");
+		watches.emit(
+			extensionsDir,
+			join("goal", "no-session", "2fca6eb7d09fc68d11abc56e", "019fa192-1633-7803-9770-f2c76bd91ca3.json"),
+		);
+		await vi.advanceTimersByTimeAsync(200);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(reload).toHaveBeenCalledTimes(0);
+	});
+
+	it("still reloads when a real extension entry under the extensions directory changes", async () => {
+		vi.useFakeTimers();
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-ext-entry-"));
+		agentDirs.push(agentDir);
+		writeFileSync(join(agentDir, "settings.json"), '{"theme":"dark"}\n', "utf-8");
+		const extensionsDir = join(agentDir, "extensions");
+		mkdirSync(extensionsDir, { recursive: true });
+		const entryPath = join(extensionsDir, "diff.js");
+		writeFileSync(entryPath, "export default () => {};\n", "utf-8");
+
+		const watches = createWatchProbe();
+		const reload = vi.fn(async () => {});
+		const extension = createManualExtension(createEventBus());
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir, requestReload: reload }),
+		);
+
+		writeFileSync(entryPath, "export default () => { /* changed */ };\n", "utf-8");
+		watches.emit(extensionsDir, "diff.js");
+		await vi.advanceTimersByTimeAsync(200);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(reload).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
## Problem

A session hot-reloaded constantly. From a real `~/.senpi/agent/logs/config-reload.log` (29246 lines): **2552 `reload_completed`**, 2557 `reload_requested`, 5980 `registration_rejected`.

Top `reload_requested` paths:

| count | path |
|---|---|
| 5981 | `~/.senpi/agent/extensions/{prompt-url-widget,tps,diff,files}.js` |
| 949 | `~/.senpi/agent/settings.json` |
| 268 | `~/.senpi/agent/extensions/goal/<state>.json` |
| 48 | `~/.senpi/agent/models.json` |
| 15+ each | dozens of unrelated `.omo` dirs under `~/local-workspaces/.omo/**/worktrees/**` |

Two independent causes.

### 1. The watched `extensions/` directories included extension runtime state

`buildWatchTargets` registered `<agentDir>/extensions` and `<projectDir>/extensions` as **unfiltered** `dir-recursive` targets, so every file beneath them was hashed and gated. The goal extension persists per-session state at `<agentDir>/extensions/goal/no-session/<hash>/<uuid>.json` (`builtin/goal/store-ref.ts:13`) — so **every `create_goal`/`update_goal` call forced a full session reload**.

### 2. `filterGlobs` could not express "immediate child"

External registrations describe watch scope only through `filterGlobs`, and every existing form (`name`, `path/suffix`, `*suffix`) matches at **any depth**. An ancestor target filtered to `.omo` therefore covered every `.omo` directory in the entire subtree — every sibling repo and worktree under `$HOME`.

## Changes

- **`config-reload/extension-watch-scope.ts` (new)** mirrors `discoverExtensionsInDir`'s one-level discovery rules from `extensions/loader.ts`. Both extension targets now carry it as a filter. Anything deeper than the loader can discover is runtime state, not configuration.
- **`matchesConfigWatchFilter`** gains a leading-`/` anchor that matches the watch root's own relative path. `literalFilterNames` strips the anchor so anchored dot-directory creation events still register in the allowList.

The engine applies a target's `filter` to both file matching and directory descent, so the extensions filter deliberately admits immediate subdirectories in order to reach `my-ext/index.ts` and `my-ext/package.json`.

## Observed behavior

Driving the **real** `config-reload` extension with the **real** `fs.watch` source against a real temp filesystem (isolated `SENPI_CODING_AGENT_DIR`; the real `~/.senpi/agent` was never touched):

| action | before | after |
|---|---|---|
| edit `.omo/drafts/tui-ux-discoverability.md` | 0 | 0 |
| write goal runtime state JSON | **1 reload** | **0** |
| create unrelated `other-repo/worktrees/scratch/.omo` | — | **0** |
| edit `settings.json` | 1 | 1 |
| edit real extension `extensions/probe.js` | 1 | 1 |

The captured `config-reload.log` from the after-run shows `reload_requested` only for `settings.json` and `extensions/probe.js`, and zero `registration_rejected`.

Replaying the exact paths that appear as `reload_requested` in the production log against both matcher versions:

```
UNRELATED SUBTREE PATHS (must be false):
  ".omo/ulw-dependency-modernization/merge-worktrees/omo-4dff9139/.omo"  before=true  after=false
  ".omo/ulw-dependency-modernization/merge-worktrees/nomad-web-85e13732/.omo"  before=true  after=false
  ".omo/cua-shared-daemon/worktrees/macos-cua/.omo"  before=true  after=false
INTENDED IMMEDIATE-CHILD PATHS (must be true):
  ".omo"            before=true   after=true
  ".omo/omo.jsonc"  before=false  after=true
  ".omo/omo.json"   before=false  after=true
```

The last two lines are a **latent bug this also fixes**: under the unanchored form the intended config globs never matched at all.

## QA

- `vitest run` on `config-reload-extension`, `config-reload-protocol`, `config-reload-watch-engine`, `config-reload-extension-watch-scope`, `config-reload-log`: **73/73 pass**.
- Both commits went through the full `npm run check` pre-commit gate (biome, tsgo, pinned deps, shrinkwrap, install-lock, web-ui).
- New coverage: runtime state under `extensions/` produces no reload; a real extension entry still reloads; anchored dot-directory creation is still detected; an unrelated nested dot directory under an anchored target is ignored; unanchored suffix matching is unchanged.

## Residual risk

The anchor is a new form in a deliberately small filter language. Existing unanchored globs are untouched, and no in-tree registrant used a leading `/` before this change. `settings.json` changes outside the routine-key set still reload by design; that path is unchanged here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops noisy config reloads by narrowing the watch scope. Runtime state under `extensions/` and unrelated nested `.omo` dirs no longer trigger reloads; only real config and manifest-declared extension entries do.

- **Bug Fixes**
  - Watch only loadable extension entries in `extensions/` (top-level `*.ts|*.js`; `index.ts|index.js|package.json` one level deep; and `pi.extensions` paths at any depth), and descend only through packages that declare such entries. Goal runtime JSON writes no longer cause session reloads; manifest-declared entries still hot-reload.

- **New Features**
  - Add root-anchored `filterGlobs` support. A leading "/" anchors to the watch root (e.g., `"/.omo"`, `"/.omo/omo.jsonc"`), preventing matches in deeper paths; anchored dot-directory creation is still detected.

<sup>Written for commit 8a86ab62a00bdc96eb24c9036a6047e5dd551f0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

