### PR TITLE
fix(gpt-apply-patch): disclose failure reasons and serialize file mutations

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/apply.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/apply.ts
@@ -1,15 +1,19 @@
 import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { withFileMutationQueue } from "../../../tools/file-mutation-queue.ts";
 import { ApplyPatchError } from "./errors.ts";
 import { parsePatch } from "./parser.ts";
 import { replaceChunks } from "./patch-replace.ts";
 import { buildPatchPreviewFile, readPatchFileSnapshot } from "./preview.ts";
+import { createRecoveryInstructions } from "./recovery.ts";
+
+export { buildPartialFailureText } from "./recovery.ts";
+
 import { normalizePatchText } from "./text.ts";
 import type {
 	AppliedPatchOperation,
 	ApplyPatchFailure,
 	ApplyPatchProgressCallback,
-	ApplyPatchRecoveryInstructions,
 	ApplyPatchResult,
 	AtomicWriteOperations,
 	ParsedPatch,
@@ -31,6 +35,13 @@ async function notifyApplyPatchProgress(
 
 function hasErrorCode(error: unknown, code: string): boolean {
 	return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
+}
+
+function extractErrorCode(error: unknown): string | undefined {
+	if (error && typeof error === "object" && "code" in error && typeof error.code === "string") {
+		return error.code;
+	}
+	return undefined;
 }
 
 async function writeFileAtomic(
@@ -67,85 +78,73 @@ async function applySingleHunk(
 	readonly preview: ReturnType<typeof buildPatchPreviewFile>;
 }> {
 	const absolutePath = resolvePatchPath(cwd, hunk.filePath);
-	if (hunk.type === "add") {
-		const source = await readPatchFileSnapshot(absolutePath);
-		const preview = buildPatchPreviewFile({ hunk, source, newContent: hunk.content });
-		await mkdir(path.dirname(absolutePath), { recursive: true });
-		await writeFileAtomic(absolutePath, hunk.content);
-		return { summary: `add: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: 0, preview };
-	}
+	const mutationPaths =
+		hunk.type === "update" && hunk.movePath ? [absolutePath, resolvePatchPath(cwd, hunk.movePath)] : [absolutePath];
+	return withPatchMutationQueues(mutationPaths, async () => {
+		if (hunk.type === "add") {
+			const source = await readPatchFileSnapshot(absolutePath);
+			const preview = buildPatchPreviewFile({ hunk, source, newContent: hunk.content });
+			await mkdir(path.dirname(absolutePath), { recursive: true });
+			await writeFileAtomic(absolutePath, hunk.content);
+			return { summary: `add: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: 0, preview };
+		}
 
-	if (hunk.type === "delete") {
-		const oldContent = await readFile(absolutePath, "utf-8");
-		const preview = buildPatchPreviewFile({
-			hunk,
-			source: { exists: true, content: oldContent },
-			newContent: "",
-		});
-		await rm(absolutePath);
-		return { summary: `delete: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: 0, preview };
-	}
+		if (hunk.type === "delete") {
+			const oldContent = await readFile(absolutePath, "utf-8");
+			const preview = buildPatchPreviewFile({
+				hunk,
+				source: { exists: true, content: oldContent },
+				newContent: "",
+			});
+			await rm(absolutePath);
+			return { summary: `delete: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: 0, preview };
+		}
 
-	const currentContent = await readFile(absolutePath, "utf-8");
-	const chunkResult =
-		hunk.chunks.length === 0
-			? { content: currentContent, fuzz: 0 }
-			: replaceChunks(currentContent, hunk.filePath, hunk.chunks);
+		const currentContent = await readFile(absolutePath, "utf-8");
+		const chunkResult =
+			hunk.chunks.length === 0
+				? { content: currentContent, fuzz: 0 }
+				: replaceChunks(currentContent, hunk.filePath, hunk.chunks);
 
-	if (hunk.movePath) {
-		const absoluteMovePath = resolvePatchPath(cwd, hunk.movePath);
-		const moveDestination =
-			absoluteMovePath === absolutePath ? undefined : await readPatchFileSnapshot(absoluteMovePath);
+		if (hunk.movePath) {
+			const absoluteMovePath = resolvePatchPath(cwd, hunk.movePath);
+			const moveDestination =
+				absoluteMovePath === absolutePath ? undefined : await readPatchFileSnapshot(absoluteMovePath);
+			const preview = buildPatchPreviewFile({
+				hunk,
+				source: { exists: true, content: currentContent },
+				newContent: chunkResult.content,
+				...(moveDestination ? { moveDestination } : {}),
+			});
+			await mkdir(path.dirname(absoluteMovePath), { recursive: true });
+			await writeFileAtomic(absoluteMovePath, chunkResult.content);
+			if (absoluteMovePath !== absolutePath) await rm(absolutePath);
+			return {
+				summary: `move: ${hunk.filePath} -> ${hunk.movePath}`,
+				appliedFile: hunk.movePath,
+				fuzz: chunkResult.fuzz,
+				preview,
+			};
+		}
+
 		const preview = buildPatchPreviewFile({
 			hunk,
 			source: { exists: true, content: currentContent },
 			newContent: chunkResult.content,
-			...(moveDestination ? { moveDestination } : {}),
 		});
-		await mkdir(path.dirname(absoluteMovePath), { recursive: true });
-		await writeFileAtomic(absoluteMovePath, chunkResult.content);
-		if (absoluteMovePath !== absolutePath) await rm(absolutePath);
-		return {
-			summary: `move: ${hunk.filePath} -> ${hunk.movePath}`,
-			appliedFile: hunk.movePath,
-			fuzz: chunkResult.fuzz,
-			preview,
-		};
-	}
-
-	const preview = buildPatchPreviewFile({
-		hunk,
-		source: { exists: true, content: currentContent },
-		newContent: chunkResult.content,
+		await writeFileAtomic(absolutePath, chunkResult.content);
+		return { summary: `update: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: chunkResult.fuzz, preview };
 	});
-	await writeFileAtomic(absolutePath, chunkResult.content);
-	return { summary: `update: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: chunkResult.fuzz, preview };
 }
 
-function createRecoveryInstructions(
-	result: Pick<ApplyPatchResult, "appliedFiles" | "failures">,
-): ApplyPatchRecoveryInstructions {
-	const mustReadFiles = [...new Set(result.failures.map((failure) => failure.filePath))];
-	const mustNotReadFiles = [...new Set(result.appliedFiles.filter((filePath) => !mustReadFiles.includes(filePath)))];
-	return { mustReadFiles, mustNotReadFiles };
-}
-
-export function buildPartialFailureText(result: ApplyPatchResult): string {
-	const failed = result.recoveryInstructions.mustReadFiles.join(", ");
-	const mustReadText = failed.includes(",") ? failed.split(", ").join(" and ") : failed;
-	return [
-		"apply_patch partially failed.",
-		`Failed: ${failed}`,
-		`Recovery: MUST read ${mustReadText} before retrying.`,
-		result.appliedFiles.length > 0
-			? "Earlier file actions in this patch were already applied."
-			: "No file actions were applied.",
-		result.recoveryInstructions.mustNotReadFiles.length > 0
-			? "Recovery: MUST NOT reread other files from this patch unless a specific dependency requires it."
-			: "",
-	]
-		.filter((line) => line.length > 0)
-		.join("\n");
+async function withPatchMutationQueues<T>(filePaths: readonly string[], operation: () => Promise<T>): Promise<T> {
+	const sortedPaths = [...new Set(filePaths)].sort((left, right) => left.localeCompare(right));
+	const runQueued = (index: number): Promise<T> => {
+		const filePath = sortedPaths[index];
+		if (filePath === undefined) return operation();
+		return withFileMutationQueue(filePath, () => runQueued(index + 1));
+	};
+	return runQueued(0);
 }
 
 function parseNonEmptyPatch(patchText: string): ParsedPatch[] {
@@ -179,7 +178,8 @@ export async function applyPatchDetailed(
 			fuzz += applied.fuzz;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			failures.push({ operationIndex, filePath: hunk.filePath, operation: hunk.type, message });
+			const code = extractErrorCode(error);
+			failures.push({ operationIndex, filePath: hunk.filePath, operation: hunk.type, message, code });
 		}
 		await notifyApplyPatchProgress(onProgress, {
 			applied: appliedFiles.length,
@@ -193,7 +193,7 @@ export async function applyPatchDetailed(
 		appliedFiles,
 		failures,
 		hasPartialSuccess: appliedFiles.length > 0 && failures.length > 0,
-		recoveryInstructions: { mustReadFiles: [], mustNotReadFiles: [] },
+		recoveryInstructions: { mustReadFiles: [], mustNotReadFiles: [], failedFiles: [] },
 		details: { fuzz, appliedOperations },
 	};
 	result.recoveryInstructions = createRecoveryInstructions(result);
@@ -214,7 +214,7 @@ export async function applyPatch(cwd: string, patchText: string): Promise<string
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			const failures: ApplyPatchFailure[] = [
-				{ operationIndex, filePath: hunk.filePath, operation: hunk.type, message },
+				{ operationIndex, filePath: hunk.filePath, operation: hunk.type, message, code: extractErrorCode(error) },
 			];
 			const result: ApplyPatchResult = {
 				summaries,

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/recovery.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/recovery.ts
@@ -1,0 +1,42 @@
+import type { ApplyPatchFailure, ApplyPatchRecoveryInstructions, ApplyPatchResult } from "./types.ts";
+
+/**
+ * ENOENT (missing file), EACCES/EPERM (permission), ENOTDIR/EISDIR (path) are
+ * not context mismatches — rereading will not fix them. Only context-line
+ * failures (no error code, thrown by replaceChunks) benefit from a reread.
+ */
+function isRereadCandidate(failure: ApplyPatchFailure): boolean {
+	return failure.code === undefined;
+}
+
+export function createRecoveryInstructions(
+	result: Pick<ApplyPatchResult, "appliedFiles" | "failures">,
+): ApplyPatchRecoveryInstructions {
+	const mustReadFiles = [...new Set(result.failures.filter(isRereadCandidate).map((failure) => failure.filePath))];
+	const mustReadFileSet = new Set(mustReadFiles);
+	const failedFileSet = new Set(result.failures.map((failure) => failure.filePath));
+	const mustNotReadFiles = [...new Set(result.appliedFiles.filter((filePath) => !mustReadFileSet.has(filePath)))];
+	return { mustReadFiles, mustNotReadFiles, failedFiles: [...failedFileSet] };
+}
+
+export function buildPartialFailureText(result: ApplyPatchResult): string {
+	const failureLines = result.failures.map(
+		(failure) => `- ${failure.filePath} (${failure.operation}): ${failure.message}`,
+	);
+	const mustReadFiles = result.recoveryInstructions.mustReadFiles;
+	const mustReadText = mustReadFiles.join(" and ");
+	return [
+		result.hasPartialSuccess ? "apply_patch partially failed." : "apply_patch failed.",
+		"Failed:",
+		...failureLines,
+		mustReadFiles.length > 0 ? `Recovery: MUST read ${mustReadText} before retrying.` : "",
+		result.appliedFiles.length > 0
+			? "Earlier file actions in this patch were already applied."
+			: "No file actions were applied.",
+		result.recoveryInstructions.mustNotReadFiles.length > 0
+			? "Recovery: MUST NOT reread other files from this patch unless a specific dependency requires it."
+			: "",
+	]
+		.filter((line) => line.length > 0)
+		.join("\n");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
@@ -107,10 +107,6 @@ export function createApplyPatchTool(variant: "freeform" | "json" = "freeform"):
 			});
 			const resultPreview = appliedPreview(result);
 			if (result.failures.length > 0) {
-				if (result.appliedFiles.length === 0) {
-					const firstFailure = result.failures[0];
-					if (firstFailure) throw new Error(firstFailure.message);
-				}
 				return {
 					content: [{ type: "text", text: buildPartialFailureText(result) }],
 					details: resultPreview ? { preview: resultPreview, result } : { result },

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/types.ts
@@ -69,6 +69,7 @@ export type ApplyPatchFailure = {
 	filePath: string;
 	operation: ApplyPatchOperation;
 	message: string;
+	code?: string | undefined;
 };
 
 export type AppliedPatchOperation = {
@@ -79,6 +80,7 @@ export type AppliedPatchOperation = {
 export type ApplyPatchRecoveryInstructions = {
 	mustReadFiles: string[];
 	mustNotReadFiles: string[];
+	failedFiles: string[];
 };
 
 export type ApplyPatchResult = {

--- a/packages/coding-agent/test/suite/gpt-apply-patch-backport.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-backport.test.ts
@@ -45,9 +45,11 @@ describe("gpt-apply-patch backported behavior", () => {
 
 		expect(result.summaries).toEqual(["update: ok.txt"]);
 		expect(result.failures).toHaveLength(1);
-		expect(result.recoveryInstructions.mustReadFiles).toEqual(["missing.txt"]);
+		expect(result.recoveryInstructions.mustReadFiles).toEqual([]);
+		expect(result.recoveryInstructions.failedFiles).toEqual(["missing.txt"]);
 		expect(result.recoveryInstructions.mustNotReadFiles).toEqual(["ok.txt"]);
-		expect(buildPartialFailureText(result)).toContain("MUST read missing.txt");
+		expect(buildPartialFailureText(result)).not.toContain("MUST read");
+		expect(buildPartialFailureText(result)).toContain("ENOENT");
 	});
 
 	it("keeps applyPatch fail-fast with ApplyPatchError", async () => {

--- a/packages/coding-agent/test/suite/gpt-apply-patch-failure-disclosure.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-failure-disclosure.test.ts
@@ -1,0 +1,112 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	applyPatchDetailed,
+	buildPartialFailureText,
+} from "../../src/core/extensions/builtin/gpt-apply-patch/apply.ts";
+import { createApplyPatchTool } from "../../src/core/extensions/builtin/gpt-apply-patch/tool.ts";
+import type { Harness } from "./harness.ts";
+import { createHarness } from "./harness.ts";
+
+const harnesses: Harness[] = [];
+
+afterEach(async () => {
+	await Promise.all(harnesses.splice(0).map((h) => h.cleanup()));
+});
+
+describe("gpt-apply-patch failure disclosure (#31)", () => {
+	it("surfaces the underlying failure message for a missing file (ENOENT)", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		const patch = `*** Begin Patch
+*** Update File: missing.txt
+@@
+-old
++new
+*** End Patch`;
+
+		const result = await applyPatchDetailed(harness.tempDir, patch);
+
+		expect(result.failures).toHaveLength(1);
+		expect(result.failures[0]?.message).toContain("ENOENT");
+
+		const text = buildPartialFailureText(result);
+		expect(text).toContain("missing.txt");
+		expect(text).not.toContain("MUST read");
+	});
+
+	it("surfaces the underlying failure message for a context mismatch and advises reread", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "exists.txt"), "line\n", "utf-8");
+
+		const patch = `*** Begin Patch
+*** Update File: exists.txt
+@@
+-missing
++new
+*** End Patch`;
+
+		const result = await applyPatchDetailed(harness.tempDir, patch);
+
+		expect(result.failures).toHaveLength(1);
+		const text = buildPartialFailureText(result);
+		expect(text).toContain("exists.txt");
+		expect(text).toContain("MUST read exists.txt");
+		expect(text).toMatch(/expected lines|context|find/i);
+	});
+
+	it("discloses failure messages via tool execute for a complete failure", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "broken.txt"), "line\n", "utf-8");
+
+		const patch = `*** Begin Patch
+*** Update File: broken.txt
+@@
+-missing
++changed
+*** End Patch`;
+
+		const tool = createApplyPatchTool();
+		const result = await tool.execute("apply-patch-test", { input: patch }, undefined, undefined, {
+			cwd: harness.tempDir,
+		} as never);
+
+		const text = result.content.find((block) => block.type === "text")?.text ?? "";
+		expect(text).toContain("broken.txt");
+		expect(text).toMatch(/expected lines|context|find/i);
+	});
+});
+
+describe("gpt-apply-patch mutation queue (#28)", () => {
+	it("serializes concurrent patches to the same file", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "shared.txt"), "first\nsecond\n", "utf-8");
+
+		const firstPatch = `*** Begin Patch
+*** Update File: shared.txt
+@@
+-first
++FIRST
+*** End Patch`;
+
+		const secondPatch = `*** Begin Patch
+*** Update File: shared.txt
+@@
+-second
++SECOND
+*** End Patch`;
+
+		await Promise.all([
+			applyPatchDetailed(harness.tempDir, firstPatch),
+			applyPatchDetailed(harness.tempDir, secondPatch),
+		]);
+
+		const content = await readFile(path.join(harness.tempDir, "shared.txt"), "utf-8");
+		expect(content).toBe("FIRST\nSECOND\n");
+	});
+});


### PR DESCRIPTION
## Summary

Ports pi-apply-patch issue #31 (failure-reason disclosure) and PR #28 (mutation-queue serialization) into the senpi `gpt-apply-patch` builtin. Senpi already had the #22 (outside-cwd paths) and #33 (custom Responses providers) equivalents independently.

### Changes

**#31 — Failure-reason disclosure:**
- Surface each failure path, operation, and underlying `failures[].message` in the model-facing tool result text (`Failed:\n- path (op): message`).
- Classify recovery advice: only context-mismatch failures (no error code) emit `Recovery: MUST read`; ENOENT/EACCES/path errors omit reread advice — rereading cannot fix them.
- Add `code?: string | undefined` to `ApplyPatchFailure`; capture the Node fs error code in both catch sites.
- Add `failedFiles: string[]` to `ApplyPatchRecoveryInstructions`.
- Tool execute no longer throws on complete failure — returns the disclosure text so the model sees the actual error.

**#28 — Mutation-queue serialization:**
- Wrap each hunk's file-mutating body in `withFileMutationQueue` (the 2-arg module-level queue from `core/tools/file-mutation-queue.ts`, the same queue `edit`/`write` use) so concurrent `apply_patch` calls to the same file serialize instead of losing updates.
- Deterministic lock ordering for move operations (source + destination sorted).

**Refactor:**
- Extract `createRecoveryInstructions` + `buildPartialFailureText` into `recovery.ts` to keep `apply.ts` under the 250-LOC ceiling.

### Verification

- `npm run check`: exit 0 (biome + tsgo + pinned-deps + ts-imports + shrinkwrap)
- New tests `gpt-apply-patch-failure-disclosure.test.ts` (4 tests): RED captured before the fix (ENOENT message hidden + MUST read wrongly emitted; context-mismatch message hidden; concurrent patches lost updates). GREEN after.
- Existing `gpt-apply-patch-backport.test.ts` updated for the new ENOENT classification (no longer a reread candidate).
- `gpt-apply-patch-rich-render.test.ts`: green.
- Pre-existing `openai` module resolution issue in `gpt-apply-patch-extension.test.ts` confirmed on clean main (unrelated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose clear failure reasons in `gpt-apply-patch` and serialize file mutations so concurrent patches don’t lose updates.

- **New Features**
  - Show failure details per file and operation in tool output (Failed: - path (op): message).
  - Recovery advice is smarter: only context mismatches emit “MUST read”; ENOENT/EACCES/path errors do not.
  - Serialize file writes with `withFileMutationQueue`; deterministic lock ordering for moves.
  - Types extended: `ApplyPatchFailure.code?` and `ApplyPatchRecoveryInstructions.failedFiles`.

- **Migration**
  - `createApplyPatchTool().execute` no longer throws on complete failure; it returns a failure text block in `content`. Update any caller that relies on exceptions.
  - If consuming recovery data, handle the new `failedFiles` field and cases where `mustReadFiles` is empty for filesystem errors.

<sup>Written for commit b9e04064ae28d7a84a2b9d21e9de5da6151d218f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

