### PR TITLE
feat(coding-agent): add omo-senpi workflow tips

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Omo-senpi coding workflow tips (2026-07-30)
+
+### What changed
+
+- `tips/catalog/subagent-tips.ts` now advertises the shipped `init-deep`, debugging, refactor,
+  remove-ai-slops, and visual-qa skills alongside the existing plan, ultrawork, research, and review tips.
+- Every new entry uses the existing `tasks` command gate so users only see omo-senpi workflow tips when
+  the task extension surface is available.
+- Coverage: `test/suite/list-tips.test.ts` pins each ID, rendered line, and command gate.
+
+### Why
+
+- The tip rotation covered the headline orchestration workflows but skipped the everyday project
+  initialization, diagnosis, cleanup, and visual-verification skills that omo-senpi also installs.
+
+### Expected merge conflict zones
+
+- LOW: additive entries in `tips/catalog/subagent-tips.ts` and one focused catalog assertion.
+
 ## Footer hides low cache hit rates (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/subagent-tips.ts
@@ -39,6 +39,38 @@ export const SUBAGENT_TIPS = [
 		render: () => 'Trigger "review work" to run parallel goal, quality, security, and hands-on QA reviews.',
 	},
 	{
+		id: "workflow-skills.init-deep",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () => 'Trigger "/init-deep" to map a project and generate a hierarchical AGENTS.md knowledge base.',
+	},
+	{
+		id: "workflow-skills.debugging",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () =>
+			'Trigger "debug this" for parallel hypotheses, a failing regression test, a minimal fix, and real-surface QA.',
+	},
+	{
+		id: "workflow-skills.refactor",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () => 'Trigger "refactor" for codebase-aware cleanup that pins behavior before changing structure.',
+	},
+	{
+		id: "workflow-skills.remove-ai-slops",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () =>
+			'Trigger "remove AI slop" to lock behavior first, then strip generated-code smells without drive-by rewrites.',
+	},
+	{
+		id: "workflow-skills.visual-qa",
+		bindings: [],
+		requiresCommand: "tasks",
+		render: () => 'Trigger "visual QA" to capture browser or xterm evidence and review web or terminal interfaces.',
+	},
+	{
 		id: "subagent-categories",
 		bindings: [],
 		requiresCommand: "tasks",

--- a/packages/coding-agent/test/suite/list-tips.test.ts
+++ b/packages/coding-agent/test/suite/list-tips.test.ts
@@ -19,6 +19,39 @@ describe("collectTips", () => {
 		expect(tips.some((tip) => tip.id === "fallback-chains-setting")).toBe(true);
 	});
 
+	it("lists the omo-senpi coding workflow skills", () => {
+		const expectedTips = [
+			{
+				id: "workflow-skills.init-deep",
+				text: 'Trigger "/init-deep" to map a project and generate a hierarchical AGENTS.md knowledge base.',
+				requiresCommand: "tasks",
+			},
+			{
+				id: "workflow-skills.debugging",
+				text: 'Trigger "debug this" for parallel hypotheses, a failing regression test, a minimal fix, and real-surface QA.',
+				requiresCommand: "tasks",
+			},
+			{
+				id: "workflow-skills.refactor",
+				text: 'Trigger "refactor" for codebase-aware cleanup that pins behavior before changing structure.',
+				requiresCommand: "tasks",
+			},
+			{
+				id: "workflow-skills.remove-ai-slops",
+				text: 'Trigger "remove AI slop" to lock behavior first, then strip generated-code smells without drive-by rewrites.',
+				requiresCommand: "tasks",
+			},
+			{
+				id: "workflow-skills.visual-qa",
+				text: 'Trigger "visual QA" to capture browser or xterm evidence and review web or terminal interfaces.',
+				requiresCommand: "tasks",
+			},
+		];
+		const expectedIds = new Set(expectedTips.map((tip) => tip.id));
+
+		expect(collectTips().filter((tip) => expectedIds.has(tip.id))).toEqual(expectedTips);
+	});
+
 	it("carries requiresCommand only for command-gated tips", () => {
 		const tips = collectTips();
 		const gated = tips.filter((tip) => tip.requiresCommand !== undefined);


### PR DESCRIPTION
## Summary

- add Senpi tip catalog entries for five shipped omo-senpi coding workflows:
  - `/init-deep`
  - debugging
  - refactor
  - remove-ai-slops
  - visual-qa
- keep the existing `tasks` availability gate used by other omo-senpi workflow tips
- pin every new ID, rendered line, and command gate in the live `collectTips()` contract

## RED -> GREEN

- RED: focused `list-tips.test.ts` failed with the expected five entries absent (`received []`)
- GREEN: the same file passed all 4 tests after the additive catalog definitions

## Verification

- real source CLI `--list-tips`: all five entries appeared exactly once with exact text and `requiresCommand: "tasks"`
- `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`: 8/8 passed
- focused Vitest file: 4/4 passed
- `npm run check`: passed
- `git diff --check`: passed
- pure LOC: catalog 98, test 60

## Risk

Low. This is an additive catalog/test/change-record increment; scheduler, rendering, command registration, and skill loading are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add omo‑senpi coding workflow tips to the interactive tips catalog, gated by the `tasks` command. This makes `/init-deep`, debugging, refactor, remove‑ai‑slops, and visual‑qa easy to discover.

- **New Features**
  - Added tips for `/init-deep`, debugging, refactor, remove‑ai‑slops, visual‑qa.
  - Tests pin each tip’s id, rendered text, and gate in `collectTips()`.

<sup>Written for commit 11aada10dbff2879e402b1d0f71eca58b8520724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

