### PR TITLE
fix(service-tier): explain why /fast is unavailable on a ChatGPT subscription

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,30 @@
 # Builtin extensions changes
 
+## service-tier: explain why `/fast` is unavailable on a subscription (2026-07-30)
+
+- Fixes the misleading notice reported in issue #499. `/fast` is registered only
+  for `openai-codex`, but `generate-models.ts` emits `-fast` priority variants
+  only for the direct `openai` provider, so no Codex model ever has a target and
+  the command could only ever answer "Fast mode is not supported for
+  openai-codex/<model>" — which reads as a per-model gap rather than a
+  plan-level limitation.
+- Generating the missing Codex variants would be wrong. Measured against
+  `chatgpt.com/backend-api/codex/responses` with a live ChatGPT Pro
+  subscription: `service_tier: "priority"` and `"default"` both return HTTP 200
+  and the response echoes `"auto"`, while `"auto"`, `"flex"` and `"scale"` are
+  rejected with HTTP 400 `Unsupported service_tier`. The backend allowlists
+  `priority` but serves it at normal tier, and
+  `getServiceTierCostMultiplier()` would still bill it at 2.5x for gpt-5.5
+  (2x elsewhere) — so synthesising variants would inflate reported cost for
+  unchanged service.
+- The no-variant branch now states that priority tier is unavailable on a
+  ChatGPT subscription and that it requires API-key billing on the `openai`
+  provider, where `-fast` variants already exist and `/fast` works.
+- `test/suite/service-tier-extension.test.ts` asserts the notice explains the
+  subscription limitation and no longer blames the model.
+- Expected merge conflict zones: LOW in `service-tier.ts` around the
+  `FAST_UNAVAILABLE_ON_SUBSCRIPTION` constant and the no-variant branch.
+
 ## service-tier: add `/fast` for OpenAI Codex (2026-07-29)
 
 - `service-tier.ts` registers `/fast` only for the `openai-codex` provider.

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -10,6 +10,26 @@ type ProviderPayload = Record<string, unknown>;
 const OPENAI_CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
 const FAST_MODEL_SUFFIX = "-fast";
+/**
+ * `/fast` is registered only for `openai-codex`, but the catalog generator emits
+ * `-fast` priority variants only for the direct `openai` provider, so no Codex
+ * model ever has a target and the command could only report "not supported".
+ *
+ * That gap is intentional rather than an oversight in the generator: measured
+ * against `chatgpt.com/backend-api/codex/responses` with a live ChatGPT Pro
+ * subscription, `service_tier: "priority"` returns HTTP 200 but the response
+ * echoes `"auto"`, while `"auto"`/`"flex"`/`"scale"` are rejected with HTTP 400
+ * `Unsupported service_tier`. Priority processing is an API-billing feature, so
+ * a subscription request is served at normal tier no matter what is sent — and
+ * `getServiceTierCostMultiplier()` would still bill it at up to 2.5x.
+ *
+ * So the honest answer is that fast mode is unavailable here, not that the
+ * model does not support it.
+ */
+const FAST_UNAVAILABLE_ON_SUBSCRIPTION =
+	"Fast mode (priority tier) is not available on a ChatGPT subscription: chatgpt.com accepts " +
+	"service_tier=priority but serves the request at normal tier. Priority processing requires " +
+	"API-key billing on the `openai` provider.";
 const SERVICE_TIER_APIS: ReadonlySet<Api> = new Set(["openai-responses", OPENAI_CODEX_RESPONSES_API]);
 
 function isRecord(value: unknown): value is ProviderPayload {
@@ -93,7 +113,7 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 			const baseModel = findBaseModel(ctx.modelRegistry, model);
 			const targetModel = baseModel ?? findFastModel(ctx.modelRegistry, model);
 			if (!targetModel) {
-				ctx.ui.notify(`Fast mode is not supported for ${model.provider}/${model.id}.`, "warning");
+				ctx.ui.notify(FAST_UNAVAILABLE_ON_SUBSCRIPTION, "warning");
 				return;
 			}
 

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -140,10 +140,15 @@ describe("service-tier builtin extension", () => {
 
 		// then
 		expect(harness.session.model).toBe(initialModel);
-		expect(notify).toHaveBeenCalledWith(
-			`Fast mode is not supported for ${CODEX_PROVIDER}/${BASE_MODEL_ID}.`,
-			"warning",
-		);
+		// Subscription requests are served at normal tier however the field is set
+		// (chatgpt.com echoes "auto" for service_tier=priority and rejects
+		// auto/flex/scale outright), so the notice must say fast mode is
+		// unavailable here rather than blaming the model. See issue #499.
+		const [[message, level]] = notify.mock.calls;
+		expect(level).toBe("warning");
+		expect(message).toContain("not available on a ChatGPT subscription");
+		expect(message).toContain("API-key billing");
+		expect(message).not.toContain("not supported for");
 	});
 
 	it("leaves incompatible api payloads unchanged", () => {


### PR DESCRIPTION
Fixes #499.

## What `/fast` does today

`/fast` is registered only for the `openai-codex` provider, and switches to a
`<id>-fast` catalog sibling carrying `serviceTier: "priority"`. But
`generate-models.ts` emits those variants only for the direct `openai`
provider — its comment says the Codex backend is "intentionally excluded". So no
Codex model ever has a compatible target, and the command's only reachable
outcome is:

```
Fast mode is not supported for openai-codex/gpt-5.5.
```

Reproduced on `2026.7.29-6` via the registry the command uses:

```
openai-codex/gpt-5.5: base=yes fast=NO
openai-codex/gpt-5.4: base=yes fast=NO
openai/gpt-4.1:       base=yes fast=yes tier=priority
```

## Why I did not just generate the Codex variants

That was my first instinct, and it is wrong. Measured directly against
`chatgpt.com/backend-api/codex/responses` with a live ChatGPT Pro subscription:

| sent `service_tier` | result |
|---|---|
| `priority` | HTTP 200, response echoes `"auto"` |
| `default` | HTTP 200, response echoes `"auto"` |
| `auto` | HTTP 400 `Unsupported service_tier` |
| `flex` | HTTP 400 `Unsupported service_tier` |
| `scale` | HTTP 400 `Unsupported service_tier` |

The backend allowlists `priority` but serves it at normal tier — priority
processing is an API-billing feature, not a subscription one. Meanwhile
`getServiceTierCostMultiplier()` bills `priority` at **2.5x for gpt-5.5** (2x
elsewhere). Synthesising `-fast` variants would therefore show users a "Fast"
model that inflates reported cost 2.5x while delivering unchanged service.

So the generator's exclusion is correct; only the message was wrong.

## This PR

Replaces the misleading no-variant notice with an accurate one: priority tier is
unavailable on a ChatGPT subscription and requires API-key billing on the
`openai` provider, where the variants already exist and `/fast` works. No
behavioural change beyond the notice text.

## Validation

- `npx vitest run test/suite/service-tier-extension.test.ts` → 7 passed
- `npx biome check --error-on-warnings` on both changed files → clean
- `changes.md` section added per `builtin/AGENTS.md`

If you would rather `/fast` refuse earlier (e.g. hide the command for
subscription-only Codex auth), happy to rework it that way.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the misleading `/fast` “not supported” message for `openai-codex` models with a clear notice that Fast (priority tier) isn’t available on ChatGPT subscriptions and requires API‑key billing on `openai`. Fixes #499 with no behavior changes.

- **Bug Fixes**
  - Update the no-variant branch to explain the subscription limitation and point to API‑key billing on `openai`.
  - Adjust tests to assert the new notice and remove model-specific blame.
  - Add a `changes.md` entry.

<sup>Written for commit c2d55fa85f14d879fe50bf7de8a6eaae475937e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

