### PR TITLE
fix(claude-agent-sdk): classify subscription-limit errors so account failover fires

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/auth-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/auth-lane.ts
@@ -182,7 +182,17 @@ function sdkFailure(message: SDKMessage): unknown | undefined {
 	if (message.type === "assistant" && message.error) return message.error;
 	if (message.type === "result" && message.subtype !== "success") {
 		const errors = "errors" in message && Array.isArray(message.errors) ? (message.errors as unknown[]) : [];
-		return new Error(errors.length > 0 ? String(errors[0]) : `Claude Code ${message.subtype}`);
+		if (errors.length > 0) return new Error(String(errors[0]));
+		// `subtype` alone is too coarse to classify: a subscription limit and an
+		// ordinary tool failure both arrive as "error_during_execution". The SDK
+		// carries the real cause in `terminal_reason` (e.g. "blocking_limit"), so
+		// append it — otherwise classifySdkError() scores every result error as
+		// non-retryable "other", the exhausted account is never blocked, and a
+		// multi-account pool never rotates past it.
+		const reason = "terminal_reason" in message && typeof message.terminal_reason === "string"
+			? message.terminal_reason
+			: "";
+		return new Error(reason ? `Claude Code ${message.subtype}: ${reason}` : `Claude Code ${message.subtype}`);
 	}
 	return undefined;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/errors.ts
@@ -46,6 +46,20 @@ export function classifySdkError(error: unknown): SdkErrorClassification {
 	if (/\b(?:http\s*)?429\b|too many requests|rate[ _-]?limit/.test(text)) {
 		return { kind: "rate_limit", retryable: true };
 	}
+	// Claude Code signals subscription exhaustion two ways, neither of which
+	// carries an SDK error code or HTTP status:
+	//   - `terminal_reason: "blocking_limit"` / `"rapid_refill_breaker"` on a
+	//     result message (surfaced by auth-lane's sdkFailure)
+	//   - prose in `errors[0]`, e.g. "You've hit your weekly limit · resets 5am
+	//     (Asia/Seoul)" and the 5-hour/daily equivalents
+	// Without these branches both classify as non-retryable "other", so the
+	// exhausted account is never blocked and a pool never rotates past it.
+	if (/\bblocking_limit\b|\brapid_refill_breaker\b/.test(text)) {
+		return { kind: "rate_limit", retryable: true };
+	}
+	if (/\b(?:hit|reached|exceeded)\b[^.]*\blimit\b|\b(?:weekly|daily|hourly|usage)\s+limit\b/.test(text)) {
+		return { kind: "rate_limit", retryable: true };
+	}
 	if (/\b(?:http\s*)?529\b|overloaded/.test(text)) return { kind: "overloaded", retryable: true };
 	return OTHER_ERROR;
 }

--- a/packages/coding-agent/test/claude-agent-sdk-failover.test.ts
+++ b/packages/coding-agent/test/claude-agent-sdk-failover.test.ts
@@ -52,6 +52,48 @@ describe("Claude Agent SDK failover", () => {
 		expect(classifySdkError("HTTP 529 overloaded")).toEqual({ kind: "overloaded", retryable: true });
 	});
 
+	it("treats Claude Code's prose subscription limits as rate limits", () => {
+		// Real message from the CLI on an exhausted Pro/Max plan: no SDK error code
+		// and no HTTP status, so without prose matching it classified as
+		// non-retryable "other" and the exhausted account was never blocked — a
+		// multi-account pool then never rotated past it.
+		expect(classifySdkError("You've hit your weekly limit \u00b7 resets 5am (Asia/Seoul)")).toEqual({
+			kind: "rate_limit",
+			retryable: true,
+		});
+		expect(classifySdkError("You've reached your 5-hour limit")).toEqual({
+			kind: "rate_limit",
+			retryable: true,
+		});
+		expect(classifySdkError("Daily limit exceeded")).toEqual({ kind: "rate_limit", retryable: true });
+	});
+
+	it("treats SDK terminal_reason limit signals as rate limits", () => {
+		// auth-lane appends `terminal_reason` to result errors because `subtype`
+		// alone reports plain "error_during_execution" for a blocked subscription.
+		expect(classifySdkError("Claude Code error_during_execution: blocking_limit")).toEqual({
+			kind: "rate_limit",
+			retryable: true,
+		});
+		expect(classifySdkError("Claude Code error_during_execution: rapid_refill_breaker")).toEqual({
+			kind: "rate_limit",
+			retryable: true,
+		});
+		expect(classifySdkError("Claude Code error_during_execution: model_error")).toEqual({
+			kind: "other",
+			retryable: false,
+		});
+	});
+
+	it("still treats unrelated errors as non-retryable", () => {
+		// The prose matcher must not swallow ordinary failures into the retry path.
+		expect(classifySdkError("context window exceeded for this request")).toEqual({
+			kind: "other",
+			retryable: false,
+		});
+		expect(classifySdkError("connection reset by peer")).toEqual({ kind: "other", retryable: false });
+	});
+
 	it("walks HRW order after a rate limit, persists the cooldown, and emits failover", async () => {
 		const store = await storeWithAccounts();
 		const sessionId = "failover-session";


### PR DESCRIPTION
## Bug

With multiple Claude accounts registered (`/claude-account add`) and the managed
lane enabled (`claudeAgentSdkProvider.tokenInjection: "oauth-slots"`), an
account that has exhausted its Pro/Max plan is never blocked, so the pool never
rotates past it. Reproduced live on `2026.7.29-6` with two real accounts.

Claude Code signals plan exhaustion two ways, and `classifySdkError()` matched
neither:

1. **Prose thrown from the query iterator** (SDK replaces the exit error):
   `Claude Code returned an error result: You've hit your weekly limit · resets
   5am (Asia/Seoul)` — no `429`, no `rate_limit` token.
2. **Result messages** whose subtype is a bare `error_during_execution`; the
   real cause lives only in `terminal_reason` (e.g. `blocking_limit`), which
   `sdkFailure()` discarded when `errors` was empty.

Both classified as non-retryable `other`, so `runFailover` threw instead of
blocking + rotating.

## Fix

- `errors.ts`: classify `blocking_limit` / `rapid_refill_breaker` and prose
  hit/reached/exceeded-limit messages as retryable `rate_limit`.
- `auth-lane.ts` `sdkFailure()`: append `terminal_reason` to the subtype so the
  classifier can see it. `subtype` alone cannot distinguish a blocked
  subscription from an ordinary tool failure.

Deliberately narrow prose patterns: `context window exceeded for this request`
and similar still classify as non-retryable `other` (covered by tests).

## Validation

- `npx vitest run test/claude-agent-sdk-failover.test.ts test/claude-agent-sdk-auth-lane.test.ts` → 13 passed
- `tsgo --noEmit` clean
- Live after rebuild, two real accounts: exhausted account blocked with
  staggered cooldown (`blockReason: rate_limit`), pool rotated to the second
  account, `AllAccountsBlockedError` guidance when both were blocked, automatic
  retry served the request after cooldown expiry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes error classification in `claude-agent-sdk` so subscription-limit hits are treated as rate limits. This blocks the exhausted account and triggers failover to the next account in the pool.

- **Bug Fixes**
  - Classify `blocking_limit`, `rapid_refill_breaker`, and prose "hit/reached/exceeded limit" messages as retryable `rate_limit`.
  - Include `terminal_reason` in result error messages so the classifier can detect subscription limits.
  - Added tests for these cases; unrelated errors (e.g., context window exceeded) remain non-retryable.

<sup>Written for commit 6d4908e29ccb49b8c31470045c81e136de22a2db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

