### PR TITLE
feat: cache-aware foreground tool timeouts

### DIFF
--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,5 +1,50 @@
 # changes.md — ai
 
+## Browser-safe prompt-cache TTL resolver (2026-07-28)
+
+### What changed
+
+- `src/utils/prompt-cache-ttl.ts` (new): `resolvePromptCacheTtlSeconds(model, env?) -> number | undefined`
+  plus `PROMPT_CACHE_TTL_SHORT_SECONDS` (300) / `PROMPT_CACHE_TTL_LONG_SECONDS` (3600). It mirrors EACH
+  target API's own `resolveCacheRetention` precedence verbatim rather than inventing a unified one:
+  anthropic-messages falls back to `"long"` and honors the bare `process.env.PI_CACHE_RETENTION`
+  set-but-not-long branch; openai-completions / openai-responses / bedrock fall back to `"short"`;
+  pi-messages returns `undefined` (backend default). Retention `"none"` and every API with unknown cache
+  semantics (google, mistral, pi-messages, unknown) resolve to `undefined`.
+- The pure compat predicates the resolver needs moved INTO that browser-safe utility and the API modules now
+  import them from there and re-export for their existing consumers: `getAnthropicCompat` +
+  `isAnthropicApiBaseUrl` (from `src/api/anthropic-messages.ts`), the resolved-compat getter (from
+  `src/api/openai-completions.ts`), and `supportsPromptCaching` (from `src/api/bedrock-converse-stream.ts`).
+- `src/index.ts` exports the new module from the browser-safe root surface.
+
+### Why
+
+- senpi sizes how long its `bash` tool and omo's `task` tool may block in the foreground on the active model's
+  prompt-cache lifetime. That lifetime is already decided per provider inside this package, so one shared
+  resolver here is the single source of truth instead of a table duplicated in every consumer.
+
+### Why the compat predicates had to move rather than be imported
+
+- The root surface is browser-safe. Importing `supportsPromptCaching` directly from
+  `src/api/bedrock-converse-stream.ts` pulled the AWS SDK (`@smithy/node-http-handler`, `agent-base`,
+  `http-proxy-agent`) into the browser bundle and broke `npm run check:browser-smoke` with 18 unresolved
+  `node:*` errors. Moving the pure predicates into the utility and re-exporting from the API modules keeps
+  one definition with no divergence risk, and keeps the root import graph free of Node-only dependencies.
+
+### Modified upstream files
+
+- `src/api/anthropic-messages.ts`
+- `src/api/bedrock-converse-stream.ts`
+- `src/api/openai-completions.ts`
+- `src/index.ts`
+
+### Expected merge conflict zones
+
+- MEDIUM: each API module's `resolveCacheRetention` / compat-getter region, where the local definition became
+  an import + re-export. If upstream edits those predicates, port the edit into
+  `src/utils/prompt-cache-ttl.ts` so the resolver and the adapters stay in agreement.
+
+
 ## Cover Claude Opus 5 in Anthropic adaptive-thinking metadata (2026-07-25)
 
 ### What changed

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -9,7 +9,6 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { calculateCost } from "../models.ts";
 import type {
-	AnthropicMessagesCompat,
 	Api,
 	AssistantMessage,
 	AssistantStopDetails,
@@ -37,6 +36,7 @@ import { splitDeferredTools } from "../utils/deferred-tools.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
+import { getAnthropicCompat, isAnthropicApiBaseUrl } from "../utils/prompt-cache-ttl.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
@@ -60,6 +60,8 @@ import {
 } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
 
+export { getAnthropicCompat } from "../utils/prompt-cache-ttl.ts";
+
 /**
  * Resolve cache retention preference.
  * Defaults to the provided fallback and uses PI_CACHE_RETENTION for backward compatibility.
@@ -79,14 +81,6 @@ function resolveCacheRetention(
 		return "short";
 	}
 	return fallback;
-}
-
-function isAnthropicApiBaseUrl(baseUrl: string): boolean {
-	try {
-		return new URL(baseUrl).hostname === "api.anthropic.com";
-	} catch {
-		return false;
-	}
 }
 
 function getCacheControl(
@@ -260,7 +254,6 @@ const NATIVE_XHIGH_EFFORT_MODEL_MARKERS = [
  * gateway rows carry no generated compat, so the family fact has to live here as well.
  */
 const DISABLED_THINKING_REJECTING_MODEL_MARKERS = ["fable-5", "mythos-5"] as const;
-const CLAUDE_FABLE_OR_MYTHOS_MODEL_ID = /^claude-(?:fable|mythos)(?:-|$)/i;
 const UNSUPPORTED_NATIVE_COMPUTER_TOOL_MODEL_MARKERS = [
 	"opus-4-6",
 	"opus-4.6",
@@ -292,53 +285,6 @@ function isInvalidUnsignedThinkingSignatureError(error: unknown): boolean {
 		error instanceof Error &&
 		/Invalid signature in thinking block/i.test(error.message)
 	);
-}
-
-function getAnthropicCompat(
-	model: Model<"anthropic-messages">,
-): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking">> {
-	// Auto-detect session affinity and cache control support from provider
-	const isFireworks = model.provider === "fireworks";
-	const isCloudflareAiGatewayAnthropic =
-		model.provider === "cloudflare-ai-gateway" && model.baseUrl.includes("anthropic");
-	const isXiaomi = model.provider === "xiaomi" || model.provider.startsWith("xiaomi-token-plan-");
-	return {
-		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? !isFireworks,
-		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? !isFireworks,
-		sendSessionAffinityHeaders:
-			model.compat?.sendSessionAffinityHeaders ?? !!(isFireworks || isCloudflareAiGatewayAnthropic),
-		supportsCacheControlOnTools: model.compat?.supportsCacheControlOnTools ?? !isFireworks,
-		supportsDisabledThinking: model.compat?.supportsDisabledThinking ?? !isXiaomi,
-		supportsTemperature: model.compat?.supportsTemperature ?? true,
-		supportsToolChoice: model.compat?.supportsToolChoice ?? true,
-		supportsForcedToolChoice:
-			model.compat?.supportsForcedToolChoice ?? !CLAUDE_FABLE_OR_MYTHOS_MODEL_ID.test(model.id),
-		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
-		unsignedThinkingReplay:
-			model.compat?.unsignedThinkingReplay ?? (model.compat?.allowEmptySignature ? "empty-signature" : "text"),
-		supportsStrictTools: model.compat?.supportsStrictTools ?? false,
-		supportsToolReferences: model.compat?.supportsToolReferences ?? defaultSupportsToolReferences(model),
-		// Default: first-party Anthropic only. Anthropic-compatible providers
-		// (kimi-coding, fireworks, copilot, gateways) may execute the server-side
-		// search but reject the replayed server_tool_use / web_search_tool_result
-		// blocks on the next request (kimi-coding 400s with `tool_call_id is not
-		// found`).
-		supportsWebSearch: model.compat?.supportsWebSearch ?? isAnthropicApiBaseUrl(model.baseUrl),
-	};
-}
-
-/**
- * Default for `supportsToolReferences`: first-party Anthropic models except
- * Haiku (rejects client-side tool_reference blocks) and models that predate
- * tool search (Claude 3.x, Opus/Sonnet 4.0, Opus 4.1).
- */
-function defaultSupportsToolReferences(model: Model<"anthropic-messages">): boolean {
-	if (model.provider !== "anthropic" || model.id.includes("haiku")) return false;
-	const version = model.id.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
-	if (!version) return false;
-	const major = Number(version[1]);
-	const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
-	return major > 4 || (major === 4 && minor >= 5);
 }
 
 export interface AnthropicOptions extends StreamOptions {

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -53,6 +53,10 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
+import {
+	getBedrockModelMatchCandidates as getModelMatchCandidates,
+	supportsPromptCaching,
+} from "../utils/prompt-cache-ttl.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { normalizeToolCallId } from "../utils/tool-call-id.ts";
@@ -66,6 +70,8 @@ import {
 	clampReasoning,
 } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
+
+export { supportsPromptCaching } from "../utils/prompt-cache-ttl.ts";
 
 export type BedrockThinkingDisplay = "summarized" | "omitted";
 
@@ -584,14 +590,6 @@ function handleContentBlockStop(
  * Checks both model ID and model name to support application inference profiles
  * whose ARNs don't contain the model name.
  */
-function getModelMatchCandidates(modelId: string, modelName?: string): string[] {
-	const values = modelName ? [modelId, modelName] : [modelId];
-	return values.flatMap((value) => {
-		const lower = value.toLowerCase();
-		return [lower, lower.replace(/[\s_.:]+/g, "-")];
-	});
-}
-
 function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
 	const candidates = getModelMatchCandidates(modelId, modelName);
 	return candidates.some(
@@ -688,39 +686,6 @@ function isAnthropicClaudeModel(model: Model<"bedrock-converse-stream">): boolea
 		name.includes("anthropic/claude") ||
 		name.includes("claude")
 	);
-}
-
-/**
- * Check if the model supports prompt caching.
- * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, Claude 4.x models, Claude 5 models
- *
- * For base models and system-defined inference profiles the model ID / ARN
- * contains the model name, so we can decide locally.
- *
- * For application inference profiles (whose ARNs don't contain the model name),
- * also checks model.name which is user-controlled via models.json or registerProvider.
- * As a last resort, set AWS_BEDROCK_FORCE_CACHE=1 to enable cache points.
- * Amazon Nova models have automatic caching and don't need explicit cache points.
- */
-function supportsPromptCaching(model: Model<"bedrock-converse-stream">, env?: ProviderEnv): boolean {
-	const candidates = getModelMatchCandidates(model.id, model.name);
-
-	const hasClaudeRef = candidates.some((s) => s.includes("claude"));
-	if (!hasClaudeRef) {
-		// Application inference profiles don't contain the model name in the ARN.
-		// Allow users to force cache points via environment variable.
-		if (getProviderEnvValue("AWS_BEDROCK_FORCE_CACHE", env) === "1") return true;
-		return false;
-	}
-	// Claude 5 models (fable-5, opus-5, sonnet-5)
-	if (candidates.some((s) => s.includes("fable-5") || s.includes("opus-5") || s.includes("sonnet-5"))) return true;
-	// Claude 4.x models (opus-4, sonnet-4, haiku-4)
-	if (candidates.some((s) => s.includes("-4-"))) return true;
-	// Claude 3.7 Sonnet
-	if (candidates.some((s) => s.includes("claude-3-7-sonnet"))) return true;
-	// Claude 3.5 Haiku
-	if (candidates.some((s) => s.includes("claude-3-5-haiku"))) return true;
-	return false;
 }
 
 /**

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -39,6 +39,10 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
+import {
+	getOpenAICompletionsCompat as getCompat,
+	type ResolvedOpenAICompletionsCompat,
+} from "../utils/prompt-cache-ttl.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
@@ -64,6 +68,11 @@ import {
 	OPENAI_COMPLETIONS_RESERVED_BODY_KEYS,
 } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
+
+export {
+	getOpenAICompletionsCompat as getCompat,
+	type ResolvedOpenAICompletionsCompat,
+} from "../utils/prompt-cache-ttl.ts";
 
 type ChatCompletionChoiceWithUsage = ChatCompletionChunk.Choice & {
 	usage?: Parameters<typeof parseChunkUsage>[0];
@@ -296,16 +305,6 @@ interface OpenAICompatCacheControl {
 	type: "ephemeral";
 	ttl?: string;
 }
-
-type ResolvedOpenAICompletionsCompat = Omit<
-	Required<OpenAICompletionsCompat>,
-	"cacheControlFormat" | "toolCallFormat" | "deferredToolsMode" | "toolSchemaFlavor"
-> & {
-	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
-	toolCallFormat?: OpenAICompletionsCompat["toolCallFormat"];
-	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
-	toolSchemaFlavor?: OpenAICompletionsCompat["toolSchemaFlavor"];
-};
 
 type ResolvedChatTemplateKwargValue = string | number | boolean | null;
 
@@ -1600,136 +1599,4 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | str
 				errorMessage: `Provider finish_reason: ${reason}`,
 			};
 	}
-}
-
-/**
- * Detect compatibility settings from provider and baseUrl for known providers.
- * Provider takes precedence over URL-based detection since it's explicitly configured.
- * Returns a fully resolved OpenAICompletionsCompat object with all fields set.
- */
-function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
-	const provider = model.provider;
-	const baseUrl = model.baseUrl;
-
-	const isZai =
-		provider === "zai" ||
-		provider === "zai-coding-cn" ||
-		baseUrl.includes("api.z.ai") ||
-		baseUrl.includes("open.bigmodel.cn");
-	const isTogether =
-		provider === "together" || baseUrl.includes("api.together.ai") || baseUrl.includes("api.together.xyz");
-	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
-	const isOpenRouter = provider === "openrouter" || baseUrl.includes("openrouter.ai");
-	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
-	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
-	const isNvidia = provider === "nvidia" || baseUrl.includes("integrate.api.nvidia.com");
-	const isAntLing = provider === "ant-ling" || baseUrl.includes("api.ant-ling.com");
-
-	const isNonStandard =
-		isNvidia ||
-		provider === "cerebras" ||
-		baseUrl.includes("cerebras.ai") ||
-		provider === "xai" ||
-		baseUrl.includes("api.x.ai") ||
-		isTogether ||
-		baseUrl.includes("chutes.ai") ||
-		baseUrl.includes("deepseek.com") ||
-		isZai ||
-		isMoonshot ||
-		provider === "opencode" ||
-		baseUrl.includes("opencode.ai") ||
-		isCloudflareWorkersAI ||
-		isCloudflareAiGateway ||
-		isAntLing;
-
-	const useMaxTokens =
-		baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isNvidia || isAntLing;
-
-	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
-	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
-	const isOpenRouterDeveloperRoleModel =
-		isOpenRouter && (model.id.startsWith("anthropic/") || model.id.startsWith("openai/"));
-	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
-
-	return {
-		supportsStore: !isNonStandard,
-		supportsDeveloperRole: isOpenRouterDeveloperRoleModel || (!isNonStandard && !isOpenRouter),
-		supportsReasoningEffort:
-			!isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia && !isAntLing,
-		supportsUsageInStreaming: true,
-		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
-		requiresToolResultName: false,
-		requiresAssistantAfterToolResult: false,
-		requiresThinkingAsText: false,
-		requiresReasoningContentOnAssistantMessages: isDeepSeek,
-		thinkingFormat: isDeepSeek
-			? "deepseek"
-			: isZai
-				? "zai"
-				: isTogether
-					? "together"
-					: isAntLing
-						? "ant-ling"
-						: isOpenRouter
-							? "openrouter"
-							: "openai",
-		openRouterRouting: {},
-		vercelGatewayRouting: {},
-		chatTemplateKwargs: {},
-		zaiToolStream: false,
-		supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia,
-		toolSchemaFlavor: isMoonshot ? "moonshot-mfjs" : undefined,
-		supportsDisabledThinking: true,
-		toolCallFormat: undefined,
-		supportsOpenAIGrammarTools: false,
-		cacheControlFormat,
-		sendSessionAffinityHeaders: false,
-		deferredToolsMode: undefined,
-		sessionAffinityFormat: isOpenRouter ? "openrouter" : "openai",
-		supportsLongCacheRetention: !(
-			isTogether ||
-			isCloudflareWorkersAI ||
-			isCloudflareAiGateway ||
-			isNvidia ||
-			isAntLing
-		),
-	};
-}
-
-/**
- * Get resolved compatibility settings for a model.
- * Auto-detects from provider/URL then overrides with explicit model.compat.
- */
-function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
-	const detected = detectCompat(model);
-	if (!model.compat) return detected;
-
-	return {
-		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
-		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
-		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
-		supportsUsageInStreaming: model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
-		maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
-		requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
-		requiresAssistantAfterToolResult:
-			model.compat.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
-		requiresThinkingAsText: model.compat.requiresThinkingAsText ?? detected.requiresThinkingAsText,
-		requiresReasoningContentOnAssistantMessages:
-			model.compat.requiresReasoningContentOnAssistantMessages ??
-			detected.requiresReasoningContentOnAssistantMessages,
-		thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
-		supportsDisabledThinking: model.compat.supportsDisabledThinking ?? detected.supportsDisabledThinking,
-		openRouterRouting: model.compat.openRouterRouting ?? detected.openRouterRouting,
-		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
-		chatTemplateKwargs: model.compat.chatTemplateKwargs ?? detected.chatTemplateKwargs,
-		zaiToolStream: model.compat.zaiToolStream ?? detected.zaiToolStream,
-		supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
-		toolCallFormat: model.compat.toolCallFormat ?? detected.toolCallFormat,
-		supportsOpenAIGrammarTools: model.compat.supportsOpenAIGrammarTools ?? detected.supportsOpenAIGrammarTools,
-		cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
-		sendSessionAffinityHeaders: model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
-		deferredToolsMode: model.compat.deferredToolsMode ?? detected.deferredToolsMode,
-		sessionAffinityFormat: model.compat.sessionAffinityFormat ?? detected.sessionAffinityFormat,
-		supportsLongCacheRetention: model.compat.supportsLongCacheRetention ?? detected.supportsLongCacheRetention,
-	};
 }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -59,6 +59,11 @@ export * from "./utils/event-stream.ts";
 export * from "./utils/json-parse.ts";
 export { extractOpenAiCodexAccountId } from "./utils/openai-codex-auth.ts";
 export * from "./utils/overflow.ts";
+export {
+	PROMPT_CACHE_TTL_LONG_SECONDS,
+	PROMPT_CACHE_TTL_SHORT_SECONDS,
+	resolvePromptCacheTtlSeconds,
+} from "./utils/prompt-cache-ttl.ts";
 export * from "./utils/retry.ts";
 export * from "./utils/server-fallback-receipt.ts";
 export * from "./utils/stop-details.ts";

--- a/packages/ai/src/utils/prompt-cache-ttl.ts
+++ b/packages/ai/src/utils/prompt-cache-ttl.ts
@@ -1,0 +1,340 @@
+import type {
+	AnthropicMessagesCompat,
+	Api,
+	CacheRetention,
+	Model,
+	OpenAICompletionsCompat,
+	ProviderEnv,
+} from "../types.ts";
+import { getProviderEnvValue } from "./provider-env.ts";
+
+export const PROMPT_CACHE_TTL_SHORT_SECONDS = 300;
+export const PROMPT_CACHE_TTL_LONG_SECONDS = 3600;
+
+export function isAnthropicApiBaseUrl(baseUrl: string): boolean {
+	try {
+		return new URL(baseUrl).hostname === "api.anthropic.com";
+	} catch {
+		return false;
+	}
+}
+
+const CLAUDE_FABLE_OR_MYTHOS_MODEL_ID = /^claude-(?:fable|mythos)(?:-|$)/i;
+
+/**
+ * Default for `supportsToolReferences`: first-party Anthropic models except
+ * Haiku (rejects client-side tool_reference blocks) and models that predate
+ * tool search (Claude 3.x, Opus/Sonnet 4.0, Opus 4.1).
+ */
+function defaultSupportsToolReferences(model: Model<"anthropic-messages">): boolean {
+	if (model.provider !== "anthropic" || model.id.includes("haiku")) return false;
+	const version = model.id.match(/^claude-(?:opus|sonnet|fable)-(\d+)(?:-(\d+))?(?:-|$)/);
+	if (!version) return false;
+	const major = Number(version[1]);
+	const minor = version[2] && version[2].length < 8 ? Number(version[2]) : 0;
+	return major > 4 || (major === 4 && minor >= 5);
+}
+
+export function getAnthropicCompat(
+	model: Model<"anthropic-messages">,
+): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking">> {
+	// Auto-detect session affinity and cache control support from provider
+	const isFireworks = model.provider === "fireworks";
+	const isCloudflareAiGatewayAnthropic =
+		model.provider === "cloudflare-ai-gateway" && model.baseUrl.includes("anthropic");
+	const isXiaomi = model.provider === "xiaomi" || model.provider.startsWith("xiaomi-token-plan-");
+	return {
+		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? !isFireworks,
+		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? !isFireworks,
+		sendSessionAffinityHeaders:
+			model.compat?.sendSessionAffinityHeaders ?? !!(isFireworks || isCloudflareAiGatewayAnthropic),
+		supportsCacheControlOnTools: model.compat?.supportsCacheControlOnTools ?? !isFireworks,
+		supportsDisabledThinking: model.compat?.supportsDisabledThinking ?? !isXiaomi,
+		supportsTemperature: model.compat?.supportsTemperature ?? true,
+		supportsToolChoice: model.compat?.supportsToolChoice ?? true,
+		supportsForcedToolChoice:
+			model.compat?.supportsForcedToolChoice ?? !CLAUDE_FABLE_OR_MYTHOS_MODEL_ID.test(model.id),
+		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
+		unsignedThinkingReplay:
+			model.compat?.unsignedThinkingReplay ?? (model.compat?.allowEmptySignature ? "empty-signature" : "text"),
+		supportsStrictTools: model.compat?.supportsStrictTools ?? false,
+		supportsToolReferences: model.compat?.supportsToolReferences ?? defaultSupportsToolReferences(model),
+		// Default: first-party Anthropic only. Anthropic-compatible providers
+		// (kimi-coding, fireworks, copilot, gateways) may execute the server-side
+		// search but reject the replayed server_tool_use / web_search_tool_result
+		// blocks on the next request (kimi-coding 400s with `tool_call_id is not
+		// found`).
+		supportsWebSearch: model.compat?.supportsWebSearch ?? isAnthropicApiBaseUrl(model.baseUrl),
+	};
+}
+
+export type ResolvedOpenAICompletionsCompat = Omit<
+	Required<OpenAICompletionsCompat>,
+	"cacheControlFormat" | "toolCallFormat" | "deferredToolsMode" | "toolSchemaFlavor"
+> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+	toolCallFormat?: OpenAICompletionsCompat["toolCallFormat"];
+	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	toolSchemaFlavor?: OpenAICompletionsCompat["toolSchemaFlavor"];
+};
+
+/**
+ * Detect compatibility settings from provider and baseUrl for known providers.
+ * Provider takes precedence over URL-based detection since it's explicitly configured.
+ * Returns a fully resolved OpenAICompletionsCompat object with all fields set.
+ */
+function detectOpenAICompletionsCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
+	const provider = model.provider;
+	const baseUrl = model.baseUrl;
+
+	const isZai =
+		provider === "zai" ||
+		provider === "zai-coding-cn" ||
+		baseUrl.includes("api.z.ai") ||
+		baseUrl.includes("open.bigmodel.cn");
+	const isTogether =
+		provider === "together" || baseUrl.includes("api.together.ai") || baseUrl.includes("api.together.xyz");
+	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
+	const isOpenRouter = provider === "openrouter" || baseUrl.includes("openrouter.ai");
+	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
+	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
+	const isNvidia = provider === "nvidia" || baseUrl.includes("integrate.api.nvidia.com");
+	const isAntLing = provider === "ant-ling" || baseUrl.includes("api.ant-ling.com");
+
+	const isNonStandard =
+		isNvidia ||
+		provider === "cerebras" ||
+		baseUrl.includes("cerebras.ai") ||
+		provider === "xai" ||
+		baseUrl.includes("api.x.ai") ||
+		isTogether ||
+		baseUrl.includes("chutes.ai") ||
+		baseUrl.includes("deepseek.com") ||
+		isZai ||
+		isMoonshot ||
+		provider === "opencode" ||
+		baseUrl.includes("opencode.ai") ||
+		isCloudflareWorkersAI ||
+		isCloudflareAiGateway ||
+		isAntLing;
+
+	const useMaxTokens =
+		baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isNvidia || isAntLing;
+
+	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
+	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+	const isOpenRouterDeveloperRoleModel =
+		isOpenRouter && (model.id.startsWith("anthropic/") || model.id.startsWith("openai/"));
+	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
+
+	return {
+		supportsStore: !isNonStandard,
+		supportsDeveloperRole: isOpenRouterDeveloperRoleModel || (!isNonStandard && !isOpenRouter),
+		supportsReasoningEffort:
+			!isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia && !isAntLing,
+		supportsUsageInStreaming: true,
+		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
+		requiresToolResultName: false,
+		requiresAssistantAfterToolResult: false,
+		requiresThinkingAsText: false,
+		requiresReasoningContentOnAssistantMessages: isDeepSeek,
+		thinkingFormat: isDeepSeek
+			? "deepseek"
+			: isZai
+				? "zai"
+				: isTogether
+					? "together"
+					: isAntLing
+						? "ant-ling"
+						: isOpenRouter
+							? "openrouter"
+							: "openai",
+		openRouterRouting: {},
+		vercelGatewayRouting: {},
+		chatTemplateKwargs: {},
+		zaiToolStream: false,
+		supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia,
+		toolSchemaFlavor: isMoonshot ? "moonshot-mfjs" : undefined,
+		supportsDisabledThinking: true,
+		toolCallFormat: undefined,
+		supportsOpenAIGrammarTools: false,
+		cacheControlFormat,
+		sendSessionAffinityHeaders: false,
+		deferredToolsMode: undefined,
+		sessionAffinityFormat: isOpenRouter ? "openrouter" : "openai",
+		supportsLongCacheRetention: !(
+			isTogether ||
+			isCloudflareWorkersAI ||
+			isCloudflareAiGateway ||
+			isNvidia ||
+			isAntLing
+		),
+	};
+}
+
+/**
+ * Get resolved compatibility settings for a model.
+ * Auto-detects from provider/URL then overrides with explicit model.compat.
+ */
+export function getOpenAICompletionsCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
+	const detected = detectOpenAICompletionsCompat(model);
+	if (!model.compat) return detected;
+
+	return {
+		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
+		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
+		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
+		supportsUsageInStreaming: model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
+		maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
+		requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
+		requiresAssistantAfterToolResult:
+			model.compat.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
+		requiresThinkingAsText: model.compat.requiresThinkingAsText ?? detected.requiresThinkingAsText,
+		requiresReasoningContentOnAssistantMessages:
+			model.compat.requiresReasoningContentOnAssistantMessages ??
+			detected.requiresReasoningContentOnAssistantMessages,
+		thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
+		supportsDisabledThinking: model.compat.supportsDisabledThinking ?? detected.supportsDisabledThinking,
+		openRouterRouting: model.compat.openRouterRouting ?? detected.openRouterRouting,
+		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
+		chatTemplateKwargs: model.compat.chatTemplateKwargs ?? detected.chatTemplateKwargs,
+		zaiToolStream: model.compat.zaiToolStream ?? detected.zaiToolStream,
+		supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
+		toolCallFormat: model.compat.toolCallFormat ?? detected.toolCallFormat,
+		supportsOpenAIGrammarTools: model.compat.supportsOpenAIGrammarTools ?? detected.supportsOpenAIGrammarTools,
+		cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
+		sendSessionAffinityHeaders: model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
+		deferredToolsMode: model.compat.deferredToolsMode ?? detected.deferredToolsMode,
+		sessionAffinityFormat: model.compat.sessionAffinityFormat ?? detected.sessionAffinityFormat,
+		supportsLongCacheRetention: model.compat.supportsLongCacheRetention ?? detected.supportsLongCacheRetention,
+	};
+}
+
+export function getBedrockModelMatchCandidates(modelId: string, modelName?: string): string[] {
+	const values = modelName ? [modelId, modelName] : [modelId];
+	return values.flatMap((value) => {
+		const lower = value.toLowerCase();
+		return [lower, lower.replace(/[\s_.:]+/g, "-")];
+	});
+}
+
+/**
+ * Check if the model supports prompt caching.
+ * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, Claude 4.x models, Claude 5 models
+ *
+ * For base models and system-defined inference profiles the model ID / ARN
+ * contains the model name, so we can decide locally.
+ *
+ * For application inference profiles (whose ARNs don't contain the model name),
+ * also checks model.name which is user-controlled via models.json or registerProvider.
+ * As a last resort, set AWS_BEDROCK_FORCE_CACHE=1 to enable cache points.
+ * Amazon Nova models have automatic caching and don't need explicit cache points.
+ */
+export function supportsPromptCaching(model: Model<"bedrock-converse-stream">, env?: ProviderEnv): boolean {
+	const candidates = getBedrockModelMatchCandidates(model.id, model.name);
+
+	const hasClaudeRef = candidates.some((s) => s.includes("claude"));
+	if (!hasClaudeRef) {
+		// Application inference profiles don't contain the model name in the ARN.
+		// Allow users to force cache points via environment variable.
+		if (getProviderEnvValue("AWS_BEDROCK_FORCE_CACHE", env) === "1") return true;
+		return false;
+	}
+	// Claude 5 models (fable-5, opus-5, sonnet-5)
+	if (candidates.some((s) => s.includes("fable-5") || s.includes("opus-5") || s.includes("sonnet-5"))) return true;
+	// Claude 4.x models (opus-4, sonnet-4, haiku-4)
+	if (candidates.some((s) => s.includes("-4-"))) return true;
+	// Claude 3.7 Sonnet
+	if (candidates.some((s) => s.includes("claude-3-7-sonnet"))) return true;
+	// Claude 3.5 Haiku
+	if (candidates.some((s) => s.includes("claude-3-5-haiku"))) return true;
+	return false;
+}
+
+function resolveAnthropicCacheRetention(
+	cacheRetention?: CacheRetention,
+	env?: ProviderEnv,
+	fallback: CacheRetention = "short",
+): CacheRetention {
+	if (cacheRetention) {
+		return cacheRetention;
+	}
+	if (getProviderEnvValue("PI_CACHE_RETENTION", env) === "long") {
+		return "long";
+	}
+	if (typeof process !== "undefined" && process.env.PI_CACHE_RETENTION !== undefined) {
+		return "short";
+	}
+	return fallback;
+}
+
+function resolveOpenAICompletionsCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEnv): CacheRetention {
+	if (cacheRetention) {
+		return cacheRetention;
+	}
+	if (getProviderEnvValue("PI_CACHE_RETENTION", env) === "long") {
+		return "long";
+	}
+	return "short";
+}
+
+function resolveBedrockCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEnv): CacheRetention {
+	if (cacheRetention) {
+		return cacheRetention;
+	}
+	if (getProviderEnvValue("PI_CACHE_RETENTION", env) === "long") {
+		return "long";
+	}
+	return "short";
+}
+
+function resolveOpenAIResponsesCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEnv): CacheRetention {
+	if (cacheRetention) {
+		return cacheRetention;
+	}
+	if (getProviderEnvValue("PI_CACHE_RETENTION", env) === "long") {
+		return "long";
+	}
+	return "short";
+}
+
+export function resolvePromptCacheTtlSeconds(model: Model<Api>, env?: ProviderEnv): number | undefined {
+	switch (model.api) {
+		case "anthropic-messages": {
+			const anthropicModel = model as Model<"anthropic-messages">;
+			const retention = resolveAnthropicCacheRetention(anthropicModel.cacheRetention, env, "long");
+			if (retention === "none") return undefined;
+			return retention === "long" &&
+				isAnthropicApiBaseUrl(anthropicModel.baseUrl) &&
+				getAnthropicCompat(anthropicModel).supportsLongCacheRetention
+				? PROMPT_CACHE_TTL_LONG_SECONDS
+				: PROMPT_CACHE_TTL_SHORT_SECONDS;
+		}
+		case "bedrock-converse-stream": {
+			const bedrockModel = model as Model<"bedrock-converse-stream">;
+			const retention = resolveBedrockCacheRetention(bedrockModel.cacheRetention, env);
+			if (retention === "none" || !supportsPromptCaching(bedrockModel, env)) return undefined;
+			return retention === "long" ? PROMPT_CACHE_TTL_LONG_SECONDS : PROMPT_CACHE_TTL_SHORT_SECONDS;
+		}
+		case "openai-completions": {
+			const completionsModel = model as Model<"openai-completions">;
+			const retention = resolveOpenAICompletionsCacheRetention(completionsModel.cacheRetention, env);
+			if (retention === "none") return undefined;
+			const compat = getOpenAICompletionsCompat(completionsModel);
+			if (compat.cacheControlFormat === "anthropic") {
+				return retention === "long" && compat.supportsLongCacheRetention
+					? PROMPT_CACHE_TTL_LONG_SECONDS
+					: PROMPT_CACHE_TTL_SHORT_SECONDS;
+			}
+			return PROMPT_CACHE_TTL_SHORT_SECONDS;
+		}
+		case "openai-responses":
+		case "openai-codex-responses":
+		case "azure-openai-responses": {
+			const retention = resolveOpenAIResponsesCacheRetention(model.cacheRetention, env);
+			return retention === "none" ? undefined : PROMPT_CACHE_TTL_SHORT_SECONDS;
+		}
+		default:
+			return undefined;
+	}
+}

--- a/packages/ai/test/prompt-cache-ttl.test.ts
+++ b/packages/ai/test/prompt-cache-ttl.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getAnthropicCompat } from "../src/api/anthropic-messages.ts";
+import { supportsPromptCaching } from "../src/api/bedrock-converse-stream.ts";
+import { getCompat as getOpenAICompletionsCompat } from "../src/api/openai-completions.ts";
+import {
+	type Api,
+	type Model,
+	PROMPT_CACHE_TTL_LONG_SECONDS,
+	PROMPT_CACHE_TTL_SHORT_SECONDS,
+	resolvePromptCacheTtlSeconds,
+} from "../src/index.ts";
+import { supportsPromptCaching as supportsPromptCachingBrowserSafe } from "../src/utils/prompt-cache-ttl.ts";
+
+function createModel<TApi extends Api>(api: TApi, overrides: Partial<Model<TApi>> = {}): Model<TApi> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api,
+		provider: "test-provider",
+		baseUrl: "https://example.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		...overrides,
+	} as Model<TApi>;
+}
+
+const anthropicModel = createModel("anthropic-messages", {
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com/v1",
+});
+
+const anthropicCompletionsModel = createModel("openai-completions", {
+	provider: "custom-proxy",
+	compat: {
+		cacheControlFormat: "anthropic",
+		supportsLongCacheRetention: true,
+	},
+});
+
+const cacheableBedrockModel = createModel("bedrock-converse-stream", {
+	id: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+	provider: "amazon-bedrock",
+});
+
+const openAIResponsesModel = createModel("openai-responses", {
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+});
+
+const originalCacheRetention = process.env.PI_CACHE_RETENTION;
+
+beforeEach(() => {
+	delete process.env.PI_CACHE_RETENTION;
+});
+
+afterEach(() => {
+	if (originalCacheRetention === undefined) {
+		delete process.env.PI_CACHE_RETENTION;
+	} else {
+		process.env.PI_CACHE_RETENTION = originalCacheRetention;
+	}
+});
+
+describe("prompt-cache TTL constants", () => {
+	it("exports the short and long cache durations from the pi-ai root", () => {
+		expect(PROMPT_CACHE_TTL_SHORT_SECONDS).toBe(300);
+		expect(PROMPT_CACHE_TTL_LONG_SECONDS).toBe(3600);
+	});
+});
+
+describe("retention precedence stays pinned to the API adapters", () => {
+	it("lets an explicit model retention override ProviderEnv", () => {
+		const env = { PI_CACHE_RETENTION: "long" };
+
+		expect(resolvePromptCacheTtlSeconds({ ...anthropicModel, cacheRetention: "short" }, env)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds({ ...anthropicCompletionsModel, cacheRetention: "short" }, env)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds({ ...cacheableBedrockModel, cacheRetention: "short" }, env)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds({ ...openAIResponsesModel, cacheRetention: "short" }, env)).toBe(300);
+	});
+
+	it("honors PI_CACHE_RETENTION=long from ProviderEnv", () => {
+		const env = { PI_CACHE_RETENTION: "long" };
+
+		expect(resolvePromptCacheTtlSeconds(anthropicModel, env)).toBe(3600);
+		expect(resolvePromptCacheTtlSeconds(anthropicCompletionsModel, env)).toBe(3600);
+		expect(resolvePromptCacheTtlSeconds(cacheableBedrockModel, env)).toBe(3600);
+		expect(resolvePromptCacheTtlSeconds(openAIResponsesModel, env)).toBe(300);
+	});
+
+	it("uses the Anthropic process.env-only short branch when the variable is set but not long", () => {
+		process.env.PI_CACHE_RETENTION = "legacy-opt-out";
+
+		expect(resolvePromptCacheTtlSeconds(anthropicModel)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds(anthropicCompletionsModel)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds(cacheableBedrockModel)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds(openAIResponsesModel)).toBe(300);
+	});
+
+	it("uses each adapter's own unset fallback", () => {
+		expect(resolvePromptCacheTtlSeconds(anthropicModel)).toBe(3600);
+		expect(resolvePromptCacheTtlSeconds(anthropicCompletionsModel)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds(cacheableBedrockModel)).toBe(300);
+		expect(resolvePromptCacheTtlSeconds(openAIResponsesModel)).toBe(300);
+	});
+});
+
+describe("Anthropic Messages TTL", () => {
+	it("returns one hour for direct Anthropic long retention", () => {
+		expect(resolvePromptCacheTtlSeconds({ ...anthropicModel, cacheRetention: "long" })).toBe(3600);
+	});
+
+	it("returns five minutes for proxied Anthropic models", () => {
+		const proxyModel = {
+			...anthropicModel,
+			baseUrl: "https://anthropic-proxy.example.com/v1",
+			cacheRetention: "long" as const,
+		};
+
+		expect(resolvePromptCacheTtlSeconds(proxyModel)).toBe(300);
+	});
+
+	it("returns undefined when caching is disabled", () => {
+		expect(resolvePromptCacheTtlSeconds({ ...anthropicModel, cacheRetention: "none" })).toBeUndefined();
+	});
+
+	it("reuses Anthropic compat defaults for Fireworks-hosted models", () => {
+		const fireworksModel = createModel("anthropic-messages", {
+			provider: "fireworks",
+			baseUrl: "https://api.anthropic.com/v1",
+			cacheRetention: "long",
+		});
+
+		expect(getAnthropicCompat(fireworksModel).supportsLongCacheRetention).toBe(false);
+		expect(resolvePromptCacheTtlSeconds(fireworksModel)).toBe(300);
+	});
+});
+
+describe("OpenAI Completions TTL", () => {
+	it("uses resolved OpenRouter compat for anthropic-prefixed models", () => {
+		const openRouterModel = createModel("openai-completions", {
+			id: "anthropic/claude-sonnet-4",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			cacheRetention: "long",
+		});
+
+		expect(getOpenAICompletionsCompat(openRouterModel).cacheControlFormat).toBe("anthropic");
+		expect(resolvePromptCacheTtlSeconds(openRouterModel)).toBe(3600);
+	});
+
+	it("uses a conservative five minutes for OpenAI-style automatic caching", () => {
+		const model = createModel("openai-completions", {
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			cacheRetention: "long",
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBe(300);
+	});
+});
+
+describe("Bedrock Converse TTL", () => {
+	it("keeps the browser-safe predicate aligned with the Bedrock API export", () => {
+		const unsupportedModel = createModel("bedrock-converse-stream", {
+			id: "meta.llama3-70b-instruct-v1:0",
+			provider: "amazon-bedrock",
+		});
+		const forcedModel = createModel("bedrock-converse-stream", {
+			id: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/custom-profile",
+			provider: "amazon-bedrock",
+		});
+		const forceEnv = { AWS_BEDROCK_FORCE_CACHE: "1" };
+
+		expect(supportsPromptCachingBrowserSafe(cacheableBedrockModel)).toBe(
+			supportsPromptCaching(cacheableBedrockModel),
+		);
+		expect(supportsPromptCachingBrowserSafe(unsupportedModel)).toBe(supportsPromptCaching(unsupportedModel));
+		expect(supportsPromptCachingBrowserSafe(forcedModel, forceEnv)).toBe(
+			supportsPromptCaching(forcedModel, forceEnv),
+		);
+	});
+
+	it("returns one hour for a cacheable Claude model with long retention", () => {
+		expect(resolvePromptCacheTtlSeconds({ ...cacheableBedrockModel, cacheRetention: "long" })).toBe(3600);
+	});
+
+	it("returns undefined for a model without explicit prompt caching support", () => {
+		const model = createModel("bedrock-converse-stream", {
+			id: "meta.llama3-70b-instruct-v1:0",
+			provider: "amazon-bedrock",
+			cacheRetention: "long",
+		});
+
+		expect(supportsPromptCaching(model)).toBe(false);
+		expect(resolvePromptCacheTtlSeconds(model)).toBeUndefined();
+	});
+
+	it("honors AWS_BEDROCK_FORCE_CACHE from ProviderEnv", () => {
+		const model = createModel("bedrock-converse-stream", {
+			id: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/custom-profile",
+			provider: "amazon-bedrock",
+			cacheRetention: "long",
+		});
+		const env = { AWS_BEDROCK_FORCE_CACHE: "1" };
+
+		expect(supportsPromptCaching(model, env)).toBe(true);
+		expect(resolvePromptCacheTtlSeconds(model, env)).toBe(3600);
+	});
+});
+
+describe("automatic and unknown cache backends", () => {
+	it.each([
+		"openai-responses",
+		"openai-codex-responses",
+		"azure-openai-responses",
+	] as const)("returns five minutes for %s", (api) => {
+		expect(resolvePromptCacheTtlSeconds(createModel(api))).toBe(300);
+	});
+
+	it("returns undefined for disabled OpenAI Responses caching", () => {
+		expect(resolvePromptCacheTtlSeconds(createModel("openai-responses", { cacheRetention: "none" }))).toBeUndefined();
+	});
+
+	it.each([
+		"google-generative-ai",
+		"google-vertex",
+		"mistral-conversations",
+		"pi-messages",
+		"unknown-api",
+	] as const)("returns undefined for %s", (api) => {
+		expect(resolvePromptCacheTtlSeconds(createModel(api))).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,32 @@
+## Prompt-cache-aware foreground tool budgets (2026-07-28)
+
+### What changed
+
+- `core/settings-manager.ts`: new `PromptCacheSettings` (`cacheAwareTimeouts?: boolean` default true,
+  `safetyBufferSeconds?: number` default 30) exposed as `Settings.promptCache`.
+- `core/prompt-cache-budget.ts` (new): `resolvePromptCacheSafeWaitSeconds(model, settings, env)` =
+  pi-ai's resolved cache TTL minus the safety buffer, or `undefined` when the feature is disabled, no model
+  is active, the TTL is unknown, or the buffer swallows the whole TTL. Also exports
+  `PROMPT_CACHE_SAFE_WAIT_ENV` and `DEFAULT_PROMPT_CACHE_SAFETY_BUFFER_SECONDS`.
+- `core/agent-session.ts`: `resolvePromptCacheSafeWaitSeconds()` recomputes from the LIVE current model, and
+  `syncPromptCacheSafeWaitEnv()` mirrors it into the advisory `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS` env var
+  (deleted when no budget applies) on session start, reload, and every model select — so out-of-process
+  readers such as the omo `task` tool can size their own foreground waits.
+- The typed `ExtensionContext.getPromptCacheSafeWaitSeconds()` getter is documented in
+  `core/extensions/changes.md`.
+
+### Why
+
+- Blocking a foreground tool past the model's prompt-cache lifetime expires the cache and forces a full
+  re-read on the next request. Sizing the ceiling by the cache TTL keeps the cache warm, and the still-running
+  work is handed to a background session alive instead of being killed.
+
+### Behavior when no budget applies
+
+- Byte-identical to previous behavior: the injected bash default and recommended maximum keep their existing
+  values, the policy prompt is unchanged under strict string equality, and the env var is absent.
+
+
 ## Cancellable `session_before_reload` veto blocks reload while extensions protect live work (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -120,6 +120,7 @@ import { type BashExecutionMessage, type CustomMessage, filterContextExcludedMes
 import { ModelRegistry } from "./model-registry.ts";
 import { type AvailableModelsSource, getModelNarrowingPatterns, resolveModelScope } from "./model-resolver.ts";
 import type { ModelRuntime } from "./model-runtime.ts";
+import { PROMPT_CACHE_SAFE_WAIT_ENV, resolvePromptCacheSafeWaitSeconds } from "./prompt-cache-budget.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
 import { RetryFallbackController } from "./retry-fallback/controller.ts";
@@ -3013,6 +3014,7 @@ export class AgentSession {
 		previousModel: Model<any> | undefined,
 		source: ModelSelectSource,
 	): Promise<SystemPromptChangeEvent | undefined> {
+		this.syncPromptCacheSafeWaitEnv();
 		if (!this._modelSelectionChangesContext(previousModel, nextModel)) return undefined;
 		const result = await this._extensionRunner.emitModelSelect({
 			type: "model_select",
@@ -4554,6 +4556,7 @@ export class AgentSession {
 			}
 
 			this._applyExtensionBindings(this._extensionRunner);
+			this.syncPromptCacheSafeWaitEnv();
 			await this._extensionRunner.emit(this._sessionStartEvent);
 			await this.extendResourcesFromExtensions(this._sessionStartEvent.reason === "reload" ? "reload" : "startup");
 		} finally {
@@ -4750,6 +4753,7 @@ export class AgentSession {
 				},
 				getContextUsage: () => this.getContextUsage(),
 				getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
+				getPromptCacheSafeWaitSeconds: () => this.resolvePromptCacheSafeWaitSeconds(),
 				getLookAtSettings: () => {
 					const global = this.settingsManager.getGlobalSettings().lookAt;
 					const project = this.settingsManager.getProjectSettings().lookAt;
@@ -5102,6 +5106,7 @@ export class AgentSession {
 			this._extensionErrorListener;
 		if (hasBindings) {
 			await options?.beforeSessionStart?.();
+			this.syncPromptCacheSafeWaitEnv();
 			await this._extensionRunner.emit({ type: "session_start", reason: "reload" });
 			await this.extendResourcesFromExtensions("reload");
 		}
@@ -5883,6 +5888,27 @@ export class AgentSession {
 			cost: usageTotals.cost,
 			contextUsage: this.getContextUsage(),
 		};
+	}
+
+	/**
+	 * Cache-safe foreground wait budget for the LIVE current model. Recomputed on
+	 * every call so a model switch takes effect immediately.
+	 */
+	resolvePromptCacheSafeWaitSeconds(): number | undefined {
+		const global = this.settingsManager.getGlobalSettings().promptCache;
+		const project = this.settingsManager.getProjectSettings().promptCache;
+		const merged = global || project ? { ...global, ...project } : undefined;
+		return resolvePromptCacheSafeWaitSeconds(this.model, merged, process.env);
+	}
+
+	/**
+	 * Mirror the budget into the advisory env var read by out-of-process tools.
+	 * Last writer wins across in-process sessions; consumers treat it as a hint.
+	 */
+	syncPromptCacheSafeWaitEnv(): void {
+		const budget = this.resolvePromptCacheSafeWaitSeconds();
+		if (budget === undefined) delete process.env[PROMPT_CACHE_SAFE_WAIT_ENV];
+		else process.env[PROMPT_CACHE_SAFE_WAIT_ENV] = String(budget);
 	}
 
 	getContextUsage(): ContextUsage | undefined {

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
@@ -25,7 +25,7 @@ export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 
 	pi.on("tool_call", async (event, ctx) => {
 		if (event.toolName !== "bash") return;
-		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx.getPromptCacheSafeWaitSeconds?.());
+		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx?.getPromptCacheSafeWaitSeconds?.());
 		const input = event.input as BashToolInputLike;
 		const updated = applyBashTimeout(input, effective);
 		if (updated !== input) {
@@ -35,7 +35,7 @@ export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
-		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx.getPromptCacheSafeWaitSeconds?.());
+		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx?.getPromptCacheSafeWaitSeconds?.());
 		return { systemPrompt: `${event.systemPrompt}${buildBashTimeoutPrompt(effective)}` };
 	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
@@ -5,33 +5,37 @@ import {
 	type BashToolInputLike,
 	buildBashTimeoutPrompt,
 	resolveBashTimeoutDefaults,
+	resolveEffectiveBashTimeouts,
 } from "./timeout.ts";
 
-export type { BashTimeoutDefaults, BashToolInputLike } from "./timeout.ts";
+export type { BashTimeoutDefaults, BashToolInputLike, EffectiveBashTimeouts } from "./timeout.ts";
 export {
 	applyBashTimeout,
 	BASH_DEFAULT_TIMEOUT_SECONDS,
 	BASH_MAX_TIMEOUT_SECONDS,
 	buildBashTimeoutPrompt,
 	resolveBashTimeoutDefaults,
+	resolveEffectiveBashTimeouts,
 } from "./timeout.ts";
 
 export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 	const env = typeof process !== "undefined" ? process.env : {};
-	const defaults = resolveBashTimeoutDefaults(env);
-	const promptSection = buildBashTimeoutPrompt(defaults);
+	const baseDefaults = resolveBashTimeoutDefaults(env);
+	let effective = resolveEffectiveBashTimeouts(baseDefaults, undefined);
 
-	pi.on("tool_call", async (event) => {
+	pi.on("tool_call", async (event, ctx) => {
 		if (event.toolName !== "bash") return;
+		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx.getPromptCacheSafeWaitSeconds?.());
 		const input = event.input as BashToolInputLike;
-		const updated = applyBashTimeout(input, defaults);
+		const updated = applyBashTimeout(input, effective);
 		if (updated !== input) {
 			const timeout = updated.timeout;
 			if (timeout !== undefined) input.timeout = timeout;
 		}
 	});
 
-	pi.on("before_agent_start", async (event) => ({
-		systemPrompt: `${event.systemPrompt}${promptSection}`,
-	}));
+	pi.on("before_agent_start", async (event, ctx) => {
+		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx.getPromptCacheSafeWaitSeconds?.());
+		return { systemPrompt: `${event.systemPrompt}${buildBashTimeoutPrompt(effective)}` };
+	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
@@ -40,7 +40,32 @@ export function applyBashTimeout<TInput extends BashToolInputLike>(
 	return input;
 }
 
-export function buildBashTimeoutPrompt(defaults: BashTimeoutDefaults): string {
+export interface EffectiveBashTimeouts extends BashTimeoutDefaults {
+	cacheCapped?: boolean;
+}
+
+/**
+ * Lower the recommended maximum to the prompt-cache safe-wait budget, so the
+ * model is never told to block past the point where the cache expires. The two
+ * `min()` expressions are the complete policy: a budget below the injected
+ * default pulls that default down with it, keeping the prompt, the injected
+ * value, and the terminal detach deadline consistent.
+ */
+export function resolveEffectiveBashTimeouts(
+	defaults: BashTimeoutDefaults,
+	safeWaitSeconds: number | undefined,
+): Required<EffectiveBashTimeouts> {
+	if (safeWaitSeconds === undefined || safeWaitSeconds >= defaults.maxSeconds) {
+		return { ...defaults, cacheCapped: false };
+	}
+	const maxSeconds = Math.min(defaults.maxSeconds, safeWaitSeconds);
+	return { defaultSeconds: Math.min(defaults.defaultSeconds, maxSeconds), maxSeconds, cacheCapped: true };
+}
+
+export function buildBashTimeoutPrompt(defaults: EffectiveBashTimeouts): string {
 	const minutes = (seconds: number): string => (seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds}s`);
-	return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool enforces timeouts even when you omit the \`timeout\` parameter:\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}). Explicit \`timeout\` values are preserved because different hosts may use different timeout units.\n- For long-running commands (builds, installs, test suites), set an explicit \`timeout\` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, start them with \`run_in_background: true\` and watch the decisive output with \`monitor\` instead of raising the timeout.\n`;
+	const maxReason = defaults.cacheCapped
+		? ` This ceiling is the prompt cache lifetime of the active model minus a safety buffer: blocking past it expires the cache and forces a full re-read on the next request. A foreground command still running at that point is handed to a background session alive instead of being killed.`
+		: "";
+	return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool enforces timeouts even when you omit the \`timeout\` parameter:\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}).${maxReason} Explicit \`timeout\` values are preserved because different hosts may use different timeout units.\n- For long-running commands (builds, installs, test suites), set an explicit \`timeout\` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, start them with \`run_in_background: true\` and watch the decisive output with \`monitor\` instead of raising the timeout.\n`;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,29 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Cache-aware foreground timeout promotion (2026-07-28)
+
+### What changed
+
+- `TerminalToolContext.timeoutAction` now receives the resolved terminal setting from
+  `extension.ts`; the previously declared `terminal.timeoutAction` setting is implemented.
+- Foreground `bash` calls whose native timeout exceeds the live prompt-cache-safe wait budget
+  auto-detach at that budget when `timeoutAction` is `background`. The original native timeout
+  remains authoritative, and a bounded post-timeout sweep preserves the existing teardown path.
+- Detach consumes the output delta once, wires the normal background completion notifier, and
+  returns the persistent `bash_N` handle with instructions for output and termination.
+
+### Why
+
+A foreground wait beyond the prompt-cache-safe deadline risks invalidating the prompt cache.
+Promotion preserves the command and its original kill deadline while returning control to the
+agent before that cache deadline. `timeoutAction: "kill"`, absent cache budgets, and timeouts at
+or below the budget retain their existing foreground behavior.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `tools/bash.ts` foreground lifecycle and `extension.ts` tool-context getters.
+
 ## Footer status for active monitors (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -58,6 +58,9 @@ function buildToolContext(state: TerminalExtensionState): TerminalToolContext {
 		get defaultRows() {
 			return state.settings.defaultRows;
 		},
+		get timeoutAction() {
+			return state.settings.timeoutAction;
+		},
 		get monitorRegistry() {
 			state.monitors ??= new MonitorRegistry((event) => state.monitorNotifier?.notifyEvent(event), {
 				onChange: (snapshot) => state.ctx?.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot)),

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
@@ -11,6 +11,7 @@ import {
 	TERMINAL_BASH_TOOL,
 } from "../shared.ts";
 import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
+import { createForegroundDetachGate } from "./foreground-detach.ts";
 import { describeExit, spawnCommandSession } from "./spawn.ts";
 
 export const ptyBashSchema = Type.Object({
@@ -171,6 +172,46 @@ function raceExitWithKillGrace(
 	});
 }
 
+function resolveAutoDetachDelayMs(ctx: TerminalToolContext, input: PtyBashInput): number | undefined {
+	if (ctx.timeoutAction === "kill") return undefined;
+	const budgetSeconds = ctx.getSessionContext?.()?.getPromptCacheSafeWaitSeconds?.();
+	if (budgetSeconds === undefined || !Number.isFinite(budgetSeconds)) return undefined;
+	const timeoutSeconds = input.timeout !== undefined && Number.isFinite(input.timeout) ? input.timeout : Infinity;
+	if (timeoutSeconds <= budgetSeconds) return undefined;
+	return Math.max(0, Math.trunc(budgetSeconds * 1000));
+}
+
+function scheduleDetachedSweep(
+	ctx: TerminalToolContext,
+	id: string,
+	runtime: TerminalRuntimeSession,
+	timeoutMs: number | undefined,
+	startedAt: number,
+): void {
+	if (timeoutMs === undefined) return;
+	const deadlineMs = timeoutMs + KILLED_SESSION_EXIT_GRACE_MS;
+	if (!Number.isFinite(deadlineMs) || deadlineMs > MAX_TIMEOUT_MS || runtime.exited) return;
+
+	const remainingMs = Math.max(0, deadlineMs - (Date.now() - startedAt));
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let unsubscribeExit: (() => void) | undefined;
+	const clearSweep = () => {
+		if (timer !== undefined) clearTimeout(timer);
+		timer = undefined;
+		unsubscribeExit?.();
+		unsubscribeExit = undefined;
+	};
+	unsubscribeExit = runtime.session.onExit(clearSweep);
+	if (runtime.exited) {
+		clearSweep();
+		return;
+	}
+	timer = setTimeout(() => {
+		clearSweep();
+		if (!runtime.exited) void ctx.manager.stop(id).catch(() => {});
+	}, remainingMs);
+}
+
 async function runForeground(
 	ctx: TerminalToolContext,
 	input: PtyBashInput,
@@ -201,22 +242,76 @@ async function runForeground(
 	onUpdate?.({ content: [], details: undefined });
 	const unsubscribeOutput = onUpdate ? runtime.onOutput(() => updateEmitter?.schedule()) : undefined;
 
-	// Interrupt means "stop now": SIGKILL the whole process group in one shot.
-	// kill() is one-shot idempotent, so a gentle SIGTERM first would block any
-	// escalation, and a SIGTERM-ignoring command would pin the agent forever.
-	const onAbort = () => runtime.session.kill("SIGKILL");
-	if (signal) {
-		if (signal.aborted) onAbort();
-		else signal.addEventListener("abort", onAbort, { once: true });
+	const detachDelayMs = resolveAutoDetachDelayMs(ctx, input);
+	let outcome: ForegroundWaitOutcome | "detached";
+	if (detachDelayMs === undefined) {
+		// Interrupt means "stop now": SIGKILL the whole process group in one shot.
+		// kill() is one-shot idempotent, so a gentle SIGTERM first would block any
+		// escalation, and a SIGTERM-ignoring command would pin the agent forever.
+		const onAbort = () => runtime.session.kill("SIGKILL");
+		if (signal) {
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
+		}
+		try {
+			outcome = await raceExitWithKillGrace(runtime, signal, timeoutMs);
+		} finally {
+			signal?.removeEventListener("abort", onAbort);
+			unsubscribeOutput?.();
+			updateEmitter?.flush();
+			updateEmitter?.dispose();
+		}
+	} else {
+		const abortGate = new AbortController();
+		const onAbort = () => {
+			runtime.session.kill("SIGKILL");
+			abortGate.abort();
+		};
+		if (signal) {
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
+		}
+		const detachGate = createForegroundDetachGate({
+			runtime,
+			signal,
+			delayMs: detachDelayMs,
+			removeAbortListener: () => signal?.removeEventListener("abort", onAbort),
+		});
+		try {
+			outcome = await Promise.race([
+				raceExitWithKillGrace(runtime, abortGate.signal, timeoutMs),
+				detachGate.detached.then(() => "detached" as const),
+			]);
+		} finally {
+			detachGate.cancel();
+			signal?.removeEventListener("abort", onAbort);
+			unsubscribeOutput?.();
+			updateEmitter?.flush();
+			updateEmitter?.dispose();
+		}
 	}
-	let outcome: ForegroundWaitOutcome;
-	try {
-		outcome = await raceExitWithKillGrace(runtime, signal, timeoutMs);
-	} finally {
-		signal?.removeEventListener("abort", onAbort);
-		unsubscribeOutput?.();
-		updateEmitter?.flush();
-		updateEmitter?.dispose();
+
+	if (outcome === "detached") {
+		scheduleDetachedSweep(ctx, id, runtime, timeoutMs, startedAt);
+		if (ctx.onBackgroundExit) runtime.session.onExit(() => ctx.onBackgroundExit?.(id, runtime));
+		const delta = runtime.readDelta();
+		const partialOutput = formatTerminalToolOutput(delta.text).text || "(no output yet)";
+		const timeoutNote =
+			input.timeout !== undefined && Number.isFinite(input.timeout)
+				? `not killed; the original ${input.timeout}s timeout still applies`
+				: "not killed; it will run until exit or kill_bash";
+		return textResult(
+			`Command is still running; auto-detached to background with ID: ${id} (${timeoutNote}).\n\nPartial output:\n${partialOutput}\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: \"${id}\" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: \"${id}\" }) to stop this session.`,
+			{
+				details: {
+					bash_id: id,
+					background: true,
+					auto_detached: true,
+					status: "running",
+					...(delta.droppedChars > 0 ? { droppedChars: delta.droppedChars } : {}),
+				},
+			},
+		);
 	}
 
 	if (outcome !== "exited") {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
@@ -301,7 +301,7 @@ async function runForeground(
 				? `not killed; the original ${input.timeout}s timeout still applies`
 				: "not killed; it will run until exit or kill_bash";
 		return textResult(
-			`Command is still running; auto-detached to background with ID: ${id} (${timeoutNote}).\n\nPartial output:\n${partialOutput}\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: \"${id}\" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: \"${id}\" }) to stop this session.`,
+			`Command is still running; auto-detached to background with ID: ${id} (${timeoutNote}).\n\nPartial output:\n${partialOutput}\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "${id}" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "${id}" }) to stop this session.`,
 			{
 				details: {
 					bash_id: id,

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
@@ -1,6 +1,7 @@
 import type { TerminalManager } from "../manager.ts";
 import type { MonitorEvent, MonitorRegistry } from "../monitor-registry.ts";
 import type { TerminalRuntimeSession } from "../runtime-session.ts";
+import type { TimeoutAction } from "../settings.ts";
 
 /** Shared dependencies handed to every terminal tool factory. */
 export interface TerminalToolContext {
@@ -10,6 +11,8 @@ export interface TerminalToolContext {
 	readonly shellPath?: string;
 	readonly defaultCols: number;
 	readonly defaultRows: number;
+	/** Configured foreground deadline behavior; omitted direct contexts default to background. */
+	readonly timeoutAction?: TimeoutAction;
 	/** Resolve the environment for spawned sessions (mirrors core bash `getShellEnv`). */
 	readonly getEnv: () => NodeJS.ProcessEnv;
 	/**

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/foreground-detach.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/foreground-detach.ts
@@ -1,0 +1,65 @@
+import type { TerminalRuntimeSession } from "../runtime-session.ts";
+
+export interface ForegroundDetachGateOptions {
+	readonly runtime: TerminalRuntimeSession;
+	readonly signal: AbortSignal | undefined;
+	readonly delayMs: number;
+	/** Removes the foreground abort listener at the detach linearization point. */
+	readonly removeAbortListener: () => void;
+}
+
+export interface ForegroundDetachGate {
+	/** Resolves only after detach has committed; it remains pending when exit or abort wins. */
+	readonly detached: Promise<void>;
+	cancel(): void;
+}
+
+/**
+ * Race a foreground command's cache deadline against exit and abort without
+ * introducing an observable gap between the final checks and promotion. The
+ * native session's `onExit` calls already-settled listeners, which makes the
+ * listener registration a linearization gate rather than a best-effort peek.
+ */
+export function createForegroundDetachGate(options: ForegroundDetachGateOptions): ForegroundDetachGate {
+	let cancelled = false;
+	let committed = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let resolveDetached!: () => void;
+	const detached = new Promise<void>((resolve) => {
+		resolveDetached = resolve;
+	});
+
+	const clearDeadline = () => {
+		if (timer === undefined) return;
+		clearTimeout(timer);
+		timer = undefined;
+	};
+
+	const linearize = () => {
+		if (cancelled || committed || options.runtime.exited) return;
+		if (options.signal?.aborted) return;
+
+		let exitedAtGate = false;
+		const unsubscribeExit = options.runtime.session.onExit(() => {
+			if (!committed) exitedAtGate = true;
+		});
+		if (cancelled || options.runtime.exited || exitedAtGate || options.signal?.aborted) {
+			unsubscribeExit();
+			return;
+		}
+
+		committed = true;
+		options.removeAbortListener();
+		unsubscribeExit();
+		resolveDetached();
+	};
+
+	timer = setTimeout(() => queueMicrotask(linearize), options.delayMs);
+	return {
+		detached,
+		cancel() {
+			cancelled = true;
+			clearDeadline();
+		},
+	};
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,35 @@
 # Core Extensions Changes
 
+## 2026-07-28 - Prompt-cache safe-wait budget on ExtensionContext
+
+### What changed and why
+
+- Added `ExtensionContext.getPromptCacheSafeWaitSeconds(): number | undefined`, the longest an extension-owned tool may block in the foreground before the active model's prompt cache expires. It is the model's cache TTL (resolved by `pi-ai`'s `resolvePromptCacheTtlSeconds`) minus a configurable safety buffer (`promptCache.safetyBufferSeconds`, default 30), and `undefined` whenever no cache-derived budget applies — unknown TTL, caching off, feature disabled, or the buffer swallowing the whole TTL.
+- Consumers: the builtin `bash-timeout` extension caps its recommended maximum at this budget, and the builtin `terminal` extension uses it as the foreground auto-detach deadline. Both fall back to byte-identical legacy behavior when the getter returns `undefined`.
+- The getter reads the LIVE current model on every call, so a `/model` switch takes effect immediately; callers must not snapshot it.
+
+### Why the extension system couldn't handle this alone
+
+Prompt-cache TTL is decided per provider inside `pi-ai`, and the resolved model plus the `promptCache` settings block live in the session core. Extensions have no access to either, so the budget must cross the boundary as a typed context getter.
+
+### Files modified
+
+- `types.ts` (`ExtensionContext`, `ExtensionContextActions`)
+- `runner.ts` (default stub, `bindCore` assignment, context exposure)
+- `../agent-session.ts` (binding + `resolvePromptCacheSafeWaitSeconds()` / `syncPromptCacheSafeWaitEnv()`)
+- `../../modes/interactive/interactive-mode.ts` (binding)
+- `../prompt-cache-budget.ts` (new), `../settings-manager.ts` (`PromptCacheSettings`)
+
+### Expected merge conflict zones on next upstream sync
+
+- HIGH: `types.ts` around the `ExtensionContext` getter block and the `ExtensionContextActions` mirror — the new member sits beside `getCompactionSettings` / `getLookAtSettings`. Resolution: keep the additive getter in both places.
+- MEDIUM: `runner.ts` context-action plumbing (three sites) and the `agent-session.ts` / `interactive-mode.ts` `contextActions` object literals.
+
+### Migration notes
+
+Hosts that construct `ExtensionContextActions` themselves must supply `getPromptCacheSafeWaitSeconds`; returning `() => undefined` preserves pre-existing behavior exactly.
+
+
 ## 2026-07-28 - session_before_reload (cancellable reload veto)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -385,6 +385,7 @@ export class ExtensionRunner {
 		reserveTokens: 16384,
 		keepRecentTokens: 20000,
 	});
+	private getPromptCacheSafeWaitSecondsFn: () => number | undefined = () => undefined;
 	private getLookAtSettingsFn: ExtensionContextActions["getLookAtSettings"] = () => ({
 		enabled: true,
 		models: undefined,
@@ -483,6 +484,9 @@ export class ExtensionRunner {
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.getCompactionSettingsFn = contextActions.getCompactionSettings;
+		if (contextActions.getPromptCacheSafeWaitSeconds)
+			if (contextActions.getPromptCacheSafeWaitSeconds)
+				this.getPromptCacheSafeWaitSecondsFn = contextActions.getPromptCacheSafeWaitSeconds;
 		this.getLookAtSettingsFn = contextActions.getLookAtSettings;
 		this.getImageSettingsFn = contextActions.getImageSettings;
 		this.sessionSettingsFn = contextActions.sessionSettings;
@@ -1013,6 +1017,10 @@ export class ExtensionRunner {
 			getCompactionSettings: () => {
 				runner.assertActive();
 				return runner.getCompactionSettingsFn();
+			},
+			getPromptCacheSafeWaitSeconds: () => {
+				runner.assertActive();
+				return runner.getPromptCacheSafeWaitSecondsFn();
 			},
 			getLookAtSettings: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -410,6 +410,12 @@ export interface ExtensionContext {
 	getContextUsage(): ContextUsage | undefined;
 	/** Get resolved compaction settings from global/project/user overrides. */
 	getCompactionSettings(): CompactionPreparation["settings"];
+	/**
+	 * Longest a tool may block in the foreground before the active model's prompt
+	 * cache expires, or `undefined` when no cache-derived budget applies. Reads the
+	 * LIVE current model, so callers must not snapshot the value.
+	 */
+	getPromptCacheSafeWaitSeconds?(): number | undefined;
 	/** Get resolved look-at settings from global/project/user overrides. */
 	getLookAtSettings(): { enabled: boolean; models: string[] | undefined };
 	/** Get resolved image settings from global/project/user overrides. */
@@ -1981,6 +1987,7 @@ export interface ExtensionContextActions {
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	getCompactionSettings: () => CompactionPreparation["settings"];
+	getPromptCacheSafeWaitSeconds?: () => number | undefined;
 	getLookAtSettings: () => { enabled: boolean; models: string[] | undefined };
 	getImageSettings: () => { autoResize: boolean; blockImages: boolean };
 	sessionSettings: ExtensionSessionSettings;

--- a/packages/coding-agent/src/core/prompt-cache-budget.ts
+++ b/packages/coding-agent/src/core/prompt-cache-budget.ts
@@ -1,0 +1,48 @@
+import type { Api, Model, ProviderEnv } from "@earendil-works/pi-ai";
+import { resolvePromptCacheTtlSeconds } from "@earendil-works/pi-ai";
+import type { PromptCacheSettings } from "./settings-manager.ts";
+
+/** Headroom subtracted from the model's prompt-cache TTL, so a wait never straddles cache expiry. */
+export const DEFAULT_PROMPT_CACHE_SAFETY_BUFFER_SECONDS = 30;
+
+/** Advisory out-of-process mirror of the resolved budget; absent means "no budget". */
+export const PROMPT_CACHE_SAFE_WAIT_ENV = "PI_PROMPT_CACHE_SAFE_WAIT_SECONDS";
+
+/**
+ * `pi-ai` provider env is a plain string map, while `process.env` values are
+ * optional. Drop the undefined entries at this boundary instead of casting.
+ */
+function toProviderEnv(env: NodeJS.ProcessEnv): ProviderEnv {
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== undefined) resolved[key] = value;
+	}
+	return resolved;
+}
+
+function resolveBufferSeconds(configured: number | undefined): number {
+	if (configured === undefined) return DEFAULT_PROMPT_CACHE_SAFETY_BUFFER_SECONDS;
+	if (!Number.isFinite(configured) || configured < 0) return DEFAULT_PROMPT_CACHE_SAFETY_BUFFER_SECONDS;
+	return Math.trunc(configured);
+}
+
+/**
+ * Longest a tool may block in the foreground without risking prompt-cache
+ * expiry: the active model's cache TTL minus a safety buffer.
+ *
+ * `undefined` means "no cache-derived budget" — the TTL is unknown, caching is
+ * off, the feature is disabled, or the buffer swallows the whole TTL. Callers
+ * treat that as today's unbounded behavior.
+ */
+export function resolvePromptCacheSafeWaitSeconds(
+	model: Model<Api> | undefined,
+	settings: PromptCacheSettings | undefined,
+	env: NodeJS.ProcessEnv,
+): number | undefined {
+	if (settings?.cacheAwareTimeouts === false) return undefined;
+	if (!model) return undefined;
+	const ttlSeconds = resolvePromptCacheTtlSeconds(model, toProviderEnv(env));
+	if (ttlSeconds === undefined) return undefined;
+	const safeWait = ttlSeconds - resolveBufferSeconds(settings?.safetyBufferSeconds);
+	return safeWait >= 1 ? safeWait : undefined;
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -63,6 +63,11 @@ export interface TerminalSettings {
 	monitorWakeBudget?: number; // default: 5 (consecutive monitor-only wake limit)
 }
 
+export interface PromptCacheSettings {
+	cacheAwareTimeouts?: boolean; // default: true (size foreground tool waits by the model's prompt-cache TTL)
+	safetyBufferSeconds?: number; // default: 30 (headroom subtracted from the cache TTL)
+}
+
 export interface ImageSettings {
 	autoResize?: boolean; // default: true (resize images to 2000x2000 max for better model compatibility)
 	blockImages?: boolean; // default: false - when true, prevents all images from being sent to LLM providers
@@ -152,6 +157,7 @@ export interface Settings {
 	hooks?: string[];
 	enableSkillCommands?: boolean; // default: true - register skills as /skill:name commands
 	terminal?: TerminalSettings;
+	promptCache?: PromptCacheSettings;
 	images?: ImageSettings;
 	lookAt?: LookAtSettings;
 	favoriteModels?: string[]; // Model patterns for Ctrl+P cycling (same format as --models CLI flag)

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2141,6 +2141,7 @@ export class InteractiveMode {
 			},
 			getContextUsage: () => this.session.getContextUsage(),
 			getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
+			getPromptCacheSafeWaitSeconds: () => this.session.resolvePromptCacheSafeWaitSeconds(),
 			getLookAtSettings: () => {
 				const global = this.settingsManager.getGlobalSettings().lookAt;
 				const project = this.settingsManager.getProjectSettings().lookAt;

--- a/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
+++ b/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
@@ -5,6 +5,7 @@ import {
 	BASH_MAX_TIMEOUT_SECONDS,
 	buildBashTimeoutPrompt,
 	resolveBashTimeoutDefaults,
+	resolveEffectiveBashTimeouts,
 } from "../../src/core/extensions/builtin/bash-timeout/timeout.ts";
 
 describe("resolveBashTimeoutDefaults", () => {
@@ -137,5 +138,82 @@ describe("buildBashTimeoutPrompt", () => {
 		expect(prompt).toContain("run_in_background");
 		expect(prompt).toContain("monitor");
 		expect(prompt).not.toContain("tmux");
+	});
+});
+
+describe("resolveEffectiveBashTimeouts", () => {
+	const base = { defaultSeconds: 120, maxSeconds: 600 };
+
+	it("leaves the defaults untouched when no cache budget applies", () => {
+		const result = resolveEffectiveBashTimeouts(base, undefined);
+
+		expect(result).toEqual({ defaultSeconds: 120, maxSeconds: 600, cacheCapped: false });
+	});
+
+	it("caps the recommended maximum at a 270s cache budget while keeping the injected default", () => {
+		const result = resolveEffectiveBashTimeouts(base, 270);
+
+		expect(result).toEqual({ defaultSeconds: 120, maxSeconds: 270, cacheCapped: true });
+	});
+
+	it("does not cap when the cache budget exceeds the configured maximum", () => {
+		const result = resolveEffectiveBashTimeouts(base, 3570);
+
+		expect(result).toEqual({ defaultSeconds: 120, maxSeconds: 600, cacheCapped: false });
+	});
+
+	it("pulls the default down with the max when the budget is below it", () => {
+		expect(resolveEffectiveBashTimeouts(base, 60)).toEqual({
+			defaultSeconds: 60,
+			maxSeconds: 60,
+			cacheCapped: true,
+		});
+		expect(resolveEffectiveBashTimeouts(base, 20)).toEqual({
+			defaultSeconds: 20,
+			maxSeconds: 20,
+			cacheCapped: true,
+		});
+	});
+
+	it("respects env-derived bases as the pre-cap values", () => {
+		const envBase = resolveBashTimeoutDefaults({
+			PI_BASH_DEFAULT_TIMEOUT_SECONDS: "30",
+			PI_BASH_MAX_TIMEOUT_SECONDS: "900",
+		});
+
+		expect(resolveEffectiveBashTimeouts(envBase, 270)).toEqual({
+			defaultSeconds: 30,
+			maxSeconds: 270,
+			cacheCapped: true,
+		});
+	});
+});
+
+describe("buildBashTimeoutPrompt cache awareness", () => {
+	const LEGACY_PROMPT =
+		"\n## Bash Tool Timeout Policy\n\nThe `bash` tool enforces timeouts even when you omit the `timeout` parameter:\n\n- Default timeout: 120s (2 min). Applied automatically when you do not set `timeout`.\n- Recommended maximum timeout: 600s (10 min). Explicit `timeout` values are preserved because different hosts may use different timeout units.\n- For long-running commands (builds, installs, test suites), set an explicit `timeout` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, start them with `run_in_background: true` and watch the decisive output with `monitor` instead of raising the timeout.\n";
+
+	it("is byte-identical to the legacy policy when no cache budget applies", () => {
+		expect(buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600, cacheCapped: false })).toBe(LEGACY_PROMPT);
+	});
+
+	it("names the cache-safe ceiling and the prompt-cache reason when capped", () => {
+		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 270, cacheCapped: true });
+
+		expect(prompt).toContain("270s");
+		expect(prompt).toMatch(/prompt cache/i);
+		expect(prompt).toContain("run_in_background");
+		expect(prompt).toContain("monitor");
+	});
+
+	it("names a tiny ceiling when the budget collapses default and max together", () => {
+		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 20, maxSeconds: 20, cacheCapped: true });
+
+		expect(prompt).toContain("20s");
+		expect(prompt).not.toContain("600s");
+	});
+
+	it("still accepts the legacy two-field defaults shape", () => {
+		expect(buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 })).toBe(LEGACY_PROMPT);
 	});
 });

--- a/packages/coding-agent/test/suite/prompt-cache-budget.test.ts
+++ b/packages/coding-agent/test/suite/prompt-cache-budget.test.ts
@@ -1,0 +1,85 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_PROMPT_CACHE_SAFETY_BUFFER_SECONDS,
+	resolvePromptCacheSafeWaitSeconds,
+} from "../../src/core/prompt-cache-budget.ts";
+
+function anthropicModel(overrides: Partial<Model<"anthropic-messages">> = {}): Model<"anthropic-messages"> {
+	return {
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+		...overrides,
+	} as Model<"anthropic-messages">;
+}
+
+function googleModel(): Model<"google-generative-ai"> {
+	return {
+		id: "gemini-3-pro",
+		name: "Gemini 3 Pro",
+		api: "google-generative-ai",
+		provider: "google",
+		baseUrl: "https://generativelanguage.googleapis.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000000,
+		maxTokens: 8192,
+	} as Model<"google-generative-ai">;
+}
+
+describe("resolvePromptCacheSafeWaitSeconds", () => {
+	it("subtracts the default 30s safety buffer from a 5m TTL", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), undefined, {})).toBe(270);
+		expect(DEFAULT_PROMPT_CACHE_SAFETY_BUFFER_SECONDS).toBe(30);
+	});
+
+	it("subtracts the buffer from a 1h TTL for direct api.anthropic.com models", () => {
+		const model = anthropicModel({ baseUrl: "https://api.anthropic.com", cacheRetention: "long" });
+		expect(resolvePromptCacheSafeWaitSeconds(model, undefined, {})).toBe(3570);
+	});
+
+	it("honors a configured safetyBufferSeconds", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), { safetyBufferSeconds: 295 }, {})).toBe(5);
+	});
+
+	it("returns undefined when the feature is disabled", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), { cacheAwareTimeouts: false }, {})).toBeUndefined();
+	});
+
+	it("returns undefined when the model TTL is unknown", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(googleModel() as Model<Api>, undefined, {})).toBeUndefined();
+	});
+
+	it("returns undefined when no model is active", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(undefined, undefined, {})).toBeUndefined();
+	});
+
+	it("returns undefined when the buffer swallows the whole TTL", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), { safetyBufferSeconds: 300 }, {})).toBeUndefined();
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), { safetyBufferSeconds: 400 }, {})).toBeUndefined();
+	});
+
+	it("ignores a negative or non-finite buffer and falls back to the default", () => {
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), { safetyBufferSeconds: -5 }, {})).toBe(270);
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), { safetyBufferSeconds: Number.NaN }, {})).toBe(270);
+	});
+
+	it("passes provider env through to the TTL resolver", () => {
+		const model = anthropicModel({ baseUrl: "https://api.anthropic.com" });
+		expect(resolvePromptCacheSafeWaitSeconds(model, undefined, { PI_CACHE_RETENTION: "long" })).toBe(3570);
+	});
+
+	it("filters undefined env values at the boundary", () => {
+		const env: NodeJS.ProcessEnv = { PI_CACHE_RETENTION: undefined, PATH: "/usr/bin" };
+		expect(resolvePromptCacheSafeWaitSeconds(anthropicModel(), undefined, env)).toBe(270);
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
+++ b/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 import type { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
 import type { TerminalRuntimeSession } from "../../src/core/extensions/builtin/terminal/runtime-session.ts";
 import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/tools/bash.ts";
 import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
-import type { TerminalToolContext, TerminalToolResult } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import type {
+	TerminalToolContext,
+	TerminalToolResult,
+} from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 
 const spawned = vi.hoisted(() => ({
 	nextId: 0,
@@ -14,7 +17,9 @@ const spawned = vi.hoisted(() => ({
 }));
 
 vi.mock("../../src/core/extensions/builtin/terminal/tools/spawn.ts", () => ({
-	describeExit: (runtime: { exitResult: { exitCode: number | null; timedOut: boolean; cancelled: boolean } | null }) => {
+	describeExit: (runtime: {
+		exitResult: { exitCode: number | null; timedOut: boolean; cancelled: boolean } | null;
+	}) => {
 		const exit = runtime.exitResult;
 		if (!exit) return null;
 		if (exit.timedOut) return "timed_out";
@@ -235,8 +240,7 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 			content: [
 				{
 					type: "text",
-					text:
-						"Command is still running; auto-detached to background with ID: bash_1 (not killed; the original 10s timeout still applies).\n\nPartial output:\nREADY\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: \"bash_1\" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: \"bash_1\" }) to stop this session.",
+					text: 'Command is still running; auto-detached to background with ID: bash_1 (not killed; the original 10s timeout still applies).\n\nPartial output:\nREADY\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "bash_1" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "bash_1" }) to stop this session.',
 				},
 			],
 			details: { bash_id: "bash_1", background: true, auto_detached: true, status: "running", droppedChars: 3 },
@@ -259,7 +263,7 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 
 		const detached = await execution;
 		expect(firstText(detached)).toBe(
-			"Command is still running; auto-detached to background with ID: bash_1 (not killed; it will run until exit or kill_bash).\n\nPartial output:\nBEFORE\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: \"bash_1\" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: \"bash_1\" }) to stop this session.",
+			'Command is still running; auto-detached to background with ID: bash_1 (not killed; it will run until exit or kill_bash).\n\nPartial output:\nBEFORE\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "bash_1" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "bash_1" }) to stop this session.',
 		);
 		expect(runtime.readDeltaCalls).toBe(1);
 

--- a/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
+++ b/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import type { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import type { TerminalRuntimeSession } from "../../src/core/extensions/builtin/terminal/runtime-session.ts";
+import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/tools/bash.ts";
+import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
+import type { TerminalToolContext, TerminalToolResult } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+
+const spawned = vi.hoisted(() => ({
+	nextId: 0,
+	runtime: undefined as unknown,
+	request: undefined as unknown,
+	exitAtMs: undefined as number | undefined,
+}));
+
+vi.mock("../../src/core/extensions/builtin/terminal/tools/spawn.ts", () => ({
+	describeExit: (runtime: { exitResult: { exitCode: number | null; timedOut: boolean; cancelled: boolean } | null }) => {
+		const exit = runtime.exitResult;
+		if (!exit) return null;
+		if (exit.timedOut) return "timed_out";
+		if (exit.cancelled) return "killed";
+		return exit.exitCode === 0 ? "completed" : `exited_${exit.exitCode}`;
+	},
+	spawnCommandSession: async (_ctx: unknown, request: unknown) => {
+		spawned.request = request;
+		const runtime = spawned.runtime as FakeRuntime;
+		if (spawned.exitAtMs !== undefined) setTimeout(() => runtime.exit(), spawned.exitAtMs);
+		return { id: `bash_${++spawned.nextId}`, runtime };
+	},
+}));
+
+type Exit = {
+	readonly exitCode: number | null;
+	readonly timedOut: boolean;
+	readonly cancelled: boolean;
+	readonly signal: string | null;
+	readonly backend: "native";
+};
+
+class FakeRuntime {
+	readonly session = {
+		kill: vi.fn(),
+		waitExit: () => this.exitPromise,
+		onExit: (listener: () => void) => {
+			if (this.exited) queueMicrotask(listener);
+			else this.exitListeners.add(listener);
+			return () => this.exitListeners.delete(listener);
+		},
+	};
+	readonly backend = "native";
+	readonly outputListeners = new Set<(chunk: string) => void>();
+	readonly exitListeners = new Set<() => void>();
+	readonly exitPromise: Promise<void>;
+	private resolveExit!: () => void;
+	private output = "";
+	private consumed = 0;
+	exited = false;
+	exitResult: Exit | null = null;
+	readDeltaCalls = 0;
+	nextDeltaDroppedChars = 0;
+
+	constructor() {
+		this.exitPromise = new Promise<void>((resolve) => {
+			this.resolveExit = resolve;
+		});
+	}
+
+	emit(text: string): void {
+		this.output += text;
+		for (const listener of this.outputListeners) listener(text);
+	}
+
+	exit(exit: Partial<Exit> = {}): void {
+		if (this.exited) return;
+		this.exited = true;
+		this.exitResult = {
+			exitCode: exit.exitCode ?? 0,
+			timedOut: exit.timedOut ?? false,
+			cancelled: exit.cancelled ?? false,
+			signal: exit.signal ?? null,
+			backend: "native",
+		};
+		for (const listener of this.exitListeners) listener();
+		this.exitListeners.clear();
+		this.resolveExit();
+	}
+
+	onOutput(listener: (chunk: string) => void): () => void {
+		this.outputListeners.add(listener);
+		return () => this.outputListeners.delete(listener);
+	}
+
+	readDelta(): { text: string; droppedChars: number } {
+		this.readDeltaCalls += 1;
+		const text = this.output.slice(this.consumed);
+		this.consumed = this.output.length;
+		const droppedChars = this.nextDeltaDroppedChars;
+		this.nextDeltaDroppedChars = 0;
+		return { text, droppedChars };
+	}
+
+	fullOutput(): string {
+		return this.output;
+	}
+}
+
+function firstText(result: TerminalToolResult): string {
+	return result.content.map((block) => block.text).join("\n");
+}
+
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function setup(options: { safeWaitSeconds?: number; timeoutAction?: "background" | "kill" } = {}) {
+	const runtime = new FakeRuntime();
+	const backgroundExit = vi.fn();
+	const manager = {
+		get: vi.fn(() => runtime as unknown as TerminalRuntimeSession),
+		stop: vi.fn(async () => true),
+	} as unknown as TerminalManager;
+	const ctx = {
+		manager,
+		cwd: "/fixture",
+		defaultCols: 120,
+		defaultRows: 40,
+		getEnv: () => ({}),
+		timeoutAction: options.timeoutAction ?? "background",
+		getSessionContext: () =>
+			({
+				getPromptCacheSafeWaitSeconds: () => options.safeWaitSeconds,
+			}) as ExtensionContext,
+		onBackgroundExit: backgroundExit,
+	} as TerminalToolContext;
+	spawned.runtime = runtime;
+	return { runtime, backgroundExit, manager, ctx, bash: createPtyBashTool(ctx), output: createBashOutputTool(ctx) };
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	spawned.nextId = 0;
+	spawned.runtime = undefined;
+	spawned.request = undefined;
+	spawned.exitAtMs = undefined;
+});
+
+afterEach(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+});
+
+describe("terminal bash foreground cache-deadline auto-detach", () => {
+	it("keeps native foreground behavior when no cache-safe budget is available", async () => {
+		const { bash, runtime } = setup();
+		const execution = bash.execute("no-budget", { command: "echo done", timeout: 10 });
+		await flushMicrotasks();
+		runtime.emit("done\n");
+		runtime.exit();
+
+		const result = await execution;
+		expect(firstText(result)).toBe("done");
+		expect(result.details).toEqual({ status: "completed" });
+		expect(runtime.readDeltaCalls).toBe(0);
+	});
+
+	it("does not auto-detach when timeoutAction is kill", async () => {
+		const { bash, runtime } = setup({ safeWaitSeconds: 5, timeoutAction: "kill" });
+		const execution = bash.execute("kill-policy", { command: "sleep", timeout: 10 });
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(runtime.exited).toBe(false);
+		expect(runtime.readDeltaCalls).toBe(0);
+
+		runtime.exit({ timedOut: true, exitCode: 124 });
+		const result = await execution;
+		expect(result.isError).toBe(true);
+		expect(firstText(result)).toBe("Command timed out after 10 seconds");
+		expect(result.details).toBeUndefined();
+	});
+
+	it("keeps native foreground behavior when the configured timeout equals the budget", async () => {
+		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("equal-budget", { command: "echo exact", timeout: 5 });
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(runtime.readDeltaCalls).toBe(0);
+
+		runtime.emit("exact\n");
+		runtime.exit();
+		const result = await execution;
+		expect(firstText(result)).toBe("exact");
+		expect(result.details).toEqual({ status: "completed" });
+	});
+
+	it("returns the exact completed result when a command exits before the budget", async () => {
+		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("early-exit", { command: "echo early", timeout: 10 });
+		await flushMicrotasks();
+		runtime.emit("early\n");
+		runtime.exit();
+
+		const result = await execution;
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(firstText(result)).toBe("early");
+		expect(result.details).toEqual({ status: "completed" });
+		expect(runtime.readDeltaCalls).toBe(0);
+	});
+
+	it("linearizes an exit exactly at D ahead of detachment", async () => {
+		spawned.exitAtMs = 5_000;
+		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("exit-at-deadline", { command: "echo same-tick", timeout: 10 });
+		await flushMicrotasks();
+		runtime.emit("same-tick\n");
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		const result = await execution;
+		expect(firstText(result)).toBe("same-tick");
+		expect(result.details).toEqual({ status: "completed" });
+		expect(runtime.readDeltaCalls).toBe(0);
+	});
+
+	it("auto-detaches a still-running finite-timeout command, preserves T, and sweeps after its native grace", async () => {
+		const { bash, runtime, manager, backgroundExit } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("detach", { command: "sleep", timeout: 10 });
+		await flushMicrotasks();
+		runtime.emit("READY\n");
+		runtime.nextDeltaDroppedChars = 3;
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		const result = await execution;
+		expect(spawned.request).toMatchObject({ timeoutMs: 10_000 });
+		expect(result).toEqual({
+			content: [
+				{
+					type: "text",
+					text:
+						"Command is still running; auto-detached to background with ID: bash_1 (not killed; the original 10s timeout still applies).\n\nPartial output:\nREADY\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: \"bash_1\" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: \"bash_1\" }) to stop this session.",
+				},
+			],
+			details: { bash_id: "bash_1", background: true, auto_detached: true, status: "running", droppedChars: 3 },
+			isError: undefined,
+		});
+		expect(runtime.readDeltaCalls).toBe(1);
+		expect(runtime.session.kill).not.toHaveBeenCalled();
+		expect(backgroundExit).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(manager.stop).toHaveBeenCalledWith("bash_1");
+	});
+
+	it("uses the no-timeout parenthetical and keeps the delta cursor continuous after detachment", async () => {
+		const { bash, output, runtime } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("no-timeout", { command: "wait forever" });
+		await flushMicrotasks();
+		runtime.emit("BEFORE\n");
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		const detached = await execution;
+		expect(firstText(detached)).toBe(
+			"Command is still running; auto-detached to background with ID: bash_1 (not killed; it will run until exit or kill_bash).\n\nPartial output:\nBEFORE\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: \"bash_1\" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: \"bash_1\" }) to stop this session.",
+		);
+		expect(runtime.readDeltaCalls).toBe(1);
+
+		runtime.emit("AFTER\n");
+		const peek = await output.execute("peek", { bash_id: "bash_1" });
+		expect(firstText(peek)).toBe("status: running\nAFTER");
+		expect(firstText(peek)).not.toContain("BEFORE");
+		expect(firstText(peek)).not.toContain("auto-detached");
+		expect(runtime.readDeltaCalls).toBe(2);
+	});
+
+	it("ignores an abort after the detach commit and notifies once when the detached session exits", async () => {
+		const controller = new AbortController();
+		const { bash, runtime, backgroundExit } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("abort-after-detach", { command: "sleep", timeout: 10 }, controller.signal);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(5_000);
+		await execution;
+
+		controller.abort();
+		expect(runtime.session.kill).not.toHaveBeenCalled();
+		runtime.exit({ cancelled: true, exitCode: null, signal: "SIGKILL" });
+		await flushMicrotasks();
+		expect(backgroundExit).toHaveBeenCalledTimes(1);
+		expect(backgroundExit).toHaveBeenCalledWith("bash_1", runtime);
+	});
+
+	it("linearizes an abort exactly at D ahead of detachment", async () => {
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 5_000);
+		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
+		const execution = bash.execute("abort-at-deadline", { command: "sleep", timeout: 10 }, controller.signal);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(runtime.session.kill).toHaveBeenCalledWith("SIGKILL");
+		expect(runtime.readDeltaCalls).toBe(0);
+
+		runtime.exit({ cancelled: true, exitCode: null, signal: "SIGKILL" });
+		const result = await execution;
+		expect(result.isError).toBe(true);
+		expect(firstText(result)).toBe("Command aborted");
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -1,6 +1,5 @@
 import { TerminalSession } from "@earendil-works/pi-pty";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import { createBuiltinParserRegistry } from "../../src/core/extensions/builtin/permission-system/parsers.ts";
 import registerTerminalExtension from "../../src/core/extensions/builtin/terminal/index.ts";
 import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
@@ -9,8 +8,12 @@ import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/to
 import { createBashInputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-input.ts";
 import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
 import { createBashResizeTool } from "../../src/core/extensions/builtin/terminal/tools/bash-resize.ts";
-import type { TerminalToolContext, TerminalToolResult } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import type {
+	TerminalToolContext,
+	TerminalToolResult,
+} from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import type { Harness } from "./harness.ts";
 import { createHarness } from "./harness.ts";
 
@@ -321,7 +324,8 @@ describe("terminal extension auto-detach wiring", () => {
 		let output = "";
 		let consumed = 0;
 		let exited = false;
-		let exitResult: { exitCode: number | null; timedOut: boolean; cancelled: boolean; signal: string | null } | null = null;
+		let exitResult: { exitCode: number | null; timedOut: boolean; cancelled: boolean; signal: string | null } | null =
+			null;
 		let resolveExit!: () => void;
 		const waitExit = new Promise<void>((resolve) => {
 			resolveExit = resolve;

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -1,5 +1,6 @@
 import { TerminalSession } from "@earendil-works/pi-pty";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import { createBuiltinParserRegistry } from "../../src/core/extensions/builtin/permission-system/parsers.ts";
 import registerTerminalExtension from "../../src/core/extensions/builtin/terminal/index.ts";
 import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
@@ -8,10 +9,29 @@ import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/to
 import { createBashInputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-input.ts";
 import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
 import { createBashResizeTool } from "../../src/core/extensions/builtin/terminal/tools/bash-resize.ts";
-import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import type { TerminalToolContext, TerminalToolResult } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
 import type { Harness } from "./harness.ts";
 import { createHarness } from "./harness.ts";
+
+const autoDetachSpawn = vi.hoisted(() => ({
+	enabled: false,
+	spawn: undefined as ((...args: unknown[]) => unknown) | undefined,
+}));
+
+vi.mock("../../src/core/extensions/builtin/terminal/tools/spawn.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../../src/core/extensions/builtin/terminal/tools/spawn.ts")>();
+	return {
+		...original,
+		spawnCommandSession: (...args: unknown[]) => {
+			if (!autoDetachSpawn.enabled) {
+				return original.spawnCommandSession(...(args as Parameters<typeof original.spawnCommandSession>));
+			}
+			if (!autoDetachSpawn.spawn) throw new Error("Auto-detach spawn was not configured");
+			return autoDetachSpawn.spawn(...args);
+		},
+	};
+});
 
 const COMPANIONS = ["bash_output", "bash_input", "bash_resize", "kill_bash", "monitor"];
 
@@ -286,5 +306,140 @@ describe("terminal builtin extension — bash_output robustness", () => {
 		const statusCheck = await output.execute("call-status-after-ghost", { bash_id: bashId });
 		expect(firstText(statusCheck)).toContain("status: running");
 		await manager.stop(bashId);
+	});
+});
+
+describe("terminal extension auto-detach wiring", () => {
+	afterEach(() => {
+		autoDetachSpawn.enabled = false;
+		autoDetachSpawn.spawn = undefined;
+		vi.useRealTimers();
+	});
+
+	it("promotes READY at the live cache deadline, preserves delta continuity, and notifies exactly once on kill", async () => {
+		vi.useFakeTimers();
+		let output = "";
+		let consumed = 0;
+		let exited = false;
+		let exitResult: { exitCode: number | null; timedOut: boolean; cancelled: boolean; signal: string | null } | null = null;
+		let resolveExit!: () => void;
+		const waitExit = new Promise<void>((resolve) => {
+			resolveExit = resolve;
+		});
+		const exitListeners = new Set<() => void>();
+		const outputListeners = new Set<(chunk: string) => void>();
+		const runtime = {
+			get exited() {
+				return exited;
+			},
+			get exitResult() {
+				return exitResult;
+			},
+			session: {
+				kill: vi.fn(),
+				waitExit: () => waitExit,
+				onExit: (listener: () => void) => {
+					if (exited) queueMicrotask(listener);
+					else exitListeners.add(listener);
+					return () => exitListeners.delete(listener);
+				},
+			},
+			onOutput: (listener: (chunk: string) => void) => {
+				outputListeners.add(listener);
+				return () => outputListeners.delete(listener);
+			},
+			fullOutput: () => output,
+			readDelta: () => {
+				const text = output.slice(consumed);
+				consumed = output.length;
+				return { text, droppedChars: 0 };
+			},
+		};
+		const emit = (text: string) => {
+			output += text;
+			for (const listener of outputListeners) listener(text);
+		};
+		const exit = () => {
+			if (exited) return;
+			exited = true;
+			exitResult = { exitCode: null, timedOut: false, cancelled: true, signal: "SIGKILL" };
+			for (const listener of exitListeners) listener();
+			exitListeners.clear();
+			resolveExit();
+		};
+
+		type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+		type Tool = { name: string; execute: (...args: never[]) => Promise<unknown> };
+		const handlers = new Map<string, Handler[]>();
+		const tools = new Map<string, Tool>();
+		const notices: string[] = [];
+		let activeTools: string[] = [];
+		const fakePi = {
+			registerTool: (tool: Tool) => tools.set(tool.name, tool),
+			on: (event: string, handler: Handler) => {
+				const registered = handlers.get(event) ?? [];
+				registered.push(handler);
+				handlers.set(event, registered);
+			},
+			sendUserMessage: (content: string) => notices.push(content),
+			getActiveTools: () => activeTools,
+			setActiveTools: (next: string[]) => {
+				activeTools = next;
+			},
+		} as unknown as ExtensionAPI;
+		autoDetachSpawn.enabled = true;
+		autoDetachSpawn.spawn = (toolContext: unknown) => {
+			const manager = (toolContext as TerminalToolContext).manager;
+			vi.spyOn(manager, "get").mockReturnValue(runtime as unknown as TerminalRuntimeSession);
+			vi.spyOn(manager, "stop").mockImplementation(async () => {
+				exit();
+				return true;
+			});
+			return { id: "bash_1", runtime };
+		};
+		registerTerminalExtension(fakePi);
+
+		const ctx = {
+			cwd: process.cwd(),
+			mode: "tui",
+			model: { id: "fixture", api: "anthropic-messages" },
+			getPromptCacheSafeWaitSeconds: () => 5,
+			ui: { notify: () => {}, setStatus: () => {} },
+		} as unknown as ExtensionContext;
+		for (const handler of handlers.get("session_start") ?? []) await handler({}, ctx);
+
+		const bash = tools.get("bash") as unknown as {
+			execute: (id: string, input: { command: string; timeout: number }) => Promise<TerminalToolResult>;
+		};
+		const bashOutput = tools.get("bash_output") as unknown as {
+			execute: (id: string, input: { bash_id: string }) => Promise<TerminalToolResult>;
+		};
+		const kill = tools.get("kill_bash") as unknown as {
+			execute: (id: string, input: { bash_id: string }) => Promise<TerminalToolResult>;
+		};
+		const execution = bash.execute("foreground", { command: "fixture", timeout: 10 });
+		await Promise.resolve();
+		await Promise.resolve();
+		emit("READY\n");
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		const detached = await execution;
+		expect(firstText(detached)).toContain("auto-detached to background with ID: bash_1");
+		expect(firstText(detached)).toContain("Partial output:\nREADY");
+		expect(exited).toBe(false);
+
+		emit("AFTER\n");
+		const peek = await bashOutput.execute("peek", { bash_id: "bash_1" });
+		expect(firstText(peek)).toBe("status: running\nAFTER");
+		expect(firstText(peek)).not.toContain("READY");
+		expect(firstText(peek)).not.toContain("auto-detached");
+
+		const killed = await kill.execute("kill", { bash_id: "bash_1" });
+		expect(firstText(killed)).toBe("Killed bash_1.");
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toContain("Background terminal session bash_1 finished: killed");
+		expect(notices[0]).toContain("AFTER");
+
+		for (const handler of handlers.get("session_shutdown") ?? []) await handler({}, ctx);
 	});
 });


### PR DESCRIPTION
## Summary

The `bash` tool (and, cross-repo, omo's `task` tool) now size how long they block in the foreground on the **active model's prompt-cache lifetime** instead of a fixed 600s ceiling. A 5-minute cache yields a ~270s safe ceiling (30s buffer); a still-running foreground command is **handed to a background session alive** at that deadline rather than blocking past cache expiry or being killed.

Blocking past the cache lifetime expires the cache and forces a full re-read on the next request. Sizing the ceiling by the TTL keeps the cache warm without losing the running work.

Plan: `.omo/plans/cache-aware-tool-timeouts.md`

## What changed

| Layer | Change |
|---|---|
| `packages/ai` | New browser-safe `resolvePromptCacheTtlSeconds(model, env?)`. Mirrors **each** API's own `resolveCacheRetention` precedence verbatim (anthropic falls back to `"long"` and honors the bare `process.env.PI_CACHE_RETENTION` branch; openai/bedrock fall back to `"short"`; pi-messages returns `undefined`). Unknown-cache APIs (google, mistral, pi-messages) and retention `"none"` → `undefined`. |
| `packages/coding-agent` core | `promptCache` settings (`cacheAwareTimeouts` default true, `safetyBufferSeconds` default 30), `prompt-cache-budget.ts`, typed `ExtensionContext.getPromptCacheSafeWaitSeconds()`, advisory `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS` env bridge refreshed on session start/reload/model select. |
| `bash-timeout` extension | `resolveEffectiveBashTimeouts()` caps the recommended max at the budget; the policy prompt is rebuilt per `before_agent_start` and names the ceiling + the prompt-cache reason. |
| `terminal` extension | The previously **declared-but-unwired** `terminal.timeoutAction` is now implemented and drives foreground auto-detach at deadment D. |

The explicit timeout `T` is **never shortened** — it stays the native PTY kill deadline, and still applies after a detach.

## Zero behavior change when no budget applies

TTL unknown (google), retention `none`, or `cacheAwareTimeouts: false` → the injected default and recommended max keep today's values and the policy prompt is **byte-identical** under strict `===` (pinned by test).

## Detach linearization

Exit > abort > detach. When D fires: queue one microtask → check exit → check abort → install the settled-aware `onExit` gate → recheck → commit detach and remove the abort listener synchronously. An exit or abort at/before that point wins; an abort after commit is ignored (`kill_bash` becomes the stop surface). `readDelta()` is called **exactly once** at detach, so `bash_output` continues without duplication.

## Verification

All green in single runs:

- `packages/ai`: `prompt-cache-ttl.test.ts` **24/24** (RED 23/23 captured first)
- `packages/coding-agent`: 8 suites (`terminal-bash-auto-detach`, `terminal-extension`, `terminal-settings-notify`, `terminal-monitor`, `bash-timeout-extension`, `prompt-cache-budget`, `prompt-surface-stale-wait-idioms`, `5943` regression) → **89/89**
- root `npm run check` → **exit 0** (includes `check:browser-smoke`)

**Real-surface QA** (real PTY, D shrunk to 5s, `timeoutAction: background`):

```
bash({ command: "echo BEFORE_DETACH; sleep 8; echo AFTER_DETACH; sleep 60", timeout: 12 })
-> detached at exactly 5.0s
-> {"bash_id":"bash_1","background":true,"auto_detached":true,"status":"running"}
-> partial output: BEFORE_DETACH  (AFTER_DETACH correctly absent)
-> "(not killed; the original 12s timeout still applies)"
-> bash_output at ~10s: AFTER_DETACH, with BEFORE_DETACH NOT repeated (delta cursor advanced once)
```

senpi-qa channels: `pty-drive` 8/8 (native backend, no orphans), `cli-smoke` 8/8, `mock-loop --with-tool --api anthropic-messages` 4/4. The real `~/.senpi/agent/auth.json` sha256 was asserted unchanged in every run.

## Note on the browser boundary

The first implementation imported `supportsPromptCaching` directly from `bedrock-converse-stream.ts`, which dragged the AWS SDK into the browser-safe root and broke `check:browser-smoke` with 18 unresolved `node:*` errors. Fixed by moving the **pure** compat predicates into the browser-safe utility, with the API modules importing from it and re-exporting — one source of truth, no divergence risk.

## Companion change

The omo side (`packages/senpi-task` bounded foreground wait + `promoteToBackground`) landed separately in the omo repo as `6846ef8c2`, written against the frozen contract (feature-detected getter, then env, else unbounded) so it works with older senpi too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes foreground tool waits cache‑aware. `bash` now caps foreground blocking to the active model’s prompt‑cache TTL (minus a buffer) and auto‑detaches before expiry so the cache stays warm and the work continues in the background. Defaults are safe; set `promptCache.cacheAwareTimeouts: false` to opt out and `terminal.timeoutAction: "background"` to enable auto‑detach.

- **New Features**
  - `packages/ai`: Added browser‑safe `resolvePromptCacheTtlSeconds(model, env?)` with `PROMPT_CACHE_TTL_SHORT_SECONDS`/`PROMPT_CACHE_TTL_LONG_SECONDS`. Moved pure compat predicates into a shared utility and re‑exported from API modules.
  - `packages/coding-agent`: New `promptCache` settings (`cacheAwareTimeouts` default true, `safetyBufferSeconds` default 30). Exposed `getPromptCacheSafeWaitSeconds()` on the extension context and mirrored the budget in `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS` (cleared when absent).
  - `bash-timeout` extension: Caps the recommended max timeout to the cache‑safe budget and updates the policy prompt to explain the cache reason. Explicit `timeout` values are unchanged.
  - `terminal` extension: Implemented `terminal.timeoutAction`. With `background`, foreground runs that exceed the budget auto‑detach at the deadline; the original native timeout still applies. No change when the budget is absent or `timeoutAction` is `kill`.

- **Bug Fixes**
  - `bash-timeout` extension: Tolerates a missing extension context in timeout handlers to avoid crashes when the context isn’t provided.

<sup>Written for commit 4cada467261c284a8958e548feb84f578ce7db86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

