### PR TITLE
test(coding-agent): stabilize risky model warning checks

### DIFF
--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -46,6 +46,7 @@ type RunContext = {
 	getUserInput: () => Promise<string>;
 	showNewVersionNotification: (version: string) => void;
 	showPackageUpdateNotification: (packages: string[]) => void;
+	showRiskyMainModelWarning: () => void;
 	showWarning: (message: string) => void;
 	showError: (message: string) => void;
 };
@@ -124,6 +125,7 @@ describe("InteractiveMode startup input", () => {
 			getUserInput,
 			showNewVersionNotification: vi.fn(),
 			showPackageUpdateNotification: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
 			showWarning: vi.fn(),
 			showError: vi.fn(),
 		};

--- a/packages/coding-agent/test/risky-main-model-warning-tui.test.ts
+++ b/packages/coding-agent/test/risky-main-model-warning-tui.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, describe, expect, test, vi } from "vitest";
 import { Container } from "../../tui/src/tui.ts";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 import { isRiskyMainModel, RISKY_MAIN_MODEL_WARNING } from "../src/modes/interactive/risky-main-model-warning.ts";
-import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 
 function model(overrides: Partial<Model<"openai-completions">>): Model<"openai-completions"> {
@@ -63,7 +63,7 @@ describe("risky main-model warning", () => {
 			const plain = stripAnsi(rendered).replace(/\s+/g, " ");
 			expect(plain).toContain(RISKY_MAIN_MODEL_WARNING);
 			expect(plain).toContain("위험한 모델 경고");
-			expect(rendered).toContain("\u001b[38;2;204;102;102m");
+			expect(rendered).toContain(theme.getFgAnsi("error"));
 			expect(fakeThis.chatContainer.children).toHaveLength(4);
 			expect(fakeThis.ui.requestRender).toHaveBeenCalledExactlyOnceWith();
 		},


### PR DESCRIPTION
## Summary

- Keep the interactive startup test fixture synchronized with the new risky-main-model warning method.
- Assert the warning box uses the semantic `error` theme color instead of hardcoding one terminal color depth.

## Why

Current `main` has a red required CI job:

1. `interactive-mode-startup-input.test.ts`
   - `InteractiveMode.run()` calls `showRiskyMainModelWarning()`.
   - The structural fake context omitted that method and threw before the test's intended loop sentinel.

2. `risky-main-model-warning-tui.test.ts`
   - The renderer correctly emits the theme's error color.
   - The test hardcoded 24-bit ANSI `38;2;204;102;102`, while GitHub's terminal capability detection legitimately selected 256-color ANSI `38;5;167`.

## RED -> GREEN

Startup fixture:

- RED: expected `Error: stop interactive loop`, received `TypeError: this.showRiskyMainModelWarning is not a function`.
- GREEN: add the method to the fake context type and initialize it with `vi.fn()`.

Terminal color:

- RED under `CI=1 COLORTERM= TERM=xterm-256color TERM_PROGRAM=`: both warning render cases emit valid 256-color error ANSI but fail the hardcoded truecolor assertion.
- GREEN: assert `theme.getFgAnsi("error")`, which preserves the semantic error-color contract across both supported color depths.

## Validation

- `npm run check` — passed
- Focused CI-mode tests — 12/12 passed
- Forced 256-color warning tests — 9/9 passed
- Forced truecolor warning tests — 9/9 passed
- Diff — exactly two test files, 4 insertions and 2 deletions

The local clean-worktree full suite encounters unrelated workspace package-export resolution failures that do not occur in the GitHub runner. This PR's real `Check and test` job is the authoritative full-suite gate.

## Scope

Test-only. No production behavior, warning copy, layout, theme values, or model-selection logic changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the risky main-model warning tests to unblock CI. Aligns the interactive startup fixture with the new warning method and switches color assertions to use the theme.

- **Bug Fixes**
  - Added `showRiskyMainModelWarning()` to the interactive mode test context and mocked with `vi.fn()` to prevent runtime errors.
  - Updated the TUI warning test to assert `theme.getFgAnsi("error")` instead of a hardcoded truecolor ANSI code, making it robust across 256-color and truecolor terminals.

<sup>Written for commit f0d659290bf058f42735bb04d04eedc3eaac7989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

