### PR TITLE
fix(agent): preserve input across provider idle retries

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -152,9 +152,22 @@ When you use the `Agent` class, assistant `message_end` processing is treated as
 ```typescript
 // After an error, retry from current state
 await agent.continue();
+
+// Keep queued user input out of the retry request and use shorter liveness
+// bounds without mutating the Agent's configured defaults.
+await agent.continue({
+  deferQueuedMessages: true,
+  timeoutMs: 30_000,
+  streamStartTimeoutMs: 30_000,
+});
 ```
 
-The last message in context must be `user` or `toolResult` (not `assistant`).
+The last message in context must be `user` or `toolResult` (not `assistant`). Continuation options are
+one-shot: queue deferral and both timeout overrides apply only to the first provider request. If that
+request succeeds and the same run continues through tools or queued input, later provider requests use
+the Agent's configured `timeoutMs` and `streamStartTimeoutMs`. `continueWithQueuedMessages(options)`
+keeps compaction recovery queue-first; the selected queued message becomes the continuation input, so
+`deferQueuedMessages` cannot defer that message, while the first-request timeout overrides still apply.
 
 ### Event Types
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -243,8 +243,7 @@ async function runLoop(
 				? {
 						...config,
 						timeoutMs: config.initialRequestTimeoutMs ?? config.timeoutMs,
-						streamStartTimeoutMs:
-							config.initialRequestStreamStartTimeoutMs ?? config.streamStartTimeoutMs,
+						streamStartTimeoutMs: config.initialRequestStreamStartTimeoutMs ?? config.streamStartTimeoutMs,
 					}
 				: config;
 			const streamIdleTimeoutMs = isInitialProviderRequest ? config.timeoutMs : requestConfig.timeoutMs;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -187,6 +187,7 @@ async function runLoop(
 	let currentContext = initialContext;
 	let config = initialConfig;
 	let firstTurn = true;
+	let firstProviderRequest = true;
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let drainedTerminatingQueue: "steering" | "followUp" | undefined;
@@ -232,8 +233,29 @@ async function runLoop(
 				pendingMessages = [];
 			}
 
-			// Stream assistant response
-			const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
+			// Stream assistant response. Continuation-scoped overrides apply to one
+			// provider request only. Once that request emits its first event, the
+			// configured idle timeout resumes so healthy reasoning gaps are not bound
+			// by the short liveness probe.
+			const isInitialProviderRequest = firstProviderRequest;
+			firstProviderRequest = false;
+			const requestConfig = isInitialProviderRequest
+				? {
+						...config,
+						timeoutMs: config.initialRequestTimeoutMs ?? config.timeoutMs,
+						streamStartTimeoutMs:
+							config.initialRequestStreamStartTimeoutMs ?? config.streamStartTimeoutMs,
+					}
+				: config;
+			const streamIdleTimeoutMs = isInitialProviderRequest ? config.timeoutMs : requestConfig.timeoutMs;
+			const message = await streamAssistantResponse(
+				currentContext,
+				requestConfig,
+				signal,
+				emit,
+				streamFunction,
+				streamIdleTimeoutMs,
+			);
 			newMessages.push(message);
 
 			if (shouldTerminateAssistantTurn(message)) {
@@ -380,6 +402,7 @@ async function streamAssistantResponse(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
+	streamIdleTimeoutMs: number | undefined,
 ): Promise<AssistantMessage> {
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
@@ -441,7 +464,7 @@ async function streamAssistantResponse(
 		const iterator = response[Symbol.asyncIterator]();
 		const eventReader = createAssistantEventReader(
 			iterator,
-			config.timeoutMs,
+			streamIdleTimeoutMs,
 			requestAbortController.signal,
 			(error) => requestAbortController.abort(error),
 			config.streamStartTimeoutMs,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -124,6 +124,13 @@ export interface AgentOptions {
 	abortServerSideFallback?: boolean;
 }
 
+export interface AgentContinuationOptions {
+	/** Keep queued steering and follow-up input out of the continuation's first provider request. */
+	deferQueuedMessages?: boolean;
+	/** Override the provider stream idle timeout for this continuation only. */
+	timeoutMs?: number;
+}
+
 class PendingMessageQueue {
 	private messages: AgentMessage[] = [];
 	private clearGeneration = 0;
@@ -408,8 +415,11 @@ export class Agent {
 		await this.continue();
 	}
 
-	/** Continue from the current transcript. The last message must be a user or tool-result message. */
-	async continue(): Promise<void> {
+	/**
+	 * Continue from the current transcript. The last message must be a user or tool-result message.
+	 * Queued input can be deferred until the continuation produces its first response.
+	 */
+	async continue(options: AgentContinuationOptions = {}): Promise<void> {
 		if (this.activeRun) {
 			throw new Error("Agent is already processing. Wait for completion before continuing.");
 		}
@@ -435,7 +445,7 @@ export class Agent {
 			throw new Error("Cannot continue from message role: assistant");
 		}
 
-		await this.runContinuation();
+		await this.runContinuation(options);
 	}
 
 	private normalizePromptInput(
@@ -473,11 +483,14 @@ export class Agent {
 		});
 	}
 
-	private async runContinuation(): Promise<void> {
+	private async runContinuation(options: AgentContinuationOptions = {}): Promise<void> {
 		await this.runWithLifecycle(async (signal) => {
 			await runAgentLoopContinue(
 				this.createContextSnapshot(),
-				this.createLoopConfig(),
+				this.createLoopConfig({
+					skipInitialSteeringPoll: options.deferQueuedMessages,
+					timeoutMs: options.timeoutMs,
+				}),
 				(event) => this.processEvents(event),
 				signal,
 				this.streamFunction,
@@ -493,7 +506,7 @@ export class Agent {
 		};
 	}
 
-	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
+	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean; timeoutMs?: number } = {}): AgentLoopConfig {
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
 		let steeringQueueGeneration = this.steeringQueue.getClearGeneration();
 		let followUpQueueGeneration = this.followUpQueue.getClearGeneration();
@@ -505,7 +518,7 @@ export class Agent {
 			onResponse: this.onResponse,
 			transport: this.transport,
 			thinkingBudgets: this.thinkingBudgets,
-			timeoutMs: this.timeoutMs,
+			timeoutMs: options.timeoutMs ?? this.timeoutMs,
 			streamStartTimeoutMs: this.streamStartTimeoutMs,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			abortServerSideFallback: this.abortServerSideFallback,
@@ -570,6 +583,7 @@ export class Agent {
 			while (
 				!abortController.signal.aborted &&
 				!this.activeRun?.suppressQueuedMessageDrain &&
+				this.canDrainQueuedMessagesAfterRun() &&
 				this.hasQueuedMessages()
 			) {
 				await this.runQueuedMessagesAfterAgentEnd(abortController.signal);
@@ -579,6 +593,14 @@ export class Agent {
 		} finally {
 			this.finishRun();
 		}
+	}
+
+	private canDrainQueuedMessagesAfterRun(): boolean {
+		const lastMessage = this._state.messages[this._state.messages.length - 1];
+		return (
+			lastMessage?.role !== "assistant" ||
+			(lastMessage.stopReason !== "error" && lastMessage.stopReason !== "aborted")
+		);
 	}
 
 	private async runQueuedMessagesAfterAgentEnd(signal: AbortSignal): Promise<void> {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -125,10 +125,12 @@ export interface AgentOptions {
 }
 
 export interface AgentContinuationOptions {
-	/** Keep queued steering and follow-up input out of the continuation's first provider request. */
+	/** Keep queued steering and follow-up input out of the continuation's first provider request only. */
 	deferQueuedMessages?: boolean;
-	/** Override the provider stream idle timeout for this continuation only. */
+	/** Override the provider stream idle timeout for the continuation's first provider request only. */
 	timeoutMs?: number;
+	/** Override the provider stream-start timeout for the continuation's first provider request only. */
+	streamStartTimeoutMs?: number;
 }
 
 class PendingMessageQueue {
@@ -349,6 +351,8 @@ export class Agent {
 	/**
 	 * Keep queued steering and follow-up messages for an external owner after
 	 * this run reaches agent_end, without changing the active abort signal.
+	 * This is ownership suppression for one active run; terminal error/abort
+	 * parking is a separate stop-reason policy enforced by the run lifecycle.
 	 */
 	suppressQueuedMessageDrain(): void {
 		if (this.activeRun) {
@@ -389,35 +393,47 @@ export class Agent {
 		await this.runPromptMessages(messages);
 	}
 
-	/** Continue by delivering queued input first when a compaction leaves custom context at the tail. */
-	async continueWithQueuedMessages(): Promise<void> {
+	/**
+	 * Continue by delivering queued input first when a compaction leaves custom context at the tail.
+	 * Queue-first recovery takes precedence over `deferQueuedMessages`: the selected queued message is
+	 * the continuation input, while timeout overrides still apply to its first provider request.
+	 */
+	async continueWithQueuedMessages(options: AgentContinuationOptions = {}): Promise<void> {
 		if (this.activeRun) {
 			throw new Error("Agent is already processing. Wait for completion before continuing.");
 		}
 
 		if (this._state.messages[this._state.messages.length - 1]?.role === "assistant") {
-			await this.continue();
+			await this.continue(options);
 			return;
 		}
 
 		const queuedSteering = this.steeringQueue.drain();
 		if (queuedSteering.length > 0) {
-			await this.runPromptMessages(queuedSteering, { skipInitialSteeringPoll: true });
+			await this.runPromptMessages(queuedSteering, {
+				skipInitialSteeringPoll: true,
+				initialRequestTimeoutMs: options.timeoutMs,
+				initialRequestStreamStartTimeoutMs: options.streamStartTimeoutMs,
+			});
 			return;
 		}
 
 		const queuedFollowUps = this.followUpQueue.drain();
 		if (queuedFollowUps.length > 0) {
-			await this.runPromptMessages(queuedFollowUps);
+			await this.runPromptMessages(queuedFollowUps, {
+				initialRequestTimeoutMs: options.timeoutMs,
+				initialRequestStreamStartTimeoutMs: options.streamStartTimeoutMs,
+			});
 			return;
 		}
 
-		await this.continue();
+		await this.continue(options);
 	}
 
 	/**
 	 * Continue from the current transcript. The last message must be a user or tool-result message.
-	 * Queued input can be deferred until the continuation produces its first response.
+	 * Queue deferral and timeout overrides apply only to the first provider request; later requests in
+	 * the same run and later runs use the configured Agent defaults.
 	 */
 	async continue(options: AgentContinuationOptions = {}): Promise<void> {
 		if (this.activeRun) {
@@ -432,13 +448,20 @@ export class Agent {
 		if (lastMessage.role === "assistant") {
 			const queuedSteering = this.steeringQueue.drain();
 			if (queuedSteering.length > 0) {
-				await this.runPromptMessages(queuedSteering, { skipInitialSteeringPoll: true });
+				await this.runPromptMessages(queuedSteering, {
+					skipInitialSteeringPoll: true,
+					initialRequestTimeoutMs: options.timeoutMs,
+					initialRequestStreamStartTimeoutMs: options.streamStartTimeoutMs,
+				});
 				return;
 			}
 
 			const queuedFollowUps = this.followUpQueue.drain();
 			if (queuedFollowUps.length > 0) {
-				await this.runPromptMessages(queuedFollowUps);
+				await this.runPromptMessages(queuedFollowUps, {
+					initialRequestTimeoutMs: options.timeoutMs,
+					initialRequestStreamStartTimeoutMs: options.streamStartTimeoutMs,
+				});
 				return;
 			}
 
@@ -469,7 +492,11 @@ export class Agent {
 
 	private async runPromptMessages(
 		messages: AgentMessage[],
-		options: { skipInitialSteeringPoll?: boolean } = {},
+		options: {
+			skipInitialSteeringPoll?: boolean;
+			initialRequestTimeoutMs?: number;
+			initialRequestStreamStartTimeoutMs?: number;
+		} = {},
 	): Promise<void> {
 		await this.runWithLifecycle(async (signal) => {
 			await runAgentLoop(
@@ -489,7 +516,8 @@ export class Agent {
 				this.createContextSnapshot(),
 				this.createLoopConfig({
 					skipInitialSteeringPoll: options.deferQueuedMessages,
-					timeoutMs: options.timeoutMs,
+					initialRequestTimeoutMs: options.timeoutMs,
+					initialRequestStreamStartTimeoutMs: options.streamStartTimeoutMs,
 				}),
 				(event) => this.processEvents(event),
 				signal,
@@ -506,7 +534,13 @@ export class Agent {
 		};
 	}
 
-	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean; timeoutMs?: number } = {}): AgentLoopConfig {
+	private createLoopConfig(
+		options: {
+			skipInitialSteeringPoll?: boolean;
+			initialRequestTimeoutMs?: number;
+			initialRequestStreamStartTimeoutMs?: number;
+		} = {},
+	): AgentLoopConfig {
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
 		let steeringQueueGeneration = this.steeringQueue.getClearGeneration();
 		let followUpQueueGeneration = this.followUpQueue.getClearGeneration();
@@ -518,8 +552,10 @@ export class Agent {
 			onResponse: this.onResponse,
 			transport: this.transport,
 			thinkingBudgets: this.thinkingBudgets,
-			timeoutMs: options.timeoutMs ?? this.timeoutMs,
+			timeoutMs: this.timeoutMs,
 			streamStartTimeoutMs: this.streamStartTimeoutMs,
+			initialRequestTimeoutMs: options.initialRequestTimeoutMs,
+			initialRequestStreamStartTimeoutMs: options.initialRequestStreamStartTimeoutMs,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			abortServerSideFallback: this.abortServerSideFallback,
 			toolExecution: this.toolExecution,
@@ -580,6 +616,9 @@ export class Agent {
 
 		try {
 			await executor(abortController.signal);
+			// A provider-returned terminal error/abort has no safe implicit owner for
+			// queued work. Park it until an external retry/compaction owner continues,
+			// or until a later admitted prompt drains it through the normal queue poll.
 			while (
 				!abortController.signal.aborted &&
 				!this.activeRun?.suppressQueuedMessageDrain &&

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -24,6 +24,17 @@
 - `types.ts`
 - `../test/agent-loop-stream-start-timeout.test.ts`
 
+## 2026-07-29 - Continuation-scoped queue and timeout controls
+
+### What changed and why
+
+- `Agent.continue()` accepts continuation-only options that defer queued input until the first provider response and
+  override the stream idle timeout without mutating the agent's configured default.
+- The core run lifecycle retains queued steering and follow-up input after terminal error or abort responses instead
+  of racing an asynchronous session-level retry controller and starting an unintended provider request.
+- Coding-agent retries use these controls after a silent provider stream so a doomed retry cannot consume newly
+  queued user input and a later ordinary turn automatically returns to the configured timeout.
+
 ## 2026-07-27 - End classifier-refused turns before tool execution
 
 ### What changed and why

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -28,12 +28,35 @@
 
 ### What changed and why
 
-- `Agent.continue()` accepts continuation-only options that defer queued input until the first provider response and
-  override the stream idle timeout without mutating the agent's configured default.
-- The core run lifecycle retains queued steering and follow-up input after terminal error or abort responses instead
-  of racing an asynchronous session-level retry controller and starting an unintended provider request.
+- `Agent.continue()` and `continueWithQueuedMessages()` accept continuation-only options that defer queued input from
+  the first provider request and override both stream idle and stream-start bounds for that request without mutating
+  the agent's configured defaults. Later requests in the same run restore the configured bounds; after the first
+  retry event, the configured idle timeout also governs inter-event gaps so healthy silent reasoning is not capped.
+- Queue-first recompaction recovery takes precedence over deferral: the selected queued message is the continuation
+  input, while first-request timeout overrides still apply.
+- The core run lifecycle intentionally parks queued steering and follow-up input after terminal error or abort
+  responses until an external retry/compaction owner or a later admitted prompt consumes it. This stop-reason policy
+  is distinct from `suppressQueuedMessageDrain()`, which transfers one active run's post-`agent_end` ownership.
 - Coding-agent retries use these controls after a silent provider stream so a doomed retry cannot consume newly
-  queued user input and a later ordinary turn automatically returns to the configured timeout.
+  queued user input and a later ordinary provider request automatically returns to the configured timeout.
+
+### Files modified
+
+- `agent.ts`
+- `types.ts`
+- `agent-loop.ts`
+- `../test/agent.test.ts`
+- `../README.md`
+
+### Why the extension system could not handle this
+
+- Provider-request queue polling, event-reader timeout selection, and post-run native queue draining happen inside
+  agent core before coding-agent extensions can safely claim or restore that work.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `agent.ts` continuation APIs/config creation and active-run lifecycle queue draining.
+- MEDIUM: `agent-loop.ts` provider-request timeout selection inside `runLoop()`.
 
 ## 2026-07-27 - End classifier-refused turns before tool execution
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -156,6 +156,12 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 */
 	streamStartTimeoutMs?: number;
 
+	/** Provider/SDK timeout override for only the first request in this loop invocation. */
+	initialRequestTimeoutMs?: number;
+
+	/** Stream-start timeout override for only the first request in this loop invocation. */
+	initialRequestStreamStartTimeoutMs?: number;
+
 	/**
 	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.
 	 *

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -91,6 +91,12 @@ function getUserMessageText(message: AgentMessage): string {
 		.join("");
 }
 
+function getStreamStartTimeoutMs(options: unknown): number | undefined {
+	if (!options || typeof options !== "object" || !("streamStartTimeoutMs" in options)) return undefined;
+	const value = (options as { streamStartTimeoutMs?: unknown }).streamStartTimeoutMs;
+	return typeof value === "number" ? value : undefined;
+}
+
 describe("Agent", () => {
 	it("uses the configured default when a legacy caller omits streamFn", async () => {
 		let calls = 0;
@@ -628,7 +634,7 @@ describe("Agent", () => {
 				);
 				providerTimeouts.push({
 					timeoutMs: options?.timeoutMs,
-					streamStartTimeoutMs: options?.streamStartTimeoutMs,
+					streamStartTimeoutMs: getStreamStartTimeoutMs(options),
 				});
 				const stream = new MockAssistantStream();
 				queueMicrotask(() => {
@@ -645,10 +651,7 @@ describe("Agent", () => {
 			streamStartTimeoutMs: 30_000,
 		});
 
-		expect(providerUserTexts).toEqual([
-			["original request"],
-			["original request", "queued steering"],
-		]);
+		expect(providerUserTexts).toEqual([["original request"], ["original request", "queued steering"]]);
 		expect(providerTimeouts).toEqual([
 			{ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 },
 			{ timeoutMs: 300_000, streamStartTimeoutMs: 90_000 },
@@ -667,7 +670,7 @@ describe("Agent", () => {
 			streamFn: (_model, _context, options) => {
 				providerTimeouts.push({
 					timeoutMs: options?.timeoutMs,
-					streamStartTimeoutMs: options?.streamStartTimeoutMs,
+					streamStartTimeoutMs: getStreamStartTimeoutMs(options),
 				});
 				const stream = new MockAssistantStream();
 				queueMicrotask(() => {
@@ -699,7 +702,7 @@ describe("Agent", () => {
 				streamFn: (_model, _context, options) => {
 					providerOptions = {
 						timeoutMs: options?.timeoutMs,
-						streamStartTimeoutMs: options?.streamStartTimeoutMs,
+						streamStartTimeoutMs: getStreamStartTimeoutMs(options),
 					};
 					const stream = new MockAssistantStream();
 					queueMicrotask(() => {
@@ -721,9 +724,9 @@ describe("Agent", () => {
 			await continuation;
 
 			expect(providerOptions).toEqual({ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 });
-			expect(agent.state.messages.at(-1)?.content).toEqual([
-				{ type: "text", text: "healthy delayed response" },
-			]);
+			const lastMessage = agent.state.messages.at(-1);
+			if (lastMessage?.role !== "assistant") throw new Error("Expected final assistant response");
+			expect(lastMessage.content).toEqual([{ type: "text", text: "healthy delayed response" }]);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -785,10 +788,7 @@ describe("Agent", () => {
 
 		expect(providerUserTexts).toEqual(
 			queue === "steering"
-				? [
-						["initial request"],
-						["initial request", "later admitted prompt", "retained queued input"],
-					]
+				? [["initial request"], ["initial request", "later admitted prompt", "retained queued input"]]
 				: [
 						["initial request"],
 						["initial request", "later admitted prompt"],

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,6 +1,6 @@
 import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	Agent,
 	type AgentEvent,
@@ -609,6 +609,193 @@ describe("Agent", () => {
 
 		expect(agent.hasQueuedMessages()).toBe(false);
 		expect(providerCalls).toBe(2);
+	});
+
+	it("defers queued input only from a continuation's first provider request", async () => {
+		const providerUserTexts: string[][] = [];
+		const providerTimeouts: Array<{ timeoutMs?: number; streamStartTimeoutMs?: number }> = [];
+		const agent = new Agent({
+			initialState: {
+				messages: [{ role: "user", content: "original request", timestamp: Date.now() }],
+			},
+			timeoutMs: 300_000,
+			streamStartTimeoutMs: 90_000,
+			streamFn: (_model, context, options) => {
+				providerUserTexts.push(
+					context.messages
+						.filter((message) => message.role === "user")
+						.map((message) => getUserMessageText(message)),
+				);
+				providerTimeouts.push({
+					timeoutMs: options?.timeoutMs,
+					streamStartTimeoutMs: options?.streamStartTimeoutMs,
+				});
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("recovered") });
+				});
+				return stream;
+			},
+		});
+		agent.steer({ role: "user", content: "queued steering", timestamp: Date.now() });
+
+		await agent.continue({
+			deferQueuedMessages: true,
+			timeoutMs: 30_000,
+			streamStartTimeoutMs: 30_000,
+		});
+
+		expect(providerUserTexts).toEqual([
+			["original request"],
+			["original request", "queued steering"],
+		]);
+		expect(providerTimeouts).toEqual([
+			{ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 },
+			{ timeoutMs: 300_000, streamStartTimeoutMs: 90_000 },
+		]);
+		expect(agent.hasQueuedMessages()).toBe(false);
+	});
+
+	it("restores configured timeouts after a call-scoped continuation override", async () => {
+		const providerTimeouts: Array<{ timeoutMs?: number; streamStartTimeoutMs?: number }> = [];
+		const agent = new Agent({
+			initialState: {
+				messages: [{ role: "user", content: "retry me", timestamp: Date.now() }],
+			},
+			timeoutMs: 300_000,
+			streamStartTimeoutMs: 90_000,
+			streamFn: (_model, _context, options) => {
+				providerTimeouts.push({
+					timeoutMs: options?.timeoutMs,
+					streamStartTimeoutMs: options?.streamStartTimeoutMs,
+				});
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("done") });
+				});
+				return stream;
+			},
+		});
+
+		await agent.continue({ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 });
+		await agent.prompt("ordinary request");
+
+		expect(providerTimeouts).toEqual([
+			{ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 },
+			{ timeoutMs: 300_000, streamStartTimeoutMs: 90_000 },
+		]);
+	});
+
+	it("restores the configured idle timeout after a capped retry stream shows life", async () => {
+		vi.useFakeTimers();
+		try {
+			let providerOptions: { timeoutMs?: number; streamStartTimeoutMs?: number } | undefined;
+			const agent = new Agent({
+				initialState: {
+					messages: [{ role: "user", content: "retry me", timestamp: Date.now() }],
+				},
+				timeoutMs: 300_000,
+				streamStartTimeoutMs: 90_000,
+				streamFn: (_model, _context, options) => {
+					providerOptions = {
+						timeoutMs: options?.timeoutMs,
+						streamStartTimeoutMs: options?.streamStartTimeoutMs,
+					};
+					const stream = new MockAssistantStream();
+					queueMicrotask(() => {
+						stream.push({ type: "start", partial: createAssistantMessage("") });
+						setTimeout(() => {
+							stream.push({
+								type: "done",
+								reason: "stop",
+								message: createAssistantMessage("healthy delayed response"),
+							});
+						}, 40_000);
+					});
+					return stream;
+				},
+			});
+
+			const continuation = agent.continue({ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 });
+			await vi.advanceTimersByTimeAsync(40_000);
+			await continuation;
+
+			expect(providerOptions).toEqual({ timeoutMs: 30_000, streamStartTimeoutMs: 30_000 });
+			expect(agent.state.messages.at(-1)?.content).toEqual([
+				{ type: "text", text: "healthy delayed response" },
+			]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it.each([
+		["error", "steering"],
+		["error", "followUp"],
+		["aborted", "steering"],
+		["aborted", "followUp"],
+	] as const)("parks queued %s-run %s input until a later admitted prompt", async (stopReason, queue) => {
+		let providerCalls = 0;
+		const providerUserTexts: string[][] = [];
+		const queuedMessage: AgentMessage = {
+			role: "user",
+			content: "retained queued input",
+			timestamp: Date.now(),
+		};
+		const agent = new Agent({
+			streamFn: (_model, context) => {
+				providerCalls++;
+				providerUserTexts.push(
+					context.messages
+						.filter((message) => message.role === "user")
+						.map((message) => getUserMessageText(message)),
+				);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (providerCalls === 1) {
+						stream.push({
+							type: "error",
+							reason: stopReason,
+							error: {
+								...createAssistantMessage(""),
+								stopReason,
+								errorMessage: `${stopReason} provider response`,
+							},
+						});
+						return;
+					}
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("recovered") });
+				});
+				return stream;
+			},
+		});
+		agent.subscribe((event) => {
+			if (event.type !== "agent_end" || providerCalls !== 1) return;
+			if (queue === "steering") agent.steer(queuedMessage);
+			else agent.followUp(queuedMessage);
+		});
+
+		await agent.prompt("initial request");
+
+		expect(agent.hasQueuedMessages()).toBe(true);
+		expect(providerCalls).toBe(1);
+		expect(agent.state.messages).not.toContain(queuedMessage);
+
+		await agent.prompt("later admitted prompt");
+
+		expect(providerUserTexts).toEqual(
+			queue === "steering"
+				? [
+						["initial request"],
+						["initial request", "later admitted prompt", "retained queued input"],
+					]
+				: [
+						["initial request"],
+						["initial request", "later admitted prompt"],
+						["initial request", "later admitted prompt", "retained queued input"],
+					],
+		);
+		expect(agent.hasQueuedMessages()).toBe(false);
 	});
 
 	it("should throw when prompt() called while streaming", async () => {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,20 @@
 # AI Source Changes
 
+## 2026-07-29 - Classify provider stream and transport timeouts precisely
+
+### What changed and why
+
+- `utils/retry.ts` exports `isProviderStreamStallError()` for the two anchored agent-loop watchdog
+  messages and `isProviderTimeoutError()` for those stalls plus the exact `Request timed out` transport
+  shape. The shared classifier accepts transport timeouts reported as `aborted` while rejecting incidental
+  timeout text from commands, MCP servers, and extensions.
+- `../test/retry.test.ts` pins the observed positive shapes, negative lookalikes, and stop-reason policy.
+
+### Expected merge conflict zones
+
+- LOW: additive classifiers beside `isRetryableAssistantError()` in `utils/retry.ts`; keep
+  `isProviderStreamStallError()` aligned with PR #453 when the branches meet.
+
 ## 2026-07-28 - Demote unavailable Anthropic tool references instead of failing the request
 
 ### What changed and why

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -246,6 +246,31 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
 }
 
 /**
+ * Matches the agent-loop stream watchdog failures ("Idle timeout waiting for
+ * provider stream after <n>ms" and "Provider stream start timed out after
+ * <n>ms"). These anchored shapes distinguish provider-stream stalls from
+ * unrelated extension, command, or MCP timeout diagnostics.
+ */
+const PROVIDER_STREAM_STALL_ERROR_PATTERN =
+	/^(?:Idle timeout waiting for provider stream after \d+ms|Provider stream start timed out after \d+ms)$/i;
+const PROVIDER_TRANSPORT_TIMEOUT_ERROR_PATTERN = /^Request timed out\.?$/i;
+
+export function isProviderStreamStallError(message: AssistantMessage): boolean {
+	return message.stopReason === "error" && PROVIDER_STREAM_STALL_ERROR_PATTERN.test(message.errorMessage ?? "");
+}
+
+/**
+ * Classifies timeout failures that originate from the provider stream or its
+ * transport. Transport timeouts may arrive as `aborted`; stream watchdog
+ * failures are ordinary error responses.
+ */
+export function isProviderTimeoutError(message: AssistantMessage): boolean {
+	if (isProviderStreamStallError(message)) return true;
+	if (message.stopReason !== "error" && message.stopReason !== "aborted") return false;
+	return PROVIDER_TRANSPORT_TIMEOUT_ERROR_PATTERN.test(message.errorMessage ?? "");
+}
+
+/**
  * Classifies a raw error-message string with the same transient-vs-terminal
  * rules as {@link isRetryableAssistantError}, for callers that hold a thrown
  * `Error` instead of an `AssistantMessage` (e.g. compaction summarization

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -81,14 +81,11 @@ describe("provider retry classification", () => {
 		["Command timed out after 30000ms", false, false],
 		["MCP server example timed out", false, false],
 		["extension timed out", false, false],
-	] as const)(
-		"classifies provider timeout provenance without matching incidental text: %s",
-		(errorMessage, expectedStall, expectedTimeout) => {
-			const message = fauxAssistantMessage("", { stopReason: "error", errorMessage });
-			expect(isProviderStreamStallError(message)).toBe(expectedStall);
-			expect(isProviderTimeoutError(message)).toBe(expectedTimeout);
-		},
-	);
+	] as const)("classifies provider timeout provenance without matching incidental text: %s", (errorMessage, expectedStall, expectedTimeout) => {
+		const message = fauxAssistantMessage("", { stopReason: "error", errorMessage });
+		expect(isProviderStreamStallError(message)).toBe(expectedStall);
+		expect(isProviderTimeoutError(message)).toBe(expectedTimeout);
+	});
 
 	it("recognizes aborted transport timeouts but not unrelated aborted work", () => {
 		expect(

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { fauxAssistantMessage } from "../src/providers/faux.ts";
-import { isRetryableAssistantError, type RetryPolicy, retryAssistantCall } from "../src/utils/retry.ts";
+import {
+	isProviderStreamStallError,
+	isProviderTimeoutError,
+	isRetryableAssistantError,
+	type RetryPolicy,
+	retryAssistantCall,
+} from "../src/utils/retry.ts";
 
 const openAIExplicitRetryMessage =
 	"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_******** in your message.";
@@ -63,6 +69,44 @@ describe("provider retry classification", () => {
 		expect(
 			isRetryableAssistantError(
 				fauxAssistantMessage("", { stopReason: "error", errorMessage: "Provider stream never started" }),
+			),
+		).toBe(false);
+	});
+
+	it.each([
+		["Idle timeout waiting for provider stream after 300000ms", true, true],
+		["Provider stream start timed out after 90000ms", true, true],
+		["Request timed out.", false, true],
+		["Request timed out", false, true],
+		["Command timed out after 30000ms", false, false],
+		["MCP server example timed out", false, false],
+		["extension timed out", false, false],
+	] as const)(
+		"classifies provider timeout provenance without matching incidental text: %s",
+		(errorMessage, expectedStall, expectedTimeout) => {
+			const message = fauxAssistantMessage("", { stopReason: "error", errorMessage });
+			expect(isProviderStreamStallError(message)).toBe(expectedStall);
+			expect(isProviderTimeoutError(message)).toBe(expectedTimeout);
+		},
+	);
+
+	it("recognizes aborted transport timeouts but not unrelated aborted work", () => {
+		expect(
+			isProviderTimeoutError(
+				fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request timed out." }),
+			),
+		).toBe(true);
+		expect(
+			isProviderTimeoutError(
+				fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Command timed out after 30000ms" }),
+			),
+		).toBe(false);
+		expect(
+			isProviderStreamStallError(
+				fauxAssistantMessage("", {
+					stopReason: "aborted",
+					errorMessage: "Idle timeout waiting for provider stream after 300000ms",
+				}),
 			),
 		).toBe(false);
 	});

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -213,10 +213,16 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the senpi version update check. Use `--
 | `retry.fallbackRevertPolicy` | `"cooldown-expiry"` \| `"never"` | `"cooldown-expiry"` | Automatic primary-model restoration policy |
 | `retry.abortServerSideFallback` | boolean | `true` | Abort a turn when the provider substitutes a different model after a classifier decline |
 | `retry.provider.timeoutMs` | number | `300000` | Provider/SDK request timeout and stream idle timeout in milliseconds |
+| `retry.provider.streamStartTimeoutMs` | number | `90000` | Maximum wait for the first provider stream event; `0` disables |
+| `retry.provider.streamRetryTimeoutMs` | number | `30000` | First-request liveness cap after a known provider stream/transport timeout; `0` disables the cap |
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay honored on the same model before the fallback chain engages (60s) |
 
 A server-requested retry delay at or below `retry.provider.maxRetryDelayMs` is honored on the same model. A longer delay means the model is unavailable rather than busy, so Senpi engages the configured fallback chain instead of waiting, suppressing the primary for the requested duration; the turn fails with an informative error only when no chain candidate can take over.
+
+After an exact provider stream/transport timeout, `retry.provider.streamRetryTimeoutMs` caps the retry's first
+provider request and defers queued user input from that request. The cap applies only to stream guards that are
+already enabled, never turns a disabled guard back on, and restores configured timeouts for later requests.
 
 Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explicitly needed. Setting it above `0` can make SDK/provider retries handle out-of-usage-limit errors before senpi sees them, which may block the agent until the provider quota resets in some circumstances.
 
@@ -228,6 +234,8 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
     "baseDelayMs": 2000,
     "provider": {
       "timeoutMs": 3600000,
+      "streamStartTimeoutMs": 90000,
+      "streamRetryTimeoutMs": 30000,
       "maxRetries": 0,
       "maxRetryDelayMs": 60000
     }

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -30,13 +30,17 @@
 
 ### What changed
 
-- `core/agent-session.ts`: retries triggered by provider timeout errors defer queued steering and follow-up input
-  until the retry produces a response. This covers both the stream reader's idle-timeout message and transport-level
-  `Request timed out` variants. Failed retries retain the queue; a successful retry lets the existing post-run queue
-  drain answer it immediately.
-- Those retries cap only their continuation-scoped stream idle timeout at 30 seconds. The initial request and later
-  ordinary turns retain the configured provider idle timeout.
-- Coverage: `test/suite/regressions/provider-idle-recovery.test.ts` pins request ordering and timeout restoration.
+- `core/agent-session.ts`: retries triggered by the shared anchored provider-timeout classifier defer queued steering
+  and follow-up input from the retry's first provider request. This covers the two agent-loop stream watchdog messages
+  and exact transport-level `Request timed out` variants without matching incidental command, MCP, or extension text.
+- `core/settings-manager.ts`: `retry.provider.streamRetryTimeoutMs` configures the first-request retry liveness cap
+  (default 30 seconds; `0` disables). The retry clamps only enabled idle/start guards, so it never re-enables an
+  explicitly disabled guard. Both timeout bounds return to their configured values for later provider requests.
+- The retry start bound is capped as well as the provider request option, while the configured idle timeout resumes
+  after the first event so healthy reasoning gaps are not limited to 30 seconds.
+- Coverage: `test/suite/regressions/provider-idle-recovery.test.ts` pins exact request text/order, configurable timeout
+  sequences, disabled guards, negative classifier shapes, and a real no-first-event stream expiry at the cap;
+  `test/settings-manager.test.ts` pins setting defaults and `0` semantics.
 
 ### Why
 
@@ -46,7 +50,8 @@
 
 ### Expected merge conflict zones on next upstream sync
 
-- LOW: one retry-continuation option branch in `core/agent-session.ts`.
+- MEDIUM: `core/agent-session.ts` retry-controller continuation options and scheduled-continuation admission.
+- LOW: `core/settings-manager.ts` provider retry settings and timeout getters.
 
 ## Absent fallback chains no longer produce a startup warning (2026-07-28)
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -38,6 +38,8 @@
   explicitly disabled guard. Both timeout bounds return to their configured values for later provider requests.
 - The retry start bound is capped as well as the provider request option, while the configured idle timeout resumes
   after the first event so healthy reasoning gaps are not limited to 30 seconds.
+- Consecutive transport timeouts reported with `stopReason: "aborted"` keep consuming the same retry counter. Only a
+  genuinely successful assistant response resets the budget or emits `auto_retry_end { success: true }`.
 - Coverage: `test/suite/regressions/provider-idle-recovery.test.ts` pins exact request text/order, configurable timeout
   sequences, disabled guards, negative classifier shapes, and a real no-first-event stream expiry at the cap;
   `test/settings-manager.test.ts` pins setting defaults and `0` semantics.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -26,6 +26,28 @@
 - LOW: one settings getter + one field in `ProviderRetrySettings`; one error message in
   `composeModelProvider`; one option in the `Agent` construction in `core/sdk.ts`.
 
+## Provider idle retries preserve user input and use a bounded retry budget (2026-07-29)
+
+### What changed
+
+- `core/agent-session.ts`: retries triggered by provider timeout errors defer queued steering and follow-up input
+  until the retry produces a response. This covers both the stream reader's idle-timeout message and transport-level
+  `Request timed out` variants. Failed retries retain the queue; a successful retry lets the existing post-run queue
+  drain answer it immediately.
+- Those retries cap only their continuation-scoped stream idle timeout at 30 seconds. The initial request and later
+  ordinary turns retain the configured provider idle timeout.
+- Coverage: `test/suite/regressions/provider-idle-recovery.test.ts` pins request ordering and timeout restoration.
+
+### Why
+
+- A silent provider stream previously consumed user steering into another full-length retry. Repeated 300-second
+  retries made the session look stuck and could leave the user's `continue` adjacent to an error instead of a real
+  answer.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: one retry-continuation option branch in `core/agent-session.ts`.
+
 ## Absent fallback chains no longer produce a startup warning (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -40,6 +40,10 @@
   after the first event so healthy reasoning gaps are not limited to 30 seconds.
 - Consecutive transport timeouts reported with `stopReason: "aborted"` keep consuming the same retry counter. Only a
   genuinely successful assistant response resets the budget or emits `auto_retry_end { success: true }`.
+- Retry continuations use the session-work barrier and revalidate atomically with the scheduled-continuation path.
+  Accepted recompaction stays queue-first while retaining timeout options; reconstructed failed assistant tails are
+  retired before continuation. A concurrent low-level `Agent.prompt()` is treated as a benign takeover, and session
+  settlement is never emitted while Agent core is still streaming.
 - Coverage: `test/suite/regressions/provider-idle-recovery.test.ts` pins exact request text/order, configurable timeout
   sequences, disabled guards, negative classifier shapes, and a real no-first-event stream expiry at the cap;
   `test/settings-manager.test.ts` pins setting defaults and `0` semantics.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -148,6 +148,8 @@ import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapp
 import { addUsageToTotals, createUsageTotals } from "./usage-totals.ts";
 
 const TURN_RETRY_SUPPRESSION_PREFIX = "senpi:no-turn-retry:";
+const PROVIDER_TIMEOUT_PATTERN = /(?:timed? out|timeout)/i;
+const PROVIDER_STREAM_IDLE_RETRY_TIMEOUT_CAP_MS = 30_000;
 
 // ============================================================================
 // Skill Block Parsing
@@ -4363,12 +4365,16 @@ export class AgentSession {
 		this._scheduledContinuationRecompacted = true;
 	}
 
-	private async _continueAgentAfterCurrentRun(): Promise<void> {
+	private async _continueAgentAfterCurrentRun(
+		options: { deferQueuedMessages?: boolean; timeoutMs?: number } = {},
+	): Promise<void> {
 		await this.agent.waitForIdle();
 		await this._revalidateScheduledContinuationAdmission();
 		const useQueuedContinuation = this._scheduledContinuationRecompacted;
 		try {
-			if (useQueuedContinuation) {
+			if (options.deferQueuedMessages || options.timeoutMs !== undefined) {
+				await this.agent.continue(options);
+			} else if (useQueuedContinuation) {
 				await this.agent.continueWithQueuedMessages();
 			} else {
 				await this.agent.continue();
@@ -5431,9 +5437,16 @@ export class AgentSession {
 		// Agent core would otherwise drain these queues before the continuation
 		// revalidates its provider admission. The scheduled continuation owns them
 		// until it either starts or reports a terminal admission failure.
+		const deferQueuedMessages = PROVIDER_TIMEOUT_PATTERN.test(errorMessage);
+		const timeoutMs = deferQueuedMessages
+			? Math.min(
+					this.agent.timeoutMs ?? PROVIDER_STREAM_IDLE_RETRY_TIMEOUT_CAP_MS,
+					PROVIDER_STREAM_IDLE_RETRY_TIMEOUT_CAP_MS,
+				)
+			: undefined;
 		this.agent.suppressQueuedMessageDrain();
 		setTimeout(() => {
-			void this._continueAgentAfterCurrentRun().catch(async (error) => {
+			void this._continueAgentAfterCurrentRun({ deferQueuedMessages, timeoutMs }).catch(async (error) => {
 				const message = error instanceof Error ? error.message : String(error);
 				this._emit({
 					type: "continuation_error",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1443,13 +1443,18 @@ export class AgentSession {
 				this._lastAssistantMessage = event.message;
 
 				const assistantMsg = event.message as AssistantMessage;
-				if (assistantMsg.stopReason !== "error") {
+				const succeeded =
+					assistantMsg.stopReason !== "error" &&
+					assistantMsg.stopReason !== "aborted" &&
+					!isClassifierRefusal(assistantMsg);
+				if (succeeded) {
 					this._overflowRecoveryAttempted = false;
 				}
 
-				// Reset retry counter immediately on successful assistant response
-				// This prevents accumulation across multiple LLM calls within a turn
-				if (assistantMsg.stopReason !== "error" && this._retryAttempt > 0) {
+				// Reset retry state only after a genuinely successful response. Provider
+				// transport timeouts can arrive as `aborted` and must keep consuming the
+				// same bounded retry budget instead of reporting a false success.
+				if (succeeded && this._retryAttempt > 0) {
 					const fallback = this._retryFallback.activeState;
 					if (fallback) {
 						this._emit({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1048,6 +1048,9 @@ export class AgentSession {
 	}
 
 	private async _emitAgentSettled(): Promise<void> {
+		if (this.agent.state.isStreaming) {
+			await this.agent.waitForIdle();
+		}
 		if (!this._isAgentRunActive) {
 			this._resolveIdleWaitIfIdle();
 			return;
@@ -4370,37 +4373,64 @@ export class AgentSession {
 		this._scheduledContinuationRecompacted = true;
 	}
 
-	private async _continueAgentAfterCurrentRun(options: AgentContinuationOptions = {}): Promise<void> {
+	private async _continueAgentAfterCurrentRun(
+		options: AgentContinuationOptions = {},
+	): Promise<"continued" | "taken-over"> {
 		await this.agent.waitForIdle();
-		await this._revalidateScheduledContinuationAdmission();
-		const useQueuedContinuation = this._scheduledContinuationRecompacted;
 		try {
-			if (options.deferQueuedMessages || options.timeoutMs !== undefined) {
-				await this.agent.continue(options);
-			} else if (useQueuedContinuation) {
-				await this.agent.continueWithQueuedMessages();
+			if (this.agent.state.isStreaming) return "taken-over";
+
+			await this._revalidateScheduledContinuationAdmission();
+			if (this.agent.state.isStreaming) return "taken-over";
+
+			if (this._scheduledContinuationRecompacted) {
+				const tail = this.agent.state.messages.at(-1);
+				if (tail?.role === "assistant" && (tail.stopReason === "error" || tail.stopReason === "aborted")) {
+					this._retireFailedRetryAssistant(tail);
+					if (this.agent.state.messages.at(-1) === tail) {
+						this.agent.state.messages = this.agent.state.messages.slice(0, -1);
+						this._incrementMessageRevision();
+					}
+				}
+				await this.agent.continueWithQueuedMessages(options);
 			} else {
-				await this.agent.continue();
+				await this.agent.continue(options);
 			}
+			return "continued";
+		} catch (error) {
+			if (
+				this.agent.state.isStreaming &&
+				error instanceof Error &&
+				error.message.startsWith("Agent is already processing")
+			) {
+				return "taken-over";
+			}
+			throw error;
 		} finally {
 			this._scheduledContinuationRecompacted = false;
 		}
 	}
 
-	private _scheduleContinuationAfterCurrentEvent(): void {
+	private _scheduleContinuationAfterCurrentEvent(
+		options: AgentContinuationOptions = {},
+		retryContinuation = false,
+	): void {
 		// Tool hooks wait for queued message persistence, so continue() cannot run inside this event promise.
 		const currentEventQueue = this._agentEventQueue;
 		const finishContinuationWork = this._sessionWorkBarrier.begin();
 		const continueAfterEvent = async (): Promise<void> => {
 			try {
-				await this._continueAgentAfterCurrentRun();
+				await this._continueAgentAfterCurrentRun(options);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				this._emit({
 					type: "continuation_error",
 					errorMessage: `Failed to continue queued messages: ${message}`,
 				});
-				await this._emitAgentSettled();
+				if (!this.agent.state.isStreaming) {
+					await this._emitAgentSettled();
+				}
+				if (retryContinuation) this._resolveRetry();
 			}
 		};
 
@@ -5453,23 +5483,15 @@ export class AgentSession {
 			this._skipNextPostRetryCompactionCheck = true;
 		}
 
-		// Retry via the shared continuation path after the event handler chain settles.
-		// Lifecycle suppression protects queued work while retry admission settles;
-		// known provider-timeout retries additionally skip the first queue poll so
-		// user input stays deferred until that retry request proves responsive.
+		// Retry through the barrier-owned scheduled-continuation path after the
+		// event handler chain settles. Lifecycle suppression protects queued work
+		// while admission settles; known provider-timeout retries additionally skip
+		// the first queue poll so user input stays deferred until that request proves
+		// responsive. A concurrent low-level Agent prompt is a benign takeover, not
+		// a terminal continuation failure.
 		const continuationOptions = this._getProviderTimeoutRetryOptions(message);
 		this.agent.suppressQueuedMessageDrain();
-		setTimeout(() => {
-			void this._continueAgentAfterCurrentRun(continuationOptions).catch(async (error) => {
-				const message = error instanceof Error ? error.message : String(error);
-				this._emit({
-					type: "continuation_error",
-					errorMessage: `Failed to continue queued messages: ${message}`,
-				});
-				await this._emitAgentSettled();
-				this._resolveRetry();
-			});
-		}, 0);
+		this._scheduleContinuationAfterCurrentEvent(continuationOptions, true);
 
 		return "continued";
 	}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -18,6 +18,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import type {
 	Agent,
+	AgentContinuationOptions,
 	AgentEvent,
 	AgentMessage,
 	AgentState,
@@ -46,6 +47,7 @@ import {
 	cleanupSessionResources,
 	isClassifierRefusal,
 	isContextOverflow,
+	isProviderTimeoutError,
 	isRetryableAssistantError,
 	modelsAreEqual,
 	type RetryCallbacks,
@@ -148,8 +150,6 @@ import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapp
 import { addUsageToTotals, createUsageTotals } from "./usage-totals.ts";
 
 const TURN_RETRY_SUPPRESSION_PREFIX = "senpi:no-turn-retry:";
-const PROVIDER_TIMEOUT_PATTERN = /(?:timed? out|timeout)/i;
-const PROVIDER_STREAM_IDLE_RETRY_TIMEOUT_CAP_MS = 30_000;
 
 // ============================================================================
 // Skill Block Parsing
@@ -4365,9 +4365,7 @@ export class AgentSession {
 		this._scheduledContinuationRecompacted = true;
 	}
 
-	private async _continueAgentAfterCurrentRun(
-		options: { deferQueuedMessages?: boolean; timeoutMs?: number } = {},
-	): Promise<void> {
+	private async _continueAgentAfterCurrentRun(options: AgentContinuationOptions = {}): Promise<void> {
 		await this.agent.waitForIdle();
 		await this._revalidateScheduledContinuationAdmission();
 		const useQueuedContinuation = this._scheduledContinuationRecompacted;
@@ -5158,7 +5156,7 @@ export class AgentSession {
 		if (!message.errorMessage) return false;
 
 		if (message.stopReason === "aborted") {
-			return /timed? out|timeout/i.test(message.errorMessage);
+			return isProviderTimeoutError(message);
 		}
 
 		return isRetryableAssistantError(message);
@@ -5208,6 +5206,23 @@ export class AgentSession {
 			return Math.ceil(value * 1000);
 		}
 		return Math.ceil(value);
+	}
+
+	private _getProviderTimeoutRetryOptions(message: AssistantMessage): AgentContinuationOptions {
+		if (!isProviderTimeoutError(message)) return {};
+
+		const capMs = this.settingsManager.getProviderStreamRetryTimeoutMs();
+		const capEnabledBound = (configuredMs: number | undefined): number | undefined => {
+			if (capMs === undefined || configuredMs === undefined) return undefined;
+			return Math.min(configuredMs, capMs);
+		};
+		const timeoutMs = capEnabledBound(this.agent.timeoutMs);
+		const streamStartTimeoutMs = capEnabledBound(this.agent.streamStartTimeoutMs);
+		return {
+			deferQueuedMessages: true,
+			...(timeoutMs === undefined ? {} : { timeoutMs }),
+			...(streamStartTimeoutMs === undefined ? {} : { streamStartTimeoutMs }),
+		};
 	}
 
 	/**
@@ -5434,19 +5449,13 @@ export class AgentSession {
 		}
 
 		// Retry via the shared continuation path after the event handler chain settles.
-		// Agent core would otherwise drain these queues before the continuation
-		// revalidates its provider admission. The scheduled continuation owns them
-		// until it either starts or reports a terminal admission failure.
-		const deferQueuedMessages = PROVIDER_TIMEOUT_PATTERN.test(errorMessage);
-		const timeoutMs = deferQueuedMessages
-			? Math.min(
-					this.agent.timeoutMs ?? PROVIDER_STREAM_IDLE_RETRY_TIMEOUT_CAP_MS,
-					PROVIDER_STREAM_IDLE_RETRY_TIMEOUT_CAP_MS,
-				)
-			: undefined;
+		// Lifecycle suppression protects queued work while retry admission settles;
+		// known provider-timeout retries additionally skip the first queue poll so
+		// user input stays deferred until that retry request proves responsive.
+		const continuationOptions = this._getProviderTimeoutRetryOptions(message);
 		this.agent.suppressQueuedMessageDrain();
 		setTimeout(() => {
-			void this._continueAgentAfterCurrentRun({ deferQueuedMessages, timeoutMs }).catch(async (error) => {
+			void this._continueAgentAfterCurrentRun(continuationOptions).catch(async (error) => {
 				const message = error instanceof Error ? error.message : String(error);
 				this._emit({
 					type: "continuation_error",

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -11,6 +11,7 @@ import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 
 export const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+export const DEFAULT_PROVIDER_STREAM_RETRY_TIMEOUT_MS = 30_000;
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -34,6 +35,7 @@ export interface BranchSummarySettings {
 export interface ProviderRetrySettings {
 	timeoutMs?: number; // SDK request timeout + agent stream idle timeout; defaults to httpIdleTimeoutMs
 	streamStartTimeoutMs?: number; // max wait for the FIRST provider stream event; default: 90000, 0 disables
+	streamRetryTimeoutMs?: number; // first-request liveness cap after a provider timeout; default: 30000, 0 disables
 	maxRetries?: number; // SDK/provider retry attempts
 	maxRetryDelayMs?: number; // default: 60000 (max server-requested delay honoured on the same model; beyond it the fallback chain engages)
 }
@@ -1106,6 +1108,20 @@ export class SettingsManager {
 			maxRetries: this.settings.retry?.provider?.maxRetries,
 			maxRetryDelayMs: this.settings.retry?.provider?.maxRetryDelayMs ?? 60000,
 		};
+	}
+
+	/**
+	 * First-request liveness cap for retries of known provider stream/transport
+	 * timeouts. `retry.provider.streamRetryTimeoutMs` overrides the 30s default;
+	 * 0 disables the cap without disabling queue deferral. The retry path clamps
+	 * only already-enabled stream guards, so this setting never re-enables one.
+	 */
+	getProviderStreamRetryTimeoutMs(): number | undefined {
+		const explicit = this.settings.retry?.provider?.streamRetryTimeoutMs;
+		if (explicit !== undefined) {
+			return explicit > 0 ? explicit : undefined;
+		}
+		return DEFAULT_PROVIDER_STREAM_RETRY_TIMEOUT_MS;
 	}
 
 	/**

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -273,6 +273,33 @@ describe("SettingsManager", () => {
 			expect(thenRetrySettings.timeoutMs).toBe(12_345);
 		});
 
+		it("should default the provider stream retry timeout to 30s", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getProviderStreamRetryTimeoutMs()).toBe(30_000);
+		});
+
+		it("should prefer retry.provider.streamRetryTimeoutMs", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ retry: { provider: { streamRetryTimeoutMs: 45_000 } } }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getProviderStreamRetryTimeoutMs()).toBe(45_000);
+		});
+
+		it("should disable the provider stream retry cap when streamRetryTimeoutMs is 0", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ retry: { provider: { streamRetryTimeoutMs: 0 } } }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getProviderStreamRetryTimeoutMs()).toBeUndefined();
+		});
+
 		it("should default the agent stream idle timeout to httpIdleTimeoutMs", () => {
 			const givenSettingsPath = join(agentDir, "settings.json");
 			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -135,11 +135,15 @@ describe("AgentSession retry and event characterization", () => {
 		harnesses.push(harness);
 		let firstCallStarted!: () => void;
 		let releaseTimeout!: () => void;
+		let steeringCallStarted!: () => void;
 		const sawFirstCall = new Promise<void>((resolve) => {
 			firstCallStarted = resolve;
 		});
 		const timeoutReady = new Promise<void>((resolve) => {
 			releaseTimeout = resolve;
+		});
+		const sawSteeringCall = new Promise<void>((resolve) => {
+			steeringCallStarted = resolve;
 		});
 		harness.setResponses([
 			async () => {
@@ -148,6 +152,10 @@ describe("AgentSession retry and event characterization", () => {
 				return fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request timed out." });
 			},
 			fauxAssistantMessage("recovered after timeout"),
+			async () => {
+				steeringCallStarted();
+				return fauxAssistantMessage("recovered queued steering");
+			},
 		]);
 
 		// when
@@ -156,15 +164,29 @@ describe("AgentSession retry and event characterization", () => {
 		await harness.session.steer(".");
 		releaseTimeout();
 		await promptPromise;
+		await sawSteeringCall;
 
 		// then
-		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.faux.state.callCount).toBe(3);
 		expect(harness.eventsOfType("auto_retry_start").map((event) => event.errorMessage)).toEqual([
 			"Request timed out.",
 		]);
 		const secondCall = harness.faux.getCallLog()[1];
+		const thirdCall = harness.faux.getCallLog()[2];
 		expect(
 			secondCall.context.messages
+				.filter((message) => message.role === "user")
+				.map((message) =>
+					typeof message.content === "string"
+						? message.content
+						: message.content
+								.filter((content) => content.type === "text")
+								.map((content) => content.text)
+								.join("\n"),
+				),
+		).not.toContain(".");
+		expect(
+			thirdCall.context.messages
 				.filter((message) => message.role === "user")
 				.map((message) =>
 					typeof message.content === "string"

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -222,6 +222,40 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.session.isRetrying).toBe(false);
 	});
 
+	it("exhausts the retry budget across consecutive aborted transport timeouts", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		let queuedSteering: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && queuedSteering === undefined) {
+				queuedSteering = harness.session.steer("retain after retry exhaustion");
+			}
+		});
+		const abortedTimeout = () =>
+			fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request timed out." });
+		harness.setResponses([
+			abortedTimeout(),
+			abortedTimeout(),
+			abortedTimeout(),
+			fauxAssistantMessage("must not run"),
+			fauxAssistantMessage("queued input must not run"),
+		]);
+
+		await harness.session.prompt("test");
+		await queuedSteering;
+
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.attempt)).toEqual([1, 2]);
+		expect(harness.eventsOfType("auto_retry_end")).toMatchObject([
+			{ success: false, attempt: 2, finalError: "Request timed out." },
+		]);
+		expect(harness.eventsOfType("auto_retry_end").some((event) => event.success)).toBe(false);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain after retry exhaustion"]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+	});
+
 	it("prompt waits for retry completion even when assistant message_end handling is delayed", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } },

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -62,11 +62,17 @@ function genericTimeoutError() {
 }
 
 function getRequestUserTexts(harness: Harness): string[][] {
-	return harness.faux.getCallLog().map((call) =>
-		call.context.messages
-			.filter((message) => message.role === "user")
-			.map((message) => getMessageText(message)),
-	);
+	return harness.faux
+		.getCallLog()
+		.map((call) =>
+			call.context.messages.filter((message) => message.role === "user").map((message) => getMessageText(message)),
+		);
+}
+
+function getStreamStartTimeoutMs(options: unknown): number | undefined {
+	if (!options || typeof options !== "object" || !("streamStartTimeoutMs" in options)) return undefined;
+	const value = (options as { streamStartTimeoutMs?: unknown }).streamStartTimeoutMs;
+	return typeof value === "number" ? value : undefined;
 }
 
 describe("provider idle recovery", () => {
@@ -136,7 +142,7 @@ describe("provider idle recovery", () => {
 			RETRY_PROVIDER_TIMEOUT_MS,
 			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
 		]);
-		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
 			DEFAULT_STREAM_START_TIMEOUT_MS,
 			RETRY_PROVIDER_TIMEOUT_MS,
 			RETRY_PROVIDER_TIMEOUT_MS,
@@ -173,7 +179,7 @@ describe("provider idle recovery", () => {
 			45_000,
 			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
 		]);
-		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
 			DEFAULT_STREAM_START_TIMEOUT_MS,
 			45_000,
 			DEFAULT_STREAM_START_TIMEOUT_MS,
@@ -192,7 +198,7 @@ describe("provider idle recovery", () => {
 		await harness.session.prompt("first request");
 
 		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([undefined, undefined]);
-		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
 			undefined,
 			undefined,
 		]);
@@ -216,7 +222,7 @@ describe("provider idle recovery", () => {
 			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
 			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
 		]);
-		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
 			DEFAULT_STREAM_START_TIMEOUT_MS,
 			DEFAULT_STREAM_START_TIMEOUT_MS,
 		]);
@@ -243,70 +249,67 @@ describe("provider idle recovery", () => {
 		["assistant", "empty"],
 		["non-assistant", "queued"],
 		["non-assistant", "empty"],
-	] as const)(
-		"keeps timeout retries queue-first after recompaction with a %s tail and %s queue",
-		async (tail, queueState) => {
-			const harness = await createHarness({
-				settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
-			});
-			harnesses.push(harness);
-			harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
-			harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
-			const internals = harness.session as unknown as ContinuationInternals;
-			vi.spyOn(internals, "_revalidateScheduledContinuationAdmission").mockImplementation(async () => {
-				internals._scheduledContinuationRecompacted = true;
-				if (tail === "assistant") {
-					harness.agent.state.messages = [
-						...harness.agent.state.messages,
-						fauxAssistantMessage("", { stopReason: "error", errorMessage: "Request timed out." }),
-					];
-					return;
-				}
+	] as const)("keeps timeout retries queue-first after recompaction with a %s tail and %s queue", async (tail, queueState) => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		const internals = harness.session as unknown as ContinuationInternals;
+		vi.spyOn(internals, "_revalidateScheduledContinuationAdmission").mockImplementation(async () => {
+			internals._scheduledContinuationRecompacted = true;
+			if (tail === "assistant") {
 				harness.agent.state.messages = [
 					...harness.agent.state.messages,
-					{
-						role: "custom",
-						customType: "compactionSummary",
-						content: "accepted retry compaction summary",
-						display: false,
-						timestamp: Date.now(),
-					},
+					fauxAssistantMessage("", { stopReason: "error", errorMessage: "Request timed out." }),
 				];
-			});
-			const queueAwareContinue = vi.spyOn(harness.agent, "continueWithQueuedMessages");
-			let queuedInput: Promise<void> | undefined;
-			harness.session.subscribe((event) => {
-				if (queueState === "queued" && event.type === "auto_retry_start" && queuedInput === undefined) {
-					queuedInput = harness.session.steer("queued after timeout");
-				}
-			});
-			harness.setResponses([
-				genericTimeoutError(),
-				fauxAssistantMessage("recovered after recompaction"),
-				fauxAssistantMessage("must not run"),
-			]);
-
-			await harness.session.prompt("original request");
-			await queuedInput;
-
-			expect(queueAwareContinue).toHaveBeenCalledTimes(1);
-			expect(harness.eventsOfType("continuation_error")).toEqual([]);
-			const retryUserTexts = [
-				"original request",
-				...(tail === "non-assistant" ? ["accepted retry compaction summary"] : []),
-				...(queueState === "queued" ? ["queued after timeout"] : []),
+				return;
+			}
+			harness.agent.state.messages = [
+				...harness.agent.state.messages,
+				{
+					role: "custom",
+					customType: "compactionSummary",
+					content: "accepted retry compaction summary",
+					display: false,
+					timestamp: Date.now(),
+				},
 			];
-			expect(getRequestUserTexts(harness)).toEqual([["original request"], retryUserTexts]);
-			expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
-				DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-				RETRY_PROVIDER_TIMEOUT_MS,
-			]);
-			expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
-				DEFAULT_STREAM_START_TIMEOUT_MS,
-				RETRY_PROVIDER_TIMEOUT_MS,
-			]);
-		},
-	);
+		});
+		const queueAwareContinue = vi.spyOn(harness.agent, "continueWithQueuedMessages");
+		let queuedInput: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (queueState === "queued" && event.type === "auto_retry_start" && queuedInput === undefined) {
+				queuedInput = harness.session.steer("queued after timeout");
+			}
+		});
+		harness.setResponses([
+			genericTimeoutError(),
+			fauxAssistantMessage("recovered after recompaction"),
+			fauxAssistantMessage("must not run"),
+		]);
+
+		await harness.session.prompt("original request");
+		await queuedInput;
+
+		expect(queueAwareContinue).toHaveBeenCalledTimes(1);
+		expect(harness.eventsOfType("continuation_error")).toEqual([]);
+		const retryUserTexts = [
+			"original request",
+			...(tail === "non-assistant" ? ["accepted retry compaction summary"] : []),
+			...(queueState === "queued" ? ["queued after timeout"] : []),
+		];
+		expect(getRequestUserTexts(harness)).toEqual([["original request"], retryUserTexts]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+		]);
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+		]);
+	});
 
 	it("retains queued input when a capped retry is aborted in flight", async () => {
 		const harness = await createHarness({
@@ -371,7 +374,7 @@ describe("provider idle recovery", () => {
 			providerCalls++;
 			providerOptions.push({
 				timeoutMs: options?.timeoutMs,
-				streamStartTimeoutMs: options?.streamStartTimeoutMs,
+				streamStartTimeoutMs: getStreamStartTimeoutMs(options),
 			});
 			const stream = createAssistantStream();
 			if (providerCalls === 1) {

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -1,0 +1,119 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+
+const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
+const RETRY_PROVIDER_IDLE_TIMEOUT_MS = 30_000;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+	});
+	try {
+		return await Promise.race([promise, timeout]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+function idleTimeoutError() {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: `Idle timeout waiting for provider stream after ${DEFAULT_PROVIDER_IDLE_TIMEOUT_MS}ms`,
+	});
+}
+
+function genericTimeoutError() {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: "Request timed out.",
+	});
+}
+
+describe("provider idle recovery", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("preserves steering until the timed-out retry recovers", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.setResponses([
+			idleTimeoutError(),
+			genericTimeoutError(),
+			fauxAssistantMessage("original request recovered"),
+			fauxAssistantMessage("steering request recovered"),
+		]);
+
+		let queuedSteering: Promise<void> | undefined;
+		let resolveSteeringResponse: (() => void) | undefined;
+		const steeringResponse = new Promise<void>((resolve) => {
+			resolveSteeringResponse = resolve;
+		});
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && queuedSteering === undefined) {
+				queuedSteering = harness.session.steer("continue");
+			}
+			if (
+				event.type === "message_end" &&
+				event.message.role === "assistant" &&
+				JSON.stringify(event.message.content).includes("steering request recovered")
+			) {
+				resolveSteeringResponse?.();
+			}
+		});
+
+		try {
+			await harness.session.prompt("original request");
+			await queuedSteering;
+			await withTimeout(
+				steeringResponse,
+				1_000,
+				`queued steering response was not produced: ${JSON.stringify(
+					harness.faux.getCallLog().map((call) => call.context.messages),
+				)}`,
+			);
+		} finally {
+			unsubscribe();
+		}
+
+		const requests = harness.faux.getCallLog().map((call) => JSON.stringify(call.context.messages));
+		expect(requests).toHaveLength(4);
+		expect(requests[1]).toContain("original request");
+		expect(requests[1]).not.toContain("continue");
+		expect(requests[2]).toContain("original request");
+		expect(requests[2]).not.toContain("continue");
+		expect(requests[3]).toContain("continue");
+		expect(getUserTexts(harness)).toEqual(["original request", "continue"]);
+	});
+
+	it("caps only automatic idle-timeout retries", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.setResponses([
+			idleTimeoutError(),
+			fauxAssistantMessage("retry recovered"),
+			fauxAssistantMessage("ordinary turn recovered"),
+		]);
+
+		await harness.session.prompt("first request");
+		await harness.session.prompt("later request");
+
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+			RETRY_PROVIDER_IDLE_TIMEOUT_MS,
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+		]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -11,6 +11,11 @@ const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
 const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
 const RETRY_PROVIDER_TIMEOUT_MS = 30_000;
 
+type ContinuationInternals = {
+	_scheduledContinuationRecompacted: boolean;
+	_revalidateScheduledContinuationAdmission(): Promise<void>;
+};
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	const timeout = new Promise<never>((_resolve, reject) => {
@@ -68,6 +73,7 @@ describe("provider idle recovery", () => {
 	const harnesses: Harness[] = [];
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		vi.useRealTimers();
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
@@ -232,6 +238,124 @@ describe("provider idle recovery", () => {
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 	});
 
+	it.each([
+		["assistant", "queued"],
+		["assistant", "empty"],
+		["non-assistant", "queued"],
+		["non-assistant", "empty"],
+	] as const)(
+		"keeps timeout retries queue-first after recompaction with a %s tail and %s queue",
+		async (tail, queueState) => {
+			const harness = await createHarness({
+				settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+			});
+			harnesses.push(harness);
+			harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+			harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+			const internals = harness.session as unknown as ContinuationInternals;
+			vi.spyOn(internals, "_revalidateScheduledContinuationAdmission").mockImplementation(async () => {
+				internals._scheduledContinuationRecompacted = true;
+				if (tail === "assistant") {
+					harness.agent.state.messages = [
+						...harness.agent.state.messages,
+						fauxAssistantMessage("", { stopReason: "error", errorMessage: "Request timed out." }),
+					];
+					return;
+				}
+				harness.agent.state.messages = [
+					...harness.agent.state.messages,
+					{
+						role: "custom",
+						customType: "compactionSummary",
+						content: "accepted retry compaction summary",
+						display: false,
+						timestamp: Date.now(),
+					},
+				];
+			});
+			const queueAwareContinue = vi.spyOn(harness.agent, "continueWithQueuedMessages");
+			let queuedInput: Promise<void> | undefined;
+			harness.session.subscribe((event) => {
+				if (queueState === "queued" && event.type === "auto_retry_start" && queuedInput === undefined) {
+					queuedInput = harness.session.steer("queued after timeout");
+				}
+			});
+			harness.setResponses([
+				genericTimeoutError(),
+				fauxAssistantMessage("recovered after recompaction"),
+				fauxAssistantMessage("must not run"),
+			]);
+
+			await harness.session.prompt("original request");
+			await queuedInput;
+
+			expect(queueAwareContinue).toHaveBeenCalledTimes(1);
+			expect(harness.eventsOfType("continuation_error")).toEqual([]);
+			const retryUserTexts = [
+				"original request",
+				...(tail === "non-assistant" ? ["accepted retry compaction summary"] : []),
+				...(queueState === "queued" ? ["queued after timeout"] : []),
+			];
+			expect(getRequestUserTexts(harness)).toEqual([["original request"], retryUserTexts]);
+			expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+				DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+				RETRY_PROVIDER_TIMEOUT_MS,
+			]);
+			expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+				DEFAULT_STREAM_START_TIMEOUT_MS,
+				RETRY_PROVIDER_TIMEOUT_MS,
+			]);
+		},
+	);
+
+	it("retains queued input when a capped retry is aborted in flight", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		const retryRequestStarted = createDeferred();
+		let queuedInput: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && queuedInput === undefined) {
+				queuedInput = harness.session.steer("retain through retry abort");
+			}
+		});
+		harness.setResponses([
+			genericTimeoutError(),
+			async (_context, options) => {
+				retryRequestStarted.resolve();
+				await new Promise<void>((resolve) => {
+					const signal = options?.signal;
+					if (signal?.aborted) {
+						resolve();
+						return;
+					}
+					signal?.addEventListener("abort", () => resolve(), { once: true });
+				});
+				return fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request was aborted" });
+			},
+			fauxAssistantMessage("must not run"),
+		]);
+
+		const prompt = harness.session.prompt("original request");
+		await retryRequestStarted.promise;
+		await queuedInput;
+		await harness.session.abort();
+		await prompt;
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.faux.getCallLog()[1]?.options?.timeoutMs).toBe(RETRY_PROVIDER_TIMEOUT_MS);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain through retry abort"]);
+		expect(harness.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.eventsOfType("continuation_error")).toEqual([]);
+		expect(harness.session.isRetrying).toBe(false);
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.agent.state.isStreaming).toBe(false);
+	});
+
 	it("expires a no-first-event retry at the retry cap instead of the configured start timeout", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({
@@ -271,7 +395,6 @@ describe("provider idle recovery", () => {
 		const prompt = harness.session.prompt("first request");
 		try {
 			await retryStarted;
-			await vi.runOnlyPendingTimersAsync();
 			await vi.runOnlyPendingTimersAsync();
 			await secondRequestStarted.promise;
 			await vi.advanceTimersByTimeAsync(RETRY_PROVIDER_TIMEOUT_MS - 1);

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -1,9 +1,15 @@
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it } from "vitest";
-import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	fauxAssistantMessage,
+} from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.ts";
 
 const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
-const RETRY_PROVIDER_IDLE_TIMEOUT_MS = 30_000;
+const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+const RETRY_PROVIDER_TIMEOUT_MS = 30_000;
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
@@ -15,6 +21,25 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: s
 	} finally {
 		if (timer !== undefined) clearTimeout(timer);
 	}
+}
+
+function createAssistantStream(): EventStream<AssistantMessageEvent, AssistantMessage> {
+	return new EventStream<AssistantMessageEvent, AssistantMessage>(
+		(event) => event.type === "done" || event.type === "error",
+		(event) => {
+			if (event.type === "done") return event.message;
+			if (event.type === "error") return event.error;
+			throw new Error("Unexpected non-terminal faux stream event");
+		},
+	);
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	return { promise, resolve };
 }
 
 function idleTimeoutError() {
@@ -31,21 +56,31 @@ function genericTimeoutError() {
 	});
 }
 
+function getRequestUserTexts(harness: Harness): string[][] {
+	return harness.faux.getCallLog().map((call) =>
+		call.context.messages
+			.filter((message) => message.role === "user")
+			.map((message) => getMessageText(message)),
+	);
+}
+
 describe("provider idle recovery", () => {
 	const harnesses: Harness[] = [];
 
 	afterEach(() => {
+		vi.useRealTimers();
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
 	});
 
-	it("preserves steering until the timed-out retry recovers", async () => {
+	it("preserves steering until the timed-out retry recovers under configured timeouts", async () => {
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 0 } },
 		});
 		harnesses.push(harness);
 		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
 		harness.setResponses([
 			idleTimeoutError(),
 			genericTimeoutError(),
@@ -65,7 +100,7 @@ describe("provider idle recovery", () => {
 			if (
 				event.type === "message_end" &&
 				event.message.role === "assistant" &&
-				JSON.stringify(event.message.content).includes("steering request recovered")
+				getMessageText(event.message) === "steering request recovered"
 			) {
 				resolveSteeringResponse?.();
 			}
@@ -77,30 +112,47 @@ describe("provider idle recovery", () => {
 			await withTimeout(
 				steeringResponse,
 				1_000,
-				`queued steering response was not produced: ${JSON.stringify(
-					harness.faux.getCallLog().map((call) => call.context.messages),
-				)}`,
+				`queued steering response was not produced: ${JSON.stringify(getRequestUserTexts(harness))}`,
 			);
 		} finally {
 			unsubscribe();
 		}
 
-		const requests = harness.faux.getCallLog().map((call) => JSON.stringify(call.context.messages));
-		expect(requests).toHaveLength(4);
-		expect(requests[1]).toContain("original request");
-		expect(requests[1]).not.toContain("continue");
-		expect(requests[2]).toContain("original request");
-		expect(requests[2]).not.toContain("continue");
-		expect(requests[3]).toContain("continue");
+		expect(getRequestUserTexts(harness)).toEqual([
+			["original request"],
+			["original request"],
+			["original request"],
+			["original request", "continue"],
+		]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+		]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+		]);
 		expect(getUserTexts(harness)).toEqual(["original request", "continue"]);
 	});
 
-	it("caps only automatic idle-timeout retries", async () => {
+	it("uses the configured provider stream retry cap", async () => {
 		const harness = await createHarness({
-			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 0,
+					provider: { streamRetryTimeoutMs: 45_000 },
+				},
+			},
 		});
 		harnesses.push(harness);
 		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
 		harness.setResponses([
 			idleTimeoutError(),
 			fauxAssistantMessage("retry recovered"),
@@ -112,8 +164,141 @@ describe("provider idle recovery", () => {
 
 		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
 			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-			RETRY_PROVIDER_IDLE_TIMEOUT_MS,
+			45_000,
 			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
 		]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+			45_000,
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+		]);
+	});
+
+	it("does not re-enable disabled stream guards during a timeout retry", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = undefined;
+		harness.agent.streamStartTimeoutMs = undefined;
+		harness.setResponses([genericTimeoutError(), fauxAssistantMessage("retry recovered")]);
+
+		await harness.session.prompt("first request");
+
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([undefined, undefined]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+			undefined,
+			undefined,
+		]);
+	});
+
+	it("does not apply provider timeout policy to incidental extension timeout text", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "extension timed out" }),
+			fauxAssistantMessage("generic retry recovered"),
+		]);
+
+		await harness.session.prompt("first request");
+
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+		]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.streamStartTimeoutMs)).toEqual([
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+		]);
+	});
+
+	it("does not retry unrelated aborted timeout text", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Command timed out after 30000ms" }),
+			fauxAssistantMessage("must not run"),
+		]);
+
+		await harness.session.prompt("first request");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+	});
+
+	it("expires a no-first-event retry at the retry cap instead of the configured start timeout", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		const providerOptions: Array<{ timeoutMs?: number; streamStartTimeoutMs?: number }> = [];
+		const secondRequestStarted = createDeferred();
+		let providerCalls = 0;
+		harness.agent.streamFunction = (_model, _context, options) => {
+			providerCalls++;
+			providerOptions.push({
+				timeoutMs: options?.timeoutMs,
+				streamStartTimeoutMs: options?.streamStartTimeoutMs,
+			});
+			const stream = createAssistantStream();
+			if (providerCalls === 1) {
+				queueMicrotask(() => {
+					const error = idleTimeoutError();
+					stream.push({ type: "error", reason: "error", error });
+				});
+			} else {
+				secondRequestStarted.resolve();
+			}
+			return stream;
+		};
+		const retryStarted = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type !== "auto_retry_start") return;
+				unsubscribe();
+				resolve();
+			});
+		});
+
+		const prompt = harness.session.prompt("first request");
+		try {
+			await retryStarted;
+			await vi.runOnlyPendingTimersAsync();
+			await vi.runOnlyPendingTimersAsync();
+			await secondRequestStarted.promise;
+			await vi.advanceTimersByTimeAsync(RETRY_PROVIDER_TIMEOUT_MS - 1);
+			expect(harness.eventsOfType("auto_retry_end")).toEqual([]);
+
+			await vi.advanceTimersByTimeAsync(1);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+			expect(providerOptions).toEqual([
+				{
+					timeoutMs: DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+					streamStartTimeoutMs: DEFAULT_STREAM_START_TIMEOUT_MS,
+				},
+				{ timeoutMs: RETRY_PROVIDER_TIMEOUT_MS, streamStartTimeoutMs: RETRY_PROVIDER_TIMEOUT_MS },
+			]);
+			const finalAssistant = harness
+				.eventsOfType("message_end")
+				.map((event) => event.message)
+				.filter((message): message is AssistantMessage => message.role === "assistant")
+				.at(-1);
+			expect(finalAssistant?.errorMessage).toBe(
+				`Provider stream start timed out after ${RETRY_PROVIDER_TIMEOUT_MS}ms`,
+			);
+		} finally {
+			if (harness.session.isStreaming) await harness.session.abort();
+			await prompt;
+		}
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/retry-fallback-continuation-revalidation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/retry-fallback-continuation-revalidation.test.ts
@@ -16,6 +16,10 @@ type ContinuationInternals = {
 	_revalidateScheduledContinuationAdmission(): Promise<void>;
 };
 
+type SessionWorkBarrier = {
+	readonly hasActiveWork: boolean;
+};
+
 function createDeferred(): Deferred {
 	let resolve: (() => void) | undefined;
 	const promise = new Promise<void>((next) => {
@@ -43,6 +47,52 @@ describe("retry fallback continuation revalidation", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("treats a concurrent low-level prompt as a benign retry-continuation takeover", async () => {
+		const revalidationStarted = createDeferred();
+		const releaseRevalidation = createDeferred();
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		const internals = harness.session as unknown as ContinuationInternals;
+		vi.spyOn(internals, "_revalidateScheduledContinuationAdmission").mockImplementation(async () => {
+			revalidationStarted.resolve();
+			await releaseRevalidation.promise;
+		});
+		const sessionWorkBarrier = Reflect.get(harness.session, "_sessionWorkBarrier") as SessionWorkBarrier;
+		const continuationErrors: string[] = [];
+		const settledStreamingStates: boolean[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "continuation_error") continuationErrors.push(event.errorMessage);
+			if (event.type === "agent_settled") settledStreamingStates.push(harness.agent.state.isStreaming);
+		});
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "Request timed out." }),
+			fauxAssistantMessage("low-level prompt won admission"),
+			fauxAssistantMessage("retry continuation must not run"),
+		]);
+
+		const sessionPrompt = harness.session.prompt("original request");
+		await revalidationStarted.promise;
+		const barrierWasClaimed = sessionWorkBarrier.hasActiveWork;
+		const lowLevelPrompt = harness.agent.prompt("concurrent low-level prompt");
+		expect(harness.agent.state.isStreaming).toBe(true);
+		releaseRevalidation.resolve();
+
+		await Promise.all([sessionPrompt, lowLevelPrompt]);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(barrierWasClaimed).toBe(true);
+		expect(continuationErrors).toEqual([]);
+		expect(settledStreamingStates).toEqual([false]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
+		expect(internals._isAgentRunActive).toBe(false);
+		expect(internals._retryPromise).toBeUndefined();
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.agent.state.isStreaming).toBe(false);
 	});
 
 	it("settles a fallback retry when continuation admission rejects before agent.continue", async () => {


### PR DESCRIPTION
## Summary

- preserve queued steering/follow-up input across provider-timeout retries
- cap only the retry continuation's provider idle timeout at 30 seconds
- restore the configured timeout automatically for later ordinary turns
- retain queued input after terminal error/abort instead of draining it into a failed run

## Root cause

A donated Senpi session showed that `monitor` creation returned immediately, but the following provider stream became silent. Senpi then retried the timeout with the full configured 300-second idle budget. Steering entered during that retry was drained into the doomed provider request, so the session remained legitimately `Working` through repeated long waits and the user's `continue` could finish without an answer.

This change defers the retry continuation's initial steering poll and applies a continuation-scoped timeout override. It does not mutate the normal configured timeout.

This is complementary to #453: fallback escalation handles repeated stalls, while this PR bounds each retry and preserves user input across the stalled retry.

## Verification

- RED captured on the unchanged implementation: retry timeout sequence remained `300000, 300000, 300000`, and queued steering entered the failed retry
- focused coding-agent regression suites: 28/28 passed
- agent-core suite: 37/37 passed
- deterministic real CLI/RPC fixture: 4/4 passed
  - silent retry completed in approximately 30 seconds
  - queued steering ran exactly once after retry recovery
  - a later ordinary turn ran longer than 30 seconds, proving timeout restoration
- targeted Biome checks passed with no suppressions, skips, or focused tests
- QA process, local server, port, sandbox, and temporary runtime resources were cleaned

The regression fixture uses a synthetic local SSE provider; no donated session content or credentials are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves user input during provider idle/transport timeout retries and scopes queue deferral and timeout overrides to the retry’s first provider request, then restores configured bounds after the first event. Adds precise timeout classifiers and serialized continuation admission so retries don’t swallow input, double-run, or misreport success.

- **Bug Fixes**
  - Defer queued steering/follow-up only from a continuation’s first provider request; after a terminal `error`/`aborted` run, park queued input until a later admitted prompt or explicit continue.
  - Cap both idle and stream-start bounds on the retry’s first provider request; resume configured `timeoutMs` and `streamStartTimeoutMs` after the first event and never re-enable disabled guards.
  - Keep consuming the same retry budget across consecutive transport timeouts reported as `aborted`; reset only on genuine success.
  - Serialize retry-continuation admission, treat a concurrent low-level prompt as a benign takeover, and wait to emit “settled” until core is idle.
  - Add `isProviderStreamStallError()` and `isProviderTimeoutError()` to classify exact provider stream stalls and transport timeouts without matching incidental timeout text.

- **New Features**
  - `Agent.continue(options)` and `continueWithQueuedMessages(options)` accept one-shot `deferQueuedMessages`, `timeoutMs`, and `streamStartTimeoutMs` overrides for the first provider request; queue-first recovery keeps the selected queued message as input while still applying first-request timeout overrides.
  - Coding-agent settings add `retry.provider.streamStartTimeoutMs` and `retry.provider.streamRetryTimeoutMs` (30s default; `0` disables) to cap first-request retries without mutating defaults; caps clamp only enabled guards and restore configured timeouts for later requests.

<sup>Written for commit ea498fa22ab62f614f9c3da83b2189de276d133a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

