### PR TITLE
fix(bash-timeout): native Anthropic bash exception + mutation-proof the detach gate

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -313,6 +313,21 @@ When unset, senpi leaves provider payloads unchanged. This setting currently app
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
 
+### Prompt Cache
+
+Sizes how long foreground tools may block on the active model's prompt-cache lifetime, so a long
+`bash` call never straddles cache expiry and forces a full re-read. When the model's cache TTL is
+unknown (e.g. Google models) or caching is off, no budget applies and timeout behavior is unchanged.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `promptCache.cacheAwareTimeouts` | boolean | `true` | Cap foreground tool waits at the model's prompt-cache TTL minus the safety buffer; `false` restores the fixed legacy ceilings |
+| `promptCache.safetyBufferSeconds` | number | `30` | Headroom subtracted from the cache TTL (a 5m TTL yields a 270s ceiling). If it consumes the whole TTL, no budget applies |
+
+A foreground `bash` command still running at the budget is handed to a live background session
+instead of being killed; its explicit `timeout` remains the kill deadline. See
+`terminal.timeoutAction` to switch that hand-off back to a kill.
+
 ### Shell
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/changes.md
@@ -1,0 +1,27 @@
+# bash-timeout builtin extension — fork surface
+
+Injects the default `timeout` into every `bash` call and appends the "Bash Tool Timeout Policy"
+section to the system prompt.
+
+## Cache-aware ceiling and native-Anthropic-bash exception (2026-07-28)
+
+### What changed
+
+- `timeout.ts`: `resolveEffectiveBashTimeouts(defaults, safeWaitSeconds)` lowers the recommended
+  maximum to the prompt-cache safe-wait budget (`ExtensionContext.getPromptCacheSafeWaitSeconds()`),
+  pulling the injected default down with it when the budget is smaller. `buildBashTimeoutPrompt`
+  names the ceiling, the prompt-cache reason, and steers cleanup through `kill_bash`.
+- `index.ts`: the policy prompt is rebuilt per `before_agent_start` from the LIVE model, and the
+  budget is suppressed when native Anthropic bash is active for an `anthropic-messages` model.
+
+### Why the native-Anthropic-bash exception exists
+
+When `PI_ANTHROPIC_BASH` is enabled the provider replaces the PTY `bash` tool and the `terminal`
+extension steps aside (`terminal/extension.ts` `shouldStepAside`). Nothing then implements the
+cache-deadline auto-detach, so advertising a cache ceiling would promise behavior that cannot
+happen. The budget therefore only applies while the PTY tool is live.
+
+### Behavior when no budget applies
+
+Byte-identical to the pre-change policy: the same injected default, the same recommended maximum,
+and a prompt string that compares equal under strict `===`.

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
@@ -1,4 +1,5 @@
-import type { ExtensionAPI } from "../../types.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 
 import {
 	applyBashTimeout,
@@ -23,9 +24,20 @@ export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 	const baseDefaults = resolveBashTimeoutDefaults(env);
 	let effective = resolveEffectiveBashTimeouts(baseDefaults, undefined);
 
+	/**
+	 * Native Anthropic bash replaces the PTY `bash` tool, and the terminal
+	 * extension steps aside with it — so nothing implements the cache-deadline
+	 * detach. Advertising a cache ceiling there would promise behavior that
+	 * cannot happen, so the budget only applies while the PTY tool is live.
+	 */
+	const resolveBudget = (ctx: ExtensionContext | undefined): number | undefined => {
+		if (isAnthropicBashEnabled() && ctx?.model?.api === "anthropic-messages") return undefined;
+		return ctx?.getPromptCacheSafeWaitSeconds?.();
+	};
+
 	pi.on("tool_call", async (event, ctx) => {
 		if (event.toolName !== "bash") return;
-		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx?.getPromptCacheSafeWaitSeconds?.());
+		effective = resolveEffectiveBashTimeouts(baseDefaults, resolveBudget(ctx));
 		const input = event.input as BashToolInputLike;
 		const updated = applyBashTimeout(input, effective);
 		if (updated !== input) {
@@ -35,7 +47,7 @@ export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
-		effective = resolveEffectiveBashTimeouts(baseDefaults, ctx?.getPromptCacheSafeWaitSeconds?.());
+		effective = resolveEffectiveBashTimeouts(baseDefaults, resolveBudget(ctx));
 		return { systemPrompt: `${event.systemPrompt}${buildBashTimeoutPrompt(effective)}` };
 	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
@@ -65,7 +65,7 @@ export function resolveEffectiveBashTimeouts(
 export function buildBashTimeoutPrompt(defaults: EffectiveBashTimeouts): string {
 	const minutes = (seconds: number): string => (seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds}s`);
 	const maxReason = defaults.cacheCapped
-		? ` This ceiling is the prompt cache lifetime of the active model minus a safety buffer: blocking past it expires the cache and forces a full re-read on the next request. A foreground command still running at that point is handed to a background session alive instead of being killed.`
+		? ` This ceiling is the prompt cache lifetime of the active model minus a safety buffer: blocking past it expires the cache and forces a full re-read on the next request. A foreground command still running at that point is handed to a background session alive instead of being killed; those sessions stay live, so stop the ones you no longer need with \`kill_bash\`.`
 		: "";
 	return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool enforces timeouts even when you omit the \`timeout\` parameter:\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}).${maxReason} Explicit \`timeout\` values are preserved because different hosts may use different timeout units.\n- For long-running commands (builds, installs, test suites), set an explicit \`timeout\` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, start them with \`run_in_background: true\` and watch the decisive output with \`monitor\` instead of raising the timeout.\n`;
 }

--- a/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
+++ b/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import bashTimeoutExtension from "../../src/core/extensions/builtin/bash-timeout/index.ts";
 import {
 	applyBashTimeout,
 	BASH_DEFAULT_TIMEOUT_SECONDS,
@@ -215,5 +216,51 @@ describe("buildBashTimeoutPrompt cache awareness", () => {
 
 	it("still accepts the legacy two-field defaults shape", () => {
 		expect(buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 })).toBe(LEGACY_PROMPT);
+	});
+});
+
+describe("bashTimeoutExtension with native Anthropic bash active", () => {
+	it("keeps the legacy policy when the PTY bash tool has stepped aside", async () => {
+		const previous = process.env.PI_ANTHROPIC_BASH;
+		process.env.PI_ANTHROPIC_BASH = "1";
+		try {
+			const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
+			const pi = {
+				on: (name: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
+					handlers.set(name, handler);
+				},
+			};
+			bashTimeoutExtension(pi as never);
+
+			const ctx = {
+				model: { api: "anthropic-messages" },
+				getPromptCacheSafeWaitSeconds: () => 270,
+			};
+			const result = (await handlers.get("before_agent_start")?.({ systemPrompt: "BASE" }, ctx)) as {
+				systemPrompt: string;
+			};
+
+			expect(result.systemPrompt).toBe(`BASE${buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 })}`);
+		} finally {
+			if (previous === undefined) delete process.env.PI_ANTHROPIC_BASH;
+			else process.env.PI_ANTHROPIC_BASH = previous;
+		}
+	});
+
+	it("still caps the ceiling when native Anthropic bash is not active", async () => {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
+		const pi = {
+			on: (name: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
+				handlers.set(name, handler);
+			},
+		};
+		bashTimeoutExtension(pi as never);
+
+		const ctx = { model: { api: "anthropic-messages" }, getPromptCacheSafeWaitSeconds: () => 270 };
+		const result = (await handlers.get("before_agent_start")?.({ systemPrompt: "BASE" }, ctx)) as {
+			systemPrompt: string;
+		};
+
+		expect(result.systemPrompt).toContain("270s");
 	});
 });

--- a/packages/coding-agent/test/suite/terminal-detach-gate.test.ts
+++ b/packages/coding-agent/test/suite/terminal-detach-gate.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TerminalRuntimeSession } from "../../src/core/extensions/builtin/terminal/runtime-session.ts";
+import { createForegroundDetachGate } from "../../src/core/extensions/builtin/terminal/tools/foreground-detach.ts";
+
+/**
+ * Deterministic stand-in for the pty session: `settle()` runs registered exit
+ * handlers synchronously (mirroring `settleExit`, which sets `settledExit`
+ * before dispatching), and `onExit` on an already-settled session defers to a
+ * microtask exactly as `TerminalSession.onExit` does.
+ */
+function fakeRuntime() {
+	const handlers = new Set<() => void>();
+	let settled = false;
+	return {
+		get exited(): boolean {
+			return settled;
+		},
+		session: {
+			onExit(handler: () => void): () => void {
+				if (settled) queueMicrotask(handler);
+				else handlers.add(handler);
+				return () => handlers.delete(handler);
+			},
+		},
+		settle(): void {
+			if (settled) return;
+			settled = true;
+			for (const handler of handlers) handler();
+			handlers.clear();
+		},
+	};
+}
+
+type Fake = ReturnType<typeof fakeRuntime>;
+
+function gateFor(runtime: Fake, signal?: AbortSignal) {
+	let removeAbortCalls = 0;
+	let detached = false;
+	const gate = createForegroundDetachGate({
+		runtime: runtime as unknown as TerminalRuntimeSession,
+		signal,
+		delayMs: 0,
+		removeAbortListener: () => {
+			removeAbortCalls += 1;
+		},
+	});
+	void gate.detached.then(() => {
+		detached = true;
+	});
+	return {
+		gate,
+		state: () => ({ detached, removeAbortCalls }),
+	};
+}
+
+/**
+ * Advance the fake clock so the deadline timer runs, WITHOUT yielding to the
+ * microtask queue — this is the exact window in which the gate must still let
+ * a late exit or abort win.
+ */
+function fireDeadlineOnly(): void {
+	vi.advanceTimersByTime(1);
+}
+
+/** Yield so queued microtasks (and therefore any commit) become observable. */
+async function settleScheduling(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("createForegroundDetachGate linearization", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("does not detach when the command exits inside the linearization window", async () => {
+		const runtime = fakeRuntime();
+		const { state } = gateFor(runtime);
+
+		fireDeadlineOnly();
+		runtime.settle();
+		await settleScheduling();
+
+		expect(state()).toEqual({ detached: false, removeAbortCalls: 0 });
+	});
+
+	it("does not detach when the command already exited before the deadline", async () => {
+		const runtime = fakeRuntime();
+		const { state } = gateFor(runtime);
+
+		runtime.settle();
+		fireDeadlineOnly();
+		await settleScheduling();
+
+		expect(state()).toEqual({ detached: false, removeAbortCalls: 0 });
+	});
+
+	it("does not detach when an abort lands inside the linearization window", async () => {
+		const runtime = fakeRuntime();
+		const controller = new AbortController();
+		const { state } = gateFor(runtime, controller.signal);
+
+		fireDeadlineOnly();
+		controller.abort();
+		await settleScheduling();
+
+		expect(state()).toEqual({ detached: false, removeAbortCalls: 0 });
+	});
+
+	it("detaches exactly once and drops the abort listener when the command is still running", async () => {
+		const runtime = fakeRuntime();
+		const { state } = gateFor(runtime);
+
+		fireDeadlineOnly();
+		await settleScheduling();
+
+		expect(state()).toEqual({ detached: true, removeAbortCalls: 1 });
+	});
+
+	it("keeps the exit result authoritative when onExit dispatches synchronously at registration", async () => {
+		const runtime = fakeRuntime();
+		const synchronousExit = {
+			get exited(): boolean {
+				return false;
+			},
+			session: {
+				onExit(handler: () => void): () => void {
+					handler();
+					return () => {};
+				},
+			},
+		};
+		const { state } = gateFor(synchronousExit as unknown as Fake);
+
+		fireDeadlineOnly();
+		await settleScheduling();
+		expect(runtime.exited).toBe(false);
+
+		expect(state()).toEqual({ detached: false, removeAbortCalls: 0 });
+	});
+
+	it("suppresses a pending detach once cancelled", async () => {
+		const runtime = fakeRuntime();
+		const { gate, state } = gateFor(runtime);
+
+		gate.cancel();
+		fireDeadlineOnly();
+		await settleScheduling();
+
+		expect(state()).toEqual({ detached: false, removeAbortCalls: 0 });
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to #422, fixing two real defects that post-merge review found. Both were confirmed against merged `main` before changing anything.

## 1. Native Anthropic bash advertised a ceiling it could not honor

When `PI_ANTHROPIC_BASH` is enabled for an `anthropic-messages` model, the provider replaces the PTY `bash` tool and the `terminal` extension **steps aside** (`shouldStepAside`). Nothing then implements the cache-deadline auto-detach — but `bash-timeout` still capped the recommended maximum and told the model a still-running command would be handed to a background session. That promised behavior that could not happen.

The budget is now suppressed on that path, restoring the byte-identical legacy policy. Failing test captured first, then fixed.

Also addressed from the same review:
- the cache-aware prompt now steers cleanup through `kill_bash` (detached sessions stay live, so the model needs to be told to reap them)
- `docs/settings.md` documents `promptCache.cacheAwareTimeouts` and `promptCache.safetyBufferSeconds`
- `builtin/bash-timeout/changes.md` added, recording the fork surface and *why* the exception exists

## 2. The detach linearization gate had tautological coverage

#422's auto-detach suite had 9 green tests but **could not fail** for the property it protected: deleting *both* the `queueMicrotask` deferral and the settled-aware `onExit` gate from `foreground-detach.ts` left all 9 passing.

Root cause: those tests register the exit/abort timers during spawn — before the detach timer exists — so they only exercise "exit was already ordered ahead of D", never the real window between the deadline firing and the queued linearization microtask committing.

`test/suite/terminal-detach-gate.test.ts` drives `createForegroundDetachGate` directly with fake timers, so the deadline can fire **without** yielding the microtask queue:

- exit inside the linearization window → no detach, abort listener untouched
- exit already settled before the deadline → no detach
- abort inside the linearization window → no detach
- still running → detaches exactly once, abort listener removed exactly once
- `onExit` dispatching synchronously at registration → exit stays authoritative (covers `exitedAtGate`)
- `cancel()` → suppresses a pending detach

### Mutation proof

| Mutation | Result |
|---|---|
| remove `queueMicrotask(linearize)` deferral | **2 tests fail** |
| remove the settled-aware `onExit` gate | **1 test fails** |
| unmodified | 6/6 pass |

The gate itself was correct — it was simply unprotected.

## Verification

`npm run check` exit 0. Focused suites 65/65 (bash-timeout-extension, bash-timeout-handlers, terminal-detach-gate, terminal-bash-auto-detach, prompt-surface-stale-wait-idioms, prompt-cache-budget).
