### PR TITLE
fix(coding-agent): defer vetoed hot-reloads quietly until the veto clears

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1778,7 +1778,7 @@ pi.events.emit("my:event", { ... });
 
 ## Config reload
 
-Senpi's default-on `config-reload` builtin watches configured global surfaces and trusted project-local `.senpi` surfaces. A real content change requests the normal full session reload when the agent is idle; busy or compacting sessions defer it until a safe idle edge. Parseable built-in files (`settings.json`, `models.json`, and `keybindings.json`) are validated before reload, so a rejected edit keeps the running configuration active.
+Senpi's default-on `config-reload` builtin watches configured global surfaces and trusted project-local `.senpi` surfaces. A real content change requests the normal full session reload when the agent is idle; busy or compacting sessions defer it until a safe idle edge. When an extension vetoes the reload through `session_before_reload` (for example while subagents it owns are still running), the change also defers quietly: one `Hot-reload deferred: <reason>` notice per distinct veto reason, silent retries on later idle edges plus a periodic veto recheck, and the usual `Hot-reloading:`/`Hot-reloaded:` notifications only once the veto clears and the reload actually runs. Parseable built-in files (`settings.json`, `models.json`, and `keybindings.json`) are validated before reload, so a rejected edit keeps the running configuration active.
 
 Configure it in `settings.json` with optional fields; omitted fields use the defaults shown here. Invalid `configReload` fields are ignored individually, so a malformed block falls back to these defaults rather than disabling watching:
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4788,6 +4788,7 @@ export class AgentSession {
 				},
 				hasPendingMessages: () => this.pendingMessageCount > 0,
 				isCompacting: () => this.isCompacting,
+				checkReloadVeto: () => this.checkReloadVeto(),
 				shutdown: () => {
 					this._extensionShutdownHandler?.();
 				},

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -22,6 +22,7 @@ import {
 	isConfigWatchValidation,
 	matchesConfigWatchFilter,
 } from "./protocol.ts";
+import { ReloadVetoDeferral } from "./reload-deferral.ts";
 import {
 	excludeRoutineOnlySettingsChanges,
 	isSettingsPath,
@@ -41,6 +42,7 @@ import {
 const BUILTIN_REGISTRATION_ID = "builtin";
 const DEFAULT_DEBOUNCE_MS = 200;
 const COMPACTION_RECHECK_MS = 250;
+const VETO_RECHECK_MS = 1000;
 const CONFIG_FILE_NAMES = ["settings.json", "models.json", "keybindings.json"] as const;
 
 /**
@@ -174,6 +176,8 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	let deferredNoticeShown = false;
 	let unavailableReloadLogged = false;
 	let compactionRecheck: ReturnType<typeof setTimeout> | undefined;
+	let vetoRecheck: ReturnType<typeof setTimeout> | undefined;
+	const vetoDeferral = new ReloadVetoDeferral();
 	let changeChain: Promise<void> = Promise.resolve();
 
 	const closeWatchers = (): void => {
@@ -186,6 +190,12 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		if (compactionRecheck === undefined) return;
 		(options.clock ?? defaultClock).clearTimeout(compactionRecheck);
 		compactionRecheck = undefined;
+	};
+
+	const clearVetoRecheck = (): void => {
+		if (vetoRecheck === undefined) return;
+		(options.clock ?? defaultClock).clearTimeout(vetoRecheck);
+		vetoRecheck = undefined;
 	};
 
 	const cleanupEventListeners = (): void => {
@@ -354,6 +364,24 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 			return;
 		}
 
+		// Probe the extension veto (session_before_reload) BEFORE announcing the
+		// reload: a vetoed hot-reload defers quietly (one notice per distinct
+		// reason) and retries on later idle edges or the veto recheck clock,
+		// instead of re-notifying "Hot-reloading:" plus the veto warning forever.
+		if (ctx.checkReloadVeto) {
+			const veto = await ctx.checkReloadVeto();
+			if (currentContext !== ctx || reloadInFlight || pending.size === 0) return;
+			if (veto.cancelled) {
+				const notice = vetoDeferral.defer(veto.reason);
+				if (notice) ctx.ui.notify(notice, "info");
+				logger.info("reload_deferred", { reason: veto.reason ?? "extension veto" });
+				armVetoRecheck();
+				return;
+			}
+		}
+		clearVetoRecheck();
+		vetoDeferral.reset();
+
 		const changes = pendingChanges(pending);
 		const paths = uniquePaths(changes.flatMap((change) => change.paths));
 		reloadInFlight = true;
@@ -386,6 +414,15 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 			compactionRecheck = undefined;
 			void flushPending();
 		}, COMPACTION_RECHECK_MS);
+	};
+
+	const armVetoRecheck = (): void => {
+		if (vetoRecheck !== undefined) return;
+		const clock = options.clock ?? defaultClock;
+		vetoRecheck = clock.setTimeout(() => {
+			vetoRecheck = undefined;
+			void flushPending();
+		}, VETO_RECHECK_MS);
 	};
 
 	const processReloadHandoff = async (event: SessionStartEvent, ctx: ExtensionContext): Promise<void> => {
@@ -439,6 +476,8 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		currentContext = undefined;
 		closeWatchers();
 		clearCompactionRecheck();
+		clearVetoRecheck();
+		vetoDeferral.reset();
 		cleanupEventListeners();
 		pending.clear();
 		if (event.reason !== "reload" && closingContext) reloadHandoffs.delete(handoffKey(closingContext));

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/log.ts
@@ -16,6 +16,7 @@ export type ConfigReloadLogEvent =
 	| "routine_settings_change_suppressed"
 	| "generated_shim_change_suppressed"
 	| "reload_requested"
+	| "reload_deferred"
 	| "reload_completed"
 	| "validation_rejected"
 	| "registration_rejected"
@@ -31,6 +32,7 @@ export interface ConfigReloadLogDetails {
 	routine_settings_change_suppressed: { path: string };
 	generated_shim_change_suppressed: { path: string };
 	reload_requested: { reason: string; paths: readonly string[] };
+	reload_deferred: { reason: string };
 	reload_completed: { durationMs: number };
 	validation_rejected: { registrationId: string; errorCount: number };
 	registration_rejected: { registrationId: string; errorCount: number };
@@ -142,6 +144,9 @@ function formatEntry<Event extends ConfigReloadLogEvent>(
 			entry.paths = safePaths(eventDetails.paths);
 			break;
 		}
+		case "reload_deferred":
+			entry.reason = safeText((details as ConfigReloadLogDetails["reload_deferred"]).reason);
+			break;
 		case "reload_completed":
 			entry.durationMs = finiteNumber((details as ConfigReloadLogDetails["reload_completed"]).durationMs);
 			break;

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/reload-deferral.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/reload-deferral.ts
@@ -1,0 +1,27 @@
+/**
+ * Veto-aware deferral state for the config-reload builtin.
+ *
+ * When an extension cancels `session_before_reload` (e.g. subagents still
+ * running), pending config changes wait silently instead of re-notifying on
+ * every idle edge: the user sees at most one notice per distinct veto reason,
+ * and the normal "Hot-reloading:" flow runs only once the veto clears.
+ */
+export class ReloadVetoDeferral {
+	#notifiedReason: string | undefined;
+
+	/**
+	 * Record a vetoed flush attempt. Returns the notice to surface for a newly
+	 * seen reason, or undefined when the same reason was already announced.
+	 */
+	defer(reason: string | undefined): string | undefined {
+		const effective = reason ?? "an extension blocked the reload";
+		if (this.#notifiedReason === effective) return undefined;
+		this.#notifiedReason = effective;
+		return `Hot-reload deferred: ${effective}`;
+	}
+
+	/** Forget the announced reason once a reload proceeds or the session shuts down. */
+	reset(): void {
+		this.#notifiedReason = undefined;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,31 @@
 # Core Extensions Changes
 
+## 2026-07-29 - Reload veto probe on ExtensionContext + quiet config-reload deferral
+
+### What changed and why
+
+- Added `ExtensionContext.checkReloadVeto(): Promise<ReloadVetoDecision>` (optional) and the matching optional `ExtensionContextActions.checkReloadVeto`. It probes the cancellable `session_before_reload` gate WITHOUT starting a reload; `AgentSession` supplies it from its existing `checkReloadVeto()`, so every host mode (TUI, RPC, print) exposes it automatically.
+- The `config-reload` builtin now probes this gate in `flushPending` before announcing a reload. A vetoed hot-reload (e.g. an extension guarding running subagents) keeps its pending changes, logs `reload_deferred`, shows at most ONE `Hot-reload deferred: <reason>` notice per distinct reason, and retries on later idle edges plus a 1s veto recheck clock. Previously every idle edge re-emitted the `Hot-reloading:` notice plus the host's veto warning, spamming the TUI for as long as the veto held. The `Hot-reloading:`/`Hot-reloaded:` notices now appear only when the reload actually proceeds. New module `builtin/config-reload/reload-deferral.ts` owns the once-per-reason notice state; `builtin/config-reload/log.ts` gained the `reload_deferred` event.
+
+### Why the extension system couldn't handle this alone
+
+Only the session core can consult `session_before_reload` without side effects; the host `requestReload` action both warns and reloads. Watching extensions need the quiet probe as a typed context accessor to distinguish "defer silently" from "reload now".
+
+### Files modified
+
+- `types.ts` (`ExtensionContext.checkReloadVeto`, `ExtensionContextActions.checkReloadVeto`, `ReloadVetoDecision`)
+- `runner.ts` (probe promotion into event contexts)
+- `../agent-session.ts` (`_bindExtensionCore` supplies the probe)
+- `builtin/config-reload/index.ts`, `builtin/config-reload/reload-deferral.ts` (new), `builtin/config-reload/log.ts`
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `types.ts` around `ExtensionContext.isCompacting`/`requestReload` and `ExtensionContextActions`; retain the optional `checkReloadVeto` members and `ReloadVetoDecision`.
+- LOW: `runner.ts` `bindCore` context-action copies and the `createContext` getters; keep the `checkReloadVeto` getter beside `requestReload`.
+- LOW: `builtin/config-reload/index.ts` `flushPending`; the veto probe must stay before the `Hot-reloading:` notify and `requestReload` call.
+
+
+
 ## 2026-07-29 - Initial model provenance on session_start
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -379,6 +379,7 @@ export class ExtensionRunner {
 	private abortFn: () => void = () => {};
 	private hasPendingMessagesFn: () => boolean = () => false;
 	private isCompactingFn: () => boolean = () => false;
+	private checkReloadVetoFn: ExtensionContextActions["checkReloadVeto"];
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private getCompactionSettingsFn: ExtensionContextActions["getCompactionSettings"] = () => ({
 		enabled: true,
@@ -481,6 +482,7 @@ export class ExtensionRunner {
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
 		this.isCompactingFn = contextActions.isCompacting;
+		this.checkReloadVetoFn = contextActions.checkReloadVeto;
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.getCompactionSettingsFn = contextActions.getCompactionSettings;
@@ -1001,6 +1003,11 @@ export class ExtensionRunner {
 			get requestReload() {
 				runner.assertActive();
 				return runner.reloadHandler ? () => runner.requestReload() : undefined;
+			},
+			get checkReloadVeto() {
+				runner.assertActive();
+				const probe = runner.checkReloadVetoFn;
+				return probe ? () => probe() : undefined;
 			},
 			isCompacting: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -405,6 +405,13 @@ export interface ExtensionContext {
 	requestReload?(): Promise<void>;
 	/** Whether session compaction or branch summarization is currently running. */
 	isCompacting?(): boolean;
+	/**
+	 * Ask extensions whether a full session reload may proceed (the cancellable
+	 * `session_before_reload` gate) WITHOUT starting a reload. Hosts with a
+	 * reload veto gate expose this so watchers can defer quietly instead of
+	 * triggering a reload that would be blocked and re-warned on every retry.
+	 */
+	checkReloadVeto?(): Promise<ReloadVetoDecision>;
 	/** Gracefully shutdown pi and exit. Available in all contexts. */
 	shutdown(): void;
 	/** Get current context usage for the active model. */
@@ -1338,6 +1345,13 @@ export interface SessionBeforeReloadResult {
 	reason?: string;
 }
 
+/** Outcome of probing the `session_before_reload` gate without reloading. */
+export interface ReloadVetoDecision {
+	cancelled: boolean;
+	/** Human-readable veto reason forwarded from the cancelling extension. */
+	reason?: string;
+}
+
 export interface SessionBeforeCompactResult {
 	cancel?: boolean;
 	compaction?: CompactionResult;
@@ -1987,6 +2001,7 @@ export interface ExtensionContextActions {
 	abort: () => void;
 	hasPendingMessages: () => boolean;
 	isCompacting: () => boolean;
+	checkReloadVeto?: () => Promise<ReloadVetoDecision>;
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	getCompactionSettings: () => CompactionPreparation["settings"];

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1611,6 +1611,28 @@ describe("ExtensionRunner", () => {
 			compacting = false;
 			expect(context.isCompacting?.()).toBe(false);
 		});
+
+		it("reflects the bound reload veto probe", async () => {
+			const runtime = createExtensionRuntime();
+			const runner = new ExtensionRunner([], runtime, tempDir, sessionManager, modelRegistry);
+			let vetoed = true;
+
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				checkReloadVeto: async () => (vetoed ? { cancelled: true, reason: "busy" } : { cancelled: false }),
+			});
+			const context = runner.createContext();
+			await expect(context.checkReloadVeto?.()).resolves.toEqual({ cancelled: true, reason: "busy" });
+			vetoed = false;
+			await expect(context.checkReloadVeto?.()).resolves.toEqual({ cancelled: false });
+		});
+
+		it("leaves checkReloadVeto undefined without a host probe", () => {
+			const runtime = createExtensionRuntime();
+			const runner = new ExtensionRunner([], runtime, tempDir, sessionManager, modelRegistry);
+
+			expect(runner.createContext().checkReloadVeto).toBeUndefined();
+		});
 	});
 
 	describe("command context", () => {

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -206,6 +206,14 @@ function silentLogger(): ConfigReloadLogger {
 	} as unknown as ConfigReloadLogger;
 }
 
+type VetoState = { active: boolean; readonly reason: string };
+
+function vetoExtensionFactory(state: VetoState): (pi: ExtensionAPI) => void {
+	return (pi) => {
+		pi.on("session_before_reload", () => (state.active ? { cancel: true, reason: state.reason } : undefined));
+	};
+}
+
 const harnesses: Harness[] = [];
 const agentDirs: string[] = [];
 
@@ -969,6 +977,73 @@ describe("config reload builtin extension", () => {
 
 		await fixture.harness.getExtensionRunner().emit({ type: "agent_settled" });
 		expect(fixture.reload).toHaveBeenCalledTimes(2);
+	});
+
+	it("defers a vetoed hot-reload silently instead of renotifying every idle edge", async () => {
+		vi.useFakeTimers();
+		const veto: VetoState = { active: true, reason: "5 subagent(s) still running: pr449, pr450" };
+		const fixture = await createFixture({ extraFactories: [vetoExtensionFactory(veto)] });
+
+		writeJson(fixture.settingsPath, { theme: "light" });
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		await fixture.harness.getExtensionRunner().emit({ type: "agent_settled" });
+		await fixture.harness.getExtensionRunner().emit({ type: "agent_settled" });
+
+		expect(fixture.reload).not.toHaveBeenCalled();
+		expect(fixture.notifications.filter((message) => message.startsWith("Hot-reloading:"))).toEqual([]);
+		const deferred = fixture.notifications.filter((message) => message.startsWith("Hot-reload deferred:"));
+		expect(deferred).toHaveLength(1);
+		expect(deferred[0]).toContain(veto.reason);
+	});
+
+	it("applies a deferred reload on the next idle edge once the veto clears", async () => {
+		vi.useFakeTimers();
+		const veto: VetoState = { active: true, reason: "1 subagent(s) still running: worker" };
+		const fixture = await createFixture({ extraFactories: [vetoExtensionFactory(veto)] });
+
+		writeJson(fixture.settingsPath, { theme: "light" });
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		veto.active = false;
+		await fixture.harness.getExtensionRunner().emit({ type: "agent_settled" });
+
+		expect(fixture.reload).toHaveBeenCalledTimes(1);
+		expect(fixture.notifications.filter((message) => message.startsWith("Hot-reloading:"))).toHaveLength(1);
+	});
+
+	it("retries a vetoed reload on the recheck clock without further agent activity", async () => {
+		vi.useFakeTimers();
+		const veto: VetoState = { active: true, reason: "2 subagent(s) still running: a, b" };
+		const fixture = await createFixture({ extraFactories: [vetoExtensionFactory(veto)] });
+
+		writeJson(fixture.settingsPath, { theme: "light" });
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		veto.active = false;
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(fixture.reload).toHaveBeenCalledTimes(1);
+		expect(fixture.notifications.filter((message) => message.startsWith("Hot-reload deferred:"))).toHaveLength(1);
+		expect(fixture.notifications.filter((message) => message.startsWith("Hot-reloading:"))).toHaveLength(1);
+	});
+
+	it("drops the veto recheck when the session shuts down", async () => {
+		vi.useFakeTimers();
+		const veto: VetoState = { active: true, reason: "1 subagent(s) still running: worker" };
+		const fixture = await createFixture({ extraFactories: [vetoExtensionFactory(veto)] });
+
+		writeJson(fixture.settingsPath, { theme: "light" });
+		await settleChange(fixture, fixture.agentDir, "settings.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
+
+		await fixture.harness.getExtensionRunner().emit({ type: "session_shutdown", reason: "quit" });
+		veto.active = false;
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(fixture.reload).not.toHaveBeenCalled();
 	});
 
 	it("starts late registrations immediately and replaces duplicate ids", async () => {


### PR DESCRIPTION
## Problem

When an extension vetoes session reload via `session_before_reload` (e.g. the omo reload-guard while subagents are running), the `config-reload` builtin re-emitted `Hot-reloading: <paths>` plus the host's veto warning on EVERY flush edge (`agent_end`/`agent_settled`), spamming the TUI for as long as the veto held:

```
Hot-reloading: /Users/.../settings.json
Warning: 5 subagent(s) still running: pr472, pr456, ... - wait for them to finish or cancel them (task_cancel) before reloading.
Hot-reloading: /Users/.../settings.json
Warning: 5 subagent(s) still running: ...
(repeats on every idle edge)
```

Deferral-route audit: busy/pending-message gates and the compaction 250ms recheck already defer silently with a one-shot notice; the extension-veto route was the only loud looping one.

## Fix

1. **`ExtensionContext.checkReloadVeto()`** (optional, + `ExtensionContextActions.checkReloadVeto`, `ReloadVetoDecision`): probes the cancellable `session_before_reload` gate WITHOUT starting a reload. `AgentSession` supplies it in `_bindExtensionCore`, so every host mode (TUI/RPC/print) exposes it automatically.
2. **`config-reload` quiet veto deferral**: `flushPending` probes the veto before announcing. Vetoed -> keep pending, log `reload_deferred`, show at most ONE `Hot-reload deferred: <reason>` notice per distinct reason, arm a 1s veto-recheck clock, and stay silent on subsequent retries. Once the veto clears (idle edge or recheck tick) the normal `Hot-reloading:` -> reload -> `Hot-reloaded:` flow runs exactly once. Manual `/reload` keeps its immediate warning; hosts without the probe keep the previous behavior.

## Tests (failing-first, captured RED before implementation)

- `test/suite/config-reload-extension.test.ts`: vetoed flush defers silently (0 `Hot-reloading:`, 0 `requestReload`, exactly 1 deferral notice across multiple idle edges); deferred reload applies on the next idle edge once the veto clears; fake-clock recheck retries and reloads without further agent activity; `session_shutdown` drops the recheck timer.
- `test/extensions-runner.test.ts`: `checkReloadVeto` promotion into event contexts; `undefined` without a host probe.
- Regression: full `config-reload-extension`, `session-before-reload`, `rpc-multi-session-isolation`, `extensions-runner` suites green in single runs; root `npm run check` green.

## QA evidence (real CLI from source, senpi-qa sandbox, zero tokens)

Real TUI via tsx in tmux (isolated `SENPI_CODING_AGENT_DIR`, `PI_OFFLINE=1`) with a sandbox extension cancelling `session_before_reload` behind a flag file:

- 3 external `settings.json` changes + recheck ticks while vetoed -> pane shows exactly ONE `Hot-reload deferred: 2 subagent(s) still running: qa-a, qa-b`, ZERO `Hot-reloading:` lines.
- `config-reload.log`: `change_detected` -> `reload_deferred` x4 (silent 1s recheck ticks) -> flag removed -> `reload_requested` -> `watcher_started` (rebuilt runtime) -> `reload_completed`, ~1s after the veto cleared with no agent activity or user input.
- Cleanup receipts recorded; real `~/.senpi/agent/auth.json` sha256 unchanged.

Evidence: `local-ignore/qa-evidence/20260729-config-reload-veto-deferral/` (gitignored, local).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quietly defer vetoed `config-reload` hot-reloads to stop repeated “Hot-reloading:” messages, and run a single reload once the veto clears. Adds an optional `checkReloadVeto()` probe to extension contexts to check the veto without triggering a reload.

- **Bug Fixes**
  - `config-reload` checks the reload veto before announcing.
  - If vetoed, keep pending, log `reload_deferred`, and show one “Hot-reload deferred: <reason>” per reason.
  - Retry on idle edges and a 1s veto recheck; no repeated “Hot-reloading:” spam.
  - Clear the recheck on session shutdown; proceed once and notify only when the veto clears.

- **New Features**
  - Added optional `ExtensionContext.checkReloadVeto(): Promise<ReloadVetoDecision>` and matching host action to probe `session_before_reload` without starting a reload.
  - Exposed via `AgentSession` in all host modes.

<sup>Written for commit a966bf3cf3143f46dd79e09241455aaf216274bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

