### PR TITLE
fix(qa): isolate sandbox HOME and disarm omo-local-update in QA children

### DIFF
--- a/.agents/skills/senpi-qa/references/env-vars.md
+++ b/.agents/skills/senpi-qa/references/env-vars.md
@@ -5,6 +5,8 @@
 | Var | Purpose |
 |---|---|
 | `SENPI_CODING_AGENT_DIR` | Agent config dir (auth.json, models.json, settings, sessions). QA points it at a temp sandbox so the real `~/.senpi/agent` is untouched. |
+| `HOME` / `USERPROFILE` | Pointed at the sandbox root by `makeSandbox()` so HOME-derived senpi paths (package discovery, omo-native detection, omo-local-update) cannot reach the real user home. |
+| `SENPI_OMO_LOCAL_UPDATE` | Set to `0` in the sandbox env so the beta omo-local-update path swap stays disarmed during QA runs. |
 | `SENPI_CODING_AGENT_SESSION_DIR` | Session storage dir. QA points it at the sandbox. |
 | `PI_OFFLINE` | `1` disables startup network operations. QA always sets it. |
 | `PI_TELEMETRY` | `0` disables install telemetry. QA always sets it. |

--- a/.agents/skills/senpi-qa/scripts/lib/common.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/common.mjs
@@ -87,6 +87,11 @@ export function makeSandbox(label = "senpi-qa") {
 		// Keep QA hermetic and quiet: no startup network, no telemetry.
 		PI_OFFLINE: "1",
 		PI_TELEMETRY: "0",
+		// HOME-derived senpi paths (package discovery, omo-native detection, omo-local-update)
+		// must resolve inside the sandbox, and the local-update path swap must stay disarmed.
+		HOME: dir,
+		USERPROFILE: dir,
+		SENPI_OMO_LOCAL_UPDATE: "0",
 		// Never let an interactive pager/editor hang a captured run.
 		PAGER: "cat",
 		GIT_PAGER: "cat",
@@ -337,7 +342,10 @@ async function selfCheck() {
 			existsSync(box.sessionDir) &&
 			box.env[ENV_AGENT_DIR] === box.agentDir &&
 			box.env[ENV_SESSION_DIR] === box.sessionDir &&
-			box.env.PI_OFFLINE === "1",
+			box.env.PI_OFFLINE === "1" &&
+			box.env.HOME === box.dir &&
+			box.env.USERPROFILE === box.dir &&
+			box.env.SENPI_OMO_LOCAL_UPDATE === "0",
 		box.dir,
 	);
 


### PR DESCRIPTION
## Problem
QA sandboxes only redirected SENPI_CODING_AGENT_DIR/SESSION_DIR; HOME stayed real, so HOME-derived senpi paths (package discovery via core/package-manager.ts getHomeDir, core/omo-native-detect.ts, beta/omo-local-update.ts incl. its rename-based plugin path swap whose kill switch is SENPI_OMO_LOCAL_UPDATE=0, not PI_OFFLINE) could reach the real user home from QA children. This is the isolation gap behind a real settings leak incident (probe root cause: HOME env inheritance).

## Fix
makeSandbox() now sets HOME/USERPROFILE to the sandbox root and SENPI_OMO_LOCAL_UPDATE=0; env-vars reference documents the contract. Parent-side realAgentDir/guardRealAuth still use the real home (they read the parent process env).

## Evidence
RED: --self-check 8/9 with the new assertions before the env change. GREEN: 9/9; child proof via box.env: sh -c 'echo $HOME' printed the sandbox root, omoKill=0 (local-ignore/qa-evidence/20260729-hardening-trio/). npm run check exit 0.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated QA sandbox `HOME`/`USERPROFILE` and disabled `omo-local-update` in child processes to prevent real-home access and settings leaks. Closes the isolation gap caused by inheriting `HOME` in QA runs.

- **Bug Fixes**
  - Set `HOME` and `USERPROFILE` to the sandbox root in `makeSandbox()` so HOME-derived paths stay inside the sandbox.
  - Force `SENPI_OMO_LOCAL_UPDATE=0` to disarm the beta local-update path swap during QA.
  - Updated `env-vars.md` to document the env contract.
  - Extended self-checks to assert `HOME`, `USERPROFILE`, and `SENPI_OMO_LOCAL_UPDATE` values.

<sup>Written for commit ec85aa065e333087916fc12e03aa57aad6edfd60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

