### PR TITLE
fix: never park compaction-queued input on failed compaction; add stuck-route session logging

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1036,3 +1036,15 @@
 The retry budget, abortable retry sleep, provider continuation, and active model state all belong to `AgentSession`; an extension cannot safely replace a model inside that lifecycle without persisting it or rebuilding context.
 - Retry fallback revert-to-primary at turn boundaries: unpinned fallback state under the `cooldown-expiry` policy restores the original model once its selector cooldown lapses (checked at prompt entry and between the retry sleep and continuation), emits `retry_fallback_reverted`, preserves user thinking-level overrides, and is abandoned on manual `setModel`/`cycleModel` (which also abort a pending fallback retry sleep).
 - Server-side fallback aborts (2026-07-25): `retry.abortServerSideFallback` (default true) forwards `abortServerSideFallback` into provider stream options via a new `Agent` field and `createLoopConfig`. `AgentSession` translates the provider's `server_fallback_aborted` diagnostic into a session event of the same name carrying `from`/`to`/`chainConfigured`, emitted synchronously from `message_end` so it precedes refusal retry handling, and the existing refusal path then routes the turn onto the configured chain. `RetryFallbackController.hasConfiguredChain()` distinguishes "no chain configured" from "chain spent", because the no-chain refusal path emits no `retry_fallback_exhausted`. Interactive mode renders the abort and names `/fallback` when no chain exists.
+
+## Session lifecycle stuck-route logging (2026-07-30)
+
+### What changed
+
+- `core/session-log.ts`: new rotating content-free JSONL logger writing `<agentDir>/logs/session.log` (5MB rotate, allow-listed scalar fields, secret redaction, `SENPI_SESSION_DEBUG=1` stderr mirror), following the existing `retry-fallback/log.ts` pattern.
+- `core/agent-session.ts`: mirrors stuck-prone lifecycle transitions into `session.log`: `compaction_decision` on every terminal `compaction_end` (reason/accepted/aborted/willRetry/rejectionCause/error), `provider_error` on assistant `message_end` errors classified as stall/timeout/error, `queue_enqueue` on native steer/followUp queueing, and `prompt_rejected` when a `RequiredCompactionError` rejects prompt admission.
+- `modes/interactive/interactive-mode.ts`: logs `compaction_queue_enqueue` when input is parked during compaction, `compaction_queue_deferred` when a failed compaction defers queued input to the native queues, and `clipboard_error` on clipboard paste failures.
+
+### Why extension system couldn't handle this
+
+The instrumented transitions (`_emit`, queue internals, `RequiredCompactionError` admission, the TUI compaction queue, clipboard catch) are private `AgentSession`/`InteractiveMode` state with no extension-visible hook carrying the needed fields; field debugging of "stuck forever" sessions (Discord report 2026-07-30) requires a single post-hoc timeline in the logs directory.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -131,6 +131,7 @@ import { RetryFallbackController } from "./retry-fallback/controller.ts";
 import { SelectorCooldowns } from "./retry-fallback/cooldown.ts";
 import { createFallbackLogger } from "./retry-fallback/log.ts";
 import { validateFallbackChains } from "./retry-fallback/validate.ts";
+import { createSessionLogger, type SessionLogger } from "./session-log.ts";
 import type { BranchSummaryEntry, CompactionEntry, SessionEntry, SessionManager } from "./session-manager.ts";
 import {
 	buildSessionContext,
@@ -557,6 +558,7 @@ export class AgentSession {
 	private _steeringMessages: string[] = [];
 	/** Tracks pending follow-up messages for UI display. Removed when delivered. */
 	private _followUpMessages: string[] = [];
+	private _sessionLogger: SessionLogger;
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
 	// Queues held while the first post-compaction response is classified. Agent
@@ -671,6 +673,7 @@ export class AgentSession {
 		this._modelRuntime = modelRuntime;
 		this._modelRegistry = config.modelRegistry ?? new ModelRegistry(modelRuntime);
 		const fallbackLogger = createFallbackLogger(config.agentDir ?? getAgentDir());
+		this._sessionLogger = createSessionLogger(config.agentDir ?? getAgentDir());
 		this._fallbackValidationWarnings = validateFallbackChains(
 			this.settingsManager.getRawFallbackChains(),
 			this._modelRegistry,
@@ -1004,8 +1007,34 @@ export class AgentSession {
 
 	/** Emit an event to all listeners */
 	private _emit(event: AgentSessionEvent): void {
+		this._logSessionEvent(event);
 		for (const l of this._eventListeners) {
 			l(event);
+		}
+	}
+
+	/** Mirror stuck-prone lifecycle transitions into logs/session.log (content-free). */
+	private _logSessionEvent(event: AgentSessionEvent): void {
+		if (event.type === "compaction_end") {
+			this._sessionLogger.info("compaction_decision", {
+				reason: event.reason,
+				accepted: event.accepted ?? event.result !== undefined,
+				aborted: event.aborted,
+				willRetry: event.willRetry,
+				rejectionCause: event.rejectionCause,
+				error: event.errorMessage,
+			});
+			return;
+		}
+		if (event.type === "message_end" && event.message.role === "assistant") {
+			const message = event.message as AssistantMessage;
+			if (message.stopReason !== "error") return;
+			const kind = isProviderStreamStallError(message)
+				? "stall"
+				: isProviderTimeoutError(message)
+					? "timeout"
+					: "error";
+			this._sessionLogger.warn("provider_error", { kind, error: message.errorMessage });
 		}
 	}
 
@@ -1099,6 +1128,7 @@ export class AgentSession {
 			const requiredCompactionError = this._requiredCompactionAdmissionError;
 			this._requiredCompactionAdmissionError = undefined;
 			if (requiredCompactionError) {
+				this._sessionLogger.warn("prompt_rejected", { stage: "admission", error: "RequiredCompactionError" });
 				throw requiredCompactionError;
 			}
 		} catch (error) {
@@ -2741,6 +2771,7 @@ export class AgentSession {
 	 */
 	private async _queueSteer(text: string, images?: ImageContent[]): Promise<void> {
 		this._steeringMessages.push(text);
+		this._sessionLogger.debug("queue_enqueue", { mode: "steer", count: this._steeringMessages.length });
 		this._emitQueueUpdate();
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images) {
@@ -2759,6 +2790,7 @@ export class AgentSession {
 	 */
 	private async _queueFollowUp(text: string, images?: ImageContent[]): Promise<void> {
 		this._followUpMessages.push(text);
+		this._sessionLogger.debug("queue_enqueue", { mode: "followUp", count: this._followUpMessages.length });
 		this._emitQueueUpdate();
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images) {

--- a/packages/coding-agent/src/core/session-log.ts
+++ b/packages/coding-agent/src/core/session-log.ts
@@ -1,0 +1,122 @@
+import { chmodSync, closeSync, mkdirSync, openSync, renameSync, rmSync, statSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const MAX_STRING_LENGTH = 200;
+const DEBUG_PREFIX = "[senpi-session]";
+const BLOCKED_KEY =
+	/^(?:__proto__|constructor|prototype|headers?|env(?:ironment)?|authorization|credential(?:s)?|password|secret|token|api_?key|client_?secret)$/i;
+const ALLOWED_DATA_KEY =
+	/^(?:disposition|stage|error|mode|count|willRetry|deferAdmission|delivered|restored|cause|accepted|rejectionCause|reason|durationMs|kind|retryable|phase|op|bytes|generation|requestId|tokens|contextWindow|attempt)$/;
+const SENSITIVE_TEXT =
+	/((?:authorization\s*[:=]\s*(?:bearer|basic)\s+)|(?:bearer\s+)|(?:[?&](?:api[_-]?key|token|secret|password|auth(?:orization)?)=))[^\s&,"'}\]]+/gi;
+
+export interface SessionLogger {
+	debug(event: string, data?: Record<string, unknown>): void;
+	info(event: string, data?: Record<string, unknown>): void;
+	warn(event: string, data?: Record<string, unknown>): void;
+}
+
+export interface SessionLoggerOptions {
+	sink?: (line: string) => void;
+	mirrorToStderr?: boolean;
+	maxBytes?: number;
+}
+
+export function createSessionLogger(agentDir: string | undefined, options: SessionLoggerOptions = {}): SessionLogger {
+	if (typeof agentDir !== "string" || agentDir.length === 0) {
+		return { debug: () => {}, info: () => {}, warn: () => {} };
+	}
+	const filePath = join(agentDir, "logs", "session.log");
+	const maxBytes = validMaxBytes(options.maxBytes);
+	let reportedWriteFailure = false;
+
+	function log(level: "debug" | "info" | "warn", event: string, data?: Record<string, unknown>): void {
+		try {
+			const line = formatLine(level, event, data);
+			options.sink?.(line);
+			writeLine(filePath, line, maxBytes);
+			if (options.mirrorToStderr ?? process.env.SENPI_SESSION_DEBUG === "1") {
+				console.error(DEBUG_PREFIX, line);
+			}
+		} catch (error) {
+			if (!reportedWriteFailure) {
+				reportedWriteFailure = true;
+				console.error("Unable to write session log", error);
+			}
+		}
+	}
+
+	return {
+		debug: (event, data) => log("debug", event, data),
+		info: (event, data) => log("info", event, data),
+		warn: (event, data) => log("warn", event, data),
+	};
+}
+
+function validMaxBytes(value: number | undefined): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : DEFAULT_MAX_BYTES;
+}
+
+function formatLine(
+	level: "debug" | "info" | "warn",
+	event: string,
+	data: Record<string, unknown> | undefined,
+): string {
+	const entry: Record<string, unknown> = {
+		ts: new Date().toISOString(),
+		level,
+		event: safeText(event),
+	};
+	if (data !== undefined) {
+		for (const [key, value] of Object.entries(data)) {
+			if (ALLOWED_DATA_KEY.test(key) && !BLOCKED_KEY.test(key)) {
+				const safeValue = serializeValue(value);
+				if (safeValue !== undefined) entry[key] = safeValue;
+			}
+		}
+	}
+	return JSON.stringify(entry);
+}
+
+function writeLine(filePath: string, line: string, maxBytes: number): void {
+	mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
+	const text = `${line}\n`;
+	if (fileExceedsCap(filePath, Buffer.byteLength(text), maxBytes)) {
+		rmSync(`${filePath}.1`, { force: true });
+		renameSync(filePath, `${filePath}.1`);
+		chmodSync(`${filePath}.1`, 0o600);
+	}
+	const descriptor = openSync(filePath, "a", 0o600);
+	try {
+		writeSync(descriptor, text);
+	} finally {
+		closeSync(descriptor);
+	}
+	chmodSync(filePath, 0o600);
+}
+
+function fileExceedsCap(filePath: string, incomingBytes: number, maxBytes: number): boolean {
+	try {
+		return statSync(filePath).size + incomingBytes > maxBytes;
+	} catch (error) {
+		if (isMissingFileError(error)) return false;
+		throw error;
+	}
+}
+
+function isMissingFileError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function serializeValue(value: unknown): unknown {
+	if (typeof value === "string") return safeText(value);
+	if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+	if (typeof value === "bigint") return value.toString();
+	return undefined;
+}
+
+function safeText(value: string): string {
+	const redacted = value.replace(SENSITIVE_TEXT, "$1[redacted]");
+	return redacted.length <= MAX_STRING_LENGTH ? redacted : `${redacted.slice(0, MAX_STRING_LENGTH - 3)}...`;
+}

--- a/packages/coding-agent/src/core/session-log.ts
+++ b/packages/coding-agent/src/core/session-log.ts
@@ -7,7 +7,7 @@ const DEBUG_PREFIX = "[senpi-session]";
 const BLOCKED_KEY =
 	/^(?:__proto__|constructor|prototype|headers?|env(?:ironment)?|authorization|credential(?:s)?|password|secret|token|api_?key|client_?secret)$/i;
 const ALLOWED_DATA_KEY =
-	/^(?:disposition|stage|error|mode|count|willRetry|deferAdmission|delivered|restored|cause|accepted|rejectionCause|reason|durationMs|kind|retryable|phase|op|bytes|generation|requestId|tokens|contextWindow|attempt)$/;
+	/^(?:disposition|stage|error|mode|count|willRetry|deferAdmission|delivered|restored|cause|accepted|rejectionCause|reason|durationMs|kind|retryable|phase|op|bytes|generation|requestId|tokens|contextWindow|attempt|aborted)$/;
 const SENSITIVE_TEXT =
 	/((?:authorization\s*[:=]\s*(?:bearer|basic)\s+)|(?:bearer\s+)|(?:[?&](?:api[_-]?key|token|secret|password|auth(?:orization)?)=))[^\s&,"'}\]]+/gi;
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1443,3 +1443,9 @@ The tip line was teaching a small slice of the product while most of the surface
 - Changed `src/modes/interactive/interactive-mode.ts` so startup no longer checks upstream npm registry version/package updates before entering the interactive loop.
 - This was changed in core UI because those startup checks are internal `InteractiveMode` methods and there is no extension hook that can reliably suppress them before they run.
 - Expected merge-conflict zone on upstream sync: startup helpers around `checkForNewVersion()` and `checkForPackageUpdates()` in `src/modes/interactive/interactive-mode.ts`.
+
+## clipboard paste error surfacing
+
+- Changed `src/modes/interactive/interactive-mode.ts` so `handleClipboardPaste()` failures show a `Clipboard paste failed: <reason>` status instead of being silently swallowed; an empty clipboard still stays quiet.
+- This was changed in core UI because clipboard paste is internal `InteractiveMode` editor wiring (`onPasteImage`); extensions cannot observe that catch path.
+- Expected merge-conflict zone on upstream sync: `handleClipboardPaste()` in `src/modes/interactive/interactive-mode.ts`.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1449,3 +1449,9 @@ The tip line was teaching a small slice of the product while most of the surface
 - Changed `src/modes/interactive/interactive-mode.ts` so `handleClipboardPaste()` failures show a `Clipboard paste failed: <reason>` status instead of being silently swallowed; an empty clipboard still stays quiet.
 - This was changed in core UI because clipboard paste is internal `InteractiveMode` editor wiring (`onPasteImage`); extensions cannot observe that catch path.
 - Expected merge-conflict zone on upstream sync: `handleClipboardPaste()` in `src/modes/interactive/interactive-mode.ts`.
+
+## compaction queue delivery after unsuccessful compaction
+
+- Changed `src/modes/interactive/interactive-mode.ts` and `compaction-queue-transfer.ts` so every terminal `compaction_end` flushes the TUI compaction queue: accepted compactions keep prompt-admission delivery, while failed/rejected/aborted ones route queued input through the native steer/followUp queues (`deferAdmission`) with a visible held-count status and a `compaction_queue_deferred` session-log event. Previously the queue was flushed only on success, so messages typed during a failing compaction were silently parked forever and lost on session switch (field report 2026-07-30).
+- This was changed in core UI because the compaction queue and `compaction_end` handling are internal `InteractiveMode` state; extensions cannot observe or drain that queue.
+- Expected merge-conflict zone on upstream sync: the `compaction_end` handler and `flushCompactionQueue()` in `src/modes/interactive/interactive-mode.ts`, plus `compaction-queue-transfer.ts` transfer options.

--- a/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
+++ b/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
@@ -7,6 +7,12 @@ export type PromptDisposition = "handled" | "queued" | "started";
 
 type TransferOptions = {
 	readonly willRetry?: boolean;
+	/**
+	 * Deliver prompts through the native steer/followUp queues instead of
+	 * prompt admission. Used after an unsuccessful compaction so queued input
+	 * is never dropped and never force-admitted into an over-budget context.
+	 */
+	readonly deferAdmission?: boolean;
 };
 
 type TransferDependencies = {
@@ -29,7 +35,7 @@ export async function transferCompactionQueue(
 
 	let acceptedCount = 0;
 	try {
-		if (options.willRetry) {
+		if (options.willRetry || options.deferAdmission) {
 			for (const message of batch) {
 				if (dependencies.isCommand(message)) {
 					await dependencies.deliverCommand(message);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -105,6 +105,7 @@ import {
 	isRecoverableInspectorVmImportError,
 } from "../../inspector-policy.ts";
 import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
+import { createSessionLogger, type SessionLogger } from "../../core/session-log.ts";
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
 import { parseGitUrl } from "../../utils/git.ts";
@@ -465,6 +466,7 @@ export class InteractiveMode {
 	private shortcutOverlay: ShortcutOverlay | undefined;
 	private lastEditorText = "";
 	private lastInputWasPaste = false;
+	private sessionLogger: SessionLogger | undefined;
 	private readonly turnWorkingTip = new WorkingTipCache();
 	private hookStatusContainer: Container;
 	private defaultEditor: CustomEditor;
@@ -3324,10 +3326,15 @@ export class InteractiveMode {
 				this.ui.requestRender();
 			}
 		} catch (error) {
-			this.showStatus(
-				`Clipboard paste failed: ${sanitizeTuiErrorMessage(error instanceof Error ? error.message : String(error))}`,
-			);
+			const message = error instanceof Error ? error.message : String(error);
+			this.getSessionLogger().warn("clipboard_error", { op: "paste", error: message });
+			this.showStatus(`Clipboard paste failed: ${sanitizeTuiErrorMessage(message)}`);
 		}
+	}
+
+	private getSessionLogger(): SessionLogger {
+		this.sessionLogger ??= createSessionLogger(this.runtimeHost.services.agentDir);
+		return this.sessionLogger;
 	}
 
 	private setupEditorSubmitHandler(): void {
@@ -3877,12 +3884,23 @@ export class InteractiveMode {
 						this.chatContainer.addChild(new Text(theme.fg("error", message), 1, 0));
 					}
 				}
-				// Only an accepted compaction transfers editor-owned input to the
-				// session. Rejections and aborts retain the draft for an explicit
-				// user retry while the UI cleanup above still always runs.
-				if (event.accepted === true || event.result !== undefined) {
-					void this.flushCompactionQueue({ willRetry: event.willRetry });
+				// Every terminal compaction_end flushes the TUI compaction queue.
+				// Accepted compactions deliver through prompt admission; unsuccessful
+				// ones route through the native steer/followUp queues so submitted
+				// input is never silently parked (field bug: messages typed during a
+				// failing compaction were held forever and lost on session switch).
+				const compactionSucceeded = event.accepted === true || event.result !== undefined;
+				const heldCount = this.compactionQueuedMessages.length;
+				if (!compactionSucceeded && heldCount > 0) {
+					this.getSessionLogger().warn("compaction_queue_deferred", {
+						count: heldCount,
+						cause: event.errorMessage ?? event.rejectionCause ?? (event.aborted ? "aborted" : "no-result"),
+					});
+					this.showStatus(
+						`${heldCount} queued message${heldCount === 1 ? "" : "s"} will send with the next turn (compaction did not complete)`,
+					);
 				}
+				void this.flushCompactionQueue({ willRetry: event.willRetry, deferAdmission: !compactionSucceeded });
 				this.ui.requestRender();
 				break;
 			}
@@ -4910,7 +4928,7 @@ export class InteractiveMode {
 		return !!extensionRunner.getCommand(commandName);
 	}
 
-	private async flushCompactionQueue(options?: { willRetry?: boolean }): Promise<void> {
+	private async flushCompactionQueue(options?: { willRetry?: boolean; deferAdmission?: boolean }): Promise<void> {
 		const session = this.session;
 		const generation = this.compactionQueueGeneration ?? 0;
 		const previousFlush = this.compactionQueueFlushTail;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3323,8 +3323,10 @@ export class InteractiveMode {
 				this.editor.insertTextAtCursor?.(text);
 				this.ui.requestRender();
 			}
-		} catch {
-			// Silently ignore clipboard errors (may not have permission, etc.)
+		} catch (error) {
+			this.showStatus(
+				`Clipboard paste failed: ${sanitizeTuiErrorMessage(error instanceof Error ? error.message : String(error))}`,
+			);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -91,6 +91,7 @@ import {
 import { detectOmoNativeInstall } from "../../core/omo-native-detect.ts";
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.ts";
+import { createSessionLogger, type SessionLogger } from "../../core/session-log.ts";
 import { type SessionEntry, SessionManager, sessionEntryToContextMessages } from "../../core/session-manager.ts";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.ts";
 import type { SourceInfo } from "../../core/source-info.ts";
@@ -105,7 +106,6 @@ import {
 	isRecoverableInspectorVmImportError,
 } from "../../inspector-policy.ts";
 import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
-import { createSessionLogger, type SessionLogger } from "../../core/session-log.ts";
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
 import { parseGitUrl } from "../../utils/git.ts";
@@ -4908,6 +4908,7 @@ export class InteractiveMode {
 
 	private queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
 		this.compactionQueuedMessages.push({ text, mode });
+		this.getSessionLogger().debug("compaction_queue_enqueue", { mode, count: this.compactionQueuedMessages.length });
 		this.editor.addToHistory?.(text);
 		this.editor.setText("");
 		this.updatePendingMessagesDisplay();

--- a/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
+++ b/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression: clipboard paste failures must never be silently swallowed.
+ *
+ * Field report (Discord 2026-07-30): the CLI appeared to freeze/misbehave
+ * around clipboard image handling with zero trace. handleClipboardPaste's
+ * catch block dropped every error, so permission failures, native-clipboard
+ * errors, and tmp-file write failures were indistinguishable from "nothing
+ * on the clipboard".
+ */
+
+const clipboardImageMock = vi.hoisted(() => ({
+	readClipboardImage: vi.fn<() => Promise<{ bytes: Uint8Array; mimeType: string } | null>>(),
+}));
+
+const clipboardTextMock = vi.hoisted(() => ({
+	readClipboardText: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("../src/utils/clipboard-image.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../src/utils/clipboard-image.ts")>();
+	return { ...original, readClipboardImage: clipboardImageMock.readClipboardImage };
+});
+
+vi.mock("../src/utils/clipboard.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../src/utils/clipboard.ts")>();
+	return { ...original, readClipboardText: clipboardTextMock.readClipboardText };
+});
+
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type HandleClipboardPaste = (this: object) => Promise<void>;
+
+function getHandleClipboardPaste(): HandleClipboardPaste {
+	const handler = Reflect.get(InteractiveMode.prototype, "handleClipboardPaste");
+	if (typeof handler !== "function") throw new Error("Expected InteractiveMode.handleClipboardPaste");
+	return handler as HandleClipboardPaste;
+}
+
+function makeContext() {
+	return {
+		editor: { insertTextAtCursor: vi.fn() },
+		ui: { requestRender: vi.fn() },
+		showStatus: vi.fn(),
+	};
+}
+
+describe("InteractiveMode clipboard paste error surfacing", () => {
+	it("surfaces a status message when clipboard image read fails", async () => {
+		clipboardImageMock.readClipboardImage.mockRejectedValueOnce(new Error("pasteboard permission denied"));
+		clipboardTextMock.readClipboardText.mockResolvedValue(null);
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+
+		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(context.showStatus).toHaveBeenCalledTimes(1);
+		const status = context.showStatus.mock.calls[0]?.[0];
+		expect(String(status)).toContain("Clipboard paste failed");
+		expect(String(status)).toContain("pasteboard permission denied");
+	});
+
+	it("surfaces a status message when clipboard text read fails after empty image", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce(null);
+		clipboardTextMock.readClipboardText.mockRejectedValueOnce(new Error("text unavailable"));
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+
+		expect(context.showStatus).toHaveBeenCalledTimes(1);
+		expect(String(context.showStatus.mock.calls[0]?.[0])).toContain("Clipboard paste failed");
+	});
+
+	it("stays quiet when the clipboard is simply empty", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce(null);
+		clipboardTextMock.readClipboardText.mockResolvedValueOnce(null);
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+
+		expect(context.showStatus).not.toHaveBeenCalled();
+		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
+++ b/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
@@ -39,10 +39,13 @@ function getHandleClipboardPaste(): HandleClipboardPaste {
 }
 
 function makeContext() {
+	const sessionLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
 	return {
 		editor: { insertTextAtCursor: vi.fn() },
 		ui: { requestRender: vi.fn() },
 		showStatus: vi.fn(),
+		sessionLogger,
+		getSessionLogger: () => sessionLogger,
 	};
 }
 
@@ -59,6 +62,10 @@ describe("InteractiveMode clipboard paste error surfacing", () => {
 		const status = context.showStatus.mock.calls[0]?.[0];
 		expect(String(status)).toContain("Clipboard paste failed");
 		expect(String(status)).toContain("pasteboard permission denied");
+		expect(context.sessionLogger.warn).toHaveBeenCalledWith(
+			"clipboard_error",
+			expect.objectContaining({ op: "paste", error: expect.stringContaining("pasteboard permission denied") }),
+		);
 	});
 
 	it("surfaces a status message when clipboard text read fails after empty image", async () => {
@@ -81,5 +88,6 @@ describe("InteractiveMode clipboard paste error surfacing", () => {
 
 		expect(context.showStatus).not.toHaveBeenCalled();
 		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-transfer.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-transfer.test.ts
@@ -16,7 +16,7 @@ type PromptOptions = {
 function getFlushCompactionQueue() {
 	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
 	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
-	return (context: object, options?: { willRetry?: boolean }): Promise<void> =>
+	return (context: object, options?: { willRetry?: boolean; deferAdmission?: boolean }): Promise<void> =>
 		Promise.resolve(flush.call(context, options));
 }
 
@@ -60,6 +60,35 @@ describe("InteractiveMode transactional compaction queue transfer", () => {
 		expect(context.compactionQueuedMessages).not.toContain(first);
 		expect(showError).toHaveBeenCalledWith("Failed to send queued messages: synthetic transfer failure");
 		expect(clearQueue).not.toHaveBeenCalled();
+	});
+
+	it("delivers via native queues without prompt admission when deferAdmission is set", async () => {
+		const steerMessage: QueueMessage = { text: "held steer", mode: "steer" };
+		const followUpMessage: QueueMessage = { text: "held follow-up", mode: "followUp" };
+		const showError = vi.fn();
+		const context = {
+			compactionQueuedMessages: [steerMessage, followUpMessage],
+			compactionInFlightMessages: [] as QueueMessage[],
+			compactionTransferAbortControllers: new Map<QueueMessage, AbortController>(),
+			isExtensionCommand: () => false,
+			showError,
+			updatePendingMessagesDisplay: vi.fn(),
+			session: {
+				clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+				prompt: vi.fn(async () => {}),
+				followUp: vi.fn(async () => {}),
+				steer: vi.fn(async () => {}),
+			},
+		};
+
+		await getFlushCompactionQueue()(context, { willRetry: false, deferAdmission: true });
+
+		expect(context.session.prompt).not.toHaveBeenCalled();
+		expect(context.session.steer).toHaveBeenCalledWith(steerMessage.text);
+		expect(context.session.followUp).toHaveBeenCalledWith(followUpMessage.text);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(showError).not.toHaveBeenCalled();
 	});
 
 	it("commits the first prompt at explicit preflight acceptance and never restores it after turn failure", async () => {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -170,6 +170,8 @@ describe("InteractiveMode compaction events", () => {
 			showError: vi.fn(),
 			showStatus: vi.fn(),
 			clearStatusIndicator: vi.fn(),
+			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
+			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
@@ -208,7 +210,7 @@ describe("InteractiveMode compaction events", () => {
 				summary: "summary",
 			}),
 		);
-		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false });
+		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false, deferAdmission: false });
 	});
 
 	test("surfaces a manual would-overflow rejection instead of silently swallowing it", async () => {
@@ -226,6 +228,8 @@ describe("InteractiveMode compaction events", () => {
 			showWarning: vi.fn(),
 			showStatus: vi.fn(),
 			clearStatusIndicator: vi.fn(),
+			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
+			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
@@ -263,9 +267,9 @@ describe("InteractiveMode compaction events", () => {
 			...fakeThis.showStatus.mock.calls.map((call) => String(call[0])),
 		].join("\n");
 		expect(feedback).toMatch(/would.?overflow|overflow|rejected/i);
-		// Rejected compaction retains editor-owned input instead of submitting it
-		// through a recursive post-compaction prompt path.
-		expect(fakeThis.flushCompactionQueue).not.toHaveBeenCalled();
+		// Rejected compaction still flushes, but through the native queues
+		// (deferAdmission) so no recursive post-compaction prompt path runs.
+		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false, deferAdmission: true });
 	});
 
 	test("sanitizes a detached continuation launch failure before rendering", async () => {
@@ -318,6 +322,8 @@ describe("InteractiveMode compaction events", () => {
 			addMessageToChat: vi.fn(),
 			showError: vi.fn(),
 			showStatus: vi.fn(),
+			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
+			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
@@ -537,6 +543,8 @@ describe("InteractiveMode compaction events", () => {
 			updateEditorBorderColor: vi.fn(),
 			showTreeSelector: vi.fn(),
 			showUserMessageSelector: vi.fn(),
+			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
+			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 			settingsManager: { getShowTerminalProgress: () => false, getDoubleEscapeAction: () => "none" },
 			turnWorkingTip: { resetForNewTurn: vi.fn(), resolve: vi.fn() },

--- a/packages/coding-agent/test/session-log-routes.test.ts
+++ b/packages/coding-agent/test/session-log-routes.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "../src/core/extensions/index.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+const harnesses: Harness[] = [];
+
+afterEach(async () => {
+	for (const harness of harnesses.splice(0)) {
+		harness.cleanup();
+	}
+});
+
+function readSessionLog(harness: Harness): Array<Record<string, unknown>> {
+	const path = join(harness.tempDir, "agent", "logs", "session.log");
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8").trim();
+	} catch {
+		return [];
+	}
+	return raw === "" ? [] : raw.split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function getRunAutoCompaction(harness: Harness) {
+	const runAutoCompaction = Reflect.get(harness.session, "_runAutoCompaction");
+	if (typeof runAutoCompaction !== "function") throw new Error("Expected AgentSession._runAutoCompaction");
+	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
+		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
+describe("session.log stuck-route instrumentation", () => {
+	it("logs compaction_decision with the rejection cause when compaction is rejected", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "test rejection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed handled")]);
+		await harness.session.prompt("seed context ".repeat(40));
+
+		await getRunAutoCompaction(harness)("threshold", false);
+		await harness.session.waitForSettledSessionWork();
+
+		const decisions = readSessionLog(harness).filter((line) => line.event === "compaction_decision");
+		expect(decisions.length).toBeGreaterThan(0);
+		expect(decisions.at(-1)).toMatchObject({
+			reason: "threshold",
+			accepted: false,
+			rejectionCause: "cancelled-by-extension",
+		});
+	});
+
+	it("logs queue_enqueue for native steer and followUp queueing", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed handled")]);
+		await harness.session.prompt("seed");
+
+		await harness.session.steer("queued steer text");
+		await harness.session.followUp("queued follow-up text");
+
+		const enqueues = readSessionLog(harness).filter((line) => line.event === "queue_enqueue");
+		expect(enqueues.map((line) => line.mode)).toEqual(["steer", "followUp"]);
+		expect(enqueues.every((line) => typeof line.count === "number" && line.count >= 1)).toBe(true);
+		expect(JSON.stringify(enqueues)).not.toContain("queued steer text");
+	});
+
+	it("logs compaction_queue_enqueue when the TUI parks input during compaction", () => {
+		const queueCompactionMessage = Reflect.get(InteractiveMode.prototype, "queueCompactionMessage");
+		if (typeof queueCompactionMessage !== "function") throw new Error("Expected queueCompactionMessage");
+		const sessionLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+		const context = {
+			compactionQueuedMessages: [] as Array<{ text: string; mode: string }>,
+			editor: { addToHistory: vi.fn(), setText: vi.fn() },
+			updatePendingMessagesDisplay: vi.fn(),
+			showStatus: vi.fn(),
+			getSessionLogger: () => sessionLogger,
+		};
+
+		queueCompactionMessage.call(context, "held message", "steer");
+
+		expect(context.compactionQueuedMessages).toHaveLength(1);
+		expect(sessionLogger.debug).toHaveBeenCalledWith(
+			"compaction_queue_enqueue",
+			expect.objectContaining({ mode: "steer", count: 1 }),
+		);
+	});
+});

--- a/packages/coding-agent/test/session-log.test.ts
+++ b/packages/coding-agent/test/session-log.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSessionLogger } from "../src/core/session-log.ts";
+
+const tempDirs: string[] = [];
+
+function makeAgentDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-session-log-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function readLines(agentDir: string): Array<Record<string, unknown>> {
+	const raw = readFileSync(join(agentDir, "logs", "session.log"), "utf-8").trim();
+	return raw === "" ? [] : raw.split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("createSessionLogger", () => {
+	it("writes JSONL lines with ts, level, and event to logs/session.log", () => {
+		const agentDir = makeAgentDir();
+		const logger = createSessionLogger(agentDir);
+
+		logger.info("compaction_queue_flush_result", { count: 2, willRetry: false, delivered: 2, restored: 0 });
+
+		const lines = readLines(agentDir);
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toMatchObject({
+			level: "info",
+			event: "compaction_queue_flush_result",
+			count: 2,
+			willRetry: false,
+			delivered: 2,
+			restored: 0,
+		});
+		expect(typeof lines[0]?.ts).toBe("string");
+	});
+
+	it("drops non-allowlisted and secret-bearing data keys", () => {
+		const agentDir = makeAgentDir();
+		const logger = createSessionLogger(agentDir);
+
+		logger.warn("prompt_rejected", {
+			error: "RequiredCompactionError",
+			stage: "admission",
+			authorization: "Bearer sk-live-secret",
+			headers: { cookie: "a=b" },
+			messageText: "the user's private prompt",
+		});
+
+		const [line] = readLines(agentDir);
+		expect(line).toMatchObject({ event: "prompt_rejected", error: "RequiredCompactionError", stage: "admission" });
+		expect(line).not.toHaveProperty("authorization");
+		expect(line).not.toHaveProperty("headers");
+		expect(line).not.toHaveProperty("messageText");
+	});
+
+	it("redacts bearer tokens embedded in allow-listed string values", () => {
+		const agentDir = makeAgentDir();
+		const logger = createSessionLogger(agentDir);
+
+		logger.warn("provider_error", { error: "authorization: Bearer sk-live-abc123 rejected" });
+
+		const [line] = readLines(agentDir);
+		expect(String(line?.error)).not.toContain("sk-live-abc123");
+		expect(String(line?.error)).toContain("[redacted]");
+	});
+
+	it("rotates the log once it exceeds maxBytes", () => {
+		const agentDir = makeAgentDir();
+		const logger = createSessionLogger(agentDir, { maxBytes: 300 });
+
+		for (let i = 0; i < 10; i++) {
+			logger.info("stream_stall", { kind: "idle", durationMs: 300_000 });
+		}
+
+		const rotated = statSync(join(agentDir, "logs", "session.log.1"));
+		expect(rotated.size).toBeGreaterThan(0);
+		expect(statSync(join(agentDir, "logs", "session.log")).size).toBeLessThanOrEqual(300);
+	});
+
+	it("is a no-op without an agentDir and never throws on write failures", () => {
+		const noopLogger = createSessionLogger(undefined);
+		expect(() => noopLogger.info("config_reload", { phase: "deferred" })).not.toThrow();
+
+		const agentDir = makeAgentDir();
+		writeFileSync(join(agentDir, "logs"), "not a directory");
+		const blockedLogger = createSessionLogger(agentDir);
+		expect(() => blockedLogger.info("config_reload", { phase: "deferred" })).not.toThrow();
+	});
+
+	it("mirrors lines to an injected sink", () => {
+		const agentDir = makeAgentDir();
+		const sinkLines: string[] = [];
+		const logger = createSessionLogger(agentDir, { sink: (line) => sinkLines.push(line) });
+
+		logger.debug("clipboard_error", { op: "read-image", error: "permission denied", durationMs: 12 });
+
+		expect(sinkLines).toHaveLength(1);
+		expect(JSON.parse(sinkLines[0] ?? "{}")).toMatchObject({ event: "clipboard_error", op: "read-image" });
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
@@ -136,6 +136,8 @@ describe("Regression: interactive-mode compaction_end fallback", () => {
 			showStatus: vi.fn(),
 			clearStatusIndicator: vi.fn(),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			compactionQueuedMessages: [] as string[],
+			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -89,13 +89,15 @@ function createTuiCompactionEventContext(harness: Harness) {
 		clearStatusIndicator: () => void;
 		rebuildChatFromMessages: () => void;
 		addMessageToChat: () => void;
-		showStatus: () => void;
+		statusMessages: string[];
+		showStatus: (message: string) => void;
 		ui: { requestRender: () => void; terminal: { setProgress: () => void } };
 		settingsManager: { getShowTerminalProgress: () => boolean };
 		flushCompactionQueue: (options: { willRetry: boolean }) => Promise<void>;
 		flushes: Promise<void>[];
 	};
 	const flushes: Promise<void>[] = [];
+	const statusMessages: string[] = [];
 	Object.assign(context, {
 		isInitialized: true,
 		footer: { invalidate: () => {} },
@@ -107,9 +109,13 @@ function createTuiCompactionEventContext(harness: Harness) {
 		clearStatusIndicator: () => {},
 		rebuildChatFromMessages: () => {},
 		addMessageToChat: () => {},
-		showStatus: () => {},
+		statusMessages,
+		showStatus: (message: string) => {
+			statusMessages.push(message);
+		},
 		ui: { requestRender: () => {}, terminal: { setProgress: () => {} } },
 		settingsManager: { getShowTerminalProgress: () => false },
+		getSessionLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {} }),
 		flushes,
 		flushCompactionQueue(options: { willRetry: boolean }) {
 			const flush = getFlushCompactionQueue()(context, options);
@@ -289,7 +295,7 @@ describe("post-compaction queued input recovery", () => {
 		["rejected threshold", "threshold" as const, false, "reject" as const],
 		["feedback-only abort", undefined, false, "abort" as const],
 	])(
-		"keeps queued TUI input owned by the editor after a %s compaction_end",
+		"routes queued TUI input to the native session queue after a %s compaction_end",
 		async (_label, reason, willRetry, outcome) => {
 			const marker = `[TUI queue remains ${outcome}]`;
 			const harness = await createHarness({
@@ -334,11 +340,13 @@ describe("post-compaction queued input recovery", () => {
 			await Promise.all(context.flushes);
 			await harness.session.waitForSettledSessionWork();
 
-			expect(context.compactionQueuedMessages).toEqual([{ text: marker, mode: "steer" }]);
+			expect(context.compactionQueuedMessages).toEqual([]);
 			expect(context.compactionInFlightMessages).toEqual([]);
+			expect(harness.session.getSteeringMessages()).toContain(marker);
 			expect(getUserTexts(harness)).not.toContain(marker);
 			expect(harness.faux.state.callCount).toBe(providerCallsBeforeCompaction);
 			expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+			expect(context.statusMessages.some((message) => message.includes("queued message"))).toBe(true);
 		},
 	);
 


### PR DESCRIPTION
## Summary

Field reports (Discord, 2026-07-30): after long sessions senpi gets "stuck forever" — compaction fails (summarization wall-clock budget trips -> circuit breaker), and every message typed afterwards is silently swallowed; a second flavor froze while pasting/reading clipboard images. This PR fixes the input-swallow root cause and adds traceable logging on every stuck-prone route so future stuck states are diagnosable from `~/.senpi/agent/logs/` alone.

## Root cause

Messages typed during an active compaction are parked in the TUI-only `compactionQueuedMessages` queue. The `compaction_end` handler flushed that queue **only on success** (`accepted === true || result !== undefined`). Failed, rejected (circuit-breaker cooldown), or aborted compactions left the queue parked forever with no notice; threshold compaction re-triggers at every next admission, funneling every subsequent message into the same dead queue; a session switch/reopen then discards the queue entirely (data loss). A prior regression test pinned this behavior under the inaccurate name "keeps queued TUI input owned by the editor" — the text was never in the editor.

Analysis was cross-reviewed by two independent deep-analysis lanes (state-machine trace + observability/fix-architecture design) plus a live repro of the reporter's session shape.

## Fix

- Every terminal `compaction_end` now flushes the compaction queue. Accepted compactions keep the existing prompt-admission delivery; unsuccessful ones route non-command messages through the native steer/followUp queues (`deferAdmission` transfer option) — no forced provider admission into an over-budget context, retries stay turn-driven (no breaker storms), message boundaries and steer/followUp modes preserved, FIFO restored. A visible status reports the held count.
- Clipboard paste failures now surface a `Clipboard paste failed: <reason>` status instead of being silently swallowed.

## Traceable logging (new `logs/session.log`)

New rotating, content-free JSONL spine (5MB rotate, allow-listed scalar fields, secret redaction, `SENPI_SESSION_DEBUG=1` stderr mirror), following the existing `retry-fallback/log.ts` pattern:

- `compaction_decision` — every terminal compaction end (reason/accepted/aborted/willRetry/rejectionCause/error)
- `provider_error` — assistant `message_end` errors classified stall / timeout / error (covers the `Idle timeout waiting for provider stream` flavor)
- `prompt_rejected` — `RequiredCompactionError` admission rejections
- `queue_enqueue` — native steer/followUp queueing (mode + count only)
- `compaction_queue_enqueue` / `compaction_queue_deferred` — TUI compaction-queue transitions
- `clipboard_error` — clipboard paste failures

## Verification

- RED->GREEN regressions: inverted the pinning regression (3 terminal shapes now assert native-queue delivery + notice, captured failing first), new `deferAdmission` transfer unit test, session-log route tests (rejected compaction decision + queue enqueues via real harness reading the log file), clipboard error surfacing tests. 44/44 across the seven touched suites.
- `npm run check` green (Biome, pinned-deps, ts-imports, shrinkwrap, tsgo, browser smoke, web-ui).
- Real-CLI QA (senpi-qa): RPC scenario — sandboxed CLI + mock model + compaction-rejecting extension: compaction attempt observably rejected, the next typed message still processed (`agent_end` + scripted marker), and `session.log` written with `compaction_decision accepted:false` by the real CLI. 4/4 checks PASS. Channel self-tests (cli-smoke, rpc-drive, mock-loop, tui-smoke) green. Evidence under `local-ignore/qa-evidence/20260730-stuck-fix/` (gitignored; transcripts + session.log + results JSON).

## Known limitations / follow-ups

- Extension-route `compaction_end` events omit `rejectionCause` (threshold/manual routes carry it); the decision line still records `accepted:false`.
- Inline kitty image rendering joins 4KB APC chunks into one multi-MB synchronous stdout write (POSIX TTY writes are synchronous) — a credible mechanism for the "froze while reading a clipboard PNG" flavor. Deliberately excluded here per review consensus; tracked as a follow-up issue with `clipboard_error`/duration data now available to confirm.
- The `--omo-senpi-config-watch-disabled` child-worker exit-1 belongs to the omo-senpi repo (separate follow-up).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sessions getting stuck after failed compaction by always flushing the TUI compaction queue and deferring queued input to native steer/followUp queues. Adds a rotating `session.log` to trace stuck routes, and surfaces clipboard paste errors with a clear status.

- **Bug Fixes**
  - Never park compaction-queued messages on failed/rejected/aborted compaction; route via native steer/followUp (`deferAdmission`) and show a held-count status.
  - Surface clipboard paste errors with “Clipboard paste failed: <reason>”.

- **New Features**
  - Add rotating JSONL session logger at `<agentDir>/logs/session.log` (5MB rotate, secret redaction, `SENPI_SESSION_DEBUG=1` stderr mirror) recording: `compaction_decision`, `provider_error`, `prompt_rejected`, `queue_enqueue`, `compaction_queue_enqueue`, `compaction_queue_deferred`, and `clipboard_error`.

<sup>Written for commit b918507187fba13a4c5619b1deb03359d9e7038c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

