### PR TITLE
fix(release): resolve Claude platform sidecars on install

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Install the Claude Agent SDK native executable for the consumer platform instead of shipping the publish runner's Linux-only sidecar, restoring `claude-agent-sdk` models on Apple Silicon ([#446](https://github.com/code-yeongyu/senpi/issues/446)).
+
 ### Removed
 
 ## [2026.7.29] - 2026-07-29

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,13 @@
 # Local fork changes
 
+## 2026-07-29 — Consumer-resolved Claude Agent SDK sidecars (#446)
+
+- Changed: publish-manifest staging now promotes a bundled package's complete platform-specific optional dependency family into the root `@code-yeongyu/senpi` manifest while continuing to exclude the publish runner's materialized native package from `bundleDependencies`.
+- Why: the universal npm tarball bundled `@anthropic-ai/claude-agent-sdk-linux-x64` from the Linux publish runner. npm did not re-resolve the bundled SDK's nested optional dependencies on install, so Apple Silicon consumers received no `darwin-arm64` Claude executable and the provider failed before authentication.
+- What changed: extracted publish-manifest construction into `scripts/prepare-senpi-publish-manifest.mjs`, kept workspace staging and pack checks in `prepare-senpi-bundled-workspaces.mjs`, split the oversized packaging test suite by responsibility, and added issue #446 plus unreadable-manifest RED→GREEN coverage. A real local release installed only `claude-agent-sdk-darwin-arm64` on this Mac and resolved its `claude` binary with `CLAUDE_CODE_EXECUTABLE` unset.
+- Why the extension system could not handle this: npm dependency bundling and consumer-side optional dependency resolution happen before the Senpi runtime and extension loader start.
+- Merge-conflict risk: low. Expected conflict zones are publish-manifest staging and the colocated packaging tests; runtime provider code is unchanged.
+
 ## 2026-07-29 — OpenAI Codex usage extension example
 
 - Changed: added a standalone `examples/extensions/openai-codex-usage/` example that resolves Senpi-managed Codex OAuth, fetches the remaining five-hour and weekly limits, and publishes them through `ctx.ui.setStatus()`. Missing windows render as unavailable; sanitized HTTP/network/parse failures replace stale values with an unavailable status. The poller is single-flight, abortable, and cleared on model changes, shutdown, or `/usage`.

--- a/scripts/prepare-senpi-bundled-workspaces-copy.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces-copy.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { copyPublishDependencies } from "./prepare-senpi-bundled-workspaces.mjs";
+
+let tempDir;
+
+afterEach(() => {
+	if (tempDir) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+function writeJson(path, value) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, undefined, "\t")}\n`);
+}
+
+function writePackage(root, name) {
+	const packageDir = join(root, "node_modules", name);
+	mkdirSync(packageDir, { recursive: true });
+	writeJson(join(packageDir, "package.json"), { name, version: "1.0.0" });
+}
+
+function writeShrinkwrap(root, packages) {
+	const codingAgentDir = join(root, "packages", "coding-agent");
+	mkdirSync(codingAgentDir, { recursive: true });
+	writeJson(join(codingAgentDir, "publish-deps.lock.json"), {
+		name: "@code-yeongyu/senpi",
+		version: "0.0.0",
+		lockfileVersion: 3,
+		requires: true,
+		packages,
+	});
+}
+
+describe("copyPublishDependencies", () => {
+	it("copies direct publish dependencies and skips internal workspaces and missing optional packages", () => {
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-deps-"));
+		writePackage(tempDir, "typebox");
+		writePackage(tempDir, "@scope/pkg");
+		writePackage(tempDir, "nested-only");
+		writeShrinkwrap(tempDir, {
+			"": { dependencies: { typebox: "1.0.0" } },
+			"node_modules/typebox": { version: "1.0.0" },
+			"node_modules/@scope/pkg": { version: "1.0.0" },
+			"node_modules/@earendil-works/pi-ai": { version: "1.0.0" },
+			"node_modules/missing-optional": { version: "1.0.0", optional: true },
+			"node_modules/typebox/node_modules/nested-only": { version: "1.0.0" },
+		});
+
+		copyPublishDependencies(tempDir);
+
+		assert.equal(
+			JSON.parse(
+				readFileSync(join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "package.json"), "utf8"),
+			).name,
+			"typebox",
+		);
+		assert.equal(
+			JSON.parse(
+				readFileSync(join(tempDir, "packages", "coding-agent", "node_modules", "@scope", "pkg", "package.json"), "utf8"),
+			).name,
+			"@scope/pkg",
+		);
+		assert.throws(
+			() =>
+				readFileSync(
+					join(tempDir, "packages", "coding-agent", "node_modules", "@earendil-works", "pi-ai", "package.json"),
+					"utf8",
+				),
+			/ENOENT/,
+		);
+		assert.throws(
+			() =>
+				readFileSync(
+					join(tempDir, "packages", "coding-agent", "node_modules", "missing-optional", "package.json"),
+					"utf8",
+				),
+			/ENOENT/,
+		);
+		assert.throws(
+			() =>
+				readFileSync(
+					join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "node_modules", "nested-only"),
+					"utf8",
+				),
+			/ENOENT/,
+		);
+	});
+
+	it("copies transitive dependencies nested inside a staged package directory", () => {
+		// Given: nested-dep is not hoisted; it lives inside typebox's own node_modules.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-transitive-"));
+		writePackage(tempDir, "typebox");
+		writePackage(join(tempDir, "node_modules", "typebox"), "nested-dep");
+		writeShrinkwrap(tempDir, {
+			"": { dependencies: { typebox: "1.0.0" } },
+			"node_modules/typebox": { version: "1.0.0" },
+			"node_modules/typebox/node_modules/nested-dep": { version: "1.0.0" },
+		});
+
+		// When
+		copyPublishDependencies(tempDir);
+
+		// Then: the transitive dependency rides along with its parent's directory copy.
+		assert.equal(
+			JSON.parse(
+				readFileSync(
+					join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "node_modules", "nested-dep", "package.json"),
+					"utf8",
+				),
+			).name,
+			"nested-dep",
+		);
+	});
+
+	it("throws when a required publish dependency is not installed", () => {
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-"));
+		writeShrinkwrap(tempDir, {
+			"": { dependencies: { typebox: "1.0.0" } },
+			"node_modules/typebox": { version: "1.0.0" },
+		});
+
+		assert.throws(() => copyPublishDependencies(tempDir), /Missing .*node_modules\/typebox/);
+	});
+});

--- a/scripts/prepare-senpi-bundled-workspaces-pack.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces-pack.test.mjs
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	SUPPORTED_NATIVE_PREBUILD_TARGETS,
+	assertSenpiPackedWorkspaceFiles,
+	bundledWorkspacePackageChecks,
+	nativePrebuildFile,
+	nativePrebuildTarget,
+} from "./prepare-senpi-bundled-workspaces.mjs";
+
+describe("assertSenpiPackedWorkspaceFiles", () => {
+	it("rejects senpi package metadata that omits bundled workspace files", () => {
+		// Given
+		const packed = {
+			files: [{ path: "package/dist/cli.js" }, { path: "package/CHANGELOG.md" }],
+		};
+
+		// When / Then
+		assert.throws(
+			() => assertSenpiPackedWorkspaceFiles(packed),
+			/package tarball is missing bundled workspace files: .*@earendil-works\/pi-ai/,
+		);
+	});
+
+	it("rejects a packed tarball that omits a declared runtime dependency", () => {
+		// Given: workspace bundles are present, but the cross-spawn registry dep is not vendored.
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/which/package.json" },
+			],
+		};
+
+		// When / Then
+		assert.throws(
+			() => assertSenpiPackedWorkspaceFiles(packed, { runtimeDependencies: ["cross-spawn", "which"] }),
+			/missing vendored runtime dependencies: cross-spawn/,
+		);
+	});
+
+	it("accepts a packed tarball whose declared runtime dependencies are all vendored", () => {
+		// Given
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/cross-spawn/package.json" },
+				{ path: "package/node_modules/@modelcontextprotocol/sdk/package.json" },
+			],
+		};
+
+		// When / Then
+		assert.doesNotThrow(() =>
+			assertSenpiPackedWorkspaceFiles(packed, { runtimeDependencies: ["cross-spawn", "@modelcontextprotocol/sdk"] }),
+		);
+	});
+
+	it("rejects a packed tarball that ships npm-shrinkwrap.json", () => {
+		// Given: a shipped npm-shrinkwrap.json is fatal — npm treats it as the complete
+		// locked tree and never installs the non-bundled direct deps (cross-spawn, the
+		// MCP sdk, ...), so the installed CLI dies with ERR_MODULE_NOT_FOUND.
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/npm-shrinkwrap.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			],
+		};
+
+		// When / Then
+		assert.throws(
+			() => assertSenpiPackedWorkspaceFiles(packed),
+			/must not ship npm-shrinkwrap\.json/,
+		);
+	});
+
+	it("accepts senpi package metadata that includes bundled workspace entrypoints", () => {
+		// Given
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			],
+		};
+
+		// When / Then
+		assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
+	});
+
+	it("accepts npm dry-run package metadata with unprefixed paths", () => {
+		// Given
+		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+		const packed = {
+			files: [
+				{ path: "dist/cli.js" },
+				{ path: "node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+				{ path: "node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			],
+		};
+
+		// When / Then
+		assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
+	});
+
+	it("rejects senpi package metadata that omits the bundled pty native loader", () => {
+		// Given
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+			],
+		};
+
+		// When / Then
+		assert.throws(
+			() => assertSenpiPackedWorkspaceFiles(packed),
+			/package tarball is missing bundled workspace files: .*@earendil-works\/pi-pty\/native\/index\.js/,
+		);
+	});
+
+	it("accepts senpi package metadata that omits the host pty prebuild (pipe fallback)", () => {
+		// Given: all loader files present, but no host native prebuild.
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			],
+		};
+
+		// When / Then: the native prebuild is optional (pipe fallback), so this must not throw.
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	it("accepts an all-OS check when a target's prebuild is absent (pipe fallback)", () => {
+		// Given: the darwin-arm64 prebuild is present but linux-x64 is not.
+		const missingTarget = "linux-x64";
+		const packed = {
+			files: [
+				{ path: "package/dist/cli.js" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+				{ path: `package/node_modules/@earendil-works/pi-pty/${nativePrebuildFile("darwin-arm64")}` },
+				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			],
+		};
+
+		// When / Then: a missing per-target prebuild is optional, so the check must not throw.
+		assert.ok(SUPPORTED_NATIVE_PREBUILD_TARGETS.includes(missingTarget));
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			assert.doesNotThrow(() =>
+				assertSenpiPackedWorkspaceFiles(packed, { nativePrebuildTargets: ["darwin-arm64", missingTarget] }),
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	it("publishes the supported native target list through package checks", () => {
+		// When
+		const checks = bundledWorkspacePackageChecks(SUPPORTED_NATIVE_PREBUILD_TARGETS);
+		const ptyCheck = checks.find((check) => check.packageName === "@earendil-works/pi-pty");
+
+		// Then
+		assert.ok(ptyCheck);
+		assert.deepEqual(
+			ptyCheck.requiredFiles.filter((file) => file.startsWith("native/prebuilds/")),
+			SUPPORTED_NATIVE_PREBUILD_TARGETS.map(nativePrebuildFile),
+		);
+	});
+});

--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { stagePublishManifest } from "./prepare-senpi-publish-manifest.mjs";
+export {
+	bundlablePublishPackageNames,
+	isPlatformConstrainedPackage,
+	listStagedPublishPackageNames,
+	ownedRegistryAliases,
+	rewriteOwnedRegistryAliases,
+	stagePublishManifest,
+} from "./prepare-senpi-publish-manifest.mjs";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 
@@ -47,29 +56,6 @@ const bundledWorkspaces = [
 	},
 ];
 const internalPackageNames = new Set(bundledWorkspaces.map((workspace) => workspace.packageName));
-export const ownedRegistryAliases = new Map([
-	["@earendil-works/pi-ai", "@code-yeongyu/senpi-ai"],
-	["@earendil-works/pi-agent-core", "@code-yeongyu/senpi-agent-core"],
-	["@earendil-works/pi-tui", "@code-yeongyu/senpi-tui"],
-	["@earendil-works/pi-pty", "@code-yeongyu/senpi-pty"],
-]);
-
-export function rewriteOwnedRegistryAliases(manifest) {
-	for (const dependencyField of ["dependencies", "optionalDependencies"]) {
-		const dependencies = manifest[dependencyField];
-		if (!dependencies) {
-			continue;
-		}
-		for (const [packageName, aliasName] of ownedRegistryAliases) {
-			const version = dependencies[packageName];
-			if (typeof version === "string" && !version.startsWith("npm:")) {
-				dependencies[packageName] = `npm:${aliasName}@${version}`;
-			}
-		}
-	}
-	return manifest;
-}
-
 function requiredFilesForWorkspace(workspace, nativeTargets) {
 	const requiredFiles = [...(workspace.requiredFiles ?? ["package.json", "dist/index.js"])];
 	if (workspace.nativePrebuild) {
@@ -111,109 +97,6 @@ export function directNodeModulesPackageName(lockPath) {
 		return parts.length === 2 ? `${parts[0]}/${parts[1]}` : undefined;
 	}
 	return parts.length === 1 ? parts[0] : undefined;
-}
-
-export function listStagedPublishPackageNames(codingAgentNodeModules) {
-	const packageNames = [];
-	for (const entry of readdirSync(codingAgentNodeModules, { withFileTypes: true })) {
-		if (!entry.isDirectory() || entry.name.startsWith(".")) {
-			continue;
-		}
-		if (entry.name.startsWith("@")) {
-			const scopeDir = join(codingAgentNodeModules, entry.name);
-			for (const scoped of readdirSync(scopeDir, { withFileTypes: true })) {
-				if (scoped.isDirectory()) {
-					packageNames.push(`${entry.name}/${scoped.name}`);
-				}
-			}
-			continue;
-		}
-		packageNames.push(entry.name);
-	}
-	return packageNames.sort((a, b) => a.localeCompare(b));
-}
-
-// npm evaluates `os`/`cpu`/`libc` against the INSTALLING machine, but bundleDependencies ships a
-// single tarball to every platform and npm republishes the bundled set as required `dependencies`
-// in the registry manifest. Bundling a native binary that only matches the publish runner
-// (linux-x64 in publish-npm.yml) therefore aborts `npm install @code-yeongyu/senpi` with
-// EBADPLATFORM on every other platform, before a single file is written. Such packages stay
-// ordinary optional registry deps: npm resolves the binary matching the installing platform, and
-// a failed fetch degrades the feature instead of failing the install.
-export function isPlatformConstrainedPackage(packageDir) {
-	let manifest;
-	try {
-		manifest = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
-	} catch {
-		// An unreadable staged package cannot be judged here; leave it bundled so the existing
-		// staging and pack gates report it instead of this filter dropping it silently.
-		return false;
-	}
-	return ["os", "cpu", "libc"].some((field) => {
-		// npm accepts a bare string as well as the documented array form.
-		const constraint = manifest[field];
-		if (typeof constraint === "string") {
-			return constraint.length > 0;
-		}
-		return Array.isArray(constraint) && constraint.length > 0;
-	});
-}
-
-export function bundlablePublishPackageNames(codingAgentNodeModules, packageNames) {
-	return packageNames.filter((name) => !isPlatformConstrainedPackage(join(codingAgentNodeModules, name)));
-}
-
-// The publish tarball must be fully self-contained: every runtime dependency edge in
-// the coding-agent manifest (registry deps AND the 5 vendored workspace packages) is
-// staged into packages/coding-agent/node_modules, and bundleDependencies lists every
-// portable staged package (platform-constrained natives are excluded — see
-// isPlatformConstrainedPackage). npm then needs no registry fetch for anything that
-// installs identically on every platform at install time. The historical
-// partial bundle (only the 5 workspace packages + their closure) forced npm to fetch
-// the other runtime deps from the registry, where arborist nondeterministically tried
-// to resolve the registry-absent `^2026.x` workspace specs (ETARGET) and aborted reify
-// mid-flight, leaving arbitrary deps (cross-spawn, which, @modelcontextprotocol/sdk)
-// missing from the installed CLI (ERR_MODULE_NOT_FOUND).
-export function stagePublishManifest(repoRoot) {
-	const codingAgentDir = join(repoRoot, "packages/coding-agent");
-	const manifestPath = join(codingAgentDir, "package.json");
-	const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-	const codingAgentNodeModules = join(codingAgentDir, "node_modules");
-	const stagedPackageNames = listStagedPublishPackageNames(codingAgentNodeModules);
-	const stagedSet = new Set(stagedPackageNames);
-
-	const runtimeDependencyFields = ["dependencies", "optionalDependencies"];
-	const missing = [];
-	for (const field of runtimeDependencyFields) {
-		for (const [name, spec] of Object.entries(manifest[field] ?? {})) {
-			if (/^(file|link|workspace):/.test(spec)) {
-				throw new Error(
-					`packages/coding-agent/package.json ${field}.${name} uses a local spec (${spec}); the published tarball must not reference local paths.`,
-				);
-			}
-			if (!stagedSet.has(name)) {
-				missing.push(name);
-			}
-		}
-	}
-	if (missing.length > 0) {
-		throw new Error(
-			`packages/coding-agent/node_modules is missing staged runtime dependencies: ${missing.join(", ")}. Run npm install before publishing.`,
-		);
-	}
-
-	const bundlablePackageNames = bundlablePublishPackageNames(codingAgentNodeModules, stagedPackageNames);
-	// Keep the original dependency keys so npm packs the modules at the import paths
-	// the compiled source uses. Resolve those keys through fork-owned aliases instead
-	// of attempting to fetch lockstep versions from the upstream-owned namespace.
-	rewriteOwnedRegistryAliases(manifest);
-	manifest.bundleDependencies = bundlablePackageNames;
-	// npm accepts both spellings; the checked-in manifest carries both, so keep them in sync.
-	if (manifest.bundledDependencies !== undefined) {
-		manifest.bundledDependencies = [...bundlablePackageNames];
-	}
-	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, "\t")}\n`);
-	return bundlablePackageNames;
 }
 
 export function copyPublishDependencies(repoRoot) {

--- a/scripts/prepare-senpi-bundled-workspaces.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.test.mjs
@@ -57,7 +57,6 @@ describe("directNodeModulesPackageName", () => {
 		assert.equal(directNodeModulesPackageName("packages/coding-agent"), undefined);
 	});
 });
-
 describe("listStagedPublishPackageNames", () => {
 	it("lists top-level and scoped packages, skipping dot directories", () => {
 		// Given
@@ -222,6 +221,62 @@ describe("stagePublishManifest", () => {
 		assert.deepEqual(manifest.optionalDependencies, { "@mariozechner/clipboard": "0.3.9" });
 	});
 
+	it("issue 446 promotes a bundled package's platform optional dependencies to the consumer manifest", () => {
+		// Given: the Linux publisher materializes only its own Claude sidecar, while the
+		// bundled SDK declares the complete cross-platform optional dependency family.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-claude-sidecars-"));
+		const platformPackages = {
+			"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+			"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220",
+		};
+		writeCodingAgentManifest(tempDir, {
+			dependencies: { "@anthropic-ai/claude-agent-sdk": "0.3.220" },
+			optionalDependencies: {},
+		});
+		stagePackage(tempDir, "@anthropic-ai/claude-agent-sdk", {
+			version: "0.3.220",
+			optionalDependencies: platformPackages,
+		});
+		stagePackage(tempDir, "@anthropic-ai/claude-agent-sdk-linux-x64", {
+			version: "0.3.220",
+			os: ["linux"],
+			cpu: ["x64"],
+			libc: ["glibc"],
+		});
+
+		// When
+		stagePublishManifest(tempDir);
+
+		// Then: npm installs the matching sidecar on the consumer instead of preserving
+		// the publisher's Linux-only binary inside the universal Senpi tarball.
+		const manifest = readStagedManifest(tempDir);
+		assert.deepEqual(manifest.optionalDependencies, platformPackages);
+		assert.ok(manifest.bundleDependencies.includes("@anthropic-ai/claude-agent-sdk"));
+		assert.ok(!manifest.bundleDependencies.includes("@anthropic-ai/claude-agent-sdk-linux-x64"));
+	});
+
+	it("keeps an unreadable staged package for the later pack validation gate", () => {
+		// Given: the existing contract leaves unreadable package metadata bundled so the
+		// dedicated staging and pack gates can report it instead of silently dropping it.
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-unreadable-"));
+		writeCodingAgentManifest(tempDir, {
+			dependencies: { "unreadable-package": "1.0.0" },
+			optionalDependencies: {},
+		});
+		const packageDir = join(tempDir, "packages", "coding-agent", "node_modules", "unreadable-package");
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(join(packageDir, "package.json"), "{");
+
+		// When / Then
+		assert.deepEqual(stagePublishManifest(tempDir), ["unreadable-package"]);
+	});
+
 	it("throws when a declared runtime dependency is not staged", () => {
 		// Given: cross-spawn is declared but missing from the staged node_modules.
 		tempDir = mkdtempSync(join(tmpdir(), "senpi-stage-missing-"));
@@ -244,357 +299,5 @@ describe("stagePublishManifest", () => {
 
 		// When / Then
 		assert.throws(() => stagePublishManifest(tempDir), /must not reference local paths/);
-	});
-});
-
-describe("copyPublishDependencies", () => {
-	it("copies direct publish dependencies and skips internal workspaces and missing optional packages", () => {
-		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-deps-"));
-		writePackage(tempDir, "typebox");
-		writePackage(tempDir, "@scope/pkg");
-		writePackage(tempDir, "nested-only");
-		writeShrinkwrap(tempDir, {
-			"": { dependencies: { typebox: "1.0.0" } },
-			"node_modules/typebox": { version: "1.0.0" },
-			"node_modules/@scope/pkg": { version: "1.0.0" },
-			"node_modules/@earendil-works/pi-ai": { version: "1.0.0" },
-			"node_modules/missing-optional": { version: "1.0.0", optional: true },
-			"node_modules/typebox/node_modules/nested-only": { version: "1.0.0" },
-		});
-
-		copyPublishDependencies(tempDir);
-
-		assert.equal(
-			JSON.parse(
-				readFileSync(join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "package.json"), "utf8"),
-			).name,
-			"typebox",
-		);
-		assert.equal(
-			JSON.parse(
-				readFileSync(join(tempDir, "packages", "coding-agent", "node_modules", "@scope", "pkg", "package.json"), "utf8"),
-			).name,
-			"@scope/pkg",
-		);
-		assert.throws(
-			() =>
-				readFileSync(
-					join(tempDir, "packages", "coding-agent", "node_modules", "@earendil-works", "pi-ai", "package.json"),
-					"utf8",
-				),
-			/ENOENT/,
-		);
-		assert.throws(
-			() =>
-				readFileSync(
-					join(tempDir, "packages", "coding-agent", "node_modules", "missing-optional", "package.json"),
-					"utf8",
-				),
-			/ENOENT/,
-		);
-		assert.throws(
-			() =>
-				readFileSync(
-					join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "node_modules", "nested-only"),
-					"utf8",
-				),
-			/ENOENT/,
-		);
-	});
-
-	it("copies transitive dependencies nested inside a staged package directory", () => {
-		// Given: nested-dep is not hoisted; it lives inside typebox's own node_modules.
-		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-transitive-"));
-		writePackage(tempDir, "typebox");
-		writePackage(join(tempDir, "node_modules", "typebox"), "nested-dep");
-		writeShrinkwrap(tempDir, {
-			"": { dependencies: { typebox: "1.0.0" } },
-			"node_modules/typebox": { version: "1.0.0" },
-			"node_modules/typebox/node_modules/nested-dep": { version: "1.0.0" },
-		});
-
-		// When
-		copyPublishDependencies(tempDir);
-
-		// Then: the transitive dependency rides along with its parent's directory copy.
-		assert.equal(
-			JSON.parse(
-				readFileSync(
-					join(tempDir, "packages", "coding-agent", "node_modules", "typebox", "node_modules", "nested-dep", "package.json"),
-					"utf8",
-				),
-			).name,
-			"nested-dep",
-		);
-	});
-
-	it("throws when a required publish dependency is not installed", () => {
-		tempDir = mkdtempSync(join(tmpdir(), "senpi-bundle-missing-"));
-		writeShrinkwrap(tempDir, {
-			"": { dependencies: { typebox: "1.0.0" } },
-			"node_modules/typebox": { version: "1.0.0" },
-		});
-
-		assert.throws(() => copyPublishDependencies(tempDir), /Missing .*node_modules\/typebox/);
-	});
-});
-
-describe("assertSenpiPackedWorkspaceFiles", () => {
-	it("rejects senpi package metadata that omits bundled workspace files", () => {
-		// Given
-		const packed = {
-			files: [{ path: "package/dist/cli.js" }, { path: "package/CHANGELOG.md" }],
-		};
-
-		// When / Then
-		assert.throws(
-			() => assertSenpiPackedWorkspaceFiles(packed),
-			/package tarball is missing bundled workspace files: .*@earendil-works\/pi-ai/,
-		);
-	});
-
-	it("rejects a packed tarball that omits a declared runtime dependency", () => {
-		// Given: workspace bundles are present, but the cross-spawn registry dep is not vendored.
-		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-				{ path: "package/node_modules/which/package.json" },
-			],
-		};
-
-		// When / Then
-		assert.throws(
-			() => assertSenpiPackedWorkspaceFiles(packed, { runtimeDependencies: ["cross-spawn", "which"] }),
-			/missing vendored runtime dependencies: cross-spawn/,
-		);
-	});
-
-	it("accepts a packed tarball whose declared runtime dependencies are all vendored", () => {
-		// Given
-		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-				{ path: "package/node_modules/cross-spawn/package.json" },
-				{ path: "package/node_modules/@modelcontextprotocol/sdk/package.json" },
-			],
-		};
-
-		// When / Then
-		assert.doesNotThrow(() =>
-			assertSenpiPackedWorkspaceFiles(packed, { runtimeDependencies: ["cross-spawn", "@modelcontextprotocol/sdk"] }),
-		);
-	});
-
-	it("rejects a packed tarball that ships npm-shrinkwrap.json", () => {
-		// Given: a shipped npm-shrinkwrap.json is fatal — npm treats it as the complete
-		// locked tree and never installs the non-bundled direct deps (cross-spawn, the
-		// MCP sdk, ...), so the installed CLI dies with ERR_MODULE_NOT_FOUND.
-		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/npm-shrinkwrap.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-			],
-		};
-
-		// When / Then
-		assert.throws(
-			() => assertSenpiPackedWorkspaceFiles(packed),
-			/must not ship npm-shrinkwrap\.json/,
-		);
-	});
-
-	it("accepts senpi package metadata that includes bundled workspace entrypoints", () => {
-		// Given
-		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-			],
-		};
-
-		// When / Then
-		assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
-	});
-
-	it("accepts npm dry-run package metadata with unprefixed paths", () => {
-		// Given
-		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
-		const packed = {
-			files: [
-				{ path: "dist/cli.js" },
-				{ path: "node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: `node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
-				{ path: "node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-			],
-		};
-
-		// When / Then
-		assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
-	});
-
-	it("rejects senpi package metadata that omits the bundled pty native loader", () => {
-		// Given
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-			],
-		};
-
-		// When / Then
-		assert.throws(
-			() => assertSenpiPackedWorkspaceFiles(packed),
-			/package tarball is missing bundled workspace files: .*@earendil-works\/pi-pty\/native\/index\.js/,
-		);
-	});
-
-	it("accepts senpi package metadata that omits the host pty prebuild (pipe fallback)", () => {
-		// Given: all loader files present, but no host native prebuild.
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-			],
-		};
-
-		// When / Then: the native prebuild is optional (pipe fallback), so this must not throw.
-		const originalWarn = console.warn;
-		console.warn = () => {};
-		try {
-			assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
-		} finally {
-			console.warn = originalWarn;
-		}
-	});
-
-	it("accepts an all-OS check when a target's prebuild is absent (pipe fallback)", () => {
-		// Given: the darwin-arm64 prebuild is present but linux-x64 is not.
-		const missingTarget = "linux-x64";
-		const packed = {
-			files: [
-				{ path: "package/dist/cli.js" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
-				{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
-				{ path: `package/node_modules/@earendil-works/pi-pty/${nativePrebuildFile("darwin-arm64")}` },
-				{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
-				{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
-				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
-			],
-		};
-
-		// When / Then: a missing per-target prebuild is optional, so the check must not throw.
-		assert.ok(SUPPORTED_NATIVE_PREBUILD_TARGETS.includes(missingTarget));
-		const originalWarn = console.warn;
-		console.warn = () => {};
-		try {
-			assert.doesNotThrow(() =>
-				assertSenpiPackedWorkspaceFiles(packed, { nativePrebuildTargets: ["darwin-arm64", missingTarget] }),
-			);
-		} finally {
-			console.warn = originalWarn;
-		}
-	});
-
-	it("publishes the supported native target list through package checks", () => {
-		// When
-		const checks = bundledWorkspacePackageChecks(SUPPORTED_NATIVE_PREBUILD_TARGETS);
-		const ptyCheck = checks.find((check) => check.packageName === "@earendil-works/pi-pty");
-
-		// Then
-		assert.ok(ptyCheck);
-		assert.deepEqual(
-			ptyCheck.requiredFiles.filter((file) => file.startsWith("native/prebuilds/")),
-			SUPPORTED_NATIVE_PREBUILD_TARGETS.map(nativePrebuildFile),
-		);
 	});
 });

--- a/scripts/prepare-senpi-publish-manifest.mjs
+++ b/scripts/prepare-senpi-publish-manifest.mjs
@@ -1,0 +1,157 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const ownedRegistryAliases = new Map([
+	["@earendil-works/pi-ai", "@code-yeongyu/senpi-ai"],
+	["@earendil-works/pi-agent-core", "@code-yeongyu/senpi-agent-core"],
+	["@earendil-works/pi-tui", "@code-yeongyu/senpi-tui"],
+	["@earendil-works/pi-pty", "@code-yeongyu/senpi-pty"],
+]);
+
+export function rewriteOwnedRegistryAliases(manifest) {
+	for (const dependencyField of ["dependencies", "optionalDependencies"]) {
+		const dependencies = manifest[dependencyField];
+		if (!dependencies) {
+			continue;
+		}
+		for (const [packageName, aliasName] of ownedRegistryAliases) {
+			const version = dependencies[packageName];
+			if (typeof version === "string" && !version.startsWith("npm:")) {
+				dependencies[packageName] = `npm:${aliasName}@${version}`;
+			}
+		}
+	}
+	return manifest;
+}
+
+export function listStagedPublishPackageNames(codingAgentNodeModules) {
+	const packageNames = [];
+	for (const entry of readdirSync(codingAgentNodeModules, { withFileTypes: true })) {
+		if (!entry.isDirectory() || entry.name.startsWith(".")) {
+			continue;
+		}
+		if (entry.name.startsWith("@")) {
+			const scopeDir = join(codingAgentNodeModules, entry.name);
+			for (const scoped of readdirSync(scopeDir, { withFileTypes: true })) {
+				if (scoped.isDirectory()) {
+					packageNames.push(`${entry.name}/${scoped.name}`);
+				}
+			}
+			continue;
+		}
+		packageNames.push(entry.name);
+	}
+	return packageNames.sort((a, b) => a.localeCompare(b));
+}
+
+// npm evaluates `os`/`cpu`/`libc` against the INSTALLING machine, but bundleDependencies ships a
+// single tarball to every platform and npm republishes the bundled set as required `dependencies`
+// in the registry manifest. Bundling a native binary that only matches the publish runner
+// (linux-x64 in publish-npm.yml) therefore aborts `npm install @code-yeongyu/senpi` with
+// EBADPLATFORM on every other platform, before a single file is written. Such packages stay
+// ordinary optional registry deps: npm resolves the binary matching the installing platform, and
+// a failed fetch degrades the feature instead of failing the install.
+function readPackageManifest(packageDir) {
+	try {
+		return JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+export function isPlatformConstrainedPackage(packageDir) {
+	const manifest = readPackageManifest(packageDir);
+	// An unreadable staged package cannot be judged here; leave it bundled so the existing
+	// staging and pack gates report it instead of this filter dropping it silently.
+	if (!manifest) return false;
+	return ["os", "cpu", "libc"].some((field) => {
+		// npm accepts a bare string as well as the documented array form.
+		const constraint = manifest[field];
+		if (typeof constraint === "string") {
+			return constraint.length > 0;
+		}
+		return Array.isArray(constraint) && constraint.length > 0;
+	});
+}
+
+export function bundlablePublishPackageNames(codingAgentNodeModules, packageNames) {
+	return packageNames.filter((name) => !isPlatformConstrainedPackage(join(codingAgentNodeModules, name)));
+}
+
+function platformOptionalDependencyFamilies(codingAgentNodeModules, packageNames) {
+	const promoted = {};
+	for (const packageName of packageNames) {
+		const manifest = readPackageManifest(join(codingAgentNodeModules, packageName));
+		if (!manifest) continue;
+		const optionalDependencies = manifest.optionalDependencies ?? {};
+		const materializedOptionalNames = Object.keys(optionalDependencies).filter((name) =>
+			existsSync(join(codingAgentNodeModules, name)),
+		);
+		if (
+			!materializedOptionalNames.some((name) =>
+				isPlatformConstrainedPackage(join(codingAgentNodeModules, name)),
+			)
+		) {
+			continue;
+		}
+		Object.assign(promoted, optionalDependencies);
+	}
+	return promoted;
+}
+
+// The publish tarball must be fully self-contained: every runtime dependency edge in
+// the coding-agent manifest (registry deps AND the 5 vendored workspace packages) is
+// staged into packages/coding-agent/node_modules, and bundleDependencies lists every
+// portable staged package (platform-constrained natives are excluded — see
+// isPlatformConstrainedPackage). npm then needs no registry fetch for anything that
+// installs identically on every platform at install time. The historical
+// partial bundle (only the 5 workspace packages + their closure) forced npm to fetch
+// the other runtime deps from the registry, where arborist nondeterministically tried
+// to resolve the registry-absent `^2026.x` workspace specs (ETARGET) and aborted reify
+// mid-flight, leaving arbitrary deps (cross-spawn, which, @modelcontextprotocol/sdk)
+// missing from the installed CLI (ERR_MODULE_NOT_FOUND).
+export function stagePublishManifest(repoRoot) {
+	const codingAgentDir = join(repoRoot, "packages/coding-agent");
+	const manifestPath = join(codingAgentDir, "package.json");
+	const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+	const codingAgentNodeModules = join(codingAgentDir, "node_modules");
+	const stagedPackageNames = listStagedPublishPackageNames(codingAgentNodeModules);
+	const stagedSet = new Set(stagedPackageNames);
+
+	const runtimeDependencyFields = ["dependencies", "optionalDependencies"];
+	const missing = [];
+	for (const field of runtimeDependencyFields) {
+		for (const [name, spec] of Object.entries(manifest[field] ?? {})) {
+			if (/^(file|link|workspace):/.test(spec)) {
+				throw new Error(
+					`packages/coding-agent/package.json ${field}.${name} uses a local spec (${spec}); the published tarball must not reference local paths.`,
+				);
+			}
+			if (!stagedSet.has(name)) {
+				missing.push(name);
+			}
+		}
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`packages/coding-agent/node_modules is missing staged runtime dependencies: ${missing.join(", ")}. Run npm install before publishing.`,
+		);
+	}
+
+	const bundlablePackageNames = bundlablePublishPackageNames(codingAgentNodeModules, stagedPackageNames);
+	manifest.optionalDependencies = {
+		...platformOptionalDependencyFamilies(codingAgentNodeModules, stagedPackageNames),
+		...(manifest.optionalDependencies ?? {}),
+	};
+	// Keep the original dependency keys so npm packs the modules at the import paths
+	// the compiled source uses. Resolve those keys through fork-owned aliases instead
+	// of attempting to fetch lockstep versions from the upstream-owned namespace.
+	rewriteOwnedRegistryAliases(manifest);
+	manifest.bundleDependencies = bundlablePackageNames;
+	// npm accepts both spellings; the checked-in manifest carries both, so keep them in sync.
+	if (manifest.bundledDependencies !== undefined) {
+		manifest.bundledDependencies = [...bundlablePackageNames];
+	}
+	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, "\t")}\n`);
+	return bundlablePackageNames;
+}


### PR DESCRIPTION
## Summary

- promote complete platform-specific optional dependency families from bundled runtime packages into Senpi's published root manifest
- keep the publish runner's materialized native package out of `bundleDependencies`
- split publish-manifest and packaging test responsibilities to stay below the repository's 250 pure-LOC ceiling
- document the Apple Silicon fix in the fork change record and `[Unreleased]` changelog

Closes #446.

## Root cause

The universal npm tarball bundled the Linux publisher's
`@anthropic-ai/claude-agent-sdk-linux-x64` package. Because the portable
Claude Agent SDK itself was bundled, npm did not re-resolve its nested
optional dependencies on the consumer machine. Apple Silicon installs
therefore received no `darwin-arm64` executable.

## Verification

- RED: `node --test --test-name-pattern "issue 446" scripts/prepare-senpi-bundled-workspaces.test.mjs`
  - failed because the staged consumer manifest exposed no Claude platform optionals
- GREEN: the same command passes after the fix
- focused packaging suite: 29 passed, 0 failed
- `npm run check`: passed after restoring CI-parity dependencies with `npm ci`
- `npm run build`: passed
- `CI=1 npm test`: passed
- canonical local release: passed
- Senpi CLI QA self-test: 8/8 passed

## Real installed-package evidence

The local release was installed outside the repository on this darwin-arm64
Mac. Its published manifest exposed all eight Claude SDK platform packages as
optional dependencies, while the installed tree contained only:

```text
@anthropic-ai/claude-agent-sdk-darwin-arm64
```

With `CLAUDE_CODE_EXECUTABLE` unset, the installed resolver returned that
package's `claude` executable. A real installed CLI prompt progressed past
native-binary resolution and stopped only at the existing credential
boundary:

```text
Failed to authenticate. API Error: 401 OAuth access token has been revoked.
```

The former error did not occur:

```text
Claude native binary not found for darwin-arm64
```

## Evidence

Local receipts are under:

```text
local-ignore/qa-evidence/20260729-issue-446/
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes consumer-side resolution of Claude Agent SDK sidecars so installs pull the correct native executable for the user’s platform. This restores `claude-agent-sdk` models on Apple Silicon by installing the `darwin-arm64` binary instead of shipping the Linux build from the publisher.

- **Bug Fixes**
  - During publish, promote the full platform-specific optional dependency family declared by bundled `@anthropic-ai/claude-agent-sdk` into the root `@code-yeongyu/senpi` manifest, and exclude the publisher’s materialized `@anthropic-ai/claude-agent-sdk-linux-x64` from `bundleDependencies`.

- **Refactors**
  - Extracted publish-manifest logic to `scripts/prepare-senpi-publish-manifest.mjs`; split packaging tests by responsibility, and updated `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/changes.md`.

<sup>Written for commit 82078f39b8ba787861f91ab08f2b47890c95e63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

