### PR TITLE
fix(release): make platform sidecars root-owned

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Make promoted native sidecars root-owned during npm installation so bundled portable packages cannot leave invalid empty platform-package directories instead of fetching the consumer's executable ([#446](https://github.com/code-yeongyu/senpi/issues/446)).
+
 ### Removed
 
 ## [2026.7.29-5] - 2026-07-29

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,13 @@
 # Local fork changes
 
+## 2026-07-30 — Root-owned consumer sidecar installation (#446)
+
+- Changed: publish staging now removes promoted platform optional-dependency edges from the bundled portable package manifest after copying the complete family to Senpi's root optional dependencies.
+- Why: npm 11 placed `claude-agent-sdk-darwin-arm64` for the root and bundled SDK edges but never fetched its tarball, leaving an invalid empty directory. A fresh `2026.7.29-5` install therefore still failed native resolution even though the universal tarball contained zero platform sidecar files.
+- What changed: the literal issue-446 test proves the root retains all eight Claude platform optionals while the staged bundled SDK owns none, so npm has one consumer-resolved edge and downloads the real Darwin executable.
+- Why the extension system could not handle this: npm synthesizes the invalid empty dependency directory before Senpi or its provider runtime starts.
+- Merge-conflict risk: low. Expected conflict zones are publish-manifest staging and the focused issue-446 packaging test.
+
 ## 2026-07-30 — Strip publisher-native packages before npm pack (#446)
 
 - Changed: after promoting complete platform optional-dependency families into the root manifest, publish staging now removes every platform-constrained package directory before npm traverses bundled dependency graphs.

--- a/scripts/prepare-senpi-bundled-workspaces.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.test.mjs
@@ -257,7 +257,11 @@ describe("stagePublishManifest", () => {
 		// Then: npm installs the matching sidecar on the consumer instead of preserving
 		// the publisher's Linux-only binary inside the universal Senpi tarball.
 		const manifest = readStagedManifest(tempDir);
+		const stagedSdkManifest = JSON.parse(
+			readFileSync(join(tempDir, "packages", "coding-agent", "node_modules", "@anthropic-ai", "claude-agent-sdk", "package.json"), "utf8"),
+		);
 		assert.deepEqual(manifest.optionalDependencies, platformPackages);
+		assert.deepEqual(stagedSdkManifest.optionalDependencies, {});
 		assert.ok(manifest.bundleDependencies.includes("@anthropic-ai/claude-agent-sdk"));
 		assert.ok(!manifest.bundleDependencies.includes("@anthropic-ai/claude-agent-sdk-linux-x64"));
 		const packed = JSON.parse(

--- a/scripts/prepare-senpi-publish-manifest.mjs
+++ b/scripts/prepare-senpi-publish-manifest.mjs
@@ -78,10 +78,11 @@ export function bundlablePublishPackageNames(codingAgentNodeModules, packageName
 	return packageNames.filter((name) => !isPlatformConstrainedPackage(join(codingAgentNodeModules, name)));
 }
 
-function platformOptionalDependencyFamilies(codingAgentNodeModules, packageNames) {
+function promotePlatformOptionalDependencyFamilies(codingAgentNodeModules, packageNames) {
 	const promoted = {};
 	for (const packageName of packageNames) {
-		const manifest = readPackageManifest(join(codingAgentNodeModules, packageName));
+		const packageDir = join(codingAgentNodeModules, packageName);
+		const manifest = readPackageManifest(packageDir);
 		if (!manifest) continue;
 		const optionalDependencies = manifest.optionalDependencies ?? {};
 		const materializedOptionalNames = Object.keys(optionalDependencies).filter((name) =>
@@ -95,6 +96,11 @@ function platformOptionalDependencyFamilies(codingAgentNodeModules, packageNames
 			continue;
 		}
 		Object.assign(promoted, optionalDependencies);
+		// npm treats optional edges owned by a bundled package as already satisfied by
+		// the bundle and only creates empty package directories. The promoted root edges
+		// must be the sole owners so npm fetches the consumer platform's real sidecar.
+		manifest.optionalDependencies = {};
+		writeFileSync(join(packageDir, "package.json"), `${JSON.stringify(manifest, null, "\t")}\n`);
 	}
 	return promoted;
 }
@@ -140,7 +146,7 @@ export function stagePublishManifest(repoRoot) {
 
 	const bundlablePackageNames = bundlablePublishPackageNames(codingAgentNodeModules, stagedPackageNames);
 	manifest.optionalDependencies = {
-		...platformOptionalDependencyFamilies(codingAgentNodeModules, stagedPackageNames),
+		...promotePlatformOptionalDependencyFamilies(codingAgentNodeModules, stagedPackageNames),
 		...(manifest.optionalDependencies ?? {}),
 	};
 	const bundlableSet = new Set(bundlablePackageNames);


### PR DESCRIPTION
## Summary

- make the eight promoted Claude platform packages root-owned optional dependencies during publish staging
- remove the duplicate platform optional family from the bundled portable Claude SDK manifest
- preserve the universal tarball contract: no Linux, Darwin, or Windows Claude sidecar files are embedded

## Root cause

The `2026.7.29-5` tarball correctly excluded all platform sidecar files and exposed all eight packages as root optionals. However, the bundled `@anthropic-ai/claude-agent-sdk` copy still declared the same optional family.

npm 11 placed the matching Darwin package for both edges but treated the bundled package's optional edge as already satisfied. It never downloaded the Darwin tarball and left an invalid empty directory, so native resolution still failed.

Promoting the family to the root and removing the duplicate nested edges gives npm one consumer-owned edge. A fresh local install now downloads the real `darwin-arm64/claude` executable.

## Verification

- `node --test --test-name-pattern "issue 446" scripts/prepare-senpi-bundled-workspaces.test.mjs`
  - RED on the nested optional-family assertion before the fix
  - GREEN after the fix
- `npm run test:scripts` — 72 passed
- `npm run check` — passed
- `npm run build` — passed
- `npm test` — passed
  - coding-agent: 5,956 passed, 33 skipped
  - AI: 1,520 passed, 804 skipped
  - agent: 303 passed, 1 skipped
  - PTY: 44 passed
  - codemode: 466 passed, 6 skipped
- `npm run release:local -- --out /tmp/senpi-issue446-layout-local-release --force --skip-check --skip-test`
  - isolated npm and Bun installs passed
  - root Claude platform optionals: 8
  - installed Claude sidecars: exactly `claude-agent-sdk-darwin-arm64`
  - Darwin package contains executable `claude`
  - packed platform sidecar entries: 0
  - bundled SDK nested platform optionals: 0
  - resolver returned the installed Darwin executable
- Senpi QA:
  - CLI smoke: 8/8 passed
  - mock loop: 43/43 passed with localhost-only model traffic and unchanged real auth

Follow-up for #446.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native sidecar installs by making all Claude platform sidecars root-owned optional dependencies and removing the duplicated optional family from the bundled `@anthropic-ai/claude-agent-sdk`. npm now downloads the correct consumer platform package (e.g., `claude-agent-sdk-darwin-arm64`) instead of leaving empty directories.

- **Bug Fixes**
  - Promote the eight platform sidecar packages to root and clear `optionalDependencies` in the bundled `@anthropic-ai/claude-agent-sdk` manifest.
  - Add tests that assert root ownership of the sidecar family and zero bundled SDK optionals; the universal tarball still embeds no platform sidecars.

<sup>Written for commit 659d2d5be340c6ffe4f3ab9d7ed654bcccdfca2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

