### PR TITLE
fix: recover malformed Kimi XTML assistant turns

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-kimi-thinking-recovery.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-kimi-thinking-recovery.mjs
@@ -1,0 +1,72 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+} from "./common.mjs";
+import { checkRealAuthUnchanged } from "./mock-loop-support.mjs";
+
+export const KIMI_THINKING_RECOVERY_SCENARIO = "kimi-xtml-thinking-recover";
+
+const RECOVERED_MARKER = "RECOVERED_VISIBLE_ANSWER";
+const MALFORMED_THINKING =
+	"Reasoning remains private. 즉 해당 키로 치는 요청은 지표 수집 대상에 정상 포함됨." +
+	"<|close|>response<|sep|><|close|>message<|sep|>";
+const XTML_PATTERN = /<\|(?:close|open|sep)\|>/u;
+
+export async function runKimiThinkingRecoveryScenario(driveTurn, evidenceSlug) {
+	installCleanupHooks();
+	const checks = createChecks(`mock-loop.mjs --scenario ${KIMI_THINKING_RECOVERY_SCENARIO}`);
+	const guard = guardRealAuth();
+	const { box, server, result } = await driveTurn({
+		apiName: "openai-completions",
+		turns: [{ reasoning: MALFORMED_THINKING }, { text: RECOVERED_MARKER }],
+		prompt: `Return ${RECOVERED_MARKER} after recovering from the malformed empty response.`,
+		extraArgs: ["--model", "kimi-k3-ultrafast"],
+		mockModels: [{ id: "kimi-k3-ultrafast", reasoning: true }],
+		timeoutMs: 90000,
+	});
+	let receiptDir;
+	try {
+		const output = `${result.stdout}\n${result.stderr}`;
+		const markerCount = output.split(RECOVERED_MARKER).length - 1;
+		const firstReasoning = server.streamLog
+			.filter((entry) => entry.streamId === 0 && entry.kind === "reasoning_delta")
+			.map((entry) => entry.delta)
+			.join("");
+		const replayBody = JSON.stringify(server.requests[1]?.body ?? {});
+		checks.ok("real CLI exits zero after one empty-response retry", result.code === 0 && !result.timedOut, `code=${result.code}`);
+		checks.ok("fake provider receives exactly two requests", server.requests.length === 2, `requests=${server.requests.length}`);
+		checks.ok("malformed reasoning payload reached the real provider parser", firstReasoning === MALFORMED_THINKING, `bytes=${firstReasoning.length}`);
+		checks.ok("recovered answer is visible exactly once", markerCount === 1, `markerCount=${markerCount}`);
+		checks.ok("raw XTML markers never reach visible CLI output", !XTML_PATTERN.test(output), `markersVisible=${XTML_PATTERN.test(output)}`);
+		checks.ok("discarded empty attempt is not replayed into request two", !replayBody.includes("<|close|>"), `markerReplayed=${replayBody.includes("<|close|>")}`);
+		checkRealAuthUnchanged(checks, guard);
+		receiptDir = evidenceDir(evidenceSlug || KIMI_THINKING_RECOVERY_SCENARIO);
+		writeFileSync(
+			join(receiptDir, "receipt.json"),
+			`${JSON.stringify(
+				{
+					scenario: KIMI_THINKING_RECOVERY_SCENARIO,
+					result: { code: result.code, stdout: result.stdout, stderr: result.stderr },
+					requestCount: server.requests.length,
+					markerCount,
+					firstReasoning,
+					replayedMalformedAttempt: replayBody.includes("<|close|>"),
+					authPath: guard.path,
+					authHash: guard.before,
+				},
+				null,
+				2,
+			)}\n`,
+		);
+	} finally {
+		await server.stop();
+		box.cleanup();
+	}
+	checks.ok("Kimi thinking recovery sandbox cleaned", !existsSync(box.cwd), box.cwd);
+	process.exit(checks.finish() ? 0 : 1);
+	return receiptDir;
+}

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
@@ -10,6 +10,10 @@ import {
 	API_PRESETS,
 	checkRealAuthUnchanged,
 } from "./mock-loop-support.mjs";
+import {
+	KIMI_THINKING_RECOVERY_SCENARIO,
+	runKimiThinkingRecoveryScenario,
+} from "./mock-loop-kimi-thinking-recovery.mjs";
 import { runAnthropicPolicyRefusalScenario } from "./mock-loop-policy-refusal.mjs";
 
 const OPENAI_SERVER_ERROR_MESSAGE =
@@ -62,7 +66,7 @@ const STANDARD_RETRY_SCENARIOS = {
 const POLICY_REFUSAL_SCENARIO = "anthropic-policy-refusal-fallback";
 
 export function retryScenarioNames() {
-	return [...Object.keys(STANDARD_RETRY_SCENARIOS), POLICY_REFUSAL_SCENARIO];
+	return [...Object.keys(STANDARD_RETRY_SCENARIOS), POLICY_REFUSAL_SCENARIO, KIMI_THINKING_RECOVERY_SCENARIO];
 }
 
 export function isRetryScenario(name) {
@@ -77,6 +81,13 @@ export async function checkStandardRetryScenarios(checks, driveTurn) {
 }
 
 export async function runRetryScenario(scenarioName, apiName, driveTurn, evidenceSlug) {
+	if (scenarioName === KIMI_THINKING_RECOVERY_SCENARIO) {
+		if (apiName !== "openai-completions") {
+			throw new Error(`${KIMI_THINKING_RECOVERY_SCENARIO} requires --api openai-completions`);
+		}
+		await runKimiThinkingRecoveryScenario(driveTurn, evidenceSlug);
+		return;
+	}
 	if (scenarioName === POLICY_REFUSAL_SCENARIO) {
 		if (apiName !== "anthropic-messages") {
 			throw new Error(`${POLICY_REFUSAL_SCENARIO} requires --api anthropic-messages`);

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -25,7 +25,7 @@
  *   (the flag is --serve-env, NOT --env-file: Node treats --env-file as a native
  *    startup flag and would try to load the path as a dotenv file before the script runs)
  *   node mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}'
- *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback
+ *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover
  *   node mock-loop.mjs --run "prompt" [--api ...] [--evidence SLUG]
  */
 
@@ -600,7 +600,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
-			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|ttsr-collapse|ttsr-leak> [--api <name>]",
+			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|ttsr-collapse|ttsr-leak> [--api <name>]",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,
 			"",

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -16,7 +16,7 @@ import {
 	normalizeTerminalAssistantMessage,
 	shouldTerminateAssistantTurn,
 } from "./assistant-terminal-state.ts";
-import { getDefaultStreamFn } from "./stream-fn.ts";
+import { getDefaultStreamFn, withEmptyAssistantRecovery } from "./stream-fn.ts";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -252,7 +252,7 @@ async function runLoop(
 				requestConfig,
 				signal,
 				emit,
-				streamFunction,
+				withEmptyAssistantRecovery(requestConfig.model, streamFunction),
 				streamIdleTimeoutMs,
 			);
 			newMessages.push(message);

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -13,7 +13,7 @@
   Kimi responses before their first visible text/tool signal, avoiding reasoning-stream regressions for other
   model families.
 - Coverage: agent-loop tests pin one-shot recovery, bounded failure, terminal-state preservation, and tool
-  execution.
+  execution. The real CLI mock-loop scenario proves the user-visible recovery path.
 
 ## 2026-07-29 - Bounded provider stream start (streamStartTimeoutMs)
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 2026-07-30 - Bound empty Kimi assistant responses
+
+### What changed and why
+
+- Kimi-family provider streams that finish with `stop` but contain neither non-empty visible text nor a tool call
+  are discarded before turn commitment and retried once with the same request.
+- A successful second attempt is the only assistant turn committed and carries an
+  `empty_assistant_response_recovery` diagnostic. A second empty response becomes a visible error instead of
+  ending the session silently or looping indefinitely.
+- Error, aborted, refusal, length, and tool-call turns keep their existing behavior. The stream gate buffers only
+  Kimi responses before their first visible text/tool signal, avoiding reasoning-stream regressions for other
+  model families.
+- Coverage: agent-loop tests pin one-shot recovery, bounded failure, terminal-state preservation, and tool
+  execution.
+
 ## 2026-07-29 - Bounded provider stream start (streamStartTimeoutMs)
 
 ### What changed and why

--- a/packages/agent/src/empty-assistant-recovery.ts
+++ b/packages/agent/src/empty-assistant-recovery.ts
@@ -1,0 +1,123 @@
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	type AssistantMessageEventStream,
+	createAssistantMessageEventStream,
+	hasKimiTextToolCallRecovery,
+	type Model,
+} from "@earendil-works/pi-ai";
+import type { StreamFn } from "./types.ts";
+
+type StreamFactory = () => AssistantMessageEventStream | Promise<AssistantMessageEventStream>;
+
+const EMPTY_RESPONSE_ERROR = "Model returned an empty response twice";
+
+function hasVisibleContent(message: AssistantMessage): boolean {
+	return message.content.some(
+		(block) => block.type === "toolCall" || (block.type === "text" && block.text.trim().length > 0),
+	);
+}
+
+function isEmptyStop(message: AssistantMessage): boolean {
+	return message.stopReason === "stop" && !hasVisibleContent(message);
+}
+
+function eventStartsVisibleContent(event: AssistantMessageEvent): boolean {
+	return event.type === "toolcall_start" || (event.type === "text_delta" && event.delta.trim().length > 0);
+}
+
+function appendRetryDiagnostic(message: AssistantMessage): AssistantMessage {
+	return {
+		...message,
+		diagnostics: [
+			...(message.diagnostics ?? []),
+			{
+				type: "empty_assistant_response_recovery",
+				timestamp: Date.now(),
+				details: { retries: 1 },
+			},
+		],
+	};
+}
+
+function createEmptyResponseFailure(message: AssistantMessage): AssistantMessage {
+	return {
+		...appendRetryDiagnostic(message),
+		content: [{ type: "text", text: EMPTY_RESPONSE_ERROR }],
+		stopReason: "error",
+		errorMessage: EMPTY_RESPONSE_ERROR,
+	};
+}
+
+function createRetryingStream(firstStream: AssistantMessageEventStream, createStream: StreamFactory) {
+	const outerStream = createAssistantMessageEventStream();
+
+	void (async (): Promise<void> => {
+		try {
+			let stream = firstStream;
+			let retrying = false;
+			for (;;) {
+				const buffered: AssistantMessageEvent[] = [];
+				let forwarding = false;
+				let retry = false;
+				for await (const event of stream) {
+					if (event.type === "done") {
+						if (isEmptyStop(event.message)) {
+							if (!retrying) {
+								retry = true;
+								break;
+							}
+							const error = createEmptyResponseFailure(event.message);
+							outerStream.push({ type: "error", reason: "error", error });
+							outerStream.end();
+							return;
+						}
+						const terminal = retrying ? { ...event, message: appendRetryDiagnostic(event.message) } : event;
+						if (!forwarding) {
+							for (const pending of buffered) outerStream.push(pending);
+						}
+						outerStream.push(terminal);
+						outerStream.end();
+						return;
+					}
+					if (event.type === "error") {
+						if (!forwarding) {
+							for (const pending of buffered) outerStream.push(pending);
+						}
+						outerStream.push(event);
+						outerStream.end();
+						return;
+					}
+					if (forwarding) {
+						outerStream.push(event);
+						continue;
+					}
+					buffered.push(event);
+					if (eventStartsVisibleContent(event)) {
+						for (const pending of buffered) outerStream.push(pending);
+						forwarding = true;
+					}
+				}
+				if (!retry) {
+					outerStream.end(retrying ? appendRetryDiagnostic(await stream.result()) : await stream.result());
+					return;
+				}
+				retrying = true;
+				stream = await createStream();
+			}
+		} catch (error) {
+			outerStream.fail(error);
+		}
+	})();
+
+	return outerStream;
+}
+
+export function withEmptyAssistantRecovery<TApi extends Api>(model: Model<TApi>, streamFunction: StreamFn): StreamFn {
+	if (!hasKimiTextToolCallRecovery(model)) return streamFunction;
+	return async (requestedModel, context, options) => {
+		const createStream = (): ReturnType<StreamFn> => streamFunction(requestedModel, context, options);
+		return createRetryingStream(await createStream(), createStream);
+	};
+}

--- a/packages/agent/src/stream-fn.ts
+++ b/packages/agent/src/stream-fn.ts
@@ -18,3 +18,5 @@ export function getDefaultStreamFn(): StreamFn {
 	}
 	return defaultStreamFn;
 }
+
+export { withEmptyAssistantRecovery } from "./empty-assistant-recovery.ts";

--- a/packages/agent/test/agent-loop-empty-assistant-recovery.test.ts
+++ b/packages/agent/test/agent-loop-empty-assistant-recovery.test.ts
@@ -1,0 +1,194 @@
+import {
+	type AssistantMessage,
+	createAssistantMessageEventStream,
+	type Message,
+	type Model,
+	Type,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+
+function assistant(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+	options: Pick<AssistantMessage, "errorMessage" | "stopDetails"> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-completions",
+		provider: "test",
+		model: "kimi-test",
+		content,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: 1,
+		...options,
+	};
+}
+
+function model(): Model<"openai-completions"> {
+	return {
+		id: "kimi-test",
+		name: "Test Model",
+		api: "openai-completions",
+		provider: "test",
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 1024,
+	};
+}
+
+function streamMessage(message: AssistantMessage) {
+	const stream = createAssistantMessageEventStream();
+	if (message.stopReason === "error" || message.stopReason === "aborted") {
+		stream.push({ type: "error", reason: message.stopReason, error: message });
+	} else stream.push({ type: "done", reason: message.stopReason, message });
+	return stream;
+}
+
+function visibleText(message: AssistantMessage): string {
+	return message.content
+		.filter((block) => block.type === "text")
+		.map((block) => (block.type === "text" ? block.text : ""))
+		.join("");
+}
+
+function isLlmMessage(message: AgentMessage): message is Message {
+	return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
+}
+
+async function collectBounded(stream: ReturnType<typeof agentLoop>) {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			(async () => {
+				const events: AgentEvent[] = [];
+				for await (const event of stream) events.push(event);
+				return { events, messages: await stream.result() };
+			})(),
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(() => reject(new Error("empty assistant recovery probe did not finish")), 500);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+function config(): AgentLoopConfig {
+	return { model: model(), convertToLlm: (messages) => messages.filter(isLlmMessage) };
+}
+
+describe("agent loop empty assistant recovery", () => {
+	it("retries one thinking-only stop before committing the assistant turn", async () => {
+		const responses = [
+			assistant([{ type: "thinking", thinking: "No visible answer." }]),
+			assistant([{ type: "text", text: "Recovered after retry" }]),
+		];
+		let streamCalls = 0;
+		const stream = agentLoop(
+			[{ role: "user", content: "answer", timestamp: 1 }],
+			{ systemPrompt: "", messages: [], tools: [] },
+			config(),
+			undefined,
+			() => streamMessage(responses[streamCalls++] ?? responses[1]),
+		);
+		const { messages } = await collectBounded(stream);
+		const assistants = messages.filter((message) => message.role === "assistant");
+
+		expect(streamCalls).toBe(2);
+		expect(assistants).toHaveLength(1);
+		expect(visibleText(assistants[0])).toBe("Recovered after retry");
+	});
+
+	it("turns a second empty stop into a visible bounded failure", async () => {
+		const empty = assistant([
+			{ type: "text", text: "" },
+			{ type: "thinking", thinking: "Still empty." },
+		]);
+		let streamCalls = 0;
+		const stream = agentLoop(
+			[{ role: "user", content: "answer", timestamp: 1 }],
+			{ systemPrompt: "", messages: [], tools: [] },
+			config(),
+			undefined,
+			() => {
+				streamCalls += 1;
+				return streamMessage(empty);
+			},
+		);
+		const { messages } = await collectBounded(stream);
+		const assistants = messages.filter((message) => message.role === "assistant");
+
+		expect(streamCalls).toBe(2);
+		expect(assistants).toHaveLength(1);
+		expect(assistants[0]).toMatchObject({
+			stopReason: "error",
+			errorMessage: "Model returned an empty response twice",
+		});
+		expect(visibleText(assistants[0])).toBe("Model returned an empty response twice");
+	});
+
+	it("does not retry terminal errors, aborts, refusals, or length stops", async () => {
+		for (const message of [
+			assistant([], "error", { errorMessage: "transport failed" }),
+			assistant([], "aborted", { errorMessage: "Request was aborted" }),
+			assistant([], "error", { errorMessage: "classified", stopDetails: { type: "refusal" } }),
+			assistant([{ type: "thinking", thinking: "truncated" }], "length"),
+		]) {
+			let streamCalls = 0;
+			const stream = agentLoop(
+				[{ role: "user", content: "answer", timestamp: 1 }],
+				{ systemPrompt: "", messages: [], tools: [] },
+				config(),
+				undefined,
+				() => {
+					streamCalls += 1;
+					return streamMessage(message);
+				},
+			);
+			const { messages } = await collectBounded(stream);
+
+			expect(streamCalls, message.stopReason).toBe(1);
+			expect(messages.filter((item) => item.role === "assistant").at(-1), message.stopReason).toMatchObject({
+				stopReason: message.stopReason,
+			});
+		}
+	});
+
+	it("preserves tool-call execution instead of treating it as empty", async () => {
+		const schema = Type.Object({ value: Type.String() });
+		const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ok" }], details: {} }));
+		const tool: AgentTool<typeof schema, Record<string, never>> = {
+			name: "Echo",
+			label: "Echo",
+			description: "Echo",
+			parameters: schema,
+			execute,
+		};
+		const responses = [
+			assistant([{ type: "toolCall", id: "call-1", name: "Echo", arguments: { value: "ok" } }], "toolUse"),
+			assistant([{ type: "text", text: "done" }]),
+		];
+		let streamCalls = 0;
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+		const stream = agentLoop([{ role: "user", content: "echo", timestamp: 1 }], context, config(), undefined, () =>
+			streamMessage(responses[streamCalls++] ?? responses[1]),
+		);
+		await collectBounded(stream);
+
+		expect(streamCalls).toBe(2);
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,18 @@
 # AI Source Changes
 
+## 2026-07-30 - Recover Kimi XTML response channels from thinking
+
+### What changed and why
+
+- Kimi-family streams now sanitize structural `think` / `response` / `message` XTML markers from final thinking
+  content and promote text only when an explicit response-open boundary makes the split unambiguous.
+- Recovery uses the existing code mask, so XTML-looking examples inside inline or fenced code remain literal.
+  Closing-marker-only payloads are sanitized but never exposed as visible chain-of-thought.
+- Model recovery composition now applies Kimi response-channel recovery even when no tools are registered, while
+  leaked text-tool-call reconstruction remains conditional on available tools.
+- Coverage: coding-agent runtime-boundary tests pin no-tools recovery, split markers, conservative malformed
+  handling, code literals, ordinary Kimi thinking, non-Kimi isolation, and existing tool-call recovery.
+
 ## 2026-07-29 - Preserve invoke-recovery protocol provenance
 
 ### What changed and why

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -52,6 +52,7 @@ export {
 	hasKimiTextToolCallRecovery,
 	shouldRecoverTextToolCalls,
 	transformContext,
+	wrapStreamWithModelRecovery,
 	wrapStreamWithToolCallMiddleware,
 } from "./tool-call-middleware/index.ts";
 export { createXtmlRecoveryStreamParser } from "./tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts";

--- a/packages/ai/src/tool-call-middleware/index.ts
+++ b/packages/ai/src/tool-call-middleware/index.ts
@@ -1,4 +1,7 @@
-import type { Api, Model, OpenAICompletionsCompat } from "../types.ts";
+import type { Api, AssistantMessageEventStream, Model, OpenAICompletionsCompat, Tool } from "../types.ts";
+import { createXtmlRecoveryStreamParser } from "./protocols/kimi-xtml/recovery-stream.ts";
+import { wrapStreamWithKimiThinkingRecovery } from "./protocols/kimi-xtml/thinking-recovery-stream.ts";
+import { wrapStreamWithInvokeRecovery } from "./recovery-stream-wrapper.ts";
 import type { ToolCallFormat } from "./types.ts";
 
 export { getProtocol, transformContext } from "./context-transformer.ts";
@@ -59,4 +62,22 @@ const KIMI_MODEL_ID_PATTERN = /(^|[^a-z0-9])kimi([^a-z0-9]|$)/i;
  */
 export function hasKimiTextToolCallRecovery<TApi extends Api>(model: Model<TApi>): boolean {
 	return KIMI_MODEL_ID_PATTERN.test(model.id);
+}
+
+export function wrapStreamWithModelRecovery<TApi extends Api>(
+	innerStream: AssistantMessageEventStream,
+	model: Model<TApi>,
+	tools: readonly Tool[],
+): AssistantMessageEventStream {
+	const recoveredStream = hasKimiTextToolCallRecovery(model)
+		? wrapStreamWithKimiThinkingRecovery(innerStream)
+		: innerStream;
+	if (!shouldRecoverTextToolCalls(model) || tools.length === 0) return recoveredStream;
+	return wrapStreamWithInvokeRecovery(
+		recoveredStream,
+		tools,
+		hasKimiTextToolCallRecovery(model)
+			? { createParser: createXtmlRecoveryStreamParser, protocol: "kimi-xtml" }
+			: undefined,
+	);
 }

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery-stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery-stream.ts
@@ -1,0 +1,33 @@
+import type { AssistantMessageEventStream } from "../../../types.ts";
+import { AssistantMessageEventStream as AssistantMessageEventStreamImpl } from "../../../utils/event-stream.ts";
+import { recoverKimiXtmlThinking } from "./thinking-recovery.ts";
+
+export function wrapStreamWithKimiThinkingRecovery(
+	innerStream: AssistantMessageEventStream,
+): AssistantMessageEventStream {
+	const outerStream = new AssistantMessageEventStreamImpl();
+
+	void (async (): Promise<void> => {
+		try {
+			for await (const event of innerStream) {
+				if (event.type === "done") {
+					const message = recoverKimiXtmlThinking(event.message);
+					outerStream.push({ type: "done", reason: event.reason, message });
+					outerStream.end();
+					return;
+				}
+				if (event.type === "error") {
+					outerStream.push(event);
+					outerStream.end();
+					return;
+				}
+				outerStream.push(event);
+			}
+			outerStream.end(recoverKimiXtmlThinking(await innerStream.result()));
+		} catch (error) {
+			outerStream.fail(error);
+		}
+	})();
+
+	return outerStream;
+}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts
@@ -1,0 +1,92 @@
+import type { AssistantMessage, ThinkingContent } from "../../../types.ts";
+import { createRecoveryCodeMask } from "../../recovery-code-mask.ts";
+
+type OutputChannel = "thinking" | "response";
+
+type RecoveredThinking = {
+	readonly thinking: string;
+	readonly response: string;
+	readonly changed: boolean;
+	readonly recoveredResponse: boolean;
+};
+
+const CHANNEL_MARKER_PATTERN = /<\|(open|close)\|>(think|response|message)<\|sep\|>/g;
+
+function recoverThinkingContent(input: string): RecoveredThinking {
+	const mask = createRecoveryCodeMask();
+	let channel: OutputChannel = "thinking";
+	let thinking = "";
+	let response = "";
+	let changed = false;
+	let recoveredResponse = false;
+
+	const append = (text: string): void => {
+		if (channel === "response") response += text;
+		else thinking += text;
+	};
+
+	const scan = (text: string): void => {
+		let offset = 0;
+		for (const match of text.matchAll(CHANNEL_MARKER_PATTERN)) {
+			const index = match.index;
+			if (index === undefined) continue;
+			append(text.slice(offset, index));
+			const action = match[1];
+			const name = match[2];
+			changed = true;
+			if (action === "open" && name === "response") {
+				channel = "response";
+				recoveredResponse = true;
+			} else if (action === "open" && name === "think") {
+				channel = "thinking";
+			} else if (action === "close" && name === "response") {
+				channel = "thinking";
+			}
+			offset = index + match[0].length;
+		}
+		append(text.slice(offset));
+	};
+
+	for (const segment of [...mask.feed(input), ...mask.finish()]) {
+		if (segment.scan) scan(segment.text);
+		else append(segment.text);
+	}
+
+	return { thinking, response, changed, recoveredResponse };
+}
+
+function recoveredThinkingBlock(block: ThinkingContent, thinking: string): ThinkingContent {
+	return { ...block, thinking };
+}
+
+export function recoverKimiXtmlThinking(message: AssistantMessage): AssistantMessage {
+	let changed = false;
+	let recoveredResponse = false;
+	const content: AssistantMessage["content"] = [];
+
+	for (const block of message.content) {
+		if (block.type !== "thinking") {
+			content.push(block);
+			continue;
+		}
+		const recovered = recoverThinkingContent(block.thinking);
+		changed = changed || recovered.changed;
+		recoveredResponse = recoveredResponse || recovered.recoveredResponse;
+		content.push(recoveredThinkingBlock(block, recovered.thinking));
+		if (recovered.response.length > 0) content.push({ type: "text", text: recovered.response });
+	}
+
+	if (!changed) return message;
+	return {
+		...message,
+		content,
+		diagnostics: [
+			...(message.diagnostics ?? []),
+			{
+				type: "kimi_xtml_thinking_recovery",
+				timestamp: Date.now(),
+				details: { recoveredResponse },
+			},
+		],
+	};
+}

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -4,6 +4,9 @@
   `wrapStreamWithModelRecovery()` boundary.
 - Kimi structural response-channel recovery therefore runs on final-answer requests with an empty tool list, while
   Claude/Kimi leaked tool-call recovery still activates only when tools are available.
+- Real CLI QA adds `--scenario kimi-xtml-thinking-recover`, proving a malformed thinking-only first response is
+  discarded, the second response is visible exactly once, XTML markers never leak, real auth is unchanged, and
+  the sandbox is cleaned.
 
 ## Bun self-updates preserve the Bun launcher (2026-07-30)
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,10 @@
+## Kimi XTML thinking recovery runs without tools (2026-07-30)
+
+- `ModelRuntime.stream()` and `streamSimple()` now compose model recovery through the AI package's shared
+  `wrapStreamWithModelRecovery()` boundary.
+- Kimi structural response-channel recovery therefore runs on final-answer requests with an empty tool list, while
+  Claude/Kimi leaked tool-call recovery still activates only when tools are available.
+
 ## Bun self-updates preserve the Bun launcher (2026-07-30)
 
 - Bun-managed global self-updates now replace Bun's generated Node-shebang symlink with a small launcher that

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -13,8 +13,6 @@ import {
 	type CredentialInfo,
 	type CredentialStore,
 	createModels,
-	createXtmlRecoveryStreamParser,
-	hasKimiTextToolCallRecovery,
 	lazyStream,
 	type Model,
 	type Models,
@@ -30,8 +28,7 @@ import {
 	type ProviderHeaders,
 	type SimpleStreamOptions,
 	type StreamOptions,
-	shouldRecoverTextToolCalls,
-	wrapStreamWithInvokeRecovery,
+	wrapStreamWithModelRecovery,
 } from "@earendil-works/pi-ai";
 import * as builtinProviderCatalog from "@earendil-works/pi-ai/providers/all";
 import { getAgentDir } from "../config.ts";
@@ -553,15 +550,7 @@ export class ModelRuntime implements Models {
 				context,
 				withPayloadRequestMetadata(prepared.options, prepared.model) as ApiStreamOptions<TApi>,
 			);
-			return shouldRecoverTextToolCalls(model) && context.tools?.length
-				? wrapStreamWithInvokeRecovery(
-						inner,
-						context.tools,
-						hasKimiTextToolCallRecovery(model)
-							? { createParser: createXtmlRecoveryStreamParser, protocol: "kimi-xtml" }
-							: undefined,
-					)
-				: inner;
+			return wrapStreamWithModelRecovery(inner, model, context.tools ?? []);
 		});
 	}
 
@@ -580,15 +569,7 @@ export class ModelRuntime implements Models {
 				context,
 				withPayloadRequestMetadata(prepared.options, prepared.model) as SimpleStreamOptions,
 			);
-			return shouldRecoverTextToolCalls(model) && context.tools?.length
-				? wrapStreamWithInvokeRecovery(
-						inner,
-						context.tools,
-						hasKimiTextToolCallRecovery(model)
-							? { createParser: createXtmlRecoveryStreamParser, protocol: "kimi-xtml" }
-							: undefined,
-					)
-				: inner;
+			return wrapStreamWithModelRecovery(inner, model, context.tools ?? []);
 		});
 	}
 	completeSimple(model: Model<Api>, context: Context, options?: ModelsSimpleStreamOptions): Promise<AssistantMessage> {

--- a/packages/coding-agent/test/kimi-xtml-thinking-recovery-runtime-boundary.test.ts
+++ b/packages/coding-agent/test/kimi-xtml-thinking-recovery-runtime-boundary.test.ts
@@ -1,0 +1,165 @@
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEventStream as AssistantStream,
+	createAssistantMessageEventStream,
+	type Model,
+	type Provider,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+
+function model(id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "thinking-recovery",
+		baseUrl: "https://example.test/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	};
+}
+
+function blankMessage(selected: Model<Api>): AssistantMessage {
+	return {
+		role: "assistant",
+		api: selected.api,
+		provider: selected.provider,
+		model: selected.id,
+		content: [],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function thinkingStream(selected: Model<Api>, chunks: readonly string[]): AssistantStream {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const partial = blankMessage(selected);
+		stream.push({ type: "start", partial });
+		partial.content = [{ type: "thinking", thinking: "" }];
+		stream.push({ type: "thinking_start", contentIndex: 0, partial });
+		let thinking = "";
+		for (const chunk of chunks) {
+			thinking += chunk;
+			partial.content = [{ type: "thinking", thinking }];
+			stream.push({ type: "thinking_delta", contentIndex: 0, delta: chunk, partial });
+		}
+		stream.push({ type: "thinking_end", contentIndex: 0, content: thinking, partial });
+		const message = blankMessage(selected);
+		message.content = [{ type: "thinking", thinking }];
+		stream.push({ type: "done", reason: "stop", message });
+	});
+	return stream;
+}
+
+async function runtimeResult(id: string, chunks: readonly string[]): Promise<AssistantMessage> {
+	const selectedModel = model(id);
+	const provider: Provider = {
+		id: selectedModel.provider,
+		name: "Thinking recovery provider",
+		auth: { apiKey: { name: "test", resolve: async () => ({ auth: { apiKey: "test" }, source: "test" }) } },
+		getModels: () => [selectedModel],
+		stream: (selected) => thinkingStream(selected, chunks),
+		streamSimple: (selected) => thinkingStream(selected, chunks),
+	};
+	const runtime = await ModelRuntime.create({
+		credentials: AuthStorage.inMemory(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerNativeProvider(provider);
+	const selected = runtime.getModel(provider.id, selectedModel.id);
+	if (!selected) throw new Error("model not registered");
+	return runtime.stream(selected, { messages: [], tools: [] }).result();
+}
+
+function visibleText(message: AssistantMessage): string {
+	return message.content
+		.filter((item) => item.type === "text")
+		.map((item) => (item.type === "text" ? item.text : ""))
+		.join("");
+}
+
+function thinkingText(message: AssistantMessage): string {
+	return message.content
+		.filter((item) => item.type === "thinking")
+		.map((item) => (item.type === "thinking" ? item.thinking : ""))
+		.join("");
+}
+
+describe("Kimi XTML thinking recovery runtime boundary", () => {
+	it("promotes an explicit response channel without registered tools", async () => {
+		const result = await runtimeResult("kimi-k3", [
+			"Reasoning stays private.",
+			"<|close|>think<|sep|><|open|>res",
+			"ponse<|sep|>Recovered answer",
+			"<|close|>response<|sep|><|close|>message<|sep|>",
+		]);
+
+		expect(visibleText(result)).toBe("Recovered answer");
+		expect(thinkingText(result)).toBe("Reasoning stays private.");
+		expect(result.content.map((item) => JSON.stringify(item)).join("")).not.toContain("<|");
+		expect(result.diagnostics).toEqual([
+			{
+				type: "kimi_xtml_thinking_recovery",
+				timestamp: expect.any(Number),
+				details: { recoveredResponse: true },
+			},
+		]);
+	});
+
+	it("sanitizes closing-only markers without exposing thinking", async () => {
+		const result = await runtimeResult("kimi-k3-ultrafast", [
+			"Reasoning and a misrouted report stay private",
+			".<|close|>response<|sep|><|close|>message<|sep|>",
+		]);
+
+		expect(visibleText(result)).toBe("");
+		expect(thinkingText(result)).toBe("Reasoning and a misrouted report stay private.");
+		expect(result.content.map((item) => JSON.stringify(item)).join("")).not.toContain("<|");
+	});
+
+	it("preserves XTML-looking literals inside fenced code", async () => {
+		const literal = [
+			"Example:\n```text\n",
+			"<|close|>think<|sep|><|open|>response<|sep|>",
+			"literal<|close|>response<|sep|><|close|>message<|sep|>\n```",
+		];
+		const result = await runtimeResult("kimi-k3", literal);
+
+		expect(visibleText(result)).toBe("");
+		expect(thinkingText(result)).toBe(literal.join(""));
+		expect(result.diagnostics).toBeUndefined();
+	});
+
+	it("leaves ordinary Kimi thinking unchanged", async () => {
+		const result = await runtimeResult("kimi-k3", ["Ordinary reasoning without protocol markers."]);
+
+		expect(visibleText(result)).toBe("");
+		expect(thinkingText(result)).toBe("Ordinary reasoning without protocol markers.");
+		expect(result.diagnostics).toBeUndefined();
+	});
+
+	it("leaves non-Kimi thinking markers untouched", async () => {
+		const leaked = "<|close|>think<|sep|><|open|>response<|sep|>Visible?<|close|>response<|sep|>";
+		const result = await runtimeResult("gpt-5", [leaked]);
+
+		expect(visibleText(result)).toBe("");
+		expect(thinkingText(result)).toBe(leaked);
+		expect(result.diagnostics).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- recover structurally explicit Kimi XTML response channels that leak into provider thinking content
- sanitize closing-only response/message markers without exposing chain-of-thought
- retry one Kimi assistant turn that stops with no visible text or tool call, then fail visibly and boundedly
- run Kimi marker recovery independently of registered tools
- add a deterministic real-CLI mock-loop scenario for the observed malformed payload

## Safety properties

- response text is promoted only after an explicit `<|open|>response<|sep|>` boundary
- closing-marker-only payloads are sanitized but never heuristically exposed
- inline and fenced XTML-looking literals remain byte-for-byte unchanged
- non-Kimi models, errors, aborts, refusals, length stops, and tool-call turns keep existing behavior
- the first empty attempt is discarded before conversation replay

## RED -> GREEN evidence

- `packages/coding-agent/test/kimi-xtml-thinking-recovery-runtime-boundary.test.ts`
  - RED: explicit response remained invisible; closing markers remained in thinking
  - GREEN: 5/5
- `packages/agent/test/agent-loop-empty-assistant-recovery.test.ts`
  - RED: both recovery scenarios stopped after one provider request
  - GREEN: 4/4
- local receipts:
  - `local-ignore/qa-evidence/20260730-kimi-xtml-recovery/criterion-1-red.txt`
  - `local-ignore/qa-evidence/20260730-kimi-xtml-recovery/criterion-1-green.txt`
  - `local-ignore/qa-evidence/20260730-kimi-xtml-recovery/criterion-3-red.txt`
  - `local-ignore/qa-evidence/20260730-kimi-xtml-recovery/criterion-3-green.txt`

## Real CLI QA

```bash
node .agents/skills/senpi-qa/scripts/mock-loop.mjs \
  --scenario kimi-xtml-thinking-recover \
  --evidence kimi-xtml-thinking-recover
```

Result: 8/8 passed.

- exactly two localhost provider requests
- recovered visible answer exactly once
- no raw XTML markers in visible output
- discarded attempt absent from request-two replay
- real auth unchanged
- fake server and sandbox cleaned

The existing `mock-loop.mjs --self-test` suite also passed across OpenAI Completions, Anthropic Messages, OpenAI Responses, complete/truncated text-tool recovery, retry/fallback paths, auth isolation, and cleanup.

## Validation

- AI scoped tests: 38/38
- agent scoped tests: 5/5
- coding-agent scoped tests: 15/15
- incoming `main` high-reasoning tests after conflict resolution: 15/15
- `npm run check`
- `npm run build`
- post-merge `npm run check`
- post-merge `npm run build`

## Commits

- `fix(ai): recover Kimi response channels from thinking`
- `fix(agent): retry empty Kimi responses once`
- `test(qa): cover Kimi thinking recovery`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes malformed Kimi XTML turns by recovering misrouted response text and adds a one‑retry guard for empty assistant turns. Users get one visible answer, and XTML markers never appear.

- **Bug Fixes**
  - Kimi XTML thinking recovery: sanitize `<|open|>/<|close|>` markers and promote text only after `response` open; preserve code literals; add `kimi_xtml_thinking_recovery` diagnostic.
  - Model-level recovery runs at the runtime boundary via `wrapStreamWithModelRecovery` even with no tools; leaked tool-call reconstruction still requires tools.
  - Empty Kimi assistant “stop” with no text/tool call is retried once; a second empty stop becomes a visible, bounded error; errors, aborts, refusals, length stops, and tool-call turns are unchanged.
  - Real CLI `mock-loop` adds `--scenario kimi-xtml-thinking-recover` to validate two requests, one visible answer, and no XTML marker leakage.

<sup>Written for commit 7def14b8e359dae12b478d39a5b8a900c6c20826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

