### PR TITLE
feat(goal): show live countdowns for continuation waits

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -23,6 +23,7 @@ goal/
 ├── cache-warm.ts     # Cache-warm metrics estimator + scheduled/resumed notices + goal-cache-warmup entry contract
 ├── cache-warm-renderer.ts # TUI entry renderer for goal-cache-warmup custom entries
 ├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
+├── wait-progress.ts  # renderGoalWaitBar + formatGoalWaitLabel (continuation-wait countdown render)
 ├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
 └── changes.md        # Fork tracker (port + budget behavior removal + wire compatibility)
 ```
@@ -94,6 +95,6 @@ Do not return an `isError` property; it is ignored.
 ## NOTES
 
 - Tests: `test/suite/goal-store.test.ts`, `goal-modules.test.ts`,
-  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
+  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts`, `goal-wait-progress.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
 - Registered last in `builtin/index.ts` `builtinExtensions`; inert until a goal
   is created.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -23,6 +23,7 @@ goal/
 ├── cache-warm.ts     # Cache-warm metrics estimator + scheduled/resumed notices + goal-cache-warmup entry contract
 ├── cache-warm-renderer.ts # TUI entry renderer for goal-cache-warmup custom entries
 ├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
+├── wait-progress.ts  # renderGoalWaitBar + formatGoalWaitLabel (continuation-wait countdown render)
 ├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
 └── changes.md        # Fork tracker (port + budget behavior removal + wire compatibility)
 ```
@@ -95,6 +96,6 @@ Do not return an `isError` property; it is ignored.
 ## NOTES
 
 - Tests: `test/suite/goal-store.test.ts`, `goal-modules.test.ts`,
-  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
+  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts`, `goal-wait-progress.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
 - Registered last in `builtin/index.ts` `builtinExtensions`; inert until a goal
   is created.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -23,7 +23,8 @@ goal/
 ├── cache-warm.ts     # Cache-warm metrics estimator + scheduled/resumed notices + goal-cache-warmup entry contract
 ├── cache-warm-renderer.ts # TUI entry renderer for goal-cache-warmup custom entries
 ├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
-├── wait-progress.ts  # renderGoalWaitBar + formatGoalWaitLabel (continuation-wait countdown render)
+├── wait-progress.ts  # Pure continuation-wait progress bar + label formatting
+├── wait-ticker.ts    # GoalWaitTicker (live footer countdown lifecycle)
 ├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
 └── changes.md        # Fork tracker (port + budget behavior removal + wire compatibility)
 ```
@@ -44,9 +45,10 @@ a stale-signature check on immediate re-entry, and a single-flight latch so only
 hidden continuation can be queued at a time. The stall notice is goal-wide: from the
 3rd consecutive toolless continuation turn it prefixes the prompt with `<goal_stall_check>`
 and switches between monitor-flavored bullets while monitors are active and generic
-recovery bullets otherwise. Accepted direct input disarms pending continuation
-and leaves an active Goal active but idle after the user turn; it reactivates only mechanically
-blocked Goals, including admitted steering. A `length` stop gets exactly one minimal truncation recovery before the goal
+recovery bullets otherwise. Accepted direct input disarms a pending continuation,
+and a clean accepted user turn arms a visible 60-second grace countdown before the Goal
+resumes; mechanically blocked Goals are reactivated on accepted input, including admitted
+steering. A `length` stop gets exactly one minimal truncation recovery before the goal
 blocks on repetition, terminal provider errors block the goal only when `AgentEndEvent.willRetry`
 is false, and resumed sessions with 8+ trailing historical continuation entries suppress
 session-start auto-resume. `tokenBudget` remains inert compatibility metadata only; this
@@ -75,6 +77,7 @@ Do not return an `isError` property; it is ignored.
 | Tune the continuation prompt | `prompt.ts` |
 | Change the footer status text | `ui.ts` |
 | Change the live footer elapsed ticker | `elapsed-ticker.ts` (+ `refreshGoalUi` in `index.ts`) |
+| Change the continuation-wait countdown | `wait-progress.ts`, `wait-ticker.ts`, and `monitor-continuation.ts` |
 | `/goal` argument parsing | `command.ts` |
 
 ## CONVENTIONS
@@ -89,9 +92,10 @@ Do not return an `isError` property; it is ignored.
   `tokensUsed`/`timeUsedSeconds`; it never changes status.
 - **Live footer is ticker-driven**: `refreshGoalUi` (index.ts) drives
   `GoalElapsedTicker` to refresh `Pursuing goal (…)` once per second while a goal
-  is `active` and its accounting window is open, so the footer advances live
-  instead of freezing between `agent_end` accounting checkpoints. The ticker only
-  runs when `ctx.hasUI` and is stopped on pause/complete/clear and session shutdown.
+  is `active` and its accounting window is open. `GoalWaitTicker` independently
+  refreshes the transient continuation countdown while a monitor or user-grace
+  timer is armed. Both tickers only run with a TUI context and stop on their owning
+  lifecycle cleanup.
 
 ## NOTES
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -110,54 +110,56 @@
 - LOW in monitor continuation tests that observe delayed persistence.
 - NONE in the goal store schema, public extension API, or status transitions.
 
-## PROPOSAL: continuation-wait countdown render layer (2026-07-31)
-
-Status: **render layer only.** The wiring that drives this into the footer is deliberately
-not part of this change and is open for maintainer direction.
+## Visible continuation-wait countdown (2026-08-03)
 
 ### What changed
 
-- New `wait-progress.ts` exports `GOAL_WAIT_BAR_CELLS` (12), `renderGoalWaitBar(elapsedRatio)`
-  and `formatGoalWaitLabel({ kind, remainingMs, totalMs, activeMonitorCount })`. It reuses
-  `formatWakeDuration` from `cache-warm.ts` so a wait countdown reads identically to the
-  existing cache-warm notices.
-- `kind: "userGrace"` renders `▰▰▰▱▱▱▱▱▱▱▱▱ goal resumes in 47s`;
-  `kind: "monitor"` renders `… goal continues in 3m 12s · 2 monitors on duty` with
-  singular/plural monitor wording. Ratios are clamped, so a late timer never overflows the bar
-  and a negative remaining time renders `0s` rather than a minus sign.
-- Nothing imports the module yet: no scheduler, event, entry, or footer behavior changes here.
+- `wait-progress.ts` exports the clamped 12-cell progress bar and the user-grace / monitor
+  wait-label formatter, reusing `formatWakeDuration` so countdowns match existing cache-warm
+  notices.
+- New `wait-ticker.ts` follows the existing `GoalElapsedTicker` / `MonitorStatusTicker` pattern:
+  it renders a dedicated `goal-wait` footer status immediately, refreshes once per second on an
+  unref'd interval, skips unchanged labels, and clears the status when its timer ends or is
+  cancelled.
+- `monitor-continuation.ts` now drives that ticker from the real delayed-continuation lifecycle.
+  It restores the 60-second `userGrace` continuation after a clean accepted user turn, keeps the
+  existing four-minute monitor delay, freezes both timers while direct-input admission is
+  unresolved, resumes rejected/handled holds with their remaining time, and clears the footer on
+  delivery, accepted replacement input, goal state changes, monitor settlement, reload, and
+  shutdown.
+- The countdown is footer-only and transient. It does not append a durable entry: a transcript
+  line per user-grace window would be permanent noise for a state whose value changes every
+  second. The existing durable `goal-cache-warmup` story remains unchanged for monitor waits.
+- Coverage keeps the nine pure rendering tests and adds lifecycle wiring assertions that observe
+  the real user-grace status before triggering the turn, advance it with fake time, then await
+  exact delivery/clear signals; cancellation is likewise observed before accepted input and
+  proves no later delivery or status tick leaks.
 
 ### Why
 
-`#schedule()` in `monitor-continuation.ts` treats its two waits asymmetrically. The `monitor`
-branch (`GOAL_MONITOR_CONTINUATION_DELAY_MS`, 240s) emits `ui.notify` plus a durable
-`goal-cache-warmup` entry, so the wait is visible. The `userGrace` branch
-(`GOAL_USER_GRACE_DELAY_MS`, `continuation.ts:11`, 60s) emits nothing at all — no notify, no
-event, no entry. A session that is waiting out the grace window is therefore
-indistinguishable from a hung one for a full minute.
+The original 60-second grace path left an active Goal silent and visually indistinguishable from
+an idle or hung session. PR #553 later removed that timer while improving correlated direct-input
+admission. This change intentionally restores the grace continuation requested here without
+removing those safeguards: accepted input still cancels an already-armed wait synchronously, and
+only the clean end of that accepted user turn starts a fresh visible grace window.
 
-Session forensics on a real transcript show the shape: gaps of 60.0s / 60.3s / 60.5s / 61.6s
-each begin immediately after a `senpi.hooks.stop-state {count:0}` record and end with a
-`goal-continuation` injection, with no rendered output in between. The 240s monitor wait in the
-same session did produce visible `goal-cache-warmup` scheduled→resumed entries. Tool calls
-paired 170/170 and child-task wakes delivered 11/11 in that transcript, so the silence is the
-unrendered wait itself and not a lost result or a dropped wake.
+A dedicated footer ticker matches the TUI's established live-status mechanism and keeps the
+countdown independent from cumulative `Pursuing goal (…)` elapsed time. Durable timeline entries
+cannot represent per-second state without transcript spam, so they are the wrong rendering
+surface for this wait.
 
-### Open questions for maintainers
+### Why the extension system could not handle this differently
 
-- Should the `userGrace` branch emit a durable entry (symmetric with `goal-cache-warmup`), a
-  transient footer segment only, or both?
-- If footer-only: extend `GoalElapsedTicker`, or add a second ticker so the wait countdown and
-  the `Pursuing goal (…)` elapsed segment stay independent?
-- Is a 12-cell bar the right footer budget, or should this be text-only?
+The scheduler and footer status are already private implementation details of the builtin Goal
+extension. The wiring stays entirely inside that builtin and uses the public `ctx.ui.setStatus`
+surface; no core extension API change is required.
 
-### Expected merge conflict zones on next upstream sync
+### Expected merge conflict zones on the next sync
 
-- NONE for `wait-progress.ts` — new fork-only file with no importers.
-- LOW in `AGENTS.md` (FILES table + tests list, additive lines only).
-- Wiring, once agreed, would touch `monitor-continuation.ts` `#schedule()` and the footer
-  status surface; both are fork-owned but `#schedule()` is actively edited, so that follow-up
-  carries real conflict risk and is intentionally left out of this change.
+- MEDIUM in `monitor-continuation.ts` around delayed timer ownership and direct-input holds.
+- LOW in `continuation.ts` for the restored `userGrace` path and in `index.ts` for ticker wiring.
+- LOW in the focused Goal monitor lifecycle tests and harness status signal.
+- NONE in the Goal store schema, public extension API, or durable cache-warm entry contract.
 
 ## Observable progress resets the persisted continuation cap streak (2026-07-30)
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -110,6 +110,55 @@
 - LOW in monitor continuation tests that observe delayed persistence.
 - NONE in the goal store schema, public extension API, or status transitions.
 
+## PROPOSAL: continuation-wait countdown render layer (2026-07-31)
+
+Status: **render layer only.** The wiring that drives this into the footer is deliberately
+not part of this change and is open for maintainer direction.
+
+### What changed
+
+- New `wait-progress.ts` exports `GOAL_WAIT_BAR_CELLS` (12), `renderGoalWaitBar(elapsedRatio)`
+  and `formatGoalWaitLabel({ kind, remainingMs, totalMs, activeMonitorCount })`. It reuses
+  `formatWakeDuration` from `cache-warm.ts` so a wait countdown reads identically to the
+  existing cache-warm notices.
+- `kind: "userGrace"` renders `▰▰▰▱▱▱▱▱▱▱▱▱ goal resumes in 47s`;
+  `kind: "monitor"` renders `… goal continues in 3m 12s · 2 monitors on duty` with
+  singular/plural monitor wording. Ratios are clamped, so a late timer never overflows the bar
+  and a negative remaining time renders `0s` rather than a minus sign.
+- Nothing imports the module yet: no scheduler, event, entry, or footer behavior changes here.
+
+### Why
+
+`#schedule()` in `monitor-continuation.ts` treats its two waits asymmetrically. The `monitor`
+branch (`GOAL_MONITOR_CONTINUATION_DELAY_MS`, 240s) emits `ui.notify` plus a durable
+`goal-cache-warmup` entry, so the wait is visible. The `userGrace` branch
+(`GOAL_USER_GRACE_DELAY_MS`, `continuation.ts:11`, 60s) emits nothing at all — no notify, no
+event, no entry. A session that is waiting out the grace window is therefore
+indistinguishable from a hung one for a full minute.
+
+Session forensics on a real transcript show the shape: gaps of 60.0s / 60.3s / 60.5s / 61.6s
+each begin immediately after a `senpi.hooks.stop-state {count:0}` record and end with a
+`goal-continuation` injection, with no rendered output in between. The 240s monitor wait in the
+same session did produce visible `goal-cache-warmup` scheduled→resumed entries. Tool calls
+paired 170/170 and child-task wakes delivered 11/11 in that transcript, so the silence is the
+unrendered wait itself and not a lost result or a dropped wake.
+
+### Open questions for maintainers
+
+- Should the `userGrace` branch emit a durable entry (symmetric with `goal-cache-warmup`), a
+  transient footer segment only, or both?
+- If footer-only: extend `GoalElapsedTicker`, or add a second ticker so the wait countdown and
+  the `Pursuing goal (…)` elapsed segment stay independent?
+- Is a 12-cell bar the right footer budget, or should this be text-only?
+
+### Expected merge conflict zones on next upstream sync
+
+- NONE for `wait-progress.ts` — new fork-only file with no importers.
+- LOW in `AGENTS.md` (FILES table + tests list, additive lines only).
+- Wiring, once agreed, would touch `monitor-continuation.ts` `#schedule()` and the footer
+  status surface; both are fork-owned but `#schedule()` is actively edited, so that follow-up
+  carries real conflict risk and is intentionally left out of this change.
+
 ## Observable progress resets the persisted continuation cap streak (2026-07-30)
 
 ### What changed
@@ -679,4 +728,3 @@ codex-aligned tool naming, and budget-driven behavior removed. An optional
 - LOW in `types.ts` around the `SessionEvent` union and `on()` overloads (additive).
 - LOW in `agent-session.ts` around `abort()` and the `AgentSessionEvent` union (additive).
 - LOW in `goal/index.ts` around the session_start handler and the new session_abort handler.
-

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -90,7 +90,55 @@
 - LOW in monitor continuation tests that observe delayed persistence.
 - NONE in the goal store schema, public extension API, or status transitions.
 
-||||||| parent of a687d47c6 (fix(coding-agent): tell users how to clear a mechanical goal block)
+## PROPOSAL: continuation-wait countdown render layer (2026-07-31)
+
+Status: **render layer only.** The wiring that drives this into the footer is deliberately
+not part of this change and is open for maintainer direction.
+
+### What changed
+
+- New `wait-progress.ts` exports `GOAL_WAIT_BAR_CELLS` (12), `renderGoalWaitBar(elapsedRatio)`
+  and `formatGoalWaitLabel({ kind, remainingMs, totalMs, activeMonitorCount })`. It reuses
+  `formatWakeDuration` from `cache-warm.ts` so a wait countdown reads identically to the
+  existing cache-warm notices.
+- `kind: "userGrace"` renders `▰▰▰▱▱▱▱▱▱▱▱▱ goal resumes in 47s`;
+  `kind: "monitor"` renders `… goal continues in 3m 12s · 2 monitors on duty` with
+  singular/plural monitor wording. Ratios are clamped, so a late timer never overflows the bar
+  and a negative remaining time renders `0s` rather than a minus sign.
+- Nothing imports the module yet: no scheduler, event, entry, or footer behavior changes here.
+
+### Why
+
+`#schedule()` in `monitor-continuation.ts` treats its two waits asymmetrically. The `monitor`
+branch (`GOAL_MONITOR_CONTINUATION_DELAY_MS`, 240s) emits `ui.notify` plus a durable
+`goal-cache-warmup` entry, so the wait is visible. The `userGrace` branch
+(`GOAL_USER_GRACE_DELAY_MS`, `continuation.ts:11`, 60s) emits nothing at all — no notify, no
+event, no entry. A session that is waiting out the grace window is therefore
+indistinguishable from a hung one for a full minute.
+
+Session forensics on a real transcript show the shape: gaps of 60.0s / 60.3s / 60.5s / 61.6s
+each begin immediately after a `senpi.hooks.stop-state {count:0}` record and end with a
+`goal-continuation` injection, with no rendered output in between. The 240s monitor wait in the
+same session did produce visible `goal-cache-warmup` scheduled→resumed entries. Tool calls
+paired 170/170 and child-task wakes delivered 11/11 in that transcript, so the silence is the
+unrendered wait itself and not a lost result or a dropped wake.
+
+### Open questions for maintainers
+
+- Should the `userGrace` branch emit a durable entry (symmetric with `goal-cache-warmup`), a
+  transient footer segment only, or both?
+- If footer-only: extend `GoalElapsedTicker`, or add a second ticker so the wait countdown and
+  the `Pursuing goal (…)` elapsed segment stay independent?
+- Is a 12-cell bar the right footer budget, or should the countdown be text-only?
+
+### Expected merge conflict zones on next upstream sync
+
+- NONE for `wait-progress.ts` — new fork-only file with no importers.
+- LOW in `AGENTS.md` (FILES table + tests list, additive lines only).
+- Wiring, once agreed, would touch `monitor-continuation.ts` `#schedule()` and the footer
+  status surface; both are fork-owned but `#schedule()` is actively edited, so that follow-up
+  carries real conflict risk and is intentionally left out of this change.
+
 ## Observable progress resets the persisted continuation cap streak (2026-07-30)
 
 ### What changed
@@ -660,4 +708,3 @@ codex-aligned tool naming, and budget-driven behavior removed. An optional
 - LOW in `types.ts` around the `SessionEvent` union and `on()` overloads (additive).
 - LOW in `agent-session.ts` around `abort()` and the `AgentSessionEvent` union (additive).
 - LOW in `goal/index.ts` around the session_start handler and the new session_abort handler.
-

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -8,8 +8,9 @@ export const GOAL_CONTINUATION_CAP = 8;
 export const GOAL_STALL_TOOLLESS_THRESHOLD = 3;
 export const GOAL_REPETITION_HASH_STREAK = 3;
 export const GOAL_LENGTH_RECOVERY_LIMIT = 1;
+export const GOAL_USER_GRACE_DELAY_MS = 60_000;
 
-export type GoalContinuationPath = "immediate" | "monitorDelayed" | "sessionStart";
+export type GoalContinuationPath = "immediate" | "monitorDelayed" | "userGrace" | "sessionStart";
 
 export type GoalContinuationInput = {
 	readonly goal: Goal | null;
@@ -91,7 +92,7 @@ export function evaluateGoalContinuation(input: GoalContinuationInput): GoalCont
 		return { kind: "deny", reason: "cap" };
 	}
 	if (
-		input.path === "immediate" &&
+		(input.path === "immediate" || input.path === "userGrace") &&
 		input.lastContinuationSignature !== undefined &&
 		input.lastContinuationSignature === input.currentSignature
 	) {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -18,6 +18,7 @@ import { registerGoalTools } from "./tool-registration.ts";
 import { TurnUsageTracker } from "./turn-usage.ts";
 import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
 import { updateGoalUi } from "./ui.ts";
+import { GOAL_WAIT_STATUS_KEY, GoalWaitTicker } from "./wait-ticker.ts";
 
 const RESUME_GOAL_CHOICE = "Resume goal";
 const LEAVE_GOAL_PAUSED_CHOICE = "Leave paused";
@@ -36,12 +37,23 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let completedThisTurnGoalId: string | null = null;
 	let continuationPending = false;
 	const turnUsage = new TurnUsageTracker();
+	const goalWaitTicker = new GoalWaitTicker({
+		render: (renderCtx, status) => {
+			try {
+				renderCtx.ui.setStatus(GOAL_WAIT_STATUS_KEY, status);
+			} catch (error) {
+				if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) return;
+				throw error;
+			}
+		},
+	});
 	const monitorContinuation = new MonitorAwareGoalContinuation(
 		pi,
 		() => continuationPending,
 		() => {
 			continuationPending = true;
 		},
+		goalWaitTicker,
 	);
 	const directInputLifecycle = new GoalDirectInputLifecycle({
 		monitor: monitorContinuation,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -13,6 +13,7 @@ import {
 	continuationTurnUsedTools,
 	evaluateGoalContinuation,
 	GOAL_STALL_TOOLLESS_THRESHOLD,
+	GOAL_USER_GRACE_DELAY_MS,
 	type GoalContinuationInput,
 	type GoalContinuationPath,
 	type GoalContinuationVerdict,
@@ -30,6 +31,8 @@ import { resetContinuationStreak } from "./store.ts";
 import { goalStoreRef } from "./store-ref.ts";
 import { collectAssistantUsage } from "./turn-usage.ts";
 import type { Goal, TokenUsageSnapshot } from "./types.ts";
+import type { GoalWaitKind } from "./wait-progress.ts";
+import type { GoalWaitTicker } from "./wait-ticker.ts";
 
 export const GOAL_MONITOR_CONTINUATION_DELAY_MS = 240_000;
 export const GOAL_CONTINUATION_SCHEDULED_EVENT = "goal_continuation_scheduled";
@@ -45,6 +48,7 @@ interface AgentEndOptions {
 }
 
 type ContinuingGoalContinuationVerdict = Extract<GoalContinuationVerdict, { kind: "continue" }>;
+type DelayedContinuationKind = GoalWaitKind;
 
 type GoalContinuationAdmission = {
 	readonly goal: Goal;
@@ -55,11 +59,12 @@ export class MonitorAwareGoalContinuation {
 	readonly #pi: ExtensionAPI;
 	readonly #isContinuationPending: () => boolean;
 	readonly #markContinuationPending: () => void;
+	readonly #waitTicker: GoalWaitTicker | undefined;
 	#activeMonitorCount = 0;
 	#ctx: ExtensionContext | undefined;
 	#goal: Goal | null = null;
 	#timer: ReturnType<typeof setTimeout> | undefined;
-	#continuationScheduled = false;
+	#scheduledContinuationKind: DelayedContinuationKind | undefined;
 	#unsubscribeMonitorState: (() => void) | undefined;
 	#lastAgentEndMessages: readonly AgentMessage[] = [];
 	#consecutiveLengthRecoveries = new Map<string, number>();
@@ -71,17 +76,19 @@ export class MonitorAwareGoalContinuation {
 	#scheduledAtMs: number | undefined;
 	#scheduledDueAtMs: number | undefined;
 	#scheduledCache: GoalCacheWarmMetrics | undefined;
-	#heldTimer: { remainingMs: number } | undefined;
+	#heldTimer: { kind: DelayedContinuationKind; remainingMs: number } | undefined;
 	#directInputHolds = new Set<string>();
 
 	constructor(
 		pi: ExtensionAPI,
 		isContinuationPending: () => boolean = () => false,
 		markContinuationPending: () => void = () => {},
+		waitTicker?: GoalWaitTicker,
 	) {
 		this.#pi = pi;
 		this.#isContinuationPending = isContinuationPending;
 		this.#markContinuationPending = markContinuationPending;
+		this.#waitTicker = waitTicker;
 	}
 
 	start(ctx: ExtensionContext): void {
@@ -99,8 +106,12 @@ export class MonitorAwareGoalContinuation {
 			if (!isTerminalMonitorStateEvent(data)) return;
 			this.#activeMonitorCount = data.activeCount;
 			if (data.activeCount === 0) {
-				if (this.#continuationScheduled) this.#cancelTimer();
+				if (this.#scheduledContinuationKind === "monitor") this.#cancelTimer();
 				this.#resetToollessContinuationStreak();
+				return;
+			}
+			if (this.#scheduledContinuationKind === "monitor") {
+				this.#waitTicker?.setActiveMonitorCount(data.activeCount);
 			}
 		});
 	}
@@ -126,16 +137,30 @@ export class MonitorAwareGoalContinuation {
 					options.goal)
 				: options.goal;
 		this.#goal = goal;
-		if (this.#endedTurnWasUserInitiated) {
-			this.#endedTurnWasUserInitiated = false;
-			this.#cancelTimer();
-			return goal;
-		}
-
 		const immediateVerdict = evaluateGoalContinuation({
 			goal,
 			...this.#buildVerdictInput(options.ctx, goal, "immediate", options.messages),
 		});
+		if (this.#endedTurnWasUserInitiated) {
+			this.#endedTurnWasUserInitiated = false;
+			this.#cancelTimer();
+			if (immediateVerdict.kind === "continue") {
+				this.#schedule(goal, "userGrace");
+				return goal;
+			}
+			switch (immediateVerdict.reason) {
+				case "not-eligible":
+				case "single-flight":
+				case "stale":
+					return goal;
+				case "cap":
+				case "repetition":
+				case "length-exhausted": {
+					const admission = await this.#admitAndQueue(options.ctx, goal, "immediate", options.messages);
+					return admission.goal;
+				}
+			}
+		}
 		if (immediateVerdict.kind === "deny" && immediateVerdict.reason === "not-eligible") return goal;
 
 		if (this.#activeMonitorCount === 0) {
@@ -143,7 +168,7 @@ export class MonitorAwareGoalContinuation {
 			const admission = await this.#admitAndQueue(options.ctx, goal, "immediate", options.messages);
 			return admission.goal;
 		}
-		this.#schedule(goal);
+		this.#schedule(goal, "monitor");
 		return goal;
 	}
 
@@ -160,13 +185,21 @@ export class MonitorAwareGoalContinuation {
 	holdDirectInput(inputId: string): void {
 		if (this.#directInputHolds.has(inputId)) return;
 		this.#directInputHolds.add(inputId);
-		if (this.#directInputHolds.size !== 1 || this.#timer === undefined || !this.#continuationScheduled) return;
+		if (
+			this.#directInputHolds.size !== 1 ||
+			this.#timer === undefined ||
+			this.#scheduledContinuationKind === undefined
+		) {
+			return;
+		}
 		this.#heldTimer = {
+			kind: this.#scheduledContinuationKind,
 			remainingMs: Math.max(0, (this.#scheduledDueAtMs ?? Date.now()) - Date.now()),
 		};
 		clearTimeout(this.#timer);
 		this.#timer = undefined;
 		this.#scheduledDueAtMs = undefined;
+		this.#waitTicker?.stop();
 	}
 
 	/** Resolves one admission hold without allowing overlapping inputs to consume each other. */
@@ -180,10 +213,10 @@ export class MonitorAwareGoalContinuation {
 		if (this.#directInputHolds.size > 0 || this.#heldTimer === undefined) return;
 		const held = this.#heldTimer;
 		this.#heldTimer = undefined;
-		this.#armTimer(held.remainingMs);
+		this.#armTimer(held.kind, held.remainingMs);
 	}
 
-	/** An accepted real user prompt disarms continuation for that user-initiated turn. */
+	/** An accepted real user prompt starts a grace-governed user turn. */
 	noteUserPrompt(): void {
 		this.#cancelTimer();
 		this.#endedTurnWasUserInitiated = true;
@@ -207,40 +240,54 @@ export class MonitorAwareGoalContinuation {
 		this.#resetContinuationState();
 	}
 
-	#schedule(goal: Goal): void {
-		if (this.#continuationScheduled) return;
-		const delayMs = GOAL_MONITOR_CONTINUATION_DELAY_MS;
-		const cache = estimateCacheWarmMetrics(this.#ctx?.model, process.env, this.#lastTurnUsage);
-		this.#scheduledCache = cache;
-		this.#scheduledAtMs = Date.now();
-		if (this.#ctx?.hasUI) {
-			this.#ctx.ui.notify(buildCacheWarmScheduledNotice(delayMs, this.#activeMonitorCount, cache), "info");
+	#schedule(goal: Goal, kind: DelayedContinuationKind): void {
+		if (this.#scheduledContinuationKind !== undefined) return;
+		const delayMs = kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS;
+		if (kind === "monitor") {
+			const cache = estimateCacheWarmMetrics(this.#ctx?.model, process.env, this.#lastTurnUsage);
+			this.#scheduledCache = cache;
+			this.#scheduledAtMs = Date.now();
+			if (this.#ctx?.hasUI) {
+				this.#ctx.ui.notify(buildCacheWarmScheduledNotice(delayMs, this.#activeMonitorCount, cache), "info");
+			}
+			this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
+				goalId: goal.id,
+				delayMs,
+				activeMonitorCount: this.#activeMonitorCount,
+				cache,
+			});
+			this.#appendWarmupEntry({
+				phase: "scheduled",
+				goalId: goal.id,
+				delayMs,
+				activeMonitorCount: this.#activeMonitorCount,
+				...(cache !== undefined ? { cache } : {}),
+			});
+		} else {
+			this.#scheduledAtMs = undefined;
+			this.#scheduledCache = undefined;
 		}
-		this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
-			goalId: goal.id,
-			delayMs,
-			activeMonitorCount: this.#activeMonitorCount,
-			cache,
-		});
-		this.#appendWarmupEntry({
-			phase: "scheduled",
-			goalId: goal.id,
-			delayMs,
-			activeMonitorCount: this.#activeMonitorCount,
-			...(cache !== undefined ? { cache } : {}),
-		});
-		this.#continuationScheduled = true;
+		this.#scheduledContinuationKind = kind;
 		if (this.#directInputHolds.size > 0) {
-			this.#heldTimer = { remainingMs: delayMs };
+			this.#heldTimer = { kind, remainingMs: delayMs };
 			return;
 		}
-		this.#armTimer(delayMs);
+		this.#armTimer(kind, delayMs);
 	}
 
-	#armTimer(delayMs: number): void {
+	#armTimer(kind: DelayedContinuationKind, delayMs: number): void {
 		this.#scheduledDueAtMs = Date.now() + delayMs;
+		const ctx = this.#ctx;
+		if (ctx?.hasUI) {
+			this.#waitTicker?.sync(ctx, {
+				kind,
+				remainingMs: delayMs,
+				totalMs: kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS,
+				activeMonitorCount: this.#activeMonitorCount,
+			});
+		}
 		this.#timer = setTimeout(() => {
-			void this.#continueIfEligible().catch((error: unknown) => {
+			void this.#continueIfEligible(kind).catch((error: unknown) => {
 				if (this.#ctx?.hasUI) {
 					const message = error instanceof Error ? error.message : String(error);
 					this.#ctx.ui.notify(`Goal continuation delivery failed: ${message}`, "error");
@@ -249,11 +296,12 @@ export class MonitorAwareGoalContinuation {
 		}, delayMs);
 	}
 
-	async #continueIfEligible(): Promise<void> {
+	async #continueIfEligible(kind: DelayedContinuationKind): Promise<void> {
 		this.#timer = undefined;
 		this.#scheduledDueAtMs = undefined;
-		this.#continuationScheduled = false;
-		const delayMs = GOAL_MONITOR_CONTINUATION_DELAY_MS;
+		this.#scheduledContinuationKind = undefined;
+		this.#waitTicker?.stop();
+		const delayMs = kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS;
 		const waitedMs = this.#scheduledAtMs === undefined ? delayMs : Math.max(0, Date.now() - this.#scheduledAtMs);
 		const cache = this.#scheduledCache;
 		this.#scheduledAtMs = undefined;
@@ -261,9 +309,14 @@ export class MonitorAwareGoalContinuation {
 		const ctx = this.#ctx;
 		const goal = this.#goal;
 		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
-		if (this.#activeMonitorCount === 0) return;
-		const admission = await this.#admitAndQueue(ctx, goal, "monitorDelayed", this.#lastAgentEndMessages);
-		if (!admission.admitted) return;
+		if (kind === "monitor" && this.#activeMonitorCount === 0) return;
+		const admission = await this.#admitAndQueue(
+			ctx,
+			goal,
+			kind === "monitor" ? "monitorDelayed" : "userGrace",
+			this.#lastAgentEndMessages,
+		);
+		if (kind !== "monitor" || !admission.admitted) return;
 		this.#pi.events?.emit(GOAL_CONTINUATION_RESUMED_EVENT, {
 			goalId: goal.id,
 			delayMs,
@@ -402,7 +455,8 @@ export class MonitorAwareGoalContinuation {
 		this.#heldTimer = undefined;
 		if (this.#timer !== undefined) clearTimeout(this.#timer);
 		this.#timer = undefined;
-		this.#continuationScheduled = false;
+		this.#scheduledContinuationKind = undefined;
+		this.#waitTicker?.stop();
 	}
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-progress.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-progress.ts
@@ -1,0 +1,43 @@
+import { formatWakeDuration } from "./cache-warm.ts";
+
+export type GoalWaitKind = "monitor" | "userGrace";
+
+export interface GoalWaitLabelInput {
+	readonly kind: GoalWaitKind;
+	readonly remainingMs: number;
+	readonly totalMs: number;
+	readonly activeMonitorCount: number;
+}
+
+export const GOAL_WAIT_BAR_CELLS = 12;
+
+const FILLED_CELL = "\u25b0";
+const EMPTY_CELL = "\u25b1";
+
+function clampRatio(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.min(1, Math.max(0, value));
+}
+
+export function renderGoalWaitBar(elapsedRatio: number): string {
+	const filled = Math.round(clampRatio(elapsedRatio) * GOAL_WAIT_BAR_CELLS);
+	return FILLED_CELL.repeat(filled) + EMPTY_CELL.repeat(GOAL_WAIT_BAR_CELLS - filled);
+}
+
+function elapsedRatioOf(remainingMs: number, totalMs: number): number {
+	if (totalMs <= 0) return 1;
+	return clampRatio((totalMs - Math.max(0, remainingMs)) / totalMs);
+}
+
+function monitorsOnDuty(count: number): string {
+	return count === 1 ? "1 monitor on duty" : `${count} monitors on duty`;
+}
+
+export function formatGoalWaitLabel(input: GoalWaitLabelInput): string {
+	const bar = renderGoalWaitBar(elapsedRatioOf(input.remainingMs, input.totalMs));
+	const remaining = formatWakeDuration(Math.max(0, input.remainingMs));
+	if (input.kind === "monitor") {
+		return `${bar} goal continues in ${remaining} \u00b7 ${monitorsOnDuty(input.activeMonitorCount)}`;
+	}
+	return `${bar} goal resumes in ${remaining}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
@@ -1,0 +1,89 @@
+import type { ExtensionContext } from "../../types.ts";
+import { formatGoalWaitLabel, type GoalWaitKind, type GoalWaitLabelInput } from "./wait-progress.ts";
+
+/** Footer countdown refresh cadence while a Goal continuation is delayed. */
+export const GOAL_WAIT_TICK_INTERVAL_MS = 1000;
+export const GOAL_WAIT_STATUS_KEY = "goal-wait";
+
+/** Receives the freshly formatted footer status text (undefined clears the status). */
+export type GoalWaitRender = (ctx: ExtensionContext, status: string | undefined) => void;
+
+export interface GoalWaitTickerOptions {
+	readonly render: GoalWaitRender;
+	/** Injectable clock for tests; defaults to Date.now. */
+	readonly now?: () => number;
+}
+
+/**
+ * Drives a once-per-second footer countdown while a Goal continuation timer is
+ * armed. Mirrors the existing GoalElapsedTicker and MonitorStatusTicker: the
+ * interval is unref'd and unchanged visible labels are not rendered again.
+ */
+export class GoalWaitTicker {
+	private readonly render: GoalWaitRender;
+	private readonly now: () => number;
+	private intervalId: NodeJS.Timeout | undefined;
+	private ctx: ExtensionContext | undefined;
+	private kind: GoalWaitKind | undefined;
+	private dueAtMs = 0;
+	private totalMs = 0;
+	private activeMonitorCount = 0;
+	private lastRenderedStatus: string | undefined;
+
+	constructor(options: GoalWaitTickerOptions) {
+		this.render = options.render;
+		this.now = options.now ?? Date.now;
+	}
+
+	get running(): boolean {
+		return this.intervalId !== undefined;
+	}
+
+	/** Render the current wait immediately and keep it live until stopped. */
+	sync(ctx: ExtensionContext, input: GoalWaitLabelInput): void {
+		this.ctx = ctx;
+		this.kind = input.kind;
+		this.dueAtMs = this.now() + Math.max(0, input.remainingMs);
+		this.totalMs = input.totalMs;
+		this.activeMonitorCount = input.activeMonitorCount;
+		this.lastRenderedStatus = undefined;
+		this.tick();
+		if (this.intervalId !== undefined) return;
+		const handle = setInterval(() => this.tick(), GOAL_WAIT_TICK_INTERVAL_MS);
+		handle.unref();
+		this.intervalId = handle;
+	}
+
+	/** Refresh monitor wording without changing the countdown deadline. */
+	setActiveMonitorCount(activeMonitorCount: number): void {
+		if (this.ctx === undefined || this.kind !== "monitor") return;
+		this.activeMonitorCount = activeMonitorCount;
+		this.tick();
+	}
+
+	/** Stop ticking, clear the footer segment, and drop the retained context. */
+	stop(): void {
+		if (this.intervalId !== undefined) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+		const ctx = this.ctx;
+		this.ctx = undefined;
+		this.kind = undefined;
+		this.lastRenderedStatus = undefined;
+		if (ctx !== undefined) this.render(ctx, undefined);
+	}
+
+	private tick(): void {
+		if (this.ctx === undefined || this.kind === undefined) return;
+		const status = formatGoalWaitLabel({
+			kind: this.kind,
+			remainingMs: Math.max(0, this.dueAtMs - this.now()),
+			totalMs: this.totalMs,
+			activeMonitorCount: this.activeMonitorCount,
+		});
+		if (status === this.lastRenderedStatus) return;
+		this.lastRenderedStatus = status;
+		this.render(this.ctx, status);
+	}
+}

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -6,6 +6,7 @@ import {
 	GOAL_LENGTH_RECOVERY_LIMIT,
 	GOAL_REPETITION_HASH_STREAK,
 	GOAL_STALL_TOOLLESS_THRESHOLD,
+	GOAL_USER_GRACE_DELAY_MS,
 	hashAssistantText,
 	normalizeAssistantText,
 } from "../../src/core/extensions/builtin/goal/continuation.ts";
@@ -54,6 +55,7 @@ describe("goal continuation verdict", () => {
 		["rejects an immediate path with pending messages", makeInput({ hasPendingMessages: true })],
 		["rejects an immediate path after an unclean end", makeInput({ lastStopReason: "error" })],
 		["requires idle state for monitor-delayed continuation", makeInput({ path: "monitorDelayed", isIdle: false })],
+		["requires idle state for user-grace continuation", makeInput({ path: "userGrace", isIdle: false })],
 		["requires idle state for session-start continuation", makeInput({ path: "sessionStart", isIdle: false })],
 	] as const)("denies as not eligible when %s", (_label, input) => {
 		expect(evaluateGoalContinuation(input)).toEqual({ kind: "deny", reason: "not-eligible" });
@@ -116,6 +118,9 @@ describe("goal continuation verdict", () => {
 		expect(evaluateGoalContinuation(makeInput({ path: "monitorDelayed", lastStopReason: "error" }))).toMatchObject({
 			kind: "continue",
 		});
+		expect(evaluateGoalContinuation(makeInput({ path: "userGrace", lastStopReason: "error" }))).toMatchObject({
+			kind: "continue",
+		});
 		expect(evaluateGoalContinuation(makeInput({ path: "sessionStart", lastStopReason: "error" }))).toMatchObject({
 			kind: "continue",
 		});
@@ -127,7 +132,7 @@ describe("goal continuation verdict", () => {
 			lastContinuationSignature: "goal-1:1/2:abc123",
 		});
 
-		for (const path of ["immediate", "monitorDelayed", "sessionStart"] as const) {
+		for (const path of ["immediate", "monitorDelayed", "userGrace", "sessionStart"] as const) {
 			expect(evaluateGoalContinuation({ ...capped, path })).toEqual({ kind: "deny", reason: "cap" });
 		}
 		expect(
@@ -177,5 +182,6 @@ describe("goal continuation verdict", () => {
 		expect(GOAL_STALL_TOOLLESS_THRESHOLD).toBe(3);
 		expect(GOAL_REPETITION_HASH_STREAK).toBe(3);
 		expect(GOAL_LENGTH_RECOVERY_LIMIT).toBe(1);
+		expect(GOAL_USER_GRACE_DELAY_MS).toBe(60_000);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
 import { goalFilePath, readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
 import type { SessionEntry } from "../../src/core/session-manager.ts";
+import { waitForGoalContinuationCount } from "./goal-monitor-test-harness.ts";
 
 type AnyTool = ToolDefinition<any, any, any>;
 type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
@@ -627,11 +629,12 @@ describe("goal extension session_start migration-lite admission", () => {
 			{ type: "agent_end", messages: [assistantMessageWithStopReason("stop")] },
 			ctx,
 		);
-		// Accepted direct input consumes continuation eligibility for this turn. The
-		// Goal remains active, but no delayed continuation resurrects it afterward.
 		expect(sent).toHaveLength(0);
-		await vi.advanceTimersByTimeAsync(60_000);
-		expect(sent).toHaveLength(0);
+		const graceDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
+		await graceDeliveryRecorded;
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
 		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
 		vi.useRealTimers();
 	});

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -156,6 +156,7 @@ describe("goal continuation gating", () => {
 
 		expect(evaluateGoalContinuation({ ...input, path: "immediate" })).toEqual({ kind: "deny", reason: "cap" });
 		expect(evaluateGoalContinuation({ ...input, path: "sessionStart" })).toEqual({ kind: "deny", reason: "cap" });
+		expect(evaluateGoalContinuation({ ...input, path: "userGrace" })).toEqual({ kind: "deny", reason: "cap" });
 		expect(evaluateGoalContinuation({ ...input, path: "monitorDelayed" })).toEqual({
 			kind: "deny",
 			reason: "cap",

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import { admitAndQueueGoalContinuation } from "../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
 import {
 	GOAL_MONITOR_CONTINUATION_DELAY_MS,
@@ -15,16 +16,19 @@ import {
 	writeGoal,
 } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import { GOAL_WAIT_STATUS_KEY } from "../../src/core/extensions/builtin/goal/wait-ticker.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
 	createGoalHarness,
+	createGoalStatusHarness,
 	createSentMessageHarness,
 	type GoalHandler,
 	makeGoalContext,
 	runGoalHandlers,
 	TestEventBus,
+	waitForGoalStatus,
 	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
@@ -440,20 +444,88 @@ describe("goal continuation while a monitor is active", () => {
 		expect(notices).toHaveLength(0);
 	});
 
-	it("leaves an accepted user turn active but idle without arming a continuation timer", async () => {
+	it("renders the user-grace countdown until delivery, then clears it", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent } = createGoalHarness();
-		const ctx = await makeGoalContext(notices, "thread-user-turn-idle");
+		const status = createGoalStatusHarness();
+		const harness = createGoalHarness();
+		const { tools, handlers, sent } = harness;
+		const ctx = await makeGoalContext(notices, "thread-user-grace-countdown", {
+			pendingMessages: false,
+			status,
+		});
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
+		const countdownStarted = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 1m") === true,
+		);
 		await runUserInitiatedTurn(handlers, ctx);
+		await countdownStarted;
+		expect(sent).toHaveLength(0);
 
+		const countdownAdvanced = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 30s") === true,
+		);
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS / 2);
+		await countdownAdvanced;
+
+		const deliveryRecorded = waitForSentCount(harness, 1);
+		const countdownCleared = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text === undefined,
+		);
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS / 2);
+		await Promise.all([deliveryRecorded, countdownCleared]);
+
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+		expect(status.updates.filter((update) => update.key === GOAL_WAIT_STATUS_KEY).at(-1)?.text).toBeUndefined();
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 1 });
+	});
+
+	it("clears the user-grace countdown and cancels delivery when new input is accepted", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const status = createGoalStatusHarness();
+		const { tools, handlers, sent } = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "thread-user-grace-countdown-cancel", {
+			pendingMessages: false,
+			status,
+		});
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		const countdownStarted = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 1m") === true,
+		);
+		await runUserInitiatedTurn(handlers, ctx);
+		await countdownStarted;
+
+		const countdownCleared = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text === undefined,
+		);
+		await runGoalHandlers(
+			handlers,
+			"input",
+			{ type: "input", inputId: "cancel-countdown", text: "new direction", source: "interactive" },
+			ctx,
+		);
+		await countdownCleared;
+		await runGoalHandlers(
+			handlers,
+			"input_disposition",
+			{ type: "input_disposition", inputId: "cancel-countdown", disposition: "started" },
+			ctx,
+		);
+
+		const waitStatusCount = status.updates.filter((update) => update.key === GOAL_WAIT_STATUS_KEY).length;
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
 		expect(sent).toHaveLength(0);
-		await vi.advanceTimersByTimeAsync(60_000);
-		expect(sent).toHaveLength(0);
-		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 0 });
+		expect(status.updates.filter((update) => update.key === GOAL_WAIT_STATUS_KEY)).toHaveLength(waitStatusCount);
 	});
 
 	it("resets monitor-delayed repetition state when a goal pauses and resumes", async () => {

--- a/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_WAIT_STATUS_KEY } from "../../src/core/extensions/builtin/goal/wait-ticker.ts";
 import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
 	createGoalHarness,
+	createGoalStatusHarness,
 	type GoalContextState,
 	type GoalHarness,
+	type GoalStatusHarness,
 	makeGoalContext,
 	runGoalHandlers,
+	waitForGoalStatus,
 	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
@@ -16,11 +20,13 @@ interface ActiveMonitorHarness {
 	readonly ctx: ExtensionContext;
 	readonly notices: string[];
 	readonly state: GoalContextState;
+	readonly status: GoalStatusHarness;
 }
 
 async function createActiveMonitorHarness(threadId: string): Promise<ActiveMonitorHarness> {
 	const notices: string[] = [];
-	const state: GoalContextState = { pendingMessages: false };
+	const status = createGoalStatusHarness();
+	const state: GoalContextState = { pendingMessages: false, status };
 	const harness = createGoalHarness();
 	const ctx = await makeGoalContext(notices, threadId, state);
 	await harness.tools
@@ -29,7 +35,7 @@ async function createActiveMonitorHarness(threadId: string): Promise<ActiveMonit
 	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
 	await harness.events.flush();
-	return { harness, ctx, notices, state };
+	return { harness, ctx, notices, state, status };
 }
 
 async function endCleanTurn(harness: GoalHarness, ctx: ExtensionContext): Promise<void> {
@@ -102,14 +108,21 @@ describe("goal monitor continuation lifecycle", () => {
 
 	it("disposes the delayed continuation on session reload", async () => {
 		vi.useFakeTimers();
-		const { harness, ctx } = await createActiveMonitorHarness("thread-monitor-reload");
-		const baselineTimerCount = vi.getTimerCount();
+		const { harness, ctx, status } = await createActiveMonitorHarness("thread-monitor-reload");
+		const countdownStarted = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal continues in 4m") === true,
+		);
 		await endCleanTurn(harness, ctx);
-		expect(vi.getTimerCount()).toBe(baselineTimerCount + 1);
+		await countdownStarted;
 
+		const countdownCleared = waitForGoalStatus(
+			status,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text === undefined,
+		);
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await countdownCleared;
 
-		expect(vi.getTimerCount()).toBe(baselineTimerCount);
 		await vi.advanceTimersByTimeAsync(240_000);
 		expect(harness.sent).toHaveLength(0);
 	});

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -49,9 +49,20 @@ export class TestEventBus {
 export type AppendedGoalEntry = { readonly customType: string; readonly data: unknown };
 
 const sentCountWaiters = Symbol("sentCountWaiters");
+const statusWaiters = Symbol("statusWaiters");
 
 type SentCountWaiter = {
 	readonly expectedCount: number;
+	readonly complete: (error?: Error) => void;
+};
+
+export type GoalStatusUpdate = {
+	readonly key: string;
+	readonly text: string | undefined;
+};
+
+type StatusWaiter = {
+	readonly matches: (update: GoalStatusUpdate) => boolean;
 	readonly complete: (error?: Error) => void;
 };
 
@@ -59,6 +70,12 @@ export interface SentMessageHarness {
 	readonly sent: SentGoalMessage[];
 	readonly sendMessage: (message: SentGoalMessage["message"], options: unknown) => void;
 	readonly [sentCountWaiters]: Set<SentCountWaiter>;
+}
+
+export interface GoalStatusHarness {
+	readonly updates: GoalStatusUpdate[];
+	readonly setStatus: (key: string, text: string | undefined) => void;
+	readonly [statusWaiters]: Set<StatusWaiter>;
 }
 
 export interface GoalHarness extends SentMessageHarness {
@@ -71,6 +88,7 @@ export interface GoalHarness extends SentMessageHarness {
 export interface GoalContextState {
 	pendingMessages: boolean;
 	model?: Model<Api>;
+	status?: GoalStatusHarness;
 }
 
 export function createSentMessageHarness(): SentMessageHarness {
@@ -83,6 +101,19 @@ export function createSentMessageHarness(): SentMessageHarness {
 		}
 	};
 	return { sent, sendMessage, [sentCountWaiters]: waiters };
+}
+
+export function createGoalStatusHarness(): GoalStatusHarness {
+	const updates: GoalStatusUpdate[] = [];
+	const waiters = new Set<StatusWaiter>();
+	const setStatus = (key: string, text: string | undefined): void => {
+		const update = { key, text };
+		updates.push(update);
+		for (const waiter of waiters) {
+			if (waiter.matches(update)) waiter.complete();
+		}
+	};
+	return { updates, setStatus, [statusWaiters]: waiters };
 }
 
 export function createGoalHarness(): GoalHarness {
@@ -126,7 +157,7 @@ export async function makeGoalContext(
 		ui: {
 			notify: (message: string) => notices.push(message),
 			select: async () => undefined,
-			setStatus: () => {},
+			setStatus: state.status?.setStatus ?? (() => {}),
 		},
 		sessionManager: {
 			getSessionFile: () => join(dir, "session.jsonl"),
@@ -139,6 +170,33 @@ export async function makeGoalContext(
 
 export async function cleanupGoalMonitorTempDirs(): Promise<void> {
 	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+}
+
+export function waitForGoalStatus(
+	harness: GoalStatusHarness,
+	matches: (update: GoalStatusUpdate) => boolean,
+	options: { readonly timeoutMs?: number } = {},
+): Promise<void> {
+	const waiters = harness[statusWaiters];
+	return new Promise((resolve, reject) => {
+		let completed = false;
+		let timeout: ReturnType<typeof setRealTimeout> | undefined;
+		const waiter: StatusWaiter = { matches, complete };
+		waiters.add(waiter);
+		timeout = setRealTimeout(
+			() => complete(new Error("Timed out waiting for Goal status update")),
+			options.timeoutMs ?? 5_000,
+		);
+
+		function complete(error: Error | undefined = undefined): void {
+			if (completed) return;
+			completed = true;
+			if (timeout !== undefined) clearRealTimeout(timeout);
+			waiters.delete(waiter);
+			if (error === undefined) resolve();
+			else reject(error);
+		}
+	});
 }
 
 export function waitForSentCount(

--- a/packages/coding-agent/test/suite/goal-wait-progress.test.ts
+++ b/packages/coding-agent/test/suite/goal-wait-progress.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatGoalWaitLabel,
+	GOAL_WAIT_BAR_CELLS,
+	renderGoalWaitBar,
+} from "../../src/core/extensions/builtin/goal/wait-progress.ts";
+
+const FILLED = "▰";
+const EMPTY = "▱";
+
+function filledCells(bar: string): number {
+	return [...bar].filter((cell) => cell === FILLED).length;
+}
+
+describe("goal wait progress bar", () => {
+	it("renders an empty bar at the start of the wait", () => {
+		expect(renderGoalWaitBar(0)).toBe(EMPTY.repeat(GOAL_WAIT_BAR_CELLS));
+	});
+
+	it("renders a full bar once the wait has elapsed", () => {
+		expect(renderGoalWaitBar(1)).toBe(FILLED.repeat(GOAL_WAIT_BAR_CELLS));
+	});
+
+	it("fills proportionally at the halfway point", () => {
+		const bar = renderGoalWaitBar(0.5);
+		expect([...bar]).toHaveLength(GOAL_WAIT_BAR_CELLS);
+		expect(filledCells(bar)).toBe(Math.round(GOAL_WAIT_BAR_CELLS / 2));
+	});
+
+	it("clamps out-of-range ratios instead of overflowing the bar", () => {
+		expect(renderGoalWaitBar(-1)).toBe(EMPTY.repeat(GOAL_WAIT_BAR_CELLS));
+		expect(renderGoalWaitBar(9)).toBe(FILLED.repeat(GOAL_WAIT_BAR_CELLS));
+	});
+});
+
+describe("goal wait label", () => {
+	it("shows remaining seconds and a partially filled bar for a user-grace wait", () => {
+		const label = formatGoalWaitLabel({
+			kind: "userGrace",
+			remainingMs: 47_000,
+			totalMs: 60_000,
+			activeMonitorCount: 0,
+		});
+
+		expect(label).toContain("47s");
+		expect(label).toContain(FILLED);
+		expect(label).toContain(EMPTY);
+	});
+
+	it("formats a multi-minute monitor wait and names the monitors on duty", () => {
+		const label = formatGoalWaitLabel({
+			kind: "monitor",
+			remainingMs: 192_000,
+			totalMs: 240_000,
+			activeMonitorCount: 2,
+		});
+
+		expect(label).toContain("3m 12s");
+		expect(label).toContain("2 monitors");
+	});
+
+	it("uses the singular monitor wording for a single monitor", () => {
+		const label = formatGoalWaitLabel({
+			kind: "monitor",
+			remainingMs: 60_000,
+			totalMs: 240_000,
+			activeMonitorCount: 1,
+		});
+
+		expect(label).toContain("1 monitor");
+		expect(label).not.toContain("1 monitors");
+	});
+
+	it("never renders a negative remaining time", () => {
+		const label = formatGoalWaitLabel({
+			kind: "userGrace",
+			remainingMs: -5_000,
+			totalMs: 60_000,
+			activeMonitorCount: 0,
+		});
+
+		expect(label).toContain("0s");
+		expect(label).not.toContain("-");
+	});
+
+	it("keeps the user-grace label free of monitor wording", () => {
+		const label = formatGoalWaitLabel({
+			kind: "userGrace",
+			remainingMs: 30_000,
+			totalMs: 60_000,
+			activeMonitorCount: 3,
+		});
+
+		expect(label).not.toContain("monitor");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_USER_GRACE_DELAY_MS } from "../../../src/core/extensions/builtin/goal/continuation.ts";
 import { readGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
 import type { SessionEntry } from "../../../src/core/session-manager.ts";
@@ -11,6 +12,7 @@ import {
 	createGoalHarness,
 	makeGoalContext,
 	runGoalHandlers,
+	waitForSentCount,
 } from "../goal-monitor-test-harness.ts";
 import { createHarness, getMessageText, type Harness } from "../harness.ts";
 
@@ -162,7 +164,7 @@ describe("issue #447: goal continuation guardrails", () => {
 		});
 	});
 
-	it("leaves an active Goal idle after a direct user message without a delayed resurrection", async () => {
+	it("resumes an active Goal after the direct-user grace window", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
 		const harness = createGoalHarness();
@@ -191,9 +193,11 @@ describe("issue #447: goal continuation guardrails", () => {
 		);
 
 		expect(harness.sent).toHaveLength(0);
-		await vi.advanceTimersByTimeAsync(60_000);
-		expect(harness.sent).toHaveLength(0);
-		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 0 });
+		const graceDeliveryRecorded = waitForSentCount(harness, 1);
+		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
+		await graceDeliveryRecorded;
+		expect(harness.sent[0]?.message.customType).toBe(GOAL_CONTINUATION_MESSAGE_TYPE);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active", consecutiveContinuations: 1 });
 	});
 
 	it("blocks the goal when a terminal provider error has no retry remaining", async () => {


### PR DESCRIPTION
## Summary

This is now the complete runtime change, not a render-only proposal.

- Wires the existing clamped 12-cell wait formatter into the real Goal continuation scheduler.
- Restores the 60-second user-grace continuation after a clean accepted user turn while preserving correlated input admission and synchronous cancellation of an already-armed wait.
- Shows both user-grace and four-minute monitor waits as a live footer countdown.
- Clears the countdown on delivery, accepted replacement input, goal state changes, monitor settlement, reload, and shutdown.

## Rendering design

The countdown is a **footer-only transient**, not a durable timeline entry.

A durable entry cannot represent per-second state without adding permanent transcript noise for every grace window. The footer is already where Senpi renders live Goal elapsed state and terminal monitor elapsed state, so this uses the same mechanism: a dedicated `GoalWaitTicker` with an unref'd one-second interval, immediate render, unchanged-label suppression, and explicit cleanup.

The wait ticker is separate from `GoalElapsedTicker` because the two values have independent meaning and lifecycle. `Pursuing goal (...)` remains cumulative Goal time; `goal resumes in ...` / `goal continues in ...` exists only while a continuation timer is armed.

## Behavior and lifecycle

- `userGrace`: `▱▱▱▱▱▱▱▱▱▱▱▱ goal resumes in 1m` counts down to the real continuation delivery.
- `monitor`: `... goal continues in 4m · N monitors on duty` uses the existing monitor delay and cache-warm durable story.
- Direct-input holds freeze the scheduler and hide the transient status while admission is unresolved; handled/rejected input restores the exact remaining time, while accepted input cancels it.
- The stale conflict-marker cleanup already present on `main` was not re-added during the rebase.

PR #553 had removed the user-grace timer while improving direct-input correlation. This change intentionally restores the delayed continuation requested here without removing those safeguards: accepted input still cancels an existing wait synchronously, and only the clean end of that accepted user turn starts a fresh visible grace window.

## Tests

- Existing pure formatter coverage: **9 passed**.
- Added lifecycle/wiring coverage proves:
  - the real user-grace wait renders immediately and advances under fake time;
  - delivery clears the status and queues exactly one hidden continuation;
  - accepted input clears the status, stops future ticks, and cancels delivery;
  - reload clears a live monitor-wait countdown without leaking the timer.
- Related Goal suite: **27 files, 264 tests passed**.
- Root `npm run check`: passed.

The async tests subscribe to exact status/delivery signals before triggering the action and use bounded timeouts; there are no fixed sleeps or polling delays.

## Real CLI QA

Ran the source TUI in the isolated `senpi-qa` tmux channel against the local fake OpenAI Responses server: **9/9 passed**, zero real provider calls, real auth unchanged.

Evidence: `local-ignore/qa-evidence/20260803-pr578-goal-countdown/`

- `goal-countdown-59s.snapshot.txt` shows `Pursuing goal (1s) ▱▱▱▱▱▱▱▱▱▱▱▱ goal resumes in 59s` during the actual wait.
- `goal-countdown-after-delivery.snapshot.txt` shows the hidden continuation delivered after 60 seconds and the transient countdown removed.
- `goal-countdown-qa-summary.json` records the passing scenario.
