### PR TITLE
test(goal): cover reload continuation cleanup

### DIFF
--- a/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
@@ -96,4 +96,18 @@ describe("goal monitor continuation lifecycle", () => {
 
 		expect(harness.sent).toHaveLength(0);
 	});
+
+	it("disposes the delayed continuation on session reload", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await createActiveMonitorHarness("thread-monitor-reload");
+		const baselineTimerCount = vi.getTimerCount();
+		await endCleanTurn(harness, ctx);
+		expect(vi.getTimerCount()).toBe(baselineTimerCount + 1);
+
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		expect(vi.getTimerCount()).toBe(baselineTimerCount);
+		await vi.advanceTimersByTimeAsync(240_000);
+		expect(harness.sent).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
## Summary

- add the explicit session-reload disposal regression required by the monitor-aware goal continuation lifecycle contract
- assert that reload removes the pending 240-second continuation timer, not merely that the eventual callback becomes a no-op
- retain the existing post-boundary assertion that no hidden continuation is sent

## Regression proof

Mutation RED:

```text
goal monitor continuation lifecycle > disposes the delayed continuation on session reload
AssertionError: expected 2 to be 1
Tests  1 failed | 4 passed (5)
```

The mutation removed `MonitorAwareGoalContinuation.start()`'s timer cancellation. This proves the new timer-count assertion fails for the intended regression.

Restored implementation GREEN:

```text
Test Files  2 passed (2)
Tests       7 passed (7)
```

Command:

```sh
cd packages/coding-agent
npm test -- test/suite/goal-monitor-lifecycle.test.ts test/suite/goal-monitor-continuation.test.ts
```

## Validation

- `npm run check` — passed
- production source diff after mutation restoration — empty
- test diff only: `packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts`

Evidence is preserved under `local-ignore/qa-evidence/20260728-goal-monitor-cadence/`.

## Context

Follow-up completion-audit coverage for #430.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test to ensure session reload cancels the delayed continuation timer for monitor-aware goals in `packages/coding-agent`. It verifies timer count before/after reload and confirms no continuation is sent after advancing 240s.

<sup>Written for commit 654899abaccb628e4fc93d404139e70dfe42e8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

