### PR TITLE
fix(coding-agent): stop terminal compaction restore from leaking abort state

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -603,7 +603,7 @@ export class AgentSession {
 	private _userAbortPromise: Promise<void> | undefined = undefined;
 	private _agentAbortSource: "user" | "system" | undefined = undefined;
 	private _suppressQueuedContinuationAfterUserAbort = false;
-	/** Set when clearQueue() drains non-empty queues, so abort() can detect the gap even after queues are cleared. */
+	/** Set when clearQueue({ abortWillFollow: true }) drains queues immediately before abort(). */
 	private _hadClearedQueuedMessages = false;
 	private _extensionEventSignal: AbortSignal | undefined = undefined;
 
@@ -3023,13 +3023,18 @@ export class AgentSession {
 
 	/**
 	 * Clear all queued messages and return them.
-	 * Useful for restoring to editor when user aborts.
+	 * @param options.abortWillFollow Mark a non-empty drain so an immediately following abort can emit session_abort.
 	 * @returns Object with steering and followUp arrays
 	 */
-	clearQueue(): { steering: string[]; followUp: string[] } {
+	clearQueue(options: { abortWillFollow: boolean } = { abortWillFollow: false }): {
+		steering: string[];
+		followUp: string[];
+	} {
 		const steering = [...this._steeringMessages];
 		const followUp = [...this._followUpMessages];
-		if (steering.length > 0 || followUp.length > 0) this._hadClearedQueuedMessages = true;
+		if (options.abortWillFollow && (steering.length > 0 || followUp.length > 0)) {
+			this._hadClearedQueuedMessages = true;
+		}
 		// Clear every queue synchronously. Deferred post-compaction messages are
 		// already represented in visible bookkeeping, so they must not be returned
 		// a second time or later resurrected into Agent's native queues.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## Queue restoration does not leak abort state (2026-07-31)
+
+### What changed
+
+- Native queue draining now records cleared messages for `session_abort` only when the caller will immediately abort the session.
+- Terminal compaction restoration and manual dequeue-to-editor drains leave later idle aborts silent, while the deliberate clear-then-abort paths retain their existing `session_abort` behavior.
+- Coverage: `test/suite/regressions/535-terminal-compaction-abort-flag.test.ts` drives terminal `compaction_end` restoration with native steer and follow-up messages and pins both sides of the abort-event distinction.
+
+### Why
+
+- Terminal compaction failure restoration previously left `_hadClearedQueuedMessages` set indefinitely. A later unrelated idle abort emitted `session_abort`, which extensions can interpret as a control-plane instruction such as blocking an active goal.
+
+### Expected merge conflict zones
+
+- LOW: queue draining in `core/agent-session.ts` and the queue restoration helpers in `interactive-mode.ts`.
+
 ## Footer marks fast mode on the model label (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4889,8 +4889,11 @@ export class InteractiveMode {
 	 * Clear all queued messages and return their contents.
 	 * Clears both session queue and compaction queue.
 	 */
-	private clearAllQueues(): { steering: string[]; followUp: string[] } {
-		const { steering, followUp } = this.session.clearQueue();
+	private clearAllQueues(options: { abortWillFollow: boolean } = { abortWillFollow: false }): {
+		steering: string[];
+		followUp: string[];
+	} {
+		const { steering, followUp } = this.session.clearQueue(options);
 		const compactionMessages = [...this.compactionInFlightMessages, ...this.compactionQueuedMessages];
 		const compactionSteering = compactionMessages.filter((msg) => msg.mode === "steer").map((msg) => msg.text);
 		const compactionFollowUp = compactionMessages.filter((msg) => msg.mode === "followUp").map((msg) => msg.text);
@@ -4924,7 +4927,7 @@ export class InteractiveMode {
 	}
 
 	private restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
-		const { steering, followUp } = this.clearAllQueues();
+		const { steering, followUp } = this.clearAllQueues({ abortWillFollow: options?.abort === true });
 		const allQueued = [...steering, ...followUp];
 		if (allQueued.length === 0) {
 			this.updatePendingMessagesDisplay();
@@ -4954,7 +4957,7 @@ export class InteractiveMode {
 	 * - The helper never auto-prompts restored queue text; the user decides whether to send it.
 	 */
 	private async abortAndFireQueuedMessages(): Promise<number> {
-		const { steering, followUp } = this.clearAllQueues();
+		const { steering, followUp } = this.clearAllQueues({ abortWillFollow: true });
 		const allQueued = [...steering, ...followUp];
 		this.updatePendingMessagesDisplay();
 		await this.session.abort();

--- a/packages/coding-agent/test/suite/regressions/535-terminal-compaction-abort-flag.test.ts
+++ b/packages/coding-agent/test/suite/regressions/535-terminal-compaction-abort-flag.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+type QueuedMessage = {
+	readonly text: string;
+	readonly mode: "steer" | "followUp";
+};
+
+type ClearQueueOptions = { abortWillFollow?: boolean };
+
+function getQueueNativeMessage(harness: Harness, mode: "Steer" | "FollowUp") {
+	const queue = Reflect.get(harness.session, `_queue${mode}`);
+	if (typeof queue !== "function") throw new Error(`Expected AgentSession._queue${mode}`);
+	return (text: string): Promise<void> => Promise.resolve(queue.call(harness.session, text));
+}
+
+function getClearAllQueues() {
+	const clear = Reflect.get(InteractiveMode.prototype, "clearAllQueues");
+	if (typeof clear !== "function") throw new Error("Expected InteractiveMode.clearAllQueues");
+	return (context: object, options?: ClearQueueOptions): { steering: string[]; followUp: string[] } =>
+		clear.call(context, options);
+}
+
+function getRestoreQueuedMessagesToEditor() {
+	const restore = Reflect.get(InteractiveMode.prototype, "restoreQueuedMessagesToEditor");
+	if (typeof restore !== "function") throw new Error("Expected InteractiveMode.restoreQueuedMessagesToEditor");
+	return (context: object): number => restore.call(context);
+}
+
+function getAbortAndFireQueuedMessages() {
+	const abortAndFire = Reflect.get(InteractiveMode.prototype, "abortAndFireQueuedMessages");
+	if (typeof abortAndFire !== "function") {
+		throw new Error("Expected InteractiveMode.abortAndFireQueuedMessages");
+	}
+	return (context: object): Promise<number> => Promise.resolve(abortAndFire.call(context));
+}
+
+function getHandleEvent() {
+	const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent");
+	if (typeof handleEvent !== "function") throw new Error("Expected InteractiveMode.handleEvent");
+	return (context: object, event: object): Promise<void> => Promise.resolve(handleEvent.call(context, event));
+}
+
+function createInteractiveContext(harness: Harness) {
+	let editorText = "";
+	const context = {
+		isInitialized: true,
+		session: harness.session,
+		compactionQueuedMessages: [] as QueuedMessage[],
+		compactionInFlightMessages: [] as QueuedMessage[],
+		compactionTransferAbortControllers: new Map<QueuedMessage, AbortController>(),
+		compactionEscapeOverrideActive: false,
+		autoCompactionEscapeHandler: undefined,
+		autoCompactionProgressText: "",
+		defaultEditor: {},
+		footer: { invalidate: () => {} },
+		statusContainer: { clear: () => {} },
+		chatContainer: { clear: () => {}, addChild: () => {} },
+		clearStatusIndicator: () => {},
+		showError: () => {},
+		showStatus: () => {},
+		getSessionLogger: () => ({ warn: () => {} }),
+		settingsManager: { getShowTerminalProgress: () => false },
+		ui: { requestRender: () => {}, terminal: { setProgress: () => {} } },
+		updatePendingMessagesDisplay: () => {},
+		editor: {
+			getText: () => editorText,
+			setText: (text: string) => {
+				editorText = text;
+			},
+		},
+		clearAllQueues(options?: ClearQueueOptions) {
+			return getClearAllQueues()(context, options);
+		},
+		restoreQueuedMessagesToEditor() {
+			return getRestoreQueuedMessagesToEditor()(context);
+		},
+	};
+	return { context, getEditorText: () => editorText };
+}
+
+async function seedNativeQueues(harness: Harness): Promise<void> {
+	await getQueueNativeMessage(harness, "Steer")("native steering");
+	await getQueueNativeMessage(harness, "FollowUp")("native follow-up");
+}
+
+describe("PR 535 terminal compaction queue restoration", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("does not leak restored queue state into a later idle abort", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await seedNativeQueues(harness);
+		const { context, getEditorText } = createInteractiveContext(harness);
+
+		await getHandleEvent()(context, {
+			type: "compaction_end",
+			reason: "manual",
+			result: undefined,
+			accepted: false,
+			aborted: false,
+			willRetry: false,
+			errorMessage: "synthetic terminal compaction failure",
+		});
+
+		expect(getEditorText()).toBe("native steering\n\nnative follow-up");
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+
+		const abortEvents: string[] = [];
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "session_abort") abortEvents.push(event.type);
+		});
+		await harness.session.abort();
+		unsubscribe();
+
+		expect(abortEvents).toEqual([]);
+	});
+
+	it("still emits session_abort when queue draining immediately precedes abort", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await seedNativeQueues(harness);
+		const { context, getEditorText } = createInteractiveContext(harness);
+		const abortEvents: string[] = [];
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "session_abort") abortEvents.push(event.type);
+		});
+
+		const restored = await getAbortAndFireQueuedMessages()(context);
+		unsubscribe();
+
+		expect(restored).toBe(2);
+		expect(getEditorText()).toBe("native steering\n\nnative follow-up");
+		expect(harness.session.getSteeringMessages()).toEqual([]);
+		expect(harness.session.getFollowUpMessages()).toEqual([]);
+		expect(abortEvents).toEqual(["session_abort"]);
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to the post-merge audit of #535. That PR routed terminal compaction failures through `restoreQueuedMessagesToEditor()`, which is correct — but it drains the native queues via `clearQueue()` **without** aborting, and `clearQueue()` unconditionally set `_hadClearedQueuedMessages`.

That marker was designed for the atomic "clear queues, then immediately abort" path. Reusing the drain without the abort turned a transient gap marker into persistent session state, so a later otherwise-idle `abort()` consumed it and emitted a spurious `session_abort`:

```
// agent-session.ts
const shouldEmitAbort = !wasMidRun && (hadRetryBackoff || hadCompactionOrPending || hadClearedQueues);
```

This is not cosmetic. `session_abort` is an extension control-plane event — the **goal extension treats it as an instruction to block an active goal**. So: native input exists during compaction → compaction fails terminally → input is correctly restored, but the flag leaks → a later idle abort blocks an unrelated active goal.

## Fix

`clearQueue({ abortWillFollow })` makes the intent explicit; the marker is set only for a non-empty drain that an abort immediately follows.

| Call site | `abortWillFollow` |
|---|---|
| terminal compaction restoration | `false` |
| manual dequeue-to-editor | `false` |
| `restoreQueuedMessagesToEditor({ abort: true })` | `true` |
| `abortAndFireQueuedMessages()` | `true` |

The parameter defaults to `false`, so any drain that is not explicitly pre-abort cannot resurrect the marker.

## Verification

New regression `test/suite/regressions/535-terminal-compaction-abort-flag.test.ts` seeds native steering + follow-up queues, drives a terminal `compaction_end` through the real interactive handler, asserts restoration and empty queues, then calls an idle `session.abort()` and asserts **no** `session_abort`. Captured failing first:

```
AssertionError: expected [ 'session_abort' ] to deeply equal []
- []
+ [ "session_abort" ]
```

then passing after the fix. The complement test proves the deliberate clear-then-abort path **still** emits `session_abort`.

Full sweep including every test that calls `clearQueue()` — **7 files / 42 tests passed**: the new regression, `interactive-mode-compaction`, `post-compaction-queued-input-resume`, `post-compaction-tool-continuation-deadlock`, `post-compaction-stale-usage-queue-exemption`, `terminating-tool-queue-ownership`, `interactive-mode-abort`. Build and `biome check` pass; `git diff --check` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops spurious `session_abort` events after terminal compaction restores queued input, preventing unrelated goals from being blocked. The fix makes abort-state tracking explicit so idle aborts stay silent unless a clear-then-abort is intentional.

- **Bug Fixes**
  - Introduced `clearQueue({ abortWillFollow })` in `AgentSession`; marker is set only when an abort immediately follows (default is `false`).
  - Updated interactive call sites: terminal compaction restore and manual dequeue pass `false`; deliberate clear-then-abort paths pass `true`.
  - Added regression test `packages/coding-agent/test/suite/regressions/535-terminal-compaction-abort-flag.test.ts` to verify no `session_abort` after restore and preserved behavior when abort follows a drain.

<sup>Written for commit 00aff55bc5a6021fedb6e29ca9b9a2b3ae627702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

