### PR TITLE
feat(coding-agent): add OpenAI Codex usage example

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,12 @@
 # Local fork changes
 
+## 2026-07-29 — OpenAI Codex usage extension example
+
+- Changed: added a standalone `examples/extensions/openai-codex-usage/` example that resolves Senpi-managed Codex OAuth, fetches the remaining five-hour and weekly limits, and publishes them through `ctx.ui.setStatus()`. The poller is single-flight, abortable, and cleared on model changes, shutdown, or `/usage`.
+- Why: users can see provider limits with the built-in footer or any custom footer that consumes extension statuses, without coupling usage retrieval to one footer implementation.
+- Extension boundary: the example uses public model-registry, lifecycle, command, and status APIs; no core footer or authentication source changes are required.
+- Merge-conflict risk: low. The change adds an isolated example directory, one test, one catalog row, documentation, and this record.
+
 ## 2026-07-28 — Billing-class provider errors always pin the session model swap
 
 - Changed: billing-class failures (credit balance, insufficient quota) engage the fallback chain with the pinned `"billing"` reason unconditionally — the candidate becomes the session model for the rest of the session and never auto-reverts. Files: `src/core/retry-fallback/billing.ts` (classifier), `src/core/retry-fallback/controller.ts` (billing reason pins and notes the cooldown), `src/core/agent-session.ts` (classifies hard-error-eligible failures). Non-billing hard errors keep the temporary, revertable switch. Supersedes the opt-in `retry.billingErrorPolicy` variant of the same change; the setting no longer exists.

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -2,9 +2,9 @@
 
 ## 2026-07-29 — OpenAI Codex usage extension example
 
-- Changed: added a standalone `examples/extensions/openai-codex-usage/` example that resolves Senpi-managed Codex OAuth, fetches the remaining five-hour and weekly limits, and publishes them through `ctx.ui.setStatus()`. The poller is single-flight, abortable, and cleared on model changes, shutdown, or `/usage`.
-- Why: users can see provider limits with the built-in footer or any custom footer that consumes extension statuses, without coupling usage retrieval to one footer implementation.
-- Extension boundary: the example uses public model-registry, lifecycle, command, and status APIs; no core footer or authentication source changes are required.
+- Changed: added a standalone `examples/extensions/openai-codex-usage/` example that resolves Senpi-managed Codex OAuth, fetches the remaining five-hour and weekly limits, and publishes them through `ctx.ui.setStatus()`. Missing windows render as unavailable; sanitized HTTP/network/parse failures replace stale values with an unavailable status. The poller is single-flight, abortable, and cleared on model changes, shutdown, or `/usage`.
+- Why: users can see provider limits with the built-in footer or any custom footer that consumes extension statuses, without coupling usage retrieval to one footer implementation or presenting unknown/stale percentages as current.
+- Extension boundary: the example uses public model-registry, lifecycle, command, and status APIs; no core footer or authentication source changes are required. Deterministic fake-API and fake-timer tests cover toggle, model-change, abort, scheduled polling, and shutdown cleanup.
 - Merge-conflict risk: low. The change adds an isolated example directory, one test, one catalog row, documentation, and this record.
 
 ## 2026-07-28 — Billing-class provider errors always pin the session model swap

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -53,6 +53,7 @@ cp permission-gate.ts ~/.senpi/agent/extensions/
 | `handoff.ts` | Transfer context to a new focused session via `/handoff <goal>` |
 | `qna.ts` | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors |
+| `openai-codex-usage/` | Shows OpenAI Codex rate-limit usage through `ctx.ui.setStatus()` |
 | `github-issue-autocomplete.ts` | Adds `#1234` issue completions by stacking a custom autocomplete provider that preloads open issues from `gh issue list` |
 | `widget-placement.ts` | Shows widgets above and below the editor via `ctx.ui.setWidget()` placement |
 | `hidden-thinking-label.ts` | Customizes the collapsed thinking label via `ctx.ui.setHiddenThinkingLabel()` |

--- a/packages/coding-agent/examples/extensions/openai-codex-usage/README.md
+++ b/packages/coding-agent/examples/extensions/openai-codex-usage/README.md
@@ -1,11 +1,12 @@
 # OpenAI Codex usage status
 
-This extension publishes the remaining five-hour and weekly OpenAI Codex limits through `ctx.ui.setStatus()`. It works with Senpi's built-in footer and any custom footer that renders extension statuses.
+This extension publishes the remaining five-hour and weekly OpenAI Codex limits through `ctx.ui.setStatus()`. Missing windows are shown as unavailable. It works with Senpi's built-in footer and any custom footer that renders extension statuses.
 
 The extension is best-effort:
 
 - It uses ChatGPT's internal `https://chatgpt.com/backend-api/wham/usage` endpoint, which is not a public API and may change or disappear.
 - It runs only for an `openai-codex` model using OAuth credentials with a ChatGPT account ID.
-- It refreshes immediately and once per minute while enabled.
+- It refreshes immediately and attempts another refresh once per minute while enabled; single-flight polling skips ticks while a refresh is still active.
+- It replaces stale percentages with an unavailable status when a refresh fails.
 - It sends the resolved OAuth bearer token and ChatGPT account ID only to `https://chatgpt.com`; redirects are rejected.
 - `/usage` toggles publication without changing the active footer.

--- a/packages/coding-agent/examples/extensions/openai-codex-usage/README.md
+++ b/packages/coding-agent/examples/extensions/openai-codex-usage/README.md
@@ -1,0 +1,11 @@
+# OpenAI Codex usage status
+
+This extension publishes the remaining five-hour and weekly OpenAI Codex limits through `ctx.ui.setStatus()`. It works with Senpi's built-in footer and any custom footer that renders extension statuses.
+
+The extension is best-effort:
+
+- It uses ChatGPT's internal `https://chatgpt.com/backend-api/wham/usage` endpoint, which is not a public API and may change or disappear.
+- It runs only for an `openai-codex` model using OAuth credentials with a ChatGPT account ID.
+- It refreshes immediately and once per minute while enabled.
+- It sends the resolved OAuth bearer token and ChatGPT account ID only to `https://chatgpt.com`; redirects are rejected.
+- `/usage` toggles publication without changing the active footer.

--- a/packages/coding-agent/examples/extensions/openai-codex-usage/codex-usage.ts
+++ b/packages/coding-agent/examples/extensions/openai-codex-usage/codex-usage.ts
@@ -1,0 +1,151 @@
+const FIVE_HOURS_SECONDS = 18_000;
+const WEEK_SECONDS = 604_800;
+const USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface CodexUsage {
+	readonly fiveHourRemainingPercent: number;
+	readonly weeklyRemainingPercent: number;
+}
+
+interface UsageResponse {
+	readonly ok: boolean;
+	json(): Promise<unknown>;
+}
+
+interface UsageRequestInit {
+	readonly headers: Readonly<Record<string, string>>;
+	readonly redirect: "error";
+	readonly signal: AbortSignal;
+}
+
+export interface CodexUsageRequestOptions {
+	readonly credentials: {
+		readonly accessToken: string;
+		readonly accountId: string | undefined;
+	};
+	readonly request?: (input: string, init: UsageRequestInit) => Promise<UsageResponse>;
+	readonly signal?: AbortSignal;
+}
+
+export interface CodexUsagePollingOptions {
+	readonly active: () => boolean;
+	readonly load: (signal: AbortSignal) => Promise<CodexUsage | null>;
+	readonly onUsage: (usage: CodexUsage | null) => void;
+	readonly onError: (error: unknown) => void;
+}
+
+export interface CodexUsagePollingController {
+	refresh(): Promise<void>;
+	stop(): void;
+}
+
+function property(value: unknown, key: string): unknown {
+	return typeof value === "object" && value !== null ? Reflect.get(value, key) : undefined;
+}
+
+function remainingPercent(value: unknown): number | undefined {
+	const usedPercent = property(value, "used_percent");
+	return typeof usedPercent === "number" && Number.isFinite(usedPercent)
+		? Math.round(100 - Math.max(0, Math.min(100, usedPercent)))
+		: undefined;
+}
+
+export function parseCodexUsage(value: unknown): CodexUsage | null {
+	const rateLimit = property(value, "rate_limit");
+	const windows = [property(rateLimit, "primary_window"), property(rateLimit, "secondary_window")];
+	let fiveHourRemainingPercent: number | undefined;
+	let weeklyRemainingPercent: number | undefined;
+
+	for (const window of windows) {
+		const duration = property(window, "limit_window_seconds");
+		const remaining = remainingPercent(window);
+		if (remaining === undefined) continue;
+		if (duration === FIVE_HOURS_SECONDS) {
+			fiveHourRemainingPercent = remaining;
+		}
+		if (duration === WEEK_SECONDS) {
+			weeklyRemainingPercent = remaining;
+		}
+	}
+
+	if (fiveHourRemainingPercent === undefined && weeklyRemainingPercent === undefined) {
+		return null;
+	}
+
+	return {
+		fiveHourRemainingPercent: fiveHourRemainingPercent ?? 100,
+		weeklyRemainingPercent: weeklyRemainingPercent ?? 100,
+	};
+}
+
+export function formatCodexUsage(usage: CodexUsage): string {
+	return `5h ${usage.fiveHourRemainingPercent}% | W ${usage.weeklyRemainingPercent}%`;
+}
+
+export function codexUsageStatusText(
+	provider: string | undefined,
+	usage: CodexUsage | null,
+	visible: boolean,
+): string | undefined {
+	return visible && provider === "openai-codex" && usage ? formatCodexUsage(usage) : undefined;
+}
+
+export async function fetchCodexUsage(options: CodexUsageRequestOptions): Promise<CodexUsage | null> {
+	const request = options.request ?? ((input: string, init: UsageRequestInit) => fetch(input, init));
+	const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+	const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+	const response = await request(USAGE_ENDPOINT, {
+		headers: {
+			Authorization: `Bearer ${options.credentials.accessToken}`,
+			...(options.credentials.accountId ? { "ChatGPT-Account-Id": options.credentials.accountId } : {}),
+		},
+		redirect: "error",
+		signal,
+	});
+	return response.ok ? parseCodexUsage(await response.json()) : null;
+}
+
+export function startCodexUsagePolling(options: CodexUsagePollingOptions): CodexUsagePollingController {
+	let errorReported = false;
+	let refreshing = false;
+	let stopped = false;
+	let activeController: AbortController | undefined;
+	const refresh = async (): Promise<void> => {
+		if (stopped || refreshing) return;
+		if (!options.active()) {
+			options.onUsage(null);
+			return;
+		}
+		refreshing = true;
+		const controller = new AbortController();
+		activeController = controller;
+		try {
+			const usage = await options.load(controller.signal);
+			if (stopped || controller.signal.aborted) return;
+			options.onUsage(usage);
+			errorReported = false;
+		} catch (error) {
+			if (!stopped && !controller.signal.aborted && !errorReported) {
+				options.onError(error);
+				errorReported = true;
+			}
+		} finally {
+			if (activeController === controller) {
+				activeController = undefined;
+			}
+			refreshing = false;
+		}
+	};
+	void refresh();
+	const timer = setInterval(() => void refresh(), 60_000);
+	return {
+		refresh,
+		stop: () => {
+			stopped = true;
+			activeController?.abort();
+			activeController = undefined;
+			clearInterval(timer);
+		},
+	};
+}

--- a/packages/coding-agent/examples/extensions/openai-codex-usage/codex-usage.ts
+++ b/packages/coding-agent/examples/extensions/openai-codex-usage/codex-usage.ts
@@ -4,12 +4,13 @@ const USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
 const REQUEST_TIMEOUT_MS = 10_000;
 
 export interface CodexUsage {
-	readonly fiveHourRemainingPercent: number;
-	readonly weeklyRemainingPercent: number;
+	readonly fiveHourRemainingPercent: number | undefined;
+	readonly weeklyRemainingPercent: number | undefined;
 }
 
 interface UsageResponse {
 	readonly ok: boolean;
+	readonly status: number;
 	json(): Promise<unknown>;
 }
 
@@ -69,18 +70,22 @@ export function parseCodexUsage(value: unknown): CodexUsage | null {
 		}
 	}
 
-	if (fiveHourRemainingPercent === undefined && weeklyRemainingPercent === undefined) {
+	if (typeof rateLimit !== "object" || rateLimit === null) {
 		return null;
 	}
 
 	return {
-		fiveHourRemainingPercent: fiveHourRemainingPercent ?? 100,
-		weeklyRemainingPercent: weeklyRemainingPercent ?? 100,
+		fiveHourRemainingPercent,
+		weeklyRemainingPercent,
 	};
 }
 
+function formatRemainingPercent(value: number | undefined): string {
+	return value === undefined ? "unavailable" : `${value}%`;
+}
+
 export function formatCodexUsage(usage: CodexUsage): string {
-	return `5h ${usage.fiveHourRemainingPercent}% | W ${usage.weeklyRemainingPercent}%`;
+	return `5h ${formatRemainingPercent(usage.fiveHourRemainingPercent)} | W ${formatRemainingPercent(usage.weeklyRemainingPercent)}`;
 }
 
 export function codexUsageStatusText(
@@ -103,7 +108,10 @@ export async function fetchCodexUsage(options: CodexUsageRequestOptions): Promis
 		redirect: "error",
 		signal,
 	});
-	return response.ok ? parseCodexUsage(await response.json()) : null;
+	if (!response.ok) {
+		throw new Error(`Codex usage endpoint returned HTTP ${response.status}`);
+	}
+	return parseCodexUsage(await response.json());
 }
 
 export function startCodexUsagePolling(options: CodexUsagePollingOptions): CodexUsagePollingController {

--- a/packages/coding-agent/examples/extensions/openai-codex-usage/index.ts
+++ b/packages/coding-agent/examples/extensions/openai-codex-usage/index.ts
@@ -1,0 +1,110 @@
+import type { ExtensionAPI, ExtensionContext } from "@code-yeongyu/senpi";
+import { extractOpenAiCodexAccountId } from "@earendil-works/pi-ai";
+
+import {
+	type CodexUsagePollingController,
+	codexUsageStatusText,
+	fetchCodexUsage,
+	startCodexUsagePolling,
+} from "./codex-usage.ts";
+
+const STATUS_KEY = "provider-usage";
+
+export function shouldLoadCodexUsage(provider: string | undefined, usingOAuth: boolean, hasUi: boolean): boolean {
+	return hasUi && provider === "openai-codex" && usingOAuth;
+}
+
+function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+	signal.throwIfAborted();
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => reject(signal.reason);
+		signal.addEventListener("abort", onAbort, { once: true });
+		operation.then(
+			(value) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
+export default function (pi: ExtensionAPI) {
+	let enabled = true;
+	let polling: CodexUsagePollingController | undefined;
+
+	const stop = (): void => {
+		polling?.stop();
+		polling = undefined;
+	};
+
+	const load = async (ctx: ExtensionContext, signal: AbortSignal) => {
+		const model = ctx.model;
+		if (!model || !shouldLoadCodexUsage(model.provider, ctx.modelRegistry.isUsingOAuth(model), ctx.hasUI)) {
+			return null;
+		}
+		const auth = await abortable(ctx.modelRegistry.getApiKeyAndHeaders(model), signal);
+		if (!auth.ok || !auth.apiKey) return null;
+		const accountId = extractOpenAiCodexAccountId(auth.apiKey);
+		if (!accountId) return null;
+		return fetchCodexUsage({
+			credentials: {
+				accessToken: auth.apiKey,
+				accountId,
+			},
+			signal,
+		});
+	};
+
+	const restart = (ctx: ExtensionContext): void => {
+		stop();
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (
+			!enabled ||
+			!ctx.model ||
+			!shouldLoadCodexUsage(ctx.model.provider, ctx.modelRegistry.isUsingOAuth(ctx.model), ctx.hasUI)
+		) {
+			return;
+		}
+		polling = startCodexUsagePolling({
+			active: () =>
+				enabled &&
+				Boolean(
+					ctx.model &&
+						shouldLoadCodexUsage(ctx.model.provider, ctx.modelRegistry.isUsingOAuth(ctx.model), ctx.hasUI),
+				),
+			load: (signal) => load(ctx, signal),
+			onUsage: (usage) => {
+				const status = codexUsageStatusText(ctx.model?.provider, usage, enabled);
+				ctx.ui.setStatus(STATUS_KEY, status ? ctx.ui.theme.fg("dim", status) : undefined);
+			},
+			onError: () => console.error("[openai-codex-usage] Refresh failed"),
+		});
+	};
+
+	pi.registerCommand("usage", {
+		description: "Toggle OpenAI Codex usage in the footer",
+		handler: async (_args, ctx) => {
+			enabled = !enabled;
+			restart(ctx);
+			ctx.ui.notify(`Provider usage: ${enabled ? "shown" : "hidden"}`, "info");
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		enabled = true;
+		restart(ctx);
+	});
+
+	pi.on("model_select", async (_event, ctx) => {
+		restart(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		stop();
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}

--- a/packages/coding-agent/examples/extensions/openai-codex-usage/index.ts
+++ b/packages/coding-agent/examples/extensions/openai-codex-usage/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./codex-usage.ts";
 
 const STATUS_KEY = "provider-usage";
+const UNAVAILABLE_STATUS = "Codex usage unavailable";
 
 export function shouldLoadCodexUsage(provider: string | undefined, usingOAuth: boolean, hasUi: boolean): boolean {
 	return hasUi && provider === "openai-codex" && usingOAuth;
@@ -81,7 +82,10 @@ export default function (pi: ExtensionAPI) {
 				const status = codexUsageStatusText(ctx.model?.provider, usage, enabled);
 				ctx.ui.setStatus(STATUS_KEY, status ? ctx.ui.theme.fg("dim", status) : undefined);
 			},
-			onError: () => console.error("[openai-codex-usage] Refresh failed"),
+			onError: () => {
+				ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", UNAVAILABLE_STATUS));
+				console.error("[openai-codex-usage] Refresh failed");
+			},
 		});
 	};
 

--- a/packages/coding-agent/test/examples/openai-codex-usage.test.ts
+++ b/packages/coding-agent/test/examples/openai-codex-usage.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	codexUsageStatusText,
+	fetchCodexUsage,
+	formatCodexUsage,
+	parseCodexUsage,
+	startCodexUsagePolling,
+} from "../../examples/extensions/openai-codex-usage/codex-usage.ts";
+import { shouldLoadCodexUsage } from "../../examples/extensions/openai-codex-usage/index.ts";
+
+describe("shouldLoadCodexUsage", () => {
+	it("requires UI, the Codex provider, and OAuth", () => {
+		expect(shouldLoadCodexUsage("openai-codex", true, true)).toBe(true);
+		expect(shouldLoadCodexUsage("openai-codex", false, true)).toBe(false);
+		expect(shouldLoadCodexUsage("openai-codex", true, false)).toBe(false);
+		expect(shouldLoadCodexUsage("anthropic", true, true)).toBe(false);
+	});
+});
+
+describe("parseCodexUsage", () => {
+	it("selects limits by window duration when slots are reversed", () => {
+		const usage = parseCodexUsage({
+			rate_limit: {
+				primary_window: {
+					used_percent: 25,
+					limit_window_seconds: 604_800,
+				},
+				secondary_window: {
+					used_percent: 40,
+					limit_window_seconds: 18_000,
+				},
+			},
+		});
+
+		expect(usage).toEqual({
+			fiveHourRemainingPercent: 60,
+			weeklyRemainingPercent: 75,
+		});
+	});
+
+	it("treats an absent five-hour cap as fully available", () => {
+		const usage = parseCodexUsage({
+			rate_limit: {
+				primary_window: null,
+				secondary_window: {
+					used_percent: 9,
+					limit_window_seconds: 604_800,
+				},
+			},
+		});
+
+		expect(usage).toEqual({
+			fiveHourRemainingPercent: 100,
+			weeklyRemainingPercent: 91,
+		});
+	});
+
+	it("rejects a response without a recognized Codex window", () => {
+		const usage = parseCodexUsage({
+			rate_limit: {
+				primary_window: {
+					used_percent: 25,
+					limit_window_seconds: 3_600,
+				},
+			},
+		});
+
+		expect(usage).toBeNull();
+	});
+});
+
+describe("formatCodexUsage", () => {
+	it("renders compact five-hour and weekly labels", () => {
+		const rendered = formatCodexUsage({
+			fiveHourRemainingPercent: 83,
+			weeklyRemainingPercent: 57,
+		});
+
+		expect(rendered).toBe("5h 83% | W 57%");
+	});
+});
+
+describe("codexUsageStatusText", () => {
+	it("renders Codex limits when visibility is enabled", () => {
+		const rendered = codexUsageStatusText(
+			"openai-codex",
+			{
+				fiveHourRemainingPercent: 88,
+				weeklyRemainingPercent: 66,
+			},
+			true,
+		);
+
+		expect(rendered).toBe("5h 88% | W 66%");
+	});
+
+	it("hides limits when visibility is disabled", () => {
+		const rendered = codexUsageStatusText(
+			"openai-codex",
+			{
+				fiveHourRemainingPercent: 88,
+				weeklyRemainingPercent: 66,
+			},
+			false,
+		);
+
+		expect(rendered).toBeUndefined();
+	});
+
+	it("hides limits for another provider", () => {
+		const rendered = codexUsageStatusText(
+			"anthropic",
+			{
+				fiveHourRemainingPercent: 88,
+				weeklyRemainingPercent: 66,
+			},
+			true,
+		);
+
+		expect(rendered).toBeUndefined();
+	});
+});
+
+describe("fetchCodexUsage", () => {
+	it("uses resolved Senpi OAuth credentials", async () => {
+		let requestedUrl = "";
+		let requestedHeaders: Headers | undefined;
+		let requestedRedirect: "error" | undefined;
+
+		const usage = await fetchCodexUsage({
+			credentials: {
+				accessToken: "test-access",
+				accountId: "test-account",
+			},
+			request: async (input, init) => {
+				requestedUrl = input;
+				requestedHeaders = new Headers(init.headers);
+				requestedRedirect = init.redirect;
+				return Response.json({
+					rate_limit: {
+						primary_window: {
+							used_percent: 12,
+							limit_window_seconds: 18_000,
+						},
+						secondary_window: {
+							used_percent: 34,
+							limit_window_seconds: 604_800,
+						},
+					},
+				});
+			},
+		});
+
+		expect({
+			usage,
+			requestedUrl,
+			authorization: requestedHeaders?.get("Authorization"),
+			accountId: requestedHeaders?.get("ChatGPT-Account-Id"),
+			redirect: requestedRedirect,
+		}).toEqual({
+			usage: {
+				fiveHourRemainingPercent: 88,
+				weeklyRemainingPercent: 66,
+			},
+			requestedUrl: "https://chatgpt.com/backend-api/wham/usage",
+			authorization: "Bearer test-access",
+			accountId: "test-account",
+			redirect: "error",
+		});
+	});
+
+	it("forwards cancellation into the HTTP request", async () => {
+		const controller = new AbortController();
+		const requestStarted = Promise.withResolvers<void>();
+		let requestSignal: AbortSignal | undefined;
+		const request = fetchCodexUsage({
+			credentials: {
+				accessToken: "test-access",
+				accountId: "test-account",
+			},
+			signal: controller.signal,
+			request: async (_input, init) => {
+				requestSignal = init.signal;
+				requestStarted.resolve();
+				await new Promise<never>((_resolve, reject) => {
+					init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+				});
+				return Response.json({});
+			},
+		});
+
+		await requestStarted.promise;
+		controller.abort();
+
+		await expect(request).rejects.toBeDefined();
+		expect(requestSignal?.aborted).toBe(true);
+	});
+});
+
+describe("startCodexUsagePolling", () => {
+	it("publishes initial usage without waiting for an interval", async () => {
+		const expected = {
+			fiveHourRemainingPercent: 88,
+			weeklyRemainingPercent: 66,
+		};
+		const observed = Promise.withResolvers<typeof expected | null>();
+		const timeout = AbortSignal.timeout(1_000);
+		const timedOut = new Promise<never>((_resolve, reject) => {
+			timeout.addEventListener("abort", () => reject(new Error("usage polling did not publish")), { once: true });
+		});
+
+		const polling = startCodexUsagePolling({
+			active: () => true,
+			load: async () => expected,
+			onUsage: observed.resolve,
+			onError: observed.reject,
+		});
+
+		try {
+			expect(await Promise.race([observed.promise, timedOut])).toEqual(expected);
+		} finally {
+			polling.stop();
+		}
+	});
+
+	it("aborts an in-flight load without reporting an error after stop", async () => {
+		const started = Promise.withResolvers<AbortSignal>();
+		const finished = Promise.withResolvers<void>();
+		const errors: unknown[] = [];
+		const usages: unknown[] = [];
+		const polling = startCodexUsagePolling({
+			active: () => true,
+			load: async (signal) => {
+				started.resolve(signal);
+				try {
+					await new Promise<never>((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), {
+							once: true,
+						});
+					});
+				} finally {
+					finished.resolve();
+				}
+				return null;
+			},
+			onUsage: (usage) => usages.push(usage),
+			onError: (error) => errors.push(error),
+		});
+
+		const signal = await started.promise;
+		polling.stop();
+		await finished.promise;
+
+		expect(signal.aborted).toBe(true);
+		expect(errors).toEqual([]);
+		expect(usages).toEqual([]);
+	});
+
+	it("does not overlap manual and scheduled refreshes", async () => {
+		const expected = {
+			fiveHourRemainingPercent: 88,
+			weeklyRemainingPercent: 66,
+		};
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const observed = Promise.withResolvers<typeof expected | null>();
+		let loadCalls = 0;
+		const polling = startCodexUsagePolling({
+			active: () => true,
+			load: async () => {
+				loadCalls += 1;
+				started.resolve();
+				await release.promise;
+				return expected;
+			},
+			onUsage: observed.resolve,
+			onError: observed.reject,
+		});
+
+		await started.promise;
+		await polling.refresh();
+		expect(loadCalls).toBe(1);
+		release.resolve();
+		expect(await observed.promise).toEqual(expected);
+		polling.stop();
+	});
+});

--- a/packages/coding-agent/test/examples/openai-codex-usage.test.ts
+++ b/packages/coding-agent/test/examples/openai-codex-usage.test.ts
@@ -1,13 +1,160 @@
-import { describe, expect, it } from "vitest";
+import { Buffer } from "node:buffer";
+import type { ExtensionAPI, ExtensionContext } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+	type CodexUsage,
 	codexUsageStatusText,
 	fetchCodexUsage,
 	formatCodexUsage,
 	parseCodexUsage,
 	startCodexUsagePolling,
 } from "../../examples/extensions/openai-codex-usage/codex-usage.ts";
-import { shouldLoadCodexUsage } from "../../examples/extensions/openai-codex-usage/index.ts";
+import codexUsageExtension, { shouldLoadCodexUsage } from "../../examples/extensions/openai-codex-usage/index.ts";
+
+type CommandHandler = (args: string, ctx: ExtensionContext) => Promise<void> | void;
+type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+type LifecycleEventName = "session_start" | "model_select" | "session_shutdown";
+
+type Deferred<T> = ReturnType<typeof Promise.withResolvers<T>>;
+
+const STATUS_KEY = "provider-usage";
+const UNAVAILABLE_STATUS = "Codex usage unavailable";
+const TEST_ACCOUNT_ID = "test-account";
+const TEST_ACCESS_TOKEN = `header.${Buffer.from(
+	JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: TEST_ACCOUNT_ID } }),
+).toString("base64url")}.signature`;
+
+function createModel(id: string, provider = "openai-codex"): NonNullable<ExtensionContext["model"]> {
+	return { id, provider } as NonNullable<ExtensionContext["model"]>;
+}
+
+function usageResponse(): Response {
+	return Response.json({
+		rate_limit: {
+			primary_window: {
+				used_percent: 12,
+				limit_window_seconds: 18_000,
+			},
+			secondary_window: {
+				used_percent: 34,
+				limit_window_seconds: 604_800,
+			},
+		},
+	});
+}
+
+function createExtensionHarness() {
+	const commands = new Map<string, CommandHandler>();
+	const handlers = new Map<string, EventHandler>();
+	const statusHistory: Array<{ key: string; text: string | undefined }> = [];
+	const statusWaiters = new Set<{
+		key: string;
+		text: string | undefined;
+		resolve: () => void;
+	}>();
+	const setStatus = vi.fn((key: string, text: string | undefined) => {
+		statusHistory.push({ key, text });
+		for (const waiter of [...statusWaiters]) {
+			if (waiter.key !== key || waiter.text !== text) continue;
+			statusWaiters.delete(waiter);
+			waiter.resolve();
+		}
+	});
+	const notify = vi.fn();
+	const isUsingOAuth = vi.fn(
+		(model: Parameters<ExtensionContext["modelRegistry"]["isUsingOAuth"]>[0]) => model.provider === "openai-codex",
+	);
+	const getApiKeyAndHeaders = vi.fn<ExtensionContext["modelRegistry"]["getApiKeyAndHeaders"]>(async () => ({
+		ok: true,
+		apiKey: TEST_ACCESS_TOKEN,
+	}));
+	const context = {
+		hasUI: true,
+		model: createModel("codex-1"),
+		modelRegistry: {
+			isUsingOAuth,
+			getApiKeyAndHeaders,
+		},
+		ui: {
+			setStatus,
+			notify,
+			theme: {
+				fg: (_color: string, text: string) => text,
+			},
+		},
+	} as unknown as ExtensionContext;
+	const api = {
+		registerCommand(name: string, definition: { handler: CommandHandler }) {
+			commands.set(name, definition.handler);
+		},
+		on(eventName: string, handler: unknown) {
+			handlers.set(eventName, handler as EventHandler);
+		},
+	} as unknown as ExtensionAPI;
+
+	codexUsageExtension(api);
+
+	return {
+		context,
+		getApiKeyAndHeaders,
+		notify,
+		setStatus,
+		statusHistory,
+		waitForStatus(key: string, text: string | undefined): Promise<void> {
+			const deferred = Promise.withResolvers<void>();
+			statusWaiters.add({ key, text, resolve: deferred.resolve });
+			return deferred.promise;
+		},
+		async emit(eventName: LifecycleEventName): Promise<void> {
+			const handler = handlers.get(eventName);
+			if (!handler) throw new Error(`Missing ${eventName} handler`);
+			const event =
+				eventName === "session_start"
+					? { type: eventName, reason: "startup" }
+					: eventName === "session_shutdown"
+						? { type: eventName, reason: "quit" }
+						: { type: eventName };
+			await handler(event, context);
+		},
+		async runUsageCommand(): Promise<void> {
+			const handler = commands.get("usage");
+			if (!handler) throw new Error("Missing usage command");
+			await handler("", context);
+		},
+	};
+}
+
+function pendingFetch(started: Deferred<AbortSignal>, aborted: Deferred<void>): typeof fetch {
+	return async (_input, init) => {
+		const signal = init?.signal;
+		if (!(signal instanceof AbortSignal)) throw new Error("Expected an AbortSignal");
+		started.resolve(signal);
+		return await new Promise<Response>((_resolve, reject) => {
+			const onAbort = () => {
+				aborted.resolve();
+				reject(signal.reason);
+			};
+			if (signal.aborted) {
+				onAbort();
+				return;
+			}
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+	};
+}
+
+const refreshFailures: Array<[string, () => Promise<Response>]> = [
+	["network or redirect rejection", async () => Promise.reject(new TypeError("fetch failed"))],
+	["timeout", async () => Promise.reject(new DOMException("timed out", "TimeoutError"))],
+	["invalid JSON", async () => new Response("{", { status: 200 })],
+];
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
 
 describe("shouldLoadCodexUsage", () => {
 	it("requires UI, the Codex provider, and OAuth", () => {
@@ -39,7 +186,7 @@ describe("parseCodexUsage", () => {
 		});
 	});
 
-	it("treats an absent five-hour cap as fully available", () => {
+	it("preserves an absent five-hour cap as unavailable", () => {
 		const usage = parseCodexUsage({
 			rate_limit: {
 				primary_window: null,
@@ -51,12 +198,13 @@ describe("parseCodexUsage", () => {
 		});
 
 		expect(usage).toEqual({
-			fiveHourRemainingPercent: 100,
+			fiveHourRemainingPercent: undefined,
 			weeklyRemainingPercent: 91,
 		});
+		expect(usage && formatCodexUsage(usage)).toBe("5h unavailable | W 91%");
 	});
 
-	it("rejects a response without a recognized Codex window", () => {
+	it("renders unavailable when the rate-limit object has no recognized window", () => {
 		const usage = parseCodexUsage({
 			rate_limit: {
 				primary_window: {
@@ -66,7 +214,15 @@ describe("parseCodexUsage", () => {
 			},
 		});
 
-		expect(usage).toBeNull();
+		expect(usage).toEqual({
+			fiveHourRemainingPercent: undefined,
+			weeklyRemainingPercent: undefined,
+		});
+		expect(usage && formatCodexUsage(usage)).toBe("5h unavailable | W unavailable");
+	});
+
+	it("rejects a response without a rate-limit object", () => {
+		expect(parseCodexUsage({ plan_type: "plus" })).toBeNull();
 	});
 });
 
@@ -131,24 +287,13 @@ describe("fetchCodexUsage", () => {
 		const usage = await fetchCodexUsage({
 			credentials: {
 				accessToken: "test-access",
-				accountId: "test-account",
+				accountId: TEST_ACCOUNT_ID,
 			},
 			request: async (input, init) => {
 				requestedUrl = input;
 				requestedHeaders = new Headers(init.headers);
 				requestedRedirect = init.redirect;
-				return Response.json({
-					rate_limit: {
-						primary_window: {
-							used_percent: 12,
-							limit_window_seconds: 18_000,
-						},
-						secondary_window: {
-							used_percent: 34,
-							limit_window_seconds: 604_800,
-						},
-					},
-				});
+				return usageResponse();
 			},
 		});
 
@@ -165,9 +310,24 @@ describe("fetchCodexUsage", () => {
 			},
 			requestedUrl: "https://chatgpt.com/backend-api/wham/usage",
 			authorization: "Bearer test-access",
-			accountId: "test-account",
+			accountId: TEST_ACCOUNT_ID,
 			redirect: "error",
 		});
+	});
+
+	it.each([401, 429, 500])("rejects HTTP %i without reading the response body", async (status) => {
+		const json = vi.fn(async () => ({ error: "sensitive body" }));
+
+		await expect(
+			fetchCodexUsage({
+				credentials: {
+					accessToken: "test-access",
+					accountId: TEST_ACCOUNT_ID,
+				},
+				request: async () => ({ ok: false, status, json }),
+			}),
+		).rejects.toThrow(`Codex usage endpoint returned HTTP ${status}`);
+		expect(json).not.toHaveBeenCalled();
 	});
 
 	it("forwards cancellation into the HTTP request", async () => {
@@ -177,7 +337,7 @@ describe("fetchCodexUsage", () => {
 		const request = fetchCodexUsage({
 			credentials: {
 				accessToken: "test-access",
-				accountId: "test-account",
+				accountId: TEST_ACCOUNT_ID,
 			},
 			signal: controller.signal,
 			request: async (_input, init) => {
@@ -204,7 +364,7 @@ describe("startCodexUsagePolling", () => {
 			fiveHourRemainingPercent: 88,
 			weeklyRemainingPercent: 66,
 		};
-		const observed = Promise.withResolvers<typeof expected | null>();
+		const observed = Promise.withResolvers<CodexUsage | null>();
 		const timeout = AbortSignal.timeout(1_000);
 		const timedOut = new Promise<never>((_resolve, reject) => {
 			timeout.addEventListener("abort", () => reject(new Error("usage polling did not publish")), { once: true });
@@ -257,14 +417,15 @@ describe("startCodexUsagePolling", () => {
 		expect(usages).toEqual([]);
 	});
 
-	it("does not overlap manual and scheduled refreshes", async () => {
+	it("does not overlap scheduled refreshes and clears the interval on stop", async () => {
+		vi.useFakeTimers();
 		const expected = {
 			fiveHourRemainingPercent: 88,
 			weeklyRemainingPercent: 66,
 		};
 		const started = Promise.withResolvers<void>();
 		const release = Promise.withResolvers<void>();
-		const observed = Promise.withResolvers<typeof expected | null>();
+		const observed = Promise.withResolvers<CodexUsage | null>();
 		let loadCalls = 0;
 		const polling = startCodexUsagePolling({
 			active: () => true,
@@ -278,11 +439,118 @@ describe("startCodexUsagePolling", () => {
 			onError: observed.reject,
 		});
 
-		await started.promise;
-		await polling.refresh();
-		expect(loadCalls).toBe(1);
-		release.resolve();
-		expect(await observed.promise).toEqual(expected);
-		polling.stop();
+		try {
+			await started.promise;
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(loadCalls).toBe(1);
+
+			release.resolve();
+			expect(await observed.promise).toEqual(expected);
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(loadCalls).toBe(2);
+
+			polling.stop();
+			await vi.advanceTimersByTimeAsync(180_000);
+			expect(loadCalls).toBe(2);
+		} finally {
+			polling.stop();
+		}
+	});
+});
+
+describe("openai-codex-usage extension lifecycle", () => {
+	it.each(refreshFailures)("replaces prior usage with unavailable after %s", async (_label, failRefresh) => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<typeof fetch>();
+		fetchMock.mockResolvedValueOnce(usageResponse()).mockImplementationOnce(failRefresh);
+		vi.stubGlobal("fetch", fetchMock);
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const harness = createExtensionHarness();
+
+		try {
+			const published = harness.waitForStatus(STATUS_KEY, "5h 88% | W 66%");
+			await harness.emit("session_start");
+			await published;
+
+			const unavailable = harness.waitForStatus(STATUS_KEY, UNAVAILABLE_STATUS);
+			await vi.advanceTimersByTimeAsync(60_000);
+			await unavailable;
+
+			expect(harness.statusHistory.at(-1)).toEqual({ key: STATUS_KEY, text: UNAVAILABLE_STATUS });
+			expect(consoleError).toHaveBeenCalledWith("[openai-codex-usage] Refresh failed");
+		} finally {
+			await harness.emit("session_shutdown");
+		}
+	});
+
+	it("toggles polling and publication through /usage", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => usageResponse());
+		vi.stubGlobal("fetch", fetchMock);
+		const harness = createExtensionHarness();
+
+		try {
+			const initiallyPublished = harness.waitForStatus(STATUS_KEY, "5h 88% | W 66%");
+			await harness.emit("session_start");
+			await initiallyPublished;
+			expect(harness.getApiKeyAndHeaders).toHaveBeenCalledTimes(1);
+
+			const cleared = harness.waitForStatus(STATUS_KEY, undefined);
+			await harness.runUsageCommand();
+			await cleared;
+			expect(harness.notify).toHaveBeenLastCalledWith("Provider usage: hidden", "info");
+			const callsWhileHidden = fetchMock.mock.calls.length;
+			await vi.advanceTimersByTimeAsync(180_000);
+			expect(fetchMock).toHaveBeenCalledTimes(callsWhileHidden);
+
+			const republished = harness.waitForStatus(STATUS_KEY, "5h 88% | W 66%");
+			await harness.runUsageCommand();
+			await republished;
+			expect(harness.notify).toHaveBeenLastCalledWith("Provider usage: shown", "info");
+			expect(fetchMock).toHaveBeenCalledTimes(callsWhileHidden + 1);
+		} finally {
+			await harness.emit("session_shutdown");
+		}
+	});
+
+	it("aborts and restarts on model change, then clears the timer on shutdown", async () => {
+		vi.useFakeTimers();
+		const firstStarted = Promise.withResolvers<AbortSignal>();
+		const firstAborted = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<AbortSignal>();
+		const secondAborted = Promise.withResolvers<void>();
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockImplementationOnce(pendingFetch(firstStarted, firstAborted))
+			.mockImplementationOnce(pendingFetch(secondStarted, secondAborted));
+		vi.stubGlobal("fetch", fetchMock);
+		const harness = createExtensionHarness();
+
+		try {
+			await harness.emit("session_start");
+			const firstSignal = await firstStarted.promise;
+
+			harness.context.model = createModel("codex-2");
+			const clearedForModel = harness.waitForStatus(STATUS_KEY, undefined);
+			await harness.emit("model_select");
+			await clearedForModel;
+			const secondSignal = await secondStarted.promise;
+			await firstAborted.promise;
+
+			expect(firstSignal.aborted).toBe(true);
+			expect(secondSignal.aborted).toBe(false);
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+
+			const clearedForShutdown = harness.waitForStatus(STATUS_KEY, undefined);
+			await harness.emit("session_shutdown");
+			await clearedForShutdown;
+			await secondAborted.promise;
+			expect(secondSignal.aborted).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(180_000);
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		} finally {
+			await harness.emit("session_shutdown");
+		}
 	});
 });


### PR DESCRIPTION
Part of #467

## Summary

- add a standalone OpenAI Codex usage extension that publishes through `ctx.ui.setStatus()`
- work with the built-in footer and any custom footer that renders extension statuses
- require Senpi-managed Codex OAuth plus a ChatGPT account ID; never read `auth.json` directly
- use single-flight, abortable polling with redirect rejection and `/usage` toggle cleanup
- document the internal best-effort ChatGPT usage endpoint and credential scope

## Verification

- `npm run check`
- `npm test --workspace=@code-yeongyu/senpi -- test/examples/openai-codex-usage.test.ts` — 13/13 passed
- installed-Senpi built-in-footer PTY QA — status rendered
- extension lifecycle driver — fetch, publish, toggle clear, and shutdown cleanup passed

## Baseline note

The full Windows workspace suite still hits unchanged platform-specific failures/hangs in script path-regex and Ollama `grep` tests; the focused suite and all repository checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone `openai-codex-usage` extension that shows remaining 5‑hour and weekly Codex limits in the footer via `ctx.ui.setStatus()`, with resilient polling and an "unavailable" fallback on errors. Supports Linear #467 by exposing provider usage without coupling to a specific footer.

- **New Features**
  - Works with the built‑in footer and any custom footer; toggle with `/usage`.
  - Only runs for `openai-codex` with Senpi OAuth; derives the ChatGPT account ID from the token; never reads `auth.json`.
  - Resilient polling: refreshes immediately, then every minute; single‑flight; 10s timeout; redirects rejected; aborts on model change and shutdown; network/HTTP/parse failures or missing windows publish "Codex usage unavailable".
  - Uses best‑effort `https://chatgpt.com/backend-api/wham/usage`; added as an isolated example with deterministic tests.

<sup>Written for commit f20232274f491a64c97cd57fac3892ee8be251e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

