### PR TITLE
fix(ai): preserve Kimi recovery stream ordering

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -422,7 +422,11 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			let textBlock: TextContent | null = null;
 			let thinkingBlock: ThinkingContent | null = null;
 			let activeBlock: StreamingBlock | null = null;
+			let deferMixedEvents = false;
 			let hasFinishReason = false;
+			const deferredTextDeltas: string[] = [];
+			const deferredThinkingDeltas: string[] = [];
+			const deferredToolCallDeltas = new Map<StreamingToolCallBlock, string[]>();
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
 			const pendingReasoningDetailsByToolCallId = new Map<string, string>();
@@ -503,27 +507,39 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			};
 			const ensureTextBlock = () => {
 				if (!textBlock) {
-					finishActiveBlock();
-					thinkingBlock = null;
+					if (!deferMixedEvents) {
+						finishActiveBlock();
+						thinkingBlock = null;
+					}
 					textBlock = { type: "text", text: "" };
 					blocks.push(textBlock);
-					activeBlock = textBlock;
-					stream.push({ type: "text_start", contentIndex: getContentIndex(textBlock), partial: output });
+					if (!deferMixedEvents) {
+						activeBlock = textBlock;
+						stream.push({ type: "text_start", contentIndex: getContentIndex(textBlock), partial: output });
+					}
 				}
 				return textBlock;
 			};
 			const ensureThinkingBlock = (thinkingSignature: string) => {
 				if (!thinkingBlock) {
-					finishActiveBlock();
-					textBlock = null;
+					if (!deferMixedEvents) {
+						finishActiveBlock();
+						textBlock = null;
+					}
 					thinkingBlock = {
 						type: "thinking",
 						thinking: "",
 						thinkingSignature,
 					};
 					blocks.push(thinkingBlock);
-					activeBlock = thinkingBlock;
-					stream.push({ type: "thinking_start", contentIndex: getContentIndex(thinkingBlock), partial: output });
+					if (!deferMixedEvents) {
+						activeBlock = thinkingBlock;
+						stream.push({
+							type: "thinking_start",
+							contentIndex: getContentIndex(thinkingBlock),
+							partial: output,
+						});
+					}
 				}
 				return thinkingBlock;
 			};
@@ -545,9 +561,11 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					block = toolCallBlocksById.get(toolCall.id);
 				}
 				if (!block) {
-					finishActiveBlock();
-					textBlock = null;
-					thinkingBlock = null;
+					if (!deferMixedEvents) {
+						finishActiveBlock();
+						textBlock = null;
+						thinkingBlock = null;
+					}
 					// Note: the "input" fallback here should/must not be taken.  in case the LLM makes up
 					// a tool we don't knwo about, we at least have a place to stash our stuff.
 					const customInputProperty = toolCall.custom
@@ -572,12 +590,14 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 						toolCallBlocksById.set(toolCall.id, block);
 					}
 					blocks.push(block);
-					activeBlock = block;
-					stream.push({
-						type: "toolcall_start",
-						contentIndex: getContentIndex(block),
-						partial: output,
-					});
+					if (!deferMixedEvents) {
+						activeBlock = block;
+						stream.push({
+							type: "toolcall_start",
+							contentIndex: getContentIndex(block),
+							partial: output,
+						});
+					}
 				}
 				if (streamIndex !== undefined && block.streamIndex === undefined) {
 					block.streamIndex = streamIndex;
@@ -600,6 +620,28 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				}
 				applyPendingReasoningDetail(block);
 				return block;
+			};
+			const flushDeferredBlocks = () => {
+				for (const block of blocks) {
+					const contentIndex = getContentIndex(block);
+					if (block.type === "text") {
+						stream.push({ type: "text_start", contentIndex, partial: output });
+						for (const delta of deferredTextDeltas) {
+							stream.push({ type: "text_delta", contentIndex, delta, partial: output });
+						}
+					} else if (block.type === "thinking") {
+						stream.push({ type: "thinking_start", contentIndex, partial: output });
+						for (const delta of deferredThinkingDeltas) {
+							stream.push({ type: "thinking_delta", contentIndex, delta, partial: output });
+						}
+					} else {
+						stream.push({ type: "toolcall_start", contentIndex, partial: output });
+						for (const delta of deferredToolCallDeltas.get(block) ?? []) {
+							stream.push({ type: "toolcall_delta", contentIndex, delta, partial: output });
+						}
+					}
+					finishBlock(block);
+				}
 			};
 
 			for await (const chunk of openaiStream) {
@@ -635,25 +677,10 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				}
 
 				if (choice.delta) {
-					if (
-						choice.delta.content !== null &&
-						choice.delta.content !== undefined &&
-						choice.delta.content.length > 0
-					) {
-						const block = ensureTextBlock();
-						block.text += choice.delta.content;
-						stream.push({
-							type: "text_delta",
-							contentIndex: getContentIndex(block),
-							delta: choice.delta.content,
-							partial: output,
-						});
-					}
-
-					// Some endpoints return reasoning in reasoning_content (llama.cpp),
-					// or reasoning (other openai compatible endpoints)
-					// Use the first non-empty reasoning field to avoid duplication
-					// (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
+					const contentDelta =
+						typeof choice.delta.content === "string" && choice.delta.content.length > 0
+							? choice.delta.content
+							: null;
 					const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
 					const deltaFields = choice.delta as Record<string, unknown>;
 					let foundReasoningField: string | null = null;
@@ -664,7 +691,29 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 							break;
 						}
 					}
+					if (blocks.length === 0 && contentDelta && foundReasoningField) {
+						deferMixedEvents = true;
+					}
 
+					if (contentDelta) {
+						const block = ensureTextBlock();
+						block.text += contentDelta;
+						if (deferMixedEvents) {
+							deferredTextDeltas.push(contentDelta);
+						} else {
+							stream.push({
+								type: "text_delta",
+								contentIndex: getContentIndex(block),
+								delta: contentDelta,
+								partial: output,
+							});
+						}
+					}
+
+					// Some endpoints return reasoning in reasoning_content (llama.cpp),
+					// or reasoning (other openai compatible endpoints)
+					// Use the first non-empty reasoning field to avoid duplication
+					// (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
 					if (foundReasoningField) {
 						const delta = deltaFields[foundReasoningField];
 						if (typeof delta === "string" && delta.length > 0) {
@@ -674,12 +723,16 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 									: foundReasoningField;
 							const block = ensureThinkingBlock(thinkingSignature);
 							block.thinking += delta;
-							stream.push({
-								type: "thinking_delta",
-								contentIndex: getContentIndex(block),
-								delta,
-								partial: output,
-							});
+							if (deferMixedEvents) {
+								deferredThinkingDeltas.push(delta);
+							} else {
+								stream.push({
+									type: "thinking_delta",
+									contentIndex: getContentIndex(block),
+									delta,
+									partial: output,
+								});
+							}
 						}
 					}
 
@@ -704,12 +757,18 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 								const nextInput = getCustomToolCallInput(block) + toolCall.custom.input;
 								delta = appendCustomToolCallInput(block, nextInput, false) ?? "";
 							}
-							stream.push({
-								type: "toolcall_delta",
-								contentIndex: getContentIndex(block),
-								delta,
-								partial: output,
-							});
+							if (deferMixedEvents) {
+								const deltas = deferredToolCallDeltas.get(block) ?? [];
+								deltas.push(delta);
+								deferredToolCallDeltas.set(block, deltas);
+							} else {
+								stream.push({
+									type: "toolcall_delta",
+									contentIndex: getContentIndex(block),
+									delta,
+									partial: output,
+								});
+							}
 						}
 					}
 
@@ -730,7 +789,8 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				}
 			}
 
-			finishActiveBlock();
+			if (deferMixedEvents) flushDeferredBlocks();
+			else finishActiveBlock();
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
 			}

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -421,6 +421,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 
 			let textBlock: TextContent | null = null;
 			let thinkingBlock: ThinkingContent | null = null;
+			let activeBlock: StreamingBlock | null = null;
 			let hasFinishReason = false;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
@@ -495,22 +496,33 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					});
 				}
 			};
+			const finishActiveBlock = () => {
+				if (!activeBlock) return;
+				finishBlock(activeBlock);
+				activeBlock = null;
+			};
 			const ensureTextBlock = () => {
 				if (!textBlock) {
+					finishActiveBlock();
+					thinkingBlock = null;
 					textBlock = { type: "text", text: "" };
 					blocks.push(textBlock);
+					activeBlock = textBlock;
 					stream.push({ type: "text_start", contentIndex: getContentIndex(textBlock), partial: output });
 				}
 				return textBlock;
 			};
 			const ensureThinkingBlock = (thinkingSignature: string) => {
 				if (!thinkingBlock) {
+					finishActiveBlock();
+					textBlock = null;
 					thinkingBlock = {
 						type: "thinking",
 						thinking: "",
 						thinkingSignature,
 					};
 					blocks.push(thinkingBlock);
+					activeBlock = thinkingBlock;
 					stream.push({ type: "thinking_start", contentIndex: getContentIndex(thinkingBlock), partial: output });
 				}
 				return thinkingBlock;
@@ -533,6 +545,9 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					block = toolCallBlocksById.get(toolCall.id);
 				}
 				if (!block) {
+					finishActiveBlock();
+					textBlock = null;
+					thinkingBlock = null;
 					// Note: the "input" fallback here should/must not be taken.  in case the LLM makes up
 					// a tool we don't knwo about, we at least have a place to stash our stuff.
 					const customInputProperty = toolCall.custom
@@ -557,6 +572,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 						toolCallBlocksById.set(toolCall.id, block);
 					}
 					blocks.push(block);
+					activeBlock = block;
 					stream.push({
 						type: "toolcall_start",
 						contentIndex: getContentIndex(block),
@@ -714,9 +730,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				}
 			}
 
-			for (const block of blocks) {
-				finishBlock(block);
-			}
+			finishActiveBlock();
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
 			}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,42 @@
 # AI Source Changes
 
+## 2026-07-29 - Preserve invoke-recovery protocol provenance
+
+### What changed and why
+
+- `wrapStreamWithInvokeRecovery()` accepts typed recovery options carrying both the parser factory and the protocol
+  identity. The previous parser-only argument selected Kimi XTML correctly but lost that provenance in shared
+  diagnostics and recovered tool-call IDs.
+- Successful Kimi recovery now reports `protocol: "kimi-xtml"` and allocates `recovered-kimi-xtml-*` IDs. Invalid
+  content/native event order and collision failures use the same protocol identity instead of always claiming
+  `antml`.
+- The default and legacy parser-function call forms remain ANTML-compatible, preserving existing Claude/default
+  recovery diagnostics and IDs.
+- Coverage: the shared wrapper pins Kimi failure diagnostics, and the coding-agent runtime boundary pins successful
+  Kimi diagnostics plus recovered IDs.
+
+### Expected merge conflict zones
+
+- MEDIUM: invoke-recovery wrapper, diagnostic, failure, and native projection constructor signatures.
+
+## 2026-07-29 - Serialize OpenAI completion content block events
+
+### What changed and why
+
+- `api/openai-completions.ts` now closes the active thinking, text, or native tool-call block before starting the
+  next block. The adapter previously accumulated every block and emitted all `*_end` events only after the wire
+  stream finished, producing overlapping canonical lifecycles such as `thinking_start -> text_start` and
+  `text_start -> toolcall_start`.
+- The invoke-recovery wrapper correctly rejects overlapping canonical content lifecycles. Kimi K3 exposed the
+  adapter bug when a normal response streamed reasoning, visible text, and native tool calls in sequence, causing
+  the user-facing terminal error `Invalid assistant content event order`.
+- Coverage: `test/openai-completions-stream-lifecycle.test.ts` drives a real local SSE endpoint through reasoning,
+  text, and a native tool call and pins the sequential start/delta/end event order.
+
+### Expected merge conflict zones
+
+- LOW: the block lifecycle helpers inside `api/openai-completions.ts`.
+
 ## 2026-07-29 - Support static credential headers without a synthetic API key
 
 ### What changed and why

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -27,11 +27,17 @@
   next block. The adapter previously accumulated every block and emitted all `*_end` events only after the wire
   stream finished, producing overlapping canonical lifecycles such as `thinking_start -> text_start` and
   `text_start -> toolcall_start`.
+- Providers that put text, reasoning, and parallel tool-call deltas in the same chunk keep their established
+  single-block aggregation. The adapter defers that mixed chunk's content events and replays text, thinking, and
+  each tool call as complete sequential lifecycles, avoiding duplicate text/thinking starts without restoring
+  overlapping events.
 - The invoke-recovery wrapper correctly rejects overlapping canonical content lifecycles. Kimi K3 exposed the
   adapter bug when a normal response streamed reasoning, visible text, and native tool calls in sequence, causing
   the user-facing terminal error `Invalid assistant content event order`.
 - Coverage: `test/openai-completions-stream-lifecycle.test.ts` drives a real local SSE endpoint through reasoning,
   text, and a native tool call and pins the sequential start/delta/end event order.
+  `test/openai-completions-tool-choice.test.ts` pins mixed text/reasoning/parallel-tool aggregation and sequential
+  event replay.
 
 ### Expected merge conflict zones
 

--- a/packages/ai/src/tool-call-middleware/recovery-diagnostics.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-diagnostics.ts
@@ -1,12 +1,17 @@
 import type { ToolCall } from "../types.ts";
 import type { StreamMessageProjection } from "./stream-wrapper-shared.ts";
+import type { ToolCallFormat } from "./types.ts";
 
-export function appendRecoveryDiagnostic(projection: StreamMessageProjection, toolCall: ToolCall): void {
+export function appendRecoveryDiagnostic(
+	projection: StreamMessageProjection,
+	toolCall: ToolCall,
+	protocol: ToolCallFormat,
+): void {
 	projection.appendDiagnostic({
 		type: "text_tool_call_recovery",
 		timestamp: Date.now(),
 		details: {
-			protocol: "antml",
+			protocol,
 			toolName: toolCall.name,
 			id: toolCall.id,
 			status: toolCall.incomplete === true ? "incomplete" : "complete",

--- a/packages/ai/src/tool-call-middleware/recovery-native-projection.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-native-projection.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage, AssistantMessageEventStream, ToolCall } from "../types.ts";
-import type { StreamParserEvent } from "./types.ts";
+import type { StreamParserEvent, ToolCallFormat } from "./types.ts";
 
 type ContentBlock = AssistantMessage["content"][number];
 type ContentRange = { start: number; end: number };
@@ -23,12 +23,14 @@ export class RecoveryNativeProjection {
 	private readonly reservedIds = new Set<string>();
 	private readonly recoveredIds = new Set<string>();
 	private readonly recoveredIdByParserIndex = new Map<number, string>();
+	private readonly recoveredIdPrefix: string;
 	private highestProjectedInnerIndex = -1;
 	private nextRecoveredId = 0;
 
-	constructor(stream: AssistantMessageEventStream, message: AssistantMessage) {
+	constructor(stream: AssistantMessageEventStream, message: AssistantMessage, protocol: ToolCallFormat = "antml") {
 		this.stream = stream;
 		this.message = message;
+		this.recoveredIdPrefix = `recovered-${protocol}-`;
 	}
 
 	reserveVisibleIds(source: AssistantMessage): void {
@@ -141,7 +143,7 @@ export class RecoveryNativeProjection {
 
 	private allocateRecoveredId(): string {
 		for (;;) {
-			const id = `recovered-antml-${this.nextRecoveredId}`;
+			const id = `${this.recoveredIdPrefix}${this.nextRecoveredId}`;
 			this.nextRecoveredId += 1;
 			if (this.reservedIds.has(id)) continue;
 			this.reservedIds.add(id);

--- a/packages/ai/src/tool-call-middleware/recovery-stream-failure.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-stream-failure.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, AssistantMessageEventStream } from "../types.ts";
 import type { StreamMessageProjection } from "./stream-wrapper-shared.ts";
+import type { ToolCallFormat } from "./types.ts";
 
 export type RecoveryStreamFailure = "collision" | "invalid_content_event_order" | "invalid_native_event_order";
 
@@ -25,9 +26,13 @@ const failureDetails: Record<RecoveryStreamFailure, { diagnosticType: string; er
 export function terminateRecoveryStreamForFailure(
 	stream: AssistantMessageEventStream,
 	projection: StreamMessageProjection,
-	source: AssistantMessage,
-	failure: RecoveryStreamFailure,
+	options: {
+		source: AssistantMessage;
+		failure: RecoveryStreamFailure;
+		protocol: ToolCallFormat;
+	},
 ): void {
+	const { source, failure, protocol } = options;
 	const details = failureDetails[failure];
 	projection.sync(source);
 	const message = projection.finalize(source, false);
@@ -39,7 +44,7 @@ export function terminateRecoveryStreamForFailure(
 		{
 			type: details.diagnosticType,
 			timestamp: Date.now(),
-			details: { protocol: "antml", status: details.status },
+			details: { protocol, status: details.status },
 		},
 	];
 	stream.push({ type: "error", reason: "error", error: message });

--- a/packages/ai/src/tool-call-middleware/recovery-stream-wrapper.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-stream-wrapper.ts
@@ -8,13 +8,22 @@ import { type RecoveryStreamFailure, terminateRecoveryStreamForFailure } from ".
 import { RecoveryStreamTerminal } from "./recovery-stream-terminal.ts";
 import { RecoveryTextProjection } from "./recovery-text-projection.ts";
 import { StreamMessageProjection } from "./stream-wrapper-shared.ts";
+import type { ToolCallFormat } from "./types.ts";
+
+export interface InvokeRecoveryOptions {
+	createParser?: (tools: readonly Tool[]) => RecoveryStreamParser;
+	protocol?: ToolCallFormat;
+}
 
 export function wrapStreamWithInvokeRecovery(
 	innerStream: AssistantMessageEventStream,
 	tools: readonly Tool[],
-	createParser: (tools: readonly Tool[]) => RecoveryStreamParser = createAntmlInvokeRecoveryStreamParser,
+	options: InvokeRecoveryOptions | ((tools: readonly Tool[]) => RecoveryStreamParser) = {},
 ): AssistantMessageEventStream {
 	const outerStream = new RecoveryAssistantMessageEventStream();
+	const resolvedOptions = typeof options === "function" ? { createParser: options } : options;
+	const createParser = resolvedOptions.createParser ?? createAntmlInvokeRecoveryStreamParser;
+	const protocol = resolvedOptions.protocol ?? "antml";
 
 	void (async (): Promise<void> => {
 		const innerIterator = innerStream[Symbol.asyncIterator]();
@@ -49,7 +58,7 @@ export function wrapStreamWithInvokeRecovery(
 		const terminateForFailure = (source: AssistantMessage, failure: RecoveryStreamFailure): void => {
 			if (!projection || !outerStream.markSourceClosed()) return;
 			finishText();
-			terminateRecoveryStreamForFailure(outerStream, projection, source, failure);
+			terminateRecoveryStreamForFailure(outerStream, projection, { source, failure, protocol });
 		};
 
 		const prepareContentEvent = (source: AssistantMessage, contentIndex: number): boolean => {
@@ -98,7 +107,7 @@ export function wrapStreamWithInvokeRecovery(
 
 		const synchronizeTerminal = (source: AssistantMessage): boolean => {
 			projection ??= new StreamMessageProjection(outerStream, source, { preserveSourceMetadata: true });
-			nativeProjection ??= new RecoveryNativeProjection(outerStream, projection.message);
+			nativeProjection ??= new RecoveryNativeProjection(outerStream, projection.message, protocol);
 			projection.sync(source);
 			nativeProjection.reserveVisibleIds(source);
 			finishText();
@@ -115,7 +124,7 @@ export function wrapStreamWithInvokeRecovery(
 						projection = new StreamMessageProjection(outerStream, event.partial, {
 							preserveSourceMetadata: true,
 						});
-						nativeProjection = new RecoveryNativeProjection(outerStream, projection.message);
+						nativeProjection = new RecoveryNativeProjection(outerStream, projection.message, protocol);
 						nativeProjection.reserveVisibleIds(event.partial);
 						outerStream.push({ type: "start", partial: projection.message });
 						break;
@@ -123,13 +132,10 @@ export function wrapStreamWithInvokeRecovery(
 						if (!canStart(event.partial, event.contentIndex, "text")) return;
 						if (!prepareContentEvent(event.partial, event.contentIndex) || !projection || !nativeProjection)
 							return;
-						const nextText = new RecoveryTextProjection(
-							tools,
-							projection,
-							nativeProjection,
-							event.contentIndex,
+						const nextText = new RecoveryTextProjection(tools, projection, nativeProjection, event.contentIndex, {
 							createParser,
-						);
+							protocol,
+						});
 						if (!nextText.start(event.partial)) {
 							terminateForFailure(event.partial, "invalid_native_event_order");
 							return;

--- a/packages/ai/src/tool-call-middleware/recovery-text-projection.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-text-projection.ts
@@ -5,7 +5,7 @@ import { createRecoveryCodeMask, type RecoveryCodeMaskSegment } from "./recovery
 import { appendRecoveryDiagnostic } from "./recovery-diagnostics.ts";
 import type { RecoveryNativeProjection } from "./recovery-native-projection.ts";
 import type { StreamMessageProjection } from "./stream-wrapper-shared.ts";
-import type { StreamParserEvent } from "./types.ts";
+import type { StreamParserEvent, ToolCallFormat } from "./types.ts";
 
 /** Owns one ordinary assistant text block's mask/parser/projection lifecycle. */
 export class RecoveryTextProjection {
@@ -13,6 +13,7 @@ export class RecoveryTextProjection {
 	private readonly nativeProjection: RecoveryNativeProjection;
 	private readonly innerIndex: number;
 	private readonly parser: RecoveryStreamParser;
+	private readonly protocol: ToolCallFormat;
 	private readonly mask = createRecoveryCodeMask();
 	private activeInvoke = false;
 	private textBuffer = "";
@@ -24,12 +25,16 @@ export class RecoveryTextProjection {
 		projection: StreamMessageProjection,
 		nativeProjection: RecoveryNativeProjection,
 		innerIndex: number,
-		createParser: (tools: readonly Tool[]) => RecoveryStreamParser = createAntmlInvokeRecoveryStreamParser,
+		options: {
+			createParser?: (tools: readonly Tool[]) => RecoveryStreamParser;
+			protocol?: ToolCallFormat;
+		} = {},
 	) {
 		this.projection = projection;
 		this.nativeProjection = nativeProjection;
 		this.innerIndex = innerIndex;
-		this.parser = createParser(tools);
+		this.parser = (options.createParser ?? createAntmlInvokeRecoveryStreamParser)(tools);
+		this.protocol = options.protocol ?? "antml";
 	}
 
 	start(source: AssistantMessage): boolean {
@@ -76,7 +81,9 @@ export class RecoveryTextProjection {
 			if (event.type === "toolcall_start") this.activeInvoke = true;
 			if (event.type === "toolcall_end") {
 				this.activeInvoke = false;
-				for (const toolCall of result.completedToolCalls) appendRecoveryDiagnostic(this.projection, toolCall);
+				for (const toolCall of result.completedToolCalls) {
+					appendRecoveryDiagnostic(this.projection, toolCall, this.protocol);
+				}
 			}
 		}
 		this.nativeProjection.extendText(this.innerIndex);

--- a/packages/ai/test/openai-completions-stream-lifecycle.test.ts
+++ b/packages/ai/test/openai-completions-stream-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server, type ServerResponse } from "node:http";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import { getModel, streamSimple } from "../src/compat.ts";
 import type { Context, Model } from "../src/types.ts";
@@ -77,6 +78,71 @@ describe("OpenAI completions stream lifecycle", () => {
 		expect(response.errorMessage).toBe("Stream ended without finish_reason");
 		expect(response.content).toEqual([
 			{ type: "thinking", thinking: "partial", thinkingSignature: "reasoning_content" },
+		]);
+	});
+
+	it("ends each content block before starting the next block type", async () => {
+		// Given
+		const baseUrl = await startServer((response) => {
+			response.writeHead(200, { "content-type": "text/event-stream" });
+			for (const delta of [
+				{ reasoning_content: "thought" },
+				{ content: "answer" },
+				{
+					tool_calls: [
+						{
+							index: 0,
+							id: "call-1",
+							type: "function",
+							function: { name: "echo", arguments: '{"text":"ok"}' },
+						},
+					],
+				},
+			]) {
+				response.write(
+					`data: ${JSON.stringify({
+						id: "chatcmpl-content-order",
+						choices: [{ index: 0, delta, finish_reason: null }],
+					})}\n\n`,
+				);
+			}
+			response.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-content-order",
+					choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+				})}\n\n`,
+			);
+			response.end("data: [DONE]\n\n");
+		});
+		const context: Context = {
+			messages: [{ role: "user", content: "Think, answer, then call echo", timestamp: Date.now() }],
+			tools: [
+				{
+					name: "echo",
+					description: "Echo text",
+					parameters: Type.Object({ text: Type.String() }),
+				},
+			],
+		};
+
+		// When
+		const response = streamSimple(testModel(baseUrl), context, { apiKey: "test", maxRetries: 0 });
+		const eventTypes: string[] = [];
+		for await (const event of response) eventTypes.push(event.type);
+
+		// Then
+		expect(eventTypes).toEqual([
+			"start",
+			"thinking_start",
+			"thinking_delta",
+			"thinking_end",
+			"text_start",
+			"text_delta",
+			"text_end",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+			"done",
 		]);
 	});
 });

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1003,6 +1003,8 @@ describe("openai-completions tool_choice", () => {
 		expect(eventTypes.filter((type) => type === "toolcall_start")).toHaveLength(4);
 		expect(eventTypes.filter((type) => type === "toolcall_delta")).toHaveLength(9);
 		expect(eventTypes.filter((type) => type === "toolcall_end")).toHaveLength(4);
+		expect(eventTypes.indexOf("text_end")).toBeLessThan(eventTypes.indexOf("thinking_start"));
+		expect(eventTypes.indexOf("thinking_end")).toBeLessThan(eventTypes.indexOf("toolcall_start"));
 		expect(toolEventsByContentIndex.get(2)).toEqual([
 			"toolcall_start",
 			"toolcall_delta",

--- a/packages/ai/test/tool-call-middleware/invoke-recovery-stream-wrapper.test.ts
+++ b/packages/ai/test/tool-call-middleware/invoke-recovery-stream-wrapper.test.ts
@@ -2,7 +2,9 @@ import { spawnSync } from "node:child_process";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { wrapStreamWithInvokeRecovery } from "../../src/index.ts";
+import { createXtmlRecoveryStreamParser } from "../../src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts";
 import type { AssistantMessageEvent, Tool } from "../../src/types.ts";
+import { AssistantMessageEventStream } from "../../src/utils/event-stream.ts";
 import { registerInvokeRecoveryContentExclusionCases } from "./invoke-recovery-content-exclusion-cases.ts";
 import { registerInvokeRecoveryContentOrderCases } from "./invoke-recovery-content-order-cases.ts";
 import { registerInvokeRecoveryNativeCases } from "./invoke-recovery-native-cases.ts";
@@ -50,6 +52,35 @@ describe("wrapStreamWithInvokeRecovery", () => {
 	registerInvokeRecoveryTerminationCases(bashTool);
 	registerInvokeRecoveryTerminalEdgeCases(bashTool);
 	registerInvokeRecoverySnapshotCancelCases(bashTool);
+
+	it("labels invalid Kimi content order with the XTML protocol", async () => {
+		// Given
+		const inner = new AssistantMessageEventStream();
+		const partial = createAssistantMessage([]);
+		const wrapped = wrapStreamWithInvokeRecovery(inner, [bashTool], {
+			createParser: createXtmlRecoveryStreamParser,
+			protocol: "kimi-xtml",
+		});
+		inner.push({ type: "start", partial: structuredClone(partial) });
+		partial.content.push({ type: "thinking", thinking: "" });
+		inner.push({ type: "thinking_start", contentIndex: 0, partial: structuredClone(partial) });
+		partial.content.push({ type: "text", text: "" });
+
+		// When
+		inner.push({ type: "text_start", contentIndex: 1, partial: structuredClone(partial) });
+		const events = await collectEvents(wrapped);
+		const result = await wrapped.result();
+
+		// Then
+		expect(events.map((event) => event.type)).toEqual(["start", "thinking_start", "error"]);
+		expect(result.diagnostics).toEqual([
+			{
+				type: "text_tool_call_recovery_invalid_content_event",
+				timestamp: expect.any(Number),
+				details: { protocol: "kimi-xtml", status: "invalid_content_event_order" },
+			},
+		]);
+	});
 
 	it("reconstructs text toolCall text and starts before the closing invoke", { timeout: 1000 }, async () => {
 		// Given

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,18 @@
+## Kimi XTML recovery preserves protocol identity (2026-07-29)
+
+### What changed
+
+- `core/model-runtime.ts` passes both `createXtmlRecoveryStreamParser` and `protocol: "kimi-xtml"` to the shared
+  invoke-recovery wrapper for Kimi models.
+- Successful recovered tool calls and terminal recovery failures now expose Kimi-specific diagnostics and
+  `recovered-kimi-xtml-*` IDs instead of misleading ANTML metadata.
+- `test/kimi-xtml-recovery-runtime-boundary.test.ts` pins the user-visible runtime result while the default ANTML
+  path remains covered in the AI package.
+
+### Expected merge conflict zones
+
+- LOW: the two invoke-recovery call sites in `core/model-runtime.ts`.
+
 ## Static credential headers participate in real provider auth resolution (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -557,7 +557,9 @@ export class ModelRuntime implements Models {
 				? wrapStreamWithInvokeRecovery(
 						inner,
 						context.tools,
-						hasKimiTextToolCallRecovery(model) ? createXtmlRecoveryStreamParser : undefined,
+						hasKimiTextToolCallRecovery(model)
+							? { createParser: createXtmlRecoveryStreamParser, protocol: "kimi-xtml" }
+							: undefined,
 					)
 				: inner;
 		});
@@ -582,7 +584,9 @@ export class ModelRuntime implements Models {
 				? wrapStreamWithInvokeRecovery(
 						inner,
 						context.tools,
-						hasKimiTextToolCallRecovery(model) ? createXtmlRecoveryStreamParser : undefined,
+						hasKimiTextToolCallRecovery(model)
+							? { createParser: createXtmlRecoveryStreamParser, protocol: "kimi-xtml" }
+							: undefined,
 					)
 				: inner;
 		});

--- a/packages/coding-agent/test/kimi-xtml-recovery-runtime-boundary.test.ts
+++ b/packages/coding-agent/test/kimi-xtml-recovery-runtime-boundary.test.ts
@@ -111,7 +111,24 @@ describe("kimi model runtime XTML recovery", () => {
 
 		// Then
 		const toolCall = result.content.find((item) => item.type === "toolCall");
-		expect(toolCall).toMatchObject({ type: "toolCall", name: "Echo", arguments: { value: "hello" } });
+		expect(toolCall).toMatchObject({
+			type: "toolCall",
+			id: "recovered-kimi-xtml-0",
+			name: "Echo",
+			arguments: { value: "hello" },
+		});
+		expect(result.diagnostics).toEqual([
+			{
+				type: "text_tool_call_recovery",
+				timestamp: expect.any(Number),
+				details: {
+					protocol: "kimi-xtml",
+					toolName: "Echo",
+					id: "recovered-kimi-xtml-0",
+					status: "complete",
+				},
+			},
+		]);
 		const visibleText = result.content
 			.filter((item) => item.type === "text")
 			.map((item) => (item.type === "text" ? item.text : ""))


### PR DESCRIPTION
## Summary

- preserve Kimi XTML protocol identity in successful recovery diagnostics, terminal recovery failures, and recovered tool-call IDs
- keep the default and parser-function compatibility paths labeled as ANTML
- serialize OpenAI-compatible reasoning, text, and native tool-call content lifecycles so recovery middleware no longer rejects valid Kimi streams with `Invalid assistant content event order`

## Root cause

Kimi correctly selected the XTML parser, but the shared recovery machinery hard-coded `antml` in diagnostics and `recovered-antml-*` IDs. Separately, the OpenAI completions adapter deferred every block-end event until stream completion, producing overlapping canonical lifecycles such as `thinking_start -> text_start`.

## RED evidence

- Kimi invalid-order diagnostic:
  - expected `protocol: "kimi-xtml"`
  - received `protocol: "antml"`
- Kimi successful recovery:
  - expected `recovered-kimi-xtml-0`
  - received `recovered-antml-0`
- OpenAI reasoning -> text -> native tool regression:
  - expected each `*_end` before the next block's `*_start`
  - received overlapping block lifecycles before the adapter fix

## Verification

- `packages/ai`: recovery wrapper + OpenAI lifecycle tests — 2 files, 36 tests passed
- `packages/coding-agent`: Kimi runtime boundary — 1 file, 2 tests passed
- `npm run check` — passed
- source CLI mock loop, OpenAI completions with tool — 4/4 passed
- CLI smoke — 8/8 passed
- real auth file unchanged

## QA evidence

Local sanitized receipts:

- `local-ignore/qa-evidence/20260729-kimi-recovery-protocol/focused-tests.txt`
- `local-ignore/qa-evidence/20260729-kimi-recovery-protocol/cli-qa.txt`

## Commits

- `4c7765f8b fix(ai): preserve Kimi recovery protocol identity`
- `10f06ad95 fix(ai): serialize completion content events`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Kimi XTML protocol identity and fixes content event ordering. OpenAI/Kimi streams now end each block before starting the next, and mixed chunks (reasoning + text + tool calls) are replayed sequentially without duplicates.

- **Bug Fixes**
  - `wrapStreamWithInvokeRecovery()` accepts `{ createParser, protocol }`; Kimi passes `createXtmlRecoveryStreamParser` with `protocol: "kimi-xtml"`.
  - Diagnostics and recovered tool-call IDs reflect Kimi: `protocol: "kimi-xtml"`, `recovered-kimi-xtml-*`; default/legacy paths remain `antml`.
  - OpenAI completions adapter closes the active block before starting the next (thinking/text/toolcall).
  - Mixed completion chunks are deferred and replayed as ordered lifecycles, preserving content while avoiding overlapping or duplicate events.

<sup>Written for commit cf6106c6f0541ce0ab376dafee12b319d6d5abe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

