### PR TITLE
fix(interactive): restore terminal compaction input to editor

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,22 @@
+## Failed pre-prompt compaction reports terminal recovery (2026-07-30)
+
+### What changed
+
+- `core/agent-session.ts`: `_runPrePromptCompaction()` now emits failed `compaction_end` events with `willRetry: false`. Its caller throws `RequiredCompactionError` when compaction fails, so no retry can follow that terminal event.
+- Coverage drives a real pre-prompt overflow compaction through a failing faux provider and pins both the truthful event and restoration of queued TUI input through the real interactive helper.
+
+### Why
+
+- Emitting `willRetry: true` deferred queued input to native session queues even though failed compaction blocks provider admission, leaving that input parked indefinitely.
+
+### Why extension system couldn't handle this alone
+
+- `willRetry` is authored inside the core pre-prompt compaction lifecycle before extensions consume the event; only the session can truthfully report whether its caller will retry.
+
+### Expected merge conflict zones
+
+- LOW: `agent-session.ts` in `_runPrePromptCompaction()`'s terminal catch emission.
+
 ## high_reasoning_warning narrowed to gpt-5.6-sol only (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4432,7 +4432,7 @@ export class AgentSession {
 				reason,
 				result: undefined,
 				aborted,
-				willRetry,
+				willRetry: false,
 				errorMessage: aborted ? undefined : `Pre-prompt compaction failed: ${errorMessage}`,
 			});
 			return false;

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Failed compaction restores queued input (2026-07-30)
+
+### What changed
+
+- Terminal compaction failures, rejections, and aborts restore messages queued during compaction to the editable composer instead of leaving them pending indefinitely.
+- Retryable compaction failures keep the native-queue handoff (`flushCompactionQueue({ willRetry: true, deferAdmission: true })`) so the queued input rides along with the retry.
+- Coverage: `test/interactive-mode-compaction.test.ts` pins truncated, timed-out, rejected, retryable, and successful compaction outcomes.
+
+### Why
+
+- Retrying queued delivery against the unchanged over-threshold context repeats the same required-compaction failure; restoring the draft lets the user edit or retry explicitly.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-mode.ts` in the `compaction_end` queue handoff branch.
+
 ## Risky main-model selection warning (2026-07-30)
 
 - Interactive startup, `/model` (including exact references), the full and favorite-model selectors, post-auth default selection, and favorite rotation now pass the selected main model through one shared warning predicate.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -4,9 +4,10 @@
 
 ### What changed
 
-- Terminal compaction failures, rejections, and aborts restore messages queued during compaction to the editable composer instead of leaving them pending indefinitely.
-- Retryable compaction failures keep the native-queue handoff (`flushCompactionQueue({ willRetry: true, deferAdmission: true })`) so the queued input rides along with the retry.
-- Coverage: `test/interactive-mode-compaction.test.ts` pins truncated, timed-out, rejected, retryable, and successful compaction outcomes.
+- Terminal compaction failures, rejections, and aborts restore messages queued during compaction to the editable composer instead of leaving them pending indefinitely. Native session steer and follow-up queues are drained into the composer too.
+- Failed pre-prompt overflow compaction now emits `willRetry: false`, so queued input follows the terminal restoration path instead of waiting for a retry that cannot run.
+- The defensive retryable-failure branch keeps the native-queue handoff (`flushCompactionQueue({ willRetry: true, deferAdmission: true })`) for any producer that can truthfully promise a retry.
+- Coverage: `test/interactive-mode-compaction.test.ts` pins truncated, timed-out, rejected, retryable, and successful compaction outcomes; `test/suite/regressions/post-compaction-queued-input-resume.test.ts` drives the real failed pre-prompt overflow path and real editor-restoration helper.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3891,23 +3891,43 @@ export class InteractiveMode {
 						this.chatContainer.addChild(new Text(theme.fg("error", message), 1, 0));
 					}
 				}
-				// Every terminal compaction_end flushes the TUI compaction queue.
-				// Accepted compactions deliver through prompt admission; unsuccessful
-				// ones route through the native steer/followUp queues so submitted
-				// input is never silently parked (field bug: messages typed during a
-				// failing compaction were held forever and lost on session switch).
+				// Every terminal compaction_end resolves the TUI compaction queue.
+				// Accepted compactions deliver through prompt admission. Retryable
+				// failures route through the native steer/followUp queues so submitted
+				// input rides along with the retry instead of being silently parked
+				// (field bug: messages typed during a failing compaction were held
+				// forever and lost on session switch). Terminal failures hand the input
+				// back to the editable composer: retrying delivery against the same
+				// over-threshold context would just repeat the failure.
 				const compactionSucceeded = event.accepted === true || event.result !== undefined;
 				const heldCount = this.compactionQueuedMessages.length;
-				if (!compactionSucceeded && heldCount > 0) {
-					this.getSessionLogger().warn("compaction_queue_deferred", {
-						count: heldCount,
-						cause: event.errorMessage ?? event.rejectionCause ?? (event.aborted ? "aborted" : "no-result"),
-					});
-					this.showStatus(
-						`${heldCount} queued message${heldCount === 1 ? "" : "s"} will send with the next turn (compaction did not complete)`,
-					);
+				const failureCause =
+					event.errorMessage ?? event.rejectionCause ?? (event.aborted ? "aborted" : "no-result");
+				if (compactionSucceeded) {
+					void this.flushCompactionQueue({ willRetry: event.willRetry, deferAdmission: false });
+				} else if (event.willRetry === true) {
+					if (heldCount > 0) {
+						this.getSessionLogger().warn("compaction_queue_deferred", {
+							count: heldCount,
+							cause: failureCause,
+						});
+						this.showStatus(
+							`${heldCount} queued message${heldCount === 1 ? "" : "s"} will send with the next turn (compaction will retry)`,
+						);
+					}
+					void this.flushCompactionQueue({ willRetry: true, deferAdmission: true });
+				} else {
+					const restoredCount = this.restoreQueuedMessagesToEditor();
+					if (restoredCount > 0) {
+						this.getSessionLogger().warn("compaction_queue_restored", {
+							restored: restoredCount,
+							cause: failureCause,
+						});
+						this.showStatus(
+							`${restoredCount} queued message${restoredCount === 1 ? "" : "s"} restored to the editor (compaction did not complete)`,
+						);
+					}
 				}
-				void this.flushCompactionQueue({ willRetry: event.willRetry, deferAdmission: !compactionSucceeded });
 				this.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3900,13 +3900,13 @@ export class InteractiveMode {
 				// back to the editable composer: retrying delivery against the same
 				// over-threshold context would just repeat the failure.
 				const compactionSucceeded = event.accepted === true || event.result !== undefined;
-				const heldCount = this.compactionQueuedMessages.length;
-				const failureCause =
-					event.errorMessage ?? event.rejectionCause ?? (event.aborted ? "aborted" : "no-result");
 				if (compactionSucceeded) {
 					void this.flushCompactionQueue({ willRetry: event.willRetry, deferAdmission: false });
 				} else if (event.willRetry === true) {
+					const heldCount = this.compactionQueuedMessages.length;
 					if (heldCount > 0) {
+						const failureCause =
+							event.errorMessage ?? event.rejectionCause ?? (event.aborted ? "aborted" : "no-result");
 						this.getSessionLogger().warn("compaction_queue_deferred", {
 							count: heldCount,
 							cause: failureCause,
@@ -3919,6 +3919,8 @@ export class InteractiveMode {
 				} else {
 					const restoredCount = this.restoreQueuedMessagesToEditor();
 					if (restoredCount > 0) {
+						const failureCause =
+							event.errorMessage ?? event.rejectionCause ?? (event.aborted ? "aborted" : "no-result");
 						this.getSessionLogger().warn("compaction_queue_restored", {
 							restored: restoredCount,
 							cause: failureCause,

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -12,6 +12,33 @@ function stripAnsi(value: string): string {
 	return value.replace(/\u001b\[[0-9;]*m/g, "");
 }
 
+function makeCompactionFakeThis<T extends object>(overrides: T) {
+	return {
+		isInitialized: true,
+		footer: { invalidate: vi.fn() },
+		autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+		autoCompactionLoader: undefined as { stop(): void } | undefined,
+		autoCompactionProgressText: "",
+		defaultEditor: {} as { onEscape?: () => void },
+		session: { abortCompaction: vi.fn() },
+		statusContainer: { clear: vi.fn() },
+		chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+		rebuildChatFromMessages: vi.fn(),
+		addMessageToChat: vi.fn(),
+		showError: vi.fn(),
+		showWarning: vi.fn(),
+		showStatus: vi.fn(),
+		clearStatusIndicator: vi.fn(),
+		compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
+		getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+		flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+		restoreQueuedMessagesToEditor: vi.fn(),
+		settingsManager: { getShowTerminalProgress: () => false },
+		ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		...overrides,
+	};
+}
+
 type PrivateMethod = (this: object, ...args: unknown[]) => void;
 
 function renderExpandedPersistedCompactionSummary(sessionManager: SessionManager): string {
@@ -65,17 +92,7 @@ describe("InteractiveMode compaction events", () => {
 
 	test("shows a context compaction loader for extension compaction starts", async () => {
 		const statusContainer = new Container();
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-			autoCompactionLoader: undefined as { stop(): void } | undefined,
-			defaultEditor: {} as { onEscape?: () => void },
-			session: { abortCompaction: vi.fn() },
-			statusContainer,
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
+		const fakeThis = makeCompactionFakeThis({ statusContainer });
 
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
@@ -99,18 +116,7 @@ describe("InteractiveMode compaction events", () => {
 
 	test("bounds streamed compaction progress to the active status row", async () => {
 		const statusContainer = new Container();
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-			autoCompactionLoader: undefined as { stop(): void } | undefined,
-			autoCompactionProgressText: "",
-			defaultEditor: {} as { onEscape?: () => void },
-			session: { abortCompaction: vi.fn() },
-			statusContainer,
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
+		const fakeThis = makeCompactionFakeThis({ statusContainer });
 
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
@@ -157,26 +163,7 @@ describe("InteractiveMode compaction events", () => {
 	});
 
 	test("rebuilds chat and appends a synthetic compaction summary at the bottom", async () => {
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-			autoCompactionLoader: undefined,
-			defaultEditor: {},
-			statusContainer: { clear: vi.fn() },
-			chatContainer: { clear: vi.fn() },
-			rebuildChatFromMessages: vi.fn(),
-			addMessageToChat: vi.fn(),
-			showError: vi.fn(),
-			showStatus: vi.fn(),
-			clearStatusIndicator: vi.fn(),
-			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
-			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
-			restoreQueuedMessagesToEditor: vi.fn(),
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
+		const fakeThis = makeCompactionFakeThis({ chatContainer: { clear: vi.fn() } });
 
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
@@ -221,26 +208,10 @@ describe("InteractiveMode compaction events", () => {
 	])(
 		"compaction queue recovery restores queued messages after terminal compaction failure: %s",
 		async (_name, errorMessage) => {
-			const fakeThis = {
-				isInitialized: true,
-				footer: { invalidate: vi.fn() },
-				autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-				autoCompactionLoader: undefined,
-				defaultEditor: {},
-				statusContainer: { clear: vi.fn() },
-				chatContainer: { clear: vi.fn(), addChild: vi.fn() },
-				rebuildChatFromMessages: vi.fn(),
-				addMessageToChat: vi.fn(),
-				showError: vi.fn(),
-				showStatus: vi.fn(),
-				clearStatusIndicator: vi.fn(),
+			const fakeThis = makeCompactionFakeThis({
 				compactionQueuedMessages: [{ text: "queued during compaction", mode: "steer" as const }],
-				getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-				flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 				restoreQueuedMessagesToEditor: vi.fn().mockReturnValue(1),
-				settingsManager: { getShowTerminalProgress: () => false },
-				ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-			};
+			});
 
 			const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 				this: typeof fakeThis,
@@ -273,26 +244,10 @@ describe("InteractiveMode compaction events", () => {
 	);
 
 	test("compaction queue recovery defers retryable failures to the native queues", async () => {
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-			autoCompactionLoader: undefined,
-			defaultEditor: {},
-			statusContainer: { clear: vi.fn() },
-			chatContainer: { clear: vi.fn(), addChild: vi.fn() },
-			rebuildChatFromMessages: vi.fn(),
-			addMessageToChat: vi.fn(),
-			showError: vi.fn(),
-			showStatus: vi.fn(),
-			clearStatusIndicator: vi.fn(),
+		const fakeThis = makeCompactionFakeThis({
 			compactionQueuedMessages: [{ text: "queued during compaction", mode: "steer" as const }],
-			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 			restoreQueuedMessagesToEditor: vi.fn().mockReturnValue(0),
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
+		});
 
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
@@ -323,27 +278,7 @@ describe("InteractiveMode compaction events", () => {
 	});
 
 	test("compaction queue recovery restores a manual would-overflow rejection instead of silently swallowing it", async () => {
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-			autoCompactionLoader: undefined,
-			defaultEditor: {},
-			statusContainer: { clear: vi.fn() },
-			chatContainer: { clear: vi.fn(), addChild: vi.fn() },
-			rebuildChatFromMessages: vi.fn(),
-			addMessageToChat: vi.fn(),
-			showError: vi.fn(),
-			showWarning: vi.fn(),
-			showStatus: vi.fn(),
-			clearStatusIndicator: vi.fn(),
-			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
-			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
-			restoreQueuedMessagesToEditor: vi.fn(),
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
+		const fakeThis = makeCompactionFakeThis({});
 
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
@@ -418,28 +353,7 @@ describe("InteractiveMode compaction events", () => {
 		const sanitizedText = sanitizeTerminalLabel(hostileText);
 		const statusContainer = new Container();
 		const chatContainer = new Container();
-		const fakeThis = {
-			isInitialized: true,
-			footer: { invalidate: vi.fn() },
-			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
-			autoCompactionLoader: undefined as { stop(): void } | undefined,
-			autoCompactionProgressText: "",
-			defaultEditor: {} as { onEscape?: () => void },
-			session: { abortCompaction: vi.fn() },
-			statusContainer,
-			chatContainer,
-			clearStatusIndicator: vi.fn(),
-			rebuildChatFromMessages: vi.fn(),
-			addMessageToChat: vi.fn(),
-			showError: vi.fn(),
-			showStatus: vi.fn(),
-			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
-			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
-			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
-			restoreQueuedMessagesToEditor: vi.fn(),
-			settingsManager: { getShowTerminalProgress: () => false },
-			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
-		};
+		const fakeThis = makeCompactionFakeThis({ statusContainer, chatContainer });
 		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 			this: typeof fakeThis,
 			event: object,

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -173,6 +173,7 @@ describe("InteractiveMode compaction events", () => {
 			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
 			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			restoreQueuedMessagesToEditor: vi.fn(),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};
@@ -211,9 +212,117 @@ describe("InteractiveMode compaction events", () => {
 			}),
 		);
 		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false, deferAdmission: false });
+		expect(fakeThis.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
 	});
 
-	test("surfaces a manual would-overflow rejection instead of silently swallowing it", async () => {
+	test.each([
+		["truncated generator", "Pre-prompt compaction failed: Compaction stream ended without a complete result"],
+		["timeout", "Pre-prompt compaction failed: Compaction timed out after 120000ms"],
+	])(
+		"compaction queue recovery restores queued messages after terminal compaction failure: %s",
+		async (_name, errorMessage) => {
+			const fakeThis = {
+				isInitialized: true,
+				footer: { invalidate: vi.fn() },
+				autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+				autoCompactionLoader: undefined,
+				defaultEditor: {},
+				statusContainer: { clear: vi.fn() },
+				chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+				rebuildChatFromMessages: vi.fn(),
+				addMessageToChat: vi.fn(),
+				showError: vi.fn(),
+				showStatus: vi.fn(),
+				clearStatusIndicator: vi.fn(),
+				compactionQueuedMessages: [{ text: "queued during compaction", mode: "steer" as const }],
+				getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+				flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+				restoreQueuedMessagesToEditor: vi.fn().mockReturnValue(1),
+				settingsManager: { getShowTerminalProgress: () => false },
+				ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+			};
+
+			const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+				this: typeof fakeThis,
+				event: {
+					type: "compaction_end";
+					reason: "threshold";
+					result: undefined;
+					aborted: false;
+					willRetry: false;
+					errorMessage: string;
+				},
+			) => Promise<void>;
+
+			await handleEvent.call(fakeThis, {
+				type: "compaction_end",
+				reason: "threshold",
+				result: undefined,
+				aborted: false,
+				willRetry: false,
+				errorMessage,
+			});
+
+			expect(fakeThis.restoreQueuedMessagesToEditor).toHaveBeenCalledTimes(1);
+			expect(fakeThis.flushCompactionQueue).not.toHaveBeenCalled();
+			// The status must describe restoration, not promise a next-turn send.
+			const statuses = fakeThis.showStatus.mock.calls.map((call) => String(call[0]));
+			expect(statuses.some((message) => /restored to the editor/i.test(message))).toBe(true);
+			expect(statuses.some((message) => /will send with the next turn/i.test(message))).toBe(false);
+		},
+	);
+
+	test("compaction queue recovery defers retryable failures to the native queues", async () => {
+		const fakeThis = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+			autoCompactionLoader: undefined,
+			defaultEditor: {},
+			statusContainer: { clear: vi.fn() },
+			chatContainer: { clear: vi.fn(), addChild: vi.fn() },
+			rebuildChatFromMessages: vi.fn(),
+			addMessageToChat: vi.fn(),
+			showError: vi.fn(),
+			showStatus: vi.fn(),
+			clearStatusIndicator: vi.fn(),
+			compactionQueuedMessages: [{ text: "queued during compaction", mode: "steer" as const }],
+			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			restoreQueuedMessagesToEditor: vi.fn().mockReturnValue(0),
+			settingsManager: { getShowTerminalProgress: () => false },
+			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+		};
+
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: {
+				type: "compaction_end";
+				reason: "overflow";
+				result: undefined;
+				aborted: false;
+				willRetry: true;
+				errorMessage: string;
+			},
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "overflow",
+			result: undefined,
+			aborted: false,
+			willRetry: true,
+			errorMessage: "Pre-prompt compaction failed: transient provider error",
+		});
+
+		// A retryable failure keeps the upstream native-queue handoff so the queued
+		// input rides along with the retry instead of returning to the editor.
+		expect(fakeThis.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
+		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: true, deferAdmission: true });
+		expect(fakeThis.showStatus.mock.calls.map((call) => String(call[0])).join("\n")).toMatch(/queued message/i);
+	});
+
+	test("compaction queue recovery restores a manual would-overflow rejection instead of silently swallowing it", async () => {
 		const fakeThis = {
 			isInitialized: true,
 			footer: { invalidate: vi.fn() },
@@ -231,6 +340,7 @@ describe("InteractiveMode compaction events", () => {
 			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
 			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			restoreQueuedMessagesToEditor: vi.fn(),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};
@@ -267,9 +377,10 @@ describe("InteractiveMode compaction events", () => {
 			...fakeThis.showStatus.mock.calls.map((call) => String(call[0])),
 		].join("\n");
 		expect(feedback).toMatch(/would.?overflow|overflow|rejected/i);
-		// Rejected compaction still flushes, but through the native queues
-		// (deferAdmission) so no recursive post-compaction prompt path runs.
-		expect(fakeThis.flushCompactionQueue).toHaveBeenCalledWith({ willRetry: false, deferAdmission: true });
+		// A terminal rejection restores editor-owned input instead of submitting it
+		// through a recursive post-compaction prompt path or a native queue handoff.
+		expect(fakeThis.flushCompactionQueue).not.toHaveBeenCalled();
+		expect(fakeThis.restoreQueuedMessagesToEditor).toHaveBeenCalledTimes(1);
 	});
 
 	test("sanitizes a detached continuation launch failure before rendering", async () => {
@@ -325,6 +436,7 @@ describe("InteractiveMode compaction events", () => {
 			compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
 			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+			restoreQueuedMessagesToEditor: vi.fn(),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};
@@ -367,6 +479,7 @@ describe("InteractiveMode compaction events", () => {
 		expect(renderedError).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
 		expect(renderedError).not.toContain("attacker.invalid");
 		expect(renderedError).not.toContain("stolen title");
+		expect(fakeThis.restoreQueuedMessagesToEditor).toHaveBeenCalledTimes(1);
 	});
 
 	test("renders persisted hostile summaries safely after a chat rebuild and session reopen", () => {

--- a/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
@@ -138,6 +138,7 @@ describe("Regression: interactive-mode compaction_end fallback", () => {
 			flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
 			compactionQueuedMessages: [] as string[],
 			getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+			restoreQueuedMessagesToEditor: vi.fn(),
 			settingsManager: { getShowTerminalProgress: () => false },
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
 		};
@@ -169,5 +170,6 @@ describe("Regression: interactive-mode compaction_end fallback", () => {
 		const message = String(fakeThis.showError.mock.calls[0]?.[0] ?? "");
 		expect(message).toMatch(/compaction/i);
 		expect(message).toMatch(/would-overflow|unknown|no result/i);
+		expect(fakeThis.restoreQueuedMessagesToEditor).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -50,6 +50,18 @@ function getFlushCompactionQueue() {
 		Promise.resolve(flush.call(context, options));
 }
 
+function getClearAllQueues() {
+	const clear = Reflect.get(InteractiveMode.prototype, "clearAllQueues");
+	if (typeof clear !== "function") throw new Error("Expected InteractiveMode.clearAllQueues");
+	return (context: object): { steering: string[]; followUp: string[] } => clear.call(context);
+}
+
+function getRestoreQueuedMessagesToEditor() {
+	const restore = Reflect.get(InteractiveMode.prototype, "restoreQueuedMessagesToEditor");
+	if (typeof restore !== "function") throw new Error("Expected InteractiveMode.restoreQueuedMessagesToEditor");
+	return (context: object): number => restore.call(context);
+}
+
 function getHandleEvent() {
 	const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent");
 	if (typeof handleEvent !== "function") throw new Error("Expected InteractiveMode.handleEvent");
@@ -61,6 +73,12 @@ function getRunAutoCompaction(harness: Harness) {
 	if (typeof runAutoCompaction !== "function") throw new Error("Expected AgentSession._runAutoCompaction");
 	return (reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> =>
 		Promise.resolve(runAutoCompaction.call(harness.session, reason, willRetry));
+}
+
+function getQueueNativeMessage(harness: Harness, mode: "Steer" | "FollowUp") {
+	const queue = Reflect.get(harness.session, `_queue${mode}`);
+	if (typeof queue !== "function") throw new Error(`Expected AgentSession._queue${mode}`);
+	return (text: string): Promise<void> => Promise.resolve(queue.call(harness.session, text));
 }
 
 function createTuiQueueContext(harness: Harness) {
@@ -96,11 +114,14 @@ function createTuiCompactionEventContext(harness: Harness) {
 		flushCompactionQueue: (options: { willRetry: boolean; deferAdmission?: boolean }) => Promise<void>;
 		flushes: Promise<void>[];
 		restoredMessages: string[][];
+		clearAllQueues: () => { steering: string[]; followUp: string[] };
+		editor: { getText: () => string; setText: (text: string) => void };
 		restoreQueuedMessagesToEditor: () => number;
 	};
 	const flushes: Promise<void>[] = [];
 	const statusMessages: string[] = [];
 	const restoredMessages: string[][] = [];
+	let editorText = "";
 	Object.assign(context, {
 		isInitialized: true,
 		footer: { invalidate: () => {} },
@@ -126,20 +147,18 @@ function createTuiCompactionEventContext(harness: Harness) {
 			flushes.push(flush);
 			return flush;
 		},
+		clearAllQueues() {
+			return getClearAllQueues()(context);
+		},
+		editor: {
+			getText: () => editorText,
+			setText: (text: string) => {
+				editorText = text;
+				restoredMessages.push(text.split("\n\n"));
+			},
+		},
 		restoreQueuedMessagesToEditor() {
-			// Mirrors the real helper: the native session queues are drained into the
-			// editor draft alongside the TUI compaction queue.
-			const { steering, followUp } = harness.session.clearQueue();
-			const restored = [
-				...context.compactionInFlightMessages,
-				...context.compactionQueuedMessages,
-				...steering.map((text) => ({ text, mode: "steer" as const })),
-				...followUp.map((text) => ({ text, mode: "followUp" as const })),
-			].map((message) => message.text);
-			context.compactionInFlightMessages = [];
-			context.compactionQueuedMessages = [];
-			restoredMessages.push(restored);
-			return restored.length;
+			return getRestoreQueuedMessagesToEditor()(context);
 		},
 	});
 	return context;
@@ -337,6 +356,10 @@ describe("post-compaction queued input recovery", () => {
 			harness.setResponses([fauxAssistantMessage("seed handled"), fauxAssistantMessage("must not execute")]);
 			await harness.session.prompt("seed context ".repeat(40));
 			const providerCallsBeforeCompaction = harness.faux.state.callCount;
+			const nativeSteer = `[native steer ${outcome}]`;
+			const nativeFollowUp = `[native follow-up ${outcome}]`;
+			await getQueueNativeMessage(harness, "Steer")(nativeSteer);
+			await getQueueNativeMessage(harness, "FollowUp")(nativeFollowUp);
 			const context = createTuiCompactionEventContext(harness);
 			context.compactionQueuedMessages.push({ text: marker, mode: "steer" });
 			harness.session.subscribe((event) => {
@@ -363,10 +386,10 @@ describe("post-compaction queued input recovery", () => {
 			// so every case here is terminal: the marker goes back to the composer and
 			// never reaches a native queue or the provider.
 			expect(context.compactionQueuedMessages).toEqual([]);
-			expect(context.restoredMessages).toEqual([[marker]]);
+			expect(context.restoredMessages).toEqual([[nativeSteer, marker, nativeFollowUp]]);
 			expect(context.compactionInFlightMessages).toEqual([]);
-			expect(harness.session.getSteeringMessages()).not.toContain(marker);
-			expect(harness.session.getFollowUpMessages()).not.toContain(marker);
+			expect(harness.session.getSteeringMessages()).toEqual([]);
+			expect(harness.session.getFollowUpMessages()).toEqual([]);
 			expect(getUserTexts(harness)).not.toContain(marker);
 			expect(harness.faux.state.callCount).toBe(providerCallsBeforeCompaction);
 			expect(harness.eventsOfType("compaction_start")).toHaveLength(1);

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -398,6 +398,59 @@ describe("post-compaction queued input recovery", () => {
 		},
 	);
 
+	it("restores queued TUI input after real pre-prompt overflow compaction failure", async () => {
+		const marker = "[TUI queue restores after failed overflow compaction]";
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+		});
+		harnesses.push(harness);
+
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "overflowing prior context ".repeat(2_000) }],
+			timestamp: Date.now() - 1_000,
+		});
+		const overflowAssistant = createOverflowResponse(harness);
+		harness.sessionManager.appendMessage(overflowAssistant);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		const failCompactionProvider: FauxResponseFactory = () => {
+			throw new Error("forced compaction provider failure");
+		};
+		harness.setResponses([failCompactionProvider]);
+
+		const context = createTuiCompactionEventContext(harness);
+		const compactionEnds: Array<Extract<(typeof harness.events)[number], { type: "compaction_end" }>> = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start" && event.reason === "overflow") {
+				context.compactionQueuedMessages.push({ text: marker, mode: "steer" });
+			}
+			if (event.type === "compaction_end" && event.reason === "overflow") {
+				compactionEnds.push(event);
+				void getHandleEvent()(context, event);
+			}
+		});
+
+		await expect(harness.session.prompt("retry after overflow")).rejects.toThrow(
+			"Context remains above the compaction threshold because compaction did not complete",
+		);
+		await Promise.all(context.flushes);
+		await harness.session.waitForSettledSessionWork();
+
+		expect(compactionEnds).toHaveLength(1);
+		expect(compactionEnds[0]).toMatchObject({
+			reason: "overflow",
+			result: undefined,
+			aborted: false,
+			willRetry: false,
+		});
+		expect(compactionEnds[0]?.errorMessage).toMatch(/Pre-prompt compaction failed/);
+		expect(context.restoredMessages).toEqual([[marker]]);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
 	it("routes queued TUI input to the native session queue after a retryable compaction_end", async () => {
 		const marker = "[TUI queue defers to retry]";
 		const harness = await createHarness({

--- a/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-queued-input-resume.test.ts
@@ -46,7 +46,7 @@ function createAcceptedCompactionExtension() {
 function getFlushCompactionQueue() {
 	const flush = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue");
 	if (typeof flush !== "function") throw new Error("Expected InteractiveMode.flushCompactionQueue");
-	return (context: object, options: { willRetry: boolean }): Promise<void> =>
+	return (context: object, options: { willRetry: boolean; deferAdmission?: boolean }): Promise<void> =>
 		Promise.resolve(flush.call(context, options));
 }
 
@@ -93,11 +93,14 @@ function createTuiCompactionEventContext(harness: Harness) {
 		showStatus: (message: string) => void;
 		ui: { requestRender: () => void; terminal: { setProgress: () => void } };
 		settingsManager: { getShowTerminalProgress: () => boolean };
-		flushCompactionQueue: (options: { willRetry: boolean }) => Promise<void>;
+		flushCompactionQueue: (options: { willRetry: boolean; deferAdmission?: boolean }) => Promise<void>;
 		flushes: Promise<void>[];
+		restoredMessages: string[][];
+		restoreQueuedMessagesToEditor: () => number;
 	};
 	const flushes: Promise<void>[] = [];
 	const statusMessages: string[] = [];
+	const restoredMessages: string[][] = [];
 	Object.assign(context, {
 		isInitialized: true,
 		footer: { invalidate: () => {} },
@@ -117,10 +120,26 @@ function createTuiCompactionEventContext(harness: Harness) {
 		settingsManager: { getShowTerminalProgress: () => false },
 		getSessionLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {} }),
 		flushes,
-		flushCompactionQueue(options: { willRetry: boolean }) {
+		restoredMessages,
+		flushCompactionQueue(options: { willRetry: boolean; deferAdmission?: boolean }) {
 			const flush = getFlushCompactionQueue()(context, options);
 			flushes.push(flush);
 			return flush;
+		},
+		restoreQueuedMessagesToEditor() {
+			// Mirrors the real helper: the native session queues are drained into the
+			// editor draft alongside the TUI compaction queue.
+			const { steering, followUp } = harness.session.clearQueue();
+			const restored = [
+				...context.compactionInFlightMessages,
+				...context.compactionQueuedMessages,
+				...steering.map((text) => ({ text, mode: "steer" as const })),
+				...followUp.map((text) => ({ text, mode: "followUp" as const })),
+			].map((message) => message.text);
+			context.compactionInFlightMessages = [];
+			context.compactionQueuedMessages = [];
+			restoredMessages.push(restored);
+			return restored.length;
 		},
 	});
 	return context;
@@ -295,7 +314,7 @@ describe("post-compaction queued input recovery", () => {
 		["rejected threshold", "threshold" as const, false, "reject" as const],
 		["feedback-only abort", undefined, false, "abort" as const],
 	])(
-		"routes queued TUI input to the native session queue after a %s compaction_end",
+		"restores queued TUI input to the editor after a terminal %s compaction_end",
 		async (_label, reason, willRetry, outcome) => {
 			const marker = `[TUI queue remains ${outcome}]`;
 			const harness = await createHarness({
@@ -340,15 +359,56 @@ describe("post-compaction queued input recovery", () => {
 			await Promise.all(context.flushes);
 			await harness.session.waitForSettledSessionWork();
 
+			// Extension rejections and feedback-only aborts always emit willRetry: false,
+			// so every case here is terminal: the marker goes back to the composer and
+			// never reaches a native queue or the provider.
 			expect(context.compactionQueuedMessages).toEqual([]);
+			expect(context.restoredMessages).toEqual([[marker]]);
 			expect(context.compactionInFlightMessages).toEqual([]);
-			expect(harness.session.getSteeringMessages()).toContain(marker);
+			expect(harness.session.getSteeringMessages()).not.toContain(marker);
+			expect(harness.session.getFollowUpMessages()).not.toContain(marker);
 			expect(getUserTexts(harness)).not.toContain(marker);
 			expect(harness.faux.state.callCount).toBe(providerCallsBeforeCompaction);
 			expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
-			expect(context.statusMessages.some((message) => message.includes("queued message"))).toBe(true);
+			expect(context.statusMessages.some((message) => message.includes("restored to the editor"))).toBe(true);
+			expect(context.statusMessages.some((message) => message.includes("will send with the next turn"))).toBe(false);
 		},
 	);
+
+	it("routes queued TUI input to the native session queue after a retryable compaction_end", async () => {
+		const marker = "[TUI queue defers to retry]";
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed handled"), fauxAssistantMessage("must not execute")]);
+		await harness.session.prompt("seed context ".repeat(40));
+		const providerCallsBeforeCompaction = harness.faux.state.callCount;
+		const context = createTuiCompactionEventContext(harness);
+		context.compactionQueuedMessages.push({ text: marker, mode: "steer" });
+
+		await getHandleEvent()(context, {
+			type: "compaction_end",
+			reason: "overflow",
+			result: undefined,
+			aborted: false,
+			willRetry: true,
+			errorMessage: "Context overflow recovery failed: transient provider error",
+		});
+		await Promise.all(context.flushes);
+		await harness.session.waitForSettledSessionWork();
+
+		// A retry is still coming, so the queued input is handed to the native steering
+		// queue instead of the editor and must not start its own provider turn.
+		expect(context.restoredMessages).toEqual([]);
+		expect(context.compactionQueuedMessages).toEqual([]);
+		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(harness.session.getSteeringMessages()).toContain(marker);
+		expect(getUserTexts(harness)).not.toContain(marker);
+		expect(harness.faux.state.callCount).toBe(providerCallsBeforeCompaction);
+		expect(context.statusMessages.some((message) => message.includes("queued message"))).toBe(true);
+	});
 
 	it("flushes accepted compaction input once through the real compaction_end handler", async () => {
 		const marker = "[TUI queue flushes once]";
@@ -374,6 +434,7 @@ describe("post-compaction queued input recovery", () => {
 
 		expect(context.compactionQueuedMessages).toEqual([]);
 		expect(context.compactionInFlightMessages).toEqual([]);
+		expect(context.restoredMessages).toEqual([]);
 		expect(getUserTexts(harness).filter((text) => text === marker)).toHaveLength(1);
 		expect(harness.faux.state.callCount).toBe(2);
 	});


### PR DESCRIPTION
## Summary

- restore compaction-queued TUI input to the editable composer after terminal failures, rejections, and aborts
- keep accepted compactions on normal prompt admission and retryable failures on the native deferred queue path
- preserve message ordering, clear queue ownership, and avoid automatic resend against the unchanged over-threshold context
- add focused branch, rejection-feedback, and post-compaction ownership regressions

## Why

PR #512 fixed permanently parked input by transferring failed-compaction messages to native queues. That transfer is still correct while a retry is pending, but a terminal failure has no recovery turn left: automatically sending the same input can immediately re-enter compaction against the same context. Returning terminal-failure input to the composer gives ownership back to the user without dropping or auto-sending it.

## Verification

- `npm run check` — 2,533 files checked, no fixes or errors
- focused changed suites — 3 files, 24 tests passed
- expanded compaction recovery suite — 5 files, 32 tests passed
- `npm run build` — all workspaces passed
- real TUI QA — `RECOVERY_COMPOSER_RESTORED=1`, `QUEUED_BADGE_CLEARED=1`, `AUTO_RESEND_COUNT=0`, `AUTH_UNCHANGED=1`, `CLEANUP_OK=1`
- rebased onto current `origin/main`; merge-tree clean

Related: #512

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore compaction-queued input to the editor after terminal compaction failures, rejections, or aborts. Failed pre-prompt compaction now emits `willRetry: false` so restoration is reliable; retryable failures still defer to native queues and accepted compactions send normally.

- **Bug Fixes**
  - `interactive-mode.ts`: three-path `compaction_end` handling
    - Success: `flushCompactionQueue({ willRetry, deferAdmission: false })`.
    - Retryable failure: `flushCompactionQueue({ willRetry: true, deferAdmission: true })`.
    - Terminal failure/rejection/abort: `restoreQueuedMessagesToEditor()` and show “restored to the editor”.
  - `agent-session.ts`: failed pre-prompt overflow compaction now emits `willRetry: false` to prevent parked input and trigger restoration.
  - Terminal restoration returns queued TUI input (and native steer/follow-up handoffs) to the editor, avoiding resend into the same over-threshold context.
  - Tests/Docs: deduplicated compaction test context setup; exercised real queued-input restoration on a failed pre-prompt overflow; updated `changes.md`.

<sup>Written for commit 1ecc62fafa8885c4fcc7b1bbb81be301e4131687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

