### PR TITLE
feat(coding-agent): count-forward, glyph-marked monitor footer status

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -81,6 +81,15 @@ or below the budget retain their existing foreground behavior.
 - `monitor-status.ts` (new): `formatMonitorStatus(snapshot)` — undefined when nothing is watched
   (clears the footer status), `watching <desc>` for one, `watching N: <d1>, <d2>` elided to a
   48-char cap for many, `(paused)` / `(k paused)` markers. `MONITOR_STATUS_KEY = "monitors"`.
+
+### Count-forward visibility rework (2026-07-28)
+
+- `formatMonitorStatus` now leads with the `◉` watch glyph (session-selector glyph family) so the
+  status is visually distinct from other extension statuses, and packs whole descriptions instead
+  of mid-word elision: `◉ watching <desc>` for one, `◉ watching N: <d1>, <d2> +k more` for many.
+  The monitor count and the `(paused)` / `(k paused)` suffix always survive truncation; only the
+  description list shrinks (whole-name packing first, single-name `…` truncation as last resort).
+  48-char cap unchanged. Tests updated in `test/suite/terminal-monitor-footer.test.ts`.
 - `extension.ts`: the session monitor registry is created with an onChange that publishes
   `ctx.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot))` — the goal-builtin
   footer-status pattern. Non-interactive modes no-op via the optional ctx; settle/shutdown

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
@@ -4,10 +4,27 @@ export const MONITOR_STATUS_KEY = "monitors";
 
 /** The footer shares one status line with other extensions; keep this brief. */
 const MAX_STATUS_LENGTH = 48;
+/** Marks the status as a live watch at a glance (same glyph family as the session selector). */
+const WATCH_GLYPH = "◉";
 
 function truncateEnd(text: string, max: number): string {
 	if (text.length <= max) return text;
 	return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+/**
+ * Fits as many whole descriptions as possible into the budget, folding the rest
+ * into a `+N more` counter so the monitor count is never truncated away.
+ */
+function packDescriptions(names: readonly string[], budget: number): string {
+	for (let kept = names.length; kept >= 1; kept--) {
+		const hiddenCount = names.length - kept;
+		const tail = hiddenCount > 0 ? ` +${hiddenCount} more` : "";
+		const joined = names.slice(0, kept).join(", ");
+		if (joined.length + tail.length <= budget) return joined + tail;
+	}
+	const tail = names.length > 1 ? ` +${names.length - 1} more` : "";
+	return truncateEnd(names[0] ?? "", Math.max(1, budget - tail.length)) + tail;
 }
 
 /** Brief footer text for the active monitors; undefined clears the status. */
@@ -15,7 +32,12 @@ export function formatMonitorStatus(snapshot: readonly MonitorSnapshotEntry[]): 
 	if (snapshot.length === 0) return undefined;
 	const pausedCount = snapshot.filter((entry) => entry.paused).length;
 	const suffix = pausedCount === 0 ? "" : pausedCount === snapshot.length ? " (paused)" : ` (${pausedCount} paused)`;
-	const names = snapshot.map((entry) => entry.description).join(", ");
-	const head = snapshot.length === 1 ? `watching ${names}` : `watching ${snapshot.length}: ${names}`;
-	return truncateEnd(head, MAX_STATUS_LENGTH - suffix.length) + suffix;
+	if (snapshot.length === 1) {
+		const head = `${WATCH_GLYPH} watching `;
+		const description = truncateEnd(snapshot[0]?.description ?? "", MAX_STATUS_LENGTH - head.length - suffix.length);
+		return head + description + suffix;
+	}
+	const head = `${WATCH_GLYPH} watching ${snapshot.length}: `;
+	const names = snapshot.map((entry) => entry.description);
+	return head + packDescriptions(names, MAX_STATUS_LENGTH - head.length - suffix.length) + suffix;
 }

--- a/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
@@ -34,29 +34,48 @@ describe("formatMonitorStatus", () => {
 		expect(formatMonitorStatus([])).toBeUndefined();
 	});
 
-	it("names the single watched thing", () => {
-		const text = formatMonitorStatus([entry("bash_1", "errors in deploy.log")]);
-		expect(text).toContain("errors in deploy.log");
-		expect(text).toContain("watching");
+	it("marks the single watched thing with the watch glyph and its full description", () => {
+		expect(formatMonitorStatus([entry("bash_1", "errors in deploy.log")])).toBe("◉ watching errors in deploy.log");
 	});
 
-	it("shows the count and elides long lists to a hard cap", () => {
+	it("lists every description when they all fit", () => {
+		const text = formatMonitorStatus([entry("bash_1", "deploy errors"), entry("bash_2", "webpack rebuild")]);
+		expect(text).toBe("◉ watching 2: deploy errors, webpack rebuild");
+	});
+
+	it("keeps whole names and folds the overflow into a +N more counter", () => {
 		const text = formatMonitorStatus([
 			entry("bash_1", "errors in deploy.log"),
 			entry("bash_2", "integration test output on ci runner four"),
 			entry("bash_3", "webpack rebuild"),
 		]);
-		expect(text).toBeDefined();
-		expect(text).toContain("3");
+		expect(text).toBe("◉ watching 3: errors in deploy.log +2 more");
 		expect((text ?? "").length).toBeLessThanOrEqual(48);
-		expect(text).toContain("…");
 	});
 
-	it("marks paused watches", () => {
+	it("never truncates away the count when the first name alone overflows", () => {
+		const text = formatMonitorStatus([
+			entry("bash_1", "a".repeat(60)),
+			entry("bash_2", "b"),
+			entry("bash_3", "c"),
+			entry("bash_4", "d"),
+		]);
+		expect(text).toContain("watching 4:");
+		expect(text).toContain("+3 more");
+		expect(text).toContain("…");
+		expect((text ?? "").length).toBeLessThanOrEqual(48);
+	});
+
+	it("marks paused watches and keeps the marker through truncation", () => {
 		const all = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b", true)]);
-		expect(all).toContain("paused");
-		const some = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b")]);
-		expect(some).toContain("1 paused");
+		expect(all).toBe("◉ watching 2: a, b (paused)");
+		const some = formatMonitorStatus([
+			entry("bash_1", "errors in deploy.log", true),
+			entry("bash_2", "integration test output on ci runner four"),
+			entry("bash_3", "webpack rebuild"),
+		]);
+		expect(some).toContain("(1 paused)");
+		expect((some ?? "").length).toBeLessThanOrEqual(48);
 	});
 });
 


### PR DESCRIPTION
## What

Monitor footer status was a plain, easily-missed text line (`watching PR 6423 CI checks`) that elided mid-word when several monitors were active. It now leads with the `◉` watch glyph (same glyph family the session selector uses) and is count-forward:

| snapshot | before | after |
|---|---|---|
| 1 monitor | `watching PR 6423 CI checks` | `◉ watching PR 6423 CI checks` |
| 3 monitors | `watching 3: PR 6423 CI checks, integrat…` | `◉ watching 3: PR 6423 CI checks +2 more` |
| paused | `watching 2: a, b (paused)` | `◉ watching 2: a, b (paused)` |

Rules: the monitor count and the `(paused)`/`(k paused)` suffix always survive truncation; descriptions pack whole-name-first, overflow folds into `+N more`; single-name `…` truncation only as last resort. 48-char footer cap unchanged. Extension-owned only (`monitor-status.ts` + tests + `changes.md`).

## QA evidence (local-ignore/qa-evidence/20260728-monitor-footer-ux/)

- RED→GREEN: `test/suite/terminal-monitor-footer.test.ts` rewritten first (5 failing), then impl — 9/9 green.
- Scoped suites green: terminal-monitor-footer, terminal-monitor-notify, terminal-monitor-state-event, terminal-monitor, terminal-extension.
- Real-surface: senpi TUI from source in an isolated sandbox (`SENPI_CODING_AGENT_DIR` temp, `PI_OFFLINE=1`), QA extension registering REAL monitors via `pi.executeTool("monitor", ...)`, rendered through xterm.js in Chrome (web-terminal visual QA):
  - `tui-3monitors/terminal.png` — footer shows `◉ watching 3: PR 6423 CI checks +2 more`
  - `tui-1monitor/terminal.png` — footer shows `◉ watching PR 6423 CI checks`
- `npm run check` green at worktree root.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the terminal monitor footer more visible and informative by adding the `◉` watch glyph and count‑forward formatting. Truncation now preserves the monitor count and paused markers within the existing 48‑char limit.

- **New Features**
  - `◉ watching <desc>` for one; `◉ watching N: <d1>, <d2> +k more` for many. Whole‑name packing first; single‑name ellipsis only as last resort.
  - `(paused)` / `(<k> paused)` always kept; the count is never truncated.
  - Implemented in `monitor-status.ts` with new packing logic; tests updated in `test/suite/terminal-monitor-footer.test.ts`; docs updated in `changes.md`.

<sup>Written for commit 26cf76fe09da09a8b1fbef5a2644ba3330eab003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

