### PR TITLE
fix(codemode): route reserved bridge names over the HTTP call route

### DIFF
--- a/packages/senpi-codemode/scripts/qa-reserved-bridge.ts
+++ b/packages/senpi-codemode/scripts/qa-reserved-bridge.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { defaultCodemodeSettings } from "../src/config/settings.ts";
+import { createCodemodeSessionManager } from "../src/extension/session-manager.ts";
+import { createInterpreterDetector, getInterpreterAvailability } from "../src/interpreters/detect.ts";
+import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
+
+class QaFailure extends Error {
+	readonly name = "QaFailure";
+}
+
+function taskResult(text: string): AgentToolResult<unknown> {
+	return { content: [{ type: "text", text }], details: { task_id: "st_qa", status: "completed" } };
+}
+
+const cell = [
+	"solo = agent('summarize the diff', agent='explore')",
+	"print('AGENT_SOLO=' + str(solo))",
+	"fan = parallel([lambda: agent('unit one'), lambda: agent('unit two')])",
+	"print('AGENT_PARALLEL=' + str(fan))",
+	"print('SCHEMA_TOOLS=' + str(tool_schema()['tools']))",
+	"print('OUTPUT=' + str(output('st_qa')))",
+].join("\n");
+
+async function main(): Promise<void> {
+	const availability = await getInterpreterAvailability(defaultCodemodeSettings, createInterpreterDetector());
+	if (!availability.py.detected.ok) throw new QaFailure("no python interpreter available");
+
+	const dir = mkdtempSync(join(tmpdir(), "qa-reserved-"));
+	const calls: string[] = [];
+	const manager = await createCodemodeSessionManager({
+		sessionId: "qa-reserved",
+		cwd: dir,
+		settings: defaultCodemodeSettings,
+		availability,
+		listTools: () => [{ name: "read", description: "read a file", parameters: { type: "object" } }],
+		executeTool: Object.assign(
+			async (toolName: string): Promise<AgentToolResult<unknown>> => {
+				if (toolName.startsWith("__")) throw new QaFailure(`Unknown tool ${toolName}`);
+				calls.push(toolName);
+				return taskResult(toolName === "task" ? "DELEGATED" : "TRANSCRIPT");
+			},
+			{ isToolAvailable: (name: string) => name === "task" || name === "task_output" },
+		),
+		complete: async () => {
+			throw new QaFailure("completion is not exercised");
+		},
+	});
+
+	const lines: string[] = [];
+	try {
+		const kernel = await manager.getKernel("py", (message: KernelToHostMessage) => {
+			if (message.type === "text") process.stdout.write(message.data);
+			if (message.type === "text") lines.push(message.data);
+		});
+		const outcome = await kernel.run({ cellId: "qa-cell-1", code: cell, timeoutMs: 60_000 });
+		if (!outcome.ok) throw new QaFailure("python cell failed");
+	} finally {
+		await manager.dispose();
+		rmSync(dir, { recursive: true, force: true });
+	}
+
+	const transcript = lines.join("");
+	for (const marker of ["AGENT_SOLO=DELEGATED", "SCHEMA_TOOLS=['read']", "OUTPUT=TRANSCRIPT"]) {
+		if (!transcript.includes(marker)) throw new QaFailure(`missing expected marker: ${marker}`);
+	}
+	if (transcript.includes("Unknown tool")) throw new QaFailure("reserved tool name leaked to executeTool");
+	console.log(`\nQA PASS — task calls: ${calls.filter((name) => name === "task").length}, tool names: ${[...new Set(calls)].join(",")}`);
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/packages/senpi-codemode/src/extension/runtime-factory.ts
+++ b/packages/senpi-codemode/src/extension/runtime-factory.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@code-yeongyu/senpi";
 import type { AgentExecuteTool } from "../bridges/agent-bridge.ts";
+import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
 import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
 import {
 	type CodemodeSettings,
@@ -23,6 +24,7 @@ import {
 export interface CodemodeRuntimeAPI {
 	readonly executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
+	getAllTools(): readonly EvalSchemaToolInfo[];
 }
 
 export interface RuntimeFactoryOptions {
@@ -71,6 +73,7 @@ export async function createRuntime(
 		availability,
 		artifactsDir: artifacts.dir,
 		executeTool,
+		listTools: () => pi.getAllTools(),
 		complete,
 	});
 	return {

--- a/packages/senpi-codemode/src/extension/session-manager.ts
+++ b/packages/senpi-codemode/src/extension/session-manager.ts
@@ -2,19 +2,28 @@ import { join } from "node:path";
 import type { ExtensionContext } from "@code-yeongyu/senpi";
 import { type BridgeServerHandle, startBridgeServer } from "../bridge/http-server.ts";
 import type { KernelToHostMessage } from "../bridge/protocol.ts";
+import { isReservedToolName, runReservedTool } from "../bridges/reserved-dispatch.ts";
+import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
 import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
-import type { CodemodeSettings } from "../config/settings.ts";
+import { type CodemodeSettings, defaultCodemodeSettings } from "../config/settings.ts";
 import type { InterpreterAvailability } from "../interpreters/detect.ts";
 import { JuliaKernel } from "../kernels/jl/kernel.ts";
 import { JavaScriptKernel } from "../kernels/js/context-manager.ts";
 import { PythonKernel } from "../kernels/py/kernel.ts";
 import { RubyKernel } from "../kernels/rb/kernel.ts";
+import { marshalToolResult } from "../tool/image.ts";
 import type { EvalKernel, EvalKernelManager, EvalLanguage, ExecuteTool } from "../tool/types.ts";
 
 export interface CodemodeSessionManager extends EvalKernelManager {
 	dispose(): Promise<void>;
 	complete(request: CompletionRequest, ctx: ExtensionContext): Promise<CompletionResult>;
 	setContext?(ctx: ExtensionContext): void;
+	bridgeEndpoint?(): BridgeEndpoint;
+}
+
+export interface BridgeEndpoint {
+	readonly port: number;
+	readonly token: string;
 }
 
 export interface EvalExecutionTracker {
@@ -32,6 +41,7 @@ export interface CreateCodemodeSessionManagerOptions {
 	/** Session-adjacent directory used for persisted eval artifacts. */
 	readonly artifactsDir?: string;
 	readonly executeTool: ExecuteTool;
+	readonly listTools?: () => readonly EvalSchemaToolInfo[];
 	readonly complete: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
 }
 
@@ -75,11 +85,31 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 
 	async start(): Promise<void> {
 		this.#bridge = await startBridgeServer({
-			onCall: async (request) =>
-				this.#options.executeTool(request.toolName, request.args, { signal: request.signal }),
+			onCall: async (request) => await this.#call(request),
 			onEmit: async () => undefined,
 			onCompletion: async (request) =>
 				this.#options.complete({ prompt: request.prompt, opts: request.opts }, this.#contextFor(request.signal)),
+		});
+	}
+
+	// Subprocess kernels (py/rb/jl) reach the host only through this route, so reserved
+	// helper names must dispatch exactly as the in-process JS path does in tool/cell-handler.ts.
+	// Forwarding them to executeTool made agent() fail with "Unknown tool __agent__".
+	async #call(request: { toolName: string; args: unknown; callId: string; signal: AbortSignal }): Promise<unknown> {
+		if (!isReservedToolName(request.toolName)) {
+			return await this.#options.executeTool(request.toolName, request.args, { signal: request.signal });
+		}
+		const taskTools = this.#options.settings.taskTools ?? defaultCodemodeSettings.taskTools;
+		return await runReservedTool(request.toolName, {
+			callId: request.callId,
+			args: request.args,
+			executeTool: this.#options.executeTool,
+			taskToolName: taskTools.task,
+			taskOutputToolName: taskTools.output,
+			listTools: this.#options.listTools,
+			signal: request.signal,
+			emitStatus: () => {},
+			marshalToolResult,
 		});
 	}
 
@@ -107,6 +137,12 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 
 	async complete(request: CompletionRequest, ctx: ExtensionContext): Promise<CompletionResult> {
 		return await this.#options.complete(request, ctx);
+	}
+
+	bridgeEndpoint(): BridgeEndpoint {
+		const bridge = this.#bridge;
+		if (!bridge) throw new Error("codemode bridge server is not running");
+		return { port: bridge.port, token: bridge.token };
 	}
 
 	setContext(ctx: ExtensionContext): void {

--- a/packages/senpi-codemode/test/session-manager-reserved-bridge.test.ts
+++ b/packages/senpi-codemode/test/session-manager-reserved-bridge.test.ts
@@ -1,0 +1,147 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it } from "vitest";
+import { RESERVED_AGENT_TOOL, RESERVED_OUTPUT_TOOL, RESERVED_SCHEMA_TOOL } from "../src/bridge/reserved.ts";
+import { defaultCodemodeSettings } from "../src/config/settings.ts";
+import {
+	type BridgeEndpoint,
+	type CodemodeSessionManager,
+	createCodemodeSessionManager,
+} from "../src/extension/session-manager.ts";
+import type { InterpreterAvailability } from "../src/interpreters/detect.ts";
+
+// Subprocess kernels (py/rb/jl) reach the host only over the bridge HTTP /call route,
+// so the reserved helper names must be routed there exactly as the in-process JS
+// kernel path routes them in tool/cell-handler.ts.
+const availability: InterpreterAvailability = {
+	js: { enabled: true, detected: { ok: true, path: "node", version: "v20" } },
+	py: { enabled: false, detected: { ok: false } },
+	rb: { enabled: false, detected: { ok: false } },
+	jl: { enabled: false, detected: { ok: false } },
+};
+
+type RecordedCall = { readonly toolName: string; readonly params: unknown };
+
+class UnknownToolError extends Error {
+	readonly name = "UnknownToolError";
+	readonly code = "unknown_tool";
+
+	constructor(toolName: string) {
+		super(`Unknown tool ${toolName}. Active tools: read, bash, task, task_output`);
+	}
+}
+
+function textResult(text: string, details: unknown = {}): AgentToolResult<unknown> {
+	return { content: [{ type: "text", text }], details };
+}
+
+function endpointOf(manager: CodemodeSessionManager): BridgeEndpoint {
+	const endpoint = manager.bridgeEndpoint?.();
+	if (!endpoint) throw new Error("session manager exposed no bridge endpoint");
+	return endpoint;
+}
+
+async function postCall(port: number, token: string, toolName: string, args: unknown): Promise<unknown> {
+	const response = await fetch(`http://127.0.0.1:${port}/call`, {
+		method: "POST",
+		headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+		body: JSON.stringify({ callId: `call-${toolName}`, toolName, args }),
+	});
+	return await response.json();
+}
+
+describe("codemode session manager reserved bridge routing", () => {
+	let manager: CodemodeSessionManager | undefined;
+	let dir = "";
+
+	afterEach(async () => {
+		await manager?.dispose();
+		manager = undefined;
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = "";
+	});
+
+	async function startManager(calls: RecordedCall[]): Promise<CodemodeSessionManager> {
+		dir = mkdtempSync(join(tmpdir(), "codemode-reserved-"));
+		return await createCodemodeSessionManager({
+			sessionId: "s",
+			cwd: dir,
+			settings: defaultCodemodeSettings,
+			availability,
+			listTools: () => [{ name: "read", description: "read a file", parameters: { type: "object" } }],
+			executeTool: Object.assign(
+				async (toolName: string, params: unknown): Promise<AgentToolResult<unknown>> => {
+					// The real agent session rejects reserved names: they are bridge-only
+					// helpers and are never registered as agent tools.
+					if (toolName.startsWith("__")) throw new UnknownToolError(toolName);
+					calls.push({ toolName, params });
+					return textResult("DELEGATED_RESULT", { task_id: "st_reserved", status: "completed" });
+				},
+				{ isToolAvailable: (name: string) => name === "task" || name === "task_output" },
+			),
+			complete: async () => {
+				throw new Error("completion is not exercised in this test");
+			},
+		});
+	}
+
+	// Regression: the bridge /call handler forwarded every toolName straight to
+	// executeTool, so agent() from a python cell failed with
+	// "Unknown tool __agent__. Active tools: ...".
+	it("routes __agent__ through the agent bridge to the task tool", async () => {
+		const calls: RecordedCall[] = [];
+		manager = await startManager(calls);
+		const bridge = endpointOf(manager);
+
+		const reply = await postCall(bridge.port, bridge.token, RESERVED_AGENT_TOOL, {
+			prompt: "summarize the diff",
+			agent: "explore",
+		});
+
+		expect(reply).toEqual({ ok: true, value: { text: "DELEGATED_RESULT" } });
+		expect(calls).toEqual([
+			{
+				toolName: "task",
+				params: { prompt: "summarize the diff", subagent_type: "explore", run_in_background: false },
+			},
+		]);
+	});
+
+	it("routes __output__ through the output bridge to the task_output tool", async () => {
+		const calls: RecordedCall[] = [];
+		manager = await startManager(calls);
+		const bridge = endpointOf(manager);
+
+		const reply = await postCall(bridge.port, bridge.token, RESERVED_OUTPUT_TOOL, { ids: ["st_reserved"] });
+
+		expect(reply).toEqual({ ok: true, value: "DELEGATED_RESULT" });
+		expect(calls).toEqual([{ toolName: "task_output", params: { task_id: "st_reserved", mode: "full" } }]);
+	});
+
+	it("answers __schema__ from the tool catalog without touching executeTool", async () => {
+		const calls: RecordedCall[] = [];
+		manager = await startManager(calls);
+		const bridge = endpointOf(manager);
+
+		const reply = await postCall(bridge.port, bridge.token, RESERVED_SCHEMA_TOOL, { name: "read" });
+
+		expect(reply).toEqual({
+			ok: true,
+			value: { name: "read", description: "read a file", parameters: { type: "object" } },
+		});
+		expect(calls).toEqual([]);
+	});
+
+	it("still forwards ordinary tool names straight to executeTool", async () => {
+		const calls: RecordedCall[] = [];
+		manager = await startManager(calls);
+		const bridge = endpointOf(manager);
+
+		const reply = await postCall(bridge.port, bridge.token, "read", { path: "a.txt" });
+
+		expect(reply).toMatchObject({ ok: true });
+		expect(calls).toEqual([{ toolName: "read", params: { path: "a.txt" } }]);
+	});
+});


### PR DESCRIPTION
## Problem

`agent()`, `output()`, and `tool_schema()` failed from Python cells with:

```
Unknown tool __agent__. Active tools: read, bash, ..., task, task_output, ...
```

Note that `task` **is** in that active-tools list — the tool was available, and the model
called the documented helper with correct arguments. This was not a model mistake.

## Root cause

Subprocess kernels (python, ruby, julia) reach the host only over the bridge HTTP
`/call` route. Its `onCall` handler in `src/extension/session-manager.ts` forwarded
every `toolName` straight to `executeTool`:

```ts
onCall: async (request) =>
    this.#options.executeTool(request.toolName, request.args, { signal: request.signal }),
```

The reserved bridge names (`__agent__`, `__output__`, `__schema__`) are helper
protocol names, never registered agent tools, so they were rejected by the agent
session. The in-process JavaScript kernel was unaffected because
`src/tool/cell-handler.ts` already checks `isReservedToolName()` and routes through
`runReservedTool()`. The HTTP route simply never got the same treatment.

Impact: every `agent()` / `output()` / `tool_schema()` call from a python (or ruby /
julia) cell failed. This reproduced across many historical sessions.

## Fix

Route reserved names through `runReservedTool()` on the HTTP route too, mirroring the
JS path, and thread the tool catalog (`listTools`) through so `tool_schema()` can answer.

## Verification

- New contract `test/session-manager-reserved-bridge.test.ts` drives the real bridge
  `/call` route. Captured RED before the fix, reproducing the exact production string
  `Unknown tool __agent__. Active tools: ...` for all three reserved names; GREEN after.
  A fourth case asserts ordinary tool names still go straight to `executeTool` — it
  passed before and after, so the regression guard is correctly scoped.
- Full package suite: **453 passed**, 6 skipped, in one run.
- `npm run check` green.
- Real-surface QA: `scripts/qa-reserved-bridge.ts` runs a live python kernel against the
  real session manager and exercises `agent()`, `parallel([agent, agent])`,
  `tool_schema()`, and `output()`:

```
AGENT_SOLO=DELEGATED
AGENT_PARALLEL=['DELEGATED', 'DELEGATED']
SCHEMA_TOOLS=['read']
OUTPUT=TRANSCRIPT
QA PASS - task calls: 3, tool names: task,task_output
```

  Mutation-checked: reverting the one-line fix makes this QA fail (exit 1); restoring it
  passes (exit 0).

## Why this escaped QA

The existing `scripts/qa-py-cell.ts` driver hardcodes its own reserved-name routing in
its `onCall`, so it exercised `runEvalAgent` but never the real `session-manager` path.
The new driver goes through `createCodemodeSessionManager`, closing that blind spot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reserved tool routing over the bridge HTTP route so `agent()`, `output()`, and `tool_schema()` work from Python/Ruby/Julia cells instead of failing with “Unknown tool __agent__”.

- Bug Fixes
  - Route `__agent__`, `__output__`, and `__schema__` through the reserved-tool dispatcher on `/call`, matching the JS kernel path.
  - Thread the tool catalog (`listTools`) into the session manager/runtime so `tool_schema()` can answer; normal tool names still go directly to `executeTool`.
  - Add a focused test that drives the real `/call` route and a QA script that runs a live Python kernel to prevent regressions.

<sup>Written for commit 78acd3ada7dc0799d9b227ccfc8bcf3e6428d606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

