### PR TITLE
feat(coding-agent): warn when a from-source run targets the real user config

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,14 @@
+## From-source real-config warning (2026-07-29)
+
+### What changed
+
+- New `from-source-config-guard.ts`: pure predicates detecting a run from TypeScript sources (module URL extension, never a bun binary) whose resolved agent dir is the real `~/.senpi/agent` with no `SENPI_CODING_AGENT_DIR` override.
+- `main.ts` prints one yellow stderr warning right after agent-dir resolution when that combination holds, advising an isolated agent dir for dev/QA runs. No change to `resolveAgentDir` precedence or any default.
+
+### Why
+
+- Ad-hoc from-source runs inside the repo (which has `.senpi/` without `agent/`) silently target the real user config; that exact setup has previously leaked writes into the user's `settings.json`. Detection is separated from policy: the warning makes the footgun visible without breaking legitimate real-config runs.
+
 ## Interactive startup loading indicator (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/from-source-config-guard.ts
+++ b/packages/coding-agent/src/from-source-config-guard.ts
@@ -1,0 +1,35 @@
+import { homedir } from "os";
+import { join } from "path";
+import { CONFIG_DIR_NAME, ENV_AGENT_DIR, isBunBinary } from "./config.ts";
+
+const SOURCE_MODULE_PATTERN = /\.(ts|mts|cts|tsx)$/;
+
+export function isFromSourceRun(moduleUrl: string = import.meta.url, bunBinary: boolean = isBunBinary): boolean {
+	return !bunBinary && SOURCE_MODULE_PATTERN.test(moduleUrl);
+}
+
+export function targetsRealUserAgentDir(
+	agentDir: string,
+	envAgentDir: string | undefined = process.env[ENV_AGENT_DIR],
+	homeDir: string = homedir(),
+): boolean {
+	return !envAgentDir && agentDir === join(homeDir, CONFIG_DIR_NAME, "agent");
+}
+
+/**
+ * A run from TypeScript sources (dev/QA) that resolves to the real user agent
+ * dir is the exact setup that has leaked writes into real user config before.
+ * Returns the warning to print, or undefined when the run is safe.
+ */
+export function getFromSourceRealConfigWarning(
+	agentDir: string,
+	moduleUrl: string = import.meta.url,
+	envAgentDir: string | undefined = process.env[ENV_AGENT_DIR],
+	homeDir: string = homedir(),
+	bunBinary: boolean = isBunBinary,
+): string | undefined {
+	if (!isFromSourceRun(moduleUrl, bunBinary) || !targetsRealUserAgentDir(agentDir, envAgentDir, homeDir)) {
+		return undefined;
+	}
+	return `Warning: running from source against the real user config (${agentDir}). Set ${ENV_AGENT_DIR} to an isolated directory for dev and QA runs.`;
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -55,6 +55,7 @@ import { SettingsManager } from "./core/settings-manager.ts";
 import { printTimings, resetTimings, time } from "./core/timings.ts";
 import { hasTrustRequiringProjectResources, ProjectTrustStore } from "./core/trust-manager.ts";
 import { builtInExtensions } from "./extensions/index.ts";
+import { getFromSourceRealConfigWarning } from "./from-source-config-guard.ts";
 import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
@@ -541,6 +542,10 @@ export async function main(args: string[], options?: MainOptions) {
 
 	const cwd = process.cwd();
 	const agentDir = getAgentDir();
+	const fromSourceWarning = getFromSourceRealConfigWarning(agentDir);
+	if (fromSourceWarning) {
+		console.error(chalk.yellow(fromSourceWarning));
+	}
 	const bootstrapSettingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });
 	applyHttpProxySettings(bootstrapSettingsManager.getGlobalSettings().httpProxy);
 	configureHttpDispatcher();

--- a/packages/coding-agent/test/from-source-config-guard.test.ts
+++ b/packages/coding-agent/test/from-source-config-guard.test.ts
@@ -1,0 +1,61 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../src/config.ts";
+import {
+	getFromSourceRealConfigWarning,
+	isFromSourceRun,
+	targetsRealUserAgentDir,
+} from "../src/from-source-config-guard.ts";
+
+const HOME = "/home/qa-user";
+const REAL_AGENT_DIR = join(HOME, CONFIG_DIR_NAME, "agent");
+
+describe("isFromSourceRun", () => {
+	it("#given a ts module url and no bun binary #then it is a from-source run", () => {
+		expect(isFromSourceRun("file:///repo/src/from-source-config-guard.ts", false)).toBe(true);
+	});
+
+	it("#given a bundled js module url #then it is not a from-source run", () => {
+		expect(isFromSourceRun("file:///opt/senpi/dist/from-source-config-guard.js", false)).toBe(false);
+	});
+
+	it("#given a bun binary #then it is never a from-source run", () => {
+		expect(isFromSourceRun("file:///repo/src/from-source-config-guard.ts", true)).toBe(false);
+	});
+});
+
+describe("targetsRealUserAgentDir", () => {
+	it("#given the real home agent dir and no env override #then it targets real config", () => {
+		expect(targetsRealUserAgentDir(REAL_AGENT_DIR, "", HOME)).toBe(true);
+	});
+
+	it("#given an env override #then it does not target real config", () => {
+		expect(targetsRealUserAgentDir(REAL_AGENT_DIR, "/tmp/sandbox/agent", HOME)).toBe(false);
+	});
+
+	it("#given a non-home agent dir #then it does not target real config", () => {
+		expect(targetsRealUserAgentDir("/tmp/sandbox/agent", "", HOME)).toBe(false);
+	});
+});
+
+describe("getFromSourceRealConfigWarning", () => {
+	const TS_URL = "file:///repo/src/from-source-config-guard.ts";
+
+	it("#given a from-source run against real config #then it returns an isolation warning", () => {
+		const warning = getFromSourceRealConfigWarning(REAL_AGENT_DIR, TS_URL, "", HOME, false);
+		expect(warning).toContain("running from source against the real user config");
+		expect(warning).toContain(ENV_AGENT_DIR);
+		expect(warning).toContain(REAL_AGENT_DIR);
+	});
+
+	it("#given an isolated env override #then it stays silent", () => {
+		expect(getFromSourceRealConfigWarning(REAL_AGENT_DIR, TS_URL, "/tmp/sandbox/agent", HOME, false)).toBeUndefined();
+	});
+
+	it("#given a bundled or bun-binary run #then it stays silent", () => {
+		expect(
+			getFromSourceRealConfigWarning(REAL_AGENT_DIR, "file:///opt/dist/guard.js", "", HOME, false),
+		).toBeUndefined();
+		expect(getFromSourceRealConfigWarning(REAL_AGENT_DIR, TS_URL, "", HOME, true)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem
Ad-hoc from-source runs inside the repo (which has .senpi/ without agent/) silently resolve to the real ~/.senpi/agent via the resolveAgentDir fallback; that exact setup has leaked writes into the user's real settings.json. The footgun was invisible.

## Fix
New from-source-config-guard.ts pure predicates (module-URL .ts detection, never bun binary, real home agent dir without SENPI_CODING_AGENT_DIR); main.ts prints one yellow stderr warning after agent-dir resolution. Detection only: no change to resolveAgentDir precedence or defaults, so real-config daily use and installed builds are untouched.

## Evidence
RED baseline: tsx cli --help without the env var -> stderr empty (WARNING_ABSENT captured). GREEN: same command prints the warning; with SENPI_CODING_AGENT_DIR set -> silent. Unit 9/9 (guard predicates incl. env-override, bundled-js, bun-binary silence). npm run check exit 0. Receipts: local-ignore/qa-evidence/20260729-hardening-trio/.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a safety warning when running the coding agent from TypeScript sources that target the real `~/.senpi/agent` without `SENPI_CODING_AGENT_DIR`. Prints a single yellow stderr message; no change to config resolution or defaults.

- **New Features**
  - Added `from-source-config-guard.ts` with predicates to detect TS source runs and real user agent dir without an env override.
  - `main.ts` prints a one-time warning after agent-dir resolution, suggesting an isolated dir via `SENPI_CODING_AGENT_DIR`.
  - Tests cover guard behavior; bundled builds and `bun` runs stay silent; normal real-config use remains unchanged.

<sup>Written for commit aa4ee917fae630c071a5ace4b91d96350b5d5434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

