### PR TITLE
fix(terminal): remove bash_output wait_for ghost params and migration guidance

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,35 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## bash_output ghost wait_for params removed (2026-07-28)
+
+### What changed
+
+- `bash_output` no longer exposes the `wait_for`, `block`, and `timeout` params,
+  and the `BASH_OUTPUT_WAIT_REMOVED_GUIDANCE` migration string and
+  `GHOST_PARAM_DESCRIPTION` were removed from `tools/bash-output.ts`.
+- `BashOutputInput` is now exactly `{ bash_id, filter?, view? }`; any caller still
+  sending the removed params gets a generic schema-validation error instead of
+  the migration text.
+- Tests that pinned the ghost guidance were removed:
+  - `test/bash-output-peek.test.ts` `describe("bash_output removed blocking params")` block.
+  - `test/suite/terminal-extension.test.ts` `it("wait_for ghost param returns migration guidance …")`.
+  - `test/prompt-surface-stale-wait-idioms.test.ts` `it("the ghost guidance exists …")`.
+- The negative guards in `prompt-surface-stale-wait-idioms.test.ts` (no surface
+  teaches `wait_for` / `block until` / tmux backgrounding) stay in place.
+
+### Why
+
+The ghost params kept the removed `wait_for` idiom visible to the model in the
+schema, so it kept being called and returning the guidance text — the migration
+message never stopped appearing. Dropping the params from the schema removes the
+mention entirely; the monitor/notification model in `terminal/prompt.ts` and
+`docs/terminal-tools.md` is already the single taught path.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: fork-owned `bash_output` schema and the removed ghost-param tests.
+
 ## Hidden agent wake notifications (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
@@ -6,18 +6,6 @@ import { errorResult, type TerminalToolContext, type TerminalToolResult, textRes
 import { renderBashOutputCall, renderBashOutputResult } from "./render.ts";
 import { describeExit } from "./spawn.ts";
 
-/**
- * Migration guidance returned when a caller passes one of the removed blocking
- * params (`wait_for`, `block`, `timeout`). The params stay in the schema as
- * deprecated ghosts so stale callers get this redirect instead of a generic
- * validation error; the blocking semantics themselves are gone.
- */
-export const BASH_OUTPUT_WAIT_REMOVED_GUIDANCE =
-	"wait_for removed - launch pattern watches through monitor({command, filter}); for an already-running session, peek with bash_output or kill_bash and relaunch under monitor; completion notifications carry the tail";
-
-const GHOST_PARAM_DESCRIPTION =
-	"Removed: bash_output no longer blocks. Passing this returns migration guidance pointing at monitor + completion notifications.";
-
 export const bashOutputSchema = Type.Object({
 	bash_id: Type.String({ description: "Session id returned by a run_in_background bash call." }),
 	filter: Type.Optional(Type.String({ description: "Only return output lines matching this regex." })),
@@ -26,9 +14,6 @@ export const bashOutputSchema = Type.Object({
 			description: "'log' returns new raw output (default); 'screen' returns the rendered xterm grid.",
 		}),
 	),
-	wait_for: Type.Optional(Type.String({ description: GHOST_PARAM_DESCRIPTION })),
-	block: Type.Optional(Type.Boolean({ description: GHOST_PARAM_DESCRIPTION })),
-	timeout: Type.Optional(Type.Number({ description: GHOST_PARAM_DESCRIPTION })),
 });
 
 export type BashOutputInput = Static<typeof bashOutputSchema>;
@@ -67,10 +52,6 @@ export function createBashOutputTool(ctx: TerminalToolContext) {
 		async execute(_toolCallId: string, input: BashOutputInput): Promise<TerminalToolResult> {
 			const runtime = ctx.manager.get(input.bash_id);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
-
-			if (input.wait_for !== undefined || input.block !== undefined || input.timeout !== undefined) {
-				return errorResult(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE);
-			}
 
 			if (input.view === "screen") {
 				return textResult(`${statusLine(runtime)}\n${screenView(runtime)}`);

--- a/packages/coding-agent/test/bash-output-peek.test.ts
+++ b/packages/coding-agent/test/bash-output-peek.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it } from "vitest";
-import {
-	BASH_OUTPUT_WAIT_REMOVED_GUIDANCE,
-	bashOutputSchema,
-	createBashOutputTool,
-} from "../src/core/extensions/builtin/terminal/tools/bash-output.ts";
+import { createBashOutputTool } from "../src/core/extensions/builtin/terminal/tools/bash-output.ts";
 import type { TerminalToolContext } from "../src/core/extensions/builtin/terminal/tools/context.ts";
 
 /**
- * bash_output is a pure non-blocking peek: it never waits for output, and the
- * removed blocking params (wait_for / block / timeout) survive only as ghost
- * params that return migration guidance pointing at monitor + notifications.
+ * bash_output is a pure non-blocking peek: it returns the latest delta, the
+ * status line, or a rendered screen snapshot without ever waiting.
  */
 class FakeRuntime {
 	exited = false;
@@ -105,46 +100,5 @@ describe("bash_output peek", () => {
 			new Promise((_, reject) => setTimeout(() => reject(new Error("peek blocked for over 1s")), 1000)),
 		]);
 		expect(firstText(result as Awaited<typeof execution>)).toContain("status: running");
-	});
-});
-
-describe("bash_output removed blocking params", () => {
-	it("wait_for returns ghost guidance naming monitor", async () => {
-		const tool = createFixture(new FakeRuntime());
-		const result = await tool.execute("call-8", { bash_id: "bash-1", wait_for: "DONE" });
-		expect(result.isError).toBe(true);
-		const text = firstText(result);
-		expect(text).toBe(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE);
-		expect(text).toContain("wait_for removed");
-		expect(text).toContain("monitor(");
-	});
-
-	it("a blocking timeout returns the same ghost guidance", async () => {
-		const tool = createFixture(new FakeRuntime());
-		const result = await tool.execute("call-9", { bash_id: "bash-1", timeout: 30 });
-		expect(result.isError).toBe(true);
-		expect(firstText(result)).toBe(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE);
-	});
-
-	it("block returns the same ghost guidance", async () => {
-		const tool = createFixture(new FakeRuntime());
-		const result = await tool.execute("call-10", { bash_id: "bash-1", block: true });
-		expect(result.isError).toBe(true);
-		expect(firstText(result)).toBe(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE);
-	});
-
-	it("guidance covers the monitor launch pattern, the already-running fallback, and the notification tail", () => {
-		expect(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE).toContain("monitor({command, filter})");
-		expect(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE).toContain("already-running");
-		expect(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE).toContain("kill_bash");
-		expect(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE).toContain("notifications carry the tail");
-	});
-
-	it("keeps the removed params in the schema only as deprecated ghosts", () => {
-		const properties = bashOutputSchema.properties as Record<string, { description?: string }>;
-		for (const key of ["wait_for", "block", "timeout"]) {
-			expect(Object.hasOwn(properties, key), `schema keeps ghost param ${key}`).toBe(true);
-			expect(properties[key]?.description?.toLowerCase()).toContain("removed");
-		}
 	});
 });

--- a/packages/coding-agent/test/prompt-surface-stale-wait-idioms.test.ts
+++ b/packages/coding-agent/test/prompt-surface-stale-wait-idioms.test.ts
@@ -9,10 +9,7 @@ import {
 import { TERMINAL_PROMPT_SECTION } from "../src/core/extensions/builtin/terminal/prompt.ts";
 import { createPtyBashTool } from "../src/core/extensions/builtin/terminal/tools/bash.ts";
 import { createBashInputTool } from "../src/core/extensions/builtin/terminal/tools/bash-input.ts";
-import {
-	BASH_OUTPUT_WAIT_REMOVED_GUIDANCE,
-	createBashOutputTool,
-} from "../src/core/extensions/builtin/terminal/tools/bash-output.ts";
+import { createBashOutputTool } from "../src/core/extensions/builtin/terminal/tools/bash-output.ts";
 import { createBashResizeTool } from "../src/core/extensions/builtin/terminal/tools/bash-resize.ts";
 import type { TerminalToolContext } from "../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createKillBashTool } from "../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
@@ -132,10 +129,5 @@ describe("stale wait-idiom consistency gate", () => {
 		expect(bashOutput.description.toLowerCase()).not.toContain("block until");
 		expect(bashOutput.description).not.toContain("wait_for");
 		expect(bashOutput.promptSnippet ?? "").not.toContain("wait_for");
-	});
-
-	it("the ghost guidance exists so removed-param callers are redirected to monitor", () => {
-		expect(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE).toContain("wait_for removed");
-		expect(BASH_OUTPUT_WAIT_REMOVED_GUIDANCE).toContain("monitor(");
 	});
 });

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -271,45 +271,6 @@ describe("terminal builtin extension — bash_output robustness", () => {
 		expect(firstText(statusCheck)).toContain("status: running");
 		await manager.stop(bashId);
 	});
-
-	it("wait_for ghost param returns migration guidance naming monitor without blocking", async () => {
-		const bash = createPtyBashTool(ctx);
-		const output = createBashOutputTool(ctx);
-		const started = await bash.execute("call-bg-ghost", { command: "sleep 30", run_in_background: true }, undefined);
-		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-		if (!bashId) throw new Error("Background bash did not return an id");
-
-		const ghostPromise = output.execute("call-ghost-wait", {
-			bash_id: bashId,
-			wait_for: "NEVER_MATCHES_THIS_PATTERN_XYZ",
-			timeout: 10,
-		});
-		const ghostCompleted = new Promise<Awaited<typeof ghostPromise>>((resolve, reject) => {
-			const timeout = setTimeout(() => reject(new Error("ghost-param call blocked for over 1 second")), 1000);
-			ghostPromise.then(
-				(value) => {
-					clearTimeout(timeout);
-					resolve(value);
-				},
-				(error: unknown) => {
-					clearTimeout(timeout);
-					reject(error);
-				},
-			);
-		});
-
-		const result = await ghostCompleted;
-		expect(result.isError).toBe(true);
-		const text = firstText(result);
-		expect(text).toContain("wait_for removed");
-		expect(text).toContain("monitor(");
-		expect(text).toContain("kill_bash");
-
-		// The session is untouched: peek still works and kill tears it down.
-		const statusCheck = await output.execute("call-status-after-ghost", { bash_id: bashId });
-		expect(firstText(statusCheck)).toContain("status: running");
-		await manager.stop(bashId);
-	});
 });
 
 describe("terminal extension auto-detach wiring", () => {


### PR DESCRIPTION
## Problem

The `bash_output` tool kept the removed blocking params (`wait_for`, `block`, `timeout`) in its schema as deprecated "ghost" params that returned a migration-guidance string (`BASH_OUTPUT_WAIT_REMOVED_GUIDANCE`). Because the params stayed advertised in the schema, the model kept calling them, and the guidance text kept surfacing in agent output — the migration message never stopped appearing.

## Fix

Drop the ghost params, the `BASH_OUTPUT_WAIT_REMOVED_GUIDANCE` constant, and `GHOST_PARAM_DESCRIPTION` entirely from `tools/bash-output.ts`.

- `BashOutputInput` is now exactly `{ bash_id, filter?, view? }`.
- Stale callers sending the removed params get a generic schema-validation error instead of the migration text.
- The monitor/notification model in `terminal/prompt.ts` and `docs/terminal-tools.md` is already the single taught path — no prompt surface needed updating.

## Tests

Removed tests that pinned the ghost guidance (they assert behavior that no longer exists):
- `test/bash-output-peek.test.ts` — `describe("bash_output removed blocking params")` block
- `test/suite/terminal-extension.test.ts` — `it("wait_for ghost param returns migration guidance …")`
- `test/prompt-surface-stale-wait-idioms.test.ts` — `it("the ghost guidance exists …")`

Kept the negative guards in `prompt-surface-stale-wait-idioms.test.ts` (no surface teaches `wait_for` / `block until` / tmux backgrounding) — they still prevent reintroduction.

## Verification

- `npm run check` — clean for changed files (pre-existing `app-server-turns.test.ts` lint errors confirmed unrelated by running check on clean `main`).
- Affected test files — 3 files, 23 tests, all green:
  ```
  Test Files  3 passed (3)
       Tests  23 passed (23)
  ```
- Re-grep of `packages/coding-agent` for `BASH_OUTPUT_WAIT_REMOVED_GUIDANCE` / `GHOST_PARAM_DESCRIPTION` / `no longer blocks` / `launch pattern watches through monitor` / `migration guidance pointing` / `wait_for removed` — zero hits in active source (only legitimate mentions in `changes.md` entries documenting the removal).

## Changes

`5 files changed, 33 insertions(+), 116 deletions(-)`

| File | Change |
|------|--------|
| `src/core/extensions/builtin/terminal/tools/bash-output.ts` | Removed constant, ghost description, 3 ghost params from schema, execute-time check |
| `src/core/extensions/builtin/terminal/changes.md` | Added 2026-07-28 reversal entry documenting the removal |
| `test/bash-output-peek.test.ts` | Removed ghost-param describe block + import |
| `test/prompt-surface-stale-wait-idioms.test.ts` | Removed ghost-guidance test + import; kept negative guards |
| `test/suite/terminal-extension.test.ts` | Removed wait_for ghost-param test |

Closes the recurring `bash_output bash_34 wait_for removed - launch pattern watches through monitor…` guidance leak.
EOF 2>&1 | tail -5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `wait_for`/`block`/`timeout` ghost params and migration guidance from `bash_output` to stop guidance text from leaking into agent output. The tool is now a pure non-blocking peek with a simplified schema; stale callers get a schema-validation error.

- **Bug Fixes**
  - Dropped ghost params and related constants from `tools/bash-output.ts`; `BashOutputInput` is now `{ bash_id, filter?, view? }`.
  - Removed tests that pinned the ghost guidance; kept guards that prevent reintroducing wait/block idioms.
  - No prompt updates needed; the monitor + notifications path remains the only taught flow.

- **Migration**
  - Stop sending `wait_for`, `block`, or `timeout` to `bash_output`.
  - Use the monitor pattern to watch commands; for running sessions, peek with `bash_output` or relaunch under monitor.

<sup>Written for commit dcfcf73349a6ba9bfe5ef0028bcaf3ad3bc19a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

