### PR TITLE
feat(coding-agent): discover nearest parent config

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -8,6 +8,21 @@
 - Coverage: `test/suite/regressions/0000-editor-paste-marker-transfer.test.ts` drives the real `setCustomEditorComponent` (prototype + fakeThis pattern) with real tui editors: registry transfer to a paste-aware editor, expanded-text fallback for a plain `EditorComponent`, restore to the default editor, full plain-editor round-trip, and the same-instance no-op.
 
 ## Cancellable `session_before_reload` veto blocks reload while extensions protect live work (2026-07-28)
+## Nearest-parent configuration discovery (2026-07-28)
+
+### What changed
+
+- `config.ts`: `getAgentDir()` now honors `SENPI_CODING_AGENT_DIR` first, otherwise finds the nearest ancestor with a real `.senpi/agent` directory before falling back to `~/.senpi/agent`. The exported `resolveAgentDir(cwd, homeDir, envDir)` makes the precedence contract deterministic for callers and tests.
+- `nearest-parent-config.ts`: centralizes the bounded upward walk for config directories. It excludes `$HOME` so global configuration remains the fallback layer and refuses symlinked `.senpi` directories.
+
+### Why
+
+- Starting senpi from a nested project directory previously ignored that project's config and always selected the home agent directory.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `config.ts` around `getAgentDir()`; the discovery helper is a focused fork-owned module.
+
 
 ### What changed
 

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -2,6 +2,7 @@ import { accessSync, constants, existsSync, readFileSync, realpathSync } from "f
 import { homedir } from "os";
 import { basename, dirname, join, resolve, sep, win32 } from "path";
 import { fileURLToPath } from "url";
+import { findNearestParentConfigDir } from "./nearest-parent-config.ts";
 import { spawnProcessSync } from "./utils/child-process.ts";
 import { normalizePath } from "./utils/paths.ts";
 
@@ -511,13 +512,18 @@ export function getShareViewerUrl(gistId: string): string {
 // User Config Paths (~/.senpi/agent/*)
 // =============================================================================
 
+/** Resolve the agent config directory from an explicit environment. */
+export function resolveAgentDir(cwd: string, homeDir: string, envDir?: string): string {
+	if (envDir) {
+		return normalizePath(envDir, { homeDir });
+	}
+	const projectConfigDir = findNearestParentConfigDir(cwd, homeDir, CONFIG_DIR_NAME, "agent");
+	return projectConfigDir ? join(projectConfigDir, "agent") : join(homeDir, CONFIG_DIR_NAME, "agent");
+}
+
 /** Get the agent config directory (e.g., ~/.senpi/agent/) */
 export function getAgentDir(): string {
-	const envDir = process.env[ENV_AGENT_DIR];
-	if (envDir) {
-		return expandTildePath(envDir);
-	}
-	return join(homedir(), CONFIG_DIR_NAME, "agent");
+	return resolveAgentDir(process.cwd(), homedir(), process.env[ENV_AGENT_DIR]);
 }
 
 /** Get path to user's custom themes directory */

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## Nearest-parent project settings discovery (2026-07-28)
+
+### What changed
+
+- `settings-manager.ts`: project settings now resolve from the nearest ancestor containing a real `.senpi` directory, rather than only from the exact cwd. If none exists, the legacy `<cwd>/.senpi/settings.json` path remains the write/read target.
+- Global settings remain loaded before project settings, so project values continue to override the selected agent-directory settings layer.
+
+### Why
+
+- Invoking senpi below a project root silently skipped that root's `.senpi/settings.json`.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `getSettingsPath()` in `settings-manager.ts`.
+
 ## claude-agent-sdk provider with native multi-account OAuth (2026-07-27)
 
 ### What changed

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -2,9 +2,11 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Transport } from "@earendil-works/pi-ai";
 import { createHash, randomUUID } from "crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
+import { findNearestParentConfigDir } from "../nearest-parent-config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 
@@ -287,10 +289,18 @@ export function __setSelfWriteTrackerClockForTests(clock: (() => number) | undef
 }
 
 /** Returns the absolute settings path for a filesystem-backed storage scope. */
-export function getSettingsPath(cwd: string, agentDir: string, scope: SettingsScope): string {
-	return scope === "global"
-		? join(resolvePath(agentDir), "settings.json")
-		: join(resolvePath(cwd), CONFIG_DIR_NAME, "settings.json");
+export function getSettingsPath(
+	cwd: string,
+	agentDir: string,
+	scope: SettingsScope,
+	homeDir: string = homedir(),
+): string {
+	if (scope === "global") {
+		return join(resolvePath(agentDir), "settings.json");
+	}
+	const resolvedCwd = resolvePath(cwd);
+	const projectConfigDir = findNearestParentConfigDir(resolvedCwd, homeDir, CONFIG_DIR_NAME);
+	return join(projectConfigDir ?? join(resolvedCwd, CONFIG_DIR_NAME), "settings.json");
 }
 
 /** Returns the stable virtual path used to identify in-memory settings storage writes. */
@@ -315,9 +325,9 @@ export class FileSettingsStorage implements SettingsStorage {
 	private globalSettingsPath: string;
 	private projectSettingsPath: string;
 
-	constructor(cwd: string, agentDir: string) {
-		this.globalSettingsPath = getSettingsPath(cwd, agentDir, "global");
-		this.projectSettingsPath = getSettingsPath(cwd, agentDir, "project");
+	constructor(cwd: string, agentDir: string, homeDir: string = homedir()) {
+		this.globalSettingsPath = getSettingsPath(cwd, agentDir, "global", homeDir);
+		this.projectSettingsPath = getSettingsPath(cwd, agentDir, "project", homeDir);
 	}
 
 	private acquireLockSyncWithRetry(path: string): () => void {

--- a/packages/coding-agent/src/nearest-parent-config.ts
+++ b/packages/coding-agent/src/nearest-parent-config.ts
@@ -1,0 +1,45 @@
+import { lstatSync } from "node:fs";
+import { dirname, join, normalize } from "node:path";
+
+export const MAX_PARENT_CONFIG_SEARCH_DEPTH = 100;
+
+function isDirectory(path: string): boolean {
+	try {
+		return lstatSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Finds the nearest non-symlinked config directory between cwd and home.
+ * Home is excluded so its config remains the global fallback layer.
+ */
+export function findNearestParentConfigDir(
+	cwd: string,
+	homeDir: string,
+	configDirName: string,
+	requiredChildDir?: string,
+): string | undefined {
+	const normalizedHomeDir = normalize(homeDir);
+	let currentDir = normalize(cwd);
+
+	for (let depth = 0; depth <= MAX_PARENT_CONFIG_SEARCH_DEPTH; depth += 1) {
+		if (currentDir === normalizedHomeDir) {
+			return undefined;
+		}
+
+		const configDir = join(currentDir, configDirName);
+		if (isDirectory(configDir) && (!requiredChildDir || isDirectory(join(configDir, requiredChildDir)))) {
+			return configDir;
+		}
+
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) {
+			return undefined;
+		}
+		currentDir = parentDir;
+	}
+
+	return undefined;
+}

--- a/packages/coding-agent/test/nearest-parent-config.test.ts
+++ b/packages/coding-agent/test/nearest-parent-config.test.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CONFIG_DIR_NAME, ENV_AGENT_DIR, getAgentDir, resolveAgentDir } from "../src/config.ts";
+import { FileSettingsStorage, getSettingsPath, SettingsManager } from "../src/core/settings-manager.ts";
+import { findNearestParentConfigDir, MAX_PARENT_CONFIG_SEARCH_DEPTH } from "../src/nearest-parent-config.ts";
+
+const tempDirs: string[] = [];
+const originalAgentDir = process.env[ENV_AGENT_DIR];
+const originalCwd = process.cwd();
+
+function createTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-nearest-parent-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function createAgentDir(root: string): string {
+	const agentDir = join(root, CONFIG_DIR_NAME, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	return agentDir;
+}
+
+afterEach(() => {
+	process.chdir(originalCwd);
+	if (originalAgentDir === undefined) {
+		delete process.env[ENV_AGENT_DIR];
+	} else {
+		process.env[ENV_AGENT_DIR] = originalAgentDir;
+	}
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("nearest parent config discovery", () => {
+	it("lets SENPI_CODING_AGENT_DIR win over a nearer project agent directory", () => {
+		const root = createTempDir();
+		const project = join(root, "project");
+		const cwd = join(project, "src", "feature");
+		const override = join(root, "override");
+		createAgentDir(project);
+		mkdirSync(cwd, { recursive: true });
+		process.env[ENV_AGENT_DIR] = override;
+		process.chdir(cwd);
+
+		expect(getAgentDir()).toBe(override);
+		expect(resolveAgentDir(cwd, join(root, "home"), override)).toBe(override);
+	});
+
+	it("finds a project agent directory from several levels below its root", () => {
+		const root = createTempDir();
+		const home = join(root, "home");
+		const project = join(root, "project");
+		const cwd = join(project, "src", "feature", "nested");
+		const agentDir = createAgentDir(project);
+		mkdirSync(cwd, { recursive: true });
+
+		expect(resolveAgentDir(cwd, home)).toBe(agentDir);
+	});
+
+	it("uses the nearest nested project agent directory", () => {
+		const root = createTempDir();
+		const home = join(root, "home");
+		const outerProject = join(root, "outer");
+		const innerProject = join(outerProject, "packages", "inner");
+		const cwd = join(innerProject, "src", "feature");
+		createAgentDir(outerProject);
+		const innerAgentDir = createAgentDir(innerProject);
+		mkdirSync(cwd, { recursive: true });
+
+		expect(resolveAgentDir(cwd, home)).toBe(innerAgentDir);
+	});
+
+	it("falls back to the home agent directory without treating home as a project", () => {
+		const root = createTempDir();
+		const home = join(root, "home");
+		const cwd = join(home, "project", "src");
+		const homeAgentDir = createAgentDir(home);
+		mkdirSync(cwd, { recursive: true });
+
+		expect(findNearestParentConfigDir(cwd, home, CONFIG_DIR_NAME, "agent")).toBeUndefined();
+		expect(resolveAgentDir(cwd, home)).toBe(homeAgentDir);
+	});
+
+	it("refuses symlinked project config directories", () => {
+		const root = createTempDir();
+		const home = join(root, "home");
+		const project = join(root, "project");
+		const cwd = join(project, "src");
+		const linkedConfigSource = join(root, "linked-config");
+		const homeAgentDir = createAgentDir(home);
+		createAgentDir(linkedConfigSource);
+		mkdirSync(cwd, { recursive: true });
+		symlinkSync(join(linkedConfigSource, CONFIG_DIR_NAME), join(project, CONFIG_DIR_NAME), "dir");
+
+		expect(resolveAgentDir(cwd, home)).toBe(homeAgentDir);
+	});
+
+	it("stops before exceeding the parent walk depth limit", () => {
+		const root = createTempDir();
+		const project = join(root, "project");
+		let cwd = project;
+		for (let depth = 0; depth <= MAX_PARENT_CONFIG_SEARCH_DEPTH; depth += 1) {
+			cwd = join(cwd, `level-${depth}`);
+		}
+		createAgentDir(project);
+		mkdirSync(cwd, { recursive: true });
+
+		expect(findNearestParentConfigDir(cwd, join(root, "home"), CONFIG_DIR_NAME, "agent")).toBeUndefined();
+	});
+});
+
+describe("project settings discovery", () => {
+	it("loads nearest project settings from a deep subdirectory", () => {
+		const root = createTempDir();
+		const agentDir = join(root, "agent");
+		const project = join(root, "project");
+		const cwd = join(project, "src", "feature", "nested");
+		const home = join(root, "home");
+		const projectSettingsPath = join(project, CONFIG_DIR_NAME, "settings.json");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(join(project, CONFIG_DIR_NAME), { recursive: true });
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ theme: "global" }));
+		writeFileSync(projectSettingsPath, JSON.stringify({ theme: "project" }));
+
+		expect(getSettingsPath(cwd, agentDir, "project", home)).toBe(projectSettingsPath);
+		expect(SettingsManager.create(cwd, agentDir).getTheme()).toBe("project");
+	});
+
+	it("writes project settings to the nearest config within the fixture", async () => {
+		const root = createTempDir();
+		const home = join(root, "home");
+		const project = join(root, "project");
+		const cwd = join(project, "src", "feature");
+		const agentDir = join(root, "agent");
+		const outerSettingsPath = join(root, CONFIG_DIR_NAME, "settings.json");
+		const projectSettingsPath = join(project, CONFIG_DIR_NAME, "settings.json");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(join(root, CONFIG_DIR_NAME), { recursive: true });
+		mkdirSync(join(project, CONFIG_DIR_NAME), { recursive: true });
+		const manager = SettingsManager.fromStorage(new FileSettingsStorage(cwd, agentDir, home));
+
+		manager.setProjectPackages([{ source: "npm:test-pkg" }]);
+		await manager.flush();
+
+		expect(readFileSync(projectSettingsPath, "utf-8")).toContain('"source": "npm:test-pkg"');
+		expect(existsSync(outerSettingsPath)).toBe(false);
+	});
+
+	it("keeps the cwd settings path when no project config exists", () => {
+		const root = createTempDir();
+		const home = join(root, "home");
+		const cwd = join(home, "cwd");
+		mkdirSync(join(home, CONFIG_DIR_NAME), { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+
+		expect(getSettingsPath(cwd, join(root, "agent"), "project", home)).toBe(
+			join(cwd, CONFIG_DIR_NAME, "settings.json"),
+		);
+	});
+});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CONFIG_DIR_NAME } from "../src/config.ts";
@@ -15,7 +15,7 @@ import {
 } from "../src/core/settings-manager.ts";
 
 describe("SettingsManager", () => {
-	const testDir = join(process.cwd(), "test-settings-tmp");
+	const testDir = join(tmpdir(), `senpi-settings-${process.pid}`);
 	const agentDir = join(testDir, "agent");
 	const projectDir = join(testDir, "project");
 


### PR DESCRIPTION
## Gap

Senpi resolved `getAgentDir()` from `SENPI_CODING_AGENT_DIR` or `$HOME` only, so running beneath a project root ignored that project's `.senpi/agent`. Project-scope settings similarly read only `<cwd>/.senpi/settings.json`, missing a project root when invoked from a subdirectory.

## Precedence

Agent-directory resolution is now:

1. `SENPI_CODING_AGENT_DIR`
2. The nearest ancestor of cwd containing a real `.senpi/agent` directory
3. `~/.senpi/agent`

## Behavioral contract

- The bounded, injectable discovery helper walks upward at most 100 levels and excludes `$HOME` from project discovery, preserving the global fallback layer.
- Symlinked `.senpi` directories are refused.
- `getAgentDir()` remains zero-argument and delegates cwd/home acquisition to the existing runtime wrapper.
- Project settings resolve from the nearest real ancestor `.senpi/settings.json`; with no project config they retain the legacy `<cwd>/.senpi/settings.json` path.
- Settings layering is unchanged: the global agent-directory layer loads before the project layer.

## Behavioral risk

Project settings writes now intentionally target the nearest ancestor `.senpi`, rather than always the exact cwd. Discovery is constrained by HOME exclusion, a 100-level cap, and refusing symlinked `.senpi` directories. `test/nearest-parent-config.test.ts` creates both outer and nearer fixture configs and proves a project-scope write reaches only the nearest fixture config, never the outer ancestor. `test/settings-manager.test.ts` now runs its mutable fixture outside the repository so test writes cannot reach the tracked repository `.senpi/settings.json`.

## Test evidence

- `CI=1 npx vitest --run test/nearest-parent-config.test.ts test/config.test.ts test/settings-manager.test.ts test/settings-manager-bug.test.ts test/settings-manager-retry-fallback.test.ts` (from `packages/coding-agent`): exit 0, 5 files / 84 tests passed.
- `npm run check` (repository root): exit 0. Biome reported 8 pre-existing unsafe-fix suggestions in `packages/tui/test/select-list-characterization.test.ts`; no fixes were applied.
- `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`: exit 0, 8/8 passed.
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`: exit 0, 42/42 passed with only isolated localhost mock-provider traffic.
- Isolated launch-time-HOME `getAgentDir()` probe from a nested project directory: exit 0; selected the project's `.senpi/agent`.

QA receipts: `local-ignore/qa-evidence/20260728-nearest-parent-config/` (ignored, not committed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nearest-parent `.senpi` discovery so the coding agent and project settings resolve to the closest project config when run from subfolders. `getAgentDir()` now prefers `SENPI_CODING_AGENT_DIR`, then the nearest ancestor `.senpi/agent`, falling back to `~/.senpi/agent`.

- **New Features**
  - Added `findNearestParentConfigDir` that walks up to 100 levels, skips `$HOME`, and rejects symlinked `.senpi`.
  - Introduced `resolveAgentDir(cwd, homeDir, envDir)`; `getAgentDir()` now delegates to it for deterministic precedence.
  - Project settings now read and write to the nearest ancestor `.senpi/settings.json`; fallback to `<cwd>/.senpi/settings.json`. Global settings still load before project settings.

<sup>Written for commit 69a47cc01c6570f7f17babd9e481672f50520c80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

