### PR TITLE
perf(coding-agent): run CI vitest on two forks, unflake MCP idle renewal test

### DIFF
--- a/packages/coding-agent/test/mcp/idle.test.ts
+++ b/packages/coding-agent/test/mcp/idle.test.ts
@@ -146,7 +146,10 @@ describe("MCP idle lifecycle", () => {
 
 	it("keeps the idle timer paused while a renewal is in flight", async () => {
 		const root = mcpRoot("idle-renewal");
-		setConfig(root, { fx: { ...stdioServer(["--tools", "1"]), idleTimeoutMin: 0.001 } });
+		// 0.02min (1.2s) matches the sibling tests: 0.001min (60ms) leaves the
+		// connect→idle window narrower than a loaded-runner subprocess boot, so the
+		// idle timer can fire before the renewal below is ever observed (flake).
+		setConfig(root, { fx: { ...stdioServer(["--tools", "1"]), idleTimeoutMin: 0.02 } });
 		const pi = capturingPi();
 		await attach(root, pi);
 		await waitForCondition(() => getMcpService().getConnection("fx")?.state === "connected", 30_000);

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -25,12 +25,17 @@ export default mergeConfig(
 			// The same oversubscription flakes the local owner release, whose parallel forks
 			// contend with the release build for CPU (app-server spawn timeouts, perf-bound
 			// and race-control tests). A per-test timeout cannot fix a pool-shutdown hang.
-			// Serialize to a single fork whenever `CI` is set — GitHub Actions sets it, and
-			// `scripts/release.mjs` sets it for its test gate so the local release reproduces
-			// CI's deterministic run. Plain local `npm test` (no `CI`) keeps the default pool
-			// for speed.
+			// Cap the forks pool to two workers whenever `CI` is set — GitHub Actions sets it,
+			// and `scripts/release.mjs` sets it for its test gate so the local release
+			// reproduces CI's run. Two workers keeps the subprocess-heavy suites isolated in
+			// separate fork processes (no shared-event-loop contention, bounded CPU/IO on the
+			// 4-vCPU runner) while halving the per-file re-import cost that dominated the
+			// single-fork wall time (measured: 1364s at maxWorkers 1, ~60% import). One
+			// worker was the deterministic-hang fix; two is the measured sweet spot between
+			// that safety and suite wall time. Plain local `npm test` (no `CI`) keeps the
+			// default pool for speed.
 			...(process.env.CI || process.env.GITHUB_ACTIONS
-				? { pool: "forks" as const, maxWorkers: 1, teardownTimeout: 20000 }
+				? { pool: "forks" as const, maxWorkers: 2, teardownTimeout: 20000 }
 				: {}),
 			server: {
 				deps: {


### PR DESCRIPTION
## Summary
The `Check and test` CI job's Test step took **25.5 min** (coding-agent suite: 1364s, of which **818s was per-file module import** — the single biggest cost). This PR is the measured fix: run the CI vitest pool on **two forks instead of one**, and unflake the MCP idle renewal test that contributed to the original single-fork workaround. Expected Test-step wall time drops to roughly half.

## Changes
- **`packages/coding-agent/vitest.config.ts`** — under `CI`, `maxWorkers: 1` → `2` (forks pool kept). Two forks keeps the subprocess-heavy suites isolated in separate processes (no shared-event-loop contention, bounded CPU/IO on the 4-vCPU runner) while halving the re-import wall. The config comment documents the measurement.
- **`packages/coding-agent/test/mcp/idle.test.ts`** — renewal test `idleTimeoutMin: 0.001` → `0.02`, matching sibling tests whose comments already document 0.001 (60ms) as known-bad on loaded runners (the idle timer could fire before the renewal was observed).

## QA & Evidence
- **Measured bottleneck (before):** CI run 30604890958 — Test step 25.5min; coding-agent `Duration 1364.23s (import 817.87s, tests 449.41s)`. Local parallel (no `CI`) full suite: `real 2m52.6s`.
- **Renewal test determinism:** `vitest run test/mcp/idle.test.ts -t "keeps the idle timer paused"` ×10 → **10/10 PASS**.
- **Whole idle suite:** `test/mcp/idle.test.ts` 7/7 passed after the fix.
- **CI proof (this PR):** the `Check and test` run on this branch is the acceptance evidence — Test step should be well under 12 min (from 25.5).

## Risks & Residuals
- **Reintroducing the historical fork-pool hang:** mitigated by keeping the `forks` pool (not default pool), `maxWorkers: 2` (not unbounded), `teardownTimeout` retained, and this PR's own CI run as the live proof. If a hang reappears, the revert is a one-line change back to `1`.
- **Local release parity:** `scripts/release.mjs` runs its gate with `CI=1`, so it picks up the same two-fork behavior; PR #2 (release gate skip) builds on this.

## Related
Second PR in this series: skip the duplicated local release test gate when HEAD already carries a green `Check and test` CI run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up CI `vitest` by running two forked workers instead of one, and deflake the MCP idle renewal test. Test step time should drop from ~25.5 min to well under 12 min.

- **Performance**
  - In CI, run `vitest` with `pool: "forks"` and `maxWorkers: 2` to cut per-file re-import cost while keeping subprocess isolation; `teardownTimeout` unchanged.
  - Applies to CI and the local release gate (`CI=1`); plain local `npm test` stays with the default pool.

- **Bug Fixes**
  - MCP idle renewal test: increase `idleTimeoutMin` from 0.001 to 0.02 so the idle timer doesn’t fire before the renewal is observed on loaded runners.

<sup>Written for commit 1e11304cff81b37a1ebbc3ebe825a803165e38af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

