### PR TITLE
fix(coding-agent): skip agent event queue wait on reentrant bridge tool calls

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -548,6 +548,7 @@ export class AgentSession {
 	 */
 	private readonly _messageEndsAwaitingPersistence = new Set<AgentMessage>();
 	private _isAgentRunActive = false;
+	private _toolExecutionDepth = 0;
 	private _promptStartPending = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
@@ -829,16 +830,36 @@ export class AgentSession {
 
 	private _installAgentToolHooks(): void {
 		this.agent.beforeToolCall = async ({ toolCall, args }) => {
-			return this._emitBeforeToolCallHooks(toolCall, args);
+			this._toolExecutionDepth++;
+			try {
+				const result = await this._emitBeforeToolCallHooks(toolCall, args);
+				if (result?.block) {
+					this._toolExecutionDepth--;
+				}
+				return result;
+			} catch (err) {
+				this._toolExecutionDepth--;
+				throw err;
+			}
 		};
 
 		this.agent.afterToolCall = async ({ toolCall, args, result, isError }) => {
-			return this._emitAfterToolCallHooks(toolCall, args, result, isError);
+			try {
+				return await this._emitAfterToolCallHooks(toolCall, args, result, isError);
+			} finally {
+				this._toolExecutionDepth--;
+			}
 		};
 	}
 
-	private async _emitBeforeToolCallHooks(toolCall: AgentToolCall, args: unknown) {
-		await this._agentEventQueue;
+	private async _emitBeforeToolCallHooks(
+		toolCall: AgentToolCall,
+		args: unknown,
+		options: { waitForEventQueue?: boolean } = {},
+	) {
+		if (options.waitForEventQueue !== false) {
+			await this._agentEventQueue;
+		}
 
 		const runner = this._extensionRunner;
 		if (!runner.hasHandlers("tool_call")) {
@@ -1934,7 +1955,9 @@ export class AgentSession {
 			);
 		}
 
-		const beforeResult = await this._emitBeforeToolCallHooks(prepared.toolCall, prepared.args);
+		const beforeResult = await this._emitBeforeToolCallHooks(prepared.toolCall, prepared.args, {
+			waitForEventQueue: this._toolExecutionDepth === 0,
+		});
 		if (beforeResult?.block) {
 			throw new ExecuteToolError(
 				"blocked",

--- a/packages/coding-agent/test/suite/regressions/470-eval-bridge-event-queue-deadlock.test.ts
+++ b/packages/coding-agent/test/suite/regressions/470-eval-bridge-event-queue-deadlock.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { AgentSession } from "../../../src/core/agent-session.ts";
+import { DefaultResourceLoader } from "../../../src/core/resource-loader.ts";
+import { SettingsManager } from "../../../src/core/settings-manager.ts";
+import type { ExtensionFactory } from "../../../src/index.ts";
+import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
+
+/**
+ * Senpi #470/#471: a reentrant Code Mode bridge call (a tool that invokes
+ * `AgentSession.executeTool` from inside its own execution) must not deadlock
+ * on `_agentEventQueue` while that queue is held by the parent tool's stream.
+ */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+async function createBridgeHarness(extensionFactory: ExtensionFactory): Promise<Harness> {
+	const tempDir = mkdtempSync(join(tmpdir(), "senpi-470-bridge-"));
+	const loader = new DefaultResourceLoader({
+		cwd: tempDir,
+		agentDir: join(tempDir, "agent"),
+		settingsManager: SettingsManager.inMemory({}),
+		extensionFactories: [extensionFactory],
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+	const harness = await createHarness({ resourceLoader: loader });
+	await harness.session.bindExtensions({});
+	return {
+		...harness,
+		cleanup() {
+			harness.cleanup();
+			rmSync(tempDir, { recursive: true, force: true });
+		},
+	};
+}
+
+describe("#470/#471 reentrant bridge calls do not deadlock on the agent event queue", () => {
+	it("settles a tool calling executeTool while the parent stream holds the queue", async () => {
+		const queueHeld = deferred();
+		const releaseQueue = deferred();
+		const bridgeFinished = deferred();
+		const sessionHolder: { current?: AgentSession } = {};
+		const extensionFactory: ExtensionFactory = (pi) => {
+			pi.registerTool({
+				name: "child_tool",
+				label: "Child Tool",
+				description: "Nested bridge target.",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "child-ok" }], details: {} }),
+			});
+			pi.registerTool({
+				name: "parent_tool",
+				label: "Parent Tool",
+				description: "Streams, then bridges into a nested tool.",
+				parameters: Type.Object({}),
+				execute: async (_toolCallId, _params, _signal, onUpdate) => {
+					onUpdate?.({ content: [{ type: "text", text: "streaming" }], details: {} });
+					await queueHeld.promise;
+					const session = sessionHolder.current;
+					if (!session) throw new Error("session not bound");
+					const child = await session.executeTool("child_tool", {});
+					bridgeFinished.resolve();
+					const text = child.content
+						.filter((part): part is { type: "text"; text: string } => part.type === "text")
+						.map((part) => part.text)
+						.join("");
+					return { content: [{ type: "text", text: `parent:${text}` }], details: {} };
+				},
+			});
+			pi.on("tool_execution_update", async () => {
+				queueHeld.resolve();
+				await releaseQueue.promise;
+			});
+		};
+		const harness = await createBridgeHarness(extensionFactory);
+		sessionHolder.current = harness.session;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		try {
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("parent_tool", {}), { stopReason: "toolUse" }),
+				(_context) => fauxAssistantMessage("done", { stopReason: "stop" }),
+			]);
+
+			// given the parent tool streams and its update handler seizes the event queue
+			const prompt = harness.session.prompt("go");
+			await queueHeld.promise;
+
+			// when the parent's reentrant bridge call runs, it must settle despite the held queue
+			const deadlock = new Promise<{ kind: "deadlock" }>((res) => {
+				timer = setTimeout(() => res({ kind: "deadlock" }), 2_000);
+			});
+			const outcome = await Promise.race([
+				bridgeFinished.promise.then(() => ({ kind: "settled" as const })),
+				deadlock,
+			]);
+			if (timer !== undefined) clearTimeout(timer);
+
+			releaseQueue.resolve();
+			await prompt;
+
+			// then the bridge completes and the parent result flows back to the assistant
+			expect(outcome.kind).toBe("settled");
+			expect(getAssistantTexts(harness).join("\n")).toContain("done");
+		} finally {
+			harness.cleanup();
+		}
+	}, 30_000);
+});


### PR DESCRIPTION
## Summary

Fixes the Code Mode bridge deadlock reported in #470 (and its duplicate #471): an `eval` cell calling a bridge tool (`tool.<name>()` / reentrant `AgentSession.executeTool`) could hang forever, most visibly on Windows.

### Root cause

- `_emitBeforeToolCallHooks` unconditionally did `await this._agentEventQueue` as its first statement.
- `_handleAgentEvent` chains every agent event's `_processAgentEvent` onto that same `_agentEventQueue`, and `_processAgentEvent` awaits `_emitExtensionEvent` for each event.
- When an eval cell makes a bridge call, `executeTool` runs **inside** the parent eval tool's own execution: the queue is occupied by the parent eval's events, whose drain depends on the parent eval completing, which awaits the bridge call → cycle → deadlock. Slower IO (Windows) widens the window where the queue is held at the reentrant await, matching the reported repro profile.

### Fix

Track tool execution depth (`_toolExecutionDepth`, incremented in `agent.beforeToolCall`, decremented in `agent.afterToolCall` / on block / on throw). `executeTool` waits for the event queue only when depth is 0 (non-reentrant). The LLM tool path is unchanged and keeps the queue await, preserving the ordering contract pinned by `execute-tool.test.ts` ("normalizes non-Error tool_call hook failures after queued events settle").

## Test plan

- New regression test `test/suite/regressions/470-eval-bridge-event-queue-deadlock.test.ts` — reentrant bridge `executeTool` while an extension event handler holds the queue.
  - RED (fix reverted): `AssertionError: expected 'deadlock' to be 'settled'` — deterministic repro of #470.
  - GREEN (with fix): passes in <1s.
- Focused suite: 5 files / 75 tests green (`codemode-bridge`, `execute-tool`, `execute-tool-hooks`, `extensions-runner`, new regression).
- Broad surface: `test/agent-session*.test.ts` + `test/extensions*.test.ts` + event-settlement regression — 19 files / 172 tests green.
- Static: biome clean on changed files; pre-commit `npm run check` passed on this branch.
- Real-surface QA (senpi-qa, evidence in `local-ignore/qa-evidence/20260729-470-eval-bridge-deadlock/`):
  - `mock-loop.mjs --self-test`: 43/43 (LLM tool-hook path through the new depth counter)
  - `mock-loop.mjs --with-tool`: 4/4 (full loop: model → bash tool → final text)
  - `rpc-drive.mjs --self-test`: 4/4

fixes #470, closes #471


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock in Code Mode where a bridge tool call from inside an eval tool could hang on the agent event queue. Reentrant `executeTool` calls now skip the queue wait, preventing hangs while preserving event ordering for normal/LLM tool calls. Fixes #470 and closes #471.

- **Bug Fixes**
  - Root cause: `_emitBeforeToolCallHooks` always awaited `_agentEventQueue`, so a nested `executeTool` waited on a queue held by its parent tool, causing a cycle.
  - Change: track tool execution depth; only wait for the event queue when depth is 0. Depth is incremented in `beforeToolCall` and decremented in `afterToolCall` and on block/error.
  - LLM tool path unchanged and still waits to keep ordering guarantees.
  - Added regression test `test/suite/regressions/470-eval-bridge-event-queue-deadlock.test.ts` to ensure nested calls settle quickly.

<sup>Written for commit 5e9664a8fff27515d3a05e43264367728102dea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

