### PR TITLE
fix(coding-agent): treat headers-only providers as configured

### DIFF
--- a/packages/ai/src/api/openai-client-auth.ts
+++ b/packages/ai/src/api/openai-client-auth.ts
@@ -1,0 +1,23 @@
+import { hasCredentialHeaders, hasHeader } from "../auth/headers.ts";
+import type { ProviderHeaders } from "../types.ts";
+
+export interface OpenAIClientAuth {
+	apiKey: string;
+	headers?: ProviderHeaders;
+}
+
+export function resolveOpenAIClientAuth(
+	provider: string,
+	apiKey: string | undefined,
+	headers: ProviderHeaders | undefined,
+): OpenAIClientAuth {
+	if (apiKey) return { apiKey, headers };
+	if (!hasCredentialHeaders(headers)) throw new Error(`No API key for provider: ${provider}`);
+	if (hasHeader(headers, "authorization") || hasHeader(headers, "cf-aig-authorization")) {
+		return { apiKey: "unused", headers };
+	}
+	return {
+		apiKey: "unused",
+		headers: { Authorization: null, ...headers },
+	};
+}

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -60,6 +60,7 @@ import {
 	resolveJsonSchemaStrictSampling,
 } from "./constrained-sampling.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
+import { resolveOpenAIClientAuth } from "./openai-client-auth.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import {
 	applyExtraBody,
@@ -196,21 +197,6 @@ function resolveReasoningEffort(
  * This is needed because Anthropic (via proxy) requires the tools param
  * to be present when messages include tool_calls or tool role messages.
  */
-function hasHeader(headers: ProviderHeaders | undefined, name: string): boolean {
-	if (!headers) return false;
-	const expected = name.toLowerCase();
-	for (const [key, value] of Object.entries(headers)) {
-		if (key.toLowerCase() === expected && value !== null && value.trim().length > 0) return true;
-	}
-	return false;
-}
-
-function getClientApiKey(provider: string, apiKey: string | undefined, headers: ProviderHeaders | undefined): string {
-	if (apiKey) return apiKey;
-	if (hasHeader(headers, "authorization") || hasHeader(headers, "cf-aig-authorization")) return "unused";
-	throw new Error(`No API key for provider: ${provider}`);
-}
-
 function hasToolHistory(messages: Message[]): boolean {
 	for (const msg of messages) {
 		if (msg.role === "toolResult") {
@@ -366,7 +352,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 		};
 
 		try {
-			const apiKey = getClientApiKey(model.provider, options?.apiKey, options?.headers);
+			const clientAuth = resolveOpenAIClientAuth(model.provider, options?.apiKey, options?.headers);
 			const compat = getCompat(model);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
 				context.tools,
@@ -374,7 +360,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention ?? model.cacheRetention, options?.env);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
+			const client = createClient(model, context, clientAuth.apiKey, clientAuth.headers, cacheSessionId, compat);
 			let params = buildParams(model, context, options, compat, cacheRetention, grammarToolInputProperties);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -778,7 +764,7 @@ export const streamSimple: StreamFunction<"openai-completions", SimpleStreamOpti
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream => {
-	getClientApiKey(model.provider, options?.apiKey, options?.headers);
+	resolveOpenAIClientAuth(model.provider, options?.apiKey, options?.headers);
 
 	const base = buildBaseOptions(model, context, options, options?.apiKey);
 	const compat = getCompat(model);

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -24,6 +24,7 @@ import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
+import { resolveOpenAIClientAuth } from "./openai-client-auth.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions, clampMaxForOpenAI, OPENAI_RESPONSES_RESERVED_BODY_KEYS } from "./simple-options.ts";
@@ -63,21 +64,6 @@ type MutableResponsesPayload = ResponseCreateParamsStreaming & {
 };
 
 const websocketSessionCache = new Map<string, CachedWebSocketConnection>();
-
-function hasHeader(headers: ProviderHeaders | undefined, name: string): boolean {
-	if (!headers) return false;
-	const expected = name.toLowerCase();
-	for (const [key, value] of Object.entries(headers)) {
-		if (key.toLowerCase() === expected && value !== null && value.trim().length > 0) return true;
-	}
-	return false;
-}
-
-function getClientApiKey(provider: string, apiKey: string | undefined, headers: ProviderHeaders | undefined): string {
-	if (apiKey) return apiKey;
-	if (hasHeader(headers, "authorization") || hasHeader(headers, "cf-aig-authorization")) return "unused";
-	throw new Error(`No API key for provider: ${provider}`);
-}
 
 function detectSessionAffinityFormat(model: Pick<Model<"openai-responses">, "provider" | "baseUrl">) {
 	return model.provider === "openrouter" || model.baseUrl.includes("openrouter.ai") ? "openrouter" : "openai";
@@ -226,7 +212,7 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 		};
 
 		try {
-			const apiKey = getClientApiKey(model.provider, options?.apiKey, options?.headers);
+			const clientAuth = resolveOpenAIClientAuth(model.provider, options?.apiKey, options?.headers);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
 			const compat = getCompat(model, options?.env);
@@ -234,7 +220,14 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 				context.tools,
 				compat.supportsOpenAIGrammarTools,
 			);
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, options?.env);
+			const client = createClient(
+				model,
+				context,
+				clientAuth.apiKey,
+				clientAuth.headers,
+				cacheSessionId,
+				options?.env,
+			);
 			let params = buildParams(model, context, options, compat, grammarToolInputProperties);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -249,7 +242,14 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 					await processWebSocketStream(
 						resolveOpenAIResponsesWebSocketUrl(model, options?.env),
 						params,
-						buildWebSocketHeaders(model, context, apiKey, options?.headers, cacheSessionId, options?.env),
+						buildWebSocketHeaders(
+							model,
+							context,
+							clientAuth.apiKey,
+							clientAuth.headers,
+							cacheSessionId,
+							options?.env,
+						),
 						output,
 						stream,
 						model,
@@ -329,7 +329,7 @@ export const streamSimple: StreamFunction<"openai-responses", SimpleStreamOption
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream => {
-	getClientApiKey(model.provider, options?.apiKey, options?.headers);
+	resolveOpenAIClientAuth(model.provider, options?.apiKey, options?.headers);
 
 	const base = buildBaseOptions(model, context, options, options?.apiKey);
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
@@ -797,6 +797,7 @@ function buildWebSocketHeaders(
 	env?: ProviderEnv,
 ): Headers {
 	const headers = new Headers(model.headers);
+	let suppressDefaultAuthorization = false;
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
 		const copilotHeaders = buildCopilotDynamicHeaders({ messages: context.messages, hasImages });
@@ -806,12 +807,13 @@ function buildWebSocketHeaders(
 	}
 	for (const [key, value] of Object.entries(optionsHeaders || {})) {
 		if (value === null) {
+			if (key.toLowerCase() === "authorization") suppressDefaultAuthorization = true;
 			headers.delete(key);
 		} else {
 			headers.set(key, value);
 		}
 	}
-	if (!headers.has("Authorization")) {
+	if (!suppressDefaultAuthorization && !headers.has("Authorization")) {
 		headers.set("Authorization", `Bearer ${apiKey}`);
 	}
 	if (sessionId) {

--- a/packages/ai/src/auth/headers.ts
+++ b/packages/ai/src/auth/headers.ts
@@ -1,0 +1,41 @@
+import type { ProviderHeaders } from "../types.ts";
+
+const CREDENTIAL_HEADER_SUFFIXES = [
+	"api-key",
+	"api-token",
+	"auth-token",
+	"access-token",
+	"authorization",
+	"client-secret",
+] as const;
+
+export function isCredentialHeaderName(name: string): boolean {
+	const normalized = name.toLowerCase();
+	return CREDENTIAL_HEADER_SUFFIXES.some((suffix) => normalized === suffix || normalized.endsWith(`-${suffix}`));
+}
+
+export function hasHeader(headers: ProviderHeaders | undefined, name: string): boolean {
+	if (!headers) return false;
+	const value = effectiveHeaders(headers).get(name.toLowerCase());
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+export function hasCredentialHeaders(headers: ProviderHeaders | undefined): boolean {
+	if (!headers) return false;
+	for (const [name, value] of effectiveHeaders(headers)) {
+		if (!isCredentialHeaderName(name) || typeof value !== "string") continue;
+		const normalized = value.trim();
+		if (!normalized) continue;
+		if (name.endsWith("authorization") && /^(?:basic|bearer)\s*$/i.test(normalized)) continue;
+		return true;
+	}
+	return false;
+}
+
+function effectiveHeaders(headers: ProviderHeaders): Map<string, string | null> {
+	const effective = new Map<string, string | null>();
+	for (const [name, value] of Object.entries(headers)) {
+		effective.set(name.toLowerCase(), value ?? null);
+	}
+	return effective;
+}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,33 @@
 # AI Source Changes
 
+## 2026-07-29 - Support static credential headers without a synthetic API key
+
+### What changed and why
+
+- `auth/headers.ts` defines the narrow, case-insensitive credential-header contract shared by auth discovery and
+  request adapters. Standard authorization, API-key, API-token, auth-token, access-token, and client-secret header
+  names count only when their effective value contains credential material; metadata such as `User-Agent`,
+  request ids, and trace tokens does not.
+- `api/openai-client-auth.ts` lets OpenAI-compatible adapters initialize from credential-bearing headers when
+  `ModelAuth.apiKey` is absent. Header-only clients suppress the SDK's default `Authorization: Bearer ...` header
+  unless an explicit Authorization or the existing Cloudflare AI Gateway authorization path owns that behavior.
+- `api/openai-completions.ts` and `api/openai-responses.ts` use the shared client-auth resolver for HTTP and
+  Responses WebSocket requests, so `x-api-key` and equivalent static credentials work without an invented bearer
+  token.
+
+### Coverage
+
+- `test/auth-headers.test.ts` covers recognized names, metadata rejection, case-insensitive overrides, and empty
+  authorization schemes.
+- `test/openai-header-auth.test.ts` exercises real OpenAI-compatible request construction for Completions and
+  Responses and proves metadata-only headers fail before any request is issued.
+
+### Expected merge conflict zones
+
+- LOW: additive auth/header helpers and root export.
+- MEDIUM: the duplicated OpenAI client-auth setup removed from `api/openai-completions.ts` and
+  `api/openai-responses.ts`.
+
 ## 2026-07-28 - Demote unavailable Anthropic tool references instead of failing the request
 
 ### What changed and why

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -21,6 +21,7 @@ export type { PiMessagesEvent, PiMessagesOptions, PiMessagesRewriteImpact } from
 export { getApiProvider } from "./api-registry.ts";
 export * from "./auth/context.ts";
 export * from "./auth/credential-store.ts";
+export * from "./auth/headers.ts";
 export * from "./auth/helpers.ts";
 export * from "./auth/types.ts";
 export type {

--- a/packages/ai/test/auth-headers.test.ts
+++ b/packages/ai/test/auth-headers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { hasCredentialHeaders, isCredentialHeaderName } from "../src/auth/headers.ts";
+
+describe("credential headers", () => {
+	it.each([
+		"Authorization",
+		"Proxy-Authorization",
+		"x-api-key",
+		"x-goog-api-key",
+		"anthropic-api-key",
+		"cf-aig-authorization",
+		"x-auth-token",
+		"x-access-token",
+		"cf-access-client-secret",
+	])("recognizes %s as credential-bearing", (name) => {
+		expect(isCredentialHeaderName(name)).toBe(true);
+		expect(hasCredentialHeaders({ [name]: "credential" })).toBe(true);
+	});
+
+	it.each([
+		"User-Agent",
+		"x-request-id",
+		"x-trace-token",
+		"content-type",
+	])("does not treat %s as credential-bearing", (name) => {
+		expect(isCredentialHeaderName(name)).toBe(false);
+		expect(hasCredentialHeaders({ [name]: "metadata" })).toBe(false);
+	});
+
+	it("uses the last case-insensitive value and rejects empty authorization schemes", () => {
+		expect(hasCredentialHeaders({ Authorization: "Bearer configured", authorization: "" })).toBe(false);
+		expect(hasCredentialHeaders({ Authorization: "Bearer " })).toBe(false);
+		expect(hasCredentialHeaders({ "x-api-key": "   " })).toBe(false);
+	});
+});

--- a/packages/ai/test/openai-header-auth.test.ts
+++ b/packages/ai/test/openai-header-auth.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamOpenAICompletions } from "../src/providers/openai-completions.ts";
+import { streamOpenAIResponses } from "../src/providers/openai-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: 0 }],
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("OpenAI-compatible static header auth", () => {
+	it("sends x-api-key without synthesizing bearer auth for chat completions", async () => {
+		let capturedHeaders: Headers | undefined;
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			capturedHeaders = new Headers(init?.headers);
+			return completionsResponse();
+		});
+
+		const result = await streamOpenAICompletions(completionsModel(), context, {
+			headers: { "x-api-key": "header-key" },
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(capturedHeaders?.get("x-api-key")).toBe("header-key");
+		expect(capturedHeaders?.has("authorization")).toBe(false);
+	});
+
+	it("sends x-api-key without synthesizing bearer auth for Responses", async () => {
+		let capturedHeaders: Headers | undefined;
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			capturedHeaders = new Headers(init?.headers);
+			return responsesResponse();
+		});
+
+		const result = await streamOpenAIResponses(responsesModel(), context, {
+			headers: { "x-api-key": "header-key" },
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(capturedHeaders?.get("x-api-key")).toBe("header-key");
+		expect(capturedHeaders?.has("authorization")).toBe(false);
+	});
+
+	it("rejects metadata-only headers before issuing a request", async () => {
+		const fetch = vi.spyOn(globalThis, "fetch");
+
+		const result = await streamOpenAICompletions(completionsModel(), context, {
+			headers: { "User-Agent": "senpi-test" },
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("No API key for provider");
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});
+
+function completionsModel(): Model<"openai-completions"> {
+	return {
+		id: "header-model",
+		name: "Header model",
+		api: "openai-completions",
+		provider: "header-provider",
+		baseUrl: "https://example.invalid/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16384,
+	};
+}
+
+function responsesModel(): Model<"openai-responses"> {
+	return {
+		...completionsModel(),
+		api: "openai-responses",
+	};
+}
+
+function completionsResponse(): Response {
+	const chunk = {
+		id: "chatcmpl-header-auth",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "header-model",
+		choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }],
+	};
+	const done = {
+		...chunk,
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		usage: { prompt_tokens: 1, completion_tokens: 1 },
+	};
+	return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: ${JSON.stringify(done)}\n\ndata: [DONE]\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function responsesResponse(): Response {
+	const event = {
+		type: "response.completed",
+		response: {
+			id: "resp_header_auth",
+			status: "completed",
+			output: [],
+			usage: {
+				input_tokens: 1,
+				output_tokens: 1,
+				total_tokens: 2,
+				input_tokens_details: { cached_tokens: 0 },
+			},
+		},
+	};
+	return new Response(`data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,34 @@
+## Static credential headers participate in real provider auth resolution (2026-07-29)
+
+### What changed
+
+- `core/provider-header-auth.ts` classifies only credential-like provider headers, preserves case-insensitive
+  override semantics, and derives distinct models.json versus extension status sources.
+- `core/provider-api-key-auth.ts` resolves credential-bearing provider headers into a genuine header-only
+  `AuthResult`, exposes the same result through `checkAuth()`, and leaves metadata-only or empty header maps
+  unconfigured. Header-only auth does not fabricate an API-key login method, and OAuth providers remain logged out
+  when their only configured headers are request metadata.
+- `configuredRequestAuthStatus()` uses the same credential-header contract, keeping synchronous registry reads,
+  asynchronous availability snapshots, TUI/RPC status, and request execution aligned.
+
+### Why this belongs in core
+
+- Auth resolution, registry availability, and status projection are package-owned provider-composition seams. An
+  extension can supply headers but cannot make the shared model runtime interpret them consistently.
+
+### Coverage
+
+- `test/provider-composer-headers-auth.test.ts` exercises models.json and extension header auth through registry
+  availability, `checkAuth()`, `getAuth()`, and runtime streaming, while locking metadata, empty-header, OAuth, API
+  key, and `authHeader` behavior.
+- `packages/ai/test/auth-headers.test.ts` and `packages/ai/test/openai-header-auth.test.ts` cover the shared
+  classification and OpenAI-compatible request path.
+
+### Expected merge conflict zones
+
+- LOW: additive `core/provider-header-auth.ts`, `core/provider-api-key-auth.ts`, and focused regression coverage.
+- MEDIUM: `core/provider-composer.ts` auth composition and status projection.
+
 ## Stream-start timeout wiring and unregistered-api error context (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/provider-api-key-auth.ts
+++ b/packages/coding-agent/src/core/provider-api-key-auth.ts
@@ -1,0 +1,149 @@
+import {
+	type ApiKeyAuth,
+	type AuthContext,
+	type AuthInteraction,
+	type AuthResult,
+	hasCredentialHeaders,
+	type ModelAuth,
+	type Provider,
+	type ProviderHeaders,
+} from "@earendil-works/pi-ai";
+import type { ModelsJsonProvider } from "./model-config.ts";
+import { checkConfiguredHeaderAuth, headerAuthResolutionSource } from "./provider-header-auth.ts";
+import {
+	getConfigValueEnvVarNames,
+	isCommandConfigValue,
+	resolveConfigValueOrThrow,
+	resolveHeadersOrThrow,
+} from "./resolve-config-value.ts";
+
+interface ProviderAuthExtensionInput {
+	apiKey?: string;
+	headers?: Record<string, string>;
+	authHeader?: boolean;
+	oauth?: unknown;
+}
+
+export function composeApiKeyAuth(
+	providerId: string,
+	base: Provider | undefined,
+	config: ModelsJsonProvider | undefined,
+	extension: ProviderAuthExtensionInput | undefined,
+): ApiKeyAuth | undefined {
+	const inherited = base?.auth.apiKey;
+	const rawKey = configuredApiKey(config, extension);
+	const oauth = extension?.oauth ?? base?.auth.oauth;
+	const rawHeaders = configuredHeaders(config, extension);
+	const headerSource = headerAuthResolutionSource(config?.headers, extension?.headers);
+	if (!inherited && rawKey === undefined && !headerSource && oauth) return undefined;
+	const authHeader = extension?.authHeader ?? config?.authHeader ?? false;
+	return {
+		name: inherited?.name ?? "API key",
+		login:
+			inherited?.login ??
+			(headerSource && rawKey === undefined
+				? undefined
+				: async (interaction: AuthInteraction) => ({
+						type: "api_key",
+						key: await interaction.prompt({ type: "secret", message: "Enter API key" }),
+					})),
+		check: async (input) => {
+			if (input.credential) {
+				const inheritedCheck = await inherited?.check?.(input);
+				if (inheritedCheck) return inheritedCheck;
+				if (input.credential.key) return { type: "api_key", source: "stored credential" };
+				const resolved = await inherited?.resolve(input);
+				if (resolved) return { type: "api_key", source: resolved.source };
+				return checkConfiguredHeaderAuth(rawHeaders, input.ctx, headerSource);
+			}
+			if (rawKey !== undefined) {
+				if (isCommandConfigValue(rawKey)) return { type: "api_key", source: "configured API key" };
+				for (const name of getConfigValueEnvVarNames(rawKey)) {
+					if ((await input.ctx.env(name)) === undefined) return undefined;
+				}
+				return { type: "api_key", source: "configured API key" };
+			}
+			const inheritedCheck = await inherited?.check?.(input);
+			if (inheritedCheck) return inheritedCheck;
+			const resolved = await inherited?.resolve(input);
+			if (resolved) return { type: "api_key", source: resolved.source };
+			return checkConfiguredHeaderAuth(rawHeaders, input.ctx, headerSource);
+		},
+		resolve: async (input) => {
+			const result = await resolveBaseAuth(providerId, inherited, rawKey, input);
+			const explicitEnv = { ...(input.credential?.env ?? {}), ...(result?.env ?? {}) };
+			const headerEnv = await configContextEnv(Object.values(rawHeaders ?? {}), input.ctx, explicitEnv);
+			const headers = resolveHeadersOrThrow(rawHeaders, `provider "${providerId}"`, headerEnv);
+			if (!result && !hasCredentialHeaders(headers)) return undefined;
+			return {
+				...result,
+				auth: withConfiguredAuth(result?.auth ?? {}, headers, authHeader),
+				source: result?.source ?? headerSource,
+			};
+		},
+	};
+}
+
+export function configuredApiKey(
+	config: ModelsJsonProvider | undefined,
+	extension: ProviderAuthExtensionInput | undefined,
+): string | undefined {
+	return extension?.apiKey ?? config?.apiKey;
+}
+
+export function configuredHeaders(
+	config: ModelsJsonProvider | undefined,
+	extension: ProviderAuthExtensionInput | undefined,
+): Record<string, string> | undefined {
+	if (!config?.headers && !extension?.headers) return undefined;
+	return { ...config?.headers, ...extension?.headers };
+}
+
+export function withConfiguredAuth(
+	auth: ModelAuth,
+	headers: ProviderHeaders | undefined,
+	authHeader: boolean,
+): ModelAuth {
+	let mergedHeaders: ProviderHeaders | undefined =
+		auth.headers || headers ? { ...auth.headers, ...headers } : undefined;
+	if (authHeader) {
+		if (!auth.apiKey) throw new Error("authHeader requires a resolved API key");
+		mergedHeaders = { ...mergedHeaders, Authorization: `Bearer ${auth.apiKey}` };
+	}
+	return { ...auth, headers: mergedHeaders };
+}
+
+async function resolveBaseAuth(
+	providerId: string,
+	inherited: ApiKeyAuth | undefined,
+	rawKey: string | undefined,
+	input: Parameters<ApiKeyAuth["resolve"]>[0],
+): Promise<AuthResult | undefined> {
+	if (input.credential) {
+		return inherited
+			? inherited.resolve(input)
+			: input.credential.key
+				? { auth: { apiKey: input.credential.key }, env: input.credential.env, source: "stored credential" }
+				: undefined;
+	}
+	if (rawKey === undefined) return inherited?.resolve(input);
+	const env = await configContextEnv([rawKey], input.ctx);
+	const key = resolveConfigValueOrThrow(rawKey, `API key for provider "${providerId}"`, env);
+	return inherited
+		? inherited.resolve({ ...input, credential: { type: "api_key", key } })
+		: { auth: { apiKey: key }, source: "configured API key" };
+}
+
+async function configContextEnv(
+	values: readonly string[],
+	ctx: AuthContext,
+	explicit?: Record<string, string>,
+): Promise<Record<string, string> | undefined> {
+	const env = { ...explicit };
+	for (const name of new Set(values.flatMap(getConfigValueEnvVarNames))) {
+		if (env[name] !== undefined) continue;
+		const value = await ctx.env(name);
+		if (value !== undefined) env[name] = value;
+	}
+	return Object.keys(env).length > 0 ? env : undefined;
+}

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -1,10 +1,6 @@
 import {
 	type Api,
-	type ApiKeyAuth,
 	type AssistantMessageEventStream,
-	type AuthContext,
-	type AuthInteraction,
-	type AuthResult,
 	type Context,
 	type Credential,
 	getApiProvider,
@@ -12,7 +8,6 @@ import {
 	getToolCallFormat,
 	lazyStream,
 	type Model,
-	type ModelAuth,
 	type OAuthAuth,
 	type OAuthCredentials,
 	type OAuthLoginCallbacks,
@@ -25,12 +20,13 @@ import {
 	wrapStreamWithToolCallMiddleware,
 } from "@earendil-works/pi-ai";
 import type { ModelConfig, ModelsJsonModel, ModelsJsonModelOverride, ModelsJsonProvider } from "./model-config.ts";
+import { composeApiKeyAuth, configuredApiKey, configuredHeaders, withConfiguredAuth } from "./provider-api-key-auth.ts";
+import { configuredHeaderAuthStatus, type HeaderAuthStatusSource } from "./provider-header-auth.ts";
 import {
 	clearConfigValueCache,
 	getConfigValueEnvVarNames,
 	isCommandConfigValue,
 	isConfigValueConfigured,
-	resolveConfigValueOrThrow,
 	resolveHeadersOrThrow,
 } from "./resolve-config-value.ts";
 
@@ -80,7 +76,14 @@ export interface ProviderConfigInput {
 
 export type AuthStatus = {
 	configured: boolean;
-	source?: "stored" | "runtime" | "environment" | "fallback" | "models_json_key" | "models_json_command";
+	source?:
+		| "stored"
+		| "runtime"
+		| "environment"
+		| "fallback"
+		| "models_json_key"
+		| "models_json_command"
+		| HeaderAuthStatusSource;
 	label?: string;
 };
 
@@ -275,115 +278,6 @@ function adaptOAuth(config: ExtensionOAuthConfig): OAuthAuth {
 		},
 		refresh: async (credential) => ({ ...(await config.refreshToken(credential)), type: "oauth" }),
 		toAuth: async (credential) => ({ apiKey: config.getApiKey(credential) }),
-	};
-}
-
-function withConfiguredAuth(
-	auth: ModelAuth,
-	headers: Record<string, string> | undefined,
-	authHeader: boolean,
-): ModelAuth {
-	let mergedHeaders: ProviderHeaders | undefined =
-		auth.headers || headers ? { ...auth.headers, ...headers } : undefined;
-	if (authHeader) {
-		if (!auth.apiKey) throw new Error("authHeader requires a resolved API key");
-		mergedHeaders = { ...mergedHeaders, Authorization: `Bearer ${auth.apiKey}` };
-	}
-	return { ...auth, headers: mergedHeaders };
-}
-
-function configuredApiKey(
-	config: ModelsJsonProvider | undefined,
-	extension: ProviderConfigInput | undefined,
-): string | undefined {
-	return extension?.apiKey ?? config?.apiKey;
-}
-
-function configuredHeaders(
-	config: ModelsJsonProvider | undefined,
-	extension: ProviderConfigInput | undefined,
-): Record<string, string> | undefined {
-	if (!config?.headers && !extension?.headers) return undefined;
-	return { ...config?.headers, ...extension?.headers };
-}
-
-async function configContextEnv(
-	values: readonly string[],
-	ctx: AuthContext,
-	explicit?: Record<string, string>,
-): Promise<Record<string, string> | undefined> {
-	const env = { ...explicit };
-	for (const name of new Set(values.flatMap(getConfigValueEnvVarNames))) {
-		if (env[name] !== undefined) continue;
-		const value = await ctx.env(name);
-		if (value !== undefined) env[name] = value;
-	}
-	return Object.keys(env).length > 0 ? env : undefined;
-}
-
-function composeApiKeyAuth(
-	providerId: string,
-	base: Provider | undefined,
-	config: ModelsJsonProvider | undefined,
-	extension: ProviderConfigInput | undefined,
-): ApiKeyAuth | undefined {
-	const inherited = base?.auth.apiKey;
-	const rawKey = configuredApiKey(config, extension);
-	const oauth = extension?.oauth ?? base?.auth.oauth;
-	// OAuth-only providers get no fabricated API-key login method.
-	if (!inherited && rawKey === undefined && oauth) return undefined;
-	const rawHeaders = configuredHeaders(config, extension);
-	const authHeader = extension?.authHeader ?? config?.authHeader ?? false;
-	return {
-		name: inherited?.name ?? "API key",
-		login:
-			inherited?.login ??
-			(async (interaction: AuthInteraction) => ({
-				type: "api_key",
-				key: await interaction.prompt({ type: "secret", message: "Enter API key" }),
-			})),
-		check: async (input) => {
-			if (input.credential) {
-				if (inherited?.check) return inherited.check(input);
-				if (input.credential.key) return { type: "api_key", source: "stored credential" };
-				const resolved = await inherited?.resolve(input);
-				return resolved ? { type: "api_key", source: resolved.source } : undefined;
-			}
-			if (rawKey !== undefined) {
-				if (isCommandConfigValue(rawKey)) return { type: "api_key", source: "configured API key" };
-				const envNames = getConfigValueEnvVarNames(rawKey);
-				for (const name of envNames) {
-					if ((await input.ctx.env(name)) === undefined) return undefined;
-				}
-				return { type: "api_key", source: "configured API key" };
-			}
-			if (inherited?.check) return inherited.check(input);
-			const resolved = await inherited?.resolve(input);
-			return resolved ? { type: "api_key", source: resolved.source } : undefined;
-		},
-		resolve: async (input) => {
-			let result: AuthResult | undefined;
-			if (input.credential) {
-				result = inherited
-					? await inherited.resolve(input)
-					: input.credential.key
-						? { auth: { apiKey: input.credential.key }, env: input.credential.env, source: "stored credential" }
-						: undefined;
-			} else if (rawKey !== undefined) {
-				const env = await configContextEnv([rawKey], input.ctx);
-				const key = resolveConfigValueOrThrow(rawKey, `API key for provider "${providerId}"`, env);
-				result = inherited
-					? await inherited.resolve({ ...input, credential: { type: "api_key", key } })
-					: { auth: { apiKey: key }, source: "configured API key" };
-			} else {
-				result = await inherited?.resolve(input);
-			}
-			if (!result) return undefined;
-			const explicitEnv = { ...(input.credential?.env ?? {}), ...(result.env ?? {}) };
-			const headerEnv = await configContextEnv(Object.values(rawHeaders ?? {}), input.ctx, explicitEnv);
-			const headers = resolveHeadersOrThrow(rawHeaders, `provider "${providerId}"`, headerEnv);
-			return { ...result, auth: withConfiguredAuth(result.auth, headers, authHeader) };
-		},
 	};
 }
 
@@ -610,9 +504,7 @@ export function configuredRequestAuthStatus(
 ): AuthStatus | undefined {
 	const value = configuredApiKey(config, extension);
 	if (value === undefined) {
-		const headers = configuredHeaders(config, extension);
-		if (!headers || Object.keys(headers).length === 0) return undefined;
-		return { configured: true, source: extension?.headers !== undefined ? "fallback" : "models_json_key" };
+		return configuredHeaderAuthStatus(config?.headers, extension?.headers);
 	}
 	if (isCommandConfigValue(value)) return { configured: true, source: "models_json_command" };
 	const names = getConfigValueEnvVarNames(value);

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -609,7 +609,11 @@ export function configuredRequestAuthStatus(
 	extension: ProviderConfigInput | undefined,
 ): AuthStatus | undefined {
 	const value = configuredApiKey(config, extension);
-	if (value === undefined) return undefined;
+	if (value === undefined) {
+		const headers = configuredHeaders(config, extension);
+		if (!headers || Object.keys(headers).length === 0) return undefined;
+		return { configured: true, source: extension?.headers !== undefined ? "fallback" : "models_json_key" };
+	}
 	if (isCommandConfigValue(value)) return { configured: true, source: "models_json_command" };
 	const names = getConfigValueEnvVarNames(value);
 	if (names.length > 0) {

--- a/packages/coding-agent/src/core/provider-header-auth.ts
+++ b/packages/coding-agent/src/core/provider-header-auth.ts
@@ -1,0 +1,100 @@
+import {
+	type AuthCheck,
+	type AuthContext,
+	hasCredentialHeaders,
+	isCredentialHeaderName,
+	type ProviderHeaders,
+} from "@earendil-works/pi-ai";
+import { getConfigValueEnvVarNames, isCommandConfigValue, isConfigValueConfigured } from "./resolve-config-value.ts";
+
+export type HeaderAuthStatusSource = "extension_headers" | "models_json_headers";
+
+interface EffectiveHeader {
+	name: string;
+	value: string;
+	source: HeaderAuthStatusSource;
+}
+
+export function configuredHeaderAuthStatus(
+	configHeaders: Record<string, string> | undefined,
+	extensionHeaders: Record<string, string> | undefined,
+):
+	| { configured: true; source: HeaderAuthStatusSource | "environment" | "models_json_command"; label?: string }
+	| { configured: false }
+	| undefined {
+	let sawCredentialHeader = false;
+	for (const header of effectiveHeaders(configHeaders, extensionHeaders).values()) {
+		if (!isCredentialHeaderName(header.name)) continue;
+		sawCredentialHeader = true;
+		if (isCommandConfigValue(header.value)) return { configured: true, source: "models_json_command" };
+		const envNames = getConfigValueEnvVarNames(header.value);
+		if (envNames.length > 0) {
+			if (isConfigValueConfigured(header.value)) {
+				return { configured: true, source: "environment", label: envNames.join(", ") };
+			}
+			continue;
+		}
+		if (hasCredentialHeaders({ [header.name]: header.value })) {
+			return { configured: true, source: header.source };
+		}
+	}
+	return sawCredentialHeader ? { configured: false } : undefined;
+}
+
+export function headerAuthResolutionSource(
+	configHeaders: Record<string, string> | undefined,
+	extensionHeaders: Record<string, string> | undefined,
+): string | undefined {
+	const headers = effectiveHeaders(configHeaders, extensionHeaders);
+	const values = Object.fromEntries([...headers.values()].map((header) => [header.name, header.value]));
+	if (!hasCredentialHeaders(values)) return undefined;
+	for (const header of headers.values()) {
+		if (!hasCredentialHeaders({ [header.name]: header.value })) continue;
+		return header.source === "extension_headers" ? "provider extension headers" : "models.json headers";
+	}
+	return undefined;
+}
+
+export async function checkConfiguredHeaderAuth(
+	headers: Record<string, string> | undefined,
+	ctx: AuthContext,
+	source: string | undefined,
+): Promise<AuthCheck | undefined> {
+	if (!headers) return undefined;
+	for (const header of effectiveHeaders(headers, undefined).values()) {
+		if (!isCredentialHeaderName(header.name)) continue;
+		if (isCommandConfigValue(header.value)) return { type: "api_key", source };
+		const envNames = getConfigValueEnvVarNames(header.value);
+		let configured = true;
+		for (const envName of envNames) {
+			if ((await ctx.env(envName)) !== undefined) continue;
+			configured = false;
+			break;
+		}
+		if (configured && hasCredentialHeaders({ [header.name]: header.value })) {
+			return { type: "api_key", source };
+		}
+	}
+	return undefined;
+}
+
+function effectiveHeaders(
+	configHeaders: Record<string, string> | undefined,
+	extensionHeaders: Record<string, string> | undefined,
+): Map<string, EffectiveHeader> {
+	const effective = new Map<string, EffectiveHeader>();
+	addHeaders(effective, configHeaders, "models_json_headers");
+	addHeaders(effective, extensionHeaders, "extension_headers");
+	return effective;
+}
+
+function addHeaders(
+	target: Map<string, EffectiveHeader>,
+	headers: ProviderHeaders | undefined,
+	source: HeaderAuthStatusSource,
+): void {
+	for (const [name, value] of Object.entries(headers ?? {})) {
+		if (typeof value !== "string") continue;
+		target.set(name.toLowerCase(), { name, value, source });
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## Credential-header auth status sources (2026-07-29)
+
+### What changed
+
+- `rpc-types.ts` mirrors the new `models_json_headers` and `extension_headers` auth-status sources emitted by the
+  model runtime. `get_auth_providers` can now distinguish static header credentials from API-key values without
+  exposing any credential material.
+
+### Why
+
+- The RPC status type must remain structurally identical to the core auth status returned by
+  `getProviderAuthStatus()`; otherwise header-auth providers type-check in core but fail response assembly.
+
+### Expected merge conflict zones
+
+- LOW: additive string literals in `RpcAuthStatus.source`.
+
 ## Claude Agent SDK provider-account RPC events (2026-07-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -149,7 +149,15 @@ export interface RpcAuthProvider {
 /** Auth status mirror (no credential values), from getProviderAuthStatus. */
 export interface RpcAuthStatus {
 	configured: boolean;
-	source?: "stored" | "runtime" | "environment" | "fallback" | "models_json_key" | "models_json_command";
+	source?:
+		| "stored"
+		| "runtime"
+		| "environment"
+		| "fallback"
+		| "models_json_key"
+		| "models_json_command"
+		| "models_json_headers"
+		| "extension_headers";
 	label?: string;
 }
 

--- a/packages/coding-agent/test/provider-composer-headers-auth.test.ts
+++ b/packages/coding-agent/test/provider-composer-headers-auth.test.ts
@@ -1,17 +1,20 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AuthContext, Model, Provider } from "@earendil-works/pi-ai";
+import type { Api, AuthContext, Model, Provider } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
 import { ModelConfig } from "../src/core/model-config.ts";
-import { composeModelProvider, configuredRequestAuthStatus } from "../src/core/provider-composer.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+import { composeModelProvider } from "../src/core/provider-composer.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 
 let tempDir: string | undefined;
-let modelConfig: ModelConfig;
+let modelsPath: string;
 
 beforeEach(() => {
 	tempDir = mkdtempSync(join(tmpdir(), "senpi-composer-headers-auth-"));
-	const modelsPath = join(tempDir, "models.json");
+	modelsPath = join(tempDir, "models.json");
 	writeFileSync(
 		modelsPath,
 		JSON.stringify({
@@ -22,10 +25,17 @@ beforeEach(() => {
 					headers: { "x-api-key": "header-key" },
 					models: [{ id: "headers-model" }],
 				},
-				unconfigured: {
+				"metadata-only": {
 					baseUrl: "https://example.invalid/v1",
 					api: "openai-completions",
-					models: [{ id: "unconfigured-model" }],
+					headers: { "User-Agent": "senpi-test" },
+					models: [{ id: "metadata-model" }],
+				},
+				"empty-headers": {
+					baseUrl: "https://example.invalid/v1",
+					api: "openai-completions",
+					headers: {},
+					models: [{ id: "empty-model" }],
 				},
 				"api-key": {
 					baseUrl: "https://example.invalid/v1",
@@ -39,7 +49,6 @@ beforeEach(() => {
 			},
 		}),
 	);
-	modelConfig = ModelConfig.loadSync(modelsPath);
 });
 
 afterEach(() => {
@@ -49,16 +58,12 @@ afterEach(() => {
 	}
 });
 
-function requestAuthStatus(providerId: string) {
-	return configuredRequestAuthStatus(modelConfig.getProvider(providerId), undefined) ?? { configured: false };
-}
-
-function authHeaderBaseProvider(): Provider {
-	const model: Model<"openai-completions"> = {
-		id: "auth-header-model",
-		name: "auth-header-model",
+function testModel(id: string, provider = "test-provider"): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
 		api: "openai-completions",
-		provider: "auth-header",
+		provider,
 		baseUrl: "https://example.invalid/v1",
 		reasoning: false,
 		input: ["text"],
@@ -66,6 +71,143 @@ function authHeaderBaseProvider(): Provider {
 		contextWindow: 128000,
 		maxTokens: 16384,
 	};
+}
+
+function requireModel(runtime: ModelRuntime, providerId: string, modelId: string): Model<"openai-completions"> {
+	const model = runtime.getModel(providerId, modelId);
+	expect(model).toBeDefined();
+	if (!isOpenAICompletionsModel(model)) {
+		throw new Error(`Missing test model ${providerId}/${modelId}`);
+	}
+	return model;
+}
+
+function isOpenAICompletionsModel(model: Model<Api> | undefined): model is Model<"openai-completions"> {
+	return model?.api === "openai-completions";
+}
+
+describe("configured request header auth", () => {
+	it("keeps registry availability, runtime auth, and streaming aligned for models.json headers", async () => {
+		const registry = await createModelRegistry(AuthStorage.inMemory(), modelsPath);
+		const runtime = getModelRuntime(registry);
+		let capturedHeaders: Record<string, string | null> | undefined;
+		runtime.registerProvider("headers-only", {
+			api: "openai-completions",
+			streamSimple: (_model, _context, options) => {
+				capturedHeaders = options?.headers;
+				throw new Error("captured");
+			},
+		});
+
+		expect(registry.getProviderAuthStatus("headers-only")).toEqual({
+			configured: true,
+			source: "models_json_headers",
+		});
+		expect(registry.getAvailable().some((model) => model.provider === "headers-only")).toBe(true);
+		expect(await runtime.checkAuth("headers-only")).toEqual({
+			type: "api_key",
+			source: "models.json headers",
+		});
+		expect(await runtime.getAuth("headers-only")).toEqual({
+			auth: { headers: { "x-api-key": "header-key" } },
+			source: "models.json headers",
+		});
+
+		await runtime.completeSimple(requireModel(runtime, "headers-only", "headers-model"), { messages: [] });
+		expect(capturedHeaders).toEqual({ "x-api-key": "header-key" });
+	});
+
+	it("does not treat metadata or empty header maps as authentication", async () => {
+		const registry = await createModelRegistry(AuthStorage.inMemory(), modelsPath);
+		const runtime = getModelRuntime(registry);
+		const availableProviders = new Set(registry.getAvailable().map((model) => model.provider));
+
+		for (const providerId of ["metadata-only", "empty-headers"]) {
+			expect(registry.getProviderAuthStatus(providerId)).toEqual({ configured: false });
+			expect(availableProviders.has(providerId)).toBe(false);
+			expect(await runtime.checkAuth(providerId)).toBeUndefined();
+			expect(await runtime.getAuth(providerId)).toBeUndefined();
+		}
+	});
+
+	it("supports extension-provided credential headers through the same runtime path", async () => {
+		const runtime = await ModelRuntime.create({
+			credentials: AuthStorage.inMemory(),
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		let capturedHeaders: Record<string, string | null> | undefined;
+		runtime.registerProvider("extension-headers", {
+			api: "openai-completions",
+			headers: { Authorization: "Bearer extension-token" },
+			streamSimple: (_model, _context, options) => {
+				capturedHeaders = options?.headers;
+				throw new Error("captured");
+			},
+			models: [testModel("extension-model")],
+		});
+		await runtime.refresh({ allowNetwork: false });
+
+		expect(runtime.getProviderAuthStatus("extension-headers")).toEqual({
+			configured: true,
+			source: "extension_headers",
+		});
+		expect(await runtime.checkAuth("extension-headers")).toEqual({
+			type: "api_key",
+			source: "provider extension headers",
+		});
+		expect(await runtime.getAuth("extension-headers")).toEqual({
+			auth: { headers: { Authorization: "Bearer extension-token" } },
+			source: "provider extension headers",
+		});
+		expect(runtime.getAvailableSnapshot().some((model) => model.provider === "extension-headers")).toBe(true);
+
+		await runtime.completeSimple(requireModel(runtime, "extension-headers", "extension-model"), { messages: [] });
+		expect(capturedHeaders).toEqual({ Authorization: "Bearer extension-token" });
+	});
+
+	it("does not mark an OAuth provider configured from metadata headers alone", async () => {
+		const runtime = await ModelRuntime.create({
+			credentials: AuthStorage.inMemory(),
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		runtime.registerProvider("oauth-metadata", {
+			headers: { "User-Agent": "senpi-test" },
+			oauth: {
+				name: "Test OAuth",
+				login: async () => ({ refresh: "refresh", access: "access", expires: Date.now() + 60_000 }),
+				refreshToken: async (credential) => credential,
+				getApiKey: (credential) => credential.access,
+			},
+			models: [testModel("oauth-model")],
+		});
+		await runtime.refresh({ allowNetwork: false });
+
+		expect(runtime.getProviderAuthStatus("oauth-metadata")).toEqual({ configured: false });
+		expect(await runtime.checkAuth("oauth-metadata")).toBeUndefined();
+		expect(runtime.getAvailableSnapshot().some((model) => model.provider === "oauth-metadata")).toBe(false);
+	});
+
+	it("preserves API-key status and authHeader missing-key behavior", async () => {
+		const config = ModelConfig.loadSync(modelsPath);
+		expect(
+			ModelRuntime.createSync({ credentials: AuthStorage.inMemory(), modelsPath }).getProviderAuthStatus("api-key"),
+		).toEqual({
+			configured: true,
+			source: "models_json_key",
+		});
+
+		const provider = composeModelProvider("auth-header", authHeaderBaseProvider(), config, undefined);
+		const apiKey = provider.auth.apiKey;
+		expect(apiKey).toBeDefined();
+		if (!apiKey) throw new Error("Expected api-key auth");
+		await expect(apiKey.resolve({ ctx: emptyAuthContext })).rejects.toThrow("authHeader requires a resolved API key");
+	});
+});
+
+function authHeaderBaseProvider(): Provider {
+	const model = testModel("auth-header-model", "auth-header");
 	return {
 		id: "auth-header",
 		name: "Auth header",
@@ -89,26 +231,3 @@ const emptyAuthContext: AuthContext = {
 	env: async () => undefined,
 	fileExists: async () => false,
 };
-
-describe("configured request auth status", () => {
-	it("reports a headers-only provider as configured", () => {
-		expect(requestAuthStatus("headers-only")).toEqual({ configured: true, source: "models_json_key" });
-	});
-
-	it("keeps providers without an API key or headers unconfigured", () => {
-		expect(requestAuthStatus("unconfigured")).toEqual({ configured: false });
-	});
-
-	it("preserves the API-key status source", () => {
-		expect(requestAuthStatus("api-key")).toEqual({ configured: true, source: "models_json_key" });
-	});
-
-	it("preserves the authHeader missing-key error", async () => {
-		const provider = composeModelProvider("auth-header", authHeaderBaseProvider(), modelConfig, undefined);
-		const apiKey = provider.auth.apiKey;
-		expect(apiKey).toBeDefined();
-		await expect(apiKey!.resolve({ ctx: emptyAuthContext })).rejects.toThrow(
-			"authHeader requires a resolved API key",
-		);
-	});
-});

--- a/packages/coding-agent/test/provider-composer-headers-auth.test.ts
+++ b/packages/coding-agent/test/provider-composer-headers-auth.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AuthContext, Model, Provider } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ModelConfig } from "../src/core/model-config.ts";
+import { composeModelProvider, configuredRequestAuthStatus } from "../src/core/provider-composer.ts";
+
+let tempDir: string | undefined;
+let modelConfig: ModelConfig;
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), "senpi-composer-headers-auth-"));
+	const modelsPath = join(tempDir, "models.json");
+	writeFileSync(
+		modelsPath,
+		JSON.stringify({
+			providers: {
+				"headers-only": {
+					baseUrl: "https://example.invalid/v1",
+					api: "openai-completions",
+					headers: { "x-api-key": "header-key" },
+					models: [{ id: "headers-model" }],
+				},
+				unconfigured: {
+					baseUrl: "https://example.invalid/v1",
+					api: "openai-completions",
+					models: [{ id: "unconfigured-model" }],
+				},
+				"api-key": {
+					baseUrl: "https://example.invalid/v1",
+					api: "openai-completions",
+					apiKey: "configured-api-key",
+					models: [{ id: "api-key-model" }],
+				},
+				"auth-header": {
+					authHeader: true,
+				},
+			},
+		}),
+	);
+	modelConfig = ModelConfig.loadSync(modelsPath);
+});
+
+afterEach(() => {
+	if (tempDir !== undefined) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+function requestAuthStatus(providerId: string) {
+	return configuredRequestAuthStatus(modelConfig.getProvider(providerId), undefined) ?? { configured: false };
+}
+
+function authHeaderBaseProvider(): Provider {
+	const model: Model<"openai-completions"> = {
+		id: "auth-header-model",
+		name: "auth-header-model",
+		api: "openai-completions",
+		provider: "auth-header",
+		baseUrl: "https://example.invalid/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16384,
+	};
+	return {
+		id: "auth-header",
+		name: "Auth header",
+		auth: {
+			apiKey: {
+				name: "Inherited auth",
+				resolve: async () => ({ auth: {} }),
+			},
+		},
+		getModels: () => [model],
+		stream: () => {
+			throw new Error("not used");
+		},
+		streamSimple: () => {
+			throw new Error("not used");
+		},
+	};
+}
+
+const emptyAuthContext: AuthContext = {
+	env: async () => undefined,
+	fileExists: async () => false,
+};
+
+describe("configured request auth status", () => {
+	it("reports a headers-only provider as configured", () => {
+		expect(requestAuthStatus("headers-only")).toEqual({ configured: true, source: "models_json_key" });
+	});
+
+	it("keeps providers without an API key or headers unconfigured", () => {
+		expect(requestAuthStatus("unconfigured")).toEqual({ configured: false });
+	});
+
+	it("preserves the API-key status source", () => {
+		expect(requestAuthStatus("api-key")).toEqual({ configured: true, source: "models_json_key" });
+	});
+
+	it("preserves the authHeader missing-key error", async () => {
+		const provider = composeModelProvider("auth-header", authHeaderBaseProvider(), modelConfig, undefined);
+		const apiKey = provider.auth.apiKey;
+		expect(apiKey).toBeDefined();
+		await expect(apiKey!.resolve({ ctx: emptyAuthContext })).rejects.toThrow(
+			"authHeader requires a resolved API key",
+		);
+	});
+});


### PR DESCRIPTION
## Problem

`ProviderConfigSchema` accepts `headers` as a standalone field, and `applyModelsJson` advertises it as sufficient configuration through its own error string:

> `Provider ${providerId}: must specify "baseUrl", "headers", "extraBody", "compat", "modelOverrides", or "models".`

But `configuredRequestAuthStatus` never consults `headers`. In `packages/coding-agent/src/core/provider-composer.ts` it begins:

```ts
const value = configuredApiKey(config, extension);
if (value === undefined) return undefined;
```

So a provider whose auth is fully expressed by `headers` — for example a gateway taking `x-api-key` — is reported unconfigured. Consumers then surface a misleading failure: `model-registry.ts` reports `No API key found for "<provider>"` even though the provider is correctly configured and would authenticate fine.

## Reproduction

A provider with `headers` and no `apiKey`:

```ts
configuredRequestAuthStatus(undefined, { headers: { "x-api-key": "tok" } })
// before: undefined  (reported unconfigured)
// after:  { configured: true }
```

## Fix

Treat a provider whose auth is fully expressed by `headers` as configured. The change is confined to the auth-status path.

Deliberately unchanged:

- Providers with neither `apiKey` nor `headers` still report unconfigured, so the fix is not over-broadened.
- `authHeader` semantics are untouched.

## Testing

- `npm run check` passes.
- New test file covers four cases: headers-only reports configured, apiKey-only still configured, neither reports unconfigured, and `authHeader` behaviour is unaffected.

Note on `npm test`: on my machine four watcher/timing suites fail nondeterministically, all in files this branch does not touch (`config-reload-watch-engine`, `footer-data-provider`, `mcp/catalog-cache`, `app-server-thread-handlers-archive`). Across three identical runs both the count and identity of the failures changed, each failing at ~5s — vitest's default `testTimeout` expiring while awaiting a real `fs.watch` event, while the tests' own guards are 10s. They reproduce on an unmodified checkout, so they look host/load-dependent rather than related to this change. Happy to look into that separately if it is useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats providers configured with credential headers (like `x-api-key`) as authenticated and usable. OpenAI-compatible requests now honor header-only auth without synthesizing a Bearer token, including for Responses over WebSocket.

- **Bug Fixes**
  - `configuredRequestAuthStatus` now detects credential-like `headers` and reports `source` as `models_json_headers` or `extension_headers` (also `environment`/`models_json_command` for templated values). Metadata-only or empty headers remain unconfigured; `authHeader` still requires a resolved API key.
  - OpenAI request path: `resolveOpenAIClientAuth` enables static credential headers; the SDK suppresses its default `Authorization` when a credential header exists or `Authorization: null` is set (HTTP and Responses WebSocket).
  - Core/RPC: header-only auth flows through `checkAuth()`/`getAuth()`; RPC `AuthStatus.source` includes `models_json_headers` and `extension_headers`. Shared detection lives in `auth/headers.ts` and is reused across auth discovery and request adapters. Tests cover header classification, OpenAI request construction, provider status/runtime auth, OAuth/API-key regressions, and `authHeader` error cases.

<sup>Written for commit 405af727c1a7b46ec0e62ce84f378a728e83083a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

