### PR TITLE
feat(coding-agent): add recommended-models builtin with default-model priority and warnings

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -22,6 +22,7 @@ import openaiWebSearchExtension from "./openai-web-search/index.ts";
 import permissionSystemExtension from "./permission-system/index.ts";
 import promptPresetExtension from "./prompt-preset/index.ts";
 import promptUrlWidgetExtension from "./prompt-url-widget.ts";
+import recommendedModelsExtension from "./recommended-models/index.ts";
 import redrawsExtension from "./redraws.ts";
 import piRulesExtension from "./rules/index.ts";
 import serviceTierExtension from "./service-tier.ts";
@@ -59,6 +60,7 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "openai-web-search", factory: openaiWebSearchExtension },
 	{ id: "service-tier", factory: serviceTierExtension },
 	{ id: "model-fallback", factory: modelFallbackExtension },
+	{ id: "recommended-models", factory: recommendedModelsExtension },
 	{ id: "bash-timeout", factory: bashTimeoutExtension },
 	// Terminal follows bash-timeout so its injected default reaches the PTY bash, and follows
 	// anthropic-bash so mutual-exclusion (companion step-aside) is evaluated after it registers.

--- a/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
@@ -1,0 +1,156 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { SettingsManager } from "../../../settings-manager.ts";
+import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
+
+const FLAG_NAME = "no-recommended-models";
+const AUTO_SWITCH_PROVENANCE = new Set<NonNullable<SessionStartEvent["initialModelProvenance"]>>([
+	"settings",
+	"provider-default",
+	"first-available",
+]);
+const MODEL_ID_SUFFIXES = ["-ultrafast", "-unlocked", "-256k", "-fast"] as const;
+
+export const RECOMMENDED_DEFAULT_MODELS = [
+	["kimi-k3", "max"],
+	["gpt-5.6-sol", "medium"],
+	["claude-fable-5", "high"],
+	["claude-opus-5", "xhigh"],
+	["glm-5.2", "max"],
+] as const satisfies ReadonlyArray<readonly [string, ThinkingLevel]>;
+
+type RecommendedModel = { modelId: string; thinkingLevel: ThinkingLevel };
+
+const DEFAULT_RECOMMENDATIONS: readonly RecommendedModel[] = RECOMMENDED_DEFAULT_MODELS.map(
+	([modelId, thinkingLevel]) => ({ modelId, thinkingLevel }),
+);
+const DEFAULT_RECOMMENDATIONS_BY_MODEL_ID = new Map(
+	DEFAULT_RECOMMENDATIONS.map((recommendation) => [recommendation.modelId, recommendation]),
+);
+
+export function canonicalModelId(modelId: string): string {
+	let canonical = modelId.toLowerCase();
+	let strippedSuffix = true;
+	while (strippedSuffix) {
+		strippedSuffix = false;
+		for (const suffix of MODEL_ID_SUFFIXES) {
+			if (canonical.endsWith(suffix)) {
+				canonical = canonical.slice(0, -suffix.length);
+				strippedSuffix = true;
+				break;
+			}
+		}
+	}
+	return canonical === "k3" ? "kimi-k3" : canonical;
+}
+
+function recommendationsFor(configuredModelIds: string[] | undefined): readonly RecommendedModel[] {
+	if (configuredModelIds === undefined) {
+		return DEFAULT_RECOMMENDATIONS;
+	}
+	return configuredModelIds
+		.map(canonicalModelId)
+		.filter((modelId) => modelId.length > 0)
+		.map(
+			(modelId): RecommendedModel =>
+				DEFAULT_RECOMMENDATIONS_BY_MODEL_ID.get(modelId) ?? { modelId, thinkingLevel: "medium" },
+		);
+}
+
+function findAvailableRecommendation(
+	recommendations: readonly RecommendedModel[],
+	ctx: ExtensionContext,
+): { recommendation: RecommendedModel; model: Model<Api> } | undefined {
+	const available = ctx.modelRegistry.getAvailable().filter((model) => ctx.modelRegistry.hasConfiguredAuth(model));
+	for (const recommendation of recommendations) {
+		const model = available.find((candidate) => canonicalModelId(candidate.id) === recommendation.modelId);
+		if (model) {
+			return { recommendation, model };
+		}
+	}
+	return undefined;
+}
+
+function isRecommended(model: Model<Api> | undefined, recommendations: readonly RecommendedModel[]): boolean {
+	return (
+		model !== undefined &&
+		recommendations.some((recommendation) => canonicalModelId(model.id) === recommendation.modelId)
+	);
+}
+
+function nonRecommendedModelWarning(model: Model<Api> | undefined): string {
+	return `Non-recommended model '${model?.id ?? "<none>"}': odd behavior is the default state; a working session is the anomaly.`;
+}
+
+export default function recommendedModelsExtension(pi: ExtensionAPI): void {
+	pi.registerFlag(FLAG_NAME, {
+		type: "boolean",
+		default: false,
+		description: "Disable recommended model selection for this run.",
+	});
+
+	let initialized = false;
+	let disabled = false;
+	let disarmed = false;
+	let automaticSelection = false;
+	let warningShown = false;
+	let canAutoSwitch = false;
+	let recommendations: readonly RecommendedModel[] = DEFAULT_RECOMMENDATIONS;
+
+	const warnWhenNoRecommendationIsAvailable = (ctx: ExtensionContext): void => {
+		if (warningShown || findAvailableRecommendation(recommendations, ctx)) {
+			return;
+		}
+		warningShown = true;
+		ctx.ui.notify(nonRecommendedModelWarning(ctx.model), "warning");
+	};
+
+	pi.on("session_start", async (event, ctx) => {
+		if (initialized) {
+			return;
+		}
+		initialized = true;
+
+		const settingsManager = SettingsManager.create(ctx.cwd);
+		disabled = pi.getFlag(FLAG_NAME) === true || settingsManager.getWarnings().offRecommendedModel === true;
+		recommendations = recommendationsFor(settingsManager.getRecommendedModels());
+		canAutoSwitch =
+			ctx.mode !== "app-server" &&
+			event.initialModelProvenance !== undefined &&
+			AUTO_SWITCH_PROVENANCE.has(event.initialModelProvenance);
+		if (disabled || !canAutoSwitch || isRecommended(ctx.model, recommendations)) {
+			return;
+		}
+
+		const target = findAvailableRecommendation(recommendations, ctx);
+		if (!target) {
+			warnWhenNoRecommendationIsAvailable(ctx);
+			return;
+		}
+
+		automaticSelection = true;
+		try {
+			if (!(await pi.setModel(target.model))) {
+				warnWhenNoRecommendationIsAvailable(ctx);
+				return;
+			}
+			pi.setThinkingLevel(target.recommendation.thinkingLevel);
+			ctx.ui.notify(`Switched to recommended model '${target.model.id}'.`, "info");
+		} finally {
+			automaticSelection = false;
+		}
+	});
+
+	pi.on("model_select", (event, ctx) => {
+		if (!initialized || disabled || disarmed || automaticSelection || !canAutoSwitch) {
+			return;
+		}
+		if (event.source === "set" || event.source === "cycle") {
+			disarmed = true;
+			return;
+		}
+		if (!isRecommended(event.model, recommendations)) {
+			warnWhenNoRecommendationIsAvailable(ctx);
+		}
+	});
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,30 @@
 # Core Extensions Changes
 
+## 2026-07-29 - Initial model provenance on session_start
+
+### What changed and why
+
+- `SessionStartEvent` now carries optional `initialModelProvenance`, identifying the branch that selected a freshly resolved startup model: `cli`, `scoped`, `settings`, `provider-default`, or `first-available`.
+- `findInitialModel()` produces this provenance and the SDK forwards it when it resolves the startup model. CLI and scoped selections supplied by `main.ts` carry their explicit provenance too.
+- The new `recommended-models` builtin uses this field to limit automatic default-model selection to settings/provider-default/first-available startup paths, preserving explicit CLI and scoped selections.
+
+### Why the extension system couldn't handle this alone
+
+The extension runs after the core resolver has selected the startup model. Without the resolver branch crossing the existing `session_start` boundary, it cannot distinguish a saved default from an explicit CLI or scoped selection.
+
+### Files modified
+
+- `types.ts` (`SessionStartEvent`)
+- `../model-resolver.ts`, `../sdk.ts`, `../../main.ts` (provenance production and forwarding)
+- `builtin/recommended-models/index.ts` (consumer)
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `types.ts` around `SessionStartEvent`; retain the optional `initialModelProvenance` field.
+- MEDIUM: `../sdk.ts` startup-model resolution and session-start event assembly; preserve provenance when the SDK resolves the initial model.
+
+
+
 ## 2026-07-28 - Prompt-cache safe-wait budget on ExtensionContext
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -56,6 +56,7 @@ import type { ReadonlyFooterDataProvider } from "../footer-data-provider.ts";
 import type { KeybindingsManager } from "../keybindings.ts";
 import type { CustomMessage } from "../messages.ts";
 import type { ModelRegistry } from "../model-registry.ts";
+import type { InitialModelProvenance } from "../model-resolver.ts";
 import type {
 	BranchSummaryEntry,
 	CompactionEntry,
@@ -690,6 +691,8 @@ export interface SessionStartEvent {
 	type: "session_start";
 	/** Why this session start happened. */
 	reason: "startup" | "reload" | "new" | "resume" | "fork";
+	/** Initial model resolver branch, when the session was resolved during this startup. */
+	initialModelProvenance?: InitialModelProvenance;
 	/** Previously active session file. Present for "new", "resume", and "fork". */
 	previousSessionFile?: string;
 }

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -579,10 +579,13 @@ export function resolveCliModel(options: {
 	};
 }
 
+export type InitialModelProvenance = "cli" | "scoped" | "settings" | "provider-default" | "first-available";
+
 export interface InitialModelResult {
 	model: Model<Api> | undefined;
 	thinkingLevel: ThinkingLevel;
 	fallbackMessage: string | undefined;
+	provenance: InitialModelProvenance;
 }
 
 /**
@@ -629,7 +632,12 @@ export async function findInitialModel(options: {
 			process.exit(1);
 		}
 		if (resolved.model) {
-			return { model: resolved.model, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
+			return {
+				model: resolved.model,
+				thinkingLevel: DEFAULT_THINKING_LEVEL,
+				fallbackMessage: undefined,
+				provenance: "cli",
+			};
 		}
 	}
 
@@ -639,6 +647,7 @@ export async function findInitialModel(options: {
 			model: scopedModels[0].model,
 			thinkingLevel: scopedModels[0].thinkingLevel ?? defaultThinkingLevel ?? DEFAULT_THINKING_LEVEL,
 			fallbackMessage: undefined,
+			provenance: "scoped",
 		};
 	}
 
@@ -650,7 +659,7 @@ export async function findInitialModel(options: {
 			if (defaultThinkingLevel) {
 				thinkingLevel = defaultThinkingLevel;
 			}
-			return { model, thinkingLevel, fallbackMessage: undefined };
+			return { model, thinkingLevel, fallbackMessage: undefined, provenance: "settings" };
 		}
 	}
 
@@ -663,16 +672,31 @@ export async function findInitialModel(options: {
 			const defaultId = defaultModelPerProvider[provider];
 			const match = availableModels.find((m) => m.provider === provider && m.id === defaultId);
 			if (match) {
-				return { model: match, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
+				return {
+					model: match,
+					thinkingLevel: DEFAULT_THINKING_LEVEL,
+					fallbackMessage: undefined,
+					provenance: "provider-default",
+				};
 			}
 		}
 
 		// If no default found, use first available
-		return { model: availableModels[0], thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
+		return {
+			model: availableModels[0],
+			thinkingLevel: DEFAULT_THINKING_LEVEL,
+			fallbackMessage: undefined,
+			provenance: "first-available",
+		};
 	}
 
 	// 5. No model found
-	return { model: undefined, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
+	return {
+		model: undefined,
+		thinkingLevel: DEFAULT_THINKING_LEVEL,
+		fallbackMessage: undefined,
+		provenance: "first-available",
+	};
 }
 
 /**

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -11,7 +11,12 @@ import type { ServiceTier } from "./extensions/builtin/service-tier.ts";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { convertToLlmForTransport, TRANSPORT_IMAGE_BUDGET_BYTES } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
-import { findInitialModel, getModelNarrowingPatterns, resolveModelScope } from "./model-resolver.ts";
+import {
+	findInitialModel,
+	getModelNarrowingPatterns,
+	type InitialModelProvenance,
+	resolveModelScope,
+} from "./model-resolver.ts";
 import { ModelRuntime } from "./model-runtime.ts";
 import { mergeProviderAttributionHeaders } from "./provider-attribution.ts";
 import type { ResourceLoader } from "./resource-loader.ts";
@@ -54,6 +59,8 @@ export interface CreateAgentSessionOptions {
 
 	/** Model to use. Default: from settings, else first available */
 	model?: Model<any>;
+	/** Provenance for an explicitly supplied initial model. Omit to leave external SDK model selection untouched. */
+	initialModelProvenance?: InitialModelProvenance;
 	/** Thinking level. Default: from settings, else 'medium' (clamped to model capabilities) */
 	thinkingLevel?: ThinkingLevel;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
@@ -236,6 +243,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const hasThinkingEntry = sessionManager.getBranch().some((entry) => entry.type === "thinking_level_change");
 
 	let model = options.model;
+	let initialModelProvenance = options.initialModelProvenance;
 	let modelFallbackMessage: string | undefined;
 
 	// If session has data, try to restore model from it
@@ -260,6 +268,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			modelRuntime,
 		});
 		model = result.model;
+		initialModelProvenance = result.provenance;
 		if (!model) {
 			modelFallbackMessage = formatNoModelsAvailableMessage();
 		} else if (modelFallbackMessage) {
@@ -392,6 +401,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		sessionManager.appendThinkingLevelChange(thinkingLevel);
 	}
 
+	const sessionStartEvent = initialModelProvenance
+		? {
+				...(options.sessionStartEvent ?? { type: "session_start" as const, reason: "startup" as const }),
+				initialModelProvenance,
+			}
+		: options.sessionStartEvent;
+
 	const session = new AgentSession({
 		agent,
 		sessionManager,
@@ -408,7 +424,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		allowedToolNames,
 		excludedToolNames,
 		extensionRunnerRef,
-		sessionStartEvent: options.sessionStartEvent,
+		sessionStartEvent,
 		autoTitleSessions: options.autoTitleSessions,
 	});
 	const extensionsResult = resourceLoader.getExtensions();

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -90,6 +90,7 @@ export interface OpenAISettings {
 
 export interface WarningSettings {
 	anthropicExtraUsage?: boolean; // default: true
+	offRecommendedModel?: boolean; // default: false
 }
 
 export type DefaultProjectTrust = "ask" | "always" | "never";
@@ -155,6 +156,7 @@ export interface Settings {
 	promptCache?: PromptCacheSettings;
 	images?: ImageSettings;
 	lookAt?: LookAtSettings;
+	recommendedModels?: string[]; // Preferred default model ids, in priority order
 	favoriteModels?: string[]; // Model patterns for Ctrl+P cycling (same format as --models CLI flag)
 	enabledModels?: string[]; // Legacy global model narrowing patterns (same format as --models CLI flag)
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
@@ -1477,6 +1479,10 @@ export class SettingsManager {
 
 	getEnabledModels(): string[] | undefined {
 		return this.settings.enabledModels;
+	}
+
+	getRecommendedModels(): string[] | undefined {
+		return this.settings.recommendedModels ? [...this.settings.recommendedModels] : undefined;
 	}
 
 	getFavoriteModels(): string[] | undefined {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -412,6 +412,7 @@ function buildSessionOptions(
 		}
 		if (resolved.model) {
 			options.model = resolved.model;
+			options.initialModelProvenance = "cli";
 			// Allow "--model <pattern>:<thinking>" as a shorthand.
 			// Explicit --thinking still takes precedence (applied later).
 			if (!parsed.thinking && resolved.thinkingLevel) {
@@ -430,12 +431,14 @@ function buildSessionOptions(
 
 		if (savedInScope) {
 			options.model = savedInScope.model;
+			options.initialModelProvenance = "scoped";
 			// Use thinking level from scoped model config if explicitly set
 			if (!parsed.thinking && savedInScope.thinkingLevel) {
 				options.thinkingLevel = savedInScope.thinkingLevel;
 			}
 		} else {
 			options.model = scopedModels[0].model;
+			options.initialModelProvenance = "scoped";
 			// Use thinking level from first scoped model if explicitly set
 			if (!parsed.thinking && scopedModels[0].thinkingLevel) {
 				options.thinkingLevel = scopedModels[0].thinkingLevel;

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -736,4 +736,71 @@ describe("default model selection", () => {
 		expect(result.model?.provider).toBe("spark-two");
 		expect(result.model?.id).toBe("deepseek-v4-flash");
 	});
+
+	test("#given each initial selection branch #when resolving #then it returns the winning provenance", async () => {
+		const openAiDefault: Model<"anthropic-messages"> = {
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			api: "anthropic-messages",
+			provider: "openai",
+			baseUrl: "https://api.openai.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+		const custom: Model<"anthropic-messages"> = {
+			...openAiDefault,
+			id: "custom-model",
+			provider: "custom",
+		};
+		const runtime = {
+			getModels: () => [openAiDefault, custom],
+			getModel: (provider: string, modelId: string) =>
+				[openAiDefault, custom].find((candidate) => candidate.provider === provider && candidate.id === modelId),
+			hasConfiguredAuth: () => true,
+			getAvailable: async () => [openAiDefault, custom],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
+
+		const cli = await findInitialModel({
+			cliProvider: "openai",
+			cliModel: "gpt-5.5",
+			scopedModels: [],
+			isContinuing: false,
+			modelRuntime: runtime,
+		});
+		const scoped = await findInitialModel({
+			scopedModels: [{ model: custom }],
+			isContinuing: false,
+			modelRuntime: runtime,
+		});
+		const settings = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: "custom",
+			defaultModelId: "custom-model",
+			modelRuntime: runtime,
+		});
+		const providerDefault = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			modelRuntime: runtime,
+		});
+		const firstAvailableRuntime = {
+			...runtime,
+			getAvailable: async () => [custom],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
+		const firstAvailable = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			modelRuntime: firstAvailableRuntime,
+		});
+
+		expect(cli.provenance).toBe("cli");
+		expect(scoped.provenance).toBe("scoped");
+		expect(settings.provenance).toBe("settings");
+		expect(providerDefault.provenance).toBe("provider-default");
+		expect(firstAvailable.provenance).toBe("first-available");
+	});
 });

--- a/packages/coding-agent/test/suite/recommended-models-extension.test.ts
+++ b/packages/coding-agent/test/suite/recommended-models-extension.test.ts
@@ -1,0 +1,318 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, registerFauxProvider, type Api, type Model } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import recommendedModelsExtension from "../../src/core/extensions/builtin/recommended-models/index.ts";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ModelSelectEvent,
+	SessionStartEvent,
+} from "../../src/core/extensions/types.ts";
+import { ModelRuntime } from "../../src/core/model-runtime.ts";
+import { createAgentSession } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createAppServerRuntime } from "../../src/modes/app-server/runtime.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
+import { configureModeEnv, scratchRoot, seedFauxConfig } from "./app-server-mode-harness.ts";
+
+type Notice = { message: string; type: "info" | "warning" | "error" | undefined };
+type SessionStartHandler = (event: SessionStartEvent, ctx: ExtensionContext) => Promise<void> | void;
+type ModelSelectHandler = (event: ModelSelectEvent, ctx: ExtensionContext) => Promise<void> | void;
+
+function model(id: string, provider = "faux"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider,
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+interface RecommendedModelsHarness {
+	readonly notices: Notice[];
+	readonly settings: SettingsManager;
+	readonly flags: Map<string, { type: "boolean" | "string"; default?: boolean | string; description?: string }>;
+	getActiveModel(): Model<Api>;
+	start(provenance: NonNullable<SessionStartEvent["initialModelProvenance"]>): Promise<void>;
+	select(model: Model<Api>, source: "set" | "cycle" | "fallback"): Promise<void>;
+}
+
+function createHarness(options: {
+	active: Model<Api>;
+	available: Model<Api>[];
+	settings?: Parameters<typeof SettingsManager.inMemory>[0];
+	flag?: boolean;
+}): RecommendedModelsHarness {
+	const settings = SettingsManager.inMemory(options.settings);
+	vi.spyOn(SettingsManager, "create").mockReturnValue(settings);
+
+	const notices: Notice[] = [];
+	const flags = new Map<string, { type: "boolean" | "string"; default?: boolean | string; description?: string }>();
+	const sessionStartHandlers: SessionStartHandler[] = [];
+	const modelSelectHandlers: ModelSelectHandler[] = [];
+	let activeModel = options.active;
+	let thinkingLevel: ThinkingLevel = "medium";
+
+	const ctx = {
+		get model() {
+			return activeModel;
+		},
+		modelRegistry: {
+			getAvailable: () => options.available,
+			hasConfiguredAuth: () => true,
+		},
+		ui: {
+			notify: (message: string, type?: Notice["type"]) => notices.push({ message, type }),
+		},
+	} as unknown as ExtensionContext;
+
+	const emitModelSelect = async (nextModel: Model<Api>, source: "set" | "cycle" | "fallback"): Promise<void> => {
+		const previousModel = activeModel;
+		activeModel = nextModel;
+		for (const handler of modelSelectHandlers) {
+			await handler(
+				{
+					type: "model_select",
+					model: nextModel,
+					previousModel,
+					source,
+					systemPrompt: "",
+					systemPromptOptions: { cwd: "/tmp" },
+				},
+				ctx,
+			);
+		}
+	};
+
+	const pi = {
+		registerFlag: (
+			name: string,
+			options: { type: "boolean" | "string"; default?: boolean | string; description?: string },
+		) => flags.set(name, options),
+		getFlag: (name: string) => (name === "no-recommended-models" ? options.flag : undefined),
+		on: (event: string, handler: SessionStartHandler | ModelSelectHandler) => {
+			if (event === "session_start") {
+				sessionStartHandlers.push(handler as SessionStartHandler);
+			}
+			if (event === "model_select") {
+				modelSelectHandlers.push(handler as ModelSelectHandler);
+			}
+		},
+		setModel: async (nextModel: Model<Api>) => {
+			settings.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+			await emitModelSelect(nextModel, "set");
+			return true;
+		},
+		getThinkingLevel: () => thinkingLevel,
+		setThinkingLevel: (level: ThinkingLevel) => {
+			thinkingLevel = level;
+			settings.setDefaultThinkingLevel(level);
+		},
+	} as unknown as ExtensionAPI;
+
+	recommendedModelsExtension(pi);
+
+	return {
+		notices,
+		settings,
+		flags,
+		getActiveModel: () => activeModel,
+		async start(provenance) {
+			for (const handler of sessionStartHandlers) {
+				await handler({ type: "session_start", reason: "startup", initialModelProvenance: provenance }, ctx);
+			}
+		},
+		select: emitModelSelect,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("recommended-models builtin", () => {
+	it("#given an off-list saved default #when settings provenance starts #then it switches, persists, and notifies", async () => {
+		const kimi = model("kimi-k3", "kimi-coding");
+		const harness = createHarness({ active: model("off-list"), available: [kimi] });
+
+		await harness.start("settings");
+
+		expect(harness.getActiveModel()).toBe(kimi);
+		expect(harness.settings.getDefaultProvider()).toBe("kimi-coding");
+		expect(harness.settings.getDefaultModel()).toBe("kimi-k3");
+		expect(harness.settings.getDefaultThinkingLevel()).toBe("max");
+		expect(harness.notices).toEqual([{ message: "Switched to recommended model 'kimi-k3'.", type: "info" }]);
+	});
+
+	it("#given no available recommendation #when settings provenance starts #then it warns once with the prescribed text", async () => {
+		const harness = createHarness({ active: model("off-list"), available: [] });
+
+		await harness.start("settings");
+		await harness.select(model("another-off-list"), "fallback");
+
+		expect(harness.notices).toEqual([
+			{
+				message:
+					"Non-recommended model 'off-list': odd behavior is the default state; a working session is the anomaly.",
+				type: "warning",
+			},
+		]);
+	});
+
+	it("#given recommended warnings are disabled #when a session starts #then it neither switches nor warns", async () => {
+		const kimi = model("kimi-k3", "kimi-coding");
+		const harness = createHarness({
+			active: model("off-list"),
+			available: [kimi],
+			settings: { warnings: { offRecommendedModel: true } },
+		});
+
+		await harness.start("settings");
+
+		expect(harness.getActiveModel().id).toBe("off-list");
+		expect(harness.settings.getDefaultModel()).toBeUndefined();
+		expect(harness.notices).toEqual([]);
+	});
+
+	it("#given a recommendedModels override #when a session starts #then it follows the override priority", async () => {
+		const kimi = model("kimi-k3", "kimi-coding");
+		const glm = model("glm-5.2", "zai-coding-plan");
+		const harness = createHarness({
+			active: model("off-list"),
+			available: [kimi, glm],
+			settings: { recommendedModels: ["glm-5.2"] },
+		});
+
+		await harness.start("provider-default");
+
+		expect(harness.getActiveModel()).toBe(glm);
+		expect(harness.settings.getDefaultThinkingLevel()).toBe("max");
+	});
+
+	it("#given suffix and k3 aliases #when the active model is already recommended #then it keeps the active model", async () => {
+		for (const activeId of ["gpt-5.6-sol-fast", "kimi-k3-ultrafast", "k3"]) {
+			const harness = createHarness({
+				active: model(activeId),
+				available: [model("kimi-k3", "kimi-coding"), model("gpt-5.6-sol", "openai")],
+			});
+
+			await harness.start("first-available");
+
+			expect(harness.getActiveModel().id).toBe(activeId);
+			expect(harness.notices).toEqual([]);
+		}
+	});
+
+	it("#given cli or scoped provenance #when an off-list model starts #then it never switches or persists", async () => {
+		for (const provenance of ["cli", "scoped"] as const) {
+			const harness = createHarness({ active: model("off-list"), available: [model("kimi-k3", "kimi-coding")] });
+
+			await harness.start(provenance);
+
+			expect(harness.getActiveModel().id).toBe("off-list");
+			expect(harness.settings.getDefaultModel()).toBeUndefined();
+			expect(harness.notices).toEqual([]);
+		}
+	});
+
+	it("#given the run flag #when a session starts #then it leaves recommended-model behavior disabled", async () => {
+		const harness = createHarness({
+			active: model("off-list"),
+			available: [model("kimi-k3", "kimi-coding")],
+			flag: true,
+		});
+
+		await harness.start("settings");
+
+		expect(harness.flags.get("no-recommended-models")).toEqual({
+			type: "boolean",
+			default: false,
+			description: "Disable recommended model selection for this run.",
+		});
+		expect(harness.getActiveModel().id).toBe("off-list");
+		expect(harness.notices).toEqual([]);
+	});
+
+	it("#given settings selection #when the SDK emits session_start #then the provenance reaches extensions", async () => {
+		const saved = model("off-list");
+		const authStorage = AuthStorage.inMemory();
+		await authStorage.modify(saved.provider, async () => ({ type: "api_key", key: "faux-key" }));
+		const modelRuntime = await ModelRuntime.create({
+			credentials: authStorage,
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		modelRuntime.registerProvider(saved.provider, {
+			baseUrl: saved.baseUrl,
+			api: saved.api,
+			models: [
+				{
+					id: saved.id,
+					name: saved.name,
+					api: saved.api,
+					reasoning: saved.reasoning,
+					input: saved.input,
+					cost: saved.cost,
+					contextWindow: saved.contextWindow,
+					maxTokens: saved.maxTokens,
+				},
+			],
+		});
+		const events: SessionStartEvent[] = [];
+		const extensionsResult = await createTestExtensionsResult([
+			(pi) => {
+				pi.on("session_start", (event) => {
+					events.push(event);
+				});
+			},
+		]);
+		const { session } = await createAgentSession({
+			cwd: "/tmp",
+			modelRuntime,
+			settingsManager: SettingsManager.inMemory({ defaultProvider: saved.provider, defaultModel: saved.id }),
+			sessionManager: SessionManager.inMemory("/tmp"),
+			resourceLoader: createTestResourceLoader({ extensionsResult }),
+		});
+		try {
+			await session.bindExtensions({});
+			expect(events).toEqual([{ type: "session_start", reason: "startup", initialModelProvenance: "settings" }]);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("#given an app-server faux settings default #when recommended models initialize #then the faux model remains selected", async () => {
+		const root = await scratchRoot();
+		const faux = registerFauxProvider();
+		faux.setResponses([fauxAssistantMessage("faux response")]);
+		await seedFauxConfig(root, faux);
+		configureModeEnv(root);
+		const runtime = createAppServerRuntime(() => {});
+		const entry = await runtime.threads.createThread({ cwd: root });
+		try {
+			expect(entry.session.model?.provider).toBe(faux.getModel().provider);
+			expect(entry.session.model?.id).toBe(faux.getModel().id);
+
+			await entry.session.prompt("use the configured faux model");
+
+			expect(faux.state.callCount).toBe(1);
+		} finally {
+			entry.session.dispose();
+			runtime.dispose();
+			faux.unregister();
+		}
+	});
+
+	it("#given builtin registration #when extensions are enumerated #then recommended-models can be disabled by id", () => {
+		expect(builtinExtensions.some((extension) => extension.id === "recommended-models")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What
- add the `recommended-models` builtin, priority selection, canonical model matching, persisted defaults, notifications, settings controls, and `--no-recommended-models`
- thread initial-model provenance through startup so explicit CLI and scoped selections are never replaced

## Why
Start sessions on an authenticated recommended model when normal default resolution selected an off-list model, while retaining explicit user selection and exposing a clear warning when no recommendation is available.

## QA
- `npm run build` in `packages/coding-agent`
- `npx vitest --run test/suite/app-server-mode-interrupt.test.ts test/suite/app-server-mode-reconnect.test.ts` - 2 passed
- `npx vitest --run test/model-resolver.test.ts test/suite/recommended-models-extension.test.ts` - 54 passed
- Regression found and fixed: app-server test fixtures inherit host-authenticated recommended providers, so automatic selection replaced their isolated faux settings default and prevented faux calls. The builtin now no-ops in `app-server` mode; the recommended-models suite covers the faux app-server path.

## Risk
The new automatic selection intentionally rewrites a normal saved/provider/default fallback selection when an authenticated recommended model is available. Explicit CLI, scoped, and app-server selections remain untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `recommended-models` builtin to auto-switch to an authenticated recommended model on startup when the chosen default is off-list, without touching explicit CLI or scoped picks. Also adds model-provenance tracking, a disable flag, settings, and clear warnings.

- **New Features**
  - New builtin `recommended-models`: switches only for `settings`/`provider-default`/`first-available` starts; never for `cli` or `scoped`.
  - Persisted defaults: saves the new provider/model and sets thinking level from the recommendation.
  - Warnings: shows a one-time warning when no recommended model is available or active.
  - Canonical matching: strips `-ultrafast`/`-unlocked`/`-256k`/`-fast` suffixes and treats `k3` as `kimi-k3`.
  - App-server safe: no-ops in `app-server` mode to keep faux models intact.
  - CLI flag: `--no-recommended-models` disables this behavior for the run.
  - Settings:
    - `recommendedModels`: priority list of preferred default model IDs.
    - `warnings.offRecommendedModel`: disable the warning.
  - Provenance: adds `initialModelProvenance` to `SessionStartEvent` and SDK/startup resolver to gate switching logic.

<sup>Written for commit 594245ec3cbd9db848aeb8cb735e214eb0b2c22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

