### PR TITLE
fix(ai): harden Kimi XTML recovery markers

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-kimi-thinking-recovery.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-kimi-thinking-recovery.mjs
@@ -13,7 +13,7 @@ export const KIMI_THINKING_RECOVERY_SCENARIO = "kimi-xtml-thinking-recover";
 const RECOVERED_MARKER = "RECOVERED_VISIBLE_ANSWER";
 const MALFORMED_THINKING =
 	"Reasoning remains private. 즉 해당 키로 치는 요청은 지표 수집 대상에 정상 포함됨." +
-	"<|close|>response<|sep|><|close|>message<|sep|>";
+	"<|close|><|sep|><|close|>tools<|sep|><|close|>response<|sep|><|close|>message<|sep|>";
 const XTML_PATTERN = /<\|(?:close|open|sep)\|>/u;
 
 export async function runKimiThinkingRecoveryScenario(driveTurn, evidenceSlug) {

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -2,6 +2,19 @@
 
 # Tool Call Middleware Changes
 
+## 2026-07-30 - Kimi XTML unnamed channel recovery hardening
+
+### What changed and why
+
+- `createXtmlRecoveryStreamParser()` now recognizes an empty channel name in malformed
+  `<|open|><|sep|>` / `<|close|><|sep|>` transitions, including markers split at every
+  internal stream boundary, instead of leaking them as visible text.
+- `recoverKimiXtmlThinking()` now strips `tools`, other valid named channels, and bare
+  XTML open/close/sep tokens while preserving the existing response/think state changes
+  and code-fenced protocol examples.
+- The deterministic Kimi mock-loop fixture includes the observed unnamed-close + tools
+  tail so real CLI QA fails if either client recovery layer regresses.
+
 ## 2026-07-29 - Kimi XTML leaked tool-call recovery in normal mode
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
@@ -23,7 +23,7 @@ type ParserMode =
 	| "argument-value"
 	| "discard-call";
 
-const CHANNEL_MARKER_PATTERN = /^<\|(?:open|close)\|>[a-zA-Z_][a-zA-Z0-9_]*<\|sep\|>/;
+const CHANNEL_MARKER_PATTERN = /^<\|(?:open|close)\|>(?:[a-zA-Z_][a-zA-Z0-9_]*)?<\|sep\|>/;
 const OPEN_PREFIX = "<|open|>";
 const CLOSE_PREFIX = "<|close|>";
 
@@ -34,7 +34,7 @@ function couldBeMarkerPrefix(tail: string): boolean {
 		const rest = tail.slice(prefix.length);
 		const angleIndex = rest.indexOf("<");
 		if (angleIndex === -1) return /^[a-zA-Z0-9_]*$/.test(rest);
-		if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(rest.slice(0, angleIndex))) return false;
+		if (!/^(?:[a-zA-Z_][a-zA-Z0-9_]*)?$/.test(rest.slice(0, angleIndex))) return false;
 		return XTML_SEP.startsWith(rest.slice(angleIndex));
 	}
 	return false;

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts
@@ -10,7 +10,7 @@ type RecoveredThinking = {
 	readonly recoveredResponse: boolean;
 };
 
-const CHANNEL_MARKER_PATTERN = /<\|(open|close)\|>(think|response|message)<\|sep\|>/g;
+const CHANNEL_MARKER_PATTERN = /<\|(open|close)\|>([a-zA-Z_][a-zA-Z0-9_]*)?<\|sep\|>|<\|(?:open|close|sep)\|>/g;
 
 function recoverThinkingContent(input: string): RecoveredThinking {
 	const mask = createRecoveryCodeMask();

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-recovery-stream.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-recovery-stream.test.ts
@@ -71,6 +71,26 @@ describe("createXtmlRecoveryStreamParser", () => {
 		expect(textOf(events)).toBe("final answer");
 	});
 
+	it("strips an unnamed close marker across every chunk split", () => {
+		// given
+		const marker = "<|close|><|sep|>";
+		const outputs: string[] = [];
+
+		// when
+		for (let split = 1; split < marker.length; split += 1) {
+			const parser = createXtmlRecoveryStreamParser([weatherTool]);
+			const events = [
+				...parser.feed(`before${marker.slice(0, split)}`),
+				...parser.feed(`${marker.slice(split)}after`),
+				...parser.finish(),
+			];
+			outputs.push(textOf(events));
+		}
+
+		// then
+		expect(outputs).toEqual(Array.from({ length: marker.length - 1 }, () => "beforeafter"));
+	});
+
 	it("reassembles markers split across chunks", () => {
 		// given
 		const parser = createXtmlRecoveryStreamParser([weatherTool]);

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-thinking-recovery.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-thinking-recovery.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { recoverKimiXtmlThinking } from "../../src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts";
+import type { AssistantMessage } from "../../src/types.ts";
+
+function messageWithThinking(thinking: string): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-completions",
+		provider: "test-provider",
+		model: "kimi-k3",
+		content: [{ type: "thinking", thinking }],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function thinkingText(message: AssistantMessage): string {
+	return message.content
+		.filter((item) => item.type === "thinking")
+		.map((item) => (item.type === "thinking" ? item.thinking : ""))
+		.join("");
+}
+
+function visibleText(message: AssistantMessage): string {
+	return message.content
+		.filter((item) => item.type === "text")
+		.map((item) => (item.type === "text" ? item.text : ""))
+		.join("");
+}
+
+describe("recoverKimiXtmlThinking", () => {
+	it("strips tools-channel and unnamed markers from thinking", () => {
+		// given
+		const message = messageWithThinking("private<|close|>tools<|sep|> reasoning<|close|><|sep|> remains<|sep|>");
+
+		// when
+		const recovered = recoverKimiXtmlThinking(message);
+
+		// then
+		expect(thinkingText(recovered)).toBe("private reasoning remains");
+		expect(visibleText(recovered)).toBe("");
+		expect(recovered.content.map((item) => JSON.stringify(item)).join("")).not.toContain("<|");
+		expect(recovered.diagnostics).toEqual([
+			{
+				type: "kimi_xtml_thinking_recovery",
+				timestamp: expect.any(Number),
+				details: { recoveredResponse: false },
+			},
+		]);
+	});
+
+	it("still promotes response content while stripping adjacent tools markers", () => {
+		// given
+		const message = messageWithThinking(
+			"private<|close|>think<|sep|><|close|>tools<|sep|><|open|>response<|sep|>visible<|close|>response<|sep|>",
+		);
+
+		// when
+		const recovered = recoverKimiXtmlThinking(message);
+
+		// then
+		expect(thinkingText(recovered)).toBe("private");
+		expect(visibleText(recovered)).toBe("visible");
+		expect(recovered.content.map((item) => JSON.stringify(item)).join("")).not.toContain("<|");
+	});
+
+	it("preserves tools and unnamed marker literals inside fenced code", () => {
+		// given
+		const literal = "Example:\n```text\n<|close|>tools<|sep|><|close|><|sep|>\n```";
+		const message = messageWithThinking(literal);
+
+		// when
+		const recovered = recoverKimiXtmlThinking(message);
+
+		// then
+		expect(recovered).toBe(message);
+		expect(thinkingText(recovered)).toBe(literal);
+		expect(recovered.diagnostics).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- recognize unnamed Kimi XTML channel transitions such as `<|close|><|sep|>` across every stream chunk split
- strip `tools`, other valid named channels, and bare XTML tokens from recovered thinking while preserving response/think state changes and fenced-code literals
- strengthen the deterministic real-CLI Kimi fixture with the observed unnamed-close + tools tail

Slack context: https://sionicai.slack.com/archives/C096C3V2RFS/p1785404686022019?thread_ts=1785402475.941019

## Root cause

The stream recovery regex and prefix validator required a non-empty channel name, so an unnamed close/sep transition was emitted as visible text. The thinking recovery scanner only recognized `think|response|message`, so `tools` and unnamed protocol tokens survived inside thinking content.

The fix stays output-side and code-mask-aware. It does not sanitize user input or tool results.

## RED -> GREEN

### Unnamed stream boundary

- RED: all 15 internal split points produced `before<|close|><|sep|>after`
- GREEN: all split points produce `beforeafter`

```text
npm --prefix packages/ai test -- test/tool-call-middleware/kimi-xtml-recovery-stream.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)
```

### Tools and unnamed thinking markers

- RED: tools and unnamed markers remained in recovered thinking; fenced-code pin already passed
- GREEN: tools/unnamed markers are removed, response promotion remains correct, fenced literals remain byte-identical

```text
npm --prefix packages/ai test -- \
  test/tool-call-middleware/kimi-xtml-thinking-recovery.test.ts \
  test/tool-call-middleware/kimi-xtml-recovery-activation.test.ts \
  test/tool-call-middleware/kimi-xtml-recovery-stream.test.ts
Test Files  3 passed (3)
Tests       14 passed (14)
```

## Real CLI QA

```text
node .agents/skills/senpi-qa/scripts/mock-loop.mjs \
  --scenario kimi-xtml-thinking-recover \
  --api openai-completions \
  --evidence kimi-xtml-tools-channel-built
```

Result: 8/8 passed. The malformed 143-byte reasoning tail reached the real parser; the recovered answer appeared once; no raw XTML reached visible output or request replay; auth was unchanged; the sandbox was removed.

Additional QA:

- mock-loop self-test: 43 PASS, 0 FAIL
- CLI smoke self-test: 8/8 passed (`--help`, version, offline model list, unknown-option rejection, auth unchanged)
- cleanup: all observed mock-loop temp directories absent; no matching process remained

## Validation

- `npm run check`
- `npm --prefix packages/ai test` — 171 files passed, 1524 tests passed
- `npm --prefix packages/ai run build`
- final LSP diagnostics — zero diagnostics in all changed TypeScript files
- `git diff --check`

## Notes

A fresh-worktree QA receipt contains an unrelated optional `senpi-codemode` extension-load warning caused by workspace export resolution. The real coding-agent loop and all eight Kimi assertions still passed; the mature main worktree does not emit the warning. No dependency or extension behavior is changed in this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Kimi XTML recovery to handle unnamed channel markers and strip stray protocol tokens from thinking, preventing `<|...|>` text from leaking into responses. Improves resilience across split stream chunks and keeps fenced-code literals intact.

- **Bug Fixes**
  - `createXtmlRecoveryStreamParser()` now handles empty channel transitions like `<|close|><|sep|>` across chunk boundaries.
  - `recoverKimiXtmlThinking()` now removes `tools`, other channel names, and bare XTML tokens from thinking while preserving response/think state and fenced-code literals.

<sup>Written for commit 69b441041a2fcfd30da36c223171f22c472f3855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

