### PR TITLE
fix(claude-agent-sdk): stop denied tool retries

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/changes.md
@@ -3,7 +3,7 @@
 ## 2026-07-30 - Terminal pre-execution denial for host-captured tools (#494)
 
 - Added an SDK `PreToolUse` hook for the six native Claude Code tools and `mcp__custom-tools__*`.
-- The hook denies before Claude Code permission handling or safe-command execution with a terminal instruction not to retry.
+- The hook denies before Claude Code permission handling or safe-command execution and terminates SDK processing via top-level `continue: false` alongside its terminal do-not-retry instruction.
 - Senpi still captures the streamed tool call and executes it through its own validation, hook, and permission pipeline.
 - Merge-conflict risk: low. Expected conflict zones are the query options and tool denial constants.
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/changes.md
@@ -1,5 +1,12 @@
 # claude-agent-sdk extension changes
 
+## 2026-07-30 - Terminal pre-execution denial for host-captured tools (#494)
+
+- Added an SDK `PreToolUse` hook for the six native Claude Code tools and `mcp__custom-tools__*`.
+- The hook denies before Claude Code permission handling or safe-command execution with a terminal instruction not to retry.
+- Senpi still captures the streamed tool call and executes it through its own validation, hook, and permission pipeline.
+- Merge-conflict risk: low. Expected conflict zones are the query options and tool denial constants.
+
 ## 2026-07-27 - Initial builtin provider
 
 - New builtin extension: Claude Agent SDK provider with native multi-account OAuth, HRW session

--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/options.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/options.ts
@@ -8,7 +8,7 @@ import {
 	type ClaudeAgentSdkTokenInjection,
 	loadClaudeAgentSdkProviderSettingsFromDisk,
 } from "./settings.ts";
-import { BUILTIN_SDK_TOOLS, canUseTool } from "./tools.ts";
+import { BUILTIN_SDK_TOOLS, canUseTool, HOST_TOOL_DENIAL_HOOKS } from "./tools.ts";
 
 export type ClaudeAgentSdkAuthLane = ClaudeAgentSdkTokenInjection;
 
@@ -185,6 +185,7 @@ export function buildClaudeAgentSdkQueryOptions(input: ClaudeAgentSdkQueryOption
 		permissionMode: "dontAsk",
 		includePartialMessages: true,
 		canUseTool,
+		hooks: HOST_TOOL_DENIAL_HOOKS,
 		systemPrompt: { type: "preset", preset: "claude_code", append: append.join("\n\n") || undefined },
 		settingSources: resolveSettingSources(providerSettings, appendSystemPrompt, authLane),
 	};

--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/tools.ts
@@ -22,8 +22,27 @@ export const PI_TO_SDK_TOOL_NAME: Readonly<Record<string, string>> = {
 
 export const BUILTIN_SDK_TOOLS = ["Read", "Write", "Edit", "Bash", "Grep", "Glob"] as const;
 export const TOOL_EXECUTION_DENIED_MESSAGE = "Tool execution is unavailable in this environment.";
+export const HOST_TOOL_EXECUTION_DENIED_MESSAGE =
+	"This tool call is captured and executed by the host. Do not retry with other tools; end the turn.";
 export const CUSTOM_TOOLS_MCP_SERVER_NAME = "custom-tools";
 export const CUSTOM_TOOLS_MCP_PREFIX = `mcp__${CUSTOM_TOOLS_MCP_SERVER_NAME}__`;
+export const HOST_CAPTURED_SDK_TOOL_MATCHER = "Bash|Write|Edit|Read|Grep|Glob|mcp__custom-tools__.*";
+export const HOST_TOOL_DENIAL_HOOKS: NonNullable<Options["hooks"]> = {
+	PreToolUse: [
+		{
+			matcher: HOST_CAPTURED_SDK_TOOL_MATCHER,
+			hooks: [
+				async () => ({
+					hookSpecificOutput: {
+						hookEventName: "PreToolUse",
+						permissionDecision: "deny",
+						permissionDecisionReason: HOST_TOOL_EXECUTION_DENIED_MESSAGE,
+					},
+				}),
+			],
+		},
+	],
+};
 
 export type ResolvedSdkTools = {
 	sdkTools: string[];

--- a/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-agent-sdk/tools.ts
@@ -33,6 +33,7 @@ export const HOST_TOOL_DENIAL_HOOKS: NonNullable<Options["hooks"]> = {
 			matcher: HOST_CAPTURED_SDK_TOOL_MATCHER,
 			hooks: [
 				async () => ({
+					continue: false,
 					hookSpecificOutput: {
 						hookEventName: "PreToolUse",
 						permissionDecision: "deny",

--- a/packages/coding-agent/test/helpers/claude-agent-sdk-local-probe.ts
+++ b/packages/coding-agent/test/helpers/claude-agent-sdk-local-probe.ts
@@ -1,0 +1,218 @@
+// Reusable local-endpoint probe for the installed Claude Agent SDK.
+// Serves an ephemeral Anthropic-shaped SSE endpoint on 127.0.0.1 and runs one
+// SDK turn with hermetic env (temp HOME/CLAUDE_CONFIG_DIR, no inherited
+// proxy/cloud/provider-routing variables), recording every observable fact the
+// regression assertions need. Probe owns its temp artifacts through try/finally.
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSdkMcpServer, query, tool } from "@anthropic-ai/claude-agent-sdk";
+import { HOST_TOOL_DENIAL_HOOKS } from "../../src/core/extensions/builtin/claude-agent-sdk/tools.ts";
+
+export type LocalSdkTurnObservation = {
+	providerRequests: number;
+	providerSawToolResult: boolean;
+	partialToolUseName: string | null;
+	finalizedToolUseName: string | null;
+	// All emitted user-message tool_result blocks, and how many of them are real
+	// executions (is_error !== true). A hook-stopped turn still emits one denial
+	// tool_result carrying non_execution_kind permission-rule and is_error true;
+	// only real executions count against the zero-execution invariant.
+	toolResults: number;
+	executedToolResults: number;
+	permissionPrompts: number;
+	customHandlerRuns: number;
+	markerExists: boolean;
+	terminalReason: string | null;
+	resultSubtype: string | null;
+};
+
+function sse(events: Array<[string, unknown]>): string {
+	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+function messageStart(id: string, inputTokens: number): [string, unknown] {
+	return [
+		"message_start",
+		{
+			type: "message_start",
+			message: {
+				id,
+				type: "message",
+				role: "assistant",
+				model: "mock",
+				content: [],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: inputTokens, output_tokens: 1 },
+			},
+		},
+	];
+}
+
+function toolUseTurn(toolName: string, inputJson: string): string {
+	return sse([
+		messageStart("msg_probe", 10),
+		[
+			"content_block_start",
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "tool_use", id: "toolu_1", name: toolName, input: {} },
+			},
+		],
+		[
+			"content_block_delta",
+			{ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: inputJson } },
+		],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		[
+			"message_delta",
+			{
+				type: "message_delta",
+				delta: { stop_reason: "tool_use", stop_sequence: null },
+				usage: { output_tokens: 4 },
+			},
+		],
+		["message_stop", { type: "message_stop" }],
+	]);
+}
+
+const endTurn = sse([
+	messageStart("msg_probe_end", 20),
+	["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+	["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "done" } }],
+	["content_block_stop", { type: "content_block_stop", index: 0 }],
+	[
+		"message_delta",
+		{ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 2 } },
+	],
+	["message_stop", { type: "message_stop" }],
+]);
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+export async function runInstalledSdkLocalTurn(toolName: string): Promise<LocalSdkTurnObservation> {
+	const tmpDir = await mkdtemp(join(tmpdir(), "senpi-494-"));
+	const markerPath = join(tmpDir, "hook-stop-marker.txt");
+	const toolInput = JSON.stringify(toolName === "Bash" ? { command: `echo hi > "${markerPath}"` } : {});
+	const requestBodies: string[] = [];
+	const server = createServer((req, res) => {
+		if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
+			let body = "";
+			req.on("data", (chunk: Buffer) => {
+				body += chunk.toString("utf8");
+			});
+			req.on("end", () => {
+				requestBodies.push(body);
+				res.writeHead(200, { "content-type": "text/event-stream" });
+				res.end(requestBodies.length === 1 ? toolUseTurn(toolName, toolInput) : endTurn);
+			});
+			return;
+		}
+		res.writeHead(200, { "content-type": "application/json" }).end("{}");
+	});
+	try {
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const { port } = server.address() as AddressInfo;
+		let permissionPrompts = 0;
+		let customHandlerRuns = 0;
+		let partialToolUseName: string | null = null;
+		let finalizedToolUseName: string | null = null;
+		let toolResults = 0;
+		let executedToolResults = 0;
+		let terminalReason: string | null = null;
+		let resultSubtype: string | null = null;
+		const stream = query({
+			prompt: "Call the requested tool exactly once, then stop.",
+			options: {
+				cwd: tmpDir,
+				model: "opus",
+				hooks: HOST_TOOL_DENIAL_HOOKS,
+				// Mirrors the production adapter: custom Pi tools are exposed through an
+				// in-process SDK MCP server, so PreToolUse hooks match mcp__custom-tools__*.
+				mcpServers: {
+					"custom-tools": createSdkMcpServer({
+						name: "custom-tools",
+						tools: [
+							tool("eval", "regression probe custom tool", {}, async () => {
+								customHandlerRuns++;
+								return { content: [{ type: "text" as const, text: "ok" }] };
+							}),
+						],
+					}),
+				},
+				// Production mode: deny-by-default with no prompts. canUseTool must stay
+				// uncalled because the PreToolUse hook terminates the turn first.
+				permissionMode: "dontAsk",
+				settingSources: [],
+				maxTurns: 5,
+				includePartialMessages: true,
+				canUseTool: async () => {
+					permissionPrompts++;
+					return { behavior: "allow", updatedInput: {} };
+				},
+				// Hermetic child environment: no inherited proxy, cloud, or
+				// provider-routing variables; only what the CLI needs to boot.
+				env: {
+					PATH: process.env.PATH ?? "",
+					TMPDIR: tmpDir,
+					HOME: join(tmpDir, "home"),
+					CLAUDE_CONFIG_DIR: join(tmpDir, "claude-config"),
+					ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+					ANTHROPIC_API_KEY: "regression-probe-key",
+					CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+				},
+			},
+		});
+		for await (const message of stream) {
+			if (message.type === "stream_event") {
+				const { event } = message;
+				if (event.type === "content_block_start" && event.content_block.type === "tool_use") {
+					partialToolUseName = event.content_block.name;
+				}
+			}
+			if (message.type === "assistant") {
+				for (const block of message.message.content) {
+					if (block.type === "tool_use") finalizedToolUseName = block.name;
+				}
+			}
+			if (message.type === "user") {
+				const content = message.message.content;
+				if (Array.isArray(content)) {
+					for (const block of content) {
+						if (block.type === "tool_result") {
+							toolResults++;
+							if (block.is_error !== true) executedToolResults++;
+						}
+					}
+				}
+			}
+			if (message.type === "result") {
+				resultSubtype = message.subtype;
+				terminalReason = message.terminal_reason ?? null;
+			}
+		}
+		return {
+			providerRequests: requestBodies.length,
+			providerSawToolResult: requestBodies.some((body) => body.includes('"type":"tool_result"')),
+			partialToolUseName,
+			finalizedToolUseName,
+			toolResults,
+			executedToolResults,
+			permissionPrompts,
+			customHandlerRuns,
+			markerExists: existsSync(markerPath),
+			terminalReason,
+			resultSubtype,
+		};
+	} finally {
+		await closeServer(server);
+		await rm(tmpDir, { recursive: true, force: true });
+	}
+}

--- a/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-denied-tool-replay.test.ts
+++ b/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-denied-tool-replay.test.ts
@@ -1,0 +1,67 @@
+import type { Api, Context, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { buildClaudeAgentSdkQueryOptions } from "../../../src/core/extensions/builtin/claude-agent-sdk/options.ts";
+
+const MODEL: Model<Api> = {
+	id: "claude-opus-5",
+	name: "Claude Opus 5",
+	api: "claude-agent-sdk",
+	provider: "claude-agent-sdk",
+	baseUrl: "claude-agent-sdk",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const CONTEXT: Context = { messages: [] };
+
+describe("issue #494: Claude Agent SDK denied tool replay", () => {
+	it("terminally denies native and custom MCP tools before Claude Code can execute or retry them", async () => {
+		// Given: the inference-only SDK adapter options.
+		const options = buildClaudeAgentSdkQueryOptions({
+			model: MODEL,
+			context: CONTEXT,
+			cwd: "/tmp",
+			providerSettings: { appendSystemPrompt: false },
+			authLane: "oauth-slots",
+		});
+
+		// When: the SDK resolves its pre-execution hook for host-captured tools.
+		const matcher = options.hooks?.PreToolUse?.[0];
+		const hook = matcher?.hooks[0];
+		if (matcher?.matcher === undefined || hook === undefined) {
+			throw new Error("Expected a PreToolUse denial hook for host-captured tools");
+		}
+		const matches = new RegExp(`^(?:${matcher.matcher})$`);
+		const output = await hook(
+			{
+				hook_event_name: "PreToolUse",
+				session_id: "session-494",
+				transcript_path: "/tmp/session-494.jsonl",
+				cwd: "/tmp",
+				tool_name: "Bash",
+				tool_input: { command: "echo once >> probe.txt" },
+				tool_use_id: "tool-494",
+			},
+			"tool-494",
+			{ signal: new AbortController().signal },
+		);
+
+		// Then: every Senpi-captured SDK tool is intercepted with a terminal, non-inciting denial.
+		expect(
+			["Bash", "Write", "Edit", "Read", "Grep", "Glob", "mcp__custom-tools__eval"].every((name) =>
+				matches.test(name),
+			),
+		).toBe(true);
+		expect(matches.test("WebSearch")).toBe(false);
+		expect(output).toEqual({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: expect.stringMatching(/host.*do not retry/i),
+			},
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-denied-tool-replay.test.ts
+++ b/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-denied-tool-replay.test.ts
@@ -18,7 +18,7 @@ const MODEL: Model<Api> = {
 const CONTEXT: Context = { messages: [] };
 
 describe("issue #494: Claude Agent SDK denied tool replay", () => {
-	it("terminally denies native and custom MCP tools before Claude Code can execute or retry them", async () => {
+	it("terminally stops the SDK turn with continue:false for native and custom MCP host-captured tools", async () => {
 		// Given: the inference-only SDK adapter options.
 		const options = buildClaudeAgentSdkQueryOptions({
 			model: MODEL,
@@ -57,6 +57,7 @@ describe("issue #494: Claude Agent SDK denied tool replay", () => {
 		).toBe(true);
 		expect(matches.test("WebSearch")).toBe(false);
 		expect(output).toEqual({
+			continue: false,
 			hookSpecificOutput: {
 				hookEventName: "PreToolUse",
 				permissionDecision: "deny",

--- a/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-installed-sdk-hook-stop.test.ts
+++ b/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-installed-sdk-hook-stop.test.ts
@@ -12,13 +12,16 @@ describe("issue #494: installed Claude Agent SDK terminal hook stop", () => {
 
 			// Then: the streamed tool call reached the SDK as a raw stream event and as a
 			// finalized assistant block, but the hook stopped the turn first - no permission
-			// callback, no Bash command side effect, no custom MCP handler invocation, no
-			// tool_result in the SDK stream or on the wire, and no second provider request.
+			// callback, no Bash command side effect, and no custom MCP handler invocation.
+			// The SDK stream carries exactly one tool_result: the non-executed denial
+			// (is_error, permission-rule); nothing was executed, and no tool_result ever
+			// went out on the wire because there is no second provider request.
 			expect(observation.partialToolUseName).toBe(toolName);
 			expect(observation.finalizedToolUseName).toBe(toolName);
 			expect(observation.permissionPrompts).toBe(0);
 			expect(observation.markerExists).toBe(false);
 			expect(observation.customHandlerRuns).toBe(0);
+			expect(observation.toolResults).toBe(1);
 			expect(observation.executedToolResults).toBe(0);
 			expect(observation.providerSawToolResult).toBe(false);
 			expect(observation.providerRequests).toBe(1);

--- a/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-installed-sdk-hook-stop.test.ts
+++ b/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-installed-sdk-hook-stop.test.ts
@@ -1,202 +1,27 @@
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
-import { createSdkMcpServer, query, tool } from "@anthropic-ai/claude-agent-sdk";
 import { describe, expect, it } from "vitest";
-import { HOST_TOOL_DENIAL_HOOKS } from "../../../src/core/extensions/builtin/claude-agent-sdk/tools.ts";
-
-type ProbeObservation = {
-	providerRequests: number;
-	sawToolResult: boolean;
-	streamedToolName: string | null;
-	permissionPrompts: number;
-	customHandlerRuns: number;
-	terminalReason: string | null;
-	resultSubtype: string | null;
-};
-
-function sse(events: Array<[string, unknown]>): string {
-	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
-}
-
-function toolUseTurn(toolName: string): string {
-	return sse([
-		[
-			"message_start",
-			{
-				type: "message_start",
-				message: {
-					id: "msg_probe",
-					type: "message",
-					role: "assistant",
-					model: "mock",
-					content: [],
-					stop_reason: null,
-					stop_sequence: null,
-					usage: { input_tokens: 10, output_tokens: 1 },
-				},
-			},
-		],
-		[
-			"content_block_start",
-			{
-				type: "content_block_start",
-				index: 0,
-				content_block: { type: "tool_use", id: "toolu_1", name: toolName, input: {} },
-			},
-		],
-		[
-			"content_block_delta",
-			{
-				type: "content_block_delta",
-				index: 0,
-				delta: { type: "input_json_delta", partial_json: '{"command":"echo hi"}' },
-			},
-		],
-		["content_block_stop", { type: "content_block_stop", index: 0 }],
-		[
-			"message_delta",
-			{
-				type: "message_delta",
-				delta: { stop_reason: "tool_use", stop_sequence: null },
-				usage: { output_tokens: 4 },
-			},
-		],
-		["message_stop", { type: "message_stop" }],
-	]);
-}
-
-const endTurn = sse([
-	[
-		"message_start",
-		{
-			type: "message_start",
-			message: {
-				id: "msg_probe_2",
-				type: "message",
-				role: "assistant",
-				model: "mock",
-				content: [],
-				stop_reason: null,
-				stop_sequence: null,
-				usage: { input_tokens: 20, output_tokens: 1 },
-			},
-		},
-	],
-	["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
-	["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "done" } }],
-	["content_block_stop", { type: "content_block_stop", index: 0 }],
-	[
-		"message_delta",
-		{ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 2 } },
-	],
-	["message_stop", { type: "message_stop" }],
-]);
-
-function closeServer(server: Server): Promise<void> {
-	return new Promise((resolve) => server.close(() => resolve()));
-}
-
-async function runInstalledSdkTurn(toolName: string): Promise<ProbeObservation> {
-	const requestBodies: string[] = [];
-	const server = createServer((req, res) => {
-		if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
-			let body = "";
-			req.on("data", (chunk: Buffer) => {
-				body += chunk.toString("utf8");
-			});
-			req.on("end", () => {
-				requestBodies.push(body);
-				res.writeHead(200, { "content-type": "text/event-stream" });
-				res.end(requestBodies.length === 1 ? toolUseTurn(toolName) : endTurn);
-			});
-			return;
-		}
-		res.writeHead(200, { "content-type": "application/json" }).end("{}");
-	});
-	try {
-		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-		const { port } = server.address() as AddressInfo;
-		let permissionPrompts = 0;
-		let customHandlerRuns = 0;
-		let streamedToolName: string | null = null;
-		let terminalReason: string | null = null;
-		let resultSubtype: string | null = null;
-		const stream = query({
-			prompt: "Call the requested tool exactly once, then stop.",
-			options: {
-				cwd: "/tmp",
-				model: "opus",
-				hooks: HOST_TOOL_DENIAL_HOOKS,
-				// Mirrors the production adapter: custom Pi tools are exposed through an
-				// in-process SDK MCP server, so PreToolUse hooks match mcp__custom-tools__*.
-				mcpServers: {
-					"custom-tools": createSdkMcpServer({
-						name: "custom-tools",
-						tools: [
-							tool("eval", "regression probe custom tool", {}, async () => {
-								customHandlerRuns++;
-								return { content: [{ type: "text" as const, text: "ok" }] };
-							}),
-						],
-					}),
-				},
-				permissionMode: "bypassPermissions",
-				allowDangerouslySkipPermissions: true,
-				settingSources: [],
-				maxTurns: 5,
-				canUseTool: async () => {
-					permissionPrompts++;
-					return { behavior: "allow", updatedInput: {} };
-				},
-				env: {
-					...process.env,
-					ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
-					ANTHROPIC_API_KEY: "regression-probe-key",
-					CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-				},
-			},
-		});
-		for await (const message of stream) {
-			if (message.type === "assistant") {
-				for (const block of message.message.content) {
-					if (block.type === "tool_use") streamedToolName = block.name;
-				}
-			}
-			if (message.type === "result") {
-				resultSubtype = message.subtype;
-				terminalReason = message.terminal_reason ?? null;
-			}
-		}
-		return {
-			providerRequests: requestBodies.length,
-			sawToolResult: requestBodies.some((body) => body.includes('"type":"tool_result"')),
-			streamedToolName,
-			permissionPrompts,
-			customHandlerRuns,
-			terminalReason,
-			resultSubtype,
-		};
-	} finally {
-		await closeServer(server);
-	}
-}
+import { runInstalledSdkLocalTurn } from "../../helpers/claude-agent-sdk-local-probe.ts";
 
 describe("issue #494: installed Claude Agent SDK terminal hook stop", () => {
 	it.each(["Bash", "mcp__custom-tools__eval"])(
 		"stops %s after exactly one provider request with terminal_reason hook_stopped",
 		async (toolName) => {
-			// Given: a local ephemeral Anthropic-compatible endpoint that streams one tool call.
-			// When: the installed SDK runs a turn guarded by Senpi's host-tool denial hooks.
-			const observation = await runInstalledSdkTurn(toolName);
+			// Given: a local ephemeral Anthropic-compatible endpoint streaming one tool call,
+			// the installed SDK + claude CLI under production dontAsk permission mode.
+			// When: Senpi's host-tool PreToolUse denial hooks guard the turn.
+			const observation = await runInstalledSdkLocalTurn(toolName);
 
-			// Then: the denial is terminal. The streamed tool call was observed by the SDK,
-			// but the hook stopped the turn before any native or custom-MCP tool handler ran,
-			// so no tool result and no second provider request ever happen.
-			expect(observation.streamedToolName).toBe(toolName);
+			// Then: the streamed tool call reached the SDK as a raw stream event and as a
+			// finalized assistant block, but the hook stopped the turn first - no permission
+			// callback, no Bash command side effect, no custom MCP handler invocation, no
+			// tool_result in the SDK stream or on the wire, and no second provider request.
+			expect(observation.partialToolUseName).toBe(toolName);
+			expect(observation.finalizedToolUseName).toBe(toolName);
 			expect(observation.permissionPrompts).toBe(0);
+			expect(observation.markerExists).toBe(false);
 			expect(observation.customHandlerRuns).toBe(0);
+			expect(observation.executedToolResults).toBe(0);
+			expect(observation.providerSawToolResult).toBe(false);
 			expect(observation.providerRequests).toBe(1);
-			expect(observation.sawToolResult).toBe(false);
 			expect(observation.terminalReason).toBe("hook_stopped");
 			expect(observation.resultSubtype).toBe("success");
 		},

--- a/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-installed-sdk-hook-stop.test.ts
+++ b/packages/coding-agent/test/suite/regressions/494-claude-agent-sdk-installed-sdk-hook-stop.test.ts
@@ -1,0 +1,205 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createSdkMcpServer, query, tool } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it } from "vitest";
+import { HOST_TOOL_DENIAL_HOOKS } from "../../../src/core/extensions/builtin/claude-agent-sdk/tools.ts";
+
+type ProbeObservation = {
+	providerRequests: number;
+	sawToolResult: boolean;
+	streamedToolName: string | null;
+	permissionPrompts: number;
+	customHandlerRuns: number;
+	terminalReason: string | null;
+	resultSubtype: string | null;
+};
+
+function sse(events: Array<[string, unknown]>): string {
+	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+function toolUseTurn(toolName: string): string {
+	return sse([
+		[
+			"message_start",
+			{
+				type: "message_start",
+				message: {
+					id: "msg_probe",
+					type: "message",
+					role: "assistant",
+					model: "mock",
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 10, output_tokens: 1 },
+				},
+			},
+		],
+		[
+			"content_block_start",
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "tool_use", id: "toolu_1", name: toolName, input: {} },
+			},
+		],
+		[
+			"content_block_delta",
+			{
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: '{"command":"echo hi"}' },
+			},
+		],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		[
+			"message_delta",
+			{
+				type: "message_delta",
+				delta: { stop_reason: "tool_use", stop_sequence: null },
+				usage: { output_tokens: 4 },
+			},
+		],
+		["message_stop", { type: "message_stop" }],
+	]);
+}
+
+const endTurn = sse([
+	[
+		"message_start",
+		{
+			type: "message_start",
+			message: {
+				id: "msg_probe_2",
+				type: "message",
+				role: "assistant",
+				model: "mock",
+				content: [],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 20, output_tokens: 1 },
+			},
+		},
+	],
+	["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+	["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "done" } }],
+	["content_block_stop", { type: "content_block_stop", index: 0 }],
+	[
+		"message_delta",
+		{ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 2 } },
+	],
+	["message_stop", { type: "message_stop" }],
+]);
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function runInstalledSdkTurn(toolName: string): Promise<ProbeObservation> {
+	const requestBodies: string[] = [];
+	const server = createServer((req, res) => {
+		if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
+			let body = "";
+			req.on("data", (chunk: Buffer) => {
+				body += chunk.toString("utf8");
+			});
+			req.on("end", () => {
+				requestBodies.push(body);
+				res.writeHead(200, { "content-type": "text/event-stream" });
+				res.end(requestBodies.length === 1 ? toolUseTurn(toolName) : endTurn);
+			});
+			return;
+		}
+		res.writeHead(200, { "content-type": "application/json" }).end("{}");
+	});
+	try {
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const { port } = server.address() as AddressInfo;
+		let permissionPrompts = 0;
+		let customHandlerRuns = 0;
+		let streamedToolName: string | null = null;
+		let terminalReason: string | null = null;
+		let resultSubtype: string | null = null;
+		const stream = query({
+			prompt: "Call the requested tool exactly once, then stop.",
+			options: {
+				cwd: "/tmp",
+				model: "opus",
+				hooks: HOST_TOOL_DENIAL_HOOKS,
+				// Mirrors the production adapter: custom Pi tools are exposed through an
+				// in-process SDK MCP server, so PreToolUse hooks match mcp__custom-tools__*.
+				mcpServers: {
+					"custom-tools": createSdkMcpServer({
+						name: "custom-tools",
+						tools: [
+							tool("eval", "regression probe custom tool", {}, async () => {
+								customHandlerRuns++;
+								return { content: [{ type: "text" as const, text: "ok" }] };
+							}),
+						],
+					}),
+				},
+				permissionMode: "bypassPermissions",
+				allowDangerouslySkipPermissions: true,
+				settingSources: [],
+				maxTurns: 5,
+				canUseTool: async () => {
+					permissionPrompts++;
+					return { behavior: "allow", updatedInput: {} };
+				},
+				env: {
+					...process.env,
+					ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+					ANTHROPIC_API_KEY: "regression-probe-key",
+					CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+				},
+			},
+		});
+		for await (const message of stream) {
+			if (message.type === "assistant") {
+				for (const block of message.message.content) {
+					if (block.type === "tool_use") streamedToolName = block.name;
+				}
+			}
+			if (message.type === "result") {
+				resultSubtype = message.subtype;
+				terminalReason = message.terminal_reason ?? null;
+			}
+		}
+		return {
+			providerRequests: requestBodies.length,
+			sawToolResult: requestBodies.some((body) => body.includes('"type":"tool_result"')),
+			streamedToolName,
+			permissionPrompts,
+			customHandlerRuns,
+			terminalReason,
+			resultSubtype,
+		};
+	} finally {
+		await closeServer(server);
+	}
+}
+
+describe("issue #494: installed Claude Agent SDK terminal hook stop", () => {
+	it.each(["Bash", "mcp__custom-tools__eval"])(
+		"stops %s after exactly one provider request with terminal_reason hook_stopped",
+		async (toolName) => {
+			// Given: a local ephemeral Anthropic-compatible endpoint that streams one tool call.
+			// When: the installed SDK runs a turn guarded by Senpi's host-tool denial hooks.
+			const observation = await runInstalledSdkTurn(toolName);
+
+			// Then: the denial is terminal. The streamed tool call was observed by the SDK,
+			// but the hook stopped the turn before any native or custom-MCP tool handler ran,
+			// so no tool result and no second provider request ever happen.
+			expect(observation.streamedToolName).toBe(toolName);
+			expect(observation.permissionPrompts).toBe(0);
+			expect(observation.customHandlerRuns).toBe(0);
+			expect(observation.providerRequests).toBe(1);
+			expect(observation.sawToolResult).toBe(false);
+			expect(observation.terminalReason).toBe("hook_stopped");
+			expect(observation.resultSubtype).toBe("success");
+		},
+		120_000,
+	);
+});


### PR DESCRIPTION
## Summary

Prevent the Claude Agent SDK adapter from letting denied tool calls enter Claude Code's retry path. The adapter now denies host-captured tools in a `PreToolUse` hook, before `dontAsk` permission handling or safe-command execution can produce a retry-inciting denial or execute a command twice.

## Changes

- Install a terminal `PreToolUse` denial for `Bash`, `Write`, `Edit`, `Read`, `Grep`, `Glob`, and `mcp__custom-tools__*`.
- Tell the SDK turn that Senpi captures and executes the tool call through the host pipeline and that it must not retry with another tool.
- Add issue-shaped regression coverage for the full native and custom-MCP matcher plus the terminal denial result.

## QA & Evidence

- **RED regression:** `npm test -- test/suite/regressions/494-claude-agent-sdk-denied-tool-replay.test.ts`
  - Failed before the fix with `Expected a PreToolUse denial hook for host-captured tools`.
- **GREEN focused tests:** `npm test -- test/claude-agent-sdk-options.test.ts test/claude-agent-sdk-tools.test.ts test/suite/regressions/494-claude-agent-sdk-denied-tool-replay.test.ts`
  - 3 files passed, 25 tests passed.
- **Static validation:** `npm run check`
  - Exit 0.
- **Real CLI mock-loop QA:** `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool --api openai-responses --evidence claude-agent-sdk-denied-tool`
  - 4/4 passed: CLI completed, two turns served, final text returned, real auth unchanged.
  - Receipt: `local-ignore/qa-evidence/20260730-claude-agent-sdk-denied-tool/mock-loop.txt`.
- **Package suite:** after building workspace artifacts, 5,950 tests passed and 7 unrelated tests failed. Isolated reruns cleared the model-runtime and app-server failures; four existing `rpc.test.ts` session-directory assertions remained unrelated to this adapter-only diff.

## Risks & Residuals

- The hook is limited to tools Senpi captures for host-side execution; unrelated Claude Code tools are not intercepted.
- Existing `canUseTool` denial remains as defense in depth, while `PreToolUse` closes the path that bypassed it under `dontAsk`.

Fixes #494

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops denied tool calls from being retried by Claude Code in the `claude-agent-sdk` adapter by adding a terminal `PreToolUse` hook that returns `continue:false`, ending the turn with `terminal_reason: hook_stopped`. Fixes #494.

- **Bug Fixes**
  - Terminal `PreToolUse` denial for Bash, Write, Edit, Read, Grep, Glob, and `mcp__custom-tools__*`, returning `continue:false` with a clear do‑not‑retry reason.
  - Hook exported as `HOST_TOOL_DENIAL_HOOKS` and wired into `buildClaudeAgentSdkQueryOptions` ahead of `dontAsk` and safe-command paths.
  - Regression coverage: confirms exactly one provider request; streamed tool call is seen; exactly one denial `tool_result` in the SDK stream (`is_error`, permission-rule) and zero executed results; no `tool_result` on the wire; no permission prompts, no Bash side effects, no custom MCP handler runs; result subtype is `success` with `terminal_reason: hook_stopped`.

<sup>Written for commit eff8cd33b67cf779723a6e9d45d4f5d7cbd738fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

