### PR TITLE
feat(interactive): mark fast mode on the footer model label

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1767,6 +1767,16 @@ const current = pi.getThinkingLevel();  // "off" | "minimal" | "low" | "medium" 
 pi.setThinkingLevel("high");
 ```
 
+### pi.setSessionFastMode(enabled)
+
+Mark the session as running in fast mode so host surfaces can show it — the TUI footer stamps a ⚡ on the model label. Session-scoped and never persisted; it is also true on its own whenever the active model is configured for the priority tier (an `openai` `-fast` catalog variant, a scoped `provider/id:priority`).
+
+This is only an indicator. It does not add `service_tier` to any request, so an extension that wants the priority tier on the wire still returns it from `before_provider_request`.
+
+```typescript
+pi.setSessionFastMode(true);
+```
+
 ### pi.events
 
 Shared event bus for communication between extensions:

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -649,6 +649,7 @@ export class AgentSession {
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
 	private _currentServiceTier: ServiceTier | undefined = undefined;
+	private _sessionFastMode = false;
 	private _lastHighReasoningWarningKey: string | undefined = undefined;
 	private _baseSystemPromptOptions!: BuildDynamicSystemPromptOptions;
 	private _systemPromptOverride?: string;
@@ -1885,6 +1886,24 @@ export class AgentSession {
 
 	get serviceTier(): ServiceTier | undefined {
 		return this._currentServiceTier;
+	}
+
+	/**
+	 * True when the active model is served at the priority ("fast") tier: either the model
+	 * itself is configured for it (an `openai` `-fast` catalog variant, a scoped
+	 * `provider/id:priority`) or an extension turned fast mode on for this session.
+	 *
+	 * Display-only: it never feeds request composition, so an extension toggling fast mode
+	 * for one provider cannot leak `service_tier` into another provider's payload.
+	 * `serviceTier` stays the single request-side source.
+	 */
+	isFastModeActive(): boolean {
+		return this._sessionFastMode || this._currentServiceTier === "priority";
+	}
+
+	/** Session-scoped fast-mode indicator; never persisted, reset on session start. */
+	setSessionFastMode(enabled: boolean): void {
+		this._sessionFastMode = enabled;
 	}
 
 	/**
@@ -4877,6 +4896,7 @@ export class AgentSession {
 					return true;
 				},
 				setSessionThinkingLevel: (level) => this.setSessionThinkingLevel(level),
+				setSessionFastMode: (enabled) => this.setSessionFastMode(enabled),
 			},
 			{
 				getModel: () => this.model,

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,15 @@
 # Builtin extensions changes
 
+## service-tier: mirror the Codex fast toggle into the session indicator (2026-07-31)
+
+- The session toggle added on 2026-07-31 lived only inside this extension, so no host surface could
+  tell that fast mode was on. It now calls `pi.setSessionFastMode()` on every toggle and clears the
+  flag on `session_start`, which is what lights the TUI footer's lightning indicator.
+- `test/suite/service-tier-extension.test.ts` asserts `session.isFastModeActive()` across the
+  toggle and the `session_start` reset.
+- Expected merge conflict zones: LOW in `service-tier.ts` around the no-variant toggle branch and
+  the `session_start` handler.
+
 ## service-tier: `/fast` toggles a session priority tier on subscription Codex models (2026-07-31)
 
 - Fixes issue #545 and reverses the conclusion of the 2026-07-30 entry below. `/fast`

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -85,6 +85,7 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		const settingsManager = SettingsManager.create(ctx.cwd);
 		settingsServiceTier = settingsManager.getOpenAIServiceTier();
 		sessionFastMode = false;
+		pi.setSessionFastMode(false);
 
 		const model = ctx.model;
 		if (model?.provider !== OPENAI_CODEX_PROVIDER) {
@@ -110,6 +111,7 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 			const targetModel = baseModel ?? findFastModel(ctx.modelRegistry, model);
 			if (!targetModel) {
 				sessionFastMode = !sessionFastMode;
+				pi.setSessionFastMode(sessionFastMode);
 				ctx.ui.notify(`Fast mode ${sessionFastMode ? "enabled" : "disabled"}: ${model.id}`, "info");
 				return;
 			}

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,26 @@
 # Core Extensions Changes
 
+## 2026-07-31 - `pi.setSessionFastMode()` for the fast-mode indicator
+
+### What changed and why
+
+- `ExtensionAPI` gains `setSessionFastMode(enabled: boolean)` (with the matching
+  `SetSessionFastModeHandler` type and `ExtensionActions.setSessionFastMode`). It flips a
+  session-scoped, never-persisted flag on `AgentSession` that hosts can surface; the TUI footer
+  stamps a lightning bolt on the model label while it is set.
+- The flag is display-only and deliberately separate from `serviceTier`. `serviceTier` feeds
+  request composition (`service-tier.ts` for non-Codex apis, `compaction/openai-remote.ts`), so
+  folding a provider-scoped fast toggle into it would inject `service_tier: "priority"` into
+  API-key-billed `openai-responses` traffic. `AgentSession.isFastModeActive()` ORs the flag with
+  `serviceTier === "priority"`, so a configured `-fast` catalog variant lights the indicator too.
+- The `service-tier` builtin mirrors its Codex session toggle through the new API and clears it on
+  `session_start`.
+
+### Expected merge conflict zones
+
+- MEDIUM: `types.ts` around the `setSession*` block in `ExtensionAPI` and `ExtensionActions`.
+- LOW: `loader.ts` stub table and `pi` implementation, `runner.ts` `bindCore` assignment.
+
 ## 2026-07-30 - Linux recursive config watches leave the interactive main thread
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -270,6 +270,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		setThinkingLevel: notInitialized,
 		setSessionModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		setSessionThinkingLevel: notInitialized,
+		setSessionFastMode: notInitialized,
 		flagValues: new Map(),
 		pendingProviderRegistrations: [],
 		pendingNativeProviderRegistrations: [],
@@ -521,6 +522,11 @@ function createExtensionAPI(
 		setSessionThinkingLevel(level) {
 			runtime.assertActive();
 			runtime.setSessionThinkingLevel(level);
+		},
+
+		setSessionFastMode(enabled) {
+			runtime.assertActive();
+			runtime.setSessionFastMode(enabled);
 		},
 
 		registerProvider(providerOrName: Provider | string, config?: ProviderConfig) {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -474,6 +474,7 @@ export class ExtensionRunner {
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;
 		this.runtime.setSessionModel = actions.setSessionModel;
 		this.runtime.setSessionThinkingLevel = actions.setSessionThinkingLevel;
+		this.runtime.setSessionFastMode = actions.setSessionFastMode;
 
 		// Context actions (required)
 		this.getModel = contextActions.getModel;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1642,6 +1642,16 @@ export interface ExtensionAPI {
 	/** Set thinking level for this session only (clamped), leaving the persisted default untouched. */
 	setSessionThinkingLevel(level: ThinkingLevel): void;
 
+	/**
+	 * Mark this session as running in fast mode so the host can surface it (the TUI
+	 * footer stamps a ⚡ on the model label). Session-scoped and never persisted.
+	 *
+	 * Purely an indicator: it does not add `service_tier` to any request. An extension
+	 * that wants the priority tier on the wire still returns it from
+	 * `before_provider_request`.
+	 */
+	setSessionFastMode(enabled: boolean): void;
+
 	// =========================================================================
 	// Provider Registration
 	// =========================================================================
@@ -1920,6 +1930,8 @@ export type GetThinkingLevelHandler = () => ThinkingLevel;
 
 export type SetThinkingLevelHandler = (level: ThinkingLevel) => void;
 
+export type SetSessionFastModeHandler = (enabled: boolean) => void;
+
 export type SetLabelHandler = (entryId: string, label: string | undefined) => void;
 
 /**
@@ -1999,6 +2011,7 @@ export interface ExtensionActions {
 	setThinkingLevel: SetThinkingLevelHandler;
 	setSessionModel: SetModelHandler;
 	setSessionThinkingLevel: SetThinkingLevelHandler;
+	setSessionFastMode: SetSessionFastModeHandler;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## Footer marks fast mode on the model label (2026-07-31)
+
+### What changed
+
+- `components/footer.ts` prefixes the right-hand model label with a lightning bolt whenever
+  `session.isFastModeActive()` is true, so a priority-tier session is visible without running
+  `/fast` again to check. The glyph is part of the `FooterSegment` plain text, so the width ladder
+  in `footer-layout.ts` accounts for it instead of overflowing narrow terminals, and
+  `colorRightSide()` paints it `warning` while the model keeps `accent` and `:thinking` keeps `dim`.
+- Coverage: `test/footer-fast-mode-icon.test.ts` pins the indicator, its absence when fast mode is
+  off, and width safety with a wide CJK model id at width 60.
+
+### Why
+
+- Both fast paths (an `openai` `-fast` catalog variant and the Codex session toggle) were invisible
+  in the footer, which is the only always-on surface showing the active model.
+
 ## Failed compaction restores queued input (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -5,6 +5,8 @@ import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provi
 import { theme } from "../theme/theme.ts";
 import { type FooterSegment, planFooterLayout } from "./footer-layout.ts";
 
+const FAST_MODE_INDICATOR = "\u26a1 ";
+
 /**
  * Sanitize text for display in a single-line status.
  * Removes newlines, tabs, carriage returns, and other control characters.
@@ -59,11 +61,13 @@ export function formatCwdForFooter(cwd: string, home: string | undefined): strin
 function colorRightSide(text: string): string {
 	if (!text) return "";
 	const providerMatch = text.match(/^\(([^)]+)\) (.*)$/);
-	const body = providerMatch ? providerMatch[2] : text;
+	const afterProvider = providerMatch ? providerMatch[2] : text;
 	const providerPrefix = providerMatch ? theme.fg("muted", `(${providerMatch[1]}) `) : "";
+	const fastPrefix = afterProvider.startsWith(FAST_MODE_INDICATOR) ? theme.fg("warning", FAST_MODE_INDICATOR) : "";
+	const body = fastPrefix ? afterProvider.slice(FAST_MODE_INDICATOR.length) : afterProvider;
 	const thinkingMatch = body.match(/^(.+):([^:]+)$/);
-	if (!thinkingMatch) return providerPrefix + theme.fg("accent", body);
-	return `${providerPrefix}${theme.fg("accent", thinkingMatch[1])}${theme.fg("dim", `:${thinkingMatch[2]}`)}`;
+	if (!thinkingMatch) return providerPrefix + fastPrefix + theme.fg("accent", body);
+	return `${providerPrefix}${fastPrefix}${theme.fg("accent", thinkingMatch[1])}${theme.fg("dim", `:${thinkingMatch[2]}`)}`;
 }
 
 /**
@@ -181,10 +185,11 @@ export class FooterComponent implements Component {
 		// Model label pinned to the right edge; the provider prefix stays only when
 		// the full line fits.
 		const modelName = state.model?.id || "no-model";
-		let minimalRight = modelName;
+		const fastIndicator = this.session.isFastModeActive() ? FAST_MODE_INDICATOR : "";
+		let minimalRight = `${fastIndicator}${modelName}`;
 		if (state.model?.reasoning) {
 			const thinkingLevel = state.thinkingLevel || "off";
-			minimalRight = thinkingLevel === "off" ? `${modelName}:off` : `${modelName}:${thinkingLevel}`;
+			minimalRight = thinkingLevel === "off" ? `${minimalRight}:off` : `${minimalRight}:${thinkingLevel}`;
 		}
 		const minimal: FooterSegment = { plain: minimalRight, colored: colorRightSide(minimalRight) };
 		const providerPrefix =

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -137,6 +137,7 @@ describe("ExtensionRunner", () => {
 		setThinkingLevel: () => {},
 		setSessionModel: async () => false,
 		setSessionThinkingLevel: () => {},
+		setSessionFastMode: () => {},
 	};
 
 	const extensionContextActions: ExtensionContextActions = {

--- a/packages/coding-agent/test/footer-fast-mode-icon.test.ts
+++ b/packages/coding-agent/test/footer-fast-mode-icon.test.ts
@@ -1,0 +1,85 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import { FooterComponent } from "../src/modes/interactive/components/footer.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+import { createFooterData, createFooterSession } from "./helpers/footer-test-fixtures.ts";
+
+const LIGHTNING = "\u26a1";
+
+function renderFooter(footer: FooterComponent, width: number): string {
+	return footer
+		.render(width)
+		.map((line) => stripAnsi(line))
+		.join("\n");
+}
+
+describe("FooterComponent fast mode indicator", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	it("marks the model label with a lightning bolt while fast mode is active", () => {
+		// given
+		const session = createFooterSession({
+			sessionName: "",
+			modelId: "gpt-5.6-sol",
+			provider: "openai-codex",
+			reasoning: true,
+			thinkingLevel: "medium",
+			fastModeActive: true,
+		});
+		const footer = new FooterComponent(session, createFooterData(2));
+
+		// when
+		const rendered = renderFooter(footer, 120);
+
+		// then
+		expect(rendered).toContain(`${LIGHTNING} gpt-5.6-sol:medium`);
+		expect(rendered).toContain(`(openai-codex) ${LIGHTNING} gpt-5.6-sol:medium`);
+	});
+
+	it("leaves the model label alone while fast mode is off", () => {
+		// given
+		const session = createFooterSession({
+			sessionName: "",
+			modelId: "gpt-5.6-sol",
+			provider: "openai-codex",
+			reasoning: true,
+			thinkingLevel: "medium",
+			fastModeActive: false,
+		});
+		const footer = new FooterComponent(session, createFooterData(2));
+
+		// when
+		const rendered = renderFooter(footer, 120);
+
+		// then
+		expect(rendered).toContain("gpt-5.6-sol:medium");
+		expect(rendered).not.toContain(LIGHTNING);
+	});
+
+	it("keeps every line inside the terminal width when the indicator is shown", () => {
+		// given
+		// The indicator has to be part of the width math, not appended after truncation:
+		// a wide CJK model id at a narrow width is where an appended glyph would overflow.
+		const width = 60;
+		const session = createFooterSession({
+			sessionName: "",
+			modelId: "模".repeat(30),
+			provider: "openai-codex",
+			reasoning: true,
+			thinkingLevel: "medium",
+			fastModeActive: true,
+		});
+		const footer = new FooterComponent(session, createFooterData(2));
+
+		// when
+		const lines = footer.render(width);
+
+		// then
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+	});
+});

--- a/packages/coding-agent/test/footer-token-format.test.ts
+++ b/packages/coding-agent/test/footer-token-format.test.ts
@@ -47,6 +47,7 @@ function createSession(latestCacheHitRate = (1_500_000 / (49 + 1_500_000 + 44_00
 			getCwd: () => "/tmp/project",
 		},
 		getContextUsage: () => ({ tokens: 44_000, contextWindow: 800_000, percent: 5.5 }),
+		isFastModeActive: () => false,
 		modelRuntime: {
 			isUsingOAuth: () => false,
 		},

--- a/packages/coding-agent/test/grok/classic-chrome-characterization.test.ts
+++ b/packages/coding-agent/test/grok/classic-chrome-characterization.test.ts
@@ -149,6 +149,7 @@ function createFooterSession(): AgentSession {
 			getCwd: () => "/tmp/project",
 		},
 		getContextUsage: () => ({ contextWindow: 200_000, percent: 12.3 }),
+		isFastModeActive: () => false,
 		modelRuntime: { isUsingOAuth: () => false },
 	} as unknown as AgentSession;
 }

--- a/packages/coding-agent/test/helpers/footer-test-fixtures.ts
+++ b/packages/coding-agent/test/helpers/footer-test-fixtures.ts
@@ -20,6 +20,7 @@ export type FooterSessionOptions = {
 	provider?: string;
 	reasoning?: boolean;
 	thinkingLevel?: string;
+	fastModeActive?: boolean;
 	usage?: AssistantUsage;
 	branchUsage?: AssistantUsage;
 	compactionUsage?: AssistantUsage;
@@ -82,6 +83,7 @@ export function createFooterSession(options: FooterSessionOptions): AgentSession
 			getCwd: () => options.cwd ?? "/tmp/project",
 		},
 		getContextUsage: () => ({ contextWindow: 200_000, percent: 12.3 }),
+		isFastModeActive: () => options.fastModeActive ?? false,
 		modelRuntime: { isUsingOAuth: () => false },
 	} as unknown as AgentSession;
 }

--- a/packages/coding-agent/test/omo-native-footer.test.ts
+++ b/packages/coding-agent/test/omo-native-footer.test.ts
@@ -24,6 +24,7 @@ function createSession(): AgentSession {
 			getCwd: () => "/tmp/project",
 		},
 		getContextUsage: () => ({ contextWindow: 200_000, percent: 12.3 }),
+		isFastModeActive: () => false,
 		modelRuntime: { isUsingOAuth: () => false },
 	} as unknown as AgentSession;
 }

--- a/packages/coding-agent/test/rules-before-agent-start.test.ts
+++ b/packages/coding-agent/test/rules-before-agent-start.test.ts
@@ -56,6 +56,7 @@ describe("rules builtin - before_agent_start delivery", () => {
 		setThinkingLevel: () => {},
 		setSessionModel: async () => false,
 		setSessionThinkingLevel: () => {},
+		setSessionFastMode: () => {},
 	};
 
 	const extensionContextActions: ExtensionContextActions = {

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -67,6 +67,7 @@ describe("service-tier builtin extension", () => {
 		harnesses.push(harness);
 		const runner = harness.getExtensionRunner();
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
+		expect(harness.session.isFastModeActive()).toBe(true);
 
 		// when
 		await harness.session.bindExtensions({});
@@ -74,6 +75,7 @@ describe("service-tier builtin extension", () => {
 		// then
 		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
 		expect(harness.session.serviceTier).toBeUndefined();
+		expect(harness.session.isFastModeActive()).toBe(false);
 		expect(harness.settingsManager.getDefaultProvider()).toBe(CODEX_PROVIDER);
 		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
 
@@ -148,6 +150,7 @@ describe("service-tier builtin extension", () => {
 		// then
 		expect(harness.session.model).toBe(initialModel);
 		expect(notify).toHaveBeenCalledWith(`Fast mode enabled: ${BASE_MODEL_ID}`, "info");
+		expect(harness.session.isFastModeActive()).toBe(true);
 		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
 			model: BASE_MODEL_ID,
 			service_tier: "priority",
@@ -158,6 +161,7 @@ describe("service-tier builtin extension", () => {
 
 		// then
 		expect(notify).toHaveBeenCalledWith(`Fast mode disabled: ${BASE_MODEL_ID}`, "info");
+		expect(harness.session.isFastModeActive()).toBe(false);
 		const defaultPayload = { model: BASE_MODEL_ID };
 		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
 	});


### PR DESCRIPTION
Fixes #548.

Stacked on #547 (the `/fast` session tier for subscription Codex models). GitHub cannot base a PR on a fork branch, so this one targets `main` and therefore carries #547's two commits as well — merge #547 first and this diff reduces to the last commit, `feat(interactive): mark fast mode on the footer model label`.

## What you see

```
~/project • main • 14K/272K (5.2%) (auto)          (openai-codex) ⚡ gpt-5.6-sol:medium
```

The bolt appears whenever the session runs at the priority tier and disappears when it does not. Both fast paths light it: the direct `openai` provider's `-fast` catalog variants (model-configured `serviceTier: "priority"`) and the ChatGPT-subscription Codex session toggle.

## How the state gets to the footer

`AgentSession` gains a session-scoped `_sessionFastMode` flag plus `isFastModeActive()`, which ORs it with `serviceTier === "priority"`. `pi.setSessionFastMode(enabled)` exposes the setter to extensions, and the `service-tier` builtin mirrors its Codex toggle through it (clearing on `session_start`).

The flag is deliberately NOT folded into `session.serviceTier`. That getter feeds request composition — `service-tier.ts`'s non-Codex branch (`ctx.serviceTier ?? settingsServiceTier`) and `compaction/openai-remote.ts` (`ctx.serviceTier ?? auth.serviceTier`) — so a provider-scoped fast toggle bleeding into it would inject `service_tier: "priority"` into API-key-billed `openai-responses` traffic, where `getServiceTierCostMultiplier()` charges 2x. Keeping the indicator display-only leaves `serviceTier` as the single request-side source.

In the footer the glyph is part of the `FooterSegment` plain text, so `planFooterLayout()` counts it in the width ladder rather than overflowing narrow terminals, and `colorRightSide()` paints it `warning` while the model keeps `accent` and `:thinking` keeps `dim`.

## Tests

`test/footer-fast-mode-icon.test.ts` (new): the indicator renders before the model id and after the `(provider)` prefix, it is absent when fast mode is off, and every line stays inside width 60 with a 30-char CJK model id. `test/suite/service-tier-extension.test.ts` additionally asserts `session.isFastModeActive()` across the toggle and the `session_start` reset.

Every assertion was mutation-proved — dropping the extension's mirror call, making `isFastModeActive()` ignore the configured tier, removing the footer indicator, stamping it unconditionally, and moving it after the model id each fail exactly the case that names them.

## Manual QA

Real TUI from source, isolated agent dir with only the subscription `openai-codex` credential, provider `baseUrl` pointed at a logging proxy, rendered through xterm.js in Chrome and screenshotted (not a `tmux capture-pane` dump):

- `/fast` → footer reads `(openai-codex) ⚡ gpt-5.6-sol:medium`, and the turn taken while it was shown sent `service_tier: "priority"` on the wire
- `/fast` again → `Fast mode disabled: gpt-5.6-sol`, no bolt anywhere in the capture

`npm run check` clean, `packages/coding-agent` suite green, build clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows fast mode in the TUI footer with a ⚡ before the model label. Adds a session fast-mode indicator and wires `/fast` on `openai-codex` to the priority tier without leaking to other providers.

- **New Features**
  - Footer: Prefixes the model label with ⚡ when fast mode is active; counted in layout, colored as a warning, and shown after the provider prefix.
  - Core: `AgentSession.isFastModeActive()` returns the session flag OR `serviceTier === "priority"`; `pi.setSessionFastMode(enabled)` exposes a display-only toggle that doesn’t affect request composition.
  - Service tier: `/fast` on `openai-codex` toggles a session priority tier and injects `service_tier: "priority"` for Codex requests; mirrors through `pi.setSessionFastMode()`, resets on `session_start`, does not leak to other providers, and explicit model tiers still win.

<sup>Written for commit d2c08654b368d2db2d8f791cf08e9da1fc9c0187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

