### PR TITLE
fix(coding-agent): preserve Bun launcher after update

### DIFF
--- a/packages/coding-agent/src/bun-global-launcher.ts
+++ b/packages/coding-agent/src/bun-global-launcher.ts
@@ -8,11 +8,11 @@ export interface BunLauncherRepairCommand {
 
 const BUN_LAUNCHER_REPAIR_SOURCE = `
 import { renameSync, writeFileSync } from "node:fs";
-const [launcher, bunPath, entrypoint] = process.argv.slice(1);
-if (!launcher || !bunPath || !entrypoint) throw new Error("Missing Bun launcher repair path");
+const [launcher, entrypoint] = process.argv.slice(1);
+if (!launcher || !entrypoint) throw new Error("Missing Bun launcher repair path");
 const quote = (value) => "'" + value.replaceAll("'", "'\\"'\\"'") + "'";
 const temporary = launcher + "." + process.pid + ".tmp";
-writeFileSync(temporary, "#!/bin/sh\\nexec " + quote(bunPath) + " " + quote(entrypoint) + " \\"$@\\"\\n", { mode: 0o755 });
+writeFileSync(temporary, "#!/bin/sh\\nexec " + quote(process.execPath) + " " + quote(entrypoint) + " \\"$@\\"\\n", { mode: 0o755 });
 renameSync(temporary, launcher);
 `.trim();
 
@@ -23,11 +23,10 @@ export function createBunLauncherRepairCommand(
 ): BunLauncherRepairCommand {
 	const packageDir = join(dirname(binDir), "install", "global", "node_modules", ...packageName.split("/"));
 	const launcher = join(binDir, executableName);
-	const bunPath = join(binDir, process.platform === "win32" ? "bun.exe" : "bun");
 	const entrypoint = join(packageDir, "dist", "cli.js");
 	return {
 		command: "bun",
-		args: ["-e", BUN_LAUNCHER_REPAIR_SOURCE, launcher, bunPath, entrypoint],
+		args: ["-e", BUN_LAUNCHER_REPAIR_SOURCE, launcher, entrypoint],
 		display: `repair Bun launcher ${launcher}`,
 	};
 }

--- a/packages/coding-agent/src/bun-global-launcher.ts
+++ b/packages/coding-agent/src/bun-global-launcher.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from "node:path";
+
+export interface BunLauncherRepairCommand {
+	readonly command: string;
+	readonly args: string[];
+	readonly display: string;
+}
+
+const BUN_LAUNCHER_REPAIR_SOURCE = `
+import { renameSync, writeFileSync } from "node:fs";
+const [launcher, bunPath, entrypoint] = process.argv.slice(1);
+if (!launcher || !bunPath || !entrypoint) throw new Error("Missing Bun launcher repair path");
+const quote = (value) => "'" + value.replaceAll("'", "'\\"'\\"'") + "'";
+const temporary = launcher + "." + process.pid + ".tmp";
+writeFileSync(temporary, "#!/bin/sh\\nexec " + quote(bunPath) + " " + quote(entrypoint) + " \\"$@\\"\\n", { mode: 0o755 });
+renameSync(temporary, launcher);
+`.trim();
+
+export function createBunLauncherRepairCommand(
+	binDir: string,
+	packageName: string,
+	executableName: string,
+): BunLauncherRepairCommand {
+	const packageDir = join(dirname(binDir), "install", "global", "node_modules", ...packageName.split("/"));
+	const launcher = join(binDir, executableName);
+	const bunPath = join(binDir, process.platform === "win32" ? "bun.exe" : "bun");
+	const entrypoint = join(packageDir, "dist", "cli.js");
+	return {
+		command: "bun",
+		args: ["-e", BUN_LAUNCHER_REPAIR_SOURCE, launcher, bunPath, entrypoint],
+		display: `repair Bun launcher ${launcher}`,
+	};
+}

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,9 @@
+## Bun self-updates preserve the Bun launcher (2026-07-30)
+
+- Bun-managed global self-updates now replace Bun's generated Node-shebang symlink with a small launcher that
+  executes the updated `dist/cli.js` through the Bun binary in the same global bin directory.
+- Coverage: `test/suite/regressions/496-bun-launcher-self-update.test.ts`.
+
 ## Kimi XTML recovery preserves protocol identity (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,7 +1,11 @@
 ## Bun self-updates preserve the Bun launcher (2026-07-30)
 
 - Bun-managed global self-updates now replace Bun's generated Node-shebang symlink with a small launcher that
-  executes the updated `dist/cli.js` through the Bun binary in the same global bin directory.
+  executes the updated `dist/cli.js` through the Bun runtime that performed the repair.
+- The repair uses the Bun runtime's own `process.execPath`, supports Bun binaries installed outside the global bin
+  directory, and is skipped on Windows where Bun uses platform-specific shims.
+- If `bun pm bin -g` does not return a global bin directory, self-update is now rejected instead of installing
+  without a launcher repair.
 - Coverage: `test/suite/regressions/496-bun-launcher-self-update.test.ts`.
 
 ## Kimi XTML recovery preserves protocol identity (2026-07-29)

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -2,6 +2,7 @@ import { accessSync, constants, existsSync, readFileSync, realpathSync } from "f
 import { homedir } from "os";
 import { basename, dirname, join, resolve, sep, win32 } from "path";
 import { fileURLToPath } from "url";
+import { createBunLauncherRepairCommand } from "./bun-global-launcher.ts";
 import { findNearestParentConfigDir } from "./nearest-parent-config.ts";
 import { spawnProcessSync } from "./utils/child-process.ts";
 import { normalizePath } from "./utils/paths.ts";
@@ -54,12 +55,18 @@ function normalizeSelfUpdatePackageTarget(target: SelfUpdatePackageTarget): {
 function makeSelfUpdateCommand(
 	installStep: SelfUpdateCommandStep,
 	uninstallStep?: SelfUpdateCommandStep,
+	postInstallStep?: SelfUpdateCommandStep,
 ): SelfUpdateCommand {
-	if (!uninstallStep) return installStep;
+	const steps = [
+		...(uninstallStep ? [uninstallStep] : []),
+		installStep,
+		...(postInstallStep ? [postInstallStep] : []),
+	];
+	if (steps.length === 1) return installStep;
 	return {
 		...installStep,
-		display: `${uninstallStep.display} && ${installStep.display}`,
-		steps: [uninstallStep, installStep],
+		display: steps.map((step) => step.display).join(" && "),
+		steps,
 	};
 }
 
@@ -151,7 +158,9 @@ function getSelfUpdateCommandForMethod(
 					? undefined
 					: makeSelfUpdateCommandStep("yarn", ["global", "remove", installedPackageName]),
 			);
-		case "bun":
+		case "bun": {
+			const binDir = readCommandOutput("bun", ["pm", "bin", "-g"]);
+			if (!binDir) return undefined;
 			return makeSelfUpdateCommand(
 				makeSelfUpdateCommandStep("bun", [
 					"install",
@@ -163,7 +172,9 @@ function getSelfUpdateCommandForMethod(
 				target.packageName === installedPackageName
 					? undefined
 					: makeSelfUpdateCommandStep("bun", ["uninstall", "-g", installedPackageName]),
+				createBunLauncherRepairCommand(binDir, target.packageName, APP_NAME),
 			);
+		}
 		case "npm": {
 			const [command = "npm", ...npmArgs] = npmCommand ?? [];
 			const inferred = npmCommand?.length ? undefined : getInferredNpmInstall();

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -172,7 +172,9 @@ function getSelfUpdateCommandForMethod(
 				target.packageName === installedPackageName
 					? undefined
 					: makeSelfUpdateCommandStep("bun", ["uninstall", "-g", installedPackageName]),
-				createBunLauncherRepairCommand(binDir, target.packageName, APP_NAME),
+				process.platform === "win32"
+					? undefined
+					: createBunLauncherRepairCommand(binDir, target.packageName, APP_NAME),
 			);
 		}
 		case "npm": {

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/config.ts";
 
 const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 const originalPath = process.env.PATH;
 const originalPiPackageDir = process.env.PI_PACKAGE_DIR;
 const originalArgv1 = process.argv[1];
@@ -25,6 +26,9 @@ function setExecPath(value: string): void {
 afterEach(() => {
 	if (execPathDescriptor) {
 		Object.defineProperty(process, "execPath", execPathDescriptor);
+	}
+	if (platformDescriptor) {
+		Object.defineProperty(process, "platform", platformDescriptor);
 	}
 	if (originalPath === undefined) {
 		delete process.env.PATH;
@@ -314,9 +318,25 @@ describe("detectInstallMethod", () => {
 				},
 				{
 					command: "bun",
-					args: ["-e", expect.any(String), expect.any(String), expect.any(String), expect.any(String)],
+					args: ["-e", expect.any(String), expect.any(String), expect.any(String)],
 				},
 			],
+		});
+	});
+
+	test("does not append the POSIX Bun launcher repair on Windows", () => {
+		createBunGlobalInstall();
+		Object.defineProperty(process, "platform", {
+			value: "win32",
+			configurable: true,
+		});
+
+		const command = getSelfUpdateCommand("@earendil-works/pi-coding-agent");
+
+		expect(command).toEqual({
+			command: "bun",
+			args: ["install", "-g", "--ignore-scripts", "--minimum-release-age=0", "@earendil-works/pi-coding-agent"],
+			display: "bun install -g --ignore-scripts --minimum-release-age=0 @earendil-works/pi-coding-agent",
 		});
 	});
 
@@ -434,7 +454,7 @@ describe("detectInstallMethod", () => {
 				},
 				{
 					command: "bun",
-					args: ["-e", expect.any(String), expect.any(String), expect.any(String), expect.any(String)],
+					args: ["-e", expect.any(String), expect.any(String), expect.any(String)],
 				},
 			],
 		});

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -292,16 +292,31 @@ describe("detectInstallMethod", () => {
 		);
 	});
 
-	test("self-updates bun global installs from bun pm bin", () => {
+	test("self-updates bun global installs from bun pm bin and repairs the launcher", () => {
 		createBunGlobalInstall();
 
 		const command = getSelfUpdateCommand("@earendil-works/pi-coding-agent");
 
 		expect(detectInstallMethod()).toBe("bun");
-		expect(command).toEqual({
+		expect(command).toMatchObject({
 			command: "bun",
 			args: ["install", "-g", "--ignore-scripts", "--minimum-release-age=0", "@earendil-works/pi-coding-agent"],
-			display: "bun install -g --ignore-scripts --minimum-release-age=0 @earendil-works/pi-coding-agent",
+			steps: [
+				{
+					command: "bun",
+					args: [
+						"install",
+						"-g",
+						"--ignore-scripts",
+						"--minimum-release-age=0",
+						"@earendil-works/pi-coding-agent",
+					],
+				},
+				{
+					command: "bun",
+					args: ["-e", expect.any(String), expect.any(String), expect.any(String), expect.any(String)],
+				},
+			],
 		});
 	});
 
@@ -405,21 +420,21 @@ describe("detectInstallMethod", () => {
 		const command = getSelfUpdateCommand("@code-yeongyu/senpi", undefined, "@new-scope/pi");
 
 		expect(detectInstallMethod()).toBe("bun");
-		expect(command).toEqual({
+		expect(command).toMatchObject({
 			command: "bun",
 			args: ["install", "-g", "--ignore-scripts", "--minimum-release-age=0", "@new-scope/pi"],
-			display:
-				"bun uninstall -g @code-yeongyu/senpi && bun install -g --ignore-scripts --minimum-release-age=0 @new-scope/pi",
 			steps: [
 				{
 					command: "bun",
 					args: ["uninstall", "-g", "@code-yeongyu/senpi"],
-					display: "bun uninstall -g @code-yeongyu/senpi",
 				},
 				{
 					command: "bun",
 					args: ["install", "-g", "--ignore-scripts", "--minimum-release-age=0", "@new-scope/pi"],
-					display: "bun install -g --ignore-scripts --minimum-release-age=0 @new-scope/pi",
+				},
+				{
+					command: "bun",
+					args: ["-e", expect.any(String), expect.any(String), expect.any(String), expect.any(String)],
 				},
 			],
 		});

--- a/packages/coding-agent/test/suite/regressions/496-bun-launcher-self-update.test.ts
+++ b/packages/coding-agent/test/suite/regressions/496-bun-launcher-self-update.test.ts
@@ -75,5 +75,5 @@ test("preserves Bun execution when a Bun global self-update replaces the launche
 	// Then: the launcher is a Bun wrapper rather than the Node entrypoint symlink.
 	expect(result.status, result.stderr).toBe(0);
 	expect(lstatSync(launcher).isSymbolicLink()).toBe(false);
-	expect(readFileSync(launcher, "utf8")).toContain(`exec '${fakeBun}' '${entrypoint}' "$@"`);
+	expect(readFileSync(launcher, "utf8")).toContain(`exec '${originalExecPath}' '${entrypoint}' "$@"`);
 });

--- a/packages/coding-agent/test/suite/regressions/496-bun-launcher-self-update.test.ts
+++ b/packages/coding-agent/test/suite/regressions/496-bun-launcher-self-update.test.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { getSelfUpdateCommand } from "../../../src/config.ts";
+
+const originalExecPath = process.execPath;
+const originalPath = process.env.PATH;
+const originalPackageDir = process.env.PI_PACKAGE_DIR;
+let fixtureRoot: string | undefined;
+
+afterEach(() => {
+	Object.defineProperty(process, "execPath", {
+		value: originalExecPath,
+		configurable: true,
+	});
+	if (originalPath === undefined) {
+		delete process.env.PATH;
+	} else {
+		process.env.PATH = originalPath;
+	}
+	if (originalPackageDir === undefined) {
+		delete process.env.PI_PACKAGE_DIR;
+	} else {
+		process.env.PI_PACKAGE_DIR = originalPackageDir;
+	}
+	if (fixtureRoot) {
+		rmSync(fixtureRoot, { recursive: true, force: true });
+		fixtureRoot = undefined;
+	}
+});
+
+test("preserves Bun execution when a Bun global self-update replaces the launcher with a Node symlink", () => {
+	// Given: a Bun global package whose install step leaves a Node-shebang symlink.
+	fixtureRoot = mkdtempSync(join(tmpdir(), "senpi-496-bun-launcher-"));
+	const bunRoot = join(fixtureRoot, ".bun");
+	const binDir = join(bunRoot, "bin");
+	const packageDir = join(bunRoot, "install", "global", "node_modules", "@code-yeongyu", "senpi");
+	const entrypoint = join(packageDir, "dist", "cli.js");
+	const launcher = join(binDir, "senpi");
+	mkdirSync(join(packageDir, "dist"), { recursive: true });
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(entrypoint, "#!/usr/bin/env node\n");
+	symlinkSync(entrypoint, launcher);
+	const fakeBun = join(binDir, "bun");
+	writeFileSync(
+		fakeBun,
+		`#!/bin/sh\nif [ "$1" = "pm" ] && [ "$2" = "bin" ] && [ "$3" = "-g" ]; then printf '%s\\n' '${binDir}'; exit 0; fi\nexit 1\n`,
+	);
+	chmodSync(fakeBun, 0o755);
+	process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	Object.defineProperty(process, "execPath", {
+		value: entrypoint,
+		configurable: true,
+	});
+
+	// When: the updater constructs and executes its post-install launcher repair.
+	const command = getSelfUpdateCommand("@code-yeongyu/senpi");
+	const steps = command?.steps ?? (command ? [command] : []);
+	const repairStep = steps.at(-1);
+	expect(repairStep?.args[0]).toBe("-e");
+	const result = spawnSync(originalExecPath, repairStep?.args ?? [], { encoding: "utf8" });
+
+	// Then: the launcher is a Bun wrapper rather than the Node entrypoint symlink.
+	expect(result.status, result.stderr).toBe(0);
+	expect(lstatSync(launcher).isSymbolicLink()).toBe(false);
+	expect(readFileSync(launcher, "utf8")).toContain(`exec '${fakeBun}' '${entrypoint}' "$@"`);
+});


### PR DESCRIPTION
## Summary

- detect Bun's global bin directory before constructing a self-update
- append a post-install repair step that atomically replaces Bun's Node-shebang symlink
- generate a launcher that executes the updated CLI through the Bun binary beside it

## Regression coverage

The issue regression creates the exact broken post-update shape: a Bun global
package whose `senpi` launcher is a symlink to a `#!/usr/bin/env node`
entrypoint. It executes the planned repair and verifies that the launcher
becomes an executable Bun wrapper.

### TDD

RED:

```text
AssertionError: expected 'install' to be '-e'
Expected: "-e"
Received: "install"
```

GREEN:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

## Verification

- `npm test -- test/config.test.ts test/self-update-bootstrap.test.ts test/suite/regressions/496-bun-launcher-self-update.test.ts`
  - 3 files passed, 19 tests passed
- `npm run check`
  - exit 0
- `.agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`
  - 8/8 passed
  - receipt: `local-ignore/qa-evidence/20260730-bun-launcher-self-update/cli-smoke.txt`

Fixes #496

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the global `bun` launcher after self-update by replacing the Node-shebang symlink with a small POSIX wrapper that execs the same `bun` runtime. Fixes #496 and restores CLI execution for `bun` global installs.

- **Bug Fixes**
  - Detects `bun`’s global bin dir via `bun pm bin -g`; aborts self-update if not found.
  - Adds a post-install repair that atomically swaps in a shell launcher running updated `dist/cli.js` with `bun`’s own `process.execPath` (safe quoting, supports `bun` outside the bin dir); skipped on Windows.
  - Adds a regression test that reproduces the broken launcher and verifies the repair, plus unit tests for Windows behavior.

<sup>Written for commit 932fc83309e0c8c4bcdb5541c93f6f451e29f4e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

