### PR TITLE
feat(coding-agent): show active monitors in the interactive footer

### DIFF
--- a/packages/coding-agent/docs/terminal-tools.md
+++ b/packages/coding-agent/docs/terminal-tools.md
@@ -12,7 +12,7 @@ platform/runtime).
 |------|---------|
 | `bash` | Run a command in a PTY. `run_in_background: true` starts a persistent session and returns a `bash_id` immediately. Foreground `timeout` (seconds) is a kill deadline. |
 | `bash_output` | Peek at a session without blocking: new output since the last read, or the status line. `filter` regex-filters lines; `view: "screen"` returns the rendered xterm grid. |
-| `monitor` | Watch a long-running command (`description`, `command`, `filter?`, `timeout_ms?`, `persistent?`) and inject matching stdout lines as coalesced events. |
+| `monitor` | Watch a long-running command (`description`, `command`, `filter?`, `timeout_ms?`, `persistent?`) and inject matching stdout lines as coalesced events. While watches are live, the interactive footer shows a brief `watching …` status (descriptions, count, paused markers). |
 | `bash_input` | Send stdin (`input`) or named keys (`keys: ["ctrl+c"]`, `["enter"]`, `["up"]`) to steer a REPL or interrupt a process. |
 | `bash_resize` | Resize a session's PTY (`cols`, `rows`) so full-screen TUIs reflow. |
 | `kill_bash` | Tree-kill one session (`bash_id`) or all (`all: true`), leaving no orphans. |

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,34 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Footer status for active monitors (2026-07-28)
+
+### What changed
+
+- `monitor-registry.ts`: `MonitorRegistry` accepts optional `MonitorRegistryOptions.onChange`, fired
+  with a `snapshot()` (`{id, description, paused}[]`) on register, pauseAll (when any paused),
+  rearm, settle, and dispose. `snapshot()` is public.
+- `monitor-status.ts` (new): `formatMonitorStatus(snapshot)` — undefined when nothing is watched
+  (clears the footer status), `watching <desc>` for one, `watching N: <d1>, <d2>` elided to a
+  48-char cap for many, `(paused)` / `(k paused)` markers. `MONITOR_STATUS_KEY = "monitors"`.
+- `extension.ts`: the session monitor registry is created with an onChange that publishes
+  `ctx.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot))` — the goal-builtin
+  footer-status pattern. Non-interactive modes no-op via the optional ctx; settle/shutdown
+  dispose clears the status.
+- `test/suite/terminal-monitor-footer.test.ts` (new): formatter cases, registry transition
+  notifications (register/pause/rearm/settle/dispose with real pipe-forced sessions), and
+  extension wiring (fake pi + ui.setStatus spy, real monitor tool execution).
+
+### Why extension system could handle this
+
+- Entirely extension-owned: `ctx.ui.setStatus` is the established footer surface
+  (goal/websearch/webfetch precedent); no core or footer-layout changes.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: fork-owned `monitor-registry.ts` constructor/notify points, `extension.ts`
+  monitorRegistry getter, new `monitor-status.ts`.
+
 ## Wait-discipline routing: bash surface redirect + guidance dedup (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -5,6 +5,7 @@ import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 import { TerminalManager } from "./manager.ts";
 import { MonitorNotifier } from "./monitor-notify.ts";
 import { MonitorRegistry } from "./monitor-registry.ts";
+import { formatMonitorStatus, MONITOR_STATUS_KEY } from "./monitor-status.ts";
 import { TerminalNotifier } from "./notify.ts";
 import { TERMINAL_PROMPT_SECTION } from "./prompt.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
@@ -58,7 +59,9 @@ function buildToolContext(state: TerminalExtensionState): TerminalToolContext {
 			return state.settings.defaultRows;
 		},
 		get monitorRegistry() {
-			state.monitors ??= new MonitorRegistry((event) => state.monitorNotifier?.notifyEvent(event));
+			state.monitors ??= new MonitorRegistry((event) => state.monitorNotifier?.notifyEvent(event), {
+				onChange: (snapshot) => state.ctx?.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot)),
+			});
 			return state.monitors;
 		},
 		getEnv: () => getShellEnv(),

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
@@ -19,6 +19,17 @@ export type MonitorEvent = MonitorLineEvent | MonitorSummaryEvent;
 
 export type MonitorRearmResult = "rearmed" | "not_paused" | "not_found";
 
+export interface MonitorSnapshotEntry {
+	readonly id: string;
+	readonly description: string;
+	readonly paused: boolean;
+}
+
+export interface MonitorRegistryOptions {
+	/** Observes every registry transition (register/pause/rearm/settle/dispose) with the live snapshot. */
+	readonly onChange?: (snapshot: readonly MonitorSnapshotEntry[]) => void;
+}
+
 export interface RegisterMonitorOptions {
 	readonly id: string;
 	readonly description: string;
@@ -46,9 +57,19 @@ interface MonitorRecord {
 export class MonitorRegistry {
 	readonly #records = new Map<string, MonitorRecord>();
 	readonly #emit: (event: MonitorEvent) => void;
+	readonly #onChange: ((snapshot: readonly MonitorSnapshotEntry[]) => void) | undefined;
 
-	constructor(emit: (event: MonitorEvent) => void) {
+	constructor(emit: (event: MonitorEvent) => void, options?: MonitorRegistryOptions) {
 		this.#emit = emit;
+		this.#onChange = options?.onChange;
+	}
+
+	snapshot(): readonly MonitorSnapshotEntry[] {
+		return [...this.#records.values()].map((record) => ({
+			id: record.id,
+			description: record.description,
+			paused: record.paused,
+		}));
 	}
 
 	register(options: RegisterMonitorOptions): void {
@@ -64,6 +85,7 @@ export class MonitorRegistry {
 			unsubscribeExit: undefined,
 		};
 		this.#records.set(record.id, record);
+		this.#notifyChange();
 
 		// Runtime output is already bounded. Read what was produced before monitor registration,
 		// then subscribe synchronously so a fast watcher cannot lose its first line.
@@ -80,6 +102,7 @@ export class MonitorRegistry {
 			record.paused = true;
 			paused.push(record.id);
 		}
+		if (paused.length > 0) this.#notifyChange();
 		return paused;
 	}
 
@@ -88,12 +111,18 @@ export class MonitorRegistry {
 		if (!record) return "not_found";
 		if (!record.paused) return "not_paused";
 		record.paused = false;
+		this.#notifyChange();
 		return "rearmed";
 	}
 
 	dispose(): void {
 		for (const record of this.#records.values()) this.#disposeRecord(record);
 		this.#records.clear();
+		this.#notifyChange();
+	}
+
+	#notifyChange(): void {
+		this.#onChange?.(this.snapshot());
 	}
 
 	#consume(record: MonitorRecord, chunk: string): void {
@@ -117,6 +146,7 @@ export class MonitorRegistry {
 		record.unsubscribeOutput?.();
 		record.unsubscribeExit?.();
 		this.#records.delete(record.id);
+		this.#notifyChange();
 		const status = describeExit(record.runtime) ?? "exited";
 		const code = record.runtime.exitResult?.exitCode;
 		const codeText = code === null || code === undefined ? "" : ` (exit code ${code})`;

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
@@ -1,0 +1,21 @@
+import type { MonitorSnapshotEntry } from "./monitor-registry.ts";
+
+export const MONITOR_STATUS_KEY = "monitors";
+
+/** The footer shares one status line with other extensions; keep this brief. */
+const MAX_STATUS_LENGTH = 48;
+
+function truncateEnd(text: string, max: number): string {
+	if (text.length <= max) return text;
+	return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+/** Brief footer text for the active monitors; undefined clears the status. */
+export function formatMonitorStatus(snapshot: readonly MonitorSnapshotEntry[]): string | undefined {
+	if (snapshot.length === 0) return undefined;
+	const pausedCount = snapshot.filter((entry) => entry.paused).length;
+	const suffix = pausedCount === 0 ? "" : pausedCount === snapshot.length ? " (paused)" : ` (${pausedCount} paused)`;
+	const names = snapshot.map((entry) => entry.description).join(", ");
+	const head = snapshot.length === 1 ? `watching ${names}` : `watching ${snapshot.length}: ${names}`;
+	return truncateEnd(head, MAX_STATUS_LENGTH - suffix.length) + suffix;
+}

--- a/packages/coding-agent/test/prompt-surface-stale-wait-idioms.test.ts
+++ b/packages/coding-agent/test/prompt-surface-stale-wait-idioms.test.ts
@@ -120,9 +120,7 @@ describe("stale wait-idiom consistency gate", () => {
 	});
 
 	it("no agent-facing terminal surface teaches tmux as the backgrounding mechanism", () => {
-		const violations = agentFacingSurfaces().filter(
-			({ text }) => /tmux/i.test(text) && !TMUX_NEGATION.test(text),
-		);
+		const violations = agentFacingSurfaces().filter(({ text }) => /tmux/i.test(text) && !TMUX_NEGATION.test(text));
 		expect(
 			violations.map(({ name, line, text }) => `${name}:${line}: ${text.trim()}`),
 			"tmux taught as a backgrounding/wait mechanism outside negative guidance",

--- a/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import {
+	MonitorRegistry,
+	type MonitorSnapshotEntry,
+} from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import { formatMonitorStatus } from "../../src/core/extensions/builtin/terminal/monitor-status.ts";
+import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import { createMonitorTool, type MonitorInput } from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+
+/** Resolves when the wrapped spy is called with a matching argument set. */
+function deferredCall<TArgs extends unknown[]>(predicate: (...args: TArgs) => boolean) {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((res, rej) => {
+		resolve = res;
+		setTimeout(() => rej(new Error("Timed out waiting for matching call")), 5000);
+	});
+	const handler = (...args: TArgs): void => {
+		if (predicate(...args)) resolve?.();
+	};
+	return { promise, handler };
+}
+
+describe("formatMonitorStatus", () => {
+	const entry = (id: string, description: string, paused = false): MonitorSnapshotEntry => ({
+		id,
+		description,
+		paused,
+	});
+
+	it("returns undefined when nothing is monitored so the footer status clears", () => {
+		expect(formatMonitorStatus([])).toBeUndefined();
+	});
+
+	it("names the single watched thing", () => {
+		const text = formatMonitorStatus([entry("bash_1", "errors in deploy.log")]);
+		expect(text).toContain("errors in deploy.log");
+		expect(text).toContain("watching");
+	});
+
+	it("shows the count and elides long lists to a hard cap", () => {
+		const text = formatMonitorStatus([
+			entry("bash_1", "errors in deploy.log"),
+			entry("bash_2", "integration test output on ci runner four"),
+			entry("bash_3", "webpack rebuild"),
+		]);
+		expect(text).toBeDefined();
+		expect(text).toContain("3");
+		expect((text ?? "").length).toBeLessThanOrEqual(48);
+		expect(text).toContain("…");
+	});
+
+	it("marks paused watches", () => {
+		const all = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b", true)]);
+		expect(all).toContain("paused");
+		const some = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b")]);
+		expect(some).toContain("1 paused");
+	});
+});
+
+describe("MonitorRegistry change notification", () => {
+	let manager: TerminalManager;
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		manager = new TerminalManager();
+	});
+
+	afterEach(async () => {
+		await manager.teardown();
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	it("reports register, pause, rearm, settle, and dispose transitions", async () => {
+		const snapshots: Array<readonly MonitorSnapshotEntry[]> = [];
+		const settled = deferredCall<[readonly MonitorSnapshotEntry[]]>((snapshot) => snapshot.length === 0);
+		const registry = new MonitorRegistry(() => {}, {
+			onChange: (snapshot) => {
+				snapshots.push(snapshot);
+				settled.handler(snapshot);
+			},
+		});
+		const ctx: TerminalToolContext = {
+			manager,
+			cwd: process.cwd(),
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => ({ ...process.env }),
+			monitorRegistry: registry,
+		};
+		const tool = createMonitorTool(ctx);
+		const input: MonitorInput = { description: "quick echo watch", command: "printf 'one\\n'" };
+		await tool.execute("call_1", input);
+
+		expect(snapshots[0]).toEqual([
+			{ id: expect.stringContaining("bash"), description: "quick echo watch", paused: false },
+		]);
+		await settled.promise;
+		expect(snapshots.at(-1)).toEqual([]);
+	});
+
+	it("snapshots pause state through pauseAll and rearm", async () => {
+		const snapshots: Array<readonly MonitorSnapshotEntry[]> = [];
+		const registry = new MonitorRegistry(() => {}, { onChange: (snapshot) => snapshots.push(snapshot) });
+		const ctx: TerminalToolContext = {
+			manager,
+			cwd: process.cwd(),
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => ({ ...process.env }),
+			monitorRegistry: registry,
+		};
+		const tool = createMonitorTool(ctx);
+		const input: MonitorInput = { description: "long lived watch", command: "cat", persistent: true };
+		await tool.execute("call_1", input);
+		const registered = snapshots.at(-1);
+		expect(registered?.[0]?.paused).toBe(false);
+
+		registry.pauseAll();
+		expect(snapshots.at(-1)?.[0]?.paused).toBe(true);
+		expect(registry.snapshot()[0]?.paused).toBe(true);
+
+		const id = registry.snapshot()[0]?.id ?? "";
+		expect(registry.rearm(id)).toBe("rearmed");
+		expect(snapshots.at(-1)?.[0]?.paused).toBe(false);
+
+		registry.dispose();
+		expect(snapshots.at(-1)).toEqual([]);
+	});
+});
+
+describe("terminal extension footer status wiring", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+	});
+
+	afterEach(() => {
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	it("publishes the monitors footer status while a watch is live and clears it on settle", async () => {
+		type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+		const handlers = new Map<string, Handler[]>();
+		const tools = new Map<string, { execute: (id: string, input: MonitorInput) => Promise<unknown> }>();
+		let activeTools: string[] = [];
+		const fakePi = {
+			registerTool: (tool: { name: string; execute: (id: string, input: MonitorInput) => Promise<unknown> }) => {
+				tools.set(tool.name, tool);
+			},
+			on: (event: string, handler: Handler) => {
+				const existing = handlers.get(event) ?? [];
+				existing.push(handler);
+				handlers.set(event, existing);
+			},
+			sendUserMessage: () => {},
+			getActiveTools: () => activeTools,
+			setActiveTools: (next: string[]) => {
+				activeTools = next;
+			},
+		} as unknown as ExtensionAPI;
+
+		registerTerminalExtension(fakePi);
+
+		const setStatus = vi.fn();
+		const cleared = deferredCall<[string, string | undefined]>(
+			(key, text) => key === "monitors" && text === undefined,
+		);
+		setStatus.mockImplementation((key: string, text: string | undefined) => cleared.handler(key, text));
+		const ctx = {
+			cwd: process.cwd(),
+			ui: { setStatus, notify: () => {} },
+		} as unknown as ExtensionContext;
+		for (const handler of handlers.get("session_start") ?? []) await handler({}, ctx);
+
+		const monitorTool = tools.get("monitor");
+		expect(monitorTool).toBeDefined();
+		await monitorTool?.execute("call_1", { description: "footer smoke watch", command: "printf 'line\\n'" });
+
+		expect(setStatus).toHaveBeenCalledWith("monitors", expect.stringContaining("footer smoke watch"));
+		await cleared.promise;
+		expect(setStatus).toHaveBeenCalledWith("monitors", undefined);
+
+		for (const handler of handlers.get("session_shutdown") ?? []) await handler({}, ctx);
+	});
+});


### PR DESCRIPTION
## What

When one or more `monitor` watches are live, the interactive footer's status line now shows what is being monitored, and clears when nothing is:

```
watching deploy log errors
watching 3: errors in deploy.log, integration te… (1 paused)
```

## How

Entirely extension-owned, following the goal-builtin footer-status pattern (`ctx.ui.setStatus`); no core or footer-layout changes:

- `MonitorRegistry` gains an optional `onChange` observer fired with a `snapshot()` (`{id, description, paused}[]`) on register / pauseAll / rearm / settle / dispose.
- New `monitor-status.ts`: `formatMonitorStatus(snapshot)` — `undefined` when idle (clears the status), single description, or capped elided list with count and paused markers (48-char hard cap; the footer status line is shared with other extensions).
- The terminal extension creates its session registry with an `onChange` that publishes `setStatus("monitors", …)`; non-interactive modes no-op via the optional ctx; settle/shutdown dispose clears it.

## Tests (RED -> GREEN, staged per criterion)

- New `test/suite/terminal-monitor-footer.test.ts`: formatter cases (0/1/many/paused/cap), registry transition notifications driven through the real monitor tool with pipe-forced PTY sessions, and extension wiring (fake `pi`, `ui.setStatus` spy, real tool execution, event-subscribed settle wait — no sleeps).
- Captured failing first in two stages (module absent; then registry/wiring absent), then green: 52 tests across the new suite + terminal-monitor, terminal-monitor-notify, stale-wait-idioms, terminal-extension, terminal-settings-notify.

## Evidence (local-ignore/qa-evidence/20260728-monitor-footer/)

- **Real TUI proof**: booted the actual interactive TUI (native PTY) in a senpi-qa sandbox with a QA extension registering a live monitor via `pi.executeTool("monitor", …)` at session_start — the rendered footer shows `watching deploy log errors` (4/4 checks, auth untouched, sandbox cleaned).
- mock-loop `--with-tool` 4/4; root `npm run check` exit 0; full workspace build exit 0.

Fork records: `terminal/changes.md` (Footer status for active monitors, 2026-07-28) + `docs/terminal-tools.md` monitor row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The interactive footer now shows active `monitor` watches as a brief “watching …” status and clears when idle. This gives quick visibility into what’s being monitored.

- **New Features**
  - `MonitorRegistry` adds optional `onChange` with a public `snapshot()` covering register/pause/rearm/settle/dispose.
  - New `monitor-status.ts`: `formatMonitorStatus()` returns a capped status or `undefined`, with counts and paused markers; `MONITOR_STATUS_KEY = "monitors"`.
  - Terminal extension publishes updates via `ctx.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(...))` and clears on shutdown; docs updated to mention the footer status.

<sup>Written for commit ad0ffa4209702d19f5cffc658ad693a2a7a919c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

