### PR TITLE
test(qa): cover OpenAI server_error retry fallback

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
@@ -1,5 +1,8 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import {
 	createChecks,
+	evidenceDir,
 	guardRealAuth,
 	installCleanupHooks,
 } from "./common.mjs";
@@ -8,6 +11,9 @@ import {
 	checkRealAuthUnchanged,
 } from "./mock-loop-support.mjs";
 import { runAnthropicPolicyRefusalScenario } from "./mock-loop-policy-refusal.mjs";
+
+const OPENAI_SERVER_ERROR_MESSAGE =
+	"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID e4026cfc-c6b6-414a-8a21-c03a6adf0336 in your message.";
 
 const STANDARD_RETRY_SCENARIOS = {
 	"transient-recover": {
@@ -21,6 +27,14 @@ const STANDARD_RETRY_SCENARIOS = {
 		error: { status: 500, message: "overloaded_error" },
 		errorCount: 4,
 		marker: "SENPI-QA-RETRY-BUDGET-EXHAUST-7a16",
+		primaryAttempts: 4,
+		fallbackAttempts: 1,
+	},
+	"server-error-fallback": {
+		apiName: "openai-responses",
+		error: { status: 500, message: OPENAI_SERVER_ERROR_MESSAGE },
+		errorCount: 4,
+		marker: "SENPI-QA-RETRY-SERVER-ERROR-FALLBACK-e402",
 		primaryAttempts: 4,
 		fallbackAttempts: 1,
 	},
@@ -45,7 +59,8 @@ export function isRetryScenario(name) {
 
 export async function checkStandardRetryScenarios(checks, driveTurn) {
 	for (const scenarioName of Object.keys(STANDARD_RETRY_SCENARIOS)) {
-		await checkStandardRetryScenario(checks, scenarioName, "openai-completions", driveTurn);
+		const scenario = STANDARD_RETRY_SCENARIOS[scenarioName];
+		await checkStandardRetryScenario(checks, scenarioName, scenario.apiName ?? "openai-completions", driveTurn);
 	}
 }
 
@@ -60,12 +75,12 @@ export async function runRetryScenario(scenarioName, apiName, driveTurn, evidenc
 	installCleanupHooks();
 	const checks = createChecks(`mock-loop.mjs --scenario ${scenarioName}`);
 	const guard = guardRealAuth();
-	await checkStandardRetryScenario(checks, scenarioName, apiName, driveTurn);
+	await checkStandardRetryScenario(checks, scenarioName, apiName, driveTurn, evidenceSlug);
 	checkRealAuthUnchanged(checks, guard);
 	process.exit(checks.finish() ? 0 : 1);
 }
 
-async function checkStandardRetryScenario(checks, scenarioName, apiName, driveTurn) {
+async function checkStandardRetryScenario(checks, scenarioName, apiName, driveTurn, evidenceSlug) {
 	const scenario = STANDARD_RETRY_SCENARIOS[scenarioName];
 	if (!scenario) throw new Error(`unknown retry scenario ${scenarioName}`);
 	const preset = API_PRESETS[apiName];
@@ -104,6 +119,26 @@ async function checkStandardRetryScenario(checks, scenarioName, apiName, driveTu
 		const markerReturned = `${result.stdout}${result.stderr}`.includes(scenario.marker);
 		const attemptsMatch = JSON.stringify(modelSequence) === JSON.stringify(expectedModels);
 		const pass = result.code === 0 && !result.timedOut && markerReturned && attemptsMatch;
+		if (evidenceSlug) {
+			const dir = evidenceDir(evidenceSlug);
+			writeFileSync(
+				join(dir, "retry-transcript.json"),
+				`${JSON.stringify(
+					{
+						scenario: scenarioName,
+						api: apiName,
+						attempts: modelSequence.length,
+						sequence: modelSequence.map((modelId) => `${preset.provider}/${modelId}`),
+						modelAttempts: Object.fromEntries(counts),
+						switched: modelSequence.includes(fallbackModelId),
+						markerReturned,
+						exitCode: result.code,
+					},
+					null,
+					2,
+				)}\n`,
+			);
+		}
 		checks.ok(
 			`${scenarioName}: scripted provider errors follow the expected retry/fallback path`,
 			pass,

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -25,7 +25,7 @@
  *   (the flag is --serve-env, NOT --env-file: Node treats --env-file as a native
  *    startup flag and would try to load the path as a dotenv file before the script runs)
  *   node mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}'
- *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|long-retry-after|anthropic-policy-refusal-fallback
+ *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|server-error-fallback|long-retry-after|anthropic-policy-refusal-fallback
  *   node mock-loop.mjs --run "prompt" [--api ...] [--evidence SLUG]
  */
 
@@ -594,7 +594,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
-			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|long-retry-after|anthropic-policy-refusal-fallback> [--api <name>]",
+			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|anthropic-policy-refusal-fallback> [--api <name>]",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,
 			"",

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -4,6 +4,8 @@ import { isRetryableAssistantError, type RetryPolicy, retryAssistantCall } from 
 
 const openAIExplicitRetryMessage =
 	"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_******** in your message.";
+const openAIServerErrorMessage =
+	"Error: Error Code server_error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID e4026cfc-c6b6-414a-8a21-c03a6adf0336 in your message.";
 const bedrockExplicitRetryMessage =
 	'{"message":"The system encountered an unexpected error during processing. Try your request again."}';
 const nvidiaNIMResourceExhaustedMessage = "ResourceExhausted: Worker local total request limit reached (288/48)";
@@ -34,6 +36,14 @@ describe("provider retry classification", () => {
 		expect(
 			isRetryableAssistantError(
 				fauxAssistantMessage("", { stopReason: "error", errorMessage: nvidiaNIMResourceExhaustedMessage }),
+			),
+		).toBe(true);
+	});
+
+	it("classifies the observed OpenAI server_error as retryable", () => {
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: openAIServerErrorMessage }),
 			),
 		).toBe(true);
 	});


### PR DESCRIPTION
## Summary

Pins the intermittent OpenAI Responses `Error Code server_error` wording observed
in Senpi and proves it follows the existing bounded retry-to-model-fallback
flow. The production classifier already handled this message; this PR closes
the coverage gap with an exact classifier regression and a real source-CLI QA
scenario.

## Changes

- Add the full observed OpenAI error wording, including the `server_error` code,
  to the provider retry-classification regression suite.
- Add `server-error-fallback` to the isolated mock-loop QA harness using the
  OpenAI Responses wire format.
- Capture a sanitized machine-readable retry transcript when `--evidence` is
  supplied, without persisting auth headers, credentials, or raw environment.
- List the new scenario in the QA CLI usage.

## QA & Evidence

- **Classifier mutation proof**
  - Command: `npm test --workspace packages/ai -- test/retry.test.ts`
  - RED: a temporary exact-message non-retryable mutation failed the new test
    with `expected false to be true` (1 failed, 22 passed).
  - GREEN: after removing the mutation, 23/23 tests passed.
- **Real CLI retry/fallback**
  - Command: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario server-error-fallback --api openai-responses --evidence server-error-retry`
  - Observed: four `openai/mock-gpt` attempts followed by one
    `openai/mock-gpt-fallback` attempt, `switched=yes`, marker returned, exit 0,
    and real auth unchanged.
- **Full mock-loop QA**
  - Command: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`
  - Observed: 42/42 passed; zero real provider calls.
- **Static validation**
  - `npm run check` passed.
  - `npm run build` passed.
  - `npm test --workspace packages/ai -- --reporter=dot` passed after the build:
    160 files passed, 25 skipped; 1411 tests passed, 803 skipped.
  - `git diff --check` passed.

## Risks & Residuals

- No production retry policy or classifier behavior changes; risk is limited to
  test and QA harness coverage.
- The registered LSP tool cannot diagnose files in sibling task worktrees
  because it rejects paths outside the request cwd. Repository check, build,
  Node syntax checks, and the affected package suite provide the static
  diagnostic coverage instead.
- Eight older unrelated `mock-loop-*` temp sandboxes predated this work and were
  left untouched. The one sandbox orphaned by this run's interrupted first
  self-test attempt was removed; no live QA processes remain.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test and QA coverage for OpenAI “server_error” to confirm it triggers bounded retries and model fallback, with optional machine-readable retry evidence.

- **New Features**
  - Add exact `server_error` wording to retry classification tests in `packages/ai`.
  - Add `server-error-fallback` to the QA `mock-loop` using `openai-responses`.
  - Write sanitized `retry-transcript.json` when `--evidence` is used.
  - Update CLI usage to include the new scenario.

<sup>Written for commit a26658b34df34e35fd44fbd8a77dd70df871bfc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

