### PR TITLE
fix(codemode): make failed eval tool calls self-correctable

### DIFF
--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -101,12 +101,18 @@ options object and asynchronous helpers are `await`-able.
 | `write(path, content)` | Creates parent directories and writes text. `local://` paths persist in the session artifact root. |
 | `env(key?, value?)` | Reads all kernel environment values, one value, or sets one value. |
 | `tool.<name>(args)` | Invokes an active Senpi tool through the normal `pi.executeTool` pipeline. |
+| `tool_schema(name?)` | Returns a tool's parameter schema without calling it; omit `name` to list tool names. |
 | `completion(prompt, model?, system?, schema?)` | Requests a one-shot host completion; `schema` asks the host to parse structured output. |
 | `agent(prompt, ...)` | Delegates to the configured active `taskTools.task` tool. Supports background handles and structured JSON results. |
 | `output(ids, format?, offset?, limit?)` | Delegates transcript retrieval to the configured active `taskTools.output` tool. |
 | `parallel(thunks)` | Runs thunks through the configured bounded pool while preserving input order. |
 | `pipeline(items, ...stages)` | Applies stages left to right with a barrier between stages. |
 | `log(message)` / `phase(title)` | Emits progress text and starts a status phase. |
+
+When a `tool.<name>()` call fails argument validation, the error delivered back
+into the cell carries the tool's expected parameters, so the cell can correct the
+arguments and retry instead of falling back to one-at-a-time tool calls.
+`tool_schema()` exposes the same catalog up front.
 
 `agent()` is available only when the configured task tool is active in the
 session. `output()` similarly requires the configured task-output tool and

--- a/packages/senpi-codemode/scripts/qa-js-cell.ts
+++ b/packages/senpi-codemode/scripts/qa-js-cell.ts
@@ -146,6 +146,22 @@ function createQaExecuteTool(options: QaOptions): OutputExecuteTool {
 	});
 }
 
+const QA_TOOL_CATALOG = [
+	{
+		name: "slow_fake",
+		description: "QA fixture tool.",
+		parameters: {
+			type: "object",
+			properties: {
+				steps: { type: "array", description: "Steps to run in order.", items: { type: "object" } },
+				app: { type: "string", description: "Target application." },
+			},
+			required: ["steps"],
+		},
+	},
+	{ name: "task_output", description: "QA transcript fixture.", parameters: { type: "object", properties: {} } },
+] as const;
+
 async function runQa(options: QaOptions): Promise<void> {
 	let dispatch: ((message: KernelToHostMessage) => void) | undefined;
 	const kernel = new JavaScriptKernel({
@@ -192,6 +208,7 @@ async function runQa(options: QaOptions): Promise<void> {
 		kernelManager,
 		cellTimeoutSeconds: options.timeoutSeconds,
 		executeTool,
+		listTools: () => QA_TOOL_CATALOG,
 	});
 	try {
 		for (const [index, code] of options.codes.entries()) {

--- a/packages/senpi-codemode/src/bridge/reserved.ts
+++ b/packages/senpi-codemode/src/bridge/reserved.ts
@@ -3,6 +3,8 @@
 export const RESERVED_AGENT_TOOL = "__agent__" as const;
 /** ADAPTATION: senpi delegates output through a reserved kernel-side tool name. */
 export const RESERVED_OUTPUT_TOOL = "__output__" as const;
+/** ADAPTATION: senpi resolves tool parameter schemas through a reserved kernel-side tool name. */
+export const RESERVED_SCHEMA_TOOL = "__schema__" as const;
 /** Canonical oh-my-pi eval-timeout pause operation. */
 export const TIMEOUT_PAUSE_OP = "timeout-pause" as const;
 /** Canonical oh-my-pi eval-timeout resume operation. */

--- a/packages/senpi-codemode/src/bridges/reserved-dispatch.ts
+++ b/packages/senpi-codemode/src/bridges/reserved-dispatch.ts
@@ -1,0 +1,56 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { RESERVED_AGENT_TOOL, RESERVED_OUTPUT_TOOL, RESERVED_SCHEMA_TOOL } from "../bridge/reserved.ts";
+import type { EvalStatusEvent, ExecuteTool } from "../tool/types.ts";
+import { type AgentExecuteTool, runEvalAgent } from "./agent-bridge.ts";
+import { type MarshalledToolResult, type OutputExecuteTool, runEvalOutput } from "./output-bridge.ts";
+import { type EvalSchemaToolInfo, runEvalSchema } from "./schema-bridge.ts";
+
+export interface ReservedDispatchContext {
+	readonly callId: string;
+	readonly args: unknown;
+	readonly executeTool: AgentExecuteTool & OutputExecuteTool & ExecuteTool;
+	readonly taskToolName: string;
+	readonly taskOutputToolName: string;
+	readonly listTools: (() => readonly EvalSchemaToolInfo[]) | undefined;
+	readonly signal: AbortSignal | undefined;
+	readonly emitStatus: (event: EvalStatusEvent) => void;
+	readonly marshalToolResult: (result: AgentToolResult<unknown>) => MarshalledToolResult;
+}
+
+class SchemaUnavailableError extends Error {
+	readonly name = "SchemaUnavailableError";
+
+	constructor() {
+		super("tool_schema() unavailable: this session does not expose a tool catalog");
+	}
+}
+
+export function isReservedToolName(toolName: string): boolean {
+	return toolName === RESERVED_AGENT_TOOL || toolName === RESERVED_OUTPUT_TOOL || toolName === RESERVED_SCHEMA_TOOL;
+}
+
+export async function runReservedTool(toolName: string, context: ReservedDispatchContext): Promise<unknown> {
+	if (toolName === RESERVED_AGENT_TOOL) {
+		return await runEvalAgent(context.args, {
+			callId: context.callId,
+			taskToolName: context.taskToolName,
+			executeTool: context.executeTool,
+			...(context.signal === undefined ? {} : { signal: context.signal }),
+			emitStatus: context.emitStatus,
+		});
+	}
+	if (toolName === RESERVED_OUTPUT_TOOL) {
+		return await runEvalOutput(context.args, {
+			taskOutputToolName: context.taskOutputToolName,
+			executeTool: context.executeTool,
+			...(context.signal === undefined ? {} : { signal: context.signal }),
+			marshalToolResult: context.marshalToolResult,
+		});
+	}
+	if (toolName === RESERVED_SCHEMA_TOOL) {
+		const listTools = context.listTools;
+		if (listTools === undefined) throw new SchemaUnavailableError();
+		return runEvalSchema(context.args, { listTools });
+	}
+	throw new Error(`runReservedTool received a non-reserved tool name: ${toolName}`);
+}

--- a/packages/senpi-codemode/src/bridges/schema-bridge.ts
+++ b/packages/senpi-codemode/src/bridges/schema-bridge.ts
@@ -1,0 +1,69 @@
+import { type Static, Type } from "typebox";
+import { Check, Errors } from "typebox/value";
+
+const schemaArgsSchema = Type.Object(
+	{ name: Type.Optional(Type.String({ minLength: 1 })) },
+	{ additionalProperties: false },
+);
+
+type SchemaArgs = Static<typeof schemaArgsSchema>;
+
+export interface EvalSchemaToolInfo {
+	readonly name: string;
+	readonly description?: string | undefined;
+	readonly parameters?: unknown;
+}
+
+export interface RunEvalSchemaOptions {
+	readonly listTools: () => readonly EvalSchemaToolInfo[];
+}
+
+export type EvalSchemaResult =
+	| { readonly tools: readonly string[] }
+	| { readonly name: string; readonly description: string | undefined; readonly parameters: unknown };
+
+class SchemaArgumentsError extends Error {
+	readonly name = "SchemaArgumentsError";
+
+	constructor(summary: string) {
+		super(`schema() received invalid arguments: ${summary}`);
+	}
+}
+
+class SchemaUnknownToolError extends Error {
+	readonly name = "SchemaUnknownToolError";
+
+	constructor(requested: string, suggestions: readonly string[]) {
+		const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+		super(`schema() found no tool named "${requested}".${hint}`);
+	}
+}
+
+export function runEvalSchema(args: unknown, options: RunEvalSchemaOptions): EvalSchemaResult {
+	const parsed = parseSchemaArgs(args);
+	const tools = options.listTools();
+	if (parsed.name === undefined) return { tools: tools.map((tool) => tool.name) };
+
+	const match = tools.find((tool) => tool.name === parsed.name);
+	if (match) return { name: match.name, description: match.description, parameters: match.parameters };
+	throw new SchemaUnknownToolError(parsed.name, nearestNames(parsed.name, tools));
+}
+
+function parseSchemaArgs(value: unknown): SchemaArgs {
+	if (Check(schemaArgsSchema, value)) return value;
+	const summary = Errors(schemaArgsSchema, value)
+		.map((error) => `${error.instancePath || "/"} ${error.message}`)
+		.join("; ");
+	throw new SchemaArgumentsError(summary || "invalid value");
+}
+
+function nearestNames(requested: string, tools: readonly EvalSchemaToolInfo[]): readonly string[] {
+	const needle = requested.toLowerCase();
+	return tools
+		.map((tool) => tool.name)
+		.filter((name) => {
+			const candidate = name.toLowerCase();
+			return candidate.includes(needle) || needle.includes(candidate);
+		})
+		.slice(0, 5);
+}

--- a/packages/senpi-codemode/src/bridges/schema-hint.ts
+++ b/packages/senpi-codemode/src/bridges/schema-hint.ts
@@ -1,0 +1,140 @@
+const SCHEMA_HINT_MAX_CHARS = 1_200;
+const SCHEMA_HINT_MAX_PROPERTIES = 30;
+const DESCRIPTION_MAX_CHARS = 80;
+const ENUM_MAX_VALUES = 8;
+const NESTED_MAX_DEPTH = 2;
+const HINT_HEADER = "Expected parameters:";
+
+interface SchemaLike {
+	readonly type?: unknown;
+	readonly properties?: unknown;
+	readonly required?: unknown;
+	readonly items?: unknown;
+	readonly description?: unknown;
+	readonly enum?: unknown;
+	readonly const?: unknown;
+	readonly oneOf?: unknown;
+	readonly anyOf?: unknown;
+	readonly allOf?: unknown;
+}
+
+export function appendSchemaHint(message: string, toolName: string, schema: unknown): string {
+	const rendered = renderSchemaHint(toolName, schema);
+	if (rendered === undefined) return message;
+	return `${message}\n\n${HINT_HEADER}\n${rendered}`;
+}
+
+export function renderSchemaHint(toolName: string, schema: unknown): string | undefined {
+	if (!isSchemaLike(schema)) return undefined;
+	const lines = renderObjectLines(schema, 0, 1);
+	if (lines.length === 0) return undefined;
+	return fitLines(lines, `[truncated; call tool_schema(${JSON.stringify(toolName)}) for the full schema]`);
+}
+
+function renderObjectLines(schema: SchemaLike, indent: number, depth: number): readonly string[] {
+	const required = stringArray(schema.required);
+	const entries = propertyEntries(schema.properties);
+	if (entries.length === 0 && required.length === 0) return [];
+
+	const ordered = [
+		...entries.filter(([name]) => required.includes(name)),
+		...entries.filter(([name]) => !required.includes(name)),
+	];
+	const pad = "  ".repeat(indent + 1);
+	const lines: string[] = [];
+	if (indent === 0 && required.length > 0) lines.push(`required: ${required.join(", ")}`);
+
+	const shown = ordered.slice(0, SCHEMA_HINT_MAX_PROPERTIES);
+	for (const [name, value] of shown) {
+		lines.push(`${pad}${name}${required.includes(name) ? "" : "?"}: ${describeProperty(value)}`);
+		lines.push(...nestedLines(value, indent, depth));
+	}
+	const hidden = ordered.length - shown.length;
+	if (hidden > 0) lines.push(`${pad}… ${hidden} more propert${hidden === 1 ? "y" : "ies"}`);
+	return lines;
+}
+
+function nestedLines(value: unknown, indent: number, depth: number): readonly string[] {
+	if (depth >= NESTED_MAX_DEPTH || !isSchemaLike(value)) return [];
+	const nested = isSchemaLike(value.items) ? value.items : value;
+	if (propertyEntries(nested.properties).length === 0) return [];
+	return renderObjectLines(nested, indent + 1, depth + 1);
+}
+
+function describeProperty(value: unknown): string {
+	if (!isSchemaLike(value)) return "unknown";
+	const parts = [typeLabel(value)];
+	const description = firstLine(value.description);
+	if (description !== undefined) parts.push(`— ${truncate(description, DESCRIPTION_MAX_CHARS)}`);
+	return parts.join(" ");
+}
+
+function typeLabel(schema: SchemaLike): string {
+	if (Object.hasOwn(schema, "const")) return JSON.stringify(schema.const);
+	const enumValues = schema.enum;
+	if (Array.isArray(enumValues) && enumValues.length > 0) return unionLabel(enumValues.map(literal));
+	const branches = schema.oneOf ?? schema.anyOf;
+	if (Array.isArray(branches) && branches.length > 0) return unionLabel(branches.map(branchLabel));
+	if (Array.isArray(schema.allOf) && schema.allOf.length > 0) return branchLabel(schema.allOf[0]);
+
+	const type = schema.type;
+	const base = typeof type === "string" ? type : Array.isArray(type) ? type.filter(isString).join("|") : "unknown";
+	if (base !== "array") return base;
+	return isSchemaLike(schema.items) ? `array<${typeLabel(schema.items)}>` : "array";
+}
+
+function unionLabel(values: readonly string[]): string {
+	const shown = values.slice(0, ENUM_MAX_VALUES).join(" | ");
+	return values.length > ENUM_MAX_VALUES ? `${shown} | … (${values.length - ENUM_MAX_VALUES} more)` : shown;
+}
+
+function branchLabel(value: unknown): string {
+	return isSchemaLike(value) ? typeLabel(value) : "unknown";
+}
+
+function literal(value: unknown): string {
+	return JSON.stringify(value) ?? String(value);
+}
+
+function fitLines(lines: readonly string[], marker: string): string {
+	const budget = SCHEMA_HINT_MAX_CHARS - HINT_HEADER.length - 1;
+	const kept: string[] = [];
+	let used = 0;
+	for (const line of lines) {
+		const next = used + line.length + (kept.length === 0 ? 0 : 1);
+		if (next > budget - marker.length - 1) {
+			kept.push(marker);
+			return kept.join("\n");
+		}
+		kept.push(line);
+		used = next;
+	}
+	return kept.join("\n");
+}
+
+function propertyEntries(properties: unknown): readonly (readonly [string, unknown])[] {
+	if (typeof properties !== "object" || properties === null || Array.isArray(properties)) return [];
+	return Object.entries(properties);
+}
+
+function stringArray(value: unknown): readonly string[] {
+	return Array.isArray(value) ? value.filter(isString) : [];
+}
+
+function firstLine(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const line = value.split("\n", 1)[0]?.trim();
+	return line === undefined || line.length === 0 ? undefined : line;
+}
+
+function truncate(value: string, maxChars: number): string {
+	return value.length <= maxChars ? value : `${value.slice(0, maxChars)}…`;
+}
+
+function isSchemaLike(value: unknown): value is SchemaLike {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+	return typeof value === "string";
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -1,6 +1,7 @@
 import * as os from "node:os";
 import type { ExtensionContext } from "@code-yeongyu/senpi";
 import type { AgentExecuteTool } from "./bridges/agent-bridge.ts";
+import type { EvalSchemaToolInfo } from "./bridges/schema-bridge.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
 import { defaultCodemodeSettings } from "./config/settings.ts";
 import { EvalNotifier } from "./extension/eval-notifier.ts";
@@ -33,6 +34,7 @@ export interface CodemodeExtensionAPI {
 	on(event: CodemodeEvent, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void;
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
+	getAllTools(): readonly EvalSchemaToolInfo[];
 	sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
 }
 
@@ -67,6 +69,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				kernelManager: manager,
 				cellTimeoutSeconds: runtime.settings.cellTimeoutSeconds,
 				executeTool: runtime.executeTool,
+				listTools: () => pi.getAllTools(),
 				complete,
 				settings: runtime.settings,
 				artifactsDir: runtime.artifactsDir,
@@ -95,6 +98,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			kernelManager: manager,
 			cellTimeoutSeconds: defaultCodemodeSettings.cellTimeoutSeconds,
 			executeTool: createExecuteTool(pi),
+			listTools: () => pi.getAllTools(),
 			complete,
 			settings: defaultCodemodeSettings,
 			cellManager: new EvalDetachedCellManager({ notifier }),

--- a/packages/senpi-codemode/src/kernels/jl/prelude.jl
+++ b/packages/senpi-codemode/src/kernels/jl/prelude.jl
@@ -194,6 +194,12 @@ function completion(prompt::AbstractString; model="default", system=nothing, sch
     get(response, "text", response)
 end
 
+function tool_schema(name=nothing)
+    arguments = Dict{String, Any}()
+    name !== nothing && (arguments["name"] = string(name))
+    senpi_with_bridge_timeout_pause(() -> senpi_call_tool("__schema__", arguments))
+end
+
 function output(ids...; format="raw", offset=nothing, limit=nothing)
     isempty(ids) && error("At least one output ID is required")
     format in ("raw", "tail") || error("output() format must be 'raw' or 'tail'")

--- a/packages/senpi-codemode/src/kernels/js/local-module-loader.ts
+++ b/packages/senpi-codemode/src/kernels/js/local-module-loader.ts
@@ -4,6 +4,7 @@ import type { BridgeConnectionConfig } from "../../bridge/protocol.ts";
 import {
 	RESERVED_AGENT_TOOL,
 	RESERVED_OUTPUT_TOOL,
+	RESERVED_SCHEMA_TOOL,
 	TIMEOUT_PAUSE_OP,
 	TIMEOUT_RESUME_OP,
 } from "../../bridge/reserved.ts";
@@ -33,6 +34,7 @@ type RuntimeModuleContext = {
 	readonly cwdUrl: string;
 	readonly localRootUrls: Readonly<Record<string, string>>;
 	readonly reservedAgentTool: string;
+	readonly reservedSchemaTool: string;
 	readonly reservedOutputTool: string;
 	readonly timeoutPauseOp: string;
 	readonly timeoutResumeOp: string;
@@ -55,6 +57,7 @@ function runtimeContext(options: LocalModuleLoaderOptions): RuntimeModuleContext
 		localRootUrls: roots,
 		reservedAgentTool: RESERVED_AGENT_TOOL,
 		reservedOutputTool: RESERVED_OUTPUT_TOOL,
+		reservedSchemaTool: RESERVED_SCHEMA_TOOL,
 		timeoutPauseOp: TIMEOUT_PAUSE_OP,
 		timeoutResumeOp: TIMEOUT_RESUME_OP,
 	};
@@ -66,6 +69,7 @@ function loaderPrelude(context: RuntimeModuleContext): string {
 		`globalThis.__senpi_module_context__ = ${serialized};`,
 		"globalThis.__senpi_reserved_agent_tool__ = globalThis.__senpi_module_context__.reservedAgentTool;",
 		"globalThis.__senpi_reserved_output_tool__ = globalThis.__senpi_module_context__.reservedOutputTool;",
+		"globalThis.__senpi_reserved_schema_tool__ = globalThis.__senpi_module_context__.reservedSchemaTool;",
 		"globalThis.__senpi_timeout_pause_op__ = globalThis.__senpi_module_context__.timeoutPauseOp;",
 		"globalThis.__senpi_timeout_resume_op__ = globalThis.__senpi_module_context__.timeoutResumeOp;",
 		"globalThis.__senpi_import__ = async (source, options) => {",

--- a/packages/senpi-codemode/src/kernels/js/worker-runtime.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-runtime.js
@@ -50,6 +50,7 @@ export class JsWorkerRuntime {
 		globalThis.read = async (path, options, ...rest) => await this.#read(path, helperOptions("read", options, rest));
 		globalThis.write = async (path, content) => await this.#write(path, content);
 		globalThis.output = async (...args) => await this.#output(args);
+		globalThis.tool_schema = async name => await this.#toolSchema(name);
 		globalThis.agent = async (prompt, options, ...rest) => await this.#agent(prompt, options, rest);
 		globalThis.parallel = async thunks => await this.#parallel(thunks);
 		globalThis.pipeline = async (items, ...stages) => await this.#pipeline(items, stages);
@@ -248,6 +249,11 @@ export class JsWorkerRuntime {
 			if (details[key] !== undefined) node[key] = details[key];
 		}
 		return node;
+	}
+
+	async #toolSchema(name) {
+		const args = name === undefined || name === null ? {} : { name: String(name) };
+		return await this.#callTool(reservedTool("__senpi_reserved_schema_tool__", "tool_schema"), args);
 	}
 
 	async #callTool(toolName, args) {

--- a/packages/senpi-codemode/src/kernels/py/prelude.py
+++ b/packages/senpi-codemode/src/kernels/py/prelude.py
@@ -37,6 +37,7 @@ EMIT_LOCK = Lock()
 # Mirrors src/bridge/reserved.ts; this standalone subprocess asset cannot import TypeScript.
 RESERVED_AGENT_TOOL = "__agent__"
 RESERVED_OUTPUT_TOOL = "__output__"
+RESERVED_SCHEMA_TOOL = "__schema__"
 TIMEOUT_PAUSE_OP = "timeout-pause"
 TIMEOUT_RESUME_OP = "timeout-resume"
 
@@ -372,6 +373,14 @@ def completion(
     if "value" in response:
         return response["value"]
     return response.get("text", response)
+
+
+def tool_schema(name: str | None = None) -> Any:
+    args: dict[str, Any] = {} if name is None else {"name": name}
+    return bridge_post(
+        "/call",
+        {"callId": f"py-{uuid.uuid4()}", "toolName": RESERVED_SCHEMA_TOOL, "args": args},
+    )
 
 
 def output(
@@ -844,6 +853,7 @@ USER_NS.update(
         "completion": completion,
         "agent": agent,
         "output": output,
+        "tool_schema": tool_schema,
         "__senpi_magic": _magic,
         "__senpi_magic_cell": _magic_cell,
         "__senpi_shell": _shell,

--- a/packages/senpi-codemode/src/kernels/rb/prelude.rb
+++ b/packages/senpi-codemode/src/kernels/rb/prelude.rb
@@ -5,6 +5,7 @@ require "uri"
 
 SENPI_RESERVED_AGENT_TOOL = "__agent__"
 SENPI_RESERVED_OUTPUT_TOOL = "__output__"
+SENPI_RESERVED_SCHEMA_TOOL = "__schema__"
 SENPI_INTERNAL_URL = Regexp.new("\\A([a-z][a-z0-9+.\\-]*)://(.*)\\z", Regexp::IGNORECASE)
 
 def __senpi_status_enabled?
@@ -185,6 +186,11 @@ def completion(prompt, model: "default", system: nil, schema: nil, **kwargs)
   return result["value"] if result.key?("value")
 
   result.fetch("text", result)
+end
+
+def tool_schema(name = nil)
+  args = name.nil? ? {} : { "name" => name.to_s }
+  __senpi_call_tool(SENPI_RESERVED_SCHEMA_TOOL, args)
 end
 
 def output(*ids, format: "raw", offset: nil, limit: nil)

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -154,6 +154,11 @@ env(key?=None, value?=None) → str | None | dict
     Task/agent output by id. Reads immediately: running tasks return their status; \`format\` selects full (\`"raw"\`) or trailing (\`"tail"\`) output.
 {{/if}}tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
+tool_schema(name?) → dict
+    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
+    Use it before calling a tool you have not called before — a failed call also
+    returns the expected parameters, so fix the args and retry in the next cell
+    instead of abandoning eval.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 {{#if spawns}}agent(prompt, agent?="{{spawnDefaultAgent}}", model?=None, label?=None, schema?=None, handle?=False) → str | dict

--- a/packages/senpi-codemode/src/tool/cell-handler.ts
+++ b/packages/senpi-codemode/src/tool/cell-handler.ts
@@ -1,8 +1,9 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@code-yeongyu/senpi";
 import type { KernelToHostMessage } from "../bridge/protocol.ts";
-import { RESERVED_AGENT_TOOL, RESERVED_OUTPUT_TOOL } from "../bridge/reserved.ts";
-import { type AgentExecuteTool, runEvalAgent } from "../bridges/agent-bridge.ts";
-import { runEvalOutput } from "../bridges/output-bridge.ts";
+import type { AgentExecuteTool } from "../bridges/agent-bridge.ts";
+import { isReservedToolName, runReservedTool } from "../bridges/reserved-dispatch.ts";
+import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
+import { appendSchemaHint } from "../bridges/schema-hint.ts";
 import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
 import { handleCompletionToolCall } from "../completion/tool-bridge.ts";
 import type { ResolvedCodemodeSettings } from "../config/settings.ts";
@@ -36,6 +37,7 @@ export interface CellState {
 
 export interface CellBridgeRuntime {
 	readonly executeTool: AgentExecuteTool;
+	readonly listTools?: () => readonly EvalSchemaToolInfo[];
 	readonly settings: ResolvedCodemodeSettings;
 	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
 	readonly ctx: ExtensionContext;
@@ -151,25 +153,17 @@ export class CellHandler {
 			});
 			return;
 		}
-		if (message.toolName === RESERVED_AGENT_TOOL) {
+		if (isReservedToolName(message.toolName)) {
 			await this.#deliverToolReply(message, async () => ({
-				value: await runEvalAgent(message.args, {
+				value: await runReservedTool(message.toolName, {
 					callId: message.callId,
-					taskToolName: this.#runtime.settings.taskTools.task,
+					args: message.args,
 					executeTool: this.#runtime.executeTool,
+					taskToolName: this.#runtime.settings.taskTools.task,
+					taskOutputToolName: this.#runtime.settings.taskTools.output,
+					listTools: this.#runtime.listTools,
 					signal: this.#state.signal,
 					emitStatus: (event) => this.#recordStatus(event),
-				}),
-				toolCallOk: true,
-			}));
-			return;
-		}
-		if (message.toolName === RESERVED_OUTPUT_TOOL) {
-			await this.#deliverToolReply(message, async () => ({
-				value: await runEvalOutput(message.args, {
-					taskOutputToolName: this.#runtime.settings.taskTools.output,
-					executeTool: this.#runtime.executeTool,
-					signal: this.#state.signal,
 					marshalToolResult,
 				}),
 				toolCallOk: true,
@@ -210,7 +204,11 @@ export class CellHandler {
 			this.#kernel.deliverToolReply({ type: "tool-reply", callId: message.callId, ok: true, value: reply.value });
 		} catch (error) {
 			if (!this.#state.active) return;
-			const text = error instanceof Error ? error.message : String(error);
+			const text = appendSchemaHint(
+				error instanceof Error ? error.message : String(error),
+				message.toolName,
+				this.#toolParameters(message.toolName),
+			);
 			this.#state.toolCalls.push({ name: message.toolName, ok: false, error: text });
 			this.#kernel.deliverToolReply({
 				type: "tool-reply",
@@ -220,6 +218,10 @@ export class CellHandler {
 			});
 		}
 		this.#emitUpdate(false);
+	}
+
+	#toolParameters(toolName: string): unknown {
+		return this.#runtime.listTools?.().find((tool) => tool.name === toolName)?.parameters;
 	}
 
 	#recordStatus(event: EvalStatusEvent): void {

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext, ToolDefinition } from "@code-yeongyu/senpi";
+import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
 import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
 import { defaultCodemodeSettings, type ResolvedCodemodeSettings } from "../config/settings.ts";
 import type { EvalExecutionTracker } from "../extension/session-manager.ts";
@@ -37,6 +38,7 @@ export interface CreateEvalToolOptions {
 	readonly kernelManager: EvalKernelManager;
 	readonly cellTimeoutSeconds: number;
 	readonly executeTool: ExecuteTool;
+	readonly listTools?: () => readonly EvalSchemaToolInfo[];
 	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
 	readonly settings?: ResolvedCodemodeSettings;
 	readonly artifactsDir?: string;
@@ -351,6 +353,7 @@ async function executeCell(
 		execution.setKernel(kernel);
 		handler = new CellHandler(kernel, state, {
 			executeTool: options.executeTool,
+			...(options.listTools === undefined ? {} : { listTools: options.listTools }),
 			settings: options.settings ?? defaultCodemodeSettings,
 			...(options.complete === undefined ? {} : { complete: options.complete }),
 			ctx: bridgeContext,

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -50,6 +50,11 @@ output(*ids, format?="raw", offset?=None, limit?=None) → str | dict | list[dic
     Task/agent output by id. Reads immediately: running tasks return their status; \`format\` selects full (\`"raw"\`) or trailing (\`"tail"\`) output.
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
+tool_schema(name?) → dict
+    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
+    Use it before calling a tool you have not called before — a failed call also
+    returns the expected parameters, so fix the args and retry in the next cell
+    instead of abandoning eval.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 agent(prompt, agent?="task", model?=None, label?=None, schema?=None, handle?=False) → str | dict
@@ -161,6 +166,11 @@ env(key?=None, value?=None) → str | None | dict
     No args → full env dict; one → value of \`key\`; two → set \`key=value\`, return value.
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
+tool_schema(name?) → dict
+    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
+    Use it before calling a tool you have not called before — a failed call also
+    returns the expected parameters, so fix the args and retry in the next cell
+    instead of abandoning eval.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 parallel(thunks) → list
@@ -232,6 +242,11 @@ env(key?=None, value?=None) → str | None | dict
     No args → full env dict; one → value of \`key\`; two → set \`key=value\`, return value.
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
+tool_schema(name?) → dict
+    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
+    Use it before calling a tool you have not called before — a failed call also
+    returns the expected parameters, so fix the args and retry in the next cell
+    instead of abandoning eval.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 parallel(thunks) → list

--- a/packages/senpi-codemode/test/schema-bridge.test.ts
+++ b/packages/senpi-codemode/test/schema-bridge.test.ts
@@ -1,0 +1,93 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { describe, expect, it, vi } from "vitest";
+import { RESERVED_AGENT_TOOL, RESERVED_OUTPUT_TOOL, RESERVED_SCHEMA_TOOL } from "../src/bridge/reserved.ts";
+import { isReservedToolName } from "../src/bridges/reserved-dispatch.ts";
+import { runEvalSchema } from "../src/bridges/schema-bridge.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { errorResult, FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+const TOOLS = [
+	{
+		name: "mcp_computer_use_batch",
+		description: "Run 1-20 canonical steps.",
+		parameters: {
+			type: "object",
+			properties: { steps: { type: "array", items: { type: "object" } } },
+			required: ["steps"],
+		},
+	},
+	{ name: "grep", description: "Search files.", parameters: { type: "object", properties: {} } },
+] as const;
+
+const listTools = () => TOOLS;
+
+describe("runEvalSchema", () => {
+	it("returns the parameter schema for a known tool", () => {
+		expect(runEvalSchema({ name: "mcp_computer_use_batch" }, { listTools })).toMatchObject({
+			name: "mcp_computer_use_batch",
+			parameters: { required: ["steps"] },
+		});
+	});
+
+	it("lists tool names when no name is given", () => {
+		expect(runEvalSchema({}, { listTools })).toMatchObject({ tools: ["mcp_computer_use_batch", "grep"] });
+	});
+
+	it("names partial matches when the tool is unknown", () => {
+		expect(() => runEvalSchema({ name: "mcp_computer_use_batchh" }, { listTools })).toThrow(/mcp_computer_use_batch/);
+	});
+
+	it("rejects unexpected arguments", () => {
+		expect(() => runEvalSchema({ nope: 1 }, { listTools })).toThrow(/invalid arguments/);
+	});
+});
+
+describe("reserved bridge names", () => {
+	it("keeps the three reserved names distinct and recognized", () => {
+		expect(RESERVED_SCHEMA_TOOL).toBe("__schema__");
+		expect(new Set([RESERVED_AGENT_TOOL, RESERVED_OUTPUT_TOOL, RESERVED_SCHEMA_TOOL]).size).toBe(3);
+		expect(isReservedToolName(RESERVED_SCHEMA_TOOL)).toBe(true);
+		expect(isReservedToolName("grep")).toBe(false);
+	});
+});
+
+describe("cell-handler dispatch for the reserved schema tool", () => {
+	it("answers from listTools without executing any tool", async () => {
+		const kernel = new FakeKernel([
+			{
+				type: "tool-call",
+				callId: "call-schema",
+				toolName: RESERVED_SCHEMA_TOOL,
+				args: { name: "mcp_computer_use_batch" },
+			},
+			errorResult("cell-1", "done"),
+		]);
+		const executeTool = Object.assign(
+			vi.fn(async (): Promise<AgentToolResult<unknown>> => {
+				throw new Error("tool_schema() must not execute a tool");
+			}),
+			{ isToolAvailable: () => true },
+		);
+		const tool = createEvalTool({
+			enabledLanguages: { js: true, py: false, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 30,
+			executeTool,
+			listTools,
+		});
+
+		await tool.execute(
+			"cell-1",
+			{ language: "js", code: 'await tool_schema("mcp_computer_use_batch")' },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(executeTool).not.toHaveBeenCalled();
+		expect(kernel.replies.at(-1)).toMatchObject({
+			ok: true,
+			value: { name: "mcp_computer_use_batch", parameters: { required: ["steps"] } },
+		});
+	});
+});

--- a/packages/senpi-codemode/test/schema-kernel.test.ts
+++ b/packages/senpi-codemode/test/schema-kernel.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { RESERVED_SCHEMA_TOOL } from "../src/bridge/reserved.ts";
+import { runEvalSchema } from "../src/bridges/schema-bridge.ts";
+import { runJavaScriptCell, withJavaScriptKernel } from "./eval/js-kernel-harness.ts";
+
+const BATCH_TOOL = {
+	name: "mcp_computer_use_batch",
+	description: "Run 1-20 canonical steps.",
+	parameters: {
+		type: "object",
+		properties: { steps: { type: "array", items: { type: "object" } } },
+		required: ["steps"],
+	},
+} as const;
+
+describe("schema() inside a real JavaScript kernel", () => {
+	it("routes through the reserved schema bridge and returns the parameter schema", async () => {
+		const seen: { toolName?: string; args?: unknown } = {};
+
+		const value = await withJavaScriptKernel(async (kernel) => {
+			const answered = (async () => {
+				const call = await kernel.nextToolCall();
+				seen.toolName = call.toolName;
+				seen.args = call.args;
+				kernel.deliverToolReply({
+					type: "tool-reply",
+					callId: call.callId,
+					ok: true,
+					value: runEvalSchema(call.args, { listTools: () => [BATCH_TOOL] }),
+				});
+			})();
+			const run = await runJavaScriptCell(
+				kernel,
+				'return JSON.stringify(await tool_schema("mcp_computer_use_batch"));',
+				10_000,
+			);
+			await answered;
+			if (!run.result.ok) throw new Error(run.result.error.message);
+			return run.result.valueRepr;
+		});
+
+		expect(seen.toolName).toBe(RESERVED_SCHEMA_TOOL);
+		expect(seen.args).toEqual({ name: "mcp_computer_use_batch" });
+		expect(String(value)).toContain("steps");
+		expect(String(value)).toContain("mcp_computer_use_batch");
+	});
+});

--- a/packages/senpi-codemode/test/tool-schema-hint.test.ts
+++ b/packages/senpi-codemode/test/tool-schema-hint.test.ts
@@ -1,0 +1,136 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { describe, expect, it, vi } from "vitest";
+import { renderSchemaHint } from "../src/bridges/schema-hint.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { errorResult, FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+type ToolResult = AgentToolResult<unknown>;
+
+/** Regression: session 019fa35f abandoned eval after a schema-less validation error. */
+const BATCH_TOOL = {
+	name: "mcp_computer_use_batch",
+	description: "Run 1-20 canonical steps.",
+	parameters: {
+		type: "object",
+		properties: {
+			steps: {
+				type: "array",
+				description: "Canonical steps to run in order.",
+				items: {
+					type: "object",
+					properties: { tool: { type: "string" }, input: { type: "object" } },
+					required: ["tool"],
+				},
+			},
+			app: { type: "string", description: "Target application." },
+		},
+		required: ["steps"],
+	},
+} as const;
+
+function replyErrorText(kernel: FakeKernel): string {
+	const reply = kernel.replies.at(-1);
+	if (typeof reply !== "object" || reply === null || !("error" in reply)) return "";
+	const error = reply.error;
+	if (typeof error !== "object" || error === null || !("message" in error)) return "";
+	return String(error.message);
+}
+
+function runFailingCall(toolName: string, listTools?: () => readonly (typeof BATCH_TOOL)[]) {
+	const kernel = new FakeKernel([
+		{ type: "tool-call", callId: "call-1", toolName, args: { app: "Safari" } },
+		errorResult("cell-1", "tool call failed"),
+	]);
+	const executeTool = Object.assign(
+		vi.fn(async (): Promise<ToolResult> => {
+			throw new Error(`Validation failed for tool "${toolName}":\n  - steps: must have required properties steps`);
+		}),
+		{ isToolAvailable: () => true },
+	);
+	const tool = createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([["js", kernel]]),
+		cellTimeoutSeconds: 30,
+		executeTool,
+		...(listTools === undefined ? {} : { listTools }),
+	});
+	return { kernel, tool };
+}
+
+describe("kernel tool-call argument failures", () => {
+	it("appends the tool parameter schema resolved from the live catalog", async () => {
+		const { kernel, tool } = runFailingCall("mcp_computer_use_batch", () => [BATCH_TOOL]);
+
+		await tool.execute(
+			"cell-1",
+			{ language: "js", code: 'await tool.mcp_computer_use_batch({app: "Safari"})' },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		const message = replyErrorText(kernel);
+		expect(message).toContain("must have required properties steps");
+		expect(message).toContain("Expected parameters:");
+		expect(message).toContain("required: steps");
+		expect(message).toContain("steps: array<object>");
+		expect(message).toContain("tool: string");
+	});
+
+	it("leaves the message untouched when the tool is not in the catalog", async () => {
+		const { kernel, tool } = runFailingCall("unlisted_tool", () => [BATCH_TOOL]);
+
+		await tool.execute(
+			"cell-1",
+			{ language: "js", code: "await tool.unlisted_tool({})" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(replyErrorText(kernel)).not.toContain("Expected parameters:");
+	});
+});
+
+describe("renderSchemaHint", () => {
+	it("renders required properties before optional ones", () => {
+		const rendered = renderSchemaHint("t", {
+			type: "object",
+			properties: { optional: { type: "string" }, needed: { type: "number" } },
+			required: ["needed"],
+		});
+
+		const lines = String(rendered).split("\n");
+		expect(lines.findIndex((line) => line.includes("needed"))).toBeLessThan(
+			lines.findIndex((line) => line.includes("optional")),
+		);
+	});
+
+	it("renders const, unions and caps long enums", () => {
+		const rendered = String(
+			renderSchemaHint("t", {
+				type: "object",
+				properties: {
+					kind: { const: "batch" },
+					mode: { enum: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"] },
+					either: { oneOf: [{ type: "string" }, { type: "number" }] },
+				},
+			}),
+		);
+
+		expect(rendered).toContain('kind?: "batch"');
+		expect(rendered).toContain("2 more)");
+		expect(rendered).toContain("either?: string | number");
+	});
+
+	it("stays within the character budget and names tool_schema when truncated", () => {
+		const properties: Record<string, unknown> = {};
+		for (let index = 0; index < 60; index++) {
+			properties[`property_${index}`] = { type: "string", description: "x".repeat(70) };
+		}
+		const rendered = String(renderSchemaHint("big_tool", { type: "object", properties }));
+
+		expect(rendered.length).toBeLessThanOrEqual(1_200);
+		expect(rendered).toContain('[truncated; call tool_schema("big_tool") for the full schema]');
+	});
+});


### PR DESCRIPTION
## Problem

In session `019fa35f-d81a-7317-a25b-c2482827b958` the model activated MCP tools with `tool_search`, then in the **same turn** wrote an `eval` cell calling `tool.mcp_computer_use_batch({app, actions})`. The real schema wants `{steps}`. The reply delivered into the cell was:

```
Validation failed for tool "mcp_computer_use_batch":
  - steps: must have required properties steps

Received arguments:
{ "app": "Safari", "actions": [ ... ] }
```

It names the violated field but never shows the schema. Two gaps compound:

1. **The error is not actionable.** `packages/ai` `validateToolArguments()` never includes the parameter schema, and `cell-handler` forwarded only `error.message`.
2. **No schema discovery.** The `tool` proxy in every kernel is call-only, and `tool_search`'s result text says tools are callable "from your NEXT turn" while listing names and descriptions but no schemas — so a cell can be written against a tool whose schema was never in model context.

The model could not recover from inside the cell. It **abandoned the eval tool entirely** and issued ~10 one-at-a-time raw MCP calls for the rest of the session, destroying the whole code-mode batching benefit over one recoverable mistake.

## Change

**Schema on error.** The failing tool's schema is resolved from the live catalog already threaded into `CellHandler` and appended to the error text. The renderer puts required properties first, recurses one level into array items, understands `const`/`enum`/`oneOf`/`anyOf`, caps enums at 8 values, and fits a 1200-char budget on whole-line boundaries.

**Schema discovery.** `tool_schema(name)` returns a tool's parameter schema without executing it; `tool_schema()` lists the catalog. Available in all four kernels (py/js/rb/jl) over a third reserved bridge name `__schema__`.

The reserved-name if-chain moved out of `cell-handler.ts` into `bridges/reserved-dispatch.ts` — that file was already past this repo's 250-pure-LOC ceiling, so the dispatch was extracted rather than grown.

### Scope

Entirely inside `packages/senpi-codemode`. An earlier draft carried the schema on `ExecuteToolError` in `packages/coding-agent`; review showed `listTools` already provides the catalog at the render boundary, so that public-API change was dropped. **`packages/ai` and the normal model tool-call path are byte-identical** — a model dispatching a tool already has its schema in context, so duplicating it there would only burn tokens.

## Evidence

Real JS kernel via `packages/senpi-codemode/scripts/qa-js-cell.ts`.

**Before** (production msg[31]): the violated field only, no schema.

**After** — wrong-args call, session-30 shape:

```
=== ERROR DELIVERED INTO CELL ===
slow_fake requires --slow-tool-ms

Expected parameters:
required: steps
  steps: array<object> - Steps to run in order.
  app?: string - Target application.
```

**After** — discovery:

```
REQUIRED:["steps"]
CATALOG:["slow_fake","task_output"]
```

Both route over `__schema__` (`toolCalls` show `"__schema__"`, `ok: true`) and never reach `executeTool`.

## Gates

- `packages/senpi-codemode`: **403 passed**, 6 skipped (pre-existing interpreter-availability skips)
- `packages/coding-agent` `execute-tool` + `mcp`: **294 passed**
- `npx tsgo --noEmit`: exit 0
- `npm run check` (root): exit 0

Tests were captured RED before each change: the schema-hint test failed reproducing the exact production string, and the discovery test failed on the absent module.

Plan: `.omo/plans/eval-tool-schema-feedback.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make eval tool errors self-correctable by appending the tool’s parameter schema and adding `tool_schema()` for schema discovery across kernels. This keeps code-mode batching intact after a bad call.

- **New Features**
  - Failed `tool.<name>(args)` now include a compact “Expected parameters” hint from the live catalog (required first, array item types, `const`/`enum`/`oneOf`/`anyOf`, 1200-char cap).
  - Added `tool_schema(name?)` in JS/Py/RB/JL via `__schema__`; returns a tool’s parameter schema or lists available tools without executing it.

- **Refactors**
  - Centralized reserved bridge routing in `bridges/reserved-dispatch.ts` and added `__schema__`; threaded `listTools` from `getAllTools()` into eval.
  - `packages/ai` and the normal model tool-call path remain unchanged.

<sup>Written for commit be05a1eb5922804bdc9b5403589a0bbb842e3df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

