### PR TITLE
feat(coding-agent): goal+monitor cache-warm continuation story (TUI + events for omo-desktop-app)

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -20,6 +20,8 @@ goal/
 ├── format.ts         # Tool/UI formatting + goalToolResponse snapshot
 ├── command.ts        # parseGoalCommand (show|pause|resume|clear|setObjective)
 ├── ui.ts             # ctx.ui.setStatus footer segment for the active goal
+├── cache-warm.ts     # Cache-warm metrics estimator + scheduled/resumed notices + goal-cache-warmup entry contract
+├── cache-warm-renderer.ts # TUI entry renderer for goal-cache-warmup custom entries
 ├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
 ├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
 └── changes.md        # Fork tracker (port + budget behavior removal + wire compatibility)

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
@@ -1,0 +1,65 @@
+import { Box, Text } from "@earendil-works/pi-tui";
+import type { EntryRenderer } from "../../types.ts";
+import {
+	formatCacheTtl,
+	formatSavedUsd,
+	formatWakeDuration,
+	formatWarmTokenCount,
+	type GoalCacheWarmMetrics,
+	type GoalCacheWarmupEntryData,
+	type GoalCacheWarmupPhase,
+} from "./cache-warm.ts";
+
+const BOLD = "\u001b[1m";
+const BOLD_OFF = "\u001b[22m";
+
+export const renderGoalCacheWarmupEntry: EntryRenderer<GoalCacheWarmupEntryData> = (entry, options, theme) => {
+	const data = entry.data;
+	if (data === undefined) return undefined;
+	const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+	box.addChild(new Text(theme.fg("accent", `${BOLD}${titleLine(data)}${BOLD_OFF}`), 0, 0));
+	box.addChild(new Text(theme.fg("dim", whyLine(data)), 0, 0));
+	const warm = warmLine(data.phase, data.cache);
+	if (warm !== undefined) box.addChild(new Text(theme.fg("success", warm), 0, 0));
+	if (options.expanded) {
+		box.addChild(
+			new Text(theme.fg("dim", `goal ${data.goalId} · planned delay ${formatWakeDuration(data.delayMs)}`), 0, 0),
+		);
+	}
+	return box;
+};
+
+function titleLine(data: GoalCacheWarmupEntryData): string {
+	const monitors =
+		data.activeMonitorCount === 1 ? "1 monitor on duty" : `${data.activeMonitorCount} monitors on duty`;
+	switch (data.phase) {
+		case "scheduled":
+			return `⚡ Cache-warm wait · ${monitors}`;
+		case "resumed":
+			return `⚡ Cache-warm wake · waited ${formatWakeDuration(data.waitedMs ?? data.delayMs)} · ${monitors}`;
+	}
+}
+
+function whyLine(data: GoalCacheWarmupEntryData): string {
+	switch (data.phase) {
+		case "scheduled": {
+			const deferred = `Continuation deferred ${formatWakeDuration(data.delayMs)}`;
+			return data.cache?.ttlSeconds !== undefined
+				? `${deferred} - the timed wake stays inside the ${formatCacheTtl(data.cache.ttlSeconds)} prompt-cache TTL.`
+				: `${deferred} - the monitor wakes the goal the moment decisive output lands.`;
+		}
+		case "resumed":
+			return "Woke on schedule to keep pursuing the goal.";
+	}
+}
+
+function warmLine(phase: GoalCacheWarmupPhase, cache: GoalCacheWarmMetrics | undefined): string | undefined {
+	if (cache === undefined || cache.cachedTokens <= 0) return undefined;
+	const tokens = `~${formatWarmTokenCount(cache.cachedTokens)} tokens`;
+	const body = phase === "scheduled" ? `${tokens} kept warm` : `${tokens} stayed warm in the prompt cache`;
+	const saved =
+		cache.estimatedSavedUsd !== undefined && cache.estimatedSavedUsd > 0
+			? ` · est. ${formatSavedUsd(cache.estimatedSavedUsd)} saved vs a cold re-read`
+			: "";
+	return `${body}${saved}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
@@ -1,0 +1,145 @@
+import type { Api, Model, ProviderEnv } from "@earendil-works/pi-ai";
+import { resolvePromptCacheTtlSeconds } from "@earendil-works/pi-ai";
+import type { TokenUsageSnapshot } from "./types.ts";
+
+/** Custom session-entry type carrying the cache-warm continuation story. */
+export const GOAL_CACHE_WARMUP_ENTRY_TYPE = "goal-cache-warmup";
+
+/** Cache context captured when a monitor-wait continuation is scheduled. */
+export interface GoalCacheWarmMetrics {
+	/** Prompt-cache TTL of the active model in seconds, when known. */
+	readonly ttlSeconds?: number;
+	/** Tokens sitting warm in the provider prompt cache after the last turn. */
+	readonly cachedTokens: number;
+	/** Estimated USD saved by re-reading those tokens from cache instead of paying a cold input read. */
+	readonly estimatedSavedUsd?: number;
+}
+
+export type GoalCacheWarmupPhase = "scheduled" | "resumed";
+
+/**
+ * Durable payload appended as a `goal-cache-warmup` custom entry and carried by
+ * the `goal_continuation_scheduled` / `goal_continuation_resumed` pi-events, so
+ * external consumers (for example omo-desktop-app) can render the story later.
+ */
+export interface GoalCacheWarmupEntryData {
+	readonly phase: GoalCacheWarmupPhase;
+	readonly goalId: string;
+	/** Planned continuation delay in milliseconds. */
+	readonly delayMs: number;
+	/** Actual wait in milliseconds; present on the `resumed` phase only. */
+	readonly waitedMs?: number;
+	readonly activeMonitorCount: number;
+	readonly cache?: GoalCacheWarmMetrics;
+}
+
+const TOKENS_PER_PRICE_UNIT = 1_000_000;
+
+export function estimateCacheWarmMetrics(
+	model: Model<Api> | undefined,
+	env: NodeJS.ProcessEnv,
+	lastTurnUsage: Pick<TokenUsageSnapshot, "cacheRead" | "cacheWrite"> | undefined,
+): GoalCacheWarmMetrics | undefined {
+	const cachedTokens = clampTokens(lastTurnUsage?.cacheRead) + clampTokens(lastTurnUsage?.cacheWrite);
+	const ttlSeconds = model === undefined ? undefined : resolvePromptCacheTtlSeconds(model, toProviderEnv(env));
+	if (ttlSeconds === undefined && cachedTokens === 0) return undefined;
+	const estimatedSavedUsd =
+		model !== undefined && cachedTokens > 0
+			? (Math.max(0, model.cost.input - model.cost.cacheRead) * cachedTokens) / TOKENS_PER_PRICE_UNIT
+			: undefined;
+	return {
+		cachedTokens,
+		...(ttlSeconds !== undefined ? { ttlSeconds } : {}),
+		...(estimatedSavedUsd !== undefined ? { estimatedSavedUsd } : {}),
+	};
+}
+
+export function buildCacheWarmScheduledNotice(
+	delayMs: number,
+	activeMonitorCount: number,
+	cache: GoalCacheWarmMetrics | undefined,
+): string {
+	const base = `${monitorsOnDuty(activeMonitorCount)} - goal continuation deferred ${formatDeferredDelay(delayMs)}`;
+	if (cache === undefined || cache.cachedTokens <= 0) {
+		return `${base} so the monitor can wake us the moment decisive output lands.`;
+	}
+	const warmTokens = `~${formatWarmTokenCount(cache.cachedTokens)} tokens`;
+	if (cache.ttlSeconds === undefined) {
+		return `${base}. The timed wake keeps ${warmTokens} warm instead of re-paying a cold read.`;
+	}
+	return `${base}. The timed wake stays inside the ${formatCacheTtl(cache.ttlSeconds)} prompt-cache TTL, keeping ${warmTokens} warm instead of re-paying a cold read.`;
+}
+
+export function buildCacheWarmResumedNotice(
+	waitedMs: number,
+	activeMonitorCount: number,
+	cache: GoalCacheWarmMetrics | undefined,
+): string {
+	const stillOnDuty =
+		activeMonitorCount === 1 ? "1 monitor still on duty" : `${activeMonitorCount} monitors still on duty`;
+	const head = `Cache-warm wake after ${formatWakeDuration(waitedMs)} - ${stillOnDuty}.`;
+	if (cache === undefined || cache.cachedTokens <= 0) return `${head} Continuing the goal.`;
+	const savings =
+		cache.estimatedSavedUsd !== undefined && cache.estimatedSavedUsd > 0
+			? ` (est. ${formatSavedUsd(cache.estimatedSavedUsd)} saved vs a cold re-read)`
+			: "";
+	return `${head} ~${formatWarmTokenCount(cache.cachedTokens)} tokens stayed warm in the prompt cache${savings}. Continuing the goal.`;
+}
+
+export function formatWarmTokenCount(tokens: number): string {
+	if (tokens >= 1_000_000) return `${trimTrailingZero((tokens / 1_000_000).toFixed(1))}M`;
+	if (tokens >= 1000) return `${trimTrailingZero((tokens / 1000).toFixed(1))}K`;
+	return String(Math.max(0, Math.trunc(tokens)));
+}
+
+export function formatWakeDuration(ms: number): string {
+	const seconds = Math.round(ms / 1000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	const restSeconds = seconds % 60;
+	if (minutes < 60) return restSeconds === 0 ? `${minutes}m` : `${minutes}m ${restSeconds}s`;
+	const hours = Math.floor(minutes / 60);
+	const restMinutes = minutes % 60;
+	return restMinutes === 0 ? `${hours}h` : `${hours}h ${restMinutes}m`;
+}
+
+export function formatCacheTtl(seconds: number): string {
+	if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+	if (seconds % 60 === 0) return `${seconds / 60}m`;
+	return `${seconds}s`;
+}
+
+export function formatSavedUsd(value: number): string {
+	if (value < 0.0005) return "<$0.001";
+	if (value < 1) return `$${value.toFixed(3)}`;
+	return `$${value.toFixed(2)}`;
+}
+
+function monitorsOnDuty(count: number): string {
+	return count === 1 ? "1 monitor on duty" : `${count} monitors on duty`;
+}
+
+function formatDeferredDelay(delayMs: number): string {
+	const seconds = Math.round(delayMs / 1000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	const restSeconds = seconds % 60;
+	if (restSeconds === 0) return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+	return `${minutes}m ${restSeconds}s`;
+}
+
+function trimTrailingZero(value: string): string {
+	return value.endsWith(".0") ? value.slice(0, -2) : value;
+}
+
+function clampTokens(value: number | undefined): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function toProviderEnv(env: NodeJS.ProcessEnv): ProviderEnv {
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== undefined) resolved[key] = value;
+	}
+	return resolved;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,43 @@
 # goal Extension Changes
 
+## Cache-warm continuation story: enriched events + durable entry + TUI renderer (2026-07-29)
+
+### What changed
+
+- New `cache-warm.ts`: `estimateCacheWarmMetrics(model, env, lastTurnUsage)` derives
+  `GoalCacheWarmMetrics {ttlSeconds?, cachedTokens, estimatedSavedUsd?}` - prompt-cache TTL via
+  pi-ai `resolvePromptCacheTtlSeconds`, warm tokens = the last turn's cacheRead+cacheWrite, and
+  savings = cachedTokens x (input - cacheRead) $/Mtok clamped >= 0 - plus the scheduled/resumed
+  notice builders and shared token/duration/TTL/USD formatters.
+- `monitor-continuation.ts`: the monitor-wait schedule notice now explains the cache-warm
+  rationale (monitors on duty, timed wake inside the prompt-cache TTL, ~tokens kept warm) while
+  preserving the "4 minutes" wording RPC clients match. `goal_continuation_scheduled` gains a
+  `cache` payload member; a new `goal_continuation_resumed` pi-event fires when the deferred
+  continuation is queued. Both moments append a durable `goal-cache-warmup` custom entry and the
+  resumed side also notifies with waited time + estimated savings.
+- New `cache-warm-renderer.ts`, registered in `index.ts` via
+  `pi.registerEntryRenderer("goal-cache-warmup", ...)`: themed transcript block (bold accent
+  title, dim why-line, success-colored warm/savings line; expanded adds goalId + planned delay).
+- Coverage: `goal-cache-warm-metrics.test.ts`, `goal-cache-warmup.test.ts`,
+  `goal-cache-warm-renderer.test.ts`; the goal monitor harness gained
+  `appendEntry`/`registerEntryRenderer` fakes, an optional ctx `model`, and usage-bearing
+  assistant stops.
+
+### Event/entry contract (consumed by omo-desktop-app later)
+
+- pi-event `goal_continuation_scheduled`: `{goalId, delayMs, activeMonitorCount, cache?}`.
+- pi-event `goal_continuation_resumed`: `{goalId, delayMs, waitedMs, activeMonitorCount, cache?}`.
+- Custom session entry `goal-cache-warmup` (`CustomEntry.data = GoalCacheWarmupEntryData`):
+  `{phase: "scheduled"|"resumed", goalId, delayMs, waitedMs?, activeMonitorCount, cache?}`,
+  `cache = {ttlSeconds?, cachedTokens, estimatedSavedUsd?}`.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `monitor-continuation.ts` around `#schedule`/`#continueIfEligible` and `index.ts`
+  renderer registration.
+- NONE in persistence, tool schemas, or status transitions; standalone `pi-goal` has no terminal
+  monitor integration.
+
 ## Monitor-wait continuation stall check (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -1,4 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { GOAL_CACHE_WARMUP_ENTRY_TYPE } from "./cache-warm.ts";
+import { renderGoalCacheWarmupEntry } from "./cache-warm-renderer.ts";
 import { registerGoalCommand } from "./command-registration.ts";
 import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
@@ -39,6 +41,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		},
 	});
 
+	pi.registerEntryRenderer(GOAL_CACHE_WARMUP_ENTRY_TYPE, renderGoalCacheWarmupEntry);
 	registerGoalTools(pi, {
 		goalStoreRef: (ctx) => buildGoalStoreRef(ctx.sessionManager, ctx.cwd),
 		accountCurrentAgentTurn,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -1,14 +1,23 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isTerminalMonitorStateEvent, TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
+import {
+	buildCacheWarmResumedNotice,
+	buildCacheWarmScheduledNotice,
+	estimateCacheWarmMetrics,
+	GOAL_CACHE_WARMUP_ENTRY_TYPE,
+	type GoalCacheWarmMetrics,
+	type GoalCacheWarmupEntryData,
+} from "./cache-warm.ts";
 import { shouldQueueGoalContinuationAfterAgentEnd, shouldQueueGoalContinuationWhenIdle } from "./continuation.ts";
 import { queueHiddenGoalPrompt } from "./lifecycle-helpers.ts";
 import { buildContinuationPrompt, buildMonitorStallNotice } from "./prompt.ts";
-import type { Goal } from "./types.ts";
+import { collectAssistantUsage } from "./turn-usage.ts";
+import type { Goal, TokenUsageSnapshot } from "./types.ts";
 
 export const GOAL_MONITOR_CONTINUATION_DELAY_MS = 240_000;
 export const GOAL_CONTINUATION_SCHEDULED_EVENT = "goal_continuation_scheduled";
-export const GOAL_MONITOR_CONTINUATION_NOTICE = "Goal continuation scheduled in 4 minutes while a monitor is active.";
+export const GOAL_CONTINUATION_RESUMED_EVENT = "goal_continuation_resumed";
 export const GOAL_MONITOR_STALL_THRESHOLD = 3;
 export const GOAL_MONITOR_STALL_EVENT = "goal_monitor_continuation_stall";
 
@@ -28,6 +37,9 @@ export class MonitorAwareGoalContinuation {
 	#unsubscribeMonitorState: (() => void) | undefined;
 	#consecutiveMonitorContinuations = 0;
 	#stallGoalId: string | null = null;
+	#lastTurnUsage: TokenUsageSnapshot | undefined;
+	#scheduledAtMs: number | undefined;
+	#scheduledCache: GoalCacheWarmMetrics | undefined;
 
 	constructor(pi: ExtensionAPI) {
 		this.#pi = pi;
@@ -54,6 +66,7 @@ export class MonitorAwareGoalContinuation {
 	afterAgentEnd(options: AgentEndOptions): void {
 		this.#ctx = options.ctx;
 		this.#goal = options.goal;
+		this.#lastTurnUsage = collectAssistantUsage([...options.messages]);
 		if (
 			options.aborted ||
 			!shouldQueueGoalContinuationAfterAgentEnd(options.goal, options.ctx.hasPendingMessages(), options.messages)
@@ -94,11 +107,27 @@ export class MonitorAwareGoalContinuation {
 
 	#schedule(goal: Goal): void {
 		if (this.#timer !== undefined) return;
-		if (this.#ctx?.hasUI) this.#ctx.ui.notify(GOAL_MONITOR_CONTINUATION_NOTICE, "info");
+		const cache = estimateCacheWarmMetrics(this.#ctx?.model, process.env, this.#lastTurnUsage);
+		this.#scheduledCache = cache;
+		this.#scheduledAtMs = Date.now();
+		if (this.#ctx?.hasUI) {
+			this.#ctx.ui.notify(
+				buildCacheWarmScheduledNotice(GOAL_MONITOR_CONTINUATION_DELAY_MS, this.#activeMonitorCount, cache),
+				"info",
+			);
+		}
 		this.#pi.events.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
 			goalId: goal.id,
 			delayMs: GOAL_MONITOR_CONTINUATION_DELAY_MS,
 			activeMonitorCount: this.#activeMonitorCount,
+			cache,
+		});
+		this.#appendWarmupEntry({
+			phase: "scheduled",
+			goalId: goal.id,
+			delayMs: GOAL_MONITOR_CONTINUATION_DELAY_MS,
+			activeMonitorCount: this.#activeMonitorCount,
+			...(cache !== undefined ? { cache } : {}),
 		});
 		this.#timer = setTimeout(() => this.#continueIfEligible(), GOAL_MONITOR_CONTINUATION_DELAY_MS);
 	}
@@ -106,11 +135,39 @@ export class MonitorAwareGoalContinuation {
 	#continueIfEligible(): void {
 		this.#timer = undefined;
 		const ctx = this.#ctx;
+		const waitedMs =
+			this.#scheduledAtMs === undefined
+				? GOAL_MONITOR_CONTINUATION_DELAY_MS
+				: Math.max(0, Date.now() - this.#scheduledAtMs);
+		const cache = this.#scheduledCache;
+		this.#scheduledAtMs = undefined;
+		this.#scheduledCache = undefined;
 		if (ctx === undefined || this.#activeMonitorCount === 0) return;
 		const goal = this.#goal;
-		if (shouldQueueGoalContinuationWhenIdle(goal, ctx.isIdle(), ctx.hasPendingMessages())) {
-			queueHiddenGoalPrompt(this.#pi, this.#buildMonitorContinuationContent(ctx, goal));
+		if (!shouldQueueGoalContinuationWhenIdle(goal, ctx.isIdle(), ctx.hasPendingMessages())) return;
+		queueHiddenGoalPrompt(this.#pi, this.#buildMonitorContinuationContent(ctx, goal));
+		this.#pi.events.emit(GOAL_CONTINUATION_RESUMED_EVENT, {
+			goalId: goal.id,
+			delayMs: GOAL_MONITOR_CONTINUATION_DELAY_MS,
+			waitedMs,
+			activeMonitorCount: this.#activeMonitorCount,
+			cache,
+		});
+		this.#appendWarmupEntry({
+			phase: "resumed",
+			goalId: goal.id,
+			delayMs: GOAL_MONITOR_CONTINUATION_DELAY_MS,
+			waitedMs,
+			activeMonitorCount: this.#activeMonitorCount,
+			...(cache !== undefined ? { cache } : {}),
+		});
+		if (ctx.hasUI) {
+			ctx.ui.notify(buildCacheWarmResumedNotice(waitedMs, this.#activeMonitorCount, cache), "info");
 		}
+	}
+
+	#appendWarmupEntry(data: GoalCacheWarmupEntryData): void {
+		this.#pi.appendEntry<GoalCacheWarmupEntryData>(GOAL_CACHE_WARMUP_ENTRY_TYPE, data);
 	}
 
 	/** Counts consecutive monitor-wait continuations; from the third one on, prepends an active stall check. */
@@ -141,6 +198,8 @@ export class MonitorAwareGoalContinuation {
 	}
 
 	#cancelTimer(): void {
+		this.#scheduledAtMs = undefined;
+		this.#scheduledCache = undefined;
 		if (this.#timer === undefined) return;
 		clearTimeout(this.#timer);
 		this.#timer = undefined;

--- a/packages/coding-agent/test/suite/goal-cache-warm-metrics.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-metrics.test.ts
@@ -1,0 +1,99 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	buildCacheWarmResumedNotice,
+	buildCacheWarmScheduledNotice,
+	estimateCacheWarmMetrics,
+} from "../../src/core/extensions/builtin/goal/cache-warm.ts";
+
+function anthropicModel(costOverrides: Partial<Model<Api>["cost"]> = {}): Model<Api> {
+	return {
+		id: "claude-cache-test",
+		name: "Claude Cache Test",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://gateway.example.invalid/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75, ...costOverrides },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	} as Model<Api>;
+}
+
+describe("goal cache-warm metrics", () => {
+	it("returns undefined when neither ttl nor cached tokens are knowable", () => {
+		expect(estimateCacheWarmMetrics(undefined, {}, undefined)).toBeUndefined();
+		expect(estimateCacheWarmMetrics(undefined, {}, { cacheRead: 0, cacheWrite: 0 })).toBeUndefined();
+	});
+
+	it("reports cached tokens even without a model", () => {
+		const metrics = estimateCacheWarmMetrics(undefined, {}, { cacheRead: 1000, cacheWrite: 200 });
+		expect(metrics?.cachedTokens).toBe(1200);
+		expect(metrics?.ttlSeconds).toBeUndefined();
+		expect(metrics?.estimatedSavedUsd).toBeUndefined();
+	});
+
+	it("derives ttl and estimated savings for a cache-capable model", () => {
+		const metrics = estimateCacheWarmMetrics(anthropicModel(), {}, { cacheRead: 100_000, cacheWrite: 20_000 });
+		expect(metrics?.cachedTokens).toBe(120_000);
+		expect(metrics?.ttlSeconds).toBe(300);
+		expect(metrics?.estimatedSavedUsd).toBeCloseTo(0.324, 6);
+	});
+
+	it("keeps ttl-only metrics before anything is cached", () => {
+		const metrics = estimateCacheWarmMetrics(anthropicModel(), {}, { cacheRead: 0, cacheWrite: 0 });
+		expect(metrics?.cachedTokens).toBe(0);
+		expect(metrics?.ttlSeconds).toBe(300);
+		expect(metrics?.estimatedSavedUsd).toBeUndefined();
+	});
+
+	it("clamps malformed usage and negative cache margins", () => {
+		expect(estimateCacheWarmMetrics(undefined, {}, { cacheRead: -50, cacheWrite: Number.NaN })).toBeUndefined();
+		const inverted = estimateCacheWarmMetrics(
+			anthropicModel({ input: 0.2, cacheRead: 0.5 }),
+			{},
+			{ cacheRead: 1000, cacheWrite: 0 },
+		);
+		expect(inverted?.estimatedSavedUsd).toBe(0);
+	});
+});
+
+describe("goal cache-warm notices", () => {
+	it("explains the deferred continuation with cache context", () => {
+		const notice = buildCacheWarmScheduledNotice(240_000, 1, {
+			ttlSeconds: 300,
+			cachedTokens: 120_000,
+			estimatedSavedUsd: 0.324,
+		});
+		expect(notice).toContain("1 monitor on duty");
+		expect(notice).toMatch(/4 minutes/i);
+		expect(notice).toContain("~120K tokens");
+		expect(notice).toContain("5m prompt-cache TTL");
+	});
+
+	it("falls back to a monitor-only explanation without cache metrics", () => {
+		const notice = buildCacheWarmScheduledNotice(240_000, 2, undefined);
+		expect(notice).toContain("2 monitors on duty");
+		expect(notice).toMatch(/4 minutes/i);
+		expect(notice).not.toContain("tokens");
+	});
+
+	it("celebrates the cache-warm wake with savings", () => {
+		const notice = buildCacheWarmResumedNotice(240_000, 1, {
+			ttlSeconds: 300,
+			cachedTokens: 120_000,
+			estimatedSavedUsd: 0.324,
+		});
+		expect(notice).toContain("Cache-warm wake after 4m");
+		expect(notice).toContain("~120K tokens stayed warm");
+		expect(notice).toContain("est. $0.324 saved");
+	});
+
+	it("stays graceful when the wake has no cache story", () => {
+		const notice = buildCacheWarmResumedNotice(45_000, 1, undefined);
+		expect(notice).toContain("Cache-warm wake after 45s");
+		expect(notice).toContain("Continuing the goal");
+		expect(notice).not.toContain("tokens");
+	});
+});

--- a/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
@@ -1,0 +1,99 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { renderGoalCacheWarmupEntry } from "../../src/core/extensions/builtin/goal/cache-warm-renderer.ts";
+import type { GoalCacheWarmupEntryData } from "../../src/core/extensions/builtin/goal/cache-warm.ts";
+import type { CustomEntry } from "../../src/core/session-manager.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+const ANSI_PATTERN = new RegExp(String.raw`\u001b\[[0-9;]*m`, "g");
+
+function warmupEntry(data: GoalCacheWarmupEntryData): CustomEntry<GoalCacheWarmupEntryData> {
+	return {
+		type: "custom",
+		id: "entry-cache-warm",
+		parentId: null,
+		timestamp: "2026-07-29T00:00:00.000Z",
+		customType: "goal-cache-warmup",
+		data,
+	};
+}
+
+function renderToText(data: GoalCacheWarmupEntryData, expanded = false): string {
+	const component = renderGoalCacheWarmupEntry(warmupEntry(data), { expanded }, theme);
+	const lines = component?.render(100) ?? [];
+	return lines.join("\n").replace(ANSI_PATTERN, "");
+}
+
+describe("goal cache-warm entry renderer", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("renders the scheduled wait with the cache story", () => {
+		const text = renderToText({
+			phase: "scheduled",
+			goalId: "goal-1",
+			delayMs: 240_000,
+			activeMonitorCount: 1,
+			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
+		});
+		expect(text).toContain("Cache-warm wait");
+		expect(text).toContain("1 monitor on duty");
+		expect(text).toContain("5m prompt-cache TTL");
+		expect(text).toContain("~120K tokens kept warm");
+		expect(text).toContain("$0.324 saved");
+	});
+
+	it("renders the resumed wake with savings", () => {
+		const text = renderToText({
+			phase: "resumed",
+			goalId: "goal-1",
+			delayMs: 240_000,
+			waitedMs: 240_000,
+			activeMonitorCount: 2,
+			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
+		});
+		expect(text).toContain("Cache-warm wake");
+		expect(text).toContain("waited 4m");
+		expect(text).toContain("2 monitors on duty");
+		expect(text).toContain("~120K tokens stayed warm");
+		expect(text).toContain("$0.324 saved");
+	});
+
+	it("stays readable without cache metrics", () => {
+		const text = renderToText({
+			phase: "scheduled",
+			goalId: "goal-1",
+			delayMs: 240_000,
+			activeMonitorCount: 1,
+		});
+		expect(text).toContain("Cache-warm wait");
+		expect(text).toContain("1 monitor on duty");
+		expect(text).not.toContain("tokens");
+	});
+
+	it("reveals goal details when expanded", () => {
+		const collapsed = renderToText({
+			phase: "resumed",
+			goalId: "goal-42",
+			delayMs: 240_000,
+			waitedMs: 200_000,
+			activeMonitorCount: 1,
+			cache: { cachedTokens: 500 },
+		});
+		expect(collapsed).not.toContain("goal-42");
+
+		const expanded = renderToText(
+			{
+				phase: "resumed",
+				goalId: "goal-42",
+				delayMs: 240_000,
+				waitedMs: 200_000,
+				activeMonitorCount: 1,
+				cache: { cachedTokens: 500 },
+			},
+			true,
+		);
+		expect(expanded).toContain("goal-42");
+		expect(expanded).toContain("waited 3m 20s");
+	});
+});

--- a/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
@@ -1,0 +1,154 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GoalCacheWarmupEntryData } from "../../src/core/extensions/builtin/goal/cache-warm.ts";
+import {
+	type AppendedGoalEntry,
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	type GoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+} from "./goal-monitor-test-harness.ts";
+
+const ENTRY_TYPE = "goal-cache-warmup";
+
+function cacheModel(): Model<Api> {
+	return {
+		id: "claude-cache-warm",
+		name: "Claude Cache Warm",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://gateway.example.invalid/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	} as Model<Api>;
+}
+
+async function setupWarmHarness(threadId: string): Promise<{ harness: GoalHarness; notices: string[] }> {
+	const notices: string[] = [];
+	const harness = createGoalHarness();
+	const ctx = await makeGoalContext(notices, threadId, { pendingMessages: false, model: cacheModel() });
+	await harness.tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
+	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+	await harness.events.flush();
+	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+	await runGoalHandlers(
+		harness.handlers,
+		"agent_end",
+		{ type: "agent_end", messages: [cleanAssistantStop({ cacheRead: 100_000, cacheWrite: 20_000 })] },
+		ctx,
+	);
+	return { harness, notices };
+}
+
+function warmupEntryData(harness: GoalHarness): GoalCacheWarmupEntryData[] {
+	return harness.entries
+		.filter((entry: AppendedGoalEntry) => entry.customType === ENTRY_TYPE)
+		.map((entry) => entry.data as GoalCacheWarmupEntryData);
+}
+
+function channelEvents(harness: GoalHarness, channel: string): unknown[] {
+	return harness.events.emitted.filter((event) => event.channel === channel).map((event) => event.data);
+}
+
+describe("goal cache-warm continuation story", () => {
+	afterEach(async () => {
+		vi.useRealTimers();
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("tells the cache-warm story when the continuation is scheduled", async () => {
+		vi.useFakeTimers();
+		const { harness, notices } = await setupWarmHarness("thread-cache-warm-scheduled");
+
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toMatch(/4 minutes/i);
+		expect(notices[0]).toContain("~120K tokens");
+
+		expect(channelEvents(harness, "goal_continuation_scheduled")).toEqual([
+			expect.objectContaining({
+				goalId: expect.any(String),
+				delayMs: 240_000,
+				activeMonitorCount: 1,
+				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
+			}),
+		]);
+
+		const scheduled = warmupEntryData(harness);
+		expect(scheduled).toHaveLength(1);
+		expect(scheduled[0]).toEqual(
+			expect.objectContaining({
+				phase: "scheduled",
+				goalId: expect.any(String),
+				delayMs: 240_000,
+				activeMonitorCount: 1,
+				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
+			}),
+		);
+	});
+
+	it("celebrates the cache-warm wake when the deferred continuation fires", async () => {
+		vi.useFakeTimers();
+		const { harness, notices } = await setupWarmHarness("thread-cache-warm-resumed");
+
+		await vi.advanceTimersByTimeAsync(240_000);
+
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.customType).toBe("goal-continuation");
+
+		expect(channelEvents(harness, "goal_continuation_resumed")).toEqual([
+			expect.objectContaining({
+				goalId: expect.any(String),
+				delayMs: 240_000,
+				waitedMs: 240_000,
+				activeMonitorCount: 1,
+				cache: expect.objectContaining({
+					cachedTokens: 120_000,
+					ttlSeconds: 300,
+					estimatedSavedUsd: expect.closeTo(0.324, 5),
+				}),
+			}),
+		]);
+
+		const resumed = warmupEntryData(harness).filter((data) => data.phase === "resumed");
+		expect(resumed).toHaveLength(1);
+		expect(resumed[0]).toEqual(
+			expect.objectContaining({
+				phase: "resumed",
+				waitedMs: 240_000,
+				activeMonitorCount: 1,
+				cache: expect.objectContaining({ cachedTokens: 120_000 }),
+			}),
+		);
+
+		expect(notices.some((notice) => /cache-warm wake/i.test(notice) && notice.includes("$0.324"))).toBe(true);
+	});
+
+	it("keeps a plain explanation when no cache context exists", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-cache-warm-plain");
+		await harness.tools
+			.get("create_goal")
+			?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
+
+		expect(notices[0]).toMatch(/4 minutes/i);
+		expect(notices[0]).not.toContain("tokens");
+
+		const scheduled = warmupEntryData(harness);
+		expect(scheduled).toHaveLength(1);
+		expect(scheduled[0]).toEqual(expect.objectContaining({ phase: "scheduled" }));
+		expect(scheduled[0]?.cache).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -34,6 +34,8 @@ function createGoalHarness(): GoalHarness {
 			handlers.set(event, list);
 		},
 		sendMessage: (message: SentMessage["message"], options: unknown) => sent.push({ message, options }),
+		registerEntryRenderer: () => {},
+		appendEntry: () => {},
 	} as unknown as ExtensionAPI;
 	goalExtension(pi);
 	return { tools, commands, handlers, sent };

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
 
@@ -42,15 +43,19 @@ export class TestEventBus {
 	}
 }
 
+export type AppendedGoalEntry = { readonly customType: string; readonly data: unknown };
+
 export interface GoalHarness {
 	readonly tools: Map<string, AnyTool>;
 	readonly handlers: Map<string, GoalHandler[]>;
 	readonly sent: SentGoalMessage[];
 	readonly events: TestEventBus;
+	readonly entries: AppendedGoalEntry[];
 }
 
 export interface GoalContextState {
 	pendingMessages: boolean;
+	model?: Model<Api>;
 }
 
 export function createGoalHarness(): GoalHarness {
@@ -58,9 +63,12 @@ export function createGoalHarness(): GoalHarness {
 	const handlers = new Map<string, GoalHandler[]>();
 	const sent: SentGoalMessage[] = [];
 	const events = new TestEventBus();
+	const entries: AppendedGoalEntry[] = [];
 	const pi = {
 		registerTool: (tool: AnyTool) => tools.set(tool.name, tool),
 		registerCommand: () => {},
+		registerEntryRenderer: () => {},
+		appendEntry: (customType: string, data?: unknown) => entries.push({ customType, data }),
 		on: (event: string, handler: GoalHandler) => {
 			const registered = handlers.get(event) ?? [];
 			registered.push(handler);
@@ -70,7 +78,7 @@ export function createGoalHarness(): GoalHarness {
 		events,
 	} as unknown as ExtensionAPI;
 	goalExtension(pi);
-	return { tools, handlers, sent, events };
+	return { tools, handlers, sent, events, entries };
 }
 
 const tempDirs: string[] = [];
@@ -85,6 +93,7 @@ export async function makeGoalContext(
 	return {
 		hasUI: true,
 		cwd: dir,
+		model: state.model,
 		isIdle: () => true,
 		hasPendingMessages: () => state.pendingMessages,
 		ui: {
@@ -116,7 +125,15 @@ export async function runGoalHandlers(
 	}
 }
 
-export function cleanAssistantStop(): AgentMessage {
+export type AssistantUsageOverrides = Partial<{
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+}>;
+
+export function cleanAssistantStop(usageOverrides: AssistantUsageOverrides = {}): AgentMessage {
 	return {
 		role: "assistant",
 		content: [{ type: "text", text: "" }],
@@ -130,6 +147,7 @@ export function cleanAssistantStop(): AgentMessage {
 			cacheWrite: 0,
 			totalTokens: 0,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			...usageOverrides,
 		},
 		stopReason: "stop",
 		timestamp: Date.now(),

--- a/packages/coding-agent/test/suite/goal-turn-usage.test.ts
+++ b/packages/coding-agent/test/suite/goal-turn-usage.test.ts
@@ -27,6 +27,8 @@ function createGoalHarness(): GoalHarness {
 			handlers.set(event, list);
 		},
 		sendMessage: () => {},
+		registerEntryRenderer: () => {},
+		appendEntry: () => {},
 	} as unknown as ExtensionAPI;
 	goalExtension(pi);
 	return { tools, handlers };


### PR DESCRIPTION
## What

While terminal monitors hold a goal continuation (the 240s cache-warm cadence), senpi now tells the user *why* the wait happened and *what the prompt cache gained* — and publishes the same story as typed events + durable session entries so `omo-desktop-app` can render it later.

- **`goal/cache-warm.ts` (new)** — `estimateCacheWarmMetrics(model, env, lastTurnUsage)` derives `{ttlSeconds?, cachedTokens, estimatedSavedUsd?}`: prompt-cache TTL via pi-ai `resolvePromptCacheTtlSeconds`, warm tokens = last turn's `cacheRead + cacheWrite`, savings = `cachedTokens x (input - cacheRead) $/Mtok` clamped `>= 0`. Plus notice builders and token/duration/TTL/USD formatters.
- **`goal/monitor-continuation.ts`** — the schedule notice now reads e.g. `1 monitor on duty - goal continuation deferred 4 minutes. The timed wake stays inside the 5m prompt-cache TTL, keeping ~120K tokens warm instead of re-paying a cold read.` (still matches the `/4 minutes/i` contract RPC clients pin). `goal_continuation_scheduled` gains a `cache` member; a new **`goal_continuation_resumed`** pi-event fires when the deferred continuation is queued (`{goalId, delayMs, waitedMs, activeMonitorCount, cache}`); both moments append a durable **`goal-cache-warmup`** custom entry, and the wake notifies `Cache-warm wake after 4m - ... (est. $0.324 saved vs a cold re-read)`.
- **`goal/cache-warm-renderer.ts` (new)** — `registerEntryRenderer("goal-cache-warmup", ...)` renders a themed transcript block (bold accent title, dim rationale, success-colored savings; expanded adds goalId + planned delay).
- Contract documented in `goal/changes.md` for the desktop-app integration.

## Event/entry contract (for omo-desktop-app)

- `goal_continuation_scheduled`: `{goalId, delayMs, activeMonitorCount, cache?}`
- `goal_continuation_resumed`: `{goalId, delayMs, waitedMs, activeMonitorCount, cache?}`
- Custom entry `goal-cache-warmup`: `{phase: "scheduled"|"resumed", goalId, delayMs, waitedMs?, activeMonitorCount, cache?}` with `cache = {ttlSeconds?, cachedTokens, estimatedSavedUsd?}`

## Tests (all failing-first)

- `goal-cache-warm-metrics.test.ts` — estimator edges (no model, malformed usage, inverted margins, ttl-only) + notice copy (9)
- `goal-cache-warmup.test.ts` — scheduled + resumed events/entries/notices through the goal harness with fake timers (3)
- `goal-cache-warm-renderer.test.ts` — rendered block content, collapsed/expanded (4)
- Full goal + terminal-monitor family: 209/209 green; root `npm run check` green

## QA evidence (`local-ignore/qa-evidence/20260729-goal-cache-warm-ux/`, gitignored)

- senpi-qa channels: cli-smoke, rpc-drive, mock-loop, tui-smoke self-tests
- Targeted real-CLI RPC run (`rpc-cache-warm-drive.mjs`): sandbox extension creates a goal + reports one live monitor against a mock provider; asserts the scheduled notify, then waits through the REAL 240s cadence and asserts the `Cache-warm wake after 4m` notify (`rpc-cache-warm-events.jsonl`)
- TUI visual triplet via `scripts/qa/xterm-render.mjs`: `.ans` + review HTML + parsed cell grid, 9/9 grid assertions (title, TTL line, `~118.4K tokens kept warm`, `$0.320 saved`, expanded goal id)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cache‑warm continuation story for monitor-held goals: users see why we wait and what we save, and the same data is exposed via events and a durable entry so `omo-desktop-app` can render it later. Includes a TUI renderer and a metrics estimator to show TTL, warm tokens, and estimated savings.

- **New Features**
  - Updated monitor notices: explain deferred wait and scheduled wake with TTL, warm tokens, and est. savings while keeping the “4 minutes” wording.
  - New event `goal_continuation_resumed` with `{goalId, delayMs, waitedMs, activeMonitorCount, cache?}`; `goal_continuation_scheduled` gains `cache`.
  - Durable entry `goal-cache-warmup` (`phase: "scheduled"|"resumed"`) with the same payload for later rendering.
  - TUI renderer for `goal-cache-warmup`: bold title, dim rationale, success line for warm tokens and savings; expanded shows goal id and planned delay.
  - Cache metrics via `estimateCacheWarmMetrics(model, env, lastTurnUsage)`: TTL from `resolvePromptCacheTtlSeconds` in `@earendil-works/pi-ai`, warm tokens from `cacheRead + cacheWrite`, and estimated USD saved.

- **Migration**
  - Clients that match notice text can keep their `/4 minutes/i` checks.
  - `omo-desktop-app`: listen to `goal_continuation_scheduled` and `goal_continuation_resumed`, and render `goal-cache-warmup` entries. Use optional `cache = { ttlSeconds?, cachedTokens, estimatedSavedUsd? }` when present; fall back gracefully when absent.

<sup>Written for commit 2be0c1dda7315abf8ba37e4bb52c1c15fca17545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

