### PR TITLE
fix(codemode): survive provider tool call id reuse and drop bogus eval durations

### DIFF
--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -68,7 +68,10 @@ export class EvalDetachedCellManager {
 
 	create(cellId: string, input: EvalToolInput): ManagedCell {
 		const existing = this.#cells.get(cellId);
-		if (existing !== undefined) throw new Error(`Eval cell ${cellId} is already managed`);
+		if (existing !== undefined) {
+			if (existing.state === "running" || existing.state === "detached") throw activeCellReuseError(existing);
+			this.#cells.delete(cellId);
+		}
 		const spillPath =
 			this.#artifactsDir === undefined
 				? undefined
@@ -230,6 +233,12 @@ export class EvalDetachedCellManager {
 			stateRetained: cell.stateRetained,
 		};
 	}
+}
+
+function activeCellReuseError(cell: ManagedCell): Error {
+	return new Error(
+		`Eval cell ${cell.cellId} from a previous call is still ${cell.state} in the ${cell.input.language} kernel. Use eval({ action: "peek", cell_id: "${cell.cellId}" }) to read it or eval({ action: "stop", cell_id: "${cell.cellId}" }) to end it before its id can be reused.`,
+	);
 }
 
 function allowsTransition(from: EvalDetachedCellState, to: EvalDetachedCellState): boolean {

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -732,7 +732,7 @@ function resultMetadata(
 ): RenderBlock[] {
 	const metadata: string[] = [];
 	if (details?.phase) metadata.push(`phase ${details.phase}`);
-	if (!options.isPartial && details) metadata.push(`took ${details.durationMs}ms`);
+	if (!options.isPartial && typeof details?.durationMs === "number") metadata.push(`took ${details.durationMs}ms`);
 	if (metadata.length === 0) return [];
 	return [{ kind: "text", text: style(theme, "muted", metadata.join(" | ")) }];
 }

--- a/packages/senpi-codemode/test/eval-cell-id-reuse.test.ts
+++ b/packages/senpi-codemode/test/eval-cell-id-reuse.test.ts
@@ -1,0 +1,144 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+type TextContent = Extract<AgentToolResult<unknown>["content"][number], { type: "text" }>;
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function textOf(toolResult: AgentToolResult<unknown>): string {
+	const texts: string[] = [];
+	for (const part of toolResult.content as readonly TextContent[]) {
+		if (part.type === "text") texts.push(part.text);
+	}
+	return texts.join("\n");
+}
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "tui" as const };
+}
+
+function createTool(manager: EvalDetachedCellManager, entries: Array<readonly [string, FakeKernel]>) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: true, rb: false, jl: false },
+		kernelManager: new FakeManager(entries),
+		cellTimeoutSeconds: 1,
+		executeTool: vi.fn(),
+		cellManager: manager,
+	});
+}
+
+async function run(
+	tool: ReturnType<typeof createTool>,
+	cellId: string,
+	language: "js" | "py",
+	code: string,
+): Promise<AgentToolResult<unknown>> {
+	return await tool.execute(cellId, { language, code }, undefined, undefined, interactiveContext());
+}
+
+async function detach(
+	tool: ReturnType<typeof createTool>,
+	kernel: FakeKernel,
+	cellId: string,
+	language: "js" | "py" = "js",
+): Promise<AgentToolResult<unknown>> {
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		cellId,
+		{ language, code: "await forever", on_timeout: "detach" },
+		undefined,
+		undefined,
+		interactiveContext(),
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	return await execution;
+}
+
+// Some providers issue per-message indexed tool call ids ("eval:0", "eval:1", ...)
+// that repeat across assistant messages. The manager must treat a reused id whose
+// previous cell reached a terminal state as a fresh cell instead of failing with
+// "Eval cell <id> is already managed".
+describe("eval cell id reuse", () => {
+	it("runs a fresh cell when a tool call id is reused after the previous cell completed", async () => {
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([result("eval:0", "first-ok")]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		const first = await run(tool, "eval:0", "js", "1 + 1");
+		expect(textOf(first)).toContain("first-ok");
+
+		kernel.replaceMessages([result("eval:0", "second-ok")]);
+		const second = await run(tool, "eval:0", "js", "2 + 2");
+		expect(textOf(second)).toContain("second-ok");
+	});
+
+	it("runs a fresh cell after a failed cell with the same id and peek follows the newest cell", async () => {
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([errorResult("eval:0", "boom")]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		const first = await run(tool, "eval:0", "js", "explode()");
+		expect(first.details).toMatchObject({ isError: true });
+
+		kernel.replaceMessages([result("eval:0", "recovered")]);
+		const second = await run(tool, "eval:0", "js", "1");
+		expect(textOf(second)).toContain("recovered");
+
+		const peek = await tool.execute(
+			"peek-call",
+			{ action: "peek", cell_id: "eval:0" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		expect(textOf(peek)).toContain("is completed");
+	});
+
+	it("still reports the same-language kernel-busy guidance when reusing the id of a detached cell", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([{ type: "text", stream: "stdout", data: "still computing\n" }]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await detach(tool, kernel, "eval:0");
+		await expect(run(tool, "eval:0", "js", "again()")).rejects.toThrow(
+			/busy running detached cell eval:0[\s\S]*still computing/u,
+		);
+
+		await manager.stop("eval:0");
+		await manager.flushNotifications();
+	});
+
+	it("rejects reusing the id of a still-active cell with peek/stop guidance instead of the bare already-managed error", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const js = new FakeKernel([]);
+		const py = new FakeKernel([result("eval:0", "py-ok")]);
+		const tool = createTool(manager, [
+			["js", js],
+			["py", py],
+		]);
+
+		await detach(tool, js, "eval:0");
+		const error = await run(tool, "eval:0", "py", "1").then(
+			() => {
+				throw new Error("expected the reuse of an active cell id to reject");
+			},
+			(reason: unknown) => reason,
+		);
+		if (!(error instanceof Error)) throw new Error("expected an Error rejection");
+		expect(error.message).toMatch(/still detached/u);
+		expect(error.message).toContain('eval({ action: "peek", cell_id: "eval:0" })');
+		expect(error.message).toContain('eval({ action: "stop", cell_id: "eval:0" })');
+		expect(error.message).not.toContain("already managed");
+
+		await manager.stop("eval:0");
+		await manager.flushNotifications();
+	});
+});

--- a/packages/senpi-codemode/test/eval-render-fixtures.ts
+++ b/packages/senpi-codemode/test/eval-render-fixtures.ts
@@ -96,3 +96,10 @@ export function evalResultWithOmittedDetails(text: string): AgentToolResult<Eval
 	Reflect.deleteProperty(result, "details");
 	return result;
 }
+
+/** Mirrors host-generated error results whose details payload is an empty object. */
+export function evalResultWithEmptyDetails(text: string): AgentToolResult<EvalToolDetails> {
+	const result = evalResult({ language: "js", durationMs: 0, toolCalls: [], truncated: false }, text);
+	for (const key of Object.keys(result.details)) Reflect.deleteProperty(result.details, key);
+	return result;
+}

--- a/packages/senpi-codemode/test/eval-render-state.test.ts
+++ b/packages/senpi-codemode/test/eval-render-state.test.ts
@@ -5,6 +5,7 @@ import type { EvalToolDetails } from "../src/tool/types.ts";
 import {
 	callContext,
 	evalResult,
+	evalResultWithEmptyDetails,
 	evalResultWithOmittedDetails,
 	renderLines,
 	resultContext,
@@ -81,6 +82,25 @@ describe("eval renderer state", () => {
 
 		// Then
 		expect(renderLines(component).join("\n")).not.toContain("took");
+	});
+
+	it("Given a host error result with empty details when rendered then no undefined duration is shown", () => {
+		// Given
+		const givenResult = evalResultWithEmptyDetails("Eval cell eval:0 is already managed");
+
+		// When
+		const component = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ isError: true }),
+		);
+
+		// Then
+		const text = renderLines(component).join("\n");
+		expect.soft(text).not.toContain("took undefinedms");
+		expect.soft(text).toContain("error");
+		expect(text).toContain("already managed");
 	});
 
 	it("Given empty text output when rendered then no-output marker is shown", () => {


### PR DESCRIPTION
## Problem

Some providers emit per-message indexed tool call ids (`eval:0`, `eval:1`, ...) that repeat across assistant messages (observed with `kimi-k3-ultrafast`). `EvalDetachedCellManager.create()` threw `Eval cell <id> is already managed` on any id reuse and never evicted terminal cells, so the second eval call of a session could permanently brick the eval tool:

```
eval ? error
took undefinedms

Eval cell eval:0 is already managed
```

The `took undefinedms` line is a second bug: host error results carry `details: {}` (agent-loop `createErrorToolResult`), and the eval renderer printed `took ${details.durationMs}ms` for any truthy details.

## Fix

- `detached-cell-manager.ts`: on id reuse, evict the previous cell when it is terminal (`completed` / `failed` / `cancelled`) and run a fresh cell. When the previous cell is still active (`running` / `detached`, e.g. a cross-language collision), throw an actionable error naming the cell state with `peek` / `stop` guidance instead of the bare "already managed". Same-language reuse of a detached cell keeps the existing kernel-busy guidance (`busyFor` pre-empts `create`).
- `render.ts`: only render `took <n>ms` when `durationMs` is actually a number.

Eviction is safe: a terminal cell has already resolved its `terminal` promise, left `#detachedByLanguage`, and queued its notification by direct reference.

## Tests

- New `test/eval-cell-id-reuse.test.ts` (all captured RED first against the old code):
  - reuse after completion runs a fresh cell
  - reuse after failure runs a fresh cell; `peek` follows the newest cell
  - same-language detached reuse still raises the kernel-busy guidance (regression pin)
  - active-collision reuse raises the actionable peek/stop error, never "already managed"
- `test/eval-render-state.test.ts`: host error result with empty details renders without `took undefinedms` (fixture `evalResultWithEmptyDetails` mirrors the agent-loop error shape).

## Verification

- `packages/senpi-codemode` vitest: 62 files passed / 1 skipped, 408 tests passed / 6 skipped (skips pre-existing)
- `npm run check` green at repo root
- Real-surface QA with the real Python kernel through `createEvalTool` + bridge server: second run with reused cellId `eval:0` succeeds, kernel state persists across the reuse (x=21 -> 42), peek follows the newest cell, renderer omits the bogus duration. Evidence: `local-ignore/qa-evidence/20260728-eval-cell-id-reuse/` (session-local).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle provider eval tool-call ID reuse and remove bogus duration text in `packages/senpi-codemode`. Reused IDs now start fresh after terminal cells; active collisions return a clear error with `peek`/`stop` guidance, and "took" is shown only when the duration is known.

- **Bug Fixes**
  - `detached-cell-manager.ts`: Evict terminal cells on ID reuse and run a new cell. If the previous cell is still running/detached, throw an actionable error with `peek`/`stop` guidance; same-language detached reuse still reports kernel busy.
  - `render.ts`: Render "took <n>ms" only when `details.durationMs` is a number to avoid "took undefinedms` on host error results.

<sup>Written for commit 7622b645defdfa3133057c223a7f3434685161c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

