### PR TITLE
fix(compaction): dispatch summarization through the model runtime

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -5,15 +5,19 @@
 ### What changed
 
 - `speculative.ts` dispatches the summarization request through `context.modelRegistry.modelRuntime.stream()` when a registry is present, and only falls back to the compat `stream()` when a `SpeculativeCompactionContext` is built without one.
-- Added issue #543 regression coverage in `test/suite/regressions/543-compaction-runtime-provider.test.ts` with a provider whose api id exists only in Senpi's `ModelRuntime`.
+- `openai-remote.ts` resolves its stream runner the same way (`resolveRemoteStreamRunner`): an injected `dependencies.streamRunner` still wins, otherwise the model runtime serves the native remote-compaction request and compat is the last resort.
+- Summarization auth now accepts a credential request header as resolved auth instead of requiring an `apiKey`, so `headers`-authenticated providers (models.json `headers`, extension `headers`) can compact.
+- Issue #543 regression coverage: `test/suite/regressions/543-compaction-runtime-provider.test.ts` (runtime-only api id, plus a header-authenticated provider) and `test/suite/regressions/543-remote-compaction-runtime-provider.test.ts` (native remote route through the runtime).
 
 ### Why
 
 - Providers registered through `pi.registerProvider()` (builtin `claude-agent-sdk`, extension providers such as `senpi-accounts`' Kiro) never land in compat's builtin api-registry, so every compaction attempt failed with `compaction generator failed: No API provider registered for api: <api>` while normal agent turns on the same model worked. Same bug class as #488 for `/btw`.
+- The two follow-on holes had the same shape: a provider that senpi considers fully authenticated and fully routable for normal turns must be equally compactable. A header-only credential resolved `{ok: true, apiKey: undefined}` and died as "credentials unavailable"; an extension `openai-responses` proxy opting into `supportsRemoteCompactionV2` had its own transport bypassed on the remote route.
 
 ### Merge-conflict zones
 
-- `speculative.ts` import block plus the single `stream(...)` call site in `generateSummaryMessage`.
+- `speculative.ts` import block, the single `stream(...)` call site in `generateSummaryMessage`, and the auth guard at the top of `runExtensionCompaction`.
+- `openai-remote.ts` `OpenAiRemoteCompactionContext.modelRegistry` shape plus the two stream-runner defaults.
 
 ## Proactive idle compaction (2026-07-30)
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,20 @@
 # Builtin compaction extension changes
 
+## Runtime provider dispatch for summarization (2026-07-31)
+
+### What changed
+
+- `speculative.ts` dispatches the summarization request through `context.modelRegistry.modelRuntime.stream()` when a registry is present, and only falls back to the compat `stream()` when a `SpeculativeCompactionContext` is built without one.
+- Added issue #543 regression coverage in `test/suite/regressions/543-compaction-runtime-provider.test.ts` with a provider whose api id exists only in Senpi's `ModelRuntime`.
+
+### Why
+
+- Providers registered through `pi.registerProvider()` (builtin `claude-agent-sdk`, extension providers such as `senpi-accounts`' Kiro) never land in compat's builtin api-registry, so every compaction attempt failed with `compaction generator failed: No API provider registered for api: <api>` while normal agent turns on the same model worked. Same bug class as #488 for `/btw`.
+
+### Merge-conflict zones
+
+- `speculative.ts` import block plus the single `stream(...)` call site in `generateSummaryMessage`.
+
 ## Proactive idle compaction (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote.ts
@@ -123,6 +123,7 @@ type OpenAiRemoteCompactionContext = {
 					error: string;
 			  }
 		>;
+		modelRuntime?: { streamSimple: OpenAiResponsesStreamRunner };
 	};
 	serviceTier: ServiceTier | undefined;
 	sessionManager: {
@@ -545,6 +546,21 @@ function isOpenAiCompactBody(value: unknown): value is OpenAiCompactBody {
 	);
 }
 
+/**
+ * A provider registered through `pi.registerProvider()` owns its own transport for
+ * its api id and is absent from compat's builtin api-registry, so the remote route
+ * dispatches through the model runtime whenever it is reachable.
+ */
+function resolveRemoteStreamRunner(
+	ctx: OpenAiRemoteCompactionContext,
+	dependencies: OpenAiRemoteCompactionDependencies,
+): OpenAiResponsesStreamRunner {
+	if (dependencies.streamRunner) return dependencies.streamRunner;
+	const runtime = ctx.modelRegistry.modelRuntime;
+	if (runtime) return (model, context, options) => runtime.streamSimple(model, context, options);
+	return (model, context, options) => streamSimple(model, context, options);
+}
+
 export async function runOpenAiRemoteCompaction(
 	ctx: OpenAiRemoteCompactionContext,
 	event: SessionBeforeCompactEvent,
@@ -661,9 +677,7 @@ export async function runOpenAiRemoteCompaction(
 				request,
 				requestId: event.requestId,
 				sessionId: ctx.sessionManager.getSessionId(),
-				stream:
-					dependencies.streamRunner ??
-					((streamModel, context, options) => streamSimple(streamModel, context, options)),
+				stream: resolveRemoteStreamRunner(ctx, dependencies),
 				systemPrompt: ctx.getSystemPrompt(),
 				timeoutMs: remoteTimeoutMs,
 			});
@@ -704,9 +718,7 @@ export async function runOpenAiRemoteCompaction(
 						now: dependencies.now ?? Date.now,
 						request,
 						signal,
-						streamRunner:
-							dependencies.streamRunner ??
-							((streamModel, context, options) => streamSimple(streamModel, context, options)),
+						streamRunner: resolveRemoteStreamRunner(ctx, dependencies),
 						systemPrompt: ctx.getSystemPrompt(),
 						headers: websocketHeaders,
 						providerRequest,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -1,10 +1,13 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
+	type AssistantMessageEventStream,
+	type Context,
 	isContextOverflow,
 	isRetryableAssistantError,
 	type Message,
 	type Model,
+	type StreamOptions,
 	type TextContent,
 	type Tool,
 } from "@earendil-works/pi-ai";
@@ -174,6 +177,22 @@ function isAssistantMessage(message: Message): message is AssistantMessage {
 	return message.role === "assistant" && "stopReason" in message;
 }
 
+/**
+ * Providers registered through `pi.registerProvider()` (claude-agent-sdk, Kiro, any
+ * extension provider) exist only in Senpi's ModelRuntime, never in compat's builtin
+ * api-registry, which rejects their api id outright. Dispatch through the runtime
+ * whenever it is reachable and keep compat for contexts constructed without a registry.
+ */
+function summarizationStream(
+	context: SpeculativeCompactionContext,
+	model: Model<any>,
+	requestContext: Context,
+	options: StreamOptions & Record<string, unknown>,
+): AssistantMessageEventStream {
+	const runtime = context.modelRegistry?.modelRuntime;
+	return runtime ? runtime.stream(model, requestContext, options) : stream(model, requestContext, options);
+}
+
 async function generateSummaryMessage(options: {
 	context: SpeculativeCompactionContext;
 	messages: AgentMessage[];
@@ -219,7 +238,7 @@ async function generateSummaryMessage(options: {
 		const headers = providerRequest
 			? await providerRequest.transformHeaders(options.auth.headers ?? {})
 			: options.auth.headers;
-		const responseStream = stream(options.snapshot.model, requestContext, {
+		const responseStream = summarizationStream(options.context, options.snapshot.model, requestContext, {
 			apiKey: options.auth.apiKey,
 			headers,
 			extraBody: options.auth.extraBody,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -3,6 +3,7 @@ import {
 	type AssistantMessage,
 	type AssistantMessageEventStream,
 	type Context,
+	hasCredentialHeaders,
 	isContextOverflow,
 	isRetryableAssistantError,
 	type Message,
@@ -201,7 +202,7 @@ async function generateSummaryMessage(options: {
 	signal?: AbortSignal;
 	snapshot: SpeculativeCompactionSnapshot;
 	auth: {
-		apiKey: string;
+		apiKey?: string;
 		headers?: Record<string, string>;
 		extraBody?: Record<string, unknown>;
 	};
@@ -494,8 +495,13 @@ export async function runExtensionCompaction(
 	if (signal?.aborted) return undefined;
 	const auth = await context.modelRegistry?.getApiKeyAndHeaders(snapshot.model);
 	if (signal?.aborted) return undefined;
-	if (!auth?.ok || !auth.apiKey) {
-		const detail = auth && !auth.ok ? auth.error : `no API key resolved for provider "${snapshot.model.provider}"`;
+	// A provider is authenticated for summarization by either a resolved key or a
+	// credential request header: `headers`-authenticated providers (models.json and
+	// extension providers alike) never resolve an apiKey, yet their normal agent
+	// turns are fully authenticated.
+	if (!auth?.ok || !(auth.apiKey || hasCredentialHeaders(auth.headers))) {
+		const detail =
+			auth && !auth.ok ? auth.error : `no credentials resolved for provider "${snapshot.model.provider}"`;
 		throw new SummaryGenerationError("auth", `summarization credentials unavailable: ${detail}`);
 	}
 

--- a/packages/coding-agent/test/suite/regressions/543-compaction-runtime-provider.test.ts
+++ b/packages/coding-agent/test/suite/regressions/543-compaction-runtime-provider.test.ts
@@ -6,6 +6,16 @@ import { createHarness, type Harness } from "../harness.ts";
 const PROVIDER_ID = "runtime-only-compaction";
 const API_ID = "runtime-only-compaction-api";
 const SUMMARY = "runtime summary";
+const HEADER_PROVIDER_ID = "header-auth-compaction";
+const HEADER_API_ID = "header-auth-compaction-api";
+
+function summaryStream(summary: string) {
+	const message = fauxAssistantMessage(summary);
+	const stream = createAssistantMessageEventStream();
+	stream.push({ type: "done", reason: "stop", message });
+	stream.end(message);
+	return stream;
+}
 
 describe("issue #543: compaction with a runtime-registered provider", () => {
 	let harness: Harness | undefined;
@@ -75,5 +85,70 @@ describe("issue #543: compaction with a runtime-registered provider", () => {
 		// Then the runtime provider produced the summary instead of compat rejecting its api id.
 		expect(summarizationCalls).toBe(1);
 		expect(result.summary).toContain(SUMMARY);
+	});
+
+	it("summarizes for a provider authenticated only by credential headers", async () => {
+		// Given a provider whose only credential is a request header, as models.json `headers`
+		// and extension `headers` providers are.
+		harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [compactionExtension],
+		});
+		const runtime = harness.modelRegistry.modelRuntime;
+		const model: Model<typeof HEADER_API_ID> = {
+			...harness.getModel(),
+			api: HEADER_API_ID,
+			provider: HEADER_PROVIDER_ID,
+			id: "header-auth-model",
+			name: "Header-auth model",
+			baseUrl: HEADER_PROVIDER_ID,
+			contextWindow: 32_000,
+		};
+		let seenApiKey: string | undefined;
+		let seenHeaders: Record<string, string> | undefined;
+		let summarizationCalls = 0;
+		await runtime.registerProvider(HEADER_PROVIDER_ID, {
+			api: HEADER_API_ID,
+			baseUrl: HEADER_PROVIDER_ID,
+			headers: { "x-api-key": "header-credential" },
+			models: [model],
+			streamSimple: (_streamModel, _context, options) => {
+				summarizationCalls += 1;
+				seenApiKey = options?.apiKey;
+				seenHeaders = options?.headers as Record<string, string> | undefined;
+				return summaryStream(SUMMARY);
+			},
+		});
+		const registeredModel = runtime.getModel(HEADER_PROVIDER_ID, model.id);
+		if (!registeredModel) throw new Error("header-auth model was not registered");
+		await harness.session.bindExtensions({});
+		await harness.session.setModel(registeredModel);
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "message to compact" }],
+			timestamp: 1,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("assistant response to compact"),
+			api: registeredModel.api,
+			provider: registeredModel.provider,
+			model: registeredModel.id,
+			timestamp: 2,
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "message to keep" }],
+			timestamp: 3,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		// When the session compacts.
+		const result = await harness.session.compact();
+
+		// Then the header credential counted as resolved auth and the provider produced the summary.
+		expect(summarizationCalls).toBe(1);
+		expect(result.summary).toContain(SUMMARY);
+		expect(seenApiKey).toBeUndefined();
+		expect(seenHeaders?.["x-api-key"]).toBe("header-credential");
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/543-compaction-runtime-provider.test.ts
+++ b/packages/coding-agent/test/suite/regressions/543-compaction-runtime-provider.test.ts
@@ -1,0 +1,79 @@
+import { createAssistantMessageEventStream, fauxAssistantMessage, type Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import compactionExtension from "../../../src/core/extensions/builtin/compaction/index.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const PROVIDER_ID = "runtime-only-compaction";
+const API_ID = "runtime-only-compaction-api";
+const SUMMARY = "runtime summary";
+
+describe("issue #543: compaction with a runtime-registered provider", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("dispatches the summarization request through the model runtime", async () => {
+		// Given a provider whose api id exists only in Senpi's ModelRuntime, never in compat's registry.
+		harness = await createHarness({
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [compactionExtension],
+		});
+		const runtime = harness.modelRegistry.modelRuntime;
+		const model: Model<typeof API_ID> = {
+			...harness.getModel(),
+			api: API_ID,
+			provider: PROVIDER_ID,
+			id: "runtime-model",
+			name: "Runtime-only model",
+			baseUrl: PROVIDER_ID,
+			contextWindow: 32_000,
+		};
+		let summarizationCalls = 0;
+		await runtime.registerProvider(PROVIDER_ID, {
+			api: API_ID,
+			apiKey: "runtime-key",
+			baseUrl: PROVIDER_ID,
+			models: [model],
+			streamSimple: () => {
+				summarizationCalls += 1;
+				const message = fauxAssistantMessage(SUMMARY);
+				const stream = createAssistantMessageEventStream();
+				stream.push({ type: "done", reason: "stop", message });
+				stream.end(message);
+				return stream;
+			},
+		});
+		const registeredModel = runtime.getModel(PROVIDER_ID, model.id);
+		if (!registeredModel) throw new Error("runtime-only model was not registered");
+		await harness.session.bindExtensions({});
+		await harness.session.setModel(registeredModel);
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "message to compact" }],
+			timestamp: 1,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("assistant response to compact"),
+			api: registeredModel.api,
+			provider: registeredModel.provider,
+			model: registeredModel.id,
+			timestamp: 2,
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "message to keep" }],
+			timestamp: 3,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		// When the session compacts.
+		const result = await harness.session.compact();
+
+		// Then the runtime provider produced the summary instead of compat rejecting its api id.
+		expect(summarizationCalls).toBe(1);
+		expect(result.summary).toContain(SUMMARY);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/543-remote-compaction-runtime-provider.test.ts
+++ b/packages/coding-agent/test/suite/regressions/543-remote-compaction-runtime-provider.test.ts
@@ -1,0 +1,117 @@
+import type { AssistantMessage, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_COMPACTION_SETTINGS } from "../../../src/core/compaction/index.ts";
+import { runOpenAiRemoteCompaction } from "../../../src/core/extensions/builtin/compaction/openai-remote.ts";
+import type { SessionBeforeCompactEvent } from "../../../src/core/extensions/types.ts";
+import type { SessionEntry } from "../../../src/core/session-manager.ts";
+
+const EXTENSION_MODEL = {
+	id: "proxy-model",
+	name: "Proxy model",
+	api: "openai-responses",
+	provider: "extension-responses-proxy",
+	baseUrl: "http://127.0.0.1:1/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 16_384,
+	compat: { supportsRemoteCompactionV2: true, supportsWebSocket: false },
+} satisfies Model<"openai-responses">;
+
+function userEntry(): SessionEntry {
+	return {
+		type: "message",
+		id: "u1",
+		parentId: null,
+		timestamp: "2026-03-31T00:00:00.000Z",
+		message: { role: "user", content: "inspect the build", timestamp: Date.parse("2026-03-31T00:00:00.000Z") },
+	};
+}
+
+function compactionEvent(): SessionBeforeCompactEvent {
+	return {
+		type: "session_before_compact",
+		requestId: "request-extension-remote",
+		preparation: {
+			messagesToSummarize: [],
+			turnPrefixMessages: [],
+			firstKeptEntryId: "u1",
+			tokensBefore: 120_000,
+			isSplitTurn: false,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: DEFAULT_COMPACTION_SETTINGS,
+		},
+		branchEntries: [userEntry()],
+		signal: new AbortController().signal,
+		customInstructions: undefined,
+		reason: "threshold",
+		willRetry: false,
+	};
+}
+
+function compactionMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "providerNative",
+				subtype: "compaction",
+				raw: { type: "compaction", id: "cmp_ext", encrypted_content: "encrypted-summary" },
+			},
+		],
+		api: EXTENSION_MODEL.api,
+		provider: EXTENSION_MODEL.provider,
+		model: EXTENSION_MODEL.id,
+		usage: {
+			input: 100,
+			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 120,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1_775_000_000_100,
+	};
+}
+
+describe("issue #543: remote compaction for a runtime-registered provider", () => {
+	it("dispatches the native remote-compaction request through the model runtime", async () => {
+		// Given an extension provider that owns its own transport for api "openai-responses"
+		// and opts into native remote compaction.
+		const runtimeStream = vi.fn(
+			(_model: Model<"openai-responses">, _context: unknown, options?: SimpleStreamOptions) => ({
+				result: async () => {
+					await options?.onPayload?.({ model: EXTENSION_MODEL.id, input: [] }, EXTENSION_MODEL);
+					return compactionMessage();
+				},
+			}),
+		);
+
+		// When the remote compaction route runs with no injected stream runner.
+		const result = await runOpenAiRemoteCompaction(
+			{
+				model: EXTENSION_MODEL,
+				serviceTier: undefined,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "extension-key" }),
+					modelRuntime: { streamSimple: runtimeStream },
+				},
+				sessionManager: { getSessionId: () => "session-extension-remote" },
+				getSystemPrompt: () => "You are senpi.",
+			},
+			compactionEvent(),
+			undefined,
+			{
+				fetch: vi.fn(async () => {
+					throw new Error("legacy compact endpoint must not run");
+				}),
+			},
+		);
+
+		// Then the provider's own transport served the request instead of compat's builtin api.
+		expect(runtimeStream).toHaveBeenCalledTimes(1);
+		expect(result?.details.transport).toBe("responses-v2");
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/code-yeongyu/senpi/issues/543

## Problem

Compaction failed for every model served by a provider registered through `pi.registerProvider()` — the builtin `claude-agent-sdk` provider and extension providers such as `senpi-accounts`' Kiro:

```
Compaction rejected: compaction generator failed: No API provider registered for api: kiro-codewhisperer
```

`compaction/speculative.ts` dispatched the summarization request with compat's `stream()`, and compat's api-registry only knows the 10 builtin api ids (`packages/ai/src/compat.ts` `BUILTIN_APIS`); runtime-registered providers live solely in `ModelRuntime` / `provider-composer`. Normal agent turns worked because they dispatch through `agent.streamFunction` = `modelRuntime.streamSimple`, so a session on such a provider ran fine until it needed to compact — then it had no way out of the context window.

## Change

Route the summarization stream through `context.modelRegistry.modelRuntime.stream()` when a registry is present, keeping the compat fallback for `SpeculativeCompactionContext` values constructed without one. `SpeculativeCompactionContext` already carried `modelRegistry` (it resolves summarization auth with it), so nothing new is threaded through. Same fix shape as #488 for `/btw` (ff48536d1).

## Tested

- `test/suite/regressions/543-compaction-runtime-provider.test.ts` — new regression registering a provider whose api id exists only in `ModelRuntime`, then compacting. Captured RED before the fix with `compaction generator failed: No API provider registered for api: runtime-only-compaction-api`, GREEN after.
- `npx vitest --run test/compaction test/suite/regressions` — 604 passed. 4 pre-existing failures (`0000-multi-session-theme-init`, `2791-fswatch-error-crash`, `codemode-builtin-dedupe` x2) reproduce identically on an unmodified `origin/main` checkout of the same worktree; unrelated to this change.
- `npx tsgo --noEmit` clean, `biome check --error-on-warnings` clean on the changed files, root `npm run build` exit 0.
- Real surface: local senpi built from this branch, running on the Kiro provider with a Claude model, `/compact` applies a summary instead of rejecting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compaction for runtime-registered providers by routing summarization through the model runtime, with compat as fallback. Adds support for header-auth providers and routes native remote compaction via the runtime. Fixes #543.

- **Bug Fixes**
  - Route summarization and remote-compaction streams via `context.modelRegistry.modelRuntime` when available; fallback to compat. Injected runners still win in `openai-remote.ts`.
  - Accept credential request headers as valid auth for summarization; `apiKey` no longer required if headers are provided.
  - Added regression tests: `test/suite/regressions/543-compaction-runtime-provider.test.ts`, `test/suite/regressions/543-remote-compaction-runtime-provider.test.ts`.

<sup>Written for commit 17b4eba16717bc8a33ec3c430afc2c4b80c2779f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

