### PR TITLE
fix(coding-agent): hide token totals in footer

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Footer omits cumulative input and output counters (2026-07-29)
+
+### What changed
+
+- `components/footer.ts` no longer adds the cumulative `↑<input>` and `↓<output>` token segments to the interactive footer.
+- Context-window usage, cache-hit rate, session name, cost, model, working directory, branch, and extension statuses remain unchanged.
+- Coverage: `test/footer-token-format.test.ts` asserts that the usage arrows are absent while the neighboring cache-hit and context details still render.
+
+### Why
+
+- The cumulative input/output counters add visual noise to the always-visible footer without helping the active context decision; the context-window segment remains the relevant token signal.
+
+### Expected merge conflict zones
+
+- LOW: `components/footer.ts` around the optional middle-stat segment construction.
+
 ## Ethos tips: the fork's voice in the tip rotation (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -110,8 +110,6 @@ export class FooterComponent implements Component {
 		// O(1) running totals maintained by SessionManager (identical to summing
 		// usage over all entries; totals are not branch-scoped).
 		const usageTotals = this.session.sessionManager.getUsageTotals();
-		const totalInput = usageTotals.input;
-		const totalOutput = usageTotals.output;
 		const totalCacheRead = usageTotals.cacheRead;
 		const totalCacheWrite = usageTotals.cacheWrite;
 		const totalCost = usageTotals.cost;
@@ -153,8 +151,6 @@ export class FooterComponent implements Component {
 		const dim = (plain: string): FooterSegment => ({ plain, colored: theme.fg("dim", plain) });
 		const middle: FooterSegment[] = [];
 		if (sessionName) middle.push({ plain: sessionName, colored: theme.fg("muted", sessionName) });
-		if (totalInput) middle.push(dim(`↑${formatTokens(totalInput)}`));
-		if (totalOutput) middle.push(dim(`↓${formatTokens(totalOutput)}`));
 		if ((totalCacheRead > 0 || totalCacheWrite > 0) && latestCacheHitRate !== undefined) {
 			middle.push(dim(`CH${latestCacheHitRate.toFixed(1)}%`));
 		}

--- a/packages/coding-agent/test/footer-token-format.test.ts
+++ b/packages/coding-agent/test/footer-token-format.test.ts
@@ -80,7 +80,7 @@ describe("formatTokens abbreviation", () => {
 });
 
 describe("FooterComponent token formatting", () => {
-	it("renders oh-my-pi-style abbreviated token counters and context window usage", async () => {
+	it("omits input and output token counters while retaining context details", async () => {
 		// given
 		const { FooterComponent } = await import("../src/modes/interactive/components/footer.ts");
 		const Footer = FooterComponent as new (
@@ -93,8 +93,8 @@ describe("FooterComponent token formatting", () => {
 		const rendered = stripAnsi(footer.render(160).join("\n"));
 
 		// then
-		expect(rendered).toContain("↑49");
-		expect(rendered).toContain("↓6.8K");
+		expect(rendered).not.toMatch(/↑\d/);
+		expect(rendered).not.toMatch(/↓\d/);
 		// Cache read/write totals were removed from the footer; only the hit rate stays.
 		expect(rendered).not.toContain("cache 1.5M/44K");
 		expect(rendered).not.toContain("cache ");


### PR DESCRIPTION
## Summary

- remove cumulative input/output token counters such as `↑996K • ↓142K` from the interactive footer
- preserve context-window usage, cache-hit rate, session name, cost, working directory, branch, model, and extension statuses
- add focused regression coverage for nonzero usage totals

## Why

The cumulative input/output totals add visual noise to the always-visible footer. The context-window segment remains the useful token signal for active-session decisions.

## Verification

### Automated

- `npm --prefix packages/coding-agent test -- footer-token-format.test.ts`
  - RED before production change: failed because the footer contained `↑49 • ↓6.8K`
  - GREEN after production change: 2/2 tests passed
- `npm --prefix packages/coding-agent test -- footer-token-format.test.ts footer-width.test.ts`
  - 15/15 tests passed
- `npm run build`
  - full workspace build passed
- `npm run check`
  - passed (exit code 0)
- `npm --prefix packages/coding-agent test`
  - final scoped package coverage after merging current `main`: 3 files and 24 tests passed, including footer formatting, width planning, and monitor-footer adjacency
- `npm run build`
  - final merged branch full workspace build passed

### Real surface

- Senpi QA TUI smoke:
  - `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence hide-footer-token-usage-built`
  - 5/5 checks passed: boot, render, input, teardown, and real-auth isolation
- browser-rendered xterm.js capture of the built TUI:
  - footer renders context usage and model without input/output arrows
- browser-rendered xterm.js capture of the actual `FooterComponent` with injected `996K` input and `142K` output usage:
  - observed `CH97.1% • 44K/800K (5.5%) (auto)`
  - observed no `↑<number>` or `↓<number>` segment

Evidence is saved locally under:
`local-ignore/qa-evidence/20260729-hide-footer-token-usage/`

## Risk

Low. The change deletes two optional middle segments from the existing footer layout and leaves the width-planning algorithm and all pinned anchor/tail segments unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the cumulative input/output token counters (↑, ↓) in the interactive footer of `packages/coding-agent` to reduce visual noise. Keep context-window usage and other footer details unchanged, and update tests to verify the arrows are gone.

<sup>Written for commit 5f833997e6391b4b07a17eef93c90ff149eff774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

