### PR TITLE
fix(session): reuse runtime key for title generation

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,11 @@
+## Runtime API keys propagate to session titles (2026-07-30)
+
+- Background session-title generation now reuses the active agent request API key before resolving provider
+  headers and compatibility options.
+- This prevents a turn launched with `--api-key` from succeeding under one credential and then sending its
+  `x-apitopia-session` title request with a different configured credential, which Apitopia rejects with 401.
+- Coverage: `test/agent-session-auto-title-routing.test.ts`.
+
 ## high_reasoning_warning for sensitive frontier models at xhigh/max (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -786,9 +786,14 @@ export class AgentSession {
 		}
 
 		try {
-			const result = await this._modelRuntime.getAuth(model);
+			const apiKey = await this.agent.getApiKey?.(model.provider);
+			const result = await this._modelRuntime.getAuth(model, { apiKey });
 			return result
-				? { apiKey: result.auth.apiKey, headers: withoutDeletedHeaders(result.auth.headers), env: result.env }
+				? {
+						apiKey: apiKey ?? result.auth.apiKey,
+						headers: withoutDeletedHeaders(result.auth.headers),
+						env: result.env,
+					}
 				: {};
 		} catch {
 			return {};

--- a/packages/coding-agent/test/agent-session-auto-title-routing.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-title-routing.test.ts
@@ -62,6 +62,25 @@ describe("agent session auto title routing", () => {
 		await expect(sessionName).resolves.toBe("Aliased Priority Task");
 	});
 
+	it("reuses the active request API key for title generation", async () => {
+		const harness = await createAutoTitleHarness();
+		harnesses.push(harness);
+		harness.agent.getApiKey = () => "runtime-key";
+		harness.agent.streamFunction = (model, context, options) => streamSimple(model, context, options);
+		harness.setResponses([
+			fauxAssistantMessage("turn complete"),
+			fauxAssistantMessage("<title>Runtime Key Task</title>"),
+		]);
+
+		const sessionName = waitForSessionName(harness);
+		await harness.session.prompt("verify runtime API key routing");
+		await waitForCallCount(harness, 2);
+
+		expect(harness.faux.getCallLog()[0]?.options?.apiKey).toBe("runtime-key");
+		expect(harness.faux.getCallLog()[1]?.options?.apiKey).toBe("runtime-key");
+		await expect(sessionName).resolves.toBe("Runtime Key Task");
+	});
+
 	it("forwards provider request hooks to title generation", async () => {
 		const onPayloadCalls: string[] = [];
 		const harness = await createAutoTitleHarness({


### PR DESCRIPTION
## Summary

- reuse the active agent request API key for background session-title generation
- preserve provider headers, compatibility options, and session routing
- prevent Apitopia session key mismatches from surfacing as `session_title_generation` 401 errors

## Root cause

The foreground turn honored `--api-key`, but title generation resolved the provider configured key again. Because the title request reused the same `x-apitopia-session`, Apitopia correctly rejected the second credential with 401.

## Verification

- RED: title call received `faux-key` instead of `runtime-key`
- focused auto-title tests: 16 passed
- Kimi/OpenAI event-order tests: 36 passed
- coding-agent suite: 5,996 passed, 33 skipped
- `npm run check`: passed
- `npm run build`: passed
- source CLI mock tool loop: 4/4 passed
- CLI smoke: 8/8 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses the runtime API key from the active agent request for background session-title generation. Passes the runtime key into `getAuth` and prefers it over configured keys to avoid Apitopia 401s from credential mismatches.

- **Bug Fixes**
  - Use the active request `apiKey` when fetching auth and fall back to the provider key; preserve provider headers, compatibility options, and session routing for the title call.
  - Add a test that asserts both the foreground turn and title request use the same runtime key; keep auto-title routing checks in `packages/coding-agent`.

<sup>Written for commit 72c95148351708c8752c39dfe4b7f0b37e6e53c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

