### PR TITLE
feat(coding-agent): warn on risky main models

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,12 @@
 # changes
 
+## Risky main-model selection warning (2026-07-30)
+
+- Interactive startup, `/model` (including exact references), the full and favorite-model selectors, post-auth default selection, and favorite rotation now pass the selected main model through one shared warning predicate.
+- Provider/model identifiers and displayed model names containing `minimax` or `qwen`, case-insensitively, render a prominent `error`-red Korean warning box. Safe model families render no warning.
+- The warning is confined to the interactive main-session model surface; task/subagent routing is unchanged.
+- Coverage: `test/risky-main-model-warning-tui.test.ts` pins matching fields, case-insensitivity, Korean/CJK output, red styling, selector/rotation paths, and a safe-model negative case.
+
 ## high_reasoning_warning TUI box (2026-07-30)
 
 - `interactive-mode.ts` consumes `high_reasoning_warning` and renders a scary red (`error`-themed) warning box via `showHighReasoningWarning`, urging use via the ultrabrain subagent. Mirrors `showNewVersionNotification` styling.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -170,6 +170,7 @@ import { GrokChrome, type InteractiveChrome, type InteractiveFooter } from "./gr
 import { restoreInteractiveStderr, takeOverInteractiveStderr } from "./interactive-stderr-guard.ts";
 import { applyKeybindingsFileEdit, seedKeybindingsFile } from "./keybindings-command.ts";
 import { getModelSearchText } from "./model-search.ts";
+import { isRiskyMainModel, RISKY_MAIN_MODEL_WARNING } from "./risky-main-model-warning.ts";
 import { resolveStartupToolPaths } from "./startup-tools.ts";
 import { DEFAULT_SMOOTH_FPS, StreamingRevealController } from "./streaming-reveal.ts";
 import {
@@ -1153,6 +1154,7 @@ export class InteractiveMode {
 			this.showWarning(warning);
 		}
 
+		this.showRiskyMainModelWarning(this.session.model);
 		void this.maybeWarnAboutAnthropicSubscriptionAuth();
 
 		// Process initial messages
@@ -4681,6 +4683,7 @@ export class InteractiveMode {
 					? `, system prompt: ${result.systemPromptChange.systemPromptName}`
 					: "";
 				this.showStatus(`Switched to ${result.model.name || result.model.id}${thinkingStr}${systemPromptStr}`);
+				this.showRiskyMainModelWarning(result.model);
 				void this.maybeWarnAboutAnthropicSubscriptionAuth(result.model);
 			}
 		} catch (error) {
@@ -4786,6 +4789,22 @@ export class InteractiveMode {
 			),
 		);
 		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+		this.ui.requestRender();
+	}
+
+	showRiskyMainModelWarning(model: Model<any> | undefined): void {
+		if (!model || !isRiskyMainModel(model)) return;
+
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
+		this.chatContainer.addChild(
+			new Text(
+				`${theme.bold(theme.fg("error", "위험한 모델 경고"))}\n${theme.fg("error", RISKY_MAIN_MODEL_WARNING)}`,
+				1,
+				0,
+			),
+		);
+		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
 		this.ui.requestRender();
 	}
 
@@ -5325,6 +5344,7 @@ export class InteractiveMode {
 				? ` (system prompt: ${systemPromptChange.systemPromptName})`
 				: "";
 			this.showStatus(`Model: ${model.id}${systemPromptStr}`);
+			this.showRiskyMainModelWarning(model);
 			void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
 			this.checkDaxnutsEasterEgg(model);
 		} catch (error) {
@@ -6096,6 +6116,7 @@ export class InteractiveMode {
 			this.showStatus(
 				`${actionLabel}. Selected ${selectedModel.id}.${systemPromptStr} Credentials saved to ${getAuthPath()}`,
 			);
+			this.showRiskyMainModelWarning(selectedModel);
 			void this.maybeWarnAboutAnthropicSubscriptionAuth(selectedModel);
 			this.checkDaxnutsEasterEgg(selectedModel);
 		} else {

--- a/packages/coding-agent/src/modes/interactive/risky-main-model-warning.ts
+++ b/packages/coding-agent/src/modes/interactive/risky-main-model-warning.ts
@@ -1,0 +1,12 @@
+import type { Model } from "@earendil-works/pi-ai";
+
+export const RISKY_MAIN_MODEL_WARNING =
+	"권장하지 않는 모델입니다. 사용자의 컴퓨터를 훼손할 수 있는 등 위험한 동작을 할 수 있고 테스트되지 않았습니다. 다른 모델을 사용해주세요.";
+
+const RISKY_MODEL_FAMILIES = ["minimax", "qwen"];
+
+/** Matches the model fields shown to users on Senpi's main-model selection surfaces. */
+export function isRiskyMainModel(model: Pick<Model<any>, "id" | "name" | "provider">): boolean {
+	const searchableLabel = `${model.provider}/${model.id} ${model.name}`.toLowerCase();
+	return RISKY_MODEL_FAMILIES.some((family) => searchableLabel.includes(family));
+}

--- a/packages/coding-agent/test/risky-main-model-warning-tui.test.ts
+++ b/packages/coding-agent/test/risky-main-model-warning-tui.test.ts
@@ -1,0 +1,125 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { Container } from "../../tui/src/tui.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { isRiskyMainModel, RISKY_MAIN_MODEL_WARNING } from "../src/modes/interactive/risky-main-model-warning.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function model(overrides: Partial<Model<"openai-completions">>): Model<"openai-completions"> {
+	return {
+		id: "safe-model",
+		name: "Safe Model",
+		api: "openai-completions",
+		provider: "safe-provider",
+		baseUrl: "http://127.0.0.1:18990/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		...overrides,
+	};
+}
+
+function renderAll(container: Container, width = 100): string {
+	return container.children.flatMap((child) => child.render(width)).join("\n");
+}
+
+function warningMethod(): (this: unknown, selectedModel: Model<any>) => void {
+	const method = Reflect.get(InteractiveMode.prototype, "showRiskyMainModelWarning");
+	if (typeof method !== "function") throw new Error("InteractiveMode.showRiskyMainModelWarning is missing");
+	return method;
+}
+
+describe("risky main-model warning", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test.each([
+		["provider/model identifier", model({ id: "QwEn3-Coder" })],
+		["provider name", model({ provider: "MiniMax" })],
+		["displayed model label", model({ name: "Hosted MINIMAX M2" })],
+	])("matches %s case-insensitively", (_case, selectedModel) => {
+		expect(isRiskyMainModel(selectedModel)).toBe(true);
+	});
+
+	test("does not match a normal model", () => {
+		expect(isRiskyMainModel(model({ id: "gpt-5.6-sol", name: "GPT 5.6 Sol", provider: "openai" }))).toBe(false);
+	});
+
+	test.each([model({ id: "minimax-m2", name: "MiniMax M2" }), model({ id: "QWEN3-CODER", name: "Qwen 3 Coder" })])(
+		"renders the Korean warning in a prominent red box for $id",
+		(selectedModel) => {
+			const fakeThis = {
+				chatContainer: new Container(),
+				ui: { requestRender: vi.fn() },
+			};
+
+			warningMethod().call(fakeThis, selectedModel);
+
+			const rendered = renderAll(fakeThis.chatContainer);
+			const plain = stripAnsi(rendered).replace(/\s+/g, " ");
+			expect(plain).toContain(RISKY_MAIN_MODEL_WARNING);
+			expect(plain).toContain("위험한 모델 경고");
+			expect(rendered).toContain("\u001b[38;2;204;102;102m");
+			expect(fakeThis.chatContainer.children).toHaveLength(4);
+			expect(fakeThis.ui.requestRender).toHaveBeenCalledExactlyOnceWith();
+		},
+	);
+
+	test("renders nothing for a normal model", () => {
+		const fakeThis = {
+			chatContainer: new Container(),
+			ui: { requestRender: vi.fn() },
+		};
+
+		warningMethod().call(fakeThis, model({ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" }));
+
+		expect(fakeThis.chatContainer.children).toHaveLength(0);
+		expect(fakeThis.ui.requestRender).not.toHaveBeenCalled();
+	});
+
+	test("checks a model selected through the full or favorites selector", async () => {
+		const selectedModel = model({ id: "qwen3-coder" });
+		const fakeThis = {
+			session: { setModel: vi.fn(async () => undefined) },
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
+			checkDaxnutsEasterEgg: vi.fn(),
+		};
+		const selectModelFromUi = Reflect.get(InteractiveMode.prototype, "selectModelFromUi");
+		if (typeof selectModelFromUi !== "function") throw new Error("InteractiveMode.selectModelFromUi is missing");
+
+		await selectModelFromUi.call(fakeThis, selectedModel);
+
+		expect(fakeThis.showRiskyMainModelWarning).toHaveBeenCalledExactlyOnceWith(selectedModel);
+	});
+
+	test("checks a model selected by favorite rotation", async () => {
+		const selectedModel = model({ id: "MINIMAX-M2" });
+		const fakeThis = {
+			session: {
+				cycleModel: vi.fn(async () => ({ model: selectedModel, thinkingLevel: "off" })),
+				favoriteModels: [{ model: selectedModel }],
+			},
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
+		};
+		const cycleModel = Reflect.get(InteractiveMode.prototype, "cycleModel");
+		if (typeof cycleModel !== "function") throw new Error("InteractiveMode.cycleModel is missing");
+
+		await cycleModel.call(fakeThis, "forward");
+
+		expect(fakeThis.showRiskyMainModelWarning).toHaveBeenCalledExactlyOnceWith(selectedModel);
+	});
+});

--- a/packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts
+++ b/packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts
@@ -59,6 +59,7 @@ describe("InteractiveMode scoped-setting caller compatibility", () => {
 			updateEditorBorderColor: vi.fn(),
 			showStatus: vi.fn(),
 			showError: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
 			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
 			checkDaxnutsEasterEgg: vi.fn(),
 		};
@@ -129,6 +130,7 @@ describe("InteractiveMode scoped-setting caller compatibility", () => {
 			updateEditorBorderColor: vi.fn(),
 			showStatus: vi.fn(),
 			showError: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
 			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
 			checkDaxnutsEasterEgg: vi.fn(),
 		};


### PR DESCRIPTION
## Summary

- warn when the interactive main model matches the MiniMax or Qwen families
- match provider/model identifiers, model IDs, and displayed names case-insensitively
- show the Korean warning in Senpi's semantic error-red boxed UI
- cover startup, exact `/model`, full selector, favorites, rotation, and post-auth default selection
- leave task/subagent routing and non-interactive fallback changes untouched

## Warning

> 권장하지 않는 모델입니다. 사용자의 컴퓨터를 훼손할 수 있는 등 위험한 동작을 할 수 있고 테스트되지 않았습니다. 다른 모델을 사용해주세요.

## Design

`isRiskyMainModel()` centralizes family detection in
`src/modes/interactive/risky-main-model-warning.ts`. Interactive main-model
selection paths call one shared renderer after a model becomes active.

Matching includes:

- provider/model reference
- model ID
- displayed model name

The match is case-insensitive for `minimax` and `qwen`.

## Verification

- focused coding-agent tests: 12 passed, 0 failed
- root `npm run check`: passed
- `git diff --check`: passed
- xterm renderer self-test: 9 passed, 0 failed

## Real source TUI QA

The real source Senpi TUI was run in isolated 140x40 tmux sessions with a mock
model catalog and no real provider traffic.

| Model | Warning | Error-red glyphs | Hangul glyphs |
| --- | ---: | ---: | ---: |
| `mock/MiniMax-M2` | visible | 347 | 64 |
| `mock/QwEn3-Coder` | visible | 347 | 64 |
| `mock/claude-safe` | absent | 0 | 0 |

The lead independently reran the source-TUI harness and grid assertions.
Real auth remained unchanged.

Evidence:

`local-ignore/qa-evidence/20260730-risky-model-warning/`

## Risks and residuals

- The warning uses the semantic `error` theme token. Built-in themes render it
  red; a custom user theme can remap that token.
- Automatic fallback and extension-driven model changes are intentionally
  outside this interactive-selection boundary.
- Task and subagent model routing is intentionally unaffected.

## Changes

- adds a focused risky-model predicate module
- wires all interactive main-model selection paths
- adds TUI/render and scoped-settings regression coverage
- records the fork-visible behavior in the interactive `changes.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns users in the interactive main session when selecting MiniMax or Qwen models by showing a Korean error-red warning across all model selection paths. Improves safety without changing task/subagent routing or non-interactive behavior in `coding-agent`.

- **New Features**
  - Adds `isRiskyMainModel()` with case-insensitive checks across provider, model ID, and display name for `minimax` and `qwen`.
  - Shows a red “위험한 모델 경고” box on startup, `/model`, full picker, favorites, favorites rotation, and post-auth default.
  - Uses the `error` theme token; behavior is limited to interactive main-model selection.
  - Adds TUI tests for matching, styling, and paths; updates `changes.md`.

<sup>Written for commit 2c4142ce3f709ef6d998ba59183ccdab315c155c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

