### PR TITLE
fix(coding-agent): close settings withLock first-write TOCTOU

### DIFF
--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,16 @@
 # changes
 
+## Settings withLock first-write TOCTOU fix (2026-07-29)
+
+### What changed
+
+- `settings-manager.ts` `FileSettingsStorage.withLock`: when the settings file does not exist yet, the merge callback used to run with no lock held and the write-time lock then overwrote whatever a concurrent process had created. The write path now re-checks existence after acquiring the lock and re-runs the merge callback against the winner's content before writing. The existing-file path additionally re-verifies existence after the lock before reading.
+- Pure read paths are unchanged: a read on a missing file still creates no directory and no lock artifacts, so loading settings in an arbitrary cwd still cannot spray `.senpi/` directories.
+
+### Why
+
+- Two processes racing the first write of a fresh `settings.json` silently lost one side's fields (`existsSync` gated the lock, so the merge ran unlocked). Deterministic regression: `test/settings-storage-lock.test.ts` injects a concurrent first-write at lock acquisition and asserts the merge preserves it.
+
 ## Nearest-parent project settings discovery (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -366,12 +366,12 @@ export class FileSettingsStorage implements SettingsStorage {
 		let release: (() => void) | undefined;
 		try {
 			// Only create directory and lock if file exists or we need to write
-			const fileExists = existsSync(path);
-			if (fileExists) {
+			let current: string | undefined;
+			if (existsSync(path)) {
 				release = this.acquireLockSyncWithRetry(path);
+				current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
 			}
-			const current = fileExists ? readFileSync(path, "utf-8") : undefined;
-			const next = fn(current);
+			let next = fn(current);
 			if (next !== undefined) {
 				// Only create directory when we actually need to write
 				if (!existsSync(dir)) {
@@ -379,9 +379,15 @@ export class FileSettingsStorage implements SettingsStorage {
 				}
 				if (!release) {
 					release = this.acquireLockSyncWithRetry(path);
+					if (existsSync(path)) {
+						// Lost the first-write race: re-merge against the winner's content under the lock.
+						next = fn(readFileSync(path, "utf-8"));
+					}
 				}
-				writeFileSync(path, next, "utf-8");
-				recordSelfWrite(path, next);
+				if (next !== undefined) {
+					writeFileSync(path, next, "utf-8");
+					recordSelfWrite(path, next);
+				}
 			}
 		} finally {
 			if (release) {

--- a/packages/coding-agent/test/settings-storage-lock.test.ts
+++ b/packages/coding-agent/test/settings-storage-lock.test.ts
@@ -1,0 +1,100 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileSettingsStorage, getSettingsPath } from "../src/core/settings-manager.ts";
+
+const lockState = vi.hoisted(() => ({ onNextAcquire: undefined as (() => void) | undefined }));
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+	const actual = await importOriginal<{ default: typeof import("proper-lockfile") }>();
+	const base = actual.default;
+	return {
+		default: {
+			...base,
+			lockSync: (path: string, options?: Parameters<typeof base.lockSync>[1]) => {
+				const hook = lockState.onNextAcquire;
+				lockState.onNextAcquire = undefined;
+				hook?.();
+				return base.lockSync(path, options);
+			},
+		},
+	};
+});
+
+describe("FileSettingsStorage.withLock", () => {
+	let root: string;
+	let agentDir: string;
+	let cwd: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "senpi-lock-test-"));
+		agentDir = join(root, "agent");
+		cwd = join(root, "work");
+		lockState.onNextAcquire = undefined;
+		settingsPath = getSettingsPath(cwd, agentDir, "global", root);
+	});
+
+	afterEach(() => {
+		lockState.onNextAcquire = undefined;
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("#given no settings file #when another process creates it before the write lock #then the merge sees the winner's content", () => {
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+		lockState.onNextAcquire = () => {
+			writeFileSync(settingsPath, JSON.stringify({ theme: "light" }), "utf-8");
+		};
+
+		storage.withLock("global", (current) => {
+			const settings: Record<string, unknown> = current ? (JSON.parse(current) as Record<string, unknown>) : {};
+			settings.defaultModel = "merged-model";
+			return JSON.stringify(settings);
+		});
+
+		const written = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+		expect(written.defaultModel).toBe("merged-model");
+		expect(written.theme).toBe("light");
+	});
+
+	it("#given no settings file #when the callback only reads #then nothing is created", () => {
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+		let observed: string | undefined = "sentinel";
+
+		storage.withLock("global", (current) => {
+			observed = current;
+			return undefined;
+		});
+
+		expect(observed).toBeUndefined();
+		expect(existsSync(agentDir)).toBe(false);
+		expect(existsSync(settingsPath)).toBe(false);
+	});
+
+	it("#given no settings file and no concurrent writer #when the callback writes #then the file is created with its output", () => {
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+
+		storage.withLock("global", () => JSON.stringify({ created: true }));
+
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8"))).toEqual({ created: true });
+	});
+
+	it("#given an existing settings file #when a writer mutates it at lock acquisition #then the callback reads under the lock", () => {
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+		storage.withLock("global", () => JSON.stringify({ x: 1 }));
+		lockState.onNextAcquire = () => {
+			writeFileSync(settingsPath, JSON.stringify({ x: 2 }), "utf-8");
+		};
+
+		storage.withLock("global", (current) => {
+			const settings: Record<string, unknown> = current ? (JSON.parse(current) as Record<string, unknown>) : {};
+			settings.y = true;
+			return JSON.stringify(settings);
+		});
+
+		const written = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+		expect(written.x).toBe(2);
+		expect(written.y).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem
FileSettingsStorage.withLock gated lock acquisition on existsSync: when settings.json did not exist yet, the merge callback ran with no lock held and the write-time lock then blindly overwrote whatever a concurrent process had created (first-write lost update). Found and independently double-confirmed during the settings-leak investigation.

## Fix
The write path re-checks existence after acquiring the lock and re-runs the merge callback against the winner's content before writing; the existing-file path re-verifies existence after the lock before reading. Pure reads on a missing file still create no directory and no lock artifacts, so settings loads cannot spray .senpi/ dirs into arbitrary cwds.

## Evidence
RED: test/settings-storage-lock.test.ts race case failed on unmodified code (expected undefined to be 'light') with 3 characterization pins green. GREEN: 69/69 across settings-storage-lock + settings-manager + settings-manager-bug. npm run check exit 0. senpi-qa cli-smoke --self-test 8/8. Receipts: local-ignore/qa-evidence/20260729-hardening-trio/.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a first-write race in `FileSettingsStorage.withLock` that could lose settings when `settings.json` is created concurrently. The merge now happens under a lock and re-merges after locking; pure reads still avoid creating `.senpi/` artifacts.

- **Bug Fixes**
  - Re-checks file existence after acquiring the lock and re-runs the merge against the winner’s content before writing.
  - Verifies existence under the lock before reading when a file is expected.
  - Adds `settings-storage-lock.test.ts` to cover concurrent first-write, read-only on missing file, and existing-file races.

<sup>Written for commit e420e15b2c47d1cb798740c10d5181d0394acb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

