### PR TITLE
fix(compaction): bound summarization streams with a wall-clock budget

### DIFF
--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,30 @@
 # changes.md — compaction
 
+## Wall-clock budget for summarization streams (2026-07-28)
+
+### What changed
+
+- `stream-watchdog.ts`: `consumeStreamWithIdleTimeout()` accepts an optional `maxDurationMs` and throws the new
+  `StreamDurationBudgetError` when one stream outlives it. The budget is a single absolute deadline for the whole
+  stream, not a per-read timer, and it is cleared alongside the idle timer. Caller aborts still win over the budget.
+- `DEFAULT_SUMMARIZATION_MAX_DURATION_MS` = 120s, applied by `compaction.ts` `completeSummarization()` and the
+  extension's `speculative.ts` request path. `retryAssistantCall` applies it per attempt.
+
+### Why
+
+- The idle watchdog only catches a *silent* connection. A summarization stream that keeps trickling events stays
+  under the 300s idle budget indefinitely, and that work is serialized on `AgentSession`'s agent-event queue, which
+  `beforeToolCall` waits on before every tool prepare. A live-but-slow summarization therefore froze a whole session:
+  tool results withheld at the parallel-batch barrier, typed input queued, TUI stuck on "Working", recoverable only by
+  ESC (which releases compaction before the run signal in `_abortActiveAgentAndRetry`).
+- Observed in a real session: two freezes of 241s and 208s, both under the idle cap, on a session whose earlier
+  auto-compaction had already blocked the same queue for 44s.
+
+### Expected merge conflict zones
+
+- LOW: `stream-watchdog.ts` around the contender race in `consumeStreamWithIdleTimeout()`.
+- LOW: `compaction.ts` around the `consumeStreamWithIdleTimeout` call in `completeSummarization()`.
+
 ## Lifecycle ownership and required-admission safety (2026-07-23)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -24,7 +24,11 @@ import {
 	type SessionEntry,
 	sessionEntryToContextMessages,
 } from "../session-manager.ts";
-import { consumeStreamWithIdleTimeout, DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS } from "./stream-watchdog.ts";
+import {
+	consumeStreamWithIdleTimeout,
+	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+} from "./stream-watchdog.ts";
 import {
 	computeFileLists,
 	contentTextForSummary,
@@ -653,6 +657,7 @@ export async function completeSummarization(
 				: streamSimple(model, context, requestOptions);
 			await consumeStreamWithIdleTimeout(responseStream, {
 				idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+				maxDurationMs: DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
 				abort: () => requestController.abort(),
 				signal: callerSignal,
 			});

--- a/packages/coding-agent/src/core/compaction/stream-watchdog.ts
+++ b/packages/coding-agent/src/core/compaction/stream-watchdog.ts
@@ -74,7 +74,12 @@ export async function consumeStreamWithIdleTimeout<T>(
 	const { idleTimeoutMs, maxDurationMs, abort, onEvent, signal } = options;
 	let removeAbortListener: (() => void) | undefined;
 	let callerAbortPromise: Promise<typeof CALLER_ABORTED> | undefined;
-	// One absolute deadline for the whole stream, not a per-read budget.
+	if (signal?.aborted) {
+		void iterator.return?.();
+		return;
+	}
+	// One absolute deadline for the whole stream, not a per-read budget. Created
+	// only after the already-aborted early return so no timer is ever leaked.
 	let budgetPromise: Promise<typeof BUDGET_TRIP> | undefined;
 	let budgetTimer: ReturnType<typeof setTimeout> | undefined;
 	let budgetMs = 0;
@@ -86,10 +91,6 @@ export async function consumeStreamWithIdleTimeout<T>(
 		budgetPromise = promise;
 	}
 	if (signal !== undefined) {
-		if (signal.aborted) {
-			void iterator.return?.();
-			return;
-		}
 		const { promise, resolve } = Promise.withResolvers<typeof CALLER_ABORTED>();
 		const onAbort = () => resolve(CALLER_ABORTED);
 		signal.addEventListener("abort", onAbort, { once: true });

--- a/packages/coding-agent/src/core/compaction/stream-watchdog.ts
+++ b/packages/coding-agent/src/core/compaction/stream-watchdog.ts
@@ -17,12 +17,39 @@ export class StreamIdleTimeoutError extends Error {
 	}
 }
 
+/**
+ * A stream that keeps trickling events never trips the idle watchdog, yet the
+ * summarization it feeds is serialized on the session's agent-event queue: a
+ * slow-but-alive request holds tool results at the batch barrier and keeps typed
+ * input queued until the user aborts. The wall-clock budget bounds that class.
+ */
+export class StreamDurationBudgetError extends Error {
+	readonly maxDurationMs: number;
+	constructor(maxDurationMs: number) {
+		super(
+			`Summarization stream exceeded its ${maxDurationMs}ms wall-clock budget; treating the request as too slow to keep the session waiting`,
+		);
+		this.name = "StreamDurationBudgetError";
+		this.maxDurationMs = maxDurationMs;
+	}
+}
+
 /** Matches the agent stream idle-timeout default (`httpIdleTimeoutMs`). */
 export const DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS = 300_000;
+
+/**
+ * Total time one summarization attempt may hold the session. Well above healthy
+ * summarizations (tens of seconds) and below the idle budget, so a live-but-slow
+ * provider fails fast enough to keep the session interactive. Retries apply this
+ * budget per attempt.
+ */
+export const DEFAULT_SUMMARIZATION_MAX_DURATION_MS = 120_000;
 
 export interface ConsumeStreamWithIdleTimeoutOptions<T> {
 	/** Silence budget per read; the timer resets on every event. */
 	readonly idleTimeoutMs: number;
+	/** Total wall-clock budget for the whole stream; omit to leave it unbounded. */
+	readonly maxDurationMs?: number;
 	/** Tear down the underlying request (abort the request-local controller). */
 	readonly abort: () => void;
 	readonly onEvent?: (event: T) => void;
@@ -31,6 +58,7 @@ export interface ConsumeStreamWithIdleTimeoutOptions<T> {
 }
 
 const IDLE_TRIP = "idle-trip" as const;
+const BUDGET_TRIP = "budget-trip" as const;
 const CALLER_ABORTED = "caller-aborted" as const;
 
 /**
@@ -43,9 +71,20 @@ export async function consumeStreamWithIdleTimeout<T>(
 	options: ConsumeStreamWithIdleTimeoutOptions<T>,
 ): Promise<void> {
 	const iterator = stream[Symbol.asyncIterator]();
-	const { idleTimeoutMs, abort, onEvent, signal } = options;
+	const { idleTimeoutMs, maxDurationMs, abort, onEvent, signal } = options;
 	let removeAbortListener: (() => void) | undefined;
 	let callerAbortPromise: Promise<typeof CALLER_ABORTED> | undefined;
+	// One absolute deadline for the whole stream, not a per-read budget.
+	let budgetPromise: Promise<typeof BUDGET_TRIP> | undefined;
+	let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+	let budgetMs = 0;
+	if (maxDurationMs !== undefined) {
+		budgetMs = maxDurationMs;
+		const { promise, resolve } = Promise.withResolvers<typeof BUDGET_TRIP>();
+		budgetTimer = setTimeout(() => resolve(BUDGET_TRIP), budgetMs);
+		budgetTimer.unref?.();
+		budgetPromise = promise;
+	}
 	if (signal !== undefined) {
 		if (signal.aborted) {
 			void iterator.return?.();
@@ -62,12 +101,12 @@ export async function consumeStreamWithIdleTimeout<T>(
 			const { promise: idlePromise, resolve: resolveIdle } = Promise.withResolvers<typeof IDLE_TRIP>();
 			const timer = setTimeout(() => resolveIdle(IDLE_TRIP), idleTimeoutMs);
 			timer.unref?.();
-			const contenders: Array<Promise<IteratorResult<T> | typeof IDLE_TRIP | typeof CALLER_ABORTED>> = [
-				iterator.next(),
-				idlePromise,
-			];
+			const contenders: Array<
+				Promise<IteratorResult<T> | typeof IDLE_TRIP | typeof BUDGET_TRIP | typeof CALLER_ABORTED>
+			> = [iterator.next(), idlePromise];
 			if (callerAbortPromise) contenders.push(callerAbortPromise);
-			let result: IteratorResult<T> | typeof IDLE_TRIP | typeof CALLER_ABORTED;
+			if (budgetPromise) contenders.push(budgetPromise);
+			let result: IteratorResult<T> | typeof IDLE_TRIP | typeof BUDGET_TRIP | typeof CALLER_ABORTED;
 			try {
 				result = await Promise.race(contenders);
 			} finally {
@@ -78,6 +117,11 @@ export async function consumeStreamWithIdleTimeout<T>(
 				void iterator.return?.();
 				throw new StreamIdleTimeoutError(idleTimeoutMs);
 			}
+			if (result === BUDGET_TRIP) {
+				abort();
+				void iterator.return?.();
+				throw new StreamDurationBudgetError(budgetMs);
+			}
 			if (result === CALLER_ABORTED) {
 				void iterator.return?.();
 				return;
@@ -87,5 +131,6 @@ export async function consumeStreamWithIdleTimeout<T>(
 		}
 	} finally {
 		removeAbortListener?.();
+		if (budgetTimer !== undefined) clearTimeout(budgetTimer);
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -11,6 +11,11 @@
   summarization that blows its wall-clock budget records a circuit-breaker failure and returns
   `{ applied: false, reason: "failed" }` rather than escaping to the ExtensionRunner as a raw stack on top of the
   `compaction_end` message the user already saw.
+- Behavior change for the pre-existing stall path: `StreamIdleTimeoutError` now degrades the same way. Its message
+  ("Summarization stream stalled: ... treating the request as dead") matches none of the transient patterns in
+  `isRetryableErrorMessage`, so before this change a stalled summarization rethrew loudly - the exact double-surface
+  the 2026-07-27 transient-degrade entry removed for network drops. Both watchdog trips are infrastructure slowness
+  and are pinned as transient in `test/compaction/summarization-budget-degrade.test.ts`.
 - `speculative.ts`: the speculative request path applies `DEFAULT_SUMMARIZATION_MAX_DURATION_MS`, so a warm-start
   summary that a blocking route later awaits cannot pin the session either.
 
@@ -19,6 +24,14 @@
 - Without the budget the freeze class described in `core/compaction/changes.md` (2026-07-28) reached the session
   queue; with it, the trip has to land in the same quiet degrade path the transient-transport work established, or
   the fix would trade a freeze for a loud extension error.
+
+### Also in this change
+
+- `index.ts`: a blocking route that inherits a speculative job whose summary failed now degrades through the shared
+  watchdog-failure path on that job instead of discarding it and paying for a second full-budget request. The job
+  keeps its settled failure next to its result promise, so the double deadline the reviewer flagged cannot recur.
+- `test/compaction/speculative-budget-handoff.test.ts`: pins the no-second-request guarantee end to end (fails as
+  `SummaryRequestError: No more faux responses queued` from `applyBlockingCompaction` when the handoff is reverted).
 
 ### Expected merge conflict zones
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,3 +1,30 @@
+# Builtin compaction extension changes
+
+## Degrade wall-clock budget trips like stalled streams (2026-07-28)
+
+### What changed
+
+- `transient-failure.ts` (new): `isTransientSummarizationFailure()` owns the degrade-vs-surface decision.
+  Watchdog trips (`StreamDurationBudgetError`, `StreamIdleTimeoutError`) always degrade; `SummaryRequestError`
+  keeps its metadata-aware verdict; everything else falls back to `isRetryableErrorMessage`.
+- `index.ts` `applyBlockingCompaction()`: uses that predicate instead of the inline classification, so a
+  summarization that blows its wall-clock budget records a circuit-breaker failure and returns
+  `{ applied: false, reason: "failed" }` rather than escaping to the ExtensionRunner as a raw stack on top of the
+  `compaction_end` message the user already saw.
+- `speculative.ts`: the speculative request path applies `DEFAULT_SUMMARIZATION_MAX_DURATION_MS`, so a warm-start
+  summary that a blocking route later awaits cannot pin the session either.
+
+### Why
+
+- Without the budget the freeze class described in `core/compaction/changes.md` (2026-07-28) reached the session
+  queue; with it, the trip has to land in the same quiet degrade path the transient-transport work established, or
+  the fix would trade a freeze for a loud extension error.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` around the `applyBlockingCompaction()` catch classification.
+- LOW: `speculative.ts` around the `consumeStreamWithIdleTimeout` options.
+
 ## Explicit Responses v2 compaction for verified proxies (2026-07-27)
 
 - `openai-remote-model.ts`: official OpenAI remains eligible by default; custom `openai-responses` providers require `compat.supportsRemoteCompactionV2: true`. Persisted checkpoint identity now retains the exact custom provider id instead of coercing it to `openai`.
@@ -41,8 +68,6 @@
   effective auth tenant (never raw credentials). Legacy, cross-endpoint, or cross-tenant entries decline replay.
 - Replay boundaries require non-enumerable message/item provenance to survive the canonical context pipeline. Missing,
   duplicated, reordered, reconstructed, or mutated provenance keeps the final transformed full payload unchanged.
-
-# Builtin compaction extension changes
 
 ## Degrade transient blocking-compaction failures instead of erroring the turn (2026-07-27)
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { isRetryableErrorMessage, type Tool } from "@earendil-works/pi-ai";
+import type { Tool } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../../compaction/index.ts";
 import { convertToLlm } from "../../../messages.ts";
 import type { CompactionEntry } from "../../../session-manager.ts";
@@ -44,10 +44,10 @@ import {
 	type SpeculativeCompactionResult,
 	type SpeculativeCompactionSnapshot,
 	SummaryGenerationError,
-	SummaryRequestError,
 } from "./speculative.ts";
 import { type CompactionExtensionState, createInitialState, resetTurnCounter } from "./state.ts";
 import * as todoBridge from "./todo-bridge.ts";
+import { isTransientSummarizationFailure } from "./transient-failure.ts";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const EMERGENCY_COMPACTION_INSTRUCTIONS =
@@ -342,9 +342,11 @@ export default function compactionExtension(
 			// own provider request surfaces the same outage once through the
 			// normal retry path. Provider `error` stops carry metadata-aware
 			// classification (a refusal with retryable-looking text stays loud);
-			// bare transport throws fall back to the message classifier. Count
-			// the failure so the circuit breaker halts repeated doomed attempts.
-			const transient = error instanceof SummaryRequestError ? error.transient : isRetryableErrorMessage(message);
+			// bare transport throws fall back to the message classifier. A watchdog
+			// trip (stalled stream, or one that outlived its wall-clock budget) is
+			// infrastructure slowness and always degrades. Count the failure so the
+			// circuit breaker halts repeated doomed attempts.
+			const transient = isTransientSummarizationFailure(error, message);
 			if (transient) {
 				state = breaker.recordFailure(state, Date.now(), { route: "extension" });
 				return { applied: false, reason: "failed" };

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -167,6 +167,9 @@ export default function compactionExtension(
 				snapshot: SpeculativeCompactionSnapshot;
 				controller: AbortController;
 				promise: Promise<CompactionResult | undefined>;
+				// Settled failure, preserved so a blocking route that inherits this job can
+				// degrade on a watchdog trip instead of starting a second full-budget request.
+				failure: Promise<Error | undefined>;
 		  }
 		| undefined;
 	const pendingMetadata = new Map<string, PendingCompactionMetadata>();
@@ -203,8 +206,13 @@ export default function compactionExtension(
 		if (!snapshot) return;
 
 		const controller = new AbortController();
-		const promise = runExtensionCompaction(ctx, snapshot, controller.signal).catch(() => undefined);
-		speculativeJob = { generation, snapshot, controller, promise };
+		const settled = runExtensionCompaction(ctx, snapshot, controller.signal).then(
+			(result) => ({ result, error: undefined }),
+			(error: unknown) => ({ result: undefined, error: error instanceof Error ? error : new Error(String(error)) }),
+		);
+		const promise = settled.then(({ result }) => result);
+		const failure = settled.then(({ error }) => error);
+		speculativeJob = { generation, snapshot, controller, promise, failure };
 	}
 
 	function capturePendingMetadata(requestId: string, ctx: ExtensionContext): void {
@@ -273,10 +281,29 @@ export default function compactionExtension(
 			if (pendingJob) {
 				const unlinkAbort = linkAbortSignal(feedbackSignal, pendingJob.controller);
 				let compaction: CompactionResult | undefined;
+				let inheritedFailure: Error | undefined;
 				try {
 					compaction = await pendingJob.promise;
+					inheritedFailure = await pendingJob.failure;
 				} finally {
 					unlinkAbort();
+				}
+				// A speculative job that tripped the wall-clock budget already spent a full
+				// summarization deadline. Starting a second full-budget blocking request here
+				// would hold the session for another whole budget and recreate the freeze this
+				// work removes, so degrade through the shared watchdog-failure path instead.
+				if (inheritedFailure !== undefined) {
+					speculativeJob = undefined;
+					if (isTransientSummarizationFailure(inheritedFailure, inheritedFailure.message)) {
+						ctx.endCompaction?.({
+							reason: "extension",
+							signal: feedbackSignal,
+							aborted: feedbackSignal?.aborted,
+							errorMessage: `Compaction failed: ${inheritedFailure.message}`,
+						});
+						state = breaker.recordFailure(state, Date.now(), { route: "extension" });
+						return { applied: false, reason: "failed" };
+					}
 				}
 				const result = await applyGeneratedCompaction(
 					ctx,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -20,6 +20,7 @@ import {
 import {
 	consumeStreamWithIdleTimeout,
 	DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
 } from "../../../compaction/stream-watchdog.ts";
 import { convertToLlm } from "../../../messages.ts";
 import type { ModelRegistry } from "../../../model-registry.ts";
@@ -224,6 +225,7 @@ async function generateSummaryMessage(options: {
 		});
 		await consumeStreamWithIdleTimeout(responseStream, {
 			idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
+			maxDurationMs: DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
 			abort: () => requestController.abort(),
 			signal: options.signal,
 			onEvent: (event) => {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/transient-failure.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/transient-failure.ts
@@ -1,0 +1,24 @@
+/**
+ * Classifies a summarization failure as transient (degrade quietly through the
+ * compaction failure path) or terminal (surface loudly).
+ *
+ * Transient failures must not escape as extension errors: the runner would print
+ * a raw stack on top of the `compaction_end` message the user already saw, while
+ * the turn's own provider request surfaces the same outage again through the
+ * normal retry path.
+ *
+ * Provider `error` stops carry metadata-aware classification through
+ * `SummaryRequestError` (a refusal whose text merely looks retryable stays
+ * loud). Watchdog trips — a stalled stream or a stream that outlived its
+ * wall-clock budget — are infrastructure-slowness outcomes and always degrade.
+ * Everything else falls back to the shared message classifier.
+ */
+import { isRetryableErrorMessage } from "@earendil-works/pi-ai";
+import { StreamDurationBudgetError, StreamIdleTimeoutError } from "../../../compaction/stream-watchdog.ts";
+import { SummaryRequestError } from "./speculative.ts";
+
+export function isTransientSummarizationFailure(error: unknown, message: string): boolean {
+	if (error instanceof StreamDurationBudgetError || error instanceof StreamIdleTimeoutError) return true;
+	if (error instanceof SummaryRequestError) return error.transient;
+	return isRetryableErrorMessage(message);
+}

--- a/packages/coding-agent/test/compaction/speculative-budget-handoff.test.ts
+++ b/packages/coding-agent/test/compaction/speculative-budget-handoff.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	connectionErrorResponse,
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+	createCompactionHandlers,
+} from "../helpers/blocking-compaction-harness.ts";
+
+/**
+ * A speculative warm-start summary that fails must not turn the next blocking
+ * route into a second full-budget request. Before the handoff fix, a blocking
+ * waiter inherited the failed job as `undefined`, discarded it, and immediately
+ * paid for a fresh request — two deadlines back to back, the exact freeze shape
+ * the wall-clock budget exists to remove. The blocking route must instead
+ * degrade through the watchdog-failure path on the job it already has.
+ *
+ * Usage math (contextWindow 10_000, adaptive ratio 0.45): trigger threshold is
+ * 4_500, speculative warm-start fires at >= 3_375. 4_000 is speculative-only;
+ * 4_600 triggers the blocking route.
+ */
+describe("Given a speculative summary that failed before a blocking route inherits it", () => {
+	const registrations: Array<{ unregister(): void }> = [];
+	afterEach(() => {
+		for (const registration of registrations.splice(0)) {
+			registration.unregister();
+		}
+	});
+
+	it("Then the blocking route degrades on that job instead of paying for a second request", async () => {
+		// Given: usage in the speculative-only range warms a summary that fails.
+		const { beforeAgentStart } = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		registrations.push(harness.registration);
+		harness.registration.setResponses([connectionErrorResponse()]);
+
+		await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.not.toThrow();
+		const callsAfterSpeculative = harness.registration.state.callCount;
+
+		// When: usage crosses into the blocking range while the failed job is pending.
+		harness.setUsageTokens(4_600);
+		await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.not.toThrow();
+
+		// Then: the blocking route did not pay for a second summarization request.
+		expect(harness.registration.state.callCount).toBe(callsAfterSpeculative);
+	});
+});

--- a/packages/coding-agent/test/compaction/summarization-budget-degrade.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-budget-degrade.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { StreamDurationBudgetError, StreamIdleTimeoutError } from "../../src/core/compaction/stream-watchdog.ts";
+import { SummaryRequestError } from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { isTransientSummarizationFailure } from "../../src/core/extensions/builtin/compaction/transient-failure.ts";
+
+/**
+ * A summarization that blows its wall-clock budget is an infrastructure-slowness
+ * outcome, exactly like a stalled stream: it must degrade through the compaction
+ * failure path (compaction_end + circuit breaker) instead of escaping to the
+ * extension runner as a raw stack on top of the message the user already saw.
+ */
+describe("isTransientSummarizationFailure", () => {
+	it("treats a wall-clock budget trip as transient", () => {
+		const error = new StreamDurationBudgetError(120_000);
+		expect(isTransientSummarizationFailure(error, error.message)).toBe(true);
+	});
+
+	it("treats a stalled-stream idle timeout as transient", () => {
+		const error = new StreamIdleTimeoutError(300_000);
+		expect(isTransientSummarizationFailure(error, error.message)).toBe(true);
+	});
+
+	it("keeps provider-classified request errors on their own verdict", () => {
+		const loud = new SummaryRequestError("refusal that mentions timeout", false);
+		expect(isTransientSummarizationFailure(loud, loud.message)).toBe(false);
+		const transient = new SummaryRequestError("overloaded", true);
+		expect(isTransientSummarizationFailure(transient, transient.message)).toBe(true);
+	});
+
+	it("falls back to the message classifier for bare transport throws", () => {
+		const network = new Error("fetch failed");
+		expect(isTransientSummarizationFailure(network, network.message)).toBe(true);
+		const bug = new TypeError("cannot read properties of undefined");
+		expect(isTransientSummarizationFailure(bug, bug.message)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/compaction/summarization-wall-clock-budget.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-wall-clock-budget.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	consumeStreamWithIdleTimeout,
+	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
+	StreamDurationBudgetError,
+} from "../../src/core/compaction/stream-watchdog.ts";
+
+/**
+ * The idle watchdog only catches a *silent* provider connection. A summarization
+ * stream that keeps trickling events stays under the idle budget forever, and
+ * that work is serialized on the session's agent-event queue: a slow-but-alive
+ * summarization freezes the whole session (tool results withheld at the batch
+ * barrier, typed input queued, UI stuck on "Working") until the user presses ESC.
+ * A wall-clock budget bounds that class the idle timer cannot see.
+ *
+ * Time is driven by fake timers: this is timer behavior, and real delays would
+ * only flake under CI load.
+ */
+
+type Tick = { type: string };
+
+/** A stream that keeps emitting just under the idle budget, forever. */
+function trickleStream(intervalMs: number): AsyncIterable<Tick> {
+	return {
+		async *[Symbol.asyncIterator]() {
+			while (true) {
+				await new Promise((resolve) => setTimeout(resolve, intervalMs));
+				yield { type: "tick" };
+			}
+		},
+	};
+}
+
+describe("consumeStreamWithIdleTimeout wall-clock budget", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("aborts a trickling stream that outlives the total duration budget", async () => {
+		let aborted = false;
+		const seen: string[] = [];
+		const outcome = consumeStreamWithIdleTimeout(trickleStream(90), {
+			idleTimeoutMs: 1000,
+			maxDurationMs: 500,
+			abort: () => {
+				aborted = true;
+			},
+			onEvent: (event) => seen.push(event.type),
+		}).catch((caught: unknown) => caught);
+
+		await vi.advanceTimersByTimeAsync(600);
+
+		const error = await outcome;
+		expect(error).toBeInstanceOf(StreamDurationBudgetError);
+		expect((error as StreamDurationBudgetError).message).toContain("500ms");
+		expect(aborted).toBe(true);
+		// The stream was healthy right up to the budget: events kept arriving.
+		expect(seen.length).toBeGreaterThan(0);
+	});
+
+	it("leaves a stream that finishes inside the budget untouched", async () => {
+		let aborted = false;
+		const events: Tick[] = [{ type: "a" }, { type: "b" }];
+		const stream = {
+			async *[Symbol.asyncIterator]() {
+				for (const event of events) {
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					yield event;
+				}
+			},
+		};
+		const seen: string[] = [];
+		const done = consumeStreamWithIdleTimeout(stream, {
+			idleTimeoutMs: 1000,
+			maxDurationMs: 5000,
+			abort: () => {
+				aborted = true;
+			},
+			onEvent: (event) => seen.push(event.type),
+		});
+		await vi.advanceTimersByTimeAsync(100);
+		await done;
+		expect(seen).toEqual(["a", "b"]);
+		expect(aborted).toBe(false);
+	});
+
+	it("caller abort still wins over the duration budget", async () => {
+		const controller = new AbortController();
+		const outcome = consumeStreamWithIdleTimeout(trickleStream(10), {
+			idleTimeoutMs: 60_000,
+			maxDurationMs: 60_000,
+			abort: () => {
+				throw new Error("watchdog fired on caller abort");
+			},
+			signal: controller.signal,
+		});
+		controller.abort();
+		await outcome;
+	});
+
+	it("exposes a default wall-clock budget below the idle timeout", () => {
+		expect(DEFAULT_SUMMARIZATION_MAX_DURATION_MS).toBe(120_000);
+	});
+});


### PR DESCRIPTION
## Summary

A senpi TUI session froze twice (241s, then 208s) showing only **"Working"**: typed user input was queued and undelivered, and a batch of 5 parallel tool calls returned **no results** until the user pressed ESC — at which point all 5 flushed within 15ms (4 `monitor` calls succeeded, the 5th `read` returned "Operation aborted").

## Root cause (evidence)

- `agent-session.ts:2989` `abort()` runs `abortCompaction()` synchronously, then `_abortActiveAgentAndRetry()` (≈line 3438) runs `abortRetry()`, `abortBranchSummary()`, **then** `agent.abort()` (fires the run signal), then `waitForIdle()`. Compaction/branch-summary work is therefore released **before** the run signal fires — exactly why the 4 monitors prepared successfully and only the last call saw the aborted signal.
- `_emitBeforeToolCallHooks` (`agent-session.ts:835`) awaits `this._agentEventQueue` before **every** tool prepare, and `executeToolCallsParallel` (`packages/agent/src/agent-loop.ts`) emits results only after `Promise.all` over the batch. Slow summarization work serialized on that queue starves the whole tool pipeline invisibly.
- The existing guard `core/compaction/stream-watchdog.ts` is **idle-only** (300s, resets on every event). A stream that keeps trickling events never trips it. Both freezes were under 300s = slow-but-alive streams.
- Same session, same class: its earlier auto-compaction at 05:47:25 had already blocked the queue for 44s.

## Fix

- `consumeStreamWithIdleTimeout()` gains an optional `maxDurationMs`, raced as **one absolute deadline** for the whole stream alongside the per-read idle timer and the caller-abort promise; new `StreamDurationBudgetError`; `DEFAULT_SUMMARIZATION_MAX_DURATION_MS = 120s`.
- Both call sites (`completeSummarization()`, `speculative.ts`) apply the default. `retryAssistantCall` applies it **per attempt**.
- New `transient-failure.ts` `isTransientSummarizationFailure()` owns the degrade-vs-surface decision, so a budget trip records a circuit-breaker failure and returns `{applied:false, reason:"failed"}` instead of escaping to the ExtensionRunner as a raw stack on top of the `compaction_end` the user already saw.

## Behavior change (documented)

`isRetryableErrorMessage()` returns **false** for both watchdog messages (probed empirically), so a `StreamIdleTimeoutError` previously rethrew loudly. Both watchdog trips are infrastructure slowness and now degrade quietly — pinned by `test/compaction/summarization-budget-degrade.test.ts` and recorded in `builtin/compaction/changes.md`.

## Round-2 (reviewer-driven) fixes

- The speculative-to-blocking handoff could still pay a second full-budget request (worst case ~240s, the exact freeze shape). The speculative job now keeps its settled failure; a blocking route inheriting a failed job degrades through the shared watchdog path without a second request. Pinned end-to-end by `test/compaction/speculative-budget-handoff.test.ts` (RED: `SummaryRequestError: No more faux responses queued` from `applyBlockingCompaction`; GREEN after).
- The budget timer is never created on the already-aborted entry path (no leak).

## Verification

- Failing-first: `test/compaction/summarization-wall-clock-budget.test.ts` RED before the fix (a trickling stream that never idles out hangs 30s on the unbounded code; 2 failed / 2 control passed) -> GREEN after (4/4, 95ms).
- `npm run check` PASS (zero biome errors/warnings). `test/compaction/` 32 files / 230 tests PASS.
- Full `packages/coding-agent` suite compared against the unmodified base commit `d9df80bb1` in an identical worktree: 16 shared failures, all environmental (worktree `node_modules` symlink resolves `@earendil-works/*` to the main repo's older `dist`, which lacks `outerKittyGraphicsMode` present at `origin/main`); the 1 extra file fails on an unrelated git-reftable fs-watcher race and passes 9/9 in isolation. Zero regressions from this diff.
- senpi-qa real-CLI channels on the fixed code: mock-loop 42/42, cli-smoke 8/8 (real auth untouched).
- Evidence: `local-ignore/qa-evidence/20260728-summarization-wall-budget/`

## Follow-up (out of scope here)

Move compaction/retry continuations off the serialized `_agentEventQueue` so a bounded-but-still-long continuation cannot delay turn settlement; add slow-extension-handler duration logging so the next freeze is attributable without live-process forensics.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 120s wall‑clock budget to summarization streams to prevent “slow-but-alive” streams from freezing sessions. Slow or stalled summaries now degrade quietly and trip the circuit breaker instead of surfacing errors.

- **Bug Fixes**
  - `consumeStreamWithIdleTimeout` accepts `maxDurationMs` and throws `StreamDurationBudgetError`; caller abort still wins and timers aren’t created on aborted paths.
  - Apply the 120s budget via `DEFAULT_SUMMARIZATION_MAX_DURATION_MS` in both `completeSummarization` and the speculative path; retries use the budget per attempt.
  - New `isTransientSummarizationFailure` treats `StreamDurationBudgetError` and `StreamIdleTimeoutError` as transient to degrade instead of erroring, and records a breaker failure.
  - Speculative→blocking handoff preserves a failed job so the blocking route degrades on the inherited failure instead of issuing a second full‑budget request.
  - Added targeted tests for the wall‑clock budget, degrade behavior, and handoff; updated compaction change docs.

<sup>Written for commit 4d9bbbdef653683bb54ba37b79f28af4f7728ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

