### PR TITLE
feat(ai): kimi-xtml protocol + normal-mode XTML recovery for Kimi K3

### DIFF
--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,11 @@
 # AI Source Changes
 
+## 2026-07-29 - kimi-xtml text tool-call protocol + ToolCallFormat union
+
+### What changed and why
+
+- `ToolCallFormat` gains `"kimi-xtml"` (Kimi K3 native XTML channel syntax); `getToolCallFormat()` whitelist, protocol registry, compat docs, and middleware TESTING.md updated accordingly. Protocol implementation lives in `tool-call-middleware/protocols/kimi-xtml/` (markers, parse, format, stream); details in `tool-call-middleware/changes.md`.
+
 ## 2026-07-28 - Demote unavailable Anthropic tool references instead of failing the request
 
 ### What changed and why

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -48,10 +48,12 @@ export * from "./session-resources.ts";
 export {
 	getProtocol,
 	getToolCallFormat,
+	hasKimiTextToolCallRecovery,
 	shouldRecoverTextToolCalls,
 	transformContext,
 	wrapStreamWithToolCallMiddleware,
 } from "./tool-call-middleware/index.ts";
+export { createXtmlRecoveryStreamParser } from "./tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts";
 export { wrapStreamWithInvokeRecovery } from "./tool-call-middleware/recovery-stream-wrapper.ts";
 export * from "./types.ts";
 export * from "./utils/diagnostics.ts";

--- a/packages/ai/src/tool-call-middleware/TESTING.md
+++ b/packages/ai/src/tool-call-middleware/TESTING.md
@@ -289,3 +289,15 @@ Look for the `toolCallFormat` field in the output. Valid values are:
 | Gemma4 | openrouter-gemma | google/gemma-4-31b-it | `senpi --provider openrouter-gemma --model "google/gemma-4-31b-it" -p "Run date command"` |
 | Anthropic XML | custom OpenAI-compatible provider | compatible text-tool model | `senpi --provider <provider> --model <model> -p "Use Bash to run printf anthropic-xml-ok"` |
 | ANTML | custom OpenAI-compatible provider | compatible text-tool model | `senpi --provider <provider> --model <model> -p "Use Bash to run printf antml-ok"` |
+
+### 7. Kimi XTML Protocol (Kimi K3 Models)
+
+The Kimi XTML format mirrors Kimi K3's native channel syntax (`<|open|>...<|sep|>` / `<|close|>...<|sep|>` markers wrapping tools/call/argument channels).
+
+Add an OpenAI-compatible custom model with `"toolCallFormat": "kimi-xtml"`, then run:
+
+```bash
+senpi --provider <kimi-provider> --model "kimi-k3" -p "List TypeScript files"
+```
+
+Look for `<|open|>tools<|sep|><|open|>call tool="..." index="1"<|sep|>` blocks in the model output; argument values are typed via `key="..." type="string|number|boolean|object|array"` attributes (object/array values are strict JSON).

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -1,5 +1,18 @@
 # Tool Call Middleware Changes
 
+# Tool Call Middleware Changes
+
+## 2026-07-29 - Kimi XTML leaked tool-call recovery in normal mode
+
+### What changed and why
+
+- `shouldRecoverTextToolCalls()` now defaults on for Kimi-family model ids (boundary regex, mirroring the Claude default), so Kimi models get the same normal-mode auto-correction Claude has when native tool calling misfires into plain text.
+- New `createXtmlRecoveryStreamParser()` (`protocols/kimi-xtml/recovery-stream.ts`): recovers leaked `<|open|>tools<|sep|>` blocks into canonical tool calls and strips stray XTML channel-transition markers (think/response/message) from visible text; code-masked spans stay untouched; `interrupt()` restores retained marker fragments as plain text like the invoke parser.
+- `wrapStreamWithInvokeRecovery()` and `RecoveryTextProjection` accept an optional recovery-parser factory (default unchanged: ANTML invoke). `ModelRuntime` selects the XTML factory for Kimi models via `hasKimiTextToolCallRecovery()`; Claude and non-Kimi behavior is byte-identical.
+
+### Why the extension system could not handle this
+
+- Recovery must observe raw provider-neutral assistant text before the coding-agent loop executes tools, and the parser selection must happen inside the stream wrapper, ahead of extension-observable events.
 ## 2026-07-29 - Kimi XTML protocol (Kimi K3 native channel syntax)
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -1,5 +1,17 @@
 # Tool Call Middleware Changes
 
+## 2026-07-29 - Kimi XTML protocol (Kimi K3 native channel syntax)
+
+### What changed and why
+
+- Added the `kimi-xtml` text-tool protocol: Kimi K3's native XTML channel format (`<|open|>name<|sep|>` / `<|close|>name<|sep|>` markers; tools blocks containing `call` channels with `argument` channels), so Kimi models can serve text-encoded tool calling through a syntax they are already trained on.
+- Typed argument coercion: string (default), number, boolean, object/array (strict JSON; malformed values reject the call via `onError` instead of coercing).
+- Streaming parser reassembles markers split across chunks, emits snapshot argument deltas per completed argument, and finalizes unterminated calls as `incomplete` with the arguments parsed so far. Unknown tools are skipped with diagnostics.
+- Registered in the `ToolCallFormat` union, the `getToolCallFormat()` whitelist, and the protocol registry; compat docs and TESTING.md updated.
+
+### Why the extension system could not handle this
+
+- Text tool-call protocols must intercept and re-encode the provider stream and message history inside the middleware, before coding-agent extensions observe assistant events.
 ## 2026-07-20 - Claude leaked invoke recovery
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/context-transformer.ts
+++ b/packages/ai/src/tool-call-middleware/context-transformer.ts
@@ -36,6 +36,13 @@ import {
 	hermesParseGeneratedText,
 } from "./protocols/hermes.ts";
 import {
+	createKimiXtmlStreamParser,
+	kimiXtmlFormatToolCall,
+	kimiXtmlFormatToolResponse,
+	kimiXtmlFormatToolsSystemPrompt,
+	parseKimiXtmlGeneratedText,
+} from "./protocols/kimi-xtml/index.ts";
+import {
 	createMorphXmlStreamParser,
 	morphXmlFormatToolCall,
 	morphXmlFormatToolResponse,
@@ -100,6 +107,14 @@ const antmlProtocol: ToolCallProtocol = {
 	createStreamParser: createAntmlStreamParser,
 };
 
+const kimiXtmlProtocol: ToolCallProtocol = {
+	formatToolsSystemPrompt: kimiXtmlFormatToolsSystemPrompt,
+	formatToolResponse: kimiXtmlFormatToolResponse,
+	formatToolCall: kimiXtmlFormatToolCall,
+	parseGeneratedText: parseKimiXtmlGeneratedText,
+	createStreamParser: createKimiXtmlStreamParser,
+};
+
 const anthropicXmlProtocol: ToolCallProtocol = {
 	formatToolsSystemPrompt: anthropicXmlFormatToolsSystemPrompt,
 	formatToolResponse: anthropicXmlFormatToolResponse,
@@ -119,6 +134,7 @@ const protocolRegistry: Record<ToolCallFormat, ToolCallProtocol> = {
 	"morph-xml": morphXmlProtocol,
 	"yaml-xml": yamlXmlProtocol,
 	"gemma4-delimiter": gemma4Protocol,
+	"kimi-xtml": kimiXtmlProtocol,
 };
 
 /**

--- a/packages/ai/src/tool-call-middleware/index.ts
+++ b/packages/ai/src/tool-call-middleware/index.ts
@@ -47,5 +47,16 @@ export function shouldRecoverTextToolCalls<TApi extends Api>(model: Model<TApi>)
 	if (model.recoverTextToolCalls !== undefined) {
 		return typeof model.recoverTextToolCalls === "boolean" ? model.recoverTextToolCalls : false;
 	}
-	return /(^|[^a-z0-9])claude([^a-z0-9]|$)/i.test(model.id);
+	return CLAUDE_MODEL_ID_PATTERN.test(model.id) || KIMI_MODEL_ID_PATTERN.test(model.id);
+}
+
+const CLAUDE_MODEL_ID_PATTERN = /(^|[^a-z0-9])claude([^a-z0-9]|$)/i;
+const KIMI_MODEL_ID_PATTERN = /(^|[^a-z0-9])kimi([^a-z0-9]|$)/i;
+
+/**
+ * Whether the model leaks Kimi XTML channel markers when tool calling fails,
+ * selecting the XTML recovery parser over the default invoke recovery parser.
+ */
+export function hasKimiTextToolCallRecovery<TApi extends Api>(model: Model<TApi>): boolean {
+	return KIMI_MODEL_ID_PATTERN.test(model.id);
 }

--- a/packages/ai/src/tool-call-middleware/index.ts
+++ b/packages/ai/src/tool-call-middleware/index.ts
@@ -34,7 +34,8 @@ export function getToolCallFormat<TApi extends Api>(model: Model<TApi>): ToolCal
 		format === "yaml-xml" ||
 		format === "gemma4-delimiter" ||
 		format === "anthropic-xml" ||
-		format === "antml"
+		format === "antml" ||
+		format === "kimi-xtml"
 	) {
 		return format;
 	}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/format.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/format.ts
@@ -1,0 +1,64 @@
+import type { ImageContent, TextContent, Tool } from "../../../types.ts";
+import {
+	XTML_ARGUMENT_CLOSE,
+	XTML_ARGUMENT_OPEN,
+	XTML_CALL_CLOSE,
+	XTML_SEP,
+	XTML_TOOLS_CLOSE,
+	XTML_TOOLS_OPEN,
+} from "./markers.ts";
+
+function inferXtmlType(value: unknown): string {
+	if (typeof value === "number") return "number";
+	if (typeof value === "boolean") return "boolean";
+	if (Array.isArray(value)) return "array";
+	if (typeof value === "object" && value !== null) return "object";
+	return "string";
+}
+
+function serializeXtmlValue(value: unknown, type: string): string {
+	if (type === "object" || type === "array") return JSON.stringify(value);
+	return String(value);
+}
+
+export function kimiXtmlFormatToolCall(name: string, args: Record<string, unknown>): string {
+	const renderedArgs = Object.entries(args)
+		.map(([key, value]) => {
+			const type = inferXtmlType(value);
+			return `${XTML_ARGUMENT_OPEN}key="${key}" type="${type}"${XTML_SEP}${serializeXtmlValue(value, type)}${XTML_ARGUMENT_CLOSE}`;
+		})
+		.join("");
+	return `${XTML_TOOLS_OPEN}${"<|open|>call "}tool="${name}" index="1"${XTML_SEP}${renderedArgs}${XTML_CALL_CLOSE}${XTML_TOOLS_CLOSE}`;
+}
+
+export function kimiXtmlFormatToolResponse(
+	toolName: string,
+	_toolCallId: string,
+	content: (TextContent | ImageContent)[],
+): string {
+	const text = content
+		.filter((item): item is TextContent => item.type === "text")
+		.map((item) => item.text)
+		.join("\n");
+	return `## Return of ${toolName}\n${text}`;
+}
+
+export function kimiXtmlFormatToolsSystemPrompt(tools: Tool[]): string {
+	if (tools.length === 0) return "";
+	const toolDescriptions = tools
+		.map((tool) => `Name: ${tool.name}\nDescription: ${tool.description}\nParameters Schema:\n${JSON.stringify(tool.parameters, null, 3)}`)
+		.join("\n\n");
+	return `You have access to the following tools. Use them when appropriate.
+
+${toolDescriptions}
+
+When you need to use a tool, format your response exactly like this, with no other text inside the tools block:
+
+${XTML_TOOLS_OPEN}${"<|open|>call "}tool="tool_name" index="1"${XTML_SEP}${XTML_ARGUMENT_OPEN}key="param" type="string"${XTML_SEP}value${XTML_ARGUMENT_CLOSE}${XTML_CALL_CLOSE}${XTML_TOOLS_CLOSE}
+
+Formatting rules:
+- Emit one ${"<|open|>call "}...${XTML_CALL_CLOSE} section per tool call inside a single tools block.
+- Argument types: string (default when type is omitted), number, boolean, object, array.
+- object and array values must be strict JSON; string values are raw text and need no quoting.
+- Example: ${XTML_TOOLS_OPEN}${"<|open|>call "}tool="get_weather" index="1"${XTML_SEP}${XTML_ARGUMENT_OPEN}key="city" type="string"${XTML_SEP}Seoul${XTML_ARGUMENT_CLOSE}${XTML_CALL_CLOSE}${XTML_TOOLS_CLOSE}`;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/format.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/format.ts
@@ -46,7 +46,10 @@ export function kimiXtmlFormatToolResponse(
 export function kimiXtmlFormatToolsSystemPrompt(tools: Tool[]): string {
 	if (tools.length === 0) return "";
 	const toolDescriptions = tools
-		.map((tool) => `Name: ${tool.name}\nDescription: ${tool.description}\nParameters Schema:\n${JSON.stringify(tool.parameters, null, 3)}`)
+		.map(
+			(tool) =>
+				`Name: ${tool.name}\nDescription: ${tool.description}\nParameters Schema:\n${JSON.stringify(tool.parameters, null, 3)}`,
+		)
 		.join("\n\n");
 	return `You have access to the following tools. Use them when appropriate.
 

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/index.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/index.ts
@@ -1,0 +1,7 @@
+export {
+	kimiXtmlFormatToolCall,
+	kimiXtmlFormatToolResponse,
+	kimiXtmlFormatToolsSystemPrompt,
+} from "./format.ts";
+export { parseKimiXtmlGeneratedText } from "./parse.ts";
+export { createKimiXtmlStreamParser } from "./stream.ts";

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/markers.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/markers.ts
@@ -1,0 +1,31 @@
+export const XTML_TOOLS_OPEN = "<|open|>tools<|sep|>";
+export const XTML_TOOLS_CLOSE = "<|close|>tools<|sep|>";
+export const XTML_CALL_OPEN = "<|open|>call ";
+export const XTML_CALL_CLOSE = "<|close|>call<|sep|>";
+export const XTML_ARGUMENT_OPEN = "<|open|>argument ";
+export const XTML_ARGUMENT_CLOSE = "<|close|>argument<|sep|>";
+export const XTML_SEP = "<|sep|>";
+
+const ATTRIBUTE_PATTERN = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s<]+))/g;
+
+export function parseXtmlAttributes(header: string): Record<string, string> {
+	const attributes: Record<string, string> = {};
+	for (const match of header.matchAll(ATTRIBUTE_PATTERN)) {
+		const key = match[1];
+		if (!key) continue;
+		attributes[key] = match[2] ?? match[3] ?? match[4] ?? "";
+	}
+	return attributes;
+}
+
+export function getPartialXtmlSuffix(text: string, tokens: readonly string[]): string {
+	for (const token of tokens) {
+		for (let length = token.length - 1; length > 0; length -= 1) {
+			const prefix = token.slice(0, length);
+			if (text.endsWith(prefix)) {
+				return prefix;
+			}
+		}
+	}
+	return "";
+}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/parse.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/parse.ts
@@ -1,0 +1,104 @@
+import type { Tool } from "../../../types.ts";
+import type { ParsedToolCall, ParserOptions } from "../../types.ts";
+import {
+	parseXtmlAttributes,
+	XTML_ARGUMENT_CLOSE,
+	XTML_ARGUMENT_OPEN,
+	XTML_CALL_CLOSE,
+	XTML_CALL_OPEN,
+	XTML_SEP,
+	XTML_TOOLS_CLOSE,
+	XTML_TOOLS_OPEN,
+} from "./markers.ts";
+
+type CoercedValue = { ok: true; value: unknown } | { ok: false };
+
+export function coerceXtmlArgumentValue(raw: string, type: string | undefined): CoercedValue {
+	switch (type) {
+		case undefined:
+		case "string":
+			return { ok: true, value: raw };
+		case "number": {
+			const parsed = Number(raw);
+			return Number.isNaN(parsed) ? { ok: false } : { ok: true, value: parsed };
+		}
+		case "boolean":
+			if (raw === "true") return { ok: true, value: true };
+			if (raw === "false") return { ok: true, value: false };
+			return { ok: false };
+		case "object":
+		case "array":
+			try {
+				return { ok: true, value: JSON.parse(raw) };
+			} catch {
+				return { ok: false };
+			}
+		default:
+			return { ok: true, value: raw };
+	}
+}
+
+function parseCallBody(
+	body: string,
+	tool: Tool,
+	options?: ParserOptions,
+): Record<string, unknown> | null {
+	const args: Record<string, unknown> = {};
+	let rest = body;
+	for (;;) {
+		rest = rest.replace(/^\s+/, "");
+		if (!rest.startsWith(XTML_ARGUMENT_OPEN)) break;
+		const headerEnd = rest.indexOf(XTML_SEP, XTML_ARGUMENT_OPEN.length);
+		if (headerEnd === -1) break;
+		const attributes = parseXtmlAttributes(rest.slice(XTML_ARGUMENT_OPEN.length, headerEnd));
+		const key = attributes.key;
+		const valueStart = headerEnd + XTML_SEP.length;
+		const valueEnd = rest.indexOf(XTML_ARGUMENT_CLOSE, valueStart);
+		if (valueEnd === -1 || !key) break;
+		const coerced = coerceXtmlArgumentValue(rest.slice(valueStart, valueEnd), attributes.type);
+		if (!coerced.ok) {
+			options?.onError?.(`kimi-xtml: invalid value for argument "${key}" on tool "${tool.name}".`, {
+				toolCall: rest.slice(0, valueEnd + XTML_ARGUMENT_CLOSE.length),
+			});
+			return null;
+		}
+		args[key] = coerced.value;
+		rest = rest.slice(valueEnd + XTML_ARGUMENT_CLOSE.length);
+	}
+	return args;
+}
+
+export function parseKimiXtmlGeneratedText(text: string, tools: Tool[], options?: ParserOptions): ParsedToolCall[] {
+	const parsed: ParsedToolCall[] = [];
+	let cursor = 0;
+	while (cursor < text.length) {
+		const blockStart = text.indexOf(XTML_TOOLS_OPEN, cursor);
+		if (blockStart === -1) break;
+		const bodyStart = blockStart + XTML_TOOLS_OPEN.length;
+		const blockEnd = text.indexOf(XTML_TOOLS_CLOSE, bodyStart);
+		const block = blockEnd === -1 ? text.slice(bodyStart) : text.slice(bodyStart, blockEnd);
+		cursor = blockEnd === -1 ? text.length : blockEnd + XTML_TOOLS_CLOSE.length;
+
+		let callCursor = 0;
+		while (callCursor < block.length) {
+			const callStart = block.indexOf(XTML_CALL_OPEN, callCursor);
+			if (callStart === -1) break;
+			const headerEnd = block.indexOf(XTML_SEP, callStart + XTML_CALL_OPEN.length);
+			if (headerEnd === -1) break;
+			const attributes = parseXtmlAttributes(block.slice(callStart + XTML_CALL_OPEN.length, headerEnd));
+			const bodyEnd = block.indexOf(XTML_CALL_CLOSE, headerEnd + XTML_SEP.length);
+			const callBody = bodyEnd === -1 ? block.slice(headerEnd + XTML_SEP.length) : block.slice(headerEnd + XTML_SEP.length, bodyEnd);
+			callCursor = bodyEnd === -1 ? block.length : bodyEnd + XTML_CALL_CLOSE.length;
+
+			const name = attributes.tool;
+			const tool = name ? tools.find((candidate) => candidate.name === name) : undefined;
+			if (!tool) {
+				options?.onError?.(`kimi-xtml: call for unknown tool "${name ?? ""}".`, { toolCall: callBody });
+				continue;
+			}
+			const args = parseCallBody(callBody, tool, options);
+			if (args) parsed.push({ name: tool.name, arguments: args });
+		}
+	}
+	return parsed;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/parse.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/parse.ts
@@ -38,11 +38,7 @@ export function coerceXtmlArgumentValue(raw: string, type: string | undefined): 
 	}
 }
 
-function parseCallBody(
-	body: string,
-	tool: Tool,
-	options?: ParserOptions,
-): Record<string, unknown> | null {
+function parseCallBody(body: string, tool: Tool, options?: ParserOptions): Record<string, unknown> | null {
 	const args: Record<string, unknown> = {};
 	let rest = body;
 	for (;;) {
@@ -87,7 +83,10 @@ export function parseKimiXtmlGeneratedText(text: string, tools: Tool[], options?
 			if (headerEnd === -1) break;
 			const attributes = parseXtmlAttributes(block.slice(callStart + XTML_CALL_OPEN.length, headerEnd));
 			const bodyEnd = block.indexOf(XTML_CALL_CLOSE, headerEnd + XTML_SEP.length);
-			const callBody = bodyEnd === -1 ? block.slice(headerEnd + XTML_SEP.length) : block.slice(headerEnd + XTML_SEP.length, bodyEnd);
+			const callBody =
+				bodyEnd === -1
+					? block.slice(headerEnd + XTML_SEP.length)
+					: block.slice(headerEnd + XTML_SEP.length, bodyEnd);
 			callCursor = bodyEnd === -1 ? block.length : bodyEnd + XTML_CALL_CLOSE.length;
 
 			const name = attributes.tool;

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
@@ -1,0 +1,212 @@
+import type { Tool } from "../../../types.ts";
+import type { ParserOptions, StreamParserEvent } from "../../types.ts";
+import type { RecoveryStreamParser } from "../anthropic-xml/recovery-stream.ts";
+import {
+	getPartialXtmlSuffix,
+	parseXtmlAttributes,
+	XTML_ARGUMENT_CLOSE,
+	XTML_ARGUMENT_OPEN,
+	XTML_CALL_CLOSE,
+	XTML_CALL_OPEN,
+	XTML_SEP,
+	XTML_TOOLS_CLOSE,
+	XTML_TOOLS_OPEN,
+} from "./markers.ts";
+import { coerceXtmlArgumentValue } from "./parse.ts";
+
+type ParserMode = "text" | "tools" | "call-header" | "call-body" | "argument-header" | "argument-value" | "discard-call";
+
+const CHANNEL_MARKER_PATTERN = /^<\|(?:open|close)\|>[a-zA-Z_][a-zA-Z0-9_]*<\|sep\|>/;
+const OPEN_PREFIX = "<|open|>";
+const CLOSE_PREFIX = "<|close|>";
+
+function couldBeMarkerPrefix(tail: string): boolean {
+	if (OPEN_PREFIX.startsWith(tail) || CLOSE_PREFIX.startsWith(tail)) return true;
+	for (const prefix of [OPEN_PREFIX, CLOSE_PREFIX]) {
+		if (!tail.startsWith(prefix)) continue;
+		const rest = tail.slice(prefix.length);
+		const angleIndex = rest.indexOf("<");
+		if (angleIndex === -1) return /^[a-zA-Z0-9_]*$/.test(rest);
+		if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(rest.slice(0, angleIndex))) return false;
+		return XTML_SEP.startsWith(rest.slice(angleIndex));
+	}
+	return false;
+}
+
+export function createXtmlRecoveryStreamParser(tools: readonly Tool[], options?: ParserOptions): RecoveryStreamParser {
+	let buffer = "";
+	let mode: ParserMode = "text";
+	let callIndex = -1;
+	let callName = "";
+	let callArgs: Record<string, unknown> = {};
+	let callStarted = false;
+	let callInvalidReason: string | null = null;
+	let argumentKey = "";
+	let argumentType: string | undefined;
+
+	function resetCall(): void {
+		callName = "";
+		callArgs = {};
+		callStarted = false;
+		callInvalidReason = null;
+		argumentKey = "";
+		argumentType = undefined;
+	}
+
+	function endCall(events: StreamParserEvent[], incomplete: boolean): void {
+		if (!callStarted) {
+			resetCall();
+			return;
+		}
+		const event: StreamParserEvent = {
+			type: "toolcall_end",
+			index: callIndex,
+			name: callName,
+			id: `recovered-xtml-${callIndex}`,
+			arguments: callArgs,
+		};
+		if (incomplete) {
+			event.incomplete = true;
+			if (callInvalidReason) event.errorMessage = callInvalidReason;
+		}
+		events.push(event);
+		resetCall();
+		mode = "tools";
+	}
+
+	function processText(events: StreamParserEvent[]): boolean {
+		const openIndex = buffer.indexOf(OPEN_PREFIX);
+		const closeIndex = buffer.indexOf(CLOSE_PREFIX);
+		const markerIndex = [openIndex, closeIndex].filter((index) => index !== -1).sort((a, b) => a - b)[0];
+		if (markerIndex === undefined) {
+			const partial = getPartialXtmlSuffix(buffer, [OPEN_PREFIX, CLOSE_PREFIX]);
+			const flushable = partial ? buffer.slice(0, -partial.length) : buffer;
+			if (flushable) events.push({ type: "text", text: flushable });
+			buffer = partial;
+			return false;
+		}
+		if (markerIndex > 0) {
+			events.push({ type: "text", text: buffer.slice(0, markerIndex) });
+			buffer = buffer.slice(markerIndex);
+			return true;
+		}
+		const markerMatch = CHANNEL_MARKER_PATTERN.exec(buffer);
+		if (markerMatch) {
+			const marker = markerMatch[0];
+			buffer = buffer.slice(marker.length);
+			if (marker === XTML_TOOLS_OPEN) mode = "tools";
+			return true;
+		}
+		if (couldBeMarkerPrefix(buffer)) return false;
+		events.push({ type: "text", text: buffer.slice(0, 2) });
+		buffer = buffer.slice(2);
+		return true;
+	}
+
+	function process(events: StreamParserEvent[]): void {
+		for (;;) {
+			if (mode === "text") {
+				if (!processText(events)) return;
+				continue;
+			}
+			if (mode === "tools") {
+				const callStart = buffer.indexOf(XTML_CALL_OPEN);
+				const toolsEnd = buffer.indexOf(XTML_TOOLS_CLOSE);
+				if (toolsEnd !== -1 && (callStart === -1 || toolsEnd < callStart)) {
+					buffer = buffer.slice(toolsEnd + XTML_TOOLS_CLOSE.length);
+					mode = "text";
+					continue;
+				}
+				if (callStart === -1) return;
+				buffer = buffer.slice(callStart + XTML_CALL_OPEN.length);
+				mode = "call-header";
+				continue;
+			}
+			if (mode === "call-header" || mode === "argument-header") {
+				const sepIndex = buffer.indexOf(XTML_SEP);
+				if (sepIndex === -1) return;
+				const attributes = parseXtmlAttributes(buffer.slice(0, sepIndex));
+				buffer = buffer.slice(sepIndex + XTML_SEP.length);
+				if (mode === "call-header") {
+					const name = attributes.tool ?? "";
+					if (!tools.some((candidate) => candidate.name === name)) {
+						options?.onError?.(`kimi-xtml recovery: call for unknown tool "${name}".`, {});
+						mode = "discard-call";
+						continue;
+					}
+					callIndex += 1;
+					callName = name;
+					callStarted = true;
+					events.push({ type: "toolcall_start", index: callIndex, name, id: `recovered-xtml-${callIndex}` });
+					mode = "call-body";
+					continue;
+				}
+				argumentKey = attributes.key ?? "";
+				argumentType = attributes.type;
+				mode = "argument-value";
+				continue;
+			}
+			if (mode === "call-body") {
+				const argStart = buffer.indexOf(XTML_ARGUMENT_OPEN);
+				const callEnd = buffer.indexOf(XTML_CALL_CLOSE);
+				if (callEnd !== -1 && (argStart === -1 || callEnd < argStart)) {
+					buffer = buffer.slice(callEnd + XTML_CALL_CLOSE.length);
+					endCall(events, callInvalidReason !== null);
+					continue;
+				}
+				if (argStart === -1) return;
+				buffer = buffer.slice(argStart + XTML_ARGUMENT_OPEN.length);
+				mode = "argument-header";
+				continue;
+			}
+			if (mode === "argument-value") {
+				const valueEnd = buffer.indexOf(XTML_ARGUMENT_CLOSE);
+				if (valueEnd === -1) return;
+				const coerced = coerceXtmlArgumentValue(buffer.slice(0, valueEnd), argumentType);
+				buffer = buffer.slice(valueEnd + XTML_ARGUMENT_CLOSE.length);
+				if (!coerced.ok) {
+					callInvalidReason = `kimi-xtml recovery: invalid value for argument "${argumentKey}".`;
+					options?.onError?.(callInvalidReason, { toolCall: callName });
+				} else if (argumentKey) {
+					callArgs[argumentKey] = coerced.value;
+					events.push({ type: "toolcall_delta", index: callIndex, argumentsDelta: JSON.stringify(callArgs) });
+				}
+				mode = "call-body";
+				continue;
+			}
+			const callEnd = buffer.indexOf(XTML_CALL_CLOSE);
+			if (callEnd === -1) return;
+			buffer = buffer.slice(callEnd + XTML_CALL_CLOSE.length);
+			resetCall();
+			mode = "tools";
+		}
+	}
+
+	return {
+		feed(textDelta: string): StreamParserEvent[] {
+			buffer += textDelta;
+			const events: StreamParserEvent[] = [];
+			process(events);
+			return events;
+		},
+		interrupt(): StreamParserEvent[] {
+			const events: StreamParserEvent[] = [];
+			if (mode === "text" && buffer) {
+				events.push({ type: "text", text: buffer });
+				buffer = "";
+			}
+			return events;
+		},
+		finish(): StreamParserEvent[] {
+			const events: StreamParserEvent[] = [];
+			if (mode === "text") {
+				if (buffer) events.push({ type: "text", text: buffer });
+			} else if (callStarted) {
+				endCall(events, true);
+			}
+			buffer = "";
+			mode = "text";
+			return events;
+		},
+	};
+}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
@@ -14,7 +14,14 @@ import {
 } from "./markers.ts";
 import { coerceXtmlArgumentValue } from "./parse.ts";
 
-type ParserMode = "text" | "tools" | "call-header" | "call-body" | "argument-header" | "argument-value" | "discard-call";
+type ParserMode =
+	| "text"
+	| "tools"
+	| "call-header"
+	| "call-body"
+	| "argument-header"
+	| "argument-value"
+	| "discard-call";
 
 const CHANNEL_MARKER_PATTERN = /^<\|(?:open|close)\|>[a-zA-Z_][a-zA-Z0-9_]*<\|sep\|>/;
 const OPEN_PREFIX = "<|open|>";

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/stream.ts
@@ -13,7 +13,14 @@ import {
 } from "./markers.ts";
 import { coerceXtmlArgumentValue } from "./parse.ts";
 
-type ParserMode = "text" | "tools" | "call-header" | "call-body" | "argument-header" | "argument-value" | "discard-call";
+type ParserMode =
+	| "text"
+	| "tools"
+	| "call-header"
+	| "call-body"
+	| "argument-header"
+	| "argument-value"
+	| "discard-call";
 
 const TEXT_BOUNDARY_TOKENS = [XTML_TOOLS_OPEN] as const;
 const TOOLS_BOUNDARY_TOKENS = [XTML_CALL_OPEN, XTML_TOOLS_CLOSE] as const;

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/stream.ts
@@ -1,0 +1,195 @@
+import type { Tool } from "../../../types.ts";
+import type { ParserOptions, StreamParser, StreamParserEvent } from "../../types.ts";
+import {
+	getPartialXtmlSuffix,
+	parseXtmlAttributes,
+	XTML_ARGUMENT_CLOSE,
+	XTML_ARGUMENT_OPEN,
+	XTML_CALL_CLOSE,
+	XTML_CALL_OPEN,
+	XTML_SEP,
+	XTML_TOOLS_CLOSE,
+	XTML_TOOLS_OPEN,
+} from "./markers.ts";
+import { coerceXtmlArgumentValue } from "./parse.ts";
+
+type ParserMode = "text" | "tools" | "call-header" | "call-body" | "argument-header" | "argument-value" | "discard-call";
+
+const TEXT_BOUNDARY_TOKENS = [XTML_TOOLS_OPEN] as const;
+const TOOLS_BOUNDARY_TOKENS = [XTML_CALL_OPEN, XTML_TOOLS_CLOSE] as const;
+
+export function createKimiXtmlStreamParser(tools: Tool[], options?: ParserOptions): StreamParser {
+	let buffer = "";
+	let mode: ParserMode = "text";
+	let callIndex = -1;
+	let callName = "";
+	let callArgs: Record<string, unknown> = {};
+	let callStarted = false;
+	let callInvalidReason: string | null = null;
+	let argumentKey = "";
+	let argumentType: string | undefined;
+
+	function resetCall(): void {
+		callName = "";
+		callArgs = {};
+		callStarted = false;
+		callInvalidReason = null;
+		argumentKey = "";
+		argumentType = undefined;
+	}
+
+	function startCall(events: StreamParserEvent[], name: string): void {
+		callIndex += 1;
+		callName = name;
+		callStarted = true;
+		events.push({ type: "toolcall_start", index: callIndex, name, id: `kimi-xtml-tool-${callIndex}` });
+	}
+
+	function endCall(events: StreamParserEvent[], incomplete: boolean): void {
+		if (!callStarted) {
+			resetCall();
+			return;
+		}
+		const event: StreamParserEvent = {
+			type: "toolcall_end",
+			index: callIndex,
+			name: callName,
+			id: `kimi-xtml-tool-${callIndex}`,
+			arguments: callArgs,
+		};
+		if (incomplete) {
+			event.incomplete = true;
+			if (callInvalidReason) event.errorMessage = callInvalidReason;
+		}
+		events.push(event);
+		resetCall();
+		mode = "tools";
+	}
+
+	function hold(events: StreamParserEvent[], tokens: readonly string[], flushAsText: boolean): void {
+		const partial = getPartialXtmlSuffix(buffer, tokens);
+		if (!flushAsText) return;
+		const flushable = partial ? buffer.slice(0, -partial.length) : buffer;
+		if (flushable) events.push({ type: "text", text: flushable });
+		buffer = partial;
+	}
+
+	function process(events: StreamParserEvent[]): void {
+		for (;;) {
+			if (mode === "text") {
+				const start = buffer.indexOf(XTML_TOOLS_OPEN);
+				if (start === -1) {
+					hold(events, TEXT_BOUNDARY_TOKENS, true);
+					return;
+				}
+				if (start > 0) events.push({ type: "text", text: buffer.slice(0, start) });
+				buffer = buffer.slice(start + XTML_TOOLS_OPEN.length);
+				mode = "tools";
+				continue;
+			}
+			if (mode === "tools") {
+				const callStart = buffer.indexOf(XTML_CALL_OPEN);
+				const toolsEnd = buffer.indexOf(XTML_TOOLS_CLOSE);
+				if (toolsEnd !== -1 && (callStart === -1 || toolsEnd < callStart)) {
+					buffer = buffer.slice(toolsEnd + XTML_TOOLS_CLOSE.length);
+					mode = "text";
+					continue;
+				}
+				if (callStart === -1) {
+					hold(events, TOOLS_BOUNDARY_TOKENS, false);
+					return;
+				}
+				buffer = buffer.slice(callStart + XTML_CALL_OPEN.length);
+				mode = "call-header";
+				continue;
+			}
+			if (mode === "call-header" || mode === "argument-header") {
+				const sepIndex = buffer.indexOf(XTML_SEP);
+				if (sepIndex === -1) {
+					hold(events, [XTML_SEP], false);
+					return;
+				}
+				const attributes = parseXtmlAttributes(buffer.slice(0, sepIndex));
+				buffer = buffer.slice(sepIndex + XTML_SEP.length);
+				if (mode === "call-header") {
+					const name = attributes.tool ?? "";
+					if (!tools.some((candidate) => candidate.name === name)) {
+						options?.onError?.(`kimi-xtml: call for unknown tool "${name}".`, {});
+						mode = "discard-call";
+						continue;
+					}
+					startCall(events, name);
+					mode = "call-body";
+					continue;
+				}
+				argumentKey = attributes.key ?? "";
+				argumentType = attributes.type;
+				mode = "argument-value";
+				continue;
+			}
+			if (mode === "call-body") {
+				const argStart = buffer.indexOf(XTML_ARGUMENT_OPEN);
+				const callEnd = buffer.indexOf(XTML_CALL_CLOSE);
+				if (callEnd !== -1 && (argStart === -1 || callEnd < argStart)) {
+					buffer = buffer.slice(callEnd + XTML_CALL_CLOSE.length);
+					endCall(events, callInvalidReason !== null);
+					continue;
+				}
+				if (argStart === -1) {
+					hold(events, [XTML_ARGUMENT_OPEN, XTML_CALL_CLOSE], false);
+					return;
+				}
+				buffer = buffer.slice(argStart + XTML_ARGUMENT_OPEN.length);
+				mode = "argument-header";
+				continue;
+			}
+			if (mode === "argument-value") {
+				const valueEnd = buffer.indexOf(XTML_ARGUMENT_CLOSE);
+				if (valueEnd === -1) {
+					hold(events, [XTML_ARGUMENT_CLOSE], false);
+					return;
+				}
+				const coerced = coerceXtmlArgumentValue(buffer.slice(0, valueEnd), argumentType);
+				buffer = buffer.slice(valueEnd + XTML_ARGUMENT_CLOSE.length);
+				if (!coerced.ok) {
+					callInvalidReason = `kimi-xtml: invalid value for argument "${argumentKey}".`;
+					options?.onError?.(callInvalidReason, { toolCall: callName });
+				} else if (argumentKey) {
+					callArgs[argumentKey] = coerced.value;
+					events.push({ type: "toolcall_delta", index: callIndex, argumentsDelta: JSON.stringify(callArgs) });
+				}
+				mode = "call-body";
+				continue;
+			}
+			const callEnd = buffer.indexOf(XTML_CALL_CLOSE);
+			if (callEnd === -1) {
+				hold(events, [XTML_CALL_CLOSE], false);
+				return;
+			}
+			buffer = buffer.slice(callEnd + XTML_CALL_CLOSE.length);
+			resetCall();
+			mode = "tools";
+		}
+	}
+
+	return {
+		feed(textDelta: string): StreamParserEvent[] {
+			buffer += textDelta;
+			const events: StreamParserEvent[] = [];
+			process(events);
+			return events;
+		},
+		finish(): StreamParserEvent[] {
+			const events: StreamParserEvent[] = [];
+			if (mode === "text") {
+				if (buffer) events.push({ type: "text", text: buffer });
+				buffer = "";
+				return events;
+			}
+			if (callStarted) endCall(events, true);
+			buffer = "";
+			mode = "text";
+			return events;
+		},
+	};
+}

--- a/packages/ai/src/tool-call-middleware/recovery-stream-wrapper.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-stream-wrapper.ts
@@ -1,11 +1,11 @@
 import type { AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream, Tool } from "../types.ts";
+import type { RecoveryStreamParser } from "./protocols/anthropic-xml/recovery-stream.ts";
+import { createAntmlInvokeRecoveryStreamParser } from "./protocols/antml/recovery-stream.ts";
 import { type RecoveryContentKind, RecoveryContentLifecycle } from "./recovery-content-lifecycle.ts";
 import { RecoveryAssistantMessageEventStream } from "./recovery-event-stream.ts";
 import { RecoveryNativeProjection } from "./recovery-native-projection.ts";
 import { type RecoveryStreamFailure, terminateRecoveryStreamForFailure } from "./recovery-stream-failure.ts";
 import { RecoveryStreamTerminal } from "./recovery-stream-terminal.ts";
-import { createAntmlInvokeRecoveryStreamParser } from "./protocols/antml/recovery-stream.ts";
-import type { RecoveryStreamParser } from "./protocols/anthropic-xml/recovery-stream.ts";
 import { RecoveryTextProjection } from "./recovery-text-projection.ts";
 import { StreamMessageProjection } from "./stream-wrapper-shared.ts";
 
@@ -123,7 +123,13 @@ export function wrapStreamWithInvokeRecovery(
 						if (!canStart(event.partial, event.contentIndex, "text")) return;
 						if (!prepareContentEvent(event.partial, event.contentIndex) || !projection || !nativeProjection)
 							return;
-						const nextText = new RecoveryTextProjection(tools, projection, nativeProjection, event.contentIndex, createParser);
+						const nextText = new RecoveryTextProjection(
+							tools,
+							projection,
+							nativeProjection,
+							event.contentIndex,
+							createParser,
+						);
 						if (!nextText.start(event.partial)) {
 							terminateForFailure(event.partial, "invalid_native_event_order");
 							return;

--- a/packages/ai/src/tool-call-middleware/recovery-stream-wrapper.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-stream-wrapper.ts
@@ -4,12 +4,15 @@ import { RecoveryAssistantMessageEventStream } from "./recovery-event-stream.ts"
 import { RecoveryNativeProjection } from "./recovery-native-projection.ts";
 import { type RecoveryStreamFailure, terminateRecoveryStreamForFailure } from "./recovery-stream-failure.ts";
 import { RecoveryStreamTerminal } from "./recovery-stream-terminal.ts";
+import { createAntmlInvokeRecoveryStreamParser } from "./protocols/antml/recovery-stream.ts";
+import type { RecoveryStreamParser } from "./protocols/anthropic-xml/recovery-stream.ts";
 import { RecoveryTextProjection } from "./recovery-text-projection.ts";
 import { StreamMessageProjection } from "./stream-wrapper-shared.ts";
 
 export function wrapStreamWithInvokeRecovery(
 	innerStream: AssistantMessageEventStream,
 	tools: readonly Tool[],
+	createParser: (tools: readonly Tool[]) => RecoveryStreamParser = createAntmlInvokeRecoveryStreamParser,
 ): AssistantMessageEventStream {
 	const outerStream = new RecoveryAssistantMessageEventStream();
 
@@ -120,7 +123,7 @@ export function wrapStreamWithInvokeRecovery(
 						if (!canStart(event.partial, event.contentIndex, "text")) return;
 						if (!prepareContentEvent(event.partial, event.contentIndex) || !projection || !nativeProjection)
 							return;
-						const nextText = new RecoveryTextProjection(tools, projection, nativeProjection, event.contentIndex);
+						const nextText = new RecoveryTextProjection(tools, projection, nativeProjection, event.contentIndex, createParser);
 						if (!nextText.start(event.partial)) {
 							terminateForFailure(event.partial, "invalid_native_event_order");
 							return;

--- a/packages/ai/src/tool-call-middleware/recovery-text-projection.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-text-projection.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, Tool } from "../types.ts";
 import { createAntmlInvokeRecoveryStreamParser } from "./protocols/antml/recovery-stream.ts";
+import type { RecoveryStreamParser } from "./protocols/anthropic-xml/recovery-stream.ts";
 import { createRecoveryCodeMask, type RecoveryCodeMaskSegment } from "./recovery-code-mask.ts";
 import { appendRecoveryDiagnostic } from "./recovery-diagnostics.ts";
 import type { RecoveryNativeProjection } from "./recovery-native-projection.ts";
@@ -11,7 +12,7 @@ export class RecoveryTextProjection {
 	private readonly projection: StreamMessageProjection;
 	private readonly nativeProjection: RecoveryNativeProjection;
 	private readonly innerIndex: number;
-	private readonly parser: ReturnType<typeof createAntmlInvokeRecoveryStreamParser>;
+	private readonly parser: RecoveryStreamParser;
 	private readonly mask = createRecoveryCodeMask();
 	private activeInvoke = false;
 	private textBuffer = "";
@@ -23,11 +24,12 @@ export class RecoveryTextProjection {
 		projection: StreamMessageProjection,
 		nativeProjection: RecoveryNativeProjection,
 		innerIndex: number,
+		createParser: (tools: readonly Tool[]) => RecoveryStreamParser = createAntmlInvokeRecoveryStreamParser,
 	) {
 		this.projection = projection;
 		this.nativeProjection = nativeProjection;
 		this.innerIndex = innerIndex;
-		this.parser = createAntmlInvokeRecoveryStreamParser(tools);
+		this.parser = createParser(tools);
 	}
 
 	start(source: AssistantMessage): boolean {

--- a/packages/ai/src/tool-call-middleware/recovery-text-projection.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-text-projection.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage, Tool } from "../types.ts";
-import { createAntmlInvokeRecoveryStreamParser } from "./protocols/antml/recovery-stream.ts";
 import type { RecoveryStreamParser } from "./protocols/anthropic-xml/recovery-stream.ts";
+import { createAntmlInvokeRecoveryStreamParser } from "./protocols/antml/recovery-stream.ts";
 import { createRecoveryCodeMask, type RecoveryCodeMaskSegment } from "./recovery-code-mask.ts";
 import { appendRecoveryDiagnostic } from "./recovery-diagnostics.ts";
 import type { RecoveryNativeProjection } from "./recovery-native-projection.ts";

--- a/packages/ai/src/tool-call-middleware/types.ts
+++ b/packages/ai/src/tool-call-middleware/types.ts
@@ -9,6 +9,7 @@ import type { ImageContent, TextContent, Tool } from "../types.ts";
  * - "gemma4-delimiter": Gemma 4 specific delimiter format
  * - "anthropic-xml": Legacy Anthropic invoke/parameter XML format
  * - "antml": ANTML function_calls/invoke format with Claude-Code-style failure tolerance
+ * - "kimi-xtml": Kimi K3 XTML channel format (<|open|>/<|close|>/<|sep|> markers)
  */
 export type ToolCallFormat =
 	| "hermes"
@@ -17,7 +18,8 @@ export type ToolCallFormat =
 	| "yaml-xml"
 	| "gemma4-delimiter"
 	| "anthropic-xml"
-	| "antml";
+	| "antml"
+	| "kimi-xtml";
 
 /**
  * Content type for tool results (text or image)

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -643,7 +643,7 @@ export interface OpenAICompletionsCompat {
 	/**
 	 * Tool call format for models that don't natively support tool calling.
 	 * When set, the middleware will intercept tool calls and format them as text.
-	 * Supported values: "hermes", "morph-xml", "xml" (deprecated alias for "morph-xml"), "yaml-xml", "gemma4-delimiter", "anthropic-xml", "antml"
+	 * Supported values: "hermes", "morph-xml", "xml" (deprecated alias for "morph-xml"), "yaml-xml", "gemma4-delimiter", "anthropic-xml", "antml", "kimi-xtml"
 	 */
 	toolCallFormat?: string;
 	/** Cache control convention for prompt caching. "anthropic" applies Anthropic-style `cache_control` markers to the system prompt, last tool definition, and last user, assistant, or tool-result text content. */

--- a/packages/ai/test/tool-call-middleware/invoke-recovery-activation.test.ts
+++ b/packages/ai/test/tool-call-middleware/invoke-recovery-activation.test.ts
@@ -13,6 +13,7 @@ const supportedTextFormats = [
 	"gemma4-delimiter",
 	"anthropic-xml",
 	"antml",
+	"kimi-xtml",
 ] as const;
 
 function createModel(id: string, overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-format.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-format.test.ts
@@ -54,7 +54,9 @@ describe("kimiXtmlFormatToolCall", () => {
 describe("kimiXtmlFormatToolResponse", () => {
 	it("renders results with the Kimi-family return convention", () => {
 		// when
-		const rendered = kimiXtmlFormatToolResponse("get_weather", "kimi-xtml-tool-0", [{ type: "text", text: "sunny, 31C" }]);
+		const rendered = kimiXtmlFormatToolResponse("get_weather", "kimi-xtml-tool-0", [
+			{ type: "text", text: "sunny, 31C" },
+		]);
 
 		// then
 		expect(rendered).toBe("## Return of get_weather\nsunny, 31C");

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-format.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-format.test.ts
@@ -1,0 +1,77 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import {
+	kimiXtmlFormatToolCall,
+	kimiXtmlFormatToolResponse,
+	kimiXtmlFormatToolsSystemPrompt,
+	parseKimiXtmlGeneratedText,
+} from "../../src/tool-call-middleware/protocols/kimi-xtml/index.ts";
+import type { Tool } from "../../src/types.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({ city: Type.String() }),
+};
+
+describe("kimiXtmlFormatToolCall", () => {
+	it("renders a call in the K3 XTML channel syntax", () => {
+		// when
+		const rendered = kimiXtmlFormatToolCall("get_weather", { city: "Seoul", count: 3 });
+
+		// then
+		expect(rendered).toBe(
+			"<|open|>tools<|sep|>" +
+				'<|open|>call tool="get_weather" index="1"<|sep|>' +
+				'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>' +
+				'<|open|>argument key="count" type="number"<|sep|>3<|close|>argument<|sep|>' +
+				"<|close|>call<|sep|>" +
+				"<|close|>tools<|sep|>",
+		);
+	});
+
+	it("serializes object and array arguments as JSON", () => {
+		// when
+		const rendered = kimiXtmlFormatToolCall("search", { filters: { a: 1 }, tags: ["x", "y"] });
+
+		// then
+		expect(rendered).toContain('<|open|>argument key="filters" type="object"<|sep|>{"a":1}<|close|>argument<|sep|>');
+		expect(rendered).toContain('<|open|>argument key="tags" type="array"<|sep|>["x","y"]<|close|>argument<|sep|>');
+	});
+
+	it("round-trips through the parser", () => {
+		// given
+		const args = { city: "Seoul", count: 3, flag: true, filters: { a: 1 }, tags: ["x"] };
+
+		// when
+		const parsed = parseKimiXtmlGeneratedText(kimiXtmlFormatToolCall("get_weather", args), [weatherTool]);
+
+		// then
+		expect(parsed).toEqual([{ name: "get_weather", arguments: args }]);
+	});
+});
+
+describe("kimiXtmlFormatToolResponse", () => {
+	it("renders results with the Kimi-family return convention", () => {
+		// when
+		const rendered = kimiXtmlFormatToolResponse("get_weather", "kimi-xtml-tool-0", [{ type: "text", text: "sunny, 31C" }]);
+
+		// then
+		expect(rendered).toBe("## Return of get_weather\nsunny, 31C");
+	});
+});
+
+describe("kimiXtmlFormatToolsSystemPrompt", () => {
+	it("teaches the exact XTML emission syntax with the tool schemas", () => {
+		// when
+		const prompt = kimiXtmlFormatToolsSystemPrompt([weatherTool]);
+
+		// then
+		expect(prompt).toContain("get_weather");
+		expect(prompt).toContain("<|open|>tools<|sep|>");
+		expect(prompt).toContain('<|open|>call tool="');
+		expect(prompt).toContain('<|open|>argument key="');
+		expect(prompt).toContain("<|close|>call<|sep|>");
+		expect(prompt).toContain("<|close|>tools<|sep|>");
+	});
+});

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-parser.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-parser.test.ts
@@ -1,0 +1,219 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { parseKimiXtmlGeneratedText } from "../../src/tool-call-middleware/protocols/kimi-xtml/index.ts";
+import type { Tool } from "../../src/types.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({
+		city: Type.String(),
+		count: Type.Optional(Type.Number()),
+		flag: Type.Optional(Type.Boolean()),
+	}),
+};
+
+const catalogTool: Tool = {
+	name: "search_catalog",
+	description: "Search a nested catalog",
+	parameters: Type.Object({
+		filters: Type.Object({ category: Type.String() }),
+		tags: Type.Array(Type.String()),
+	}),
+};
+
+describe("parseKimiXtmlGeneratedText", () => {
+	it("parses a full XTML tools block with typed arguments", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+			'<|open|>argument key="count" type="number"<|sep|>3<|close|>argument<|sep|>',
+			'<|open|>argument key="flag" type="boolean"<|sep|>true<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([
+			{
+				name: "get_weather",
+				arguments: { city: "Seoul", count: 3, flag: true },
+			},
+		]);
+	});
+
+	it("parses object and array arguments from strict JSON values", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="search_catalog" index="1"<|sep|>',
+			'<|open|>argument key="filters" type="object"<|sep|>{"category":"books"}<|close|>argument<|sep|>',
+			'<|open|>argument key="tags" type="array"<|sep|>["fiction","award"]<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [catalogTool]);
+
+		// then
+		expect(result).toEqual([
+			{
+				name: "search_catalog",
+				arguments: { filters: { category: "books" }, tags: ["fiction", "award"] },
+			},
+		]);
+	});
+
+	it("parses multiple calls inside one tools block", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			'<|open|>call tool="get_weather" index="2"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Busan<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([
+			{ name: "get_weather", arguments: { city: "Seoul" } },
+			{ name: "get_weather", arguments: { city: "Busan" } },
+		]);
+	});
+
+	it("accepts single-quoted and unquoted header attributes", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			"<|open|>call tool='get_weather' index='1'<|sep|>",
+			"<|open|>argument key=city type=string<|sep|>Seoul<|close|>argument<|sep|>",
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([{ name: "get_weather", arguments: { city: "Seoul" } }]);
+	});
+
+	it("ignores narrative text outside tools blocks", () => {
+		// given
+		const text = [
+			"Let me check that for you.",
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+			"One moment.",
+		].join("\n");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([{ name: "get_weather", arguments: { city: "Seoul" } }]);
+	});
+
+	it("treats a missing type attribute as a raw string", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([{ name: "get_weather", arguments: { city: "Seoul" } }]);
+	});
+
+	it("treats an unknown type attribute as a raw string", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="mystery"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([{ name: "get_weather", arguments: { city: "Seoul" } }]);
+	});
+
+	it("skips a call for an unknown tool and reports the error", () => {
+		// given
+		const onError = vi.fn();
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_traffic" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool], { onError });
+
+		// then
+		expect(result).toEqual([]);
+		expect(onError).toHaveBeenCalledOnce();
+	});
+
+	it("rejects malformed JSON in an object argument and reports the error", () => {
+		// given
+		const onError = vi.fn();
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="search_catalog" index="1"<|sep|>',
+			'<|open|>argument key="filters" type="object"<|sep|>{category:books}<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [catalogTool], { onError });
+
+		// then
+		expect(result).toEqual([]);
+		expect(onError).toHaveBeenCalledOnce();
+	});
+
+	it("parses a complete call even when the closing tools marker is missing", () => {
+		// given
+		const text = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+		].join("");
+
+		// when
+		const result = parseKimiXtmlGeneratedText(text, [weatherTool]);
+
+		// then
+		expect(result).toEqual([{ name: "get_weather", arguments: { city: "Seoul" } }]);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-recovery-activation.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-recovery-activation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { shouldRecoverTextToolCalls } from "../../src/index.ts";
+import { getToolCallFormat } from "../../src/tool-call-middleware/index.ts";
+import type { Model } from "../../src/types.ts";
+
+function createModel(id: string, overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "test-provider",
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+		...overrides,
+	};
+}
+
+describe("kimi recovery activation", () => {
+	it("defaults recovery on for Kimi-family identifiers like the Claude family", () => {
+		for (const id of [
+			"kimi-k3",
+			"kimi-k3-ultrafast",
+			"kimi-k3-256k",
+			"kimi-k2-thinking",
+			"kimi-for-coding-highspeed",
+			"moonshot/kimi-k3",
+			"apitopia/kimi-k3-unlocked",
+			"x-kimi",
+			"KIMI-K3",
+		]) {
+			expect(shouldRecoverTextToolCalls(createModel(id)), id).toBe(true);
+		}
+	});
+
+	it("rejects substring false positives", () => {
+		for (const id of ["kimiko", "sikimi", "kimi3", "grokimi", "kimiai"]) {
+			expect(shouldRecoverTextToolCalls(createModel(id)), id).toBe(false);
+		}
+	});
+
+	it("keeps text-protocol mutual exclusion precedence for kimi-xtml", () => {
+		const model = createModel("kimi-k3", {
+			recoverTextToolCalls: true,
+			compat: { toolCallFormat: "kimi-xtml" },
+		});
+		expect(getToolCallFormat(model)).toBe("kimi-xtml");
+		expect(shouldRecoverTextToolCalls(model)).toBe(false);
+	});
+
+	it("honors the explicit recoverTextToolCalls override on kimi models", () => {
+		expect(shouldRecoverTextToolCalls(createModel("kimi-k3", { recoverTextToolCalls: false }))).toBe(false);
+		expect(shouldRecoverTextToolCalls(createModel("gpt-5", { recoverTextToolCalls: true }))).toBe(true);
+	});
+});

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-recovery-stream.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-recovery-stream.test.ts
@@ -1,0 +1,116 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { createXtmlRecoveryStreamParser } from "../../src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts";
+import type { StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({ city: Type.String() }),
+};
+
+function textOf(events: readonly StreamParserEvent[]): string {
+	return events
+		.filter((event) => event.type === "text")
+		.map((event) => (event.type === "text" ? event.text : ""))
+		.join("");
+}
+
+const LEAKED_BLOCK = [
+	"<|open|>tools<|sep|>",
+	'<|open|>call tool="get_weather" index="1"<|sep|>',
+	'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+	"<|close|>call<|sep|>",
+	"<|close|>tools<|sep|>",
+].join("");
+
+describe("createXtmlRecoveryStreamParser", () => {
+	it("recovers a leaked XTML tools block into tool call events", () => {
+		// given
+		const parser = createXtmlRecoveryStreamParser([weatherTool]);
+
+		// when
+		const events = [...parser.feed(`One moment. ${LEAKED_BLOCK} Done.`), ...parser.finish()];
+
+		// then
+		const end = events.find((event) => event.type === "toolcall_end");
+		expect(end).toMatchObject({ name: "get_weather", arguments: { city: "Seoul" } });
+		expect(events.find((event) => event.type === "toolcall_start")).toMatchObject({ name: "get_weather" });
+		const text = textOf(events);
+		expect(text).toContain("One moment.");
+		expect(text).toContain("Done.");
+		expect(text).not.toContain("<|");
+	});
+
+	it("strips leaked channel-transition markers from visible text", () => {
+		// given
+		const parser = createXtmlRecoveryStreamParser([weatherTool]);
+
+		// when
+		const events = [
+			...parser.feed("reasoning about the weather<|close|>think<|sep|><|open|>response<|sep|>The answer is 31C."),
+			...parser.finish(),
+		];
+
+		// then
+		expect(textOf(events)).toBe("reasoning about the weatherThe answer is 31C.");
+	});
+
+	it("strips a leaked message-close marker sequence", () => {
+		// given
+		const parser = createXtmlRecoveryStreamParser([weatherTool]);
+
+		// when
+		const events = [
+			...parser.feed("final answer<|close|>response<|sep|><|close|>message<|sep|>"),
+			...parser.finish(),
+		];
+
+		// then
+		expect(textOf(events)).toBe("final answer");
+	});
+
+	it("reassembles markers split across chunks", () => {
+		// given
+		const parser = createXtmlRecoveryStreamParser([weatherTool]);
+		const chunks = ["One moment. <|op", "en|>tools<|se", "p|>", LEAKED_BLOCK.slice(XTML_TOOLS_OPEN_LENGTH), " Done."];
+
+		// when
+		const events: StreamParserEvent[] = [];
+		for (const chunk of chunks) events.push(...parser.feed(chunk));
+		events.push(...parser.finish());
+
+		// then
+		expect(events.find((event) => event.type === "toolcall_end")).toMatchObject({
+			name: "get_weather",
+			arguments: { city: "Seoul" },
+		});
+		expect(textOf(events)).not.toContain("<|");
+	});
+
+	it("restores a dangling partial marker as plain text on interrupt", () => {
+		// given
+		const parser = createXtmlRecoveryStreamParser([weatherTool]);
+
+		// when
+		const events = [...parser.feed("hello<|op"), ...parser.interrupt()];
+
+		// then
+		expect(textOf(events)).toBe("hello<|op");
+	});
+
+	it("passes ordinary text without markers through untouched", () => {
+		// given
+		const parser = createXtmlRecoveryStreamParser([weatherTool]);
+
+		// when
+		const events = [...parser.feed("plain answer with <xml> and |pipes|"), ...parser.finish()];
+
+		// then
+		expect(textOf(events)).toBe("plain answer with <xml> and |pipes|");
+		expect(events.some((event) => event.type === "toolcall_start")).toBe(false);
+	});
+});
+
+const XTML_TOOLS_OPEN_LENGTH = "<|open|>tools<|sep|>".length;

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-stream.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-stream.test.ts
@@ -1,0 +1,151 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { createKimiXtmlStreamParser } from "../../src/tool-call-middleware/protocols/kimi-xtml/index.ts";
+import type { StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { Tool } from "../../src/types.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({
+		city: Type.String(),
+		count: Type.Optional(Type.Number()),
+	}),
+};
+
+function seededRandom(seed: number): () => number {
+	let current = seed;
+	return () => {
+		current = (current * 9301 + 49_297) % 233_280;
+		return current / 233_280;
+	};
+}
+
+function randomChunkSplit(text: string, minSize = 1, maxSize = 8, seed = 0): string[] {
+	const random = seededRandom(seed);
+	const chunks: string[] = [];
+	let index = 0;
+	while (index < text.length) {
+		const size = Math.floor(random() * (maxSize - minSize + 1)) + minSize;
+		chunks.push(text.slice(index, index + size));
+		index += size;
+	}
+	return chunks;
+}
+
+function feedAll(chunks: string[]): StreamParserEvent[] {
+	const parser = createKimiXtmlStreamParser([weatherTool]);
+	const events: StreamParserEvent[] = [];
+	for (const chunk of chunks) {
+		events.push(...parser.feed(chunk));
+	}
+	events.push(...parser.finish());
+	return events;
+}
+
+const FULL_BLOCK = [
+	"<|open|>tools<|sep|>",
+	'<|open|>call tool="get_weather" index="1"<|sep|>',
+	'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+	'<|open|>argument key="count" type="number"<|sep|>3<|close|>argument<|sep|>',
+	"<|close|>call<|sep|>",
+	"<|close|>tools<|sep|>",
+].join("");
+
+describe("createKimiXtmlStreamParser", () => {
+	it("emits start, argument deltas, and end for a single full feed", () => {
+		// when
+		const events = feedAll([FULL_BLOCK]);
+		const kinds = events.map((event) => event.type);
+
+		// then
+		expect(kinds).toContain("toolcall_start");
+		expect(kinds).toContain("toolcall_delta");
+		expect(kinds).toContain("toolcall_end");
+		const end = events.find((event) => event.type === "toolcall_end");
+		expect(end).toMatchObject({
+			index: 0,
+			name: "get_weather",
+			id: "kimi-xtml-tool-0",
+			arguments: { city: "Seoul", count: 3 },
+		});
+	});
+
+	it("passes narrative text through and never leaks XTML markers as text", () => {
+		// when
+		const events = feedAll([`Checking now. ${FULL_BLOCK} Done waiting.`]);
+		const text = events
+			.filter((event) => event.type === "text")
+			.map((event) => (event.type === "text" ? event.text : ""))
+			.join("");
+
+		// then
+		expect(text).toContain("Checking now.");
+		expect(text).toContain("Done waiting.");
+		expect(text).not.toContain("<|open|>");
+		expect(text).not.toContain("<|close|>");
+		expect(text).not.toContain("<|sep|>");
+	});
+
+	it("reassembles markers split across random chunk boundaries", () => {
+		// given
+		for (const seed of [1, 7, 42, 1337]) {
+			const chunks = randomChunkSplit(FULL_BLOCK, 1, 8, seed);
+
+			// when
+			const events = feedAll(chunks);
+			const end = events.find((event) => event.type === "toolcall_end");
+			const text = events
+				.filter((event) => event.type === "text")
+				.map((event) => (event.type === "text" ? event.text : ""))
+				.join("");
+
+			// then
+			expect(end, `seed ${seed}`).toMatchObject({
+				name: "get_weather",
+				arguments: { city: "Seoul", count: 3 },
+			});
+			expect(text, `seed ${seed}`).not.toContain("<|");
+		}
+	});
+
+	it("handles a marker split exactly mid-token", () => {
+		// when
+		const events = feedAll(["<|op", "en|>tools<|se", "p|>", '<|open|>call tool="get_weather" index="1"<|sep|>', '<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>', "<|close|>call<|sep|>", "<|close|>tools<|sep|>"]);
+		const end = events.find((event) => event.type === "toolcall_end");
+
+		// then
+		expect(end).toMatchObject({ name: "get_weather", arguments: { city: "Seoul" } });
+	});
+
+	it("finalizes an unterminated call as incomplete with the arguments parsed so far", () => {
+		// given: call never closes, stream ends after one complete argument
+		const partial = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+		].join("");
+
+		// when
+		const events = feedAll([partial]);
+		const end = events.find((event) => event.type === "toolcall_end");
+
+		// then
+		expect(end).toMatchObject({
+			name: "get_weather",
+			arguments: { city: "Seoul" },
+			incomplete: true,
+		});
+	});
+
+	it("recovers text flow after a closed tools block", () => {
+		// when
+		const events = feedAll([FULL_BLOCK, "after the call"]);
+		const kinds = events.map((event) => event.type);
+		const lastText = events.filter((event) => event.type === "text").at(-1);
+
+		// then
+		expect(kinds.at(-1)).toBe("text");
+		expect(lastText).toMatchObject({ type: "text", text: "after the call" });
+	});
+});

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-stream.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-stream.test.ts
@@ -111,7 +111,15 @@ describe("createKimiXtmlStreamParser", () => {
 
 	it("handles a marker split exactly mid-token", () => {
 		// when
-		const events = feedAll(["<|op", "en|>tools<|se", "p|>", '<|open|>call tool="get_weather" index="1"<|sep|>', '<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>', "<|close|>call<|sep|>", "<|close|>tools<|sep|>"]);
+		const events = feedAll([
+			"<|op",
+			"en|>tools<|se",
+			"p|>",
+			'<|open|>call tool="get_weather" index="1"<|sep|>',
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		]);
 		const end = events.find((event) => event.type === "toolcall_end");
 
 		// then

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -13,6 +13,8 @@ import {
 	type CredentialInfo,
 	type CredentialStore,
 	createModels,
+	createXtmlRecoveryStreamParser,
+	hasKimiTextToolCallRecovery,
 	lazyStream,
 	type Model,
 	type Models,
@@ -28,8 +30,6 @@ import {
 	type ProviderHeaders,
 	type SimpleStreamOptions,
 	type StreamOptions,
-	createXtmlRecoveryStreamParser,
-	hasKimiTextToolCallRecovery,
 	shouldRecoverTextToolCalls,
 	wrapStreamWithInvokeRecovery,
 } from "@earendil-works/pi-ai";

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -28,6 +28,8 @@ import {
 	type ProviderHeaders,
 	type SimpleStreamOptions,
 	type StreamOptions,
+	createXtmlRecoveryStreamParser,
+	hasKimiTextToolCallRecovery,
 	shouldRecoverTextToolCalls,
 	wrapStreamWithInvokeRecovery,
 } from "@earendil-works/pi-ai";
@@ -552,7 +554,11 @@ export class ModelRuntime implements Models {
 				withPayloadRequestMetadata(prepared.options, prepared.model) as ApiStreamOptions<TApi>,
 			);
 			return shouldRecoverTextToolCalls(model) && context.tools?.length
-				? wrapStreamWithInvokeRecovery(inner, context.tools)
+				? wrapStreamWithInvokeRecovery(
+						inner,
+						context.tools,
+						hasKimiTextToolCallRecovery(model) ? createXtmlRecoveryStreamParser : undefined,
+					)
 				: inner;
 		});
 	}
@@ -573,7 +579,11 @@ export class ModelRuntime implements Models {
 				withPayloadRequestMetadata(prepared.options, prepared.model) as SimpleStreamOptions,
 			);
 			return shouldRecoverTextToolCalls(model) && context.tools?.length
-				? wrapStreamWithInvokeRecovery(inner, context.tools)
+				? wrapStreamWithInvokeRecovery(
+						inner,
+						context.tools,
+						hasKimiTextToolCallRecovery(model) ? createXtmlRecoveryStreamParser : undefined,
+					)
 				: inner;
 		});
 	}

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+# changes
+
+## Ethos tips: tool-call repair now names Kimi K3 (2026-07-29)
+
+### What changed
+
+- `tips/catalog/ethos-tips.ts`: the `ethos.tool-call-repair` copy now covers Kimi K3 alongside Claude - "claude's sloppy invokes, kimi k3's leaked XTML channels, all of it" - matching the new normal-mode XTML recovery in `packages/ai` (Kimi models get the same leaked tool-call auto-correction Claude has).
+- Coverage: `test/suite/ethos-tips.test.ts` pin updated verbatim.
+
+### Why
+
+- The repair tip only described the Claude/antml case. With XTML recovery shipped for Kimi models, the brag undersells the feature.
+
+### Expected merge conflict zones
+
+- LOW: single render string in `ethos-tips.ts` and its verbatim pin.
 ## Ethos tips: the fork's voice in the tip rotation (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/ethos-tips.ts
@@ -84,6 +84,6 @@ export const ETHOS_TIPS = [
 		id: "ethos.tool-call-repair",
 		bindings: [],
 		render: () =>
-			"senpi catches malformed tool calls on the wire, fixes them, and salvages the turn. Other harnesses retry the whole thing and bill you for the privilege. *table stakes, honestly*",
+			"senpi catches malformed tool calls on the wire, fixes them, and salvages the turn - claude's sloppy invokes, kimi k3's leaked XTML channels, all of it. Other harnesses retry the whole thing and bill you for the privilege. *table stakes, honestly*",
 	},
 ] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/test/kimi-xtml-recovery-runtime-boundary.test.ts
+++ b/packages/coding-agent/test/kimi-xtml-recovery-runtime-boundary.test.ts
@@ -1,0 +1,136 @@
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEventStream as AssistantStream,
+	type Context,
+	createAssistantMessageEventStream,
+	type Model,
+	type Provider,
+	Type,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+
+const tools: Context["tools"] = [
+	{ name: "Echo", description: "Echo text", parameters: Type.Object({ value: Type.String() }) },
+];
+
+function model(id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "runtime-recovery",
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	};
+}
+
+function blankMessage(selected: Model<Api>): AssistantMessage {
+	return {
+		role: "assistant",
+		api: selected.api,
+		provider: selected.provider,
+		model: selected.id,
+		content: [],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function leakingStream(selected: Model<Api>, text: string): AssistantStream {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const partial = blankMessage(selected);
+		stream.push({ type: "start", partial });
+		partial.content = [{ type: "text", text: "" }];
+		stream.push({ type: "text_start", contentIndex: 0, partial });
+		const mid = Math.ceil(text.length / 2);
+		partial.content = [{ type: "text", text: text.slice(0, mid) }];
+		stream.push({ type: "text_delta", contentIndex: 0, delta: text.slice(0, mid), partial });
+		partial.content = [{ type: "text", text }];
+		stream.push({ type: "text_delta", contentIndex: 0, delta: text.slice(mid), partial });
+		stream.push({ type: "text_end", contentIndex: 0, partial });
+		const message = blankMessage(selected);
+		message.content = [{ type: "text", text }];
+		stream.push({ type: "done", reason: "stop", message });
+	});
+	return stream;
+}
+
+async function runtimeWithModel(id: string, text: string): Promise<AssistantMessage> {
+	const selectedModel = model(id);
+	const provider: Provider = {
+		id: selectedModel.provider,
+		name: "Boundary provider",
+		auth: { apiKey: { name: "test", resolve: async () => ({ auth: { apiKey: "test" }, source: "test" }) } },
+		getModels: () => [selectedModel],
+		stream: (selected) => leakingStream(selected, text),
+		streamSimple: (selected) => leakingStream(selected, text),
+	};
+	const runtime = await ModelRuntime.create({
+		credentials: AuthStorage.inMemory(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerNativeProvider(provider);
+	const selected = runtime.getModel(provider.id, selectedModel.id);
+	if (!selected) throw new Error("model not registered");
+	return runtime.stream(selected, { messages: [], tools }).result();
+}
+
+const LEAKED_XTML = [
+	"Checking the weather.",
+	"<|close|>think<|sep|><|open|>response<|sep|>",
+	"Sure, one moment.",
+	"<|open|>tools<|sep|>",
+	'<|open|>call tool="Echo" index="1"<|sep|>',
+	'<|open|>argument key="value" type="string"<|sep|>hello<|close|>argument<|sep|>',
+	"<|close|>call<|sep|>",
+	"<|close|>tools<|sep|>",
+	"Done.",
+].join("");
+
+describe("kimi model runtime XTML recovery", () => {
+	it("recovers leaked XTML into an executable tool call for kimi models", async () => {
+		// When
+		const result = await runtimeWithModel("kimi-k3", LEAKED_XTML);
+
+		// Then
+		const toolCall = result.content.find((item) => item.type === "toolCall");
+		expect(toolCall).toMatchObject({ type: "toolCall", name: "Echo", arguments: { value: "hello" } });
+		const visibleText = result.content
+			.filter((item) => item.type === "text")
+			.map((item) => (item.type === "text" ? item.text : ""))
+			.join("");
+		expect(visibleText).toContain("Sure, one moment.");
+		expect(visibleText).toContain("Done.");
+		expect(visibleText).not.toContain("<|");
+	});
+
+	it("leaves non-kimi models without recovery untouched", async () => {
+		// When
+		const result = await runtimeWithModel("gpt-5", LEAKED_XTML);
+
+		// Then
+		expect(result.content.some((item) => item.type === "toolCall")).toBe(false);
+		const visibleText = result.content
+			.filter((item) => item.type === "text")
+			.map((item) => (item.type === "text" ? item.text : ""))
+			.join("");
+		expect(visibleText).toContain("<|open|>tools<|sep|>");
+	});
+});

--- a/packages/coding-agent/test/kimi-xtml-recovery-runtime-boundary.test.ts
+++ b/packages/coding-agent/test/kimi-xtml-recovery-runtime-boundary.test.ts
@@ -63,7 +63,7 @@ function leakingStream(selected: Model<Api>, text: string): AssistantStream {
 		stream.push({ type: "text_delta", contentIndex: 0, delta: text.slice(0, mid), partial });
 		partial.content = [{ type: "text", text }];
 		stream.push({ type: "text_delta", contentIndex: 0, delta: text.slice(mid), partial });
-		stream.push({ type: "text_end", contentIndex: 0, partial });
+		stream.push({ type: "text_end", contentIndex: 0, content: text, partial });
 		const message = blankMessage(selected);
 		message.content = [{ type: "text", text }];
 		stream.push({ type: "done", reason: "stop", message });

--- a/packages/coding-agent/test/kimi-xtml-registration.test.ts
+++ b/packages/coding-agent/test/kimi-xtml-registration.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { getProtocol, getToolCallFormat } from "../../ai/src/tool-call-middleware/index.ts";
+import type { Model, Tool } from "../../ai/src/types.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRegistry } from "../src/core/model-registry.ts";
+
+const weatherTool: Tool = {
+	name: "get_weather",
+	description: "Get weather for a city",
+	parameters: Type.Object({ city: Type.String() }),
+};
+
+const kimiXtmlModel = {
+	id: "kimi-k3",
+	name: "Kimi K3",
+	api: "openai-completions",
+	provider: "registration-test",
+	baseUrl: "https://example.invalid/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 1024,
+	compat: { toolCallFormat: "kimi-xtml" },
+} satisfies Model<"openai-completions">;
+
+describe("kimi-xtml registration", () => {
+	let tempDir: string | undefined;
+
+	afterEach(() => {
+		if (tempDir !== undefined) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
+
+	it("activates kimi-xtml for an openai-completions model with compat", () => {
+		// When
+		const format = getToolCallFormat(kimiXtmlModel);
+
+		// Then
+		expect(format).toBe("kimi-xtml");
+	});
+
+	it("parses an XTML block through the registered protocol", () => {
+		// Given
+		const generatedText =
+			"<|open|>tools<|sep|>" +
+			'<|open|>call tool="get_weather" index="1"<|sep|>' +
+			'<|open|>argument key="city" type="string"<|sep|>Seoul<|close|>argument<|sep|>' +
+			"<|close|>call<|sep|>" +
+			"<|close|>tools<|sep|>";
+
+		// When
+		const parsed = getProtocol("kimi-xtml").parseGeneratedText(generatedText, [weatherTool]);
+
+		// Then
+		expect(parsed).toEqual([{ name: "get_weather", arguments: { city: "Seoul" } }]);
+	});
+
+	it("accepts kimi-xtml in a models.json compatibility block", () => {
+		// Given
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-kimi-xtml-registration-"));
+		const modelsJsonPath = join(tempDir, "models.json");
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"registration-test": {
+						api: "openai-completions",
+						baseUrl: "https://example.invalid/v1",
+						compat: { toolCallFormat: "kimi-xtml" },
+						models: [{ id: "kimi-xtml-model" }],
+					},
+				},
+			}),
+		);
+
+		// When
+		const registry = ModelRegistry.create(AuthStorage.create(join(tempDir, "auth.json")), modelsJsonPath);
+
+		// Then
+		expect(registry.getError()).toBeUndefined();
+		expect(registry.find("registration-test", "kimi-xtml-model")?.id).toBe("kimi-xtml-model");
+	});
+});

--- a/packages/coding-agent/test/suite/ethos-tips.test.ts
+++ b/packages/coding-agent/test/suite/ethos-tips.test.ts
@@ -72,7 +72,7 @@ describe("ethos tips", () => {
 			'Built on the official agent SDK, speaking the protocol natively. No reverse-engineered wrapper, no ToS gray zone, no "will I get banned for this" anxiety. *Sleep easy, ship loud.*',
 		);
 		expect(byId.get("ethos.tool-call-repair")).toBe(
-			"senpi catches malformed tool calls on the wire, fixes them, and salvages the turn. Other harnesses retry the whole thing and bill you for the privilege. *table stakes, honestly*",
+			"senpi catches malformed tool calls on the wire, fixes them, and salvages the turn - claude's sloppy invokes, kimi k3's leaked XTML channels, all of it. Other harnesses retry the whole thing and bill you for the privilege. *table stakes, honestly*",
 		);
 	});
 


### PR DESCRIPTION
## What

Three increments for Kimi K3 tool-call support, from the research in `.omo/ulw-research/20260729-120715/`:

1. **`kimi-xtml` text tool-call protocol** (`packages/ai/src/tool-call-middleware/protocols/kimi-xtml/`) — Kimi K3's native XTML channel syntax (`<|open|>/<|close|>/<|sep|>` markers wrapping tools/call/argument channels) as a registered `ToolCallFormat`. Typed argument coercion (string/number/boolean/object/array, strict JSON), chunk-split-safe streaming with snapshot argument deltas, incomplete-call finalization. Registered in the union, whitelist, registry, compat docs, TESTING.md.
2. **Normal-mode auto-correction for Kimi models** — `shouldRecoverTextToolCalls()` now defaults on for Kimi-family ids (boundary regex, same as Claude). New `createXtmlRecoveryStreamParser()` recovers leaked `<|open|>tools<|sep|>` blocks into executable tool calls and strips stray XTML channel markers (think/response/message) from visible text. The recovery wrapper takes an optional parser factory; `ModelRuntime` selects XTML recovery for Kimi models. Claude and non-Kimi behavior is byte-identical.
3. **Tip copy** — the `ethos.tool-call-repair` tip now names kimi k3's leaked XTML channels next to claude's sloppy invokes.

## Why

Kimi K3's native tool-call encoding is XTML (Moonshot first-party `encoding_k3.py`, tokenizer IDs 163587-9; vLLM `kimi_k3` unified parser). When a gateway serves raw XTML into visible text, the turn used to die or show marker junk; now the calls execute and the text stays clean — the same auto-correction Claude models already had.

## Evidence

- RED→GREEN per increment: new-module import failure / `Unsupported tool call format: kimi-xtml` → green; kimi activation default-false → green; runtime boundary no-toolCall → green; tip verbatim mismatch → green.
- `packages/ai` middleware suite: **479/479** (37 files). coding-agent recovery sweep: 24/24. tips: 4/4.
- Root `npm run check`: exit 0. `tsgo` both packages: exit 0.
- senpi-qa mock loop: self-test **43/43**, `--with-tool` **4/4** (real auth untouched). Receipts: `local-ignore/qa-evidence/20260729-kimi-xtml/`.
- Live e2e (source CLI, isolated `SENPI_CODING_AGENT_DIR`, `compat.toolCallFormat: "kimi-xtml"` on `kimi-k3-ultrafast`): model emitted XTML → canonical `toolCall` (`kimi-xtml-tool-0`, bash) → command executed → `DONE`. Artifact: `e2e-session.jsonl` in the same evidence dir.
- Regression: existing invoke-recovery activation test extended with `kimi-xtml` in the mutual-exclusion list; all existing protocol suites untouched and green.

Plan: `.omo/plans/kimi-xtml-protocol.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `kimi-xtml` text tool-call protocol and enables normal-mode XTML recovery for Kimi models, converting leaked Kimi K3 XTML into executable tool calls and removing channel markers from visible text. Claude and non-Kimi behavior is unchanged.

- **New Features**
  - `kimi-xtml` protocol (`<|open|>/<|close|>/<|sep|>`): typed args (string/number/boolean/object/array with strict JSON), chunk-safe streaming with argument deltas, and incomplete-call finalization; registered in `ToolCallFormat` and the protocol registry.
  - Normal-mode recovery for Kimi models: `shouldRecoverTextToolCalls()` defaults on for Kimi-family ids; `createXtmlRecoveryStreamParser()` recovers leaked XTML and cleans stray markers; `wrapStreamWithInvokeRecovery()` takes an optional parser factory; `ModelRuntime` uses `hasKimiTextToolCallRecovery()` to pick XTML recovery for Kimi models.
  - Public exports: `createXtmlRecoveryStreamParser`, `hasKimiTextToolCallRecovery`; docs updated (`TESTING.md`, changes).
  - Tests added for protocol parsing/streaming, recovery activation/streaming, runtime boundary, and registration; ethos tip copy updated to name Kimi K3.

<sup>Written for commit 6c7b4e8a5306103b5262c52968eacbe40f26499b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

