### PR TITLE
feat(tui): render LaTeX as terminal Unicode

### DIFF
--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -7,14 +7,16 @@
 - `components/markdown.ts` registers bounded Marked block and inline tokenizers for `$...$`, `$$...$$`, `\(...\)`,
   and `\[...\]` math. Dollar delimiters require non-word outer boundaries, and bracket/parenthesis candidates stop at
   inline-code or competing opener boundaries. Currency, shell variables, code spans, and malformed delimiters remain
-  literal.
+  literal, including partial streamed currency/shell pairs and math-like text after an unclosed inline-code opener.
 - The dependency-free `components/latex.ts` converter uses a balanced parser for nested fractions, roots, text
   wrappers, symbols, and Unicode sub/superscripts. Formula length and nesting budgets fall back to the original text
-  instead of partially converting or repeatedly rescanning untrusted input.
+  instead of partially converting or repeatedly rescanning untrusted input. A leading combining mark receives a
+  dotted-circle anchor so terminal cell width agrees with the differential renderer.
 - TeX epsilon/phi variants and escaped script markers stay distinct, complete command names prevent prefix
   corruption, and unknown commands remain readable. Display formulas inherit their surrounding style context.
-- Coverage: `test/markdown.test.ts` proves ordinary-text boundaries, nested/budgeted conversion, CJK wide cells,
-  inherited styles, code/malformed preservation, and focused `VirtualTerminal` cell widths.
+- Coverage: `test/markdown.test.ts` proves ordinary-text boundaries, nested/budgeted conversion, streamed partial
+  currency/shell and inline-code frames, CJK wide cells, inherited styles, malformed preservation, and focused
+  `VirtualTerminal` cell widths including a column-zero combining mark.
 
 ### Why this cannot be expressed externally
 

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -4,14 +4,17 @@
 
 ### What changed
 
-- `components/markdown.ts` registers conservative Marked block and inline tokenizers for `$...$`, `$$...$$`,
-  `\(...\)`, and `\[...\]` math. Recognized formulas render as width-stable Unicode text through the new
-  dependency-free `components/latex.ts` converter.
-- The converter handles common operators, relations, arrows, Greek letters, grouped fractions and roots, and
-  Unicode sub/superscripts. Unknown commands remain readable instead of invoking external processes or hiding input.
-- Marked still owns fenced and inline code tokenization, so math-looking code stays literal. Unmatched bracket or
-  parenthesis delimiters are emitted literally rather than losing their backslashes to Markdown escape normalization.
-- Coverage: `test/markdown.test.ts` proves inline/display rendering and code/malformed delimiter preservation.
+- `components/markdown.ts` registers bounded Marked block and inline tokenizers for `$...$`, `$$...$$`, `\(...\)`,
+  and `\[...\]` math. Dollar delimiters require non-word outer boundaries, and bracket/parenthesis candidates stop at
+  inline-code or competing opener boundaries. Currency, shell variables, code spans, and malformed delimiters remain
+  literal.
+- The dependency-free `components/latex.ts` converter uses a balanced parser for nested fractions, roots, text
+  wrappers, symbols, and Unicode sub/superscripts. Formula length and nesting budgets fall back to the original text
+  instead of partially converting or repeatedly rescanning untrusted input.
+- TeX epsilon/phi variants and escaped script markers stay distinct, complete command names prevent prefix
+  corruption, and unknown commands remain readable. Display formulas inherit their surrounding style context.
+- Coverage: `test/markdown.test.ts` proves ordinary-text boundaries, nested/budgeted conversion, CJK wide cells,
+  inherited styles, code/malformed preservation, and focused `VirtualTerminal` cell widths.
 
 ### Why this cannot be expressed externally
 

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,28 @@
 # TUI delta rendering fork changes
 
+## 2026-07-29: Native Unicode LaTeX in Markdown conversations
+
+### What changed
+
+- `components/markdown.ts` registers conservative Marked block and inline tokenizers for `$...$`, `$$...$$`,
+  `\(...\)`, and `\[...\]` math. Recognized formulas render as width-stable Unicode text through the new
+  dependency-free `components/latex.ts` converter.
+- The converter handles common operators, relations, arrows, Greek letters, grouped fractions and roots, and
+  Unicode sub/superscripts. Unknown commands remain readable instead of invoking external processes or hiding input.
+- Marked still owns fenced and inline code tokenization, so math-looking code stays literal. Unmatched bracket or
+  parenthesis delimiters are emitted literally rather than losing their backslashes to Markdown escape normalization.
+- Coverage: `test/markdown.test.ts` proves inline/display rendering and code/malformed delimiter preservation.
+
+### Why this cannot be expressed externally
+
+The `Markdown` component owns tokenization before extension-facing coding-agent UI hooks run. Rendering formulas
+consistently in assistant messages, nested Markdown structures, and every direct TUI consumer requires the parser seam.
+
+### Expected merge conflict zones
+
+- MEDIUM: `components/markdown.ts` parser construction and custom token branches.
+- LOW: `components/latex.ts` symbol/script conversion tables and `test/markdown.test.ts` LaTeX cases.
+
 ## 2026-07-28: over-wide diagnostics stop rescanning settled large histories
 
 ### What changed

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -228,6 +228,10 @@ class LatexParser {
 		if (command === "\\left" || command === "\\right") {
 			this.skipSpaces();
 			const delimiter = this.input[this.index];
+			if (delimiter === ".") {
+				this.index += 1;
+				return "";
+			}
 			const escapedDelimiter = delimiter === "\\" ? this.input[this.index + 1] : undefined;
 			if (escapedDelimiter !== undefined && "{}".includes(escapedDelimiter)) {
 				this.index += 2;
@@ -240,6 +244,9 @@ class LatexParser {
 		}
 		if (command === "\\quad") return "  ";
 		let fallback = command;
+		const argumentStart = this.index;
+		this.skipSpaces();
+		if (this.input[this.index] !== "{") this.index = argumentStart;
 		while (this.input[this.index] === "{") {
 			const group = this.parseGroup(depth);
 			if (group === undefined) return undefined;

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -199,7 +199,8 @@ class LatexParser {
 		if (!/[A-Za-z]/.test(first)) {
 			this.index += 1;
 			if ("_^{}[]()$%&#".includes(first)) return first;
-			if (",;:!".includes(first)) return " ";
+			if (first === "!") return "";
+			if (",;:".includes(first)) return " ";
 			return `\\${first}`;
 		}
 

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -128,6 +128,7 @@ const SUBSCRIPTS: Readonly<Record<string, string>> = {
 
 const MAX_FORMULA_LENGTH = 4096;
 const MAX_NESTING_DEPTH = 64;
+const LEADING_COMBINING_MARK_REGEX = /^\p{Mark}/u;
 const STYLE_COMMANDS = new Set(["\\mathrm", "\\mathbf", "\\mathit", "\\text", "\\operatorname"]);
 
 const scriptText = (text: string, alphabet: Readonly<Record<string, string>>): string | undefined => {
@@ -282,7 +283,10 @@ class LatexParser {
 
 export const latexToUnicode = (formula: string): string => {
 	const trimmed = formula.trim();
-	if (trimmed.length > MAX_FORMULA_LENGTH) return trimmed;
-	const normalized = trimmed.replace(/\s+/g, " ");
-	return new LatexParser(normalized).parse() ?? trimmed;
+	let rendered = trimmed;
+	if (trimmed.length <= MAX_FORMULA_LENGTH) {
+		const normalized = trimmed.replace(/\s+/g, " ");
+		rendered = new LatexParser(normalized).parse() ?? trimmed;
+	}
+	return LEADING_COMBINING_MARK_REGEX.test(rendered) ? `◌${rendered}` : rendered;
 };

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -256,6 +256,11 @@ class LatexParser {
 			if (body === undefined) return undefined;
 			return scriptText(body, alphabet) ?? `${marker}{${body}}`;
 		}
+		if (this.input[this.index] === "\\") {
+			const body = this.parseCommand(depth);
+			if (body === undefined) return undefined;
+			return scriptText(body, alphabet) ?? `${marker}${body}`;
+		}
 		const codePoint = this.input.codePointAt(this.index);
 		if (codePoint === undefined) return marker;
 		const body = String.fromCodePoint(codePoint);

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -174,7 +174,7 @@ class LatexParser {
 			if (character === "{") {
 				const group = this.parseGroup(depth);
 				if (group === undefined) return undefined;
-				output.push(`{${group}}`);
+				output.push(group);
 				continue;
 			}
 			output.push(character ?? "");
@@ -209,26 +209,42 @@ class LatexParser {
 		const symbol = SYMBOLS[command];
 		if (symbol !== undefined) return symbol;
 		if (STYLE_COMMANDS.has(command)) {
+			this.skipSpaces();
 			return this.input[this.index] === "{" ? this.parseGroup(depth) : command;
 		}
 		if (command === "\\sqrt") {
+			this.skipSpaces();
 			const body = this.parseGroup(depth);
 			return body === undefined ? undefined : `√(${body})`;
 		}
 		if (command === "\\frac") {
+			this.skipSpaces();
 			const numerator = this.parseGroup(depth);
+			this.skipSpaces();
 			const denominator = numerator === undefined ? undefined : this.parseGroup(depth);
 			return numerator === undefined || denominator === undefined ? undefined : `(${numerator})⁄(${denominator})`;
 		}
 		if (command === "\\left" || command === "\\right") {
+			this.skipSpaces();
 			const delimiter = this.input[this.index];
+			const escapedDelimiter = delimiter === "\\" ? this.input[this.index + 1] : undefined;
+			if (escapedDelimiter !== undefined && "{}".includes(escapedDelimiter)) {
+				this.index += 2;
+				return escapedDelimiter;
+			}
 			if (delimiter !== undefined && "()[]{}|".includes(delimiter)) {
 				this.index += 1;
 				return delimiter;
 			}
 		}
 		if (command === "\\quad") return "  ";
-		return command;
+		let fallback = command;
+		while (this.input[this.index] === "{") {
+			const group = this.parseGroup(depth);
+			if (group === undefined) return undefined;
+			fallback += `{${group}}`;
+		}
+		return fallback;
 	}
 
 	private parseScript(marker: "^" | "_", depth: number): string | undefined {
@@ -244,6 +260,10 @@ class LatexParser {
 		const body = String.fromCodePoint(codePoint);
 		this.index += body.length;
 		return alphabet[body] ?? `${marker}${body}`;
+	}
+
+	private skipSpaces(): void {
+		while (this.input[this.index] === " ") this.index += 1;
 	}
 }
 

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -159,11 +159,11 @@ const replaceScripts = (input: string, marker: "^" | "_", alphabet: Readonly<Rec
 
 export const latexToUnicode = (formula: string): string => {
 	let output = formula.trim().replace(/\s+/g, " ");
-	output = replaceBraced(output, "\\sqrt", (body) => `√(${body})`);
-	output = output.replace(/\\frac\{([^{}]*)\}\{([^{}]*)\}/g, "($1)⁄($2)");
 	for (const command of ["\\mathrm", "\\mathbf", "\\mathit", "\\text", "\\operatorname"]) {
 		output = replaceBraced(output, command, (body) => body);
 	}
+	output = replaceBraced(output, "\\sqrt", (body) => `√(${body})`);
+	output = output.replace(/\\frac\{([^{}]*)\}\{([^{}]*)\}/g, "($1)⁄($2)");
 	output = output.replace(/\\(?:left|right)(?=[()[\]{}|])/g, "");
 	for (const [command, symbol] of Object.entries(SYMBOLS).sort(([a], [b]) => b.length - a.length)) {
 		output = output.replace(new RegExp(`${escapeRegex(command)}(?![A-Za-z])`, "g"), symbol);

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -1,0 +1,175 @@
+const SYMBOLS: Readonly<Record<string, string>> = {
+	"\\aleph": "ℵ",
+	"\\alpha": "α",
+	"\\approx": "≈",
+	"\\beta": "β",
+	"\\cdot": "·",
+	"\\chi": "χ",
+	"\\Delta": "Δ",
+	"\\delta": "δ",
+	"\\div": "÷",
+	"\\epsilon": "ε",
+	"\\equiv": "≡",
+	"\\eta": "η",
+	"\\exists": "∃",
+	"\\forall": "∀",
+	"\\Gamma": "Γ",
+	"\\gamma": "γ",
+	"\\ge": "≥",
+	"\\geq": "≥",
+	"\\in": "∈",
+	"\\infty": "∞",
+	"\\int": "∫",
+	"\\iota": "ι",
+	"\\kappa": "κ",
+	"\\Lambda": "Λ",
+	"\\lambda": "λ",
+	"\\le": "≤",
+	"\\leftarrow": "←",
+	"\\leftrightarrow": "↔",
+	"\\leq": "≤",
+	"\\mu": "μ",
+	"\\nabla": "∇",
+	"\\ne": "≠",
+	"\\neq": "≠",
+	"\\ni": "∋",
+	"\\notin": "∉",
+	"\\nu": "ν",
+	"\\Omega": "Ω",
+	"\\omega": "ω",
+	"\\otimes": "⊗",
+	"\\partial": "∂",
+	"\\Phi": "Φ",
+	"\\phi": "φ",
+	"\\Pi": "Π",
+	"\\pi": "π",
+	"\\pm": "±",
+	"\\prod": "∏",
+	"\\Psi": "Ψ",
+	"\\psi": "ψ",
+	"\\rho": "ρ",
+	"\\rightarrow": "→",
+	"\\Sigma": "Σ",
+	"\\sigma": "σ",
+	"\\sim": "∼",
+	"\\subset": "⊂",
+	"\\subseteq": "⊆",
+	"\\sum": "∑",
+	"\\supset": "⊃",
+	"\\supseteq": "⊇",
+	"\\tau": "τ",
+	"\\Theta": "Θ",
+	"\\theta": "θ",
+	"\\times": "×",
+	"\\to": "→",
+	"\\Upsilon": "Υ",
+	"\\upsilon": "υ",
+	"\\varepsilon": "ϵ",
+	"\\varphi": "φ",
+	"\\vartheta": "ϑ",
+	"\\xi": "ξ",
+	"\\zeta": "ζ",
+};
+
+const SUPERSCRIPTS: Readonly<Record<string, string>> = {
+	"0": "⁰",
+	"1": "¹",
+	"2": "²",
+	"3": "³",
+	"4": "⁴",
+	"5": "⁵",
+	"6": "⁶",
+	"7": "⁷",
+	"8": "⁸",
+	"9": "⁹",
+	"+": "⁺",
+	"-": "⁻",
+	"=": "⁼",
+	"(": "⁽",
+	")": "⁾",
+	i: "ⁱ",
+	n: "ⁿ",
+};
+
+const SUBSCRIPTS: Readonly<Record<string, string>> = {
+	"0": "₀",
+	"1": "₁",
+	"2": "₂",
+	"3": "₃",
+	"4": "₄",
+	"5": "₅",
+	"6": "₆",
+	"7": "₇",
+	"8": "₈",
+	"9": "₉",
+	"+": "₊",
+	"-": "₋",
+	"=": "₌",
+	"(": "₍",
+	")": "₎",
+	a: "ₐ",
+	e: "ₑ",
+	h: "ₕ",
+	i: "ᵢ",
+	j: "ⱼ",
+	k: "ₖ",
+	l: "ₗ",
+	m: "ₘ",
+	n: "ₙ",
+	o: "ₒ",
+	p: "ₚ",
+	r: "ᵣ",
+	s: "ₛ",
+	t: "ₜ",
+	u: "ᵤ",
+	v: "ᵥ",
+	x: "ₓ",
+};
+
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const replaceBraced = (input: string, command: string, render: (body: string) => string): string => {
+	const pattern = new RegExp(`${escapeRegex(command)}\\{([^{}]*)\\}`, "g");
+	let output = input;
+	let previous: string;
+	do {
+		previous = output;
+		output = output.replace(pattern, (_match, body: string) => render(body));
+	} while (output !== previous);
+	return output;
+};
+
+const scriptText = (text: string, alphabet: Readonly<Record<string, string>>): string | undefined => {
+	let output = "";
+	for (const character of text) {
+		const replacement = alphabet[character];
+		if (replacement === undefined) return undefined;
+		output += replacement;
+	}
+	return output;
+};
+
+const replaceScripts = (input: string, marker: "^" | "_", alphabet: Readonly<Record<string, string>>): string => {
+	const grouped = new RegExp(`${escapeRegex(marker)}\\{([^{}\\n]+)\\}`, "g");
+	const single = new RegExp(`${escapeRegex(marker)}([A-Za-z0-9+\\-=()])`, "g");
+	return input
+		.replace(grouped, (raw, body: string) => scriptText(body, alphabet) ?? raw)
+		.replace(single, (raw, body: string) => scriptText(body, alphabet) ?? raw);
+};
+
+export const latexToUnicode = (formula: string): string => {
+	let output = formula.trim().replace(/\s+/g, " ");
+	output = replaceBraced(output, "\\sqrt", (body) => `√(${body})`);
+	output = output.replace(/\\frac\{([^{}]*)\}\{([^{}]*)\}/g, "($1)⁄($2)");
+	for (const command of ["\\mathrm", "\\mathbf", "\\mathit", "\\text", "\\operatorname"]) {
+		output = replaceBraced(output, command, (body) => body);
+	}
+	output = output.replace(/\\(?:left|right)(?=[()[\]{}|])/g, "");
+	for (const [command, symbol] of Object.entries(SYMBOLS).sort(([a], [b]) => b.length - a.length)) {
+		output = output.replace(new RegExp(`${escapeRegex(command)}(?![A-Za-z])`, "g"), symbol);
+	}
+	output = replaceScripts(output, "^", SUPERSCRIPTS);
+	output = replaceScripts(output, "_", SUBSCRIPTS);
+	output = output.replace(/\\(?:,|;|:|!)/g, " ").replace(/\\quad/g, "  ");
+	return output.trim();
+};

--- a/packages/tui/src/components/latex.ts
+++ b/packages/tui/src/components/latex.ts
@@ -8,7 +8,7 @@ const SYMBOLS: Readonly<Record<string, string>> = {
 	"\\Delta": "Δ",
 	"\\delta": "δ",
 	"\\div": "÷",
-	"\\epsilon": "ε",
+	"\\epsilon": "ϵ",
 	"\\equiv": "≡",
 	"\\eta": "η",
 	"\\exists": "∃",
@@ -40,7 +40,7 @@ const SYMBOLS: Readonly<Record<string, string>> = {
 	"\\otimes": "⊗",
 	"\\partial": "∂",
 	"\\Phi": "Φ",
-	"\\phi": "φ",
+	"\\phi": "ϕ",
 	"\\Pi": "Π",
 	"\\pi": "π",
 	"\\pm": "±",
@@ -64,7 +64,7 @@ const SYMBOLS: Readonly<Record<string, string>> = {
 	"\\to": "→",
 	"\\Upsilon": "Υ",
 	"\\upsilon": "υ",
-	"\\varepsilon": "ϵ",
+	"\\varepsilon": "ε",
 	"\\varphi": "φ",
 	"\\vartheta": "ϑ",
 	"\\xi": "ξ",
@@ -126,18 +126,9 @@ const SUBSCRIPTS: Readonly<Record<string, string>> = {
 	x: "ₓ",
 };
 
-const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-const replaceBraced = (input: string, command: string, render: (body: string) => string): string => {
-	const pattern = new RegExp(`${escapeRegex(command)}\\{([^{}]*)\\}`, "g");
-	let output = input;
-	let previous: string;
-	do {
-		previous = output;
-		output = output.replace(pattern, (_match, body: string) => render(body));
-	} while (output !== previous);
-	return output;
-};
+const MAX_FORMULA_LENGTH = 4096;
+const MAX_NESTING_DEPTH = 64;
+const STYLE_COMMANDS = new Set(["\\mathrm", "\\mathbf", "\\mathit", "\\text", "\\operatorname"]);
 
 const scriptText = (text: string, alphabet: Readonly<Record<string, string>>): string | undefined => {
 	let output = "";
@@ -149,27 +140,116 @@ const scriptText = (text: string, alphabet: Readonly<Record<string, string>>): s
 	return output;
 };
 
-const replaceScripts = (input: string, marker: "^" | "_", alphabet: Readonly<Record<string, string>>): string => {
-	const grouped = new RegExp(`${escapeRegex(marker)}\\{([^{}\\n]+)\\}`, "g");
-	const single = new RegExp(`${escapeRegex(marker)}([A-Za-z0-9+\\-=()])`, "g");
-	return input
-		.replace(grouped, (raw, body: string) => scriptText(body, alphabet) ?? raw)
-		.replace(single, (raw, body: string) => scriptText(body, alphabet) ?? raw);
-};
+class LatexParser {
+	private index = 0;
+	private readonly input: string;
+
+	constructor(input: string) {
+		this.input = input;
+	}
+
+	parse(): string | undefined {
+		const output = this.parseSequence(0, false);
+		return output !== undefined && this.index === this.input.length ? output : undefined;
+	}
+
+	private parseSequence(depth: number, stopAtBrace: boolean): string | undefined {
+		if (depth > MAX_NESTING_DEPTH) return undefined;
+		const output: string[] = [];
+		while (this.index < this.input.length) {
+			const character = this.input[this.index];
+			if (character === "}" && stopAtBrace) return output.join("");
+			if (character === "\\") {
+				const command = this.parseCommand(depth);
+				if (command === undefined) return undefined;
+				output.push(command);
+				continue;
+			}
+			if (character === "^" || character === "_") {
+				const script = this.parseScript(character, depth);
+				if (script === undefined) return undefined;
+				output.push(script);
+				continue;
+			}
+			if (character === "{") {
+				const group = this.parseGroup(depth);
+				if (group === undefined) return undefined;
+				output.push(`{${group}}`);
+				continue;
+			}
+			output.push(character ?? "");
+			this.index += 1;
+		}
+		return stopAtBrace ? undefined : output.join("");
+	}
+
+	private parseGroup(depth: number): string | undefined {
+		if (this.input[this.index] !== "{") return undefined;
+		this.index += 1;
+		const body = this.parseSequence(depth + 1, true);
+		if (body === undefined || this.input[this.index] !== "}") return undefined;
+		this.index += 1;
+		return body;
+	}
+
+	private parseCommand(depth: number): string | undefined {
+		this.index += 1;
+		const first = this.input[this.index];
+		if (first === undefined) return "\\";
+		if (!/[A-Za-z]/.test(first)) {
+			this.index += 1;
+			if ("_^{}[]()$%&#".includes(first)) return first;
+			if (",;:!".includes(first)) return " ";
+			return `\\${first}`;
+		}
+
+		const start = this.index;
+		while (/[A-Za-z]/.test(this.input[this.index] ?? "")) this.index += 1;
+		const command = `\\${this.input.slice(start, this.index)}`;
+		const symbol = SYMBOLS[command];
+		if (symbol !== undefined) return symbol;
+		if (STYLE_COMMANDS.has(command)) {
+			return this.input[this.index] === "{" ? this.parseGroup(depth) : command;
+		}
+		if (command === "\\sqrt") {
+			const body = this.parseGroup(depth);
+			return body === undefined ? undefined : `√(${body})`;
+		}
+		if (command === "\\frac") {
+			const numerator = this.parseGroup(depth);
+			const denominator = numerator === undefined ? undefined : this.parseGroup(depth);
+			return numerator === undefined || denominator === undefined ? undefined : `(${numerator})⁄(${denominator})`;
+		}
+		if (command === "\\left" || command === "\\right") {
+			const delimiter = this.input[this.index];
+			if (delimiter !== undefined && "()[]{}|".includes(delimiter)) {
+				this.index += 1;
+				return delimiter;
+			}
+		}
+		if (command === "\\quad") return "  ";
+		return command;
+	}
+
+	private parseScript(marker: "^" | "_", depth: number): string | undefined {
+		this.index += 1;
+		const alphabet = marker === "^" ? SUPERSCRIPTS : SUBSCRIPTS;
+		if (this.input[this.index] === "{") {
+			const body = this.parseGroup(depth);
+			if (body === undefined) return undefined;
+			return scriptText(body, alphabet) ?? `${marker}{${body}}`;
+		}
+		const codePoint = this.input.codePointAt(this.index);
+		if (codePoint === undefined) return marker;
+		const body = String.fromCodePoint(codePoint);
+		this.index += body.length;
+		return alphabet[body] ?? `${marker}${body}`;
+	}
+}
 
 export const latexToUnicode = (formula: string): string => {
-	let output = formula.trim().replace(/\s+/g, " ");
-	for (const command of ["\\mathrm", "\\mathbf", "\\mathit", "\\text", "\\operatorname"]) {
-		output = replaceBraced(output, command, (body) => body);
-	}
-	output = replaceBraced(output, "\\sqrt", (body) => `√(${body})`);
-	output = output.replace(/\\frac\{([^{}]*)\}\{([^{}]*)\}/g, "($1)⁄($2)");
-	output = output.replace(/\\(?:left|right)(?=[()[\]{}|])/g, "");
-	for (const [command, symbol] of Object.entries(SYMBOLS).sort(([a], [b]) => b.length - a.length)) {
-		output = output.replace(new RegExp(`${escapeRegex(command)}(?![A-Za-z])`, "g"), symbol);
-	}
-	output = replaceScripts(output, "^", SUPERSCRIPTS);
-	output = replaceScripts(output, "_", SUBSCRIPTS);
-	output = output.replace(/\\(?:,|;|:|!)/g, " ").replace(/\\quad/g, "  ");
-	return output.trim();
+	const trimmed = formula.trim();
+	if (trimmed.length > MAX_FORMULA_LENGTH) return trimmed;
+	const normalized = trimmed.replace(/\s+/g, " ");
+	return new LatexParser(normalized).parse() ?? trimmed;
 };

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -30,7 +30,7 @@ interface LatexToken extends Tokens.Generic {
 }
 
 const MAX_LATEX_FORMULA_LENGTH = 4096;
-const WORD_CHARACTER_REGEX = /[\p{L}\p{N}_]/u;
+const WORD_CHARACTER_REGEX = /[\p{L}\p{M}\p{N}_]/u;
 
 function createLatexToken(type: LatexToken["type"], raw: string, text: string): LatexToken {
 	return { raw, text, type };
@@ -67,8 +67,9 @@ function findInlineMath(
 		if (src[index] === "\n" || src[index] === "`") return undefined;
 		if (src.startsWith(close, index)) {
 			const text = src.slice(bodyStart, index);
-			if (!text || /^\s|\s$/.test(text)) return undefined;
-			return { raw: src.slice(0, index + close.length), text };
+			const normalizedText = open === close ? text : text.trim();
+			if (!normalizedText || (open === close && /^\s|\s$/.test(text))) return undefined;
+			return { raw: src.slice(0, index + close.length), text: normalizedText };
 		}
 		if (open !== close && src.startsWith(open, index)) return undefined;
 		if (src[index] === "\\") {
@@ -172,6 +173,7 @@ const inlineMathTokenizer: TokenizerExtension = {
 		if (src.startsWith("$")) {
 			if (src.startsWith("$$")) return createLatexToken("latex_literal", "$$", "$$");
 			const match = findInlineMath(src, "$", "$");
+			if (match?.text.startsWith("{")) return createLatexToken("latex_literal", "$", "$");
 			const previous = previousRawCharacter(tokens);
 			const next = match ? firstCharacter(src.slice(match.raw.length)) : undefined;
 			if (

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -119,6 +119,14 @@ function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" 
 	return competingOpener ? src.slice(0, scanEnd) : undefined;
 }
 
+function isLikelyShellDollarBody(text: string): boolean {
+	return (
+		text.startsWith("{") ||
+		/^\([^)\r\n]*\)[/\\]$/.test(text) ||
+		/^[!#$?@*-][/\\]$/.test(text)
+	);
+}
+
 function findBlockMath(
 	src: string,
 	open: "$$" | "\\[",
@@ -138,7 +146,7 @@ function findBlockMath(
 		while (rawLineEnd < lineValidationEnd && src[rawLineEnd] !== "\n" && /[ \t]/.test(src[rawLineEnd] ?? "")) {
 			rawLineEnd += 1;
 		}
-		if (rawLineEnd < src.length && src[rawLineEnd] !== "\n") continue;
+		if (rawLineEnd < src.length && src[rawLineEnd] !== "\n") return undefined;
 		const text = src.slice(bodyStart, index).trim();
 		if (!text) return undefined;
 		let rawEnd = rawLineEnd;
@@ -177,7 +185,7 @@ const inlineMathTokenizer: TokenizerExtension = {
 		if (src.startsWith("$")) {
 			if (src.startsWith("$$")) return createLatexToken("latex_literal", "$$", "$$");
 			const match = findInlineMath(src, "$", "$");
-			if (match?.text.startsWith("{")) return createLatexToken("latex_literal", "$", "$");
+			if (match && isLikelyShellDollarBody(match.text)) return createLatexToken("latex_literal", "$", "$");
 			const previous = previousRawCharacter(tokens);
 			const next = match ? firstCharacter(src.slice(match.raw.length)) : undefined;
 			if (

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -89,7 +89,11 @@ function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" 
 		if (src[index] === "\n" || src[index] === "`") {
 			return competingOpener ? src.slice(0, index) : undefined;
 		}
-		const nestedOpen = src.startsWith("\\(", index) ? "\\(" : src.startsWith("\\[", index) ? "\\[" : undefined;
+		const nestedOpen = src.startsWith("\\(", index)
+			? "\\("
+			: src.startsWith("\\[", index)
+				? "\\["
+				: undefined;
 		if (nestedOpen !== undefined) {
 			competingOpener = true;
 			closers.push(nestedOpen === "\\(" ? "\\)" : "\\]");

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -71,7 +71,10 @@ function findInlineMath(
 			return { raw: src.slice(0, index + close.length), text };
 		}
 		if (open !== close && src.startsWith(open, index)) return undefined;
-		if (src[index] === "\\") index += 1;
+		if (src[index] === "\\") {
+			if (src[index + 1] === "\n" || src[index + 1] === "\r") return undefined;
+			index += 1;
+		}
 	}
 	return undefined;
 }
@@ -80,24 +83,33 @@ function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" 
 	if (!src.startsWith(open)) return undefined;
 	const scanEnd = Math.min(src.length, open.length + MAX_LATEX_FORMULA_LENGTH + 1);
 	let competingOpener = false;
-	let depth = 1;
+	const closers = [close];
 	for (let index = open.length; index < scanEnd; index += 1) {
 		if (src[index] === "\n" || src[index] === "`") {
 			return competingOpener ? src.slice(0, index) : undefined;
 		}
-		if (src.startsWith(open, index)) {
+		const nestedOpen = src.startsWith("\\(", index) ? "\\(" : src.startsWith("\\[", index) ? "\\[" : undefined;
+		if (nestedOpen !== undefined) {
 			competingOpener = true;
-			depth += 1;
-			index += open.length - 1;
+			closers.push(nestedOpen === "\\(" ? "\\)" : "\\]");
+			index += nestedOpen.length - 1;
 			continue;
 		}
-		if (src.startsWith(close, index)) {
-			depth -= 1;
-			if (depth === 0) return competingOpener ? src.slice(0, index + close.length) : undefined;
-			index += close.length - 1;
+		const expectedClose = closers.at(-1);
+		if (expectedClose !== undefined && src.startsWith(expectedClose, index)) {
+			closers.pop();
+			if (closers.length === 0) {
+				return competingOpener ? src.slice(0, index + expectedClose.length) : undefined;
+			}
+			index += expectedClose.length - 1;
 			continue;
 		}
-		if (src[index] === "\\") index += 1;
+		if (src[index] === "\\") {
+			if (src[index + 1] === "\n" || src[index + 1] === "\r") {
+				return competingOpener ? src.slice(0, index) : undefined;
+			}
+			index += 1;
+		}
 	}
 	return competingOpener ? src.slice(0, scanEnd) : undefined;
 }
@@ -153,14 +165,8 @@ const inlineMathTokenizer: TokenizerExtension = {
 	name: "latex_inline",
 	level: "inline",
 	start(src) {
-		const starts = [
-			src.indexOf("$"),
-			src.indexOf("\\("),
-			src.indexOf("\\["),
-			src.indexOf("\\)"),
-			src.indexOf("\\]"),
-		].filter((index) => index >= 0);
-		return starts.length > 0 ? Math.min(...starts) : undefined;
+		const index = src.search(/\$|\\[()[\]]/);
+		return index >= 0 ? index : undefined;
 	},
 	tokenizer(src, tokens) {
 		if (src.startsWith("$")) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -32,6 +32,14 @@ interface LatexToken extends Tokens.Generic {
 const MAX_LATEX_FORMULA_LENGTH = 4096;
 const WORD_CHARACTER_REGEX = /[\p{L}\p{M}\p{N}_]/u;
 
+interface InlineCodePrefixState {
+	hasUnclosedCodeSpan: boolean;
+	lastProcessedRaw?: string;
+	processedTokenCount: number;
+}
+
+const inlineCodePrefixStates = new WeakMap<Token[], InlineCodePrefixState>();
+
 function createLatexToken(type: LatexToken["type"], raw: string, text: string): LatexToken {
 	return { raw, text, type };
 }
@@ -52,6 +60,25 @@ function previousRawCharacter(tokens: Token[]): string | undefined {
 function firstCharacter(value: string): string | undefined {
 	const codePoint = value.codePointAt(0);
 	return codePoint === undefined ? undefined : String.fromCodePoint(codePoint);
+}
+
+function followsUnclosedCodeSpan(tokens: Token[]): boolean {
+	let state = inlineCodePrefixStates.get(tokens);
+	const previousProcessedToken = state ? tokens[state.processedTokenCount - 1] : undefined;
+	if (!state || previousProcessedToken?.raw !== state.lastProcessedRaw) {
+		state = { hasUnclosedCodeSpan: false, processedTokenCount: 0 };
+		inlineCodePrefixStates.set(tokens, state);
+	}
+
+	for (let index = state.processedTokenCount; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (token?.type === "text" && token.raw.includes("`")) {
+			state.hasUnclosedCodeSpan = true;
+		}
+	}
+	state.processedTokenCount = tokens.length;
+	state.lastProcessedRaw = tokens.at(-1)?.raw;
+	return state.hasUnclosedCodeSpan;
 }
 
 function findInlineMath(
@@ -89,11 +116,7 @@ function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" 
 		if (src[index] === "\n" || src[index] === "`") {
 			return competingOpener ? src.slice(0, index) : undefined;
 		}
-		const nestedOpen = src.startsWith("\\(", index)
-			? "\\("
-			: src.startsWith("\\[", index)
-				? "\\["
-				: undefined;
+		const nestedOpen = src.startsWith("\\(", index) ? "\\(" : src.startsWith("\\[", index) ? "\\[" : undefined;
 		if (nestedOpen !== undefined) {
 			competingOpener = true;
 			closers.push(nestedOpen === "\\(" ? "\\)" : "\\]");
@@ -119,11 +142,13 @@ function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" 
 	return competingOpener ? src.slice(0, scanEnd) : undefined;
 }
 
-function isLikelyShellDollarBody(text: string): boolean {
+function isLikelyLiteralDollarBody(text: string): boolean {
 	return (
 		text.startsWith("{") ||
 		/^\([^)\r\n]*\)[/\\]$/.test(text) ||
-		/^[!#$?@*-][/\\]$/.test(text)
+		/^[!#$?@*-][/\\]$/.test(text) ||
+		/^[A-Za-z_][A-Za-z0-9_]*[./\\:-]$/.test(text) ||
+		/^\d[\d,.]*(?:[-–—]|[/\\])$/.test(text)
 	);
 }
 
@@ -182,10 +207,16 @@ const inlineMathTokenizer: TokenizerExtension = {
 		return index >= 0 ? index : undefined;
 	},
 	tokenizer(src, tokens) {
+		const codeSpanLiteral = /^(?:\${1,2}|\\\(|\\\)|\\\[|\\\])/.exec(src)?.[0];
+		if (codeSpanLiteral && followsUnclosedCodeSpan(tokens)) {
+			return createLatexToken("latex_literal", codeSpanLiteral, codeSpanLiteral);
+		}
 		if (src.startsWith("$")) {
 			if (src.startsWith("$$")) return createLatexToken("latex_literal", "$$", "$$");
 			const match = findInlineMath(src, "$", "$");
-			if (match && isLikelyShellDollarBody(match.text)) return createLatexToken("latex_literal", "$", "$");
+			if (match && isLikelyLiteralDollarBody(match.text)) {
+				return createLatexToken("latex_literal", match.raw, match.raw);
+			}
 			const previous = previousRawCharacter(tokens);
 			const next = match ? firstCharacter(src.slice(match.raw.length)) : undefined;
 			if (

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -76,6 +76,25 @@ function findInlineMath(
 	return undefined;
 }
 
+function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" | "\\]"): string | undefined {
+	if (!src.startsWith(open)) return undefined;
+	const scanEnd = Math.min(src.length, open.length + MAX_LATEX_FORMULA_LENGTH + 1);
+	let competingOpener = false;
+	for (let index = open.length; index < scanEnd; index += 1) {
+		if (src[index] === "\n" || src[index] === "`") return undefined;
+		if (src.startsWith(open, index)) {
+			competingOpener = true;
+			index += open.length - 1;
+			continue;
+		}
+		if (src.startsWith(close, index)) {
+			return competingOpener ? src.slice(0, index + close.length) : undefined;
+		}
+		if (src[index] === "\\") index += 1;
+	}
+	return undefined;
+}
+
 function findBlockMath(
 	src: string,
 	open: "$$" | "\\[",
@@ -151,6 +170,10 @@ const inlineMathTokenizer: TokenizerExtension = {
 			}
 			return createLatexToken("latex_literal", "$", "$");
 		}
+		const malformedParens = findMalformedInlineSpan(src, "\\(", "\\)");
+		if (malformedParens) return createLatexToken("latex_literal", malformedParens, malformedParens);
+		const malformedBrackets = findMalformedInlineSpan(src, "\\[", "\\]");
+		if (malformedBrackets) return createLatexToken("latex_literal", malformedBrackets, malformedBrackets);
 		const repeatedParens = repeatedMalformedOpeners(src, "\\(");
 		if (repeatedParens) return createLatexToken("latex_literal", repeatedParens, repeatedParens);
 		const repeatedBrackets = repeatedMalformedOpeners(src, "\\[");

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -29,6 +29,9 @@ interface LatexToken extends Tokens.Generic {
 	type: "latex_block" | "latex_inline" | "latex_literal";
 }
 
+const MAX_LATEX_FORMULA_LENGTH = 4096;
+const WORD_CHARACTER_REGEX = /[\p{L}\p{N}_]/u;
+
 function createLatexToken(type: LatexToken["type"], raw: string, text: string): LatexToken {
 	return { raw, text, type };
 }
@@ -41,18 +44,81 @@ function isLatexToken(token: Token): token is LatexToken {
 	);
 }
 
+function previousRawCharacter(tokens: Token[]): string | undefined {
+	const raw = tokens[tokens.length - 1]?.raw;
+	return raw ? Array.from(raw).at(-1) : undefined;
+}
+
+function firstCharacter(value: string): string | undefined {
+	const codePoint = value.codePointAt(0);
+	return codePoint === undefined ? undefined : String.fromCodePoint(codePoint);
+}
+
+function findInlineMath(
+	src: string,
+	open: "$" | "\\(" | "\\[",
+	close: "$" | "\\)" | "\\]",
+): { raw: string; text: string } | undefined {
+	if (!src.startsWith(open)) return undefined;
+	const bodyStart = open.length;
+	const scanEnd = Math.min(src.length, bodyStart + MAX_LATEX_FORMULA_LENGTH + 1);
+
+	for (let index = bodyStart; index < scanEnd; index += 1) {
+		if (src[index] === "\n" || src[index] === "`") return undefined;
+		if (src.startsWith(close, index)) {
+			const text = src.slice(bodyStart, index);
+			if (!text || /^\s|\s$/.test(text)) return undefined;
+			return { raw: src.slice(0, index + close.length), text };
+		}
+		if (open !== close && src.startsWith(open, index)) return undefined;
+		if (src[index] === "\\") index += 1;
+	}
+	return undefined;
+}
+
+function findBlockMath(
+	src: string,
+	open: "$$" | "\\[",
+	close: "$$" | "\\]",
+): { raw: string; text: string } | undefined {
+	if (!src.startsWith(open)) return undefined;
+	const bodyStart = open.length;
+	const scanEnd = Math.min(src.length, bodyStart + MAX_LATEX_FORMULA_LENGTH + 1);
+	const lineValidationEnd = Math.min(src.length, scanEnd + close.length + 256);
+
+	for (let index = bodyStart; index < scanEnd; index += 1) {
+		if (src[index] === "`") return undefined;
+		if (open !== close && src.startsWith(open, index)) return undefined;
+		if (!src.startsWith(close, index)) continue;
+		const closeEnd = index + close.length;
+		let rawLineEnd = closeEnd;
+		while (rawLineEnd < lineValidationEnd && src[rawLineEnd] !== "\n" && /[ \t]/.test(src[rawLineEnd] ?? "")) {
+			rawLineEnd += 1;
+		}
+		if (rawLineEnd < src.length && src[rawLineEnd] !== "\n") continue;
+		const text = src.slice(bodyStart, index).trim();
+		if (!text) return undefined;
+		let rawEnd = rawLineEnd;
+		while (rawEnd < lineValidationEnd && src[rawEnd] === "\n") rawEnd += 1;
+		return { raw: src.slice(0, rawEnd), text };
+	}
+	return undefined;
+}
+
+function repeatedMalformedOpeners(src: string, opener: "\\(" | "\\["): string | undefined {
+	let end = opener.length;
+	while (src.startsWith(opener, end)) end += opener.length;
+	return end > opener.length ? src.slice(0, end) : undefined;
+}
+
 const blockMathTokenizer: TokenizerExtension = {
 	name: "latex_block",
 	level: "block",
 	tokenizer(src) {
-		const dollars = /^ {0,3}\$\$[ \t]*\n?([\s\S]*?)\n?[ \t]*\$\$[ \t]*(?:\n+|$)/.exec(src);
-		if (dollars?.[1]?.trim()) {
-			return createLatexToken("latex_block", dollars[0], dollars[1]);
-		}
-		const brackets = /^ {0,3}\\\[[ \t]*\n?([\s\S]*?)\n?[ \t]*\\\][ \t]*(?:\n+|$)/.exec(src);
-		if (brackets?.[1]?.trim()) {
-			return createLatexToken("latex_block", brackets[0], brackets[1]);
-		}
+		const leadingSpaces = /^ {0,3}/.exec(src)?.[0] ?? "";
+		const candidate = src.slice(leadingSpaces.length);
+		const match = findBlockMath(candidate, "$$", "$$") ?? findBlockMath(candidate, "\\[", "\\]");
+		if (match) return createLatexToken("latex_block", `${leadingSpaces}${match.raw}`, match.text);
 		return undefined;
 	},
 };
@@ -70,19 +136,29 @@ const inlineMathTokenizer: TokenizerExtension = {
 		].filter((index) => index >= 0);
 		return starts.length > 0 ? Math.min(...starts) : undefined;
 	},
-	tokenizer(src) {
-		const parens = /^\\\((.*?)\\\)/.exec(src);
-		if (parens?.[1] && !parens[1].includes("\n")) {
-			return createLatexToken("latex_inline", parens[0], parens[1]);
+	tokenizer(src, tokens) {
+		if (src.startsWith("$")) {
+			if (src.startsWith("$$")) return createLatexToken("latex_literal", "$$", "$$");
+			const match = findInlineMath(src, "$", "$");
+			const previous = previousRawCharacter(tokens);
+			const next = match ? firstCharacter(src.slice(match.raw.length)) : undefined;
+			if (
+				match &&
+				(previous === undefined || !WORD_CHARACTER_REGEX.test(previous)) &&
+				(next === undefined || !WORD_CHARACTER_REGEX.test(next))
+			) {
+				return createLatexToken("latex_inline", match.raw, match.text);
+			}
+			return createLatexToken("latex_literal", "$", "$");
 		}
-		const brackets = /^\\\[([\s\S]+?)\\\]/.exec(src);
-		if (brackets?.[1]) {
-			return createLatexToken("latex_inline", brackets[0], brackets[1]);
-		}
-		const dollars = /^\$([^$\n]+?)\$/.exec(src);
-		if (dollars?.[1] && !/^\s|\s$/.test(dollars[1])) {
-			return createLatexToken("latex_inline", dollars[0], dollars[1]);
-		}
+		const repeatedParens = repeatedMalformedOpeners(src, "\\(");
+		if (repeatedParens) return createLatexToken("latex_literal", repeatedParens, repeatedParens);
+		const repeatedBrackets = repeatedMalformedOpeners(src, "\\[");
+		if (repeatedBrackets) return createLatexToken("latex_literal", repeatedBrackets, repeatedBrackets);
+		const parens = findInlineMath(src, "\\(", "\\)");
+		if (parens) return createLatexToken("latex_inline", parens.raw, parens.text);
+		const brackets = findInlineMath(src, "\\[", "\\]");
+		if (brackets) return createLatexToken("latex_inline", brackets.raw, brackets.text);
 		const literal = /^(?:\\\(|\\\)|\\\[|\\\])/.exec(src);
 		return literal ? createLatexToken("latex_literal", literal[0], literal[0]) : undefined;
 	},
@@ -575,7 +651,8 @@ export class Markdown implements Component {
 
 			case "latex_block":
 				if (isLatexToken(token)) {
-					lines.push(this.applyDefaultStyle(latexToUnicode(token.text)));
+					const formula = latexToUnicode(token.text);
+					lines.push(styleContext ? styleContext.applyText(formula) : this.applyDefaultStyle(formula));
 					if (nextTokenType && nextTokenType !== "space") {
 						lines.push("");
 					}

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -80,19 +80,26 @@ function findMalformedInlineSpan(src: string, open: "\\(" | "\\[", close: "\\)" 
 	if (!src.startsWith(open)) return undefined;
 	const scanEnd = Math.min(src.length, open.length + MAX_LATEX_FORMULA_LENGTH + 1);
 	let competingOpener = false;
+	let depth = 1;
 	for (let index = open.length; index < scanEnd; index += 1) {
-		if (src[index] === "\n" || src[index] === "`") return undefined;
+		if (src[index] === "\n" || src[index] === "`") {
+			return competingOpener ? src.slice(0, index) : undefined;
+		}
 		if (src.startsWith(open, index)) {
 			competingOpener = true;
+			depth += 1;
 			index += open.length - 1;
 			continue;
 		}
 		if (src.startsWith(close, index)) {
-			return competingOpener ? src.slice(0, index + close.length) : undefined;
+			depth -= 1;
+			if (depth === 0) return competingOpener ? src.slice(0, index + close.length) : undefined;
+			index += close.length - 1;
+			continue;
 		}
 		if (src[index] === "\\") index += 1;
 	}
-	return undefined;
+	return competingOpener ? src.slice(0, scanEnd) : undefined;
 }
 
 function findBlockMath(
@@ -179,11 +186,35 @@ const inlineMathTokenizer: TokenizerExtension = {
 		const repeatedBrackets = repeatedMalformedOpeners(src, "\\[");
 		if (repeatedBrackets) return createLatexToken("latex_literal", repeatedBrackets, repeatedBrackets);
 		const parens = findInlineMath(src, "\\(", "\\)");
-		if (parens) return createLatexToken("latex_inline", parens.raw, parens.text);
+		if (parens) {
+			const previous = previousRawCharacter(tokens);
+			const next = firstCharacter(src.slice(parens.raw.length));
+			if (
+				(previous === undefined || !WORD_CHARACTER_REGEX.test(previous)) &&
+				(next === undefined || !WORD_CHARACTER_REGEX.test(next))
+			) {
+				return createLatexToken("latex_inline", parens.raw, parens.text);
+			}
+			return undefined;
+		}
 		const brackets = findInlineMath(src, "\\[", "\\]");
-		if (brackets) return createLatexToken("latex_inline", brackets.raw, brackets.text);
+		if (brackets) {
+			const previous = previousRawCharacter(tokens);
+			const next = firstCharacter(src.slice(brackets.raw.length));
+			if (
+				(previous === undefined || !WORD_CHARACTER_REGEX.test(previous)) &&
+				(next === undefined || !WORD_CHARACTER_REGEX.test(next))
+			) {
+				return createLatexToken("latex_inline", brackets.raw, brackets.text);
+			}
+			return undefined;
+		}
 		const literal = /^(?:\\\(|\\\)|\\\[|\\\])/.exec(src);
-		return literal ? createLatexToken("latex_literal", literal[0], literal[0]) : undefined;
+		if (!literal) return undefined;
+		const previous = previousRawCharacter(tokens);
+		return previous !== undefined && WORD_CHARACTER_REGEX.test(previous)
+			? undefined
+			: createLatexToken("latex_literal", literal[0], literal[0]);
 	},
 };
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,8 +1,9 @@
 // allow: SIZE_OK - existing markdown renderer is oversized; this merge only preserves behavior and cache-key correctness.
-import { Marked, type Token, Tokenizer, type Tokens } from "marked";
+import { Marked, type Token, Tokenizer, type TokenizerExtension, type Tokens } from "marked";
 import { getCapabilities, hyperlink, isImageLine } from "../terminal-image.ts";
 import type { Component } from "../tui.ts";
 import { applyBackgroundToLine, visibleWidth, wrapTextWithAnsi } from "../utils.ts";
+import { latexToUnicode } from "./latex.ts";
 
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
 
@@ -22,6 +23,70 @@ class StrictStrikethroughTokenizer extends Tokenizer {
 		};
 	}
 }
+
+interface LatexToken extends Tokens.Generic {
+	text: string;
+	type: "latex_block" | "latex_inline" | "latex_literal";
+}
+
+function createLatexToken(type: LatexToken["type"], raw: string, text: string): LatexToken {
+	return { raw, text, type };
+}
+
+function isLatexToken(token: Token): token is LatexToken {
+	return (
+		(token.type === "latex_block" || token.type === "latex_inline" || token.type === "latex_literal") &&
+		"text" in token &&
+		typeof token.text === "string"
+	);
+}
+
+const blockMathTokenizer: TokenizerExtension = {
+	name: "latex_block",
+	level: "block",
+	tokenizer(src) {
+		const dollars = /^ {0,3}\$\$[ \t]*\n?([\s\S]*?)\n?[ \t]*\$\$[ \t]*(?:\n+|$)/.exec(src);
+		if (dollars?.[1]?.trim()) {
+			return createLatexToken("latex_block", dollars[0], dollars[1]);
+		}
+		const brackets = /^ {0,3}\\\[[ \t]*\n?([\s\S]*?)\n?[ \t]*\\\][ \t]*(?:\n+|$)/.exec(src);
+		if (brackets?.[1]?.trim()) {
+			return createLatexToken("latex_block", brackets[0], brackets[1]);
+		}
+		return undefined;
+	},
+};
+
+const inlineMathTokenizer: TokenizerExtension = {
+	name: "latex_inline",
+	level: "inline",
+	start(src) {
+		const starts = [
+			src.indexOf("$"),
+			src.indexOf("\\("),
+			src.indexOf("\\["),
+			src.indexOf("\\)"),
+			src.indexOf("\\]"),
+		].filter((index) => index >= 0);
+		return starts.length > 0 ? Math.min(...starts) : undefined;
+	},
+	tokenizer(src) {
+		const parens = /^\\\((.*?)\\\)/.exec(src);
+		if (parens?.[1] && !parens[1].includes("\n")) {
+			return createLatexToken("latex_inline", parens[0], parens[1]);
+		}
+		const brackets = /^\\\[([\s\S]+?)\\\]/.exec(src);
+		if (brackets?.[1]) {
+			return createLatexToken("latex_inline", brackets[0], brackets[1]);
+		}
+		const dollars = /^\$([^$\n]+?)\$/.exec(src);
+		if (dollars?.[1] && !/^\s|\s$/.test(dollars[1])) {
+			return createLatexToken("latex_inline", dollars[0], dollars[1]);
+		}
+		const literal = /^(?:\\\(|\\\)|\\\[|\\\])/.exec(src);
+		return literal ? createLatexToken("latex_literal", literal[0], literal[0]) : undefined;
+	},
+};
 
 function trimPartialClosingFences(tokens: readonly Token[]): void {
 	const token = tokens[tokens.length - 1];
@@ -49,6 +114,7 @@ function trimPartialClosingFences(tokens: readonly Token[]): void {
 }
 
 const markdownParser = new Marked();
+markdownParser.use({ extensions: [blockMathTokenizer, inlineMathTokenizer] });
 markdownParser.setOptions({
 	tokenizer: new StrictStrikethroughTokenizer(),
 });
@@ -507,6 +573,15 @@ export class Markdown implements Component {
 				break;
 			}
 
+			case "latex_block":
+				if (isLatexToken(token)) {
+					lines.push(this.applyDefaultStyle(latexToUnicode(token.text)));
+					if (nextTokenType && nextTokenType !== "space") {
+						lines.push("");
+					}
+				}
+				break;
+
 			case "text":
 				lines.push(this.renderInlineTokens([token], styleContext));
 				break;
@@ -655,6 +730,18 @@ export class Markdown implements Component {
 
 				case "codespan":
 					result += this.theme.code(token.text) + stylePrefix;
+					break;
+
+				case "latex_inline":
+					if (isLatexToken(token)) {
+						result += applyTextWithNewlines(latexToUnicode(token.text));
+					}
+					break;
+
+				case "latex_literal":
+					if (isLatexToken(token)) {
+						result += applyTextWithNewlines(token.text);
+					}
 					break;
 
 				case "link": {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1552,7 +1552,9 @@ bar`,
 					"Before \\(unfinished before `\\)` after",
 					"Nested \\(outer \\(inner\\) remains literal",
 					"Nested siblings \\(outer \\(a\\) and \\(b\\)\\) remain literal",
+					"Mixed nested \\(outer \\[inner\\] remains literal",
 					"Escaped identifier punctuation: array\\[0\\] and call\\(arg\\)",
+					"Escaped newline: $a\\\nb$",
 				].join("\n"),
 				0,
 				0,
@@ -1567,7 +1569,10 @@ bar`,
 			assert.ok(rendered.includes("Before \\(unfinished before \\) after"), rendered);
 			assert.ok(rendered.includes("Nested \\(outer \\(inner\\) remains literal"), rendered);
 			assert.ok(rendered.includes("Nested siblings \\(outer \\(a\\) and \\(b\\)\\) remain literal"), rendered);
+			assert.ok(rendered.includes("Mixed nested \\(outer \\[inner\\] remains literal"), rendered);
 			assert.ok(rendered.includes("Escaped identifier punctuation: array[0] and call(arg)"), rendered);
+			assert.ok(rendered.includes("$a"), rendered);
+			assert.ok(rendered.includes("b$"), rendered);
 		});
 
 		it("LaTeX preserves separated malformed openers", () => {
@@ -1578,6 +1583,16 @@ bar`,
 				.map((line) => stripAnsi(line).trimEnd())
 				.join("\n");
 			assert.strictEqual(rendered, malformed);
+		});
+
+		it("LaTeX preserves repeated literal dollar markers", () => {
+			const literalDollars = "a$$".repeat(2000);
+			const markdown = new Markdown(literalDollars, 0, 0, defaultMarkdownTheme);
+			const rendered = markdown
+				.render(7000)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+			assert.strictEqual(rendered, literalDollars);
 		});
 
 		it("LaTeX converts nested structures and preserves command distinctions", () => {
@@ -1594,6 +1609,7 @@ bar`,
 			assert.strictEqual(latexToUnicode("\\sqrt {x}"), "√(x)");
 			assert.strictEqual(latexToUnicode("\\text {한}"), "한");
 			assert.strictEqual(latexToUnicode("f\\!(x)"), "f(x)");
+			assert.strictEqual(latexToUnicode("A^\\mathrm{T}"), "A^T");
 			assert.strictEqual(latexToUnicode("a+{b}"), "a+b");
 			assert.strictEqual(latexToUnicode("\\foo{bar}"), "\\foo{bar}");
 		});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -5,6 +5,7 @@ import { Chalk } from "chalk";
 import { Markdown } from "../src/components/markdown.ts";
 import { resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.ts";
 import { type Component, TUI } from "../src/tui.ts";
+import { visibleWidth } from "../src/utils.ts";
 import { defaultMarkdownTheme } from "./test-themes.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
@@ -1451,6 +1452,41 @@ bar`,
 
 			assert.ok(rendered.includes("Fallback: \\foo{bar} + α."), rendered);
 			assert.ok(!rendered.includes("$"), rendered);
+		});
+
+		it("LaTeX renders Korean Japanese and Chinese formulas", () => {
+			const markdown = new Markdown(
+				[
+					"한국어: $\\text{속도} = \\frac{\\text{거리}}{\\text{시간}}$",
+					"日本語: $\\text{面積} = \\pi \\times \\text{半径}^2$",
+					"中文: $\\text{能量} = \\text{质量} \\times \\text{光速}^2$",
+					"",
+					"Inline code: `$\\text{속도}$`.",
+					"",
+					"```tex",
+					"$\\text{面積}$",
+					"```",
+					"",
+					"Unmatched: \\[未完",
+				].join("\n"),
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(40).map((line) => stripAnsi(line).trimEnd());
+			const rendered = lines.join("\n");
+
+			assert.ok(rendered.includes("한국어: 속도 = (거리)⁄(시간)"), rendered);
+			assert.ok(rendered.includes("日本語: 面積 = π × 半径²"), rendered);
+			assert.ok(rendered.includes("中文: 能量 = 质量 × 光速²"), rendered);
+			assert.ok(rendered.includes("$\\text{속도}$"), rendered);
+			assert.ok(rendered.includes("$\\text{面積}$"), rendered);
+			assert.ok(rendered.includes("Unmatched: \\[未完"), rendered);
+			assert.ok(
+				lines.every((line) => visibleWidth(line) <= 40),
+				rendered,
+			);
 		});
 	});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { afterEach, describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import { Chalk } from "chalk";
+import { latexToUnicode } from "../src/components/latex.ts";
 import { Markdown } from "../src/components/markdown.ts";
 import { resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.ts";
 import { type Component, TUI } from "../src/tui.ts";
@@ -30,6 +31,15 @@ function getCellUnderline(terminal: VirtualTerminal, row: number, col: number): 
 	const cell = line.getCell(col);
 	assert.ok(cell, `Missing cell at row ${row} col ${col}`);
 	return cell.isUnderline();
+}
+
+function getCellWidth(terminal: VirtualTerminal, row: number, col: number): number {
+	const xterm: XtermTerminalType = Reflect.get(terminal, "xterm");
+	const line = xterm.buffer.active.getLine(xterm.buffer.active.viewportY + row);
+	assert.ok(line, `Missing buffer line at row ${row}`);
+	const cell = line.getCell(col);
+	assert.ok(cell, `Missing cell at row ${row} col ${col}`);
+	return cell.getWidth();
 }
 
 function stripAnsi(line: string): string {
@@ -1487,6 +1497,115 @@ bar`,
 				lines.every((line) => visibleWidth(line) <= 40),
 				rendered,
 			);
+		});
+
+		it("LaTeX preserves ordinary dollar-delimited text", () => {
+			const markdown = new Markdown(
+				[
+					"Budget: $5-$10",
+					"use $HOME/$USER",
+					"identifier$token$tail",
+					"The US$5$ bill remains payable.",
+					"Astral suffix: $x$𐐀",
+					"Astral prefix: 𐐀$x$",
+					"Valid math: $x^2$.",
+				].join("\n"),
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const rendered = markdown
+				.render(80)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+
+			assert.ok(rendered.includes("Budget: $5-$10"), rendered);
+			assert.ok(rendered.includes("use $HOME/$USER"), rendered);
+			assert.ok(rendered.includes("identifier$token$tail"), rendered);
+			assert.ok(rendered.includes("The US$5$ bill remains payable."), rendered);
+			assert.ok(rendered.includes("Astral suffix: $x$𐐀"), rendered);
+			assert.ok(rendered.includes("Astral prefix: 𐐀$x$"), rendered);
+			assert.ok(rendered.includes("Valid math: x²."), rendered);
+		});
+
+		it("LaTeX preserves malformed nested and over-budget blocks", () => {
+			const nested = "\\[\nouter\n\\[\nx\n\\]\n";
+			const falseCloser = `$$x$$not-close${"y".repeat(5000)}\n\nValid: $z^2$.`;
+			const overBudget = `$$${"x".repeat(4097)}$$`;
+			const markdown = new Markdown(`${nested}\n${falseCloser}\n\n${overBudget}`, 0, 0, defaultMarkdownTheme);
+			const rendered = markdown
+				.render(6000)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+
+			assert.strictEqual(rendered.match(/\\\[/g)?.length, 2, rendered.slice(0, 200));
+			assert.strictEqual(rendered.match(/\\\]/g)?.length, 1, rendered.slice(0, 200));
+			assert.ok(rendered.includes("$$x$$not-close"), rendered.slice(0, 200));
+			assert.ok(rendered.includes("Valid: z²."), rendered.slice(-100));
+			assert.ok(rendered.includes(overBudget), rendered.slice(-4200));
+		});
+
+		it("LaTeX delimiters do not cross inline code spans", () => {
+			const markdown = new Markdown(
+				["Before \\[unfinished before `\\]` after", "Before \\(unfinished before `\\)` after"].join("\n"),
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const rendered = markdown
+				.render(80)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+
+			assert.ok(rendered.includes("Before \\[unfinished before \\] after"), rendered);
+			assert.ok(rendered.includes("Before \\(unfinished before \\) after"), rendered);
+		});
+
+		it("LaTeX converts nested structures and preserves command distinctions", () => {
+			assert.strictEqual(latexToUnicode("\\sqrt{\\frac{거리}{시간}}"), "√((거리)⁄(시간))");
+			assert.strictEqual(latexToUnicode("\\frac{1}{\\frac{2}{3}}"), "(1)⁄((2)⁄(3))");
+			assert.strictEqual(latexToUnicode("\\epsilon \\varepsilon \\phi \\varphi"), "ϵ ε ϕ φ");
+			assert.strictEqual(latexToUnicode("\\text{file\\_1 and x\\^2}"), "file_1 and x^2");
+			assert.strictEqual(latexToUnicode("\\quadruple"), "\\quadruple");
+		});
+
+		it("LaTeX falls back literally beyond conversion budgets", () => {
+			const tooDeep = `${"\\sqrt{".repeat(65)}x${"}".repeat(65)}`;
+			const tooLong = `\\alpha${"x".repeat(4096)}`;
+			assert.strictEqual(latexToUnicode(tooDeep), tooDeep);
+			assert.strictEqual(latexToUnicode(tooLong), tooLong);
+
+			const markdown = new Markdown(`$${tooLong}$`, 0, 0, defaultMarkdownTheme);
+			const rendered = markdown
+				.render(5000)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+			assert.ok(rendered.includes(`$${tooLong}$`), rendered.slice(0, 100));
+		});
+
+		it("LaTeX display math inherits blockquote style context", () => {
+			const markdown = new Markdown("> $$x^2$$", 0, 0, defaultMarkdownTheme, {
+				color: (text) => chalk.gray(text),
+			});
+			const rendered = markdown.render(80).join("\n");
+
+			assert.ok(stripAnsi(rendered).includes("│ x²"), rendered);
+			assert.ok(!rendered.includes("\x1b[90m"), rendered);
+		});
+
+		it("LaTeX renders CJK math through headless terminal cells", async () => {
+			const markdown = new Markdown("한 $x^2$ 中", 0, 0, defaultMarkdownTheme);
+			const terminal = new VirtualTerminal(40, 4);
+			const tui = new TUI(terminal);
+			tui.addChild(markdown);
+			tui.start();
+			await terminal.waitForRender();
+
+			assert.ok(terminal.getViewport()[0]?.includes("한 x² 中"));
+			assert.strictEqual(getCellWidth(terminal, 0, 0), 2);
+			assert.strictEqual(getCellWidth(terminal, 0, 1), 0);
+			assert.strictEqual(getCellWidth(terminal, 0, 6), 2);
+			tui.stop();
 		});
 	});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1551,6 +1551,8 @@ bar`,
 					"Before \\[unfinished before `\\]` after",
 					"Before \\(unfinished before `\\)` after",
 					"Nested \\(outer \\(inner\\) remains literal",
+					"Nested siblings \\(outer \\(a\\) and \\(b\\)\\) remain literal",
+					"Escaped identifier punctuation: array\\[0\\] and call\\(arg\\)",
 				].join("\n"),
 				0,
 				0,
@@ -1564,6 +1566,18 @@ bar`,
 			assert.ok(rendered.includes("Before \\[unfinished before \\] after"), rendered);
 			assert.ok(rendered.includes("Before \\(unfinished before \\) after"), rendered);
 			assert.ok(rendered.includes("Nested \\(outer \\(inner\\) remains literal"), rendered);
+			assert.ok(rendered.includes("Nested siblings \\(outer \\(a\\) and \\(b\\)\\) remain literal"), rendered);
+			assert.ok(rendered.includes("Escaped identifier punctuation: array[0] and call(arg)"), rendered);
+		});
+
+		it("LaTeX preserves separated malformed openers", () => {
+			const malformed = "\\(a".repeat(2000);
+			const markdown = new Markdown(malformed, 0, 0, defaultMarkdownTheme);
+			const rendered = markdown
+				.render(7000)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+			assert.strictEqual(rendered, malformed);
 		});
 
 		it("LaTeX converts nested structures and preserves command distinctions", () => {
@@ -1579,6 +1593,7 @@ bar`,
 			assert.strictEqual(latexToUnicode("\\frac {a}{b}"), "(a)⁄(b)");
 			assert.strictEqual(latexToUnicode("\\sqrt {x}"), "√(x)");
 			assert.strictEqual(latexToUnicode("\\text {한}"), "한");
+			assert.strictEqual(latexToUnicode("f\\!(x)"), "f(x)");
 			assert.strictEqual(latexToUnicode("a+{b}"), "a+b");
 			assert.strictEqual(latexToUnicode("\\foo{bar}"), "\\foo{bar}");
 		});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1508,7 +1508,7 @@ bar`,
 					"The US$5$ bill remains payable.",
 					"Astral suffix: $x$𐐀",
 					"Astral prefix: 𐐀$x$",
-					"Braced shell: ${HOME}/${USER}",
+					"Braced shell: $" + "{HOME}/$" + "{USER}",
 					"Combining suffix: Cafe\u0301$x$",
 					"Valid math: $x^2$.",
 				].join("\n"),
@@ -1527,7 +1527,7 @@ bar`,
 			assert.ok(rendered.includes("The US$5$ bill remains payable."), rendered);
 			assert.ok(rendered.includes("Astral suffix: $x$𐐀"), rendered);
 			assert.ok(rendered.includes("Astral prefix: 𐐀$x$"), rendered);
-			assert.ok(rendered.includes("Braced shell: ${HOME}/${USER}"), rendered);
+			assert.ok(rendered.includes("Braced shell: $" + "{HOME}/$" + "{USER}"), rendered);
 			assert.ok(rendered.includes("Combining suffix: Cafe\u0301$x$"), rendered);
 			assert.ok(rendered.includes("Valid math: x²."), rendered);
 		});

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1536,6 +1536,27 @@ bar`,
 			assert.ok(rendered.includes("Valid math: x²."), rendered);
 		});
 
+		it("LaTeX preserves partial streamed currency and shell pairs", () => {
+			const markdown = new Markdown("", 0, 0, defaultMarkdownTheme);
+			const bracedShellPair = "use $HOME/$" + "{USER}";
+			const frames = [
+				["Budget: $5-$", "Budget: $5-$"],
+				["Budget: $5-$10", "Budget: $5-$10"],
+				["use $HOME/$", "use $HOME/$"],
+				["use $HOME/$USER", "use $HOME/$USER"],
+				[bracedShellPair, bracedShellPair],
+			] as const;
+
+			for (const [frame, expected] of frames) {
+				markdown.setText(frame);
+				const rendered = markdown
+					.render(80)
+					.map((line) => stripAnsi(line).trimEnd())
+					.join("\n");
+				assert.strictEqual(rendered, expected, frame);
+			}
+		});
+
 		it("LaTeX preserves malformed nested and over-budget blocks", () => {
 			const nested = "\\[\nouter\n\\[\nx\n\\]\n";
 			const falseCloser = `$$x$$not-close${"y".repeat(5000)}\n\nValid: $z^2$.`;
@@ -1590,6 +1611,26 @@ bar`,
 			assert.ok(rendered.includes("$a"), rendered);
 			assert.ok(rendered.includes("b$"), rendered);
 			assert.ok(rendered.includes("Padded explicit: x²."), rendered);
+		});
+
+		it("LaTeX preserves partial streamed inline code spans", () => {
+			const markdown = new Markdown("", 0, 0, defaultMarkdownTheme);
+			const frames = [
+				["Inline: `$x^2$", "Inline: `$x^2$"],
+				["Explicit: `\\(x^2\\)", "Explicit: `\\(x^2\\)"],
+				["Nested formatting: `code **bold** $x^2$", "Nested formatting: `code bold $x^2$"],
+				["Escaped backtick: \\` then $x^2$.", "Escaped backtick: ` then x²."],
+				["Inline: `$x^2$`", "Inline: $x^2$"],
+			] as const;
+
+			for (const [frame, expected] of frames) {
+				markdown.setText(frame);
+				const rendered = markdown
+					.render(80)
+					.map((line) => stripAnsi(line).trimEnd())
+					.join("\n");
+				assert.strictEqual(rendered, expected, frame);
+			}
 		});
 
 		it("LaTeX preserves separated malformed openers", () => {
@@ -1655,6 +1696,22 @@ bar`,
 
 			assert.ok(stripAnsi(rendered).includes("│ x²"), rendered);
 			assert.ok(!rendered.includes("\x1b[90m"), rendered);
+		});
+
+		it("LaTeX anchors leading combining marks to terminal width", async () => {
+			const formula = latexToUnicode("\\text{\u0301}");
+			assert.strictEqual(formula, "◌\u0301");
+
+			const markdown = new Markdown("$\\text{\u0301}$", 0, 0, defaultMarkdownTheme);
+			const rendered = stripAnsi(markdown.render(10)[0] ?? "").trimEnd();
+			assert.strictEqual(rendered, formula);
+
+			const terminal = new VirtualTerminal(10, 2);
+			terminal.write(formula);
+			await terminal.flush();
+			assert.strictEqual(terminal.getCursorPosition().x, visibleWidth(formula));
+			assert.strictEqual(getCellWidth(terminal, 0, 0), 1);
+			terminal.stop();
 		});
 
 		it("LaTeX renders CJK math through headless terminal cells", async () => {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1508,6 +1508,8 @@ bar`,
 					"The US$5$ bill remains payable.",
 					"Astral suffix: $x$𐐀",
 					"Astral prefix: 𐐀$x$",
+					"Braced shell: ${HOME}/${USER}",
+					"Combining suffix: Cafe\u0301$x$",
 					"Valid math: $x^2$.",
 				].join("\n"),
 				0,
@@ -1525,6 +1527,8 @@ bar`,
 			assert.ok(rendered.includes("The US$5$ bill remains payable."), rendered);
 			assert.ok(rendered.includes("Astral suffix: $x$𐐀"), rendered);
 			assert.ok(rendered.includes("Astral prefix: 𐐀$x$"), rendered);
+			assert.ok(rendered.includes("Braced shell: ${HOME}/${USER}"), rendered);
+			assert.ok(rendered.includes("Combining suffix: Cafe\u0301$x$"), rendered);
 			assert.ok(rendered.includes("Valid math: x²."), rendered);
 		});
 
@@ -1555,6 +1559,7 @@ bar`,
 					"Mixed nested \\(outer \\[inner\\] remains literal",
 					"Escaped identifier punctuation: array\\[0\\] and call\\(arg\\)",
 					"Escaped newline: $a\\\nb$",
+					"Padded explicit: \\( x^2 \\).",
 				].join("\n"),
 				0,
 				0,
@@ -1573,6 +1578,7 @@ bar`,
 			assert.ok(rendered.includes("Escaped identifier punctuation: array[0] and call(arg)"), rendered);
 			assert.ok(rendered.includes("$a"), rendered);
 			assert.ok(rendered.includes("b$"), rendered);
+			assert.ok(rendered.includes("Padded explicit: x²."), rendered);
 		});
 
 		it("LaTeX preserves separated malformed openers", () => {
@@ -1612,6 +1618,8 @@ bar`,
 			assert.strictEqual(latexToUnicode("A^\\mathrm{T}"), "A^T");
 			assert.strictEqual(latexToUnicode("a+{b}"), "a+b");
 			assert.strictEqual(latexToUnicode("\\foo{bar}"), "\\foo{bar}");
+			assert.strictEqual(latexToUnicode("\\foo {bar}"), "\\foo{bar}");
+			assert.strictEqual(latexToUnicode("\\left. f(x) \\right|_0^1"), " f(x) |₀¹");
 		});
 
 		it("LaTeX falls back literally beyond conversion budgets", () => {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1509,6 +1509,8 @@ bar`,
 					"Astral suffix: $x$𐐀",
 					"Astral prefix: 𐐀$x$",
 					"Braced shell: $" + "{HOME}/$" + "{USER}",
+					"Subshells: $(pwd)/$(whoami)",
+					"Special parameters: $?/$!",
 					"Combining suffix: Cafe\u0301$x$",
 					"Valid math: $x^2$.",
 				].join("\n"),
@@ -1528,6 +1530,8 @@ bar`,
 			assert.ok(rendered.includes("Astral suffix: $x$𐐀"), rendered);
 			assert.ok(rendered.includes("Astral prefix: 𐐀$x$"), rendered);
 			assert.ok(rendered.includes("Braced shell: $" + "{HOME}/$" + "{USER}"), rendered);
+			assert.ok(rendered.includes("Subshells: $(pwd)/$(whoami)"), rendered);
+			assert.ok(rendered.includes("Special parameters: $?/$!"), rendered);
 			assert.ok(rendered.includes("Combining suffix: Cafe\u0301$x$"), rendered);
 			assert.ok(rendered.includes("Valid math: x²."), rendered);
 		});
@@ -1535,8 +1539,14 @@ bar`,
 		it("LaTeX preserves malformed nested and over-budget blocks", () => {
 			const nested = "\\[\nouter\n\\[\nx\n\\]\n";
 			const falseCloser = `$$x$$not-close${"y".repeat(5000)}\n\nValid: $z^2$.`;
+			const prematureCloser = "$$x$$ trailing\nparagraph\n$$";
 			const overBudget = `$$${"x".repeat(4097)}$$`;
-			const markdown = new Markdown(`${nested}\n${falseCloser}\n\n${overBudget}`, 0, 0, defaultMarkdownTheme);
+			const markdown = new Markdown(
+				`${nested}\n${falseCloser}\n\n${prematureCloser}\n\n${overBudget}`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
 			const rendered = markdown
 				.render(6000)
 				.map((line) => stripAnsi(line).trimEnd())
@@ -1546,6 +1556,7 @@ bar`,
 			assert.strictEqual(rendered.match(/\\\]/g)?.length, 1, rendered.slice(0, 200));
 			assert.ok(rendered.includes("$$x$$not-close"), rendered.slice(0, 200));
 			assert.ok(rendered.includes("Valid: z²."), rendered.slice(-100));
+			assert.ok(rendered.includes(prematureCloser), rendered);
 			assert.ok(rendered.includes(overBudget), rendered.slice(-4200));
 		});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1397,6 +1397,63 @@ bar`,
 		});
 	});
 
+	describe("LaTeX math", () => {
+		it("LaTeX renders inline and display math", () => {
+			const markdown = new Markdown("Energy is $E=mc^2$.\n\n$$\\int_0^1 x^2 dx$$", 0, 0, defaultMarkdownTheme);
+
+			const plain = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+			const rendered = plain.join("\n");
+
+			assert.ok(rendered.includes("Energy is E=mc²."), rendered);
+			assert.ok(rendered.includes("∫₀¹ x² dx"), rendered);
+			assert.ok(!rendered.includes("$"), rendered);
+			assert.ok(!rendered.includes("\\int"), rendered);
+		});
+
+		it("LaTeX preserves malformed and code literals", () => {
+			const markdown = new Markdown(
+				[
+					"Outside \\(x^2\\).",
+					"",
+					"Unmatched $x and \\[y",
+					"",
+					"Inline code: `$x^2$` and `\\(y^2\\)`.",
+					"",
+					"```tex",
+					"$$x^2$$",
+					"\\[y^2\\]",
+					"```",
+				].join("\n"),
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown
+				.render(80)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+
+			assert.ok(rendered.includes("Outside x²."), rendered);
+			assert.ok(rendered.includes("Unmatched $x and \\[y"), rendered);
+			assert.ok(rendered.includes("`$x^2$`") || rendered.includes("$x^2$"), rendered);
+			assert.ok(rendered.includes("\\(y^2\\)"), rendered);
+			assert.ok(rendered.includes("$$x^2$$"), rendered);
+			assert.ok(rendered.includes("\\[y^2\\]"), rendered);
+		});
+
+		it("LaTeX preserves unknown command grouping", () => {
+			const markdown = new Markdown("Fallback: $\\foo{bar} + \\alpha$.", 0, 0, defaultMarkdownTheme);
+			const rendered = markdown
+				.render(80)
+				.map((line) => stripAnsi(line).trimEnd())
+				.join("\n");
+
+			assert.ok(rendered.includes("Fallback: \\foo{bar} + α."), rendered);
+			assert.ok(!rendered.includes("$"), rendered);
+		});
+	});
+
 	describe("Streaming code fences", () => {
 		it("stabilizes partial closing fence rendering", () => {
 			const cases = [

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1547,7 +1547,11 @@ bar`,
 
 		it("LaTeX delimiters do not cross inline code spans", () => {
 			const markdown = new Markdown(
-				["Before \\[unfinished before `\\]` after", "Before \\(unfinished before `\\)` after"].join("\n"),
+				[
+					"Before \\[unfinished before `\\]` after",
+					"Before \\(unfinished before `\\)` after",
+					"Nested \\(outer \\(inner\\) remains literal",
+				].join("\n"),
 				0,
 				0,
 				defaultMarkdownTheme,
@@ -1559,6 +1563,7 @@ bar`,
 
 			assert.ok(rendered.includes("Before \\[unfinished before \\] after"), rendered);
 			assert.ok(rendered.includes("Before \\(unfinished before \\) after"), rendered);
+			assert.ok(rendered.includes("Nested \\(outer \\(inner\\) remains literal"), rendered);
 		});
 
 		it("LaTeX converts nested structures and preserves command distinctions", () => {
@@ -1567,6 +1572,15 @@ bar`,
 			assert.strictEqual(latexToUnicode("\\epsilon \\varepsilon \\phi \\varphi"), "ϵ ε ϕ φ");
 			assert.strictEqual(latexToUnicode("\\text{file\\_1 and x\\^2}"), "file_1 and x^2");
 			assert.strictEqual(latexToUnicode("\\quadruple"), "\\quadruple");
+		});
+
+		it("LaTeX handles TeX delimiter whitespace and grouping", () => {
+			assert.strictEqual(latexToUnicode("\\left\\{x\\right\\}"), "{x}");
+			assert.strictEqual(latexToUnicode("\\frac {a}{b}"), "(a)⁄(b)");
+			assert.strictEqual(latexToUnicode("\\sqrt {x}"), "√(x)");
+			assert.strictEqual(latexToUnicode("\\text {한}"), "한");
+			assert.strictEqual(latexToUnicode("a+{b}"), "a+b");
+			assert.strictEqual(latexToUnicode("\\foo{bar}"), "\\foo{bar}");
 		});
 
 		it("LaTeX falls back literally beyond conversion budgets", () => {


### PR DESCRIPTION
## Summary

- recognize `$...$`, `$$...$$`, `\(...\)`, and `\[...\]` in the shared TUI Markdown parser
- render common LaTeX operators, Greek letters, relations, roots/fractions, and sub/superscripts as width-stable Unicode
- preserve unmatched delimiters, inline/fenced code, and unknown command grouping without adding runtime dependencies

## Design references

- [pss-runtime PR #280](https://github.com/minpeter/pss-runtime/pull/280): display-math image renderer and delimiter/code-boundary handling
- [pi-markdown-preview](https://github.com/omaclaren/pi-markdown-preview): Pi extension using Pandoc/MathML/MathJax/Chromium image previews
- [OpenAI Codex Markdown renderer](https://github.com/openai/codex/blob/main/codex-rs/tui/src/markdown.rs): current terminal Markdown baseline (no native math path)

Senpi uses a dependency-free text path instead of TeX/Pandoc/Chromium at runtime so streamed conversation rendering stays fast, portable, and width-aware.

## Verification

- RED→GREEN: inline/display math rendering
- RED→GREEN: malformed delimiters and code literals
- RED→GREEN: unknown-command brace preservation
- `cd packages/tui && npm test`
- changed-source LSP diagnostics clean; `tsgo --noEmit`, pinned-dependency, lock, browser-smoke, and web-ui checks pass
- real OS PTY → xterm.js 5.5.0 → Chrome 150 capture: readable Unicode math, max width 42/100, no overflow or border drift, cleanup verified
- independent functional visual QA: PASS
- independent Unicode fidelity visual QA: PASS
- HEAVY code review: APPROVED

Local QA receipts are stored under the required ignored path `local-ignore/qa-evidence/20260729-senpi-latex/`. A final exact `npm run check` rerun was blocked before repository checks by another concurrent ignored worktree's nested Biome root/import fixture; the wrapper passed earlier, and every affected/stage-equivalent check passed after the final delta.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render LaTeX in TUI Markdown as width‑stable Unicode with no runtime deps. Preserves TeX spacing and delimiter semantics with strict tokenization; CJK math renders correctly.

- **New Features**
  - Adds conservative `marked` tokenizer extensions for `$...$`, `$$...$$`, `\(...\)`, and `\[...\]`.
  - Converts common symbols, fractions/roots, and sub/superscripts to Unicode; unknown commands and code stay literal.
  - Includes tests for inline/display math, grouping preservation, style inheritance, CJK width, shell‑dollar cases, and streamed partial code/currency frames.

- **Bug Fixes**
  - Hardens boundaries: `$...$` only with non‑word outer chars (Unicode/astral); doesn’t cross inline code; inline `$$` stays literal; block closers must end the line.
  - Quarantines malformed spans and repeated/competing/mixed `\(`/`\[` openers as literals; unmatched/over‑long/deep formulas fall back to literals.
  - Preserves TeX spacing and `\left...\right` (incl. `\left.\right|`); accepts whitespace around args.
  - Preserves CJK terminal cell widths and shell `$` literals (currency, env vars, `${...}`, `$()`, `$?`, `$!`); aligns width checks with CI; keeps streamed partial inline‑code and currency/shell pairs literal until completion.

<sup>Written for commit 639415ebf855090322ff9aa7a4b961c865191ebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

