### PR TITLE
fix(config-reload): offload recursive Linux watchers

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-engine.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-engine.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import { lstatSync, readdirSync, readFileSync, type Stats } from "node:fs";
 import { basename, isAbsolute, join, normalize, resolve, sep } from "node:path";
-import { watchWithErrorHandler } from "../../../../utils/fs-watch.ts";
+
+export { createFsWatchEventSource } from "./watch-event-source.ts";
 
 export type WatchTarget = {
 	readonly id: string;
@@ -363,19 +364,6 @@ export class ConfigReloadWatchEngine {
 			// Error reporting must not take down the watcher.
 		}
 	}
-}
-
-/** Production event source. Tests inject a deterministic source instead. */
-export function createFsWatchEventSource(onError: (error: unknown, path: string) => void = () => {}): WatchEventSource {
-	return (path, listener, options) => {
-		const watcher = watchWithErrorHandler(
-			path,
-			listener,
-			() => onError(new Error(`fs.watch failed for ${path}`), path),
-			{ recursive: options?.recursive ?? false },
-		);
-		return () => watcher?.close();
-	};
 }
 
 function hashFile(path: string): string {

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
@@ -1,0 +1,141 @@
+import { Worker } from "node:worker_threads";
+import { watchWithErrorHandler } from "../../../../utils/fs-watch.ts";
+import type { WatchEventListener, WatchEventSource } from "./watch-engine.ts";
+
+export interface RecursiveWatchWorker {
+	on(event: "message", listener: (message: unknown) => void): this;
+	on(event: "error", listener: (error: Error) => void): this;
+	postMessage(message: unknown): void;
+	terminate(): Promise<number>;
+}
+
+export type RecursiveWatchWorkerFactory = () => RecursiveWatchWorker;
+
+export type FsWatchEventSourceOptions = {
+	readonly platform?: NodeJS.Platform;
+	readonly createRecursiveWorker?: RecursiveWatchWorkerFactory;
+};
+
+type RecursiveWatchMessage =
+	| { readonly kind: "event"; readonly id: number; readonly eventType: string; readonly filename: string | null }
+	| { readonly kind: "error"; readonly id: number; readonly message: string };
+
+const RECURSIVE_WATCH_WORKER_SOURCE = `
+const { watch } = require("node:fs");
+const { parentPort } = require("node:worker_threads");
+
+if (!parentPort) throw new Error("Recursive watch worker requires a parent port");
+
+const watchers = new Map();
+parentPort.on("message", (message) => {
+	if (message.kind === "unwatch") {
+		watchers.get(message.id)?.close();
+		watchers.delete(message.id);
+		return;
+	}
+	if (message.kind !== "watch") return;
+	try {
+		const watcher = watch(
+			message.path,
+			{ recursive: true, encoding: "utf8" },
+			(eventType, filename) => {
+				parentPort.postMessage({
+					kind: "event",
+					id: message.id,
+					eventType,
+					filename: typeof filename === "string" ? filename : null,
+				});
+			},
+		);
+		watcher.on("error", (error) => {
+			parentPort.postMessage({
+				kind: "error",
+				id: message.id,
+				message: error instanceof Error ? error.message : String(error),
+			});
+		});
+		watchers.set(message.id, watcher);
+	} catch (error) {
+		parentPort.postMessage({
+			kind: "error",
+			id: message.id,
+			message: error instanceof Error ? error.message : String(error),
+		});
+	}
+});
+`;
+
+function createRecursiveWatchWorker(): RecursiveWatchWorker {
+	return new Worker(RECURSIVE_WATCH_WORKER_SOURCE, {
+		eval: true,
+	});
+}
+
+function isRecursiveWatchMessage(message: unknown): message is RecursiveWatchMessage {
+	if (typeof message !== "object" || message === null || !("kind" in message)) return false;
+	if (!("id" in message) || typeof message.id !== "number") return false;
+	if (message.kind === "error") return "message" in message && typeof message.message === "string";
+	return (
+		message.kind === "event" &&
+		"eventType" in message &&
+		typeof message.eventType === "string" &&
+		"filename" in message &&
+		(message.filename === null || typeof message.filename === "string")
+	);
+}
+
+/** Production event source. Linux recursive setup runs off the interactive main thread. */
+export function createFsWatchEventSource(
+	onError: (error: unknown, path: string) => void = () => {},
+	options: FsWatchEventSourceOptions = {},
+): WatchEventSource {
+	const recursiveSubscriptions = new Map<number, { readonly path: string; readonly listener: WatchEventListener }>();
+	let recursiveWorker: RecursiveWatchWorker | undefined;
+	let nextSubscriptionId = 1;
+
+	const ensureRecursiveWorker = (): RecursiveWatchWorker => {
+		if (recursiveWorker) return recursiveWorker;
+		const worker = (options.createRecursiveWorker ?? createRecursiveWatchWorker)();
+		worker.on("message", (message) => {
+			if (!isRecursiveWatchMessage(message)) return;
+			const subscription = recursiveSubscriptions.get(message.id);
+			if (!subscription) return;
+			if (message.kind === "event") {
+				subscription.listener(message.eventType, message.filename);
+				return;
+			}
+			onError(new Error(message.message), subscription.path);
+		});
+		worker.on("error", (error) => {
+			for (const subscription of recursiveSubscriptions.values()) onError(error, subscription.path);
+		});
+		recursiveWorker = worker;
+		return worker;
+	};
+
+	return (path, listener, watchOptions) => {
+		if ((options.platform ?? process.platform) === "linux" && watchOptions?.recursive) {
+			const id = nextSubscriptionId++;
+			const worker = ensureRecursiveWorker();
+			recursiveSubscriptions.set(id, { path, listener });
+			worker.postMessage({ kind: "watch", id, path });
+			return () => {
+				if (!recursiveSubscriptions.delete(id)) return;
+				if (recursiveSubscriptions.size > 0) {
+					worker.postMessage({ kind: "unwatch", id });
+					return;
+				}
+				recursiveWorker = undefined;
+				void worker.terminate().catch((error: unknown) => onError(error, path));
+			};
+		}
+
+		const watcher = watchWithErrorHandler(
+			path,
+			listener,
+			() => onError(new Error(`fs.watch failed for ${path}`), path),
+			{ recursive: watchOptions?.recursive ?? false },
+		);
+		return () => watcher?.close();
+	};
+}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,25 @@
 # Core Extensions Changes
 
+## 2026-07-30 - Linux recursive config watches leave the interactive main thread
+
+### What changed and why
+
+- `builtin/config-reload/watch-event-source.ts` now routes Linux recursive `fs.watch` subscriptions through one
+  session-local worker thread, while non-recursive config file/directory subscriptions keep the existing direct
+  watcher path. The worker owns setup, reconciliation, and event delivery for every recursive target registered by
+  that config-reload instance.
+- This preserves recursive config/resource reload behavior and avoids one worker per target, but keeps Node's
+  expensive recursive directory enumeration off the TUI event loop. Issue #477 captured 350,387 inotify watches and
+  a V8 profile dominated by `node:internal/fs/recursive_watch`, `readdir`, and path normalization while terminal input
+  was frozen.
+- `test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts` asserts the backend choice directly: Linux
+  recursive targets share the worker, and non-recursive targets still call `fs.watch` with `recursive: false`.
+
+### Expected merge conflict zones
+
+- LOW: `builtin/config-reload/watch-engine.ts` now re-exports the production event source from its dedicated module.
+- NONE: the new worker-backed event source is fork-owned and does not change the public `config-watch:*` protocol.
+
 ## 2026-07-29 - Reload veto probe on ExtensionContext + quiet config-reload deferral
 
 ### What changed and why

--- a/packages/coding-agent/test/config-reload-watch-engine.test.ts
+++ b/packages/coding-agent/test/config-reload-watch-engine.test.ts
@@ -327,7 +327,10 @@ describe("config reload watch engine", () => {
 		mocks.fsWatch.mockClear();
 		createEngine({
 			targets: [{ id: "settings", kind: "dir-recursive", path: tempDir, allowList: ["settings.json"] }],
-			subscribe: createFsWatchEventSource(),
+			// Pin the direct fs.watch backend: on Linux the production source routes
+			// recursive watches through a worker thread (issue #477), which is covered
+			// by test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts.
+			subscribe: createFsWatchEventSource(undefined, { platform: "darwin" }),
 			onRealChange: (change) => {
 				if (change.changedPaths.includes(settingsPath)) resolveSettingsChange?.(change);
 			},

--- a/packages/coding-agent/test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createFsWatchEventSource,
+	type WatchEventListener,
+} from "../../../src/core/extensions/builtin/config-reload/watch-engine.ts";
+
+const mocks = vi.hoisted(() => ({ fsWatch: vi.fn() }));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, watch: mocks.fsWatch };
+});
+
+class WatcherProbe extends EventEmitter {
+	readonly close = vi.fn();
+}
+
+class WorkerProbe extends EventEmitter {
+	readonly postMessage = vi.fn();
+	readonly terminate = vi.fn(async () => 0);
+}
+
+describe("issue #477 recursive watch main-thread stall", () => {
+	beforeEach(() => {
+		mocks.fsWatch.mockReset();
+	});
+
+	it("offloads Linux recursive watch setup instead of calling fs.watch on the main thread", () => {
+		const worker = new WorkerProbe();
+		const createRecursiveWorker = vi.fn(() => worker);
+		const listener = vi.fn<WatchEventListener>();
+		const source = createFsWatchEventSource(vi.fn(), {
+			platform: "linux",
+			createRecursiveWorker,
+		});
+
+		const unsubscribe = source("/large-workspace-mount", listener, { recursive: true });
+		const unsubscribeSecond = source("/another-config-root", vi.fn(), { recursive: true });
+		worker.emit("message", { kind: "event", id: 1, eventType: "change", filename: ".omo/omo.json" });
+
+		expect(createRecursiveWorker).toHaveBeenCalledTimes(1);
+		expect(worker.postMessage).toHaveBeenCalledWith({
+			kind: "watch",
+			id: 1,
+			path: "/large-workspace-mount",
+		});
+		expect(worker.postMessage).toHaveBeenCalledWith({
+			kind: "watch",
+			id: 2,
+			path: "/another-config-root",
+		});
+		expect(mocks.fsWatch).not.toHaveBeenCalled();
+		expect(listener).toHaveBeenCalledWith("change", ".omo/omo.json");
+
+		unsubscribe();
+		expect(worker.terminate).not.toHaveBeenCalled();
+		unsubscribeSecond();
+		expect(worker.terminate).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps non-recursive config file watches on direct fs.watch", () => {
+		const watcher = new WatcherProbe();
+		mocks.fsWatch.mockReturnValue(watcher);
+		const createRecursiveWorker = vi.fn(() => new WorkerProbe());
+		const source = createFsWatchEventSource(vi.fn(), {
+			platform: "linux",
+			createRecursiveWorker,
+		});
+
+		const unsubscribe = source("/small-config-directory", vi.fn(), { recursive: false });
+
+		expect(mocks.fsWatch).toHaveBeenCalledWith(
+			"/small-config-directory",
+			expect.objectContaining({ recursive: false }),
+			expect.any(Function),
+		);
+		expect(createRecursiveWorker).not.toHaveBeenCalled();
+
+		unsubscribe();
+		expect(watcher.close).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- route Linux recursive config-reload subscriptions through a worker thread instead of calling `fs.watch({ recursive: true })` on the interactive Node main thread
- share one worker across all recursive targets in a config-reload instance, avoiding one V8 isolate per target
- preserve the existing direct `fs.watch` path for non-recursive config file and directory watches
- add an issue-shaped regression that asserts the backend and recursive options chosen without relying on wall-clock timing

## Why this approach

Issue #477 captured a 20-second profile with only 0.2% idle/program time while the TUI was frozen:

- `readdir`: 21.7% self time
- `node:internal/fs/recursive_watch#watchFolder`: 17.3%
- path normalization/join/relative/resolve: about 55% combined
- 350,387 inotify watches across 8 resolved targets

Node performs recursive watch setup synchronously. Moving that setup and its recursive reconciliation into a dedicated worker keeps the interactive event loop responsive without weakening config-reload coverage or changing the public `config-watch:*` protocol. A single worker owns all recursive targets for the session; non-recursive targets remain direct and lightweight.

This is deliberately the smallest semantic-preserving fix. It removes the main-thread stall reported by the profile; it does not attempt to reinterpret extension watch filters or change which paths third-party registrations request.

## TDD evidence

RED before implementation:

```text
FAIL  477-recursive-watch-main-thread-stall.test.ts
AssertionError: expected "vi.fn()" to be called with arguments: [ '/large-workspace-mount' ]
Number of calls: 0
```

GREEN after implementation:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
Duration    819ms
```

## Validation

- `npm test -- test/config-reload-watch-engine.test.ts test/suite/config-reload-extension.test.ts test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts`
  - 3 files passed, 63 tests passed
- `npm run check`
  - exit 0
- Senpi QA common self-check
  - 9/9 passed
- real TUI smoke through tmux
  - 5/5 passed; booted, rendered, accepted a composer keystroke, and cleaned up
- actual worker-path probe
  - forced the Linux backend against a missing path and received the expected worker error callback within a bounded timeout
- evidence: `local-ignore/qa-evidence/20260730-issue-477-recursive-watch/`

An additional full coding-agent `npm test` run was attempted. The watcher-related scoped files remained green, while unrelated suites failed because workspace `dist` modules were not built in the fresh worktree and an inspector endpoint handoff timed out. The required scoped suite and static validation above pass.

Fixes #477

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Linux recursive config-reload watchers off the Node main thread into a single worker to prevent TUI stalls during setup. Non-recursive watches stay direct. Fixes #477.

- **Bug Fixes**
  - Route Linux recursive `fs.watch` through a shared worker; keep setup and reconciliation off the interactive loop.
  - Preserve direct `fs.watch` for non-recursive targets.
  - Add a Linux regression test for the worker path and pin the production adapter test to the direct backend (`platform: "darwin"`) for CI stability.
  - No changes to the public `config-watch:*` protocol.

<sup>Written for commit 84e2533bb928169efb2577b2857fa3d9ecea4d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

