### PR TITLE
fix(ai): demote unavailable Anthropic tool references in request payloads

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -790,6 +790,165 @@ function sanitizeUnsupportedNativeTools(
 	return changed ? (sanitized as MessageCreateParamsStreaming) : params;
 }
 
+/**
+ * Anthropic validates that every tool referenced by the message history is
+ * available in the same request — defined in `tools` or discovered through a
+ * `tool_reference` block — and rejects the whole request otherwise
+ * ("Tool reference '<name>' not found in available tools"). Sessions outlive
+ * their tools: an MCP server can be absent after a resume, an extension can
+ * stop registering a tool, or a payload hook can strip a definition while the
+ * history still carries the call. Demote those references to plain text so
+ * the turn can proceed; the matching tool_result is demoted in lockstep so no
+ * orphan pairing error replaces the original one.
+ */
+function demoteUnavailableToolReferences(params: MessageCreateParamsStreaming): MessageCreateParamsStreaming {
+	const messages = params.messages;
+	if (!Array.isArray(messages) || messages.length === 0) return params;
+
+	const definedNames = new Set<string>();
+	if (Array.isArray(params.tools)) {
+		for (const tool of params.tools) {
+			if (isRecord(tool) && typeof tool.name === "string") definedNames.add(tool.name);
+		}
+	}
+
+	// `tool_reference` blocks — emitted for deferred tools or replayed from a
+	// server-side tool search — make their targets available without a
+	// non-deferred definition.
+	const discoveredNames = new Set<string>();
+	collectToolReferenceNames(messages, discoveredNames);
+
+	const demotedCallNames = new Map<string, string>();
+	for (const message of messages) {
+		if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+		for (const block of message.content) {
+			if (
+				isRecord(block) &&
+				block.type === "tool_use" &&
+				typeof block.name === "string" &&
+				!definedNames.has(block.name) &&
+				!discoveredNames.has(block.name)
+			) {
+				demotedCallNames.set(block.id, block.name);
+			}
+		}
+	}
+
+	// A `tool_reference` without its definition 400s the same way.
+	const danglingReferenceNames = new Set<string>();
+	for (const name of discoveredNames) {
+		if (!definedNames.has(name)) danglingReferenceNames.add(name);
+	}
+
+	if (demotedCallNames.size === 0 && danglingReferenceNames.size === 0) return params;
+
+	let changed = false;
+	const rewrittenMessages: MessageParam[] = [];
+	for (const message of messages) {
+		if (!Array.isArray(message.content)) {
+			rewrittenMessages.push(message);
+			continue;
+		}
+		let messageChanged = false;
+		const content: ContentBlockParam[] = [];
+		for (const block of message.content) {
+			if (message.role === "assistant" && isRecord(block) && block.type === "tool_use") {
+				const demotedName = demotedCallNames.get(block.id);
+				if (demotedName !== undefined) {
+					messageChanged = true;
+					content.push({ type: "text", text: demotedToolCallText(demotedName, block.input) });
+					continue;
+				}
+			}
+			if (isRecord(block) && block.type === "tool_result") {
+				const demotedName = demotedCallNames.get(block.tool_use_id);
+				if (demotedName !== undefined) {
+					messageChanged = true;
+					content.push({ type: "text", text: demotedToolResultText(demotedName, block.content) });
+					continue;
+				}
+				if (danglingReferenceNames.size > 0 && Array.isArray(block.content)) {
+					const kept: unknown[] = [];
+					const omitted: string[] = [];
+					for (const item of block.content) {
+						if (
+							isRecord(item) &&
+							item.type === "tool_reference" &&
+							typeof item.tool_name === "string" &&
+							danglingReferenceNames.has(item.tool_name)
+						) {
+							omitted.push(item.tool_name);
+							continue;
+						}
+						kept.push(item);
+					}
+					if (omitted.length > 0) {
+						messageChanged = true;
+						const nextContent =
+							kept.length > 0
+								? kept
+								: [{ type: "text", text: `Tool reference unavailable: ${[...new Set(omitted)].join(", ")}` }];
+						content.push({ ...block, content: nextContent } as ContentBlockParam);
+						continue;
+					}
+				}
+			}
+			content.push(block);
+		}
+		if (content.length === 0) {
+			changed = true;
+			continue;
+		}
+		if (messageChanged) {
+			changed = true;
+			rewrittenMessages.push({ ...message, content });
+			continue;
+		}
+		rewrittenMessages.push(message);
+	}
+
+	if (!changed) return params;
+	return { ...params, messages: rewrittenMessages };
+}
+
+function collectToolReferenceNames(value: unknown, names: Set<string>): void {
+	if (Array.isArray(value)) {
+		for (const item of value) collectToolReferenceNames(item, names);
+		return;
+	}
+	if (!isRecord(value)) return;
+	if (value.type === "tool_reference" && typeof value.tool_name === "string") names.add(value.tool_name);
+	for (const nested of Object.values(value)) collectToolReferenceNames(nested, names);
+}
+
+function demotedToolCallText(name: string, input: unknown): string {
+	let serializedInput: string;
+	try {
+		serializedInput = JSON.stringify(input ?? {});
+	} catch {
+		serializedInput = "{}";
+	}
+	return `[Called tool "${name}" (no longer available in this session) with input: ${serializedInput}]`;
+}
+
+function demotedToolResultText(name: string, content: unknown): string {
+	return `[Result of unavailable tool "${name}": ${toolResultText(content)}]`;
+}
+
+function toolResultText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		const parts: string[] = [];
+		for (const item of content) {
+			if (!isRecord(item)) continue;
+			if (item.type === "text" && typeof item.text === "string") parts.push(item.text);
+			else if (typeof item.type === "string") parts.push(`[${item.type}]`);
+		}
+		if (parts.length > 0) return parts.join("\n");
+	}
+	return "Tool output unavailable.";
+}
+
 function sanitizeAdaptiveThinkingPayload(
 	model: Model<"anthropic-messages">,
 	params: MessageCreateParamsStreaming,
@@ -1104,6 +1263,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				}
 				params = sanitizeAdaptiveThinkingPayload(model, params, options);
 				params = sanitizeUnsupportedNativeTools(model, params);
+				params = demoteUnavailableToolReferences(params);
 				const payloadRequestMetadata = extractPayloadRequestMetadata(params);
 				params = payloadRequestMetadata.params;
 				const requestOptions = {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,29 @@
 # AI Source Changes
 
+## 2026-07-28 - Demote unavailable Anthropic tool references instead of failing the request
+
+### What changed and why
+
+- `api/anthropic-messages.ts` gains a final payload pass, `demoteUnavailableToolReferences()`, applied after
+  `sanitizeUnsupportedNativeTools()` on every request. Anthropic rejects a request whose message history references
+  a tool that is neither defined in `tools` nor discovered through a `tool_reference` block in the same request
+  (`400 invalid_request_error: Tool reference '<name>' not found in available tools`). Sessions outlive their
+  tools: an MCP server can be absent after a `senpi --session` resume, an extension can stop registering a tool,
+  or an `onPayload` hook can strip a definition while the history still carries the call.
+- The pass collects defined tool names and names discovered via `tool_reference` blocks (including replayed
+  server-side tool-search results), then demotes offending `tool_use` blocks to plain text, demotes their
+  `tool_result` blocks in lockstep (preserving the original result text), and strips `tool_reference` entries
+  whose definition vanished — so neither the original 400 nor an orphan-pairing 400 can occur.
+- `../test/anthropic-tool-reference-integrity.test.ts` drives the full request path offline through a fake
+  Anthropic client: single and mixed-turn demotion, still-available tools kept intact, deferred
+  `tool_reference` discovery kept intact, and dangling-reference stripping after a payload hook removes a
+  definition.
+
+### Expected merge conflict zones
+
+- LOW: the request-finalization chain inside `createRequest()` in `api/anthropic-messages.ts`.
+- LOW: new unexported helpers near the other payload sanitizers in `api/anthropic-messages.ts`.
+
 ## 2026-07-28 - Retry OpenAI-compatible stream failures before the first chunk
 
 ### What changed and why

--- a/packages/ai/test/anthropic-tool-reference-integrity.test.ts
+++ b/packages/ai/test/anthropic-tool-reference-integrity.test.ts
@@ -1,0 +1,300 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/compat.ts";
+import { streamAnthropic } from "../src/providers/anthropic.ts";
+import { fauxAssistantMessage, fauxToolCall } from "../src/providers/faux.ts";
+import type { Context, Tool, ToolResultMessage, UserMessage } from "../src/types.ts";
+
+/**
+ * Anthropic rejects a request whose message history references a tool that is
+ * neither defined in `tools` nor discovered through a `tool_reference` block:
+ *
+ *   400 invalid_request_error: Tool reference 'mcp_computer_use_drag' not
+ *   found in available tools
+ *
+ * Sessions outlive their tools — an MCP server can be absent after a resume,
+ * an extension can stop registering a tool, or a payload hook can strip a
+ * definition while history still carries the call. The provider must demote
+ * those references to plain text (in lockstep with their tool_results) so the
+ * turn can proceed instead of failing the whole request.
+ */
+
+interface CapturedRequest {
+	params: Record<string, unknown>;
+}
+
+function createSseResponse(events: Array<{ event: string; data: string }>): Response {
+	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function finalTextResponse(): Response {
+	return createSseResponse([
+		{
+			event: "message_start",
+			data: JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_test",
+					usage: { input_tokens: 3, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+				},
+			}),
+		},
+		{
+			event: "content_block_start",
+			data: JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+		},
+		{
+			event: "content_block_delta",
+			data: JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }),
+		},
+		{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+		{
+			event: "message_delta",
+			data: JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 1 },
+			}),
+		},
+		{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+	]);
+}
+
+function createFakeAnthropicClient(captured: CapturedRequest): Anthropic {
+	return {
+		messages: {
+			create: (params: unknown) => {
+				captured.params = params as Record<string, unknown>;
+				return { asResponse: async () => finalTextResponse() };
+			},
+		},
+	} as Anthropic;
+}
+
+function userMessage(content: string): UserMessage {
+	return { role: "user", content, timestamp: Date.now() };
+}
+
+function toolResultMessage(
+	toolCallId: string,
+	toolName: string,
+	text: string,
+	addedToolNames?: string[],
+): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+		...(addedToolNames ? { addedToolNames } : {}),
+	};
+}
+
+function makeTool(name: string): Tool {
+	return {
+		name,
+		description: `Test tool ${name}`,
+		parameters: Type.Object({ input: Type.Optional(Type.String()) }),
+	};
+}
+
+async function captureParams(
+	context: Context,
+	onPayload?: (payload: unknown) => unknown,
+	modelId: "claude-haiku-4-5" | "claude-sonnet-4-6" = "claude-haiku-4-5",
+): Promise<Record<string, unknown>> {
+	const captured: CapturedRequest = { params: {} };
+	const model = getModel("anthropic", modelId);
+	const s = streamAnthropic(model, context, {
+		apiKey: "fake-key",
+		client: createFakeAnthropicClient(captured),
+		...(onPayload ? { onPayload: (payload) => onPayload(payload) as never } : {}),
+	});
+	await s.result();
+	return captured.params;
+}
+
+interface Block {
+	type: string;
+	id?: string;
+	name?: string;
+	tool_use_id?: string;
+	text?: string;
+	content?: unknown;
+}
+
+function messagesOf(params: Record<string, unknown>): Array<{ role: string; content: unknown }> {
+	return params.messages as Array<{ role: string; content: unknown }>;
+}
+
+function blocksOf(message: { content: unknown }): Block[] {
+	return Array.isArray(message.content) ? (message.content as Block[]) : [];
+}
+
+function allBlocks(params: Record<string, unknown>): Block[] {
+	return messagesOf(params).flatMap((message) => blocksOf(message));
+}
+
+function toolUseBlocks(params: Record<string, unknown>): Block[] {
+	return allBlocks(params).filter((block) => block.type === "tool_use");
+}
+
+function toolResultBlocks(params: Record<string, unknown>): Block[] {
+	return allBlocks(params).filter((block) => block.type === "tool_result");
+}
+
+function textBlocks(params: Record<string, unknown>): Block[] {
+	return allBlocks(params).filter((block) => block.type === "text");
+}
+
+function toolNamesIn(params: Record<string, unknown>): string[] {
+	const tools = (params.tools ?? []) as Array<{ name: string }>;
+	return tools.map((tool) => tool.name);
+}
+
+describe("Anthropic tool-reference integrity", () => {
+	it("demotes history tool calls whose tool is no longer available", async () => {
+		const context: Context = {
+			messages: [
+				userMessage("drag the window"),
+				fauxAssistantMessage(fauxToolCall("mcp_computer_use_drag", { x: 10, y: 20 }, { id: "call_gone" }), {
+					stopReason: "toolUse",
+				}),
+				toolResultMessage("call_gone", "mcp_computer_use_drag", "dragged to 10,20"),
+				userMessage("thanks"),
+			],
+			tools: [],
+		};
+
+		const params = await captureParams(context);
+
+		// No tool_use or tool_result may reference the missing tool.
+		expect(toolUseBlocks(params).map((block) => block.name)).not.toContain("mcp_computer_use_drag");
+		expect(toolResultBlocks(params).map((block) => block.tool_use_id)).not.toContain("call_gone");
+
+		// The history intent survives as plain text instead of failing the request.
+		const texts = textBlocks(params)
+			.map((block) => block.text ?? "")
+			.join("\n");
+		expect(texts).toContain("mcp_computer_use_drag");
+		expect(texts).toContain("dragged to 10,20");
+
+		// No empty-content messages may be left behind.
+		for (const message of messagesOf(params)) {
+			if (Array.isArray(message.content)) expect(message.content.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("demotes only the missing tool in a mixed assistant turn", async () => {
+		const context: Context = {
+			messages: [
+				userMessage("drag then read"),
+				fauxAssistantMessage(
+					[
+						fauxToolCall("mcp_computer_use_drag", { x: 1, y: 2 }, { id: "call_gone" }),
+						fauxToolCall("read", { input: "f" }, { id: "call_kept" }),
+					],
+					{ stopReason: "toolUse" },
+				),
+				toolResultMessage("call_gone", "mcp_computer_use_drag", "dragged"),
+				toolResultMessage("call_kept", "read", "file contents"),
+				userMessage("go on"),
+			],
+			tools: [makeTool("read")],
+		};
+
+		const params = await captureParams(context);
+
+		expect(toolUseBlocks(params).map((block) => block.name)).toEqual(["read"]);
+		expect(toolResultBlocks(params).map((block) => block.tool_use_id)).toEqual(["call_kept"]);
+		expect(toolNamesIn(params)).toEqual(["read"]);
+	});
+
+	it("keeps tool calls for tools that are still available", async () => {
+		const context: Context = {
+			messages: [
+				userMessage("drag the window"),
+				fauxAssistantMessage(fauxToolCall("mcp_computer_use_drag", { x: 10, y: 20 }, { id: "call_kept" }), {
+					stopReason: "toolUse",
+				}),
+				toolResultMessage("call_kept", "mcp_computer_use_drag", "dragged"),
+				userMessage("thanks"),
+			],
+			tools: [makeTool("mcp_computer_use_drag")],
+		};
+
+		const params = await captureParams(context);
+
+		expect(toolUseBlocks(params).map((block) => block.name)).toContain("mcp_computer_use_drag");
+		expect(toolResultBlocks(params).map((block) => block.tool_use_id)).toContain("call_kept");
+	});
+
+	it("keeps deferred tools discovered through tool_reference blocks", async () => {
+		const context: Context = {
+			messages: [
+				userMessage("find a tool"),
+				fauxAssistantMessage(fauxToolCall("tool_search", { query: "drag" }, { id: "call_search" }), {
+					stopReason: "toolUse",
+				}),
+				toolResultMessage("call_search", "tool_search", "1 tool(s) activated", ["mcp_computer_use_drag"]),
+				userMessage("done"),
+			],
+			tools: [makeTool("tool_search"), makeTool("mcp_computer_use_drag")],
+		};
+
+		const params = await captureParams(context, undefined, "claude-sonnet-4-6");
+
+		// The unused activated tool ships deferred, and its tool_reference must survive.
+		const tools = (params.tools ?? []) as Array<{ name: string; defer_loading?: boolean }>;
+		expect(tools.some((tool) => tool.name === "mcp_computer_use_drag" && tool.defer_loading === true)).toBe(true);
+		const references = toolResultBlocks(params).flatMap((block) =>
+			Array.isArray(block.content) ? (block.content as Array<{ type: string; tool_name?: string }>) : [],
+		);
+		expect(references.some((ref) => ref.type === "tool_reference" && ref.tool_name === "mcp_computer_use_drag")).toBe(
+			true,
+		);
+	});
+
+	it("strips tool_reference blocks whose definition was removed by a payload hook", async () => {
+		const context: Context = {
+			messages: [
+				userMessage("find a tool"),
+				fauxAssistantMessage(fauxToolCall("tool_search", { query: "drag" }, { id: "call_search" }), {
+					stopReason: "toolUse",
+				}),
+				toolResultMessage("call_search", "tool_search", "1 tool(s) activated", ["mcp_computer_use_drag"]),
+				userMessage("done"),
+			],
+			tools: [makeTool("tool_search"), makeTool("mcp_computer_use_drag")],
+		};
+
+		const params = await captureParams(
+			context,
+			(payload) => {
+				const mutable = payload as { tools?: Array<{ name: string }> };
+				mutable.tools = (mutable.tools ?? []).filter((tool) => tool.name !== "mcp_computer_use_drag");
+				return payload;
+			},
+			"claude-sonnet-4-6",
+		);
+
+		expect(toolNamesIn(params)).not.toContain("mcp_computer_use_drag");
+		const references = toolResultBlocks(params).flatMap((block) =>
+			Array.isArray(block.content) ? (block.content as Array<{ type: string; tool_name?: string }>) : [],
+		);
+		expect(references.some((ref) => ref.type === "tool_reference" && ref.tool_name === "mcp_computer_use_drag")).toBe(
+			false,
+		);
+		// The reference-carrying tool_result must not end up with empty content.
+		for (const block of toolResultBlocks(params)) {
+			if (Array.isArray(block.content)) expect(block.content.length).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Resuming a session whose history contains calls to tools that no longer exist in the request — e.g. an MCP server absent after `senpi --session <id>` resume, a deactivated extension tool, or an `onPayload` hook stripping a definition — fails the entire turn:

```
400 invalid_request_error: Tool reference 'mcp_computer_use_drag' not found in available tools
```

Anthropic validates that every tool referenced by the message history is available in the same request: defined in `tools`, or discovered through a `tool_reference` block. The codebase already repaired *pairing* (orphan `tool_result`s, dangling calls) but never *referential integrity* between history and the tool definitions, so one missing MCP server bricked the whole resumed session.

## Fix

`demoteUnavailableToolReferences()` in `packages/ai/src/api/anthropic-messages.ts` — a final payload pass applied after `sanitizeUnsupportedNativeTools()` on every request, right before send:

1. Collects defined tool names (`params.tools`) and discovered names (any nested `tool_reference`, including replayed server-side tool-search results).
2. Demotes `tool_use` blocks referencing unavailable tools to plain text (name + input preserved).
3. Demotes their `tool_result`s in lockstep (original result text preserved) so no orphan-pairing 400 replaces the original one.
4. Strips `tool_reference` entries whose definition vanished (e.g. removed by a payload hook), never leaving empty `tool_result` content.

Deferred-tool discovery (`splitDeferredTools` + `tool_reference`) is untouched and covered by a guard test.

## Evidence

- New `packages/ai/test/anthropic-tool-reference-integrity.test.ts`: 5 tests driving the full request path offline through a fake Anthropic client — single/mixed-turn demotion, still-available tools intact, deferred `tool_reference` discovery intact, dangling-reference stripping. Red before, green after.
- `packages/ai` full suite: 1458 passed (the one initial suite failure was an unbuilt `packages/tui/dist` in the fresh worktree; green after `npm run build` there — unrelated to this change).
- Root `npm run check`: exit 0.
- senpi-qa (`local-ignore/qa-evidence/20260728-anthropic-tool-ref-integrity/`):
  - `mock-loop.mjs --self-test --api anthropic-messages`: 20/20 passed, zero real provider calls, real auth unchanged.
  - `cli-smoke.mjs --self-test`: 8/8 passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Anthropic 400s when history references tools that aren’t in the current request by demoting those tool calls/results to text and removing dangling `tool_reference` entries so the turn can continue.

- **Bug Fixes**
  - Added `demoteUnavailableToolReferences()` in `packages/ai/src/api/anthropic-messages.ts`, run after `sanitizeUnsupportedNativeTools()` on every request.
  - Collects available tool names from `tools` and nested `tool_reference` blocks; converts missing `tool_use` to text (keeps name + input) and demotes paired `tool_result` (keeps result text) to avoid orphan errors.
  - Strips `tool_reference` items whose definitions were removed (e.g., by an `onPayload` hook) without leaving empty `tool_result` content; deferred discovery remains intact.
  - Added `packages/ai/test/anthropic-tool-reference-integrity.test.ts` to cover mixed turns, still-available tools, deferred `tool_reference` flows, and dangling-reference stripping.

<sup>Written for commit 5ecb30463348f14d710edd21a12783032837e639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

