### PR TITLE
fix(goal): bound goal auto-continuation with guardrails (fixes #447)

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1399,19 +1399,19 @@ export class AgentSession {
 			}
 		}
 
+		const agentEndWillRetry = event.type === "agent_end" && this._willRetryAfterAgentEnd(event.messages);
+
 		// Emit to extensions first. Agent event persistence is intentionally
 		// asynchronous, so retain the source run signal while dispatching.
 		this._extensionEventSignal = signal;
 		try {
-			await this._emitExtensionEvent(event);
+			await this._emitExtensionEvent(event, agentEndWillRetry);
 		} finally {
 			this._extensionEventSignal = undefined;
 		}
 
 		// Notify all listeners
-		this._emit(
-			event.type === "agent_end" ? { ...event, willRetry: this._willRetryAfterAgentEnd(event.messages) } : event,
-		);
+		this._emit(event.type === "agent_end" ? { ...event, willRetry: agentEndWillRetry } : event);
 
 		// Handle session persistence
 		if (event.type === "message_end") {
@@ -1635,7 +1635,7 @@ export class AgentSession {
 	}
 
 	/** Emit extension events based on agent events */
-	private async _emitExtensionEvent(event: AgentEvent): Promise<void> {
+	private async _emitExtensionEvent(event: AgentEvent, agentEndWillRetry = false): Promise<void> {
 		if (event.type === "agent_start") {
 			this._turnIndex = 0;
 			await this._extensionRunner.emit({ type: "agent_start" });
@@ -1644,9 +1644,9 @@ export class AgentSession {
 			const aborted =
 				abortSource !== undefined || this._findLastAssistantInMessages(event.messages)?.stopReason === "aborted";
 			try {
-				await this._extensionRunner.emit({
-					type: "agent_end",
+				await this._extensionRunner.emitAgentEnd({
 					messages: event.messages,
+					willRetry: agentEndWillRetry,
 					...(aborted ? { aborted: true } : {}),
 					...(abortSource === undefined ? {} : { abortSource }),
 				});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1654,7 +1654,8 @@ export class AgentSession {
 			const aborted =
 				abortSource !== undefined || this._findLastAssistantInMessages(event.messages)?.stopReason === "aborted";
 			try {
-				await this._extensionRunner.emitAgentEnd({
+				await this._extensionRunner.emit({
+					type: "agent_end",
 					messages: event.messages,
 					willRetry: agentEndWillRetry,
 					...(aborted ? { aborted: true } : {}),

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -15,6 +15,44 @@
 
 - LOW: `getSettingsPath()` in `settings-manager.ts`.
 
+## messages.ts keep-latest exclusion for goal-continuation (2026-07-29)
+
+### What changed
+
+- `messages.ts` now excludes consumed `goal-continuation` custom messages by position instead of by type: every
+  `role === "custom" && customType === GOAL_CONTINUATION_MESSAGE_TYPE` entry is dropped except the last one.
+  The same keep-latest rule is applied in both `filterContextExcludedMessages` and `convertToLlm`, so token estimation
+  and provider payload assembly stay in sync.
+- `isContextExcludedCustomMessage` remains `false` for this custom type; the live triggering message still needs to be
+  visible to per-entry consumers such as compaction and branch summarization.
+
+### Why
+
+- Goal continuation messages accumulate across long sessions, and stale consumed entries must stay out of the next
+  provider request without hiding the active trigger or letting the estimator disagree with the payload.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW in `messages.ts` around the shared keep-latest helper, `filterContextExcludedMessages`, and `convertToLlm`.
+- NONE in the per-entry custom-message predicate semantics.
+
+## AgentEndEvent.willRetry extension event field (2026-07-29)
+
+### What changed
+
+- `extensions/types.ts` now exposes an optional `willRetry?: boolean` on `AgentEndEvent`, mirroring the agent-session
+  end event so builtin extensions can tell a terminal provider error from a retryable one.
+- The field is additive only; existing extension consumers that ignore it continue to behave the same.
+
+### Why
+
+- The goal builtin needs to block on terminal provider errors only after retries are exhausted. Without the retry
+  signal, a terminal error could be misclassified while a fallback retry was still in flight.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW in `extensions/types.ts` and the runner plumbing that forwards agent-session end events to builtin extensions.
+
 ## claude-agent-sdk provider with native multi-account OAuth (2026-07-27)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -34,6 +34,20 @@ metadata. The builtin tools do not create or interpret it. There is no
 budget-driven status transition. `tokensUsed` and `timeUsedSeconds` remain
 display-only usage metrics. Status is `active | paused | blocked | complete`; `blocked` carries `blockedReason`/`blockedAt` and suppresses continuations.
 
+## CONTINUATION POLICY
+
+Continuation admission is guarded by a persisted consecutive-continuation cap of 8,
+a stale-signature check on immediate re-entry, and a single-flight latch so only one
+hidden continuation can be queued at a time. The stall notice is goal-wide: from the
+3rd consecutive toolless continuation turn it prefixes the prompt with `<goal_stall_check>`
+and switches between monitor-flavored bullets while monitors are active and generic
+recovery bullets otherwise. A real user prompt imposes a 60s grace window before
+resuming, a `length` stop gets exactly one minimal truncation recovery before the goal
+blocks on repetition, terminal provider errors block the goal only when `AgentEndEvent.willRetry`
+is false, and resumed sessions with 8+ trailing historical continuation entries suppress
+session-start auto-resume. `tokenBudget` remains inert compatibility metadata only; this
+policy is budget-free by design.
+
 ## PERSISTENCE
 
 `store.ts` writes `GoalFile{version:1, goal}` to

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -10,7 +10,7 @@
   `<goal_monitor_stall_check>` block (`buildMonitorStallNotice` in `prompt.ts`) telling
   the agent the repeated wait looks abnormal and to actively inspect the monitored state
   (bash_output, process health, kill_bash + alternate approach, or the blocked audit)
-  before waiting again. A `goal_monitor_continuation_stall` event is emitted and a UI
+  before waiting again. A `goal_continuation_scheduled`/stall notice is emitted and a UI
   notice shown when the check is injected.
 - The streak resets on every signal that breaks the unattended wait loop: monitor
   completion (`terminal_monitor_state` activeCount 0), a real user prompt
@@ -24,6 +24,42 @@
 - LOW in `monitor-continuation.ts` around `#continueIfEligible` and the monitor-state
   subscription.
 - LOW in `prompt.ts` (appended exported builder) and `index.ts` `before_agent_start`.
+
+## Goal continuation guardrails (2026-07-29)
+
+### What changed
+
+- `continuation.ts` now persists the continuation cap as stateful goal metadata and treats
+  continued stale signatures and repeated normalized assistant outputs as stop conditions.
+  The cap remains 8, stale-signature comparison stays immediate-path only, and a single-flight
+  latch prevents duplicate queued continuations.
+- `prompt.ts` generalizes the stall notice from monitor-only to goal-wide: the same
+  continuation block now covers toolless continuation streaks from the 3rd consecutive turn,
+  uses `<goal_stall_check>` for the renamed block, keeps the monitor-flavored bullets when
+  monitors are active, and emits generic recovery bullets otherwise. The user-prompt grace
+  delay remains 60s, truncation recovery remains one minimal prompt, and terminal provider
+  errors now block the goal when `AgentEndEvent.willRetry` is false.
+- `monitor-continuation.ts`, `lifecycle-helpers.ts`, and `index.ts` route immediate,
+  monitor-delayed, and session-start continuation entry points through the verdict engine;
+  user prompts reset the streak state, and the session-start admission path suppresses
+  resumed flooded sessions with 8+ historical trailing continuation entries.
+- `types.ts` and persistence/store code now carry the continuation streak and signature
+  fields so a restart cannot bypass the cap, while the existing `tokenBudget` field stays
+  inert compatibility metadata only.
+
+### Why
+
+- The built-in goal feature had multiple independent loop sources: repeated clean agent turns,
+  stale hidden control prompts after state changes, immediate re-entry after a real user turn,
+  truncation loops, silent provider terminal failures, and resumed sessions that replayed long
+  continuation histories. These guards close those paths without introducing budget-based policy.
+
+### Expected merge conflict zones on the next sync
+
+- HIGH in `continuation.ts`, `monitor-continuation.ts`, `lifecycle-helpers.ts`, and `index.ts`
+  where continuation admission and reset state are wired.
+- MEDIUM in `prompt.ts` and the goal store/persistence files for the new guard state.
+- LOW in `extensions/types.ts` and related core event plumbing for `AgentEndEvent.willRetry`.
 
 ## Blank reasons treated as omitted for update_goal complete (2026-07-28)
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -10,7 +10,7 @@ export const GOAL_REPETITION_HASH_STREAK = 3;
 export const GOAL_LENGTH_RECOVERY_LIMIT = 1;
 export const GOAL_USER_GRACE_DELAY_MS = 60_000;
 
-export type GoalContinuationPath = "immediate" | "monitorDelayed" | "sessionStart";
+export type GoalContinuationPath = "immediate" | "monitorDelayed" | "userGrace" | "sessionStart";
 
 export type GoalContinuationInput = {
 	readonly goal: Goal | null;
@@ -93,7 +93,7 @@ export function evaluateGoalContinuation(input: GoalContinuationInput): GoalCont
 		return { kind: "deny", reason: "cap" };
 	}
 	if (
-		input.path === "immediate" &&
+		(input.path === "immediate" || input.path === "userGrace") &&
 		input.lastContinuationSignature !== undefined &&
 		input.lastContinuationSignature === input.currentSignature
 	) {
@@ -147,7 +147,7 @@ function isEligibleForGoalContinuation(input: GoalContinuationInput): boolean {
 }
 
 function isContinuationCapPath(path: GoalContinuationPath): boolean {
-	return path === "immediate" || path === "sessionStart";
+	return path === "immediate" || path === "userGrace" || path === "sessionStart";
 }
 
 function hasRepeatedNormalizedOutputHash(hashes: readonly string[]): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -4,6 +4,37 @@ import type { Goal } from "./types.ts";
 type AssistantAgentMessage = Extract<AgentMessage, { role: "assistant" }>;
 type ToolResultAgentMessage = Extract<AgentMessage, { role: "toolResult" }>;
 
+export const GOAL_CONTINUATION_CAP = 8;
+export const GOAL_STALL_TOOLLESS_THRESHOLD = 3;
+export const GOAL_REPETITION_HASH_STREAK = 3;
+export const GOAL_LENGTH_RECOVERY_LIMIT = 1;
+export const GOAL_USER_GRACE_DELAY_MS = 60_000;
+
+export type GoalContinuationPath = "immediate" | "monitorDelayed" | "sessionStart";
+
+export type GoalContinuationInput = {
+	readonly goal: Goal | null;
+	readonly isIdle: boolean;
+	readonly hasPendingMessages: boolean;
+	readonly path: GoalContinuationPath;
+	readonly lastStopReason: AssistantAgentMessage["stopReason"] | undefined;
+	readonly consecutiveContinuations: number;
+	readonly lastContinuationSignature: string | undefined;
+	readonly currentSignature: string | undefined;
+	readonly consecutiveLengthRecoveries: number;
+	readonly recentNormalizedOutputHashes: readonly string[];
+	readonly toollessContinuationStreak: number;
+	readonly endedTurnWasUserInitiated: boolean;
+	readonly continuationPending: boolean;
+};
+
+export type GoalContinuationVerdict =
+	| { kind: "continue"; prompt: "full" | "minimal"; stallNotice: boolean }
+	| {
+			kind: "deny";
+			reason: "not-eligible" | "single-flight" | "cap" | "stale" | "grace" | "repetition" | "length-exhausted";
+	  };
+
 export function shouldQueueGoalContinuationWhenIdle(
 	goal: Goal | null,
 	isIdle: boolean,
@@ -51,4 +82,85 @@ function isContinuableStopReason(stopReason: AssistantAgentMessage["stopReason"]
 function isAbortedToolResult(message: ToolResultAgentMessage): boolean {
 	if (!message.isError) return false;
 	return message.content.some((content) => content.type === "text" && /\babort(?:ed)?\b/i.test(content.text));
+}
+
+export function evaluateGoalContinuation(input: GoalContinuationInput): GoalContinuationVerdict {
+	if (!isEligibleForGoalContinuation(input)) return { kind: "deny", reason: "not-eligible" };
+	if (input.continuationPending) return { kind: "deny", reason: "single-flight" };
+	if (hasRepeatedNormalizedOutputHash(input.recentNormalizedOutputHashes))
+		return { kind: "deny", reason: "repetition" };
+	if (isContinuationCapPath(input.path) && input.consecutiveContinuations >= GOAL_CONTINUATION_CAP) {
+		return { kind: "deny", reason: "cap" };
+	}
+	if (
+		input.path === "immediate" &&
+		input.lastContinuationSignature !== undefined &&
+		input.lastContinuationSignature === input.currentSignature
+	) {
+		return { kind: "deny", reason: "stale" };
+	}
+	if (input.path === "immediate" && input.endedTurnWasUserInitiated) return { kind: "deny", reason: "grace" };
+	if (input.lastStopReason === "length") {
+		if (input.consecutiveLengthRecoveries >= GOAL_LENGTH_RECOVERY_LIMIT) {
+			return { kind: "deny", reason: "length-exhausted" };
+		}
+		return { kind: "continue", prompt: "minimal", stallNotice: shouldShowStallNotice(input) };
+	}
+	return { kind: "continue", prompt: "full", stallNotice: shouldShowStallNotice(input) };
+}
+
+/** Produces a stable, whitespace-insensitive representation for repetition detection. */
+export function normalizeAssistantText(text: string): string {
+	return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Hashes normalized assistant text with the deterministic 32-bit FNV-1a algorithm. */
+export function hashAssistantText(text: string): string {
+	const normalized = normalizeAssistantText(text);
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < normalized.length; index++) {
+		hash ^= normalized.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Identifies the observable goal progress for stale-continuation admission.
+ * Deliberately excludes goal.updatedAt because usage accounting updates it after every agent turn.
+ */
+export function buildGoalContinuationSignature(
+	goal: Pick<Goal, "id">,
+	openTodos: number,
+	totalTodos: number,
+	lastAssistantTextHash: string,
+): string {
+	return `${goal.id}:${openTodos}/${totalTodos}:${lastAssistantTextHash}`;
+}
+
+function isEligibleForGoalContinuation(input: GoalContinuationInput): boolean {
+	if (input.goal?.status !== "active" || input.hasPendingMessages) return false;
+	if (input.path === "immediate") {
+		return input.lastStopReason !== undefined && isContinuableStopReason(input.lastStopReason);
+	}
+	return input.isIdle;
+}
+
+function isContinuationCapPath(path: GoalContinuationPath): boolean {
+	return path === "immediate" || path === "sessionStart";
+}
+
+function hasRepeatedNormalizedOutputHash(hashes: readonly string[]): boolean {
+	const latestHash = hashes.at(-1);
+	if (latestHash === undefined) return false;
+
+	let streak = 0;
+	for (let index = hashes.length - 1; index >= 0 && hashes[index] === latestHash; index--) {
+		streak += 1;
+	}
+	return streak >= GOAL_REPETITION_HASH_STREAK;
+}
+
+function shouldShowStallNotice(input: GoalContinuationInput): boolean {
+	return input.toollessContinuationStreak >= GOAL_STALL_TOOLLESS_THRESHOLD;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { registerGoalCommand } from "./command-registration.ts";
 import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
@@ -135,6 +135,13 @@ export default function goalExtension(pi: ExtensionAPI): void {
 				{ status: "blocked", reason: "user interrupted the turn" },
 				"model",
 			);
+		} else if (didTerminalProviderErrorEndTurn(event) && goal?.status === "active") {
+			goal = await updateGoal(
+				goalStoreRef(ctx),
+				{ status: "blocked", reason: "provider error ended the turn (retries exhausted)" },
+				"model",
+			);
+			if (ctx.hasUI) ctx.ui.notify(`Goal ${goalStatusLabel(goal.status)}\n${formatGoalForTool(goal)}`, "warning");
 		}
 		if (goal?.status === "active") {
 			beginAgentGoalAccounting(goal);
@@ -297,6 +304,16 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		}
 		return goal;
 	}
+}
+
+function didTerminalProviderErrorEndTurn(event: AgentEndEvent): boolean {
+	if (event.willRetry !== false) return false;
+	for (let index = event.messages.length - 1; index >= 0; index--) {
+		const message = event.messages[index];
+		if (message?.role !== "assistant") continue;
+		return message.stopReason === "error" || (message.stopReason === "aborted" && event.abortSource !== "user");
+	}
+	return false;
 }
 
 function goalStoreRef(ctx: ExtensionContext): GoalStoreRef {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -1,5 +1,8 @@
+import { GOAL_CONTINUATION_MESSAGE_TYPE } from "../../../messages.ts";
+import type { SessionEntry } from "../../../session-manager.ts";
 import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { registerGoalCommand } from "./command-registration.ts";
+import { GOAL_CONTINUATION_CAP } from "./continuation.ts";
 import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { isResumeOfPausedGoal, queueGoalContinuation } from "./lifecycle-helpers.ts";
@@ -80,7 +83,20 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		}
 		// A config reload must not auto-start an agent that was stopped. Only a fresh
 		// startup or explicit resume may re-engage an active goal via a continuation.
-		if (goal && event.reason !== "reload") await queueGoalContinuationForCurrentSession(pi, ctx, goal);
+		if (goal && event.reason !== "reload") {
+			// Migration-lite admission: a resumed session carrying a trailing flood of
+			// historical continuations must not reignite on load. Skip the auto-queue,
+			// leave the goal active (no status rewrite), and tell the user how to resume.
+			const trailingContinuations = countTrailingGoalContinuationEntries(ctx.sessionManager.getBranch());
+			if (trailingContinuations >= GOAL_CONTINUATION_CAP) {
+				ctx.ui.notify(
+					`Goal auto-continuation suppressed for this resumed session (${trailingContinuations} historical continuations). Send a message to resume.`,
+					"info",
+				);
+			} else {
+				await queueGoalContinuationForCurrentSession(pi, ctx, goal);
+			}
+		}
 	});
 
 	pi.on("before_agent_start", async (_event, ctx) => {
@@ -304,6 +320,22 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		}
 		return goal;
 	}
+}
+
+/**
+ * Counts goal-continuation entries queued since the most recent real user message
+ * in the current branch (mirrors the todo-gate / todo-bridge backward branch read).
+ * A real user message is the only reset: the assistant turns in between are exactly
+ * the unattended loop this admission guard exists to stop.
+ */
+function countTrailingGoalContinuationEntries(entries: readonly SessionEntry[]): number {
+	let count = 0;
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry?.type === "message" && entry.message.role === "user") break;
+		if (entry?.type === "custom_message" && entry.customType === GOAL_CONTINUATION_MESSAGE_TYPE) count += 1;
+	}
+	return count;
 }
 
 function didTerminalProviderErrorEndTurn(event: AgentEndEvent): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -4,7 +4,7 @@ import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { isResumeOfPausedGoal, queueGoalContinuation } from "./lifecycle-helpers.ts";
 import { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
-import { accountGoalUsage, readGoal, updateGoal } from "./store.ts";
+import { accountGoalUsage, readGoal, resetContinuationStreak, updateGoal } from "./store.ts";
 import { goalStoreRef as buildGoalStoreRef } from "./store-ref.ts";
 import { registerGoalTools } from "./tool-registration.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
@@ -25,8 +25,15 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let agentGoalAccounting: AgentGoalAccounting | null = null;
 	let blockedThisTurnGoalId: string | null = null;
 	let completedThisTurnGoalId: string | null = null;
+	let continuationPending = false;
 	const turnUsage = new TurnUsageTracker();
-	const monitorContinuation = new MonitorAwareGoalContinuation(pi);
+	const monitorContinuation = new MonitorAwareGoalContinuation(
+		pi,
+		() => continuationPending,
+		() => {
+			continuationPending = true;
+		},
+	);
 
 	const goalTicker = new GoalElapsedTicker({
 		render: (renderCtx, renderGoal, live) => {
@@ -53,7 +60,9 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		beginAgentGoalAccounting,
 		stopAgentGoalAccounting,
 		clearAgentGoalAccounting,
-		queueGoalContinuation,
+		queueGoalContinuation: (extensionApi, commandCtx, goal) => {
+			void queueGoalContinuationForCurrentSession(extensionApi, commandCtx, goal);
+		},
 		refreshGoalUi,
 	});
 
@@ -71,7 +80,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		}
 		// A config reload must not auto-start an agent that was stopped. Only a fresh
 		// startup or explicit resume may re-engage an active goal via a continuation.
-		if (goal && event.reason !== "reload") queueGoalContinuation(pi, ctx, goal);
+		if (goal && event.reason !== "reload") await queueGoalContinuationForCurrentSession(pi, ctx, goal);
 	});
 
 	pi.on("before_agent_start", async (_event, ctx) => {
@@ -81,14 +90,18 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		// flag, means a rejected run cannot leak a stale resume signal to a later
 		// continuation-style turn that starts the agent without a preceding user prompt.
 		monitorContinuation.noteUserPrompt();
-		const goal = await readGoal(goalStoreRef(ctx));
+		const ref = goalStoreRef(ctx);
+		let goal = await resetContinuationStreak(ref);
 		if (goal?.status === "blocked") {
-			const resumed = await updateGoal(goalStoreRef(ctx), { status: "active" }, "user");
-			refreshGoalUi(ctx, resumed);
+			goal = await updateGoal(ref, { status: "active" }, "user");
 		}
+		if (goal !== null) refreshGoalUi(ctx, goal);
 	});
 
 	pi.on("agent_start", async (_event, ctx) => {
+		const continuationStarted = continuationPending;
+		continuationPending = false;
+		if (continuationStarted) monitorContinuation.noteContinuationStarted();
 		agentTurnInProgress = true;
 		blockedThisTurnGoalId = null;
 		completedThisTurnGoalId = null;
@@ -129,12 +142,16 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			clearAgentGoalAccounting();
 		}
 		refreshGoalUiBestEffort(ctx, goal);
-		monitorContinuation.afterAgentEnd({
-			ctx,
-			goal,
-			messages: event.messages,
-			aborted: event.aborted === true,
-		});
+		const continuationGoal = await monitorContinuation.afterAgentEnd({ ctx, goal, messages: event.messages });
+		if (continuationGoal !== goal) {
+			goal = continuationGoal;
+			if (goal?.status === "active") {
+				beginAgentGoalAccounting(goal);
+			} else {
+				clearAgentGoalAccounting();
+			}
+			refreshGoalUiBestEffort(ctx, goal);
+		}
 	});
 
 	pi.on("session_abort", async (_event, ctx) => {
@@ -181,8 +198,25 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		beginAgentGoalAccounting(resumed);
 		refreshGoalUi(ctx, resumed);
 		ctx.ui.notify(`Goal ${goalStatusLabel(resumed.status)}\n${formatGoalForTool(resumed)}`, "info");
-		queueGoalContinuation(pi, ctx, resumed);
+		await queueGoalContinuationForCurrentSession(pi, ctx, resumed);
 		return true;
+	}
+
+	async function queueGoalContinuationForCurrentSession(
+		extensionApi: ExtensionAPI,
+		ctx: ExtensionContext,
+		goal: Goal,
+	): Promise<void> {
+		const continuedGoal = await queueGoalContinuation(extensionApi, ctx, goal, {
+			continuationPending,
+			markContinuationPending: () => {
+				continuationPending = true;
+			},
+		});
+		if (continuedGoal.status === goal.status) return;
+		if (continuedGoal.status === "active") beginAgentGoalAccounting(continuedGoal);
+		else clearAgentGoalAccounting();
+		refreshGoalUiBestEffort(ctx, continuedGoal);
 	}
 
 	function beginAgentGoalAccounting(goal: Goal): void {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -1,8 +1,33 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { GOAL_CONTINUATION_MESSAGE_TYPE } from "../../../messages.ts";
+import { getLatestPhasesFromBranchEntries } from "../todotools/state.ts";
+import type { SessionEntry } from "../../../session-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
-import { shouldQueueGoalContinuationWhenIdle } from "./continuation.ts";
-import { buildContinuationPrompt } from "./prompt.ts";
+import {
+	buildGoalContinuationSignature,
+	evaluateGoalContinuation,
+	hashAssistantText,
+	type GoalContinuationInput,
+	type GoalContinuationVerdict,
+} from "./continuation.ts";
+import { buildContinuationPrompt, buildTruncationRecoveryPrompt } from "./prompt.ts";
+import { recordContinuationDelivered, updateGoal } from "./store.ts";
+import { goalStoreRef } from "./store-ref.ts";
+import { openTodoTaskContents } from "./todo-gate.ts";
 import type { Goal } from "./types.ts";
+
+type ContinuingGoalContinuationVerdict = Extract<GoalContinuationVerdict, { kind: "continue" }>;
+
+type GoalContinuationDeliveryOptions = {
+	readonly input: Omit<GoalContinuationInput, "goal">;
+	readonly content: (verdict: ContinuingGoalContinuationVerdict) => string;
+	readonly markContinuationPending: () => void;
+};
+
+export type SessionStartContinuationOptions = {
+	readonly continuationPending: boolean;
+	readonly markContinuationPending: () => void;
+};
 
 export function isResumeOfPausedGoal(
 	ctx: ExtensionContext,
@@ -18,9 +43,117 @@ export function isResumeOfPausedGoal(
 	);
 }
 
-export function queueGoalContinuation(pi: ExtensionAPI, ctx: ExtensionContext, goal: Goal): void {
-	if (shouldQueueGoalContinuationWhenIdle(goal, ctx.isIdle(), ctx.hasPendingMessages())) {
-		queueHiddenGoalPrompt(pi, buildContinuationPrompt(goal));
+/** Evaluates and delivers a continuation only after all guardrail checks admit it. */
+export async function admitAndQueueGoalContinuation(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	goal: Goal,
+	options: GoalContinuationDeliveryOptions,
+): Promise<Goal> {
+	const verdict = evaluateGoalContinuation({ goal, ...options.input });
+	if (verdict.kind === "deny") return handleDeniedContinuation(pi, ctx, goal, options.input, verdict.reason);
+
+	options.markContinuationPending();
+	queueHiddenGoalPrompt(pi, options.content(verdict));
+	if (options.input.path === "monitorDelayed") return goal;
+
+	return (await recordContinuationDelivered(goalStoreRef(ctx.sessionManager, ctx.cwd), options.input.currentSignature)) ?? goal;
+}
+
+/** Routes startup and resume continuations through the same verdict and delivery accounting as agent-end paths. */
+export async function queueGoalContinuation(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	goal: Goal,
+	options: SessionStartContinuationOptions,
+): Promise<Goal> {
+	const signature = buildCurrentGoalContinuationSignature(ctx, goal, lastAssistantTextFromEntries(ctx.sessionManager.getBranch()));
+	return admitAndQueueGoalContinuation(pi, ctx, goal, {
+		input: {
+			isIdle: ctx.isIdle(),
+			hasPendingMessages: ctx.hasPendingMessages(),
+			path: "sessionStart",
+			lastStopReason: undefined,
+			consecutiveContinuations: goal.consecutiveContinuations ?? 0,
+			lastContinuationSignature: goal.lastContinuationSignature,
+			currentSignature: signature,
+			consecutiveLengthRecoveries: 0,
+			recentNormalizedOutputHashes: [],
+			toollessContinuationStreak: 0,
+			endedTurnWasUserInitiated: false,
+			continuationPending: options.continuationPending,
+		},
+		content: () => buildContinuationPrompt(goal),
+		markContinuationPending: options.markContinuationPending,
+	});
+}
+
+export function buildCurrentGoalContinuationSignature(
+	ctx: ExtensionContext,
+	goal: Goal,
+	lastAssistantText: string,
+): string {
+	const entries = ctx.sessionManager.getBranch();
+	const openTodos = openTodoTaskContents(entries).length;
+	const totalTodos = getLatestPhasesFromBranchEntries(entries).reduce((count, phase) => count + phase.tasks.length, 0);
+	return buildGoalContinuationSignature(goal, openTodos, totalTodos, hashAssistantText(lastAssistantText));
+}
+
+export function lastAssistantText(messages: readonly AgentMessage[]): string {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message?.role === "assistant") return textContent(message);
+	}
+	return "";
+}
+
+function lastAssistantTextFromEntries(entries: readonly SessionEntry[]): string {
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry?.type === "message" && entry.message.role === "assistant") return textContent(entry.message);
+	}
+	return "";
+}
+
+function textContent(message: Extract<AgentMessage, { role: "assistant" }>): string {
+	return message.content.filter((content) => content.type === "text").map((content) => content.text).join("\n");
+}
+
+async function handleDeniedContinuation(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	goal: Goal,
+	input: Omit<GoalContinuationInput, "goal">,
+	reason: Extract<GoalContinuationVerdict, { kind: "deny" }>["reason"],
+): Promise<Goal> {
+	const blockedReason = blockedReasonForContinuationGuard(reason);
+	if (blockedReason === undefined) return goal;
+
+	const blocked = await updateGoal(goalStoreRef(ctx.sessionManager, ctx.cwd), { status: "blocked", reason: blockedReason }, "model");
+	if (ctx.hasUI) ctx.ui.notify(`Goal continuation blocked: ${blockedReason}`, "warning");
+	pi.events?.emit("goal_continuation_guard_tripped", {
+		goalId: goal.id,
+		reason,
+		count: input.consecutiveContinuations,
+	});
+	return blocked;
+}
+
+function blockedReasonForContinuationGuard(
+	reason: Extract<GoalContinuationVerdict, { kind: "deny" }>["reason"],
+): string | undefined {
+	switch (reason) {
+		case "cap":
+			return "continuation cap reached";
+		case "repetition":
+			return "repeated assistant output";
+		case "length-exhausted":
+			return "output truncation repeated";
+		case "not-eligible":
+		case "single-flight":
+		case "stale":
+		case "grace":
+			return undefined;
 	}
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -55,9 +55,12 @@ export async function admitAndQueueGoalContinuation(
 
 	options.markContinuationPending();
 	queueHiddenGoalPrompt(pi, options.content(verdict));
-	if (options.input.path === "monitorDelayed") return goal;
+	if (options.input.path === "monitorDelayed" || options.input.currentSignature === undefined) return goal;
 
-	return (await recordContinuationDelivered(goalStoreRef(ctx.sessionManager, ctx.cwd), options.input.currentSignature)) ?? goal;
+	return (
+		(await recordContinuationDelivered(goalStoreRef(ctx.sessionManager, ctx.cwd), options.input.currentSignature)) ??
+		goal
+	);
 }
 
 /** Routes startup and resume continuations through the same verdict and delivery accounting as agent-end paths. */

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -10,7 +10,7 @@ import {
 	type GoalContinuationVerdict,
 	hashAssistantText,
 } from "./continuation.ts";
-import { buildContinuationPrompt, buildTruncationRecoveryPrompt } from "./prompt.ts";
+import { buildContinuationPrompt } from "./prompt.ts";
 import { recordContinuationDelivered, updateGoal } from "./store.ts";
 import { goalStoreRef } from "./store-ref.ts";
 import { openTodoTaskContents } from "./todo-gate.ts";

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -1,9 +1,8 @@
+import { GOAL_CONTINUATION_MESSAGE_TYPE } from "../../../messages.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { shouldQueueGoalContinuationWhenIdle } from "./continuation.ts";
 import { buildContinuationPrompt } from "./prompt.ts";
 import type { Goal } from "./types.ts";
-
-const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
 
 export function isResumeOfPausedGoal(
 	ctx: ExtensionContext,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -1,14 +1,14 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { GOAL_CONTINUATION_MESSAGE_TYPE } from "../../../messages.ts";
-import { getLatestPhasesFromBranchEntries } from "../todotools/state.ts";
 import type { SessionEntry } from "../../../session-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
+import { getLatestPhasesFromBranchEntries } from "../todotools/state.ts";
 import {
 	buildGoalContinuationSignature,
 	evaluateGoalContinuation,
-	hashAssistantText,
 	type GoalContinuationInput,
 	type GoalContinuationVerdict,
+	hashAssistantText,
 } from "./continuation.ts";
 import { buildContinuationPrompt, buildTruncationRecoveryPrompt } from "./prompt.ts";
 import { recordContinuationDelivered, updateGoal } from "./store.ts";
@@ -70,7 +70,11 @@ export async function queueGoalContinuation(
 	goal: Goal,
 	options: SessionStartContinuationOptions,
 ): Promise<Goal> {
-	const signature = buildCurrentGoalContinuationSignature(ctx, goal, lastAssistantTextFromEntries(ctx.sessionManager.getBranch()));
+	const signature = buildCurrentGoalContinuationSignature(
+		ctx,
+		goal,
+		lastAssistantTextFromEntries(ctx.sessionManager.getBranch()),
+	);
 	return admitAndQueueGoalContinuation(pi, ctx, goal, {
 		input: {
 			isIdle: ctx.isIdle(),
@@ -119,7 +123,10 @@ function lastAssistantTextFromEntries(entries: readonly SessionEntry[]): string 
 }
 
 function textContent(message: Extract<AgentMessage, { role: "assistant" }>): string {
-	return message.content.filter((content) => content.type === "text").map((content) => content.text).join("\n");
+	return message.content
+		.filter((content) => content.type === "text")
+		.map((content) => content.text)
+		.join("\n");
 }
 
 async function handleDeniedContinuation(
@@ -132,7 +139,11 @@ async function handleDeniedContinuation(
 	const blockedReason = blockedReasonForContinuationGuard(reason);
 	if (blockedReason === undefined) return goal;
 
-	const blocked = await updateGoal(goalStoreRef(ctx.sessionManager, ctx.cwd), { status: "blocked", reason: blockedReason }, "model");
+	const blocked = await updateGoal(
+		goalStoreRef(ctx.sessionManager, ctx.cwd),
+		{ status: "blocked", reason: blockedReason },
+		"model",
+	);
 	if (ctx.hasUI) ctx.ui.notify(`Goal continuation blocked: ${blockedReason}`, "warning");
 	pi.events?.emit("goal_continuation_guard_tripped", {
 		goalId: goal.id,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -171,7 +171,12 @@ export class MonitorAwareGoalContinuation {
 		const goal = this.#goal;
 		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
 		if (kind === "monitor" && this.#activeMonitorCount === 0) return;
-		await this.#admitAndQueue(ctx, goal, kind === "monitor" ? "monitorDelayed" : "userGrace", this.#lastAgentEndMessages);
+		await this.#admitAndQueue(
+			ctx,
+			goal,
+			kind === "monitor" ? "monitorDelayed" : "userGrace",
+			this.#lastAgentEndMessages,
+		);
 	}
 
 	async #admitAndQueue(

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -3,6 +3,7 @@ import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isTerminalMonitorStateEvent, TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
 import {
 	evaluateGoalContinuation,
+	GOAL_USER_GRACE_DELAY_MS,
 	type GoalContinuationInput,
 	type GoalContinuationPath,
 	type GoalContinuationVerdict,
@@ -29,6 +30,7 @@ interface AgentEndOptions {
 }
 
 type ContinuingGoalContinuationVerdict = Extract<GoalContinuationVerdict, { kind: "continue" }>;
+type DelayedContinuationKind = "monitor" | "userGrace";
 
 export class MonitorAwareGoalContinuation {
 	readonly #pi: ExtensionAPI;
@@ -38,6 +40,7 @@ export class MonitorAwareGoalContinuation {
 	#ctx: ExtensionContext | undefined;
 	#goal: Goal | null = null;
 	#timer: ReturnType<typeof setTimeout> | undefined;
+	#scheduledContinuationKind: DelayedContinuationKind | undefined;
 	#unsubscribeMonitorState: (() => void) | undefined;
 	#lastAgentEndMessages: readonly AgentMessage[] = [];
 	#consecutiveLengthRecoveries = 0;
@@ -70,7 +73,7 @@ export class MonitorAwareGoalContinuation {
 			if (!isTerminalMonitorStateEvent(data)) return;
 			this.#activeMonitorCount = data.activeCount;
 			if (data.activeCount === 0) {
-				this.#cancelTimer();
+				if (this.#scheduledContinuationKind === "monitor") this.#cancelTimer();
 				this.#resetToollessContinuationStreak();
 			}
 		});
@@ -82,18 +85,27 @@ export class MonitorAwareGoalContinuation {
 		this.#goal = options.goal;
 		this.#lastAgentEndMessages = options.messages;
 		this.#recordAssistantOutput(options.messages);
-		if (options.goal === null) return options.goal;
+		if (options.goal?.status !== "active") {
+			this.#cancelTimer();
+			return options.goal;
+		}
 		this.#recordToollessContinuationTurn(options.goal, options.messages);
 
 		const immediateInput = this.#buildVerdictInput(options.ctx, options.goal, "immediate", options.messages);
 		const immediateVerdict = evaluateGoalContinuation({ goal: options.goal, ...immediateInput });
-		if (immediateVerdict.kind === "deny" && immediateVerdict.reason === "not-eligible") return options.goal;
+		if (immediateVerdict.kind === "deny") {
+			if (immediateVerdict.reason === "not-eligible") return options.goal;
+			if (immediateVerdict.reason === "grace") {
+				this.#schedule(options.goal, "userGrace");
+				return options.goal;
+			}
+		}
 
 		if (this.#activeMonitorCount === 0) {
 			this.#cancelTimer();
 			return this.#admitAndQueue(options.ctx, options.goal, "immediate", options.messages);
 		}
-		this.#schedule(options.goal);
+		this.#schedule(options.goal, "monitor");
 		return options.goal;
 	}
 
@@ -108,6 +120,7 @@ export class MonitorAwareGoalContinuation {
 
 	/** A real user prompt breaks unattended continuation state before its agent turn begins. */
 	noteUserPrompt(): void {
+		this.#cancelTimer();
 		this.#endedTurnWasUserInitiated = true;
 		this.#resetContinuationState();
 	}
@@ -128,22 +141,28 @@ export class MonitorAwareGoalContinuation {
 		this.#resetContinuationState();
 	}
 
-	#schedule(goal: Goal): void {
+	#schedule(goal: Goal, kind: DelayedContinuationKind): void {
 		if (this.#timer !== undefined) return;
-		if (this.#ctx?.hasUI) this.#ctx.ui.notify(GOAL_MONITOR_CONTINUATION_NOTICE, "info");
-		this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
-			goalId: goal.id,
-			delayMs: GOAL_MONITOR_CONTINUATION_DELAY_MS,
-			activeMonitorCount: this.#activeMonitorCount,
-		});
-		this.#timer = setTimeout(() => void this.#continueIfEligible(), GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		const delayMs = kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS;
+		if (kind === "monitor") {
+			if (this.#ctx?.hasUI) this.#ctx.ui.notify(GOAL_MONITOR_CONTINUATION_NOTICE, "info");
+			this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
+				goalId: goal.id,
+				delayMs,
+				activeMonitorCount: this.#activeMonitorCount,
+			});
+		}
+		this.#scheduledContinuationKind = kind;
+		this.#timer = setTimeout(() => void this.#continueIfEligible(kind), delayMs);
 	}
 
-	async #continueIfEligible(): Promise<void> {
+	async #continueIfEligible(kind: DelayedContinuationKind): Promise<void> {
 		this.#timer = undefined;
+		this.#scheduledContinuationKind = undefined;
 		const ctx = this.#ctx;
 		const goal = this.#goal;
-		if (ctx === undefined || goal === null || this.#activeMonitorCount === 0) return;
+		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
+		if (kind === "monitor" && this.#activeMonitorCount === 0) return;
 		await this.#admitAndQueue(ctx, goal, "monitorDelayed", this.#lastAgentEndMessages);
 	}
 
@@ -241,9 +260,9 @@ export class MonitorAwareGoalContinuation {
 	}
 
 	#cancelTimer(): void {
-		if (this.#timer === undefined) return;
-		clearTimeout(this.#timer);
+		if (this.#timer !== undefined) clearTimeout(this.#timer);
 		this.#timer = undefined;
+		this.#scheduledContinuationKind = undefined;
 	}
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -3,24 +3,23 @@ import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isTerminalMonitorStateEvent, TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
 import {
 	evaluateGoalContinuation,
-	hashAssistantText,
-	normalizeAssistantText,
 	type GoalContinuationInput,
 	type GoalContinuationPath,
 	type GoalContinuationVerdict,
+	hashAssistantText,
+	normalizeAssistantText,
 } from "./continuation.ts";
 import {
 	admitAndQueueGoalContinuation,
 	buildCurrentGoalContinuationSignature,
 	lastAssistantText,
 } from "./lifecycle-helpers.ts";
-import { buildContinuationPrompt, buildGoalStallNotice, buildMonitorStallNotice, buildTruncationRecoveryPrompt } from "./prompt.ts";
+import { buildContinuationPrompt, buildGoalStallNotice, buildTruncationRecoveryPrompt } from "./prompt.ts";
 import type { Goal } from "./types.ts";
 
 export const GOAL_MONITOR_CONTINUATION_DELAY_MS = 240_000;
 export const GOAL_CONTINUATION_SCHEDULED_EVENT = "goal_continuation_scheduled";
 export const GOAL_MONITOR_CONTINUATION_NOTICE = "Goal continuation scheduled in 4 minutes while a monitor is active.";
-export const GOAL_MONITOR_STALL_THRESHOLD = 3;
 export const GOAL_MONITOR_STALL_EVENT = "goal_monitor_continuation_stall";
 
 interface AgentEndOptions {
@@ -41,11 +40,10 @@ export class MonitorAwareGoalContinuation {
 	#timer: ReturnType<typeof setTimeout> | undefined;
 	#unsubscribeMonitorState: (() => void) | undefined;
 	#lastAgentEndMessages: readonly AgentMessage[] = [];
-	#consecutiveMonitorContinuations = 0;
-	#stallGoalId: string | null = null;
 	#consecutiveLengthRecoveries = 0;
 	#recentNormalizedOutputHashes: string[] = [];
 	#toollessContinuationStreak = 0;
+	#toollessStreakGoalId: string | null = null;
 	#endedTurnWasUserInitiated = false;
 
 	constructor(
@@ -63,9 +61,9 @@ export class MonitorAwareGoalContinuation {
 		this.#unsubscribeMonitorState?.();
 		this.#ctx = ctx;
 		this.#activeMonitorCount = 0;
+		this.#goal = null;
 		this.#lastAgentEndMessages = [];
 		this.#resetContinuationState();
-		this.#resetStallStreak();
 		const events = this.#pi.events;
 		if (events === undefined) return;
 		this.#unsubscribeMonitorState = events.on(TERMINAL_MONITOR_STATE_EVENT, (data) => {
@@ -73,17 +71,19 @@ export class MonitorAwareGoalContinuation {
 			this.#activeMonitorCount = data.activeCount;
 			if (data.activeCount === 0) {
 				this.#cancelTimer();
-				this.#resetStallStreak();
+				this.#resetToollessContinuationStreak();
 			}
 		});
 	}
 
 	async afterAgentEnd(options: AgentEndOptions): Promise<Goal | null> {
+		if (options.goal?.id !== this.#goal?.id) this.#resetToollessContinuationStreak();
 		this.#ctx = options.ctx;
 		this.#goal = options.goal;
 		this.#lastAgentEndMessages = options.messages;
 		this.#recordAssistantOutput(options.messages);
 		if (options.goal === null) return options.goal;
+		this.#recordToollessContinuationTurn(options.goal, options.messages);
 
 		const immediateInput = this.#buildVerdictInput(options.ctx, options.goal, "immediate", options.messages);
 		const immediateVerdict = evaluateGoalContinuation({ goal: options.goal, ...immediateInput });
@@ -91,7 +91,6 @@ export class MonitorAwareGoalContinuation {
 
 		if (this.#activeMonitorCount === 0) {
 			this.#cancelTimer();
-			this.#resetStallStreak();
 			return this.#admitAndQueue(options.ctx, options.goal, "immediate", options.messages);
 		}
 		this.#schedule(options.goal);
@@ -99,10 +98,11 @@ export class MonitorAwareGoalContinuation {
 	}
 
 	syncGoal(goal: Goal | null): void {
+		if (goal?.id !== this.#goal?.id) this.#resetToollessContinuationStreak();
 		this.#goal = goal;
 		if (goal?.status !== "active") {
 			this.#cancelTimer();
-			this.#resetStallStreak();
+			this.#resetToollessContinuationStreak();
 		}
 	}
 
@@ -110,7 +110,6 @@ export class MonitorAwareGoalContinuation {
 	noteUserPrompt(): void {
 		this.#endedTurnWasUserInitiated = true;
 		this.#resetContinuationState();
-		this.#resetStallStreak();
 	}
 
 	/** A queued hidden continuation has started, so the next end is not user-initiated. */
@@ -127,7 +126,6 @@ export class MonitorAwareGoalContinuation {
 		this.#activeMonitorCount = 0;
 		this.#lastAgentEndMessages = [];
 		this.#resetContinuationState();
-		this.#resetStallStreak();
 	}
 
 	#schedule(goal: Goal): void {
@@ -157,13 +155,13 @@ export class MonitorAwareGoalContinuation {
 	): Promise<Goal> {
 		const admittedGoal = await admitAndQueueGoalContinuation(this.#pi, ctx, goal, {
 			input: this.#buildVerdictInput(ctx, goal, path, messages),
-			content: (verdict) => this.#buildContinuationContent(ctx, goal, path, verdict),
+			content: (verdict) => this.#buildContinuationContent(ctx, goal, verdict),
 			markContinuationPending: this.#markContinuationPending,
 		});
 		this.#goal = admittedGoal;
 		if (admittedGoal.status !== "active") {
 			this.#cancelTimer();
-			this.#resetStallStreak();
+			this.#resetToollessContinuationStreak();
 		}
 		return admittedGoal;
 	}
@@ -191,40 +189,25 @@ export class MonitorAwareGoalContinuation {
 		};
 	}
 
-	#buildContinuationContent(
-		ctx: ExtensionContext,
-		goal: Goal,
-		path: GoalContinuationPath,
-		verdict: ContinuingGoalContinuationVerdict,
-	): string {
+	#buildContinuationContent(ctx: ExtensionContext, goal: Goal, verdict: ContinuingGoalContinuationVerdict): string {
 		let content = verdict.prompt === "minimal" ? buildTruncationRecoveryPrompt() : buildContinuationPrompt(goal);
-		if (verdict.stallNotice) {
-			content = `${buildGoalStallNotice(this.#toollessContinuationStreak, {
-				monitorsActive: this.#activeMonitorCount > 0,
-			})}\n\n${content}`;
-		}
-		return path === "monitorDelayed" ? this.#buildMonitorContinuationContent(ctx, goal, content) : content;
-	}
+		if (!verdict.stallNotice) return content;
 
-	/** Counts consecutive monitor-wait continuations; from the third one on, prepends an active stall check. */
-	#buildMonitorContinuationContent(ctx: ExtensionContext, goal: Goal, content: string): string {
-		if (goal.id !== this.#stallGoalId) {
-			this.#stallGoalId = goal.id;
-			this.#consecutiveMonitorContinuations = 0;
-		}
-		this.#consecutiveMonitorContinuations += 1;
-		if (this.#consecutiveMonitorContinuations < GOAL_MONITOR_STALL_THRESHOLD) return content;
+		const monitorsActive = this.#activeMonitorCount > 0;
 		this.#pi.events?.emit(GOAL_MONITOR_STALL_EVENT, {
 			goalId: goal.id,
-			consecutiveContinuations: this.#consecutiveMonitorContinuations,
+			consecutiveContinuations: this.#toollessContinuationStreak,
+			toolless: true,
 		});
 		if (ctx.hasUI) {
+			const context = monitorsActive ? "while monitors stayed active" : "without tool use";
 			ctx.ui.notify(
-				`Goal continuation repeated ${this.#consecutiveMonitorContinuations} times while monitors stayed active - injected a stall check.`,
+				`Goal continuation repeated ${this.#toollessContinuationStreak} toolless turns ${context} - injected a stall check.`,
 				"info",
 			);
 		}
-		return `${buildMonitorStallNotice(this.#consecutiveMonitorContinuations)}\n\n${content}`;
+		content = `${buildGoalStallNotice(this.#toollessContinuationStreak, { monitorsActive })}\n\n${content}`;
+		return content;
 	}
 
 	#recordAssistantOutput(messages: readonly AgentMessage[]): void {
@@ -233,15 +216,28 @@ export class MonitorAwareGoalContinuation {
 		this.#recentNormalizedOutputHashes = [...this.#recentNormalizedOutputHashes, hashAssistantText(text)].slice(-3);
 	}
 
+	#recordToollessContinuationTurn(goal: Goal, messages: readonly AgentMessage[]): void {
+		if (goal.id !== this.#toollessStreakGoalId) {
+			this.#toollessStreakGoalId = goal.id;
+			this.#toollessContinuationStreak = 0;
+		}
+		if (this.#endedTurnWasUserInitiated) return;
+		if (continuationTurnUsedTools(messages)) {
+			this.#toollessContinuationStreak = 0;
+			return;
+		}
+		this.#toollessContinuationStreak += 1;
+	}
+
 	#resetContinuationState(): void {
 		this.#consecutiveLengthRecoveries = 0;
 		this.#recentNormalizedOutputHashes = [];
-		this.#toollessContinuationStreak = 0;
+		this.#resetToollessContinuationStreak();
 	}
 
-	#resetStallStreak(): void {
-		this.#consecutiveMonitorContinuations = 0;
-		this.#stallGoalId = null;
+	#resetToollessContinuationStreak(): void {
+		this.#toollessContinuationStreak = 0;
+		this.#toollessStreakGoalId = null;
 	}
 
 	#cancelTimer(): void {
@@ -249,6 +245,13 @@ export class MonitorAwareGoalContinuation {
 		clearTimeout(this.#timer);
 		this.#timer = undefined;
 	}
+}
+
+function continuationTurnUsedTools(messages: readonly AgentMessage[]): boolean {
+	return messages.some((message) => {
+		if (message?.role === "toolResult") return true;
+		return message?.role === "assistant" && message.content.some((content) => content.type === "toolCall");
+	});
 }
 
 function findLastAssistantMessage(

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -43,7 +43,7 @@ export class MonitorAwareGoalContinuation {
 	#scheduledContinuationKind: DelayedContinuationKind | undefined;
 	#unsubscribeMonitorState: (() => void) | undefined;
 	#lastAgentEndMessages: readonly AgentMessage[] = [];
-	#consecutiveLengthRecoveries = 0;
+	#consecutiveLengthRecoveries = new Map<string, number>();
 	#recentNormalizedOutputHashes: string[] = [];
 	#toollessContinuationStreak = 0;
 	#toollessStreakGoalId: string | null = null;
@@ -84,6 +84,7 @@ export class MonitorAwareGoalContinuation {
 		this.#ctx = options.ctx;
 		this.#goal = options.goal;
 		this.#lastAgentEndMessages = options.messages;
+		this.#resetLengthRecoveryAfterCleanStop(options.goal, options.messages);
 		this.#recordAssistantOutput(options.messages);
 		if (options.goal?.status !== "active") {
 			this.#cancelTimer();
@@ -172,11 +173,16 @@ export class MonitorAwareGoalContinuation {
 		path: GoalContinuationPath,
 		messages: readonly AgentMessage[],
 	): Promise<Goal> {
+		const input = this.#buildVerdictInput(ctx, goal, path, messages);
+		const verdict = evaluateGoalContinuation({ goal, ...input });
 		const admittedGoal = await admitAndQueueGoalContinuation(this.#pi, ctx, goal, {
-			input: this.#buildVerdictInput(ctx, goal, path, messages),
-			content: (verdict) => this.#buildContinuationContent(ctx, goal, verdict),
+			input,
+			content: (continuationVerdict) => this.#buildContinuationContent(ctx, goal, continuationVerdict),
 			markContinuationPending: this.#markContinuationPending,
 		});
+		if (verdict.kind === "continue" && input.lastStopReason === "length") {
+			this.#consecutiveLengthRecoveries.set(goal.id, input.consecutiveLengthRecoveries + 1);
+		}
 		this.#goal = admittedGoal;
 		if (admittedGoal.status !== "active") {
 			this.#cancelTimer();
@@ -200,7 +206,7 @@ export class MonitorAwareGoalContinuation {
 			consecutiveContinuations: goal.consecutiveContinuations ?? 0,
 			lastContinuationSignature: goal.lastContinuationSignature,
 			currentSignature: buildCurrentGoalContinuationSignature(ctx, goal, lastAssistantText(messages)),
-			consecutiveLengthRecoveries: this.#consecutiveLengthRecoveries,
+			consecutiveLengthRecoveries: this.#consecutiveLengthRecoveries.get(goal.id) ?? 0,
 			recentNormalizedOutputHashes: this.#recentNormalizedOutputHashes,
 			toollessContinuationStreak: this.#toollessContinuationStreak,
 			endedTurnWasUserInitiated: this.#endedTurnWasUserInitiated,
@@ -248,8 +254,13 @@ export class MonitorAwareGoalContinuation {
 		this.#toollessContinuationStreak += 1;
 	}
 
+	#resetLengthRecoveryAfterCleanStop(goal: Goal | null, messages: readonly AgentMessage[]): void {
+		if (goal === null || findLastAssistantMessage(messages)?.stopReason !== "stop") return;
+		this.#consecutiveLengthRecoveries.delete(goal.id);
+	}
+
 	#resetContinuationState(): void {
-		this.#consecutiveLengthRecoveries = 0;
+		this.#consecutiveLengthRecoveries.clear();
 		this.#recentNormalizedOutputHashes = [];
 		this.#resetToollessContinuationStreak();
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -1,9 +1,20 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isTerminalMonitorStateEvent, TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
-import { shouldQueueGoalContinuationAfterAgentEnd, shouldQueueGoalContinuationWhenIdle } from "./continuation.ts";
-import { queueHiddenGoalPrompt } from "./lifecycle-helpers.ts";
-import { buildContinuationPrompt, buildMonitorStallNotice } from "./prompt.ts";
+import {
+	evaluateGoalContinuation,
+	hashAssistantText,
+	normalizeAssistantText,
+	type GoalContinuationInput,
+	type GoalContinuationPath,
+	type GoalContinuationVerdict,
+} from "./continuation.ts";
+import {
+	admitAndQueueGoalContinuation,
+	buildCurrentGoalContinuationSignature,
+	lastAssistantText,
+} from "./lifecycle-helpers.ts";
+import { buildContinuationPrompt, buildGoalStallNotice, buildMonitorStallNotice, buildTruncationRecoveryPrompt } from "./prompt.ts";
 import type { Goal } from "./types.ts";
 
 export const GOAL_MONITOR_CONTINUATION_DELAY_MS = 240_000;
@@ -16,21 +27,35 @@ interface AgentEndOptions {
 	readonly ctx: ExtensionContext;
 	readonly goal: Goal | null;
 	readonly messages: readonly AgentMessage[];
-	readonly aborted: boolean;
 }
+
+type ContinuingGoalContinuationVerdict = Extract<GoalContinuationVerdict, { kind: "continue" }>;
 
 export class MonitorAwareGoalContinuation {
 	readonly #pi: ExtensionAPI;
+	readonly #isContinuationPending: () => boolean;
+	readonly #markContinuationPending: () => void;
 	#activeMonitorCount = 0;
 	#ctx: ExtensionContext | undefined;
 	#goal: Goal | null = null;
 	#timer: ReturnType<typeof setTimeout> | undefined;
 	#unsubscribeMonitorState: (() => void) | undefined;
+	#lastAgentEndMessages: readonly AgentMessage[] = [];
 	#consecutiveMonitorContinuations = 0;
 	#stallGoalId: string | null = null;
+	#consecutiveLengthRecoveries = 0;
+	#recentNormalizedOutputHashes: string[] = [];
+	#toollessContinuationStreak = 0;
+	#endedTurnWasUserInitiated = false;
 
-	constructor(pi: ExtensionAPI) {
+	constructor(
+		pi: ExtensionAPI,
+		isContinuationPending: () => boolean = () => false,
+		markContinuationPending: () => void = () => {},
+	) {
 		this.#pi = pi;
+		this.#isContinuationPending = isContinuationPending;
+		this.#markContinuationPending = markContinuationPending;
 	}
 
 	start(ctx: ExtensionContext): void {
@@ -38,6 +63,8 @@ export class MonitorAwareGoalContinuation {
 		this.#unsubscribeMonitorState?.();
 		this.#ctx = ctx;
 		this.#activeMonitorCount = 0;
+		this.#lastAgentEndMessages = [];
+		this.#resetContinuationState();
 		this.#resetStallStreak();
 		const events = this.#pi.events;
 		if (events === undefined) return;
@@ -51,22 +78,24 @@ export class MonitorAwareGoalContinuation {
 		});
 	}
 
-	afterAgentEnd(options: AgentEndOptions): void {
+	async afterAgentEnd(options: AgentEndOptions): Promise<Goal | null> {
 		this.#ctx = options.ctx;
 		this.#goal = options.goal;
-		if (
-			options.aborted ||
-			!shouldQueueGoalContinuationAfterAgentEnd(options.goal, options.ctx.hasPendingMessages(), options.messages)
-		) {
-			return;
-		}
+		this.#lastAgentEndMessages = options.messages;
+		this.#recordAssistantOutput(options.messages);
+		if (options.goal === null) return options.goal;
+
+		const immediateInput = this.#buildVerdictInput(options.ctx, options.goal, "immediate", options.messages);
+		const immediateVerdict = evaluateGoalContinuation({ goal: options.goal, ...immediateInput });
+		if (immediateVerdict.kind === "deny" && immediateVerdict.reason === "not-eligible") return options.goal;
+
 		if (this.#activeMonitorCount === 0) {
 			this.#cancelTimer();
 			this.#resetStallStreak();
-			queueHiddenGoalPrompt(this.#pi, buildContinuationPrompt(options.goal));
-			return;
+			return this.#admitAndQueue(options.ctx, options.goal, "immediate", options.messages);
 		}
 		this.#schedule(options.goal);
+		return options.goal;
 	}
 
 	syncGoal(goal: Goal | null): void {
@@ -77,9 +106,16 @@ export class MonitorAwareGoalContinuation {
 		}
 	}
 
-	/** A real user prompt breaks the unattended monitor-wait loop; restart the stall count. */
+	/** A real user prompt breaks unattended continuation state before its agent turn begins. */
 	noteUserPrompt(): void {
+		this.#endedTurnWasUserInitiated = true;
+		this.#resetContinuationState();
 		this.#resetStallStreak();
+	}
+
+	/** A queued hidden continuation has started, so the next end is not user-initiated. */
+	noteContinuationStarted(): void {
+		this.#endedTurnWasUserInitiated = false;
 	}
 
 	dispose(): void {
@@ -89,40 +125,96 @@ export class MonitorAwareGoalContinuation {
 		this.#ctx = undefined;
 		this.#goal = null;
 		this.#activeMonitorCount = 0;
+		this.#lastAgentEndMessages = [];
+		this.#resetContinuationState();
 		this.#resetStallStreak();
 	}
 
 	#schedule(goal: Goal): void {
 		if (this.#timer !== undefined) return;
 		if (this.#ctx?.hasUI) this.#ctx.ui.notify(GOAL_MONITOR_CONTINUATION_NOTICE, "info");
-		this.#pi.events.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
+		this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
 			goalId: goal.id,
 			delayMs: GOAL_MONITOR_CONTINUATION_DELAY_MS,
 			activeMonitorCount: this.#activeMonitorCount,
 		});
-		this.#timer = setTimeout(() => this.#continueIfEligible(), GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		this.#timer = setTimeout(() => void this.#continueIfEligible(), GOAL_MONITOR_CONTINUATION_DELAY_MS);
 	}
 
-	#continueIfEligible(): void {
+	async #continueIfEligible(): Promise<void> {
 		this.#timer = undefined;
 		const ctx = this.#ctx;
-		if (ctx === undefined || this.#activeMonitorCount === 0) return;
 		const goal = this.#goal;
-		if (shouldQueueGoalContinuationWhenIdle(goal, ctx.isIdle(), ctx.hasPendingMessages())) {
-			queueHiddenGoalPrompt(this.#pi, this.#buildMonitorContinuationContent(ctx, goal));
+		if (ctx === undefined || goal === null || this.#activeMonitorCount === 0) return;
+		await this.#admitAndQueue(ctx, goal, "monitorDelayed", this.#lastAgentEndMessages);
+	}
+
+	async #admitAndQueue(
+		ctx: ExtensionContext,
+		goal: Goal,
+		path: GoalContinuationPath,
+		messages: readonly AgentMessage[],
+	): Promise<Goal> {
+		const admittedGoal = await admitAndQueueGoalContinuation(this.#pi, ctx, goal, {
+			input: this.#buildVerdictInput(ctx, goal, path, messages),
+			content: (verdict) => this.#buildContinuationContent(ctx, goal, path, verdict),
+			markContinuationPending: this.#markContinuationPending,
+		});
+		this.#goal = admittedGoal;
+		if (admittedGoal.status !== "active") {
+			this.#cancelTimer();
+			this.#resetStallStreak();
 		}
+		return admittedGoal;
+	}
+
+	#buildVerdictInput(
+		ctx: ExtensionContext,
+		goal: Goal,
+		path: GoalContinuationPath,
+		messages: readonly AgentMessage[],
+	): Omit<GoalContinuationInput, "goal"> {
+		const lastAssistant = findLastAssistantMessage(messages);
+		return {
+			isIdle: ctx.isIdle(),
+			hasPendingMessages: ctx.hasPendingMessages(),
+			path,
+			lastStopReason: lastAssistant?.stopReason,
+			consecutiveContinuations: goal.consecutiveContinuations ?? 0,
+			lastContinuationSignature: goal.lastContinuationSignature,
+			currentSignature: buildCurrentGoalContinuationSignature(ctx, goal, lastAssistantText(messages)),
+			consecutiveLengthRecoveries: this.#consecutiveLengthRecoveries,
+			recentNormalizedOutputHashes: this.#recentNormalizedOutputHashes,
+			toollessContinuationStreak: this.#toollessContinuationStreak,
+			endedTurnWasUserInitiated: this.#endedTurnWasUserInitiated,
+			continuationPending: this.#isContinuationPending(),
+		};
+	}
+
+	#buildContinuationContent(
+		ctx: ExtensionContext,
+		goal: Goal,
+		path: GoalContinuationPath,
+		verdict: ContinuingGoalContinuationVerdict,
+	): string {
+		let content = verdict.prompt === "minimal" ? buildTruncationRecoveryPrompt() : buildContinuationPrompt(goal);
+		if (verdict.stallNotice) {
+			content = `${buildGoalStallNotice(this.#toollessContinuationStreak, {
+				monitorsActive: this.#activeMonitorCount > 0,
+			})}\n\n${content}`;
+		}
+		return path === "monitorDelayed" ? this.#buildMonitorContinuationContent(ctx, goal, content) : content;
 	}
 
 	/** Counts consecutive monitor-wait continuations; from the third one on, prepends an active stall check. */
-	#buildMonitorContinuationContent(ctx: ExtensionContext, goal: Goal): string {
+	#buildMonitorContinuationContent(ctx: ExtensionContext, goal: Goal, content: string): string {
 		if (goal.id !== this.#stallGoalId) {
 			this.#stallGoalId = goal.id;
 			this.#consecutiveMonitorContinuations = 0;
 		}
 		this.#consecutiveMonitorContinuations += 1;
-		const content = buildContinuationPrompt(goal);
 		if (this.#consecutiveMonitorContinuations < GOAL_MONITOR_STALL_THRESHOLD) return content;
-		this.#pi.events.emit(GOAL_MONITOR_STALL_EVENT, {
+		this.#pi.events?.emit(GOAL_MONITOR_STALL_EVENT, {
 			goalId: goal.id,
 			consecutiveContinuations: this.#consecutiveMonitorContinuations,
 		});
@@ -135,6 +227,18 @@ export class MonitorAwareGoalContinuation {
 		return `${buildMonitorStallNotice(this.#consecutiveMonitorContinuations)}\n\n${content}`;
 	}
 
+	#recordAssistantOutput(messages: readonly AgentMessage[]): void {
+		const text = lastAssistantText(messages);
+		if (normalizeAssistantText(text).length === 0) return;
+		this.#recentNormalizedOutputHashes = [...this.#recentNormalizedOutputHashes, hashAssistantText(text)].slice(-3);
+	}
+
+	#resetContinuationState(): void {
+		this.#consecutiveLengthRecoveries = 0;
+		this.#recentNormalizedOutputHashes = [];
+		this.#toollessContinuationStreak = 0;
+	}
+
 	#resetStallStreak(): void {
 		this.#consecutiveMonitorContinuations = 0;
 		this.#stallGoalId = null;
@@ -145,4 +249,14 @@ export class MonitorAwareGoalContinuation {
 		clearTimeout(this.#timer);
 		this.#timer = undefined;
 	}
+}
+
+function findLastAssistantMessage(
+	messages: readonly AgentMessage[],
+): Extract<AgentMessage, { role: "assistant" }> | undefined {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message?.role === "assistant") return message;
+	}
+	return undefined;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -111,11 +111,11 @@ export class MonitorAwareGoalContinuation {
 	}
 
 	syncGoal(goal: Goal | null): void {
-		if (goal?.id !== this.#goal?.id) this.#resetToollessContinuationStreak();
+		if (goal?.id !== this.#goal?.id) this.#resetContinuationState();
 		this.#goal = goal;
 		if (goal?.status !== "active") {
 			this.#cancelTimer();
-			this.#resetToollessContinuationStreak();
+			this.#resetContinuationState();
 		}
 	}
 
@@ -154,7 +154,14 @@ export class MonitorAwareGoalContinuation {
 			});
 		}
 		this.#scheduledContinuationKind = kind;
-		this.#timer = setTimeout(() => void this.#continueIfEligible(kind), delayMs);
+		this.#timer = setTimeout(() => {
+			void this.#continueIfEligible(kind).catch((error: unknown) => {
+				if (this.#ctx?.hasUI) {
+					const message = error instanceof Error ? error.message : String(error);
+					this.#ctx.ui.notify(`Goal continuation delivery failed: ${message}`, "error");
+				}
+			});
+		}, delayMs);
 	}
 
 	async #continueIfEligible(kind: DelayedContinuationKind): Promise<void> {
@@ -164,7 +171,7 @@ export class MonitorAwareGoalContinuation {
 		const goal = this.#goal;
 		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
 		if (kind === "monitor" && this.#activeMonitorCount === 0) return;
-		await this.#admitAndQueue(ctx, goal, "monitorDelayed", this.#lastAgentEndMessages);
+		await this.#admitAndQueue(ctx, goal, kind === "monitor" ? "monitorDelayed" : "userGrace", this.#lastAgentEndMessages);
 	}
 
 	async #admitAndQueue(

--- a/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
@@ -67,7 +67,7 @@ function parseGoalFile(raw: string): GoalFile {
 	if (parsed.version !== STORE_VERSION) throw new UnsupportedGoalStoreVersionError("unsupported goal store version");
 	if (parsed.goal !== null && !isGoal(parsed.goal))
 		throw new InvalidGoalStoreError("goal store contains an invalid goal");
-	return { version: STORE_VERSION, goal: parsed.goal };
+	return { version: STORE_VERSION, goal: parsed.goal === null ? null : sanitizeContinuationState(parsed.goal) };
 }
 
 function recoverGoalFileWithStaleClosingBraces(raw: string): string | undefined {
@@ -132,6 +132,13 @@ function hasValidBlockedFields(value: Record<string, unknown>, status: GoalStatu
 		);
 	}
 	return value.blockedReason === undefined && value.blockedAt === undefined;
+}
+
+function sanitizeContinuationState(goal: Goal): Goal {
+	const next: Goal = { ...goal };
+	if (!isNonNegativeSafeInteger(next.consecutiveContinuations)) delete next.consecutiveContinuations;
+	if (typeof next.lastContinuationSignature !== "string") delete next.lastContinuationSignature;
+	return next;
 }
 
 function isMissingFile(error: unknown): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
@@ -52,7 +52,7 @@ export function buildTruncationRecoveryPrompt(): string {
 export function buildGoalStallNotice(consecutiveToollessTurns: number, options: { monitorsActive: boolean }): string {
 	if (options.monitorsActive) {
 		return [
-			"<goal_monitor_stall_check>",
+			"<goal_stall_check>",
 			`System check: this is monitor-wait goal continuation #${consecutiveToollessTurns} in a row. The same monitor(s) stayed active across ${consecutiveToollessTurns} consecutive continuation turns with no new user input and no monitor completion. The current situation is likely abnormal - a stalled or dead wait.`,
 			"Before waiting on the monitors again, actively investigate:",
 			"- Inspect the monitored sessions' output now (bash_output) and verify the watched condition can still occur.",
@@ -60,18 +60,18 @@ export function buildGoalStallNotice(consecutiveToollessTurns: number, options: 
 			"- If the wait target is wrong or no longer needed, kill the monitor (kill_bash) and pursue the goal another way.",
 			"- If the goal truly cannot progress, run the blocked audit instead of waiting again.",
 			"Do not end this turn with only another passive wait.",
-			"</goal_monitor_stall_check>",
+			"</goal_stall_check>",
 		].join("\n");
 	}
 	return [
-		"<goal_monitor_stall_check>",
+		"<goal_stall_check>",
 		`System check: this is goal continuation #${consecutiveToollessTurns} in a row with no tool use and no new user input. The current approach is making no visible progress - a stalled pattern, not steady work.`,
 		"Before continuing in the same way, change what you are doing:",
 		"- Re-read the todo list and inspect the actual worktree state; treat it as authoritative over memory of earlier turns.",
 		"- Take one concrete action that moves the goal forward: edit a file, run a command, or verify a real result.",
 		"- If the goal truly cannot progress, run the blocked audit instead of repeating the same turn.",
 		"Do not end this turn with only narration about what you intend to do.",
-		"</goal_monitor_stall_check>",
+		"</goal_stall_check>",
 	].join("\n");
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
@@ -38,18 +38,45 @@ export function buildContinuationPrompt(goal: Goal): string {
 	].join("\n");
 }
 
-export function buildMonitorStallNotice(consecutiveContinuations: number): string {
+export function buildTruncationRecoveryPrompt(): string {
+	return [
+		"Your previous response was cut off by the output-token limit before it finished.",
+		"",
+		"Continue exactly where it stopped: resume the interrupted sentence, tool call, or code block at the cut point.",
+		"- Do not restart, restate, or re-plan the work; the earlier content is already in the conversation.",
+		"- Do not repeat completed sections; produce only the missing remainder.",
+		"- Keep the continuation focused so this response fits within the limit.",
+	].join("\n");
+}
+
+export function buildGoalStallNotice(consecutiveToollessTurns: number, options: { monitorsActive: boolean }): string {
+	if (options.monitorsActive) {
+		return [
+			"<goal_monitor_stall_check>",
+			`System check: this is monitor-wait goal continuation #${consecutiveToollessTurns} in a row. The same monitor(s) stayed active across ${consecutiveToollessTurns} consecutive continuation turns with no new user input and no monitor completion. The current situation is likely abnormal - a stalled or dead wait.`,
+			"Before waiting on the monitors again, actively investigate:",
+			"- Inspect the monitored sessions' output now (bash_output) and verify the watched condition can still occur.",
+			"- Check whether the underlying process is hung, exited silently, or waiting on input; restart or replace it if so.",
+			"- If the wait target is wrong or no longer needed, kill the monitor (kill_bash) and pursue the goal another way.",
+			"- If the goal truly cannot progress, run the blocked audit instead of waiting again.",
+			"Do not end this turn with only another passive wait.",
+			"</goal_monitor_stall_check>",
+		].join("\n");
+	}
 	return [
 		"<goal_monitor_stall_check>",
-		`System check: this is monitor-wait goal continuation #${consecutiveContinuations} in a row. The same monitor(s) stayed active across ${consecutiveContinuations} consecutive continuation turns with no new user input and no monitor completion. The current situation is likely abnormal - a stalled or dead wait.`,
-		"Before waiting on the monitors again, actively investigate:",
-		"- Inspect the monitored sessions' output now (bash_output) and verify the watched condition can still occur.",
-		"- Check whether the underlying process is hung, exited silently, or waiting on input; restart or replace it if so.",
-		"- If the wait target is wrong or no longer needed, kill the monitor (kill_bash) and pursue the goal another way.",
-		"- If the goal truly cannot progress, run the blocked audit instead of waiting again.",
-		"Do not end this turn with only another passive wait.",
+		`System check: this is goal continuation #${consecutiveToollessTurns} in a row with no tool use and no new user input. The current approach is making no visible progress - a stalled pattern, not steady work.`,
+		"Before continuing in the same way, change what you are doing:",
+		"- Re-read the todo list and inspect the actual worktree state; treat it as authoritative over memory of earlier turns.",
+		"- Take one concrete action that moves the goal forward: edit a file, run a command, or verify a real result.",
+		"- If the goal truly cannot progress, run the blocked audit instead of repeating the same turn.",
+		"Do not end this turn with only narration about what you intend to do.",
 		"</goal_monitor_stall_check>",
 	].join("\n");
+}
+
+export function buildMonitorStallNotice(consecutiveContinuations: number): string {
+	return buildGoalStallNotice(consecutiveContinuations, { monitorsActive: true });
 }
 
 function escapeXmlText(value: string): string {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
@@ -52,6 +52,7 @@ export async function createGoal(ref: GoalStoreRef, objective: string, tokenBudg
 		status: "active",
 		tokensUsed: 0,
 		timeUsedSeconds: 0,
+		consecutiveContinuations: 0,
 		createdAt: now,
 		updatedAt: now,
 		lastStartedAt: now,
@@ -88,6 +89,7 @@ export async function updateGoal(
 			status,
 			tokensUsed: 0,
 			timeUsedSeconds: 0,
+			consecutiveContinuations: 0,
 			createdAt: now,
 			updatedAt: now,
 			...(tokenBudget === undefined ? {} : { tokenBudget }),
@@ -106,6 +108,10 @@ export async function updateGoal(
 		update.reason,
 		now,
 	);
+	if (next.status !== current.status) {
+		next.consecutiveContinuations = 0;
+		delete next.lastContinuationSignature;
+	}
 	if (tokenBudget === undefined) delete next.tokenBudget;
 	else next.tokenBudget = tokenBudget;
 	if (validatedObjective?.truncated) await writeFullObjectiveText(ref, update.objective ?? "");
@@ -148,6 +154,27 @@ export async function accountGoalUsage(
 		timeUsedSeconds: goal.timeUsedSeconds + Math.max(0, Math.trunc(elapsedSeconds)),
 		updatedAt: nextUpdatedAt(goal.updatedAt),
 	};
+	await writeGoal(ref, next);
+	return next;
+}
+
+export async function recordContinuationDelivered(ref: GoalStoreRef, signature: string): Promise<Goal | null> {
+	const goal = await readGoal(ref);
+	if (!goal) return goal;
+	const next: Goal = {
+		...goal,
+		consecutiveContinuations: (goal.consecutiveContinuations ?? 0) + 1,
+		lastContinuationSignature: signature,
+	};
+	await writeGoal(ref, next);
+	return next;
+}
+
+export async function resetContinuationStreak(ref: GoalStoreRef): Promise<Goal | null> {
+	const goal = await readGoal(ref);
+	if (!goal) return goal;
+	const next: Goal = { ...goal, consecutiveContinuations: 0 };
+	delete next.lastContinuationSignature;
 	await writeGoal(ref, next);
 	return next;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/types.ts
@@ -20,6 +20,8 @@ export type Goal = {
 	tokenBudget?: number;
 	tokensUsed: number;
 	timeUsedSeconds: number;
+	consecutiveContinuations?: number;
+	lastContinuationSignature?: string;
 	createdAt: number;
 	updatedAt: number;
 	lastStartedAt?: number;

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -16,6 +16,7 @@ import { SettingsManager } from "../settings-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import { drainPendingProviderRegistrations } from "./loader.ts";
 import type {
+	AgentEndEvent,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	BeforeProviderHeadersEvent,
@@ -1125,6 +1126,10 @@ export class ExtensionRunner {
 			event.type === "session_before_compact" ||
 			event.type === "session_before_tree"
 		);
+	}
+
+	async emitAgentEnd(event: Omit<AgentEndEvent, "type">): Promise<void> {
+		await this.emit({ type: "agent_end", ...event });
 	}
 
 	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -16,7 +16,6 @@ import { SettingsManager } from "../settings-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import { drainPendingProviderRegistrations } from "./loader.ts";
 import type {
-	AgentEndEvent,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	BeforeProviderHeadersEvent,
@@ -1126,10 +1125,6 @@ export class ExtensionRunner {
 			event.type === "session_before_compact" ||
 			event.type === "session_before_tree"
 		);
-	}
-
-	async emitAgentEnd(event: Omit<AgentEndEvent, "type">): Promise<void> {
-		await this.emit({ type: "agent_end", ...event });
 	}
 
 	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -908,6 +908,8 @@ export interface AgentEndEvent {
 	messages: AgentMessage[];
 	/** True when the agent run ended through an abort rather than normal completion. */
 	aborted?: boolean;
+	/** Whether the session will automatically retry or fall back after this end event. */
+	willRetry?: boolean;
 	/** Present when the host can attribute the abort to a user action or internal operation. */
 	abortSource?: "user" | "system";
 }

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -23,12 +23,40 @@ export const BRANCH_SUMMARY_PREFIX = `The following is a summary of a branch tha
 
 export const BRANCH_SUMMARY_SUFFIX = `</summary>`;
 
+export const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
+
+/**
+ * Per-type exclusion must remain false: compaction and branch summarization
+ * inspect entries independently, where excluding this type would hide the live
+ * goal-continuation message. Whole-context filtering below removes only stale
+ * goal-continuation entries while retaining the last triggering message.
+ */
 export function isContextExcludedCustomMessage(_customType: string): boolean {
 	return false;
 }
 
+function keepLatestGoalContinuationMessage(messages: AgentMessage[]): AgentMessage[] {
+	let lastGoalContinuationIndex = -1;
+
+	for (let index = 0; index < messages.length; index++) {
+		const message = messages[index];
+		if (message.role === "custom" && message.customType === GOAL_CONTINUATION_MESSAGE_TYPE) {
+			lastGoalContinuationIndex = index;
+		}
+	}
+
+	if (lastGoalContinuationIndex === -1) return messages;
+
+	return messages.filter(
+		(message, index) =>
+			index === lastGoalContinuationIndex ||
+			message.role !== "custom" ||
+			message.customType !== GOAL_CONTINUATION_MESSAGE_TYPE,
+	);
+}
+
 export function filterContextExcludedMessages(messages: AgentMessage[]): AgentMessage[] {
-	return messages;
+	return keepLatestGoalContinuationMessage(messages);
 }
 
 /**
@@ -158,7 +186,7 @@ export function createCustomMessage(
 export function convertToLlm(messages: AgentMessage[]): Message[] {
 	const withContextProvenance = <T extends Message>(source: AgentMessage, target: T): T =>
 		copyContextProvenance(source, target);
-	return messages
+	return keepLatestGoalContinuationMessage(messages)
 		.map((m): Message | undefined => {
 			switch (m.role) {
 				case "bashExecution":

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -31,7 +31,17 @@ describe("AgentSession retry and event characterization", () => {
 	});
 
 	it("retries after a transient error and succeeds", async () => {
-		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
+		const extensionWillRetry: Array<boolean | undefined> = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_end", (event) => {
+						extensionWillRetry.push(event.willRetry);
+					});
+				},
+			],
+		});
 		harnesses.push(harness);
 		const retryEvents: string[] = [];
 		harness.session.subscribe((event) => {
@@ -47,6 +57,7 @@ describe("AgentSession retry and event characterization", () => {
 		await harness.session.prompt("test");
 
 		expect(retryEvents).toEqual(["start:1", "end:true"]);
+		expect(extensionWillRetry).toEqual([true, false]);
 		expect(harness.eventsOfType("agent_end").map((event) => event.willRetry)).toEqual([true, false]);
 		expect(harness.faux.state.callCount).toBe(2);
 		expect(harness.session.isRetrying).toBe(false);

--- a/packages/coding-agent/test/suite/goal-continuation-context-exclusion.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-context-exclusion.test.ts
@@ -1,0 +1,90 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Message } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { type CustomMessage, convertToLlm, filterContextExcludedMessages } from "../../src/core/messages.ts";
+
+const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
+
+function goalContinuation(content: string, timestamp: number): CustomMessage {
+	return {
+		role: "custom",
+		customType: GOAL_CONTINUATION_MESSAGE_TYPE,
+		content,
+		display: false,
+		timestamp,
+	};
+}
+
+function customMessage(content: string, timestamp: number): CustomMessage {
+	return {
+		role: "custom",
+		customType: "test-note",
+		content,
+		display: false,
+		timestamp,
+	};
+}
+
+function llmText(message: Message): string {
+	if (typeof message.content === "string") return message.content;
+	return message.content.map((block) => (block.type === "text" ? block.text : "[non-text]")).join("");
+}
+
+function continuationContents(messages: AgentMessage[]): string[] {
+	return messages.flatMap((message) =>
+		message.role === "custom" && message.customType === GOAL_CONTINUATION_MESSAGE_TYPE
+			? [typeof message.content === "string" ? message.content : "[non-text]"]
+			: [],
+	);
+}
+
+describe("goal-continuation context exclusion", () => {
+	test.each([
+		{ name: "zero", messages: [] as AgentMessage[], expected: [] as string[] },
+		{
+			name: "one",
+			messages: [goalContinuation("live continuation", 1)] as AgentMessage[],
+			expected: ["live continuation"],
+		},
+		{
+			name: "many",
+			messages: [
+				goalContinuation("stale continuation one", 1),
+				goalContinuation("stale continuation two", 2),
+				goalContinuation("live continuation", 3),
+			] as AgentMessage[],
+			expected: ["live continuation"],
+		},
+	])("keeps only the last continuation when the array has $name", ({ messages, expected }) => {
+		expect(continuationContents(filterContextExcludedMessages(messages))).toEqual(expected);
+		expect(convertToLlm(messages).map(llmText)).toEqual(expected);
+	});
+
+	test("keeps non-goal messages and their ordering unchanged", () => {
+		const messages: AgentMessage[] = [
+			{ role: "user", content: "before", timestamp: 1 },
+			goalContinuation("stale continuation", 2),
+			customMessage("non-goal custom", 3),
+			goalContinuation("live continuation", 4),
+			{ role: "user", content: "after", timestamp: 5 },
+		];
+
+		const filtered = filterContextExcludedMessages(messages);
+
+		expect(filtered).toEqual([messages[0], messages[2], messages[3], messages[4]]);
+		expect(convertToLlm(messages).map(llmText)).toEqual(["before", "non-goal custom", "live continuation", "after"]);
+	});
+
+	test("is idempotent across filtering and conversion", () => {
+		const messages: AgentMessage[] = [
+			goalContinuation("stale continuation", 1),
+			customMessage("non-goal custom", 2),
+			goalContinuation("live continuation", 3),
+		];
+
+		const filtered = filterContextExcludedMessages(messages);
+
+		expect(filterContextExcludedMessages(filtered)).toEqual(filtered);
+		expect(convertToLlm(filtered)).toEqual(convertToLlm(messages));
+	});
+});

--- a/packages/coding-agent/test/suite/goal-continuation-context-exclusion.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-context-exclusion.test.ts
@@ -1,7 +1,20 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { Message } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
 import { describe, expect, test } from "vitest";
-import { type CustomMessage, convertToLlm, filterContextExcludedMessages } from "../../src/core/messages.ts";
+import { prepareBranchEntries } from "../../src/core/compaction/branch-summarization.ts";
+import {
+	DEFAULT_COMPACTION_SETTINGS,
+	estimateContextTokens,
+	estimateTokens,
+	prepareCompaction,
+} from "../../src/core/compaction/compaction.ts";
+import {
+	type CustomMessage,
+	convertToLlm,
+	filterContextExcludedMessages,
+	isContextExcludedCustomMessage,
+} from "../../src/core/messages.ts";
+import { buildSessionContext, type SessionEntry } from "../../src/core/session-manager.ts";
 
 const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
 
@@ -86,5 +99,137 @@ describe("goal-continuation context exclusion", () => {
 
 		expect(filterContextExcludedMessages(filtered)).toEqual(filtered);
 		expect(convertToLlm(filtered)).toEqual(convertToLlm(messages));
+	});
+});
+
+describe("goal-continuation call-site consistency (300-message fixture)", () => {
+	const FIXTURE_CONTINUATIONS = 300;
+	const LIVE_CONTINUATION = `goal continuation ${FIXTURE_CONTINUATIONS - 1}`;
+
+	function fixtureAssistantMessage(text: string, timestamp: number): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "fixture-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp,
+		};
+	}
+
+	function buildMassFixture(): AgentMessage[] {
+		const messages: AgentMessage[] = [];
+		for (let index = 0; index < FIXTURE_CONTINUATIONS; index++) {
+			messages.push({ role: "user", content: `user turn ${index}`, timestamp: index * 3 });
+			messages.push(goalContinuation(`goal continuation ${index}`, index * 3 + 1));
+			messages.push(fixtureAssistantMessage(`assistant reply ${index}`, index * 3 + 2));
+		}
+		return messages;
+	}
+
+	function buildMassFixtureEntries(): SessionEntry[] {
+		const entries: SessionEntry[] = [];
+		let parentId: string | null = null;
+		for (let index = 0; index < FIXTURE_CONTINUATIONS; index++) {
+			const userId = `mass-user-${index}`;
+			entries.push({
+				type: "message",
+				id: userId,
+				parentId,
+				timestamp: new Date(1_700_000_000_000 + index * 3).toISOString(),
+				message: { role: "user", content: `user turn ${index}`, timestamp: index * 3 },
+			});
+			const continuationId = `mass-continuation-${index}`;
+			entries.push({
+				type: "custom_message",
+				id: continuationId,
+				parentId: userId,
+				timestamp: new Date(1_700_000_000_000 + index * 3 + 1).toISOString(),
+				customType: GOAL_CONTINUATION_MESSAGE_TYPE,
+				content: `goal continuation ${index}`,
+				display: false,
+			});
+			const assistantId = `mass-assistant-${index}`;
+			entries.push({
+				type: "message",
+				id: assistantId,
+				parentId: continuationId,
+				timestamp: new Date(1_700_000_000_000 + index * 3 + 2).toISOString(),
+				message: fixtureAssistantMessage(`assistant reply ${index}`, index * 3 + 2),
+			});
+			parentId = assistantId;
+		}
+		return entries;
+	}
+
+	test("convertToLlm emits exactly one continuation-derived user message from 300", () => {
+		const fixture = buildMassFixture();
+
+		const converted = convertToLlm(fixture);
+
+		expect(converted).toHaveLength(fixture.length - (FIXTURE_CONTINUATIONS - 1));
+		const continuationDerived = converted.filter((message) => llmText(message).startsWith("goal continuation"));
+		expect(continuationDerived).toHaveLength(1);
+		expect(continuationDerived[0].role).toBe("user");
+		expect(llmText(continuationDerived[0])).toBe(LIVE_CONTINUATION);
+	});
+
+	test("estimateContextTokens over the filtered fixture drops the same 299 continuations", () => {
+		const fixture = buildMassFixture();
+		const continuations = fixture.filter(
+			(message) => message.role === "custom" && message.customType === GOAL_CONTINUATION_MESSAGE_TYPE,
+		);
+		expect(continuations).toHaveLength(FIXTURE_CONTINUATIONS);
+
+		const filtered = filterContextExcludedMessages(fixture);
+
+		expect(filtered).toHaveLength(fixture.length - (FIXTURE_CONTINUATIONS - 1));
+		expect(continuationContents(filtered)).toEqual([LIVE_CONTINUATION]);
+
+		const unfilteredTokens = estimateContextTokens(fixture).tokens;
+		const filteredTokens = estimateContextTokens(filtered).tokens;
+		const staleTokens = continuations.slice(0, -1).reduce((sum, message) => sum + estimateTokens(message), 0);
+
+		expect(filteredTokens).toBeLessThan(unfilteredTokens);
+		expect(unfilteredTokens - filteredTokens).toBe(staleTokens);
+	});
+
+	test("prepareCompaction applies the same filter to the flooded fixture without error", () => {
+		const entries = buildMassFixtureEntries();
+		const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 100 };
+
+		const preparation = prepareCompaction(entries, settings);
+
+		expect(preparation).toBeDefined();
+		const contextMessages = buildSessionContext(entries).messages;
+		const expectedFilteredTokens = estimateContextTokens(filterContextExcludedMessages(contextMessages)).tokens;
+		const unfilteredTokens = estimateContextTokens(contextMessages).tokens;
+		expect(preparation!.tokensBefore).toBe(expectedFilteredTokens);
+		expect(preparation!.tokensBefore).toBeLessThan(unfilteredTokens);
+	});
+
+	test("branch summarization still sees every goal-continuation entry", () => {
+		const entries = buildMassFixtureEntries();
+
+		const preparation = prepareBranchEntries(entries);
+
+		expect(isContextExcludedCustomMessage(GOAL_CONTINUATION_MESSAGE_TYPE)).toBe(false);
+		const visibleContinuations = preparation.messages.filter(
+			(message): message is CustomMessage =>
+				message.role === "custom" && message.customType === GOAL_CONTINUATION_MESSAGE_TYPE,
+		);
+		expect(visibleContinuations).toHaveLength(FIXTURE_CONTINUATIONS);
+		const visibleContents = visibleContinuations.map((message) => message.content);
+		expect(visibleContents).toContain("goal continuation 0");
+		expect(visibleContents).toContain(LIVE_CONTINUATION);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildGoalContinuationSignature,
+	evaluateGoalContinuation,
+	GOAL_CONTINUATION_CAP,
+	GOAL_LENGTH_RECOVERY_LIMIT,
+	GOAL_REPETITION_HASH_STREAK,
+	GOAL_STALL_TOOLLESS_THRESHOLD,
+	GOAL_USER_GRACE_DELAY_MS,
+	hashAssistantText,
+	normalizeAssistantText,
+} from "../../src/core/extensions/builtin/goal/continuation.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+
+type VerdictInput = Parameters<typeof evaluateGoalContinuation>[0];
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+	return {
+		id: "goal-1",
+		threadId: "thread-1",
+		objective: "Ship the feature",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides,
+	};
+}
+
+function makeInput(overrides: Partial<VerdictInput> = {}): VerdictInput {
+	return {
+		goal: makeGoal(),
+		isIdle: true,
+		hasPendingMessages: false,
+		path: "immediate",
+		lastStopReason: "stop",
+		consecutiveContinuations: 0,
+		lastContinuationSignature: undefined,
+		currentSignature: "goal-1:1/2:abc123",
+		consecutiveLengthRecoveries: 0,
+		recentNormalizedOutputHashes: [],
+		toollessContinuationStreak: 0,
+		endedTurnWasUserInitiated: false,
+		continuationPending: false,
+		...overrides,
+	};
+}
+
+describe("goal continuation verdict", () => {
+	it.each([
+		[
+			"requires an active immediate goal with no pending messages and a clean end",
+			makeInput({ goal: makeGoal({ status: "paused" }) }),
+		],
+		["rejects an immediate path with pending messages", makeInput({ hasPendingMessages: true })],
+		["rejects an immediate path after an unclean end", makeInput({ lastStopReason: "error" })],
+		["requires idle state for monitor-delayed continuation", makeInput({ path: "monitorDelayed", isIdle: false })],
+		["requires idle state for session-start continuation", makeInput({ path: "sessionStart", isIdle: false })],
+	] as const)("denies as not eligible when %s", (_label, input) => {
+		expect(evaluateGoalContinuation(input)).toEqual({ kind: "deny", reason: "not-eligible" });
+	});
+
+	it.each([
+		["single-flight", makeInput({ continuationPending: true })],
+		[
+			"cap",
+			makeInput({
+				consecutiveContinuations: GOAL_CONTINUATION_CAP,
+			}),
+		],
+		[
+			"stale",
+			makeInput({
+				lastContinuationSignature: "goal-1:1/2:abc123",
+			}),
+		],
+		[
+			"grace",
+			makeInput({
+				endedTurnWasUserInitiated: true,
+			}),
+		],
+		[
+			"repetition",
+			makeInput({
+				recentNormalizedOutputHashes: ["same", "same", "same"],
+			}),
+		],
+		[
+			"length-exhausted",
+			makeInput({
+				lastStopReason: "length",
+				consecutiveLengthRecoveries: GOAL_LENGTH_RECOVERY_LIMIT,
+			}),
+		],
+	] as const)("denies with %s", (reason, input) => {
+		expect(evaluateGoalContinuation(input)).toEqual({ kind: "deny", reason });
+	});
+
+	it.each([
+		["a clean ordinary end", makeInput(), { kind: "continue", prompt: "full", stallNotice: false }],
+		[
+			"the first output truncation",
+			makeInput({ lastStopReason: "length" }),
+			{ kind: "continue", prompt: "minimal", stallNotice: false },
+		],
+	] as const)("continues with %s using the correct prompt", (_label, input, verdict) => {
+		expect(evaluateGoalContinuation(input)).toEqual(verdict);
+	});
+
+	it("preserves per-path eligibility semantics", () => {
+		expect(evaluateGoalContinuation(makeInput({ isIdle: false }))).toMatchObject({ kind: "continue" });
+		expect(evaluateGoalContinuation(makeInput({ path: "monitorDelayed", lastStopReason: "error" }))).toMatchObject({
+			kind: "continue",
+		});
+		expect(evaluateGoalContinuation(makeInput({ path: "sessionStart", lastStopReason: "error" }))).toMatchObject({
+			kind: "continue",
+		});
+	});
+
+	it("exempts monitor-delayed continuations from cap and stale guards while session start remains capped", () => {
+		const capped = makeInput({
+			consecutiveContinuations: GOAL_CONTINUATION_CAP,
+			lastContinuationSignature: "goal-1:1/2:abc123",
+		});
+
+		expect(evaluateGoalContinuation({ ...capped, path: "monitorDelayed" })).toMatchObject({ kind: "continue" });
+		expect(evaluateGoalContinuation({ ...capped, path: "sessionStart" })).toEqual({ kind: "deny", reason: "cap" });
+		expect(
+			evaluateGoalContinuation({
+				...capped,
+				path: "sessionStart",
+				consecutiveContinuations: GOAL_CONTINUATION_CAP - 1,
+			}),
+		).toMatchObject({ kind: "continue" });
+	});
+
+	it.each([
+		[GOAL_STALL_TOOLLESS_THRESHOLD - 1, false],
+		[GOAL_STALL_TOOLLESS_THRESHOLD, true],
+		[GOAL_STALL_TOOLLESS_THRESHOLD + 1, true],
+	] as const)("sets stall notice to %s at a toolless streak of %i", (toollessContinuationStreak, stallNotice) => {
+		expect(evaluateGoalContinuation(makeInput({ toollessContinuationStreak }))).toEqual({
+			kind: "continue",
+			prompt: "full",
+			stallNotice,
+		});
+	});
+
+	it("normalizes assistant text and hashes its normalized form stably", () => {
+		expect(normalizeAssistantText("  Hello\tWORLD\nagain  ")).toBe("hello world again");
+		expect(normalizeAssistantText(" \n\t ")).toBe("");
+		expect(hashAssistantText("Hello\nworld")).toBe(hashAssistantText("  hello   WORLD "));
+		expect(hashAssistantText("Hello world")).not.toBe(hashAssistantText("Goodbye world"));
+		expect(hashAssistantText("Hello world")).toBe("d58b3fa7");
+	});
+
+	it("builds a progress signature without goal.updatedAt", () => {
+		const hash = hashAssistantText("Made progress");
+		expect(buildGoalContinuationSignature(makeGoal({ updatedAt: 1 }), 2, 5, hash)).toBe(`goal-1:2/5:${hash}`);
+		expect(buildGoalContinuationSignature(makeGoal({ updatedAt: 9_999 }), 2, 5, hash)).toBe(`goal-1:2/5:${hash}`);
+	});
+
+	it("keeps the public policy constants at their specified values", () => {
+		expect(GOAL_CONTINUATION_CAP).toBe(8);
+		expect(GOAL_STALL_TOOLLESS_THRESHOLD).toBe(3);
+		expect(GOAL_REPETITION_HASH_STREAK).toBe(3);
+		expect(GOAL_LENGTH_RECOVERY_LIMIT).toBe(1);
+		expect(GOAL_USER_GRACE_DELAY_MS).toBe(60_000);
+	});
+});

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -56,6 +56,7 @@ describe("goal continuation verdict", () => {
 		["rejects an immediate path with pending messages", makeInput({ hasPendingMessages: true })],
 		["rejects an immediate path after an unclean end", makeInput({ lastStopReason: "error" })],
 		["requires idle state for monitor-delayed continuation", makeInput({ path: "monitorDelayed", isIdle: false })],
+		["requires idle state for user-grace continuation", makeInput({ path: "userGrace", isIdle: false })],
 		["requires idle state for session-start continuation", makeInput({ path: "sessionStart", isIdle: false })],
 	] as const)("denies as not eligible when %s", (_label, input) => {
 		expect(evaluateGoalContinuation(input)).toEqual({ kind: "deny", reason: "not-eligible" });
@@ -119,7 +120,7 @@ describe("goal continuation verdict", () => {
 		});
 	});
 
-	it("exempts monitor-delayed continuations from cap and stale guards while session start remains capped", () => {
+	it("exempts only monitor-delayed continuations from cap and stale guards", () => {
 		const capped = makeInput({
 			consecutiveContinuations: GOAL_CONTINUATION_CAP,
 			lastContinuationSignature: "goal-1:1/2:abc123",
@@ -127,6 +128,14 @@ describe("goal continuation verdict", () => {
 
 		expect(evaluateGoalContinuation({ ...capped, path: "monitorDelayed" })).toMatchObject({ kind: "continue" });
 		expect(evaluateGoalContinuation({ ...capped, path: "sessionStart" })).toEqual({ kind: "deny", reason: "cap" });
+		expect(evaluateGoalContinuation({ ...capped, path: "userGrace" })).toEqual({ kind: "deny", reason: "cap" });
+		expect(
+			evaluateGoalContinuation({
+				...capped,
+				path: "userGrace",
+				consecutiveContinuations: GOAL_CONTINUATION_CAP - 1,
+			}),
+		).toEqual({ kind: "deny", reason: "stale" });
 		expect(
 			evaluateGoalContinuation({
 				...capped,

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -402,7 +402,9 @@ describe("goal extension contract (budget-free)", () => {
 	it("blocks a non-user aborted turn after retries are exhausted", async () => {
 		const { tools, handlers } = createGoalHarness();
 		const ctx = await makeCtx("thread-system-abort-provider-guard");
-		await tools.get("create_goal")?.execute("c1", { objective: "Recover from provider aborts" }, undefined, undefined, ctx);
+		await tools
+			.get("create_goal")
+			?.execute("c1", { objective: "Recover from provider aborts" }, undefined, undefined, ctx);
 
 		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 		await runHandlers(

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
 import { goalFilePath, readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
@@ -81,8 +81,12 @@ async function makeUiCtx(
 	} as unknown as ExtensionContext;
 }
 
-async function makeNotifyingCtx(notices: string[], threadId: string): Promise<ExtensionContext> {
-	const base = await makeCtx(threadId);
+async function makeNotifyingCtx(
+	notices: string[],
+	threadId: string,
+	branchEntries: SessionEntry[] = [],
+): Promise<ExtensionContext> {
+	const base = await makeCtx(threadId, branchEntries);
 	return {
 		...base,
 		hasUI: true,
@@ -549,6 +553,124 @@ describe("goal extension reload does not auto-start a stopped agent", () => {
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
 	});
 });
+
+describe("goal extension session_start migration-lite admission", () => {
+	it("suppresses auto-continuation and notifies when a resumed session ends in a continuation flood", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-flooded-resume", [
+			userMessageEntry(),
+			...goalContinuationEntries(300),
+		]);
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(sent).toHaveLength(0);
+		expect(notices).toContainEqual(
+			"Goal auto-continuation suppressed for this resumed session (300 historical continuations). Send a message to resume.",
+		);
+		// Migration-lite is load-time admission only: the stored goal keeps its status untouched.
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+	});
+
+	it("queues a continuation normally when only a few trailing continuations exist", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-healthy-resume", [
+			userMessageEntry(),
+			...goalContinuationEntries(3),
+		]);
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+		expect(notices).toEqual([]);
+	});
+
+	it("queues a continuation normally when historical continuations are followed by a real user message", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-flood-then-user", [
+			...goalContinuationEntries(300),
+			userMessageEntry(),
+		]);
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+		expect(notices).toEqual([]);
+	});
+
+	it("resumes normally on the next clean turn after a real user prompt follows a suppressed load", async () => {
+		vi.useFakeTimers();
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-suppressed-then-prompt", [
+			userMessageEntry(),
+			...goalContinuationEntries(300),
+		]);
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+		expect(sent).toHaveLength(0);
+
+		await runHandlers(handlers, "before_agent_start", { type: "before_agent_start" }, ctx);
+		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantMessageWithStopReason("stop")] },
+			ctx,
+		);
+		// A user-initiated turn end triggers the 60s grace delay (todo 6), so nothing
+		// is queued immediately. The continuation fires after the grace window.
+		expect(sent).toHaveLength(0);
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+		vi.useRealTimers();
+	});
+
+	it("keeps reload sessions inert even with a flooded branch (no queue, no suppression notice)", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-flooded-reload", [
+			userMessageEntry(),
+			...goalContinuationEntries(300),
+		]);
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		expect(sent).toHaveLength(0);
+		expect(notices).toEqual([]);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+	});
+});
+
+function userMessageEntry(): SessionEntry {
+	return {
+		type: "message",
+		message: {
+			role: "user",
+			content: [{ type: "text", text: "a real user message" }],
+			timestamp: Date.now(),
+		},
+	} as unknown as SessionEntry;
+}
+
+function goalContinuationEntries(count: number): SessionEntry[] {
+	return Array.from({ length: count }, () => ({
+		type: "custom_message",
+		customType: "goal-continuation",
+		content: "continue the goal",
+		display: false,
+	})) as unknown as SessionEntry[];
+}
 
 describe("goal extension session_abort blocks an active goal outside an agent run", () => {
 	it("blocks an active goal when session_abort fires (abort during retry backoff or queued continuation)", async () => {

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -81,6 +81,15 @@ async function makeUiCtx(
 	} as unknown as ExtensionContext;
 }
 
+async function makeNotifyingCtx(notices: string[], threadId: string): Promise<ExtensionContext> {
+	const base = await makeCtx(threadId);
+	return {
+		...base,
+		hasUI: true,
+		ui: { notify: (message: string) => notices.push(message), select: async () => undefined, setStatus: () => {} },
+	} as unknown as ExtensionContext;
+}
+
 function storeRefFor(ctx: ExtensionContext) {
 	return {
 		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
@@ -314,6 +323,101 @@ describe("goal extension contract (budget-free)", () => {
 		);
 
 		expect(sent).toHaveLength(0);
+	});
+
+	it("blocks a goal when a provider error ends after retries are exhausted", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-terminal-provider-error");
+		await tools
+			.get("create_goal")
+			?.execute("c1", { objective: "Recover from provider errors" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantMessageWithStopReason("error")], willRetry: false },
+			ctx,
+		);
+
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "provider error ended the turn (retries exhausted)",
+		});
+		expect(notices).toContainEqual(expect.stringContaining("provider error ended the turn (retries exhausted)"));
+		expect(sent).toHaveLength(0);
+	});
+
+	it("keeps a goal active while a provider-error retry is pending", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-provider-retry-pending");
+		await tools
+			.get("create_goal")
+			?.execute("c1", { objective: "Wait for retry recovery" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantMessageWithStopReason("error")], willRetry: true },
+			ctx,
+		);
+
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({ status: "active" });
+		expect(notices).toEqual([]);
+		expect(sent).toHaveLength(0);
+	});
+
+	it("preserves the user-abort block reason", async () => {
+		const { tools, handlers } = createGoalHarness();
+		const ctx = await makeCtx("thread-user-abort-provider-guard");
+		await tools.get("create_goal")?.execute("c1", { objective: "Allow interruption" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runHandlers(
+			handlers,
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [assistantMessageWithStopReason("aborted")],
+				aborted: true,
+				abortSource: "user",
+				willRetry: false,
+			},
+			ctx,
+		);
+
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "user interrupted the turn",
+		});
+	});
+
+	it("blocks a non-user aborted turn after retries are exhausted", async () => {
+		const { tools, handlers } = createGoalHarness();
+		const ctx = await makeCtx("thread-system-abort-provider-guard");
+		await tools.get("create_goal")?.execute("c1", { objective: "Recover from provider aborts" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runHandlers(
+			handlers,
+			"agent_end",
+			{
+				type: "agent_end",
+				messages: [assistantMessageWithStopReason("aborted")],
+				aborted: true,
+				abortSource: "system",
+				willRetry: false,
+			},
+			ctx,
+		);
+
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "provider error ended the turn (retries exhausted)",
+		});
 	});
 
 	it("rejects update_goal complete while todo tasks remain open, naming them", async () => {

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from "vitest";
 import { parseGoalCommand } from "../../src/core/extensions/builtin/goal/command.ts";
 import {
 	evaluateGoalContinuation,
+	type GoalContinuationInput,
 	shouldQueueGoalContinuationAfterAgentEnd,
 	shouldQueueGoalContinuationWhenIdle,
-	type GoalContinuationInput,
 } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import {
 	formatGoalElapsedSeconds,

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -252,8 +252,8 @@ describe("goal truncation recovery prompt", () => {
 describe("goal stall notice", () => {
 	it("emits generic toolless-stall bullets when no monitors are active", () => {
 		const notice = buildGoalStallNotice(3, { monitorsActive: false });
-		expect(notice).toContain("<goal_monitor_stall_check>");
-		expect(notice).toContain("</goal_monitor_stall_check>");
+		expect(notice).toContain("<goal_stall_check>");
+		expect(notice).toContain("</goal_stall_check>");
 		expect(notice).toContain("3");
 		expect(notice).not.toContain("bash_output");
 		expect(notice).not.toContain("kill_bash");
@@ -265,7 +265,7 @@ describe("goal stall notice", () => {
 
 	it("keeps the monitor-investigation bullets while monitors are active", () => {
 		const notice = buildGoalStallNotice(4, { monitorsActive: true });
-		expect(notice).toContain("<goal_monitor_stall_check>");
+		expect(notice).toContain("<goal_stall_check>");
 		expect(notice).toContain("bash_output");
 		expect(notice).toContain("kill_bash");
 		expect(notice).toContain("4");
@@ -273,7 +273,7 @@ describe("goal stall notice", () => {
 
 	it("keeps buildMonitorStallNotice as a legacy wrapper over the generalized notice", () => {
 		const legacy = buildMonitorStallNotice(5);
-		expect(legacy).toContain("<goal_monitor_stall_check>");
+		expect(legacy).toContain("<goal_stall_check>");
 		expect(legacy).toBe(buildGoalStallNotice(5, { monitorsActive: true }));
 	});
 });

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -2,8 +2,10 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { parseGoalCommand } from "../../src/core/extensions/builtin/goal/command.ts";
 import {
+	evaluateGoalContinuation,
 	shouldQueueGoalContinuationAfterAgentEnd,
 	shouldQueueGoalContinuationWhenIdle,
+	type GoalContinuationInput,
 } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import {
 	formatGoalElapsedSeconds,
@@ -130,6 +132,31 @@ describe("goal continuation gating", () => {
 				abortedToolResultMessage(),
 			]),
 		).toBe(false);
+	});
+
+	it("applies the persisted cap on immediate and session-start paths but not monitor-delayed paths", () => {
+		const input = {
+			goal: makeGoal({ consecutiveContinuations: 8 }),
+			isIdle: true,
+			hasPendingMessages: false,
+			lastStopReason: "stop",
+			consecutiveContinuations: 8,
+			lastContinuationSignature: undefined,
+			currentSignature: undefined,
+			consecutiveLengthRecoveries: 0,
+			recentNormalizedOutputHashes: [],
+			toollessContinuationStreak: 0,
+			endedTurnWasUserInitiated: false,
+			continuationPending: false,
+		} satisfies Omit<GoalContinuationInput, "path">;
+
+		expect(evaluateGoalContinuation({ ...input, path: "immediate" })).toEqual({ kind: "deny", reason: "cap" });
+		expect(evaluateGoalContinuation({ ...input, path: "sessionStart" })).toEqual({ kind: "deny", reason: "cap" });
+		expect(evaluateGoalContinuation({ ...input, path: "monitorDelayed" })).toEqual({
+			kind: "continue",
+			prompt: "full",
+			stallNotice: false,
+		});
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -11,7 +11,12 @@ import {
 	formatTokensCompact,
 	goalToolResponse,
 } from "../../src/core/extensions/builtin/goal/format.ts";
-import { buildContinuationPrompt } from "../../src/core/extensions/builtin/goal/prompt.ts";
+import {
+	buildContinuationPrompt,
+	buildGoalStallNotice,
+	buildMonitorStallNotice,
+	buildTruncationRecoveryPrompt,
+} from "../../src/core/extensions/builtin/goal/prompt.ts";
 import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
 import { goalStatusText, STATUS_KEY, updateGoalUi } from "../../src/core/extensions/builtin/goal/ui.ts";
 
@@ -196,6 +201,53 @@ describe("goal continuation prompt (budget-free)", () => {
 		expect(prompt).toMatch(/status report|done-claim/i);
 		expect(prompt).not.toMatch(/wait_for/);
 		expect(prompt).not.toMatch(/tmux/i);
+	});
+});
+
+describe("goal truncation recovery prompt", () => {
+	it("stays short and re-injects no objective text or audit blocks", () => {
+		const prompt = buildTruncationRecoveryPrompt();
+		expect(prompt.split(/\s+/).filter(Boolean).length).toBeLessThanOrEqual(120);
+		expect(prompt).not.toContain("<untrusted_objective>");
+		expect(prompt.toLowerCase()).not.toContain("objective");
+		expect(prompt.toLowerCase()).not.toContain("audit");
+	});
+
+	it("tells the model to continue from the cut point without restarting or restating", () => {
+		const prompt = buildTruncationRecoveryPrompt();
+		expect(prompt).toMatch(/output[- ]token limit|token limit/i);
+		expect(prompt).toMatch(/continue/i);
+		expect(prompt).toMatch(/do not restart|not restart|without restarting/i);
+		expect(prompt).toMatch(/restate/i);
+	});
+});
+
+describe("goal stall notice", () => {
+	it("emits generic toolless-stall bullets when no monitors are active", () => {
+		const notice = buildGoalStallNotice(3, { monitorsActive: false });
+		expect(notice).toContain("<goal_monitor_stall_check>");
+		expect(notice).toContain("</goal_monitor_stall_check>");
+		expect(notice).toContain("3");
+		expect(notice).not.toContain("bash_output");
+		expect(notice).not.toContain("kill_bash");
+		expect(notice).toMatch(/todo list/i);
+		expect(notice).toMatch(/concrete action/i);
+		expect(notice).toMatch(/blocked audit/i);
+		expect(notice).toMatch(/do not end/i);
+	});
+
+	it("keeps the monitor-investigation bullets while monitors are active", () => {
+		const notice = buildGoalStallNotice(4, { monitorsActive: true });
+		expect(notice).toContain("<goal_monitor_stall_check>");
+		expect(notice).toContain("bash_output");
+		expect(notice).toContain("kill_bash");
+		expect(notice).toContain("4");
+	});
+
+	it("keeps buildMonitorStallNotice as a legacy wrapper over the generalized notice", () => {
+		const legacy = buildMonitorStallNotice(5);
+		expect(legacy).toContain("<goal_monitor_stall_check>");
+		expect(legacy).toBe(buildGoalStallNotice(5, { monitorsActive: true }));
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -24,9 +24,13 @@ function goalStoreRef(ctx: ExtensionContext) {
 }
 
 function cleanAssistantStopWithText(text: string): AgentMessage {
+	return assistantStopWithReason("stop", text);
+}
+
+function assistantStopWithReason(stopReason: "stop" | "length", text: string): AgentMessage {
 	const message = cleanAssistantStop();
 	if (message.role !== "assistant") throw new Error("Expected assistant stop message");
-	return { ...message, content: [{ type: "text", text }] };
+	return { ...message, content: [{ type: "text", text }], stopReason };
 }
 
 function activeGoal(id: string): Goal {
@@ -197,6 +201,110 @@ describe("goal continuation while a monitor is active", () => {
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 45_000);
 
 		expect(sent).toHaveLength(0);
+	});
+
+	it("queues one minimal recovery prompt after an output truncation", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-length-minimal");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantStopWithReason("length", "unfinished implementation")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+		expect(sent[0]?.message.content).toContain("cut off");
+		expect(sent[0]?.message.content).not.toContain("<untrusted_objective>");
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 1 });
+	});
+
+	it("blocks a second consecutive output truncation without queuing another prompt", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-length-exhausted");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantStopWithReason("length", "first unfinished implementation")] },
+			ctx,
+		);
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantStopWithReason("length", "second unfinished implementation")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "output truncation repeated",
+		});
+		expect(events.emitted).toContainEqual({
+			channel: "goal_continuation_guard_tripped",
+			data: expect.objectContaining({ reason: "length-exhausted" }),
+		});
+	});
+
+	it("resets truncation recovery after a clean stop", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-length-reset");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantStopWithReason("length", "first unfinished implementation")] },
+			ctx,
+		);
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStopWithText("completed a clean step")] },
+			ctx,
+		);
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantStopWithReason("length", "second unfinished implementation")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(3);
+		expect(sent[2]?.message.content).toContain("cut off");
+		expect(sent[2]?.message.content).not.toContain("<untrusted_objective>");
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [assistantStopWithReason("length", "third unfinished implementation")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(3);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "output truncation repeated",
+		});
 	});
 
 	it("blocks the ninth clean immediate continuation without queuing a ninth hidden prompt", async () => {

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -9,7 +9,12 @@ import {
 	GOAL_MONITOR_CONTINUATION_DELAY_MS,
 	MonitorAwareGoalContinuation,
 } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
-import { readGoal, recordContinuationDelivered, updateGoal, writeGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import {
+	readGoal,
+	recordContinuationDelivered,
+	updateGoal,
+	writeGoal,
+} from "../../src/core/extensions/builtin/goal/store.ts";
 import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
@@ -17,9 +22,9 @@ import {
 	cleanupGoalMonitorTempDirs,
 	createGoalHarness,
 	type GoalHandler,
-	TestEventBus,
 	makeGoalContext,
 	runGoalHandlers,
+	TestEventBus,
 } from "./goal-monitor-test-harness.ts";
 
 function goalStoreRef(ctx: ExtensionContext) {

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -1,8 +1,9 @@
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { admitAndQueueGoalContinuation } from "../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
 import { readGoal, recordContinuationDelivered } from "../../src/core/extensions/builtin/goal/store.ts";
-import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
@@ -181,5 +182,48 @@ describe("goal continuation while a monitor is active", () => {
 
 		expect(sent).toHaveLength(1);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 1 });
+	});
+
+	it("delivers an unsigned immediate continuation without recording its streak", async () => {
+		const notices: string[] = [];
+		const { tools } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-unsigned-continuation");
+		await tools
+			.get("create_goal")
+			?.execute("create", { objective: "Continue without a signature" }, undefined, undefined, ctx);
+		const goal = await readGoal(goalStoreRef(ctx));
+		if (goal === null) throw new Error("Expected persisted goal");
+
+		let continuationMarked = false;
+		const result = await admitAndQueueGoalContinuation(
+			{ sendMessage: () => {} } as unknown as ExtensionAPI,
+			ctx,
+			goal,
+			{
+				input: {
+					isIdle: true,
+					hasPendingMessages: false,
+					path: "immediate",
+					lastStopReason: "stop",
+					consecutiveContinuations: goal.consecutiveContinuations ?? 0,
+					lastContinuationSignature: goal.lastContinuationSignature,
+					currentSignature: undefined,
+					consecutiveLengthRecoveries: 0,
+					recentNormalizedOutputHashes: [],
+					toollessContinuationStreak: 0,
+					endedTurnWasUserInitiated: false,
+					continuationPending: false,
+				},
+				content: () => "Continue",
+				markContinuationPending: () => {
+					continuationMarked = true;
+				},
+			},
+		);
+
+		expect(continuationMarked).toBe(true);
+		expect(result.consecutiveContinuations ?? 0).toBe(0);
+		expect(result.lastContinuationSignature).toBeUndefined();
+		expect((await readGoal(goalStoreRef(ctx)))?.consecutiveContinuations ?? 0).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -1,10 +1,15 @@
+import { watch } from "node:fs";
 import { join } from "node:path";
+import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import { admitAndQueueGoalContinuation } from "../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
-import { MonitorAwareGoalContinuation } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
-import { readGoal, recordContinuationDelivered } from "../../src/core/extensions/builtin/goal/store.ts";
+import {
+	GOAL_MONITOR_CONTINUATION_DELAY_MS,
+	MonitorAwareGoalContinuation,
+} from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { readGoal, recordContinuationDelivered, updateGoal, writeGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
@@ -12,6 +17,7 @@ import {
 	cleanupGoalMonitorTempDirs,
 	createGoalHarness,
 	type GoalHandler,
+	TestEventBus,
 	makeGoalContext,
 	runGoalHandlers,
 } from "./goal-monitor-test-harness.ts";
@@ -21,6 +27,35 @@ function goalStoreRef(ctx: ExtensionContext) {
 		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
 		threadId: ctx.sessionManager.getSessionId(),
 	};
+}
+
+function waitForGoalContinuationCount(ctx: ExtensionContext, expectedCount: number): Promise<void> {
+	const ref = goalStoreRef(ctx);
+	const goalFileName = `${encodeURIComponent(ref.threadId)}.json`;
+	return new Promise((resolve, reject) => {
+		let completed = false;
+		let timeout: ReturnType<typeof setRealTimeout> | undefined;
+		const watcher = watch(ref.baseDir, { encoding: "utf8" }, (_eventType, changedFileName) => {
+			if (changedFileName !== goalFileName) return;
+			void readGoal(ref).then((goal) => {
+				if (goal?.consecutiveContinuations === expectedCount) complete();
+			}, complete);
+		});
+		timeout = setRealTimeout(
+			() => complete(new Error(`Timed out waiting for continuation count ${expectedCount}`)),
+			5_000,
+		);
+		watcher.once("error", complete);
+
+		function complete(error: Error | undefined = undefined): void {
+			if (completed) return;
+			completed = true;
+			if (timeout !== undefined) clearRealTimeout(timeout);
+			watcher.close();
+			if (error === undefined) resolve();
+			else reject(error);
+		}
+	});
 }
 
 function cleanAssistantStopWithText(text: string): AgentMessage {
@@ -46,12 +81,14 @@ function activeGoal(id: string): Goal {
 	};
 }
 
-function createDirectMonitorHarness(): { monitor: MonitorAwareGoalContinuation; sent: string[] } {
+function createDirectMonitorHarness(): { monitor: MonitorAwareGoalContinuation; sent: string[]; events: TestEventBus } {
 	const sent: string[] = [];
+	const events = new TestEventBus();
 	const pi = {
 		sendMessage: (message: { readonly content: string }) => sent.push(message.content),
+		events,
 	} as unknown as ExtensionAPI;
-	return { monitor: new MonitorAwareGoalContinuation(pi), sent };
+	return { monitor: new MonitorAwareGoalContinuation(pi), sent, events };
 }
 
 async function runUserInitiatedTurn(handlers: Map<string, GoalHandler[]>, ctx: ExtensionContext): Promise<void> {
@@ -109,22 +146,55 @@ describe("goal continuation while a monitor is active", () => {
 		expect(notices).toHaveLength(0);
 	});
 
-	it("waits sixty seconds before continuing a clean user-initiated turn", async () => {
+	it("counts user grace delivery toward the continuation cap", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent } = createGoalHarness();
-		const ctx = await makeGoalContext(notices, "thread-user-grace-delay");
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-user-grace-counted");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
 		await runUserInitiatedTurn(handlers, ctx);
 		expect(sent).toHaveLength(0);
-
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 1);
 		expect(sent).toHaveLength(0);
+		const graceDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
 		await vi.advanceTimersByTimeAsync(1);
+		await graceDeliveryRecorded;
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ consecutiveContinuations: 1 });
+
+		for (let turn = 2; turn <= 8; turn++) {
+			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+			await runGoalHandlers(
+				handlers,
+				"agent_end",
+				{ type: "agent_end", messages: [cleanAssistantStopWithText(`progress ${turn}`)] },
+				ctx,
+			);
+		}
+
+		expect(sent).toHaveLength(8);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 8 });
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStopWithText("progress 9")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(8);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "continuation cap reached",
+		});
+		expect(events.emitted).toContainEqual({
+			channel: "goal_continuation_guard_tripped",
+			data: expect.objectContaining({ reason: "cap", count: 8 }),
+		});
 	});
 
 	it("continues after user grace even when an active monitor settles", async () => {
@@ -140,7 +210,9 @@ describe("goal continuation while a monitor is active", () => {
 		await runUserInitiatedTurn(handlers, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 0 });
 		await events.flush();
+		const graceDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
+		await graceDeliveryRecorded;
 
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
@@ -198,6 +270,70 @@ describe("goal continuation while a monitor is active", () => {
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 45_000);
 
 		expect(sent).toHaveLength(0);
+	});
+
+	it("resets monitor-delayed repetition state when a goal pauses and resumes", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-monitor-repetition-resume");
+		const { monitor, sent, events } = createDirectMonitorHarness();
+		const goal = activeGoal("goal-monitor-repetition-resume");
+		await writeGoal(goalStoreRef(ctx), goal);
+		monitor.start(ctx);
+		events.emit("terminal_monitor_state", { activeCount: 1 });
+		await events.flush();
+
+		for (let turn = 1; turn <= 2; turn++) {
+			await monitor.afterAgentEnd({
+				ctx,
+				goal,
+				messages: [cleanAssistantStopWithText("unchanged monitor output")],
+			});
+			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		}
+
+		const paused = await updateGoal(goalStoreRef(ctx), { status: "paused" }, "user");
+		monitor.syncGoal(paused);
+		const resumed = await updateGoal(goalStoreRef(ctx), { status: "active" }, "user");
+		monitor.syncGoal(resumed);
+		await monitor.afterAgentEnd({
+			ctx,
+			goal: resumed,
+			messages: [cleanAssistantStopWithText("unchanged monitor output")],
+		});
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+
+		expect(sent).toHaveLength(3);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
+	});
+
+	it("resets truncation recovery state when a goal pauses and resumes", async () => {
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-length-resume");
+		const { monitor, sent } = createDirectMonitorHarness();
+		const goal = activeGoal("goal-length-resume");
+		await writeGoal(goalStoreRef(ctx), goal);
+		monitor.start(ctx);
+
+		await monitor.afterAgentEnd({
+			ctx,
+			goal,
+			messages: [assistantStopWithReason("length", "first unfinished implementation")],
+		});
+		expect(sent).toHaveLength(1);
+
+		const paused = await updateGoal(goalStoreRef(ctx), { status: "paused" }, "user");
+		monitor.syncGoal(paused);
+		const resumed = await updateGoal(goalStoreRef(ctx), { status: "active" }, "user");
+		monitor.syncGoal(resumed);
+		await monitor.afterAgentEnd({
+			ctx,
+			goal: resumed,
+			messages: [assistantStopWithReason("length", "second unfinished implementation")],
+		});
+
+		expect(sent).toHaveLength(2);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
 	});
 
 	it("queues one minimal recovery prompt after an output truncation", async () => {

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -1,4 +1,8 @@
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readGoal, recordContinuationDelivered } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
@@ -6,6 +10,19 @@ import {
 	makeGoalContext,
 	runGoalHandlers,
 } from "./goal-monitor-test-harness.ts";
+
+function goalStoreRef(ctx: ExtensionContext) {
+	return {
+		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+		threadId: ctx.sessionManager.getSessionId(),
+	};
+}
+
+function cleanAssistantStopWithText(text: string): AgentMessage {
+	const message = cleanAssistantStop();
+	if (message.role !== "assistant") throw new Error("Expected assistant stop message");
+	return { ...message, content: [{ type: "text", text }] };
+}
 
 describe("goal continuation while a monitor is active", () => {
 	afterEach(async () => {
@@ -53,5 +70,116 @@ describe("goal continuation while a monitor is active", () => {
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
 		expect(notices).toHaveLength(0);
+	});
+
+	it("blocks the ninth clean immediate continuation without queuing a ninth hidden prompt", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-immediate-cap");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		for (let turn = 1; turn <= 8; turn++) {
+			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+			await runGoalHandlers(
+				handlers,
+				"agent_end",
+				{ type: "agent_end", messages: [cleanAssistantStopWithText(`progress ${turn}`)] },
+				ctx,
+			);
+		}
+
+		expect(sent).toHaveLength(8);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 8 });
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStopWithText("progress 9")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(8);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "continuation cap reached",
+		});
+		expect(events.emitted).toContainEqual({
+			channel: "goal_continuation_guard_tripped",
+			data: expect.objectContaining({ reason: "cap", count: 8 }),
+		});
+	});
+
+	it("silently skips a stale continuation after two real agent_end cycles with unchanged progress", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-stale-real-cycles");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStopWithText("No progress yet")] },
+			ctx,
+		);
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStopWithText("No progress yet")] },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 1 });
+		expect(events.emitted).not.toContainEqual(
+			expect.objectContaining({ channel: "goal_continuation_guard_tripped" }),
+		);
+	});
+
+	it("counts session_start deliveries and applies the persisted cap on a later session_start", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-session-start-cap");
+		await tools.get("create_goal")?.execute("create", { objective: "Resume work" }, undefined, undefined, ctx);
+
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+		expect(sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ consecutiveContinuations: 1 });
+
+		const goal = await readGoal(goalStoreRef(ctx));
+		if (goal === null) throw new Error("Expected persisted goal");
+		for (let count = 2; count <= 8; count++) {
+			await recordContinuationDelivered(goalStoreRef(ctx), `${goal.id}:0/0:seed-${count}`);
+		}
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "continuation cap reached",
+			consecutiveContinuations: 0,
+		});
+		expect(events.emitted).toContainEqual({
+			channel: "goal_continuation_guard_tripped",
+			data: expect.objectContaining({ reason: "cap", count: 8 }),
+		});
+	});
+
+	it("does not queue a second session_start continuation while the first is pending", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-single-flight");
+		await tools.get("create_goal")?.execute("create", { objective: "Resume once" }, undefined, undefined, ctx);
+
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 1 });
 	});
 });

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -54,10 +54,7 @@ function createDirectMonitorHarness(): { monitor: MonitorAwareGoalContinuation; 
 	return { monitor: new MonitorAwareGoalContinuation(pi), sent };
 }
 
-async function runUserInitiatedTurn(
-	handlers: Map<string, GoalHandler[]>,
-	ctx: ExtensionContext,
-): Promise<void> {
+async function runUserInitiatedTurn(handlers: Map<string, GoalHandler[]>, ctx: ExtensionContext): Promise<void> {
 	await runGoalHandlers(handlers, "before_agent_start", { type: "before_agent_start" }, ctx);
 	await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 	await runGoalHandlers(handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
@@ -165,9 +162,10 @@ describe("goal continuation while a monitor is active", () => {
 		expect(sent).toHaveLength(0);
 	});
 
-	it.each(["paused", "complete"] as const)(
-	"cancels a pending user grace continuation when the goal becomes %s",
-	async (status) => {
+	it.each([
+		"paused",
+		"complete",
+	] as const)("cancels a pending user grace continuation when the goal becomes %s", async (status) => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
 		const ctx = await makeGoalContext(notices, `thread-user-grace-${status}-cancel`);
@@ -182,8 +180,7 @@ describe("goal continuation while a monitor is active", () => {
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
 
 		expect(sent).toHaveLength(0);
-	},
-);
+	});
 
 	it("does not continue a pending user grace turn after pending messages arrive", async () => {
 		vi.useFakeTimers();

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -1,13 +1,17 @@
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import { admitAndQueueGoalContinuation } from "../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
+import { MonitorAwareGoalContinuation } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
 import { readGoal, recordContinuationDelivered } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
 	createGoalHarness,
+	type GoalHandler,
 	makeGoalContext,
 	runGoalHandlers,
 } from "./goal-monitor-test-harness.ts";
@@ -23,6 +27,36 @@ function cleanAssistantStopWithText(text: string): AgentMessage {
 	const message = cleanAssistantStop();
 	if (message.role !== "assistant") throw new Error("Expected assistant stop message");
 	return { ...message, content: [{ type: "text", text }] };
+}
+
+function activeGoal(id: string): Goal {
+	return {
+		id,
+		threadId: `${id}-thread`,
+		objective: "Keep moving",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+function createDirectMonitorHarness(): { monitor: MonitorAwareGoalContinuation; sent: string[] } {
+	const sent: string[] = [];
+	const pi = {
+		sendMessage: (message: { readonly content: string }) => sent.push(message.content),
+	} as unknown as ExtensionAPI;
+	return { monitor: new MonitorAwareGoalContinuation(pi), sent };
+}
+
+async function runUserInitiatedTurn(
+	handlers: Map<string, GoalHandler[]>,
+	ctx: ExtensionContext,
+): Promise<void> {
+	await runGoalHandlers(handlers, "before_agent_start", { type: "before_agent_start" }, ctx);
+	await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+	await runGoalHandlers(handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
 }
 
 describe("goal continuation while a monitor is active", () => {
@@ -58,7 +92,8 @@ describe("goal continuation while a monitor is active", () => {
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
 	});
 
-	it("continues immediately after a clean turn when no monitor is active", async () => {
+	it("continues immediately after a clean continuation turn when no monitor is active", async () => {
+		vi.useFakeTimers();
 		const notices: string[] = [];
 		const { tools, handlers, sent } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-no-monitor");
@@ -71,6 +106,97 @@ describe("goal continuation while a monitor is active", () => {
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
 		expect(notices).toHaveLength(0);
+	});
+
+	it("waits sixty seconds before continuing a clean user-initiated turn", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const { tools, handlers, sent } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-user-grace-delay");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runUserInitiatedTurn(handlers, ctx);
+		expect(sent).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 1);
+		expect(sent).toHaveLength(0);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+	});
+
+	it("continues after user grace even when an active monitor settles", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-user-grace-monitor-settles");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		events.emit("terminal_monitor_state", { activeCount: 1 });
+		await events.flush();
+
+		await runUserInitiatedTurn(handlers, ctx);
+		events.emit("terminal_monitor_state", { activeCount: 0 });
+		await events.flush();
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+	});
+
+	it("cancels a pending user grace continuation when another user prompt arrives", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const { tools, handlers, sent } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-user-grace-prompt-cancel");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runUserInitiatedTurn(handlers, ctx);
+		await vi.advanceTimersByTimeAsync(30_000);
+		await runGoalHandlers(handlers, "before_agent_start", { type: "before_agent_start" }, ctx);
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
+
+		expect(sent).toHaveLength(0);
+	});
+
+	it.each(["paused", "complete"] as const)(
+	"cancels a pending user grace continuation when the goal becomes %s",
+	async (status) => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, `thread-user-grace-${status}-cancel`);
+		const { monitor, sent } = createDirectMonitorHarness();
+		const goal = activeGoal(`goal-user-grace-${status}`);
+		monitor.start(ctx);
+		monitor.noteUserPrompt();
+		await monitor.afterAgentEnd({ ctx, goal, messages: [cleanAssistantStop()] });
+
+		await vi.advanceTimersByTimeAsync(45_000);
+		monitor.syncGoal({ ...goal, status });
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
+
+		expect(sent).toHaveLength(0);
+	},
+);
+
+	it("does not continue a pending user grace turn after pending messages arrive", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const state = { pendingMessages: false };
+		const ctx = await makeGoalContext(notices, "thread-user-grace-pending-cancel", state);
+		const { monitor, sent } = createDirectMonitorHarness();
+		const goal = activeGoal("goal-user-grace-pending-cancel");
+		monitor.start(ctx);
+		monitor.noteUserPrompt();
+		await monitor.afterAgentEnd({ ctx, goal, messages: [cleanAssistantStop()] });
+
+		await vi.advanceTimersByTimeAsync(45_000);
+		state.pendingMessages = true;
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 45_000);
+
+		expect(sent).toHaveLength(0);
 	});
 
 	it("blocks the ninth clean immediate continuation without queuing a ninth hidden prompt", async () => {

--- a/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
@@ -9,7 +10,7 @@ import {
 	runGoalHandlers,
 } from "./goal-monitor-test-harness.ts";
 
-const STALL_MARKER = "<goal_monitor_stall_check>";
+const STALL_MARKER = "<goal_stall_check>";
 const STALL_EVENT = "goal_monitor_continuation_stall";
 
 interface StallHarness {
@@ -18,7 +19,7 @@ interface StallHarness {
 	readonly notices: string[];
 }
 
-async function createStallHarness(threadId: string): Promise<StallHarness> {
+async function createStallHarness(threadId: string, monitorsActive = true): Promise<StallHarness> {
 	const notices: string[] = [];
 	const harness = createGoalHarness();
 	const ctx = await makeGoalContext(notices, threadId);
@@ -26,14 +27,51 @@ async function createStallHarness(threadId: string): Promise<StallHarness> {
 		.get("create_goal")
 		?.execute("create", { objective: "Keep monitoring" }, undefined, undefined, ctx);
 	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
-	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
-	await harness.events.flush();
+	if (monitorsActive) {
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+	}
 	return { harness, ctx, notices };
 }
 
-async function runMonitorContinuationCycle(harness: GoalHarness, ctx: ExtensionContext): Promise<void> {
+function cleanAssistantStopWithText(text: string): AgentMessage {
+	const message = cleanAssistantStop();
+	if (message.role !== "assistant") throw new Error("Expected an assistant message");
+	return { ...message, content: [{ type: "text", text }] };
+}
+
+function toolUsingContinuationMessages(text: string): AgentMessage[] {
+	const finalAssistant = cleanAssistantStopWithText(text);
+	if (finalAssistant.role !== "assistant") throw new Error("Expected an assistant message");
+	return [
+		{
+			...finalAssistant,
+			content: [{ type: "toolCall", id: "stall-reset-tool", name: "bash", arguments: { command: "true" } }],
+			stopReason: "toolUse",
+		},
+		{
+			role: "toolResult",
+			toolCallId: "stall-reset-tool",
+			toolName: "bash",
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+			timestamp: finalAssistant.timestamp,
+		},
+		finalAssistant,
+	];
+}
+
+async function runContinuationCycle(
+	harness: GoalHarness,
+	ctx: ExtensionContext,
+	messages: readonly AgentMessage[] = [cleanAssistantStop()],
+): Promise<void> {
 	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
-	await runGoalHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
+	await runGoalHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [...messages] }, ctx);
+}
+
+async function runMonitorContinuationCycle(harness: GoalHarness, ctx: ExtensionContext): Promise<void> {
+	await runContinuationCycle(harness, ctx);
 	await vi.advanceTimersByTimeAsync(240_000);
 }
 
@@ -61,12 +99,48 @@ describe("goal monitor continuation stall check", () => {
 		await runMonitorContinuationCycle(harness, ctx);
 		expect(harness.sent).toHaveLength(3);
 		expect(harness.sent[2]?.message.content).toContain(STALL_MARKER);
-		expect(stallEvents(harness)).toEqual([expect.objectContaining({ consecutiveContinuations: 3 })]);
+		expect(harness.sent[2]?.message.content).toContain("bash_output");
+		expect(harness.sent[2]?.message.content).toContain("kill_bash");
+		expect(stallEvents(harness)).toEqual([expect.objectContaining({ consecutiveContinuations: 3, toolless: true })]);
 		expect(notices.some((notice) => /stall/i.test(notice))).toBe(true);
 
 		await runMonitorContinuationCycle(harness, ctx);
 		expect(harness.sent[3]?.message.content).toContain(STALL_MARKER);
 		expect(stallEvents(harness)).toHaveLength(2);
+	});
+
+	it("injects the stall check from the third toolless immediate continuation", async () => {
+		const { harness, ctx } = await createStallHarness("thread-stall-no-monitor", false);
+
+		for (let turn = 1; turn <= 3; turn++) {
+			await runContinuationCycle(harness, ctx, [cleanAssistantStopWithText(`toolless turn ${turn}`)]);
+		}
+
+		expect(harness.sent).toHaveLength(3);
+		expect(harness.sent[0]?.message.content).not.toContain(STALL_MARKER);
+		expect(harness.sent[1]?.message.content).not.toContain(STALL_MARKER);
+		expect(harness.sent[2]?.message.content).toContain(STALL_MARKER);
+		expect(harness.sent[2]?.message.content).not.toContain("bash_output");
+		expect(stallEvents(harness)).toEqual([expect.objectContaining({ consecutiveContinuations: 3, toolless: true })]);
+	});
+
+	it("resets the toolless streak after a continuation turn uses tools", async () => {
+		const { harness, ctx } = await createStallHarness("thread-stall-tool-reset", false);
+
+		await runContinuationCycle(harness, ctx, [cleanAssistantStopWithText("toolless turn 1")]);
+		await runContinuationCycle(harness, ctx, [cleanAssistantStopWithText("toolless turn 2")]);
+		await runContinuationCycle(harness, ctx, toolUsingContinuationMessages("tool-ful turn"));
+		await runContinuationCycle(harness, ctx, [cleanAssistantStopWithText("toolless turn 3")]);
+		await runContinuationCycle(harness, ctx, [cleanAssistantStopWithText("toolless turn 4")]);
+
+		expect(harness.sent).toHaveLength(5);
+		for (const sent of harness.sent) {
+			expect(sent.message.content).not.toContain(STALL_MARKER);
+		}
+		expect(stallEvents(harness)).toHaveLength(0);
+
+		await runContinuationCycle(harness, ctx, [cleanAssistantStopWithText("toolless turn 5")]);
+		expect(harness.sent[5]?.message.content).toContain(STALL_MARKER);
 	});
 
 	it("resets the streak when the monitors settle and a new monitor starts", async () => {

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -8,6 +8,8 @@ import {
 	createGoal,
 	goalFilePath,
 	readGoal,
+	recordContinuationDelivered,
+	resetContinuationStreak,
 	updateGoal,
 	writeGoal,
 } from "../../src/core/extensions/builtin/goal/store.ts";
@@ -316,5 +318,135 @@ describe("goal store (budget-free)", () => {
 		expect(await clearGoal(ref)).toBe(true);
 		expect(await readGoal(ref)).toBeNull();
 		expect(await readFile(goalFilePath(ref), "utf8")).toContain('"version": 1');
+	});
+});
+
+describe("goal continuation streak persistence", () => {
+	it("starts new goals at zero continuations with no signature", async () => {
+		const ref = await tempStore("thread-streak-new");
+		const goal = await createGoal(ref, "Start clean");
+
+		expect(goal.consecutiveContinuations).toBe(0);
+		expect(goal.lastContinuationSignature).toBeUndefined();
+		expect(await readGoal(ref)).toMatchObject({ consecutiveContinuations: 0 });
+	});
+
+	it("round-trips delivered continuations and their signature", async () => {
+		const ref = await tempStore("thread-streak-roundtrip");
+		const goal = await createGoal(ref, "Count continuations");
+
+		const first = await recordContinuationDelivered(ref, `${goal.id}:0/3:hash-a`);
+		expect(first).toMatchObject({
+			consecutiveContinuations: 1,
+			lastContinuationSignature: `${goal.id}:0/3:hash-a`,
+		});
+
+		const second = await recordContinuationDelivered(ref, `${goal.id}:0/3:hash-b`);
+		expect(second?.consecutiveContinuations).toBe(2);
+
+		const persisted = await readGoal(ref);
+		expect(persisted).toMatchObject({
+			consecutiveContinuations: 2,
+			lastContinuationSignature: `${goal.id}:0/3:hash-b`,
+		});
+
+		const fileContents = await readFile(goalFilePath(ref), "utf8");
+		expect(fileContents).toContain('"consecutiveContinuations": 2');
+		expect(fileContents).toContain("hash-b");
+	});
+
+	it("leaves updatedAt unchanged when a continuation is delivered", async () => {
+		const ref = await tempStore("thread-streak-updated-at");
+		const goal = await createGoal(ref, "Steady clock");
+
+		const delivered = await recordContinuationDelivered(ref, `${goal.id}:1/2:hash-c`);
+
+		expect(delivered?.updatedAt).toBe(goal.updatedAt);
+		expect((await readGoal(ref))?.updatedAt).toBe(goal.updatedAt);
+	});
+
+	it("parses goals written before continuation tracking with default streak semantics", async () => {
+		const ref = await tempStore("thread-streak-legacy");
+		await createGoal(ref, "Legacy goal");
+		const raw = JSON.parse(await readFile(goalFilePath(ref), "utf8")) as { goal: Record<string, unknown> };
+		delete raw.goal.consecutiveContinuations;
+		delete raw.goal.lastContinuationSignature;
+		await writeRawGoalFile(ref, `${JSON.stringify(raw, null, 2)}\n`);
+
+		const persisted = await readGoal(ref);
+
+		expect(persisted?.consecutiveContinuations ?? 0).toBe(0);
+		expect(persisted?.lastContinuationSignature).toBeUndefined();
+		expect(persisted).not.toHaveProperty("consecutiveContinuations");
+
+		const delivered = await recordContinuationDelivered(ref, `${persisted?.id ?? ""}:0/1:hash-legacy`);
+		expect(delivered?.consecutiveContinuations).toBe(1);
+	});
+
+	it("drops corrupt continuation fields without throwing", async () => {
+		const ref = await tempStore("thread-streak-corrupt");
+		await createGoal(ref, "Corrupt streak");
+		const raw = JSON.parse(await readFile(goalFilePath(ref), "utf8")) as { goal: Record<string, unknown> };
+		raw.goal.consecutiveContinuations = "eight";
+		raw.goal.lastContinuationSignature = 42;
+		await writeRawGoalFile(ref, `${JSON.stringify(raw, null, 2)}\n`);
+
+		const persisted = await readGoal(ref);
+		expect(persisted?.consecutiveContinuations).toBeUndefined();
+		expect(persisted?.lastContinuationSignature).toBeUndefined();
+
+		raw.goal.consecutiveContinuations = -3;
+		await writeRawGoalFile(ref, `${JSON.stringify(raw, null, 2)}\n`);
+		const reread = await readGoal(ref);
+		expect(reread?.consecutiveContinuations).toBeUndefined();
+		expect((await recordContinuationDelivered(ref, "sig-corrupt"))?.consecutiveContinuations).toBe(1);
+	});
+
+	it("resets the streak when the goal status changes", async () => {
+		const ref = await tempStore("thread-streak-status-reset");
+		const goal = await createGoal(ref, "Reset on status");
+		await recordContinuationDelivered(ref, `${goal.id}:0/1:hash-d`);
+		await recordContinuationDelivered(ref, `${goal.id}:0/1:hash-d`);
+
+		const paused = await updateGoal(ref, { status: "paused" }, "user");
+
+		expect(paused.consecutiveContinuations).toBe(0);
+		expect(paused.lastContinuationSignature).toBeUndefined();
+		expect(await readGoal(ref)).toMatchObject({ consecutiveContinuations: 0 });
+	});
+
+	it("resets the streak when the objective is replaced", async () => {
+		const ref = await tempStore("thread-streak-objective-reset");
+		const goal = await createGoal(ref, "Original objective");
+		await recordContinuationDelivered(ref, `${goal.id}:0/1:hash-e`);
+
+		const replaced = await updateGoal(ref, { objective: "Replacement objective" }, "user");
+
+		expect(replaced.id).not.toBe(goal.id);
+		expect(replaced.consecutiveContinuations).toBe(0);
+		expect(replaced.lastContinuationSignature).toBeUndefined();
+	});
+
+	it("resetContinuationStreak clears count and signature without bumping updatedAt", async () => {
+		const ref = await tempStore("thread-streak-reset");
+		const goal = await createGoal(ref, "Reset helper");
+		const delivered = await recordContinuationDelivered(ref, `${goal.id}:2/5:hash-f`);
+		expect(delivered?.consecutiveContinuations).toBe(1);
+
+		const reset = await resetContinuationStreak(ref);
+
+		expect(reset?.consecutiveContinuations).toBe(0);
+		expect(reset?.lastContinuationSignature).toBeUndefined();
+		expect(reset?.updatedAt).toBe(goal.updatedAt);
+		const persisted = await readGoal(ref);
+		expect(persisted?.consecutiveContinuations).toBe(0);
+		expect(persisted?.lastContinuationSignature).toBeUndefined();
+	});
+
+	it("returns null from streak helpers when no goal exists", async () => {
+		const ref = await tempStore("thread-streak-no-goal");
+
+		expect(await recordContinuationDelivered(ref, "sig")).toBeNull();
+		expect(await resetContinuationStreak(ref)).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -2,7 +2,6 @@ import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import goalExtension from "../../../src/core/extensions/builtin/goal/index.ts";
 import { readGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
 import type { SessionEntry } from "../../../src/core/session-manager.ts";

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -219,7 +219,7 @@ describe("issue #447: goal continuation guardrails", () => {
 		expect(harness.sent).toHaveLength(0);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
 		expect(notices).toContainEqual(
-		"Goal auto-continuation suppressed for this resumed session (300 historical continuations). Send a message to resume.",
-	);
+			"Goal auto-continuation suppressed for this resumed session (300 historical continuations). Send a message to resume.",
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -1,0 +1,225 @@
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import goalExtension from "../../../src/core/extensions/builtin/goal/index.ts";
+import { readGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
+import type { SessionEntry } from "../../../src/core/session-manager.ts";
+import {
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+} from "../goal-monitor-test-harness.ts";
+import { createHarness, getMessageText, type Harness } from "../harness.ts";
+
+const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
+const GOAL_CONTINUATION_CAP = 8;
+const GOAL_USER_GRACE_DELAY_MS = 60_000;
+
+const harnesses: Harness[] = [];
+
+afterEach(async () => {
+	vi.useRealTimers();
+	while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	await cleanupGoalMonitorTempDirs();
+});
+
+function goalStoreRef(ctx: ExtensionContext) {
+	return {
+		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+		threadId: ctx.sessionManager.getSessionId(),
+	};
+}
+
+function cleanAssistantStopWithText(text: string): AgentMessage {
+	const message = cleanAssistantStop();
+	if (message.role !== "assistant") throw new Error("Expected an assistant message");
+	return { ...message, content: [{ type: "text", text }] };
+}
+
+function assistantStopWithReason(reason: "length" | "error", text: string): AgentMessage {
+	const message = cleanAssistantStopWithText(text);
+	if (message.role !== "assistant") throw new Error("Expected an assistant message");
+	return { ...message, stopReason: reason };
+}
+
+async function createActiveGoal(
+	harness: ReturnType<typeof createGoalHarness>,
+	ctx: ExtensionContext,
+	objective: string,
+): Promise<void> {
+	const createGoal = harness.tools.get("create_goal");
+	if (createGoal === undefined) throw new Error("Goal tool was not registered");
+	await createGoal.execute("issue-447-create", { objective }, undefined, undefined, ctx);
+}
+
+async function runContinuationTurn(
+	harness: ReturnType<typeof createGoalHarness>,
+	ctx: ExtensionContext,
+	message: AgentMessage,
+	willRetry?: boolean,
+): Promise<void> {
+	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+	await runGoalHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [message], willRetry }, ctx);
+}
+
+function continuationEntries(count: number): SessionEntry[] {
+	return Array.from({ length: count }, (_, index) => ({
+		type: "custom_message",
+		customType: GOAL_CONTINUATION_MESSAGE_TYPE,
+		content: `historical continuation ${index}`,
+		display: false,
+	})) as unknown as SessionEntry[];
+}
+
+function floodedBranch(): SessionEntry[] {
+	return [
+		{
+			type: "message",
+			message: { role: "user", content: "start the goal", timestamp: 1 },
+		} as unknown as SessionEntry,
+		...continuationEntries(300),
+	];
+}
+
+function contextWithBranch(ctx: ExtensionContext, branch: SessionEntry[]): ExtensionContext {
+	return {
+		...ctx,
+		sessionManager: {
+			...ctx.sessionManager,
+			getBranch: () => branch,
+		},
+	} as ExtensionContext;
+}
+
+describe("issue #447: goal continuation guardrails", () => {
+	it("caps 50 clean synthetic goal turns at eight and never queues more than one pending continuation", async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-447-cap");
+		await createActiveGoal(harness, ctx, "Finish the issue #447 regression");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		for (let turn = 1; turn <= 50; turn++) {
+			const promptsBeforeTurn = harness.sent.length;
+			await runContinuationTurn(harness, ctx, cleanAssistantStopWithText(`completed distinct step ${turn}`));
+
+			// agent_start consumes the previous hidden follow-up. At most one new follow-up
+			// may be pending after the clean end, even while the goal remains active.
+			expect(harness.sent.length - promptsBeforeTurn).toBeLessThanOrEqual(1);
+		}
+
+		expect(harness.sent).toHaveLength(GOAL_CONTINUATION_CAP);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "continuation cap reached",
+		});
+		expect(notices).toContainEqual(expect.stringContaining("continuation cap reached"));
+	});
+
+	it("does not send consumed goal-continuation prompts in the next faux-provider request", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.sessionManager.appendMessage({ role: "user", content: "begin the goal", timestamp: 1 });
+		for (let index = 0; index < 300; index++) {
+			harness.sessionManager.appendCustomMessageEntry(
+				GOAL_CONTINUATION_MESSAGE_TYPE,
+				`consumed continuation ${index}`,
+				false,
+			);
+		}
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([fauxAssistantMessage("the live continuation was received")]);
+
+		await harness.session.prompt("make the next provider request");
+
+		const request = harness.faux.getCallLog()[0];
+		if (request === undefined) throw new Error("Expected one faux-provider request");
+		const continuationPrompts = request.context.messages.filter(
+			(message) => message.role === "user" && getMessageText(message).startsWith("consumed continuation"),
+		);
+		expect(continuationPrompts).toHaveLength(1);
+		expect(getMessageText(continuationPrompts[0]!)).toBe("consumed continuation 299");
+	});
+
+	it("allows one truncation recovery, then blocks rather than looping on length stops", async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-447-length");
+		await createActiveGoal(harness, ctx, "Finish the truncated response");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runContinuationTurn(harness, ctx, assistantStopWithReason("length", "first response cut off"));
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.content).toContain("cut off");
+		expect(harness.sent[0]?.message.content).not.toContain("<untrusted_objective>");
+
+		await runContinuationTurn(harness, ctx, assistantStopWithReason("length", "second response cut off"));
+		expect(harness.sent).toHaveLength(1);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "output truncation repeated",
+		});
+	});
+
+	it("waits the full 60-second grace window after a direct user message before resuming", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-447-user-grace");
+		await createActiveGoal(harness, ctx, "Answer the direct user question first");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runGoalHandlers(harness.handlers, "before_agent_start", { type: "before_agent_start" }, ctx);
+		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStopWithText("answered the user directly")] },
+			ctx,
+		);
+
+		expect(harness.sent).toHaveLength(0);
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 1);
+		expect(harness.sent).toHaveLength(0);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.customType).toBe(GOAL_CONTINUATION_MESSAGE_TYPE);
+	});
+
+	it("blocks the goal when a terminal provider error has no retry remaining", async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-447-terminal-error");
+		await createActiveGoal(harness, ctx, "Recover only when the provider can retry");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		await runContinuationTurn(harness, ctx, assistantStopWithReason("error", "provider exhausted retries"), false);
+
+		expect(harness.sent).toHaveLength(0);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "provider error ended the turn (retries exhausted)",
+		});
+		expect(notices).toContainEqual(expect.stringContaining("provider error ended the turn"));
+	});
+
+	it("does not replay hundreds of trailing continuations when the flooded session loads", async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const baseCtx = await makeGoalContext(notices, "issue-447-flooded-load");
+		const ctx = contextWithBranch(baseCtx, floodedBranch());
+		await createActiveGoal(harness, ctx, "Resume safely after a historical flood");
+
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(harness.sent).toHaveLength(0);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
+		expect(notices).toContainEqual(
+		"Goal auto-continuation suppressed for this resumed session (300 historical continuations). Send a message to resume.",
+	);
+	});
+});


### PR DESCRIPTION
## What

Fixes the built-in Goal auto-continuation runaway reported in #447 (observed: 281 persisted hidden continuation messages, ~350M processed tokens, self-reinforcing degenerate output, auto-resume <1s after a direct user question).

Four-layer guardrails on the goal continuation engine:

1. **Bounded continuation** — a persisted consecutive-continuation cap (8) with a stale-progress signature guard and single-flight latch, enforced through one pure verdict engine (`evaluateGoalContinuation`) at all three entry points (immediate, monitor-delayed, session-start). A tripped cap blocks the goal with a visible reason; the next real user message revives it with streaks reset.
2. **Context hygiene** — positional keep-latest exclusion for `goal-continuation` custom messages, applied identically in `filterContextExcludedMessages` and `convertToLlm`, so estimators and the provider payload share one rule and consumed control prompts stop accumulating in LLM context.
3. **Turn-boundary correctness** — a 60s grace delay after a real user prompt (no more 0.996s auto-resume); `length` stops get exactly one minimal truncation-recovery continuation, then the goal blocks; terminal provider errors (retry exhaustion) block the goal via a new additive `AgentEndEvent.willRetry` field.
4. **Generalized stall detection** — the monitor-only stall check is now a goal-level no-tool-call streak (3+) that works on both immediate and monitor-delayed paths, with monitor-flavored guidance while monitors are active; the 4-minute monitor cadence is untouched and exempt from cap/stale.

Plus: migration-lite suppression for sessions already flooded with historical continuations, a dedicated issue-447 regression suite (6 behaviors, 6 mutation probes), and full fork docs (`changes.md`, `AGENTS.md`).

## What it does NOT do

- No token-budget enforcement — `tokenBudget` remains inert compatibility metadata (explicit owner decision; the loop is bounded structurally instead).
- No new settings keys, no protocol schema changes, no status rewrites of stored sessions.

## Verification

- **TDD throughout**: every behavior todo captured RED before GREEN (evidence in `.omo/evidence/task-*`).
- **Independent adversarial verification** per wave: fresh reruns (87 / 155 / 75 tests), 6 mutation probes each failing then restored byte-identically.
- **Reviewer loop**: full-diff review found 2 lifecycle blockers (grace path cap-bypass, partial state reset on goal transitions) — both fixed and re-reviewed to **APPROVED**.
- **Real-CLI QA** (senpi-qa mock-loop, event-gated fake server): stall notice from the 3rd toolless continuation, hard block at the 8th with visible reason, real user message revives, exactly one length recovery then block — 4/4 scenarios, 57 artifacts under `local-ignore/qa-evidence/20260729-goal-continuation-guardrails/`.
- `npm run check` green; tsgo clean; biome clean.
- Full-suite note: a handful of timing-sensitive integration tests (daemon spawn, SSE races) flake non-deterministically under load in this environment — the same files fail identically on unmodified `origin/main` (verified in a clean baseline worktree) and pass in isolation; none overlap this change set.

Closes #447.

Plan: .omo/plans/goal-continuation-guardrails.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runaway Goal auto-continuation by adding hard guardrails and cleaning up context so loops stop and user activity is respected. Also standardizes `agent_end` emission with `willRetry` so continuation decisions are consistent. Fixes #447.

- **Bug Fixes**
  - Cap consecutive hidden continuations at 8 with a stale-progress signature check and single-flight; block with a clear reason, and reset on the next real user message.
  - Use one verdict engine across all paths (immediate, monitor-delayed, user-grace, session-start) to decide continuation vs block.
  - Add a 60s grace period after a user prompt; give `length` stops one minimal truncation recovery, then block on repetition; block on terminal provider errors via `AgentEndEvent.willRetry`, and emit `agent_end` via the standard path so `willRetry` is available to extensions before goal logic runs.
  - Generalize stall detection: after 3 toolless continuations, inject a `<goal_stall_check>` notice (monitor-flavored while monitors are active).
  - Keep context clean by retaining only the latest `goal-continuation` custom message in both the estimator and provider payload.
  - Persist continuation state on the goal (`consecutiveContinuations`, `lastContinuationSignature`) and reset on status changes; sanitize on load to handle old sessions.
  - Suppress auto-resume when loading sessions already flooded with historical continuations.
  - Add a regression suite for #447 and focused unit tests; update docs for the new guardrails.

- **Refactors**
  - Remove unused imports and apply formatting to satisfy `biome` checks.

<sup>Written for commit 7c48841b1513ddd4a2f73978df474923ad274a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

