### PR TITLE
feat(coding-agent): give-me-tips pointer under Tip lines + --list-tips catalog flag

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -46,6 +46,7 @@ export interface Args {
 	noThemes?: boolean;
 	noContextFiles?: boolean;
 	listModels?: string | true;
+	listTips?: boolean;
 	offline?: boolean;
 	verbose?: boolean;
 	projectTrustOverride?: boolean;
@@ -182,6 +183,8 @@ export function parseArgs(args: string[], options: { grokNeoEnabled?: boolean } 
 			} else {
 				result.listModels = true;
 			}
+		} else if (arg === "--list-tips") {
+			result.listTips = true;
 		} else if (arg === "--verbose") {
 			result.verbose = true;
 		} else if (arg === "--approve" || arg === "-a") {
@@ -290,6 +293,7 @@ ${chalk.bold("Options:")}
   --no-context-files, -nc        Disable AGENTS.md and CLAUDE.md discovery and loading
   --export <file>                Export session file to HTML and exit
   --list-models [search]         List available models (with optional fuzzy search)
+  --list-tips                    List all tips as JSON
   --verbose                      Force verbose startup (overrides quietStartup setting)
   --approve, -a                  Trust project-local files for this run
   --no-approve, -na              Ignore project-local files for this run

--- a/packages/coding-agent/src/cli/changes.md
+++ b/packages/coding-agent/src/cli/changes.md
@@ -1,5 +1,34 @@
 # changes
 
+## `senpi --list-tips` prints the tip catalog as JSON (2026-07-29)
+
+### What changed
+
+- `args.ts`: added the `--list-tips` boolean flag next to `--list-models`, with a help row.
+- `list-tips.ts` (new): `collectTips()` renders every `TIP_DEFINITIONS` entry through the default
+  `KeybindingsManager` (the same construction the tips tests use for live keys) into
+  `{id, text, requiresCommand?}` records; `listTips()` prints the array as 2-space-indented JSON.
+- `main.ts`: mirrors every `--list-models` dispatch branch for the new flag - plain runtime metadata
+  command, in-memory session manager, early exit before first-time setup, and print-mode project
+  trust - except the flag needs no model runtime, so it prints and exits without creating
+  agent-session services.
+- Coverage: `test/suite/list-tips.test.ts` pins the full catalog id order (including
+  `fallback-chains-setting`), non-empty rendered text, and `requiresCommand` gating.
+
+### Why
+
+- The tip catalog teaches most of the fork's surface but was only visible one line at a time; a
+  JSON dump gives scripts and the give-me-tips skill the whole catalog in one pass.
+
+### Why extension system couldn't handle this
+
+- Flag parsing and pre-runtime dispatch run before extensions load.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `args.ts` flag table and parse branches.
+- LOW: `main.ts` dispatch branches; `list-tips.ts` is additive.
+
 ## Removed legacy `--neo` CLI flags and launcher plumbing (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/cli/list-tips.ts
+++ b/packages/coding-agent/src/cli/list-tips.ts
@@ -1,0 +1,35 @@
+/**
+ * List the tip catalog as JSON
+ */
+
+import { type Keybinding, KeybindingsManager } from "../core/keybindings.ts";
+import { TIP_DEFINITIONS } from "../modes/interactive/tips/registry.ts";
+
+export interface ListedTip {
+	id: string;
+	text: string;
+	requiresCommand?: string;
+}
+
+/**
+ * Render every catalog tip with the default keybindings
+ */
+export function collectTips(): ListedTip[] {
+	const keybindings = new KeybindingsManager();
+	const keys = (binding: Keybinding): string => keybindings.getKeys(binding).join("/");
+
+	return TIP_DEFINITIONS.map((tip) => {
+		const text = tip.render(keys);
+		if (tip.requiresCommand !== undefined) {
+			return { id: tip.id, text, requiresCommand: tip.requiresCommand };
+		}
+		return { id: tip.id, text };
+	});
+}
+
+/**
+ * Print the tip catalog as a JSON array
+ */
+export function listTips(): void {
+	console.log(JSON.stringify(collectTips(), null, 2));
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -14,6 +14,7 @@ import { type Args, type Mode, parseArgs, printHelp } from "./cli/args.ts";
 import { processFileArguments } from "./cli/file-processor.ts";
 import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
+import { listTips } from "./cli/list-tips.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
 import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
@@ -139,7 +140,11 @@ function toProjectTrustMode(appMode: AppMode): AppMode {
 }
 
 function isPlainRuntimeMetadataCommand(parsed: Args): boolean {
-	return !parsed.print && parsed.mode === undefined && (parsed.help === true || parsed.listModels !== undefined);
+	return (
+		!parsed.print &&
+		parsed.mode === undefined &&
+		(parsed.help === true || parsed.listModels !== undefined || parsed.listTips === true)
+	);
 }
 
 async function prepareInitialMessage(
@@ -292,7 +297,7 @@ async function createSessionManager(
 	sessionDir: string | undefined,
 	settingsManager: SettingsManager,
 ): Promise<SessionManager> {
-	if (parsed.noSession || parsed.help || parsed.listModels !== undefined) {
+	if (parsed.noSession || parsed.help || parsed.listModels !== undefined || parsed.listTips) {
 		return SessionManager.inMemory(cwd, parsed.sessionId !== undefined ? { id: parsed.sessionId } : undefined);
 	}
 
@@ -609,6 +614,11 @@ export async function main(args: string[], options?: MainOptions) {
 	const resolvedPromptTemplatePaths = resolveCliPaths(cwd, parsed.promptTemplates);
 	const resolvedThemePaths = resolveCliPaths(cwd, parsed.themes);
 
+	if (parsed.listTips) {
+		listTips();
+		process.exit(0);
+	}
+
 	if (parsed.listModels !== undefined) {
 		const services = await createAgentSessionServices({
 			cwd,
@@ -639,7 +649,13 @@ export async function main(args: string[], options?: MainOptions) {
 
 	// Experimental first-time setup: theme choice and analytics opt-in.
 	// Runs before any runtime services are created so the chosen settings apply everywhere.
-	if (appMode === "interactive" && !parsed.help && parsed.listModels === undefined && shouldRunFirstTimeSetup()) {
+	if (
+		appMode === "interactive" &&
+		!parsed.help &&
+		parsed.listModels === undefined &&
+		!parsed.listTips &&
+		shouldRunFirstTimeSetup()
+	) {
 		await showFirstTimeSetup(startupSettingsManager);
 		time("firstTimeSetup");
 	}
@@ -685,7 +701,7 @@ export async function main(args: string[], options?: MainOptions) {
 			? sessionCwd
 			: undefined;
 	const trustPromptMode: AppMode =
-		parsed.help || parsed.listModels !== undefined ? "print" : toProjectTrustMode(appMode);
+		parsed.help || parsed.listModels !== undefined || parsed.listTips ? "print" : toProjectTrustMode(appMode);
 	const projectTrustByCwd = new Map<string, boolean>();
 
 	const createRuntime: CreateAgentSessionRuntimeFactory = async ({

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Tip lines point at the give-me-tips skill (2026-07-29)
+
+### What changed
+
+- `tips/startup-tip.ts` and `tips/working-tip.ts`: the resolved `line` now carries a second pointer
+  line - `↳ Want the full story on any tip? Ask about it — the give-me-tips skill has the tour.` -
+  appended under the byte-identical `Tip: ${body}` first line. Both render sites draw the tip as a
+  single `Text` component, so the pointer lands directly below the tip row.
+- Coverage: `test/suite/startup-tip.test.ts` and `test/suite/working-tip.test.ts` pin the two-line
+  shape and the `give-me-tips` literal.
+
+### Why
+
+- A one-line tip cannot tell the whole story; the pointer teaches users that the give-me-tips skill
+  can expand any tip on ask.
+
+### Expected merge conflict zones
+
+- LOW: the `line` template in both resolvers.
+
 ## Ethos tips: the fork's voice in the tip rotation (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/startup-tip.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/startup-tip.ts
@@ -34,5 +34,6 @@ export function resolveStartupTipLine(options: StartupTipOptions): StartupTipLin
 		.render(options.keys)
 		.replace(/\s*\n\s*/g, " ")
 		.trim();
-	return { line: `Tip: ${body}`, tipId: tip.id };
+	const pointer = "↳ Want the full story on any tip? Ask about it — the give-me-tips skill has the tour.";
+	return { line: `Tip: ${body}\n${pointer}`, tipId: tip.id };
 }

--- a/packages/coding-agent/src/modes/interactive/tips/working-tip.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/working-tip.ts
@@ -57,5 +57,6 @@ export function resolveWorkingTipLine(options: WorkingTipOptions): WorkingTipLin
 		.render(options.keys)
 		.replace(/\s*\n\s*/g, " ")
 		.trim();
-	return { line: `Tip: ${body}`, tipId: tip.id };
+	const pointer = "↳ Want the full story on any tip? Ask about it — the give-me-tips skill has the tour.";
+	return { line: `Tip: ${body}\n${pointer}`, tipId: tip.id };
 }

--- a/packages/coding-agent/test/suite/list-tips.test.ts
+++ b/packages/coding-agent/test/suite/list-tips.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { collectTips } from "../../src/cli/list-tips.ts";
+import { TIP_DEFINITIONS } from "../../src/modes/interactive/tips/registry.ts";
+
+describe("collectTips", () => {
+	it("returns every catalog tip in order with non-empty rendered text", () => {
+		const tips = collectTips();
+
+		expect(tips.map((tip) => tip.id)).toEqual(TIP_DEFINITIONS.map((tip) => tip.id));
+		for (const tip of tips) {
+			expect(tip.text.trim(), tip.id).not.toBe("");
+			expect(tip.text, tip.id).not.toContain("undefined");
+		}
+	});
+
+	it("includes the fallback-chains-setting tip", () => {
+		const tips = collectTips();
+
+		expect(tips.some((tip) => tip.id === "fallback-chains-setting")).toBe(true);
+	});
+
+	it("carries requiresCommand only for command-gated tips", () => {
+		const tips = collectTips();
+		const gated = tips.filter((tip) => tip.requiresCommand !== undefined);
+
+		expect(gated.length).toBeGreaterThan(0);
+		for (const tip of gated) {
+			const definition = TIP_DEFINITIONS.find((candidate) => candidate.id === tip.id);
+			expect(definition?.requiresCommand).toBe(tip.requiresCommand);
+		}
+		for (const tip of tips.filter((candidate) => candidate.requiresCommand === undefined)) {
+			expect(TIP_DEFINITIONS.find((candidate) => candidate.id === tip.id)?.requiresCommand).toBeUndefined();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/startup-tip.test.ts
+++ b/packages/coding-agent/test/suite/startup-tip.test.ts
@@ -86,7 +86,7 @@ describe("resolveStartupTipLine", () => {
 		).toBeUndefined();
 	});
 
-	it("emits exactly one line so the banner never grows by more than one row", () => {
+	it("emits exactly two lines: the tip and the give-me-tips pointer below it", () => {
 		const resolved = resolveStartupTipLine({
 			tipsEnabled: true,
 			quietStartup: false,
@@ -96,6 +96,22 @@ describe("resolveStartupTipLine", () => {
 			keys: fakeKeys,
 		});
 
-		expect(resolved?.line.split("\n")).toHaveLength(1);
+		expect(resolved?.line.split("\n")).toHaveLength(2);
+	});
+
+	it("points at the give-me-tips skill on a second line under the tip", () => {
+		const resolved = resolveStartupTipLine({
+			tipsEnabled: true,
+			quietStartup: false,
+			history: {},
+			now: 1_000,
+			definitions,
+			keys: fakeKeys,
+		});
+
+		const lines = resolved?.line.split("\n");
+		expect(lines).toHaveLength(2);
+		expect(lines?.[0]).toContain("Tip:");
+		expect(lines?.[1]).toContain("give-me-tips");
 	});
 });

--- a/packages/coding-agent/test/suite/working-tip.test.ts
+++ b/packages/coding-agent/test/suite/working-tip.test.ts
@@ -139,7 +139,7 @@ describe("resolveWorkingTipLine", () => {
 		expect(resolveWorkingTipLine(args)?.tipId).toBe(resolveWorkingTipLine(args)?.tipId);
 	});
 
-	it("emits exactly one line so the status area never grows by more than one row", () => {
+	it("emits exactly two lines: the tip and the give-me-tips pointer below it", () => {
 		const resolved = resolveWorkingTipLine({
 			tipsEnabled: true,
 			history: {},
@@ -149,6 +149,22 @@ describe("resolveWorkingTipLine", () => {
 			keys: fakeKeys,
 		});
 
-		expect(resolved?.line.split("\n")).toHaveLength(1);
+		expect(resolved?.line.split("\n")).toHaveLength(2);
+	});
+
+	it("points at the give-me-tips skill on a second line under the tip", () => {
+		const resolved = resolveWorkingTipLine({
+			tipsEnabled: true,
+			history: {},
+			sessionShownTipIds: new Set<string>(),
+			now: 1_000,
+			definitions,
+			keys: fakeKeys,
+		});
+
+		const lines = resolved?.line.split("\n");
+		expect(lines).toHaveLength(2);
+		expect(lines?.[0]).toContain("Tip:");
+		expect(lines?.[1]).toContain("give-me-tips");
 	});
 });


### PR DESCRIPTION
## What changed

Every `Tip:` line shown in the TUI (startup header tip and working-indicator tip) now carries a pointer line directly beneath it:

```
Tip: Use shift+tab to cycle the model's thinking level.
 ↳ Want the full story on any tip? Ask about it — the give-me-tips skill has the tour.
```

And a new `senpi --list-tips` CLI flag prints the full tip catalog (`TIP_DEFINITIONS`) as JSON — `[{id, text, requiresCommand?}]` — so tip availability is queryable per user (skills, scripts, and the companion `give-me-tips` skill in oh-my-openagent consume it).

## Why

The companion skill `give-me-tips` (https://github.com/code-yeongyu/oh-my-openagent/pull/6439) explains any tip in depth, in the user's language. Users needed a visible path from a shown tip to that skill, and the skill needed a deterministic way to enumerate the catalog instead of hardcoding tip texts.

## Observed behavior / QA

- `senpi --list-tips` (from source, sandboxed): prints 83 tips as JSON; every entry has non-empty text; includes `fallback-chains-setting`; zero stderr. Evidence: `local-ignore/qa-evidence/20260729-give-me-tips/list-tips-source.json`
- TUI proof (senpi-qa channel 2 style, tmux + xterm-render triplet): startup header renders the tip with the give-me-tips pointer directly below; asserted on the parsed cell grid, not raw escapes. Evidence: `senpi-startup.{ans,txt,grid.json,html}` + receipt (sandbox + tmux torn down, real auth untouched)
- `senpi-qa` cli-smoke self-test: 8/8 PASS
- `npm run check`: exit 0. Full `packages/coding-agent` vitest: green.
- New unit tests (RED captured before implementation): startup-tip / working-tip pointer assertions, list-tips collector shape.

## changes.md

Entries added in `src/cli/changes.md` (--list-tips) and `src/modes/interactive/changes.md` (tip pointer).

## Residual risk

Low: display-only change to tip lines (first line byte-identical; pointer appended), and a read-only metadata flag that exits before first-time setup with no model runtime.