### PR TITLE
fix(release): validate staged bundle dependencies

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Allow consumer-resolved native optional dependencies to remain outside the universal tarball's vendored bundle, enabling the cross-platform Claude Agent SDK sidecar fix to publish successfully ([#446](https://github.com/code-yeongyu/senpi/issues/446)).
+
 ### Removed
 
 ## [2026.7.29-2] - 2026-07-29

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,13 @@
 # Local fork changes
 
+## 2026-07-30 — Publish gate honors consumer-resolved platform optionals (#446)
+
+- Changed: `assertSenpiPackedWorkspaceFiles()` now validates the staged `bundleDependencies` contract when it is available, while retaining the legacy all-runtime fallback for callers without a staged manifest.
+- Why: issue #446 intentionally promotes complete native optional-dependency families into the published root manifest so npm can select the consumer platform. The publish-only workflow still treated those non-bundled optionals as missing vendored files and stopped before npm publication.
+- What changed: `publish.mjs` passes the staged bundle list into the pack assertion, and focused RED→GREEN coverage proves a bundled portable Claude SDK may omit the consumer-resolved `darwin-arm64` package from the universal tarball.
+- Why the extension system could not handle this: the failure occurs in npm tarball validation before package publication or runtime extension loading.
+- Merge-conflict risk: low. Expected conflict zones are the publish pack assertion, `publish.mjs`, and the focused packaging test.
+
 ## 2026-07-29 — Consumer-resolved Claude Agent SDK sidecars (#446)
 
 - Changed: publish-manifest staging now promotes a bundled package's complete platform-specific optional dependency family into the root `@code-yeongyu/senpi` manifest while continuing to exclude the publish runner's materialized native package from `bundleDependencies`.

--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -134,12 +134,11 @@ export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
 	const prebuildFiles = new Set(nativeTargets.map(nativePrebuildFile));
 	const filePaths = new Set((packed.files ?? []).map((file) => file.path));
 
-	// Every runtime dependency of the publish manifest must be vendored in the tarball.
-	// npm only packs node_modules entries reachable from bundleDependencies, so a dep
-	// missing here means it would be fetched from the registry at install time — the
-	// exact failure mode (nondeterministic ERR_MODULE_NOT_FOUND) the full bundle removes.
+	// Every dependency selected by the staged bundle manifest must be vendored in the
+	// tarball. Platform-specific optional dependencies intentionally stay outside this
+	// list so npm can resolve the matching native package on the consumer machine.
 	const missingRuntimeDependencies = [];
-	for (const dependencyName of options.runtimeDependencies ?? []) {
+	for (const dependencyName of options.bundledDependencies ?? options.runtimeDependencies ?? []) {
 		const packageJsonPath = `node_modules/${dependencyName}/package.json`;
 		if (!filePaths.has(`package/${packageJsonPath}`) && !filePaths.has(packageJsonPath)) {
 			missingRuntimeDependencies.push(dependencyName);

--- a/scripts/prepare-senpi-publish-optionals.test.mjs
+++ b/scripts/prepare-senpi-publish-optionals.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import {
+	assertSenpiPackedWorkspaceFiles,
+	nativePrebuildFile,
+	nativePrebuildTarget,
+} from "./prepare-senpi-bundled-workspaces.mjs";
+
+it("accepts consumer-resolved platform optionals outside the packed bundle", () => {
+	// Given: the portable SDK is bundled, while npm must install the target-native
+	// optional package on the consumer machine.
+	const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
+	const packed = {
+		files: [
+			{ path: "package/dist/cli.js" },
+			{ path: "package/node_modules/@earendil-works/pi-agent-core/package.json" },
+			{ path: "package/node_modules/@earendil-works/pi-agent-core/dist/index.js" },
+			{ path: "package/node_modules/@earendil-works/pi-ai/package.json" },
+			{ path: "package/node_modules/@earendil-works/pi-ai/dist/index.js" },
+			{ path: "package/node_modules/@earendil-works/pi-pty/package.json" },
+			{ path: "package/node_modules/@earendil-works/pi-pty/dist/index.js" },
+			{ path: "package/node_modules/@earendil-works/pi-pty/native/index.js" },
+			{ path: `package/node_modules/@earendil-works/pi-pty/${hostPrebuild}` },
+			{ path: "package/node_modules/@earendil-works/pi-tui/package.json" },
+			{ path: "package/node_modules/@earendil-works/pi-tui/dist/index.js" },
+			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
+			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
+			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			{ path: "package/node_modules/@anthropic-ai/claude-agent-sdk/package.json" },
+		],
+	};
+
+	// When / Then
+	assert.doesNotThrow(() =>
+		assertSenpiPackedWorkspaceFiles(packed, {
+			runtimeDependencies: [
+				"@anthropic-ai/claude-agent-sdk",
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64",
+			],
+			bundledDependencies: ["@anthropic-ai/claude-agent-sdk"],
+		}),
+	);
+});

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -105,6 +105,7 @@ function validatePack(directory) {
 				...Object.keys(packageJson.dependencies ?? {}),
 				...Object.keys(packageJson.optionalDependencies ?? {}),
 			],
+			bundledDependencies: packageJson.bundleDependencies ?? packageJson.bundledDependencies,
 		});
 	}
 	if (sourceOnlyPackages.has(packageJson.name)) {


### PR DESCRIPTION
## Summary

- validate the staged `bundleDependencies` list instead of requiring every
  consumer-resolved optional dependency to be physically present in the npm
  tarball
- preserve the legacy all-runtime fallback for callers without a staged
  bundle manifest
- add focused RED→GREEN coverage for the publish-only failure
- document the issue #446 publication recovery

## Failure reproduced

Publish-only workflow
[30466062567](https://github.com/code-yeongyu/senpi/actions/runs/30466062567)
stopped before npm publication:

```text
senpi package tarball is missing vendored runtime dependencies:
@anthropic-ai/claude-agent-sdk-darwin-arm64, ...
```

The complete platform optional family is intentionally declared at the root
so npm can select the consumer architecture. Only the portable SDK belongs in
the universal bundle.

## RED→GREEN

```text
node --test scripts/prepare-senpi-publish-optionals.test.mjs
```

- RED: 0 passed, 1 failed on missing
  `@anthropic-ai/claude-agent-sdk-darwin-arm64`
- GREEN: 1 passed, 0 failed
- adjacent pack suite: 10 passed, 0 failed

## Validation

- syntax checks and `git diff --check`
- `npm run check`
- `npm run build`
- `CI=1 npm test`
- canonical local release
- Senpi CLI smoke: 8/8

The previous `v2026.7.29-2` tag remains unpublished. After this PR merges,
release recovery will use the next CalVer rather than rerunning the old tag.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish gate to validate only the staged `bundleDependencies`, so consumer-resolved native optionals can stay out of the tarball. Unblocks publishing for the cross-platform Claude Agent SDK setup from issue #446.

- **Bug Fixes**
  - `assertSenpiPackedWorkspaceFiles()` now checks `bundleDependencies` when provided, with a fallback to all runtime deps if not.
  - `publish.mjs` passes the staged `bundleDependencies` into the validator.
  - Added focused test proving `@anthropic-ai/claude-agent-sdk` is bundled while `@anthropic-ai/claude-agent-sdk-darwin-arm64` may be excluded.
  - Updated docs and changelog.

<sup>Written for commit d108cc4c1415131fc0bb48648685f2f9d68bfd30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

