### PR TITLE
fix(compaction): enforce guards on blocking routes

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -248,6 +248,14 @@ export default function compactionExtension(
 		ctx: ExtensionContext,
 		customInstructions: string,
 	): Promise<SpeculativeCompactionResult> {
+		if (breaker.isTripped(state, Date.now())) {
+			getLogger(ctx).debug("skip_breaker", { route: "blocking" });
+			return { applied: false, reason: "rejected" };
+		}
+		if (cap.shouldRejectByCap(state).cancel) {
+			getLogger(ctx).debug("skip_cap", { route: "blocking" });
+			return { applied: false, reason: "rejected" };
+		}
 		let feedbackSignal = ctx.beginCompaction?.({ reason: "extension" });
 		try {
 			if (isOpenAiRemoteCompactionModel(ctx.model)) {
@@ -520,6 +528,7 @@ export default function compactionExtension(
 						savingsRatio: sy.savingsRatio,
 					})
 				) {
+					state = cap.incrementIneffective(state);
 					getLogger(ctx).debug("ineffective_counted", {
 						tokensBefore: compactEvent.compactionEntry.tokensBefore,
 						savedTokens: sy.savedTokens,

--- a/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
@@ -1,0 +1,111 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FAILURE_TRIP_THRESHOLD } from "../../src/core/extensions/builtin/compaction/circuit-breaker.ts";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
+import { softCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
+import type { ExtensionHandler } from "../../src/core/extensions/index.ts";
+import {
+	connectionErrorResponse,
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+} from "../helpers/blocking-compaction-harness.ts";
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) registration.unregister();
+});
+
+function captureHandlers(): Map<string, ExtensionHandler<never, unknown>> {
+	const handlers = new Map<string, ExtensionHandler<never, unknown>>();
+	compactionExtension({
+		on: (event: string, handler: ExtensionHandler<never, unknown>) => handlers.set(event, handler),
+	} as never);
+	return handlers;
+}
+
+function acceptedCompactionEvent(round: number, savedTokens: number) {
+	return {
+		type: "session_compact",
+		reason: "extension",
+		requestId: `guard-${round}`,
+		accepted: true,
+		fromExtension: true,
+		willRetry: false,
+		compactionEntry: {
+			type: "compaction",
+			id: `cmp-guard-${round}`,
+			parentId: null,
+			timestamp: new Date(round).toISOString(),
+			summary: "summary",
+			firstKeptEntryId: "keep",
+			tokensBefore: 9_950,
+			fromHook: true,
+			details: {
+				structuralYield: { savedTokens, savingsRatio: savedTokens / 9_950 },
+			},
+		},
+	};
+}
+
+describe("blocking compaction route guards (issue #527)", () => {
+	it("stops hard-limit blocking attempts when the circuit breaker trips", async () => {
+		const handlers = captureHandlers();
+		const beforeAgentStart = handlers.get("before_agent_start");
+		expect(beforeAgentStart).toBeDefined();
+		const harness = createBlockingContext({ usageTokens: 9_950 });
+		registrations.push(harness.registration);
+		harness.registration.setResponses(Array.from({ length: 8 }, () => connectionErrorResponse()));
+
+		for (let attempt = 0; attempt < 8; attempt++) {
+			await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
+		}
+
+		expect(harness.registration.state.callCount).toBe(FAILURE_TRIP_THRESHOLD);
+	});
+
+	it("bounds successful hard-limit blocking compactions by the soft cap", async () => {
+		const handlers = captureHandlers();
+		const beforeAgentStart = handlers.get("before_agent_start");
+		const sessionCompact = handlers.get("session_compact");
+		expect(beforeAgentStart).toBeDefined();
+		expect(sessionCompact).toBeDefined();
+		const harness = createBlockingContext({ usageTokens: 9_950 });
+		registrations.push(harness.registration);
+		const attempts = softCap * 4;
+		harness.registration.setResponses(
+			Array.from({ length: attempts }, () => fauxAssistantMessage("## Goal\ncompact summary")),
+		);
+
+		for (let round = 0; round < attempts; round++) {
+			const appliedBefore = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
+			await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
+			const appliedAfter = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
+			if (appliedAfter > appliedBefore) {
+				await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
+			}
+		}
+
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(softCap);
+	});
+
+	it("counts zero-yield attempts before admitting turn-end recovery", async () => {
+		const handlers = captureHandlers();
+		const turnEnd = handlers.get("turn_end");
+		const sessionCompact = handlers.get("session_compact");
+		expect(turnEnd).toBeDefined();
+		expect(sessionCompact).toBeDefined();
+		const controller = new AbortController();
+		controller.abort();
+		const beginCompaction = vi.fn(() => controller.signal);
+		const harness = createBlockingContext({ usageTokens: 9_950, beginCompaction });
+		registrations.push(harness.registration);
+		harness.registration.setResponses([fauxAssistantMessage("## Goal\nrecovery summary")]);
+
+		await sessionCompact?.(acceptedCompactionEvent(0, 0) as never, harness.ctx);
+		await sessionCompact?.(acceptedCompactionEvent(1, 0) as never, harness.ctx);
+		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
+
+		expect(beginCompaction).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What changed

`applyBlockingCompaction()` now enforces the circuit breaker and the per-turn soft cap at its entry, and the `session_compact` accepted branch wires the previously dead `cap.incrementIneffective` counter.

## Why

The per-turn cap (soft 3 / hard 10) and circuit breaker (3 failures → 60s cooldown) were only consulted in the `session_before_compact` hook. Every blocking trigger — `before_agent_start` hard-limit, `agent_end` idle, `turn_end` zero-yield recovery, degradation-monitor recovery — generates a summary via `applyBlockingCompaction()` and applies it precomputed, which skips `session_before_compact` in `_executeCompaction` (`if (!compactionResult)` branch). Both guards were dead on those routes, so compaction could repeat without bound, each iteration paying a real LLM summarization request. Additionally, `incrementIneffective` was never called from `src/`, so ineffective attempts never counted toward the soft cap and the `turn_end` zero-yield route retriggered on every tool turn.

Reproduced three unbounded loops with deterministic faux-provider tests (details in #527):

1. hard-limit + transient summarization failure: 8 prompts → 8 summarization calls (breaker ignored);
2. hard-limit + successful-but-ineffective compaction: 12 prompts → 12 compactions (caps ignored);
3. zero-yield accepted compaction: 5 sequential tool turns → 5 recovery compactions.

## Observed behavior after fix

- Hard-limit transient failure stops at `FAILURE_TRIP_THRESHOLD` (3) summarization calls.
- Accepted blocking compactions stop at the per-turn soft cap (3).
- Zero-yield recovery runs exactly once per turn, then the soft cap refuses further attempts.

## QA / evidence

Full receipts: `local-ignore/qa-evidence/20260730-issue-527-blocking-route-guards/`.

- New `test/compaction/blocking-compaction-route-guards.test.ts`: red before fix (8/12/5 calls), green after (3/3 pass).
- `npx vitest --run test/compaction/ test/compaction*.test.ts test/trigger-compact-extension.test.ts`: 47 files, 362 tests pass.
- Session-level compaction suites + `test/suite/regressions/`: 336 tests pass after workspace build (the only initial failures were unbuilt-`dist` module errors in a fresh clone; green after `npm run build`).
- `npx biome check` clean on changed files; root `npx tsgo --noEmit` exit 0.
- Live CLI QA `compaction-remote-qa.mjs --self-test`: 5/6, identical on pristine `main` (the one FAIL is a pre-existing payload-replay assertion, A/B verified via `git stash`). `compaction-wave1.mjs` fails identically on `main` (fake model never called in this environment) — not caused by this change.

## Residual risk

- Automatic blocking routes now share the soft cap with the hook route, so a pathological same-turn context can refuse a 4th blocking compaction; the turn then proceeds to the normal provider-overflow recovery path (one-shot), which is the existing fail-closed behavior.

closes #527

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded blocking compaction loops by enforcing the circuit breaker and per-turn cap on all blocking routes and counting ineffective compactions toward the cap. This bounds retries and avoids wasted LLM summarization calls (addresses #527).

- **Bug Fixes**
  - Gate `applyBlockingCompaction()` with the circuit breaker and per-turn soft cap; reject when tripped or capped.
  - Count ineffective accepted compactions via `cap.incrementIneffective` to stop zero-yield retriggers in the same turn.
  - Add tests: breaker trips after 3 failures; hard-limit compactions capped at 3; turn-end recovery runs once per turn.

<sup>Written for commit 73f7647c4aadf26384259b151aa2404cff1b3963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

