### PR TITLE
perf(release): skip the local test gate when HEAD already has green CI

### DIFF
--- a/scripts/release-test-gate.mjs
+++ b/scripts/release-test-gate.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Decide whether the release test gate must run the full suite locally.
+ *
+ * The canonical release flow already requires CI green on `main` before a release
+ * commit is cut, so re-running `CI=1 npm test` locally duplicates a gate GitHub
+ * already ran for the exact same tree. This module answers one question: does HEAD
+ * already carry a green "Check and test" check run? Pure decision logic lives here
+ * (unit-testable without network); `release.mjs` owns the `gh` lookup.
+ */
+
+export const REQUIRED_CHECK_NAME = "Check and test";
+
+/**
+ * @param {Array<{name: string, status: string, conclusion: string|null, head_sha: string}>} checkRuns
+ * @param {string} sha
+ */
+export function isCiCheckGreen(checkRuns, sha) {
+	return checkRuns.some(
+		(run) =>
+			run.name === REQUIRED_CHECK_NAME &&
+			run.status === "completed" &&
+			run.conclusion === "success" &&
+			run.head_sha === sha,
+	);
+}
+
+/**
+ * @param {{forceTests: boolean, dryRun: boolean, sha: string, checkRuns: Array|null}} input
+ *   checkRuns === null means the lookup failed (offline, gh missing, API error).
+ * @returns {{skip: boolean, reason: string}}
+ */
+export function decideTestGate({ forceTests, dryRun, sha, checkRuns }) {
+	if (forceTests) {
+		return { skip: false, reason: "--force-tests given; running the test gate unconditionally" };
+	}
+	if (dryRun) {
+		return { skip: false, reason: "dry-run previews the real gate; tests still listed" };
+	}
+	if (checkRuns === null) {
+		return { skip: false, reason: "CI check lookup failed; running the test gate locally" };
+	}
+	if (isCiCheckGreen(checkRuns, sha)) {
+		return {
+			skip: true,
+			reason: `HEAD ${sha.slice(0, 12)} already has a green "${REQUIRED_CHECK_NAME}" CI run; skipping the duplicated local test gate`,
+		};
+	}
+	return { skip: false, reason: `no green "${REQUIRED_CHECK_NAME}" check for HEAD ${sha.slice(0, 12)}` };
+}

--- a/scripts/release-test-gate.test.mjs
+++ b/scripts/release-test-gate.test.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { decideTestGate, isCiCheckGreen } from "./release-test-gate.mjs";
+
+const CHECK_NAME = "Check and test";
+
+describe("isCiCheckGreen", () => {
+	it("accepts a completed success check for the exact HEAD sha", () => {
+		assert.equal(
+			isCiCheckGreen(
+				[{ name: CHECK_NAME, status: "completed", conclusion: "success", head_sha: "abc123" }],
+				"abc123",
+			),
+			true,
+		);
+	});
+
+	it("rejects a check whose sha does not match HEAD", () => {
+		assert.equal(
+			isCiCheckGreen(
+				[{ name: CHECK_NAME, status: "completed", conclusion: "success", head_sha: "other" }],
+				"abc123",
+			),
+			false,
+		);
+	});
+
+	it("rejects in-progress and failed checks", () => {
+		assert.equal(
+			isCiCheckGreen(
+				[{ name: CHECK_NAME, status: "in_progress", conclusion: null, head_sha: "abc123" }],
+				"abc123",
+			),
+			false,
+		);
+		assert.equal(
+			isCiCheckGreen(
+				[{ name: CHECK_NAME, status: "completed", conclusion: "failure", head_sha: "abc123" }],
+				"abc123",
+			),
+			false,
+		);
+	});
+
+	it("rejects when the required check is absent entirely", () => {
+		assert.equal(isCiCheckGreen([], "abc123"), false);
+		assert.equal(
+			isCiCheckGreen(
+				[{ name: "Other job", status: "completed", conclusion: "success", head_sha: "abc123" }],
+				"abc123",
+			),
+			false,
+		);
+	});
+});
+
+describe("decideTestGate", () => {
+	const greenChecks = [{ name: CHECK_NAME, status: "completed", conclusion: "success", head_sha: "abc123" }];
+
+	it("skips when HEAD already has a green Check and test run", () => {
+		const decision = decideTestGate({ forceTests: false, dryRun: false, sha: "abc123", checkRuns: greenChecks });
+		assert.equal(decision.skip, true);
+		assert.match(decision.reason, /abc123/);
+	});
+
+	it("runs tests when --force-tests is given even with green CI", () => {
+		const decision = decideTestGate({ forceTests: true, dryRun: false, sha: "abc123", checkRuns: greenChecks });
+		assert.equal(decision.skip, false);
+		assert.match(decision.reason, /force-tests/);
+	});
+
+	it("runs tests when check lookup failed (null = error/unavailable)", () => {
+		const decision = decideTestGate({ forceTests: false, dryRun: false, sha: "abc123", checkRuns: null });
+		assert.equal(decision.skip, false);
+	});
+
+	it("runs tests when the check is not green", () => {
+		const decision = decideTestGate({
+			forceTests: false,
+			dryRun: false,
+			sha: "abc123",
+			checkRuns: [{ name: CHECK_NAME, status: "completed", conclusion: "failure", head_sha: "abc123" }],
+		});
+		assert.equal(decision.skip, false);
+	});
+
+	it("never skips in dry-run mode (preview stays a preview of the real gate)", () => {
+		const decision = decideTestGate({ forceTests: false, dryRun: true, sha: "abc123", checkRuns: greenChecks });
+		assert.equal(decision.skip, false);
+	});
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -43,6 +43,7 @@ import {
 	runShrinkwrap,
 } from "./release-artifacts.mjs";
 import { reAddUnreleasedSections, stampChangelogs } from "./release-changelog.mjs";
+import { decideTestGate } from "./release-test-gate.mjs";
 import { applyWorkspaceVersions, runSyncVersions } from "./release-packages.mjs";
 
 const VERSION_RE = /^\d{4}\.\d{1,2}\.\d{1,2}(-\d+)?$/;
@@ -60,6 +61,8 @@ function printUsage() {
 		"  --dry-run       Preview every shell command and file write; modify nothing.",
 		"                  Read-only git/npm reads (status, branch, tag --list,",
 		"                  npm view) still execute so the plan is accurate.",
+		"  --force-tests   Run the CI=1 npm test gate even when HEAD already",
+		"                  carries a green \"Check and test\" CI run.",
 		"  --help, -h      Show this help and exit.",
 		"",
 		"Default flow: compute next version via scripts/calver.mjs, then release.",
@@ -68,11 +71,13 @@ function printUsage() {
 }
 
 function parseArgs(argv) {
-	const args = { dryRun: false, version: null, help: false };
+	const args = { dryRun: false, version: null, help: false, forceTests: false };
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === "--help" || arg === "-h") {
 			args.help = true;
+		} else if (arg === "--force-tests") {
+			args.forceTests = true;
 		} else if (arg === "--dry-run") {
 			args.dryRun = true;
 		} else if (arg === "--version") {
@@ -261,9 +266,43 @@ function runBuild(dryRun) {
 	runCommand("npm", ["run", "build"]);
 }
 
-function runTests(dryRun) {
+function lookupCiCheckRuns(sha) {
+	try {
+		const raw = execFileSync(
+			"gh",
+			["api", `repos/{owner}/{repo}/commits/${sha}/check-runs`, "--paginate", "--slurp"],
+			{ encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+		);
+		const pages = JSON.parse(raw);
+		const runs = Array.isArray(pages)
+			? pages.flatMap((page) => (Array.isArray(page.check_runs) ? page.check_runs : []))
+			: Array.isArray(pages.check_runs)
+				? pages.check_runs
+				: [];
+		return runs.map((run) => ({
+			name: run.name,
+			status: run.status,
+			conclusion: run.conclusion,
+			head_sha: run.head_sha,
+		}));
+	} catch {
+		return null;
+	}
+}
+
+function runTests(dryRun, forceTests) {
 	if (dryRun) {
+		const sha = captureCommand("git", ["rev-parse", "HEAD"]).trim();
+		const checkRuns = lookupCiCheckRuns(sha);
+		const decision = decideTestGate({ forceTests, dryRun: true, sha, checkRuns });
+		dryRunLog(`test gate decision (preview): ${decision.reason}`);
 		dryRunLog("CI=1 npm test");
+		return;
+	}
+	const sha = captureCommand("git", ["rev-parse", "HEAD"]).trim();
+	const decision = decideTestGate({ forceTests, dryRun: false, sha, checkRuns: lookupCiCheckRuns(sha) });
+	log(`test gate: ${decision.reason}`);
+	if (decision.skip) {
 		return;
 	}
 	// Run the gate with CI=1 so packages reproduce their CI test behavior — notably
@@ -303,7 +342,7 @@ function main() {
 	stampChangelogs(version, date, args.dryRun, capturedChangelogSubsections, log, dryRunLog);
 	runCheck(args.dryRun);
 	runBuild(args.dryRun);
-	runTests(args.dryRun);
+	runTests(args.dryRun, args.forceTests);
 
 	stageChangedFiles(args.dryRun);
 	gitCommit(`release: v${version}`, args.dryRun);


### PR DESCRIPTION
## Summary
The canonical release flow already requires CI green on `main` before cutting a release commit — then `release.mjs` re-ran `CI=1 npm test` locally, duplicating a gate GitHub already ran for the exact same tree (~20+ min serialized locally). This PR makes the release script skip that duplicated local test gate when the exact HEAD already carries a green `Check and test` CI run.

## Changes
- **`scripts/release-test-gate.mjs`** (new) — pure decision logic: `isCiCheckGreen` + `decideTestGate`. Unit-testable with no network; lookup failure fails safe to running tests.
- **`scripts/release-test-gate.test.mjs`** (new) — 9 cases: exact-sha green → skip, `--force-tests` → run, lookup failed → run, check not green → run, dry-run never skips.
- **`scripts/release.mjs`** — `lookupCiCheckRuns(sha)` via `gh api …/check-runs`; the test gate logs its decision loudly and returns early on skip; `--force-tests` flag added to `parseArgs` and `--help`.

## QA & Evidence
- **Unit (RED→GREEN):** `node --test scripts/release-test-gate.test.mjs` → **9/9 pass** (module authored after the test file; first run failed with `ERR_MODULE_NOT_FOUND`).
- **Real-surface:** decision fn driven with live `gh api` data for HEAD `c0c9e6c` — green → `skip: true` with a reason naming the sha; in-progress → `skip: false`.
- **Dry-run:** `node scripts/release.mjs --dry-run` exercises the decision path and prints the `[dry-run] test gate decision (preview): …` line before previewing `CI=1 npm test`.

## Risks & Residuals
- **Skipping masks a real regression:** the gate is gated on the *exact* HEAD sha having a green `Check and test` run; `check` and `build` still run locally; `--force-tests` is the escape hatch. Lookup failure (offline/no gh) fails safe to running the full gate.
- **Behavioral surface:** release tooling only; no runtime change.

## Related
Companion PR: `perf(coding-agent): run CI vitest on two forks` (#575) — together they remove the two slowest waits in the release/CI loop.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the local release test gate when HEAD already has a green "Check and test" CI run, cutting ~20 minutes of duplicate work. Adds a `--force-tests` flag and clear logging; lookup failures fall back to running tests.

- **Refactors**
  - Added `scripts/release-test-gate.mjs` with pure decision logic and unit tests.
  - Updated `scripts/release.mjs` to query check runs via `gh api`, honor `--force-tests`, preview decisions in `--dry-run`, and skip when eligible.

<sup>Written for commit d0eec0419096ad7c0d883f8d2659ea5d73d6fe75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

