### PR TITLE
fix(coding-agent): tell users how to clear a mechanical goal block

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,39 @@
 # goal Extension Changes
 
+## Mechanical continuation blocks tell the user how to resume (2026-07-31)
+
+### What changed
+
+- New `continuation-recovery.ts` owns the three mechanical continuation-guard
+  reasons (`continuation cap reached`, `repeated assistant output`,
+  `output truncation repeated`) as exported constants, classifies them with
+  `isMechanicalContinuationBlock`, and builds the user notice with
+  `continuationCapRecoveryHint`.
+- `lifecycle-helpers.ts` consumes both: `blockedReasonForContinuationGuard`
+  returns the named constants, and the blocked notify now renders
+  `Goal continuation blocked: <reason>. Send any message to resume.` for
+  mechanical guards only.
+- Intentional blocks (`user interrupted the turn`, provider-error exhaustion,
+  model-authored blocks) keep the bare notice; no resume guidance is implied
+  where a message does not clear the block.
+
+### Why
+
+- A user reported that `continuation cap reached` "stops the session so much"
+  and "is not an easy guardrail to pass". The cap is a deliberate runaway
+  backstop and already resets on tool use or observable progress, and
+  `before_agent_start` already reactivates a cap-blocked goal on any real user
+  prompt. The gap was purely informational: the warning named the guard without
+  saying that one ordinary message clears it, so the state read as terminal.
+- Behavior of the guard itself is unchanged: `GOAL_CONTINUATION_CAP` stays 8,
+  admission logic is untouched, and the existing prompt-based recovery path is
+  preserved rather than replaced.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `lifecycle-helpers.ts` around the guard-reason switch and the notify call.
+- NONE in the verdict engine, goal store schema, persistence, or public extension API.
+
 ## Monitor-delayed continuations consume the persisted cap (2026-07-31)
 
 ### What changed
@@ -26,6 +60,7 @@
 - LOW in monitor continuation tests that observe delayed persistence.
 - NONE in the goal store schema, public extension API, or status transitions.
 
+||||||| parent of a687d47c6 (fix(coding-agent): tell users how to clear a mechanical goal block)
 ## Observable progress resets the persisted continuation cap streak (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation-recovery.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation-recovery.ts
@@ -1,0 +1,21 @@
+export const CONTINUATION_CAP_BLOCKED_REASON = "continuation cap reached";
+export const REPETITION_BLOCKED_REASON = "repeated assistant output";
+export const LENGTH_EXHAUSTED_BLOCKED_REASON = "output truncation repeated";
+
+const MECHANICAL_CONTINUATION_BLOCKS: readonly string[] = [
+	CONTINUATION_CAP_BLOCKED_REASON,
+	REPETITION_BLOCKED_REASON,
+	LENGTH_EXHAUSTED_BLOCKED_REASON,
+];
+
+const RESUME_GUIDANCE = "Send any message to resume.";
+
+export function isMechanicalContinuationBlock(blockedReason: string | undefined): boolean {
+	if (blockedReason === undefined) return false;
+	return MECHANICAL_CONTINUATION_BLOCKS.includes(blockedReason);
+}
+
+export function continuationCapRecoveryHint(blockedReason: string): string {
+	if (!isMechanicalContinuationBlock(blockedReason)) return `Goal continuation blocked: ${blockedReason}`;
+	return `Goal continuation blocked: ${blockedReason}. ${RESUME_GUIDANCE}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -10,6 +10,12 @@ import {
 	type GoalContinuationVerdict,
 	hashAssistantText,
 } from "./continuation.ts";
+import {
+	CONTINUATION_CAP_BLOCKED_REASON,
+	continuationCapRecoveryHint,
+	LENGTH_EXHAUSTED_BLOCKED_REASON,
+	REPETITION_BLOCKED_REASON,
+} from "./continuation-recovery.ts";
 import { buildContinuationPrompt } from "./prompt.ts";
 import { recordContinuationDelivered, updateGoal } from "./store.ts";
 import { goalStoreRef } from "./store-ref.ts";
@@ -147,7 +153,7 @@ async function handleDeniedContinuation(
 		{ status: "blocked", reason: blockedReason },
 		"model",
 	);
-	if (ctx.hasUI) ctx.ui.notify(`Goal continuation blocked: ${blockedReason}`, "warning");
+	if (ctx.hasUI) ctx.ui.notify(continuationCapRecoveryHint(blockedReason), "warning");
 	pi.events?.emit("goal_continuation_guard_tripped", {
 		goalId: goal.id,
 		reason,
@@ -161,11 +167,11 @@ function blockedReasonForContinuationGuard(
 ): string | undefined {
 	switch (reason) {
 		case "cap":
-			return "continuation cap reached";
+			return CONTINUATION_CAP_BLOCKED_REASON;
 		case "repetition":
-			return "repeated assistant output";
+			return REPETITION_BLOCKED_REASON;
 		case "length-exhausted":
-			return "output truncation repeated";
+			return LENGTH_EXHAUSTED_BLOCKED_REASON;
 		case "not-eligible":
 		case "single-flight":
 		case "stale":

--- a/packages/coding-agent/test/suite/regressions/goal-cap-recovery-guidance.test.ts
+++ b/packages/coding-agent/test/suite/regressions/goal-cap-recovery-guidance.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+	continuationCapRecoveryHint,
+	isMechanicalContinuationBlock,
+} from "../../../src/core/extensions/builtin/goal/continuation-recovery.ts";
+
+// The cap stays as a runaway backstop; tripping it must not strand the user.
+describe("goal continuation cap recovery guidance", () => {
+	it("classifies every mechanical continuation guard as prompt-recoverable", () => {
+		expect(isMechanicalContinuationBlock("continuation cap reached")).toBe(true);
+		expect(isMechanicalContinuationBlock("repeated assistant output")).toBe(true);
+		expect(isMechanicalContinuationBlock("output truncation repeated")).toBe(true);
+	});
+
+	it("does not classify intentional blocks as mechanical", () => {
+		expect(isMechanicalContinuationBlock("user interrupted the turn")).toBe(false);
+		expect(isMechanicalContinuationBlock("provider error ended the turn (retries exhausted)")).toBe(false);
+		expect(isMechanicalContinuationBlock("Waiting on a user decision")).toBe(false);
+		expect(isMechanicalContinuationBlock(undefined)).toBe(false);
+	});
+
+	it("tells the user how to recover from a mechanical block instead of only naming it", () => {
+		const hint = continuationCapRecoveryHint("continuation cap reached");
+		expect(hint).toContain("continuation cap reached");
+		expect(hint).toMatch(/send any message to resume/i);
+	});
+
+	it("omits resume guidance for blocks a message does not clear", () => {
+		expect(continuationCapRecoveryHint("user interrupted the turn")).not.toMatch(/send any message to resume/i);
+	});
+});


### PR DESCRIPTION
## Summary

A user reported that `continuation cap reached` "stops the session so much" and "is not an easy guardrail to pass". This makes that state self-explanatory instead of changing the guard.

## Why this shape

The cap is a deliberate runaway backstop and it is already well behaved:

- the streak resets on tool use **or** observable progress (`monitor-continuation.ts` `afterAgentEnd`), so it only trips after 8 consecutive zero-progress continuations
- `before_agent_start` already resets the streak **and** flips a cap-blocked goal back to `active` on any real user prompt

So recovery was already one message away. The actual defect was informational: the notice named the guard (`Goal continuation blocked: continuation cap reached`) without saying that one ordinary message clears it, so a recoverable state read as terminal.

Two alternatives were rejected on evidence:

- **Switching the cap to `paused`** would be *worse*: `paused` is user-intentional and is not auto-resumed by `before_agent_start`, and `transitions.ts` only allows `paused -> active` from a `user` source. That makes recovery stickier, not easier.
- **Raising `GOAL_CONTINUATION_CAP`** weakens the runaway backstop to fix a wording problem.

## What changed

- New `continuation-recovery.ts` owns the three mechanical guard reasons as constants, classifies them with `isMechanicalContinuationBlock`, and renders the notice via `continuationCapRecoveryHint`.
- `lifecycle-helpers.ts` returns the named constants from `blockedReasonForContinuationGuard` and appends `Send any message to resume.` for mechanical guards **only**.
- Intentional blocks (`user interrupted the turn`, provider-error exhaustion, model-authored blocks) keep the bare notice — no resume guidance where a message does not clear the block.

`GOAL_CONTINUATION_CAP` stays 8. Admission logic, the verdict engine, the store schema, and the public extension API are untouched.

## Verification

- New regression `test/suite/regressions/goal-cap-recovery-guidance.test.ts`: captured RED first (module absent), then GREEN — 4/4.
- Goal regression sweep green: `goal-cap-recovery-guidance`, `goal-continuation-verdict`, `goal-monitor-continuation`, `goal-extension`, `issue-447-goal-continuation` — **5 files / 86 tests passed**.
- `npm run check` passed clean.
- New file is 17 pure LOC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add recovery guidance for mechanical goal continuation blocks (cap, repetition, truncation) so users know any message resumes. This reduces confusion around “continuation cap reached” without changing guard behavior.

- **Bug Fixes**
  - New `continuation-recovery.ts` with constants, `isMechanicalContinuationBlock`, and `continuationCapRecoveryHint`.
  - Notify now uses `continuationCapRecoveryHint` in `lifecycle-helpers.ts`; intentional blocks unchanged.
  - Guard limits unchanged: `GOAL_CONTINUATION_CAP` stays 8; engine and APIs untouched.
  - Added regression test `goal-cap-recovery-guidance.test.ts`.

<sup>Written for commit bd3e982d1a0ad329c1980f84bc7bb4aae83e1d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

