### PR TITLE
fix(goal): clear the repetition window on tool-using turns

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,36 @@
 # goal Extension Changes
 
+## Tool-using turns clear the output-repetition window (2026-07-31)
+
+### What changed
+
+- `monitor-continuation.ts` computes `turnUsedTools` before recording assistant
+  output, and `#recordAssistantOutput` now clears
+  `#recentNormalizedOutputHashes` for a tool-using turn instead of appending its
+  final text hash. Only three consecutive **toolless** identical outputs can
+  trip the `repetition` verdict and block the goal with
+  "repeated assistant output".
+- Coverage adds the issue #566 regression: tool-using turns with identical
+  final text stay active, a mid-streak tool turn resets the window, and the
+  three-toolless-identical-outputs block is pinned unchanged.
+
+### Why
+
+- The repetition guard recorded the last assistant text hash on every
+  `agent_end`, so a goal doing real tool work each turn but ending turns with
+  an identical status line (the monitor-wait pattern) was blocked after three
+  turns — exactly the state a live resumption channel was about to wake. The
+  cap already treats tool use as progress (#539); the repetition window now
+  follows the same principle. The stale-signature guard still suppresses
+  continuation spam for identical no-progress turns without blocking.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `monitor-continuation.ts` around `afterAgentEnd` ordering and
+  `#recordAssistantOutput`.
+- NONE in `continuation.ts`, the goal store schema, or the public extension
+  API.
+
 ## Mechanical continuation blocks tell the user how to resume (2026-07-31)
 
 ### What changed
@@ -33,7 +64,6 @@
 
 - LOW in `lifecycle-helpers.ts` around the guard-reason switch and the notify call.
 - NONE in the verdict engine, goal store schema, persistence, or public extension API.
-
 ## Monitor-delayed continuations consume the persisted cap (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -110,12 +110,12 @@ export class MonitorAwareGoalContinuation {
 		this.#lastAgentEndMessages = options.messages;
 		this.#lastTurnUsage = collectAssistantUsage([...options.messages]);
 		this.#resetLengthRecoveryAfterCleanStop(options.goal, options.messages);
-		this.#recordAssistantOutput(options.messages);
+		const turnUsedTools = continuationTurnUsedTools(options.messages);
+		this.#recordAssistantOutput(options.messages, turnUsedTools);
 		if (options.goal?.status !== "active") {
 			this.#cancelTimer();
 			return options.goal;
 		}
-		const turnUsedTools = continuationTurnUsedTools(options.messages);
 		this.#recordToollessContinuationTurn(options.goal, turnUsedTools);
 		const immediateInput = this.#buildVerdictInput(options.ctx, options.goal, "immediate", options.messages);
 		const goal =
@@ -327,7 +327,12 @@ export class MonitorAwareGoalContinuation {
 		return content;
 	}
 
-	#recordAssistantOutput(messages: readonly AgentMessage[]): void {
+	/** A tool-using turn is forward progress, so it clears the repetition window instead of extending it. */
+	#recordAssistantOutput(messages: readonly AgentMessage[], turnUsedTools: boolean): void {
+		if (turnUsedTools) {
+			this.#recentNormalizedOutputHashes = [];
+			return;
+		}
 		const text = lastAssistantText(messages);
 		if (normalizeAssistantText(text).length === 0) return;
 		this.#recentNormalizedOutputHashes = [...this.#recentNormalizedOutputHashes, hashAssistantText(text)].slice(-3);

--- a/packages/coding-agent/test/suite/regressions/issue-566-goal-repetition-tool-reset.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-566-goal-repetition-tool-reset.test.ts
@@ -1,0 +1,160 @@
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { MonitorAwareGoalContinuation } from "../../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { readGoal, writeGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
+import type { Goal } from "../../../src/core/extensions/builtin/goal/types.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../../src/core/extensions/types.ts";
+import {
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	makeGoalContext,
+	TestEventBus,
+} from "../goal-monitor-test-harness.ts";
+
+const REPEATED_STATUS_LINE = "WORKING: waiting for CI; ending the turn.";
+
+function goalStoreRef(ctx: ExtensionContext) {
+	return {
+		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+		threadId: ctx.sessionManager.getSessionId(),
+	};
+}
+
+function activeGoal(id: string): Goal {
+	return {
+		id,
+		threadId: `${id}-thread`,
+		objective: "Keep moving",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+function assistantStopWithText(text: string): AgentMessage {
+	const message = cleanAssistantStop();
+	if (message.role !== "assistant") throw new Error("Expected an assistant stop message");
+	return { ...message, content: [{ type: "text", text }] };
+}
+
+function toolUsingTurnWithText(text: string, turn: number): AgentMessage[] {
+	const finalAssistant = assistantStopWithText(text);
+	if (finalAssistant.role !== "assistant") throw new Error("Expected an assistant stop message");
+	const toolCallId = `issue-566-tool-${turn}`;
+	return [
+		{
+			...finalAssistant,
+			content: [{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "true" } }],
+			stopReason: "toolUse",
+		},
+		{
+			role: "toolResult",
+			toolCallId,
+			toolName: "bash",
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+			timestamp: finalAssistant.timestamp,
+		},
+		finalAssistant,
+	];
+}
+
+function createMonitorHarness(): {
+	monitor: MonitorAwareGoalContinuation;
+	sent: string[];
+	events: TestEventBus;
+} {
+	const sent: string[] = [];
+	const events = new TestEventBus();
+	const pi = {
+		sendMessage: (message: { readonly content: string }) => sent.push(message.content),
+		events,
+	} as unknown as ExtensionAPI;
+	return { monitor: new MonitorAwareGoalContinuation(pi), sent, events };
+}
+
+async function runTurns(
+	monitor: MonitorAwareGoalContinuation,
+	ctx: ExtensionContext,
+	goal: Goal,
+	turns: readonly (readonly AgentMessage[])[],
+): Promise<void> {
+	let current: Goal | null = goal;
+	for (const messages of turns) {
+		if (current === null) throw new Error("Expected the goal to survive the turn");
+		current = await monitor.afterAgentEnd({ ctx, goal: current, messages });
+	}
+}
+
+describe("issue #566: repetition guard must not block tool-using turns", () => {
+	afterEach(async () => {
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("keeps the goal active when every turn uses tools despite identical final text", async () => {
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "issue-566-tool-turns");
+		const { monitor } = createMonitorHarness();
+		const goal = activeGoal("goal-issue-566-tool-turns");
+		await writeGoal(goalStoreRef(ctx), goal);
+		monitor.start(ctx);
+
+		await runTurns(
+			monitor,
+			ctx,
+			goal,
+			[1, 2, 3, 4].map((turn) => toolUsingTurnWithText(REPEATED_STATUS_LINE, turn)),
+		);
+
+		expect(notices).not.toContainEqual(expect.stringContaining("repeated assistant output"));
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
+	});
+
+	it("still blocks after three consecutive toolless identical outputs", async () => {
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "issue-566-toolless-loop");
+		const { monitor, events } = createMonitorHarness();
+		const goal = activeGoal("goal-issue-566-toolless-loop");
+		await writeGoal(goalStoreRef(ctx), goal);
+		monitor.start(ctx);
+
+		await runTurns(monitor, ctx, goal, [
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+		]);
+
+		expect(notices).toContainEqual(expect.stringContaining("repeated assistant output"));
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "repeated assistant output",
+		});
+		expect(events.emitted).toContainEqual({
+			channel: "goal_continuation_guard_tripped",
+			data: expect.objectContaining({ reason: "repetition" }),
+		});
+	});
+
+	it("clears the repetition window when a tool-using turn interrupts the streak", async () => {
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "issue-566-interrupted-streak");
+		const { monitor } = createMonitorHarness();
+		const goal = activeGoal("goal-issue-566-interrupted-streak");
+		await writeGoal(goalStoreRef(ctx), goal);
+		monitor.start(ctx);
+
+		await runTurns(monitor, ctx, goal, [
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+			toolUsingTurnWithText(REPEATED_STATUS_LINE, 3),
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+			[assistantStopWithText(REPEATED_STATUS_LINE)],
+		]);
+
+		expect(notices).not.toContainEqual(expect.stringContaining("repeated assistant output"));
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #566.

`Warning: Goal continuation blocked: repeated assistant output` fired while goal sessions were actively working, permanently blocking the goal right before the event that would have resumed it (monitor notification, child-task completion) arrived.

## Root cause

`MonitorAwareGoalContinuation#recordAssistantOutput` appended the last-assistant-text hash on **every** `agent_end`, and the repetition guard blocks at a 3-streak of identical hashes. A session doing real tool work each turn but ending turns with an identical status line (the monitor-wait pattern: "waiting for CI; ending the turn") was blocked after 3 turns.

This is inconsistent with the merged principle that tool use / observable progress resets continuation guard state (#539, `448bef2`): those fixes reset the continuation **cap** but never the repetition hash window. For reference, codex's `ext/goal` has no mechanical output-repetition block at all — its spec only instructs a model-side blocked audit — so the senpi-only hash guard must at minimum respect tool-using turns as progress.

## Fix

Compute `turnUsedTools` before recording assistant output; a tool-using turn now **clears** `#recentNormalizedOutputHashes` instead of extending it. Only 3 consecutive **toolless** identical outputs can trip the `repetition` verdict. The guard still catches genuine toolless identical-output loops, and the stale-signature guard keeps suppressing continuation spam for identical no-progress turns without blocking.

## Evidence

- RED (pre-fix): `test/suite/regressions/issue-566-goal-repetition-tool-reset.test.ts` — 2 failed with the exact user-visible notice `"Goal continuation blocked: repeated assistant output"` produced by tool-using turns; the toolless characterization pin passed pre-fix.
- GREEN: same file 3/3 after the fix.
- Full goal suite: 11 files, 153/153 passed.
- `npm run check`: green.
- senpi-qa mock-loop: `--self-test` 43/43, `--with-tool` pass; evidence under `local-ignore/qa-evidence/`.

## Merge-conflict zones

- LOW in `monitor-continuation.ts` around `afterAgentEnd` ordering and `#recordAssistantOutput` (documented in `goal/changes.md`).
- Orthogonal to open PRs #553 / #562 (recovery UX); this PR removes the spurious trigger itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false “Goal continuation blocked: repeated assistant output” during tool-using turns by clearing the repetition window when tools are used. Only three consecutive toolless identical outputs can now trigger the repetition guard. Fixes #566.

- **Bug Fixes**
  - Compute `turnUsedTools` before recording output; pass it to `#recordAssistantOutput`, which now clears `#recentNormalizedOutputHashes` on tool-using turns.
  - Streak advances only on toolless turns; guard trips after 3 identical toolless outputs.
  - Added regression test `packages/coding-agent/test/suite/regressions/issue-566-goal-repetition-tool-reset.test.ts`.

<sup>Written for commit 7db72343778319ce906d32276ede01bb82a20125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

