### PR TITLE
fix(coding-agent): bulk-clear todo rm when both targets are blank

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -1,5 +1,38 @@
 # todotools Fork Tracker
 
+## 2026-07-30 - Bulk-clear rm when both targets arrive blank
+
+### What changed
+
+- `{"op":"rm","task":"","phase":""}` now normalizes to a bulk clear with one
+  `[auto-corrected]` correction instead of the `Blank "task"` dead-end
+  error. GPT-5.x-style function calling serializes every schema property
+  and pads omitted strings with `""`, so telling the model to "omit the
+  field entirely" pointed at an option its serializer cannot express;
+  session 019fabf3 (2026-07-29, apitopia) showed the same failing call
+  retried verbatim. Both targets blank together is unambiguous — the only
+  documented no-target rm form is a bulk clear (the prompt table already
+  documents "rm: omit both to clear").
+- Guard scope is unchanged for everything else: rm with exactly one target
+  blank, and `start`/`done`/`drop` with blank targets, still return the
+  `Blank "target"` error. Widening the single-blank or bulk form of those
+  ops from padding could silently complete or abandon every task, so the
+  defensive error is kept there.
+- Regression coverage pins the two layers: unit normalization cases in
+  `test/suite/todo-normalize.test.ts` (`rm both-blank padding`, including
+  the verbatim padded payload and non-mutation), plus registered-execute
+  assertions in `test/suite/todo-rm-blank-bulk-clear.test.ts` that the
+  padded payload bulk-clears through the real tool (correction surfaced,
+  state emptied, one state entry appended) and that `done` with both
+  targets blank still throws.
+
+### Expected merge conflict zones
+
+- HIGH: `normalize.ts` — the blank-target guard block and the hoisted
+  `corrections` declaration if upstream ships similar correction logic.
+- LOW: `test/suite/todo-normalize.test.ts` and the new
+  `test/suite/todo-rm-blank-bulk-clear.test.ts` (fork-only).
+
 ## 2026-07-29 - Keep active work visible in long todo widgets
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/normalize.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/normalize.ts
@@ -92,11 +92,23 @@ export function normalizeTodoParams(
 	const op = isOperation(rawOp) ? rawOp : undefined;
 	const task = nonBlank(raw.task);
 	const phase = nonBlank(raw.phase);
+	const corrections: string[] = [];
 	if (op === "start" || op === "done" || op === "drop" || op === "rm") {
-		if (isBlank(raw.task) && !phase) {
+		// GPT-5.x-style function calling serializes every schema property and pads
+		// omitted strings with "". When BOTH targets arrive blank on rm, the only
+		// documented no-target rm form is a bulk clear, so the padding is
+		// unambiguous — drop it instead of demanding a field omission the
+		// serializer cannot express. Single-blank targets and the destructive-bulk
+		// ops (start/done/drop) still error, so a truncated single target never
+		// widens into a bulk action.
+		if (op === "rm" && isBlank(raw.task) && isBlank(raw.phase)) {
+			corrections.push(
+				'[auto-corrected] "task" and "phase" were both blank; treated as a bulk clear. ' +
+					'For a single target pass the exact text: {"op":"rm","task":"<exact task content>"}.',
+			);
+		} else if (isBlank(raw.task) && !phase) {
 			return error('Blank "task" — pass the exact task text, or omit the field entirely for a bulk operation.');
-		}
-		if (isBlank(raw.phase) && !task) {
+		} else if (isBlank(raw.phase) && !task) {
 			return error('Blank "phase" — pass the exact phase text, or omit the field entirely for a bulk operation.');
 		}
 	}
@@ -113,7 +125,6 @@ export function normalizeTodoParams(
 	const alias = aliases[0];
 	let effectiveItems = rawItems && rawItems.length > 0 ? rawItems : undefined;
 	let candidate: Alias | undefined;
-	const corrections: string[] = [];
 	if (alias) {
 		if (op && op !== alias.name) return error(CONFLICTING_SHAPES);
 		effectiveItems = alias.items;

--- a/packages/coding-agent/test/suite/todo-normalize.test.ts
+++ b/packages/coding-agent/test/suite/todo-normalize.test.ts
@@ -276,3 +276,49 @@ describe("normalizeTodoParams", () => {
 		});
 	});
 });
+
+describe("normalizeTodoParams rm both-blank padding", () => {
+	// Verbatim GPT-5.x all-fields padding observed in senpi session
+	// 019fabf3 (2026-07-29, apitopia): the serializer emits every schema
+	// property and pads omitted strings with "".
+	const PADDED = { op: "rm", list: [], task: "", phase: "", items: [] };
+
+	it("treats rm with both targets blank as a bulk clear with one correction", () => {
+		const result = normalizeTodoParams(PADDED, populatedPhases);
+		expect(result.error).toBeUndefined();
+		expect(result.entry).toEqual({ op: "rm" });
+		expect(result.corrections).toHaveLength(1);
+		expect(result.corrections[0]).toContain("[auto-corrected]");
+		expect(result.corrections[0]).toContain("bulk clear");
+	});
+
+	it("does not mutate the padded raw payload", () => {
+		const raw = { op: "rm", list: [], task: "", phase: "", items: [] };
+		normalizeTodoParams(raw, populatedPhases);
+		expect(raw).toEqual(PADDED);
+	});
+
+	it("treats whitespace-only rm targets the same as empty strings", () => {
+		const result = normalizeTodoParams({ op: "rm", task: " \t", phase: " \n " }, populatedPhases);
+		expect(result.error).toBeUndefined();
+		expect(result.entry).toEqual({ op: "rm" });
+	});
+
+	it.each(["start", "done", "drop"] as const)("still rejects %s with both targets blank", (op) => {
+		expect(expectError({ op, task: "", phase: "" })).toBe(
+			'Blank "task" — pass the exact task text, or omit the field entirely for a bulk operation.',
+		);
+	});
+
+	it("still rejects rm with only the task blank", () => {
+		expect(expectError({ op: "rm", task: "" })).toBe(
+			'Blank "task" — pass the exact task text, or omit the field entirely for a bulk operation.',
+		);
+	});
+
+	it("still rejects rm with only the phase blank", () => {
+		expect(expectError({ op: "rm", phase: " " })).toBe(
+			'Blank "phase" — pass the exact phase text, or omit the field entirely for a bulk operation.',
+		);
+	});
+});

--- a/packages/coding-agent/test/suite/todo-rm-blank-bulk-clear.test.ts
+++ b/packages/coding-agent/test/suite/todo-rm-blank-bulk-clear.test.ts
@@ -1,0 +1,122 @@
+// Real-surface regression for the padded-rm dead-end observed in senpi session
+// 019fabf3 (2026-07-29, apitopia workspace, gpt-5.6-sol): the model emitted
+// {"op":"rm","list":[],"task":"","phase":"","items":[]} - every schema field
+// present, strings blank - and the tool threw 'Blank "task"' back twice.
+// These tests drive the registered todo tool execute (real normalization,
+// applyParams, and result rendering) end to end.
+
+import type { Static } from "typebox";
+import { describe, expect, it } from "vitest";
+import {
+	clonePhases,
+	type TodoPhase,
+	type TodoToolDetails,
+} from "../../src/core/extensions/builtin/todotools/state.ts";
+import { registerTodoTool, type TODO_PARAMS_SCHEMA } from "../../src/core/extensions/builtin/todotools/tools/todo.ts";
+import type {
+	AgentToolResult,
+	ExtensionAPI,
+	ExtensionContext,
+	ToolDefinition,
+} from "../../src/core/extensions/types.ts";
+
+type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
+type RegisteredTodoTool = ToolDefinition<typeof TODO_PARAMS_SCHEMA, TodoToolDetails, unknown>;
+
+function captureTodoTool(initialPhases: readonly TodoPhase[]) {
+	let capturedTool: RegisteredTodoTool | undefined;
+	let currentPhases = clonePhases(initialPhases);
+	let appendCalls = 0;
+	const pi = {
+		registerTool(tool: RegisteredTodoTool) {
+			capturedTool = tool;
+		},
+		appendEntry() {
+			appendCalls += 1;
+		},
+	} as Pick<ExtensionAPI, "registerTool" | "appendEntry"> as ExtensionAPI;
+	registerTodoTool(pi, {
+		getCurrentPhases: () => clonePhases(currentPhases),
+		setCurrentPhases: (phases) => {
+			currentPhases = clonePhases(phases);
+		},
+		syncWidget: () => {},
+	});
+	if (!capturedTool) throw new Error("Expected todo tool to be registered");
+
+	return {
+		tool: capturedTool,
+		getCurrentPhases: () => clonePhases(currentPhases),
+		getAppendCalls: () => appendCalls,
+		context: { sessionManager: { getSessionFile: () => undefined } } as unknown as ExtensionContext,
+	};
+}
+
+async function executeTodo(
+	tool: RegisteredTodoTool,
+	rawArgs: Record<string, unknown>,
+	context: ExtensionContext,
+): Promise<AgentToolResult<TodoToolDetails>> {
+	if (!tool.execute) throw new Error("Expected todo execute");
+	return tool.execute("todo-rm-blank-bulk-clear", rawArgs as TodoParams, undefined, undefined, context);
+}
+
+async function executeError(
+	tool: RegisteredTodoTool,
+	rawArgs: Record<string, unknown>,
+	context: ExtensionContext,
+): Promise<Error> {
+	try {
+		await executeTodo(tool, rawArgs, context);
+	} catch (error) {
+		if (error instanceof Error) return error;
+		throw error;
+	}
+	throw new Error("Expected todo execute to throw");
+}
+
+function resultText(result: AgentToolResult<TodoToolDetails>): string {
+	return result.content
+		.filter((content): content is { type: "text"; text: string } => content.type === "text")
+		.map((content) => content.text)
+		.join("\n");
+}
+
+const seeded: TodoPhase[] = [
+	{
+		name: "Setup",
+		tasks: [
+			{ content: "Seed task one", status: "in_progress" },
+			{ content: "Seed task two", status: "pending" },
+		],
+	},
+];
+
+describe("todo rm both-blank bulk clear through registered execute", () => {
+	it("bulk-clears the padded rm payload instead of throwing the blank-target error", async () => {
+		const captured = captureTodoTool(seeded);
+		const result = await executeTodo(
+			captured.tool,
+			{ op: "rm", list: [], task: "", phase: "", items: [] },
+			captured.context,
+		);
+		const text = resultText(result);
+
+		expect(result.details.op).toBe("rm");
+		expect(text).toContain("[auto-corrected]");
+		expect(text).toContain("bulk clear");
+		expect(text).not.toContain('Blank "task"');
+		expect(text).not.toContain("Seed task one");
+		expect(captured.getCurrentPhases()).toEqual([{ name: "Setup", tasks: [] }]);
+		expect(captured.getAppendCalls()).toBe(1);
+	});
+
+	it("still throws the blank-target error for done with both targets blank", async () => {
+		const captured = captureTodoTool(seeded);
+		const error = await executeError(captured.tool, { op: "done", task: "", phase: "" }, captured.context);
+
+		expect(error.message).toContain('Blank "task"');
+		expect(captured.getCurrentPhases()).toEqual(seeded);
+		expect(captured.getAppendCalls()).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

`{"op":"rm","task":"","phase":""}` now normalizes to a **bulk clear** with one
`[auto-corrected]` correction instead of the `Blank "task"` dead-end error.

### Root cause (observed in production session)

GPT-5.x-style function calling serializes **every** schema property and pads
omitted strings with `""`. The blank-target guard's error tells the model to
"omit the field entirely for a bulk operation" — an option its serializer
cannot express. In senpi session `019fabf3` (2026-07-29, apitopia workspace,
gpt-5.6-sol) the model retried the **byte-identical failing call** on the
next turn despite reasoning about an "omit field workaround". The error
message created an unrecoverable loop; only switching to `init` recovered.

Both targets blank together is unambiguous: the only documented no-target
`rm` form is a bulk clear (the ops table already documents "omit both to
clear").

### What changed

- `normalize.ts`: when `op === "rm"` and **both** `task` and `phase` are
  present-but-blank, drop the padding and emit one `[auto-corrected]`
  correction message. `corrections` is hoisted so the guard can contribute
  to it.
- Guard scope is unchanged everywhere else: `rm` with exactly one target
  blank, and `start`/`done`/`drop` with blank targets, still return the
  `Blank "<target>"` error — widening the bulk form of those ops from
  padding could silently complete or abandon every task.
- `todotools/changes.md`: fork-note entry (2026-07-30).

### Evidence

- **Failing-first**: 3 new tests captured RED before any production change
  (unit normalization layer + registered-execute layer reproducing the
  verbatim session error, incl. `Remaining items (2): Seed task one...`).
- **GREEN**: scoped vitest — 2 files / 48 tests; full todo scope 10 files /
  144 tests green. `npm run check` exit 0.
- **Mutation proof**: widening the new branch to `done` flips both
  `done`-both-blank pins RED; reverting restores green — the pins are live
  coverage, not tautologies.
- **Real-CLI QA (senpi-qa channel 3, custom driver over the mock-loop
  harness)**: scripted 3-turn loop `todo init` → padded `todo rm` → final
  marker against the real CLI from source.
  - Unfixed `main`: `Blank "task"` reproduced in the relayed tool result
    (RED receipt, 6/6).
  - This branch: tool result shows `[auto-corrected] "task" and "phase"
    were both blank; treated as a bulk clear…` + `Todo list cleared.` (7/7,
    real auth asserted unchanged).
  - Artifacts: `local-ignore/qa-evidence/20260730-todo-rm-blank-bulk-clear-{broken,fixed}/`.

### Files

- `packages/coding-agent/src/core/extensions/builtin/todotools/normalize.ts`
- `packages/coding-agent/src/core/extensions/builtin/todotools/changes.md`
- `packages/coding-agent/test/suite/todo-normalize.test.ts`
- `packages/coding-agent/test/suite/todo-rm-blank-bulk-clear.test.ts` (new)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `todo rm` calls with both `task` and `phase` blank as a bulk clear instead of throwing `Blank "task"`, preventing padded function-call loops and showing a single `[auto-corrected]` notice.

- **Bug Fixes**
  - In `normalize.ts`, when `op: "rm"` and both `task` and `phase` are blank, normalize to bulk clear and add one correction; hoist `corrections` so the guard can contribute.
  - Guards stay strict elsewhere: single-blank `rm` and all `start`/`done`/`drop` blanks still error.
  - Tests added: unit normalization cases and an end-to-end registered execute test for padded `rm` showing `[auto-corrected]` and clearing the list.
  - `todotools/changes.md` updated with the fork note.

<sup>Written for commit 08becc168a7112749d9bad08905dd4e83b3f4eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

