### PR TITLE
ci: shard the coding-agent test suite across three runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ concurrency:
 
 jobs:
   check:
-    name: Check and test
+    name: Static checks
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -41,9 +41,148 @@ jobs:
       - name: Build workspace package entries
         run: npm run build
 
-      - name: Test
-        timeout-minutes: 50
-        run: npm test
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Static checks"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # The coding-agent vitest suite dominates CI wall time (748+ files; measured
+  # 1364s single-fork, ~60% per-file import cost). Sharding it across three
+  # runners divides that wall while each shard keeps the CI fork-pool settings
+  # from vitest.config.ts (forks pool, capped workers) that prevent the historical
+  # subprocess-suite pool hang.
+  test-coding-agent:
+    name: Test (coding-agent ${{ matrix.shard }}/3)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install system dependencies
+        run: |
+          sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
+          sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build workspace package entries
+        run: npm run build
+
+      - name: Test shard
+        timeout-minutes: 25
+        run: npx vitest run --shard=${{ matrix.shard }}/3
+        working-directory: packages/coding-agent
+
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Test (coding-agent ${{ matrix.shard }}/3)"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test-workspaces:
+    name: Test (workspaces + scripts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install system dependencies
+        run: |
+          sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y \
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
+          sudo ln -sf "$(which fdfind)" /usr/local/bin/fd
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build workspace package entries
+        run: npm run build
+
+      - name: Script tests
+        run: npm run test:scripts
+
+      - name: Workspace tests (all but coding-agent)
+        timeout-minutes: 25
+        run: >
+          npm run test
+          --workspace packages/agent
+          --workspace packages/ai
+          --workspace packages/pty
+          --workspace packages/senpi-codemode
+          --workspace packages/server
+          --workspace packages/tui
+          --if-present
+
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Test (workspaces + scripts)"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Fan-in gate carrying the exact context name branch protection requires
+  # ("Check and test"). It succeeds only when every check/test job above passed,
+  # so the required-status contract is unchanged while the work runs in parallel.
+  check-and-test:
+    name: Check and test
+    needs: [check, test-coding-agent, test-workspaces]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all gates
+        shell: bash
+        run: |
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "gate results: $results"
+          for r in $results; do
+            if [ "$r" != "success" ]; then
+              echo "::error::a required CI job finished with result '$r'"
+              exit 1
+            fi
+          done
+
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Check and test (fan-in)"
+            echo "- check: ${{ needs.check.result }}"
+            echo "- test-coding-agent: ${{ needs.test-coding-agent.result }}"
+            echo "- test-workspaces: ${{ needs.test-workspaces.result }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   terminal-cross-os:
     name: Terminal tools (${{ matrix.os }})


### PR DESCRIPTION
## Summary
Follow-up to #575 (two-fork vitest, Test step 25.5min → 15m57s). That halved the wall but the coding-agent suite's per-file import cost still dominates. This PR shards that suite across **three runners** (`vitest run --shard=1..3/3`) and moves static checks/build plus the remaining workspaces into their own parallel jobs — targeting a Test wall of ~5-6min.

## Changes
- **`.github/workflows/ci.yml`** — the single `Check and test` job becomes four jobs:
  - `Static checks` — `npm run check` + `npm run build` (unchanged content).
  - `Test (coding-agent 1..3/3)` — matrix of 3, each `npx vitest run --shard=N/3` in `packages/coding-agent` after install+build. Keeps the CI fork-pool settings from `vitest.config.ts` (forks, capped workers) that prevent the historical subprocess-suite pool hang.
  - `Test (workspaces + scripts)` — `test:scripts` + all non-coding-agent workspaces.
  - `Check and test` (fan-in) — `needs` all three, fails unless every one succeeded. **Keeps the exact required status context name** so branch protection is untouched.

## QA & Evidence
- **Baseline:** run 30604890958 Test step 25.5min; #575 run 30608624215 Test step 15m57s (two-fork).
- **YAML validity:** parsed clean; `name: Check and test` preserved exactly once (fan-in).
- **Acceptance:** this PR's own CI run — the three shard jobs + fan-in should each finish well under the old single-job wall; `Check and test` context still satisfies branch protection.

## Risks & Residuals
- **Required-check name drift:** mitigated by the fan-in job keeping `name: Check and test`; verified `gh api .../branches/main/protection` requires exactly that context.
- **Shard imbalance:** vitest `--shard` round-robins test files; the subprocess-heavy suites stay under the capped CI fork pool on each shard, so no single shard should approach the old hang profile.
- **Cost:** 3 runners × ~5min vs 1 × ~16min — public repo, runners are free; wall time is the metric that matters here.

## Related
- #575 (merged) — two-fork vitest + MCP idle flake fix.
- #577 — release test-gate skip (independent).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sharded the `packages/coding-agent` `vitest` suite across three runners and split CI into parallel jobs to cut the test wall time from ~16 min to ~5–6 min. The required status check name `Check and test` is preserved via a fan-in job.

- **Refactors**
  - Split the single CI job into three parallel jobs (Static checks, Test (coding-agent 1..3/3), Test (workspaces + scripts)) plus a fan-in gate that keeps the `Check and test` status.
  - Shard coding-agent tests across 3 runners with `npx vitest run --shard=N/3` and keep the CI fork-pool limits from `packages/coding-agent/vitest.config.ts`.
  - Run non-coding-agent workspaces and `npm run test:scripts` in a separate job; static checks and `npm run build` in another.

<sup>Written for commit 03749d15e2c863d307b1bb2d8b064f887cff4991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

