### PR TITLE
feat(goal): inject stall check after repeated monitor continuations

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,30 @@
 # goal Extension Changes
 
+## Monitor-wait continuation stall check (2026-07-28)
+
+### What changed
+
+- `monitor-continuation.ts` counts consecutive monitor-wait continuations per goal
+  (`GOAL_MONITOR_STALL_THRESHOLD = 3`). From the third consecutive delayed continuation
+  fired while monitors stayed active, the hidden continuation prompt is prefixed with a
+  `<goal_monitor_stall_check>` block (`buildMonitorStallNotice` in `prompt.ts`) telling
+  the agent the repeated wait looks abnormal and to actively inspect the monitored state
+  (bash_output, process health, kill_bash + alternate approach, or the blocked audit)
+  before waiting again. A `goal_monitor_continuation_stall` event is emitted and a UI
+  notice shown when the check is injected.
+- The streak resets on every signal that breaks the unattended wait loop: monitor
+  completion (`terminal_monitor_state` activeCount 0), a real user prompt
+  (`before_agent_start` via the new `noteUserPrompt()`), the goal leaving `active` or
+  being replaced (goal id change), the immediate no-monitor continuation path, session
+  start, and dispose.
+- Coverage: `test/suite/goal-monitor-stall.test.ts` (threshold + all reset paths).
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `monitor-continuation.ts` around `#continueIfEligible` and the monitor-state
+  subscription.
+- LOW in `prompt.ts` (appended exported builder) and `index.ts` `before_agent_start`.
+
 ## Blank reasons treated as omitted for update_goal complete (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -80,6 +80,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		// Resuming a blocked goal here, instead of deferring to agent_start via a sticky
 		// flag, means a rejected run cannot leak a stale resume signal to a later
 		// continuation-style turn that starts the agent without a preceding user prompt.
+		monitorContinuation.noteUserPrompt();
 		const goal = await readGoal(goalStoreRef(ctx));
 		if (goal?.status === "blocked") {
 			const resumed = await updateGoal(goalStoreRef(ctx), { status: "active" }, "user");

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -3,12 +3,14 @@ import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isTerminalMonitorStateEvent, TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
 import { shouldQueueGoalContinuationAfterAgentEnd, shouldQueueGoalContinuationWhenIdle } from "./continuation.ts";
 import { queueHiddenGoalPrompt } from "./lifecycle-helpers.ts";
-import { buildContinuationPrompt } from "./prompt.ts";
+import { buildContinuationPrompt, buildMonitorStallNotice } from "./prompt.ts";
 import type { Goal } from "./types.ts";
 
 export const GOAL_MONITOR_CONTINUATION_DELAY_MS = 240_000;
 export const GOAL_CONTINUATION_SCHEDULED_EVENT = "goal_continuation_scheduled";
 export const GOAL_MONITOR_CONTINUATION_NOTICE = "Goal continuation scheduled in 4 minutes while a monitor is active.";
+export const GOAL_MONITOR_STALL_THRESHOLD = 3;
+export const GOAL_MONITOR_STALL_EVENT = "goal_monitor_continuation_stall";
 
 interface AgentEndOptions {
 	readonly ctx: ExtensionContext;
@@ -24,6 +26,8 @@ export class MonitorAwareGoalContinuation {
 	#goal: Goal | null = null;
 	#timer: ReturnType<typeof setTimeout> | undefined;
 	#unsubscribeMonitorState: (() => void) | undefined;
+	#consecutiveMonitorContinuations = 0;
+	#stallGoalId: string | null = null;
 
 	constructor(pi: ExtensionAPI) {
 		this.#pi = pi;
@@ -34,12 +38,16 @@ export class MonitorAwareGoalContinuation {
 		this.#unsubscribeMonitorState?.();
 		this.#ctx = ctx;
 		this.#activeMonitorCount = 0;
+		this.#resetStallStreak();
 		const events = this.#pi.events;
 		if (events === undefined) return;
 		this.#unsubscribeMonitorState = events.on(TERMINAL_MONITOR_STATE_EVENT, (data) => {
 			if (!isTerminalMonitorStateEvent(data)) return;
 			this.#activeMonitorCount = data.activeCount;
-			if (data.activeCount === 0) this.#cancelTimer();
+			if (data.activeCount === 0) {
+				this.#cancelTimer();
+				this.#resetStallStreak();
+			}
 		});
 	}
 
@@ -54,6 +62,7 @@ export class MonitorAwareGoalContinuation {
 		}
 		if (this.#activeMonitorCount === 0) {
 			this.#cancelTimer();
+			this.#resetStallStreak();
 			queueHiddenGoalPrompt(this.#pi, buildContinuationPrompt(options.goal));
 			return;
 		}
@@ -62,7 +71,15 @@ export class MonitorAwareGoalContinuation {
 
 	syncGoal(goal: Goal | null): void {
 		this.#goal = goal;
-		if (goal?.status !== "active") this.#cancelTimer();
+		if (goal?.status !== "active") {
+			this.#cancelTimer();
+			this.#resetStallStreak();
+		}
+	}
+
+	/** A real user prompt breaks the unattended monitor-wait loop; restart the stall count. */
+	noteUserPrompt(): void {
+		this.#resetStallStreak();
 	}
 
 	dispose(): void {
@@ -72,6 +89,7 @@ export class MonitorAwareGoalContinuation {
 		this.#ctx = undefined;
 		this.#goal = null;
 		this.#activeMonitorCount = 0;
+		this.#resetStallStreak();
 	}
 
 	#schedule(goal: Goal): void {
@@ -91,8 +109,35 @@ export class MonitorAwareGoalContinuation {
 		if (ctx === undefined || this.#activeMonitorCount === 0) return;
 		const goal = this.#goal;
 		if (shouldQueueGoalContinuationWhenIdle(goal, ctx.isIdle(), ctx.hasPendingMessages())) {
-			queueHiddenGoalPrompt(this.#pi, buildContinuationPrompt(goal));
+			queueHiddenGoalPrompt(this.#pi, this.#buildMonitorContinuationContent(ctx, goal));
 		}
+	}
+
+	/** Counts consecutive monitor-wait continuations; from the third one on, prepends an active stall check. */
+	#buildMonitorContinuationContent(ctx: ExtensionContext, goal: Goal): string {
+		if (goal.id !== this.#stallGoalId) {
+			this.#stallGoalId = goal.id;
+			this.#consecutiveMonitorContinuations = 0;
+		}
+		this.#consecutiveMonitorContinuations += 1;
+		const content = buildContinuationPrompt(goal);
+		if (this.#consecutiveMonitorContinuations < GOAL_MONITOR_STALL_THRESHOLD) return content;
+		this.#pi.events.emit(GOAL_MONITOR_STALL_EVENT, {
+			goalId: goal.id,
+			consecutiveContinuations: this.#consecutiveMonitorContinuations,
+		});
+		if (ctx.hasUI) {
+			ctx.ui.notify(
+				`Goal continuation repeated ${this.#consecutiveMonitorContinuations} times while monitors stayed active - injected a stall check.`,
+				"info",
+			);
+		}
+		return `${buildMonitorStallNotice(this.#consecutiveMonitorContinuations)}\n\n${content}`;
+	}
+
+	#resetStallStreak(): void {
+		this.#consecutiveMonitorContinuations = 0;
+		this.#stallGoalId = null;
 	}
 
 	#cancelTimer(): void {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
@@ -38,6 +38,20 @@ export function buildContinuationPrompt(goal: Goal): string {
 	].join("\n");
 }
 
+export function buildMonitorStallNotice(consecutiveContinuations: number): string {
+	return [
+		"<goal_monitor_stall_check>",
+		`System check: this is monitor-wait goal continuation #${consecutiveContinuations} in a row. The same monitor(s) stayed active across ${consecutiveContinuations} consecutive continuation turns with no new user input and no monitor completion. The current situation is likely abnormal - a stalled or dead wait.`,
+		"Before waiting on the monitors again, actively investigate:",
+		"- Inspect the monitored sessions' output now (bash_output) and verify the watched condition can still occur.",
+		"- Check whether the underlying process is hung, exited silently, or waiting on input; restart or replace it if so.",
+		"- If the wait target is wrong or no longer needed, kill the monitor (kill_bash) and pursue the goal another way.",
+		"- If the goal truly cannot progress, run the blocked audit instead of waiting again.",
+		"Do not end this turn with only another passive wait.",
+		"</goal_monitor_stall_check>",
+	].join("\n");
+}
+
 function escapeXmlText(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }

--- a/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import {
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	type GoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+} from "./goal-monitor-test-harness.ts";
+
+const STALL_MARKER = "<goal_monitor_stall_check>";
+const STALL_EVENT = "goal_monitor_continuation_stall";
+
+interface StallHarness {
+	readonly harness: GoalHarness;
+	readonly ctx: ExtensionContext;
+	readonly notices: string[];
+}
+
+async function createStallHarness(threadId: string): Promise<StallHarness> {
+	const notices: string[] = [];
+	const harness = createGoalHarness();
+	const ctx = await makeGoalContext(notices, threadId);
+	await harness.tools
+		.get("create_goal")
+		?.execute("create", { objective: "Keep monitoring" }, undefined, undefined, ctx);
+	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+	await harness.events.flush();
+	return { harness, ctx, notices };
+}
+
+async function runMonitorContinuationCycle(harness: GoalHarness, ctx: ExtensionContext): Promise<void> {
+	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+	await runGoalHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
+	await vi.advanceTimersByTimeAsync(240_000);
+}
+
+function stallEvents(harness: GoalHarness): unknown[] {
+	return harness.events.emitted.filter((event) => event.channel === STALL_EVENT).map((event) => event.data);
+}
+
+describe("goal monitor continuation stall check", () => {
+	afterEach(async () => {
+		vi.useRealTimers();
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("injects the stall check from the third consecutive monitor continuation onward", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx, notices } = await createStallHarness("thread-stall-threshold");
+
+		await runMonitorContinuationCycle(harness, ctx);
+		await runMonitorContinuationCycle(harness, ctx);
+		expect(harness.sent).toHaveLength(2);
+		expect(harness.sent[0]?.message.content).not.toContain(STALL_MARKER);
+		expect(harness.sent[1]?.message.content).not.toContain(STALL_MARKER);
+		expect(stallEvents(harness)).toHaveLength(0);
+
+		await runMonitorContinuationCycle(harness, ctx);
+		expect(harness.sent).toHaveLength(3);
+		expect(harness.sent[2]?.message.content).toContain(STALL_MARKER);
+		expect(stallEvents(harness)).toEqual([expect.objectContaining({ consecutiveContinuations: 3 })]);
+		expect(notices.some((notice) => /stall/i.test(notice))).toBe(true);
+
+		await runMonitorContinuationCycle(harness, ctx);
+		expect(harness.sent[3]?.message.content).toContain(STALL_MARKER);
+		expect(stallEvents(harness)).toHaveLength(2);
+	});
+
+	it("resets the streak when the monitors settle and a new monitor starts", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await createStallHarness("thread-stall-settle-reset");
+
+		await runMonitorContinuationCycle(harness, ctx);
+		await runMonitorContinuationCycle(harness, ctx);
+
+		harness.events.emit("terminal_monitor_state", { activeCount: 0 });
+		await harness.events.flush();
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+
+		await runMonitorContinuationCycle(harness, ctx);
+		expect(harness.sent).toHaveLength(3);
+		expect(harness.sent[2]?.message.content).not.toContain(STALL_MARKER);
+		expect(stallEvents(harness)).toHaveLength(0);
+	});
+
+	it("resets the streak when a real user prompt starts a turn", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await createStallHarness("thread-stall-user-reset");
+
+		await runMonitorContinuationCycle(harness, ctx);
+		await runMonitorContinuationCycle(harness, ctx);
+
+		await runGoalHandlers(harness.handlers, "before_agent_start", { type: "before_agent_start" }, ctx);
+
+		await runMonitorContinuationCycle(harness, ctx);
+		expect(harness.sent).toHaveLength(3);
+		expect(harness.sent[2]?.message.content).not.toContain(STALL_MARKER);
+		expect(stallEvents(harness)).toHaveLength(0);
+	});
+
+	it("does not carry the streak across a completed goal into its replacement", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await createStallHarness("thread-stall-goal-reset");
+
+		await runMonitorContinuationCycle(harness, ctx);
+		await runMonitorContinuationCycle(harness, ctx);
+
+		await harness.tools.get("update_goal")?.execute("complete", { status: "complete" }, undefined, undefined, ctx);
+		await harness.tools
+			.get("create_goal")
+			?.execute("create", { objective: "Fresh objective" }, undefined, undefined, ctx);
+
+		const sentBefore = harness.sent.length;
+		await runMonitorContinuationCycle(harness, ctx);
+		const sentAfter = harness.sent.slice(sentBefore);
+		expect(sentAfter.length).toBeGreaterThan(0);
+		for (const sent of sentAfter) {
+			expect(sent.message.content).not.toContain(STALL_MARKER);
+		}
+		expect(stallEvents(harness)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

When the monitor-wait goal continuation (`MonitorAwareGoalContinuation`) fires **3+ consecutive times for the same goal** with no reset signal in between, the hidden continuation prompt now carries a `<goal_monitor_stall_check>` block telling the agent the situation looks abnormal and to actively investigate the monitored state (inspect `bash_output`, check process health, `kill_bash` + alternate approach, or run the blocked audit) instead of passively waiting again. A `goal_monitor_continuation_stall` event is emitted and a UI notice shown when the check is injected.

## State management (reset signals)

The consecutive counter resets on every signal that breaks the unattended wait loop:

- monitor completion (`terminal_monitor_state` `activeCount === 0`)
- a real user prompt (`before_agent_start` -> new `noteUserPrompt()`)
- goal leaving `active` or goal replacement (streak is keyed by goal id)
- the immediate no-monitor continuation path
- `session_start` / `dispose`

## Tests (TDD, RED captured before implementation)

`packages/coding-agent/test/suite/goal-monitor-stall.test.ts` (fake timers, faux harness):

- 1st/2nd monitor continuations carry no stall block; 3rd and 4th carry it + emit the stall event + UI notice
- reset on monitor settle -> re-activation
- reset on real user prompt
- no streak carry-over across a completed goal into its replacement

Regression: `goal-monitor-continuation`, `goal-monitor-lifecycle`, `goal-extension`, `goal-modules`, `goal-abort-extension`, `goal-turn-usage` all green (58/58 across 7 files).

## Evidence

- Root `npm run check`: exit 0
- senpi-qa channels from this worktree (evidence under `local-ignore/qa-evidence/20260728-goal-monitor-stall/`, gitignored):
  - `common.mjs --self-check` 9/9
  - `mock-loop.mjs --self-test` 43/43 (zero real provider calls, real auth unchanged)
  - `cli-smoke.mjs --self-test` 8/8
- The 3x4-minute wall-clock cadence itself is proven by the fake-timer vitest scenarios (240s advances), as real-time QA of a 12+ minute stall loop is impractical.

`goal/changes.md` records the behavior + expected merge-conflict zones.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects a stall check into the hidden continuation prompt when the monitor-wait continuation fires 3+ times in a row for the same goal. This pushes the agent to investigate likely stalls instead of passively waiting again.

- New Features
  - Track consecutive monitor-wait continuations per goal; from the 3rd onward, prepend a `<goal_monitor_stall_check>` with guidance (inspect `bash_output`, check process health, `kill_bash`, or run the blocked audit).
  - Emit `goal_monitor_continuation_stall` and show a UI notice when injected.
  - Reset the streak when monitors settle (`activeCount === 0`), on a real user prompt (`before_agent_start` via `noteUserPrompt()`), on goal status/ID change, on the immediate no-monitor path, and on session start/dispose.
  - Tests: added `goal-monitor-stall.test.ts` covering the threshold and all reset paths.

<sup>Written for commit 505d212ab8c806f14436854296ed895adb1858bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

