### PR TITLE
feat(coding-agent): immediate loading indicator during interactive startup

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,32 @@
+## Interactive startup loading indicator (2026-07-29)
+
+### What changed
+
+- New `cli/startup-loading-indicator.ts`: single-line dim ANSI spinner (`⠋ Loading senpi… <phase>`) with a
+  120ms grace delay (fast startups stay flash-free), phase updates, pause/resume, and an idempotent `stop()`
+  that clears the line and restores the cursor (also via a `process` exit hook). It engages only when
+  `appMode === "interactive"`, stdout is a TTY, and `--help` was not requested.
+- `main.ts` starts the indicator before `createAgentSessionRuntime` — the extensions/models/trust window that
+  previously rendered nothing — switches the phase to `opening session` before the initial session is created,
+  and stops it in a `.finally` before any other stdout writer (TUI, help, diagnostics) takes over.
+- Mid-load project-trust prompts (`createProjectTrustContext` `ui.select`/`confirm`/`input`) are wrapped by
+  `pauseIndicatorDuringPrompts`, so the trust selector TUI never fights the spinner for the terminal.
+- Coverage: `test/startup-loading-indicator.test.ts` (grace delay, frame animation, phase updates,
+  pause/resume, stop idempotency, TTY/help gating, prompt-pause wrapping).
+
+### Why
+
+- Interactive startup completed the entire heavy runtime creation before the TUI existed, leaving the terminal
+  blank and apparently stuck (QA repro: ~23s of empty screen with a slow-loading extension). Codex's TUI
+  addresses the same window by rendering a dim placeholder header until the session is configured
+  (`codex-rs/tui` chatwidget); this is the minimal-conflict equivalent for senpi's pre-TUI bootstrap window.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: the import block and indicator wiring around `createAgentSessionRuntime` in `main.ts`; the module itself
+  has no upstream counterpart.
+- LOW: the `projectTrustContext` fallback wrap inside `createRuntime`.
+
 ## Availability-aware default Fable fallback chain (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/cli/startup-loading-indicator.ts
+++ b/packages/coding-agent/src/cli/startup-loading-indicator.ts
@@ -1,0 +1,198 @@
+import type { ProjectTrustContext } from "../core/extensions/types.ts";
+import type { AppMode } from "../core/project-trust.ts";
+
+const HIDE_CURSOR = "\u001b[?25l";
+const SHOW_CURSOR = "\u001b[?25h";
+const CLEAR_LINE = "\r\u001b[2K";
+const DIM = "\u001b[2m";
+const RESET = "\u001b[0m";
+
+const DEFAULT_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const DEFAULT_LABEL = "Loading";
+const DEFAULT_GRACE_MS = 120;
+const DEFAULT_INTERVAL_MS = 80;
+
+export interface StartupLoadingIndicatorOptions {
+	readonly writer: (chunk: string) => void;
+	readonly isTTY: boolean;
+	readonly label?: string;
+	readonly graceMs?: number;
+	readonly intervalMs?: number;
+	readonly frames?: readonly string[];
+}
+
+export interface StartupLoadingIndicator {
+	start(): void;
+	setPhase(phase: string | undefined): void;
+	pause(): void;
+	resume(): void;
+	stop(): void;
+	readonly running: boolean;
+}
+
+/**
+ * Single-line ANSI loading indicator for the pre-TUI startup window, borrowed
+ * from codex's UI-first startup design (codex-rs/tui keeps a dim placeholder
+ * header until the session is configured). The grace delay keeps fast startups
+ * flash-free; stop() must run before any other stdout writer (TUI, prompts,
+ * help) takes over the terminal.
+ */
+class AnsiStartupLoadingIndicator implements StartupLoadingIndicator {
+	private readonly writer: (chunk: string) => void;
+	private readonly isTTY: boolean;
+	private readonly label: string;
+	private readonly graceMs: number;
+	private readonly intervalMs: number;
+	private readonly frames: readonly string[];
+	private phase: string | undefined = undefined;
+	private frameIndex = 0;
+	private drawn = false;
+	private graceElapsed = false;
+	private started = false;
+	private paused = false;
+	private stopped = false;
+	private graceTimer: NodeJS.Timeout | undefined = undefined;
+	private frameTimer: NodeJS.Timeout | undefined = undefined;
+	private exitListener: (() => void) | undefined = undefined;
+
+	constructor(options: StartupLoadingIndicatorOptions) {
+		this.writer = options.writer;
+		this.isTTY = options.isTTY;
+		this.label = options.label ?? DEFAULT_LABEL;
+		this.graceMs = options.graceMs ?? DEFAULT_GRACE_MS;
+		this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+		this.frames = options.frames && options.frames.length > 0 ? options.frames : DEFAULT_FRAMES;
+	}
+
+	get running(): boolean {
+		return this.started && !this.stopped;
+	}
+
+	start(): void {
+		if (!this.isTTY || this.started || this.stopped) return;
+		this.started = true;
+		this.exitListener = () => {
+			if (this.drawn) this.writer(CLEAR_LINE + SHOW_CURSOR);
+		};
+		process.on("exit", this.exitListener);
+		this.startGraceTimer();
+	}
+
+	setPhase(phase: string | undefined): void {
+		this.phase = phase;
+		if (this.drawn && !this.paused && !this.stopped) {
+			this.draw(false);
+		}
+	}
+
+	pause(): void {
+		if (!this.started || this.stopped || this.paused) return;
+		this.paused = true;
+		this.clearTimers();
+		this.eraseLine();
+	}
+
+	resume(): void {
+		if (!this.started || this.stopped || !this.paused) return;
+		this.paused = false;
+		if (this.graceElapsed) {
+			this.beginAnimation();
+		} else {
+			this.startGraceTimer();
+		}
+	}
+
+	stop(): void {
+		if (this.stopped) return;
+		this.stopped = true;
+		this.clearTimers();
+		this.eraseLine();
+		if (this.exitListener) {
+			process.removeListener("exit", this.exitListener);
+			this.exitListener = undefined;
+		}
+	}
+
+	private startGraceTimer(): void {
+		this.graceTimer = setTimeout(() => {
+			this.graceElapsed = true;
+			this.beginAnimation();
+		}, this.graceMs);
+	}
+
+	private beginAnimation(): void {
+		this.draw(true);
+		this.frameTimer = setInterval(() => {
+			this.frameIndex = (this.frameIndex + 1) % this.frames.length;
+			this.draw(false);
+		}, this.intervalMs);
+	}
+
+	private draw(hideCursor: boolean): void {
+		const frame = this.frames[this.frameIndex] ?? "";
+		const phaseSuffix = this.phase ? ` ${this.phase}` : "";
+		const line = `${DIM}${frame} ${this.label}…${phaseSuffix}${RESET}`;
+		this.writer(`${hideCursor ? HIDE_CURSOR : ""}${CLEAR_LINE}${line}`);
+		this.drawn = true;
+	}
+
+	private eraseLine(): void {
+		if (!this.drawn) return;
+		this.writer(CLEAR_LINE + SHOW_CURSOR);
+		this.drawn = false;
+	}
+
+	private clearTimers(): void {
+		if (this.graceTimer) {
+			clearTimeout(this.graceTimer);
+			this.graceTimer = undefined;
+		}
+		if (this.frameTimer) {
+			clearInterval(this.frameTimer);
+			this.frameTimer = undefined;
+		}
+	}
+}
+
+export function createStartupLoadingIndicator(options: StartupLoadingIndicatorOptions): StartupLoadingIndicator {
+	return new AnsiStartupLoadingIndicator(options);
+}
+
+export function shouldShowStartupLoadingIndicator(input: {
+	readonly appMode: AppMode;
+	readonly stdoutIsTTY: boolean;
+	readonly helpRequested: boolean;
+}): boolean {
+	return input.appMode === "interactive" && input.stdoutIsTTY && !input.helpRequested;
+}
+
+/**
+ * Project-trust prompts open their own startup TUI mid-load; pausing the
+ * indicator around each prompt keeps the two from fighting over the terminal.
+ */
+export function pauseIndicatorDuringPrompts(
+	context: ProjectTrustContext,
+	indicator: Pick<StartupLoadingIndicator, "pause" | "resume">,
+): ProjectTrustContext {
+	const wrapPrompt =
+		<Args extends readonly unknown[], Result>(
+			prompt: (...args: Args) => Promise<Result>,
+		): ((...args: Args) => Promise<Result>) =>
+		async (...args: Args): Promise<Result> => {
+			indicator.pause();
+			try {
+				return await prompt(...args);
+			} finally {
+				indicator.resume();
+			}
+		};
+	return {
+		...context,
+		ui: {
+			select: wrapPrompt(context.ui.select),
+			confirm: wrapPrompt(context.ui.confirm),
+			input: wrapPrompt(context.ui.input),
+			notify: context.ui.notify,
+		},
+	};
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -17,8 +17,13 @@ import { listModels } from "./cli/list-models.ts";
 import { listTips } from "./cli/list-tips.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
+import {
+	createStartupLoadingIndicator,
+	pauseIndicatorDuringPrompts,
+	shouldShowStartupLoadingIndicator,
+} from "./cli/startup-loading-indicator.ts";
 import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
-import { ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
+import { APP_NAME, ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
 import {
 	type AgentSessionRuntimeDiagnostic,
@@ -707,6 +712,25 @@ export async function main(args: string[], options?: MainOptions) {
 		parsed.help || parsed.listModels !== undefined || parsed.listTips ? "print" : toProjectTrustMode(appMode);
 	const projectTrustByCwd = new Map<string, boolean>();
 
+	// Immediate feedback while the heavy runtime (extensions, models, trust) is
+	// created; without it the terminal stays blank and looks stuck (codex-style
+	// UI-first startup). Stopped before any other surface writes to stdout.
+	const startupLoadingIndicator = createStartupLoadingIndicator({
+		writer: (chunk) => process.stdout.write(chunk),
+		isTTY: process.stdout.isTTY === true,
+		label: `Loading ${APP_NAME}`,
+	});
+	if (
+		shouldShowStartupLoadingIndicator({
+			appMode,
+			stdoutIsTTY: process.stdout.isTTY === true,
+			helpRequested: parsed.help === true,
+		})
+	) {
+		startupLoadingIndicator.start();
+		startupLoadingIndicator.setPhase("extensions & models");
+	}
+
 	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
 		cwd,
 		agentDir,
@@ -743,12 +767,15 @@ export async function main(args: string[], options?: MainOptions) {
 								extensionsResult,
 								projectTrustContext:
 									projectTrustContext ??
-									createProjectTrustContext({
-										cwd,
-										mode: isInitialRuntime ? trustPromptMode : toProjectTrustMode(appMode),
-										settingsManager: startupSettingsManager,
-										hasUI: isInitialRuntime && trustPromptMode === "interactive",
-									}),
+									pauseIndicatorDuringPrompts(
+										createProjectTrustContext({
+											cwd,
+											mode: isInitialRuntime ? trustPromptMode : toProjectTrustMode(appMode),
+											settingsManager: startupSettingsManager,
+											hasUI: isInitialRuntime && trustPromptMode === "interactive",
+										}),
+										startupLoadingIndicator,
+									),
 								onExtensionError: (message) => projectTrustDiagnostics.push({ type: "warning", message }),
 							});
 							projectTrustByCwd.set(cwd, trusted);
@@ -826,6 +853,9 @@ export async function main(args: string[], options?: MainOptions) {
 			}
 		}
 
+		if (isInitialRuntime) {
+			startupLoadingIndicator.setPhase("opening session");
+		}
 		const created = await createAgentSessionFromServices({
 			services,
 			sessionManager,
@@ -872,6 +902,8 @@ export async function main(args: string[], options?: MainOptions) {
 		cwd: sessionManager.getCwd(),
 		agentDir,
 		sessionManager,
+	}).finally(() => {
+		startupLoadingIndicator.stop();
 	});
 	time("createAgentSessionRuntime");
 	const { services, session, modelFallbackMessage } = runtime;

--- a/packages/coding-agent/test/startup-loading-indicator.test.ts
+++ b/packages/coding-agent/test/startup-loading-indicator.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createStartupLoadingIndicator,
+	pauseIndicatorDuringPrompts,
+	type StartupLoadingIndicator,
+	shouldShowStartupLoadingIndicator,
+} from "../src/cli/startup-loading-indicator.ts";
+import type { ProjectTrustContext } from "../src/core/extensions/types.ts";
+
+const HIDE_CURSOR = "\u001b[?25l";
+const SHOW_CURSOR = "\u001b[?25h";
+const CLEAR_LINE = "\r\u001b[2K";
+const FRAMES = ["A", "B", "C"] as const;
+
+function makeIndicator(overrides: { isTTY?: boolean } = {}): {
+	indicator: StartupLoadingIndicator;
+	writes: string[];
+} {
+	const writes: string[] = [];
+	const indicator = createStartupLoadingIndicator({
+		writer: (chunk) => writes.push(chunk),
+		isTTY: overrides.isTTY ?? true,
+		label: "Loading senpi",
+		graceMs: 120,
+		intervalMs: 80,
+		frames: FRAMES,
+	});
+	return { indicator, writes };
+}
+
+describe("createStartupLoadingIndicator", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("writes nothing before the grace delay and nothing when stopped within it", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(119);
+		expect(writes).toEqual([]);
+		indicator.stop();
+		vi.advanceTimersByTime(1000);
+		expect(writes).toEqual([]);
+	});
+
+	it("draws the first frame after the grace delay with a hidden cursor", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(120);
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toContain(HIDE_CURSOR);
+		expect(writes[0]).toContain(CLEAR_LINE);
+		expect(writes[0]).toContain("A");
+		expect(writes[0]).toContain("Loading senpi");
+	});
+
+	it("animates frames on the interval, rewriting a single line", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(120);
+		vi.advanceTimersByTime(80);
+		vi.advanceTimersByTime(80);
+		expect(writes).toHaveLength(3);
+		expect(writes[1]).toContain(CLEAR_LINE);
+		expect(writes[1]).toContain("B");
+		expect(writes[1]).not.toContain(HIDE_CURSOR);
+		expect(writes[2]).toContain("C");
+	});
+
+	it("setPhase updates the rendered line immediately once drawing", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(120);
+		indicator.setPhase("opening session");
+		expect(writes.at(-1)).toContain("opening session");
+	});
+
+	it("pause clears the line and suppresses writes; resume redraws", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(120);
+		indicator.pause();
+		const pauseWrite = writes.at(-1) ?? "";
+		expect(pauseWrite).toContain(CLEAR_LINE);
+		expect(pauseWrite).toContain(SHOW_CURSOR);
+		expect(pauseWrite).not.toContain("Loading senpi");
+		const countAfterPause = writes.length;
+		vi.advanceTimersByTime(800);
+		expect(writes).toHaveLength(countAfterPause);
+		indicator.resume();
+		expect(writes.length).toBeGreaterThan(countAfterPause);
+		expect(writes.at(-1)).toContain("Loading senpi");
+		const countAfterResume = writes.length;
+		vi.advanceTimersByTime(80);
+		expect(writes.length).toBeGreaterThan(countAfterResume);
+	});
+
+	it("stop clears the line, restores the cursor, and is idempotent", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(120);
+		indicator.stop();
+		const stopWrite = writes.at(-1) ?? "";
+		expect(stopWrite).toContain(CLEAR_LINE);
+		expect(stopWrite).toContain(SHOW_CURSOR);
+		const countAfterStop = writes.length;
+		vi.advanceTimersByTime(1000);
+		indicator.stop();
+		expect(writes).toHaveLength(countAfterStop);
+	});
+
+	it("stop while paused emits nothing extra", () => {
+		const { indicator, writes } = makeIndicator();
+		indicator.start();
+		vi.advanceTimersByTime(120);
+		indicator.pause();
+		const countAfterPause = writes.length;
+		indicator.stop();
+		expect(writes).toHaveLength(countAfterPause);
+	});
+
+	it("is completely inert without a TTY", () => {
+		const { indicator, writes } = makeIndicator({ isTTY: false });
+		indicator.start();
+		vi.advanceTimersByTime(1000);
+		indicator.stop();
+		expect(writes).toEqual([]);
+	});
+
+	it("registers an exit listener while running and removes it on stop", () => {
+		const before = process.listeners("exit").length;
+		const { indicator } = makeIndicator();
+		indicator.start();
+		expect(process.listeners("exit").length).toBe(before + 1);
+		indicator.stop();
+		expect(process.listeners("exit").length).toBe(before);
+	});
+});
+
+describe("shouldShowStartupLoadingIndicator", () => {
+	it("engages only for interactive mode on a TTY without --help", () => {
+		expect(
+			shouldShowStartupLoadingIndicator({ appMode: "interactive", stdoutIsTTY: true, helpRequested: false }),
+		).toBe(true);
+		expect(shouldShowStartupLoadingIndicator({ appMode: "print", stdoutIsTTY: true, helpRequested: false })).toBe(
+			false,
+		);
+		expect(shouldShowStartupLoadingIndicator({ appMode: "rpc", stdoutIsTTY: true, helpRequested: false })).toBe(
+			false,
+		);
+		expect(
+			shouldShowStartupLoadingIndicator({ appMode: "interactive", stdoutIsTTY: false, helpRequested: false }),
+		).toBe(false);
+		expect(
+			shouldShowStartupLoadingIndicator({ appMode: "interactive", stdoutIsTTY: true, helpRequested: true }),
+		).toBe(false);
+	});
+});
+
+describe("pauseIndicatorDuringPrompts", () => {
+	function makeContext(events: string[], behavior: { reject?: boolean } = {}): ProjectTrustContext {
+		return {
+			cwd: "/tmp/project",
+			mode: "tui",
+			hasUI: true,
+			ui: {
+				select: async (_title, _options) => {
+					events.push("select");
+					if (behavior.reject) throw new Error("prompt failed");
+					return "picked";
+				},
+				confirm: async (_title, _message) => {
+					events.push("confirm");
+					return true;
+				},
+				input: async (_title, _placeholder) => {
+					events.push("input");
+					return "typed";
+				},
+				notify: (_message, _type) => {
+					events.push("notify");
+				},
+			},
+		};
+	}
+
+	function makePauseSpy(events: string[]): Pick<StartupLoadingIndicator, "pause" | "resume"> {
+		return {
+			pause: () => events.push("pause"),
+			resume: () => events.push("resume"),
+		};
+	}
+
+	it("pauses around select/confirm/input and passes results through", async () => {
+		const events: string[] = [];
+		const wrapped = pauseIndicatorDuringPrompts(makeContext(events), makePauseSpy(events));
+		await expect(wrapped.ui.select("t", ["a"])).resolves.toBe("picked");
+		await expect(wrapped.ui.confirm("t", "m")).resolves.toBe(true);
+		await expect(wrapped.ui.input("t", "p")).resolves.toBe("typed");
+		expect(events).toEqual(["pause", "select", "resume", "pause", "confirm", "resume", "pause", "input", "resume"]);
+	});
+
+	it("resumes even when the prompt rejects", async () => {
+		const events: string[] = [];
+		const wrapped = pauseIndicatorDuringPrompts(makeContext(events, { reject: true }), makePauseSpy(events));
+		await expect(wrapped.ui.select("t", ["a"])).rejects.toThrow("prompt failed");
+		expect(events).toEqual(["pause", "select", "resume"]);
+	});
+
+	it("leaves notify untouched", () => {
+		const events: string[] = [];
+		const wrapped = pauseIndicatorDuringPrompts(makeContext(events), makePauseSpy(events));
+		wrapped.ui.notify("hello", "info");
+		expect(events).toEqual(["notify"]);
+	});
+});


### PR DESCRIPTION
## Problem

Interactive `senpi` startup completes the entire heavy runtime creation (extension loading, model runtime, provider registration, trust resolution) before `InteractiveMode` ever constructs the TUI. Until that finishes, the terminal shows nothing — the app looks stuck. QA repro with a slow-loading extension captured ~23 seconds of completely blank screen before first paint.

## Approach (hint borrowed from codex)

codex's TUI is UI-first: it renders a dim placeholder session header until `SessionConfigured` arrives (`codex-rs/tui/src/chatwidget.rs` — `placeholder_session_header_cell`, model display name defaults to `"loading"`). senpi cannot start its full TUI before the runtime exists, so this PR ships the minimal-conflict equivalent for the pre-TUI window: an immediate, single-line dim ANSI loading indicator that lives exactly as long as the heavy bootstrap.

- New `cli/startup-loading-indicator.ts` (178 pure LOC): `⠋ Loading senpi… <phase>` with a 120 ms grace delay (fast startups stay flash-free), 80 ms frame interval, phase updates (`extensions & models` → `opening session`), pause/resume, and an idempotent `stop()` that clears the line and restores the cursor (also via a `process` exit hook).
- `main.ts` starts it right before `createAgentSessionRuntime` and stops it in a `.finally` before any other stdout writer (TUI, help, diagnostics) takes over.
- Gating: engages only when `appMode === "interactive"`, stdout is a TTY, and `--help` was not requested.
- Mid-load project-trust prompts open their own startup TUI; `pauseIndicatorDuringPrompts` wraps `ui.select`/`confirm`/`input` so the prompt and the spinner never fight over the terminal.

## Evidence (`local-ignore/qa-evidence/20260729-startup-loading-indicator/`, not committed)

- RED (before): tmux sandbox boot with a 3 s slow-load extension — samples 01–46 (~23 s) completely empty, 0 samples with any loading feedback (`red/`).
- GREEN (after): same scenario — samples 24–30 show the animated dim loading line with phase text; clean handoff, 0 residual loading text in the booted pane (`green/`).
- `--help` on a real TTY via `script(1)` raw capture: 0 loading-line hits, 0 hide-cursor escapes, help text intact.
- Unit: `test/startup-loading-indicator.test.ts` — 13 tests (grace delay, animation, phase, pause/resume, stop idempotency, exit-listener hygiene, TTY/help gating, prompt-pause wrapping), written RED-first against a stub.
- `npm run check` green; coding-agent package vitest suite green; senpi-qa mock-loop `--self-test` and TUI smoke `--self-test` green.

## Merge-conflict posture

Fork record updated in `src/changes.md`. The module has no upstream counterpart; `main.ts` touch is limited to the import block, the indicator wiring around `createAgentSessionRuntime`, and the `projectTrustContext` fallback wrap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an immediate, single-line loading indicator during interactive startup so users see progress while extensions and models load. This removes the blank-screen delay and cleanly hands off control to the TUI.

- **New Features**
  - Single-line dim ANSI spinner with a 120 ms grace delay, 80 ms frame interval, phase text, pause/resume, and an idempotent stop that clears the line and restores the cursor.
  - Wired into `main.ts` around `createAgentSessionRuntime`; phases update from “extensions & models” to “opening session”. Only runs when interactive, on a TTY, and `--help` is not requested.
  - Spinner auto-pauses around project-trust prompts to prevent output conflicts.

<sup>Written for commit 0e311c58ced887dbc25a842c293038997f358ba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

