### PR TITLE
fix(coding-agent): initialize theme before the multi-session RPC host

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,18 @@
+## Multi-session RPC host initializes the theme before serving sessions (2026-07-28)
+
+### What changed
+
+- `main.ts`: the `--mode rpc --multi-session` branch now calls `initTheme(startupSettingsManager.getTheme(), false)` immediately before `runMultiSessionHost(...)`. The host returns `Promise<never>`, so the pre-existing `initTheme()` call further down `main()` is unreachable on this path and the theme proxy stayed uninitialized for the whole host lifetime.
+- Regression: `test/suite/regressions/0000-multi-session-theme-init.test.ts` spawns the real CLI in multi-session mode with a global extension that touches `theme` at load time and opens a session; pre-fix the extension load crashes with "Theme not initialized. Call initTheme() first." (surfaced by embedders such as T3 Code as transcript errors), post-fix the probe loads and the transcript stays clean.
+
+### Why
+
+- Extensions load per `open_session` inside the multi-session host, and any extension (or render helper) that reads the `theme` proxy crashed the session with "Theme not initialized". An extension cannot fix this ordering itself: the theme must be initialized by the host bootstrap before extension code runs, so this is a core `main.ts` fix.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: one additive call (plus comment) inside the multi-session dispatch branch in `main.ts`; upstream edits to that branch will conflict trivially.
+
 ## Experimental `--grok-neo` mode: env-gated grok chrome for the interactive loop (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -833,6 +833,12 @@ export async function main(args: string[], options?: MainOptions) {
 	};
 	time("createRuntime");
 	if (appMode === "rpc" && parsed.multiSession) {
+		// The multi-session host never returns, so the initTheme() call further down
+		// is unreachable on this path. Extensions loaded per open_session (and any
+		// tool render helper) read the theme proxy and would otherwise crash with
+		// "Theme not initialized. Call initTheme() first." (surfaced in embedders
+		// like T3 Code as transcript errors).
+		initTheme(startupSettingsManager.getTheme(), false);
 		printTimings();
 		await runMultiSessionHost({
 			agentDir,

--- a/packages/coding-agent/test/suite/regressions/0000-multi-session-theme-init.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0000-multi-session-theme-init.test.ts
@@ -1,0 +1,113 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+
+/**
+ * Regression: `senpi --mode rpc --multi-session` entered `runMultiSessionHost()`
+ * (which never returns) BEFORE `main()` reached its `initTheme()` call, so the
+ * theme proxy stayed uninitialized for the whole host lifetime. Any extension
+ * that touches `theme` during `open_session` (extensions load per session in
+ * multi-session mode) crashed with "Theme not initialized. Call initTheme()
+ * first." — surfaced by embedders like T3 Code as transcript errors.
+ *
+ * The probe extension below touches the theme at module load time and then
+ * writes a marker file. Pre-fix the touch throws, the marker never appears, and
+ * the error text shows up in the host transcript. Post-fix the marker exists
+ * and the transcript is clean.
+ */
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(testDir, "..", "..", "..");
+const repoRoot = path.resolve(packageDir, "..", "..");
+const tsxCli = path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const senpiCli = path.join(packageDir, "src", "cli.ts");
+const themeModule = path.join(packageDir, "src", "modes", "interactive", "theme", "theme.ts");
+
+describe("multi-session host initializes the interactive theme", () => {
+	let child: ChildProcess | undefined;
+	let tmp: string | undefined;
+
+	afterEach(() => {
+		child?.kill("SIGTERM");
+		child = undefined;
+		if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+		tmp = undefined;
+	});
+
+	test("open_session loads a theme-touching extension without crashing", async () => {
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), "senpi-theme-init-"));
+		const agentDir = path.join(tmp, "agent");
+		const extensionsDir = path.join(agentDir, "extensions");
+		const workspace = path.join(tmp, "workspace");
+		const marker = path.join(tmp, "theme-probe-loaded");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.writeFileSync(
+			path.join(extensionsDir, "theme-probe.ts"),
+			[
+				`import * as fs from "node:fs";`,
+				`import { theme } from ${JSON.stringify(themeModule)};`,
+				"// Touching the theme at extension load time is exactly what crashed pre-fix.",
+				`theme.fg("accent", "probe");`,
+				`fs.writeFileSync(${JSON.stringify(marker)}, "loaded");`,
+				"export default function themeProbe() {}",
+			].join("\n"),
+		);
+
+		const spawned = spawn(process.execPath, [tsxCli, senpiCli, "--mode", "rpc", "--multi-session"], {
+			cwd: workspace,
+			env: { ...process.env, SENPI_CODING_AGENT_DIR: agentDir, NO_COLOR: "1" },
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		child = spawned;
+
+		let stdout = "";
+		let stderr = "";
+		spawned.stdout.on("data", (chunk: Buffer) => {
+			stdout += String(chunk);
+		});
+		spawned.stderr.on("data", (chunk: Buffer) => {
+			stderr += String(chunk);
+		});
+
+		const response = await new Promise<Record<string, unknown>>((resolve, reject) => {
+			const fail = (reason: unknown) =>
+				reject(
+					new Error(`host ended before responding (${String(reason)})\nstdout:\n${stdout}\nstderr:\n${stderr}`),
+				);
+			spawned.on("error", fail);
+			spawned.on("exit", (code) => fail(`exit ${code}`));
+			let buffer = "";
+			spawned.stdout.on("data", (chunk: Buffer) => {
+				buffer += String(chunk);
+				let newline = buffer.indexOf("\n");
+				while (newline !== -1) {
+					const line = buffer.slice(0, newline).trim();
+					buffer = buffer.slice(newline + 1);
+					newline = buffer.indexOf("\n");
+					if (!line) continue;
+					try {
+						const parsed = JSON.parse(line) as Record<string, unknown>;
+						if (parsed.type === "response" && parsed.id === "open-1") {
+							resolve(parsed);
+							return;
+						}
+					} catch {
+						// Non-JSON startup noise is fine; only framed responses matter.
+					}
+				}
+			});
+			spawned.stdin.write(`${JSON.stringify({ id: "open-1", type: "open_session", cwd: workspace })}\n`);
+		});
+
+		const transcript = `${stdout}\n${stderr}`;
+		expect(transcript).not.toContain("Theme not initialized");
+		expect(
+			fs.existsSync(marker),
+			`theme probe extension never loaded\nresponse: ${JSON.stringify(response)}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+		).toBe(true);
+	}, 120_000);
+});


### PR DESCRIPTION
## Problem

Running `senpi --mode rpc --multi-session` (the mode embedders like T3 Code use for the shared senpi process) never initializes the interactive theme: the multi-session branch in `main()` enters `runMultiSessionHost()`, which returns `Promise<never>`, so the `initTheme()` call further down `main()` is unreachable on that path.

Extensions load per `open_session` inside the host. Any extension (or render helper) that reads the `theme` proxy crashes the session with:

```
Theme not initialized. Call initTheme() first.
```

In T3 Code this surfaced as raw error text in chat transcripts. Same class as the #4333 theme-sharing fix, but an ordering hole rather than a scope hole.

## Fix

Call `initTheme(startupSettingsManager.getTheme(), false)` in the multi-session branch immediately before `runMultiSessionHost(...)`. One additive call; no other paths change (the host never returns, so the later `initTheme()` still owns every other mode).

## Regression test

`test/suite/regressions/0000-multi-session-theme-init.test.ts` spawns the real CLI in `--mode rpc --multi-session` with an isolated `SENPI_CODING_AGENT_DIR` containing a global extension that touches `theme` at module load time and then writes a marker file, then opens a session over JSONL.

- **Pre-fix (verified by reverting the fix and re-running): fails** - the probe never loads and the theme error appears in the transcript.
- **Post-fix: passes** - marker exists, transcript clean. Child, sockets and temp dirs are cleaned up; no providers, no tokens.

## Validation

- `packages/coding-agent`: `npm run build` green
- regression test green (and proven red pre-fix)
- root `npm run check` green
- `src/changes.md` fork-contract entry added (what/why/why-not-extension/conflict zones)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the interactive theme before starting the multi-session RPC host. This prevents "Theme not initialized" crashes when extensions or render helpers read the theme (seen in embedders like T3 Code).

- **Bug Fixes**
  - In `senpi --mode rpc --multi-session`, call `initTheme(startupSettingsManager.getTheme(), false)` right before `runMultiSessionHost(...)`; other modes are unchanged.
  - Add a regression test that spawns the CLI, loads a theme-touching extension, and verifies a clean transcript without the error.

<sup>Written for commit db1cfefc543a695e71a51e0009cb3ae002003f25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

