### PR TITLE
feat(coding-agent): cancellable session_before_reload veto so extensions can block reload

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -354,6 +354,12 @@ user sends another prompt ◄─────────────────
   ├─► session_start { reason: "fork", previousSessionFile }
   └─► resources_discover { reason: "startup" }
 
+/reload or ctx.reload() (config hot-reload included)
+  ├─► session_before_reload (can cancel — blocks the whole reload)
+  ├─► session_shutdown { reason: "reload" }
+  ├─► session_start { reason: "reload" }
+  └─► resources_discover { reason: "reload" }
+
 /name or pi.setSessionName()
   └─► session_info_changed
 
@@ -476,6 +482,23 @@ pi.on("session_before_fork", async (event, ctx) => {
 
 After a successful fork or clone, pi emits `session_shutdown` for the old extension instance, reloads and rebinds extensions for the new session, then emits `session_start` with `reason: "fork"` and `previousSessionFile`.
 Do cleanup work in `session_shutdown`, then reestablish any in-memory state in `session_start`.
+
+#### session_before_reload
+
+Fired before a full session reload (`/reload`, `ctx.reload()`, or the config hot-reload path) tears down and rebuilds the extension runtime. Cancelling prevents the reload entirely: no `session_shutdown` is emitted, nothing is reloaded, and interactive hosts show `reason` as a warning.
+
+```typescript
+pi.on("session_before_reload", () => {
+  if (backgroundWorkers.size > 0) {
+    return {
+      cancel: true,
+      reason: `${backgroundWorkers.size} background worker(s) still running - wait or cancel them before reloading.`,
+    };
+  }
+});
+```
+
+Use this to protect state a reload would destroy — for example running background children owned by the extension runtime. Keep handlers fast and side-effect free; hosts may consult the veto more than once per reload attempt.
 
 #### session_before_compact / session_compact
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,28 @@
+## Cancellable `session_before_reload` veto blocks reload while extensions protect live work (2026-07-28)
+
+### What changed
+
+- New cancellable extension event `session_before_reload` (`core/extensions/types.ts`, routed through the
+  existing session-before machinery in `core/extensions/runner.ts`). `AgentSession.reload()`
+  (`core/agent-session.ts`) now returns `{ cancelled: boolean; reason?: string }` and consults the new
+  `checkReloadVeto()` BEFORE emitting `session_shutdown`, so a cancelling extension prevents the entire
+  teardown on every reload path (`/reload`, `ctx.reload()`, config hot-reload, direct SDK/rpc/print calls).
+- Interactive `/reload` pre-checks the veto and surfaces the extension's `reason` as a warning
+  (`modes/interactive/interactive-mode.ts`). Docs: `docs/extensions.md` event flow + `#session_before_reload`.
+- Coverage: `test/suite/session-before-reload.test.ts` pins veto-aborts-before-shutdown, normal reload
+  passthrough, and the side-effect-free `checkReloadVeto()` probe.
+
+### Why
+
+- A reload tears down the extension runtime; extensions running background subagents (omo-senpi task
+  runtime) had their children killed mid-flight by `/reload` or a config hot-reload. Only the session owns
+  the teardown ordering, so the veto checkpoint must live in core, mirroring `session_before_switch`.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: additive event plumbing in `extensions/types.ts` / `extensions/runner.ts`; MEDIUM: head of
+  `reload()` in `agent-session.ts` (early-return veto + return-type change).
+
 ## Multi-session RPC host initializes the theme before serving sessions (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5035,7 +5035,14 @@ export class AgentSession {
 		});
 	}
 
-	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void> {
+	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<{
+		cancelled: boolean;
+		reason?: string;
+	}> {
+		const veto = await this.checkReloadVeto();
+		if (veto.cancelled) {
+			return veto;
+		}
 		resetTimings("reload");
 		const oldExtensionRunner = this._extensionRunner;
 		const oldExtensionIdentities = oldExtensionRunner.getExtensionIdentities();
@@ -5099,6 +5106,25 @@ export class AgentSession {
 			await this.extendResourcesFromExtensions("reload");
 		}
 		time("lifecycle", "reload");
+		return { cancelled: false };
+	}
+
+	/**
+	 * Ask extensions whether a full session reload may proceed by emitting the
+	 * cancellable `session_before_reload` event. `reload()` always consults this
+	 * gate itself, so a cancelling extension prevents the teardown on every
+	 * reload path; interactive hosts may additionally pre-check it to warn
+	 * without starting their reload UI.
+	 */
+	async checkReloadVeto(): Promise<{ cancelled: boolean; reason?: string }> {
+		if (!this._extensionRunner.hasHandlers("session_before_reload")) {
+			return { cancelled: false };
+		}
+		const result = await this._extensionRunner.emit({ type: "session_before_reload" });
+		if (result?.cancel !== true) {
+			return { cancelled: false };
+		}
+		return result.reason === undefined ? { cancelled: true } : { cancelled: true, reason: result.reason };
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,34 @@
 # Core Extensions Changes
 
+## 2026-07-28 - session_before_reload (cancellable reload veto)
+
+### What changed
+
+- `types.ts` adds `SessionBeforeReloadEvent` (`{ type: "session_before_reload" }`) to the `SessionEvent` union,
+  `SessionBeforeReloadResult` (`{ cancel?: boolean; reason?: string }`), and the matching `pi.on` overload.
+- `runner.ts` routes the event through the existing session-before machinery: `SessionBeforeEvent` /
+  `SessionBeforeEventResult` unions, the `RunnerEmitResult` mapping, and `isSessionBeforeEvent`, so the first
+  handler returning `cancel: true` short-circuits exactly like `session_before_switch`.
+- `agent-session.ts` `reload()` now returns `{ cancelled: boolean; reason?: string }` and consults the new
+  `checkReloadVeto()` before `emitSessionShutdownEvent`: a cancelling extension prevents the entire reload
+  (no shutdown, no settings/models/resources reload, no runtime rebuild) on every path — `/reload`,
+  `ctx.reload()`, the builtin config-reload hot path, and direct SDK/rpc/print callers.
+- Interactive mode pre-checks the veto in `handleReloadCommand` and shows the `reason` as a warning without
+  flashing the reload box; it also honors a cancelled result from `reload()` itself (race window).
+
+### Why extension system couldn't handle this alone
+
+- Only the session owns the reload teardown ordering; an extension cannot intercept `session_shutdown`
+  emission or refuse it. Extensions that own long-lived work (e.g. running background subagents in
+  omo-senpi's task runtime) were killed mid-flight by any reload. The veto gives the owning extension a
+  cancellable checkpoint, mirroring the established `session_before_switch`/`fork`/`compact` family.
+
+### Expected merge conflict zones
+
+- LOW: additive event/result/overload entries in `types.ts` and the union/mapping lines in `runner.ts`.
+- MEDIUM: the head of `reload()` in `agent-session.ts` (return-type change plus early return); upstream
+  edits to the reload sequence will conflict there and must keep the veto check first.
+
 ## 2026-07-27 - registerLazyToolActivator (on-demand activation of inactive tools)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -62,6 +62,7 @@ import type {
 	ServiceTier,
 	SessionBeforeCompactResult,
 	SessionBeforeForkResult,
+	SessionBeforeReloadResult,
 	SessionBeforeSwitchResult,
 	SessionBeforeTreeResult,
 	SessionShutdownEvent,
@@ -147,12 +148,20 @@ type RunnerEmitEvent = Exclude<
 
 type SessionBeforeEvent = Extract<
 	RunnerEmitEvent,
-	{ type: "session_before_switch" | "session_before_fork" | "session_before_compact" | "session_before_tree" }
+	{
+		type:
+			| "session_before_switch"
+			| "session_before_fork"
+			| "session_before_reload"
+			| "session_before_compact"
+			| "session_before_tree";
+	}
 >;
 
 type SessionBeforeEventResult =
 	| SessionBeforeSwitchResult
 	| SessionBeforeForkResult
+	| SessionBeforeReloadResult
 	| SessionBeforeCompactResult
 	| SessionBeforeTreeResult;
 
@@ -160,11 +169,13 @@ type RunnerEmitResult<TEvent extends RunnerEmitEvent> = TEvent extends { type: "
 	? SessionBeforeSwitchResult | undefined
 	: TEvent extends { type: "session_before_fork" }
 		? SessionBeforeForkResult | undefined
-		: TEvent extends { type: "session_before_compact" }
-			? SessionBeforeCompactResult | undefined
-			: TEvent extends { type: "session_before_tree" }
-				? SessionBeforeTreeResult | undefined
-				: undefined;
+		: TEvent extends { type: "session_before_reload" }
+			? SessionBeforeReloadResult | undefined
+			: TEvent extends { type: "session_before_compact" }
+				? SessionBeforeCompactResult | undefined
+				: TEvent extends { type: "session_before_tree" }
+					? SessionBeforeTreeResult | undefined
+					: undefined;
 
 function cloneJsonValue<T>(value: T): T {
 	const serialized = JSON.stringify(value);
@@ -1102,6 +1113,7 @@ export class ExtensionRunner {
 		return (
 			event.type === "session_before_switch" ||
 			event.type === "session_before_fork" ||
+			event.type === "session_before_reload" ||
 			event.type === "session_before_compact" ||
 			event.type === "session_before_tree"
 		);

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -709,6 +709,17 @@ export interface SessionBeforeForkEvent {
 	position: "before" | "at";
 }
 
+/**
+ * Fired before a full session reload (`/reload`, `ctx.reload()`, or the
+ * config-reload hot path) tears down and rebuilds the extension runtime.
+ * Cancelling prevents the reload entirely: no `session_shutdown` is emitted and
+ * no resources are reloaded. Use this to protect work that a reload would
+ * destroy (e.g. running background children owned by the extension runtime).
+ */
+export interface SessionBeforeReloadEvent {
+	type: "session_before_reload";
+}
+
 /** Fired before context compaction (can be cancelled or customized) */
 export interface SessionBeforeCompactEvent {
 	type: "session_before_compact";
@@ -821,6 +832,7 @@ export type SessionEvent =
 	| SessionInfoChangedEvent
 	| SessionBeforeSwitchEvent
 	| SessionBeforeForkEvent
+	| SessionBeforeReloadEvent
 	| SessionBeforeCompactEvent
 	| SessionCompactEvent
 	| SessionShutdownEvent
@@ -1307,6 +1319,16 @@ export interface SessionBeforeForkResult {
 	skipConversationRestore?: boolean;
 }
 
+export interface SessionBeforeReloadResult {
+	cancel?: boolean;
+	/**
+	 * Short human-readable reason shown by hosts when the reload is blocked.
+	 * Prefer an actionable sentence ("2 subagents still running: a, b - wait or
+	 * cancel them before reloading").
+	 */
+	reason?: string;
+}
+
 export interface SessionBeforeCompactResult {
 	cancel?: boolean;
 	compaction?: CompactionResult;
@@ -1409,6 +1431,10 @@ export interface ExtensionAPI {
 		handler: ExtensionHandler<SessionBeforeSwitchEvent, SessionBeforeSwitchResult>,
 	): void;
 	on(event: "session_before_fork", handler: ExtensionHandler<SessionBeforeForkEvent, SessionBeforeForkResult>): void;
+	on(
+		event: "session_before_reload",
+		handler: ExtensionHandler<SessionBeforeReloadEvent, SessionBeforeReloadResult>,
+	): void;
 	on(
 		event: "session_before_compact",
 		handler: ExtensionHandler<SessionBeforeCompactEvent, SessionBeforeCompactResult>,

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## /reload honors the session_before_reload extension veto (2026-07-28)
+
+### What changed
+
+- `interactive-mode.ts` `handleReloadCommand()`: before building the reload box, the handler calls
+  `session.checkReloadVeto()`; when an extension cancels (`session_before_reload` returning
+  `cancel: true`), the command shows the extension's `reason` as a warning and returns — no reload box,
+  no focus steal, no teardown. A cancelled result from `session.reload()` itself (late veto) dismisses
+  the box back to the previous editor and shows the same warning.
+
+### Why
+
+- Reload destroys the extension runtime; extensions owning live background work (running subagents in
+  omo-senpi) need a way to block it. The streaming/compaction guards already set the warning precedent.
+
 ## Fix: the startup tip is destroyed by extension headers (2026-07-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6191,6 +6191,14 @@ export class InteractiveMode {
 			this.showWarning("Wait for compaction to finish before reloading.");
 			return;
 		}
+		// Pre-check the extension veto (session_before_reload) so a blocked reload
+		// warns without flashing the reload box or stealing editor focus. reload()
+		// re-checks internally, so the race window below is still covered.
+		const veto = await this.session.checkReloadVeto();
+		if (veto.cancelled) {
+			this.showWarning(veto.reason ?? "Reload blocked by an extension.");
+			return;
+		}
 
 		this.resetExtensionUI();
 
@@ -6236,7 +6244,13 @@ export class InteractiveMode {
 		};
 
 		try {
-			await this.session.reload({ beforeSessionStart: restoreChatBeforeSessionStart });
+			const reloadResult = await this.session.reload({ beforeSessionStart: restoreChatBeforeSessionStart });
+			if (reloadResult.cancelled) {
+				dismissReloadBox(previousEditor as Component);
+				reloadBoxDismissed = true;
+				this.showWarning(reloadResult.reason ?? "Reload blocked by an extension.");
+				return;
+			}
 			restoreChatBeforeSessionStart();
 			configureHttpDispatcher(this.settingsManager.getHttpIdleTimeoutMs());
 			this.keybindings.reload();

--- a/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
@@ -89,7 +89,8 @@ type ReloadCommandContext = {
 	session: {
 		isStreaming: boolean;
 		isCompacting: boolean;
-		reload: (options?: { beforeSessionStart?: () => void | Promise<void> }) => Promise<void>;
+		reload: (options?: { beforeSessionStart?: () => void | Promise<void> }) => Promise<{ cancelled: boolean; reason?: string }>;
+		checkReloadVeto: () => Promise<{ cancelled: boolean; reason?: string }>;
 		resourceLoader: { getThemes: () => { themes: [] } };
 		extensionRunner: unknown;
 		modelRegistry: { getError: () => string | undefined };
@@ -160,7 +161,9 @@ function createReloadCommandContext(overrides: ReloadCommandContextOverrides = {
 			isCompacting: false,
 			reload: async (options) => {
 				await options?.beforeSessionStart?.();
+				return { cancelled: false };
 			},
+			checkReloadVeto: async () => ({ cancelled: false }),
 			resourceLoader: { getThemes: () => ({ themes: [] }) },
 			extensionRunner: {},
 			modelRegistry: { getError: () => undefined },
@@ -455,6 +458,7 @@ describe("regression #5943: session_start transient UI", () => {
 					events.push("reload");
 					await options?.beforeSessionStart?.();
 					events.push(`start:${context.hideThinkingBlock}`);
+					return { cancelled: false };
 				},
 			},
 			rebuildChatFromMessages: () => {
@@ -489,6 +493,7 @@ describe("regression #5943: session_start transient UI", () => {
 					await options?.beforeSessionStart?.();
 					markReloadWaiting();
 					await reloadFinished;
+					return { cancelled: false };
 				},
 			},
 			ui: {

--- a/packages/coding-agent/test/suite/session-before-reload.test.ts
+++ b/packages/coding-agent/test/suite/session-before-reload.test.ts
@@ -1,0 +1,151 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionFromServices,
+	createAgentSessionRuntime,
+	createAgentSessionServices,
+} from "../../src/core/agent-session-runtime.ts";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import type { InlineExtension } from "../../src/core/extensions/types.ts";
+import { ModelRuntime } from "../../src/core/model-runtime.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+const cleanups: Array<() => void> = [];
+
+async function createReloadSession(extensionFactories: InlineExtension[]) {
+	const tempDir = join(tmpdir(), `pi-before-reload-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const agentDir = join(tempDir, "agent");
+	mkdirSync(agentDir, { recursive: true });
+
+	const faux = registerFauxProvider({ models: [{ id: "faux-1", reasoning: false }] });
+	const authStorage = AuthStorage.inMemory();
+	await authStorage.modify(faux.getModel().provider, async () => ({ type: "api_key", key: "faux-key" }));
+	const modelRuntime = await ModelRuntime.create({
+		credentials: authStorage,
+		modelsPath: join(agentDir, "models.json"),
+	});
+
+	const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+		const services = await createAgentSessionServices({
+			cwd,
+			agentDir,
+			modelRuntime,
+			resourceLoaderOptions: {
+				extensionFactories: [
+					(pi) => {
+						pi.registerProvider(faux.getModel().provider, {
+							baseUrl: faux.getModel().baseUrl,
+							apiKey: "faux-key",
+							api: faux.api,
+							models: faux.models.map((registeredModel) => ({
+								id: registeredModel.id,
+								name: registeredModel.name,
+								api: registeredModel.api,
+								reasoning: registeredModel.reasoning,
+								input: registeredModel.input,
+								cost: registeredModel.cost,
+								contextWindow: registeredModel.contextWindow,
+								maxTokens: registeredModel.maxTokens,
+							})),
+						});
+					},
+					...extensionFactories,
+				],
+			},
+		});
+		return {
+			...(await createAgentSessionFromServices({
+				services,
+				sessionManager,
+				sessionStartEvent,
+				model: faux.getModel(),
+			})),
+			services,
+			diagnostics: services.diagnostics,
+		};
+	};
+
+	const runtime = await createAgentSessionRuntime(createRuntime, {
+		cwd: tempDir,
+		agentDir,
+		sessionManager: SessionManager.create(tempDir),
+	});
+
+	cleanups.push(() => {
+		runtime.session.dispose();
+		faux.unregister();
+		if (existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	return { runtime };
+}
+
+describe("session_before_reload veto", () => {
+	afterEach(() => {
+		while (cleanups.length > 0) {
+			cleanups.pop()?.();
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("aborts reload before any teardown when an extension cancels", async () => {
+		const shutdownReasons: string[] = [];
+		const { runtime } = await createReloadSession([
+			(pi) => {
+				pi.on("session_before_reload", () => ({ cancel: true, reason: "2 subagents still running" }));
+				pi.on("session_shutdown", (event) => {
+					shutdownReasons.push(event.reason);
+				});
+			},
+		]);
+		const settingsReload = vi.spyOn(runtime.services.settingsManager, "reload");
+		const runnerBefore = runtime.session.extensionRunner;
+
+		const result = await runtime.session.reload();
+
+		expect(result).toEqual({ cancelled: true, reason: "2 subagents still running" });
+		expect(shutdownReasons).toEqual([]);
+		expect(settingsReload).not.toHaveBeenCalled();
+		expect(runtime.session.extensionRunner).toBe(runnerBefore);
+	});
+
+	it("reloads normally when no handler cancels", async () => {
+		const shutdownReasons: string[] = [];
+		const { runtime } = await createReloadSession([
+			(pi) => {
+				pi.on("session_before_reload", () => undefined);
+				pi.on("session_shutdown", (event) => {
+					shutdownReasons.push(event.reason);
+				});
+			},
+		]);
+
+		const result = await runtime.session.reload();
+
+		expect(result).toEqual({ cancelled: false });
+		expect(shutdownReasons).toEqual(["reload"]);
+	});
+
+	it("checkReloadVeto reports the veto without tearing anything down", async () => {
+		const shutdownReasons: string[] = [];
+		const { runtime } = await createReloadSession([
+			(pi) => {
+				pi.on("session_before_reload", () => ({ cancel: true, reason: "team members active" }));
+				pi.on("session_shutdown", (event) => {
+					shutdownReasons.push(event.reason);
+				});
+			},
+		]);
+
+		const veto = await runtime.session.checkReloadVeto();
+
+		expect(veto).toEqual({ cancelled: true, reason: "team members active" });
+		expect(shutdownReasons).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

New cancellable extension event `session_before_reload`, mirroring the existing `session_before_switch`/`fork`/`compact` family. An extension returning `{ cancel: true, reason }` blocks the ENTIRE session reload before `session_shutdown` is emitted — no extension teardown, no settings/models/resources reload, no runtime rebuild — on every reload path: `/reload`, `ctx.reload()`, the builtin config hot-reload flow, and direct SDK/rpc/print callers.

- `extensions/types.ts`: `SessionBeforeReloadEvent`, `SessionBeforeReloadResult { cancel?, reason? }`, `pi.on` overload, `SessionEvent` union entry.
- `extensions/runner.ts`: routed through the existing session-before emit machinery (first cancelling handler short-circuits).
- `agent-session.ts`: `reload()` now returns `{ cancelled: boolean; reason?: string }` and consults the new `checkReloadVeto()` first.
- `interactive-mode.ts`: `/reload` pre-checks the veto and shows the extension's `reason` as a warning (no reload box flash / focus steal); a late cancelled result from `reload()` restores the previous editor.
- Docs (`docs/extensions.md`) + all three `changes.md` trackers updated with merge-conflict zones.

## Why

Reload destroys the extension runtime. Extensions that own long-lived work — concretely omo-senpi's task runtime running background subagents/team members — had every resident child killed mid-flight by a `/reload` or an automatic config hot-reload (`teardownOnSessionShutdown` on `session_shutdown { reason: "reload" }`). Only the session owns the teardown ordering, so the cancellable checkpoint must live in core. The paired omo-senpi guard (separate PR in the omo repo) cancels with "N subagent(s) still running: ..." while children are running.

## QA / evidence

- RED→GREEN: `test/suite/session-before-reload.test.ts` — captured failing pre-implementation (veto ignored, `session_shutdown` still emitted; `checkReloadVeto` missing), 3/3 green post-implementation.
- Scoped regressions green: `session-before-reload` + `reload-efficiency` + `reload-timings` + `agent-session-runtime` (4 files / 20 tests).
- `npm run check` exit 0.
- Real-CLI QA (senpi-qa Channel 2 recipe, tmux + isolated sandbox + `PI_OFFLINE=1`): TUI booted with a `-e` veto extension; `/reload` showed `Warning: QA-VETO: 2 subagents still running…` with zero `Reloaded keybindings` occurrences; after `/qa-unblock`, `/reload` printed the full `Reloaded keybindings, extensions, skills, prompts, themes, and context files` line. Evidence: `local-ignore/qa-evidence/20260728-session-before-reload/` (01-booted / 02-reload-blocked / 03-reload-after-unblock / summary.md). Sandbox removed, tmux session killed, real `auth.json` sha unchanged.
- Mock-loop self-test run for loop regression confidence.

## Residual risk

- Return-type of `reload()` widened from `Promise<void>` to `Promise<{ cancelled, reason? }>` — existing callers ignore the result, so this is source-compatible; the head of `reload()` is a MEDIUM merge-conflict zone on upstream sync (documented in changes.md).
- Blocked config hot-reloads keep their pending changes and retry on the next `agent_end`/`agent_settled`, so a deferred hot-reload self-heals once the veto lifts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cancellable `session_before_reload` event so extensions can veto a session reload before teardown. Reload checks the veto first, and `/reload` shows the provided reason instead of flashing the reload UI.

- **New Features**
  - New `session_before_reload` event; returning `{ cancel: true, reason }` blocks reload across `/reload`, `ctx.reload()`, config hot-reload, and SDK/RPC callers.
  - `AgentSession.reload()` now returns `{ cancelled: boolean; reason?: string }` and consults `checkReloadVeto()` before `session_shutdown`; interactive `/reload` pre-checks the veto, warns with the reason, and restores the previous editor on a late cancel.
  - Docs updated; tests added, including a new suite and an updated 5943 regression fixture for the new interface.

- **Migration**
  - `reload()` return type changed from `Promise<void>` to `Promise<{ cancelled: boolean; reason?: string }>`; callers may ignore or handle `cancelled`.

<sup>Written for commit c440f44da20aa8091a6f190954048357f16c21a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

