### PR TITLE
feat(coding-agent): remind to set the goal when todos are added without a live one

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,29 @@
 # goal Extension Changes
 
+## Stale-goal system reminder on todo add operations (2026-07-29)
+
+### What changed
+
+- `todo-gate.ts` gained the reverse-direction bridge: `todoResultAddsOpenTasks(details)`
+  (structural guard: a todo result whose op is `init`/`append` and whose resulting phases
+  still hold at least one open task) and `staleGoalTodoReminder(goal)` (a
+  `<system-reminder>` block naming `create_goal` when the thread has no goal or only a
+  stale, already-`complete` one; silent for active/paused/blocked goals).
+- `index.ts` registers a `tool_result` handler on the builtin `todo` tool that appends the
+  reminder to the tool-result content, plus a `turn_start` reset so at most one reminder
+  is injected per assistant turn (init + append in the same turn nudges once). Mirrors the
+  nested-agents-md `tool_result` injection pattern.
+- Coverage: `test/suite/goal-todo-stale-reminder.test.ts` - unit pins for both helpers and
+  four real-AgentSession e2e scenarios (no goal, stale complete goal, active goal +
+  non-add ops stay silent, per-turn dedupe).
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `index.ts` around the event-handler block and in `todo-gate.ts`; both are
+  fork-owned surfaces.
+- NONE in todotools: the feature reads `TodoToolDetails` structurally without touching the
+  todo tool itself.
+
 ## Cache-warm continuation story: enriched events + durable entry + TUI renderer (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -8,6 +8,7 @@ import { isResumeOfPausedGoal, queueGoalContinuation } from "./lifecycle-helpers
 import { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
 import { accountGoalUsage, readGoal, updateGoal } from "./store.ts";
 import { goalStoreRef as buildGoalStoreRef } from "./store-ref.ts";
+import { staleGoalTodoReminder, todoResultAddsOpenTasks } from "./todo-gate.ts";
 import { registerGoalTools } from "./tool-registration.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
 import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
@@ -24,6 +25,7 @@ type AgentGoalAccounting = {
 
 export default function goalExtension(pi: ExtensionAPI): void {
 	let agentTurnInProgress = false;
+	let staleGoalReminderSentThisTurn = false;
 	let agentGoalAccounting: AgentGoalAccounting | null = null;
 	let blockedThisTurnGoalId: string | null = null;
 	let completedThisTurnGoalId: string | null = null;
@@ -89,6 +91,22 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			const resumed = await updateGoal(goalStoreRef(ctx), { status: "active" }, "user");
 			refreshGoalUi(ctx, resumed);
 		}
+	});
+
+	pi.on("turn_start", async () => {
+		staleGoalReminderSentThisTurn = false;
+	});
+
+	// When the model starts tracking new open todo work while the thread has no
+	// goal (or only a stale, already-complete one), append a system reminder to
+	// the todo result so the model registers the goal when the work warrants it.
+	pi.on("tool_result", async (event, ctx) => {
+		if (event.toolName !== "todo" || event.isError || staleGoalReminderSentThisTurn) return undefined;
+		if (!todoResultAddsOpenTasks(event.details)) return undefined;
+		const reminder = staleGoalTodoReminder(await readGoal(goalStoreRef(ctx)));
+		if (reminder === undefined) return undefined;
+		staleGoalReminderSentThisTurn = true;
+		return { content: [...event.content, { type: "text" as const, text: reminder }] };
 	});
 
 	pi.on("agent_start", async (_event, ctx) => {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/todo-gate.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/todo-gate.ts
@@ -1,5 +1,7 @@
 import type { SessionEntry } from "../../../session-manager.ts";
-import { getLatestPhasesFromBranchEntries, isIncompleteTodo } from "../todotools/state.ts";
+import { getLatestPhasesFromBranchEntries, isIncompleteTodo, isTodoPhaseArray } from "../todotools/state.ts";
+import type { Goal } from "./types.ts";
+import { isRecord } from "./types.ts";
 
 const MAX_LISTED_TASKS = 5;
 
@@ -26,4 +28,42 @@ export function openTodoCompletionError(openTasks: readonly string[]): string {
 		"Finish each task and mark it done, or drop tasks that are genuinely no longer needed, " +
 		"then run the completion audit again and retry update_goal."
 	);
+}
+
+/**
+ * True when a successful todo tool result came from an add operation (init /
+ * append) that left at least one open (pending / in_progress) task behind.
+ */
+export function todoResultAddsOpenTasks(details: unknown): boolean {
+	if (!isRecord(details)) return false;
+	const op = details.op;
+	if (op !== "init" && op !== "append") return false;
+	const phases = details.phases;
+	if (!isTodoPhaseArray(phases)) return false;
+	return phases.some((phase) => phase.tasks.some(isIncompleteTodo));
+}
+
+/**
+ * System reminder injected into a todo tool result when new open tasks were
+ * added while the thread has no goal, or only a stale (already complete) one.
+ * The mirror of the completion gate above: newly tracked work should be
+ * anchored to a live goal when it serves a durable objective.
+ */
+export function staleGoalTodoReminder(goal: Goal | null): string | undefined {
+	if (goal !== null && goal.status !== "complete") return undefined;
+	const staleLine =
+		goal === null
+			? "New todo tasks were added, but this thread has no goal registered."
+			: "New todo tasks were added, but the registered goal is already complete (stale), so the new work is untracked.";
+	const fixLine =
+		goal === null
+			? "If this todo list tracks a durable objective (multi-step work that should survive across turns), register it now with create_goal so progress is tracked and audited."
+			: "If this todo list tracks a durable objective (multi-step work that should survive across turns), register it now with create_goal; creating a new goal archives the completed one and replaces it.";
+	return [
+		"<system-reminder>",
+		staleLine,
+		fixLine,
+		"If the todos are trivial short-lived bookkeeping for the current turn, continue without a goal.",
+		"</system-reminder>",
+	].join("\n");
 }

--- a/packages/coding-agent/test/suite/goal-todo-stale-reminder.test.ts
+++ b/packages/coding-agent/test/suite/goal-todo-stale-reminder.test.ts
@@ -1,0 +1,210 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
+import { staleGoalTodoReminder, todoResultAddsOpenTasks } from "../../src/core/extensions/builtin/goal/todo-gate.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import todotoolsExtension from "../../src/core/extensions/builtin/todotools/index.ts";
+import type { TodoPhase, TodoToolDetails } from "../../src/core/extensions/builtin/todotools/state.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+	for (const harness of harnesses.splice(0)) {
+		harness.cleanup();
+	}
+});
+
+function goalFixture(status: Goal["status"]): Goal {
+	return {
+		id: "goal-1",
+		threadId: "thread-1",
+		objective: "Ship the feature",
+		status,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 1,
+		updatedAt: 1,
+		...(status === "blocked" ? { blockedReason: "stuck", blockedAt: 1 } : {}),
+		...(status === "complete" ? { completedAt: 1 } : {}),
+	};
+}
+
+function todoDetails(op: TodoToolDetails["op"], phases: TodoPhase[]): TodoToolDetails {
+	return { op, phases, storage: "memory" };
+}
+
+const OPEN_PHASES: TodoPhase[] = [
+	{
+		name: "Tasks",
+		tasks: [
+			{ content: "Write the failing test", status: "in_progress" },
+			{ content: "Make it pass", status: "pending" },
+		],
+	},
+];
+
+const CLOSED_PHASES: TodoPhase[] = [
+	{
+		name: "Tasks",
+		tasks: [
+			{ content: "Write the failing test", status: "completed" },
+			{ content: "Make it pass", status: "abandoned" },
+		],
+	},
+];
+
+describe("staleGoalTodoReminder", () => {
+	it("prompts goal registration when no goal exists", () => {
+		const reminder = staleGoalTodoReminder(null);
+		expect(reminder).toBeDefined();
+		expect(reminder).toContain("<system-reminder>");
+		expect(reminder).toContain("</system-reminder>");
+		expect(reminder).toContain("create_goal");
+		expect(reminder).toContain("no goal");
+	});
+
+	it("prompts goal replacement when the goal is already complete", () => {
+		const reminder = staleGoalTodoReminder(goalFixture("complete"));
+		expect(reminder).toBeDefined();
+		expect(reminder).toContain("<system-reminder>");
+		expect(reminder).toContain("create_goal");
+		expect(reminder).toContain("complete");
+	});
+
+	it.each(["active", "paused", "blocked"] as const)("stays silent for a %s goal", (status) => {
+		expect(staleGoalTodoReminder(goalFixture(status))).toBeUndefined();
+	});
+});
+
+describe("todoResultAddsOpenTasks", () => {
+	it("accepts init results that leave open tasks", () => {
+		expect(todoResultAddsOpenTasks(todoDetails("init", OPEN_PHASES))).toBe(true);
+	});
+
+	it("accepts append results that leave open tasks", () => {
+		expect(todoResultAddsOpenTasks(todoDetails("append", OPEN_PHASES))).toBe(true);
+	});
+
+	it.each(["start", "done", "drop", "rm", "view"] as const)("rejects the non-add %s operation", (op) => {
+		expect(todoResultAddsOpenTasks(todoDetails(op, OPEN_PHASES))).toBe(false);
+	});
+
+	it("rejects add results that leave no open task", () => {
+		expect(todoResultAddsOpenTasks(todoDetails("init", CLOSED_PHASES))).toBe(false);
+	});
+
+	it("rejects malformed details", () => {
+		expect(todoResultAddsOpenTasks(undefined)).toBe(false);
+		expect(todoResultAddsOpenTasks(null)).toBe(false);
+		expect(todoResultAddsOpenTasks({})).toBe(false);
+		expect(todoResultAddsOpenTasks({ op: "init" })).toBe(false);
+		expect(todoResultAddsOpenTasks({ op: "init", phases: "nope" })).toBe(false);
+	});
+});
+
+async function createGoalTodoHarness(): Promise<Harness> {
+	const harness = await createHarness({ extensionFactories: [goalExtension, todotoolsExtension] });
+	harnesses.push(harness);
+	return harness;
+}
+
+function todoResultTexts(harness: Harness): string[] {
+	return harness.sessionManager
+		.getEntries()
+		.filter((entry) => entry.type === "message")
+		.map((entry) => entry.message)
+		.filter((message): message is typeof message & { role: "toolResult"; toolName: string } => {
+			const candidate = message as { role?: string; toolName?: string };
+			return candidate.role === "toolResult" && candidate.toolName === "todo";
+		})
+		.map((message) => getMessageText(message));
+}
+
+function reminderCount(texts: readonly string[]): number {
+	return texts.filter((text) => text.includes("<system-reminder>")).length;
+}
+
+describe("stale-goal todo reminder end-to-end through the real AgentSession", () => {
+	it("injects a create_goal reminder into the todo result when no goal is registered", async () => {
+		const harness = await createGoalTodoHarness();
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				[fauxToolCall("todo", { op: "init", list: [{ phase: "Build", items: ["Task A", "Task B"] }] })],
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("todos registered"),
+		]);
+		await harness.session.prompt("track this work");
+
+		const texts = todoResultTexts(harness);
+		expect(texts).toHaveLength(1);
+		expect(texts[0]).toContain("<system-reminder>");
+		expect(texts[0]).toContain("create_goal");
+		expect(texts[0]).toContain("no goal");
+	}, 20_000);
+
+	it("injects a stale-goal reminder when the registered goal is already complete", async () => {
+		const harness = await createGoalTodoHarness();
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("create_goal", { objective: "Ship the feature" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage([fauxToolCall("update_goal", { status: "complete" })], { stopReason: "toolUse" }),
+			fauxAssistantMessage([fauxToolCall("todo", { op: "init", items: ["Follow-up task"] })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage("todos registered"),
+		]);
+		await harness.session.prompt("finish the goal then queue new work");
+
+		const texts = todoResultTexts(harness);
+		expect(texts).toHaveLength(1);
+		expect(texts[0]).toContain("<system-reminder>");
+		expect(texts[0]).toContain("create_goal");
+		expect(texts[0]).toContain("complete");
+	}, 20_000);
+
+	it("stays silent when the goal is active and for non-add operations", async () => {
+		const harness = await createGoalTodoHarness();
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("create_goal", { objective: "Ship the feature" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage([fauxToolCall("todo", { op: "init", items: ["Task A"] })], { stopReason: "toolUse" }),
+			fauxAssistantMessage([fauxToolCall("todo", { op: "done", task: "Task A" })], { stopReason: "toolUse" }),
+			fauxAssistantMessage([fauxToolCall("update_goal", { status: "complete" })], { stopReason: "toolUse" }),
+			fauxAssistantMessage("all done"),
+		]);
+		await harness.session.prompt("set the goal, work, and finish");
+
+		const texts = todoResultTexts(harness);
+		expect(texts).toHaveLength(2);
+		expect(reminderCount(texts)).toBe(0);
+	}, 20_000);
+
+	it("injects at most one reminder per turn when init and append run in the same turn", async () => {
+		const harness = await createGoalTodoHarness();
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				[
+					fauxToolCall("todo", { op: "init", list: [{ phase: "Build", items: ["Task A"] }] }),
+					fauxToolCall("todo", { op: "append", phase: "Build", items: ["Task B"] }),
+				],
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("todos registered"),
+		]);
+		await harness.session.prompt("track this work");
+
+		const texts = todoResultTexts(harness);
+		expect(texts).toHaveLength(2);
+		expect(reminderCount(texts)).toBe(1);
+		expect(texts[0]).toContain("<system-reminder>");
+		expect(texts[1]).not.toContain("<system-reminder>");
+	}, 20_000);
+});


### PR DESCRIPTION
## What

When the model adds new open todo tasks (`todo` op `init`/`append`) while the thread's goal is **not set** or **stale** (status `complete`), the goal builtin now injects a `<system-reminder>` into the todo tool result instructing the model to register/replace the objective via `create_goal` when the work is durable — or to continue without one when it is trivial.

## How

- `goal/todo-gate.ts` (the existing goal<->todo bridge) gains two pure functions:
  - `todoResultAddsOpenTasks(details)` — structural guard: op is `init`/`append` and the resulting phases still hold at least one open task.
  - `staleGoalTodoReminder(goal)` — the `<system-reminder>` text for the null-goal and stale-complete cases; `undefined` for active/paused/blocked.
- `goal/index.ts` registers a `tool_result` handler on the builtin `todo` tool (same injection pattern as `nested-agents-md`) plus a `turn_start` reset, so at most one reminder is injected per assistant turn (init + append in one turn nudges once).
- Fork tracker: `goal/changes.md` entry with expected merge-conflict zones (LOW, fork-owned files only; todotools untouched).

## Evidence

- TDD: `test/suite/goal-todo-stale-reminder.test.ts` captured RED first (17 failed — missing exports + `reminderCount 0` e2e assertions), then GREEN 18/18: unit pins for both helpers and four real-AgentSession e2e scenarios (no goal, stale complete goal, active goal + non-add ops silent, per-turn dedupe).
- Scoped suites: `vitest test/suite/goal test/suite/todo test/compaction/todo-preservation.test.ts test/suite/regressions/goal` -> 25 files / 263 tests passed.
- `npm run check` -> exit 0.
- senpi-qa mock-loop (real CLI from source, fake model server, zero tokens): scripted `todo init` with no goal -> the second wire request (tool-result feedback to the model) contains the `<system-reminder>` naming `create_goal` and `no goal registered`; real auth sha unchanged; 6/6 checks PASS. Receipts under `local-ignore/qa-evidence/20260729-goal-stale-todo-reminder/` (gitignored).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reminds the model to set a goal when it adds new todos and no live goal exists. Appends a `<system-reminder>` to the `todo` tool result to nudge using `create_goal` for durable work.

- **New Features**
  - Adds a `tool_result` handler on `todo` to inject a reminder when `init`/`append` leaves open tasks and the goal is missing or `complete`.
  - Limits to one reminder per assistant turn via a `turn_start` reset.
  - Stays silent for active/paused/blocked goals and for non-add operations.
  - Introduces `todoResultAddsOpenTasks` and `staleGoalTodoReminder` helpers in `goal/todo-gate.ts`; tests added for unit and e2e coverage.

<sup>Written for commit 87afd715dd0ad4907f3d057e4e424e369f80e62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

