### PR TITLE
fix(service-tier): make /fast work on ChatGPT-subscription Codex models

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,33 @@
 # Builtin extensions changes
 
+## service-tier: `/fast` toggles a session priority tier on subscription Codex models (2026-07-31)
+
+- Fixes issue #545 and reverses the conclusion of the 2026-07-30 entry below. `/fast`
+  on an `openai-codex` model has no `-fast` catalog sibling to switch to, and the
+  previous change turned that into a "priority tier is not available on a ChatGPT
+  subscription" notice. That premise was wrong.
+- Measured with a live ChatGPT Pro token:
+  `chatgpt.com/backend-api/codex/models?client_version=0.145.0` (originator
+  `codex_cli_rs`) advertises
+  `service_tiers: [{ id: "priority", name: "Fast", description: "1.5x speed, increased usage" }]`
+  and `additional_speed_tiers: ["fast"]` for gpt-5.6-sol/terra/luna, gpt-5.5 and
+  gpt-5.4 (empty for gpt-5.4-mini and gpt-5.3-codex-spark). The first-party Codex
+  CLI 0.145.0, routed through a logging proxy on subscription OAuth, sends
+  `service_tier: "priority"` in the `POST /backend-api/codex/responses` body.
+- The earlier "served at normal tier" reading came from the SSE echo, which is not
+  a confirmation channel: `response.created` reports `auto` and
+  `response.completed` reports `default` whether `priority` was sent or nothing was.
+- The no-variant branch now toggles a session-scoped priority tier that the
+  existing `before_provider_request` handler injects, so `/fast` reports
+  `Fast mode enabled: <model>` and the next Codex request carries
+  `service_tier: "priority"`. The tier is session-only (never persisted) and
+  resets on `session_start`; an explicit model/scoped tier still wins.
+- `test/suite/service-tier-extension.test.ts` replaces the "clear no-op" case with
+  the toggle assertion on the payload.
+- Expected merge conflict zones: LOW in `service-tier.ts` around the
+  `sessionFastMode` flag, the no-variant branch, and the
+  `before_provider_request` tier resolution.
+
 ## service-tier: explain why `/fast` is unavailable on a subscription (2026-07-30)
 
 - Fixes the misleading notice reported in issue #499. `/fast` is registered only

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -23,7 +23,9 @@
   `service_tier: "priority"`. The tier is session-only (never persisted) and
   resets on `session_start`; an explicit model/scoped tier still wins.
 - `test/suite/service-tier-extension.test.ts` replaces the "clear no-op" case with
-  the toggle assertion on the payload.
+  the toggle assertion on the payload, and covers a mid-session switch to another
+  Codex model keeping the tier, a hop to a non-OpenAI model dropping it,
+  explicit-tier precedence, and the `session_start` reset.
 - Expected merge conflict zones: LOW in `service-tier.ts` around the
   `sessionFastMode` flag, the no-variant branch, and the
   `before_provider_request` tier resolution.

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -10,26 +10,7 @@ type ProviderPayload = Record<string, unknown>;
 const OPENAI_CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
 const FAST_MODEL_SUFFIX = "-fast";
-/**
- * `/fast` is registered only for `openai-codex`, but the catalog generator emits
- * `-fast` priority variants only for the direct `openai` provider, so no Codex
- * model ever has a target and the command could only report "not supported".
- *
- * That gap is intentional rather than an oversight in the generator: measured
- * against `chatgpt.com/backend-api/codex/responses` with a live ChatGPT Pro
- * subscription, `service_tier: "priority"` returns HTTP 200 but the response
- * echoes `"auto"`, while `"auto"`/`"flex"`/`"scale"` are rejected with HTTP 400
- * `Unsupported service_tier`. Priority processing is an API-billing feature, so
- * a subscription request is served at normal tier no matter what is sent — and
- * `getServiceTierCostMultiplier()` would still bill it at up to 2.5x.
- *
- * So the honest answer is that fast mode is unavailable here, not that the
- * model does not support it.
- */
-const FAST_UNAVAILABLE_ON_SUBSCRIPTION =
-	"Fast mode (priority tier) is not available on a ChatGPT subscription: chatgpt.com accepts " +
-	"service_tier=priority but serves the request at normal tier. Priority processing requires " +
-	"API-key billing on the `openai` provider.";
+const PRIORITY_TIER: ServiceTier = "priority";
 const SERVICE_TIER_APIS: ReadonlySet<Api> = new Set(["openai-responses", OPENAI_CODEX_RESPONSES_API]);
 
 function isRecord(value: unknown): value is ProviderPayload {
@@ -85,10 +66,25 @@ function findFastModel(modelRegistry: ModelRegistry, baseModel: Model<Api>): Mod
 
 export default function serviceTierExtension(pi: ExtensionAPI): void {
 	let settingsServiceTier: ServiceTier | undefined;
+	/**
+	 * Session-level fast mode for Codex models that have no `-fast` catalog sibling.
+	 *
+	 * The catalog generator emits `-fast` priority variants only for the direct
+	 * `openai` provider, so `openai-codex` models never have a switch target. The
+	 * ChatGPT backend still offers the tier to subscriptions:
+	 * `chatgpt.com/backend-api/codex/models` advertises a `priority` service tier
+	 * labelled "Fast" ("1.5x speed, increased usage")
+	 * for gpt-5.4/5.5/5.6-*, and the first-party Codex CLI sends
+	 * `service_tier: "priority"` on subscription OAuth. The response echo is not a
+	 * confirmation channel — it reads `auto`/`default` whether or not a tier was
+	 * sent — so this toggle drives the request field directly. See issue #545.
+	 */
+	let sessionFastMode = false;
 
 	pi.on("session_start", async (_event, ctx) => {
 		const settingsManager = SettingsManager.create(ctx.cwd);
 		settingsServiceTier = settingsManager.getOpenAIServiceTier();
+		sessionFastMode = false;
 
 		const model = ctx.model;
 		if (model?.provider !== OPENAI_CODEX_PROVIDER) {
@@ -113,7 +109,8 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 			const baseModel = findBaseModel(ctx.modelRegistry, model);
 			const targetModel = baseModel ?? findFastModel(ctx.modelRegistry, model);
 			if (!targetModel) {
-				ctx.ui.notify(FAST_UNAVAILABLE_ON_SUBSCRIPTION, "warning");
+				sessionFastMode = !sessionFastMode;
+				ctx.ui.notify(`Fast mode ${sessionFastMode ? "enabled" : "disabled"}: ${model.id}`, "info");
 				return;
 			}
 
@@ -129,7 +126,9 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 
 	pi.on("before_provider_request", (event, ctx) => {
 		const effectiveServiceTier =
-			ctx.model?.api === OPENAI_CODEX_RESPONSES_API ? ctx.serviceTier : (ctx.serviceTier ?? settingsServiceTier);
+			ctx.model?.api === OPENAI_CODEX_RESPONSES_API
+				? (ctx.serviceTier ?? (sessionFastMode ? PRIORITY_TIER : undefined))
+				: (ctx.serviceTier ?? settingsServiceTier);
 		return addServiceTierToPayload(ctx.model?.api, event.payload, effectiveServiceTier);
 	});
 }

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -9,6 +9,8 @@ const CODEX_PROVIDER = "openai-codex";
 const CODEX_API = "openai-codex-responses";
 const BASE_MODEL_ID = "gpt-5.6-sol";
 const FAST_MODEL_ID = `${BASE_MODEL_ID}-fast`;
+const OTHER_CODEX_MODEL_ID = "gpt-5.5";
+const ANTHROPIC_MODEL_ID = "claude-sonnet-4-5";
 
 describe("service-tier builtin extension", () => {
 	const harnesses: Harness[] = [];
@@ -156,6 +158,136 @@ describe("service-tier builtin extension", () => {
 
 		// then
 		expect(notify).toHaveBeenCalledWith(`Fast mode disabled: ${BASE_MODEL_ID}`, "info");
+		const defaultPayload = { model: BASE_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
+	});
+
+	it("keeps session fast mode on across a mid-session switch to another Codex model", async () => {
+		// given
+		// Fast mode is a session intent, not a property of the selected model, so switching
+		// models mid-session (/model, Ctrl+P) must keep sending the tier. See issue #545.
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_PROVIDER,
+			models: [{ id: BASE_MODEL_ID }, { id: OTHER_CODEX_MODEL_ID }],
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+		const notify = vi.spyOn(runner.getUIContext(), "notify");
+		const otherModel = harness.getModel(OTHER_CODEX_MODEL_ID);
+		expect(otherModel).toBeDefined();
+
+		// when
+		await harness.session.prompt("/fast");
+		await harness.session.setSessionModel(otherModel!);
+
+		// then
+		expect(harness.session.model?.id).toBe(OTHER_CODEX_MODEL_ID);
+		expect(await runner.emitBeforeProviderRequest({ model: OTHER_CODEX_MODEL_ID })).toEqual({
+			model: OTHER_CODEX_MODEL_ID,
+			service_tier: "priority",
+		});
+
+		// when
+		await harness.session.prompt("/fast");
+
+		// then
+		expect(notify).toHaveBeenCalledWith(`Fast mode disabled: ${OTHER_CODEX_MODEL_ID}`, "info");
+		const defaultPayload = { model: OTHER_CODEX_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
+	});
+
+	it("stops sending the tier when fast mode is on and the session moves to a non-Codex model", async () => {
+		// given
+		// The tier is an OpenAI-family request field; a mid-session hop to Anthropic must not
+		// carry it over, even while the Codex session intent is still enabled.
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_PROVIDER,
+			models: [{ id: BASE_MODEL_ID }, { id: OTHER_CODEX_MODEL_ID }],
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+		await harness.authStorage.modify("anthropic", async () => ({ type: "api_key", key: "faux-key" }));
+		harness.modelRegistry.registerProvider("anthropic", {
+			baseUrl: "https://api.anthropic.com",
+			apiKey: "faux-key",
+			api: "anthropic-messages",
+			models: [
+				{
+					id: ANTHROPIC_MODEL_ID,
+					name: ANTHROPIC_MODEL_ID,
+					api: "anthropic-messages",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+			],
+		});
+		const anthropicModel = harness.modelRegistry.find("anthropic", ANTHROPIC_MODEL_ID);
+		expect(anthropicModel).toBeDefined();
+
+		// when
+		await harness.session.prompt("/fast");
+		await harness.session.setSessionModel(anthropicModel!);
+
+		// then
+		expect(harness.session.model?.provider).toBe("anthropic");
+		const anthropicPayload = { model: ANTHROPIC_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(anthropicPayload)).toBe(anthropicPayload);
+	});
+
+	it("lets an explicitly configured model tier win over session fast mode", async () => {
+		// given
+		// A models.json/scoped tier is a deliberate per-model choice; the session toggle is a
+		// fallback for Codex models that have none, so it must never overwrite the explicit value.
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_PROVIDER,
+			models: [{ id: BASE_MODEL_ID }, { id: FAST_MODEL_ID }],
+			serviceTier: "flex",
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+		expect(harness.session.serviceTier).toBe("flex");
+
+		// when
+		await harness.session.prompt("/fast");
+
+		// then
+		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
+			model: BASE_MODEL_ID,
+			service_tier: "flex",
+		});
+	});
+
+	it("drops session fast mode when a new session starts", async () => {
+		// given
+		// The toggle is session-scoped and never persisted, so a fresh session_start must not
+		// inherit a priority tier from the previous one.
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_PROVIDER,
+			models: [{ id: BASE_MODEL_ID }, { id: FAST_MODEL_ID }],
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+		await harness.session.prompt("/fast");
+		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
+			model: BASE_MODEL_ID,
+			service_tier: "priority",
+		});
+
+		// when
+		await harness.session.bindExtensions({});
+
+		// then
 		const defaultPayload = { model: BASE_MODEL_ID };
 		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
 	});

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -122,8 +122,13 @@ describe("service-tier builtin extension", () => {
 		expect(notify).toHaveBeenCalledWith("Fast mode is only available for OpenAI Codex models.", "warning");
 	});
 
-	it("is a clear no-op when the Codex model has no compatible fast variant", async () => {
+	it("toggles a session-level priority tier when the Codex model has no compatible fast variant", async () => {
 		// given
+		// chatgpt.com/backend-api/codex/models advertises
+		// service_tiers [{ id: "priority", name: "Fast" }] to subscription accounts, and the
+		// first-party Codex CLI sends service_tier=priority over that same OAuth, so a missing
+		// `-fast` catalog sibling must fall back to a session tier toggle rather than declaring
+		// fast mode unavailable. See issue #545.
 		const harness = await createHarness({
 			api: CODEX_API,
 			provider: CODEX_PROVIDER,
@@ -140,15 +145,19 @@ describe("service-tier builtin extension", () => {
 
 		// then
 		expect(harness.session.model).toBe(initialModel);
-		// Subscription requests are served at normal tier however the field is set
-		// (chatgpt.com echoes "auto" for service_tier=priority and rejects
-		// auto/flex/scale outright), so the notice must say fast mode is
-		// unavailable here rather than blaming the model. See issue #499.
-		const [[message, level]] = notify.mock.calls;
-		expect(level).toBe("warning");
-		expect(message).toContain("not available on a ChatGPT subscription");
-		expect(message).toContain("API-key billing");
-		expect(message).not.toContain("not supported for");
+		expect(notify).toHaveBeenCalledWith(`Fast mode enabled: ${BASE_MODEL_ID}`, "info");
+		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
+			model: BASE_MODEL_ID,
+			service_tier: "priority",
+		});
+
+		// when
+		await harness.session.prompt("/fast");
+
+		// then
+		expect(notify).toHaveBeenCalledWith(`Fast mode disabled: ${BASE_MODEL_ID}`, "info");
+		const defaultPayload = { model: BASE_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
 	});
 
 	it("leaves incompatible api payloads unchanged", () => {


### PR DESCRIPTION
Fixes #545. Reverses the conclusion of my own #503: the ChatGPT Codex backend does offer a priority ("Fast") tier to subscription accounts, so `/fast` should work there.

## Why the previous notice was wrong

`/fast` is registered for `openai-codex` but switches through an `openai-codex/<id>-fast` catalog sibling that `generate-models.ts` only emits for the direct `openai` provider. #503 turned that dead end into a notice claiming priority tier is unavailable on a ChatGPT subscription. Its evidence was the SSE `service_tier` echo — and that echo carries no information:

| sent | `response.created` echo | `response.completed` echo | status |
|---|---|---|---|
| `priority` | `auto` | `default` | 200 |
| (absent) | `auto` | `default` | 200 |
| `default` | `auto` | `default` | 200 |
| `auto` / `flex` / `scale` | — | — | 400 `Unsupported service_tier` |

Identical echoes for `priority` and for sending nothing, so the echo cannot distinguish the tier that served the request.

## What the backend and the first-party client actually do

`GET https://chatgpt.com/backend-api/codex/models?client_version=0.145.0` with `originator: codex_cli_rs` and a live ChatGPT Pro token (`chatgpt_plan_type: pro`) returns, per model:

| model | `service_tiers` | `additional_speed_tiers` |
|---|---|---|
| gpt-5.6-sol / -terra / -luna, gpt-5.5, gpt-5.4 | `[{"id":"priority","name":"Fast","description":"1.5x speed, increased usage"}]` | `["fast"]` |
| gpt-5.4-mini, gpt-5.3-codex-spark, codex-auto-review | `[]` | `[]` |

`"1.5x speed, increased usage"` is the backend's own description of the tier, returned to a subscription account.

Official `@openai/codex` 0.145.0 on ChatGPT OAuth (`requires_openai_auth = true`), routed through a local logging proxy to `chatgpt.com`:

- `service_tier = "priority"` in `config.toml` → `POST /backend-api/codex/responses` body contains `"service_tier": "priority"`, turn completes (200)
- line removed → body has no `service_tier`

So this is not an API-key-only field.

## The change

When an `openai-codex` model has no compatible `-fast` catalog sibling, `/fast` now flips a session-scoped priority tier instead of reporting the feature unavailable. The existing `before_provider_request` handler injects it — `addServiceTierToPayload` already whitelists `openai-codex-responses` and `api/openai-codex-responses.ts` already forwards `options.serviceTier` — so there is no core or provider change. The catalog-variant path for the direct `openai` provider is untouched.

Semantics:

- session-only, never persisted, reset on `session_start`
- an explicit model/scoped `serviceTier` (models.json, `provider/id:tier`) still wins
- non-Codex providers keep the existing "only available for OpenAI Codex models" warning, and a mid-session hop to a non-OpenAI model stops sending the field

## Tests

`test/suite/service-tier-extension.test.ts` (11 cases, all green) now covers the toggle payload, a mid-session switch to another Codex model keeping the tier, a hop to an Anthropic model dropping it, explicit-tier precedence, and the `session_start` reset. Each new assertion was mutation-proved — removing the injection fails 3 cases, leaking the tier to every api fails 2, inverting precedence fails 1, dropping the reset fails 1.

## Manual QA

Real TUI, subscription OAuth, provider `baseUrl` pointed at a logging proxy, request bodies decoded:

```
turn 1 "reply with exactly: one"    -> one    | gpt-5.6-sol  service_tier=<absent>
/fast                               -> Fast mode enabled: gpt-5.6-sol
turn 2 "reply with exactly: two"    -> two    | gpt-5.6-sol  service_tier=priority
/model openai-codex/gpt-5.5         -> Model: gpt-5.5
turn 3 "reply with exactly: three"  -> three  | gpt-5.5      service_tier=priority
/fast                               -> Fast mode disabled: gpt-5.5
turn 4 "reply with exactly: four"   -> four   | gpt-5.5      service_tier=<absent>
```

`npm run check` clean; `packages/coding-agent` `test/suite` green apart from a pre-existing `app-server-thread-handlers-archive` timestamp-monotonicity flake that also fails with this change stashed.

## Open question

`getServiceTierCostMultiplier()` in `api/openai-codex-responses.ts` multiplies displayed cost by 2 (2.5 for gpt-5.5) for `priority`. On a subscription the dollar figure is notional (`(sub)` in the footer) but the backend does say "increased usage", so I left the multiplier alone rather than guessing a subscription-specific number. Happy to change it if you have a preference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Fast mode on ChatGPT-subscription Codex models by toggling a session-scoped `priority` tier when no `-fast` catalog variant exists. This makes `/fast` work on `openai-codex` models and replaces the incorrect “unavailable on subscription” notice. Fixes #545.

- **Bug Fixes**
  - `/fast` now toggles a session `priority` tier for `openai-codex` models without a `-fast` sibling, with notify messages for enabled/disabled.
  - Injects the tier in `before_provider_request` for `openai-codex-responses`; other providers unchanged.
  - Semantics: session-only and reset on `session_start`; explicit model `serviceTier` still wins; switching between Codex models keeps the tier; moving to non-OpenAI drops it.
  - Tests cover payload injection, mid-session model switches, dropping on non-OpenAI, explicit-tier precedence, and session reset.

<sup>Written for commit 144048a44e06747aae636311756fcf63314be5b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

