### PR TITLE
fix(ai): retry pre-output stream failures

### DIFF
--- a/.agents/skills/senpi-qa/scripts/mock-loop-stream-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop-stream-retry.mjs
@@ -1,0 +1,167 @@
+/**
+ * Channel 3 proof for an OpenAI-compatible SSE error before the first chunk.
+ *
+ * The first request returns a protocol-level `event: error` carrying the exact
+ * DigitalOcean message. The second request returns one successful completion.
+ * The real source CLI must retry inside the provider adapter and print exactly
+ * one final marker.
+ */
+
+import { createServer } from "node:http";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	runCli,
+} from "./lib/common.mjs";
+import {
+	API_PRESETS,
+	checkRealAuthUnchanged,
+	hermeticEnv,
+	writeMockModelsJson,
+} from "./lib/mock-loop-support.mjs";
+
+const ERROR_MESSAGE = "Upstream error from DigitalOcean: stream failed";
+const FINAL_MARKER = "SENPI-QA-DIGITALOCEAN-STREAM-RECOVERED-7a4f";
+const EVIDENCE_SLUG = "digitalocean-stream-retry";
+
+function startServer() {
+	const requests = [];
+	let attempts = 0;
+	const server = createServer((request, response) => {
+		const chunks = [];
+		request.on("data", (chunk) => chunks.push(chunk));
+		request.on("end", () => {
+			attempts++;
+			requests.push({
+				attempt: attempts,
+				url: request.url,
+				body: Buffer.concat(chunks).toString("utf8"),
+			});
+			response.writeHead(200, {
+				"content-type": "text/event-stream",
+				"cache-control": "no-cache",
+				connection: "keep-alive",
+			});
+			if (attempts === 1) {
+				response.end(`event: error\ndata: ${JSON.stringify({ error: { message: ERROR_MESSAGE, type: "server_error" } })}\n\n`);
+				return;
+			}
+			const base = {
+				id: "chatcmpl-digitalocean-retry",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: API_PRESETS["openai-completions"].modelId,
+			};
+			const send = (delta, finishReason = null) => {
+				response.write(
+					`data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta, finish_reason: finishReason }] })}\n\n`,
+				);
+			};
+			send({ role: "assistant", content: "" });
+			send({ content: FINAL_MARKER });
+			send({}, "stop");
+			response.write(
+				`data: ${JSON.stringify({
+					...base,
+					choices: [],
+					usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+				})}\n\n`,
+			);
+			response.end("data: [DONE]\n\n");
+		});
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("Failed to resolve fake server port"));
+				return;
+			}
+			const origin = `http://127.0.0.1:${address.port}`;
+			resolve({
+				url: `${origin}/v1`,
+				origin,
+				port: address.port,
+				requests,
+				stop: () => new Promise((done) => server.close(done)),
+			});
+		});
+	});
+}
+
+async function main() {
+	installCleanupHooks();
+	const checks = createChecks("mock-loop-stream-retry.mjs");
+	const guard = guardRealAuth();
+	const box = makeSandbox("mock-loop-digitalocean-stream-retry");
+	const server = await startServer();
+	try {
+		writeMockModelsJson(box.agentDir, server, "openai-completions", {}, {
+			retry: {
+				enabled: false,
+				maxRetries: 0,
+				baseDelayMs: 0,
+				provider: { maxRetries: 1, maxRetryDelayMs: 60000 },
+			},
+		});
+		const preset = API_PRESETS["openai-completions"];
+		const result = await runCli(
+			[
+				"--provider",
+				preset.provider,
+				"--model",
+				preset.modelId,
+				"--no-context-files",
+				"--no-extensions",
+				"--print",
+				`Return ${FINAL_MARKER} after the transient stream error.`,
+			],
+			{ env: hermeticEnv(box.env), cwd: box.cwd, timeoutMs: 60000 },
+		);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		const finalCount = combined.split(FINAL_MARKER).length - 1;
+		const pass = result.code === 0 && !result.timedOut && server.requests.length === 2 && finalCount === 1;
+		checks.ok(
+			"real CLI retries the literal pre-output stream failure exactly once",
+			pass,
+			`code=${result.code} requests=${server.requests.length} finalCount=${finalCount}`,
+		);
+		checkRealAuthUnchanged(checks, guard);
+		const dir = evidenceDir(EVIDENCE_SLUG);
+		writeFileSync(join(dir, "mock-loop-stream-retry-stdout.txt"), result.stdout);
+		writeFileSync(join(dir, "mock-loop-stream-retry-stderr.txt"), result.stderr);
+		writeFileSync(
+			join(dir, "mock-loop-stream-retry-summary.json"),
+			`${JSON.stringify(
+				{
+					command: "node .agents/skills/senpi-qa/scripts/mock-loop-stream-retry.mjs",
+					literalError: ERROR_MESSAGE,
+					exitCode: result.code,
+					timedOut: result.timedOut,
+					serverPort: server.port,
+					sandboxDir: box.dir,
+					requests: server.requests.length,
+					finalMarkerCount: finalCount,
+					pass,
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		process.exitCode = checks.finish() ? 0 : 1;
+	} finally {
+		await server.stop();
+		box.cleanup();
+	}
+}
+
+main().catch((error) => {
+	process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+	process.exit(1);
+});

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -404,14 +404,17 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					throw error;
 				}
 			};
-			const { stream: openaiStream, metadata: response } = await retryProviderStreamRequest(
+			const { stream: openaiStream } = await retryProviderStreamRequest(
 				async () => {
 					const { data, response } = await createRequest();
+					await options?.onResponse?.(
+						{ status: response.status, headers: headersToRecord(response.headers) },
+						model,
+					);
 					return { stream: data, metadata: response };
 				},
 				{ maxRetries: options?.maxRetries, maxRetryDelayMs: options?.maxRetryDelayMs, signal: options?.signal },
 			);
-			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
 			interface StreamingToolCallBlock extends ToolCall {

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -40,7 +40,7 @@ import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
-import { retryProviderRequest } from "../utils/provider-retry.ts";
+import { retryProviderStreamRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { isForcedToolChoiceUnsupportedError, omitToolChoiceParam } from "../utils/tool-choice-fallback.ts";
 import {
@@ -404,11 +404,13 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					throw error;
 				}
 			};
-			const { data: openaiStream, response } = await retryProviderRequest(createRequest, {
-				maxRetries: options?.maxRetries,
-				maxRetryDelayMs: options?.maxRetryDelayMs,
-				signal: options?.signal,
-			});
+			const { stream: openaiStream, metadata: response } = await retryProviderStreamRequest(
+				async () => {
+					const { data, response } = await createRequest();
+					return { stream: data, metadata: response };
+				},
+				{ maxRetries: options?.maxRetries, maxRetryDelayMs: options?.maxRetryDelayMs, signal: options?.signal },
+			);
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,26 @@
 # AI Source Changes
 
+## 2026-07-28 - Retry OpenAI-compatible stream failures before the first chunk
+
+### What changed and why
+
+- `utils/provider-retry.ts` now prefetches the first SDK stream result inside the existing bounded, abortable provider
+  retry policy. A retry creates a fresh request only when stream consumption fails before any wire chunk can reach
+  the public event stream.
+- `api/openai-completions.ts` uses that prefetch wrapper for OpenAI-compatible providers. Once the first chunk exists,
+  the stream is replayed exactly once and any later failure remains terminal, preventing duplicated text or tool
+  effects.
+- The exact property-less gateway error `Upstream error from DigitalOcean: stream failed` is recognized as transient;
+  arbitrary property-less errors remain non-retryable.
+- `../test/openai-completions-retry.test.ts` covers recovery, retry exhaustion, non-retryable failures, and the
+  post-first-chunk no-retry boundary. The isolated mock-loop driver
+  `.agents/skills/senpi-qa/scripts/mock-loop-stream-retry.mjs` proves the same behavior through the real source CLI.
+
+### Expected merge conflict zones
+
+- LOW: the request creation/retry block in `api/openai-completions.ts`.
+- LOW: shared provider retry classification and stream-prefetch helper in `utils/provider-retry.ts`.
+
 ## 2026-07-27 - Codex reasoning summary null omits the field instead of sending "off"
 
 ### What changed and why

--- a/packages/ai/src/utils/provider-retry.ts
+++ b/packages/ai/src/utils/provider-retry.ts
@@ -1,4 +1,5 @@
 const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
+const DIGITALOCEAN_STREAM_FAILURE_MESSAGE = "Upstream error from DigitalOcean: stream failed";
 
 interface ProviderRetryOptions {
 	maxRetries?: number;
@@ -12,7 +13,9 @@ interface ProviderError extends Error {
 }
 
 function isProviderError(error: unknown): error is ProviderError {
-	if (!(error instanceof Error) || !("status" in error) || !("headers" in error)) return false;
+	if (!(error instanceof Error)) return false;
+	if (error.message === DIGITALOCEAN_STREAM_FAILURE_MESSAGE) return true;
+	if (!("status" in error) || !("headers" in error)) return false;
 	return (
 		(error.status === undefined || typeof error.status === "number") &&
 		(error.headers === undefined || error.headers instanceof Headers)
@@ -122,4 +125,54 @@ export async function retryProviderRequest<T>(
 			await abortableSleep(getRetryDelayMs(error, retryIndex, options.maxRetryDelayMs), options.signal);
 		}
 	}
+}
+
+interface ProviderStreamAttempt<TChunk, TMetadata> {
+	stream: AsyncIterable<TChunk>;
+	metadata: TMetadata;
+}
+
+async function* replayPrefetchedStream<TChunk>(
+	first: IteratorResult<TChunk>,
+	iterator: AsyncIterator<TChunk>,
+): AsyncGenerator<TChunk> {
+	if (first.done) return;
+	let completed = false;
+	let providerFailed = false;
+	try {
+		yield first.value;
+		for (;;) {
+			let next: IteratorResult<TChunk>;
+			try {
+				next = await iterator.next();
+			} catch (error) {
+				providerFailed = true;
+				throw error;
+			}
+			if (next.done) {
+				completed = true;
+				return;
+			}
+			yield next.value;
+		}
+	} finally {
+		if (!completed && !providerFailed) {
+			await iterator.return?.();
+		}
+	}
+}
+
+export async function retryProviderStreamRequest<TChunk, TMetadata>(
+	request: () => Promise<ProviderStreamAttempt<TChunk, TMetadata>>,
+	options: ProviderRetryOptions = {},
+): Promise<ProviderStreamAttempt<TChunk, TMetadata>> {
+	return retryProviderRequest(async () => {
+		const attempt = await request();
+		const iterator = attempt.stream[Symbol.asyncIterator]();
+		const first = await iterator.next();
+		return {
+			stream: replayPrefetchedStream(first, iterator),
+			metadata: attempt.metadata,
+		};
+	}, options);
 }

--- a/packages/ai/test/openai-completions-retry.test.ts
+++ b/packages/ai/test/openai-completions-retry.test.ts
@@ -2,9 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
 import type { Context, Model } from "../src/types.ts";
 
+type StreamBehavior =
+	| { readonly kind: "success"; readonly text?: string }
+	| { readonly kind: "error"; readonly error: Error; readonly afterChunks: 0 | 1 };
+
 const mockState = vi.hoisted(() => ({
 	requestOptions: [] as unknown[],
 	requestErrors: [] as Error[],
+	streamBehaviors: [] as StreamBehavior[],
 }));
 
 vi.mock("openai", () => {
@@ -13,12 +18,24 @@ vi.mock("openai", () => {
 			completions: {
 				create: (_params: unknown, options: unknown) => {
 					mockState.requestOptions.push(options);
+					const behavior = mockState.streamBehaviors.shift();
 					const stream = {
 						async *[Symbol.asyncIterator]() {
+							if (behavior?.kind === "error" && behavior.afterChunks === 0) {
+								throw behavior.error;
+							}
 							yield {
 								id: "chatcmpl-test",
-								choices: [{ index: 0, delta: { content: "ok" } }],
+								choices: [
+									{
+										index: 0,
+										delta: { content: behavior?.kind === "success" ? (behavior.text ?? "ok") : "ok" },
+									},
+								],
 							};
+							if (behavior?.kind === "error" && behavior.afterChunks === 1) {
+								throw behavior.error;
+							}
 							yield {
 								id: "chatcmpl-test",
 								choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
@@ -78,6 +95,7 @@ describe("openai-completions provider retries", () => {
 	beforeEach(() => {
 		mockState.requestOptions = [];
 		mockState.requestErrors = [];
+		mockState.streamBehaviors = [];
 	});
 
 	afterEach(() => {
@@ -135,5 +153,78 @@ describe("openai-completions provider retries", () => {
 		expect(result.errorMessage).toContain("Server requested 277403s retry delay (max: 1s)");
 		expect(result.errorMessage).toContain("rate limited");
 		expect(mockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 0 })]);
+	});
+
+	it("retries the observed DigitalOcean failure before the first stream chunk", async () => {
+		vi.useFakeTimers();
+		mockState.streamBehaviors = [
+			{
+				kind: "error",
+				afterChunks: 0,
+				error: new Error("Upstream error from DigitalOcean: stream failed"),
+			},
+			{ kind: "success", text: "recovered" },
+		];
+
+		const result = consume({ maxRetries: 1 });
+		await vi.advanceTimersByTimeAsync(500);
+		const message = await result;
+
+		expect(message.stopReason).toBe("stop");
+		expect(message.content).toEqual([{ type: "text", text: "recovered" }]);
+		expect(mockState.requestOptions).toHaveLength(2);
+	});
+
+	it("bounds retries for repeated pre-chunk stream failures", async () => {
+		vi.useFakeTimers();
+		const streamFailure = () => new Error("Upstream error from DigitalOcean: stream failed");
+		mockState.streamBehaviors = [
+			{ kind: "error", afterChunks: 0, error: streamFailure() },
+			{ kind: "error", afterChunks: 0, error: streamFailure() },
+		];
+
+		const result = consume({ maxRetries: 1 });
+		await vi.advanceTimersByTimeAsync(500);
+		const message = await result;
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Upstream error from DigitalOcean: stream failed");
+		expect(mockState.requestOptions).toHaveLength(2);
+	});
+
+	it("does not retry non-retryable pre-chunk stream failures", async () => {
+		mockState.streamBehaviors = [
+			{
+				kind: "error",
+				afterChunks: 0,
+				error: Object.assign(new Error("invalid request"), {
+					status: 400,
+					headers: new Headers(),
+				}),
+			},
+		];
+
+		const message = await consume({ maxRetries: 2, maxRetryDelayMs: 100 });
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("invalid request");
+		expect(mockState.requestOptions).toHaveLength(1);
+	});
+
+	it("does not retry after the first stream chunk", async () => {
+		mockState.streamBehaviors = [
+			{
+				kind: "error",
+				afterChunks: 1,
+				error: new Error("Upstream error from DigitalOcean: stream failed"),
+			},
+			{ kind: "success", text: "duplicate" },
+		];
+
+		const message = await consume({ maxRetries: 2, maxRetryDelayMs: 100 });
+
+		expect(message.stopReason).toBe("error");
+		expect(message.content).toEqual([{ type: "text", text: "ok" }]);
+		expect(mockState.requestOptions).toHaveLength(1);
 	});
 });

--- a/packages/ai/test/provider-retry.test.ts
+++ b/packages/ai/test/provider-retry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { retryProviderRequest } from "../src/utils/provider-retry.ts";
+import { retryProviderRequest, retryProviderStreamRequest } from "../src/utils/provider-retry.ts";
 
 function providerError(status: number | undefined, headers?: Record<string, string>): Error {
 	return Object.assign(new Error(`Provider error: ${status}`), {
@@ -77,5 +77,27 @@ describe("provider request retries", () => {
 		await expect(result).rejects.toMatchObject({ name: "AbortError" });
 		expect(request).toHaveBeenCalledTimes(1);
 		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("forwards early consumer cancellation to the provider stream", async () => {
+		const closeStream = vi.fn(async () => ({ done: true as const, value: undefined }));
+		const iterator: AsyncIterator<string> = {
+			next: vi.fn(async () => ({ done: false as const, value: "first" })),
+			return: closeStream,
+		};
+		const attempt = await retryProviderStreamRequest(
+			async () => ({
+				stream: { [Symbol.asyncIterator]: () => iterator },
+				metadata: "response",
+			}),
+			{ maxRetries: 1 },
+		);
+
+		for await (const chunk of attempt.stream) {
+			expect(chunk).toBe("first");
+			break;
+		}
+
+		expect(closeStream).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

- retry OpenAI-compatible stream failures that occur before the first wire chunk using the existing bounded, abortable provider retry policy
- recognize the exact property-less DigitalOcean gateway error while leaving arbitrary property-less errors non-retryable
- stop retrying after any chunk has been received, preventing duplicate assistant text or tool effects
- preserve underlying async-iterator cleanup when a consumer exits early
- add deterministic unit coverage and an isolated real-CLI mock-loop scenario

## Verification

- RED -> GREEN: `npx vitest run test/openai-completions-retry.test.ts`
  - exact DigitalOcean error recovers with one retry
  - retry exhaustion is bounded
  - status 400 is not retried
  - failure after the first content chunk is not retried
- Reviewer blocker RED -> GREEN: `npx vitest run test/provider-retry.test.ts`
  - early consumer cancellation now forwards to the provider iterator's `return()`
- Focused suite: `npx vitest run test/provider-retry.test.ts test/openai-completions-retry.test.ts` (13/13)
- Static validation: `npm run check`
- Real CLI: `node .agents/skills/senpi-qa/scripts/mock-loop-stream-retry.mjs`
  - exact SSE error on request 1
  - successful response on request 2
  - exactly one final marker
  - isolated sandbox and real-auth integrity checks
- Standard real CLI regression: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --api openai-completions` (20/20)
- HEAVY reviewer: unconditional `APPROVE` after the iterator-cancellation blocker was fixed and revalidated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI-compatible streaming by retrying failures before the first SSE chunk and ensuring `onResponse` fires once in the right order. Handles DigitalOcean’s “stream failed” error, avoids duplicate output, and preserves iterator cleanup.

- **Bug Fixes**
  - Added `retryProviderStreamRequest` to prefetch the first chunk under the existing bounded, abortable provider retry policy.
  - Treated the exact DigitalOcean error “Upstream error from DigitalOcean: stream failed” as retryable; other property-less errors remain non-retryable.
  - Switched `openai-completions` to the new stream retry wrapper; `onResponse` now fires only after a successful prefetch and before `start`, preserving callback ordering.
  - Disabled retries once the first chunk is seen to prevent duplicate assistant text or tool effects.
  - Forwarded early consumer cancellation to the provider stream’s `return()` for proper cleanup.
  - Added targeted tests and a mock CLI loop to validate recovery, bounds, and non-retryable cases.

<sup>Written for commit 6012db58339a19691ba1dabef00debca6b4c243f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

