### PR TITLE
fix(mcp): let an eval cell use a searchable tool that is not active yet

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1876,7 +1876,12 @@ export class AgentSession {
 	): Promise<AgentToolResult<TDetails>> {
 		let activeTools = this.getActiveToolNames();
 		let tool = this.agent.state.tools.find((candidate) => candidate.name === toolName);
-		if (!tool && this._toolDefinitions.has(toolName) && this._activateLazyTool(toolName)) {
+		if (
+			!tool &&
+			options?.activateInactiveTool === true &&
+			this._toolDefinitions.has(toolName) &&
+			this._activateLazyTool(toolName)
+		) {
 			activeTools = this.getActiveToolNames();
 			tool = this.agent.state.tools.find((candidate) => candidate.name === toolName);
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1957,17 +1957,17 @@ export class AgentSession {
 		};
 	}
 
+	/** Lets a registering extension activate its own inactive tool on demand; it owns eligibility. */
+	private _activateLazyTool(toolName: string): boolean {
+		return this._lazyToolActivators.some((activate) => activate(toolName));
+	}
+
 	/**
 	 * Set active tools by name.
 	 * Only tools in the registry can be enabled. Unknown tool names are ignored.
 	 * Also rebuilds the system prompt to reflect the new tool set.
 	 * Changes take effect on the next agent turn.
 	 */
-	/** Lets a registering extension activate its own inactive tool on demand; it owns eligibility. */
-	private _activateLazyTool(toolName: string): boolean {
-		return this._lazyToolActivators.some((activate) => activate(toolName));
-	}
-
 	setActiveToolsByName(toolNames: string[]): void {
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -112,6 +112,7 @@ import type {
 	ApplyCompactionResult,
 	CompactionReason,
 	CompactionRejectionCause,
+	LazyToolActivator,
 	ModelSelectSource,
 } from "./extensions/types.ts";
 import { RUNTIME_EXTENSION_PATH } from "./extensions/types.ts";
@@ -627,6 +628,7 @@ export class AgentSession {
 
 	// Tool registry for extension getTools/setTools
 	private _toolRegistry: Map<string, AgentTool> = new Map();
+	private _lazyToolActivators: LazyToolActivator[] = [];
 	private _toolDefinitions: Map<string, ToolDefinitionEntry> = new Map();
 	private _toolPromptSnippets: Map<string, string> = new Map();
 	private _toolPromptGuidelines: Map<string, string[]> = new Map();
@@ -1872,8 +1874,12 @@ export class AgentSession {
 		params: unknown,
 		options?: ExecuteToolOptions<TDetails>,
 	): Promise<AgentToolResult<TDetails>> {
-		const activeTools = this.getActiveToolNames();
-		const tool = this.agent.state.tools.find((candidate) => candidate.name === toolName);
+		let activeTools = this.getActiveToolNames();
+		let tool = this.agent.state.tools.find((candidate) => candidate.name === toolName);
+		if (!tool && this._toolDefinitions.has(toolName) && this._activateLazyTool(toolName)) {
+			activeTools = this.getActiveToolNames();
+			tool = this.agent.state.tools.find((candidate) => candidate.name === toolName);
+		}
 		if (!tool) {
 			const knownToolNames = new Set(this._toolDefinitions.keys());
 			const code = knownToolNames.has(toolName) ? "inactive_tool" : "unknown_tool";
@@ -1952,6 +1958,11 @@ export class AgentSession {
 	 * Also rebuilds the system prompt to reflect the new tool set.
 	 * Changes take effect on the next agent turn.
 	 */
+	/** Lets a registering extension activate its own inactive tool on demand; it owns eligibility. */
+	private _activateLazyTool(toolName: string): boolean {
+		return this._lazyToolActivators.some((activate) => activate(toolName));
+	}
+
 	setActiveToolsByName(toolNames: string[]): void {
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];
@@ -4698,6 +4709,9 @@ export class AgentSession {
 				refreshTools: () => this._refreshToolRegistry(),
 				registerRemovedToolHint: (name, hint) => {
 					this.agent.removedToolHints[name] = hint;
+				},
+				registerLazyToolActivator: (activator) => {
+					this._lazyToolActivators.push(activator);
 				},
 				getCommands,
 				setModel: async (model) => {

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/lazy-activate.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/lazy-activate.ts
@@ -1,0 +1,50 @@
+// Lazy tool activation for code-mode (eval) callers.
+//
+// An eval cell that names an MCP tool held inactive by SEARCH-mode exposure used
+// to fail with `inactive_tool`, even though tool_search may promote that exact
+// tool. Eligibility is therefore the tier-B searchable catalog and nothing else:
+// permission-denied tools, `list_changed` rug-pull additions, removed-tool
+// tombstones, and model-gated tools (look_at / read_video) are never eligible.
+// Activation is delegated to the tier-B `activate()` path so stub-swap, name
+// filtering, and active-set ordering keep their existing semantics.
+
+export interface LazySearchableTool {
+	readonly name: string;
+}
+
+export interface LazyActivationState {
+	readonly searchable: readonly LazySearchableTool[];
+	readonly active: readonly string[];
+}
+
+export interface LazyToolActivatorDeps {
+	readonly getSearchable: () => readonly LazySearchableTool[];
+	readonly getActiveTools: () => readonly string[];
+	readonly activate: (names: readonly string[]) => void;
+}
+
+export function resolveLazyActivationTargets(
+	requested: readonly string[],
+	state: LazyActivationState,
+): readonly string[] {
+	const eligible = new Set(state.searchable.map((tool) => tool.name));
+	const active = new Set(state.active);
+	const targets: string[] = [];
+	for (const name of requested) {
+		if (!eligible.has(name) || active.has(name) || targets.includes(name)) continue;
+		targets.push(name);
+	}
+	return targets;
+}
+
+export function createLazyToolActivator(deps: LazyToolActivatorDeps): (toolName: string) => boolean {
+	return (toolName: string): boolean => {
+		const targets = resolveLazyActivationTargets([toolName], {
+			searchable: deps.getSearchable(),
+			active: deps.getActiveTools(),
+		});
+		if (targets.length === 0) return false;
+		deps.activate(targets);
+		return true;
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -1,6 +1,7 @@
 import { bindToProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import type { ExtensionAPI, ExtensionContext, ExtensionFactory, SessionStartEvent } from "../../types.ts";
 import { registerMcpCommands } from "./commands.ts";
+import { createLazyToolActivator } from "./expose/lazy-activate.ts";
 import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
 import { TOOL_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
 import { injectMcpInstructions, refreshMcpInstructionsForSession } from "./instructions.ts";
@@ -55,6 +56,18 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 		pi.on("context", (event) => {
 			service.maybeRehydrateFromHistory(event.messages);
 		});
+
+		// A code-mode (eval) cell may name a search-mode tool that tool_search would
+		// promote but that is not active yet. Activating it here keeps the catalog the
+		// only eligible set, so permission-denied, tombstoned, and capability-gated
+		// tools stay inactive, and routes through tier-B activate() for stub swapping.
+		pi.registerLazyToolActivator(
+			createLazyToolActivator({
+				getSearchable: () => service.getTierBSearchable(),
+				getActiveTools: () => pi.getActiveTools(),
+				activate: (names) => service.activateSkillMcpTools(names),
+			}),
+		);
 
 		// skills-carry-MCP (todo 37): skills declaring MCP servers (mcp.json
 		// sidecar or SKILL.md frontmatter) register lazily with tools hidden;

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,31 @@
 # Core Extensions Changes
 
+## 2026-07-27 - registerLazyToolActivator (on-demand activation of inactive tools)
+
+### What changed
+
+- `types.ts` exports `LazyToolActivator = (toolName: string) => boolean` and adds
+  `registerLazyToolActivator(activator)` to `ExtensionAPI`, `ExtensionActions`, and the runtime handler bag.
+- `agent-session.ts` `executeTool()`: when a name resolves to a registered-but-inactive tool, registered
+  activators run before the `inactive_tool` throw. An activator returning `true` means it has actually
+  activated the tool, and execution proceeds; `unknown_tool` is unaffected.
+- `loader.ts`/`runner.ts` stash activators on the extension and replay them after `bindCore()`, mirroring
+  `registerRemovedToolHint` — extension factories run before core is bound.
+- `builtin/mcp` registers an activator whose eligibility is the tier-B searchable catalog only, routed through
+  the existing tier-B `activate()` so stub-swap and name filtering keep their semantics.
+
+### Why extension system couldn't handle this alone
+
+- Only the session owns the active set and the `inactive_tool` decision; an extension cannot intercept it.
+  Eligibility, however, must stay with the registering extension: `_toolDefinitions` also contains
+  permission-denied tools, MCP `list_changed` additions held inactive as rug-pull defense, removed-tool
+  tombstones, and capability-gated tools (`look_at`, `read_video`). Core deliberately does not decide.
+
+### Expected merge conflict zones
+
+- LOW: additive handler entries in `types.ts`, `loader.ts`, `runner.ts`.
+- MEDIUM: the tool-resolution block at the top of `executeTool()` in `agent-session.ts`.
+
 ## 2026-07-27 - RUNTIME_EXTENSION_PATH sentinel constant
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -39,6 +39,7 @@ import type {
 	ExtensionAPI,
 	ExtensionFactory,
 	ExtensionRuntime,
+	LazyToolActivator,
 	LoadExtensionsResult,
 	MessageRenderer,
 	PendingProviderRegistration,
@@ -262,6 +263,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		// registerTool() is valid during extension load; refresh is only needed post-bind.
 		refreshTools: () => {},
 		registerRemovedToolHint: () => {},
+		registerLazyToolActivator: () => {},
 		getCommands: notInitialized,
 		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		getThinkingLevel: notInitialized,
@@ -349,6 +351,14 @@ function createExtensionAPI(
 				sourceInfo: extension.sourceInfo,
 			});
 			runtime.refreshTools();
+		},
+
+		registerLazyToolActivator(activator: LazyToolActivator): void {
+			runtime.assertActive();
+			const activators = extension.lazyToolActivators ?? [];
+			activators.push(activator);
+			extension.lazyToolActivators = activators;
+			runtime.registerLazyToolActivator(activator);
 		},
 
 		registerRemovedToolHint(name: string, hint: string): void {
@@ -578,6 +588,7 @@ function createExtension(extensionPath: string, resolvedPath: string, registrati
 		handlers: new Map(),
 		tools: new Map(),
 		removedToolHints: new Map(),
+		lazyToolActivators: [],
 		messageRenderers: new Map(),
 		entryRenderers: undefined,
 		commands: new Map(),

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -454,6 +454,7 @@ export class ExtensionRunner {
 		this.runtime.setActiveTools = actions.setActiveTools;
 		this.runtime.refreshTools = actions.refreshTools;
 		this.runtime.registerRemovedToolHint = actions.registerRemovedToolHint;
+		this.runtime.registerLazyToolActivator = actions.registerLazyToolActivator;
 		this.runtime.getCommands = actions.getCommands;
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
@@ -487,6 +488,9 @@ export class ExtensionRunner {
 		for (const extension of this.extensions) {
 			for (const [name, hint] of extension.removedToolHints ?? []) {
 				actions.registerRemovedToolHint(name, hint);
+			}
+			for (const activator of extension.lazyToolActivators ?? []) {
+				actions.registerLazyToolActivator(activator);
 			}
 		}
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1800,6 +1800,13 @@ export type ExecuteToolUpdateCallback<T = unknown> = AgentToolUpdateCallback<T>;
 export interface ExecuteToolOptions<TDetails = unknown> {
 	signal?: AbortSignal;
 	onUpdate?: ExecuteToolUpdateCallback<TDetails>;
+	/**
+	 * Opt in to lazy activation: when the tool is registered but inactive, registered
+	 * activators may activate it instead of failing. Off by default so ordinary callers
+	 * keep the `inactive_tool` contract; code-mode sets it because a cell names tools
+	 * directly and cannot run tool_search first.
+	 */
+	activateInactiveTool?: boolean;
 }
 
 export type ExecuteToolResult<TDetails = unknown> = AgentToolResult<TDetails>;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1458,6 +1458,15 @@ export interface ExtensionAPI {
 	/** Register migration guidance returned when an intentionally removed tool is called. */
 	registerRemovedToolHint(name: string, hint: string): void;
 
+	/**
+	 * Register a callback that may activate a registered-but-inactive tool on demand.
+	 * Called only when executeTool would otherwise fail with `inactive_tool`. Return
+	 * true only after the tool has actually been activated; returning false preserves
+	 * the `inactive_tool` error. Eligibility is owned by the registering extension so
+	 * permission-denied, tombstoned, and capability-gated tools stay inactive.
+	 */
+	registerLazyToolActivator(activator: LazyToolActivator): void;
+
 	/** Register an MCP server that the agent can use. Factory-time only. */
 	registerMcpServer(name: string, config: McpServerDeclaration): void;
 
@@ -1817,6 +1826,10 @@ export type ExecuteToolHandler = <TDetails = unknown>(
 	options?: ExecuteToolOptions<TDetails>,
 ) => Promise<ExecuteToolResult<TDetails>>;
 
+export type LazyToolActivator = (toolName: string) => boolean;
+
+export type RegisterLazyToolActivatorHandler = (activator: LazyToolActivator) => void;
+
 export type GetActiveToolsHandler = () => string[];
 
 /** Tool info with name, description, parameter schema, prompt guidelines, and source metadata. */
@@ -1912,6 +1925,7 @@ export interface ExtensionActions {
 	setActiveTools: SetActiveToolsHandler;
 	refreshTools: RefreshToolsHandler;
 	registerRemovedToolHint: RegisterRemovedToolHintHandler;
+	registerLazyToolActivator: RegisterLazyToolActivatorHandler;
 	getCommands: GetCommandsHandler;
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
@@ -2010,6 +2024,7 @@ export interface Extension {
 	tools: Map<string, RegisteredTool>;
 	/** Optional for compatibility with extension records created before this additive registry. */
 	removedToolHints?: Map<string, string>;
+	lazyToolActivators?: LazyToolActivator[];
 	messageRenderers: Map<string, MessageRenderer>;
 	entryRenderers?: Map<string, EntryRenderer>;
 	commands: Map<string, RegisteredCommand>;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -118,6 +118,7 @@ describe("ExtensionRunner", () => {
 	});
 
 	const extensionActions: ExtensionActions = {
+		registerLazyToolActivator: () => {},
 		sendMessage: () => {},
 		sendUserMessage: () => {},
 		appendEntry: () => {},

--- a/packages/coding-agent/test/mcp/eval-auto-activate-session.test.ts
+++ b/packages/coding-agent/test/mcp/eval-auto-activate-session.test.ts
@@ -26,7 +26,7 @@ async function harnessWith(factory: (pi: ExtensionAPI) => void) {
 }
 
 describe("lazy tool activation through executeTool", () => {
-	it("activates an eligible inactive tool and runs it", async () => {
+	it("activates an eligible inactive tool for an opted-in caller", async () => {
 		const harness = await harnessWith((pi) => {
 			pi.registerTool(makeTool("mcp_fx_click"));
 			pi.registerLazyToolActivator((toolName) => {
@@ -40,10 +40,29 @@ describe("lazy tool activation through executeTool", () => {
 			harness.session.setActiveToolsByName(["read"]);
 			expect(harness.session.getActiveToolNames()).not.toContain("mcp_fx_click");
 
-			const result = await harness.api.executeTool("mcp_fx_click", {});
+			const result = await harness.api.executeTool("mcp_fx_click", {}, { activateInactiveTool: true });
 
 			expect(JSON.stringify(result.content)).toContain("mcp_fx_click-ran");
 			expect(harness.session.getActiveToolNames()).toContain("mcp_fx_click");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps inactive_tool for an ordinary caller that did not opt in", async () => {
+		const harness = await harnessWith((pi) => {
+			pi.registerTool(makeTool("mcp_fx_click"));
+			pi.registerLazyToolActivator((toolName) => {
+				if (toolName !== "mcp_fx_click") return false;
+				pi.setActiveTools([...pi.getActiveTools(), toolName]);
+				return true;
+			});
+		});
+
+		try {
+			harness.session.setActiveToolsByName(["read"]);
+			await expect(harness.api.executeTool("mcp_fx_click", {})).rejects.toMatchObject({ code: "inactive_tool" });
+			expect(harness.session.getActiveToolNames()).not.toContain("mcp_fx_click");
 		} finally {
 			harness.cleanup();
 		}
@@ -57,7 +76,9 @@ describe("lazy tool activation through executeTool", () => {
 
 		try {
 			harness.session.setActiveToolsByName(["read"]);
-			await expect(harness.api.executeTool("gated_tool", {})).rejects.toMatchObject({ code: "inactive_tool" });
+			await expect(harness.api.executeTool("gated_tool", {}, { activateInactiveTool: true })).rejects.toMatchObject({
+				code: "inactive_tool",
+			});
 			expect(harness.session.getActiveToolNames()).not.toContain("gated_tool");
 		} finally {
 			harness.cleanup();
@@ -71,7 +92,9 @@ describe("lazy tool activation through executeTool", () => {
 
 		try {
 			harness.session.setActiveToolsByName(["read"]);
-			await expect(harness.api.executeTool("never_registered", {})).rejects.toMatchObject({ code: "unknown_tool" });
+			await expect(
+				harness.api.executeTool("never_registered", {}, { activateInactiveTool: true }),
+			).rejects.toMatchObject({ code: "unknown_tool" });
 			expect(harness.session.getActiveToolNames()).toEqual(["read"]);
 		} finally {
 			harness.cleanup();

--- a/packages/coding-agent/test/mcp/eval-auto-activate-session.test.ts
+++ b/packages/coding-agent/test/mcp/eval-auto-activate-session.test.ts
@@ -1,0 +1,93 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { ExtensionAPI, ExtensionFactory } from "../../src/index.ts";
+import { createHarness } from "../suite/harness.ts";
+
+function makeTool(name: string) {
+	return {
+		name,
+		label: name,
+		description: `${name} tool`,
+		parameters: Type.Object({}),
+		execute: async () => ({ content: [{ type: "text" as const, text: `${name}-ran` }], details: {} }),
+	};
+}
+
+async function harnessWith(factory: (pi: ExtensionAPI) => void) {
+	let api: ExtensionAPI | undefined;
+	const extensionFactories: ExtensionFactory[] = [
+		(pi) => {
+			api = pi;
+			factory(pi);
+		},
+	];
+	const harness = await createHarness({ extensionFactories });
+	return { ...harness, api: api as ExtensionAPI };
+}
+
+describe("lazy tool activation through executeTool", () => {
+	it("activates an eligible inactive tool and runs it", async () => {
+		const harness = await harnessWith((pi) => {
+			pi.registerTool(makeTool("mcp_fx_click"));
+			pi.registerLazyToolActivator((toolName) => {
+				if (toolName !== "mcp_fx_click") return false;
+				pi.setActiveTools([...pi.getActiveTools(), toolName]);
+				return true;
+			});
+		});
+
+		try {
+			harness.session.setActiveToolsByName(["read"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("mcp_fx_click");
+
+			const result = await harness.api.executeTool("mcp_fx_click", {});
+
+			expect(JSON.stringify(result.content)).toContain("mcp_fx_click-ran");
+			expect(harness.session.getActiveToolNames()).toContain("mcp_fx_click");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps inactive_tool when the activator declines", async () => {
+		const harness = await harnessWith((pi) => {
+			pi.registerTool(makeTool("gated_tool"));
+			pi.registerLazyToolActivator(() => false);
+		});
+
+		try {
+			harness.session.setActiveToolsByName(["read"]);
+			await expect(harness.api.executeTool("gated_tool", {})).rejects.toMatchObject({ code: "inactive_tool" });
+			expect(harness.session.getActiveToolNames()).not.toContain("gated_tool");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps unknown_tool for a never-registered name", async () => {
+		const harness = await harnessWith((pi) => {
+			pi.registerLazyToolActivator(() => true);
+		});
+
+		try {
+			harness.session.setActiveToolsByName(["read"]);
+			await expect(harness.api.executeTool("never_registered", {})).rejects.toMatchObject({ code: "unknown_tool" });
+			expect(harness.session.getActiveToolNames()).toEqual(["read"]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps inactive_tool when no activator is registered", async () => {
+		const harness = await harnessWith((pi) => {
+			pi.registerTool(makeTool("plain_tool"));
+		});
+
+		try {
+			harness.session.setActiveToolsByName(["read"]);
+			await expect(harness.api.executeTool("plain_tool", {})).rejects.toMatchObject({ code: "inactive_tool" });
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/mcp/eval-auto-activate.test.ts
+++ b/packages/coding-agent/test/mcp/eval-auto-activate.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createLazyToolActivator,
+	resolveLazyActivationTargets,
+} from "../../src/core/extensions/builtin/mcp/expose/lazy-activate.ts";
+
+const SEARCHABLE = [
+	{ name: "mcp_computer_use_click", toolName: "click", server: "computer_use" },
+	{ name: "mcp_computer_use_batch", toolName: "batch", server: "computer_use" },
+] as const;
+
+describe("resolveLazyActivationTargets", () => {
+	it("selects a searchable tool that is registered but inactive", () => {
+		expect(
+			resolveLazyActivationTargets(["mcp_computer_use_click"], {
+				searchable: SEARCHABLE,
+				active: ["read", "bash"],
+			}),
+		).toEqual(["mcp_computer_use_click"]);
+	});
+
+	it("skips a tool that is already active", () => {
+		expect(
+			resolveLazyActivationTargets(["mcp_computer_use_click"], {
+				searchable: SEARCHABLE,
+				active: ["read", "mcp_computer_use_click"],
+			}),
+		).toEqual([]);
+	});
+
+	it("refuses a tool outside the searchable catalog", () => {
+		expect(resolveLazyActivationTargets(["look_at"], { searchable: SEARCHABLE, active: ["read"] })).toEqual([]);
+	});
+
+	it("refuses an unknown tool", () => {
+		expect(resolveLazyActivationTargets(["nope"], { searchable: SEARCHABLE, active: ["read"] })).toEqual([]);
+	});
+
+	it("coalesces several names into one deduplicated batch", () => {
+		expect(
+			resolveLazyActivationTargets(
+				["mcp_computer_use_click", "mcp_computer_use_click", "mcp_computer_use_batch", "look_at"],
+				{ searchable: SEARCHABLE, active: ["read"] },
+			),
+		).toEqual(["mcp_computer_use_click", "mcp_computer_use_batch"]);
+	});
+});
+
+describe("createLazyToolActivator", () => {
+	it("routes activation through the tier-B activate path exactly once", () => {
+		const activate = vi.fn();
+		const activator = createLazyToolActivator({
+			getSearchable: () => SEARCHABLE,
+			getActiveTools: () => ["read"],
+			activate,
+		});
+
+		expect(activator("mcp_computer_use_click")).toBe(true);
+		expect(activate).toHaveBeenCalledTimes(1);
+		expect(activate).toHaveBeenCalledWith(["mcp_computer_use_click"]);
+	});
+
+	it("never calls activate for an ineligible tool", () => {
+		const activate = vi.fn();
+		const activator = createLazyToolActivator({
+			getSearchable: () => SEARCHABLE,
+			getActiveTools: () => ["read"],
+			activate,
+		});
+
+		expect(activator("look_at")).toBe(false);
+		expect(activate).not.toHaveBeenCalled();
+	});
+});

--- a/packages/senpi-codemode/src/extension/runtime-factory.ts
+++ b/packages/senpi-codemode/src/extension/runtime-factory.ts
@@ -87,8 +87,10 @@ export async function createRuntime(
 }
 
 export function createExecuteTool(pi: CodemodeRuntimeAPI, activeTools?: ReadonlySet<string>): AgentExecuteTool {
+	// A cell names tools directly and cannot run tool_search first, so eval opts in to
+	// lazy activation. Eligibility still belongs to the extension that registered the tool.
 	const executeTool: AgentExecuteTool = (toolName, params, executeOptions) =>
-		pi.executeTool(toolName, params, executeOptions);
+		pi.executeTool(toolName, params, { ...executeOptions, activateInactiveTool: true });
 	return Object.assign(executeTool, {
 		isToolAvailable: (name: string): boolean => activeTools?.has(name) ?? pi.getActiveTools().includes(name),
 	});

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -110,7 +110,7 @@ export interface EvalKernelManager {
 export type ExecuteTool = (
 	toolName: string,
 	params: unknown,
-	options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback<unknown> },
+	options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback<unknown>; activateInactiveTool?: boolean },
 ) => Promise<AgentToolResult<unknown>>;
 
 export interface EvalToolCallSummary {


### PR DESCRIPTION
## Problem

In session `019fa397-dbbc-7a05-baa2-6a68852ff384` an `eval` cell ran:

```py
tool.mcp_computer_use_click({'x':826,'y':371,'button':'left','clickCount':1})
```

and got back:

```
Tool mcp_computer_use_click is registered but inactive.
Active tools: read, bash, apply_patch, todo, ...
```

The assistant then emitted **empty text and stalled** (msg 22). The user had to intervene — *"no use eval just pure tool call plz"* (msg 25) — and eval was abandoned for the rest of the session.

The tool was **registered**, just not active. Moments later the model called `tool_search`, which **activated those exact same tools**, and the identical work succeeded. Search-mode MCP exposure registers the whole catalog but keeps only `directTools` active, and only `tool_search` could promote from it. That asymmetry — `tool_search` may promote, a code-mode cell may not — is the bug.

## Change

`executeTool()` resolved a name against the active set and, on a miss, consulted the definition registry *only* to choose between `inactive_tool` and `unknown_tool` before throwing.

Add `registerLazyToolActivator(activator)`. When a name resolves to a registered-but-inactive tool, registered activators run before the throw; one returning `true` means it actually activated the tool, and execution proceeds.

**Core deliberately does not decide eligibility.** `builtin/mcp` registers an activator whose eligible set is the tier-B searchable catalog and nothing else.

### Why not blanket activation

A one-line "activate anything registered" change is unsafe. `_toolDefinitions` also holds:

| Kind | Why it must stay inactive | Anchor |
|---|---|---|
| Permission-denied tools | `deny *` rules are applied by *deactivating* | `permission-system/index.ts:96-100`, `config.ts:71-84` |
| MCP `list_changed` additions | documented **rug-pull defense** | `mcp/notifications.ts:1-9` |
| Removed-tool tombstones | re-registered specifically to stay inactive | `mcp/service.ts:436-439` |
| `look_at` / `read_video` | capability gates (model lacks vision/video) | `look-at/index.ts:37-48` |

None are in the searchable catalog, so all stay inactive. Activation also routes through the tier-B `activate()` path rather than the generic active-set setter, so `stubSwap` still swaps the registered stub for the full definition — marking a stub active would have returned **stub output** while the active-set assertion looked correct.

An activator returning `false` preserves `inactive_tool` byte for byte; `unknown_tool` is untouched. `execute-tool.test.ts` and `look-at-extension.test.ts` pass **unmodified**.

## Evidence

Real `AgentSession` through `pi.executeTool`, same tool and coordinates as the failing session:

```
BEFORE active: read
RESULT: [{"type":"text","text":"clicked 826,371"}]
AFTER active: read,mcp_computer_use_click
look_at REFUSED: inactive_tool
unknown REFUSED: unknown_tool
FINAL active: read,mcp_computer_use_click
```

The capability-gated tool is still refused and never enters the active set.

## Gates

- `test/mcp/` + `execute-tool` + `look-at-extension` + `extensions-runner` + `permission/`: **849 passed** (63 files)
- `packages/senpi-codemode`: **403 passed**, 6 skipped (pre-existing interpreter skips)
- `npx tsgo --noEmit`: exit 0
- `npm run check` (root): exit 0

Both criteria were captured RED first: the policy test failed on the absent module, and the session-wiring test failed with `pi.registerLazyToolActivator is not a function`.

## Review

Reviewed by `momus`, which returned **REJECT / SAFE-ONLY-IF** on the original blanket-activation design. Every blocker was applied: catalog-scoped eligibility, tier-B `activate()` for stub-swap, opt-in registration, and tests covering the refusal paths rather than only the happy path.

Plan: `.omo/plans/eval-auto-activate-tools.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stalled eval cells by lazily activating eligible searchable MCP tools just in time for eval. Activation is opt-in via `activateInactiveTool` (enabled only for eval), and gated, tombstoned, and permission‑denied tools remain inactive.

- **Bug Fixes**
  - `executeTool()` now, when `activateInactiveTool` is true, runs registered lazy activators for registered‑but‑inactive tools and executes on success.
  - Restores the `setActiveToolsByName` docblock after introducing `_activateLazyTool`.

- **New Features**
  - Adds `registerLazyToolActivator(activator)` to the Extension API and `ExecuteToolOptions.activateInactiveTool`. The codemode wrapper enables it for eval; other callers keep `inactive_tool`/`unknown_tool` unchanged.
  - `builtin/mcp` registers an activator that promotes only tier‑B searchable tools via its `activate()` path, preserving stub‑swap and catalog rules. Extension loader/runner persist and replay activators across `bindCore()`.

<sup>Written for commit 07ab203a464b4d37b1305e3db60c7cc1e06508e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

