### PR TITLE
feat(coding-agent): add ethos tip catalog for the forks voice

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -6,8 +6,9 @@
 
 - `tips/catalog/ethos-tips.ts` (new): a `ETHOS_TIPS` catalog of seven manifesto tips framing how `@code-yeongyu/senpi` is tuned - system-prompt discipline for `gpt-5.6-sol`, tools that stay out of the way, spending tokens to buy time, and pointers to `ulw-plan` on `fable-5 xhigh` and the `ulw loop`.
 - `tips/registry.ts`: `TIP_DEFINITIONS` now concatenates `...ETHOS_TIPS` after `SUBAGENT_TIPS`.
-- The two command-referencing tips (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`) declare `requiresCommand: "tasks"`, so they only surface when the omo plugin's `tasks` command is registered - matching the `workflow-skills.*` tips in `subagent-tips.ts`. The five pure manifesto tips are keyless and ungated.
-- Coverage: `test/suite/ethos-tips.test.ts` pins the seven ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
+- The two command-referencing tips (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`) declare `requiresCommand: "tasks"`, so they only surface when the omo plugin's `tasks` command is registered - matching the `workflow-skills.*` tips in `subagent-tips.ts`. The eight pure manifesto tips (including the monitor/cache bragging tips) are keyless and ungated.
+- Three additional tips brag about the harness's monitor tool (subscribe to stdout, never sleep), the prompt-cache budget (never block past cache TTL), and the live cache-hit rate in the footer. All three are keyless and ungated.
+- Coverage: `test/suite/ethos-tips.test.ts` pins the ten ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -9,7 +9,8 @@
 - The two command-referencing tips (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`) declare `requiresCommand: "tasks"`, so they only surface when the omo plugin's `tasks` command is registered - matching the `workflow-skills.*` tips in `subagent-tips.ts`. The eight pure manifesto tips (including the monitor/cache bragging tips) are keyless and ungated.
 - Three additional tips brag about the harness's monitor tool (subscribe to stdout, never sleep), the prompt-cache budget (never block past cache TTL), and the live cache-hit rate in the footer. All three are keyless and ungated.
 - Three more tips brag about multimodal vision (the agent sees screenshots, PDFs, diagrams), Claude Code OAuth multi-account (switch logins, not env vars), and the agent-SDK foundation (no ToS gray zone, no ban anxiety). All three are keyless and ungated.
-- Coverage: `test/suite/ethos-tips.test.ts` pins the thirteen ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
+- One tip brags about the tool-call repair middleware (malformed antml:invoke calls are intercepted, corrected, and salvaged instead of failing the turn). Keyless and ungated.
+- Coverage: `test/suite/ethos-tips.test.ts` pins the fourteen ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -8,7 +8,8 @@
 - `tips/registry.ts`: `TIP_DEFINITIONS` now concatenates `...ETHOS_TIPS` after `SUBAGENT_TIPS`.
 - The two command-referencing tips (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`) declare `requiresCommand: "tasks"`, so they only surface when the omo plugin's `tasks` command is registered - matching the `workflow-skills.*` tips in `subagent-tips.ts`. The eight pure manifesto tips (including the monitor/cache bragging tips) are keyless and ungated.
 - Three additional tips brag about the harness's monitor tool (subscribe to stdout, never sleep), the prompt-cache budget (never block past cache TTL), and the live cache-hit rate in the footer. All three are keyless and ungated.
-- Coverage: `test/suite/ethos-tips.test.ts` pins the ten ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
+- Three more tips brag about multimodal vision (the agent sees screenshots, PDFs, diagrams), Claude Code OAuth multi-account (switch logins, not env vars), and the agent-SDK foundation (no ToS gray zone, no ban anxiety). All three are keyless and ungated.
+- Coverage: `test/suite/ethos-tips.test.ts` pins the thirteen ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Ethos tips: the fork's voice in the tip rotation (2026-07-29)
+
+### What changed
+
+- `tips/catalog/ethos-tips.ts` (new): a `ETHOS_TIPS` catalog of seven manifesto tips framing how `@code-yeongyu/senpi` is tuned - system-prompt discipline for `gpt-5.6-sol`, tools that stay out of the way, spending tokens to buy time, and pointers to `ulw-plan` on `fable-5 xhigh` and the `ulw loop`.
+- `tips/registry.ts`: `TIP_DEFINITIONS` now concatenates `...ETHOS_TIPS` after `SUBAGENT_TIPS`.
+- The two command-referencing tips (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`) declare `requiresCommand: "tasks"`, so they only surface when the omo plugin's `tasks` command is registered - matching the `workflow-skills.*` tips in `subagent-tips.ts`. The five pure manifesto tips are keyless and ungated.
+- Coverage: `test/suite/ethos-tips.test.ts` pins the seven ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.
+
+### Why
+
+- The tip line taught mechanics and commands but had no voice for the fork's tuning philosophy. These tips surface the system-prompt-tuning claim (a 5-minute job takes 5 minutes, a 12-hour job takes 12), the anti-tool-study stance, and the spend-tokens-for-time trade, which are the fork's reason for existing.
+- Gating the ulw command tips on `tasks` preserves the existing honesty invariant: never advertise commands the session cannot run.
+
+### Expected merge conflict zones
+
+- LOW: `tips/registry.ts` import block and the `TIP_DEFINITIONS` concatenation tail.
+
 ## Footer prepends (OmO Native) badge when the OMO native stack is active (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
@@ -44,4 +44,22 @@ export const ETHOS_TIPS = [
 		render: () =>
 			"For days when deep thought sounds awful, run the ulw loop with gpt-5.6-sol fast/medium. Fair warning: shallow thinking sends invoices.",
 	},
+	{
+		id: "ethos.monitor-subscribe",
+		bindings: [],
+		render: () =>
+			"Subscribe to a command's stdout and forget it. CI finishes, server boots, log line lands... you're mid-edit and the news finds *you*. No sleep loops, no polling, no re-reading context like a chump.",
+	},
+	{
+		id: "ethos.cache-budget",
+		bindings: [],
+		render: () =>
+			"My harness knows the prompt cache's expiry to the second and never blocks past it. Cold re-read tax? *Refused on your behalf.* Other agents eat that cost, mine declines it.",
+	},
+	{
+		id: "ethos.cache-hit-rate",
+		bindings: [],
+		render: () =>
+			"Live cache-hit rate in the footer, plus a running tab of misses, idle gaps, and model swaps. I can point at the exact moment cache broke and why. Watching tokens you never re-pay stack up? Smug doesn't cover it.",
+	},
 ] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
@@ -62,4 +62,22 @@ export const ETHOS_TIPS = [
 		render: () =>
 			"Live cache-hit rate in the footer, plus a running tab of misses, idle gaps, and model swaps. I can point at the exact moment cache broke and why. Watching tokens you never re-pay stack up? Smug doesn't cover it.",
 	},
+	{
+		id: "ethos.multimodal-vision",
+		bindings: [],
+		render: () =>
+			"Drop a screenshot, a PDF, a crusty whiteboard photo... senpi actually sees it, reads it, reasons about it. Your agent has eyes now. *Yes, really.*",
+	},
+	{
+		id: "ethos.oauth-multi-account",
+		bindings: [],
+		render: () =>
+			"Hit a rate limit, switch accounts. Wrong org, switch again. senpi treats your Claude logins like a roster, not a single lifeline. *Env vars could never.*",
+	},
+	{
+		id: "ethos.agent-sdk-foundation",
+		bindings: [],
+		render: () =>
+			'Built on the official agent SDK, speaking the protocol natively. No reverse-engineered wrapper, no ToS gray zone, no "will I get banned for this" anxiety. *Sleep easy, ship loud.*',
+	},
 ] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
@@ -1,0 +1,47 @@
+import type { TipDefinition } from "./types.ts";
+
+export const ETHOS_TIPS = [
+	{
+		id: "ethos.tuning-discipline",
+		bindings: [],
+		render: () =>
+			"gpt-5.6-sol used to turn a sprint into a marathon. We tuned the system prompt and killed that habit: 5-minute jobs take 5 minutes, 12-hour jobs take 12.",
+	},
+	{
+		id: "ethos.tools-transparent",
+		bindings: [],
+		render: () =>
+			"Don't study our tools. A tool that needs studying is a tool that failed. We just ride shotgun while you keep doing your actual job.",
+	},
+	{
+		id: "ethos.only-harness",
+		bindings: [],
+		render: () =>
+			"The only harness that actually knows how to drive gpt-5.6-sol. Same job, feels up to 30% faster. *we counted*",
+	},
+	{
+		id: "ethos.spend-tokens",
+		bindings: [],
+		render: () => "Stop hoarding tokens. Spend them like they buy your hours back, because they do.",
+	},
+	{
+		id: "ethos.deep-work",
+		bindings: [],
+		render: () =>
+			"Using our tools means your work is already the deep, valuable kind. Keep your eyes on the essence of your craft. The rest is our problem now, and we're great at problems.",
+	},
+	{
+		id: "ethos.ulw-plan-sage",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () =>
+			"Try ulw-plan on fable-5 xhigh. A patient sage obsessed with the essence does the agonizing for you and fills in every blank you were pretending not to see.",
+	},
+	{
+		id: "ethos.ulw-loop-shallow",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () =>
+			"For days when deep thought sounds awful, run the ulw loop with gpt-5.6-sol fast/medium. Fair warning: shallow thinking sends invoices.",
+	},
+] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
@@ -80,4 +80,10 @@ export const ETHOS_TIPS = [
 		render: () =>
 			'Built on the official agent SDK, speaking the protocol natively. No reverse-engineered wrapper, no ToS gray zone, no "will I get banned for this" anxiety. *Sleep easy, ship loud.*',
 	},
+	{
+		id: "ethos.tool-call-repair",
+		bindings: [],
+		render: () =>
+			"senpi catches malformed tool calls on the wire, fixes them, and salvages the turn. Other harnesses retry the whole thing and bill you for the privilege. *table stakes, honestly*",
+	},
 ] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/src/modes/interactive/tips/registry.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/registry.ts
@@ -1,4 +1,5 @@
 import { CLI_TIPS } from "./catalog/cli-tips.ts";
+import { ETHOS_TIPS } from "./catalog/ethos-tips.ts";
 import { INPUT_TIPS } from "./catalog/input-tips.ts";
 import { MODEL_TIPS } from "./catalog/model-tips.ts";
 import { SESSION_TIPS } from "./catalog/session-tips.ts";
@@ -17,4 +18,5 @@ export const TIP_DEFINITIONS: readonly TipDefinition[] = [
 	...SETTINGS_TIPS,
 	...CLI_TIPS,
 	...SUBAGENT_TIPS,
+	...ETHOS_TIPS,
 ];

--- a/packages/coding-agent/test/suite/ethos-tips.test.ts
+++ b/packages/coding-agent/test/suite/ethos-tips.test.ts
@@ -15,6 +15,7 @@ const ETHOS_IDS = [
 	"ethos.multimodal-vision",
 	"ethos.oauth-multi-account",
 	"ethos.agent-sdk-foundation",
+	"ethos.tool-call-repair",
 ] as const;
 
 const noopKeys = (): string => "";
@@ -70,6 +71,9 @@ describe("ethos tips", () => {
 		expect(byId.get("ethos.agent-sdk-foundation")).toBe(
 			'Built on the official agent SDK, speaking the protocol natively. No reverse-engineered wrapper, no ToS gray zone, no "will I get banned for this" anxiety. *Sleep easy, ship loud.*',
 		);
+		expect(byId.get("ethos.tool-call-repair")).toBe(
+			"senpi catches malformed tool calls on the wire, fixes them, and salvages the turn. Other harnesses retry the whole thing and bill you for the privilege. *table stakes, honestly*",
+		);
 	});
 
 	it("gates the ulw command tips on the tasks command", () => {
@@ -94,6 +98,7 @@ describe("ethos tips", () => {
 			"ethos.multimodal-vision",
 			"ethos.oauth-multi-account",
 			"ethos.agent-sdk-foundation",
+			"ethos.tool-call-repair",
 		] as const) {
 			const tip = byId.get(id);
 			expect(tip?.bindings, id).toEqual([]);

--- a/packages/coding-agent/test/suite/ethos-tips.test.ts
+++ b/packages/coding-agent/test/suite/ethos-tips.test.ts
@@ -9,6 +9,9 @@ const ETHOS_IDS = [
 	"ethos.deep-work",
 	"ethos.ulw-plan-sage",
 	"ethos.ulw-loop-shallow",
+	"ethos.monitor-subscribe",
+	"ethos.cache-budget",
+	"ethos.cache-hit-rate",
 ] as const;
 
 const noopKeys = (): string => "";
@@ -46,6 +49,15 @@ describe("ethos tips", () => {
 		expect(byId.get("ethos.ulw-loop-shallow")).toBe(
 			"For days when deep thought sounds awful, run the ulw loop with gpt-5.6-sol fast/medium. Fair warning: shallow thinking sends invoices.",
 		);
+		expect(byId.get("ethos.monitor-subscribe")).toBe(
+			"Subscribe to a command's stdout and forget it. CI finishes, server boots, log line lands... you're mid-edit and the news finds *you*. No sleep loops, no polling, no re-reading context like a chump.",
+		);
+		expect(byId.get("ethos.cache-budget")).toBe(
+			"My harness knows the prompt cache's expiry to the second and never blocks past it. Cold re-read tax? *Refused on your behalf.* Other agents eat that cost, mine declines it.",
+		);
+		expect(byId.get("ethos.cache-hit-rate")).toBe(
+			"Live cache-hit rate in the footer, plus a running tab of misses, idle gaps, and model swaps. I can point at the exact moment cache broke and why. Watching tokens you never re-pay stack up? Smug doesn't cover it.",
+		);
 	});
 
 	it("gates the ulw command tips on the tasks command", () => {
@@ -64,6 +76,9 @@ describe("ethos tips", () => {
 			"ethos.only-harness",
 			"ethos.spend-tokens",
 			"ethos.deep-work",
+			"ethos.monitor-subscribe",
+			"ethos.cache-budget",
+			"ethos.cache-hit-rate",
 		] as const) {
 			const tip = byId.get(id);
 			expect(tip?.bindings, id).toEqual([]);

--- a/packages/coding-agent/test/suite/ethos-tips.test.ts
+++ b/packages/coding-agent/test/suite/ethos-tips.test.ts
@@ -12,6 +12,9 @@ const ETHOS_IDS = [
 	"ethos.monitor-subscribe",
 	"ethos.cache-budget",
 	"ethos.cache-hit-rate",
+	"ethos.multimodal-vision",
+	"ethos.oauth-multi-account",
+	"ethos.agent-sdk-foundation",
 ] as const;
 
 const noopKeys = (): string => "";
@@ -58,6 +61,15 @@ describe("ethos tips", () => {
 		expect(byId.get("ethos.cache-hit-rate")).toBe(
 			"Live cache-hit rate in the footer, plus a running tab of misses, idle gaps, and model swaps. I can point at the exact moment cache broke and why. Watching tokens you never re-pay stack up? Smug doesn't cover it.",
 		);
+		expect(byId.get("ethos.multimodal-vision")).toBe(
+			"Drop a screenshot, a PDF, a crusty whiteboard photo... senpi actually sees it, reads it, reasons about it. Your agent has eyes now. *Yes, really.*",
+		);
+		expect(byId.get("ethos.oauth-multi-account")).toBe(
+			"Hit a rate limit, switch accounts. Wrong org, switch again. senpi treats your Claude logins like a roster, not a single lifeline. *Env vars could never.*",
+		);
+		expect(byId.get("ethos.agent-sdk-foundation")).toBe(
+			'Built on the official agent SDK, speaking the protocol natively. No reverse-engineered wrapper, no ToS gray zone, no "will I get banned for this" anxiety. *Sleep easy, ship loud.*',
+		);
 	});
 
 	it("gates the ulw command tips on the tasks command", () => {
@@ -79,6 +91,9 @@ describe("ethos tips", () => {
 			"ethos.monitor-subscribe",
 			"ethos.cache-budget",
 			"ethos.cache-hit-rate",
+			"ethos.multimodal-vision",
+			"ethos.oauth-multi-account",
+			"ethos.agent-sdk-foundation",
 		] as const) {
 			const tip = byId.get(id);
 			expect(tip?.bindings, id).toEqual([]);

--- a/packages/coding-agent/test/suite/ethos-tips.test.ts
+++ b/packages/coding-agent/test/suite/ethos-tips.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { TIP_DEFINITIONS } from "../../src/modes/interactive/tips/registry.ts";
+
+const ETHOS_IDS = [
+	"ethos.tuning-discipline",
+	"ethos.tools-transparent",
+	"ethos.only-harness",
+	"ethos.spend-tokens",
+	"ethos.deep-work",
+	"ethos.ulw-plan-sage",
+	"ethos.ulw-loop-shallow",
+] as const;
+
+const noopKeys = (): string => "";
+
+describe("ethos tips", () => {
+	it("registers every ethos tip id", () => {
+		const ids = new Set(TIP_DEFINITIONS.map((tip) => tip.id));
+
+		for (const id of ETHOS_IDS) {
+			expect(ids, `missing ${id}`).toContain(id);
+		}
+	});
+
+	it("renders the approved English copy verbatim", () => {
+		const byId = new Map(TIP_DEFINITIONS.map((tip) => [tip.id, tip.render(noopKeys)]));
+
+		expect(byId.get("ethos.tuning-discipline")).toBe(
+			"gpt-5.6-sol used to turn a sprint into a marathon. We tuned the system prompt and killed that habit: 5-minute jobs take 5 minutes, 12-hour jobs take 12.",
+		);
+		expect(byId.get("ethos.tools-transparent")).toBe(
+			"Don't study our tools. A tool that needs studying is a tool that failed. We just ride shotgun while you keep doing your actual job.",
+		);
+		expect(byId.get("ethos.only-harness")).toBe(
+			"The only harness that actually knows how to drive gpt-5.6-sol. Same job, feels up to 30% faster. *we counted*",
+		);
+		expect(byId.get("ethos.spend-tokens")).toBe(
+			"Stop hoarding tokens. Spend them like they buy your hours back, because they do.",
+		);
+		expect(byId.get("ethos.deep-work")).toBe(
+			"Using our tools means your work is already the deep, valuable kind. Keep your eyes on the essence of your craft. The rest is our problem now, and we're great at problems.",
+		);
+		expect(byId.get("ethos.ulw-plan-sage")).toBe(
+			"Try ulw-plan on fable-5 xhigh. A patient sage obsessed with the essence does the agonizing for you and fills in every blank you were pretending not to see.",
+		);
+		expect(byId.get("ethos.ulw-loop-shallow")).toBe(
+			"For days when deep thought sounds awful, run the ulw loop with gpt-5.6-sol fast/medium. Fair warning: shallow thinking sends invoices.",
+		);
+	});
+
+	it("gates the ulw command tips on the tasks command", () => {
+		const byId = new Map(TIP_DEFINITIONS.map((tip) => [tip.id, tip]));
+
+		expect(byId.get("ethos.ulw-plan-sage")?.requiresCommand).toBe("tasks");
+		expect(byId.get("ethos.ulw-loop-shallow")?.requiresCommand).toBe("tasks");
+	});
+
+	it("leaves the pure manifesto tips unbound and ungated", () => {
+		const byId = new Map(TIP_DEFINITIONS.map((tip) => [tip.id, tip]));
+
+		for (const id of [
+			"ethos.tuning-discipline",
+			"ethos.tools-transparent",
+			"ethos.only-harness",
+			"ethos.spend-tokens",
+			"ethos.deep-work",
+		] as const) {
+			const tip = byId.get(id);
+			expect(tip?.bindings, id).toEqual([]);
+			expect(tip?.requiresCommand, id).toBeUndefined();
+		}
+	});
+});


### PR DESCRIPTION
## What

Adds a `ETHOS_TIPS` catalog (7 manifesto tips) to the tip rotation, giving the fork a voice in the tip line: system-prompt tuning discipline for `gpt-5.6-sol`, tools that stay out of the way, spending tokens to buy time, and pointers to `ulw-plan` on `fable-5 xhigh` and the `ulw loop`.

## Changes

- `tips/catalog/ethos-tips.ts` (new): `ETHOS_TIPS`, 7 entries. Five pure manifesto tips are keyless and ungated; two (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`) gate on `requiresCommand: "tasks"` so they only surface when the omo plugin is loaded — matching the `workflow-skills.*` tips in `subagent-tips.ts`.
- `tips/registry.ts`: concatenates `...ETHOS_TIPS` (total tips 70 -> 76).
- `changes.md`: fork entry dated 2026-07-29.
- `test/suite/ethos-tips.test.ts`: pins the 7 ids, the verbatim approved English copy, the `tasks` gating, and the unbound/ungated manifesto set.

## The 7 tips

1. gpt-5.6-sol used to turn a sprint into a marathon. We tuned the system prompt and killed that habit: 5-minute jobs take 5 minutes, 12-hour jobs take 12.
2. Don't study our tools. A tool that needs studying is a tool that failed. We just ride shotgun while you keep doing your actual job.
3. The only harness that actually knows how to drive gpt-5.6-sol. Same job, feels up to 30% faster. *we counted*
4. Stop hoarding tokens. Spend them like they buy your hours back, because they do.
5. Using our tools means your work is already the deep, valuable kind. Keep your eyes on the essence of your craft. The rest is our problem now, and we're great at problems.
6. Try ulw-plan on fable-5 xhigh. A patient sage obsessed with the essence does the agonizing for you and fills in every blank you were pretending not to see. (gated: tasks)
7. For days when deep thought sounds awful, run the ulw loop with gpt-5.6-sol fast/medium. Fair warning: shallow thinking sends invoices. (gated: tasks)

## Evidence

- RED -> GREEN: `ethos-tips.test.ts` 4/4 failing before impl (ids absent from registry) -> 4/4 + `tips-registry.test.ts` 8/8 = 12/12 pass after.
- Surface proof: rendered all 7 tips through the real `TIP_DEFINITIONS` registry path; correct copy, correct gating (5 ungated, 2 gated on `tasks`), total 76 tips.
- Regression: full tips suite (5 files) = 40/40 pass.
- Static gate: `npm run check` exit 0, no fixes applied.
- File sizes (pure LOC, ceiling 250): ethos-tips.ts 46, registry.ts 20, test 63.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ETHOS_TIPS` catalog (14 tips) to the interactive rotation to give the fork a clear voice. Covers prompt‑tuning for `gpt-5.6-sol`, zero‑study tools, spending tokens, monitor/cache visibility, multimodal vision, OAuth multi‑account, agent‑SDK foundation, tool‑call repair, and pointers to `ulw-plan` and the `ulw` loop; the two command tips gate on `tasks`.

- **New Features**
  - Added `tips/catalog/ethos-tips.ts` with `ETHOS_TIPS`: 12 ungated manifesto tips (including monitor/cache, multimodal, OAuth, SDK, and tool‑call repair) and 2 tips gated on `tasks` (`ethos.ulw-plan-sage`, `ethos.ulw-loop-shallow`).
  - Updated `tips/registry.ts` to include `...ETHOS_TIPS` in `TIP_DEFINITIONS`.
  - Added `test/suite/ethos-tips.test.ts` to pin 14 ids, verbatim copy, and `tasks` gating.

<sup>Written for commit b8bd7c7c68d6d5eeec866eb10b5af692fb3d2d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

