### PR TITLE
feat(coding-agent): add two-line footer example

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,12 @@
 # Local fork changes
 
+## 2026-07-29 — Two-line footer extension example
+
+- Changed: added a public-API-only `examples/extensions/two-line-footer/` example with compact path, token, cache, context, model, and generic extension-status rendering. Extension statuses are preserved verbatim, sorted by key, and reserved at the right edge before left-side metrics are truncated.
+- Why: users can opt into a denser two-row footer without adding core behavior or coupling status-producing extensions to a specific footer implementation.
+- Extension boundary: the example uses `ctx.ui.setFooter()` and `footerData.getExtensionStatuses()` exclusively; no core footer source changes are required.
+- Merge-conflict risk: low. The change adds an isolated example directory, one test, one catalog row, and this record.
+
 ## 2026-07-28 — Billing-class provider errors always pin the session model swap
 
 - Changed: billing-class failures (credit balance, insufficient quota) engage the fallback chain with the pinned `"billing"` reason unconditionally — the candidate becomes the session model for the rest of the session and never auto-reverts. Files: `src/core/retry-fallback/billing.ts` (classifier), `src/core/retry-fallback/controller.ts` (billing reason pins and notes the cooldown), `src/core/agent-session.ts` (classifies hard-error-eligible failures). Non-billing hard errors keep the temporary, revertable switch. Supersedes the opt-in `retry.billingErrorPolicy` variant of the same change; the setting no longer exists.

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -2,9 +2,9 @@
 
 ## 2026-07-29 — Two-line footer extension example
 
-- Changed: added a public-API-only `examples/extensions/two-line-footer/` example with compact path, token, cache, context, model, and generic extension-status rendering. Extension statuses are preserved verbatim, sorted by key, and reserved at the right edge before left-side metrics are truncated.
+- Changed: added a public-API-only `examples/extensions/two-line-footer/` example with compact path, token, cache, context, model, and generic extension-status rendering. Built-in anchor indicators remain visible, one built-in context counter stays with the left-side metrics, and other extension statuses are sorted by key and reserved at the right edge before left-side metrics are truncated.
 - Why: users can opt into a denser two-row footer without adding core behavior or coupling status-producing extensions to a specific footer implementation.
-- Extension boundary: the example uses `ctx.ui.setFooter()` and `footerData.getExtensionStatuses()` exclusively; no core footer source changes are required.
+- Extension boundary: the example uses `ctx.ui.setFooter()` and public `footerData` accessors exclusively; no core footer source changes are required.
 - Merge-conflict risk: low. The change adds an isolated example directory, one test, one catalog row, and this record.
 
 ## 2026-07-28 — Billing-class provider errors always pin the session model swap

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-29 — Two-line footer extension example
 
-- Changed: added a public-API-only `examples/extensions/two-line-footer/` example with compact path, token, cache, context, model, and generic extension-status rendering. Built-in anchor indicators remain visible, one built-in context counter stays with the left-side metrics, and other extension statuses are sorted by key and reserved at the right edge before left-side metrics are truncated.
+- Changed: added a public-API-only `examples/extensions/two-line-footer/` example with compact path, token, cache, context, model, and generic extension-status rendering. Long paths elide from the head before session metadata yields, built-in anchor indicators remain visible, one built-in context counter stays with the left-side metrics, and other extension statuses are sorted by key and reserved at the right edge.
 - Why: users can opt into a denser two-row footer without adding core behavior or coupling status-producing extensions to a specific footer implementation.
 - Extension boundary: the example uses `ctx.ui.setFooter()` and public `footerData` accessors exclusively; no core footer source changes are required.
 - Merge-conflict risk: low. The change adds an isolated example directory, one test, one catalog row, and this record.

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -69,7 +69,7 @@ cp permission-gate.ts ~/.senpi/agent/extensions/
 | `titlebar-spinner.ts` | Braille spinner animation in terminal title while the agent is working |
 | `summarize.ts` | Summarize conversation with GPT-5.2 and show in transient UI |
 | `custom-footer.ts` | Custom footer with git branch and token stats via `ctx.ui.setFooter()` |
-| `two-line-footer/` | Two-line footer with compact stats and right-aligned extension statuses |
+| `two-line-footer/` | Two-line footer with compact stats, left-side built-in counters, and right-aligned extension statuses |
 | `custom-header.ts` | Custom header via `ctx.ui.setHeader()` |
 | `overlay-test.ts` | Test overlay compositing with inline text inputs and edge cases |
 | `overlay-qa-tests.ts` | Comprehensive overlay QA tests: anchors, margins, stacking, overflow, animation |

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -69,7 +69,7 @@ cp permission-gate.ts ~/.senpi/agent/extensions/
 | `titlebar-spinner.ts` | Braille spinner animation in terminal title while the agent is working |
 | `summarize.ts` | Summarize conversation with GPT-5.2 and show in transient UI |
 | `custom-footer.ts` | Custom footer with git branch and token stats via `ctx.ui.setFooter()` |
-| `two-line-footer/` | Two-line footer with compact stats, left-side built-in counters, and right-aligned extension statuses |
+| `two-line-footer/` | Responsive two-line footer with head-elided paths, compact stats, left counters, and right-aligned statuses |
 | `custom-header.ts` | Custom header via `ctx.ui.setHeader()` |
 | `overlay-test.ts` | Test overlay compositing with inline text inputs and edge cases |
 | `overlay-qa-tests.ts` | Comprehensive overlay QA tests: anchors, margins, stacking, overflow, animation |

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -69,6 +69,7 @@ cp permission-gate.ts ~/.senpi/agent/extensions/
 | `titlebar-spinner.ts` | Braille spinner animation in terminal title while the agent is working |
 | `summarize.ts` | Summarize conversation with GPT-5.2 and show in transient UI |
 | `custom-footer.ts` | Custom footer with git branch and token stats via `ctx.ui.setFooter()` |
+| `two-line-footer/` | Two-line footer with compact stats and right-aligned extension statuses |
 | `custom-header.ts` | Custom header via `ctx.ui.setHeader()` |
 | `overlay-test.ts` | Test overlay compositing with inline text inputs and edge cases |
 | `overlay-qa-tests.ts` | Comprehensive overlay QA tests: anchors, margins, stacking, overflow, animation |

--- a/packages/coding-agent/examples/extensions/two-line-footer/footer-layout.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/footer-layout.ts
@@ -32,10 +32,29 @@ export interface FooterUsageSegment {
 	readonly text: string;
 }
 
+export interface FooterTopLeftSegment {
+	readonly color: "accent" | "muted" | "success" | "warning";
+	readonly text: string;
+}
+
+export interface FooterTopLeftInput {
+	readonly path: string;
+	readonly branch: string;
+	readonly sessionName: string;
+	readonly omoNative: boolean;
+}
+
+export interface FooterStatusGroups {
+	readonly left: readonly string[];
+	readonly right: readonly string[];
+}
+
 export interface FooterBottomLine {
 	readonly left: string;
 	readonly right: string;
 }
+
+export const FOOTER_SEPARATOR = " • ";
 
 function trimOneDecimal(value: number): string {
 	const formatted = value.toFixed(1);
@@ -56,6 +75,17 @@ export function compactWorkingDirectory(cwd: string): string {
 	const compactPath = parts.slice(-2).join(pathSeparator);
 
 	return compactPath ? `[${compactPath}]` : "[]";
+}
+
+export function buildFooterTopLeftSegments(input: FooterTopLeftInput): readonly FooterTopLeftSegment[] {
+	const segments: FooterTopLeftSegment[] = [];
+	if (input.omoNative) {
+		segments.push({ color: "success", text: "(🏴‍☠️ OmO Native)" });
+	}
+	segments.push({ color: "accent", text: input.path });
+	if (input.branch) segments.push({ color: "warning", text: input.branch });
+	if (input.sessionName) segments.push({ color: "muted", text: input.sessionName });
+	return segments;
 }
 
 export function formatTokens(count: number): string {
@@ -113,7 +143,7 @@ export function fitFooterSegments(
 	maxWidth: number,
 	measure: (text: string) => number = visibleWidth,
 ): string {
-	const separator = " | ";
+	const separator = FOOTER_SEPARATOR;
 	const statusText = statusSegments.join(separator);
 	if (!statusText) return leadingSegments.join(separator);
 
@@ -131,10 +161,16 @@ export function fitFooterSegments(
 	return measure(elided) <= maxWidth ? elided : statusText;
 }
 
-export function sortedFooterStatuses(statuses: ReadonlyMap<string, string>): readonly string[] {
-	return Array.from(statuses.entries())
-		.sort(([left], [right]) => left.localeCompare(right))
-		.map(([, text]) => sanitizeFooterLabel(text));
+export function sortedFooterStatuses(statuses: ReadonlyMap<string, string>): FooterStatusGroups {
+	const left: string[] = [];
+	const right: string[] = [];
+	for (const [key, text] of Array.from(statuses.entries()).sort(([leftKey], [rightKey]) =>
+		leftKey.localeCompare(rightKey),
+	)) {
+		const target = key === "ext:nested-agents:status" ? left : right;
+		target.push(sanitizeFooterLabel(text));
+	}
+	return { left, right };
 }
 
 export function planFooterBottomLine(
@@ -145,7 +181,7 @@ export function planFooterBottomLine(
 	measure: (text: string) => number = visibleWidth,
 ): FooterBottomLine {
 	return {
-		left: usageSegments.join(" | "),
+		left: usageSegments.join(FOOTER_SEPARATOR),
 		right: fitFooterSegments([contextText], statusSegments, maxRightWidth, measure),
 	};
 }

--- a/packages/coding-agent/examples/extensions/two-line-footer/footer-layout.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/footer-layout.ts
@@ -1,0 +1,189 @@
+import { stripVTControlCharacters } from "node:util";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+export interface FooterText {
+	readonly colored: string;
+	readonly plain: string;
+}
+
+export interface FooterLine {
+	readonly left: FooterText;
+	readonly right: FooterText;
+	readonly width: number;
+}
+
+export interface FooterTextTools {
+	readonly measure: (text: string) => number;
+	readonly truncate: (text: string, width: number, ellipsis: string) => string;
+	readonly colorTruncatedLeft: (text: string) => string;
+}
+
+export interface FooterUsageTotals {
+	readonly input: number;
+	readonly output: number;
+	readonly cacheRead: number;
+	readonly cacheWrite: number;
+	readonly latestCacheHitRate: number | undefined;
+	readonly cost: number;
+}
+
+export interface FooterUsageSegment {
+	readonly color: "dim" | "success";
+	readonly text: string;
+}
+
+export interface FooterBottomLine {
+	readonly left: string;
+	readonly right: string;
+}
+
+function trimOneDecimal(value: number): string {
+	const formatted = value.toFixed(1);
+	return formatted.endsWith(".0") ? formatted.slice(0, -2) : formatted;
+}
+
+export function sanitizeFooterLabel(value: string): string {
+	return stripVTControlCharacters(value)
+		.replace(/[\u0000-\u001f\u007f-\u009f]+/gu, " ")
+		.replace(/\s+/gu, " ")
+		.trim();
+}
+
+export function compactWorkingDirectory(cwd: string): string {
+	const safeCwd = sanitizeFooterLabel(cwd);
+	const parts = safeCwd.replaceAll("\\", "/").replace(/\/+$/, "").split("/").filter(Boolean);
+	const pathSeparator = /^[A-Za-z]:[\\/]/.test(safeCwd) || safeCwd.includes("\\") ? "\\" : "/";
+	const compactPath = parts.slice(-2).join(pathSeparator);
+
+	return compactPath ? `[${compactPath}]` : "[]";
+}
+
+export function formatTokens(count: number): string {
+	const rounded = Math.round(count);
+	if (rounded < 1_000) return rounded.toString();
+	if (rounded < 10_000) return `${trimOneDecimal(rounded / 1_000)}K`;
+	if (rounded < 1_000_000) return `${Math.round(rounded / 1_000)}K`;
+	if (rounded < 10_000_000) {
+		return `${trimOneDecimal(rounded / 1_000_000)}M`;
+	}
+	if (rounded < 1_000_000_000) {
+		return `${Math.round(rounded / 1_000_000)}M`;
+	}
+	if (rounded < 10_000_000_000) {
+		return `${trimOneDecimal(rounded / 1_000_000_000)}B`;
+	}
+	return `${Math.round(rounded / 1_000_000_000)}B`;
+}
+
+export function buildFooterUsageSegments(
+	usage: FooterUsageTotals,
+	usingSubscription: boolean,
+): readonly FooterUsageSegment[] {
+	const segments: FooterUsageSegment[] = [];
+	if (usage.input) {
+		segments.push({ color: "dim", text: `↑${formatTokens(usage.input)}` });
+	}
+	if (usage.output) {
+		segments.push({ color: "dim", text: `↓${formatTokens(usage.output)}` });
+	}
+	if (usage.cacheRead || usage.cacheWrite) {
+		segments.push({
+			color: "dim",
+			text: `cache ${formatTokens(usage.cacheRead)}/${formatTokens(usage.cacheWrite)}`,
+		});
+	}
+	if ((usage.cacheRead > 0 || usage.cacheWrite > 0) && usage.latestCacheHitRate !== undefined) {
+		segments.push({
+			color: "dim",
+			text: `CH${usage.latestCacheHitRate.toFixed(1)}%`,
+		});
+	}
+	if (usage.cost || usingSubscription) {
+		segments.push({
+			color: "success",
+			text: `$${usage.cost.toFixed(3)}${usingSubscription ? " (sub)" : ""}`,
+		});
+	}
+	return segments;
+}
+
+export function fitFooterSegments(
+	leadingSegments: readonly string[],
+	statusSegments: readonly string[],
+	maxWidth: number,
+	measure: (text: string) => number = visibleWidth,
+): string {
+	const separator = " | ";
+	const statusText = statusSegments.join(separator);
+	if (!statusText) return leadingSegments.join(separator);
+
+	const reservedWidth = measure(statusText);
+	if (reservedWidth >= maxWidth) return statusText;
+
+	const availableLeading = maxWidth - reservedWidth - measure(separator);
+	const leadingText = leadingSegments.join(separator);
+	if (!leadingText) return statusText;
+	if (measure(leadingText) <= availableLeading) {
+		return `${leadingText}${separator}${statusText}`;
+	}
+
+	const elided = `...${separator}${statusText}`;
+	return measure(elided) <= maxWidth ? elided : statusText;
+}
+
+export function sortedFooterStatuses(statuses: ReadonlyMap<string, string>): readonly string[] {
+	return Array.from(statuses.entries())
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([, text]) => sanitizeFooterLabel(text));
+}
+
+export function planFooterBottomLine(
+	usageSegments: readonly string[],
+	contextText: string,
+	statusSegments: readonly string[],
+	maxRightWidth: number,
+	measure: (text: string) => number = visibleWidth,
+): FooterBottomLine {
+	return {
+		left: usageSegments.join(" | "),
+		right: fitFooterSegments([contextText], statusSegments, maxRightWidth, measure),
+	};
+}
+
+export function alignStyledFooterLine(line: FooterLine, tools: FooterTextTools): string {
+	const rightWidth = tools.measure(line.right.plain);
+	if (rightWidth >= line.width) {
+		const renderedRight = tools.truncate(line.right.colored, line.width, "");
+		const renderedWidth = tools.measure(renderedRight);
+		return `${" ".repeat(Math.max(0, line.width - renderedWidth))}${renderedRight}`;
+	}
+
+	const minimumPadding = line.left.plain ? 2 : 0;
+	const availableLeft = Math.max(0, line.width - rightWidth - minimumPadding);
+	let renderedLeft = line.left.colored;
+	let leftWidth = tools.measure(line.left.plain);
+
+	if (leftWidth > availableLeft) {
+		const truncatedLeft = tools.truncate(line.left.plain, availableLeft, "...");
+		renderedLeft = tools.colorTruncatedLeft(truncatedLeft);
+		leftWidth = tools.measure(truncatedLeft);
+	}
+
+	const padding = " ".repeat(Math.max(0, line.width - leftWidth - rightWidth));
+	return `${renderedLeft}${padding}${line.right.colored}`;
+}
+
+export function alignFooterLine(left: string, right: string, width: number): string {
+	return alignStyledFooterLine(
+		{
+			left: { colored: left, plain: left },
+			right: { colored: right, plain: right },
+			width,
+		},
+		{
+			colorTruncatedLeft: (text) => text,
+			measure: visibleWidth,
+			truncate: (text, maxWidth, ellipsis) => truncateToWidth(text, maxWidth, ellipsis).replaceAll("\u001b[0m", ""),
+		},
+	);
+}

--- a/packages/coding-agent/examples/extensions/two-line-footer/footer-layout.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/footer-layout.ts
@@ -34,6 +34,7 @@ export interface FooterUsageSegment {
 
 export interface FooterTopLeftSegment {
 	readonly color: "accent" | "muted" | "success" | "warning";
+	readonly kind: "badge" | "branch" | "fallback" | "path" | "session";
 	readonly text: string;
 }
 
@@ -80,12 +81,28 @@ export function compactWorkingDirectory(cwd: string): string {
 export function buildFooterTopLeftSegments(input: FooterTopLeftInput): readonly FooterTopLeftSegment[] {
 	const segments: FooterTopLeftSegment[] = [];
 	if (input.omoNative) {
-		segments.push({ color: "success", text: "(🏴‍☠️ OmO Native)" });
+		segments.push({ color: "success", kind: "badge", text: "(🏴‍☠️ OmO Native)" });
 	}
-	segments.push({ color: "accent", text: input.path });
-	if (input.branch) segments.push({ color: "warning", text: input.branch });
-	if (input.sessionName) segments.push({ color: "muted", text: input.sessionName });
+	segments.push({ color: "accent", kind: "path", text: input.path });
+	if (input.branch) segments.push({ color: "warning", kind: "branch", text: input.branch });
+	if (input.sessionName) segments.push({ color: "muted", kind: "session", text: input.sessionName });
 	return segments;
+}
+
+export function elideHead(text: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
+	if (visibleWidth(text) <= maxWidth) return text;
+	if (maxWidth === 1) return "…";
+	const budget = maxWidth - visibleWidth("…");
+	const kept: string[] = [];
+	let used = 0;
+	for (const char of [...text].reverse()) {
+		const charWidth = visibleWidth(char);
+		if (used + charWidth > budget) break;
+		kept.unshift(char);
+		used += charWidth;
+	}
+	return `…${kept.join("")}`;
 }
 
 export function formatTokens(count: number): string {
@@ -200,7 +217,7 @@ export function alignStyledFooterLine(line: FooterLine, tools: FooterTextTools):
 	let leftWidth = tools.measure(line.left.plain);
 
 	if (leftWidth > availableLeft) {
-		const truncatedLeft = tools.truncate(line.left.plain, availableLeft, "...");
+		const truncatedLeft = elideHead(line.left.plain, availableLeft);
 		renderedLeft = tools.colorTruncatedLeft(truncatedLeft);
 		leftWidth = tools.measure(truncatedLeft);
 	}

--- a/packages/coding-agent/examples/extensions/two-line-footer/index.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/index.ts
@@ -1,0 +1,37 @@
+import type { ExtensionAPI, ExtensionContext } from "@code-yeongyu/senpi";
+
+import { createTwoLineFooterFactory } from "./two-line-footer.ts";
+
+export default function (pi: ExtensionAPI) {
+	let enabled = false;
+
+	const toggleFooter = (ctx: ExtensionContext, showNotification: boolean): void => {
+		enabled = !enabled;
+
+		if (!enabled) {
+			ctx.ui.setFooter(undefined);
+			if (showNotification) {
+				ctx.ui.notify("Default footer restored", "info");
+			}
+			return;
+		}
+
+		ctx.ui.setFooter(createTwoLineFooterFactory(ctx));
+		if (showNotification) {
+			ctx.ui.notify("Two-line footer enabled", "info");
+		}
+	};
+
+	pi.registerCommand("footer", {
+		description: "Toggle two-line footer",
+		handler: async (_args, ctx) => {
+			toggleFooter(ctx, true);
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		enabled = false;
+		toggleFooter(ctx, false);
+	});
+}

--- a/packages/coding-agent/examples/extensions/two-line-footer/top-line-layout.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/top-line-layout.ts
@@ -1,0 +1,104 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+import { elideHead, FOOTER_SEPARATOR, type FooterTopLeftSegment } from "./footer-layout.ts";
+
+export interface FooterTopLineInput {
+	readonly width: number;
+	readonly segments: readonly FooterTopLeftSegment[];
+	readonly minimalRight: string;
+	readonly fullRight: string | undefined;
+	readonly separator?: string;
+	readonly minPadding?: number;
+}
+
+export interface FooterTopLinePlan {
+	readonly segments: readonly FooterTopLeftSegment[];
+	readonly right: string;
+}
+
+function segmentsWidth(segments: readonly FooterTopLeftSegment[], separator: string): number {
+	if (segments.length === 0) return 0;
+	return (
+		segments.reduce((total, segment) => total + visibleWidth(segment.text), 0) +
+		visibleWidth(separator) * (segments.length - 1)
+	);
+}
+
+function fits(segments: readonly FooterTopLeftSegment[], right: string, input: FooterTopLineInput): boolean {
+	return (
+		segmentsWidth(segments, input.separator ?? FOOTER_SEPARATOR) + (input.minPadding ?? 2) + visibleWidth(right) <=
+		input.width
+	);
+}
+
+function elidePathToFit(
+	segments: readonly FooterTopLeftSegment[],
+	right: string,
+	input: FooterTopLineInput,
+): readonly FooterTopLeftSegment[] | undefined {
+	const path = segments.find((segment) => segment.kind === "path");
+	if (!path) return undefined;
+	const separator = input.separator ?? FOOTER_SEPARATOR;
+	const rest = segments.filter((segment) => segment.kind !== "path");
+	const budget =
+		input.width -
+		(input.minPadding ?? 2) -
+		visibleWidth(right) -
+		segmentsWidth(rest, separator) -
+		(rest.length > 0 ? visibleWidth(separator) : 0);
+	if (budget < 2) return undefined;
+	return segments.map((segment) =>
+		segment.kind === "path" ? { ...segment, text: elideHead(segment.text, budget) } : segment,
+	);
+}
+
+function planForRight(right: string, input: FooterTopLineInput): FooterTopLinePlan | undefined {
+	if (fits(input.segments, right, input)) {
+		return { segments: input.segments, right };
+	}
+
+	const path = input.segments.find((segment) => segment.kind === "path");
+	const preferPathElision = path !== undefined && visibleWidth(path.text) > Math.floor(input.width / 3);
+	if (preferPathElision) {
+		const elided = elidePathToFit(input.segments, right, input);
+		if (elided && fits(elided, right, input)) {
+			return { segments: elided, right };
+		}
+	}
+
+	const withoutSession = input.segments.filter((segment) => segment.kind !== "session");
+	if (fits(withoutSession, right, input)) {
+		return { segments: withoutSession, right };
+	}
+	const elided = elidePathToFit(withoutSession, right, input);
+	return elided && fits(elided, right, input) ? { segments: elided, right } : undefined;
+}
+
+export function planFooterTopLine(input: FooterTopLineInput): FooterTopLinePlan {
+	if (input.fullRight) {
+		const full = planForRight(input.fullRight, input);
+		if (full) return full;
+	}
+	const minimal = planForRight(input.minimalRight, input);
+	if (minimal) return minimal;
+
+	const separator = input.separator ?? FOOTER_SEPARATOR;
+	const anchors = input.segments.filter((segment) => segment.kind !== "session");
+	const leftBudget = input.width - (input.minPadding ?? 2) - visibleWidth(input.minimalRight);
+	if (leftBudget >= 1) {
+		return {
+			segments: [
+				{
+					color: "muted",
+					kind: "fallback",
+					text: elideHead(anchors.map((segment) => segment.text).join(separator), leftBudget),
+				},
+			],
+			right: input.minimalRight,
+		};
+	}
+	return {
+		segments: [],
+		right: truncateToWidth(input.minimalRight, input.width, ""),
+	};
+}

--- a/packages/coding-agent/examples/extensions/two-line-footer/two-line-footer.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/two-line-footer.ts
@@ -14,6 +14,7 @@ import {
 	sanitizeFooterLabel,
 	sortedFooterStatuses,
 } from "./footer-layout.ts";
+import { planFooterTopLine } from "./top-line-layout.ts";
 
 type FooterFactory = Exclude<Parameters<ExtensionContext["ui"]["setFooter"]>[0], undefined>;
 
@@ -97,8 +98,6 @@ export function createTwoLineFooterFactory(ctx: ExtensionContext): FooterFactory
 					sessionName,
 					omoNative: footerData.isOmoNative(),
 				});
-				const topLeftPlain = topLeftSegments.map(({ text }) => text).join(FOOTER_SEPARATOR);
-				const topLeftColored = topLeftSegments.map(({ color, text }) => theme.fg(color, text)).join(separator);
 
 				const modelName = sanitizeFooterLabel(ctx.model?.id ?? "no-model");
 				const thinkingSuffix = ctx.model?.reasoning ? `:${ctx.thinkingLevel ?? "off"}` : "";
@@ -108,15 +107,22 @@ export function createTwoLineFooterFactory(ctx: ExtensionContext): FooterFactory
 						? `(${sanitizeFooterLabel(ctx.model.provider)}) `
 						: "";
 				const modelWithProvider = `${providerPrefix}${modelWithoutProvider}`;
-				const modelPlain =
-					visibleWidth(topLeftPlain) + 2 + visibleWidth(modelWithProvider) <= width
-						? modelWithProvider
-						: modelWithoutProvider;
 				const coloredModel = `${theme.fg("accent", modelName)}${theme.fg("dim", thinkingSuffix)}`;
+				const topLine = planFooterTopLine({
+					width,
+					segments: topLeftSegments,
+					minimalRight: modelWithoutProvider,
+					fullRight: providerPrefix ? modelWithProvider : undefined,
+				});
+				const topLeftPlain = topLine.segments.map(({ text }) => text).join(FOOTER_SEPARATOR);
+				const topLeftColored = topLine.segments.map(({ color, text }) => theme.fg(color, text)).join(separator);
+				const modelPlain = topLine.right;
 				const modelColored =
 					modelPlain === modelWithProvider && providerPrefix
 						? `${theme.fg("muted", providerPrefix)}${coloredModel}`
-						: coloredModel;
+						: modelPlain === modelWithoutProvider
+							? coloredModel
+							: theme.fg("accent", modelPlain);
 
 				const usingSubscription = ctx.model
 					? ctx.model.provider === "kimi-coding" || ctx.modelRegistry.isUsingOAuth(ctx.model)

--- a/packages/coding-agent/examples/extensions/two-line-footer/two-line-footer.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/two-line-footer.ts
@@ -1,0 +1,157 @@
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+import {
+	alignStyledFooterLine,
+	buildFooterUsageSegments,
+	compactWorkingDirectory,
+	type FooterText,
+	type FooterUsageTotals,
+	formatTokens,
+	planFooterBottomLine,
+	sanitizeFooterLabel,
+	sortedFooterStatuses,
+} from "./footer-layout.ts";
+
+type FooterFactory = Exclude<Parameters<ExtensionContext["ui"]["setFooter"]>[0], undefined>;
+
+function collectUsageTotals(sessionManager: ExtensionContext["sessionManager"]): FooterUsageTotals {
+	let input = 0;
+	let output = 0;
+	let cacheRead = 0;
+	let cacheWrite = 0;
+	let cost = 0;
+	let latestCacheHitRate: number | undefined;
+
+	for (const entry of sessionManager.getEntries()) {
+		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+		const usage = entry.message.usage;
+		if (!usage) continue;
+		input += usage.input;
+		output += usage.output;
+		cacheRead += usage.cacheRead;
+		cacheWrite += usage.cacheWrite;
+		cost += usage.cost?.total ?? 0;
+		const latestPromptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+		latestCacheHitRate = latestPromptTokens > 0 ? (usage.cacheRead / latestPromptTokens) * 100 : undefined;
+	}
+
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		cost,
+		latestCacheHitRate,
+	};
+}
+
+export function createTwoLineFooterFactory(ctx: ExtensionContext): FooterFactory {
+	return (tui, theme, footerData) => {
+		const unsubscribe = footerData.onBranchChange(() => tui.requestRender());
+
+		return {
+			dispose: unsubscribe,
+			invalidate() {},
+			render(width: number): string[] {
+				const separator = theme.fg("borderMuted", " | ");
+				const footerTextTools = {
+					colorTruncatedLeft: (text: string) => theme.fg("muted", text),
+					measure: visibleWidth,
+					truncate: truncateToWidth,
+				};
+				const alignLine = (left: FooterText, right: FooterText): string =>
+					alignStyledFooterLine({ left, right, width }, footerTextTools);
+
+				const usage = collectUsageTotals(ctx.sessionManager);
+				const contextUsage = ctx.getContextUsage();
+				const contextWindow = contextUsage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
+				const contextPercentValue = contextUsage?.percent ?? 0;
+				const contextPercent = typeof contextUsage?.percent === "number" ? contextUsage.percent.toFixed(1) : "?";
+				const contextTokens =
+					typeof contextUsage?.tokens === "number"
+						? formatTokens(contextUsage.tokens)
+						: typeof contextUsage?.percent === "number"
+							? formatTokens(Math.round((contextWindow * contextUsage.percent) / 100))
+							: "?";
+				const autoIndicator = ctx.getCompactionSettings().enabled ? " (auto)" : "";
+				const contextText =
+					contextPercent === "?"
+						? `${contextTokens}/${formatTokens(contextWindow)} (?)${autoIndicator}`
+						: `${contextTokens}/${formatTokens(contextWindow)} (${contextPercent}%)${autoIndicator}`;
+				const contextColored =
+					contextPercentValue > 90
+						? theme.fg("error", contextText)
+						: contextPercentValue > 70
+							? theme.fg("warning", contextText)
+							: theme.fg("muted", contextText);
+
+				const path = compactWorkingDirectory(ctx.cwd);
+				const branch = sanitizeFooterLabel(footerData.getGitBranch() ?? "");
+				const sessionName = sanitizeFooterLabel(ctx.sessionManager.getSessionName() ?? "");
+				const topPlainSegments = [path];
+				const topColoredSegments = [theme.fg("accent", path)];
+				if (branch) {
+					topPlainSegments.push(branch);
+					topColoredSegments.push(theme.fg("warning", branch));
+				}
+				if (sessionName) {
+					topPlainSegments.push(sessionName);
+					topColoredSegments.push(theme.fg("muted", sessionName));
+				}
+				const topLeftPlain = topPlainSegments.join(" | ");
+				const topLeftColored = topColoredSegments.join(separator);
+
+				const modelName = sanitizeFooterLabel(ctx.model?.id ?? "no-model");
+				const thinkingSuffix = ctx.model?.reasoning ? `:${ctx.thinkingLevel ?? "off"}` : "";
+				const modelWithoutProvider = `${modelName}${thinkingSuffix}`;
+				const providerPrefix =
+					footerData.getAvailableProviderCount() > 1 && ctx.model
+						? `(${sanitizeFooterLabel(ctx.model.provider)}) `
+						: "";
+				const modelWithProvider = `${providerPrefix}${modelWithoutProvider}`;
+				const modelPlain =
+					visibleWidth(topLeftPlain) + 2 + visibleWidth(modelWithProvider) <= width
+						? modelWithProvider
+						: modelWithoutProvider;
+				const coloredModel = `${theme.fg("accent", modelName)}${theme.fg("dim", thinkingSuffix)}`;
+				const modelColored =
+					modelPlain === modelWithProvider && providerPrefix
+						? `${theme.fg("muted", providerPrefix)}${coloredModel}`
+						: coloredModel;
+
+				const usingSubscription = ctx.model
+					? ctx.model.provider === "kimi-coding" || ctx.modelRegistry.isUsingOAuth(ctx.model)
+					: false;
+				const usageSegments = buildFooterUsageSegments(usage, usingSubscription);
+				const bottomPlainSegments = usageSegments.map(({ text }) => text);
+				const bottomColoredSegments = usageSegments.map(({ color, text }) => theme.fg(color, text));
+				const statuses = sortedFooterStatuses(footerData.getExtensionStatuses());
+				const bottomLine = planFooterBottomLine(bottomPlainSegments, contextText, statuses, width, visibleWidth);
+				const statusColored = statuses.map((status) => theme.fg("dim", status)).join(separator);
+				const bottomRightColored =
+					statuses.length === 0
+						? contextColored
+						: bottomLine.right === statuses.join(" | ")
+							? statusColored
+							: bottomLine.right === `${contextText} | ${statuses.join(" | ")}`
+								? [contextColored, statusColored].join(separator)
+								: `${theme.fg("dim", "...")}${separator}${statusColored}`;
+
+				return [
+					alignLine(
+						{ colored: topLeftColored, plain: topLeftPlain },
+						{ colored: modelColored, plain: modelPlain },
+					),
+					alignLine(
+						{
+							colored: bottomColoredSegments.join(separator),
+							plain: bottomLine.left,
+						},
+						{ colored: bottomRightColored, plain: bottomLine.right },
+					),
+				];
+			},
+		};
+	};
+}

--- a/packages/coding-agent/examples/extensions/two-line-footer/two-line-footer.ts
+++ b/packages/coding-agent/examples/extensions/two-line-footer/two-line-footer.ts
@@ -3,8 +3,10 @@ import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 import {
 	alignStyledFooterLine,
+	buildFooterTopLeftSegments,
 	buildFooterUsageSegments,
 	compactWorkingDirectory,
+	FOOTER_SEPARATOR,
 	type FooterText,
 	type FooterUsageTotals,
 	formatTokens,
@@ -54,7 +56,7 @@ export function createTwoLineFooterFactory(ctx: ExtensionContext): FooterFactory
 			dispose: unsubscribe,
 			invalidate() {},
 			render(width: number): string[] {
-				const separator = theme.fg("borderMuted", " | ");
+				const separator = theme.fg("borderMuted", FOOTER_SEPARATOR);
 				const footerTextTools = {
 					colorTruncatedLeft: (text: string) => theme.fg("muted", text),
 					measure: visibleWidth,
@@ -89,18 +91,14 @@ export function createTwoLineFooterFactory(ctx: ExtensionContext): FooterFactory
 				const path = compactWorkingDirectory(ctx.cwd);
 				const branch = sanitizeFooterLabel(footerData.getGitBranch() ?? "");
 				const sessionName = sanitizeFooterLabel(ctx.sessionManager.getSessionName() ?? "");
-				const topPlainSegments = [path];
-				const topColoredSegments = [theme.fg("accent", path)];
-				if (branch) {
-					topPlainSegments.push(branch);
-					topColoredSegments.push(theme.fg("warning", branch));
-				}
-				if (sessionName) {
-					topPlainSegments.push(sessionName);
-					topColoredSegments.push(theme.fg("muted", sessionName));
-				}
-				const topLeftPlain = topPlainSegments.join(" | ");
-				const topLeftColored = topColoredSegments.join(separator);
+				const topLeftSegments = buildFooterTopLeftSegments({
+					path,
+					branch,
+					sessionName,
+					omoNative: footerData.isOmoNative(),
+				});
+				const topLeftPlain = topLeftSegments.map(({ text }) => text).join(FOOTER_SEPARATOR);
+				const topLeftColored = topLeftSegments.map(({ color, text }) => theme.fg(color, text)).join(separator);
 
 				const modelName = sanitizeFooterLabel(ctx.model?.id ?? "no-model");
 				const thinkingSuffix = ctx.model?.reasoning ? `:${ctx.thinkingLevel ?? "off"}` : "";
@@ -124,17 +122,26 @@ export function createTwoLineFooterFactory(ctx: ExtensionContext): FooterFactory
 					? ctx.model.provider === "kimi-coding" || ctx.modelRegistry.isUsingOAuth(ctx.model)
 					: false;
 				const usageSegments = buildFooterUsageSegments(usage, usingSubscription);
-				const bottomPlainSegments = usageSegments.map(({ text }) => text);
-				const bottomColoredSegments = usageSegments.map(({ color, text }) => theme.fg(color, text));
 				const statuses = sortedFooterStatuses(footerData.getExtensionStatuses());
-				const bottomLine = planFooterBottomLine(bottomPlainSegments, contextText, statuses, width, visibleWidth);
-				const statusColored = statuses.map((status) => theme.fg("dim", status)).join(separator);
+				const bottomPlainSegments = [...statuses.left, ...usageSegments.map(({ text }) => text)];
+				const bottomColoredSegments = [
+					...statuses.left.map((status) => theme.fg("dim", status)),
+					...usageSegments.map(({ color, text }) => theme.fg(color, text)),
+				];
+				const bottomLine = planFooterBottomLine(
+					bottomPlainSegments,
+					contextText,
+					statuses.right,
+					width,
+					visibleWidth,
+				);
+				const statusColored = statuses.right.map((status) => theme.fg("dim", status)).join(separator);
 				const bottomRightColored =
-					statuses.length === 0
+					statuses.right.length === 0
 						? contextColored
-						: bottomLine.right === statuses.join(" | ")
+						: bottomLine.right === statuses.right.join(FOOTER_SEPARATOR)
 							? statusColored
-							: bottomLine.right === `${contextText} | ${statuses.join(" | ")}`
+							: bottomLine.right === `${contextText}${FOOTER_SEPARATOR}${statuses.right.join(FOOTER_SEPARATOR)}`
 								? [contextColored, statusColored].join(separator)
 								: `${theme.fg("dim", "...")}${separator}${statusColored}`;
 

--- a/packages/coding-agent/test/examples/two-line-footer.test.ts
+++ b/packages/coding-agent/test/examples/two-line-footer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	alignFooterLine,
+	buildFooterTopLeftSegments,
 	buildFooterUsageSegments,
 	compactWorkingDirectory,
 	fitFooterSegments,
@@ -17,7 +18,7 @@ describe("planFooterBottomLine", () => {
 
 		expect(line).toEqual({
 			left: "↑1K",
-			right: "32K/372K (8.6%) | quota 88%",
+			right: "32K/372K (8.6%) • quota 88%",
 		});
 	});
 });
@@ -32,7 +33,7 @@ describe("fitFooterSegments", () => {
 	it("includes context before status when space permits", () => {
 		const rendered = fitFooterSegments(["32K/372K (8.6%)"], ["quota 88%"], 40);
 
-		expect(rendered).toBe("32K/372K (8.6%) | quota 88%");
+		expect(rendered).toBe("32K/372K (8.6%) • quota 88%");
 	});
 
 	it("drops context before overflowing a wide status", () => {
@@ -85,15 +86,39 @@ describe("compactWorkingDirectory", () => {
 });
 
 describe("sortedFooterStatuses", () => {
-	it("preserves every extension status without key-specific substitution", () => {
+	it("keeps the nested-agent counter on the left and other statuses on the right", () => {
 		const statuses = sortedFooterStatuses(
 			new Map([
 				["provider", "quota 88%"],
 				["fast", "fast mode"],
+				["ext:nested-agents:status", "🤖 2"],
 			]),
 		);
 
-		expect(statuses).toEqual(["fast mode", "quota 88%"]);
+		expect(statuses).toEqual({
+			left: ["🤖 2"],
+			right: ["fast mode", "quota 88%"],
+		});
+	});
+});
+
+describe("buildFooterTopLeftSegments", () => {
+	it("prepends the built-in native badge only when the default footer exposes it", () => {
+		const active = buildFooterTopLeftSegments({
+			path: "[project/src]",
+			branch: "main",
+			sessionName: "",
+			omoNative: true,
+		});
+		const inactive = buildFooterTopLeftSegments({
+			path: "[project/src]",
+			branch: "main",
+			sessionName: "",
+			omoNative: false,
+		});
+
+		expect(active.at(0)).toEqual({ color: "success", text: "(🏴‍☠️ OmO Native)" });
+		expect(inactive.at(0)).toEqual({ color: "accent", text: "[project/src]" });
 	});
 });
 

--- a/packages/coding-agent/test/examples/two-line-footer.test.ts
+++ b/packages/coding-agent/test/examples/two-line-footer.test.ts
@@ -11,6 +11,7 @@ import {
 	sanitizeFooterLabel,
 	sortedFooterStatuses,
 } from "../../examples/extensions/two-line-footer/footer-layout.ts";
+import { planFooterTopLine } from "../../examples/extensions/two-line-footer/top-line-layout.ts";
 
 describe("planFooterBottomLine", () => {
 	it("keeps extension statuses in the right-aligned footer block", () => {
@@ -54,7 +55,7 @@ describe("alignFooterLine", () => {
 	it("truncates leading text before reserved text", () => {
 		const rendered = alignFooterLine("very-long-left", "right", 16);
 
-		expect(rendered).toBe("very-l...  right");
+		expect(rendered).toBe("…ong-left  right");
 	});
 
 	it("measures wide glyphs by terminal columns", () => {
@@ -68,6 +69,15 @@ describe("alignFooterLine", () => {
 		const rendered = alignFooterLine("", "상태상태상태", 9);
 
 		expect(visibleWidth(rendered)).toBe(9);
+	});
+
+	it("keeps the identifying tail when a long path must shrink", () => {
+		const rendered = alignFooterLine("[workspace/very-long-project/src] • main", "model", 36);
+
+		expect(rendered.startsWith("…")).toBe(true);
+		expect(rendered).toContain("project/src] • main");
+		expect(rendered.endsWith("model")).toBe(true);
+		expect(visibleWidth(rendered)).toBe(36);
 	});
 });
 
@@ -117,8 +127,58 @@ describe("buildFooterTopLeftSegments", () => {
 			omoNative: false,
 		});
 
-		expect(active.at(0)).toEqual({ color: "success", text: "(🏴‍☠️ OmO Native)" });
-		expect(inactive.at(0)).toEqual({ color: "accent", text: "[project/src]" });
+		expect(active.at(0)).toEqual({
+			color: "success",
+			kind: "badge",
+			text: "(🏴‍☠️ OmO Native)",
+		});
+		expect(inactive.at(0)).toEqual({
+			color: "accent",
+			kind: "path",
+			text: "[project/src]",
+		});
+	});
+});
+
+describe("planFooterTopLine", () => {
+	it("shrinks a long path before dropping the session", () => {
+		const segments = buildFooterTopLeftSegments({
+			path: "[workspace/very-long-project-name/src]",
+			branch: "main",
+			sessionName: "work",
+			omoNative: false,
+		});
+
+		const plan = planFooterTopLine({
+			width: 55,
+			segments,
+			minimalRight: "model",
+			fullRight: "(provider) model",
+		});
+
+		expect(plan.right).toBe("(provider) model");
+		expect(plan.segments.some((segment) => segment.kind === "session")).toBe(true);
+		expect(plan.segments.find((segment) => segment.kind === "path")?.text).toMatch(/^….*name\/src\]$/);
+	});
+
+	it("drops the session before shrinking a short path", () => {
+		const segments = buildFooterTopLeftSegments({
+			path: "[project/src]",
+			branch: "main",
+			sessionName: "a-very-long-session-name",
+			omoNative: false,
+		});
+
+		const plan = planFooterTopLine({
+			width: 42,
+			segments,
+			minimalRight: "model",
+			fullRight: "(provider) model",
+		});
+
+		expect(plan.right).toBe("(provider) model");
+		expect(plan.segments.some((segment) => segment.kind === "session")).toBe(false);
+		expect(plan.segments.find((segment) => segment.kind === "path")?.text).toBe("[project/src]");
 	});
 });
 

--- a/packages/coding-agent/test/examples/two-line-footer.test.ts
+++ b/packages/coding-agent/test/examples/two-line-footer.test.ts
@@ -1,0 +1,130 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+
+import {
+	alignFooterLine,
+	buildFooterUsageSegments,
+	compactWorkingDirectory,
+	fitFooterSegments,
+	planFooterBottomLine,
+	sanitizeFooterLabel,
+	sortedFooterStatuses,
+} from "../../examples/extensions/two-line-footer/footer-layout.ts";
+
+describe("planFooterBottomLine", () => {
+	it("keeps extension statuses in the right-aligned footer block", () => {
+		const line = planFooterBottomLine(["↑1K"], "32K/372K (8.6%)", ["quota 88%"], 40);
+
+		expect(line).toEqual({
+			left: "↑1K",
+			right: "32K/372K (8.6%) | quota 88%",
+		});
+	});
+});
+
+describe("fitFooterSegments", () => {
+	it("keeps reserved status unchanged when space is tight", () => {
+		const rendered = fitFooterSegments(["32K/372K (8.6%)"], ["quota 88%"], 9);
+
+		expect(rendered).toBe("quota 88%");
+	});
+
+	it("includes context before status when space permits", () => {
+		const rendered = fitFooterSegments(["32K/372K (8.6%)"], ["quota 88%"], 40);
+
+		expect(rendered).toBe("32K/372K (8.6%) | quota 88%");
+	});
+
+	it("drops context before overflowing a wide status", () => {
+		const rendered = fitFooterSegments(["문맥"], ["상태상태"], 10);
+
+		expect(rendered).toBe("상태상태");
+		expect(visibleWidth(rendered)).toBeLessThanOrEqual(10);
+	});
+});
+
+describe("alignFooterLine", () => {
+	it("places the reserved text at the right edge", () => {
+		const rendered = alignFooterLine("left", "right", 24);
+
+		expect(rendered).toBe("left               right");
+	});
+
+	it("truncates leading text before reserved text", () => {
+		const rendered = alignFooterLine("very-long-left", "right", 16);
+
+		expect(rendered).toBe("very-l...  right");
+	});
+
+	it("measures wide glyphs by terminal columns", () => {
+		const rendered = alignFooterLine("경로", "상태", 16);
+
+		expect(visibleWidth(rendered)).toBe(16);
+		expect(rendered.endsWith("상태")).toBe(true);
+	});
+
+	it("keeps a truncated wide right block at the right edge", () => {
+		const rendered = alignFooterLine("", "상태상태상태", 9);
+
+		expect(visibleWidth(rendered)).toBe(9);
+	});
+});
+
+describe("compactWorkingDirectory", () => {
+	it("keeps the last two Windows path segments", () => {
+		const rendered = compactWorkingDirectory("C:\\workspace\\project\\src");
+
+		expect(rendered).toBe("[project\\src]");
+	});
+
+	it("preserves POSIX separators", () => {
+		const rendered = compactWorkingDirectory("/workspace/project/src");
+
+		expect(rendered).toBe("[project/src]");
+	});
+});
+
+describe("sortedFooterStatuses", () => {
+	it("preserves every extension status without key-specific substitution", () => {
+		const statuses = sortedFooterStatuses(
+			new Map([
+				["provider", "quota 88%"],
+				["fast", "fast mode"],
+			]),
+		);
+
+		expect(statuses).toEqual(["fast mode", "quota 88%"]);
+	});
+});
+
+describe("sanitizeFooterLabel", () => {
+	it("removes terminal controls and forces a single line", () => {
+		const rendered = sanitizeFooterLabel("\u001b]52;c;Y2xpcGJvYXJk\u0007line1\n\t\u001b[31mline2\u001b[0m\u0000");
+
+		expect(rendered).toBe("line1 line2");
+	});
+});
+
+describe("buildFooterUsageSegments", () => {
+	it("formats token, cache, and subscription cost segments", () => {
+		const segments = buildFooterUsageSegments(
+			{
+				input: 1_234,
+				output: 2_000,
+				cacheRead: 3_000,
+				cacheWrite: 400,
+				latestCacheHitRate: 87.65,
+				cost: 0.1234,
+			},
+			true,
+		);
+
+		expect(segments).toEqual([
+			{ color: "dim", text: "↑1.2K" },
+			{ color: "dim", text: "↓2K" },
+			{ color: "dim", text: "cache 3K/400" },
+			{ color: "dim", text: "CH87.7%" },
+			{ color: "success", text: "$0.123 (sub)" },
+		]);
+	});
+});


### PR DESCRIPTION
Part of #467

## Summary

- add a public-API-only responsive two-line footer extension example
- head-elide long paths before dropping session metadata, preserving identifying path tails and the right-aligned model
- preserve host-provided built-in anchor indicators under the same condition as the default footer
- keep the built-in agent-context counter with left-side metrics while reserving other extension statuses at the right edge
- use the default footer's bullet separator instead of pipe separators
- sanitize terminal labels and preserve CJK-aware width handling

## Verification

- `npm run check`
- `npm test --workspace=@code-yeongyu/senpi -- test/examples/two-line-footer.test.ts` — 17/17 passed
- fresh installed-Senpi PTY QA at 120 columns with short and long path states
- long-path capture remained two lines, retained session metadata, and ended both model and quota status at xterm cell 120
- independent TUI evidence review — PASS

## Baseline note

The full Windows workspace suite still hits unchanged platform-specific failures/hangs in script path-regex and Ollama `grep` tests; the focused suite and all repository checks pass.