### PR TITLE
fix(compaction): hold the emergency prune engaged so the prompt cache survives

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -492,3 +492,27 @@ Expected upstream conflict zones: `builtin/compaction/index.ts` around `applyBlo
 - Extension system is sufficient because the feature only needs tool-call observation, compaction lifecycle events, and custom-message injection.
 
 Expected upstream conflict zones: `builtin/compaction/index.ts`, `builtin/compaction/state.ts`, and `core/compaction/compaction.ts` if upstream changes compaction settings or extension hook wiring.
+
+## 2026-07-28 - Emergency-prune hysteresis (prompt-cache thrash)
+
+### What changed
+- `speculative.ts`: added `EMERGENCY_CONTEXT_RELEASE_RATIO` (0.85) alongside the existing
+  `EMERGENCY_CONTEXT_TARGET_RATIO` (0.95), plus `EmergencyPruneLatch` / `createEmergencyPruneLatch()`.
+  `hardLimitEmergencyPrune(messages, contextWindow, latch?)` now takes an optional latch: once the prune
+  engages it stays engaged until the estimate falls below the release ratio. Called without a latch the
+  function keeps its exact previous single-threshold behaviour, so existing callers and tests are unaffected.
+- `index.ts`: the compaction extension owns one latch per instance (per session) and passes it at the
+  `context` hook call site.
+
+### Why
+A session parked near the emergency threshold alternated between the pruned and un-pruned history on
+consecutive requests. Because pruning rewrites old tool results, every alternation changed the message
+prefix and invalidated the provider prompt cache. Measured on a real session (`quotio-openai/gpt-5.6-sol-fast`,
+372k context): `cacheRead` collapsed from ~263,000 to the 39,424-token head on 23 turns in 13 minutes,
+re-billing ~226K tokens per turn at $10/M instead of $1/M — about $44 wasted in a single session. A sibling
+session on the same gateway and model in the same minutes had zero misses, isolating this to the prune toggle.
+
+### Scope
+Only *when* the prune disengages changes; what gets pruned and the `needsAggressiveCompaction` signal are
+untouched. Expected upstream conflict zones: `builtin/compaction/speculative.ts` around
+`hardLimitEmergencyPrune`, and `builtin/compaction/index.ts` around the `context` hook.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -37,6 +37,7 @@ import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
 import * as restoration from "./restoration-tracker.ts";
 import {
 	applyGeneratedCompaction,
+	createEmergencyPruneLatch,
 	createSpeculativeCompactionSnapshot,
 	getPromptVariant,
 	hardLimitEmergencyPrune,
@@ -157,6 +158,10 @@ export default function compactionExtension(
 	remoteCompactionDependencies: OpenAiRemoteCompactionDependencies = {},
 ): void {
 	let state: CompactionExtensionState = createInitialState();
+	// One latch per session: keeps the emergency prune engaged until the context
+	// falls clear of the threshold, so consecutive requests keep a byte-identical
+	// cacheable prefix instead of alternating and re-billing the whole prompt.
+	const emergencyPruneLatch = createEmergencyPruneLatch();
 	const degradationState = createDegradationMonitorState();
 	const restorationState = state.restoration ?? restoration.createRestorationTrackerState();
 	state = { ...state, restoration: restorationState };
@@ -582,7 +587,7 @@ export default function compactionExtension(
 		})
 			? reduceContextMessages(event.messages, BUILTIN_CONTEXT_REDUCTION_OPTIONS).messages
 			: event.messages;
-		const emergency = hardLimitEmergencyPrune(sourceMessages, promptContextWindow);
+		const emergency = hardLimitEmergencyPrune(sourceMessages, promptContextWindow, emergencyPruneLatch);
 		const marked = markOpenAiRemoteReplayBoundary(emergency.messages, {
 			model: ctx.model,
 			branchEntries: ctx.sessionManager.getBranch(),

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -35,6 +35,12 @@ import * as truncation from "./tool-truncation.ts";
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const COMPACTION_BUDGET_RATIO = 0.6;
 const EMERGENCY_CONTEXT_TARGET_RATIO = 0.95;
+// Hysteresis: the emergency prune engages at EMERGENCY_CONTEXT_TARGET_RATIO but only
+// releases once the context falls below this lower ratio. A single threshold makes a
+// session parked near the limit alternate between the pruned and un-pruned history on
+// consecutive requests; because pruning rewrites old tool results, every alternation
+// invalidates the provider prompt-cache prefix and re-bills the whole conversation.
+const EMERGENCY_CONTEXT_RELEASE_RATIO = 0.85;
 const SUMMARY_TOKEN_HEADROOM = 32_768;
 const SUMMARY_CONTEXT_WINDOW_RESERVE_RATIO = 0.5;
 const SUMMARY_SCHEMA = "senpi.compaction.summary.v1";
@@ -359,15 +365,38 @@ function estimateTotalTokens(messages: AgentMessage[]): number {
 	return total;
 }
 
+/**
+ * Sticky engage/release state for {@link hardLimitEmergencyPrune}. Callers that
+ * issue many requests for one session share a single latch so the emitted context
+ * shape stays stable while the estimate hovers around the engage threshold.
+ */
+export interface EmergencyPruneLatch {
+	engaged: boolean;
+}
+
+export function createEmergencyPruneLatch(): EmergencyPruneLatch {
+	return { engaged: false };
+}
+
 export function hardLimitEmergencyPrune(
 	messages: AgentMessage[],
 	contextWindow: number,
+	latch?: EmergencyPruneLatch,
 ): {
 	messages: AgentMessage[];
 	needsAggressiveCompaction: boolean;
 } {
 	const targetTokens = Math.floor(contextWindow * EMERGENCY_CONTEXT_TARGET_RATIO);
-	if (estimateTotalTokens(messages) <= targetTokens) {
+	const releaseTokens = Math.floor(contextWindow * EMERGENCY_CONTEXT_RELEASE_RATIO);
+	const totalTokens = estimateTotalTokens(messages);
+	// Without a latch this keeps the historical single-threshold behaviour.
+	const engaged = latch
+		? latch.engaged
+			? totalTokens > releaseTokens
+			: totalTokens > targetTokens
+		: totalTokens > targetTokens;
+	if (latch) latch.engaged = engaged;
+	if (!engaged) {
 		return { messages, needsAggressiveCompaction: false };
 	}
 	const noLlmPruned = truncateContextMessages(pruneToolResults(messages, contextWindow));

--- a/packages/coding-agent/test/compaction/emergency-prune-hysteresis.test.ts
+++ b/packages/coding-agent/test/compaction/emergency-prune-hysteresis.test.ts
@@ -1,0 +1,126 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, ToolResultMessage, Usage, UserMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	createEmergencyPruneLatch,
+	hardLimitEmergencyPrune,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function userMessage(text: string, timestamp: number): UserMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+function assistantToolCall(id: string, timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name: "bash", arguments: { command: `echo ${id}` } }],
+		api: "faux-completion",
+		provider: "faux",
+		model: "faux-model",
+		usage: emptyUsage(),
+		stopReason: "toolUse",
+		timestamp,
+	};
+}
+
+function toolResultText(id: string, text: string, timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "bash",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+/**
+ * The cacheable prefix the provider sees. Any change to an older message
+ * invalidates the prompt cache from that message onward, so byte-equality of
+ * this serialization across consecutive requests is exactly what decides
+ * whether the provider can reuse its cached prefix.
+ */
+function serializeShape(messages: AgentMessage[]): string {
+	return JSON.stringify(messages);
+}
+
+/**
+ * A long-running session that parks near the emergency threshold: an oversized
+ * tool result early in the history, then one small turn appended per request.
+ * `growth` walks the estimate across the engage threshold and back, which is
+ * what a polling loop does when each turn adds a little and pruning removes it.
+ */
+function buildHistory(extraTurns: number): AgentMessage[] {
+	const oversized = `${"A".repeat(9_000)}MID-SENTINEL-7f3a1c${"B".repeat(9_000)}`;
+	const messages: AgentMessage[] = [
+		userMessage("initial request", 1),
+		assistantToolCall("call-1", 2),
+		toolResultText("call-1", oversized, 3),
+	];
+	for (let index = 0; index < extraTurns; index++) {
+		messages.push(assistantToolCall(`poll-${index}`, 100 + index * 2));
+		messages.push(toolResultText(`poll-${index}`, `poll result ${index}`, 101 + index * 2));
+	}
+	messages.push(userMessage("latest request", 9_000));
+	return messages;
+}
+
+describe("emergency prune hysteresis", () => {
+	it("keeps the cacheable prefix stable while the estimate oscillates around the engage threshold", () => {
+		// Given a fixed conversation prefix and a session whose estimated size drifts
+		// back and forth across the engage threshold between consecutive requests.
+		const history = buildHistory(0);
+		const totalEstimate = 18_035;
+		// windows chosen so the estimate lands just above the engage ratio, then just
+		// below it (but still above the release ratio) -- the exact parked-at-the-limit
+		// condition that made a real session re-bill its whole prompt every turn.
+		const oscillatingWindows = [
+			Math.ceil(totalEstimate / 0.95) - 10, // estimate > engage -> prune
+			Math.ceil(totalEstimate / 0.9), // estimate < engage, > release -> must stay pruned
+			Math.ceil(totalEstimate / 0.95) - 10,
+			Math.ceil(totalEstimate / 0.9),
+			Math.ceil(totalEstimate / 0.88),
+		];
+		const latch = createEmergencyPruneLatch();
+
+		// When each request runs through the shared latch.
+		const shapes = oscillatingWindows.map((contextWindow) =>
+			serializeShape(hardLimitEmergencyPrune(history, contextWindow, latch).messages),
+		);
+
+		// Then every emitted shape is identical, so the provider prompt-cache prefix
+		// survives. With a single threshold these alternate and the cache is re-billed.
+		expect(new Set(shapes).size).toBe(1);
+	});
+
+	it("releases the latch once the context drops well below the engage threshold", () => {
+		// Given a latch that has already engaged on an oversized context.
+		const contextWindow = 5_000;
+		const latch = createEmergencyPruneLatch();
+		hardLimitEmergencyPrune(buildHistory(0), contextWindow, latch);
+
+		// When a compaction shrinks the history far below the release threshold.
+		const smallHistory: AgentMessage[] = [
+			userMessage("post-compaction summary", 1),
+			assistantToolCall("call-9", 2),
+			toolResultText("call-9", "small result", 3),
+			userMessage("latest request", 4),
+		];
+		const result = hardLimitEmergencyPrune(smallHistory, contextWindow, latch);
+
+		// Then the messages pass through untouched again.
+		expect(result.needsAggressiveCompaction).toBe(false);
+		expect(serializeShape(result.messages)).toBe(serializeShape(smallHistory));
+	});
+});

--- a/packages/coding-agent/test/compaction/emergency-prune-hysteresis.test.ts
+++ b/packages/coding-agent/test/compaction/emergency-prune-hysteresis.test.ts
@@ -105,10 +105,11 @@ describe("emergency prune hysteresis", () => {
 	});
 
 	it("releases the latch once the context drops well below the engage threshold", () => {
-		// Given a latch that has already engaged on an oversized context.
+		// Given a latch already engaged on an oversized context.
 		const contextWindow = 5_000;
 		const latch = createEmergencyPruneLatch();
 		hardLimitEmergencyPrune(buildHistory(0), contextWindow, latch);
+		expect(latch.engaged).toBe(true);
 
 		// When a compaction shrinks the history far below the release threshold.
 		const smallHistory: AgentMessage[] = [
@@ -119,8 +120,27 @@ describe("emergency prune hysteresis", () => {
 		];
 		const result = hardLimitEmergencyPrune(smallHistory, contextWindow, latch);
 
-		// Then the messages pass through untouched again.
+		// Then the latch actually disengages -- asserting only on the returned messages
+		// would pass even if the latch stayed stuck, because pruning a small history is
+		// a no-op. The latch state is what proves a shrunken context is not pinned in
+		// pruned form forever.
+		expect(latch.engaged).toBe(false);
 		expect(result.needsAggressiveCompaction).toBe(false);
 		expect(serializeShape(result.messages)).toBe(serializeShape(smallHistory));
+	});
+
+	it("keeps a still-large context pruned while it sits inside the hysteresis band", () => {
+		// Given an engaged latch.
+		const contextWindow = 5_000;
+		const latch = createEmergencyPruneLatch();
+		hardLimitEmergencyPrune(buildHistory(0), contextWindow, latch);
+
+		// When the context is still above the release threshold, the latch must hold,
+		// so the shape stays pruned rather than snapping back and busting the cache.
+		const banded = hardLimitEmergencyPrune(buildHistory(0), contextWindow, latch);
+
+		// Then it is still engaged.
+		expect(latch.engaged).toBe(true);
+		expect(serializeShape(banded.messages)).not.toBe(serializeShape(buildHistory(0)));
 	});
 });


### PR DESCRIPTION
## Problem

`hardLimitEmergencyPrune()` is called from the compaction extension's `context` hook on **every** provider request, and it was a stateless function with a single threshold (`estimate > contextWindow * 0.95`).

When a long-running session parks near that threshold, consecutive requests land on *opposite sides* of it: one request sends the pruned history, the next sends the un-pruned one. Because pruning rewrites old tool results, every alternation changes the message prefix and **invalidates the provider prompt cache**.

Measured on a real session (`quotio-openai/gpt-5.6-sol-fast`, 372k context window):

- `cacheRead` collapsed from ~263,000 to the 39,424-token head (system prompt + tools) on **23 turns in 13 minutes**
- ~226K tokens re-billed per turn at `$10/M` input instead of `$1/M` cached — **~$44 wasted in one session** ($124.07 total)
- A sibling session on the **same gateway and same model in the same minutes** had **zero** misses, isolating this to the prune toggle rather than the upstream gateway

## Fix

Add hysteresis: engage at `0.95` (unchanged), release only below `EMERGENCY_CONTEXT_RELEASE_RATIO = 0.85`.

- `hardLimitEmergencyPrune(messages, contextWindow, latch?)` — the latch is **optional**; called with two args the function keeps its exact previous behaviour, so every existing caller and test is unaffected.
- The compaction extension owns one latch per instance (per session) and passes it at the `context` hook call site.

Only *when* the prune disengages changes. What gets pruned and the `needsAggressiveCompaction` signal are untouched.

## Evidence

**RED first.** A probe against the current 2-arg API, using the same oscillating scenario:

```
FAIL  keeps the cacheable prefix stable while the estimate oscillates around the engage threshold
AssertionError: expected 2 to be 1   <- two distinct context shapes = cache destroyed
```

**GREEN.** Same scenario with the latch: 1 shape.

**Real-surface QA** (`local-ignore/qa-evidence/20260728-cache-thrash-hysteresis/`) replays a parked session through the real module and hashes the serialized outgoing context per request:

```
WITHOUT latch (old behaviour)   estimate=108116
  req 1  window=112806  prefix-sha=4a3239603b042743  bytes=11391
  req 2  window=120128  prefix-sha=9e1c2a1cc7dbe65c  bytes=111177
  req 3  window=112806  prefix-sha=4a3239603b042743  bytes=11391
  req 4  window=120128  prefix-sha=9e1c2a1cc7dbe65c  bytes=111177
  distinct shapes = 2  => CACHE THRASH (prompt re-billed every flip)

WITH latch (fixed)              estimate=108116
  req 1..5                      prefix-sha=4a3239603b042743  bytes=11391
  distinct shapes = 1  => CACHE PRESERVED
```

## Verification

- `packages/coding-agent/test/compaction/` — **33 files / 232 tests passed**, including the 4 pre-existing emergency-prune tests that pin the old contract
- `npm run check` — exit 0
- Biome clean on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hold the emergency prune engaged with hysteresis to stop prompt-cache thrash near the context limit, preserving a stable cacheable prefix and avoiding re-billing in long sessions.

- **Bug Fixes**
  - Engage at 0.95 and release below 0.85 using a per-session latch to keep context shape stable across requests.
  - `hardLimitEmergencyPrune(messages, contextWindow, latch?)` is backward compatible; the compaction extension creates and passes one latch per session from the `context` hook.
  - Added tests that pin stable cacheable prefixes and explicitly assert latch release state (avoids false positives from no-op pruning).

<sup>Written for commit f2f1f363325b094b3302fae328384e0f2d5d9e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

