### PR TITLE
feat(coding-agent): pin footer anchors and drop the cache totals segment

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## Footer cache segment removal and anchor-pinned layout (2026-07-27)
+
+### What changed
+
+- `components/footer-layout.ts` (new): pure width planning for the classic footer. `planFooterLayout()` picks the
+  richest layout that fits the terminal: full line, then middle segments elided right-most-first behind a single
+  dim "…" marker, then the pwd head-elided ("…/senpi"), then the whole left block head-elided, with the model
+  label truncated only as the last resort. `elideHead()` keeps the tail of a path, which carries the most
+  identifying information.
+- `components/footer.ts`: the `cache <read>/<write>` totals segment was removed (the `CH<x>%` cache-hit-rate
+  segment stays); rendering now builds plain/colored `FooterSegment` pairs and delegates fitting to
+  `planFooterLayout()`, so the model label and the pwd • branch • context-usage block stay visible at any width
+  instead of the right side being truncated away first.
+
+### Why
+
+- The cache read/write totals cost footer space out of proportion to their value, and the old truncation logic
+  sacrificed the right-side model label whenever the left overflowed — the two anchors users watch (context
+  usage, current model) were the first things to disappear on narrow terminals.
+
+### Expected merge conflict zones
+
+- MEDIUM: `components/footer.ts` `render()` was rewritten around `FooterSegment` pairs; upstream footer layout
+  changes will conflict textually. `components/footer-layout.ts` is additive.
+
 ## Runtime-error headline rendering (2026-07-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer-layout.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer-layout.ts
@@ -1,0 +1,117 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+/**
+ * A single footer segment: plain text drives the width math, colored text is
+ * what actually renders. Kept as a pair so truncation decisions never have to
+ * strip ANSI codes.
+ */
+export interface FooterSegment {
+	readonly plain: string;
+	readonly colored: string;
+}
+
+export interface FooterRightLabel {
+	/** Model label only (e.g. "gpt-5.6:high"); the form that must always fit. */
+	readonly minimal: FooterSegment;
+	/** Model label with provider prefix; used only when the full layout fits. */
+	readonly full: FooterSegment | undefined;
+}
+
+export interface FooterLayoutInput {
+	readonly width: number;
+	/** Always-kept leading segments (pwd first, then branch). */
+	readonly anchor: readonly [FooterSegment, ...FooterSegment[]];
+	/** Droppable middle segments in display order; dropped from the right end first. */
+	readonly middle: readonly FooterSegment[];
+	/** Always-kept trailing segment (context usage). */
+	readonly tail: FooterSegment;
+	readonly right: FooterRightLabel;
+	/** Plain separator placed between left segments. */
+	readonly separator: string;
+	/** Minimum gap between the left block and the right label. */
+	readonly minPadding: number;
+	/** Marker shown where middle segments were elided. */
+	readonly ellipsisMarker: FooterSegment;
+}
+
+/**
+ * How the footer fits the terminal width, from "everything visible" down to
+ * "only the model label survives". The caller materializes the plan into text.
+ */
+export type FooterLayout =
+	| { readonly kind: "full"; readonly useFullRight: boolean }
+	| { readonly kind: "middle-elided"; readonly keptMiddleCount: number; readonly showMarker: boolean }
+	| { readonly kind: "pwd-elided"; readonly pwdPlain: string }
+	| { readonly kind: "left-elided"; readonly leftPlain: string }
+	| { readonly kind: "right-truncated"; readonly rightPlain: string };
+
+function segmentsWidth(segments: readonly FooterSegment[], separator: string): number {
+	if (segments.length === 0) return 0;
+	let total = visibleWidth(separator) * (segments.length - 1);
+	for (const segment of segments) total += visibleWidth(segment.plain);
+	return total;
+}
+
+function fits(left: readonly FooterSegment[], right: FooterSegment, input: FooterLayoutInput): boolean {
+	return segmentsWidth(left, input.separator) + input.minPadding + visibleWidth(right.plain) <= input.width;
+}
+
+/**
+ * Elide the head of a string so it fits maxWidth, keeping the tail (the most
+ * identifying part of a path) and marking the cut with a single "…".
+ */
+export function elideHead(text: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
+	if (visibleWidth(text) <= maxWidth) return text;
+	if (maxWidth === 1) return "…";
+	const budget = maxWidth - visibleWidth("…");
+	const chars = [...text];
+	const kept: string[] = [];
+	let used = 0;
+	for (let i = chars.length - 1; i >= 0; i--) {
+		const char = chars[i];
+		if (char === undefined) break;
+		const charWidth = visibleWidth(char);
+		if (used + charWidth > budget) break;
+		kept.unshift(char);
+		used += charWidth;
+	}
+	return `…${kept.join("")}`;
+}
+
+/**
+ * Pick the richest layout that fits the width. The model label is pinned to
+ * the right edge and the anchor/tail segments stay visible; the middle stats
+ * yield first (right-most first), then the pwd shrinks from its head.
+ */
+export function planFooterLayout(input: FooterLayoutInput): FooterLayout {
+	const { anchor, middle, tail, right } = input;
+	const fullLeft = [...anchor, ...middle, tail];
+	if (right.full !== undefined && fits(fullLeft, right.full, input)) {
+		return { kind: "full", useFullRight: true };
+	}
+	if (fits(fullLeft, right.minimal, input)) {
+		return { kind: "full", useFullRight: false };
+	}
+	for (let kept = middle.length - 1; kept >= 0; kept--) {
+		const candidate = [...anchor, ...middle.slice(0, kept), input.ellipsisMarker, tail];
+		if (fits(candidate, right.minimal, input)) {
+			return { kind: "middle-elided", keptMiddleCount: kept, showMarker: true };
+		}
+	}
+	if (fits([...anchor, tail], right.minimal, input)) {
+		return { kind: "middle-elided", keptMiddleCount: 0, showMarker: false };
+	}
+	const [, ...anchorRest] = anchor;
+	const restWidth = segmentsWidth([...anchorRest, tail], input.separator) + visibleWidth(input.separator);
+	const pwdBudget = input.width - input.minPadding - visibleWidth(right.minimal.plain) - restWidth;
+	if (pwdBudget >= 2) {
+		return { kind: "pwd-elided", pwdPlain: elideHead(anchor[0].plain, pwdBudget) };
+	}
+	const leftBudget = input.width - input.minPadding - visibleWidth(right.minimal.plain);
+	if (leftBudget >= 1) {
+		const allLeftPlain = [...anchor, tail].map((segment) => segment.plain).join(input.separator);
+		return { kind: "left-elided", leftPlain: elideHead(allLeftPlain, leftBudget) };
+	}
+	return { kind: "right-truncated", rightPlain: truncateToWidth(right.minimal.plain, input.width, "") };
+}

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -3,6 +3,7 @@ import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/p
 import type { AgentSession } from "../../../core/agent-session.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
 import { theme } from "../theme/theme.ts";
+import { type FooterSegment, planFooterLayout } from "./footer-layout.ts";
 
 /**
  * Sanitize text for display in a single-line status.
@@ -129,9 +130,11 @@ export class FooterComponent implements Component {
 					? formatTokens(Math.round((contextWindow * contextUsage.percent) / 100))
 					: "?";
 
-		// Build colored segments. Each segment carries its own theme color
-		// so the HUD stays readable at a glance instead of being one dim wash.
-		const sep = theme.fg("borderMuted", " • ");
+		// Segments in priority order: anchors (pwd, branch, context) and the model
+		// label always stay; middle stats elide from the right when space runs out.
+		// The width ladder itself lives in ./footer-layout.ts.
+		const separator = " • ";
+		const sepColored = theme.fg("borderMuted", separator);
 		const pwdRaw = formatCwdForFooter(
 			this.session.sessionManager.getCwd(),
 			process.env.HOME || process.env.USERPROFILE,
@@ -139,35 +142,16 @@ export class FooterComponent implements Component {
 		const branch = this.footerData.getGitBranch();
 		const sessionName = this.session.sessionManager.getSessionName();
 
-		const coloredSegments: string[] = [theme.fg("accent", pwdRaw)];
-		const plainSegments: string[] = [pwdRaw];
-		if (branch) {
-			coloredSegments.push(theme.fg("warning", branch));
-			plainSegments.push(branch);
-		}
-		if (sessionName) {
-			coloredSegments.push(theme.fg("muted", sessionName));
-			plainSegments.push(sessionName);
-		}
-		if (totalInput) {
-			const text = `↑${formatTokens(totalInput)}`;
-			coloredSegments.push(theme.fg("dim", text));
-			plainSegments.push(text);
-		}
-		if (totalOutput) {
-			const text = `↓${formatTokens(totalOutput)}`;
-			coloredSegments.push(theme.fg("dim", text));
-			plainSegments.push(text);
-		}
-		if (totalCacheRead || totalCacheWrite) {
-			const text = `cache ${formatTokens(totalCacheRead)}/${formatTokens(totalCacheWrite)}`;
-			coloredSegments.push(theme.fg("dim", text));
-			plainSegments.push(text);
-		}
+		const anchor: [FooterSegment, ...FooterSegment[]] = [{ plain: pwdRaw, colored: theme.fg("accent", pwdRaw) }];
+		if (branch) anchor.push({ plain: branch, colored: theme.fg("warning", branch) });
+
+		const dim = (plain: string): FooterSegment => ({ plain, colored: theme.fg("dim", plain) });
+		const middle: FooterSegment[] = [];
+		if (sessionName) middle.push({ plain: sessionName, colored: theme.fg("muted", sessionName) });
+		if (totalInput) middle.push(dim(`↑${formatTokens(totalInput)}`));
+		if (totalOutput) middle.push(dim(`↓${formatTokens(totalOutput)}`));
 		if ((totalCacheRead > 0 || totalCacheWrite > 0) && latestCacheHitRate !== undefined) {
-			const text = `CH${latestCacheHitRate.toFixed(1)}%`;
-			coloredSegments.push(theme.fg("dim", text));
-			plainSegments.push(text);
+			middle.push(dim(`CH${latestCacheHitRate.toFixed(1)}%`));
 		}
 
 		// Kimi Coding is subscription-backed despite using API-key authentication.
@@ -176,8 +160,7 @@ export class FooterComponent implements Component {
 			: false;
 		if (totalCost || usingSubscription) {
 			const costStr = `$${totalCost.toFixed(3)}${usingSubscription ? " (sub)" : ""}`;
-			coloredSegments.push(theme.fg("success", costStr));
-			plainSegments.push(costStr);
+			middle.push({ plain: costStr, colored: theme.fg("success", costStr) });
 		}
 
 		const autoIndicator = this.autoCompactEnabled ? " (auto)" : "";
@@ -191,60 +174,69 @@ export class FooterComponent implements Component {
 				: contextPercentValue > 70
 					? theme.fg("warning", ctxDisplay)
 					: theme.fg("muted", ctxDisplay);
-		coloredSegments.push(ctxColored);
-		plainSegments.push(ctxDisplay);
+		const tail: FooterSegment = { plain: ctxDisplay, colored: ctxColored };
 
-		const statsLeftPlain = plainSegments.join(" • ");
-		let statsLeft = coloredSegments.join(sep);
-		let statsLeftWidth = visibleWidth(statsLeftPlain);
-
-		// If statsLeft is too wide, truncate the plain version (color codes break truncation)
-		if (statsLeftWidth > width) {
-			const truncated = truncateToWidth(statsLeftPlain, width, "...");
-			statsLeft = theme.fg("muted", truncated);
-			statsLeftWidth = visibleWidth(truncated);
-		}
-
-		// Calculate available space for padding (minimum 2 spaces between stats and model)
-		const minPadding = 2;
-
-		// Add thinking level indicator if model supports reasoning
+		// Model label pinned to the right edge; the provider prefix stays only when
+		// the full line fits.
 		const modelName = state.model?.id || "no-model";
-		let rightSideWithoutProvider = modelName;
+		let minimalRight = modelName;
 		if (state.model?.reasoning) {
 			const thinkingLevel = state.thinkingLevel || "off";
-			rightSideWithoutProvider = thinkingLevel === "off" ? `${modelName}:off` : `${modelName}:${thinkingLevel}`;
+			minimalRight = thinkingLevel === "off" ? `${modelName}:off` : `${modelName}:${thinkingLevel}`;
+		}
+		const minimal: FooterSegment = { plain: minimalRight, colored: colorRightSide(minimalRight) };
+		const providerPrefix =
+			this.footerData.getAvailableProviderCount() > 1 && state.model ? `(${state.model.provider}) ` : "";
+		const full: FooterSegment | undefined = providerPrefix
+			? { plain: `${providerPrefix}${minimalRight}`, colored: colorRightSide(`${providerPrefix}${minimalRight}`) }
+			: undefined;
+
+		const marker: FooterSegment = { plain: "…", colored: theme.fg("dim", "…") };
+		const plan = planFooterLayout({
+			width,
+			anchor,
+			middle,
+			tail,
+			right: { minimal, full },
+			separator,
+			minPadding: 2,
+			ellipsisMarker: marker,
+		});
+
+		const joinSegments = (segments: readonly FooterSegment[]): { colored: string; width: number } => ({
+			colored: segments.map((segment) => segment.colored).join(sepColored),
+			width: visibleWidth(segments.map((segment) => segment.plain).join(separator)),
+		});
+
+		let left: { colored: string; width: number };
+		let right: FooterSegment;
+		if (plan.kind === "full") {
+			right = plan.useFullRight && full ? full : minimal;
+			left = joinSegments([...anchor, ...middle, tail]);
+		} else if (plan.kind === "middle-elided") {
+			right = minimal;
+			const segments = [...anchor, ...middle.slice(0, plan.keptMiddleCount)];
+			if (plan.showMarker) segments.push(marker);
+			segments.push(tail);
+			left = joinSegments(segments);
+		} else if (plan.kind === "pwd-elided") {
+			right = minimal;
+			left = joinSegments([
+				{ plain: plan.pwdPlain, colored: theme.fg("accent", plan.pwdPlain) },
+				...anchor.slice(1),
+				tail,
+			]);
+		} else if (plan.kind === "left-elided") {
+			right = minimal;
+			left = { colored: theme.fg("muted", plan.leftPlain), width: visibleWidth(plan.leftPlain) };
+		} else {
+			left = { colored: "", width: 0 };
+			right = { plain: plan.rightPlain, colored: colorRightSide(plan.rightPlain) };
 		}
 
-		// Prepend the provider in parentheses if there are multiple providers and there's enough room
-		let rightSidePlain = rightSideWithoutProvider;
-		if (this.footerData.getAvailableProviderCount() > 1 && state.model) {
-			const withProvider = `(${state.model.provider}) ${rightSideWithoutProvider}`;
-			if (statsLeftWidth + minPadding + visibleWidth(withProvider) <= width) {
-				rightSidePlain = withProvider;
-			}
-		}
-
-		const rightSideWidth = visibleWidth(rightSidePlain);
-		const totalNeeded = statsLeftWidth + minPadding + rightSideWidth;
-
-		let rightSideRendered = rightSidePlain;
-		let actualRightWidth = rightSideWidth;
-		if (totalNeeded > width) {
-			const availableForRight = width - statsLeftWidth - minPadding;
-			if (availableForRight > 0) {
-				rightSideRendered = truncateToWidth(rightSidePlain, availableForRight, "");
-				actualRightWidth = visibleWidth(rightSideRendered);
-			} else {
-				rightSideRendered = "";
-				actualRightWidth = 0;
-			}
-		}
-
-		// Color the right side: provider muted, model accent, thinking dim
-		const coloredRight = colorRightSide(rightSideRendered);
-		const padding = " ".repeat(Math.max(0, width - statsLeftWidth - actualRightWidth));
-		const lines = [statsLeft + padding + coloredRight];
+		const rightWidth = visibleWidth(right.plain);
+		const padding = " ".repeat(Math.max(0, width - left.width - rightWidth));
+		const lines = [left.colored + padding + right.colored];
 
 		// Add extension statuses on a single line, sorted by key alphabetically
 		const extensionStatuses = this.footerData.getExtensionStatuses();

--- a/packages/coding-agent/test/footer-token-format.test.ts
+++ b/packages/coding-agent/test/footer-token-format.test.ts
@@ -94,7 +94,10 @@ describe("FooterComponent token formatting", () => {
 		// then
 		expect(rendered).toContain("↑49");
 		expect(rendered).toContain("↓6.8K");
-		expect(rendered).toContain("cache 1.5M/44K");
+		// Cache read/write totals were removed from the footer; only the hit rate stays.
+		expect(rendered).not.toContain("cache 1.5M/44K");
+		expect(rendered).not.toContain("cache ");
+		expect(rendered).toContain("CH97.1%");
 		expect(rendered).toContain("44K/800K (5.5%) (auto)");
 		expect(rendered).not.toContain("44,000/800,000");
 		expect(rendered).not.toContain("↓6,800");

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -240,6 +240,9 @@ describe("FooterComponent width handling", () => {
 			.map((line) => stripAnsi(line))
 			.join("\n");
 		expect(renderedFooter).toContain("CH25.0%");
+		// The cache read/write totals segment was removed; only the hit rate remains.
+		expect(renderedFooter).not.toContain("cache 50/50");
+		expect(renderedFooter).not.toContain("cache ");
 	});
 
 	it("marks Kimi Coding costs as subscription estimates", () => {
@@ -263,5 +266,58 @@ describe("FooterComponent width handling", () => {
 			.map((line) => stripAnsi(line))
 			.join("\n");
 		expect(renderedFooter).toContain("$1.234 (sub)");
+	});
+
+	it("keeps the model label and context block visible at narrow widths", () => {
+		const width = 60;
+		const session = createSession({
+			sessionName: "deep-work-on-footer-layout",
+			modelId: "test-model",
+			reasoning: true,
+			thinkingLevel: "high",
+			usage: {
+				input: 12_345,
+				output: 6_789,
+				cacheRead: 50,
+				cacheWrite: 50,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(session, createFooterData(2));
+
+		const lines = footer.render(width);
+		const plain = lines.map((line) => stripAnsi(line)).join("\n");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+		expect(plain).toContain("test-model:high");
+		expect(plain).toContain("main");
+		expect(plain).toContain("(auto)");
+		expect(plain).toContain("…");
+	});
+
+	it("still renders the model label at very narrow widths", () => {
+		const width = 30;
+		const session = createSession({
+			sessionName: "deep-work-on-footer-layout",
+			modelId: "test-model",
+			reasoning: true,
+			thinkingLevel: "high",
+			usage: {
+				input: 12_345,
+				output: 6_789,
+				cacheRead: 50,
+				cacheWrite: 50,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(session, createFooterData(2));
+
+		const lines = footer.render(width);
+		const plain = lines.map((line) => stripAnsi(line)).join("\n");
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+		expect(plain).toContain("test-model");
 	});
 });


### PR DESCRIPTION
## Summary

The interactive footer spent its scarcest resource — narrow-terminal width — on the `cache <read>/<write>` totals segment, and when space ran out it truncated the whole left block and then dropped the right-side model label entirely. This PR removes the cache totals segment (the `CH<x>%` cache-hit-rate stays) and reworks width fitting so the two anchors users actually watch never disappear: the left block (cwd • branch • context usage `(auto)`) and the right-side `model:thinking` label (e.g. `gpt-5.6-sol-fast:medium`).

Observable behavior after this PR: at full width the footer is unchanged minus the cache segment; as the terminal narrows, middle segments (session name, ↑input, ↓output, CH%, $cost) elide right-most-first behind a single dim `…` marker; under more pressure the cwd head-elides (`…/senpi`) while branch, context usage, and the model label stay put. Every rendered line stays within the terminal width at any width.

## Changes

- **`components/footer-layout.ts` (new):** pure width-planning for the classic footer. `planFooterLayout()` picks the richest layout that fits — full line, middle-elided, pwd-elided, left-elided, and model-truncation only as the last resort. `elideHead()` keeps the tail of a path, which carries the most identifying information. Segments are plain/colored pairs so width math never touches ANSI codes.
- **`components/footer.ts`:** `render()` now builds `FooterSegment` groups (anchor / middle / tail / right label) and materializes the planner's decision. The `cache <read>/<write>` segment is deleted; provider-prefix behavior is preserved (shown only when the full line fits).
- **Tests:** `footer-width.test.ts` gains anchor-visibility tests at 60 and 30 cols (both failed before the implementation); `footer-token-format.test.ts` now pins the absence of the cache segment and the presence of `CH97.1%`.
- **`changes.md`:** fork-visible change recorded with expected merge-conflict zones.

## QA & Evidence

- **What was tested:** footer unit suites — new assertions were captured failing (RED) before the production change, then passing (GREEN).
  - **Observed result:** vitest 22/22 across footer-width, footer-token-format, footer-data-provider, and grok/footer.
- **What was tested:** the real interactive TUI booted from this branch in an isolated senpi-qa sandbox with a session seeded with 1.4B cache-read / 1.2M cache-write usage (the exact shape that used to render `cache 1.4B/1.2M`), captured through a true-color xterm.js web terminal at 140, 90, and 60 columns.
  - **Observed result:** no `cache ` segment at any width; `gpt-5.6-sol-fast:medium` pinned bottom-right at every width; cwd/branch/context anchors always present. w140 renders the full middle (`↑300 • ↓600 • CH99.6% • $1.237`), w90 elides to `↑300 • ↓600 • … • 50K/1M (5.0%) (auto)`, w60 head-elides to `…3001 • main • 50K/1M (5.0%) (auto)`.
  - **Artifact:** `local-ignore/qa-evidence/20260727-footer-cache-layout/` — terminal.png + terminal.txt per width (QA-only, gitignored).
  - **Why sufficient:** proves the user-visible contract on the real surface, not just the unit seam.
- **What was tested:** adjacent surfaces — senpi-qa mock-loop self-test (agent loop), tui-smoke self-test (boot/render/input), the pre-existing footer-abbrev real-turn TUI QA, and root static validation.
  - **Observed result:** mock-loop 42/42, tui-smoke 5/5, footer-abbrev 6/6, `npm run check` exit 0.

## Risks & Residuals

- The fork's merge-conflict surface in `footer.ts` `render()` grows with this rewrite; `changes.md` documents the expected zones, and `footer-layout.ts` is additive (low risk).
- At widths below the model label's own width the label truncates (last-resort branch) — behavior identical to before and unreachable in realistic terminals.
- The grok chrome footer is intentionally untouched (it is model+cwd only by design).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the footer’s key anchors (cwd, branch, context) and the model:thinking label so they stay visible at any width. Removes the `cache <read>/<write>` totals segment to free space; the `CHx%` hit rate remains.

- **Refactors**
  - Added `components/footer-layout.ts` with `planFooterLayout()` and head-elision via `elideHead()`.
  - Reworked `components/footer.ts` to build segment groups and delegate width fitting; provider prefix shows only when the full line fits.
  - Elision order: middle stats drop right-to-left behind a single `…`, then cwd head-elides; model truncates only as a last resort.
  - Updated tests to assert anchor visibility at 60/30 cols and the removal of the cache totals segment.

- **Bug Fixes**
  - Prevents the right-side model label from disappearing on narrow terminals.
  - Ensures every rendered line fits the terminal width.

<sup>Written for commit 257806aca9488b54f1f8f350c331b3f0bf47cc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

