### PR TITLE
fix(compaction): avoid unsupported minimal reasoning

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,3 +1,9 @@
+## Portable low-cost reasoning for compaction summaries (2026-07-27)
+
+- `speculative.ts`: compaction summarization now starts at `low` instead of forcing `minimal`. Some OpenAI-compatible gateways expose stale or narrower capability metadata and reject `minimal` even when the local model map advertises it; `low` is the lowest portable effort across those endpoints.
+- The selector still falls upward through `medium` and `high`, respects explicit `null` unsupported entries, disables Anthropic thinking, and omits the override when no low-cost level is available.
+- Regression coverage exercises OpenAI Responses and Completions models that advertise both `minimal` and `low`, plus a model with every low-cost level explicitly disabled.
+
 ## Canonical remote compaction provenance and route ownership (2026-07-24)
 
 - `openai-remote-model.ts`: provenance now hashes the normalized endpoint and every final header by default. The only excluded volatile transport headers are `content-length`, `user-agent`, `request-id`, `x-request-id`, and `x-client-request-id`; raw values are never persisted. This binds non-Codex checkpoints to authorization plus final tenant/workspace routing headers.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -134,7 +134,7 @@ function summaryMaxTokens(model: Model<any>, contextWindow: number): number {
 function summarizationReasoningOptions(model: Model<any>): Record<string, unknown> {
 	if (!model.reasoning) return {};
 	if (model.api === "anthropic-messages") return { thinkingEnabled: false };
-	const reasoningEffort = (["minimal", "low", "medium", "high"] as const).find(
+	const reasoningEffort = (["low", "medium", "high"] as const).find(
 		(level) => model.thinkingLevelMap?.[level] !== null,
 	);
 	if (!reasoningEffort) return {};

--- a/packages/coding-agent/test/compaction/summarization-reasoning-options.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-reasoning-options.test.ts
@@ -19,8 +19,14 @@ afterEach(() => {
 	}
 });
 
-function createContext(registration: Registration): SpeculativeCompactionContext {
-	const model = registration.getModel();
+function createContext(
+	registration: Registration,
+	thinkingLevelMap?: NonNullable<SpeculativeCompactionContext["model"]>["thinkingLevelMap"],
+): SpeculativeCompactionContext {
+	const model = {
+		...registration.getModel(),
+		thinkingLevelMap,
+	};
 	const authStorage = AuthStorage.inMemory();
 	authStorage.setRuntimeApiKey(model.provider, "faux-key");
 	const modelRegistry = ModelRegistry.inMemory(authStorage);
@@ -79,11 +85,12 @@ function createContext(registration: Registration): SpeculativeCompactionContext
 async function captureSummarizationOptions(
 	api: string,
 	models: FauxModelDefinition[],
+	thinkingLevelMap?: NonNullable<SpeculativeCompactionContext["model"]>["thinkingLevelMap"],
 ): Promise<Record<string, unknown> | undefined> {
 	const registration = registerFauxProvider({ api, models });
 	registrations.push(registration);
 	registration.setResponses([fauxAssistantMessage("summary")]);
-	const context = createContext(registration);
+	const context = createContext(registration, thinkingLevelMap);
 	const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
 	if (!snapshot) throw new Error("expected a compaction snapshot");
 	await runExtensionCompaction(context, snapshot);
@@ -106,14 +113,30 @@ describe("summarization reasoning overrides", () => {
 	});
 
 	it("minimizes reasoning for openai-responses summarization", async () => {
-		const options = await captureSummarizationOptions("openai-responses", [reasoningModel]);
-		expect(options?.reasoningEffort).toBe("minimal");
+		const options = await captureSummarizationOptions("openai-responses", [reasoningModel], {
+			minimal: "minimal",
+			low: "low",
+		});
+		expect(options?.reasoningEffort).toBe("low");
 		expect(options?.reasoningSummary).toBeNull();
 	});
 
 	it("minimizes reasoning for openai-completions summarization", async () => {
-		const options = await captureSummarizationOptions("openai-completions", [reasoningModel]);
-		expect(options?.reasoningEffort).toBe("minimal");
+		const options = await captureSummarizationOptions("openai-completions", [reasoningModel], {
+			minimal: "minimal",
+			low: "low",
+		});
+		expect(options?.reasoningEffort).toBe("low");
+	});
+
+	it("omits the override when no low-cost reasoning level is supported", async () => {
+		const options = await captureSummarizationOptions("openai-responses", [reasoningModel], {
+			low: null,
+			medium: null,
+			high: null,
+		});
+		expect(options?.reasoningEffort).toBeUndefined();
+		expect(options?.reasoningSummary).toBeUndefined();
 	});
 
 	it("leaves non-reasoning models untouched", async () => {

--- a/packages/coding-agent/test/compaction/summarization-reasoning-payload.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-reasoning-payload.test.ts
@@ -107,7 +107,7 @@ const payloadCases = [
 			...getModel("azure-openai-responses", "gpt-5.4"),
 			baseUrl: "https://test-resource.openai.azure.com/openai/v1",
 		},
-		effort: "minimal",
+		effort: "low",
 		summary: undefined,
 	},
 ] as const;


### PR DESCRIPTION
## Summary

- start compaction summary reasoning at `low` instead of forcing `minimal`
- preserve fallback through `medium` and `high`, explicit unsupported levels, Anthropic disablement, and summary suppression
- cover OpenAI Responses, OpenAI Completions, Azure Responses, and no-supported-low-cost cases

## Why

Some OpenAI-compatible gateways reject `reasoning_effort=minimal` even when local model metadata advertises it. That caused blocking/speculative compaction to fail before the next agent turn with:

```text
level "minimal" not supported, valid levels: low, medium, high, xhigh, max
```

`low` is the lowest portable effort across these endpoints.

## Evidence

### RED -> GREEN

- RED: focused options test failed 3 cases with actual `minimal` versus expected `low`/omission.
- GREEN: `npx vitest run test/compaction/summarization-reasoning-options.test.ts` — 5/5 passed.
- Focused payload scope: `npx vitest run test/compaction/summarization-reasoning-options.test.ts test/compaction/summarization-reasoning-payload.test.ts` — 9/9 passed.

### Real CLI

An isolated source CLI RPC run used a local OpenAI-compatible endpoint that returns the reported HTTP 400 for any `minimal` request. Automatic blocking compaction ran before the third turn:

```text
REAL_SURFACE_PASS=1
REASONING_EFFORTS=["medium","medium","low","medium"]
MINIMAL_REQUESTS=0
```

Real auth remained unchanged, and the RPC child, server, and sandbox were cleaned up.

### Static validation

- `npm run check` — passed
- Oracle review — unconditional APPROVE

## Risk

Low. The production change removes one non-portable candidate from the compaction-only selector. Normal agent reasoning selection is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch compaction summarization to request `low` reasoning effort instead of `minimal` to avoid unsupported-level errors on some OpenAI‑compatible gateways. Fallback to `medium`/`high` remains, Anthropic thinking is disabled, and the override is omitted when no low‑cost level is available.

- **Bug Fixes**
  - Updated `speculative.ts` to pick from `["low","medium","high"]` via `thinkingLevelMap` (skips explicit `null`).
  - Adjusted tests to expect `low` for OpenAI Responses/Completions and Azure, and added a case with no supported low-cost levels.
  - Added change note in `changes.md`.

<sup>Written for commit c83f60b70019f330f161344a6f24642cc818ca81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

