### PR TITLE
fix(devenv): run npm on Windows

### DIFF
--- a/scripts/devenv-setup.mjs
+++ b/scripts/devenv-setup.mjs
@@ -89,7 +89,7 @@ function hasCmd(cmd) {
 
 function npm(cwd, npmArgs) {
 	const bin = isWindows ? "npm.cmd" : "npm";
-	execFileSync(bin, npmArgs, { cwd, stdio: "inherit" });
+	execFileSync(bin, npmArgs, { cwd, stdio: "inherit", shell: isWindows });
 }
 
 function run(cmd, cmdArgs, options = {}) {
@@ -135,8 +135,10 @@ function installDeps() {
 		log("Installing senpi-qa skill deps (node-pty for cross-platform TUI QA)...");
 		try {
 			npm(skillDir, ["install", "--no-audit", "--no-fund"]);
-		} catch {
-			warn("senpi-qa skill deps failed to install (node-pty native build). TUI QA falls back to tmux on POSIX.");
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			const fallback = isWindows ? "" : " TUI QA can fall back to tmux on POSIX.";
+			warn(`senpi-qa skill deps failed to install: ${detail}.${fallback}`);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Windows bootstrap failed because Node no longer directly spawns `npm.cmd` after the CVE-2024-27980 hardening. This change runs npm through the shell only on Windows, while preserving direct execution on POSIX.

The optional senpi-qa dependency install now reports the actual caught error and only mentions the tmux fallback on POSIX, rather than always claiming a node-pty native build failure.

## Changes

- Set `shell: true` only for the Windows `npm.cmd` invocation used by workspace and senpi-qa dependency installation.
- Include the underlying npm error in the senpi-qa warning.
- Omit the POSIX-only tmux fallback message on Windows.

## Validation

- **RED regression proof:** simulated the `win32` npm helper path before the fix; expected `options.shell === true`, observed `undefined`.
- **GREEN regression proof:** repeated the same simulation after the fix; 1/1 assertion passed.
- **Error reporting scenario:** injected a failing npm executable; the setup output included the simulated npm failure and the caught command failure rather than attributing it to node-pty.
- `node scripts/devenv-setup.mjs` on macOS: passed and installed the senpi-qa dependencies successfully.
- `npm run test:scripts`: 72/72 passed.
- `npm run check`: passed.
- `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`: 9/9 passed.
- `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`: 8/8 passed with real auth unchanged.

Evidence was captured under `local-ignore/qa-evidence/20260730-issue-454/` and remains intentionally uncommitted.

## Environment surface sync

No `.devcontainer/devcontainer.json` change is required. This fix does not change dependencies, the Node version, provider/environment variables, QA channels, build commands, or forwarded ports; it only corrects platform-specific process spawning and error reporting inside the existing setup entry point.

Fixes #454


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows bootstrap by running `npm` through the shell on Windows, restoring workspace and `senpi-qa` dependency installs after CVE-2024-27980 hardening. Also improves `senpi-qa` install errors and avoids the POSIX-only tmux fallback message on Windows.

- **Bug Fixes**
  - Spawn `npm.cmd` with `shell: true` on Windows; keep direct exec on POSIX.
  - Show the actual `npm` error in `senpi-qa` install warnings.
  - Only mention the tmux fallback on POSIX.

<sup>Written for commit 0a20425efcaa7167a3d327f8557dd73eb065f6ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

