### PR TITLE
fix(terminal): flatten monitor schema so Anthropic payloads keep its fields

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,28 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Monitor flat schema + subscribe-not-poll prompt (2026-07-27)
+
+### What changed
+
+- `monitorSchema` is now a single flat `Type.Object` (action via a string enum; description,
+  command, filter, timeout_ms, persistent, bash_id all optional at schema level). Branch
+  requirements moved to runtime: create requires description+command, rearm requires bash_id,
+  each returning a clear `errorResult` instead of relying on schema-union validation.
+- Why: several provider payload paths rebuild tool schemas from top-level `properties` only
+  (Anthropic's legacy input_schema conversion in packages/ai `convertTools`), so the previous
+  top-level `Type.Union` reached Claude as an EMPTY schema — the model saw a parameterless
+  `monitor` tool and fell back to foreground sleep/poll loops.
+- Tool description, promptSnippet, promptGuidelines, and the `prompt.ts` monitor bullet were
+  rewritten to event-subscription framing (subscribe-not-poll, command shaped by notification
+  count), referencing Claude Code's Monitor tool prompt but far shorter.
+- `renderMonitorCall` falls back to command/empty when the now-optional description is absent.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `tools/monitor.ts` (fork-owned tool), `tools/render.ts` label line, `prompt.ts` monitor
+  bullet, `test/suite/terminal-monitor.test.ts` new schema/validation cases.
+
 ## bash_output peek-only (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
@@ -13,11 +13,13 @@ manual \`&\` backgrounding — use the built-in session tools:
   since the last read, the status line, or a rendered full-screen snapshot of TUIs via
   \`view: "screen"\`. Completion arrives as a notification carrying the exit code and output
   tail — peeking is for steering, never for waiting.
-- \`monitor({ description, command, filter?, timeout_ms?, persistent? })\` starts a watcher in the
-  same \`bash_id\` namespace and injects coalesced matching stdout-line events while you keep
-  working. Emit only decision-relevant lines: filter noisy logs at the command source, peek with
-  \`bash_output\`, stop with \`kill_bash\`, and use \`monitor({ action: "rearm", bash_id })\` only after
-  a wake-budget pause.
+- \`monitor({ description, command, filter?, timeout_ms?, persistent? })\` subscribes you to a
+  command: its stdout lines arrive as injected events while you keep working. Any wait on
+  observable state (CI checks, builds, log patterns, deploys) is a monitor, never a foreground
+  sleep/poll loop. Shape the command by notifications needed: exit-on-condition for one
+  completion event; emit-per-occurrence (\`tail -f | grep --line-buffered\`, a polling loop
+  inside the command) for a stream. Filter noise at the command source, stop with \`kill_bash\`,
+  and use \`monitor({ action: "rearm", bash_id })\` only after a wake-budget pause.
 - \`bash_input({ bash_id, input, keys, submit })\` sends stdin or named keys (e.g.
   \`["ctrl+c"]\`, \`["enter"]\`) to steer a REPL or interrupt a process.
 - \`bash_resize({ bash_id, cols, rows })\` resizes the PTY so full-screen programs reflow.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -1,3 +1,4 @@
+import { StringEnum } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { MonitorRegistry } from "../monitor-registry.ts";
 import { DEFAULT_COLS, DEFAULT_ROWS, TERMINAL_MONITOR_TOOL } from "../shared.ts";
@@ -8,14 +9,30 @@ import { spawnCommandSession } from "./spawn.ts";
 export const DEFAULT_MONITOR_TIMEOUT_MS = 300_000;
 export const MAX_MONITOR_TIMEOUT_MS = 3_600_000;
 
-const createMonitorSchema = Type.Object({
-	action: Type.Optional(Type.Literal("create")),
-	description: Type.String({
-		minLength: 1,
-		maxLength: 200,
-		description: "Short label for the watcher and its decision-relevant events.",
-	}),
-	command: Type.String({ description: "Shell command to run and watch in a PTY-backed monitor session." }),
+/**
+ * One flat object schema, no top-level union: several provider payload paths
+ * (e.g. Anthropic's legacy input_schema conversion) rebuild tool schemas from
+ * top-level `properties` only, so a root anyOf would reach the model as an
+ * empty schema. Branch requirements are enforced at runtime in `execute`.
+ */
+export const monitorSchema = Type.Object({
+	action: Type.Optional(
+		StringEnum(["create", "rearm"] as const, {
+			description: "Defaults to create. rearm resumes a monitor paused by the wake budget.",
+		}),
+	),
+	description: Type.Optional(
+		Type.String({
+			minLength: 1,
+			maxLength: 200,
+			description: "Create (required): specific label shown with every event, e.g. 'errors in deploy.log'.",
+		}),
+	),
+	command: Type.Optional(
+		Type.String({
+			description: "Create (required): shell command to run and watch in a PTY-backed monitor session.",
+		}),
+	),
 	filter: Type.Optional(Type.String({ description: "Only stdout lines matching this regex become monitor events." })),
 	timeout_ms: Type.Optional(
 		Type.Number({
@@ -27,17 +44,20 @@ const createMonitorSchema = Type.Object({
 	persistent: Type.Optional(
 		Type.Boolean({ description: "Keep watching until the command exits or kill_bash stops its bash_id." }),
 	),
+	bash_id: Type.Optional(Type.String({ description: "Rearm (required): paused monitor bash_id to resume." })),
 });
-
-const rearmMonitorSchema = Type.Object({
-	action: Type.Literal("rearm"),
-	bash_id: Type.String({ description: "Paused monitor bash_id to resume after a wake-budget pause." }),
-});
-
-export const monitorSchema = Type.Union([createMonitorSchema, rearmMonitorSchema]);
 export type MonitorInput = Static<typeof monitorSchema>;
 
-type MonitorCreateInput = Static<typeof createMonitorSchema>;
+type MonitorCreateInput = MonitorInput & { description: string; command: string };
+
+function isCreateInput(input: MonitorInput): input is MonitorCreateInput {
+	return (
+		typeof input.description === "string" &&
+		input.description.length > 0 &&
+		typeof input.command === "string" &&
+		input.command.length > 0
+	);
+}
 
 function resolveDimension(value: number | undefined, fallback: number): number {
 	if (value === undefined || !Number.isFinite(value) || value < 1) return fallback;
@@ -91,10 +111,11 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 		name: TERMINAL_MONITOR_TOOL,
 		label: "monitor",
 		description:
-			"Watch a background shell command and emit decision-relevant stdout-line events. Returns a bash_id immediately; peek with bash_output or stop with kill_bash.",
-		promptSnippet: "Watch a long-running command; monitor emits matching stdout lines as events",
+			"Subscribe to events from a command instead of polling for them: each stdout line arrives as an injected event while you keep working. Returns a bash_id immediately; peek with bash_output, stop with kill_bash.",
+		promptSnippet: "Subscribe to a command's stdout lines as injected events instead of polling",
 		promptGuidelines: [
-			"Use monitor only for decision-relevant lines; filter noisy output at the source when possible.",
+			"Waiting on observable state (CI checks, builds, log patterns, deploys) means a monitor, never a foreground sleep/poll loop.",
+			"Shape the command by notifications needed: exit-on-condition for one completion event; emit-per-occurrence (`tail -f | grep --line-buffered`, a polling loop inside the command) for a stream. Filter noise at the source.",
 		],
 		parameters: monitorSchema,
 		renderCall: renderMonitorCall,
@@ -107,11 +128,16 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 		): Promise<TerminalToolResult> {
 			const registry = getRegistry();
 			if (input.action === "rearm") {
-				const outcome = registry.rearm(input.bash_id);
-				if (outcome === "not_found") return errorResult(`No active monitor found with id: ${input.bash_id}`);
-				if (outcome === "not_paused") return textResult(`Monitor ${input.bash_id} is not paused; no action taken.`);
-				ctx.onMonitorRearmed?.(input.bash_id);
-				return textResult(`Monitor ${input.bash_id} re-armed.`);
+				const bashId = input.bash_id;
+				if (bashId === undefined || bashId.length === 0) return errorResult("monitor rearm requires bash_id.");
+				const outcome = registry.rearm(bashId);
+				if (outcome === "not_found") return errorResult(`No active monitor found with id: ${bashId}`);
+				if (outcome === "not_paused") return textResult(`Monitor ${bashId} is not paused; no action taken.`);
+				ctx.onMonitorRearmed?.(bashId);
+				return textResult(`Monitor ${bashId} re-armed.`);
+			}
+			if (!isCreateInput(input)) {
+				return errorResult("monitor requires description and command to start a watcher.");
 			}
 			return createMonitor(ctx, registry, input, execCtx);
 		},

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/render.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/render.ts
@@ -44,7 +44,10 @@ export function renderMonitorCall(
 	args: MonitorInput,
 	theme: Parameters<NonNullable<MonitorToolDefinition["renderCall"]>>[1],
 ): Text {
-	const label = args.action === "rearm" ? `monitor rearm ${args.bash_id}` : `monitor ${args.description}`;
+	const label =
+		args.action === "rearm"
+			? `monitor rearm ${args.bash_id ?? ""}`.trimEnd()
+			: `monitor ${args.description ?? args.command ?? ""}`.trimEnd();
 	return new Text(theme.fg("toolTitle", theme.bold(label)), 0, 0);
 }
 

--- a/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
@@ -182,6 +182,9 @@ describe("terminal monitor event delivery", () => {
 
 	it("teaches watcher discipline in the terminal prompt", () => {
 		expect(TERMINAL_PROMPT_SECTION).toContain("monitor");
-		expect(TERMINAL_PROMPT_SECTION).toContain("decision-relevant");
+		// Discipline is the routing rule (waits are monitors, not poll loops) plus noise control,
+		// not any particular wording — assert the guidance, never a pinned sentence.
+		expect(TERMINAL_PROMPT_SECTION).toMatch(/never a foreground\s+sleep\/poll loop/);
+		expect(TERMINAL_PROMPT_SECTION).toMatch(/Filter noise at the command source/);
 	});
 });

--- a/packages/coding-agent/test/suite/terminal-monitor.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor.test.ts
@@ -8,7 +8,11 @@ import {
 } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
 import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
-import { createMonitorTool } from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+import {
+	createMonitorTool,
+	type MonitorInput,
+	monitorSchema,
+} from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
 
 function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
 	return result.content.find((block) => block.type === "text")?.text ?? "";
@@ -69,6 +73,30 @@ describe("terminal monitor tool", () => {
 		await manager.teardown();
 		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
 		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	it("exposes a flat object schema so providers' legacy object conversion keeps every field", () => {
+		const shape = monitorSchema as unknown as { type?: string; properties?: Record<string, unknown> };
+		expect(shape.type).toBe("object");
+		const properties = Object.keys(shape.properties ?? {});
+		for (const field of ["action", "description", "command", "filter", "timeout_ms", "persistent", "bash_id"]) {
+			expect(properties).toContain(field);
+		}
+	});
+
+	it("rejects a create call missing description and command instead of spawning", async () => {
+		const tool = createMonitorTool(ctx);
+		const result = await tool.execute("monitor-empty", {} as MonitorInput);
+		expect(result.isError).toBe(true);
+		expect(firstText(result)).toContain("description");
+		expect(firstText(result)).toContain("command");
+	});
+
+	it("rejects rearm without bash_id", async () => {
+		const tool = createMonitorTool(ctx);
+		const result = await tool.execute("monitor-rearm-missing", { action: "rearm" } as MonitorInput);
+		expect(result.isError).toBe(true);
+		expect(firstText(result)).toContain("bash_id");
 	});
 
 	it("returns a bash_id immediately and emits complete stdout lines in order before its summary", async () => {


### PR DESCRIPTION
## Summary

The `monitor` tool's parameter schema was a top-level `Type.Union` (create | rearm). Anthropic's legacy `input_schema` conversion in `packages/ai` rebuilds every tool schema from top-level `properties` only, so on `anthropic-messages` models the union reached Claude as an **empty schema** — the model saw a parameterless `monitor` tool it could not call, and fell back to foreground sleep/poll loops (observed live: a session with 211 `bash` calls, 0 `monitor` calls, and a 9-minute `sleep 30` loop watching `gh pr checks`). This PR flattens the schema so every provider payload path keeps the fields, moves branch requirements to runtime validation, and reframes the monitor prompt surfaces to actively steer event subscription over polling.

## Changes

- **Schema/behavior** (`tools/monitor.ts`, `tools/render.ts`): single flat `Type.Object` (`action` string-enum; `description`, `command`, `filter`, `timeout_ms`, `persistent`, `bash_id` optional at schema level). `execute` now returns a clear `errorResult` when create lacks `description`/`command` or rearm lacks `bash_id`. Render label falls back when `description` is absent.
- **Prompt surfaces** (`tools/monitor.ts` description/snippet/guidelines, `prompt.ts` monitor bullet): subscribe-not-poll framing — waits on observable state (CI, builds, log patterns) are monitors, never sleep/poll loops; commands shaped by notifications needed (exit-on-condition vs emit-per-occurrence). Referenced Claude Code's Monitor tool prompt (8,632 chars) but kept ours at 1,279 chars total.
- **Fork record** (`terminal/changes.md`): documents the change and expected merge-conflict zones.

## QA & Evidence

- **What was tested:** new unit tests in `test/suite/terminal-monitor.test.ts` — schema is a flat object carrying all 7 fields; `execute({})` and `execute({action:"rearm"})` rejected with named-field errors. **Observed:** captured RED before the fix (union schema has no top-level `properties`; empty create spawned instead of erroring), GREEN after — 11/11, plus `terminal-extension` and `prompt-surface-stale-wait-idioms` suites (26/26 total). **Why sufficient:** pins the exact conversion-visible contract that regressed.
- **What was tested:** real CLI turn through the senpi-qa mock loop (`mock-loop.mjs --run --api anthropic-messages`), asserting the recorded `/v1/messages` request body. **Observed:** `tools[monitor].input_schema.type == "object"` with properties `[action, bash_id, command, description, filter, persistent, timeout_ms]`. **Artifact:** `local-ignore/qa-evidence/20260727-monitor-anthropic-schema/mock-loop-anthropic-messages-requests.json` (gitignored, retained locally). **Why sufficient:** proves the fix on the actual Anthropic payload path end to end.
- **What was tested:** `mock-loop.mjs --self-test --api anthropic-messages` (20/20), `--with-tool` anthropic loop (4/4), `pty-drive.mjs --self-test` (8/8, evidence `20260727-monitor-pty`), root `npm run check` (exit 0). **Why sufficient:** agent loop, terminal tool surface, and static validation all green; QA sandboxes auto-cleaned and real auth untouched (guard PASS in every run).

## Risks & Residuals

- Create/rearm argument validation moved from schema union to runtime — mitigated by the new unit tests naming each missing field.
- All-optional schema admits `{}` at the validation layer by design (that is what keeps the fields visible to Anthropic); the runtime guard returns actionable errors, so a misparameterized call degrades to a clear message instead of a spawn failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened the `monitor` tool schema into one flat object so Anthropic payloads keep all fields, fixing empty tool schemas that caused foreground sleep/poll loops. Moved create/rearm checks to runtime and updated prompts to steer event subscription over polling.

- **Bug Fixes**
  - Replaced top-level union with a flat `Type.Object` (all fields optional) so providers that rebuild from top-level `properties` (e.g. `anthropic-messages`) receive a usable schema.
  - Render label now falls back to `command` when `description` is missing.

- **Refactors**
  - Enforce create (`description` + `command`) and rearm (`bash_id`) at runtime with clear errors.
  - Rewrote monitor docs and terminal prompt to “subscribe, not poll.”
  - Made the prompt test assert semantics (monitor over foreground poll; filter noise at the source) instead of a pinned phrase.

<sup>Written for commit 3a682ae5bdba7276412cc4a00309ad0d4cfc53c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

