### PR TITLE
fix(coding-agent): stop counting zombies as live pids in the tree-kill proof

### DIFF
--- a/packages/coding-agent/test/omo-local-update.test.ts
+++ b/packages/coding-agent/test/omo-local-update.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
@@ -112,10 +112,23 @@ function makeOmoLayout(
 	return { repoRoot, pluginPath, agentDir };
 }
 
+/**
+ * A zombie has exited and holds no resources, but its pid entry survives until the
+ * parent reaps it, so `process.kill(pid, 0)` still succeeds. Killing a process tree
+ * therefore leaves a window where the reparented grandchild looks alive, which made
+ * the tree-kill proof below fail on slow runners. Windows has no zombies.
+ */
 function pidAlive(pid: number): boolean {
 	try {
 		process.kill(pid, 0);
-		return true;
+	} catch {
+		return false;
+	}
+	if (process.platform === "win32") return true;
+	try {
+		return !execFileSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf-8" })
+			.trim()
+			.startsWith("Z");
 	} catch {
 		return false;
 	}
@@ -1092,5 +1105,52 @@ describe("runOmoLocalUpdateBeta orchestrator", () => {
 		expect(readStamp(agentDir)).toBeUndefined();
 		expect(existsSync(omoLocalUpdateLockPath(agentDir))).toBe(false);
 		expect(existsSync(omoLocalUpdateBuildWorktreePath(agentDir))).toBe(false);
+	});
+
+	it("does not report an unreaped zombie as alive", async () => {
+		if (process.platform === "win32") return;
+		// A perl parent forks a child that exits immediately, prints the child pid, releases
+		// fd 3, then sleeps WITHOUT reaping. EOF on fd 3 therefore proves the child exited AND
+		// the parent released its copy, so from that moment the child is a zombie until the
+		// parent is killed. Event-driven like the tree-kill proof: no sleeps, no polling.
+		const script =
+			'use POSIX (); my $pid = fork(); if ($pid == 0) { exit 0; } $| = 1; print "$pid\\n"; POSIX::close(3); sleep 30;';
+		const parent = spawn("perl", ["-e", script], { stdio: ["ignore", "pipe", "ignore", "pipe"] });
+		try {
+			let stdout = "";
+			const parentStdout = parent.stdout;
+			if (parentStdout === null) throw new Error("expected a readable stdout pipe");
+			parentStdout.on("data", (chunk) => {
+				stdout += String(chunk);
+			});
+			const zombieFd = parent.stdio[3];
+			if (zombieFd === null || zombieFd === undefined || typeof zombieFd === "number") {
+				throw new Error("expected a readable pipe on fd 3");
+			}
+			await new Promise<void>((resolveEof) => zombieFd.on("end", () => resolveEof()));
+
+			const zombiePid = Number(stdout.trim());
+			expect(Number.isInteger(zombiePid)).toBe(true);
+			expect(execFileSync("ps", ["-o", "stat=", "-p", String(zombiePid)], { encoding: "utf-8" }).trim()).toMatch(
+				/^Z/,
+			);
+
+			expect(pidAlive(zombiePid)).toBe(false);
+		} finally {
+			parent.kill("SIGKILL");
+		}
+	});
+
+	it("reports a running process as alive and a reaped pid as dead", async () => {
+		expect(pidAlive(process.pid)).toBe(true);
+
+		// Node reaps a child before emitting "exit", so once that fires the pid is fully gone
+		// rather than a zombie. Event-driven: the exit event is the signal, not a wait.
+		const shortLived = spawn(process.execPath, ["-e", "process.exit(0)"], { stdio: "ignore" });
+		const reapedPid = shortLived.pid;
+		if (reapedPid === undefined) throw new Error("expected a pid for the spawned process");
+		await new Promise<void>((resolveExit) => shortLived.on("exit", () => resolveExit()));
+
+		expect(pidAlive(reapedPid)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem

`Check and test` failed twice in a row on an unrelated PR, both times at exactly this assertion:

```
FAIL  test/omo-local-update.test.ts > kills the whole process tree and reports timedOut on timeout
AssertionError: expected true to be false
  ❯ expect(pidAlive(pids.grandchild)).toBe(false)
```

4970/5003 otherwise passing, `main` green, other PRs green. It reproduces only on the slower CI runner.

## Cause

`pidAlive` is `process.kill(pid, 0)`, which **succeeds for a zombie**. An exited process keeps its pid entry until its parent reaps it.

The tree-kill proof resolves on pipe EOF. EOF only proves both processes released fd 1, which happens *while* they exit. Immediately after that the grandchild is an unreaped zombie: its parent died too, so it is reparented to init and reaped asynchronously. On a slow runner the assertion lands inside that window and `pidAlive` reports the tree as still alive.

The test's own comment claims "no wall-clock deadline, no liveness polling, nothing that can pass by timing luck". The deadline was removed, but this race stayed.

## Change

A zombie is a dead process: it runs no code and holds no resources. `pidAlive` now checks process state and treats `Z` as dead. Windows keeps the previous behaviour because it has no zombies.

## Verification

**Failing-first.** A new case builds a genuine zombie and asserts `pidAlive` is false. Captured RED before the fix:

```
AssertionError: expected true to be false
  ❯ expect(pidAlive(zombiePid)).toBe(false)
```

The `ps -o stat=` assertion directly above it passed, so RED was for the right reason — a real zombie, not a broken fixture.

**The fixture adds no sleep.** A perl parent forks a child that exits, prints the child pid, releases fd 3, then sleeps without ever waiting. EOF on fd 3 therefore proves the child exited *and* the parent released its copy, so from that moment the pid is a zombie until the parent is killed. Same event-driven shape the tree-kill proof already uses.

**Characterization.** A second case pins the surrounding behaviour so the fix cannot over-correct into "always false": a running pid is alive, and a pid Node has already reaped is dead. Both green before and after the change.

**Results.** 50/50 pass in `test/omo-local-update.test.ts` (48 existing + 2 new). The tree-kill test is untouched and still asserts both pids. Nothing skipped, deleted, or weakened. The tree-kill test also passes 4/4 under ten concurrent CPU hogs locally. Full `npm run check` gate green.

## Note

An earlier draft of the characterization used `pidAlive(-1)` as the "dead pid" case. It failed on unmodified code because `process.kill(-1, 0)` signals every reachable process and succeeds. That assertion was wrong rather than the code, and it was replaced with a deterministically reaped pid.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop counting zombies as live PIDs in the `coding-agent` tree-kill proof to remove a CI race on slow runners. `pidAlive` now treats zombies as dead on Unix; Windows behavior is unchanged.

- **Bug Fixes**
  - `pidAlive` checks process state with `ps` on non-Windows and returns false for `Z` (zombie) state; keeps previous logic on Windows.
  - Added deterministic tests: build a real zombie and assert false; also verify a running PID is true and a reaped PID is false.

<sup>Written for commit b03aca0745b9c16258f85d287cac6b989e73b2fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

