### PR TITLE
feat(coding-agent): show (OmO Native) footer badge when omo-senpi + senpi-task installed

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,22 @@
+## Footer shows (OmO Native) when the local omo-senpi + senpi-task stack is installed (2026-07-28)
+
+### What changed
+
+- `core/omo-native-detect.ts` (new): `detectOmoNativeInstall(packages, agentDir)` — sync, dependency-free detection of the "OMO Native" local install. A settings `packages` entry that is a local path resolving to a dir whose package.json name is `@code-yeongyu/omo-senpi`, whose derived repo root (`pluginPath/../../..`) contains both workspace packages `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task`. Mirrors gates 1 and 2 of the beta `detectOmoLocalInstall` (beta/omo-local-update.ts), dropping gate 3 (the `git rev-parse --show-toplevel` integrity check) so it stays sync and cheap for footer rendering; the beta module's export policy forbids importing its helpers into production core.
+- `core/footer-data-provider.ts`: `FooterDataProvider` gains `setOmoNative(boolean)` / `isOmoNative()` (field-backed, matching the existing `availableProviderCount` injection pattern) and `isOmoNative` is exposed on `ReadonlyFooterDataProvider`.
+- `modes/interactive/interactive-mode.ts`: after constructing the provider, calls `setOmoNative(detectOmoNativeInstall(this.settingsManager.getPackages(), getAgentDir()))`.
+- Coverage: `test/omo-native-detect.test.ts` pins happy + edge cases; `test/omo-native-footer.test.ts` pins the rendered segment; `test/footer-width.test.ts`, `test/grok/footer.test.ts`, `test/grok/classic-chrome-characterization.test.ts` updated for the new `isOmoNative` Pick member.
+
+### Why
+
+- A senpi session backed by the local OMO source checkout (omo-senpi + senpi-task workspace packages installed as a local-path package) is the "OMO Native" configuration; surfacing it in the footer makes the active stack visible at a glance, mirroring the detection already used by the beta `senpi update` local-update flow.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `core/footer-data-provider.ts` around the `availableProviderCount` field and the `ReadonlyFooterDataProvider` Pick (additive).
+- LOW: `modes/interactive/interactive-mode.ts` around the `FooterDataProvider` construction site.
+- NEW file `core/omo-native-detect.ts` — no upstream counterpart, no conflict.
+
 ## Provider-qualified fallback selectors resolve inside their own provider (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -111,6 +111,7 @@ export class FooterDataProvider {
 	private reftableTablesListPath: string | null = null;
 	private branchChangeCallbacks = new Set<() => void>();
 	private availableProviderCount = 0;
+	private omoNative = false;
 	private refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private gitWatcherRetryTimer: ReturnType<typeof setTimeout> | null = null;
 	private refreshInFlight = false;
@@ -164,6 +165,14 @@ export class FooterDataProvider {
 	/** Internal: update available provider count */
 	setAvailableProviderCount(count: number): void {
 		this.availableProviderCount = count;
+	}
+
+	setOmoNative(enabled: boolean): void {
+		this.omoNative = enabled;
+	}
+
+	isOmoNative(): boolean {
+		return this.omoNative;
 	}
 
 	setCwd(cwd: string): void {
@@ -384,5 +393,5 @@ export class FooterDataProvider {
 /** Read-only view for extensions - excludes setExtensionStatus, setAvailableProviderCount and dispose */
 export type ReadonlyFooterDataProvider = Pick<
 	FooterDataProvider,
-	"getGitBranch" | "getExtensionStatuses" | "getAvailableProviderCount" | "onBranchChange"
+	"getGitBranch" | "getExtensionStatuses" | "getAvailableProviderCount" | "onBranchChange" | "isOmoNative"
 >;

--- a/packages/coding-agent/src/core/omo-native-detect.ts
+++ b/packages/coding-agent/src/core/omo-native-detect.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { isLocalPath, resolvePath } from "../utils/paths.ts";
+import type { PackageSource } from "./settings-manager.ts";
+
+/**
+ * Synchronous, dependency-free detection of the "OMO Native" local install: a settings
+ * `packages` entry that is a local path resolving to a dir whose package.json name is
+ * `@code-yeongyu/omo-senpi`, whose derived repo root (pluginPath/../../..) contains both
+ * workspace packages `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task`.
+ *
+ * This mirrors gates 1 and 2 of the beta `detectOmoLocalInstall` (beta/omo-local-update.ts)
+ * but drops gate 3 (the `git rev-parse --show-toplevel` integrity check) so it stays sync and
+ * cheap enough for footer rendering. The beta module's export policy forbids importing its
+ * helpers into production core, so this isolated module is the footer's own detection.
+ */
+const OMO_SENPI_PLUGIN_PACKAGE = "@code-yeongyu/omo-senpi";
+const OMO_SENPI_WORKSPACE_PACKAGE = "@oh-my-opencode/omo-senpi";
+const SENPI_TASK_WORKSPACE_PACKAGE = "@oh-my-opencode/senpi-task";
+
+function homeDir(): string {
+	return process.env.HOME || homedir();
+}
+
+function readPackageName(packageJsonPath: string): string | undefined {
+	try {
+		const json = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { name?: unknown };
+		const name = json.name;
+		return typeof name === "string" ? name : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function detectOmoNativeInstall(packages: PackageSource[] | undefined, agentDir: string): boolean {
+	if (!packages) {
+		return false;
+	}
+	for (const entry of packages) {
+		const source = typeof entry === "string" ? entry : entry.source;
+		if (!isLocalPath(source)) {
+			continue;
+		}
+		const pluginPath = resolvePath(source, agentDir, { homeDir: homeDir(), trim: true });
+		if (readPackageName(join(pluginPath, "package.json")) !== OMO_SENPI_PLUGIN_PACKAGE) {
+			continue;
+		}
+		const repoRoot = resolve(pluginPath, "..", "..", "..");
+		const omoSenpiPkg = join(repoRoot, "packages", "omo-senpi", "package.json");
+		if (!existsSync(omoSenpiPkg) || readPackageName(omoSenpiPkg) !== OMO_SENPI_WORKSPACE_PACKAGE) {
+			continue;
+		}
+		const senpiTaskPkg = join(repoRoot, "packages", "senpi-task", "package.json");
+		if (!existsSync(senpiTaskPkg) || readPackageName(senpiTaskPkg) !== SENPI_TASK_WORKSPACE_PACKAGE) {
+			continue;
+		}
+		return true;
+	}
+	return false;
+}

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Footer prepends (OmO Native) badge when the OMO native stack is active (2026-07-28)
+
+### What changed
+
+- `components/footer.ts`: `render()` prepends an `(OmO Native)` anchor segment (colored `success`) as the leftmost footer element when `footerData.isOmoNative()` returns true, before pwd and branch. The badge participates in the existing width-elision ladder as an anchor (never dropped, only elided with pwd when space is exhausted).
+- The badge is fed by `FooterDataProvider.isOmoNative()`, set once at startup by `interactive-mode.ts` from `detectOmoNativeInstall()` (see root `src/changes.md`).
+- Coverage: `test/omo-native-footer.test.ts` asserts the segment is the leftmost rendered text when active and absent when inactive.
+
+### Why
+
+- Makes the OMO native install state visible in the bottom-left footer without a separate status line.
+
+### Expected merge conflict zones
+
+- LOW: `components/footer.ts` around the anchor segment construction.
+
 ## Large resumed sessions use event-driven Working updates (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -142,7 +142,12 @@ export class FooterComponent implements Component {
 		const branch = this.footerData.getGitBranch();
 		const sessionName = this.session.sessionManager.getSessionName();
 
+		const omoNativeBadge: FooterSegment | undefined = this.footerData.isOmoNative()
+			? { plain: "(OmO Native)", colored: theme.fg("success", "(OmO Native)") }
+			: undefined;
+
 		const anchor: [FooterSegment, ...FooterSegment[]] = [{ plain: pwdRaw, colored: theme.fg("accent", pwdRaw) }];
+		if (omoNativeBadge) anchor.unshift(omoNativeBadge);
 		if (branch) anchor.push({ plain: branch, colored: theme.fg("warning", branch) });
 
 		const dim = (plain: string): FooterSegment => ({ plain, colored: theme.fg("dim", plain) });

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -88,6 +88,7 @@ import {
 	resolveModelScope,
 	type ScopedModel,
 } from "../../core/model-resolver.ts";
+import { detectOmoNativeInstall } from "../../core/omo-native-detect.ts";
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.ts";
 import { type SessionEntry, SessionManager, sessionEntryToContextMessages } from "../../core/session-manager.ts";
@@ -671,6 +672,7 @@ export class InteractiveMode {
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor as Component);
 		this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
+		this.footerDataProvider.setOmoNative(detectOmoNativeInstall(this.settingsManager.getPackages(), getAgentDir()));
 		this.footer = this.chrome
 			? this.chrome.createFooter(this.session, this.footerDataProvider)
 			: new FooterComponent(this.session, this.footerDataProvider);

--- a/packages/coding-agent/test/footer-token-format.test.ts
+++ b/packages/coding-agent/test/footer-token-format.test.ts
@@ -61,6 +61,7 @@ function createFooterData(): unknown {
 		getExtensionStatuses: () => new Map<string, string>(),
 		getAvailableProviderCount: () => 1,
 		onBranchChange: () => () => {},
+		isOmoNative: () => false,
 	};
 }
 

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -122,6 +122,7 @@ function createFooterData(providerCount: number): ReadonlyFooterDataProvider {
 		getGitBranch: () => "main",
 		getExtensionStatuses: () => new Map<string, string>(),
 		getAvailableProviderCount: () => providerCount,
+		isOmoNative: () => false,
 		onBranchChange: (callback: () => void) => {
 			void callback;
 			return () => {};

--- a/packages/coding-agent/test/grok/chrome.test.ts
+++ b/packages/coding-agent/test/grok/chrome.test.ts
@@ -25,6 +25,7 @@ function createRuntime(): AgentSessionRuntime {
 				getEditorPaddingX: () => 0,
 				getHideThinkingBlock: () => false,
 				getOutputPad: () => 1,
+				getPackages: () => [],
 				getShowHardwareCursor: () => false,
 				getSmoothStreaming: () => false,
 				getSmoothStreamingFps: () => 60,

--- a/packages/coding-agent/test/grok/classic-chrome-characterization.test.ts
+++ b/packages/coding-agent/test/grok/classic-chrome-characterization.test.ts
@@ -125,6 +125,7 @@ function createClassicRuntime(): AgentSessionRuntime {
 				getEditorPaddingX: () => 0,
 				getHideThinkingBlock: () => false,
 				getOutputPad: () => 1,
+				getPackages: () => [],
 				getShowHardwareCursor: () => false,
 				getSmoothStreaming: () => false,
 				getSmoothStreamingFps: () => 60,
@@ -156,6 +157,7 @@ const footerData: ReadonlyFooterDataProvider = {
 	getGitBranch: () => null,
 	getExtensionStatuses: () => new Map(),
 	getAvailableProviderCount: () => 0,
+	isOmoNative: () => false,
 	onBranchChange: () => () => {},
 };
 

--- a/packages/coding-agent/test/grok/footer.test.ts
+++ b/packages/coding-agent/test/grok/footer.test.ts
@@ -13,6 +13,7 @@ const footerData = {
 	getGitBranch: () => null,
 	getExtensionStatuses: () => new Map(),
 	getAvailableProviderCount: () => 0,
+	isOmoNative: () => false,
 	onBranchChange: () => () => {},
 } as ReadonlyFooterDataProvider;
 

--- a/packages/coding-agent/test/omo-native-detect.test.ts
+++ b/packages/coding-agent/test/omo-native-detect.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectOmoNativeInstall } from "../src/core/omo-native-detect.ts";
+import type { PackageSource } from "../src/core/settings-manager.ts";
+
+/**
+ * Build a temp "omo repo" with the layout detectOmoNativeInstall expects:
+ *   <repoRoot>/packages/omo-senpi/package.json   name @oh-my-opencode/omo-senpi
+ *   <repoRoot>/packages/senpi-task/package.json  name @oh-my-opencode/senpi-task
+ *   <repoRoot>/a/b/c/package.json                 name @code-yeongyu/omo-senpi  (plugin install path, 3 deep)
+ * pluginPath/../../.. resolves to repoRoot, matching the beta detectOmoLocalInstall derivation.
+ */
+function buildRepo(opts: {
+	omoSenpiWorkspaceName?: string;
+	senpiTaskWorkspaceName?: string;
+	pluginName?: string;
+	skipSenpiTask?: boolean;
+	skipOmoSenpiWorkspace?: boolean;
+	skipPluginPackageJson?: boolean;
+}): { repoRoot: string; pluginPath: string } {
+	const repoRoot = mkdtempSync(join(tmpdir(), "omo-native-detect-"));
+	mkdirSync(join(repoRoot, "packages"), { recursive: true });
+	if (!opts.skipOmoSenpiWorkspace) {
+		mkdirSync(join(repoRoot, "packages", "omo-senpi"), { recursive: true });
+		writeFileSync(
+			join(repoRoot, "packages", "omo-senpi", "package.json"),
+			JSON.stringify({ name: opts.omoSenpiWorkspaceName ?? "@oh-my-opencode/omo-senpi" }),
+		);
+	}
+	if (!opts.skipSenpiTask) {
+		mkdirSync(join(repoRoot, "packages", "senpi-task"), { recursive: true });
+		writeFileSync(
+			join(repoRoot, "packages", "senpi-task", "package.json"),
+			JSON.stringify({ name: opts.senpiTaskWorkspaceName ?? "@oh-my-opencode/senpi-task" }),
+		);
+	}
+	const pluginPath = join(repoRoot, "a", "b", "c");
+	mkdirSync(pluginPath, { recursive: true });
+	if (!opts.skipPluginPackageJson) {
+		writeFileSync(
+			join(pluginPath, "package.json"),
+			JSON.stringify({ name: opts.pluginName ?? "@code-yeongyu/omo-senpi" }),
+		);
+	}
+	return { repoRoot, pluginPath };
+}
+
+const createdDirs: string[] = [];
+afterEach(() => {
+	for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+	createdDirs.length = 0;
+});
+
+describe("detectOmoNativeInstall", () => {
+	it("returns true when a local-path @code-yeongyu/omo-senpi plugin has both workspace packages", () => {
+		const { pluginPath } = buildRepo({});
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(true);
+	});
+
+	it("accepts the object package-source form", () => {
+		const { pluginPath } = buildRepo({});
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [{ source: pluginPath, autoload: true }];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(true);
+	});
+
+	it("returns false for undefined packages", () => {
+		expect(detectOmoNativeInstall(undefined, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false for an empty packages array", () => {
+		expect(detectOmoNativeInstall([], "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false for non-local package sources (npm:, git:, https:)", () => {
+		const packages: PackageSource[] = [
+			"npm:@code-yeongyu/omo-senpi",
+			"git:github.com/foo/bar",
+			"https://example.com",
+		];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when the local-path plugin package name is not @code-yeongyu/omo-senpi", () => {
+		const { pluginPath } = buildRepo({ pluginName: "@some-other/package" });
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when the plugin package.json is missing", () => {
+		const { pluginPath } = buildRepo({ skipPluginPackageJson: true });
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when the senpi-task workspace package is missing", () => {
+		const { pluginPath } = buildRepo({ skipSenpiTask: true });
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when the omo-senpi workspace package is missing", () => {
+		const { pluginPath } = buildRepo({ skipOmoSenpiWorkspace: true });
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when the omo-senpi workspace package name is wrong", () => {
+		const { pluginPath } = buildRepo({ omoSenpiWorkspaceName: "@wrong/omo-senpi" });
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when the senpi-task workspace package name is wrong", () => {
+		const { pluginPath } = buildRepo({ senpiTaskWorkspaceName: "@wrong/senpi-task" });
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = [pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns false when a local path points to a non-existent directory", () => {
+		const packages: PackageSource[] = ["/tmp/definitely-not-a-real-path-omo-native"];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(false);
+	});
+
+	it("returns true when the omo-senpi plugin is the second of two package entries", () => {
+		const { pluginPath } = buildRepo({});
+		createdDirs.push(pluginPath);
+		const packages: PackageSource[] = ["npm:some/other-package", pluginPath];
+		expect(detectOmoNativeInstall(packages, "/tmp/nonexistent-agent-dir")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/omo-native-footer.test.ts
+++ b/packages/coding-agent/test/omo-native-footer.test.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.ts";
+import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provider.ts";
+import { FooterComponent } from "../src/modes/interactive/components/footer.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function createSession(): AgentSession {
+	return {
+		state: {
+			model: { id: "test-model", provider: "test", contextWindow: 200_000, reasoning: false },
+			thinkingLevel: "off",
+		},
+		sessionManager: {
+			getUsageTotals: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: 0,
+				latestCacheHitRate: undefined,
+			}),
+			getSessionName: () => "test",
+			getCwd: () => "/tmp/project",
+		},
+		getContextUsage: () => ({ contextWindow: 200_000, percent: 12.3 }),
+		modelRuntime: { isUsingOAuth: () => false },
+	} as unknown as AgentSession;
+}
+
+function createFooterData(omoNative: boolean): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => "main",
+		getExtensionStatuses: () => new Map<string, string>(),
+		getAvailableProviderCount: () => 1,
+		onBranchChange: () => () => {},
+		isOmoNative: () => omoNative,
+	};
+}
+
+describe("FooterComponent (OmO Native) indicator", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	it("prepends (OmO Native) as the leftmost segment when isOmoNative is true", () => {
+		const footer = new FooterComponent(createSession(), createFooterData(true));
+		const lines = footer.render(120);
+		const firstLine = lines[0] ?? "";
+		expect(stripAnsi(firstLine).startsWith("(OmO Native)")).toBe(true);
+	});
+
+	it("omits (OmO Native) when isOmoNative is false", () => {
+		const footer = new FooterComponent(createSession(), createFooterData(false));
+		const lines = footer.render(120);
+		const firstLine = lines[0] ?? "";
+		expect(stripAnsi(firstLine).includes("(OmO Native)")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

Show `(OmO Native)` in the bottom-left of the senpi interactive TUI footer when both the `omo-senpi` and `senpi-task` packages are installed as a local-path package (the "OMO Native" setup).

## Why

A senpi session backed by the local OMO source checkout (omo-senpi + senpi-task workspace packages installed as a local-path `packages` entry) is the "OMO Native" configuration — the same layout the beta `senpi update` local-update flow already detects. Surfacing it in the footer makes the active stack visible at a glance.

## Changes

- **`core/omo-native-detect.ts` (new)**: `detectOmoNativeInstall(packages, agentDir)` — sync, dependency-free detection. Mirrors gates 1+2 of the beta `detectOmoLocalInstall`: a settings `packages` entry that is a local path resolving to a dir whose `package.json` name is `@code-yeongyu/omo-senpi`, whose derived repo root (`pluginPath/../../..`) contains both workspace packages `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task`. Drops gate 3 (the `git rev-parse --show-toplevel` integrity check) so it stays sync and cheap for footer rendering; the beta module's export policy forbids importing its helpers into production core, so this is an isolated module.
- **`core/footer-data-provider.ts`**: `FooterDataProvider` gains `setOmoNative(boolean)` / `isOmoNative()` (field-backed, matching the existing `availableProviderCount` injection pattern); `isOmoNative` is exposed on `ReadonlyFooterDataProvider`. (File is pre-existing over the 250-LOC ceiling; only 3 trivial delegation lines added — no logic. Splitting the git-watcher unit out is a separate refactor.)
- **`modes/interactive/interactive-mode.ts`**: after constructing the provider, calls `setOmoNative(detectOmoNativeInstall(this.settingsManager.getPackages(), getAgentDir()))`.
- **`modes/interactive/components/footer.ts`**: `render()` prepends an `(OmO Native)` anchor segment (colored `success`) as the leftmost footer element when `footerData.isOmoNative()` is true, before pwd and branch. The badge participates in the existing width-elision ladder as an anchor (never dropped, elides with pwd when space is exhausted).

## Observed behavior (QA evidence)

- `npx vitest run` on the footer test scope (7 files): **41 passed (41)** — new `omo-native-detect` (13 cases: happy + edge) + `omo-native-footer` (segment present/absent) + regression (`footer-width`, `footer-provider-count`, `footer-token-format`, `grok/footer`, `grok/classic-chrome-characterization`).
- RED captured before impl (4 assertion failures for the right reason), GREEN after.
- `tsgo --noEmit` **EXIT 0**; `biome check` clean (10 files, no fixes).
- Surface render (real `FooterComponent` + real theme + real layout planner):
  - `isOmoNative=true`, width 120: `(OmO Native) • ~/local-workspaces/omo • dev • feature-work • … • 85K/200K (42.7%) (auto)  (anthropic) claude-opus-5:high`
  - `isOmoNative=false`, width 120: starts with pwd, no badge.
  - `isOmoNative=true`, narrow width 60: badge elides with pwd via `…` marker; pinned model label survives (correct anchor behavior).

## Residual risk

- LOW. Detection is read-only filesystem checks; no behavior change when the OMO stack is absent (badge simply doesn't render). The `isOmoNative` Pick addition required additive stub updates in 4 existing footer tests (done).
- Pre-existing smell: `footer-data-provider.ts` is 354 pure LOC (over the 250 ceiling before this change). Extracting the git-watcher unit (~150 LOC) would bring it under; out of scope for this feature.

## Changes.md

Entries added to `src/changes.md` and `src/modes/interactive/changes.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an “(OmO Native)” badge in the TUI footer when the local OMO stack is active, so users can see at a glance when `@code-yeongyu/omo-senpi` + `@oh-my-opencode/senpi-task` are sourced from a local checkout.

- **New Features**
  - Added `detectOmoNativeInstall()` (`core/omo-native-detect.ts`): sync check for a local-path `@code-yeongyu/omo-senpi` whose repo root contains `@oh-my-opencode/omo-senpi` and `@oh-my-opencode/senpi-task`.
  - `FooterDataProvider` now has `setOmoNative()` / `isOmoNative()` and exposes `isOmoNative` via `ReadonlyFooterDataProvider`.
  - `interactive-mode` sets the flag at startup using settings packages and the agent dir.
  - `FooterComponent` prepends “(OmO Native)” (success color) as the leftmost anchor; it elides with the path on narrow widths.

- **Bug Fixes**
  - Tests: stubbed `getPackages()` in grok chrome tests to match the new startup call and prevent a runtime error.

<sup>Written for commit e934c451dfd52c914921a0029fce828bc4d070f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

