### PR TITLE
fix(coding-agent): bound compaction stream acquisition

### DIFF
--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,27 @@
 # changes.md — compaction
 
+## Wall-clock budget includes provider stream acquisition (2026-07-28)
+
+### What changed
+
+- `stream-watchdog.ts`: `consumeStreamWithIdleTimeout()` now accepts a promised stream and starts its absolute
+  duration budget before waiting for that promise to resolve.
+- `compaction.ts`: `completeSummarization()` passes the provider stream promise directly into the watchdog instead of
+  awaiting connection setup outside the protected interval.
+
+### Why
+
+- A provider adapter that never returned its event stream left compaction permanently stuck before either the idle or
+  wall-clock watchdog existed. The request-local abort controller and normal compaction failure cleanup now run after
+  the same 120s bound whether the provider stalls before or after stream creation.
+- Session `019fa809-5ef4-7db3-bdc3-048da7e0fd9d` exposed the user-visible failure mode: the TUI stayed in compaction
+  long enough to appear permanently frozen while provider-side summarization work held the session lifecycle open.
+
+### Expected merge conflict zones
+
+- LOW: `stream-watchdog.ts` around promised-stream acquisition.
+- LOW: `compaction.ts` around the `completeSummarization()` stream setup.
+
 ## Wall-clock budget for summarization streams (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -652,16 +652,16 @@ export async function completeSummarization(
 		}
 		try {
 			const requestOptions = { ...isolatedOptions, signal: requestController.signal };
-			const responseStream = streamFn
-				? await streamFn(model, context, requestOptions)
-				: streamSimple(model, context, requestOptions);
+			const responseStream = Promise.resolve(
+				streamFn ? streamFn(model, context, requestOptions) : streamSimple(model, context, requestOptions),
+			);
 			await consumeStreamWithIdleTimeout(responseStream, {
 				idleTimeoutMs: DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS,
 				maxDurationMs: DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
 				abort: () => requestController.abort(),
 				signal: callerSignal,
 			});
-			return await responseStream.result();
+			return await (await responseStream).result();
 		} finally {
 			if (callerSignal) callerSignal.removeEventListener("abort", onCallerAbort);
 		}

--- a/packages/coding-agent/src/core/compaction/stream-watchdog.ts
+++ b/packages/coding-agent/src/core/compaction/stream-watchdog.ts
@@ -67,15 +67,14 @@ const CALLER_ABORTED = "caller-aborted" as const;
  * stream's own abort outcome, never masked as an idle timeout.
  */
 export async function consumeStreamWithIdleTimeout<T>(
-	stream: AsyncIterable<T>,
+	stream: AsyncIterable<T> | PromiseLike<AsyncIterable<T>>,
 	options: ConsumeStreamWithIdleTimeoutOptions<T>,
 ): Promise<void> {
-	const iterator = stream[Symbol.asyncIterator]();
 	const { idleTimeoutMs, maxDurationMs, abort, onEvent, signal } = options;
+	let iterator: AsyncIterator<T> | undefined;
 	let removeAbortListener: (() => void) | undefined;
 	let callerAbortPromise: Promise<typeof CALLER_ABORTED> | undefined;
 	if (signal?.aborted) {
-		void iterator.return?.();
 		return;
 	}
 	// One absolute deadline for the whole stream, not a per-read budget. Created
@@ -98,6 +97,25 @@ export async function consumeStreamWithIdleTimeout<T>(
 		callerAbortPromise = promise;
 	}
 	try {
+		let resolvedStream: AsyncIterable<T>;
+		if (Symbol.asyncIterator in stream) {
+			resolvedStream = stream;
+		} else {
+			const streamContenders: Array<Promise<AsyncIterable<T> | typeof BUDGET_TRIP | typeof CALLER_ABORTED>> = [
+				Promise.resolve(stream),
+			];
+			if (callerAbortPromise) streamContenders.push(callerAbortPromise);
+			if (budgetPromise) streamContenders.push(budgetPromise);
+			const resolution = await Promise.race(streamContenders);
+			if (resolution === BUDGET_TRIP) {
+				abort();
+				throw new StreamDurationBudgetError(budgetMs);
+			}
+			if (resolution === CALLER_ABORTED) return;
+			resolvedStream = resolution;
+		}
+		iterator = resolvedStream[Symbol.asyncIterator]();
+
 		while (true) {
 			const { promise: idlePromise, resolve: resolveIdle } = Promise.withResolvers<typeof IDLE_TRIP>();
 			const timer = setTimeout(() => resolveIdle(IDLE_TRIP), idleTimeoutMs);
@@ -115,16 +133,16 @@ export async function consumeStreamWithIdleTimeout<T>(
 			}
 			if (result === IDLE_TRIP) {
 				abort();
-				void iterator.return?.();
+				void iterator?.return?.();
 				throw new StreamIdleTimeoutError(idleTimeoutMs);
 			}
 			if (result === BUDGET_TRIP) {
 				abort();
-				void iterator.return?.();
+				void iterator?.return?.();
 				throw new StreamDurationBudgetError(budgetMs);
 			}
 			if (result === CALLER_ABORTED) {
-				void iterator.return?.();
+				void iterator?.return?.();
 				return;
 			}
 			if (result.done) return;

--- a/packages/coding-agent/test/compaction/summarization-wall-clock-budget.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-wall-clock-budget.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { completeSummarization } from "../../src/core/compaction/compaction.ts";
 import {
 	consumeStreamWithIdleTimeout,
 	DEFAULT_SUMMARIZATION_MAX_DURATION_MS,
 	StreamDurationBudgetError,
 } from "../../src/core/compaction/stream-watchdog.ts";
+import { OPENAI_NATIVE_LEGACY_MODEL } from "./openai-remote-test-models.ts";
 
 /**
  * The idle watchdog only catches a *silent* provider connection. A summarization
@@ -100,6 +102,26 @@ describe("consumeStreamWithIdleTimeout wall-clock budget", () => {
 		});
 		controller.abort();
 		await outcome;
+	});
+
+	it("starts the duration budget before the provider returns a stream", async () => {
+		let requestSignal: AbortSignal | undefined;
+		const outcome = completeSummarization(
+			OPENAI_NATIVE_LEGACY_MODEL,
+			{ systemPrompt: "", messages: [] },
+			{ maxTokens: 32 },
+			async (_model, _context, options) => {
+				requestSignal = options?.signal;
+				return await new Promise<never>(() => undefined);
+			},
+		).catch((caught: unknown) => caught);
+
+		await vi.advanceTimersByTimeAsync(DEFAULT_SUMMARIZATION_MAX_DURATION_MS + 1);
+
+		const pending = Symbol("pending");
+		const observed = await Promise.race([outcome, Promise.resolve(pending)]);
+		expect(observed).toBeInstanceOf(StreamDurationBudgetError);
+		expect(requestSignal?.aborted).toBe(true);
 	});
 
 	it("exposes a default wall-clock budget below the idle timeout", () => {


### PR DESCRIPTION
## Summary

- start the compaction wall-clock budget before an async provider returns its event stream
- abort a provider request that remains stuck during stream acquisition
- preserve the synchronous-stream fast path and existing idle-watchdog behavior
- add a regression for a provider stream promise that never resolves

## Root cause

`completeSummarization()` awaited the provider's stream promise before calling
`consumeStreamWithIdleTimeout()`. If connection setup never returned a stream,
neither the idle watchdog nor the 120-second wall-clock budget existed yet, so
the session remained in compaction indefinitely.

The reported session tail shows `tool_search` completed, the assistant then
ended with `stopReason: error`, and no later compaction or assistant entry was
persisted while the TUI remained on `Working`.

## Verification

- focused wall-clock regression: 5/5 passed
- stream-watchdog pair: 10/10 passed
- full coding-agent compaction suite: 283/283 passed
- root `npm run check`: passed
- TypeScript LSP: no diagnostics in the watchdog or regression test; only two pre-existing unreachable-code hints outside the changed `compaction.ts` hunk
- manual target-session-affinity driver: `StreamDurationBudgetError`, request signal aborted
- CLI smoke QA: 8/8 passed
- mock-loop QA: 43/43 passed with localhost-only providers and real auth unchanged

## QA note

The existing remote-compaction QA passed 5/6 checks. Its unrelated native
compaction replay assertion failed; the compact route, response schema,
follow-up prompt, and real-auth guard passed. This change does not touch the
remote compaction replay path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction sessions hanging by starting the 120s wall-clock budget before provider stream acquisition and aborting stuck requests. Keeps the current idle watchdog and synchronous fast path.

- Bug Fixes
  - `consumeStreamWithIdleTimeout()` now accepts a promised stream and starts the duration budget before it resolves; aborts on budget expiry or caller signal.
  - `completeSummarization()` passes the stream promise into the watchdog and awaits the final result after protected consumption.
  - Added a regression test for a provider stream promise that never resolves, asserting `StreamDurationBudgetError` and request abortion.

<sup>Written for commit 63321d11339a761128e8cc8a3d08c7a43a3cf8c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

