### PR TITLE
feat(coding-agent): high_reasoning_warning RPC event + scary TUI warning box

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,22 @@
+## high_reasoning_warning for sensitive frontier models at xhigh/max (2026-07-30)
+
+### What changed
+
+- New `core/high-reasoning-warning.ts`: provider-agnostic, model-name-based detection (`isSensitiveHighReasoningModel`, reusing `supportsXhigh`/`supportsMax`) plus `shouldWarnHighReasoning` and `buildHighReasoningWarning`.
+- `agent-session.ts`: emits a new `high_reasoning_warning` `AgentSessionEvent` when a sensitive model is driven at xhigh/max, deduped by provider/model/level, wired into `_switchActiveModel` and `_setThinkingLevel`.
+
+### Why
+
+- Frontier reasoning models (gpt-5.x, deepseek-v4-pro/flash, opus-4-6..5, sonnet-5, fable-5) at xhigh/max are acutely prompt-sensitive: human-prompted runs risk non-stopping, unrequested actions, or risky behavior. The warning urges use via the ultrabrain subagent and states direct-use responsibility.
+
+### Why extension system couldn't handle this alone
+
+- The event must fire from session model/thinking-level transitions inside `AgentSession`, which extensions can only observe after the fact; the dedupe + emit belongs in the session lifecycle.
+
+### Expected merge conflict zones
+
+- LOW: `agent-session.ts` `_switchActiveModel`/`_setThinkingLevel` and the `AgentSessionEvent` union.
+
 ## Bun self-updates preserve the Bun launcher (2026-07-30)
 
 - Bun-managed global self-updates now replace Bun's generated Node-shebang symlink with a small launcher that

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -145,6 +145,7 @@ import type { SettingsManager } from "./settings-manager.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";
 import { getSupportedThinkingLevels, supportsMax, supportsXhigh } from "./thinking-levels.ts";
+import { shouldWarnHighReasoning } from "./high-reasoning-warning.ts";
 import { resetTimings, time } from "./timings.ts";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.ts";
 import { createAllToolDefinitions } from "./tools/index.ts";
@@ -201,6 +202,7 @@ export type AgentSessionEvent =
 	| ExtensionToolHookLifecycleEvent
 	| SystemPromptChangeEvent
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
+	| { type: "high_reasoning_warning"; modelId: string; provider: string; thinkingLevel: ThinkingLevel }
 	| {
 			type: "compaction_end";
 			reason: CompactionReason;
@@ -647,6 +649,7 @@ export class AgentSession {
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
 	private _currentServiceTier: ServiceTier | undefined = undefined;
+	private _lastHighReasoningWarningKey: string | undefined = undefined;
 	private _baseSystemPromptOptions!: BuildDynamicSystemPromptOptions;
 	private _systemPromptOverride?: string;
 
@@ -3213,6 +3216,8 @@ export class AgentSession {
 			this.setSessionThinkingLevel(thinkingLevel);
 		}
 
+		this._emitHighReasoningWarningIfNeeded();
+
 		if (!opts.emitModelSelect) return undefined;
 		return await this._emitModelSelect(model, previousModel, opts.modelSelectSource);
 	}
@@ -3328,7 +3333,28 @@ export class AgentSession {
 				level: effectiveLevel,
 				previousLevel,
 			});
+			this._emitHighReasoningWarningIfNeeded();
 		}
+	}
+
+	private _emitHighReasoningWarningIfNeeded(): void {
+		const model = this.model;
+		const level = this.thinkingLevel;
+		if (!model || !shouldWarnHighReasoning(model, level)) {
+			this._lastHighReasoningWarningKey = undefined;
+			return;
+		}
+		const key = `${model.provider}/${model.id}:${level}`;
+		if (this._lastHighReasoningWarningKey === key) {
+			return;
+		}
+		this._lastHighReasoningWarningKey = key;
+		this._emit({
+			type: "high_reasoning_warning",
+			modelId: model.id,
+			provider: model.provider,
+			thinkingLevel: level,
+		});
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -119,6 +119,7 @@ import type {
 	ModelSelectSource,
 } from "./extensions/types.ts";
 import { RUNTIME_EXTENSION_PATH } from "./extensions/types.ts";
+import { shouldWarnHighReasoning } from "./high-reasoning-warning.ts";
 import { type BashExecutionMessage, type CustomMessage, filterContextExcludedMessages } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
 import { type AvailableModelsSource, getModelNarrowingPatterns, resolveModelScope } from "./model-resolver.ts";
@@ -145,7 +146,6 @@ import type { SettingsManager } from "./settings-manager.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";
 import { getSupportedThinkingLevels, supportsMax, supportsXhigh } from "./thinking-levels.ts";
-import { shouldWarnHighReasoning } from "./high-reasoning-warning.ts";
 import { resetTimings, time } from "./timings.ts";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.ts";
 import { createAllToolDefinitions } from "./tools/index.ts";

--- a/packages/coding-agent/src/core/high-reasoning-warning.ts
+++ b/packages/coding-agent/src/core/high-reasoning-warning.ts
@@ -16,7 +16,7 @@ export interface HighReasoningWarningContent {
 }
 
 export function buildHighReasoningWarning(
-	model: Model<Api>,
+	model: Pick<Model<Api>, "id" | "provider">,
 	thinkingLevel: ThinkingLevel,
 ): HighReasoningWarningContent {
 	const modelId = model.id;

--- a/packages/coding-agent/src/core/high-reasoning-warning.ts
+++ b/packages/coding-agent/src/core/high-reasoning-warning.ts
@@ -1,0 +1,36 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { supportsMax, supportsXhigh } from "./thinking-levels.ts";
+
+export function isSensitiveHighReasoningModel(model: Model<Api>): boolean {
+	return supportsXhigh(model) || supportsMax(model);
+}
+
+export function shouldWarnHighReasoning(model: Model<Api>, thinkingLevel: ThinkingLevel): boolean {
+	return (thinkingLevel === "xhigh" || thinkingLevel === "max") && isSensitiveHighReasoningModel(model);
+}
+
+export interface HighReasoningWarningContent {
+	readonly title: string;
+	readonly body: readonly string[];
+}
+
+export function buildHighReasoningWarning(
+	model: Model<Api>,
+	thinkingLevel: ThinkingLevel,
+): HighReasoningWarningContent {
+	const modelId = model.id;
+	const title = `⚠ HIGH-REASONING MODEL WARNING — ${model.provider}/${modelId} @ ${thinkingLevel}`;
+	const body = [
+		`${modelId} is a frontier reasoning model. Running it at "${thinkingLevel}" effort makes it acutely sensitive to prompt quality.`,
+		"Driving this model directly from a human prompt is NOT recommended. Risks include:",
+		"  • The model may refuse to stop, looping or working far past the stated goal.",
+		"  • It may perform unrequested actions in order to \"complete\" the task.",
+		"  • It may take risky, irreversible, or dangerous actions to force completion.",
+		"Strongly recommended: use this model ONLY through the ultrabrain subagent.",
+		"Human prompts leave gaps; an agent-authored prompt is denser and stricter than a human's — exactly what these high-effort models need to stay bounded.",
+		'From the main agent, delegate instead: "query ultrabrain with <task>".',
+		`If you drive this model directly at ${thinkingLevel}, YOU assume ALL responsibility for the consequences.`,
+	];
+	return { title, body };
+}

--- a/packages/coding-agent/src/core/high-reasoning-warning.ts
+++ b/packages/coding-agent/src/core/high-reasoning-warning.ts
@@ -25,7 +25,7 @@ export function buildHighReasoningWarning(
 		`${modelId} is a frontier reasoning model. Running it at "${thinkingLevel}" effort makes it acutely sensitive to prompt quality.`,
 		"Driving this model directly from a human prompt is NOT recommended. Risks include:",
 		"  • The model may refuse to stop, looping or working far past the stated goal.",
-		"  • It may perform unrequested actions in order to \"complete\" the task.",
+		'  • It may perform unrequested actions in order to "complete" the task.',
 		"  • It may take risky, irreversible, or dangerous actions to force completion.",
 		"Strongly recommended: use this model ONLY through the ultrabrain subagent.",
 		"Human prompts leave gaps; an agent-authored prompt is denser and stricter than a human's — exactly what these high-effort models need to stay bounded.",

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,10 @@
 # changes
 
+## high_reasoning_warning TUI box (2026-07-30)
+
+- `interactive-mode.ts` consumes `high_reasoning_warning` and renders a scary red (`error`-themed) warning box via `showHighReasoningWarning`, urging use via the ultrabrain subagent. Mirrors `showNewVersionNotification` styling.
+- QA: `local-ignore/qa-evidence/20260730-high-reasoning-warning/` (ans/html/grid triplet; 916 red cells; WARNING+ultrabrain+responsibility confirmed).
+
 ## Footer hides low cache hit rates (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,7 +7,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@earendil-works/pi-ai/compat";
 import type {
@@ -56,6 +56,7 @@ import {
 	VERSION,
 } from "../../config.ts";
 import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
+import { buildHighReasoningWarning } from "../../core/high-reasoning-warning.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import { isApiKeyLoginProvider } from "../../core/auth-providers.ts";
 import {
@@ -3617,6 +3618,10 @@ export class InteractiveMode {
 				this.updateEditorBorderColor();
 				break;
 
+			case "high_reasoning_warning":
+				this.showHighReasoningWarning(event);
+				break;
+
 			case "message_start":
 				if (event.message.role === "custom") {
 					this.addMessageToChat(event.message);
@@ -4781,6 +4786,24 @@ export class InteractiveMode {
 			),
 		);
 		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+		this.ui.requestRender();
+	}
+
+	showHighReasoningWarning(event: { modelId: string; provider: string; thinkingLevel: ThinkingLevel }): void {
+		const { title, body } = buildHighReasoningWarning(
+			{ id: event.modelId, provider: event.provider },
+			event.thinkingLevel,
+		);
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
+		this.chatContainer.addChild(
+			new Text(
+				`${theme.bold(theme.fg("error", title))}\n${body.map((line) => theme.fg("error", line)).join("\n")}`,
+				1,
+				0,
+			),
+		);
+		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -56,7 +56,6 @@ import {
 	VERSION,
 } from "../../config.ts";
 import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
-import { buildHighReasoningWarning } from "../../core/high-reasoning-warning.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import { isApiKeyLoginProvider } from "../../core/auth-providers.ts";
 import {
@@ -80,6 +79,7 @@ import type {
 } from "../../core/extensions/index.ts";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
 import { appendHiddenTuiStdout } from "../../core/hidden-stdout-log.ts";
+import { buildHighReasoningWarning } from "../../core/high-reasoning-warning.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
 import { createCompactionSummaryMessage } from "../../core/messages.ts";

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,9 @@
 # changes
 
+## high_reasoning_warning RPC event (2026-07-30)
+
+- New `RpcHighReasoningWarningEvent` contract (`{ type: "high_reasoning_warning"; modelId; provider; thinkingLevel }`), auto-published to RPC stdout via the existing `session.subscribe -> outputEvent` seam. No new wiring; the event is a session event forwarded like `thinking_level_changed`.
+
 ## Credential-header auth status sources (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -445,6 +445,13 @@ export interface RpcThinkingLevelChangedEvent {
 	level: ThinkingLevel;
 }
 
+export interface RpcHighReasoningWarningEvent {
+	type: "high_reasoning_warning";
+	modelId: string;
+	provider: string;
+	thinkingLevel: ThinkingLevel;
+}
+
 /** Emitted after an account is added, removed, pinned, or blocked by refresh failure. */
 export interface RpcAuthAccountsChangedEvent {
 	type: "auth_accounts_changed";

--- a/packages/coding-agent/test/high-reasoning-warning-event.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-event.test.ts
@@ -1,0 +1,157 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent, type AgentEvent, type AgentTool } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai/compat";
+import { type Api, type Model } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession, type AgentSessionEvent } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function sensitiveModel(id = "claude-fable-5", provider = "anthropic"): Model<Api> {
+	return {
+		id,
+		provider,
+		reasoning: true,
+		api: "anthropic-messages",
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	} as unknown as Model<Api>;
+}
+
+function plainModel(): Model<Api> {
+	return getModel("anthropic", "claude-sonnet-4-5")!;
+}
+
+function warningEvents(events: AgentSessionEvent[]): AgentSessionEvent[] {
+	return events.filter((e) => e.type === "high_reasoning_warning");
+}
+
+describe("AgentSession high_reasoning_warning event", () => {
+	let session: AgentSession;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-hrw-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (session) session.dispose();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	async function createSession(initialModel: Model<Api> = plainModel()): Promise<{
+		session: AgentSession;
+		events: AgentSessionEvent[];
+	}> {
+		const events: AgentSessionEvent[] = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: initialModel, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const msg: AssistantMessage = {
+						role: "assistant",
+						content: [{ type: "text", text: "ok" }],
+						api: "anthropic-messages",
+						provider: "anthropic",
+						model: "mock",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "done", reason: "stop", message: msg });
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: createTestResourceLoader(),
+		});
+		session.subscribe((event) => {
+			events.push(event);
+		});
+		return { session, events };
+	}
+
+	it("emits high_reasoning_warning when a sensitive model is raised to xhigh", async () => {
+		const { session, events } = await createSession();
+		session.agent.state.model = sensitiveModel();
+		session.setThinkingLevel("xhigh");
+		expect(warningEvents(events).length).toBe(1);
+		const e = warningEvents(events)[0] as { type: string; modelId: string; provider: string; thinkingLevel: string };
+		expect(e.type).toBe("high_reasoning_warning");
+		expect(e.modelId).toBe("claude-fable-5");
+		expect(e.provider).toBe("anthropic");
+		expect(e.thinkingLevel).toBe("xhigh");
+	});
+
+	it("does not emit when a sensitive model is set to high (not 'above high')", async () => {
+		const { session, events } = await createSession();
+		session.agent.state.model = sensitiveModel();
+		session.setThinkingLevel("high");
+		expect(warningEvents(events).length).toBe(0);
+	});
+
+	it("does not emit when a non-sensitive model is raised to xhigh", async () => {
+		const { session, events } = await createSession(plainModel());
+		session.setThinkingLevel("xhigh");
+		expect(warningEvents(events).length).toBe(0);
+	});
+
+	it("dedupes: raising to xhigh twice emits exactly one warning", async () => {
+		const { session, events } = await createSession();
+		session.agent.state.model = sensitiveModel();
+		session.setThinkingLevel("xhigh");
+		session.setThinkingLevel("xhigh");
+		expect(warningEvents(events).length).toBe(1);
+	});
+
+	it("emits when switching to a different sensitive model while already at xhigh", async () => {
+		const { session, events } = await createSession();
+		session.agent.state.model = sensitiveModel("claude-fable-5");
+		session.setThinkingLevel("xhigh");
+		expect(warningEvents(events).length).toBe(1);
+		await session.setModel(sensitiveModel("claude-opus-4-8"));
+		expect(warningEvents(events).length).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/high-reasoning-warning-event.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-event.test.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Agent, type AgentEvent, type AgentTool } from "@earendil-works/pi-agent-core";
+import { Agent } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai/compat";
-import { type Api, type Model } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession, type AgentSessionEvent } from "../src/core/agent-session.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";

--- a/packages/coding-agent/test/high-reasoning-warning-rpc.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-rpc.test.ts
@@ -1,0 +1,125 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createRpcEventOutputBuffer } from "../src/modes/rpc/event-output-buffer.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function sensitiveModel(): Model<Api> {
+	return {
+		id: "claude-fable-5",
+		provider: "anthropic",
+		reasoning: true,
+		api: "anthropic-messages",
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	} as unknown as Model<Api>;
+}
+
+describe("RPC publishes high_reasoning_warning", () => {
+	let session: AgentSession;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-hrw-rpc-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (session) session.dispose();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	it("serializes the event onto the RPC stdout sink via the real output buffer", async () => {
+		const sinkChunks: string[] = [];
+		const scheduledFlushes: Array<() => void> = [];
+		const eventOutput = createRpcEventOutputBuffer(
+			(chunk) => sinkChunks.push(chunk),
+			(flush) => scheduledFlushes.push(flush),
+		);
+		const outputEvent = (event: object) => eventOutput.enqueueEvent(event);
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: sensitiveModel(), systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const msg: AssistantMessage = {
+						role: "assistant",
+						content: [{ type: "text", text: "ok" }],
+						api: "anthropic-messages",
+						provider: "anthropic",
+						model: "mock",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "done", reason: "stop", message: msg });
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		session.subscribe((event) => outputEvent(event));
+		session.setThinkingLevel("xhigh");
+		for (const flush of scheduledFlushes) flush();
+
+		const lines = sinkChunks
+			.join("")
+			.split("\n")
+			.filter((line) => line.length > 0);
+		const warning = lines
+			.map((line) => JSON.parse(line) as Record<string, unknown>)
+			.find((record) => record.type === "high_reasoning_warning");
+
+		expect(warning).toBeDefined();
+		expect(warning?.modelId).toBe("claude-fable-5");
+		expect(warning?.provider).toBe("anthropic");
+		expect(warning?.thinkingLevel).toBe("xhigh");
+	});
+});

--- a/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
@@ -27,8 +27,9 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 			thinkingLevel: "xhigh",
 		} as Extract<AgentSessionEvent, { type: "high_reasoning_warning" }>;
 
-		(InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } })
-			.prototype.showHighReasoningWarning.call(fakeThis, event);
+		(
+			InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } }
+		).prototype.showHighReasoningWarning.call(fakeThis, event);
 
 		expect(fakeThis.chatContainer.children).toHaveLength(4);
 		const rendered = stripAnsi(renderAll(fakeThis.chatContainer));
@@ -52,8 +53,9 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 			thinkingLevel: "max",
 		} as Extract<AgentSessionEvent, { type: "high_reasoning_warning" }>;
 
-		(InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } })
-			.prototype.showHighReasoningWarning.call(fakeThis, event);
+		(
+			InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } }
+		).prototype.showHighReasoningWarning.call(fakeThis, event);
 
 		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("max");
 		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("claude-opus-4-8");

--- a/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { Container } from "../../tui/src/tui.ts";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function renderAll(container: Container, width = 220): string {
+	return container.children.flatMap((child) => child.render(width)).join("\n");
+}
+
+describe("InteractiveMode.showHighReasoningWarning", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("renders a scary warning box naming the model+level and urging ultrabrain", () => {
+		const fakeThis: { chatContainer: Container; ui: { requestRender: () => void } } = {
+			chatContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+		};
+
+		const event = {
+			type: "high_reasoning_warning",
+			modelId: "gpt-5.6-sol",
+			provider: "openai",
+			thinkingLevel: "xhigh",
+		} as Extract<AgentSessionEvent, { type: "high_reasoning_warning" }>;
+
+		(InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } })
+			.prototype.showHighReasoningWarning.call(fakeThis, event);
+
+		expect(fakeThis.chatContainer.children).toHaveLength(4);
+		const rendered = stripAnsi(renderAll(fakeThis.chatContainer));
+		expect(rendered).toMatch(/WARNING/i);
+		expect(rendered).toContain("gpt-5.6-sol");
+		expect(rendered).toContain("xhigh");
+		expect(rendered).toMatch(/ultrabrain/i);
+		expect(rendered).toMatch(/responsibilit/i);
+		expect(rendered).toMatch(/stop|loop/i);
+	});
+
+	test("reflects the max level when max is selected", () => {
+		const fakeThis: { chatContainer: Container; ui: { requestRender: () => void } } = {
+			chatContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+		};
+		const event = {
+			type: "high_reasoning_warning",
+			modelId: "claude-opus-4-8",
+			provider: "anthropic",
+			thinkingLevel: "max",
+		} as Extract<AgentSessionEvent, { type: "high_reasoning_warning" }>;
+
+		(InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } })
+			.prototype.showHighReasoningWarning.call(fakeThis, event);
+
+		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("max");
+		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("claude-opus-4-8");
+	});
+});

--- a/packages/coding-agent/test/high-reasoning-warning.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning.test.ts
@@ -1,0 +1,79 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	buildHighReasoningWarning,
+	isSensitiveHighReasoningModel,
+	shouldWarnHighReasoning,
+} from "../src/core/high-reasoning-warning.ts";
+
+function mkModel(id: string, provider = "openai"): Model<Api> {
+	return { id, provider, reasoning: true, api: "openai-responses" } as unknown as Model<Api>;
+}
+
+describe("high-reasoning-warning", () => {
+	describe("isSensitiveHighReasoningModel", () => {
+		it("flags gpt-5.6-sol-like frontier models (provider-agnostic, name-based)", () => {
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6-sol"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.2-mini"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("claude-opus-4-8"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("opus-4.7"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("fable-5"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("deepseek-v4-pro"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("deepseek-v4-flash"))).toBe(true);
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6-sol", "openrouter"))).toBe(true);
+		});
+
+		it("does not flag non-frontier models", () => {
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-4o"))).toBe(false);
+			expect(isSensitiveHighReasoningModel(mkModel("claude-3-5-sonnet"))).toBe(false);
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-5"))).toBe(false);
+			expect(isSensitiveHighReasoningModel(mkModel("llama-3.3-70b"))).toBe(false);
+		});
+	});
+
+	describe("shouldWarnHighReasoning", () => {
+		it("warns for a sensitive model driven at xhigh or max", () => {
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "xhigh")).toBe(true);
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "max")).toBe(true);
+			expect(shouldWarnHighReasoning(mkModel("claude-opus-4-8"), "max")).toBe(true);
+			expect(shouldWarnHighReasoning(mkModel("fable-5"), "xhigh")).toBe(true);
+		});
+
+		it("does not warn for a non-sensitive model even at xhigh/max", () => {
+			expect(shouldWarnHighReasoning(mkModel("gpt-4o"), "xhigh")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel("gpt-4o"), "max")).toBe(false);
+		});
+
+		it("does not warn for a sensitive model at or below high", () => {
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "high")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "medium")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "low")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "minimal")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "off")).toBe(false);
+		});
+	});
+
+	describe("buildHighReasoningWarning", () => {
+		it("produces a scary warning that names the model+level and urges ultrabrain", () => {
+			const w = buildHighReasoningWarning(mkModel("gpt-5.6-sol", "openai"), "xhigh");
+			expect(w.title).toMatch(/WARNING/i);
+			expect(w.title).toContain("gpt-5.6-sol");
+			expect(w.title).toContain("xhigh");
+			const body = w.body.join("\n");
+			expect(body).toMatch(/ultrabrain/i);
+			expect(body).toMatch(/responsibilit/i);
+			expect(body).toMatch(/stop|loop|halt/i);
+			expect(body).toMatch(/unrequested|not asked|not requested/i);
+			expect(body).toMatch(/risk|irreversible|dangerous/i);
+			expect(body).toMatch(/query ultrabrain|delegate|subagent|sub-agent/i);
+			expect(body.length).toBeGreaterThan(200);
+		});
+
+		it("reflects the max level in the title when max is selected", () => {
+			const w = buildHighReasoningWarning(mkModel("claude-opus-4-8", "anthropic"), "max");
+			expect(w.title).toContain("max");
+			expect(w.title).toContain("claude-opus-4-8");
+		});
+	});
+});

--- a/scripts/qa/high-reasoning-warning-render.ts
+++ b/scripts/qa/high-reasoning-warning-render.ts
@@ -1,0 +1,19 @@
+import { Container } from "../../packages/tui/src/tui.ts";
+import { Spacer } from "../../packages/tui/src/components/spacer.ts";
+import { Text } from "../../packages/tui/src/components/text.ts";
+import { DynamicBorder } from "../../packages/coding-agent/src/modes/interactive/components/dynamic-border.ts";
+import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+import { buildHighReasoningWarning } from "../../packages/coding-agent/src/core/high-reasoning-warning.ts";
+
+initTheme("dark");
+const event = { modelId: "gpt-5.6-sol", provider: "openai", thinkingLevel: "xhigh" as const };
+const { title, body } = buildHighReasoningWarning({ id: event.modelId, provider: event.provider }, event.thinkingLevel);
+const chat = new Container();
+chat.addChild(new Spacer(1));
+chat.addChild(new DynamicBorder((s) => theme.fg("error", s)));
+chat.addChild(
+	new Text(`${theme.bold(theme.fg("error", title))}\n${body.map((l) => theme.fg("error", l)).join("\n")}`, 1, 0),
+);
+chat.addChild(new DynamicBorder((s) => theme.fg("error", s)));
+const lines = chat.children.flatMap((c) => c.render(100));
+process.stdout.write(lines.join("\n") + "\n");


### PR DESCRIPTION
## What

When a sensitive frontier reasoning model (gpt-5.x, deepseek-v4-pro/flash, opus-4-6..5, sonnet-5, fable-5) is driven at **xhigh/max** thinking effort, `AgentSession` now emits a `high_reasoning_warning` event. RPC auto-publishes it to stdout via the existing `session.subscribe -> outputEvent` seam (no new wiring), and the interactive TUI renders a scary red warning box urging the user to drive these models **only through the ultrabrain subagent** — explaining the risks (non-stopping, unrequested actions, risky behavior) and that direct use means assuming all responsibility.

Detection is **provider-agnostic and purely model-name-based**, reusing the existing `supportsXhigh`/`supportsMax` gates so the "sensitive" set cannot drift from capability gating.

## Why

Human prompts have gaps; these high-effort frontier models are acutely prompt-sensitive and may refuse to stop, perform unrequested actions, or take risky actions to force completion. Agent-authored prompts (via the ultrabrain subagent) are denser and stricter — exactly what these models need to stay bounded. The warning makes that recommendation explicit and scary.

## How

- `packages/coding-agent/src/core/high-reasoning-warning.ts` — `isSensitiveHighReasoningModel`, `shouldWarnHighReasoning`, `buildHighReasoningWarning`.
- `packages/coding-agent/src/core/agent-session.ts` — new `AgentSessionEvent` variant + `_emitHighReasoningWarningIfNeeded` (deduped by provider/model/level), wired into `_switchActiveModel` and `_setThinkingLevel`.
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` — `case "high_reasoning_warning"` -> `showHighReasoningWarning` (red `error`-themed box, mirrors `showNewVersionNotification`).
- `packages/coding-agent/src/modes/rpc/rpc-types.ts` — `RpcHighReasoningWarningEvent` contract.

## Evidence (TDD: RED -> GREEN captured before each production change)

- **C1/C2 detection** — `test/high-reasoning-warning.test.ts` (7 tests): happy + non-sensitive/non-high negatives.
- **C3 emit** — `test/high-reasoning-warning-event.test.ts` (5 tests): setModel/setThinkingLevel emits; non-sensitive / `high` / dedupe negatives.
- **C4 RPC publish** — `test/high-reasoning-warning-rpc.test.ts`: real `createRpcEventOutputBuffer` + `session.subscribe -> outputEvent`; asserts the `high_reasoning_warning` JSONL line lands on the stdout sink.
- **C5 TUI draw** — `test/high-reasoning-warning-tui.test.ts` (2 tests) + real-terminal triplet at `local-ignore/qa-evidence/20260730-high-reasoning-warning/` (`warning.ans` + `warning.html` + `warning.grid.json`; 916 red `#cc6666` cells; WARNING + ultrabrain + responsibility + gpt-5.6-sol + xhigh confirmed in the cell grid).

## Validation

- `npx vitest run` on all 4 new test files: **15 passed**.
- `npx tsgo --noEmit`: **exit 0**.
- `npm run check` (biome + tsgo + lockfile + install-lock + web-ui checks): **exit 0**.
- Existing `agent-session-retry.test.ts` regression: **5 passed** (no breakage).

## Commits

1. `c4ef59a3b` feat(coding-agent): add high-reasoning-warning detection module
2. `a628d3124` feat(coding-agent): emit high_reasoning_warning AgentSession event
3. `f880f24d3` feat(coding-agent): render high_reasoning_warning in the interactive TUI
4. `d2b39fc51` test(coding-agent): prove high_reasoning_warning over RPC + TUI + docs

Plan: `.omo/plans/high-reasoning-warning.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `high_reasoning_warning` when a sensitive frontier model runs at `xhigh` or `max`, steering users to use the ultrabrain subagent. The event is provider-agnostic, forwarded over RPC, and shown as a red warning box in the interactive TUI.

- **New Features**
  - `AgentSession` emits `high_reasoning_warning` with `modelId`, `provider`, and `thinkingLevel`; deduped per provider/model/level; fires on model switch and level changes.
  - Detection is name-based and reuses `supportsXhigh`/`supportsMax` (provider-agnostic).
  - RPC: added `RpcHighReasoningWarningEvent`; auto-published via the existing `session.subscribe -> outputEvent` path.
  - Interactive TUI: renders an error-themed warning box with guidance to use the ultrabrain subagent and accept responsibility if proceeding.
  - Sensitive set includes `gpt-5.x`, `deepseek-v4-pro/flash`, `opus-4-6..5`, `sonnet-5`, `fable-5`.

<sup>Written for commit d2b39fc516492d3f51a4d23209cacbd7bec5da3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

