### PR TITLE
fix(coding-agent): stop headless recommended-model auto-switch from clobbering user defaults

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4733,6 +4733,12 @@ export class AgentSession {
 				},
 				getThinkingLevel: () => this.thinkingLevel,
 				setThinkingLevel: (level) => this.setThinkingLevel(level),
+				setSessionModel: async (model) => {
+					if (!this._modelRuntime.hasConfiguredAuth(model.provider)) return false;
+					await this.setSessionModel(model);
+					return true;
+				},
+				setSessionThinkingLevel: (level) => this.setSessionThinkingLevel(level),
 			},
 			{
 				getModel: () => this.model,

--- a/packages/coding-agent/src/core/extensions/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/AGENTS.md
@@ -30,7 +30,7 @@ extensions/
 | Flags | `registerFlag`, `getFlag` | New CLI flag |
 | Providers | `registerProvider`, `unregisterProvider` | New LLM provider (extension-local) |
 | Messages | `sendMessage`, `sendUserMessage`, `appendEntry`, `registerMessageRenderer` | Inject messages/entries into the session |
-| Model | `setModel`, `getThinkingLevel`, `setThinkingLevel` | Model + thinking-level control |
+| Model | `setModel`, `setSessionModel`, `getThinkingLevel`, `setThinkingLevel`, `setSessionThinkingLevel` | Model + thinking-level control (`setSession*` variants leave persisted defaults untouched) |
 | Session metadata | `setSessionName`, `getSessionName`, `setLabel` | Session display name + entry labels |
 | Tool execution | `executeTool` | Run a tool through the normal validation/hook/permission pipeline |
 | Events | `on(<event>, handler)` | 30+ events (session_start, tool_call, message_update, before_provider_request, before_agent_start, model_select, system_prompt_change, session_before_compact, session_compact, resources_discover, etc.) |

--- a/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
@@ -128,13 +128,19 @@ export default function recommendedModelsExtension(pi: ExtensionAPI): void {
 			return;
 		}
 
+		const persistAsDefault = ctx.mode === "tui";
 		automaticSelection = true;
 		try {
-			if (!(await pi.setModel(target.model))) {
+			const switched = persistAsDefault ? await pi.setModel(target.model) : await pi.setSessionModel(target.model);
+			if (!switched) {
 				warnWhenNoRecommendationIsAvailable(ctx);
 				return;
 			}
-			pi.setThinkingLevel(target.recommendation.thinkingLevel);
+			if (persistAsDefault) {
+				pi.setThinkingLevel(target.recommendation.thinkingLevel);
+			} else {
+				pi.setSessionThinkingLevel(target.recommendation.thinkingLevel);
+			}
 			ctx.ui.notify(`Switched to recommended model '${target.model.id}'.`, "info");
 		} finally {
 			automaticSelection = false;

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,30 @@
 # Core Extensions Changes
 
+## 2026-07-29 - Session-scoped model APIs; headless recommended-model switch no longer persists
+
+### What changed and why
+
+- `ExtensionAPI` gains `setSessionModel(model)` and `setSessionThinkingLevel(level)`: session-scoped counterparts of `setModel`/`setThinkingLevel`. They change the active session model/thinking level (still recorded in session history) without rewriting the user's persisted `defaultProvider`/`defaultModel`/`defaultThinkingLevel`.
+- The `recommended-models` builtin persists its automatic startup switch only in interactive (`tui`) mode. Headless modes (`print`, `rpc`, `json`) switch session-scoped, so background/child sessions no longer rewrite the user's real `~/.senpi/agent/settings.json` defaults on every start. Observed in the field: concurrent headless sessions with differing provider auth repeatedly overwrote the user's saved defaults minutes after the user restored them.
+
+### Why the extension system couldn't handle this alone
+
+`AgentSession.setSessionModel`/`setSessionThinkingLevel` already existed but were not exposed through the extension runtime, so extensions could only make persisting switches.
+
+### Files modified
+
+- `types.ts` (`ExtensionAPI`, `ExtensionActions`)
+- `loader.ts`, `runner.ts` (runtime stubs, facade, action binding)
+- `../agent-session.ts` (action wiring to the existing session-scoped setters)
+- `builtin/recommended-models/index.ts` (mode-scoped persistence)
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `types.ts` around the Model/Thinking Level API block; retain both session-scoped methods.
+- LOW: `runner.ts` action copy block and `loader.ts` runtime stub/facade lists; keep the session-scoped entries.
+
+
+
 ## 2026-07-29 - Initial model provenance on session_start
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -268,6 +268,8 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		getThinkingLevel: notInitialized,
 		setThinkingLevel: notInitialized,
+		setSessionModel: () => Promise.reject(new Error("Extension runtime not initialized")),
+		setSessionThinkingLevel: notInitialized,
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
 		pendingNativeProviderRegistrations: [],
@@ -509,6 +511,16 @@ function createExtensionAPI(
 		setThinkingLevel(level) {
 			runtime.assertActive();
 			runtime.setThinkingLevel(level);
+		},
+
+		setSessionModel(model) {
+			runtime.assertActive();
+			return runtime.setSessionModel(model);
+		},
+
+		setSessionThinkingLevel(level) {
+			runtime.assertActive();
+			runtime.setSessionThinkingLevel(level);
 		},
 
 		registerProvider(providerOrName: Provider | string, config?: ProviderConfig) {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -471,6 +471,8 @@ export class ExtensionRunner {
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;
+		this.runtime.setSessionModel = actions.setSessionModel;
+		this.runtime.setSessionThinkingLevel = actions.setSessionThinkingLevel;
 
 		// Context actions (required)
 		this.getModel = contextActions.getModel;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1617,6 +1617,15 @@ export interface ExtensionAPI {
 	/** Set thinking level (clamped to model capabilities). */
 	setThinkingLevel(level: ThinkingLevel): void;
 
+	/**
+	 * Set the model for this session only, leaving the user's persisted default
+	 * model untouched. Returns false if no API key is available.
+	 */
+	setSessionModel(model: Model<any>): Promise<boolean>;
+
+	/** Set thinking level for this session only (clamped), leaving the persisted default untouched. */
+	setSessionThinkingLevel(level: ThinkingLevel): void;
+
 	// =========================================================================
 	// Provider Registration
 	// =========================================================================
@@ -1972,6 +1981,8 @@ export interface ExtensionActions {
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
 	setThinkingLevel: SetThinkingLevelHandler;
+	setSessionModel: SetModelHandler;
+	setSessionThinkingLevel: SetThinkingLevelHandler;
 }
 
 /**

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -135,6 +135,8 @@ describe("ExtensionRunner", () => {
 		setModel: async () => false,
 		getThinkingLevel: () => "off",
 		setThinkingLevel: () => {},
+		setSessionModel: async () => false,
+		setSessionThinkingLevel: () => {},
 	};
 
 	const extensionContextActions: ExtensionContextActions = {

--- a/packages/coding-agent/test/suite/extension-session-model-api.test.ts
+++ b/packages/coding-agent/test/suite/extension-session-model-api.test.ts
@@ -1,0 +1,88 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
+import { ModelRuntime } from "../../src/core/model-runtime.ts";
+import { createAgentSession } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
+import { model } from "./recommended-models-harness.ts";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+async function createBoundSession(models: Model<Api>[], factory: (pi: ExtensionAPI) => void) {
+	const provider = models[0].provider;
+	const authStorage = AuthStorage.inMemory();
+	await authStorage.modify(provider, async () => ({ type: "api_key", key: "faux-key" }));
+	const modelRuntime = await ModelRuntime.create({
+		credentials: authStorage,
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	modelRuntime.registerProvider(provider, {
+		baseUrl: models[0].baseUrl,
+		api: models[0].api,
+		models: models.map((entry) => ({
+			id: entry.id,
+			name: entry.name,
+			api: entry.api,
+			reasoning: entry.reasoning,
+			input: entry.input,
+			cost: entry.cost,
+			contextWindow: entry.contextWindow,
+			maxTokens: entry.maxTokens,
+		})),
+	});
+	const settingsManager = SettingsManager.inMemory({ defaultProvider: provider, defaultModel: models[0].id });
+	const extensionsResult = await createTestExtensionsResult([factory]);
+	const { session } = await createAgentSession({
+		cwd: "/tmp",
+		modelRuntime,
+		settingsManager,
+		sessionManager: SessionManager.inMemory("/tmp"),
+		resourceLoader: createTestResourceLoader({ extensionsResult }),
+	});
+	await session.bindExtensions({});
+	return { session, settingsManager };
+}
+
+describe("extension session-scoped model API", () => {
+	it("#given a saved default #when an extension calls setSessionModel #then the session switches and defaults stay", async () => {
+		const saved = model("saved-model");
+		const other = model("other-model");
+		const { session, settingsManager } = await createBoundSession([saved, other], (pi) => {
+			pi.on("session_start", async () => {
+				await pi.setSessionModel(other);
+				pi.setSessionThinkingLevel("high");
+			});
+		});
+		try {
+			expect(session.model?.id).toBe("other-model");
+			expect(session.thinkingLevel).toBe("high");
+			expect(settingsManager.getDefaultModel()).toBe("saved-model");
+			expect(settingsManager.getDefaultProvider()).toBe("faux");
+			expect(settingsManager.getDefaultThinkingLevel()).toBeUndefined();
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("#given a saved default #when an extension calls setModel #then the persisted default follows", async () => {
+		const saved = model("saved-model");
+		const other = model("other-model");
+		const { session, settingsManager } = await createBoundSession([saved, other], (pi) => {
+			pi.on("session_start", async () => {
+				await pi.setModel(other);
+			});
+		});
+		try {
+			expect(session.model?.id).toBe("other-model");
+			expect(settingsManager.getDefaultModel()).toBe("other-model");
+		} finally {
+			session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/recommended-models-extension.test.ts
+++ b/packages/coding-agent/test/suite/recommended-models-extension.test.ts
@@ -1,15 +1,8 @@
-import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { fauxAssistantMessage, registerFauxProvider, type Api, type Model } from "@earendil-works/pi-ai/compat";
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
-import recommendedModelsExtension from "../../src/core/extensions/builtin/recommended-models/index.ts";
-import type {
-	ExtensionAPI,
-	ExtensionContext,
-	ModelSelectEvent,
-	SessionStartEvent,
-} from "../../src/core/extensions/types.ts";
+import type { SessionStartEvent } from "../../src/core/extensions/types.ts";
 import { ModelRuntime } from "../../src/core/model-runtime.ts";
 import { createAgentSession } from "../../src/core/sdk.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
@@ -17,123 +10,7 @@ import { SettingsManager } from "../../src/core/settings-manager.ts";
 import { createAppServerRuntime } from "../../src/modes/app-server/runtime.ts";
 import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
 import { configureModeEnv, scratchRoot, seedFauxConfig } from "./app-server-mode-harness.ts";
-
-type Notice = { message: string; type: "info" | "warning" | "error" | undefined };
-type SessionStartHandler = (event: SessionStartEvent, ctx: ExtensionContext) => Promise<void> | void;
-type ModelSelectHandler = (event: ModelSelectEvent, ctx: ExtensionContext) => Promise<void> | void;
-
-function model(id: string, provider = "faux"): Model<Api> {
-	return {
-		id,
-		name: id,
-		api: "anthropic-messages",
-		provider,
-		baseUrl: "https://example.invalid",
-		reasoning: true,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128_000,
-		maxTokens: 8_192,
-	};
-}
-
-interface RecommendedModelsHarness {
-	readonly notices: Notice[];
-	readonly settings: SettingsManager;
-	readonly flags: Map<string, { type: "boolean" | "string"; default?: boolean | string; description?: string }>;
-	getActiveModel(): Model<Api>;
-	start(provenance: NonNullable<SessionStartEvent["initialModelProvenance"]>): Promise<void>;
-	select(model: Model<Api>, source: "set" | "cycle" | "fallback"): Promise<void>;
-}
-
-function createHarness(options: {
-	active: Model<Api>;
-	available: Model<Api>[];
-	settings?: Parameters<typeof SettingsManager.inMemory>[0];
-	flag?: boolean;
-}): RecommendedModelsHarness {
-	const settings = SettingsManager.inMemory(options.settings);
-	vi.spyOn(SettingsManager, "create").mockReturnValue(settings);
-
-	const notices: Notice[] = [];
-	const flags = new Map<string, { type: "boolean" | "string"; default?: boolean | string; description?: string }>();
-	const sessionStartHandlers: SessionStartHandler[] = [];
-	const modelSelectHandlers: ModelSelectHandler[] = [];
-	let activeModel = options.active;
-	let thinkingLevel: ThinkingLevel = "medium";
-
-	const ctx = {
-		get model() {
-			return activeModel;
-		},
-		modelRegistry: {
-			getAvailable: () => options.available,
-			hasConfiguredAuth: () => true,
-		},
-		ui: {
-			notify: (message: string, type?: Notice["type"]) => notices.push({ message, type }),
-		},
-	} as unknown as ExtensionContext;
-
-	const emitModelSelect = async (nextModel: Model<Api>, source: "set" | "cycle" | "fallback"): Promise<void> => {
-		const previousModel = activeModel;
-		activeModel = nextModel;
-		for (const handler of modelSelectHandlers) {
-			await handler(
-				{
-					type: "model_select",
-					model: nextModel,
-					previousModel,
-					source,
-					systemPrompt: "",
-					systemPromptOptions: { cwd: "/tmp" },
-				},
-				ctx,
-			);
-		}
-	};
-
-	const pi = {
-		registerFlag: (
-			name: string,
-			options: { type: "boolean" | "string"; default?: boolean | string; description?: string },
-		) => flags.set(name, options),
-		getFlag: (name: string) => (name === "no-recommended-models" ? options.flag : undefined),
-		on: (event: string, handler: SessionStartHandler | ModelSelectHandler) => {
-			if (event === "session_start") {
-				sessionStartHandlers.push(handler as SessionStartHandler);
-			}
-			if (event === "model_select") {
-				modelSelectHandlers.push(handler as ModelSelectHandler);
-			}
-		},
-		setModel: async (nextModel: Model<Api>) => {
-			settings.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
-			await emitModelSelect(nextModel, "set");
-			return true;
-		},
-		getThinkingLevel: () => thinkingLevel,
-		setThinkingLevel: (level: ThinkingLevel) => {
-			thinkingLevel = level;
-			settings.setDefaultThinkingLevel(level);
-		},
-	} as unknown as ExtensionAPI;
-
-	recommendedModelsExtension(pi);
-
-	return {
-		notices,
-		settings,
-		flags,
-		getActiveModel: () => activeModel,
-		async start(provenance) {
-			for (const handler of sessionStartHandlers) {
-				await handler({ type: "session_start", reason: "startup", initialModelProvenance: provenance }, ctx);
-			}
-		},
-		select: emitModelSelect,
-	};
-}
+import { createHarness, model } from "./recommended-models-harness.ts";
 
 afterEach(() => {
 	vi.restoreAllMocks();

--- a/packages/coding-agent/test/suite/recommended-models-harness.ts
+++ b/packages/coding-agent/test/suite/recommended-models-harness.ts
@@ -1,0 +1,142 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { vi } from "vitest";
+import recommendedModelsExtension from "../../src/core/extensions/builtin/recommended-models/index.ts";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionMode,
+	ModelSelectEvent,
+	SessionStartEvent,
+} from "../../src/core/extensions/types.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+export type Notice = { message: string; type: "info" | "warning" | "error" | undefined };
+type SessionStartHandler = (event: SessionStartEvent, ctx: ExtensionContext) => Promise<void> | void;
+type ModelSelectHandler = (event: ModelSelectEvent, ctx: ExtensionContext) => Promise<void> | void;
+
+export function model(id: string, provider = "faux"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider,
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+export interface RecommendedModelsHarness {
+	readonly notices: Notice[];
+	readonly settings: SettingsManager;
+	readonly flags: Map<string, { type: "boolean" | "string"; default?: boolean | string; description?: string }>;
+	getActiveModel(): Model<Api>;
+	getThinkingLevel(): ThinkingLevel;
+	start(provenance: NonNullable<SessionStartEvent["initialModelProvenance"]>): Promise<void>;
+	select(model: Model<Api>, source: "set" | "cycle" | "fallback"): Promise<void>;
+}
+
+export function createHarness(options: {
+	active: Model<Api>;
+	available: Model<Api>[];
+	settings?: Parameters<typeof SettingsManager.inMemory>[0];
+	flag?: boolean;
+	mode?: ExtensionMode;
+}): RecommendedModelsHarness {
+	const settings = SettingsManager.inMemory(options.settings);
+	vi.spyOn(SettingsManager, "create").mockReturnValue(settings);
+
+	const notices: Notice[] = [];
+	const flags = new Map<string, { type: "boolean" | "string"; default?: boolean | string; description?: string }>();
+	const sessionStartHandlers: SessionStartHandler[] = [];
+	const modelSelectHandlers: ModelSelectHandler[] = [];
+	let activeModel = options.active;
+	let thinkingLevel: ThinkingLevel = "medium";
+
+	const ctx = {
+		mode: options.mode ?? "tui",
+		get model() {
+			return activeModel;
+		},
+		modelRegistry: {
+			getAvailable: () => options.available,
+			hasConfiguredAuth: () => true,
+		},
+		ui: {
+			notify: (message: string, type?: Notice["type"]) => notices.push({ message, type }),
+		},
+	} as unknown as ExtensionContext;
+
+	const emitModelSelect = async (nextModel: Model<Api>, source: "set" | "cycle" | "fallback"): Promise<void> => {
+		const previousModel = activeModel;
+		activeModel = nextModel;
+		for (const handler of modelSelectHandlers) {
+			await handler(
+				{
+					type: "model_select",
+					model: nextModel,
+					previousModel,
+					source,
+					systemPrompt: "",
+					systemPromptOptions: { cwd: "/tmp" },
+				},
+				ctx,
+			);
+		}
+	};
+
+	const pi = {
+		registerFlag: (
+			name: string,
+			flagOptions: { type: "boolean" | "string"; default?: boolean | string; description?: string },
+		) => flags.set(name, flagOptions),
+		getFlag: (name: string) => (name === "no-recommended-models" ? options.flag : undefined),
+		on: (event: string, handler: SessionStartHandler | ModelSelectHandler) => {
+			if (event === "session_start") {
+				sessionStartHandlers.push(handler as SessionStartHandler);
+			}
+			if (event === "model_select") {
+				modelSelectHandlers.push(handler as ModelSelectHandler);
+			}
+		},
+		// Mirrors the real API contract: setModel persists the global default.
+		setModel: async (nextModel: Model<Api>) => {
+			settings.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+			await emitModelSelect(nextModel, "set");
+			return true;
+		},
+		// Mirrors the real API contract: setSessionModel never touches persisted defaults.
+		setSessionModel: async (nextModel: Model<Api>) => {
+			await emitModelSelect(nextModel, "set");
+			return true;
+		},
+		getThinkingLevel: () => thinkingLevel,
+		setThinkingLevel: (level: ThinkingLevel) => {
+			thinkingLevel = level;
+			settings.setDefaultThinkingLevel(level);
+		},
+		setSessionThinkingLevel: (level: ThinkingLevel) => {
+			thinkingLevel = level;
+		},
+	} as unknown as ExtensionAPI;
+
+	recommendedModelsExtension(pi);
+
+	return {
+		notices,
+		settings,
+		flags,
+		getActiveModel: () => activeModel,
+		getThinkingLevel: () => thinkingLevel,
+		async start(provenance) {
+			for (const handler of sessionStartHandlers) {
+				await handler({ type: "session_start", reason: "startup", initialModelProvenance: provenance }, ctx);
+			}
+		},
+		select: emitModelSelect,
+	};
+}

--- a/packages/coding-agent/test/suite/recommended-models-session-scope.test.ts
+++ b/packages/coding-agent/test/suite/recommended-models-session-scope.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, model } from "./recommended-models-harness.ts";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("recommended-models headless session scope", () => {
+	it("#given a headless session #when settings provenance starts #then it switches without persisting defaults", async () => {
+		for (const mode of ["print", "rpc", "json"] as const) {
+			const kimi = model("kimi-k3", "kimi-coding");
+			const harness = createHarness({ active: model("off-list"), available: [kimi], mode });
+
+			await harness.start("settings");
+
+			expect(harness.getActiveModel()).toBe(kimi);
+			expect(harness.getThinkingLevel()).toBe("max");
+			expect(harness.settings.getDefaultProvider()).toBeUndefined();
+			expect(harness.settings.getDefaultModel()).toBeUndefined();
+			expect(harness.settings.getDefaultThinkingLevel()).toBeUndefined();
+			expect(harness.notices).toEqual([{ message: "Switched to recommended model 'kimi-k3'.", type: "info" }]);
+		}
+	});
+
+	it("#given a tui session #when settings provenance starts #then it still persists the recommendation", async () => {
+		const kimi = model("kimi-k3", "kimi-coding");
+		const harness = createHarness({ active: model("off-list"), available: [kimi], mode: "tui" });
+
+		await harness.start("settings");
+
+		expect(harness.getActiveModel()).toBe(kimi);
+		expect(harness.settings.getDefaultProvider()).toBe("kimi-coding");
+		expect(harness.settings.getDefaultModel()).toBe("kimi-k3");
+		expect(harness.settings.getDefaultThinkingLevel()).toBe("max");
+	});
+});


### PR DESCRIPTION
## Problem

The `recommended-models` builtin (#466) persists its automatic startup switch into the user's global settings. `pi.setModel` routes to `AgentSession.setModel` -> `_setModel(model, true)` -> `settingsManager.setDefaultModelAndProvider(...)`, and the persisting `setThinkingLevel` path writes `defaultThinkingLevel` too.

Because `canAutoSwitch` only excludes `app-server`, every headless session (print/rpc child tasks, background QA drivers) with different provider-auth availability rewrote the real `~/.senpi/agent/settings.json` `defaultProvider`/`defaultModel`/`defaultThinkingLevel` on start. Observed in the field today: the user's saved default was overwritten to `apitopia/kimi-k3-unlocked:max` (the top recommendation pair) minutes after each manual restore, by concurrent headless sessions.

## Fix

- Expose the already-existing session-scoped setters to extensions: `pi.setSessionModel(model)` and `pi.setSessionThinkingLevel(level)` (`types.ts`, `loader.ts`, `runner.ts`, `agent-session.ts` action wiring). Session history still records the change; persisted defaults are untouched.
- `recommended-models` now persists only in interactive (`tui`) mode; `print`/`rpc`/`json` sessions switch session-scoped. Interactive sticky-default behavior from #466 is preserved (existing test unchanged and green).

## Evidence

- RED first: `test/suite/recommended-models-session-scope.test.ts` failed against unmodified extension code with `expected 'kimi-coding' to be undefined` (headless start persisted), existing 11 tests green.
- GREEN: 14/14 across `recommended-models-session-scope.test.ts`, `recommended-models-extension.test.ts` (harness extracted to `recommended-models-harness.ts`), and the new real-wiring `extension-session-model-api.test.ts` (real `createAgentSession` + in-memory settings: `setSessionModel` leaves defaults, `setModel` persists).
- Real-surface QA (senpi-qa mock loop, sandboxed `SENPI_CODING_AGENT_DIR`): live CLI `--print` with settings default `mock/mock-model` and `kimi-k3` available auto-switched (fake server received `model: kimi-k3`) while the sandbox `settings.json` stayed `mock/mock-model`. Receipt: `local-ignore/qa-evidence/20260729-recommended-models-session-scope/` (verdict `PASS: true`).
- Root `npm run check` exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops headless sessions from overwriting user defaults. The `recommended-models` auto-switch is now session-scoped outside TUI, and session-scoped model APIs are available to extensions.

- **New Features**
  - Added `pi.setSessionModel(model)` and `pi.setSessionThinkingLevel(level)` to change only the active session without touching saved defaults; `setSessionModel` returns `false` if no provider auth is configured. Documented in `AGENTS.md` and wired through the `ExtensionAPI`.

- **Bug Fixes**
  - The `recommended-models` builtin now persists its automatic switch only in interactive (`tui`) mode. Headless modes (`print`, `rpc`, `json`) switch session-scoped, so `~/.senpi/agent/settings.json` `defaultProvider`/`defaultModel`/`defaultThinkingLevel` are no longer clobbered. Interactive sticky-default behavior remains unchanged.

<sup>Written for commit a1607b9b68e192bbc98fa233990bf46aed15db8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

