### PR TITLE
fix(coding-agent): preserve terminal sessions and monitors across reload

### DIFF
--- a/packages/coding-agent/docs/terminal-tools.md
+++ b/packages/coding-agent/docs/terminal-tools.md
@@ -21,6 +21,10 @@ Background sessions are NEVER killed by `timeout` (they live until they exit or 
 call `kill_bash`), even though the bash-timeout extension injects a default `timeout`
 into every `bash` call. Foreground calls behave like the classic `bash` tool.
 
+Background sessions and monitors also survive a session reload (`/reload`): existing
+`bash_N` ids stay addressable, watchers keep injecting events, and completion
+notifications keep arriving. Quitting or switching sessions still tears everything down.
+
 Typical flow: start with `run_in_background: true`, watch for patterns with `monitor`,
 peek with `bash_output`, steer with `bash_input`, then `kill_bash` when done. Completion
 arrives as a notification carrying the exit code and output tail, so a follow-up

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,45 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Background sessions and monitors survive session reload (2026-07-29)
+
+### What changed
+
+- `session-bundle.ts` (new): `TerminalSessionBundle` owns the long-lived per-session runtime
+  (the `TerminalManager` plus the `MonitorRegistry`) and routes monitor events, monitor-state
+  snapshots, and background-exit notifications through mutable sinks the current extension
+  instance binds. A module-level parked map (`parkBundle`/`claimParkedBundle`/
+  `teardownParkedBundle`, keyed by `ctx.sessionManager.getSessionId()`, at most one parked
+  bundle per session) hands the bundle across the extension-runner replacement a reload performs.
+- `extension.ts`: `session_shutdown` with `reason:"reload"` parks the bundle instead of tearing
+  it down; every other reason (`quit`/`new`/`resume`/`fork`) keeps the full teardown AND sweeps
+  any stale parked bundle. `session_start` with `reason:"reload"` claims the parked bundle,
+  re-binds sinks to the new instance's notifiers, re-publishes the `monitors` footer status, and
+  flushes events buffered during the reload window (bounded: 100 monitor events, 32 exits);
+  other reasons keep today's fresh-bundle behavior. `onBackgroundExit` now dispatches through
+  the bundle so exit listeners registered before a reload reach the post-reload notifier.
+- Result: after `/reload`, existing `bash_N` ids remain addressable (`bash_output`,
+  `bash_input`, `kill_bash`), monitors keep injecting events, and background completion
+  notifications reach the new runner instead of dying with the old one. Previously reload
+  tree-killed every background session and orphaned every watcher the model knew about.
+- Known bounds: terminal `maxSessions`/`scrollback` setting changes apply to bundles created
+  after a non-reload session start (a preserved bundle keeps its construction-time caps); a
+  headless host that skips `session_start` after reload leaves the bundle parked until the next
+  real shutdown sweep.
+- Tests: `test/suite/terminal-reload-survival.test.ts` (monitor survival + footer re-publish,
+  background-session id survival via screen peek, post-reload completion-notification routing,
+  quit-teardown characterization pin).
+
+### Why
+
+Observed live: a reload during an active `gh pr checks --watch` monitor orphaned the watcher
+(process kept running, session lost the subscription, footer went blank, all bash ids dangled).
+Waiting state parked behind a reload must keep waiting, cleanly.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: fork-owned `extension.ts` session lifecycle handlers and the new `session-bundle.ts`.
+
 ## bash_output ghost wait_for params removed (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -3,13 +3,18 @@ import { SettingsManager } from "../../../settings-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 import { TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
-import { TerminalManager } from "./manager.ts";
 import { MonitorNotifier } from "./monitor-notify.ts";
-import { MonitorRegistry } from "./monitor-registry.ts";
 import { formatMonitorStatus, MONITOR_STATUS_KEY } from "./monitor-status.ts";
 import { TerminalNotifier } from "./notify.ts";
 import { TERMINAL_PROMPT_SECTION } from "./prompt.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
+import {
+	claimParkedBundle,
+	parkBundle,
+	type TerminalEventSinks,
+	TerminalSessionBundle,
+	teardownParkedBundle,
+} from "./session-bundle.ts";
 import { loadTerminalSettings, type ResolvedTerminalSettings, TERMINAL_SETTINGS_DEFAULTS } from "./settings.ts";
 import { TERMINAL_BASH_TOOL, TERMINAL_COMPANION_TOOLS } from "./shared.ts";
 import { createPtyBashTool } from "./tools/bash.ts";
@@ -21,31 +26,54 @@ import { createKillBashTool } from "./tools/kill-bash.ts";
 import { createMonitorTool } from "./tools/monitor.ts";
 
 interface TerminalExtensionState {
-	manager: TerminalManager | null;
+	bundle: TerminalSessionBundle | null;
 	settings: ResolvedTerminalSettings;
 	notifier: TerminalNotifier | null;
 	monitorNotifier: MonitorNotifier | null;
-	monitors: MonitorRegistry | null;
 	ctx: ExtensionContext | undefined;
 	shellPath: string | undefined;
 	steppedAside: boolean;
 	noticeShown: boolean;
 }
 
+/** Tests and SDK callers may hand partial contexts without a session manager. */
+function sessionKeyOf(ctx: ExtensionContext | undefined): string | undefined {
+	return ctx?.sessionManager?.getSessionId?.();
+}
+
+function createBundle(state: TerminalExtensionState): TerminalSessionBundle {
+	return new TerminalSessionBundle({
+		maxSessions: state.settings.maxSessions,
+		scrollback: state.settings.scrollback,
+	});
+}
+
+/** Sinks read the live instance state at call time, so notifier swaps need no re-bind. */
+function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalEventSinks {
+	return {
+		onMonitorEvent: (event) => state.monitorNotifier?.notifyEvent(event),
+		onMonitorState: (snapshot) => {
+			state.ctx?.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot));
+			pi.events?.emit(TERMINAL_MONITOR_STATE_EVENT, { activeCount: snapshot.length });
+		},
+		onBackgroundExit: (id, runtime) => state.notifier?.notifyCompletion(id, runtime),
+	};
+}
+
 function buildToolContext(pi: ExtensionAPI, state: TerminalExtensionState): TerminalToolContext {
-	const requireManager = (): TerminalManager => {
-		// Lazily create a manager so the tool works even when invoked directly (e.g. via the
+	const requireBundle = (): TerminalSessionBundle => {
+		// Lazily create a bundle so the tools work even when invoked directly (e.g. via the
 		// SDK) before `session_start` initializes one. `session_start` replaces it with a
-		// settings-configured manager and tears down any earlier one.
-		state.manager ??= new TerminalManager({
-			maxSessions: state.settings.maxSessions,
-			scrollback: state.settings.scrollback,
-		});
-		return state.manager;
+		// settings-configured bundle and tears down any earlier one.
+		if (!state.bundle) {
+			state.bundle = createBundle(state);
+			state.bundle.bind(bundleSinks(pi, state));
+		}
+		return state.bundle;
 	};
 	return {
 		get manager() {
-			return requireManager();
+			return requireBundle().manager;
 		},
 		get cwd() {
 			return state.ctx?.cwd ?? process.cwd();
@@ -63,21 +91,14 @@ function buildToolContext(pi: ExtensionAPI, state: TerminalExtensionState): Term
 			return state.settings.timeoutAction;
 		},
 		get monitorRegistry() {
-			state.monitors ??= new MonitorRegistry((event) => state.monitorNotifier?.notifyEvent(event), {
-				onChange: (snapshot) => {
-					state.ctx?.ui.setStatus(MONITOR_STATUS_KEY, formatMonitorStatus(snapshot));
-					const events = pi.events;
-					if (events !== undefined) {
-						events.emit(TERMINAL_MONITOR_STATE_EVENT, { activeCount: snapshot.length });
-					}
-				},
-			});
-			return state.monitors;
+			return requireBundle().monitors;
 		},
 		getEnv: () => getShellEnv(),
 		getSessionContext: () => state.ctx,
+		// Exit listeners registered before a reload reach the post-reload owner through the
+		// shared bundle, so this must dispatch via the bundle, never the instance notifier.
 		onBackgroundExit: (id: string, runtime: TerminalRuntimeSession) => {
-			state.notifier?.notifyCompletion(id, runtime);
+			state.bundle?.notifyBackgroundExit(id, runtime);
 		},
 		onMonitorRearmed: (id: string) => state.monitorNotifier?.rearm(id),
 	};
@@ -114,11 +135,10 @@ function syncToolset(pi: ExtensionAPI, state: TerminalExtensionState): void {
 
 export function registerTerminalExtension(pi: ExtensionAPI): void {
 	const state: TerminalExtensionState = {
-		manager: null,
+		bundle: null,
 		settings: TERMINAL_SETTINGS_DEFAULTS,
 		notifier: null,
 		monitorNotifier: null,
-		monitors: null,
 		ctx: undefined,
 		shellPath: undefined,
 		steppedAside: false,
@@ -133,7 +153,7 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 	pi.registerTool(createKillBashTool(toolCtx));
 	pi.registerTool(createMonitorTool(toolCtx));
 
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", async (event, ctx) => {
 		state.ctx = ctx;
 		const settingsManager = SettingsManager.create(ctx.cwd);
 		state.settings = loadTerminalSettings(settingsManager);
@@ -149,15 +169,22 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 			getContext: () => state.ctx,
 			getMode: () => state.settings.notify,
 			getSettings: () => state.settings.monitor,
-			pauseMonitors: () => state.monitors?.pauseAll() ?? [],
+			pauseMonitors: () => state.bundle?.monitors.pauseAll() ?? [],
 		});
-		state.monitors?.dispose();
-		state.monitors = null;
-		await state.manager?.teardown();
-		state.manager = new TerminalManager({
-			maxSessions: state.settings.maxSessions,
-			scrollback: state.settings.scrollback,
-		});
+		const sessionKey = sessionKeyOf(ctx);
+		if (event.reason === "reload") {
+			const claimed = sessionKey === undefined ? undefined : claimParkedBundle(sessionKey);
+			if (claimed) {
+				await state.bundle?.teardown();
+				state.bundle = claimed;
+			}
+		} else {
+			if (sessionKey !== undefined) await teardownParkedBundle(sessionKey);
+			await state.bundle?.teardown();
+			state.bundle = createBundle(state);
+		}
+		state.bundle ??= createBundle(state);
+		state.bundle.bind(bundleSinks(pi, state));
 		syncToolset(pi, state);
 	});
 
@@ -179,13 +206,22 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		return { systemPrompt: `${event.systemPrompt}\n${TERMINAL_PROMPT_SECTION}` };
 	});
 
-	pi.on("session_shutdown", async () => {
+	pi.on("session_shutdown", async (event, ctx) => {
 		state.monitorNotifier?.dispose();
 		state.monitorNotifier = null;
-		state.monitors?.dispose();
-		state.monitors = null;
-		await state.manager?.teardown();
-		state.manager = null;
+		state.notifier = null;
+		const sessionKey = sessionKeyOf(ctx) ?? sessionKeyOf(state.ctx);
+		if (event.reason === "reload" && state.bundle && sessionKey !== undefined) {
+			// Keep state.bundle referenced: exit listeners captured by this instance's tool
+			// context still route through the shared bundle after the new owner claims it.
+			state.bundle.park();
+			await parkBundle(sessionKey, state.bundle);
+			return;
+		}
+		const bundle = state.bundle;
+		state.bundle = null;
+		await bundle?.teardown();
+		if (sessionKey !== undefined) await teardownParkedBundle(sessionKey);
 	});
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/session-bundle.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/session-bundle.ts
@@ -1,0 +1,103 @@
+import { TerminalManager, type TerminalManagerOptions } from "./manager.ts";
+import { type MonitorEvent, MonitorRegistry, type MonitorSnapshotEntry } from "./monitor-registry.ts";
+import type { TerminalRuntimeSession } from "./runtime-session.ts";
+
+export interface TerminalEventSinks {
+	readonly onMonitorEvent: (event: MonitorEvent) => void;
+	readonly onMonitorState: (snapshot: readonly MonitorSnapshotEntry[]) => void;
+	readonly onBackgroundExit: (id: string, runtime: TerminalRuntimeSession) => void;
+}
+
+const MAX_PARKED_MONITOR_EVENTS = 100;
+const MAX_PARKED_EXITS = 32;
+
+/**
+ * The long-lived terminal runtime for one agent session: the PTY session manager plus
+ * the monitor registry. A session reload replaces the extension runner and re-runs the
+ * extension factory, so this state must outlive any single extension instance; event
+ * routing goes through mutable sinks the current owner instance binds. While parked
+ * (the reload window, or a headless reload that never re-binds) events buffer bounded.
+ */
+export class TerminalSessionBundle {
+	readonly manager: TerminalManager;
+	readonly monitors: MonitorRegistry;
+	#sinks: TerminalEventSinks | null = null;
+	#parkedMonitorEvents: MonitorEvent[] = [];
+	#parkedExits = new Map<string, TerminalRuntimeSession>();
+	#torndown = false;
+
+	constructor(options: TerminalManagerOptions) {
+		this.manager = new TerminalManager(options);
+		this.monitors = new MonitorRegistry((event) => this.#dispatchMonitorEvent(event), {
+			onChange: (snapshot) => this.#sinks?.onMonitorState(snapshot),
+		});
+	}
+
+	/** Install live sinks, re-publish monitor state, and flush everything buffered while parked. */
+	bind(sinks: TerminalEventSinks): void {
+		if (this.#torndown) return;
+		this.#sinks = sinks;
+		const parkedMonitorEvents = this.#parkedMonitorEvents;
+		this.#parkedMonitorEvents = [];
+		const parkedExits = [...this.#parkedExits];
+		this.#parkedExits.clear();
+		sinks.onMonitorState(this.monitors.snapshot());
+		for (const event of parkedMonitorEvents) sinks.onMonitorEvent(event);
+		for (const [id, runtime] of parkedExits) sinks.onBackgroundExit(id, runtime);
+	}
+
+	park(): void {
+		this.#sinks = null;
+	}
+
+	notifyBackgroundExit(id: string, runtime: TerminalRuntimeSession): void {
+		if (this.#torndown) return;
+		if (this.#sinks) {
+			this.#sinks.onBackgroundExit(id, runtime);
+			return;
+		}
+		if (this.#parkedExits.size >= MAX_PARKED_EXITS) return;
+		this.#parkedExits.set(id, runtime);
+	}
+
+	async teardown(): Promise<void> {
+		if (this.#torndown) return;
+		this.#torndown = true;
+		this.#parkedMonitorEvents = [];
+		this.#parkedExits.clear();
+		this.monitors.dispose();
+		this.#sinks = null;
+		await this.manager.teardown();
+	}
+
+	#dispatchMonitorEvent(event: MonitorEvent): void {
+		if (this.#torndown) return;
+		if (this.#sinks) {
+			this.#sinks.onMonitorEvent(event);
+			return;
+		}
+		this.#parkedMonitorEvents.push(event);
+		if (this.#parkedMonitorEvents.length > MAX_PARKED_MONITOR_EVENTS) this.#parkedMonitorEvents.shift();
+	}
+}
+
+const parkedBundles = new Map<string, TerminalSessionBundle>();
+
+/** Park a bundle across a reload; at most one parked bundle per session, older ones torn down. */
+export async function parkBundle(sessionKey: string, bundle: TerminalSessionBundle): Promise<void> {
+	const previous = parkedBundles.get(sessionKey);
+	parkedBundles.set(sessionKey, bundle);
+	if (previous && previous !== bundle) await previous.teardown();
+}
+
+export function claimParkedBundle(sessionKey: string): TerminalSessionBundle | undefined {
+	const bundle = parkedBundles.get(sessionKey);
+	parkedBundles.delete(sessionKey);
+	return bundle;
+}
+
+export async function teardownParkedBundle(sessionKey: string): Promise<void> {
+	const bundle = parkedBundles.get(sessionKey);
+	parkedBundles.delete(sessionKey);
+	await bundle?.teardown();
+}

--- a/packages/coding-agent/test/suite/terminal-reload-survival.test.ts
+++ b/packages/coding-agent/test/suite/terminal-reload-survival.test.ts
@@ -1,0 +1,261 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+interface ToolResultLike {
+	content: Array<{ type: string; text?: string }>;
+	isError?: boolean;
+}
+
+interface ToolLike {
+	name: string;
+	execute: (id: string, input: Record<string, unknown>) => Promise<ToolResultLike>;
+}
+
+/**
+ * One extension-runner generation. A real reload replaces the runner and re-runs
+ * every extension factory, so each generation gets its own fake pi, tools, and
+ * notification stream — exactly the seam `AgentSession.reload()` exercises.
+ */
+interface FakeRunner {
+	pi: ExtensionAPI;
+	tools: Map<string, ToolLike>;
+	sentMessages: string[];
+	setStatus: ReturnType<typeof vi.fn>;
+	emit(eventType: string, payload: Record<string, unknown>, ctx: ExtensionContext): Promise<void>;
+	waitForMessage(predicate: (content: string) => boolean, label: string): Promise<string>;
+}
+
+function createRunner(): FakeRunner {
+	const handlers = new Map<string, Handler[]>();
+	const tools = new Map<string, ToolLike>();
+	const sentMessages: string[] = [];
+	const listeners = new Set<(content: string) => void>();
+	let activeTools: string[] = [];
+	const pi = {
+		registerTool: (tool: ToolLike) => {
+			tools.set(tool.name, tool);
+		},
+		on: (eventType: string, handler: Handler) => {
+			const existing = handlers.get(eventType) ?? [];
+			existing.push(handler);
+			handlers.set(eventType, existing);
+		},
+		sendMessage: (message: { content: string }) => {
+			sentMessages.push(message.content);
+			for (const listener of listeners) listener(message.content);
+		},
+		sendUserMessage: () => {},
+		getActiveTools: () => activeTools,
+		setActiveTools: (next: string[]) => {
+			activeTools = next;
+		},
+	} as unknown as ExtensionAPI;
+	return {
+		pi,
+		tools,
+		sentMessages,
+		setStatus: vi.fn(),
+		async emit(eventType, payload, ctx) {
+			for (const handler of handlers.get(eventType) ?? []) await handler(payload, ctx);
+		},
+		waitForMessage(predicate, label) {
+			return new Promise<string>((resolve, reject) => {
+				const existing = sentMessages.find(predicate);
+				if (existing !== undefined) {
+					resolve(existing);
+					return;
+				}
+				const timeout = setTimeout(() => {
+					listeners.delete(listener);
+					reject(new Error(`Timed out waiting for ${label}`));
+				}, 8000);
+				const listener = (content: string) => {
+					if (!predicate(content)) return;
+					clearTimeout(timeout);
+					listeners.delete(listener);
+					resolve(content);
+				};
+				listeners.add(listener);
+			});
+		},
+	};
+}
+
+function makeCtx(runner: FakeRunner, cwd: string, sessionId: string): ExtensionContext {
+	return {
+		cwd,
+		mode: "tui",
+		model: { id: "test-model", api: "openai-completions" },
+		ui: { setStatus: runner.setStatus, notify: () => {} },
+		sessionManager: { getSessionId: () => sessionId, getSessionFile: () => undefined },
+	} as unknown as ExtensionContext;
+}
+
+function firstText(result: ToolResultLike): string {
+	return result.content.find((block) => block.type === "text")?.text ?? "";
+}
+
+function extractBashId(text: string): string {
+	const match = /ID: (bash_\d+)/.exec(text);
+	if (!match?.[1]) throw new Error(`No bash id in tool result: ${text}`);
+	return match[1];
+}
+
+describe("terminal extension — background state survives reload", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+	const savedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+	let tmp: string;
+	let cwd: string;
+	let sessionId: string;
+	let sessionCounter = 0;
+	/** Every live generation gets a quit shutdown in afterEach so no PTY leaks across tests. */
+	let liveGenerations: Array<{ runner: FakeRunner; ctx: ExtensionContext }> = [];
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		tmp = mkdtempSync(join(tmpdir(), "senpi-reload-survival-"));
+		process.env.SENPI_CODING_AGENT_DIR = join(tmp, "agent-home");
+		cwd = join(tmp, "project");
+		mkdirSync(join(cwd, ".senpi"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".senpi", "settings.json"),
+			JSON.stringify({ terminal: { monitorCoalesceWindowMs: 25, monitorRateLimitMs: 25, notify: "wake" } }),
+		);
+		sessionId = `reload-survival-${++sessionCounter}`;
+		liveGenerations = [];
+	});
+
+	afterEach(async () => {
+		for (const generation of liveGenerations) {
+			await generation.runner.emit("session_shutdown", { type: "session_shutdown", reason: "quit" }, generation.ctx);
+		}
+		rmSync(tmp, { recursive: true, force: true });
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+		if (savedAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+		else process.env.SENPI_CODING_AGENT_DIR = savedAgentDir;
+	});
+
+	async function startGeneration(reason: string): Promise<{ runner: FakeRunner; ctx: ExtensionContext }> {
+		const runner = createRunner();
+		registerTerminalExtension(runner.pi);
+		const ctx = makeCtx(runner, cwd, sessionId);
+		await runner.emit("session_start", { type: "session_start", reason }, ctx);
+		liveGenerations.push({ runner, ctx });
+		return { runner, ctx };
+	}
+
+	/** Mirrors AgentSession.reload(): shutdown(reason reload) on the old runner, fresh factory + session_start(reason reload) on the new one. */
+	async function reloadInto(previous: { runner: FakeRunner; ctx: ExtensionContext }): Promise<{
+		runner: FakeRunner;
+		ctx: ExtensionContext;
+	}> {
+		await previous.runner.emit("session_shutdown", { type: "session_shutdown", reason: "reload" }, previous.ctx);
+		return await startGeneration("reload");
+	}
+
+	it("keeps a monitor watching and re-publishes its footer status across reload (C1)", async () => {
+		const gen1 = await startGeneration("startup");
+		const trigger = join(tmp, "fire-c1");
+		const created = await gen1.runner.tools.get("monitor")?.execute("c1", {
+			description: "reload survivor watch",
+			command: `sh -c 'while [ ! -e "${trigger}" ]; do sleep 0.05; done; echo event-after-reload'`,
+			persistent: true,
+		});
+		expect(created?.isError).toBeFalsy();
+		extractBashId(firstText(created ?? { content: [] }));
+
+		const gen2 = await reloadInto(gen1);
+
+		expect(gen2.runner.setStatus).toHaveBeenCalledWith("monitors", expect.stringContaining("reload survivor watch"));
+
+		const delivered = gen2.runner.waitForMessage(
+			(content) => content.includes("event-after-reload"),
+			"post-reload monitor line on the new runner",
+		);
+		writeFileSync(trigger, "");
+		expect(await delivered).toContain("reload survivor watch");
+	});
+
+	it("keeps a background session alive and addressable by its original id across reload (C2)", async () => {
+		const gen1 = await startGeneration("startup");
+		const created = await gen1.runner.tools.get("bash")?.execute("c2", {
+			command: "sh -c 'echo alive-before-reload; cat'",
+			run_in_background: true,
+		});
+		expect(created?.isError).toBeFalsy();
+		const bashId = extractBashId(firstText(created ?? { content: [] }));
+
+		const gen2 = await reloadInto(gen1);
+
+		const peeked = await gen2.runner.tools
+			.get("bash_output")
+			?.execute("c2-peek", { bash_id: bashId, view: "screen" });
+		expect(peeked?.isError).toBeFalsy();
+		const peekedText = firstText(peeked ?? { content: [] });
+		expect(peekedText).toContain("status: running");
+		expect(peekedText).toContain("alive-before-reload");
+	});
+
+	it("routes a post-reload background completion notification through the new runner (C3)", async () => {
+		const gen1 = await startGeneration("startup");
+		const trigger = join(tmp, "fire-c3");
+		const created = await gen1.runner.tools.get("bash")?.execute("c3", {
+			command: `sh -c 'while [ ! -e "${trigger}" ]; do sleep 0.05; done; echo finishing-now'`,
+			run_in_background: true,
+		});
+		const bashId = extractBashId(firstText(created ?? { content: [] }));
+
+		const gen2 = await reloadInto(gen1);
+
+		const delivered = gen2.runner.waitForMessage(
+			(content) => content.includes(`session ${bashId} finished`),
+			"post-reload completion notification on the new runner",
+		);
+		writeFileSync(trigger, "");
+		expect(await delivered).toContain("finishing-now");
+	});
+
+	it("still tears everything down on a non-reload shutdown (C4 pin)", async () => {
+		const gen1 = await startGeneration("startup");
+		const pidFile = join(tmp, "pid-c4");
+		await gen1.runner.tools.get("bash")?.execute("c4", {
+			command: `sh -c 'echo $$ > "${pidFile}"; cat'`,
+			run_in_background: true,
+		});
+		await expect.poll(() => existsSync(pidFile), { timeout: 3000 }).toBe(true);
+		const monitorResult = await gen1.runner.tools.get("monitor")?.execute("c4-mon", {
+			description: "quit teardown watch",
+			command: "cat",
+			persistent: true,
+		});
+		expect(monitorResult?.isError).toBeFalsy();
+		expect(gen1.runner.setStatus).toHaveBeenCalledWith("monitors", expect.stringContaining("quit teardown watch"));
+
+		await gen1.runner.emit("session_shutdown", { type: "session_shutdown", reason: "quit" }, gen1.ctx);
+		liveGenerations = [];
+
+		expect(gen1.runner.setStatus).toHaveBeenCalledWith("monitors", undefined);
+		const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+		expect(Number.isFinite(pid)).toBe(true);
+		await expect
+			.poll(
+				() => {
+					try {
+						process.kill(pid, 0);
+						return true;
+					} catch {
+						return false;
+					}
+				},
+				{ timeout: 5000 },
+			)
+			.toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

`/reload` (`AgentSession.reload()`) emits `session_shutdown {reason:"reload"}` and rebuilds the extension runner. The terminal builtin ignored the reason: it disposed the monitor registry/notifier and tree-killed every background PTY session, then `session_start` created fresh empty state. After any reload, every `bash_N` id the model knew dangled, monitors stopped injecting events, and the footer watch status vanished. Observed live: a reload orphaned an active `gh pr checks --watch` monitor mid-delivery-loop.

## Fix

- New `terminal/session-bundle.ts`: `TerminalSessionBundle` owns the long-lived per-session runtime (TerminalManager + MonitorRegistry) with mutable event sinks; a module-level parked map (keyed by durable session id, max one entry per session) hands the bundle across the runner replacement.
- `extension.ts`: shutdown `reason:"reload"` parks instead of tearing down; `session_start {reason:"reload"}` claims, re-binds sinks to the new instance's notifiers, re-publishes the `monitors` footer status, and flushes events buffered during the reload window (bounded). All other reasons (`quit`/`new`/`resume`/`fork`) keep full teardown and sweep stale parked state. `onBackgroundExit` routes through the bundle so pre-reload exit listeners reach the post-reload notifier.

## Evidence

- TDD: `test/suite/terminal-reload-survival.test.ts` written first and captured RED (C1 monitor survival + footer re-publish, C2 bg-session id survival, C3 post-reload completion-notification routing failing; C4 quit-teardown characterization pinned green), then GREEN after the fix.
- Regression sweep: 12 terminal-surface test files, 85 tests green; root `npm run check` exit 0.
- Real-CLI QA (senpi-qa, tmux + fake model server, zero tokens): real TUI from source spawned a background session with a marker, ran `/reload` ("Reloaded keybindings..." observed), then `bash_output` on the original `bash_1` returned `status: running` plus the pre-reload marker in the recorded model request; `/exit` tore everything down with no orphaned processes. Receipts: `local-ignore/qa-evidence/20260729-reload-preserve-terminal/`.

## Known bounds

- `maxSessions`/`scrollback` changes apply to bundles created at a non-reload session start.
- A headless host that skips `session_start` after reload leaves the bundle parked until the next real shutdown sweep (bounded to one bundle per session).
- Follow-up (separate PR): `senpi-codemode` drops its eval kernel on any `session_shutdown`, same defect class.

Plan: .omo/plans/reload-preserve-terminal-state.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves terminal background sessions and monitors across `/reload`, so `bash_N` ids stay usable and monitor events keep flowing. Fixes orphaned watchers and missing completion notifications after reload.

- **Bug Fixes**
  - Added `TerminalSessionBundle` to persist `TerminalManager` and `MonitorRegistry` across runner reloads, with a parked bundle map keyed by session id.
  - Updated `session_start`/`session_shutdown`: park/claim on `reason: "reload"`; fully teardown and sweep any parked state on other reasons; rebind event sinks, re-publish the monitor footer, and route `onBackgroundExit` through the bundle.
  - Bounded buffering during reload: up to 100 monitor events and 32 background exits are flushed to the new instance.
  - Tests verify monitor survival, background session id continuity, post-reload completion notifications, and quit teardown; docs updated to note reload survival (tooling still backed by `@earendil-works/pi-pty`).

<sup>Written for commit c297bffb4d678d90f2e9b9e1db8ecec1ad73977f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

