### PR TITLE
fix(coding-agent): stop update_goal rejecting blank reason on complete

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,20 @@
 # goal Extension Changes
 
+## Blank reasons treated as omitted for update_goal complete (2026-07-28)
+
+### What changed
+
+- `tool-registration.ts` normalizes `reason` at the model boundary (trim, non-string
+  treated as absent) before validating. An empty, whitespace-only, or null `reason`
+  no longer triggers "reason must not be provided when status is complete" — strict
+  tool-calling providers that serialize omitted optional strings as `""`/`null`
+  previously hit that rejection on every retry and spun. A non-empty reason remains
+  rejected for `complete`; `blocked` still requires a non-blank reason.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `tool-registration.ts` around the update_goal execute validation.
+
 ## Continuity across newer user instructions (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
@@ -74,11 +74,11 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 			{ additionalProperties: false },
 		),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const reason = params.reason?.trim();
+			const reason = typeof params.reason === "string" ? params.reason.trim() : undefined;
 			if (params.status === "blocked" && (reason === undefined || reason.length === 0)) {
 				throw new Error("reason is required when status is blocked");
 			}
-			if (params.status === "complete" && params.reason !== undefined) {
+			if (params.status === "complete" && reason !== undefined && reason.length > 0) {
 				throw new Error("reason must not be provided when status is complete");
 			}
 			if (params.status === "complete") {

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -235,6 +235,34 @@ describe("goal extension contract (budget-free)", () => {
 		expect(sent).toHaveLength(0);
 	});
 
+	it("treats an empty, whitespace-only, or null reason as omitted when completing a goal", async () => {
+		for (const reason of ["", "   ", null]) {
+			const { tools } = createGoalHarness();
+			const ctx = await makeCtx(`thread/blank-reason-${String(reason)}`);
+			const ref = storeRefFor(ctx);
+			await tools
+				.get("create_goal")
+				?.execute("c1", { objective: "Complete despite sloppy args" }, undefined, undefined, ctx);
+
+			await tools.get("update_goal")?.execute("u1", { status: "complete", reason }, undefined, undefined, ctx);
+
+			expect((await readGoal(ref))?.status).toBe("complete");
+		}
+	});
+
+	it("still rejects blocking with a blank reason", async () => {
+		const { tools } = createGoalHarness();
+		const ctx = await makeCtx("thread/blank-reason-blocked");
+		await tools
+			.get("create_goal")
+			?.execute("c1", { objective: "Block with blank reason" }, undefined, undefined, ctx);
+
+		await expect(
+			tools.get("update_goal")?.execute("u1", { status: "blocked", reason: "  " }, undefined, undefined, ctx),
+		).rejects.toThrow("reason is required");
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+	});
+
 	it("queues a hidden continuation prompt after agent_end while a goal is active", async () => {
 		const { tools, handlers, sent } = createGoalHarness();
 		const ctx = await makeCtx();


### PR DESCRIPTION
## Summary

`update_goal` with `status: "complete"` rejected any non-`undefined` `reason`, including the empty string (and whitespace / `null`). Providers that serialize an omitted optional string field as `""`/`null` (strict tool-calling modes, several OpenAI/Gemini/Anthropic-style adapters) therefore hit `reason must not be provided when status is complete` on every retry — the model believes it omitted the field, the tool rejects it identically, and the agent stalls in a retry spin (observed as repeated identical `update_goal` failures + multi-minute stalls in the TUI). The `blocked` path already normalized with `params.reason?.trim()`; the `complete` path checked raw `!== undefined` — that asymmetry was the bug. Now `reason` is normalized at the model boundary (trim, non-string treated as absent): blank/`null` reasons are treated as omitted, while a **non-empty** reason for `complete` is still rejected and `blocked` still requires a non-blank reason (both pinned by tests).

## Changes

- **`update_goal` boundary validation** (`tool-registration.ts`, 4 lines): normalize `reason` (`typeof ... === "string" ? trim() : undefined`) and decide rejection on the normalized value, so blank-string/`null` "reasons" no longer count as provided.
- **Regression + pin tests** (`goal-extension.test.ts`, +28): repro of the exact failure shape (empty / whitespace / `null` reason on `complete` succeeds), plus a pin that `blocked` with a blank reason still rejects with `reason is required`.
- **Fork tracker entry** (`goal/changes.md`): records the boundary normalization and merge-conflict zone.

## QA & Evidence

- **Failing-first proof:** before the fix, the new test failed with the verbatim rejection `reason must not be provided when status is complete` thrown at `tool-registration.ts:82` (24/25 passing). After the fix, all goal suites pass: `npx vitest run test/suite/goal-*.test.ts test/suite/app-server-thread-goal.test.ts` → **96/96 across 11 files**. Existing pins (non-empty reason on complete rejects; blocked without reason rejects; todo completion gate) unchanged and green.
- **Real-CLI QA (senpi-qa harness, mock loop Channel 3):** driver at `.agents`-based scripts in `local-ignore/qa-drivers/goal-blank-reason/drive.mjs` runs the real CLI from source against the local fake model server in an isolated sandbox for **both** `openai-completions` and `anthropic-messages`: scripted turn 1 `create_goal` → turn 2 `update_goal {status:"complete", reason:""}` → turn 3 final text. Observed: exit 0, 3 model requests, goal created (status active), goal completed via blank reason, **no** `reason must not be provided` in any tool result, mock-only auth, real auth file sha unchanged. Artifacts under `local-ignore/qa-evidence/20260728-goal-blank-reason/` (driver log, transcripts, extracted tool results); sandboxes and fake servers torn down.
- **Static gates:** root `npm run check` → exit 0 (biome, pinned-deps, ts-imports, shrinkwrap/install-lock, tsgo, web-ui).
- **Why sufficient:** the failing unit repro proves the exact reported regression; the real-CLI driver proves the user-visible behavior end-to-end on both wire protocols with zero tokens and no credential exposure.

## Risks & Residuals

- **Risk: silently ignoring a real reason on `complete`.** Mitigated — only blank-insignificant values normalize to omitted; non-empty strings keep the hard rejection (pinned).
- **Risk: `blocked` contract drift.** Mitigated — `blocked` still requires a non-blank reason (pinned by existing + new test).
- **Note:** `goal-extension.test.ts` is ~437 pure LOC (>250 soft ceiling); the additions follow the repo's established per-extension suite convention; a suite split would be its own refactor PR.
- Pre-existing harness noise: the codemode bundled extension logs a module-resolution warning inside the QA sandbox on this worktree (unrelated to goal tools; not introduced here).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes update_goal so completing a goal no longer rejects blank or null reasons, preventing agent retry loops with strict tool-calling providers. Reason is normalized at the tool boundary; non-empty reasons on complete still error, and blocked still requires a non-blank reason.

- **Bug Fixes**
  - Normalize `reason` in `update_goal` (trim; non-string -> undefined) before validation.
  - Treat empty/whitespace/null as omitted for `status: "complete"`; still reject non-empty reasons.
  - Require a non-blank reason for `status: "blocked"`.

<sup>Written for commit a5b1be5a631a4c0e9e6a50bdbb1b0bf11556a5b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

