### PR TITLE
fix(coding-agent): add default Fable fallback chain

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,32 @@
+## Availability-aware default Fable fallback chain (2026-07-29)
+
+### What changed
+
+- `core/retry-fallback/settings.ts` now owns retry setting types and normalization, including the shipped default
+  `anthropic/claude-fable-5` chain:
+  `apitopia/kimi-k3-unlocked:max` -> `anthropic/claude-opus-5:xhigh` ->
+  `anthropic/claude-opus-4-8:xhigh`.
+- The default applies only when `retry.fallbackChains` is absent or malformed. Explicit chain maps, including
+  an explicitly empty map, remain authoritative.
+- `core/retry-fallback/chains.ts` and the model-fallback builtin omit unavailable models and remove chains with
+  no usable candidates, so runtime selection and `/fallback` display agree.
+- Existing defaults remain enabled: model fallback on, server-side fallback abort on, and cooldown-expiry revert.
+- Coverage: `test/settings-manager-retry-fallback.test.ts`,
+  `test/suite/model-fallback-command.test.ts`, and `test/suite/model-fallback-host-wiring.test.ts`.
+
+### Why
+
+- A fresh Senpi install previously aborted provider-side fallback by default but had no client chain, producing a
+  dead-end warning. Shipping the preferred chain makes that default policy actionable while keeping optional model
+  providers safe: missing models are skipped rather than warned about or selected.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: retry settings imports and delegation in `core/settings-manager.ts`; the new retry settings module has no
+  upstream counterpart.
+- LOW: canonical chain construction in `core/retry-fallback/chains.ts`.
+- LOW: registry-aware loading in `core/extensions/builtin/model-fallback/`.
+
 ## Stream-start timeout wiring and unregistered-api error context (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/model-fallback/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/model-fallback/index.ts
@@ -21,23 +21,23 @@ export default function modelFallbackExtension(pi: ExtensionAPI): void {
 async function handleFallbackCommand(rawArgs: string, ctx: ExtensionCommandContext): Promise<void> {
 	const args = rawArgs.trim().split(/\s+/).filter(Boolean);
 	if (args.length === 0) {
-		const settings = loadFallbackSettings(ctx.sessionSettings);
+		const settings = loadFallbackSettings(ctx.sessionSettings, ctx.modelRegistry);
 		await runFallbackMenu(ctx, settings, {
 			setChain: (target, entries) => saveChain(ctx, target, entries),
 			removeChain: async (target) => {
-				await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+				await updateFallbackSettings(ctx.sessionSettings, ctx.modelRegistry, (sessionSettings) =>
 					sessionSettings.removeFallbackChain(target),
 				);
 				ctx.ui.notify(`Removed fallback chain for ${target}.`);
 			},
 			toggle: async () => {
-				await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+				await updateFallbackSettings(ctx.sessionSettings, ctx.modelRegistry, (sessionSettings) =>
 					sessionSettings.setModelFallbackEnabled(!settings.modelFallback),
 				);
 				ctx.ui.notify(`Model fallback ${settings.modelFallback ? "disabled" : "enabled"}.`);
 			},
 			setRevertPolicy: async (policy) => {
-				await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+				await updateFallbackSettings(ctx.sessionSettings, ctx.modelRegistry, (sessionSettings) =>
 					sessionSettings.setFallbackRevertPolicy(policy),
 				);
 				ctx.ui.notify(`Fallback revert policy set to ${policy}.`);
@@ -58,7 +58,7 @@ async function saveChain(ctx: ExtensionCommandContext, target: string, entries: 
 		ctx.ui.notify(warnings.join("\n"), "warning");
 		return false;
 	}
-	await updateFallbackSettings(ctx.sessionSettings, (sessionSettings) =>
+	await updateFallbackSettings(ctx.sessionSettings, ctx.modelRegistry, (sessionSettings) =>
 		sessionSettings.setFallbackChain(target, entries),
 	);
 	ctx.ui.notify(`Fallback chain saved for ${target}.`);

--- a/packages/coding-agent/src/core/extensions/builtin/model-fallback/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/model-fallback/settings.ts
@@ -1,17 +1,29 @@
+import { canonicalizeFallbackChains, type FallbackModelLookup } from "../../../retry-fallback/chains.ts";
 import type { ExtensionSessionSettings, RetryFallbackSettings } from "../../types.ts";
 
 export type FallbackSettings = RetryFallbackSettings;
 
-export function loadFallbackSettings(settings: ExtensionSessionSettings): FallbackSettings {
-	return settings.getRetryFallbackSettings();
+function withAvailableChains(settings: FallbackSettings, models: FallbackModelLookup): FallbackSettings {
+	return {
+		...settings,
+		chains: canonicalizeFallbackChains(settings.chains, models),
+	};
+}
+
+export function loadFallbackSettings(
+	settings: ExtensionSessionSettings,
+	models: FallbackModelLookup,
+): FallbackSettings {
+	return withAvailableChains(settings.getRetryFallbackSettings(), models);
 }
 
 export async function updateFallbackSettings(
 	settings: ExtensionSessionSettings,
+	models: FallbackModelLookup,
 	update: (settings: ExtensionSessionSettings) => Promise<void>,
 ): Promise<FallbackSettings> {
 	await update(settings);
-	return settings.getRetryFallbackSettings();
+	return withAvailableChains(settings.getRetryFallbackSettings(), models);
 }
 
 export function isModelFallbackDisabled(flag: boolean | string | undefined, environment = process.env): boolean {

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -93,7 +93,9 @@ export function canonicalizeFallbackChains(chains: FallbackChains, lookup: Fallb
 			const parsedEntry = parseFallbackSelector(entry, lookup);
 			return parsedEntry ? [formatParsedSelector(parsedEntry)] : [];
 		});
-		canonical[formatParsedSelector(parsedKey)] = canonicalEntries;
+		if (canonicalEntries.length > 0) {
+			canonical[formatParsedSelector(parsedKey)] = canonicalEntries;
+		}
 	}
 
 	return canonical;

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -1,0 +1,73 @@
+import type { FallbackChains } from "./chains.ts";
+
+export interface ProviderRetrySettings {
+	timeoutMs?: number;
+	streamStartTimeoutMs?: number;
+	maxRetries?: number;
+	maxRetryDelayMs?: number;
+}
+
+export interface RetrySettings {
+	enabled?: boolean;
+	maxRetries?: number;
+	baseDelayMs?: number;
+	provider?: ProviderRetrySettings;
+	modelFallback?: boolean;
+	fallbackChains?: Record<string, string[]>;
+	fallbackRevertPolicy?: "cooldown-expiry" | "never";
+	abortServerSideFallback?: boolean;
+}
+
+export interface ResolvedRetryFallbackSettings {
+	modelFallback: boolean;
+	chains: FallbackChains;
+	revertPolicy: "cooldown-expiry" | "never";
+}
+
+export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {
+	"anthropic/claude-fable-5": [
+		"apitopia/kimi-k3-unlocked:max",
+		"anthropic/claude-opus-5:xhigh",
+		"anthropic/claude-opus-4-8:xhigh",
+	],
+};
+
+function cloneDefaultFallbackChains(): Record<string, readonly string[]> {
+	const chains: Record<string, readonly string[]> = {};
+	for (const [key, entries] of Object.entries(DEFAULT_FALLBACK_CHAINS)) {
+		chains[key] = [...entries];
+	}
+	return chains;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function resolveFallbackChains(value: unknown): FallbackChains {
+	if (value === undefined) return cloneDefaultFallbackChains();
+	if (!isPlainObject(value)) return cloneDefaultFallbackChains();
+
+	const chains: Record<string, readonly string[]> = {};
+	for (const [key, entries] of Object.entries(value)) {
+		if (!isStringArray(entries)) return cloneDefaultFallbackChains();
+		chains[key] = [...entries];
+	}
+	return chains;
+}
+
+export function resolveRetryFallbackSettings(settings: RetrySettings | undefined): ResolvedRetryFallbackSettings {
+	return {
+		modelFallback: typeof settings?.modelFallback === "boolean" ? settings.modelFallback : true,
+		chains: resolveFallbackChains(settings?.fallbackChains),
+		revertPolicy: settings?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
+	};
+}
+
+export function resolveAbortServerSideFallback(settings: RetrySettings | undefined): boolean {
+	return typeof settings?.abortServerSideFallback === "boolean" ? settings.abortServerSideFallback : true;
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -9,6 +9,14 @@ import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
 import { findNearestParentConfigDir } from "../nearest-parent-config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
+import {
+	type ResolvedRetryFallbackSettings,
+	type RetrySettings as RetrySettingsConfig,
+	resolveAbortServerSideFallback,
+	resolveRetryFallbackSettings,
+} from "./retry-fallback/settings.ts";
+
+export type { ProviderRetrySettings, RetrySettings } from "./retry-fallback/settings.ts";
 
 export const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
 
@@ -29,24 +37,6 @@ export interface CompactionSettings {
 export interface BranchSummarySettings {
 	reserveTokens?: number; // default: 16384 (tokens reserved for prompt + LLM response)
 	skipPrompt?: boolean; // default: false - when true, skips "Summarize branch?" prompt and defaults to no summary
-}
-
-export interface ProviderRetrySettings {
-	timeoutMs?: number; // SDK request timeout + agent stream idle timeout; defaults to httpIdleTimeoutMs
-	streamStartTimeoutMs?: number; // max wait for the FIRST provider stream event; default: 90000, 0 disables
-	maxRetries?: number; // SDK/provider retry attempts
-	maxRetryDelayMs?: number; // default: 60000 (max server-requested delay honoured on the same model; beyond it the fallback chain engages)
-}
-
-export interface RetrySettings {
-	enabled?: boolean; // default: true
-	maxRetries?: number; // default: 3
-	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
-	provider?: ProviderRetrySettings;
-	modelFallback?: boolean; // default: true
-	fallbackChains?: Record<string, string[]>;
-	fallbackRevertPolicy?: "cooldown-expiry" | "never"; // default: "cooldown-expiry"
-	abortServerSideFallback?: boolean; // default: true
 }
 
 export interface TerminalSettings {
@@ -135,7 +125,7 @@ export interface Settings {
 	theme?: string;
 	compaction?: CompactionSettings;
 	branchSummary?: BranchSummarySettings;
-	retry?: RetrySettings;
+	retry?: RetrySettingsConfig;
 	hideThinkingBlock?: boolean;
 	smoothStreaming?: boolean; // default: true
 	smoothStreamingFps?: number; // default: 60, clamped to 30-120 when read
@@ -993,9 +983,7 @@ export class SettingsManager {
 	 * fallback chain instead of the provider. Defaults to enabled.
 	 */
 	getAbortServerSideFallback(): boolean {
-		return typeof this.settings.retry?.abortServerSideFallback === "boolean"
-			? this.settings.retry.abortServerSideFallback
-			: true;
+		return resolveAbortServerSideFallback(this.settings.retry);
 	}
 
 	/** Raw retry.fallbackChains value before sanitization, for startup validation warnings. */
@@ -1003,32 +991,8 @@ export class SettingsManager {
 		return this.settings.retry?.fallbackChains;
 	}
 
-	getRetryFallbackSettings(): {
-		modelFallback: boolean;
-		chains: Readonly<Record<string, readonly string[]>>;
-		revertPolicy: "cooldown-expiry" | "never";
-	} {
-		const fallbackChains = this.settings.retry?.fallbackChains;
-		const chains: Record<string, readonly string[]> = {};
-		if (typeof fallbackChains === "object" && fallbackChains !== null && !Array.isArray(fallbackChains)) {
-			for (const [key, entries] of Object.entries(fallbackChains)) {
-				if (!Array.isArray(entries) || !entries.every((entry) => typeof entry === "string")) {
-					return {
-						modelFallback:
-							typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
-						chains: {},
-						revertPolicy: this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
-					};
-				}
-				chains[key] = [...entries];
-			}
-		}
-		return {
-			modelFallback:
-				typeof this.settings.retry?.modelFallback === "boolean" ? this.settings.retry.modelFallback : true,
-			chains,
-			revertPolicy: this.settings.retry?.fallbackRevertPolicy === "never" ? "never" : "cooldown-expiry",
-		};
+	getRetryFallbackSettings(): ResolvedRetryFallbackSettings {
+		return resolveRetryFallbackSettings(this.settings.retry);
 	}
 
 	setFallbackChain(key: string, entries: string[]): void {

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -24,6 +24,14 @@ afterEach(() => {
 });
 
 describe("SettingsManager retry fallback settings", () => {
+	const defaultChains = {
+		"anthropic/claude-fable-5": [
+			"apitopia/kimi-k3-unlocked:max",
+			"anthropic/claude-opus-5:xhigh",
+			"anthropic/claude-opus-4-8:xhigh",
+		],
+	};
+
 	it("defaults abortServerSideFallback to true and round-trips an explicit false", () => {
 		const { agentDir, projectDir } = createPaths();
 		expect(SettingsManager.create(projectDir, agentDir).getAbortServerSideFallback()).toBe(true);
@@ -39,7 +47,7 @@ describe("SettingsManager retry fallback settings", () => {
 		const { agentDir, projectDir } = createPaths();
 		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
 			modelFallback: true,
-			chains: {},
+			chains: defaultChains,
 			revertPolicy: "cooldown-expiry",
 		});
 
@@ -56,7 +64,7 @@ describe("SettingsManager retry fallback settings", () => {
 
 		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
 			modelFallback: true,
-			chains: {},
+			chains: defaultChains,
 			revertPolicy: "cooldown-expiry",
 		});
 	});

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -20,6 +20,9 @@ const dirs: string[] = [];
 let previousAgentDir: string | undefined;
 const primary = model("anthropic", "claude-fable-5", true);
 const fallback = model("ccapi", "kimi-k3", true);
+const kimiK3 = model("apitopia", "kimi-k3-unlocked", true);
+const opus5 = model("anthropic", "claude-opus-5", true);
+const opus48 = model("anthropic", "claude-opus-4-8", true);
 
 type Command = {
 	description?: string;
@@ -35,7 +38,7 @@ function model(provider: string, id: string, reasoning: boolean): Model<Api> {
 		api: "faux",
 		baseUrl: "https://models.example.test/v1",
 		reasoning,
-		thinkingLevelMap: { max: "max" },
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
 		input: ["text"],
 		contextWindow: 1,
 		maxTokens: 1,
@@ -88,18 +91,23 @@ function createUi(notices: string[], choices: string[]): ExtensionUIContext {
 	};
 }
 
-function createModelRegistry(): ModelRegistry {
+function createModelRegistry(registeredModels: Model<Api>[] = [primary, fallback]): ModelRegistry {
 	const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory());
-	modelRegistry.getAll = () => [primary, fallback];
-	modelRegistry.getAvailable = () => [primary, fallback];
+	modelRegistry.getAll = () => registeredModels;
+	modelRegistry.getAvailable = () => registeredModels;
 	modelRegistry.find = (provider: string, id: string) =>
-		[primary, fallback].find((registeredModel) => registeredModel.provider === provider && registeredModel.id === id);
+		registeredModels.find((registeredModel) => registeredModel.provider === provider && registeredModel.id === id);
 	return modelRegistry;
 }
 
-async function context(dir: string, notices: string[], choices: string[] = []): Promise<ExtensionCommandContext> {
+async function context(
+	dir: string,
+	notices: string[],
+	choices: string[] = [],
+	registeredModels?: Model<Api>[],
+): Promise<ExtensionCommandContext> {
 	const settings = SettingsManager.create(dir);
-	const modelRegistry = createModelRegistry();
+	const modelRegistry = createModelRegistry(registeredModels);
 	return {
 		ui: createUi(notices, choices),
 		mode: choices.length > 0 ? "tui" : "print",
@@ -192,7 +200,7 @@ describe("model fallback builtin command", () => {
 		dirs.push(dir);
 		const notices: string[] = [];
 		await (await harness()).get("fallback")?.handler("bogus/model nope", await context(dir, notices));
-		expect(SettingsManager.create(dir).getRetryFallbackSettings().chains).toEqual({});
+		expect(SettingsManager.create(dir).getGlobalSettings().retry).toBeUndefined();
 		expect(notices.join("\n")).toContain("not a valid or known model selector");
 	});
 
@@ -200,6 +208,34 @@ describe("model fallback builtin command", () => {
 		expect(isModelFallbackDisabled(true, {})).toBe(true);
 		expect(isModelFallbackDisabled(false, { SENPI_NO_FALLBACK: "1" })).toBe(true);
 		expect(isModelFallbackDisabled(false, {})).toBe(false);
+	});
+
+	it.each([
+		{
+			name: "all default models are available",
+			models: [primary, kimiK3, opus5, opus48],
+			expected:
+				"anthropic/claude-fable-5 -> apitopia/kimi-k3-unlocked:max, anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
+		},
+		{
+			name: "Kimi K3 is unavailable",
+			models: [primary, opus5, opus48],
+			expected: "anthropic/claude-fable-5 -> anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
+		},
+		{
+			name: "Fable 5 is unavailable",
+			models: [opus5, opus48],
+			expected: "No fallback chains configured.",
+		},
+	])("shows the availability-filtered default chain when $name", async ({ models, expected }) => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
+		dirs.push(dir);
+		const notices: string[] = [];
+		const choices = ["Show chains & live state"];
+
+		await (await harness()).get("fallback")?.handler("", await context(dir, notices, choices, models));
+
+		expect(notices.join("\n")).toContain(expected);
 	});
 
 	it("handles a headless menu invocation cleanly", async () => {

--- a/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
@@ -18,6 +18,25 @@ describe("model fallback host wiring", () => {
 		while (harnesses.length > 0) harnesses.pop()?.cleanup();
 	});
 
+	it("uses the first available candidate from the shipped Fable 5 chain", async () => {
+		const harness = await createHarness({
+			provider: "anthropic",
+			models: [{ id: "claude-fable-5" }, { id: "claude-opus-5" }, { id: "claude-opus-4-8" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, maxRetries: 0 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("recovered"),
+		]);
+
+		await harness.session.prompt("use the default Fable fallback chain");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: "anthropic/claude-fable-5", to: "anthropic/claude-opus-5" },
+		]);
+	});
+
 	it("makes a quick-set chain visible to the running retry engine", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
@@ -27,7 +46,7 @@ describe("model fallback host wiring", () => {
 		harnesses.push(harness);
 		const context = harness.getExtensionRunner().createCommandContext();
 
-		expect(harness.settingsManager.getRetryFallbackSettings().chains).toEqual({});
+		expect(harness.settingsManager.getRawFallbackChains()).toBeUndefined();
 		await getFallbackCommand(harness).handler(`${primary} ${fallback}`, context);
 		expect(harness.settingsManager.getRetryFallbackSettings().chains).toEqual({ [primary]: [fallback] });
 


### PR DESCRIPTION
## Summary

- ship an availability-aware default fallback chain for `anthropic/claude-fable-5`
- preserve explicit user-authored chains, including an explicitly empty map
- move retry fallback normalization out of the oversized settings manager
- keep `/fallback` display and runtime fallback resolution aligned with the active model registry

## Default behavior

When `retry.fallbackChains` is absent or malformed:

1. `apitopia/kimi-k3-unlocked:max`
2. `anthropic/claude-opus-5:xhigh`
3. `anthropic/claude-opus-4-8:xhigh`

Unavailable primary/candidate models are omitted. Existing defaults remain:

- model fallback enabled
- provider-side server fallback aborted by client policy
- fallback revert policy `cooldown-expiry`

Explicit configured chains and explicit `{}` continue to win.

## Verification

- RED -> GREEN settings proof:
  - `test/settings-manager-retry-fallback.test.ts`
  - final: 4/4 passed
- RED -> GREEN availability/runtime proof:
  - `test/suite/model-fallback-command.test.ts`
  - `test/suite/model-fallback-host-wiring.test.ts`
  - final combined focused suite: 3 files, 16/16 passed
- `npm run check`: passed
- Senpi QA:
  - CLI smoke: 8/8 passed
  - TUI smoke: 5/5 passed
  - mock loop: 43/43 passed
  - zero real provider calls; real auth unchanged
- real terminal `/fallback` QA:
  - event-driven node-pty capture, no fixed sleeps
  - xterm.js browser replay at 140x45
  - exact chain, `Model fallback: enabled`, and `Revert policy: cooldown-expiry` visible
  - geometry verifier: no overflow or border misalignment
  - two independent visual reviewers: PASS, no blockers
  - all PTY/browser/config/session resources cleaned up

Evidence is stored locally under:

`local-ignore/qa-evidence/20260729-default-fable-fallback/`

## Risk

- Low: explicit chain precedence is unchanged and covered.
- Low: model availability is resolved through the existing canonical registry path.
- Low: `settings-manager.ts` shrinks by 35 pure LOC; new retry settings logic lives in a 73-line cohesive module.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an availability-aware default fallback chain for `anthropic/claude-fable-5` and aligns `/fallback` display with runtime model resolution. Also moves retry/fallback normalization into a dedicated module to simplify settings.

- **New Features**
  - Default chain for `anthropic/claude-fable-5`: `apitopia/kimi-k3-unlocked:max` → `anthropic/claude-opus-5:xhigh` → `anthropic/claude-opus-4-8:xhigh`.
  - Only applies when `retry.fallbackChains` is missing or malformed; explicit chains (including `{}`) win.
  - Unavailable models are skipped; empty chains are dropped so `/fallback` mirrors the active registry.

- **Refactors**
  - Extracted retry/fallback types and resolution to `core/retry-fallback/settings.ts`; simplified `settings-manager`.
  - Preserved defaults: model fallback on, client aborts server-side fallback, revert policy `cooldown-expiry`.
  - Updated tests to cover defaults, availability filtering, and host wiring.

<sup>Written for commit da71bc5ca7994909f990a07cc0ae98fcadd83cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

