### PR TITLE
fix(coding-agent): keep the startup tip visible when extensions set a header

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,16 @@
 # changes
 
+## Fix: the startup tip is destroyed by extension headers (2026-07-27)
+
+### What changed
+
+- `tips/startup-header.ts` (new): `appendStartupHeader()` attaches the built-in header and the startup tip to the header container as **separate children**.
+- `interactive-mode.ts`: the tip is no longer interpolated into the `ExpandableText` header closures.
+
+### Why
+
+`ui.setHeader()` replaces the built-in header component in place, and the builtin `prompt-preset` extension calls it on every `session_start`. Because the tip was part of the header's own text, that replacement silently discarded it: the tip resolved and was recorded into `tipsHistory`, but never reached the terminal. Keeping the tip as a sibling of the header makes it survive any extension header override.
+
 ## Feature discoverability: tips, `?` overlay, live favorite hints, `/keybindings` (2026-07-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -184,6 +184,7 @@ import { InteractiveThemeController } from "./theme/theme-controller.ts";
 import { buildFavoriteCycleStatusMessage } from "./tips/favorite-messages.ts";
 import { recordTipShown } from "./tips/history-writer.ts";
 import { TIP_DEFINITIONS } from "./tips/registry.ts";
+import { appendStartupHeader } from "./tips/startup-header.ts";
 import { resolveStartupTipLine } from "./tips/startup-tip.ts";
 import { resolveWorkingTipLine, WorkingTipCache, type WorkingTipLine } from "./tips/working-tip.ts";
 import { ToolArgsRevealController } from "./tool-args-reveal.ts";
@@ -999,23 +1000,20 @@ export class InteractiveMode {
 			if (startupTip) {
 				this.recordShownTip(startupTip.tipId);
 			}
-			const tipLine = startupTip ? `\n${theme.fg("dim", startupTip.line)}` : "";
+			const tipLine = startupTip ? theme.fg("dim", startupTip.line) : undefined;
 			const onboarding = theme.fg(
 				"dim",
 				`Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.`,
 			);
 			this.builtInHeader = new ExpandableText(
-				() => `${logo}\n${compactInstructions}\n${compactOnboarding}${tipLine}\n\n${onboarding}`,
-				() => `${logo}\n${expandedInstructions}${tipLine}\n\n${onboarding}`,
+				() => `${logo}\n${compactInstructions}\n${compactOnboarding}\n\n${onboarding}`,
+				() => `${logo}\n${expandedInstructions}\n\n${onboarding}`,
 				this.getStartupExpansionState(),
 				1,
 				0,
 			);
 
-			// Setup UI layout
-			this.headerContainer.addChild(new Spacer(1));
-			this.headerContainer.addChild(this.builtInHeader);
-			this.headerContainer.addChild(new Spacer(1));
+			appendStartupHeader(this.headerContainer, this.builtInHeader, tipLine);
 		} else {
 			// Minimal header when silenced
 			this.builtInHeader = new Text("", 0, 0);

--- a/packages/coding-agent/src/modes/interactive/tips/startup-header.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/startup-header.ts
@@ -1,0 +1,26 @@
+import type { Component, Container } from "@earendil-works/pi-tui";
+import { Spacer, Text } from "@earendil-works/pi-tui";
+
+/**
+ * The tip must stay a sibling of the header, never part of its text:
+ * `ui.setHeader()` swaps the header component in place (the builtin
+ * `prompt-preset` extension does this on every `session_start`), which discards
+ * anything embedded inside it.
+ */
+export function appendStartupHeader(
+	container: Container,
+	header: Component,
+	tipLine: string | undefined,
+): Text | undefined {
+	container.addChild(new Spacer(1));
+	container.addChild(header);
+
+	let tipComponent: Text | undefined;
+	if (tipLine) {
+		tipComponent = new Text(tipLine, 1, 0);
+		container.addChild(tipComponent);
+	}
+
+	container.addChild(new Spacer(1));
+	return tipComponent;
+}

--- a/packages/coding-agent/test/suite/startup-tip-extension-header.test.ts
+++ b/packages/coding-agent/test/suite/startup-tip-extension-header.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Container, Text } from "@earendil-works/pi-tui";
+import { describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
+import { appendStartupHeader } from "../../src/modes/interactive/tips/startup-header.ts";
+
+const INTERACTIVE_MODE_SOURCE = readFileSync(
+	fileURLToPath(new URL("../../src/modes/interactive/interactive-mode.ts", import.meta.url)),
+	"utf8",
+);
+
+function renderAll(container: Container): string {
+	return container.render(120).flat().join("\n");
+}
+
+describe("startup tip survives an extension header override", () => {
+	test("the tip is never interpolated into the built-in header text", () => {
+		const logoToken = ["$", "{logo}"].join("");
+		const expandedToken = ["$", "{expandedInstructions}"].join("");
+		const headerClosures = INTERACTIVE_MODE_SOURCE.split("\n").filter(
+			(line) => line.includes(logoToken) || line.includes(expandedToken),
+		);
+
+		expect(headerClosures.length).toBeGreaterThan(0);
+		for (const closure of headerClosures) {
+			expect(closure).not.toContain("tipLine");
+		}
+	});
+
+	test("keeps the tip line after an extension replaces the built-in header", () => {
+		const headerContainer = new Container();
+		const builtInHeader = new Text("pi v2026.7.27\nctrl+c to interrupt", 1, 0);
+		appendStartupHeader(headerContainer, builtInHeader, "Tip: Rotate favorites with ctrl+p.");
+
+		expect(renderAll(headerContainer)).toContain("Tip: Rotate favorites with ctrl+p.");
+
+		const fakeThis = {
+			builtInHeader,
+			customHeader: undefined as unknown,
+			headerContainer,
+			toolOutputExpanded: false,
+			ui: { requestRender: vi.fn() },
+		};
+		const setExtensionHeader = Reflect.get(InteractiveMode.prototype, "setExtensionHeader") as (
+			this: typeof fakeThis,
+			factory: (() => { render: () => string[]; invalidate: () => void }) | undefined,
+		) => void;
+
+		setExtensionHeader.call(fakeThis, () => ({
+			render: () => ["Prompt preset: fallback (senpi-current)"],
+			invalidate: () => {},
+		}));
+
+		const rendered = renderAll(headerContainer);
+		expect(rendered).toContain("Prompt preset: fallback (senpi-current)");
+		expect(rendered).toContain("Tip: Rotate favorites with ctrl+p.");
+		expect(rendered).not.toContain("ctrl+c to interrupt");
+	});
+
+	test("adds no tip child when there is no tip to show", () => {
+		const headerContainer = new Container();
+		const builtInHeader = new Text("pi v2026.7.27", 1, 0);
+		const tip = appendStartupHeader(headerContainer, builtInHeader, undefined);
+
+		expect(tip).toBeUndefined();
+		expect(headerContainer.children).toHaveLength(3);
+	});
+});


### PR DESCRIPTION
## Problem

The startup tip shipped in #405 never reached users.

`ui.setHeader()` replaces the built-in header component **in place**, and the builtin `prompt-preset` extension calls it on every `session_start`. The tip was interpolated into the header's own text, so that swap silently discarded it.

The failure was invisible from the outside: the tip resolved correctly and was recorded into `tipsHistory`, so state looked healthy while nothing was ever displayed.

Captured from a real TUI boot (stack trace, instrumented):

```
BRANCH=elseif tip={"line":"Tip: Rotate through favorite models with ctrl+p; ..."}
SETEXTHEADER factory=true
  at InteractiveMode.setExtensionHeader (interactive-mode.ts:2662)
  at Object.setHeader (interactive-mode.ts:2759)
  at refreshHeader (core/extensions/builtin/prompt-preset/index.ts:45)
```

## Fix

`tips/startup-header.ts` attaches the header and the tip as **separate children** of the header container, so replacing the header cannot take the tip with it.

## Verification

Real TUI boots (PTY, isolated sandbox, `PI_OFFLINE=1`, real `auth.json` untouched):

- boot 1 → `Tip: Use shift+tab to cycle the model's thinking level.`
- boot 2 → `Tip: Rotate through favorite models with ctrl+p; go backward with shift+ctrl+p.`

Rotation and persistence confirmed across boots; keys rendered live from config.

- Regression test captured RED first, then GREEN, and mutation-proven (re-embedding the tip into the header text fails the test).
- `npx tsgo --noEmit` clean; `biome check --error-on-warnings` clean for changed files.
- Full package suite: 5049 passed, 3 pre-existing app-server failures also present on pristine `origin/main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that hid the startup tip when extensions replaced the header. The tip now renders as a sibling of the header, so it stays visible even after `ui.setHeader()` runs.

- **Bug Fixes**
  - Added `appendStartupHeader()` in `tips/startup-header.ts` to attach the header and tip as separate children.
  - Updated `interactive-mode.ts` to remove tip interpolation from `ExpandableText` and call `appendStartupHeader`.
  - Added `startup-tip-extension-header.test.ts` to confirm the tip persists after an extension header override.

<sup>Written for commit c1fab112d1396d8f9b9f247c598d008188e64177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

