### PR TITLE
feat(codemode): show detached eval cells in the footer status line

### DIFF
--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -133,6 +133,10 @@ cell keeps only its own language kernel busy. A new same-language call returns
 a busy error with its cell id and output tail; calls in other languages continue
 normally. Do not re-run the cell.
 
+While any cell is detached, the interactive footer shows a highlighted
+`↗ <language> · <title>` status on the extension status line (the cell id when
+the call had no title), clearing as soon as the last detached cell settles.
+
 Use `eval({ action: "peek", cell_id })` for its state and buffered output, or
 `eval({ action: "stop", cell_id })` to cancel it. Python stop interrupts the
 existing kernel and preserves variables. JavaScript stop kills and restarts its

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,0 +1,18 @@
+# senpi-codemode fork changes
+
+- `src/extension/eval-status.ts` (new): `formatEvalCellStatus(entries)` — undefined when
+  no cell is detached, `↗ <lang> · <title>` for one (cellId fallback when untitled),
+  `↗ eval N: <packed titles>` for many, 48-char budget with whole-label packing and a
+  `+N more` tail. `EVAL_CELLS_STATUS_KEY = "eval-cells"`. Semantics mirror the terminal
+  extension's monitor-status so both live watches read the same in the footer.
+- `src/tool/detached-cell-manager.ts`: `EvalDetachedCellStatusEntry` plus the
+  `onStatusChange` option. Emissions happen only inside `#transition` (the single
+  detach/terminal boundary) and in `detach()`, so the listener always observes the
+  exact live detached set; an empty array means "clear the status".
+- `src/index.ts`: `showDetachedCells` publishes the formatted status through
+  `ctx.ui.setStatus("eval-cells", ...)`, highlighted with `selectedBg` in tui mode and
+  left plain elsewhere. Hosts that hand a partial ui surface (no theme) fall back to
+  plain text instead of breaking the cell lifecycle.
+- Tests: `test/eval-status.test.ts` (formatter), new `eval detached cell status
+  emissions` block in `test/eval-detach.test.ts` (manager contract), and
+  `test/eval-status-wiring.test.ts` (extension → footer wiring through session_start).

--- a/packages/senpi-codemode/src/extension/eval-status.ts
+++ b/packages/senpi-codemode/src/extension/eval-status.ts
@@ -1,0 +1,44 @@
+import type { EvalDetachedCellStatusEntry } from "../tool/detached-cell-manager.ts";
+
+export const EVAL_CELLS_STATUS_KEY = "eval-cells";
+
+/** The footer shares one status line with other extensions; keep this brief. */
+const MAX_STATUS_LENGTH = 48;
+/** Same glyph the transcript uses for a detached cell, so the two surfaces read as one state. */
+const DETACHED_GLYPH = "↗";
+
+function truncateEnd(text: string, max: number): string {
+	if (text.length <= max) return text;
+	return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+/**
+ * Fits as many whole labels as possible into the budget, folding the rest into
+ * a `+N more` counter so the detached-cell count is never truncated away.
+ */
+function packLabels(labels: readonly string[], budget: number): string {
+	for (let kept = labels.length; kept >= 1; kept--) {
+		const hiddenCount = labels.length - kept;
+		const tail = hiddenCount > 0 ? ` +${hiddenCount} more` : "";
+		const joined = labels.slice(0, kept).join(", ");
+		if (joined.length + tail.length <= budget) return joined + tail;
+	}
+	const tail = labels.length > 1 ? ` +${labels.length - 1} more` : "";
+	return truncateEnd(labels[0] ?? "", Math.max(1, budget - tail.length)) + tail;
+}
+
+function labelOf(entry: EvalDetachedCellStatusEntry): string {
+	return entry.title === undefined || entry.title.length === 0 ? entry.cellId : entry.title;
+}
+
+/** Brief footer text for the cells still running detached; undefined clears the status. */
+export function formatEvalCellStatus(entries: readonly EvalDetachedCellStatusEntry[]): string | undefined {
+	const first = entries[0];
+	if (first === undefined) return undefined;
+	if (entries.length === 1) {
+		const head = `${DETACHED_GLYPH} ${first.language} · `;
+		return head + truncateEnd(labelOf(first), MAX_STATUS_LENGTH - head.length);
+	}
+	const head = `${DETACHED_GLYPH} eval ${entries.length}: `;
+	return head + packLabels(entries.map(labelOf), MAX_STATUS_LENGTH - head.length);
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -5,6 +5,7 @@ import type { EvalSchemaToolInfo } from "./bridges/schema-bridge.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
 import { defaultCodemodeSettings } from "./config/settings.ts";
 import { EvalNotifier } from "./extension/eval-notifier.ts";
+import { EVAL_CELLS_STATUS_KEY, formatEvalCellStatus } from "./extension/eval-status.ts";
 import {
 	createExecuteTool,
 	createRuntime,
@@ -13,7 +14,7 @@ import {
 } from "./extension/runtime-factory.ts";
 import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
-import { EvalDetachedCellManager } from "./tool/detached-cell-manager.ts";
+import { EvalDetachedCellManager, type EvalDetachedCellStatusEntry } from "./tool/detached-cell-manager.ts";
 import { createEvalTool } from "./tool/eval-tool.ts";
 import { renderEvalCall, renderEvalResult } from "./tool/render.ts";
 
@@ -58,6 +59,18 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		getContext: () => activeContext,
 		getMode: () => "wake",
 	});
+	const showDetachedCells = (entries: readonly EvalDetachedCellStatusEntry[]): void => {
+		const ctx = activeContext;
+		if (ctx?.ui?.setStatus === undefined) return;
+		const status = formatEvalCellStatus(entries);
+		const theme = ctx.ui.theme;
+		ctx.ui.setStatus(
+			EVAL_CELLS_STATUS_KEY,
+			status === undefined || ctx.mode !== "tui" || theme === undefined
+				? status
+				: theme.bg("selectedBg", theme.fg("text", status)),
+		);
+	};
 	const registerEvalForRuntime = (
 		runtime: SessionRuntime,
 		modelId: string | undefined,
@@ -101,7 +114,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			listTools: () => pi.getAllTools(),
 			complete,
 			settings: defaultCodemodeSettings,
-			cellManager: new EvalDetachedCellManager({ notifier }),
+			cellManager: new EvalDetachedCellManager({ notifier, onStatusChange: showDetachedCells }),
 			executionTracker: manager,
 			renderers,
 			hostLine: hostLine(),
@@ -126,7 +139,11 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		if (!replaced) return;
 		notifier.reset();
 		activeContext = ctx;
-		const cellManager = new EvalDetachedCellManager({ artifactsDir: runtime.artifactsDir, notifier });
+		const cellManager = new EvalDetachedCellManager({
+			artifactsDir: runtime.artifactsDir,
+			notifier,
+			onStatusChange: showDetachedCells,
+		});
 		activeCells = cellManager;
 		activeRuntime = runtime;
 		activeModelId = ctx.model?.id;

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -41,9 +41,18 @@ export interface EvalDetachedCellNotifier {
 	notify(cells: readonly EvalDetachedCellNotification[]): void;
 }
 
+/** One live detached cell, as shown in the footer status line. */
+export interface EvalDetachedCellStatusEntry {
+	readonly cellId: string;
+	readonly language: EvalLanguage;
+	readonly title?: string;
+}
+
 export interface EvalDetachedCellManagerOptions {
 	readonly artifactsDir?: string;
 	readonly notifier?: EvalDetachedCellNotifier;
+	/** Called with every detached cell whenever that set changes; empty clears the status. */
+	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
 }
 
 /**
@@ -56,6 +65,7 @@ export interface EvalDetachedCellManagerOptions {
 export class EvalDetachedCellManager {
 	readonly #artifactsDir: string | undefined;
 	readonly #notifier: EvalDetachedCellNotifier | undefined;
+	readonly #onStatusChange: ((entries: readonly EvalDetachedCellStatusEntry[]) => void) | undefined;
 	readonly #cells = new Map<string, ManagedCell>();
 	readonly #detachedByLanguage = new Map<EvalLanguage, ManagedCell>();
 	#notificationQueue: ManagedCell[] = [];
@@ -64,6 +74,7 @@ export class EvalDetachedCellManager {
 	constructor(options: EvalDetachedCellManagerOptions = {}) {
 		this.#artifactsDir = options.artifactsDir;
 		this.#notifier = options.notifier;
+		this.#onStatusChange = options.onStatusChange;
 	}
 
 	create(cellId: string, input: EvalToolInput): ManagedCell {
@@ -105,6 +116,7 @@ export class EvalDetachedCellManager {
 		if (!cell.canDetach || !this.#transition(cell, "detached")) return false;
 		cell.wasDetached = true;
 		this.#detachedByLanguage.set(cell.input.language, cell);
+		this.#emitStatus();
 		return true;
 	}
 
@@ -164,9 +176,22 @@ export class EvalDetachedCellManager {
 		if (cell.wasDetached && next !== "detached") {
 			if (this.#detachedByLanguage.get(cell.input.language) === cell)
 				this.#detachedByLanguage.delete(cell.input.language);
+			this.#emitStatus();
 			this.#queueNotification(cell);
 		}
 		return true;
+	}
+
+	#emitStatus(): void {
+		const emit = this.#onStatusChange;
+		if (emit === undefined) return;
+		emit(
+			[...this.#detachedByLanguage.values()].map((cell) => ({
+				cellId: cell.cellId,
+				language: cell.input.language,
+				...(cell.input.title === undefined ? {} : { title: cell.input.title }),
+			})),
+		);
 	}
 
 	#queueNotification(cell: ManagedCell): void {

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentToolResult } from "@code-yeongyu/senpi";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { EvalDetachedCellManager, type EvalDetachedCellNotification } from "../src/tool/detached-cell-manager.ts";
+import {
+	EvalDetachedCellManager,
+	type EvalDetachedCellNotification,
+	type EvalDetachedCellStatusEntry,
+} from "../src/tool/detached-cell-manager.ts";
 import { createEvalTool } from "../src/tool/eval-tool.ts";
 import { errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
 
@@ -290,5 +294,118 @@ describe("eval detached cells", () => {
 		expect(recorder.notices[0]?.content).toContain("kernel crashed");
 		expect(recorder.notices[0]?.content).toContain("local://detached-eval-crashed-detached.log");
 		expect(existsSync(join(artifactsDir, "local", "detached-eval-crashed-detached.log"))).toBe(true);
+	});
+});
+
+describe("eval detached cell status emissions", () => {
+	function statusRecorder(): {
+		readonly emissions: EvalDetachedCellStatusEntry[][];
+		readonly onStatusChange: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
+	} {
+		const emissions: EvalDetachedCellStatusEntry[][] = [];
+		return { emissions, onStatusChange: (entries) => emissions.push([...entries]) };
+	}
+
+	async function detachTitled(
+		tool: ReturnType<typeof createTool>,
+		kernel: FakeKernel,
+		cellId: string,
+		title: string,
+		language: "js" | "py" = "js",
+	): Promise<void> {
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			cellId,
+			{ language, code: "await forever", title, on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+	}
+
+	it("emits the detached cell on detach and an empty list once it completes", async () => {
+		vi.useFakeTimers();
+		const status = statusRecorder();
+		const manager = new EvalDetachedCellManager({
+			notifier: new NotificationRecorder(),
+			onStatusChange: status.onStatusChange,
+		});
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await detachTitled(tool, kernel, "status-cell", "numpy feather rerun");
+
+		expect(status.emissions).toEqual([[{ cellId: "status-cell", language: "js", title: "numpy feather rerun" }]]);
+
+		kernel.completeDeferredRun(result("status-cell", "42"));
+		await manager.waitForTerminal("status-cell");
+
+		expect(status.emissions.at(-1)).toEqual([]);
+		await manager.flushNotifications();
+	});
+
+	it("keeps the remaining detached cells listed when one of several is stopped", async () => {
+		vi.useFakeTimers();
+		const status = statusRecorder();
+		const manager = new EvalDetachedCellManager({
+			notifier: new NotificationRecorder(),
+			onStatusChange: status.onStatusChange,
+		});
+		const js = new FakeKernel([]);
+		const py = new FakeKernel([]);
+		const tool = createTool(manager, [
+			["js", js],
+			["py", py],
+		]);
+
+		await detachTitled(tool, js, "js-cell", "bundle build", "js");
+		await detachTitled(tool, py, "py-cell", "strip repairs", "py");
+
+		expect(status.emissions.at(-1)).toEqual([
+			{ cellId: "js-cell", language: "js", title: "bundle build" },
+			{ cellId: "py-cell", language: "py", title: "strip repairs" },
+		]);
+
+		await manager.stop("js-cell");
+
+		expect(status.emissions.at(-1)).toEqual([{ cellId: "py-cell", language: "py", title: "strip repairs" }]);
+		await manager.stop("py-cell");
+		await manager.flushNotifications();
+	});
+
+	it("omits the title when the cell had none and stays silent for cells that never detach", async () => {
+		vi.useFakeTimers();
+		const status = statusRecorder();
+		const manager = new EvalDetachedCellManager({
+			notifier: new NotificationRecorder(),
+			onStatusChange: status.onStatusChange,
+		});
+		const kernel = new FakeKernel([result("plain-cell", "1")]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await tool.execute("plain-cell", { language: "js", code: "1" }, undefined, undefined, interactiveContext());
+
+		expect(status.emissions).toEqual([]);
+
+		const detachedKernel = new FakeKernel([]);
+		const detachedTool = createTool(manager, [["js", detachedKernel]]);
+		const started = detachedKernel.deferNextRun();
+		const execution = detachedTool.execute(
+			"untitled-cell",
+			{ language: "js", code: "await forever", on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+
+		expect(status.emissions).toEqual([[{ cellId: "untitled-cell", language: "js" }]]);
+		await manager.stop("untitled-cell");
+		await manager.flushNotifications();
 	});
 });

--- a/packages/senpi-codemode/test/eval-status-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-status-wiring.test.ts
@@ -1,0 +1,176 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CodemodeSessionManager } from "../src/extension/session-manager.ts";
+import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
+import type { EvalKernel } from "../src/tool/types.ts";
+import { FakeKernel, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+interface StatusCall {
+	readonly key: string;
+	readonly text: string | undefined;
+}
+
+class WiringPi {
+	readonly handlers: Array<{
+		readonly event: string;
+		readonly handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void;
+	}> = [];
+	readonly messages: string[] = [];
+	registeredTool: Parameters<CodemodeExtensionAPI["registerTool"]>[0] | undefined;
+
+	registerTool(tool: Parameters<CodemodeExtensionAPI["registerTool"]>[0]): void {
+		if (tool.name === "eval") this.registeredTool = tool;
+	}
+	registerRemovedToolHint(): void {}
+	on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void {
+		this.handlers.push({ event, handler });
+	}
+	getActiveTools(): string[] {
+		return ["eval"];
+	}
+	getAllTools(): readonly { readonly name: string }[] {
+		return [{ name: "eval" }];
+	}
+	async executeTool(): Promise<never> {
+		throw new Error("nested tool execution was not expected");
+	}
+	sendUserMessage(content: string): void {
+		this.messages.push(content);
+	}
+	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
+		for (const entry of this.handlers.filter((handler) => handler.event === event)) await entry.handler(payload, ctx);
+	}
+}
+
+class WiringSessionManager implements CodemodeSessionManager {
+	readonly kernel: FakeKernel;
+
+	constructor(kernel: FakeKernel) {
+		this.kernel = kernel;
+	}
+	async getKernel(): Promise<EvalKernel> {
+		return this.kernel;
+	}
+	async dispose(): Promise<void> {}
+	async complete(): Promise<{
+		readonly text: string;
+		readonly details: { readonly model: string; readonly structured: false };
+	}> {
+		return { text: "ok", details: { model: "fake/fake-model", structured: false } };
+	}
+}
+
+const artifactsRoot = join(tmpdir(), `senpi-codemode-status-wiring-${process.pid}`);
+const directories: string[] = [];
+
+afterEach(async () => {
+	vi.useRealTimers();
+	await Promise.all(directories.splice(0).map(async (path) => await rm(path, { recursive: true, force: true })));
+	await rm(artifactsRoot, { recursive: true, force: true });
+});
+
+async function sessionCwd(): Promise<string> {
+	const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-status-"));
+	directories.push(cwd);
+	await mkdir(join(cwd, ".senpi"), { recursive: true });
+	await writeFile(
+		join(cwd, ".senpi", "codemode.json"),
+		JSON.stringify({ languages: { py: false, js: true, rb: false, jl: false }, cellTimeoutSeconds: 1 }),
+	);
+	return cwd;
+}
+
+function wiringContext(cwd: string, mode: "tui" | "rpc", calls: StatusCall[], themeCalls: string[]): ExtensionContext {
+	const base = fakeExtensionContext();
+	// Object.create(null) keeps the fake structurally typed like fakeExtensionContext()'s ui,
+	// so only the members the status wiring touches need to exist.
+	const theme = Object.create(null);
+	theme.fg = (color: string, text: string): string => {
+		themeCalls.push(`fg:${color}`);
+		return text;
+	};
+	theme.bg = (color: string, text: string): string => {
+		themeCalls.push(`bg:${color}`);
+		return text;
+	};
+	const ui = Object.create(null);
+	ui.setStatus = (key: string, text: string | undefined): void => {
+		calls.push({ key, text });
+	};
+	ui.theme = theme;
+	const sessionManager = Object.create(null);
+	sessionManager.getSessionFile = (): string => join(artifactsRoot, `${crypto.randomUUID()}.jsonl`);
+	return { ...base, cwd, mode, hasUI: true, ui, sessionManager };
+}
+
+async function detachOne(
+	pi: WiringPi,
+	kernel: FakeKernel,
+	ctx: ExtensionContext,
+	cellId: string,
+	title: string,
+): Promise<void> {
+	const tool = pi.registeredTool;
+	if (!tool) throw new Error("eval tool was not registered");
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		cellId,
+		{ language: "js", code: "await forever", title, on_timeout: "detach" },
+		undefined,
+		undefined,
+		ctx,
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	await execution;
+}
+
+describe("detached eval cell footer status wiring", () => {
+	it("highlights the detached cell in the TUI footer and clears it on completion", async () => {
+		const cwd = await sessionCwd();
+		const pi = new WiringPi();
+		const kernel = new FakeKernel([]);
+		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
+		const calls: StatusCall[] = [];
+		const themeCalls: string[] = [];
+		const ctx = wiringContext(cwd, "tui", calls, themeCalls);
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+
+		vi.useFakeTimers();
+		await detachOne(pi, kernel, ctx, "wiring-cell", "wiring probe");
+
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · wiring probe" });
+		expect(themeCalls).toContain("bg:selectedBg");
+		expect(themeCalls).toContain("fg:text");
+
+		kernel.completeDeferredRun(result("wiring-cell", "42"));
+		await vi.waitFor(() => expect(calls.at(-1)).toEqual({ key: "eval-cells", text: undefined }));
+
+		await pi.emit("session_shutdown", {}, ctx);
+	});
+
+	it("sets a plain status outside the TUI", async () => {
+		const cwd = await sessionCwd();
+		const pi = new WiringPi();
+		const kernel = new FakeKernel([]);
+		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
+		const calls: StatusCall[] = [];
+		const themeCalls: string[] = [];
+		const ctx = wiringContext(cwd, "rpc", calls, themeCalls);
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+
+		vi.useFakeTimers();
+		await detachOne(pi, kernel, ctx, "rpc-cell", "rpc probe");
+
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · rpc probe" });
+		expect(themeCalls).toEqual([]);
+
+		kernel.completeDeferredRun(result("rpc-cell", "7"));
+		await vi.waitFor(() => expect(calls.at(-1)).toEqual({ key: "eval-cells", text: undefined }));
+
+		await pi.emit("session_shutdown", {}, ctx);
+	});
+});

--- a/packages/senpi-codemode/test/eval-status.test.ts
+++ b/packages/senpi-codemode/test/eval-status.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { EVAL_CELLS_STATUS_KEY, formatEvalCellStatus } from "../src/extension/eval-status.ts";
+import type { EvalDetachedCellStatusEntry } from "../src/tool/detached-cell-manager.ts";
+
+function entry(cellId: string, language: "js" | "py", title?: string): EvalDetachedCellStatusEntry {
+	return title === undefined ? { cellId, language } : { cellId, language, title };
+}
+
+describe("formatEvalCellStatus", () => {
+	it("exports the footer status key used for detached eval cells", () => {
+		expect(EVAL_CELLS_STATUS_KEY).toBe("eval-cells");
+	});
+
+	it("returns undefined when no cells are detached, clearing the footer status", () => {
+		expect(formatEvalCellStatus([])).toBeUndefined();
+	});
+
+	it("shows glyph, language, and title for a single detached cell", () => {
+		expect(formatEvalCellStatus([entry("cell-1", "py", "numpy feather rerun")])).toBe("↗ py · numpy feather rerun");
+	});
+
+	it("falls back to the cell id when the cell has no title", () => {
+		expect(formatEvalCellStatus([entry("cell-123", "js")])).toBe("↗ js · cell-123");
+	});
+
+	it("truncates an overlong single title to the shared 48-char budget with an ellipsis", () => {
+		const longTitle = "x".repeat(80);
+		const status = formatEvalCellStatus([entry("cell-1", "py", longTitle)]);
+		expect(status).toBe(`↗ py · ${"x".repeat(48 - "↗ py · ".length - 1)}…`);
+		expect(status?.length).toBe(48);
+	});
+
+	it("lists every title when multiple detached cells fit the budget", () => {
+		expect(formatEvalCellStatus([entry("a", "js", "alpha"), entry("b", "py", "beta")])).toBe("↗ eval 2: alpha, beta");
+	});
+
+	it("keeps only whole titles and folds the rest into a +N more tail", () => {
+		const entries = [
+			entry("a", "js", "first-cell-title"),
+			entry("b", "py", "second-cell-title"),
+			entry("c", "js", "third-cell-title"),
+		];
+		const status = formatEvalCellStatus(entries);
+		expect(status).toBe("↗ eval 3: first-cell-title +2 more");
+		expect(status?.length).toBeLessThanOrEqual(48);
+	});
+
+	it("keeps the +N more counter when not even one whole title fits", () => {
+		const entries = [
+			entry("a", "js", "a-very-long-cell-title-that-cannot-fit"),
+			entry("b", "py", "another-long-cell-title-that-cannot-fit"),
+		];
+		const status = formatEvalCellStatus(entries);
+		expect(status).toMatch(/^↗ eval 2: a-very-long-cell-title-tha\S*… \+1 more$/u);
+		expect(status?.length).toBeLessThanOrEqual(48);
+	});
+});


### PR DESCRIPTION
## What

Detached eval cells now surface in the interactive TUI footer status line — the same line monitors use for `◉ watching …`. While any cell is detached the footer shows a highlighted `↗ <language> · <title>` (cell id fallback), packing multiple cells into `↗ eval N: <titles> +N more` within the shared 48-char budget, and clears the moment the last detached cell settles.

## Why

A detached cell was invisible until its completion notification arrived: the transcript showed the detached state once, then nothing said work was still running. Monitors already claim the footer's extension status line for exactly this kind of live watch.

## How

- `EvalDetachedCellManager` accepts an `onStatusChange` listener and emits the live detached-cell set (`cellId`, `language`, `title`) at its single transition boundary — on detach and on every terminal transition.
- New `src/extension/eval-status.ts` formats the status, mirroring the terminal extension's monitor-status conventions (48-char budget, whole-label packing, the transcript's detached glyph `↗`).
- `src/index.ts` publishes it via `ctx.ui.setStatus("eval-cells", …)`, highlighted with `selectedBg` in tui mode, plain elsewhere. Hosts with a partial ui surface (no theme) fall back to plain text instead of breaking the cell lifecycle (caught by the existing extension lifecycle suite).

## Evidence (TDD, RED→GREEN)

- RED: `test/eval-status.test.ts` (module missing), `test/eval-detach.test.ts` emissions block (no emissions), `test/eval-status-wiring.test.ts` (setStatus never called) — all failed for the right reasons before implementation.
- GREEN: focus files 33/33, full `senpi-codemode` suite 466 passed / 6 pre-existing skips, root `npm run check` exit 0.
- Real-surface QA (senpi-qa channel, tmux + local fake model server, real CLI from this branch): footer rendered `↗ js · qa-detach-footer` while detached and cleared after completion; only the mock key hit the provider; real auth untouched. Artifacts: `local-ignore/qa-evidence/20260729-eval-detach-footer-status/` (`02-footer-detached.txt`, `04-footer-cleared.txt`, `summary.json` = all PASS, cleanup CLEAN).

## Notes

- No new public API beyond the manager option + exported formatter.
- `packages/senpi-codemode/changes.md` created per fork convention; README's *Detached cells* section documents the new footer status.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show detached eval cells in the footer status line so users can see ongoing background work at a glance. The status updates live and clears as soon as the last detached cell finishes.

- **New Features**
  - Footer shows `↗ <language> · <title>` for one cell and `↗ eval N: <titles> +N more` for many, within a 48‑char budget; clears on completion.
  - `EvalDetachedCellManager` adds `onStatusChange` to emit the current detached set at detach and on terminal transitions.
  - New `src/extension/eval-status.ts` (`formatEvalCellStatus`) formats the text; published via `ctx.ui.setStatus("eval-cells", …)` with `selectedBg` highlight in TUI and plain text elsewhere.

<sup>Written for commit 71a384c4a5e94817917f776dbd778827a71f74bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

