### PR TITLE
fix(coding-agent): reset continuation cap after tool use

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,34 @@
 # goal Extension Changes
 
+## Tool-using continuations reset the persisted cap streak (2026-07-30)
+
+### What changed
+
+- `monitor-continuation.ts` now classifies tool use once from the completed
+  continuation turn and resets the persisted `consecutiveContinuations` streak
+  before admitting the next immediate or user-grace continuation.
+- The existing cap remains 8 consecutive tool-less automatic continuations.
+  Monitor-delayed accounting, stale/repetition guards, single-flight delivery,
+  user-prompt resets, and session-start persistence are unchanged.
+- Coverage: `test/suite/goal-monitor-continuation.test.ts` runs nine consecutive
+  tool-using turns and proves they remain active while the existing tool-less
+  boundary test still blocks the ninth continuation.
+
+### Why
+
+- Tool calls are observable progress, but the persisted cap previously counted
+  every automatic continuation delivery. A long-running goal that kept using
+  tools therefore blocked itself after eight turns with `continuation cap
+  reached`, even though the separate stall detector already recognized those
+  turns as non-stalled.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `monitor-continuation.ts` around `afterAgentEnd` and the tool-less
+  streak helper.
+- NONE in the verdict engine, goal store schema, persistence, or public
+  extension API.
+
 ## A newly created goal starts immediately instead of waiting for user grace (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -25,6 +25,8 @@ import {
 	lastAssistantText,
 } from "./lifecycle-helpers.ts";
 import { buildContinuationPrompt, buildGoalStallNotice, buildTruncationRecoveryPrompt } from "./prompt.ts";
+import { resetContinuationStreak } from "./store.ts";
+import { goalStoreRef } from "./store-ref.ts";
 import { collectAssistantUsage } from "./turn-usage.ts";
 import type { Goal, TokenUsageSnapshot } from "./types.ts";
 
@@ -111,25 +113,32 @@ export class MonitorAwareGoalContinuation {
 			this.#cancelTimer();
 			return options.goal;
 		}
-		this.#recordToollessContinuationTurn(options.goal, options.messages);
+		const turnUsedTools = continuationTurnUsedTools(options.messages);
+		this.#recordToollessContinuationTurn(options.goal, turnUsedTools);
+		const goal =
+			!this.#endedTurnWasUserInitiated && turnUsedTools
+				? ((await resetContinuationStreak(goalStoreRef(options.ctx.sessionManager, options.ctx.cwd))) ??
+					options.goal)
+				: options.goal;
+		this.#goal = goal;
 
-		const immediateInput = this.#buildVerdictInput(options.ctx, options.goal, "immediate", options.messages);
-		const immediateVerdict = evaluateGoalContinuation({ goal: options.goal, ...immediateInput });
+		const immediateInput = this.#buildVerdictInput(options.ctx, goal, "immediate", options.messages);
+		const immediateVerdict = evaluateGoalContinuation({ goal, ...immediateInput });
 		if (immediateVerdict.kind === "deny") {
-			if (immediateVerdict.reason === "not-eligible") return options.goal;
+			if (immediateVerdict.reason === "not-eligible") return goal;
 			if (immediateVerdict.reason === "grace") {
-				this.#schedule(options.goal, "userGrace");
-				return options.goal;
+				this.#schedule(goal, "userGrace");
+				return goal;
 			}
 		}
 
 		if (this.#activeMonitorCount === 0) {
 			this.#cancelTimer();
-			const admission = await this.#admitAndQueue(options.ctx, options.goal, "immediate", options.messages);
+			const admission = await this.#admitAndQueue(options.ctx, goal, "immediate", options.messages);
 			return admission.goal;
 		}
-		this.#schedule(options.goal, "monitor");
-		return options.goal;
+		this.#schedule(goal, "monitor");
+		return goal;
 	}
 
 	syncGoal(goal: Goal | null): void {
@@ -319,13 +328,13 @@ export class MonitorAwareGoalContinuation {
 		this.#recentNormalizedOutputHashes = [...this.#recentNormalizedOutputHashes, hashAssistantText(text)].slice(-3);
 	}
 
-	#recordToollessContinuationTurn(goal: Goal, messages: readonly AgentMessage[]): void {
+	#recordToollessContinuationTurn(goal: Goal, turnUsedTools: boolean): void {
 		if (goal.id !== this.#toollessStreakGoalId) {
 			this.#toollessStreakGoalId = goal.id;
 			this.#toollessContinuationStreak = 0;
 		}
 		if (this.#endedTurnWasUserInitiated) return;
-		if (continuationTurnUsedTools(messages)) {
+		if (turnUsedTools) {
 			this.#toollessContinuationStreak = 0;
 			return;
 		}

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -67,6 +67,28 @@ function cleanAssistantStopWithText(text: string): AgentMessage {
 	return assistantStopWithReason("stop", text);
 }
 
+function toolUsingContinuationMessages(turn: number): AgentMessage[] {
+	const finalAssistant = cleanAssistantStopWithText(`progress ${turn}`);
+	if (finalAssistant.role !== "assistant") throw new Error("Expected an assistant stop message");
+	const toolCallId = `continuation-tool-${turn}`;
+	return [
+		{
+			...finalAssistant,
+			content: [{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "true" } }],
+			stopReason: "toolUse",
+		},
+		{
+			role: "toolResult",
+			toolCallId,
+			toolName: "bash",
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+			timestamp: finalAssistant.timestamp,
+		},
+		finalAssistant,
+	];
+}
+
 function assistantStopWithReason(stopReason: "stop" | "length", text: string): AgentMessage {
 	const message = cleanAssistantStop();
 	if (message.role !== "assistant") throw new Error("Expected assistant stop message");
@@ -443,6 +465,36 @@ describe("goal continuation while a monitor is active", () => {
 			status: "blocked",
 			blockedReason: "output truncation repeated",
 		});
+	});
+
+	it("keeps admitting immediate continuations when every turn uses tools", async () => {
+		const notices: string[] = [];
+		const { tools, handlers, sent, events } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-immediate-tool-progress");
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		for (let turn = 1; turn <= 9; turn++) {
+			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+			await runGoalHandlers(
+				handlers,
+				"agent_end",
+				{ type: "agent_end", messages: toolUsingContinuationMessages(turn) },
+				ctx,
+			);
+		}
+
+		expect(sent).toHaveLength(9);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "active",
+			consecutiveContinuations: 1,
+		});
+		expect(events.emitted).not.toContainEqual(
+			expect.objectContaining({
+				channel: "goal_continuation_guard_tripped",
+				data: expect.objectContaining({ reason: "cap" }),
+			}),
+		);
 	});
 
 	it("blocks the ninth clean immediate continuation without queuing a ninth hidden prompt", async () => {


### PR DESCRIPTION
## Summary

- Treat tool calls as observable progress for the persisted goal-continuation cap.
- Reset `consecutiveContinuations` after a non-user-initiated continuation turn uses tools.
- Preserve the existing eight-turn cap for consecutive tool-less automatic continuations.

## Root cause

Senpi already classified `toolCall` / `toolResult` messages to reset the in-memory tool-less stall-warning streak, but the persisted continuation counter was incremented for every admitted continuation. Long-running goals therefore blocked after eight turns even while repeatedly using tools.

The fix reuses the existing tool-use classifier and `resetContinuationStreak()` before immediate admission or user-grace scheduling. The verdict engine, store schema, persistence format, monitor-delayed accounting, and public APIs remain unchanged.

## RED -> GREEN

- RED: the new regression expected nine tool-backed continuations but observed only eight because the ninth was blocked by the cap.
- GREEN: `goal-monitor-continuation.test.ts` passes 19/19, including:
  - nine consecutive tool-backed continuations remain active;
  - the persisted count resets and returns to one after the next delivery;
  - the existing tool-less test still blocks the ninth continuation.
- Mutation proof: changing the existing cap boundary from `>=` to `>` made the tool-less assertion fail with nine queued prompts instead of eight; restoring the boundary returned it to green.

## Real CLI QA

The isolated `senpi-qa` fake-model harness drove the real CLI from source:

1. Tool-progress scenario
   - 22 model requests
   - goal creation
   - nine bash-backed automatic continuation cycles
   - final `update_goal complete`
   - result: exit 0, goal `complete`, no blocked reason

2. Tool-less scenario
   - 10 model requests
   - eight unique text-only automatic continuation cycles
   - result: exit 0, no extra request, goal `blocked` with `continuation cap reached`

All fake servers and sandboxes were removed; real credentials were unchanged.

## Validation

- `npm run check` — passed
- Focused goal suites — 98/98 passed
- CLI smoke — 8/8 passed
- LSP diagnostics for the changed goal/test areas — 0 errors
- Full coding-agent suite — 6099 passed, 1 unrelated `--inspect-brk` handoff timeout
  - the exact inspector regression passed directly 2/2 in 5.56s
  - no unrelated debugger code was changed

## Merge risk

Low. The runtime change is confined to `MonitorAwareGoalContinuation.afterAgentEnd` and its existing tool-less streak helper. The test and fork change note are colocated with the existing continuation guardrails.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the persisted goal continuation streak after an automatic continuation turn uses tools, preventing long-running goals from hitting the 8-turn cap while making tool-backed progress. The 8-turn cap for tool-less automatic continuations remains unchanged.

- **Bug Fixes**
  - Treat tool calls as progress and reset `consecutiveContinuations` via `resetContinuationStreak` before the next immediate or user-grace continuation.
  - Apply the reset only for non-user-initiated turns; user-initiated behavior is unchanged.
  - Added tests for nine consecutive tool-using turns; confirmed the tool-less path still blocks at the ninth. Public APIs and persistence remain unchanged.

<sup>Written for commit 448bef6b2dd1071c06d19694d154893d4bf46a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

