### PR TITLE
fix(coding-agent): reset goal continuation cap on progress

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,40 @@
 # goal Extension Changes
 
+## Observable progress resets the persisted continuation cap streak (2026-07-30)
+
+### What changed
+
+- `continuation.ts` now exposes `hasGoalContinuationProgress`, which treats a
+  changed persisted continuation signature as observable goal progress.
+- `monitor-continuation.ts` resets `consecutiveContinuations` before the next
+  admission when a non-user continuation turn either used tools or changed that
+  signature. The verdict is rebuilt from the reset goal so the cap remains a
+  backstop for uninterrupted non-progress rather than a raw turn counter.
+- The cap stays at 8, remains inclusive at the boundary, and still applies to
+  immediate, user-grace, and session-start paths. User-prompt resets,
+  single-flight delivery, stale/repetition/length guards, monitor scheduling,
+  and blocked-state deduplication are unchanged.
+- Coverage rewrites the former distinct-text cap pins in
+  `goal-monitor-continuation.test.ts` and
+  `regressions/issue-447-goal-continuation.test.ts`, and adds an explicit
+  below-cap/at-cap verdict boundary assertion.
+
+### Why
+
+- Codex has no deterministic continuation counter; its blocked audit restarts
+  whenever the goal makes meaningful progress. Senpi intentionally retains an
+  eight-turn safety cap, but previously reset it only for tool use. A goal that
+  made distinct toolless progress therefore blocked on the ninth continuation,
+  resumed on user input, then repeated the same false block cycle.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `continuation.ts` around signature helpers and in
+  `monitor-continuation.ts` around `afterAgentEnd`.
+- LOW in the two cap regression tests whose old expectations encoded raw turn
+  counting rather than progress-aware streak accounting.
+- NONE in persistence schema, public extension API, or goal status transitions.
+
 ## Tool-using continuations reset the persisted cap streak (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -138,6 +138,23 @@ export function buildGoalContinuationSignature(
 	return `${goal.id}:${openTodos}/${totalTodos}:${lastAssistantTextHash}`;
 }
 
+export function hasGoalContinuationProgress(
+	input: Pick<GoalContinuationInput, "lastContinuationSignature" | "currentSignature">,
+): boolean {
+	return (
+		input.lastContinuationSignature !== undefined &&
+		input.currentSignature !== undefined &&
+		input.lastContinuationSignature !== input.currentSignature
+	);
+}
+
+export function continuationTurnUsedTools(messages: readonly AgentMessage[]): boolean {
+	return messages.some((message) => {
+		if (message?.role === "toolResult") return true;
+		return message?.role === "assistant" && message.content.some((content) => content.type === "toolCall");
+	});
+}
+
 function isEligibleForGoalContinuation(input: GoalContinuationInput): boolean {
 	if (input.goal?.status !== "active" || input.hasPendingMessages) return false;
 	if (input.path === "immediate") {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -10,12 +10,14 @@ import {
 	type GoalCacheWarmupEntryData,
 } from "./cache-warm.ts";
 import {
+	continuationTurnUsedTools,
 	evaluateGoalContinuation,
 	GOAL_STALL_TOOLLESS_THRESHOLD,
 	GOAL_USER_GRACE_DELAY_MS,
 	type GoalContinuationInput,
 	type GoalContinuationPath,
 	type GoalContinuationVerdict,
+	hasGoalContinuationProgress,
 	hashAssistantText,
 	normalizeAssistantText,
 } from "./continuation.ts";
@@ -115,15 +117,18 @@ export class MonitorAwareGoalContinuation {
 		}
 		const turnUsedTools = continuationTurnUsedTools(options.messages);
 		this.#recordToollessContinuationTurn(options.goal, turnUsedTools);
+		const immediateInput = this.#buildVerdictInput(options.ctx, options.goal, "immediate", options.messages);
 		const goal =
-			!this.#endedTurnWasUserInitiated && turnUsedTools
+			!this.#endedTurnWasUserInitiated && (turnUsedTools || hasGoalContinuationProgress(immediateInput))
 				? ((await resetContinuationStreak(goalStoreRef(options.ctx.sessionManager, options.ctx.cwd))) ??
 					options.goal)
 				: options.goal;
 		this.#goal = goal;
 
-		const immediateInput = this.#buildVerdictInput(options.ctx, goal, "immediate", options.messages);
-		const immediateVerdict = evaluateGoalContinuation({ goal, ...immediateInput });
+		const immediateVerdict = evaluateGoalContinuation({
+			goal,
+			...this.#buildVerdictInput(options.ctx, goal, "immediate", options.messages),
+		});
 		if (immediateVerdict.kind === "deny") {
 			if (immediateVerdict.reason === "not-eligible") return goal;
 			if (immediateVerdict.reason === "grace") {
@@ -364,13 +369,6 @@ export class MonitorAwareGoalContinuation {
 		this.#timer = undefined;
 		this.#scheduledContinuationKind = undefined;
 	}
-}
-
-function continuationTurnUsedTools(messages: readonly AgentMessage[]): boolean {
-	return messages.some((message) => {
-		if (message?.role === "toolResult") return true;
-		return message?.role === "assistant" && message.content.some((content) => content.type === "toolCall");
-	});
 }
 
 function findLastAssistantMessage(

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -99,6 +99,16 @@ describe("goal continuation verdict", () => {
 		expect(evaluateGoalContinuation(input)).toEqual({ kind: "deny", reason });
 	});
 
+	it("admits below the continuation cap and denies at the boundary", () => {
+		expect(
+			evaluateGoalContinuation(makeInput({ consecutiveContinuations: GOAL_CONTINUATION_CAP - 1 })),
+		).toMatchObject({ kind: "continue" });
+		expect(evaluateGoalContinuation(makeInput({ consecutiveContinuations: GOAL_CONTINUATION_CAP }))).toEqual({
+			kind: "deny",
+			reason: "cap",
+		});
+	});
+
 	it.each([
 		["a clean ordinary end", makeInput(), { kind: "continue", prompt: "full", stallNotice: false }],
 		[

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -1,6 +1,4 @@
-import { watch } from "node:fs";
 import { join } from "node:path";
-import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
@@ -25,6 +23,7 @@ import {
 	makeGoalContext,
 	runGoalHandlers,
 	TestEventBus,
+	waitForGoalContinuationCount,
 } from "./goal-monitor-test-harness.ts";
 
 function goalStoreRef(ctx: ExtensionContext) {
@@ -32,35 +31,6 @@ function goalStoreRef(ctx: ExtensionContext) {
 		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
 		threadId: ctx.sessionManager.getSessionId(),
 	};
-}
-
-function waitForGoalContinuationCount(ctx: ExtensionContext, expectedCount: number): Promise<void> {
-	const ref = goalStoreRef(ctx);
-	const goalFileName = `${encodeURIComponent(ref.threadId)}.json`;
-	return new Promise((resolve, reject) => {
-		let completed = false;
-		let timeout: ReturnType<typeof setRealTimeout> | undefined;
-		const watcher = watch(ref.baseDir, { encoding: "utf8" }, (_eventType, changedFileName) => {
-			if (changedFileName !== goalFileName) return;
-			void readGoal(ref).then((goal) => {
-				if (goal?.consecutiveContinuations === expectedCount) complete();
-			}, complete);
-		});
-		timeout = setRealTimeout(
-			() => complete(new Error(`Timed out waiting for continuation count ${expectedCount}`)),
-			5_000,
-		);
-		watcher.once("error", complete);
-
-		function complete(error: Error | undefined = undefined): void {
-			if (completed) return;
-			completed = true;
-			if (timeout !== undefined) clearRealTimeout(timeout);
-			watcher.close();
-			if (error === undefined) resolve();
-			else reject(error);
-		}
-	});
 }
 
 function cleanAssistantStopWithText(text: string): AgentMessage {
@@ -176,52 +146,24 @@ describe("goal continuation while a monitor is active", () => {
 	it("counts user grace delivery toward the continuation cap", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent, events } = createGoalHarness();
+		const { tools, handlers, sent } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-user-grace-counted");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
 		await runUserInitiatedTurn(handlers, ctx);
 		expect(sent).toHaveLength(0);
+		const goal = await readGoal(goalStoreRef(ctx));
+		if (goal === null) throw new Error("Expected persisted goal");
+		await writeGoal(goalStoreRef(ctx), { ...goal, consecutiveContinuations: 7 });
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 1);
 		expect(sent).toHaveLength(0);
-		const graceDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
+		const graceDeliveryRecorded = waitForGoalContinuationCount(ctx, 8);
 		await vi.advanceTimersByTimeAsync(1);
 		await graceDeliveryRecorded;
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
-		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ consecutiveContinuations: 1 });
-
-		for (let turn = 2; turn <= 8; turn++) {
-			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
-			await runGoalHandlers(
-				handlers,
-				"agent_end",
-				{ type: "agent_end", messages: [cleanAssistantStopWithText(`progress ${turn}`)] },
-				ctx,
-			);
-		}
-
-		expect(sent).toHaveLength(8);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 8 });
-
-		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
-		await runGoalHandlers(
-			handlers,
-			"agent_end",
-			{ type: "agent_end", messages: [cleanAssistantStopWithText("progress 9")] },
-			ctx,
-		);
-
-		expect(sent).toHaveLength(8);
-		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
-			status: "blocked",
-			blockedReason: "continuation cap reached",
-		});
-		expect(events.emitted).toContainEqual({
-			channel: "goal_continuation_guard_tripped",
-			data: expect.objectContaining({ reason: "cap", count: 8 }),
-		});
 	});
 
 	it("continues after user grace even when an active monitor settles", async () => {
@@ -497,14 +439,14 @@ describe("goal continuation while a monitor is active", () => {
 		);
 	});
 
-	it("blocks the ninth clean immediate continuation without queuing a ninth hidden prompt", async () => {
+	it("keeps admitting distinct progress beyond the continuation cap", async () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent, events } = createGoalHarness();
-		const ctx = await makeGoalContext(notices, "thread-immediate-cap");
+		const ctx = await makeGoalContext(notices, "thread-immediate-distinct-progress");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
-		for (let turn = 1; turn <= 8; turn++) {
+		for (let turn = 1; turn <= 9; turn++) {
 			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 			await runGoalHandlers(
 				handlers,
@@ -514,26 +456,17 @@ describe("goal continuation while a monitor is active", () => {
 			);
 		}
 
-		expect(sent).toHaveLength(8);
-		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 8 });
-
-		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
-		await runGoalHandlers(
-			handlers,
-			"agent_end",
-			{ type: "agent_end", messages: [cleanAssistantStopWithText("progress 9")] },
-			ctx,
-		);
-
-		expect(sent).toHaveLength(8);
+		expect(sent).toHaveLength(9);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
-			status: "blocked",
-			blockedReason: "continuation cap reached",
+			status: "active",
+			consecutiveContinuations: 1,
 		});
-		expect(events.emitted).toContainEqual({
-			channel: "goal_continuation_guard_tripped",
-			data: expect.objectContaining({ reason: "cap", count: 8 }),
-		});
+		expect(events.emitted).not.toContainEqual(
+			expect.objectContaining({
+				channel: "goal_continuation_guard_tripped",
+				data: expect.objectContaining({ reason: "cap" }),
+			}),
+		);
 	});
 
 	it("silently skips a stale continuation after two real agent_end cycles with unchanged progress", async () => {

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -1,9 +1,12 @@
+import { watch } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
+import { readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
 
 type AnyTool = ToolDefinition;
@@ -112,6 +115,36 @@ export async function makeGoalContext(
 
 export async function cleanupGoalMonitorTempDirs(): Promise<void> {
 	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+}
+
+export function waitForGoalContinuationCount(ctx: ExtensionContext, expectedCount: number): Promise<void> {
+	const baseDir = join(ctx.sessionManager.getSessionDir(), "extensions", "goal");
+	const threadId = ctx.sessionManager.getSessionId();
+	const goalFileName = `${encodeURIComponent(threadId)}.json`;
+	return new Promise((resolve, reject) => {
+		let completed = false;
+		let timeout: ReturnType<typeof setRealTimeout> | undefined;
+		const watcher = watch(baseDir, { encoding: "utf8" }, (_eventType, changedFileName) => {
+			if (changedFileName !== goalFileName) return;
+			void readGoal({ baseDir, threadId }).then((goal) => {
+				if (goal?.consecutiveContinuations === expectedCount) complete();
+			}, complete);
+		});
+		timeout = setRealTimeout(
+			() => complete(new Error(`Timed out waiting for continuation count ${expectedCount}`)),
+			5_000,
+		);
+		watcher.once("error", complete);
+
+		function complete(error: Error | undefined = undefined): void {
+			if (completed) return;
+			completed = true;
+			if (timeout !== undefined) clearRealTimeout(timeout);
+			watcher.close();
+			if (error === undefined) resolve();
+			else reject(error);
+		}
+	});
 }
 
 export async function runGoalHandlers(

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -11,11 +11,11 @@ import {
 	createGoalHarness,
 	makeGoalContext,
 	runGoalHandlers,
+	waitForGoalContinuationCount,
 } from "../goal-monitor-test-harness.ts";
 import { createHarness, getMessageText, type Harness } from "../harness.ts";
 
 const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
-const GOAL_CONTINUATION_CAP = 8;
 const GOAL_USER_GRACE_DELAY_MS = 60_000;
 
 const harnesses: Harness[] = [];
@@ -95,10 +95,10 @@ function contextWithBranch(ctx: ExtensionContext, branch: SessionEntry[]): Exten
 }
 
 describe("issue #447: goal continuation guardrails", () => {
-	it("caps 50 clean synthetic goal turns at eight and never queues more than one pending continuation", async () => {
+	it("keeps 50 distinct progress turns active and never queues more than one pending continuation", async () => {
 		const notices: string[] = [];
 		const harness = createGoalHarness();
-		const ctx = await makeGoalContext(notices, "issue-447-cap");
+		const ctx = await makeGoalContext(notices, "issue-447-distinct-progress");
 		await createActiveGoal(harness, ctx, "Finish the issue #447 regression");
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
@@ -111,12 +111,12 @@ describe("issue #447: goal continuation guardrails", () => {
 			expect(harness.sent.length - promptsBeforeTurn).toBeLessThanOrEqual(1);
 		}
 
-		expect(harness.sent).toHaveLength(GOAL_CONTINUATION_CAP);
+		expect(harness.sent).toHaveLength(50);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
-			status: "blocked",
-			blockedReason: "continuation cap reached",
+			status: "active",
+			consecutiveContinuations: 1,
 		});
-		expect(notices).toContainEqual(expect.stringContaining("continuation cap reached"));
+		expect(notices).not.toContainEqual(expect.stringContaining("continuation cap reached"));
 	});
 
 	it("does not send consumed goal-continuation prompts in the next faux-provider request", async () => {
@@ -184,7 +184,9 @@ describe("issue #447: goal continuation guardrails", () => {
 		expect(harness.sent).toHaveLength(0);
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS - 1);
 		expect(harness.sent).toHaveLength(0);
+		const resumed = waitForGoalContinuationCount(ctx, 1);
 		await vi.advanceTimersByTimeAsync(1);
+		await resumed;
 		expect(harness.sent).toHaveLength(1);
 		expect(harness.sent[0]?.message.customType).toBe(GOAL_CONTINUATION_MESSAGE_TYPE);
 	});


### PR DESCRIPTION
## Summary

- reset the persisted goal continuation streak when the observable continuation signature changes, not only when a turn uses tools
- keep Senpi's intentional inclusive cap of eight for the safety boundary
- update the issue #447 regression to prove 50 distinct progress turns stay active
- replace a grace-timer cleanup race with an exact persisted-count subscription

## Root cause

Codex has no deterministic continuation counter; its blocked audit restarts when
the goal makes meaningful progress. Senpi intentionally adds an eight-turn
safety cap, but only reset the counter for tool-using turns. Distinct toolless
progress therefore accumulated to eight, blocked on the ninth continuation, and
repeated the same false block cycle after each user resume.

## RED -> GREEN

- RED: nine distinct `progress N` turns queued only eight continuations and
  failed at `goal-monitor-continuation.test.ts:517`
- GREEN: the same scenario queues nine continuations, leaves the goal active,
  persists streak `1`, and emits no cap guard event
- boundary mutation proof: changing `>=` to `>` made the at-cap assertion fail;
  restoring `>=` passes below-cap admission and at-cap denial

## Verification

- affected goal lifecycle suites: 11 files, 156 tests passed
- focused post-refactor tests:
  - goal monitor continuation: 19/19
  - continuation verdict: 23/23
  - issue #447 regression: 6/6
- `npm run check`: passed after Biome, dependency/import/lock checks, tsgo,
  browser smoke, and web UI checks
- Senpi QA harness:
  - common self-check: 9/9
  - mock-loop self-test: 43/43
  - RPC self-test: 4/4
- real source RPC QA:
  - progress path: 9 automatic continuations, 0 cap events, active, streak 1
  - safety boundary: blocked with `continuation cap reached`
- cleanup: RPC children exited, fake servers stopped, auth unchanged,
  sandboxes/temp driver removed, no matching process or temp directory remains

## Diagnostics note

The native session LSP tool rejects files in a task worktree outside the
session's original cwd. No diagnostic was suppressed; the clean
`tsgo --noEmit` pass in `npm run check` is the compiler-diagnostic fallback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the goal continuation streak when observable progress is detected (changed continuation signature), not only when tools are used. This prevents toolless goals from falsely hitting the 8-turn cap while keeping the cap as a safety backstop.

- **Bug Fixes**
  - Reset `consecutiveContinuations` for non-user turns when the continuation signature changes or tools are used.
  - Keep the cap at 8 (inclusive) across immediate, user-grace, and session-start paths; block only uninterrupted non-progress.
  - Update tests and the issue #447 regression: 50 distinct progress turns continue; added an explicit cap boundary check; harness now waits on the persisted count to avoid a grace-timer race.

<sup>Written for commit 2ad3d0c3089ec65a51294719345dbfd67b96811c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

