### PR TITLE
fix(tui): hide low cache hit rates

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## Footer hides low cache hit rates (2026-07-29)
+
+### What changed
+
+- `components/footer.ts`: the cache-hit segment is omitted when the latest hit rate is below 10%; rates at 10% and above continue to render.
+- Coverage: `test/footer-token-format.test.ts` pins the 9.9% hidden case and the 10% boundary.
+
+### Why
+
+- Very low hit rates add a footer block without providing useful cache-health signal.
+
+### Expected merge conflict zones
+
+- LOW: `components/footer.ts` around optional middle-stat construction.
+
 ## Long footer paths yield before cache and cost stats (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -152,7 +152,7 @@ export class FooterComponent implements Component {
 		const dim = (plain: string): FooterSegment => ({ plain, colored: theme.fg("dim", plain) });
 		const middle: FooterSegment[] = [];
 		if (sessionName) middle.push({ plain: sessionName, colored: theme.fg("muted", sessionName) });
-		if ((totalCacheRead > 0 || totalCacheWrite > 0) && latestCacheHitRate !== undefined) {
+		if ((totalCacheRead > 0 || totalCacheWrite > 0) && latestCacheHitRate !== undefined && latestCacheHitRate >= 10) {
 			middle.push(dim(`CH${latestCacheHitRate.toFixed(1)}%`));
 		}
 

--- a/packages/coding-agent/test/footer-token-format.test.ts
+++ b/packages/coding-agent/test/footer-token-format.test.ts
@@ -8,7 +8,7 @@ vi.mock("../src/modes/interactive/theme/theme.js", () => ({
 	},
 }));
 
-function createSession(): unknown {
+function createSession(latestCacheHitRate = (1_500_000 / (49 + 1_500_000 + 44_000)) * 100): unknown {
 	const session = {
 		state: {
 			model: {
@@ -41,7 +41,7 @@ function createSession(): unknown {
 				cacheRead: 1_500_000,
 				cacheWrite: 44_000,
 				cost: 0,
-				latestCacheHitRate: (1_500_000 / (49 + 1_500_000 + 44_000)) * 100,
+				latestCacheHitRate,
 			}),
 			getSessionName: () => "",
 			getCwd: () => "/tmp/project",
@@ -80,6 +80,23 @@ describe("formatTokens abbreviation", () => {
 });
 
 describe("FooterComponent token formatting", () => {
+	it("hides cache hit rates below 10% while retaining the threshold", async () => {
+		// given
+		const { FooterComponent } = await import("../src/modes/interactive/components/footer.ts");
+		const Footer = FooterComponent as new (
+			session: unknown,
+			footerData: unknown,
+		) => { render(width: number): string[] };
+
+		// when
+		const belowThreshold = stripAnsi(new Footer(createSession(9.9), createFooterData()).render(160).join("\n"));
+		const atThreshold = stripAnsi(new Footer(createSession(10), createFooterData()).render(160).join("\n"));
+
+		// then
+		expect(belowThreshold).not.toContain("CH9.9%");
+		expect(atThreshold).toContain("CH10.0%");
+	});
+
 	it("omits input and output token counters while retaining context details", async () => {
 		// given
 		const { FooterComponent } = await import("../src/modes/interactive/components/footer.ts");


### PR DESCRIPTION
## Summary

- hide the interactive footer cache-hit block when the latest hit ratio is below 10%
- preserve the block at the 10% boundary and above
- add focused threshold coverage and the required interactive fork-change note

## QA & Evidence

- RED: `local-ignore/qa-evidence/20260729-cache-hit-footer/red-below-threshold.log`
  - failed because the rendered 9.9% footer still contained `CH9.9%`
- GREEN: `local-ignore/qa-evidence/20260729-cache-hit-footer/final-footer-token-format.log`
  - `footer-token-format.test.ts`: 3/3 passed
- agent-browser + xterm.js visual proof:
  - screenshot: `local-ignore/qa-evidence/20260729-cache-hit-footer/footer-threshold-xterm.png`
  - action log: `local-ignore/qa-evidence/20260729-cache-hit-footer/agent-browser-action.log`
  - live PTY transcripts: `below-10.txt`, `at-10.txt`
- repository static validation:
  - `local-ignore/qa-evidence/20260729-cache-hit-footer/npm-run-check.log`
  - `npm run check`: exit 0
- real Senpi CLI QA:
  - `local-ignore/qa-evidence/20260729-cache-hit-footer/senpi-qa-tui-smoke.log`
  - common self-check 9/9; TUI smoke 5/5
- cleanup:
  - `local-ignore/qa-evidence/20260729-cache-hit-footer/cleanup-receipt.log`

## Risks & Residuals

- The condition is isolated to footer presentation; usage accounting and layout priority are unchanged.
- The harness LSP command was unavailable because its packaged daemon CLI is missing. Root `tsgo --noEmit` completed successfully as part of `npm run check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the cache-hit metric in the interactive footer when the latest hit rate is below 10% to reduce noise. Keep it visible at 10% and above.

- **Bug Fixes**
  - Updated `packages/coding-agent/src/modes/interactive/components/footer.ts` to show `CH` only when `latestCacheHitRate >= 10`.
  - Added tests in `packages/coding-agent/test/footer-token-format.test.ts` to assert 9.9% is hidden and 10.0% is shown.

<sup>Written for commit e3d109bbdc73ddbb80fda549ccde29c7bb4a1864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

