### PR TITLE
fix(coding-agent): highlight active monitor footer

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,28 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Theme-aware active-monitor footer (2026-07-29)
+
+### What changed
+
+- Active monitor footer text is wrapped with the current TUI theme's `text` foreground and
+  `selectedBg` background before publication through `ctx.ui.setStatus`.
+- Styling is restricted to `ctx.mode === "tui"`; RPC, app-server, JSON, and print contexts keep
+  the original plain status string, and an empty monitor snapshot still clears with `undefined`.
+- The formatter remains unchanged, so the 48-column cap, whole-description packing, watch glyph,
+  monitor count, and paused suffix stay independent of ANSI byte length.
+
+### Why
+
+The live `◉ watching …` row could blend into adjacent footer content. Reusing the active theme's
+selection background creates a visible but restrained chip in both dark and light themes without
+introducing a monitor-specific color token.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: the fork-owned monitor registry `onChange` callback in `extension.ts` and its focused footer
+  wiring test.
+
 ## bash_output ghost wait_for params removed (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -65,7 +65,14 @@ function buildToolContext(pi: ExtensionAPI, state: TerminalExtensionState): Term
 		get monitorRegistry() {
 			state.monitors ??= new MonitorRegistry((event) => state.monitorNotifier?.notifyEvent(event), {
 				onChange: (snapshot) => {
-					state.ctx?.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot));
+					const ctx = state.ctx;
+					const status = formatMonitorStatus(snapshot);
+					ctx?.ui.setStatus(
+						MONITOR_STATUS_KEY,
+						status === undefined || ctx.mode !== "tui"
+							? status
+							: ctx.ui.theme.bg("selectedBg", ctx.ui.theme.fg("text", status)),
+					);
 					const events = pi.events;
 					if (events !== undefined) {
 						events.emit(TERMINAL_MONITOR_STATE_EVENT, { activeCount: snapshot.length });

--- a/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
@@ -9,6 +9,7 @@ import { formatMonitorStatus } from "../../src/core/extensions/builtin/terminal/
 import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createMonitorTool, type MonitorInput } from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
 
 /** Resolves when the wrapped spy is called with a matching argument set. */
 function deferredCall<TArgs extends unknown[]>(predicate: (...args: TArgs) => boolean) {
@@ -165,6 +166,7 @@ describe("terminal extension footer status wiring", () => {
 	});
 
 	it("publishes the monitors footer status while a watch is live and clears it on settle", async () => {
+		initTheme("dark");
 		type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
 		const handlers = new Map<string, Handler[]>();
 		const tools = new Map<string, { execute: (id: string, input: MonitorInput) => Promise<unknown> }>();
@@ -194,15 +196,19 @@ describe("terminal extension footer status wiring", () => {
 		setStatus.mockImplementation((key: string, text: string | undefined) => cleared.handler(key, text));
 		const ctx = {
 			cwd: process.cwd(),
-			ui: { setStatus, notify: () => {} },
+			hasUI: true,
+			mode: "tui",
+			ui: { setStatus, notify: () => {}, theme },
 		} as unknown as ExtensionContext;
 		for (const handler of handlers.get("session_start") ?? []) await handler({}, ctx);
 
 		const monitorTool = tools.get("monitor");
 		expect(monitorTool).toBeDefined();
-		await monitorTool?.execute("call_1", { description: "footer smoke watch", command: "printf 'line\\n'" });
+		const description = "PR 453 checks on new head f40d4d15c";
+		await monitorTool?.execute("call_1", { description, command: "printf 'line\\n'" });
 
-		expect(setStatus).toHaveBeenCalledWith("monitors", expect.stringContaining("footer smoke watch"));
+		const plainStatus = `◉ watching ${description}`;
+		expect(setStatus).toHaveBeenCalledWith("monitors", theme.bg("selectedBg", theme.fg("text", plainStatus)));
 		await cleared.promise;
 		expect(setStatus).toHaveBeenCalledWith("monitors", undefined);
 


### PR DESCRIPTION
## Summary

Active `monitor` footer rows now use the current TUI theme's normal text color on its selection background. This makes lines such as `◉ watching PR 453 checks on new head f40d4d15c` easier to distinguish from adjacent footer content while preserving the existing glyph, wording, count-forward packing, paused suffixes, and 48-column cap.

Styling is applied only in TUI mode. RPC, app-server, JSON, and print contexts continue to receive the original plain status string, and empty monitor snapshots still clear the footer with `undefined`.

## Verification

- `npm test --workspace=@code-yeongyu/senpi -- test/suite/terminal-monitor-footer.test.ts` — 9/9 passed
- `npm run check` — passed
- `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence monitor-theme-bg-tui` — 5/5 passed
- `node .agents/skills/senpi-qa/scripts/pty-drive.mjs --self-test --evidence monitor-theme-bg` — 8/8 passed on the native backend
- xterm.js true-color visual QA — dark and light theme chips both readable; long paused sample preserved `+2 more (1 paused)`
- two independent visual reviews — PASS, no clipping, glyph drift, or contrast defect

## Evidence

Local sanitized QA receipts:

- `local-ignore/qa-evidence/20260729-monitor-theme-bg/red.txt`
- `local-ignore/qa-evidence/20260729-monitor-theme-bg/green.txt`
- `local-ignore/qa-evidence/20260729-monitor-theme-bg/tui-web-terminal/`
- `local-ignore/qa-evidence/20260729-monitor-theme-bg-tui/`

These artifacts are intentionally ignored and are not part of the PR diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlights the active monitor footer in TUI using the current theme’s selected background and text color so the `◉ watching …` row stands out. Other modes keep the original plain status.

- **Bug Fixes**
  - Apply theme styling only when `ctx.mode === "tui"`; otherwise publish the plain status or clear with `undefined`.
  - Keep formatter unchanged (48-col cap, glyph, count packing, paused suffix); styling wraps the string only.
  - Update tests to assert themed footer and clearing; add entry to `changes.md`.

<sup>Written for commit 4b519565109e2e9b7c3532e718c3c76aa0c57316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

