### PR TITLE
docs: update plugsuits link to pss-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,4 +354,4 @@ A tiny, completely unserious love letter to the [Ganbare Ganbare Senpai](https:/
 
 Yes, the entire project name is a senpai pun. Type strictly, run the tests, write a `changes.md`, keep the merge surface tiny — and *gan ganbare ganbare senpi ora!*
 
-Shoutout to [plugsuits](https://github.com/minpeter/plugsuits): senpi's compaction system takes inspiration from its design.
+Shoutout to [plugsuits](https://github.com/minpeter/pss-runtime): senpi's compaction system takes inspiration from its design.


### PR DESCRIPTION
## Summary
- Point the README shoutout link at `https://github.com/minpeter/pss-runtime` (the repo moved from `minpeter/plugsuits`).

## Testing
- `git diff --check` clean; docs-only change, no runtime QA needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README shoutout link from `minpeter/plugsuits` to `minpeter/pss-runtime` to reflect the repo move and fix the outdated link.

<sup>Written for commit f8c443bee0515f25d23d13c8e887a20c136399b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

