### PR TITLE
fix(btw): route side queries through model runtime

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/btw/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/changes.md
@@ -1,5 +1,25 @@
 # changes — btw
 
+## Runtime provider dispatch for side queries (2026-07-30)
+
+### What changed
+
+- `/btw` now passes a stream function backed by `ctx.modelRegistry.modelRuntime`
+  into the side-query runner instead of allowing it to fall back to the compat
+  API registry.
+- Added issue #488 regression coverage with a provider whose API id exists only
+  in Senpi's runtime registry.
+
+### Why
+
+- Providers registered through `pi.registerProvider()` work in the main loop but
+  may not exist in compat's built-in API registry. `/btw` therefore failed before
+  invoking their registered stream implementation.
+
+### Merge-conflict zones
+
+- `index.ts` side-query dependency construction only.
+
 ## Parallel side questions via `/btw` (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/btw/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/index.ts
@@ -97,6 +97,8 @@ export default function btwExtension(pi: ExtensionAPI) {
 						auth: { apiKey: auth.apiKey, headers: auth.headers, extraBody: auth.extraBody },
 						sessionId,
 						thinkingLevel: thinkingLevel === "off" ? undefined : thinkingLevel,
+						streamFn: (streamModel, streamContext, options) =>
+							ctx.modelRegistry.modelRuntime.streamSimple(streamModel, streamContext, options),
 					},
 					context,
 					{

--- a/packages/coding-agent/test/suite/regressions/488-btw-runtime-provider.test.ts
+++ b/packages/coding-agent/test/suite/regressions/488-btw-runtime-provider.test.ts
@@ -1,0 +1,55 @@
+import { createAssistantMessageEventStream, fauxAssistantMessage, type Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import btwExtension from "../../../src/core/extensions/builtin/btw/index.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const PROVIDER_ID = "runtime-only";
+const API_ID = "runtime-only-api";
+
+describe("issue #488: /btw with a runtime-registered provider", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("dispatches the side query through the model runtime", async () => {
+		// Given a provider available only through Senpi's ModelRuntime.
+		harness = await createHarness({ extensionFactories: [btwExtension] });
+		const runtime = harness.modelRegistry.modelRuntime;
+		const model: Model<typeof API_ID> = {
+			...harness.getModel(),
+			api: API_ID,
+			provider: PROVIDER_ID,
+			id: "runtime-model",
+			name: "Runtime-only model",
+			baseUrl: PROVIDER_ID,
+		};
+		let sideQueryCalls = 0;
+		await runtime.registerProvider(PROVIDER_ID, {
+			api: API_ID,
+			apiKey: "runtime-key",
+			baseUrl: PROVIDER_ID,
+			models: [model],
+			streamSimple: () => {
+				sideQueryCalls += 1;
+				const message = fauxAssistantMessage("runtime side answer");
+				const stream = createAssistantMessageEventStream();
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "runtime side answer", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+				stream.end();
+				return stream;
+			},
+		});
+		const registeredModel = runtime.getModel(PROVIDER_ID, model.id);
+		if (!registeredModel) throw new Error("runtime-only model was not registered");
+		await harness.session.setModel(registeredModel);
+
+		// When the user asks a side question.
+		await harness.session.prompt("/btw what did we discuss?");
+
+		// Then the runtime provider handles the request instead of compat rejecting its API id.
+		expect(sideQueryCalls).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

- route `/btw` side-query streams through Senpi's `ModelRuntime`
- preserve the existing generic side-query runner while supplying the same provider dispatch path used by the main loop
- add issue-shaped regression coverage for an API id registered only in the runtime

## Why

`/btw` resolved authentication through the model runtime but omitted its stream function. The side-query runner therefore fell back to compat `streamSimple`, whose built-in API registry does not contain providers registered through `pi.registerProvider()`. Runtime-only providers failed before their registered stream implementation could run.

## Verification

- RED: issue regression failed with runtime provider call count `0`, expected `1`
- GREEN: issue regression passed (`1/1`)
- scoped BTW suite: `2` files, `12` tests passed
- `npm run check`: exit `0`
- Senpi QA isolation self-check: `9/9` passed
- real CLI mock-loop self-test: `43/43` passed, zero real provider calls, real auth unchanged
- evidence: `local-ignore/qa-evidence/20260730-btw-runtime-provider/`

Fixes #488


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `/btw` side-query streams through the runtime provider path to match the main loop and fix failures with runtime-only providers. Fixes #488.

- **Bug Fixes**
  - Inject `streamFn` from `ctx.modelRegistry.modelRuntime.streamSimple` into the side-query runner; no compat fallback.
  - Keep the existing side-query runner; only change the dispatch path.
  - Add regression test for a runtime-only API id to ensure the provider’s stream is called.

<sup>Written for commit ff48536d16a85d370c08c42d31061e571aaa5751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

