### PR TITLE
fix(coding-agent): high_reasoning_warning fires only for gpt-5.6-sol, not every frontier model

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,21 @@
+## high_reasoning_warning narrowed to gpt-5.6-sol only (2026-07-30)
+
+### What changed
+
+- `high-reasoning-warning.ts`: `isSensitiveHighReasoningModel` now matches ONLY gpt-5.x "sol" variants via a dedicated regex (`/gpt-5(?:\.\d+)?-sol(?![a-z])/i`), fully decoupled from `supportsXhigh`/`supportsMax`. The prior implementation reused those capability gates, so the scary warning wrongly fired for every frontier model that merely supports xhigh/max (claude-fable-5, opus, sonnet-5, deepseek-v4).
+
+### Why
+
+- The warning is about a specific risky model family (gpt-5.6-sol-like), not about xhigh/max capability. Conflating the two surfaced the warning on anthropic/claude-fable-5 @ xhigh, which was not intended. The negative lookahead keeps unrelated ids such as `upstage/solar-pro-3` from matching.
+
+### Why extension system couldn't handle this alone
+
+- The detection is consumed by the in-session emit path (`agent-session.ts`); it is core risk logic, not an extension concern.
+
+### Expected merge conflict zones
+
+- LOW: `high-reasoning-warning.ts` `isSensitiveHighReasoningModel`. `thinking-levels.ts` is deliberately unchanged so capability gating (fable-5 still supports xhigh/max) is preserved.
+
 ## Runtime API keys propagate to session titles (2026-07-30)
 
 - Background session-title generation now reuses the active agent request API key before resolving provider

--- a/packages/coding-agent/src/core/high-reasoning-warning.ts
+++ b/packages/coding-agent/src/core/high-reasoning-warning.ts
@@ -1,12 +1,17 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { supportsMax, supportsXhigh } from "./thinking-levels.ts";
 
-export function isSensitiveHighReasoningModel(model: Model<Api>): boolean {
-	return supportsXhigh(model) || supportsMax(model);
+// Matches only the gpt-5.x "sol" variants (gpt-5.6-sol, -sol-fast, -sol-pro and
+// provider-prefixed forms such as openai/ or openai.). The trailing negative
+// lookahead stops unrelated ids that merely continue with letters after "sol" —
+// notably upstage/solar-pro-3 — from matching.
+const SOL_MODEL_ID_PATTERN = /gpt-5(?:\.\d+)?-sol(?![a-z])/i;
+
+export function isSensitiveHighReasoningModel(model: Pick<Model<Api>, "id">): boolean {
+	return SOL_MODEL_ID_PATTERN.test(model.id);
 }
 
-export function shouldWarnHighReasoning(model: Model<Api>, thinkingLevel: ThinkingLevel): boolean {
+export function shouldWarnHighReasoning(model: Pick<Model<Api>, "id">, thinkingLevel: ThinkingLevel): boolean {
 	return (thinkingLevel === "xhigh" || thinkingLevel === "max") && isSensitiveHighReasoningModel(model);
 }
 

--- a/packages/coding-agent/test/high-reasoning-warning-event.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-event.test.ts
@@ -25,7 +25,7 @@ class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMe
 	}
 }
 
-function sensitiveModel(id = "claude-fable-5", provider = "anthropic"): Model<Api> {
+function sensitiveModel(id = "gpt-5.6-sol", provider = "anthropic"): Model<Api> {
 	return {
 		id,
 		provider,
@@ -120,7 +120,7 @@ describe("AgentSession high_reasoning_warning event", () => {
 		expect(warningEvents(events).length).toBe(1);
 		const e = warningEvents(events)[0] as { type: string; modelId: string; provider: string; thinkingLevel: string };
 		expect(e.type).toBe("high_reasoning_warning");
-		expect(e.modelId).toBe("claude-fable-5");
+		expect(e.modelId).toBe("gpt-5.6-sol");
 		expect(e.provider).toBe("anthropic");
 		expect(e.thinkingLevel).toBe("xhigh");
 	});
@@ -146,12 +146,26 @@ describe("AgentSession high_reasoning_warning event", () => {
 		expect(warningEvents(events).length).toBe(1);
 	});
 
-	it("emits when switching to a different sensitive model while already at xhigh", async () => {
+	it("emits when switching to a different sol variant while already at xhigh", async () => {
+		const { session, events } = await createSession();
+		session.agent.state.model = sensitiveModel("gpt-5.6-sol");
+		session.setThinkingLevel("xhigh");
+		expect(warningEvents(events).length).toBe(1);
+		await session.setModel(sensitiveModel("openai/gpt-5.6-sol-pro"));
+		expect(warningEvents(events).length).toBe(2);
+	});
+
+	it("does NOT emit for claude-fable-5 at xhigh (reported bug)", async () => {
 		const { session, events } = await createSession();
 		session.agent.state.model = sensitiveModel("claude-fable-5");
 		session.setThinkingLevel("xhigh");
-		expect(warningEvents(events).length).toBe(1);
-		await session.setModel(sensitiveModel("claude-opus-4-8"));
-		expect(warningEvents(events).length).toBe(2);
+		expect(warningEvents(events).length).toBe(0);
+	});
+
+	it("does NOT emit for claude-fable-5 at max (reported bug)", async () => {
+		const { session, events } = await createSession();
+		session.agent.state.model = sensitiveModel("claude-fable-5");
+		session.setThinkingLevel("max");
+		expect(warningEvents(events).length).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/high-reasoning-warning-rpc.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-rpc.test.ts
@@ -26,9 +26,9 @@ class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMe
 	}
 }
 
-function sensitiveModel(): Model<Api> {
+function modelWithId(id: string): Model<Api> {
 	return {
-		id: "claude-fable-5",
+		id,
 		provider: "anthropic",
 		reasoning: true,
 		api: "anthropic-messages",
@@ -37,7 +37,27 @@ function sensitiveModel(): Model<Api> {
 	} as unknown as Model<Api>;
 }
 
-describe("RPC publishes high_reasoning_warning", () => {
+function mockAssistantMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("RPC publish of high_reasoning_warning", () => {
 	let session: AgentSession;
 	let tempDir: string;
 
@@ -51,38 +71,21 @@ describe("RPC publishes high_reasoning_warning", () => {
 		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
 	});
 
-	it("serializes the event onto the RPC stdout sink via the real output buffer", async () => {
+	async function captureRpcRecords(modelId: string): Promise<Array<Record<string, unknown>>> {
 		const sinkChunks: string[] = [];
 		const scheduledFlushes: Array<() => void> = [];
 		const eventOutput = createRpcEventOutputBuffer(
 			(chunk) => sinkChunks.push(chunk),
 			(flush) => scheduledFlushes.push(flush),
 		);
-		const outputEvent = (event: object) => eventOutput.enqueueEvent(event);
 
 		const agent = new Agent({
 			getApiKey: () => "test-key",
-			initialState: { model: sensitiveModel(), systemPrompt: "Test", tools: [] },
+			initialState: { model: modelWithId(modelId), systemPrompt: "Test", tools: [] },
 			streamFn: () => {
 				const stream = new MockAssistantStream();
 				queueMicrotask(() => {
-					const msg: AssistantMessage = {
-						role: "assistant",
-						content: [{ type: "text", text: "ok" }],
-						api: "anthropic-messages",
-						provider: "anthropic",
-						model: "mock",
-						usage: {
-							input: 0,
-							output: 0,
-							cacheRead: 0,
-							cacheWrite: 0,
-							totalTokens: 0,
-							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-						},
-						stopReason: "stop",
-						timestamp: Date.now(),
-					};
+					const msg = mockAssistantMessage();
 					stream.push({ type: "start", partial: msg });
 					stream.push({ type: "done", reason: "stop", message: msg });
 				});
@@ -105,21 +108,30 @@ describe("RPC publishes high_reasoning_warning", () => {
 			resourceLoader: createTestResourceLoader(),
 		});
 
-		session.subscribe((event) => outputEvent(event));
+		session.subscribe((event) => eventOutput.enqueueEvent(event));
 		session.setThinkingLevel("xhigh");
 		for (const flush of scheduledFlushes) flush();
 
-		const lines = sinkChunks
+		return sinkChunks
 			.join("")
 			.split("\n")
-			.filter((line) => line.length > 0);
-		const warning = lines
-			.map((line) => JSON.parse(line) as Record<string, unknown>)
-			.find((record) => record.type === "high_reasoning_warning");
+			.filter((line) => line.length > 0)
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+	}
+
+	it("serializes the warning onto the RPC stdout sink for gpt-5.6-sol", async () => {
+		const records = await captureRpcRecords("gpt-5.6-sol");
+		const warning = records.find((record) => record.type === "high_reasoning_warning");
 
 		expect(warning).toBeDefined();
-		expect(warning?.modelId).toBe("claude-fable-5");
+		expect(warning?.modelId).toBe("gpt-5.6-sol");
 		expect(warning?.provider).toBe("anthropic");
 		expect(warning?.thinkingLevel).toBe("xhigh");
+	});
+
+	it("emits NO warning line on the RPC stdout sink for claude-fable-5 (reported bug)", async () => {
+		const records = await captureRpcRecords("claude-fable-5");
+		expect(records.find((record) => record.type === "high_reasoning_warning")).toBeUndefined();
+		expect(records.some((record) => record.type === "thinking_level_changed")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
@@ -41,15 +41,15 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 		expect(rendered).toMatch(/stop|loop/i);
 	});
 
-	test("reflects the max level when max is selected", () => {
+	test("reflects the max level for a sol variant when max is selected", () => {
 		const fakeThis: { chatContainer: Container; ui: { requestRender: () => void } } = {
 			chatContainer: new Container(),
 			ui: { requestRender: vi.fn() },
 		};
 		const event = {
 			type: "high_reasoning_warning",
-			modelId: "claude-opus-4-8",
-			provider: "anthropic",
+			modelId: "openai/gpt-5.6-sol-pro",
+			provider: "openai",
 			thinkingLevel: "max",
 		} as Extract<AgentSessionEvent, { type: "high_reasoning_warning" }>;
 
@@ -58,6 +58,6 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 		).prototype.showHighReasoningWarning.call(fakeThis, event);
 
 		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("max");
-		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("claude-opus-4-8");
+		expect(stripAnsi(renderAll(fakeThis.chatContainer))).toContain("openai/gpt-5.6-sol-pro");
 	});
 });

--- a/packages/coding-agent/test/high-reasoning-warning.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning.test.ts
@@ -5,52 +5,95 @@ import {
 	isSensitiveHighReasoningModel,
 	shouldWarnHighReasoning,
 } from "../src/core/high-reasoning-warning.ts";
+import { getSupportedThinkingLevels, supportsMax, supportsXhigh } from "../src/core/thinking-levels.ts";
 
 function mkModel(id: string, provider = "openai"): Model<Api> {
 	return { id, provider, reasoning: true, api: "openai-responses" } as unknown as Model<Api>;
 }
 
+const SOL_MODEL_IDS = [
+	"gpt-5.6-sol",
+	"gpt-5.6-sol-fast",
+	"openai.gpt-5.6-sol",
+	"openai/gpt-5.6-sol",
+	"openai/gpt-5.6-sol-pro",
+];
+
+const NON_SOL_MODEL_IDS = [
+	"upstage/solar-pro-3",
+	"gpt-5.6-luna",
+	"gpt-5.6-luna-fast",
+	"gpt-5.6-terra",
+	"gpt-5.6",
+	"gpt-5.5",
+	"gpt-5.2",
+	"gpt-5.3-codex-spark",
+	"gpt-4o",
+	"claude-fable-5",
+	"claude-opus-4-8",
+	"opus-4.7",
+	"opus-5",
+	"claude-sonnet-5",
+	"deepseek-v4-pro",
+	"deepseek-v4-flash",
+];
+
 describe("high-reasoning-warning", () => {
 	describe("isSensitiveHighReasoningModel", () => {
-		it("flags gpt-5.6-sol-like frontier models (provider-agnostic, name-based)", () => {
-			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6-sol"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.2-mini"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("claude-opus-4-8"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("opus-4.7"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("fable-5"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("deepseek-v4-pro"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("deepseek-v4-flash"))).toBe(true);
-			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6-sol", "openrouter"))).toBe(true);
+		it.each(SOL_MODEL_IDS)("flags the gpt-5.6-sol variant %s", (id) => {
+			expect(isSensitiveHighReasoningModel(mkModel(id))).toBe(true);
 		});
 
-		it("does not flag non-frontier models", () => {
-			expect(isSensitiveHighReasoningModel(mkModel("gpt-4o"))).toBe(false);
-			expect(isSensitiveHighReasoningModel(mkModel("claude-3-5-sonnet"))).toBe(false);
-			expect(isSensitiveHighReasoningModel(mkModel("gpt-5"))).toBe(false);
-			expect(isSensitiveHighReasoningModel(mkModel("llama-3.3-70b"))).toBe(false);
+		it.each(["openai", "openrouter", "azure", "anthropic"])("is provider-agnostic for provider %s", (provider) => {
+			expect(isSensitiveHighReasoningModel(mkModel("gpt-5.6-sol", provider))).toBe(true);
+		});
+
+		it.each(NON_SOL_MODEL_IDS)("does NOT flag %s", (id) => {
+			expect(isSensitiveHighReasoningModel(mkModel(id))).toBe(false);
 		});
 	});
 
 	describe("shouldWarnHighReasoning", () => {
-		it("warns for a sensitive model driven at xhigh or max", () => {
+		it("warns for a gpt-5.6-sol variant at xhigh or max", () => {
 			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "xhigh")).toBe(true);
 			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "max")).toBe(true);
-			expect(shouldWarnHighReasoning(mkModel("claude-opus-4-8"), "max")).toBe(true);
-			expect(shouldWarnHighReasoning(mkModel("fable-5"), "xhigh")).toBe(true);
+			expect(shouldWarnHighReasoning(mkModel("openai/gpt-5.6-sol-pro"), "xhigh")).toBe(true);
 		});
 
-		it("does not warn for a non-sensitive model even at xhigh/max", () => {
-			expect(shouldWarnHighReasoning(mkModel("gpt-4o"), "xhigh")).toBe(false);
-			expect(shouldWarnHighReasoning(mkModel("gpt-4o"), "max")).toBe(false);
+		it("does NOT warn for claude-fable-5 at xhigh or max (reported bug)", () => {
+			expect(shouldWarnHighReasoning(mkModel("claude-fable-5", "anthropic"), "xhigh")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel("claude-fable-5", "anthropic"), "max")).toBe(false);
 		});
 
-		it("does not warn for a sensitive model at or below high", () => {
-			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "high")).toBe(false);
-			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "medium")).toBe(false);
-			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "low")).toBe(false);
-			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "minimal")).toBe(false);
-			expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), "off")).toBe(false);
+		it.each(NON_SOL_MODEL_IDS)("does NOT warn for non-sol model %s at xhigh", (id) => {
+			expect(shouldWarnHighReasoning(mkModel(id), "xhigh")).toBe(false);
+			expect(shouldWarnHighReasoning(mkModel(id), "max")).toBe(false);
+		});
+
+		it.each(["high", "medium", "low", "minimal", "off"] as const)(
+			"does NOT warn for gpt-5.6-sol at level %s",
+			(level) => {
+				expect(shouldWarnHighReasoning(mkModel("gpt-5.6-sol"), level)).toBe(false);
+			},
+		);
+	});
+
+	describe("capability gating is untouched by the warning narrowing", () => {
+		it("keeps xhigh/max capability for claude-fable-5 even though it no longer warns", () => {
+			const fable = mkModel("claude-fable-5", "anthropic");
+			expect(supportsXhigh(fable)).toBe(true);
+			expect(supportsMax(fable)).toBe(true);
+			const levels = getSupportedThinkingLevels(fable);
+			expect(levels).toContain("xhigh");
+			expect(levels).toContain("max");
+			expect(shouldWarnHighReasoning(fable, "xhigh")).toBe(false);
+		});
+
+		it("keeps xhigh capability for gpt-5.6-sol, which also warns", () => {
+			const sol = mkModel("gpt-5.6-sol");
+			expect(supportsXhigh(sol)).toBe(true);
+			expect(getSupportedThinkingLevels(sol)).toContain("xhigh");
+			expect(shouldWarnHighReasoning(sol, "xhigh")).toBe(true);
 		});
 	});
 
@@ -68,12 +111,6 @@ describe("high-reasoning-warning", () => {
 			expect(body).toMatch(/risk|irreversible|dangerous/i);
 			expect(body).toMatch(/query ultrabrain|delegate|subagent|sub-agent/i);
 			expect(body.length).toBeGreaterThan(200);
-		});
-
-		it("reflects the max level in the title when max is selected", () => {
-			const w = buildHighReasoningWarning(mkModel("claude-opus-4-8", "anthropic"), "max");
-			expect(w.title).toContain("max");
-			expect(w.title).toContain("claude-opus-4-8");
 		});
 	});
 });


### PR DESCRIPTION
## The bug

The `high_reasoning_warning` shipped in #517 fired for **every** frontier model that supports xhigh/max — including `anthropic/claude-fable-5 @ xhigh` (screenshotted by the user). Root cause: `isSensitiveHighReasoningModel` was implemented as `supportsXhigh(model) || supportsMax(model)`, conflating a **capability** question ("can this model run at xhigh/max") with a **risk** question ("is this a gpt-5.6-sol-like model").

The user's requirement: **only gpt-5.6-sol**.

## The fix

`isSensitiveHighReasoningModel` now matches **only** gpt-5.x "sol" variants via a dedicated regex, fully decoupled from capability gating:

```
/gpt-5(?:\.\d+)?-sol(?![a-z])/i
```

The trailing negative lookahead stops unrelated ids that merely continue with letters after `sol` — notably **`upstage/solar-pro-3`** — from matching. `thinking-levels.ts` is **untouched**, so capability gating is preserved: `claude-fable-5` still *supports* xhigh/max, it just no longer *warns*.

## Evidence (TDD: RED captured before the fix)

- **Detection matrix** — `high-reasoning-warning.test.ts` (51 cases): all sol variants (`gpt-5.6-sol`, `-sol-fast`, `openai/gpt-5.6-sol-pro`, provider-agnostic) → `true`; `solar-pro-3` / `gpt-5.6-luna` / `gpt-5.6-terra` / `gpt-5.6` / `claude-fable-5` / `opus-*` / `sonnet-5` / `deepseek-v4-*` → `false`. RED captured before the fix (30 failed — the frontier negatives returned `true`).
- **No capability regression** — a test asserts `claude-fable-5` still `supportsXhigh`/`supportsMax` and `getSupportedThinkingLevels` still contains `xhigh`+`max`, while `shouldWarnHighReasoning(fable, "xhigh") === false`.
- **AgentSession emit** — `high-reasoning-warning-event.test.ts`: emits for `gpt-5.6-sol` @ xhigh; emits **nothing** for `claude-fable-5` @ xhigh/max (the exact reported case).
- **RPC real surface** — `high-reasoning-warning-rpc.test.ts`: the `high_reasoning_warning` JSONL line appears for `gpt-5.6-sol`; for `claude-fable-5` there is **no** such line (only `thinking_level_changed`).
- **TUI real surface** — `local-ignore/qa-evidence/20260730-high-reasoning-warning-sol-only/` (ans+html+grid): the box renders for `gpt-5.6-sol` (WARNING + gpt-5.6-sol + ultrabrain + responsibility, 1075 red `#cc6666` cells, no fable/opus/sonnet text).

## Validation

- All 62 high-reasoning-warning tests green · thinking-levels regressions 7/7 · agent-session-retry 5/5.
- `npx tsgo --noEmit` exit 0 · `npm run check` exit 0 · biome clean.
- `thinking-levels.ts` diff vs main: **empty** (capability gating byte-identical).

Fixes the `claude-fable-5 @ xhigh` false warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the high_reasoning_warning to trigger only for gpt-5.x "sol" models (e.g., gpt-5.6-sol). Removes the false warning for `claude-fable-5` at xhigh/max.

- **Bug Fixes**
  - Narrowed detection with `/gpt-5(?:\.\d+)?-sol(?![a-z])/i`, provider-agnostic and excluding ids like `upstage/solar-pro-3`; functions now read only `model.id`.
  - Left capability gating untouched; `claude-fable-5` still supports `xhigh`/`max` but no longer warns.
  - Expanded tests (detection, event emit, RPC, TUI) to cover sol variants like `openai/gpt-5.6-sol-pro` and assert no warnings for `claude-fable-5` at `xhigh`/`max`.

<sup>Written for commit 6efdecdc0787a3bb00f6248de235be37e0629d64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

