### PR TITLE
chore: remove broken release QA symlink

### DIFF
--- a/.tmp/issue-541-qa
+++ b/.tmp/issue-541-qa
@@ -1,1 +1,0 @@
-/Users/yeongyu/local-workspaces/senpi-wt/issue-541-qa


### PR DESCRIPTION
## Summary

Remove the absolute `.tmp/issue-541-qa` symlink accidentally tracked by the v2026.7.31 release commit.

## Why

The target exists only on one developer machine. Every clean CI checkout reports `internalError/fs: Dereferenced symlink` and fails the required `Check and test` job before tests run. Current `main` and all branches based on it are red for this reason.

## Verification

- confirmed the tracked entry is mode `120000` and points to `/Users/yeongyu/local-workspaces/senpi-wt/issue-541-qa`
- removal is the complete diff

This is an infrastructure unblock; no runtime code changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an accidentally committed absolute symlink at `.tmp/issue-541-qa`. This fixes the CI failure (dereferenced symlink error) and unblocks the required checks.

<sup>Written for commit 86ccc57809296ed5b31848259e5f7115f9fcb055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

