### PR TITLE
fix: bound provider stream start so dead upstreams fail fast instead of freezing sessions

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -163,6 +163,16 @@ class StreamIdleTimeoutError extends Error {
 	}
 }
 
+// The wording must keep matching the retryable-error classifier
+// ("timed out" in packages/ai/src/utils/retry.ts) so a dead stream start is
+// retried instead of dead-ending the session.
+class StreamStartTimeoutError extends Error {
+	constructor(timeoutMs: number) {
+		super(`Provider stream start timed out after ${timeoutMs}ms`);
+		this.name = "StreamStartTimeoutError";
+	}
+}
+
 /**
  * Main loop logic shared by agentLoop and agentLoopContinue.
  */
@@ -434,6 +444,7 @@ async function streamAssistantResponse(
 			config.timeoutMs,
 			requestAbortController.signal,
 			(error) => requestAbortController.abort(error),
+			config.streamStartTimeoutMs,
 		);
 		try {
 			while (true) {
@@ -544,14 +555,20 @@ type AssistantEventReader = {
 	dispose(): void;
 };
 
+function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+	return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined;
+}
+
 function createAssistantEventReader(
 	iterator: AsyncIterator<AssistantMessageEvent>,
 	timeoutMs: number | undefined,
 	signal: AbortSignal | undefined,
-	onIdleTimeout?: (error: StreamIdleTimeoutError) => void,
+	onIdleTimeout?: (error: Error) => void,
+	streamStartTimeoutMs?: number,
 ): AssistantEventReader {
-	const idleTimeoutMs =
-		typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined;
+	const idleTimeoutMs = normalizeTimeoutMs(timeoutMs);
+	const startTimeoutMs = normalizeTimeoutMs(streamStartTimeoutMs);
+	let sawFirstEvent = false;
 	let removeAbortListener: (() => void) | undefined;
 	let abortPromise: Promise<typeof ABORTED> | undefined;
 
@@ -568,12 +585,27 @@ function createAssistantEventReader(
 	}
 
 	return {
-		next: () => {
+		next: async () => {
 			if (signal?.aborted) {
 				void iterator.return?.();
 				return Promise.reject(new Error("Request was aborted"));
 			}
-			return readNextAssistantEvent(iterator, idleTimeoutMs, abortPromise, onIdleTimeout);
+			// The start bound applies only until the provider proves the request is
+			// alive with its first event; afterwards the idle bound governs as before.
+			const useStartBound = !sawFirstEvent && startTimeoutMs !== undefined;
+			const readTimeoutMs = useStartBound ? startTimeoutMs : idleTimeoutMs;
+			const makeTimeoutError = useStartBound
+				? (ms: number) => new StreamStartTimeoutError(ms)
+				: (ms: number) => new StreamIdleTimeoutError(ms);
+			const result = await readNextAssistantEvent(
+				iterator,
+				readTimeoutMs,
+				makeTimeoutError,
+				abortPromise,
+				onIdleTimeout,
+			);
+			if (!result.done) sawFirstEvent = true;
+			return result;
 		},
 		dispose: () => removeAbortListener?.(),
 	};
@@ -582,8 +614,9 @@ function createAssistantEventReader(
 async function readNextAssistantEvent(
 	iterator: AsyncIterator<AssistantMessageEvent>,
 	idleTimeoutMs: number | undefined,
+	makeTimeoutError: (timeoutMs: number) => Error,
 	abortPromise: Promise<typeof ABORTED> | undefined,
-	onIdleTimeout?: (error: StreamIdleTimeoutError) => void,
+	onIdleTimeout?: (error: Error) => void,
 ): Promise<IteratorResult<AssistantMessageEvent>> {
 	if (idleTimeoutMs === undefined && abortPromise === undefined) {
 		return iterator.next();
@@ -604,7 +637,7 @@ async function readNextAssistantEvent(
 
 		if (idleTimeoutMs !== undefined) {
 			timeout = setTimeout(() => {
-				const error = new StreamIdleTimeoutError(idleTimeoutMs);
+				const error = makeTimeoutError(idleTimeoutMs);
 				void iterator.return?.();
 				settle(() => reject(error));
 				// Abort after settling so the failure surfaces as an idle timeout,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -117,6 +117,7 @@ export interface AgentOptions {
 	thinkingBudgets?: ThinkingBudgets;
 	transport?: Transport;
 	timeoutMs?: number;
+	streamStartTimeoutMs?: number;
 	maxRetryDelayMs?: number;
 	toolExecution?: ToolExecutionMode;
 	removedToolHints?: Record<string, string>;
@@ -217,6 +218,8 @@ export class Agent {
 	/** Preferred transport forwarded to the stream function. */
 	public transport: Transport;
 	public timeoutMs?: number;
+	/** Optional bound on the wait for the first provider stream event. */
+	public streamStartTimeoutMs?: number;
 	/** Optional cap for provider-requested retry delays. */
 	public maxRetryDelayMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
@@ -246,6 +249,7 @@ export class Agent {
 		this.thinkingBudgets = runtimeOptions.thinkingBudgets;
 		this.transport = runtimeOptions.transport ?? "auto";
 		this.timeoutMs = runtimeOptions.timeoutMs;
+		this.streamStartTimeoutMs = runtimeOptions.streamStartTimeoutMs;
 		this.maxRetryDelayMs = runtimeOptions.maxRetryDelayMs;
 		this.toolExecution = runtimeOptions.toolExecution ?? "parallel";
 		this.removedToolHints = runtimeOptions.removedToolHints ?? {};
@@ -502,6 +506,7 @@ export class Agent {
 			transport: this.transport,
 			thinkingBudgets: this.thinkingBudgets,
 			timeoutMs: this.timeoutMs,
+			streamStartTimeoutMs: this.streamStartTimeoutMs,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			abortServerSideFallback: this.abortServerSideFallback,
 			toolExecution: this.toolExecution,

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,29 @@
 # Changes
 
+## 2026-07-29 - Bounded provider stream start (streamStartTimeoutMs)
+
+### What changed and why
+
+- `agent-loop.ts` bounds the wait for the FIRST provider stream event with a new optional
+  `AgentLoopConfig.streamStartTimeoutMs`. Providers emit their first event only once the HTTP
+  response begins, so a dead upstream that accepts a request and never answers was previously
+  bounded only by `timeoutMs` (the idle timeout, default 5 minutes): every attempt froze the
+  session for 300s with zero events, zero usage, and nothing persisted. Observed in a donated
+  5h session log where the same session hung deterministically on reopen while new sessions
+  worked. After the first event arrives the idle bound governs as before.
+- The failure message `Provider stream start timed out after <ms>ms` deliberately contains
+  "timed out" so the existing retryable-error classifier (`isRetryableErrorMessage`) retries
+  it instead of dead-ending the session; the request-local abort controller tears the dead
+  request down exactly like an idle timeout.
+- `agent.ts` plumbs `streamStartTimeoutMs` through `AgentOptions`/`Agent` into the loop config.
+
+### Files modified
+
+- `agent-loop.ts`
+- `agent.ts`
+- `types.ts`
+- `../test/agent-loop-stream-start-timeout.test.ts`
+
 ## 2026-07-27 - End classifier-refused turns before tool execution
 
 ### What changed and why

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -147,6 +147,16 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
 
 	/**
+	 * Maximum time in milliseconds to wait for the FIRST provider stream event.
+	 * Providers emit their first event only once the HTTP response begins, so a
+	 * dead upstream that accepts the request but never answers is otherwise only
+	 * bounded by `timeoutMs` (the idle timeout, default 5 minutes). After the
+	 * first event arrives, `timeoutMs` governs inter-event idleness as before.
+	 * Unset or non-positive values disable the start bound.
+	 */
+	streamStartTimeoutMs?: number;
+
+	/**
 	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.
 	 *
 	 * Each AgentMessage must be converted to a UserMessage, AssistantMessage, or ToolResultMessage

--- a/packages/agent/test/agent-loop-stream-start-timeout.test.ts
+++ b/packages/agent/test/agent-loop-stream-start-timeout.test.ts
@@ -1,0 +1,244 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.ts";
+
+/**
+ * Regression coverage for the stream-start bound.
+ *
+ * A dead upstream can accept a request and never send a first byte. Providers
+ * only push the "start" event once the HTTP response begins, so before this
+ * bound existed the only protection was the idle timeout (default 300s) — a
+ * stuck session froze for 5 minutes per attempt with zero persisted output.
+ * (Reported via a donated 5h session log: 4 failures, all usage=0.)
+ */
+
+class AssistantEventStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+class NeverStartingStream extends AssistantEventStream {
+	override async *[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
+		await new Promise<never>(() => {});
+	}
+}
+
+class StartThenHangStream extends AssistantEventStream {
+	override async *[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
+		yield { type: "start", partial: createAssistantMessage([{ type: "text", text: "partial answer" }]) };
+		await new Promise<never>(() => {});
+	}
+}
+
+class SlowButAliveStream extends AssistantEventStream {
+	private readonly gapMs: number;
+
+	constructor(gapMs: number) {
+		super();
+		this.gapMs = gapMs;
+	}
+
+	override async *[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
+		const partial = createAssistantMessage([{ type: "text", text: "answer" }]);
+		yield { type: "start", partial };
+		await new Promise((resolve) => setTimeout(resolve, this.gapMs));
+		yield { type: "text_delta", contentIndex: 0, delta: "answer", partial };
+		await new Promise((resolve) => setTimeout(resolve, this.gapMs));
+		yield { type: "done", reason: "stop", message: partial };
+	}
+
+	override result(): Promise<AssistantMessage> {
+		return Promise.resolve(createAssistantMessage([{ type: "text", text: "answer" }]));
+	}
+}
+
+async function collectAgentEvents(
+	stream: AsyncIterable<AgentEvent> & { result(): Promise<AgentMessage[]> },
+	timeoutMs = 500,
+): Promise<{ events: AgentEvent[]; messages: AgentMessage[] }> {
+	const events: AgentEvent[] = [];
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			(async () => {
+				for await (const event of stream) {
+					events.push(event);
+				}
+				return { events, messages: await stream.result() };
+			})(),
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(() => reject(new Error("agentLoop stream did not terminate")), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+	}
+}
+
+function createUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: createUsage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function createUserMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() };
+}
+
+const identityConverter = (messages: AgentMessage[]): Message[] => messages as unknown as Message[];
+
+function createContext(): AgentContext {
+	return { systemPrompt: "You are helpful.", messages: [], tools: [] };
+}
+
+function findAssistant(messages: AgentMessage[]): AssistantMessage | undefined {
+	return messages.find((message): message is AssistantMessage => message.role === "assistant");
+}
+
+describe("agent loop stream-start timeout", () => {
+	it("fails fast when the provider stream never emits a first event", async () => {
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamStartTimeoutMs: 20,
+			timeoutMs: 10_000,
+		};
+
+		let requestSignal: AbortSignal | undefined;
+		const stream = agentLoop([createUserMessage("Hello")], createContext(), config, undefined, (_m, _c, options) => {
+			requestSignal = options?.signal;
+			return new NeverStartingStream();
+		});
+
+		const { messages } = await collectAgentEvents(stream);
+		const assistantMessage = findAssistant(messages);
+		expect(assistantMessage?.stopReason).toBe("error");
+		expect(assistantMessage?.errorMessage).toBe("Provider stream start timed out after 20ms");
+		expect(requestSignal?.aborted).toBe(true);
+		expect(String(requestSignal?.reason)).toContain("Provider stream start timed out after 20ms");
+	});
+
+	it("stops applying the start bound once the first event arrived", async () => {
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamStartTimeoutMs: 20,
+			timeoutMs: 60,
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], createContext(), config, undefined, () => {
+			return new StartThenHangStream();
+		});
+
+		const { messages } = await collectAgentEvents(stream);
+		const assistantMessage = findAssistant(messages);
+		expect(assistantMessage?.stopReason).toBe("error");
+		expect(assistantMessage?.errorMessage).toBe("Idle timeout waiting for provider stream after 60ms");
+	});
+
+	it("lets slow-but-alive streams finish despite gaps above the start bound", async () => {
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamStartTimeoutMs: 20,
+			timeoutMs: 200,
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], createContext(), config, undefined, () => {
+			return new SlowButAliveStream(40);
+		});
+
+		const { messages } = await collectAgentEvents(stream);
+		const assistantMessage = findAssistant(messages);
+		expect(assistantMessage?.stopReason).toBe("stop");
+		expect(assistantMessage?.errorMessage).toBeUndefined();
+	});
+
+	it("keeps today's idle-only behavior when streamStartTimeoutMs is unset", async () => {
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			timeoutMs: 20,
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], createContext(), config, undefined, () => {
+			return new NeverStartingStream();
+		});
+
+		const { messages } = await collectAgentEvents(stream);
+		const assistantMessage = findAssistant(messages);
+		expect(assistantMessage?.stopReason).toBe("error");
+		expect(assistantMessage?.errorMessage).toBe("Idle timeout waiting for provider stream after 20ms");
+	});
+
+	it("ignores non-positive start bounds", async () => {
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamStartTimeoutMs: 0,
+			timeoutMs: 20,
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], createContext(), config, undefined, () => {
+			return new NeverStartingStream();
+		});
+
+		const { messages } = await collectAgentEvents(stream);
+		const assistantMessage = findAssistant(messages);
+		expect(assistantMessage?.stopReason).toBe("error");
+		expect(assistantMessage?.errorMessage).toBe("Idle timeout waiting for provider stream after 20ms");
+	});
+});

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -40,6 +40,33 @@ describe("provider retry classification", () => {
 		).toBe(true);
 	});
 
+	it("classifies agent-loop stream timeout errors as retryable", () => {
+		// Wordings produced by packages/agent/src/agent-loop.ts; the "timed out"
+		// coupling is what lets a dead stream start retry instead of dead-ending
+		// the session.
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "Provider stream start timed out after 90000ms",
+				}),
+			),
+		).toBe(true);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "Idle timeout waiting for provider stream after 300000ms",
+				}),
+			),
+		).toBe(true);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "Provider stream never started" }),
+			),
+		).toBe(false);
+	});
+
 	it("classifies the observed OpenAI server_error as retryable", () => {
 		expect(
 			isRetryableAssistantError(

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,31 @@
+## Stream-start timeout wiring and unregistered-api error context (2026-07-29)
+
+### What changed
+
+- `core/settings-manager.ts`: new `retry.provider.streamStartTimeoutMs` setting and
+  `getAgentStreamStartTimeoutMs()` (default 90000ms; 0 disables; the default is clamped to a
+  shorter idle timeout and disabled together with a disabled idle guard). `core/sdk.ts` and the
+  interactive settings handler wire it into `Agent.streamStartTimeoutMs`.
+- `core/provider-composer.ts`: the stream-time `No API provider registered for api: <api>` error
+  now names the model (`provider/id`) and points at the models.json provider entry or the missing
+  provider extension.
+- Coverage: `test/settings-manager.test.ts` (retry describe), `test/provider-composer-unknown-api.test.ts`,
+  `packages/ai/test/retry.test.ts` (stream timeout wordings stay retryable).
+
+### Why
+
+- Incident (donated session log): a dead upstream accepted requests but never sent a first byte.
+  With only the 300s idle bound, each turn attempt froze the session for 5 minutes with `usage: 0`
+  and nothing persisted; retries repeated the same 300s wait, making the session practically
+  unrecoverable while new sessions worked. A 90s first-event bound with the retryable wording lets
+  the retry/fallback ladder engage quickly. Related incident error `No API provider registered for
+  api: kiro-api` carried no context about which model or config produced it.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: one settings getter + one field in `ProviderRetrySettings`; one error message in
+  `composeModelProvider`; one option in the `Agent` construction in `core/sdk.ts`.
+
 ## Absent fallback chains no longer produce a startup warning (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -512,7 +512,12 @@ export function composeModelProvider(
 					: base.stream(model, context, options);
 			}
 			const api = getApiProvider(model.api);
-			if (!api) throw new Error(`No API provider registered for api: ${model.api}`);
+			if (!api) {
+				throw new Error(
+					`No API provider registered for api: ${model.api} (model "${model.provider}/${model.id}"). ` +
+						`Load the extension that implements this api, or fix the "api" value for provider "${providerId}" in models.json.`,
+				);
+			}
 			return simple
 				? api.streamSimple(model, context, options as SimpleStreamOptions)
 				: api.stream(model, context, options);

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -374,6 +374,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		transport: settingsManager.getTransport(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
 		timeoutMs: settingsManager.getAgentStreamIdleTimeoutMs(),
+		streamStartTimeoutMs: settingsManager.getAgentStreamStartTimeoutMs(),
 		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
 	});
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -10,6 +10,8 @@ import { findNearestParentConfigDir } from "../nearest-parent-config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 
+export const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
 	reserveTokens?: number; // default: 16384
@@ -31,6 +33,7 @@ export interface BranchSummarySettings {
 
 export interface ProviderRetrySettings {
 	timeoutMs?: number; // SDK request timeout + agent stream idle timeout; defaults to httpIdleTimeoutMs
+	streamStartTimeoutMs?: number; // max wait for the FIRST provider stream event; default: 90000, 0 disables
 	maxRetries?: number; // SDK/provider retry attempts
 	maxRetryDelayMs?: number; // default: 60000 (max server-requested delay honoured on the same model; beyond it the fallback chain engages)
 }
@@ -1120,6 +1123,27 @@ export class SettingsManager {
 		}
 		const httpIdleTimeoutMs = this.getHttpIdleTimeoutMs();
 		return httpIdleTimeoutMs === 0 ? undefined : httpIdleTimeoutMs;
+	}
+
+	/**
+	 * Bound on the time to the FIRST provider stream event. Providers only emit
+	 * their first event once the HTTP response begins, so a dead upstream that
+	 * accepts the request but never answers is otherwise bounded only by the
+	 * idle timeout (default 5 minutes) — long enough to make a session feel
+	 * permanently stuck. `retry.provider.streamStartTimeoutMs` overrides the
+	 * 90s default (0 disables). The default never exceeds the idle timeout and
+	 * is disabled together with a disabled idle guard.
+	 */
+	getAgentStreamStartTimeoutMs(): number | undefined {
+		const explicit = this.settings.retry?.provider?.streamStartTimeoutMs;
+		if (explicit !== undefined) {
+			return explicit > 0 ? explicit : undefined;
+		}
+		const idleTimeoutMs = this.getAgentStreamIdleTimeoutMs();
+		if (idleTimeoutMs === undefined) {
+			return undefined;
+		}
+		return Math.min(DEFAULT_STREAM_START_TIMEOUT_MS, idleTimeoutMs);
 	}
 
 	getWebSocketConnectTimeoutMs(): number | undefined {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5099,6 +5099,7 @@ export class InteractiveMode {
 						this.settingsManager.setHttpIdleTimeoutMs(timeoutMs);
 						configureHttpDispatcher(timeoutMs);
 						this.session.agent.timeoutMs = this.settingsManager.getAgentStreamIdleTimeoutMs();
+						this.session.agent.streamStartTimeoutMs = this.settingsManager.getAgentStreamStartTimeoutMs();
 						this.showStatus(`HTTP idle timeout: ${formatHttpIdleTimeoutMs(timeoutMs)}`);
 					},
 					onThinkingLevelChange: (level) => {

--- a/packages/coding-agent/test/provider-composer-unknown-api.test.ts
+++ b/packages/coding-agent/test/provider-composer-unknown-api.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ModelConfig } from "../src/core/model-config.ts";
+import { composeModelProvider } from "../src/core/provider-composer.ts";
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+	if (tempDir !== undefined) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+function createProviderWithUnregisteredApi() {
+	tempDir = mkdtempSync(join(tmpdir(), "senpi-composer-unknown-api-"));
+	const modelsPath = join(tempDir, "models.json");
+	writeFileSync(
+		modelsPath,
+		JSON.stringify({
+			providers: {
+				kiro: {
+					api: "kiro-api",
+					apiKey: "test-key",
+					baseUrl: "https://example.invalid/v1",
+					models: [{ id: "claude-x" }],
+				},
+			},
+		}),
+	);
+
+	const provider = composeModelProvider("kiro", undefined, ModelConfig.loadSync(modelsPath), undefined);
+	const model = provider.getModels()[0];
+	if (model === undefined) throw new Error("Expected the models.json custom model");
+	return { provider, model };
+}
+
+describe("composed provider with an unregistered api", () => {
+	// Incident: a session model resolved to api "kiro-api" with no registered
+	// implementation; the bare "No API provider registered for api: kiro-api"
+	// error gave the user nothing to act on.
+	it("names the model and the fix in the stream error", async () => {
+		const { provider, model } = createProviderWithUnregisteredApi();
+
+		const stream = provider.stream(model, {
+			messages: [{ role: "user", content: "hello", timestamp: 0 }],
+		});
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("No API provider registered for api: kiro-api");
+		expect(result.errorMessage).toContain('model "kiro/claude-x"');
+		expect(result.errorMessage).toContain("models.json");
+	});
+});

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -311,6 +311,63 @@ describe("SettingsManager", () => {
 
 			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBe(5_000);
 		});
+
+		it("should default the agent stream start timeout to 90s", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBe(90_000);
+		});
+
+		it("should prefer retry.provider.streamStartTimeoutMs for the agent stream start timeout", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ retry: { provider: { streamStartTimeoutMs: 30_000 } } }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBe(30_000);
+		});
+
+		it("should disable the agent stream start timeout when streamStartTimeoutMs is 0", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ retry: { provider: { streamStartTimeoutMs: 0 } } }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBeUndefined();
+		});
+
+		it("should disable the default agent stream start timeout when the idle guard is disabled", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ httpIdleTimeoutMs: 0 }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBeUndefined();
+		});
+
+		it("should clamp the default agent stream start timeout to a shorter idle timeout", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ httpIdleTimeoutMs: 60_000 }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBe(60_000);
+		});
+
+		it("should keep an explicit agent stream start timeout even above the idle timeout", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(
+				givenSettingsPath,
+				JSON.stringify({ httpIdleTimeoutMs: 60_000, retry: { provider: { streamStartTimeoutMs: 120_000 } } }),
+			);
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBe(120_000);
+		});
 	});
 
 	describe("project trust", () => {


### PR DESCRIPTION
## Problem

A long-running session became permanently stuck (reported by @sigridjineth with a donated session log): the provider upstream accepted requests but never sent a first byte. Providers push their first stream event only once the HTTP response begins, so the only bound on time-to-first-event was the idle timeout (default **300s**). Each attempt:

- froze the session for 5 minutes with `usage: 0` (request never reached the model),
- persisted **nothing** (`message_start` is only emitted after the provider `start` event), so the log shows gaps instead of failures,
- and a retry or `continue` repeated the same silent 300s wait — practically unrecoverable, while new sessions (fresh upstream path) worked fine.

Log evidence (from the donated JSONL, sha256 `6dbf9125…`): failures at lines 1839/1907 (`Request timed out.`, usage=0), 1920 (`Idle timeout waiting for provider stream after 300000ms`, exactly start+300s), and a user turn at 01:25 that left no assistant record at all.

A related incident error, `No API provider registered for api: kiro-api`, carried no context about which model/config produced it.

## Fix

1. **packages/agent** — `AgentLoopConfig.streamStartTimeoutMs`: a separate bound on the FIRST provider stream event. After the first event, the idle bound governs as before. The error wording `Provider stream start timed out after <ms>ms` intentionally matches the retryable-error classifier so retry/model-fallback engage instead of dead-ending the session; the dead request is torn down via the same request-local abort as idle timeouts.
2. **packages/coding-agent** — `retry.provider.streamStartTimeoutMs` setting; default **90s**, `0` disables, the default never exceeds the idle timeout and is disabled together with a disabled idle guard. Wired through `Agent` construction and the interactive settings handler.
3. **provider-composer** — the unregistered-api stream error now names the model (`provider/id`) and points at the models.json provider entry / missing provider extension.

## Verification

- New unit tests (written failing first): `packages/agent/test/agent-loop-stream-start-timeout.test.ts` (never-starting stream fails fast; start bound stops applying after the first event; slow-but-alive streams finish; unset/0 keeps today's behavior), settings-manager retry cases, `provider-composer-unknown-api.test.ts`, retryability wordings in `packages/ai/test/retry.test.ts`.
- Full `packages/agent` suite green (296 passed), `npm run check` green.
- Real-CLI QA (senpi-qa harness, isolated sandbox): CLI from source against a local HTTP server that accepts and never responds — turn failed in **12.5s** with `Provider stream start timed out after 5000ms` instead of freezing 300s; real auth untouched. Evidence: `local-ignore/qa-evidence/20260729-stream-start-timeout/qa-result.txt`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the wait for the first provider stream event so dead upstreams fail fast instead of freezing sessions for 5 minutes. Adds `streamStartTimeoutMs` (90s default in `coding-agent`) and improves the unregistered-API stream error with model context.

- **Bug Fixes**
  - Separate start-bound: fail with "Provider stream start timed out after <ms>ms" until the first event; then the idle timeout applies. This wording stays retryable so fallback engages instead of dead-ending sessions.
  - Provider-composer error now includes the model (`provider/id`) and guidance when no API implementation is registered.

- **New Features**
  - `agent`: supports `streamStartTimeoutMs` on `AgentOptions`; applies only before the first provider event.
  - `coding-agent`: new setting `retry.provider.streamStartTimeoutMs` (default 90s; 0 disables). Default is clamped to the idle timeout and wired through session creation and interactive settings.

<sup>Written for commit 3a67789e2fffa1d80bc6441397a97c07144c881b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

