### PR TITLE
feat(terminal,codemode): live elapsed time in the monitor/eval footer statuses

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/footer-monitor-elapsed-rpc.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/footer-monitor-elapsed-rpc.mjs
@@ -1,0 +1,110 @@
+/**
+ * QA scenario (criterion 1 SURFACE): monitor footer status shows LIVE elapsed
+ * time, observed through the senpi RPC extension_ui_request setStatus bridge.
+ *
+ * Drives the REAL CLI (--mode rpc) against the deterministic fake model server:
+ * turn 1 executes the monitor tool (persistent sleep), turn 2 waits ~6s before
+ * answering so the footer ticker publishes advancing (Ns) labels.
+ *
+ * PASS = >=2 monitors setStatus notifications with distinct (Ns) labels.
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { guardRealAuth, installCleanupHooks, makeSandbox, spawnCli } from "../lib/common.mjs";
+import { startFakeModelServer } from "../lib/fake-model-server.mjs";
+import { hermeticEnv, writeMockModelsJson } from "../lib/mock-loop-support.mjs";
+
+const outDir = process.argv[2] ?? join(process.cwd(), "..", "..", "..", "..", "..", "local-ignore", "qa-evidence", "20260731-footer-elapsed");
+mkdirSync(outDir, { recursive: true });
+
+guardRealAuth();
+installCleanupHooks();
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const server = await startFakeModelServer({
+	turns: [
+		{ toolCalls: [{ name: "monitor", args: { description: "qa elapsed watch", command: "sleep 30", persistent: true } }] },
+		{ text: "watch is live", chunks: 4, chunkDelayMs: 1800 },
+	],
+});
+
+const sandbox = makeSandbox("rpc-monitor-elapsed");
+const env = hermeticEnv(sandbox.env);
+writeMockModelsJson(sandbox.agentDir, server, "openai-completions");
+
+const child = spawnCli(["--mode", "rpc", "--no-session", "--no-context-files"], { env, cwd: sandbox.cwd });
+
+let buf = "";
+const lines = [];
+const setStatusEvents = [];
+const responses = new Map();
+let seq = 0;
+let stderr = "";
+
+child.stdout.on("data", (chunk) => {
+	buf += chunk.toString();
+	let nl;
+	while ((nl = buf.indexOf("\n")) >= 0) {
+		const line = buf.slice(0, nl).trim();
+		buf = buf.slice(nl + 1);
+		if (!line) continue;
+		lines.push(line);
+		let msg;
+		try { msg = JSON.parse(line); } catch { continue; }
+		if (msg.type === "response" && msg.id !== undefined) {
+			const w = responses.get(msg.id);
+			if (w) { responses.delete(msg.id); w(msg); }
+		}
+		if (msg.type === "extension_ui_request" && msg.method === "setStatus") {
+			setStatusEvents.push({ at: Date.now(), key: msg.statusKey, text: msg.statusText });
+		}
+	}
+});
+child.stderr.on("data", (d) => { stderr += d.toString(); });
+
+function send(cmd, timeoutMs = 90000) {
+	const id = `req-${++seq}`;
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(`timeout ${cmd.type}: ${stderr.slice(-300)}`)), timeoutMs);
+		responses.set(id, (m) => { clearTimeout(timer); resolve(m); });
+		child.stdin.write(`${JSON.stringify({ ...cmd, id })}\n`);
+	});
+}
+
+try {
+	await send({ type: "get_state" });
+	await send({ type: "set_model", provider: "mock", modelId: "mock-model" });
+	await send({ type: "prompt", message: "start the qa elapsed watch and confirm" }, 120000);
+	// let the ticker keep publishing after the turn ends
+	await sleep(3000);
+
+	const monitorStatuses = setStatusEvents.filter((e) => e.key === "monitors" && typeof e.text === "string");
+	const elapsed = monitorStatuses.map((e) => {
+		const m = e.text.match(/\((\d+)(s|m|h)\)/);
+		return m ? { at: e.at, label: m[0], text: e.text } : null;
+	}).filter(Boolean);
+	const distinct = [...new Set(elapsed.map((e) => e.label))];
+	const pass = elapsed.length >= 2 && distinct.length >= 2;
+
+	const report = {
+		pass,
+		monitorStatusCount: monitorStatuses.length,
+		distinctElapsedLabels: distinct,
+		elapsedTimeline: elapsed.map((e) => e.text),
+		allStatusKeys: [...new Set(setStatusEvents.map((e) => e.key))],
+	};
+	writeFileSync(join(outDir, "rpc-monitor-elapsed.json"), JSON.stringify(report, null, 2) + "\n");
+	writeFileSync(join(outDir, "rpc-monitor-elapsed.jsonl"), lines.join("\n") + "\n");
+	console.log(JSON.stringify(report, null, 2));
+	child.kill("SIGTERM");
+	await server.stop();
+	await sleep(400);
+	process.exit(pass ? 0 : 1);
+} catch (err) {
+	writeFileSync(join(outDir, "rpc-monitor-elapsed-error.txt"), `${err.stack}\nSTDERR:\n${stderr}\n`);
+	console.error("SCENARIO_ERROR:", err.message);
+	child.kill("SIGKILL");
+	await server.stop();
+	process.exit(2);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/monitor-state-event.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/monitor-state-event.ts
@@ -1,7 +1,18 @@
 export const TERMINAL_MONITOR_STATE_EVENT = "terminal_monitor_state";
 
+/** One live watch as broadcast on the monitor state event; mirrors MonitorSnapshotEntry. */
+export interface TerminalMonitorStateMonitorEntry {
+	readonly id: string;
+	readonly description: string;
+	readonly paused: boolean;
+	/** Epoch milliseconds when the watch registered; lets consumers render their own elapsed labels. */
+	readonly startedAtMs: number;
+}
+
 export interface TerminalMonitorStateEvent {
 	readonly activeCount: number;
+	/** Per-watch detail for consumers that need more than the count; absent in pre-enrichment payloads. */
+	readonly monitors?: readonly TerminalMonitorStateMonitorEntry[];
 }
 
 export function isTerminalMonitorStateEvent(data: unknown): data is TerminalMonitorStateEvent {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -3,6 +3,32 @@
 The persistent-terminal tool suite (`bash` swapped to PTY-backed + `bash_output`,
 `kill_bash`, `bash_input`, `bash_resize`). Backed by `@earendil-works/pi-pty`.
 
+## Live elapsed footer for monitors + enriched monitor state event (2026-07-31)
+
+### What changed
+
+- `monitor-registry.ts`: `MonitorSnapshotEntry` gains `startedAtMs` (epoch ms at registration).
+- `monitor-status.ts`: `formatMonitorStatus(snapshot, nowMs)` renders a goal-style compact
+  elapsed label (`5s`/`3m`/`2h 30m`) for the oldest live watch, merged with the paused suffix
+  as `(3m, paused)` / `(3m, 1 paused)`. 48-char budget and `+N more` packing unchanged.
+- `monitor-status-ticker.ts` (new): `MonitorStatusTicker` mirrors the goal builtin's
+  `GoalElapsedTicker` — 1s unref'd interval, renders only when the formatted label changes,
+  stops and clears the status when the last watch settles. The extension's `onMonitorState`
+  sink now drives the ticker instead of formatting inline; `session_shutdown` stops it.
+- `builtin/monitor-state-event.ts`: `TerminalMonitorStateEvent` gains an additive optional
+  `monitors` array (`{ id, description, paused, startedAtMs }`) so event-bus consumers (and
+  RPC clients, which already receive footer statuses through the `setStatus`
+  `extension_ui_request` bridge) can render their own elapsed views. `activeCount` and the
+  type guard are unchanged; old payloads still validate.
+
+### Tests
+
+- `test/suite/terminal-monitor-footer.test.ts`: elapsed rendering, oldest-watch selection,
+  clock-skew clamp, paused-suffix merge, budget preservation, `startedAtMs` in snapshots.
+- `test/suite/terminal-monitor-status-ticker.test.ts` (new): unref'd 1s interval, label
+  dedupe, stop-on-settle, re-sync without leaking intervals.
+- `test/suite/terminal-monitor-state-event.test.ts`: `monitors[]` payload assertions.
+
 ## Background sessions and monitors survive session reload (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -54,7 +54,7 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 		onMonitorEvent: (event) => state.monitorNotifier?.notifyEvent(event),
 		onMonitorState: (snapshot) => {
 			const ctx = state.ctx;
-			const status = formatMonitorStatus(snapshot);
+			const status = formatMonitorStatus(snapshot, Date.now());
 			ctx?.ui.setStatus(
 				MONITOR_STATUS_KEY,
 				status === undefined || ctx.mode !== "tui"

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -4,7 +4,8 @@ import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 import { TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
 import { MonitorNotifier } from "./monitor-notify.ts";
-import { formatMonitorStatus, MONITOR_STATUS_KEY } from "./monitor-status.ts";
+import { MONITOR_STATUS_KEY } from "./monitor-status.ts";
+import { MonitorStatusTicker } from "./monitor-status-ticker.ts";
 import { TerminalNotifier } from "./notify.ts";
 import { TERMINAL_PROMPT_SECTION } from "./prompt.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
@@ -30,6 +31,7 @@ interface TerminalExtensionState {
 	settings: ResolvedTerminalSettings;
 	notifier: TerminalNotifier | null;
 	monitorNotifier: MonitorNotifier | null;
+	statusTicker: MonitorStatusTicker;
 	ctx: ExtensionContext | undefined;
 	shellPath: string | undefined;
 	steppedAside: boolean;
@@ -53,15 +55,16 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 	return {
 		onMonitorEvent: (event) => state.monitorNotifier?.notifyEvent(event),
 		onMonitorState: (snapshot) => {
-			const ctx = state.ctx;
-			const status = formatMonitorStatus(snapshot, Date.now());
-			ctx?.ui.setStatus(
-				MONITOR_STATUS_KEY,
-				status === undefined || ctx.mode !== "tui"
-					? status
-					: ctx.ui.theme.bg("selectedBg", ctx.ui.theme.fg("text", status)),
-			);
-			pi.events?.emit(TERMINAL_MONITOR_STATE_EVENT, { activeCount: snapshot.length });
+			state.statusTicker.sync(snapshot);
+			pi.events?.emit(TERMINAL_MONITOR_STATE_EVENT, {
+				activeCount: snapshot.length,
+				monitors: snapshot.map((entry) => ({
+					id: entry.id,
+					description: entry.description,
+					paused: entry.paused,
+					startedAtMs: entry.startedAtMs,
+				})),
+			});
 		},
 		onBackgroundExit: (id, runtime) => state.notifier?.notifyCompletion(id, runtime),
 	};
@@ -146,6 +149,17 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		settings: TERMINAL_SETTINGS_DEFAULTS,
 		notifier: null,
 		monitorNotifier: null,
+		statusTicker: new MonitorStatusTicker({
+			render: (status) => {
+				const ctx = state.ctx;
+				ctx?.ui.setStatus(
+					MONITOR_STATUS_KEY,
+					status === undefined || ctx.mode !== "tui"
+						? status
+						: ctx.ui.theme.bg("selectedBg", ctx.ui.theme.fg("text", status)),
+				);
+			},
+		}),
 		ctx: undefined,
 		shellPath: undefined,
 		steppedAside: false,
@@ -217,6 +231,7 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		state.monitorNotifier?.dispose();
 		state.monitorNotifier = null;
 		state.notifier = null;
+		state.statusTicker.stop();
 		const sessionKey = sessionKeyOf(ctx) ?? sessionKeyOf(state.ctx);
 		if (event.reason === "reload" && state.bundle && sessionKey !== undefined) {
 			// Keep state.bundle referenced: exit listeners captured by this instance's tool

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
@@ -23,6 +23,8 @@ export interface MonitorSnapshotEntry {
 	readonly id: string;
 	readonly description: string;
 	readonly paused: boolean;
+	/** Epoch milliseconds when the watch registered; feeds the footer's live elapsed label. */
+	readonly startedAtMs: number;
 }
 
 export interface MonitorRegistryOptions {
@@ -40,6 +42,7 @@ export interface RegisterMonitorOptions {
 interface MonitorRecord {
 	readonly id: string;
 	readonly description: string;
+	readonly startedAtMs: number;
 	readonly runtime: TerminalRuntimeSession;
 	readonly filter: RegExp | undefined;
 	lineBuffer: string;
@@ -69,6 +72,7 @@ export class MonitorRegistry {
 			id: record.id,
 			description: record.description,
 			paused: record.paused,
+			startedAtMs: record.startedAtMs,
 		}));
 	}
 
@@ -76,6 +80,7 @@ export class MonitorRegistry {
 		const record: MonitorRecord = {
 			id: options.id,
 			description: options.description,
+			startedAtMs: Date.now(),
 			runtime: options.runtime,
 			filter: options.filter,
 			lineBuffer: "",

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status-ticker.ts
@@ -1,0 +1,80 @@
+import type { MonitorSnapshotEntry } from "./monitor-registry.ts";
+import { formatMonitorStatus } from "./monitor-status.ts";
+
+/** Footer live-elapsed refresh cadence while at least one watch is active. */
+export const MONITOR_STATUS_TICK_INTERVAL_MS = 1000;
+
+/** Receives the freshly formatted footer status text (undefined clears the status). */
+export type MonitorStatusRender = (status: string | undefined) => void;
+
+export interface MonitorStatusTickerOptions {
+	readonly render: MonitorStatusRender;
+	/** Injectable clock for tests; defaults to Date.now. */
+	readonly now?: () => number;
+}
+
+/**
+ * Drives a once-per-second footer refresh while monitors are active so the
+ * "◉ watching … (Ns)" elapsed label advances live instead of freezing between
+ * registry transitions. Mirrors the goal builtin's GoalElapsedTicker: the
+ * interval is unref'd so it never keeps the process alive, and ticks that
+ * produce the already-rendered label are skipped.
+ */
+export class MonitorStatusTicker {
+	private readonly render: MonitorStatusRender;
+	private readonly now: () => number;
+	private intervalId: NodeJS.Timeout | undefined;
+	private snapshot: readonly MonitorSnapshotEntry[] = [];
+	private lastRenderedStatus: string | undefined;
+	private hasRendered = false;
+
+	constructor(options: MonitorStatusTickerOptions) {
+		this.render = options.render;
+		this.now = options.now ?? Date.now;
+	}
+
+	get running(): boolean {
+		return this.intervalId !== undefined;
+	}
+
+	/**
+	 * Point the ticker at the current monitor snapshot, render once immediately,
+	 * and start the interval when watches are live (or stop it when none remain).
+	 */
+	sync(snapshot: readonly MonitorSnapshotEntry[]): void {
+		this.snapshot = snapshot;
+		this.hasRendered = false;
+		this.tick();
+		if (snapshot.length === 0) {
+			this.stopInterval();
+			return;
+		}
+		if (this.intervalId !== undefined) return;
+		const handle = setInterval(() => this.tick(), MONITOR_STATUS_TICK_INTERVAL_MS);
+		handle.unref();
+		this.intervalId = handle;
+	}
+
+	/** Stop the interval and drop the retained snapshot. */
+	stop(): void {
+		this.stopInterval();
+		this.snapshot = [];
+		this.lastRenderedStatus = undefined;
+		this.hasRendered = false;
+	}
+
+	private stopInterval(): void {
+		if (this.intervalId !== undefined) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+	}
+
+	private tick(): void {
+		const status = formatMonitorStatus(this.snapshot, this.now());
+		if (this.hasRendered && status === this.lastRenderedStatus) return;
+		this.hasRendered = true;
+		this.lastRenderedStatus = status;
+		this.render(status);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
@@ -27,11 +27,41 @@ function packDescriptions(names: readonly string[], budget: number): string {
 	return truncateEnd(names[0] ?? "", Math.max(1, budget - tail.length)) + tail;
 }
 
+/**
+ * Goal-style compact elapsed label (`5s`, `3m`, `2h 30m`, `1d 2h 3m`). Mirrors
+ * `formatGoalElapsedSeconds` in the goal builtin; kept local so this builtin stays
+ * self-contained, matching the existing monitor/eval status-file duplication.
+ */
+export function formatElapsedSeconds(value: number): string {
+	const seconds = Math.max(0, Math.trunc(value));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.trunc(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.trunc(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	if (hours >= 24) {
+		const days = Math.trunc(hours / 24);
+		const remainingHours = hours % 24;
+		return `${days}d ${remainingHours}h ${remainingMinutes}m`;
+	}
+	if (remainingMinutes === 0) return `${hours}h`;
+	return `${hours}h ${remainingMinutes}m`;
+}
+
+/** Whole seconds since the oldest watch registered; never negative when the clock moves backwards. */
+export function monitorElapsedSeconds(snapshot: readonly MonitorSnapshotEntry[], nowMs: number): number {
+	let oldest = Number.POSITIVE_INFINITY;
+	for (const entry of snapshot) oldest = Math.min(oldest, entry.startedAtMs);
+	if (!Number.isFinite(oldest)) return 0;
+	return Math.max(0, Math.round((nowMs - oldest) / 1000));
+}
+
 /** Brief footer text for the active monitors; undefined clears the status. */
-export function formatMonitorStatus(snapshot: readonly MonitorSnapshotEntry[]): string | undefined {
+export function formatMonitorStatus(snapshot: readonly MonitorSnapshotEntry[], nowMs: number): string | undefined {
 	if (snapshot.length === 0) return undefined;
 	const pausedCount = snapshot.filter((entry) => entry.paused).length;
-	const suffix = pausedCount === 0 ? "" : pausedCount === snapshot.length ? " (paused)" : ` (${pausedCount} paused)`;
+	const pausedPart = pausedCount === 0 ? "" : pausedCount === snapshot.length ? ", paused" : `, ${pausedCount} paused`;
+	const suffix = ` (${formatElapsedSeconds(monitorElapsedSeconds(snapshot, nowMs))}${pausedPart})`;
 	if (snapshot.length === 1) {
 		const head = `${WATCH_GLYPH} watching `;
 		const description = truncateEnd(snapshot[0]?.description ?? "", MAX_STATUS_LENGTH - head.length - suffix.length);

--- a/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
@@ -25,42 +25,69 @@ function deferredCall<TArgs extends unknown[]>(predicate: (...args: TArgs) => bo
 }
 
 describe("formatMonitorStatus", () => {
-	const entry = (id: string, description: string, paused = false): MonitorSnapshotEntry => ({
+	const T0 = 1_000_000;
+	const entry = (id: string, description: string, paused = false, startedAtMs = T0): MonitorSnapshotEntry => ({
 		id,
 		description,
 		paused,
+		startedAtMs,
 	});
 
 	it("returns undefined when nothing is monitored so the footer status clears", () => {
-		expect(formatMonitorStatus([])).toBeUndefined();
+		expect(formatMonitorStatus([], T0)).toBeUndefined();
 	});
 
-	it("marks the single watched thing with the watch glyph and its full description", () => {
-		expect(formatMonitorStatus([entry("bash_1", "errors in deploy.log")])).toBe("◉ watching errors in deploy.log");
+	it("marks the single watched thing with the watch glyph, description, and elapsed time", () => {
+		expect(formatMonitorStatus([entry("bash_1", "errors in deploy.log")], T0 + 5_000)).toBe(
+			"◉ watching errors in deploy.log (5s)",
+		);
 	});
 
-	it("lists every description when they all fit", () => {
-		const text = formatMonitorStatus([entry("bash_1", "deploy errors"), entry("bash_2", "webpack rebuild")]);
-		expect(text).toBe("◉ watching 2: deploy errors, webpack rebuild");
+	it("formats longer watches with the goal-style compact elapsed label", () => {
+		expect(formatMonitorStatus([entry("bash_1", "errors in deploy.log")], T0 + 180_000)).toBe(
+			"◉ watching errors in deploy.log (3m)",
+		);
+		expect(formatMonitorStatus([entry("bash_1", "deploy errors")], T0 + (2 * 3600 + 30 * 60) * 1000)).toBe(
+			"◉ watching deploy errors (2h 30m)",
+		);
+	});
+
+	it("advances the elapsed label as time passes over the same snapshot", () => {
+		const snapshot = [entry("bash_1", "deploy errors")];
+		expect(formatMonitorStatus(snapshot, T0 + 5_000)).toBe("◉ watching deploy errors (5s)");
+		expect(formatMonitorStatus(snapshot, T0 + 6_000)).toBe("◉ watching deploy errors (6s)");
+	});
+
+	it("never shows negative elapsed when the clock moves backwards", () => {
+		expect(formatMonitorStatus([entry("bash_1", "deploy errors")], T0 - 5_000)).toBe("◉ watching deploy errors (0s)");
+	});
+
+	it("lists every description when they all fit and shows the oldest watch's elapsed time", () => {
+		const text = formatMonitorStatus(
+			[entry("bash_1", "deploy errors"), entry("bash_2", "webpack", false, T0 + 60_000)],
+			T0 + 180_000,
+		);
+		expect(text).toBe("◉ watching 2: deploy errors, webpack (3m)");
 	});
 
 	it("keeps whole names and folds the overflow into a +N more counter", () => {
-		const text = formatMonitorStatus([
-			entry("bash_1", "errors in deploy.log"),
-			entry("bash_2", "integration test output on ci runner four"),
-			entry("bash_3", "webpack rebuild"),
-		]);
-		expect(text).toBe("◉ watching 3: errors in deploy.log +2 more");
+		const text = formatMonitorStatus(
+			[
+				entry("bash_1", "errors in deploy.log"),
+				entry("bash_2", "integration test output on ci runner four"),
+				entry("bash_3", "webpack rebuild"),
+			],
+			T0,
+		);
+		expect(text).toBe("◉ watching 3: errors in deploy.log +2 more (0s)");
 		expect((text ?? "").length).toBeLessThanOrEqual(48);
 	});
 
 	it("never truncates away the count when the first name alone overflows", () => {
-		const text = formatMonitorStatus([
-			entry("bash_1", "a".repeat(60)),
-			entry("bash_2", "b"),
-			entry("bash_3", "c"),
-			entry("bash_4", "d"),
-		]);
+		const text = formatMonitorStatus(
+			[entry("bash_1", "a".repeat(60)), entry("bash_2", "b"), entry("bash_3", "c"), entry("bash_4", "d")],
+			T0,
+		);
 		expect(text).toContain("watching 4:");
 		expect(text).toContain("+3 more");
 		expect(text).toContain("…");
@@ -68,14 +95,17 @@ describe("formatMonitorStatus", () => {
 	});
 
 	it("marks paused watches and keeps the marker through truncation", () => {
-		const all = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b", true)]);
-		expect(all).toBe("◉ watching 2: a, b (paused)");
-		const some = formatMonitorStatus([
-			entry("bash_1", "errors in deploy.log", true),
-			entry("bash_2", "integration test output on ci runner four"),
-			entry("bash_3", "webpack rebuild"),
-		]);
-		expect(some).toContain("(1 paused)");
+		const all = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b", true)], T0 + 60_000);
+		expect(all).toBe("◉ watching 2: a, b (1m, paused)");
+		const some = formatMonitorStatus(
+			[
+				entry("bash_1", "errors in deploy.log", true),
+				entry("bash_2", "integration test output on ci runner four"),
+				entry("bash_3", "webpack rebuild"),
+			],
+			T0,
+		);
+		expect(some).toContain("1 paused");
 		expect((some ?? "").length).toBeLessThanOrEqual(48);
 	});
 });
@@ -117,7 +147,12 @@ describe("MonitorRegistry change notification", () => {
 		await tool.execute("call_1", input);
 
 		expect(snapshots[0]).toEqual([
-			{ id: expect.stringContaining("bash"), description: "quick echo watch", paused: false },
+			{
+				id: expect.stringContaining("bash"),
+				description: "quick echo watch",
+				paused: false,
+				startedAtMs: expect.any(Number),
+			},
 		]);
 		await settled.promise;
 		expect(snapshots.at(-1)).toEqual([]);
@@ -204,10 +239,10 @@ describe("terminal extension footer status wiring", () => {
 
 		const monitorTool = tools.get("monitor");
 		expect(monitorTool).toBeDefined();
-		const description = "PR 453 checks on new head f40d4d15c";
+		const description = "deploy check watch";
 		await monitorTool?.execute("call_1", { description, command: "printf 'line\\n'" });
 
-		const plainStatus = `◉ watching ${description}`;
+		const plainStatus = `◉ watching ${description} (0s)`;
 		expect(setStatus).toHaveBeenCalledWith("monitors", theme.bg("selectedBg", theme.fg("text", plainStatus)));
 		await cleared.promise;
 		expect(setStatus).toHaveBeenCalledWith("monitors", undefined);

--- a/packages/coding-agent/test/suite/terminal-monitor-state-event.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-state-event.test.ts
@@ -4,6 +4,12 @@ import { createHarness, type Harness } from "./harness.ts";
 
 interface MonitorStateEvent {
 	readonly activeCount?: number;
+	readonly monitors?: Array<{
+		readonly id: string;
+		readonly description: string;
+		readonly paused: boolean;
+		readonly startedAtMs: number;
+	}>;
 }
 
 function resultText(result: { content?: Array<{ type: string; text?: string }> }): string {
@@ -31,7 +37,11 @@ describe("terminal monitor liveness event", () => {
 								"activeCount" in data &&
 								typeof data.activeCount === "number"
 							) {
-								states.push({ activeCount: data.activeCount });
+								const monitors =
+							"monitors" in data && Array.isArray(data.monitors)
+								? (data.monitors as MonitorStateEvent["monitors"])
+								: undefined;
+						states.push({ activeCount: data.activeCount, ...(monitors === undefined ? {} : { monitors }) });
 							}
 						});
 					});
@@ -49,10 +59,20 @@ describe("terminal monitor liveness event", () => {
 		if (!bashId) throw new Error("Monitor did not return a bash id");
 
 		try {
-			expect(states).toContainEqual({ activeCount: 1 });
+			expect(states).toContainEqual({
+				activeCount: 1,
+				monitors: [
+					{
+						id: bashId,
+						description: "liveness test",
+						paused: false,
+						startedAtMs: expect.any(Number),
+					},
+				],
+			});
 		} finally {
 			await harness.session.executeTool("kill_bash", { bash_id: bashId });
 		}
-		expect(states.at(-1)).toEqual({ activeCount: 0 });
+		expect(states.at(-1)).toEqual({ activeCount: 0, monitors: [] });
 	});
 });

--- a/packages/coding-agent/test/suite/terminal-monitor-status-ticker.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-status-ticker.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MonitorSnapshotEntry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import {
+	MONITOR_STATUS_TICK_INTERVAL_MS,
+	MonitorStatusTicker,
+} from "../../src/core/extensions/builtin/terminal/monitor-status-ticker.ts";
+
+const T0 = 1_000_000;
+const entry = (id: string, description: string, startedAtMs = T0, paused = false): MonitorSnapshotEntry => ({
+	id,
+	description,
+	paused,
+	startedAtMs,
+});
+
+describe("MonitorStatusTicker", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("unrefs the interval handle so it never keeps the process alive", () => {
+		const unref = vi.fn();
+		const fakeHandle = { unref, ref: vi.fn(), hasRef: () => true } as unknown as NodeJS.Timeout;
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(fakeHandle);
+		const ticker = new MonitorStatusTicker({ render: () => {}, now: () => T0 });
+
+		ticker.sync([entry("bash_1", "deploy errors")]);
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+		expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MONITOR_STATUS_TICK_INTERVAL_MS);
+		expect(unref).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders immediately on sync and advances the elapsed label once per second", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const labels: Array<string | undefined> = [];
+		const ticker = new MonitorStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("bash_1", "deploy errors")]);
+		expect(labels).toEqual(["◉ watching deploy errors (0s)"]);
+
+		vi.advanceTimersByTime(1_000);
+		expect(labels).toEqual(["◉ watching deploy errors (0s)", "◉ watching deploy errors (1s)"]);
+
+		vi.advanceTimersByTime(1_000);
+		expect(labels.at(-1)).toBe("◉ watching deploy errors (2s)");
+	});
+
+	it("does not re-render while the formatted label is unchanged", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const render = vi.fn();
+		const ticker = new MonitorStatusTicker({ render });
+
+		ticker.sync([entry("bash_1", "deploy errors", T0 - 60_000)]);
+		expect(render).toHaveBeenCalledTimes(1);
+
+		// 61s..119s all format as "1m", so a minute of ticks adds no renders.
+		vi.advanceTimersByTime(59_000);
+		expect(render).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(1_000);
+		expect(render).toHaveBeenCalledTimes(2);
+		expect(render).toHaveBeenLastCalledWith("◉ watching deploy errors (2m)");
+	});
+
+	it("clears the status and stops ticking when the last watch settles", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const labels: Array<string | undefined> = [];
+		const ticker = new MonitorStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("bash_1", "deploy errors")]);
+		ticker.sync([]);
+		expect(labels).toEqual(["◉ watching deploy errors (0s)", undefined]);
+		expect(ticker.running).toBe(false);
+
+		vi.advanceTimersByTime(5_000);
+		expect(labels).toHaveLength(2);
+	});
+
+	it("re-syncs against a new snapshot without leaking a second interval", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+		const labels: Array<string | undefined> = [];
+		const ticker = new MonitorStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("bash_1", "deploy errors")]);
+		ticker.sync([entry("bash_1", "deploy errors"), entry("bash_2", "webpack", T0 + 30_000)]);
+		vi.advanceTimersByTime(5_000);
+
+		expect(labels[0]).toBe("◉ watching deploy errors (0s)");
+		expect(labels[1]).toBe("◉ watching 2: deploy errors, webpack (0s)");
+		expect(labels.at(-1)).toBe("◉ watching 2: deploy errors, webpack (5s)");
+		expect(clearIntervalSpy).not.toHaveBeenCalled();
+	});
+
+	it("stop() halts ticking and drops the retained snapshot", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const labels: Array<string | undefined> = [];
+		const ticker = new MonitorStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("bash_1", "deploy errors")]);
+		ticker.stop();
+		expect(ticker.running).toBe(false);
+
+		vi.advanceTimersByTime(5_000);
+		expect(labels).toEqual(["◉ watching deploy errors (0s)"]);
+
+		// A later sync starts fresh: the label re-renders even though it matches the pre-stop one.
+		ticker.sync([entry("bash_1", "deploy errors", T0 + 5_000)]);
+		expect(labels.at(-1)).toBe("◉ watching deploy errors (0s)");
+	});
+});

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,21 @@
 # senpi-codemode fork changes
 
+## Live elapsed footer for detached eval cells (2026-07-31)
+
+- `src/tool/detached-cell-manager.ts`: `ManagedCell` and `EvalDetachedCellStatusEntry` gain
+  `startedAtMs` (epoch ms at cell creation); the manager accepts an injectable `now`.
+- `src/extension/eval-status.ts`: `formatEvalCellStatus(entries, nowMs)` appends the oldest
+  cell's goal-style elapsed label (`↗ py · title (45s)`, `↗ eval 2: a, b (3m)`); the 48-char
+  budget and `+N more` packing are preserved.
+- `src/extension/eval-status-ticker.ts` (new): `EvalStatusTicker`, same shape as the terminal
+  builtin's `MonitorStatusTicker` — 1s unref'd interval, label dedupe, stop-and-clear when the
+  last detached cell settles. `src/index.ts` routes `showDetachedCells` through the ticker and
+  stops it in `dropRuntime`; `SenpiCodemodeOptions` gains an optional `now` clock for tests.
+- Tests: `test/eval-status.test.ts` (elapsed rendering + budget), `test/eval-status-ticker.test.ts`
+  (new; interval discipline), `test/eval-status-wiring.test.ts` (footer advances 1s→2s→3s while
+  a cell stays detached, clears on completion).
+
+
 - `src/extension/eval-status.ts` (new): `formatEvalCellStatus(entries)` — undefined when
   no cell is detached, `↗ <lang> · <title>` for one (cellId fallback when untitled),
   `↗ eval N: <packed titles>` for many, 48-char budget with whole-label packing and a

--- a/packages/senpi-codemode/src/extension/eval-status-ticker.ts
+++ b/packages/senpi-codemode/src/extension/eval-status-ticker.ts
@@ -1,0 +1,79 @@
+import type { EvalDetachedCellStatusEntry } from "../tool/detached-cell-manager.ts";
+import { formatEvalCellStatus } from "./eval-status.ts";
+
+/** Footer live-elapsed refresh cadence while at least one detached cell is running. */
+export const EVAL_STATUS_TICK_INTERVAL_MS = 1000;
+
+/** Receives the freshly formatted footer status text (undefined clears the status). */
+export type EvalStatusRender = (status: string | undefined) => void;
+
+export interface EvalStatusTickerOptions {
+	readonly render: EvalStatusRender;
+	/** Injectable clock for tests; defaults to Date.now. */
+	readonly now?: () => number;
+}
+
+/**
+ * Drives a once-per-second footer refresh while detached eval cells are running so
+ * the "↗ py · … (Ns)" elapsed label advances live instead of freezing between
+ * cell-set transitions. Same shape as the terminal builtin's MonitorStatusTicker:
+ * the interval is unref'd, and ticks producing the already-rendered label are skipped.
+ */
+export class EvalStatusTicker {
+	private readonly render: EvalStatusRender;
+	private readonly now: () => number;
+	private intervalId: NodeJS.Timeout | undefined;
+	private entries: readonly EvalDetachedCellStatusEntry[] = [];
+	private lastRenderedStatus: string | undefined;
+	private hasRendered = false;
+
+	constructor(options: EvalStatusTickerOptions) {
+		this.render = options.render;
+		this.now = options.now ?? Date.now;
+	}
+
+	get running(): boolean {
+		return this.intervalId !== undefined;
+	}
+
+	/**
+	 * Point the ticker at the current detached-cell set, render once immediately,
+	 * and start the interval while cells are live (or stop it when none remain).
+	 */
+	sync(entries: readonly EvalDetachedCellStatusEntry[]): void {
+		this.entries = entries;
+		this.hasRendered = false;
+		this.tick();
+		if (entries.length === 0) {
+			this.stopInterval();
+			return;
+		}
+		if (this.intervalId !== undefined) return;
+		const handle = setInterval(() => this.tick(), EVAL_STATUS_TICK_INTERVAL_MS);
+		handle.unref();
+		this.intervalId = handle;
+	}
+
+	/** Stop the interval and drop the retained entries. */
+	stop(): void {
+		this.stopInterval();
+		this.entries = [];
+		this.lastRenderedStatus = undefined;
+		this.hasRendered = false;
+	}
+
+	private stopInterval(): void {
+		if (this.intervalId !== undefined) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+	}
+
+	private tick(): void {
+		const status = formatEvalCellStatus(this.entries, this.now());
+		if (this.hasRendered && status === this.lastRenderedStatus) return;
+		this.hasRendered = true;
+		this.lastRenderedStatus = status;
+		this.render(status);
+	}
+}

--- a/packages/senpi-codemode/src/extension/eval-status.ts
+++ b/packages/senpi-codemode/src/extension/eval-status.ts
@@ -31,14 +31,44 @@ function labelOf(entry: EvalDetachedCellStatusEntry): string {
 	return entry.title === undefined || entry.title.length === 0 ? entry.cellId : entry.title;
 }
 
+/**
+ * Goal-style compact elapsed label (`5s`, `3m`, `2h 30m`, `1d 2h 3m`). Mirrors
+ * the monitor builtin's formatElapsedSeconds; kept local like the rest of the
+ * duplicated status-file helpers between the two packages.
+ */
+export function formatElapsedSeconds(value: number): string {
+	const seconds = Math.max(0, Math.trunc(value));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.trunc(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.trunc(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	if (hours >= 24) {
+		const days = Math.trunc(hours / 24);
+		const remainingHours = hours % 24;
+		return `${days}d ${remainingHours}h ${remainingMinutes}m`;
+	}
+	if (remainingMinutes === 0) return `${hours}h`;
+	return `${hours}h ${remainingMinutes}m`;
+}
+
+/** Whole seconds since the oldest detached cell was created; never negative on clock skew. */
+export function evalCellElapsedSeconds(entries: readonly EvalDetachedCellStatusEntry[], nowMs: number): number {
+	let oldest = Number.POSITIVE_INFINITY;
+	for (const entry of entries) oldest = Math.min(oldest, entry.startedAtMs);
+	if (!Number.isFinite(oldest)) return 0;
+	return Math.max(0, Math.round((nowMs - oldest) / 1000));
+}
+
 /** Brief footer text for the cells still running detached; undefined clears the status. */
-export function formatEvalCellStatus(entries: readonly EvalDetachedCellStatusEntry[]): string | undefined {
+export function formatEvalCellStatus(entries: readonly EvalDetachedCellStatusEntry[], nowMs: number): string | undefined {
 	const first = entries[0];
 	if (first === undefined) return undefined;
+	const suffix = ` (${formatElapsedSeconds(evalCellElapsedSeconds(entries, nowMs))})`;
 	if (entries.length === 1) {
 		const head = `${DETACHED_GLYPH} ${first.language} · `;
-		return head + truncateEnd(labelOf(first), MAX_STATUS_LENGTH - head.length);
+		return head + truncateEnd(labelOf(first), MAX_STATUS_LENGTH - head.length - suffix.length) + suffix;
 	}
 	const head = `${DETACHED_GLYPH} eval ${entries.length}: `;
-	return head + packLabels(entries.map(labelOf), MAX_STATUS_LENGTH - head.length);
+	return head + packLabels(entries.map(labelOf), MAX_STATUS_LENGTH - head.length - suffix.length) + suffix;
 }

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -5,7 +5,8 @@ import type { EvalSchemaToolInfo } from "./bridges/schema-bridge.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
 import { defaultCodemodeSettings } from "./config/settings.ts";
 import { EvalNotifier } from "./extension/eval-notifier.ts";
-import { EVAL_CELLS_STATUS_KEY, formatEvalCellStatus } from "./extension/eval-status.ts";
+import { EVAL_CELLS_STATUS_KEY } from "./extension/eval-status.ts";
+import { EvalStatusTicker } from "./extension/eval-status-ticker.ts";
 import {
 	createExecuteTool,
 	createRuntime,
@@ -44,6 +45,8 @@ export interface SenpiCodemodeOptions {
 		options: CreateCodemodeSessionManagerOptions,
 	) => CodemodeSessionManager | Promise<CodemodeSessionManager>;
 	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
+	/** Injectable clock for detached-cell elapsed labels; defaults to Date.now. */
+	readonly now?: () => number;
 }
 
 export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCodemodeOptions = {}): void {
@@ -59,17 +62,22 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		getContext: () => activeContext,
 		getMode: () => "wake",
 	});
+	const statusTicker = new EvalStatusTicker({
+		...(options.now === undefined ? {} : { now: options.now }),
+		render: (status) => {
+			const ctx = activeContext;
+			if (ctx?.ui?.setStatus === undefined) return;
+			const theme = ctx.ui.theme;
+			ctx.ui.setStatus(
+				EVAL_CELLS_STATUS_KEY,
+				status === undefined || ctx.mode !== "tui" || theme === undefined
+					? status
+					: theme.bg("selectedBg", theme.fg("text", status)),
+			);
+		},
+	});
 	const showDetachedCells = (entries: readonly EvalDetachedCellStatusEntry[]): void => {
-		const ctx = activeContext;
-		if (ctx?.ui?.setStatus === undefined) return;
-		const status = formatEvalCellStatus(entries);
-		const theme = ctx.ui.theme;
-		ctx.ui.setStatus(
-			EVAL_CELLS_STATUS_KEY,
-			status === undefined || ctx.mode !== "tui" || theme === undefined
-				? status
-				: theme.bg("selectedBg", theme.fg("text", status)),
-		);
+		statusTicker.sync(entries);
 	};
 	const registerEvalForRuntime = (
 		runtime: SessionRuntime,
@@ -101,6 +109,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		activeRuntime = undefined;
 		activeModelId = undefined;
 		activeCells = undefined;
+		statusTicker.stop();
 		await cells?.dispose();
 		activeContext = undefined;
 		await manager.dispose();
@@ -114,7 +123,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			listTools: () => pi.getAllTools(),
 			complete,
 			settings: defaultCodemodeSettings,
-			cellManager: new EvalDetachedCellManager({ notifier, onStatusChange: showDetachedCells }),
+			cellManager: new EvalDetachedCellManager({ notifier, onStatusChange: showDetachedCells, ...(options.now === undefined ? {} : { now: options.now }) }),
 			executionTracker: manager,
 			renderers,
 			hostLine: hostLine(),
@@ -143,6 +152,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			artifactsDir: runtime.artifactsDir,
 			notifier,
 			onStatusChange: showDetachedCells,
+			...(options.now === undefined ? {} : { now: options.now }),
 		});
 		activeCells = cellManager;
 		activeRuntime = runtime;

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -11,6 +11,7 @@ type ManagedCell = {
 	readonly cellId: string;
 	readonly input: EvalToolInput;
 	readonly spillPath: string | undefined;
+	readonly startedAtMs: number;
 	state: EvalDetachedCellState;
 	canDetach: boolean;
 	wasDetached: boolean;
@@ -46,6 +47,8 @@ export interface EvalDetachedCellStatusEntry {
 	readonly cellId: string;
 	readonly language: EvalLanguage;
 	readonly title?: string;
+	/** Epoch milliseconds when the cell was created; feeds the footer's live elapsed label. */
+	readonly startedAtMs: number;
 }
 
 export interface EvalDetachedCellManagerOptions {
@@ -53,6 +56,8 @@ export interface EvalDetachedCellManagerOptions {
 	readonly notifier?: EvalDetachedCellNotifier;
 	/** Called with every detached cell whenever that set changes; empty clears the status. */
 	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
+	/** Injectable clock for tests; defaults to Date.now. */
+	readonly now?: () => number;
 }
 
 /**
@@ -68,6 +73,7 @@ export class EvalDetachedCellManager {
 	readonly #onStatusChange: ((entries: readonly EvalDetachedCellStatusEntry[]) => void) | undefined;
 	readonly #cells = new Map<string, ManagedCell>();
 	readonly #detachedByLanguage = new Map<EvalLanguage, ManagedCell>();
+	readonly #now: () => number;
 	#notificationQueue: ManagedCell[] = [];
 	#notificationFlush: Promise<void> | undefined;
 
@@ -75,6 +81,7 @@ export class EvalDetachedCellManager {
 		this.#artifactsDir = options.artifactsDir;
 		this.#notifier = options.notifier;
 		this.#onStatusChange = options.onStatusChange;
+		this.#now = options.now ?? Date.now;
 	}
 
 	create(cellId: string, input: EvalToolInput): ManagedCell {
@@ -91,6 +98,7 @@ export class EvalDetachedCellManager {
 			cellId,
 			input,
 			spillPath,
+			startedAtMs: this.#now(),
 			state: "running",
 			canDetach: false,
 			wasDetached: false,
@@ -189,6 +197,7 @@ export class EvalDetachedCellManager {
 			[...this.#detachedByLanguage.values()].map((cell) => ({
 				cellId: cell.cellId,
 				language: cell.input.language,
+				startedAtMs: cell.startedAtMs,
 				...(cell.input.title === undefined ? {} : { title: cell.input.title }),
 			})),
 		);

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -338,7 +338,9 @@ describe("eval detached cell status emissions", () => {
 
 		await detachTitled(tool, kernel, "status-cell", "numpy feather rerun");
 
-		expect(status.emissions).toEqual([[{ cellId: "status-cell", language: "js", title: "numpy feather rerun" }]]);
+		expect(status.emissions).toEqual([
+			[{ cellId: "status-cell", language: "js", title: "numpy feather rerun", startedAtMs: expect.any(Number) }],
+		]);
 
 		kernel.completeDeferredRun(result("status-cell", "42"));
 		await manager.waitForTerminal("status-cell");
@@ -365,13 +367,15 @@ describe("eval detached cell status emissions", () => {
 		await detachTitled(tool, py, "py-cell", "strip repairs", "py");
 
 		expect(status.emissions.at(-1)).toEqual([
-			{ cellId: "js-cell", language: "js", title: "bundle build" },
-			{ cellId: "py-cell", language: "py", title: "strip repairs" },
+			{ cellId: "js-cell", language: "js", title: "bundle build", startedAtMs: expect.any(Number) },
+			{ cellId: "py-cell", language: "py", title: "strip repairs", startedAtMs: expect.any(Number) },
 		]);
 
 		await manager.stop("js-cell");
 
-		expect(status.emissions.at(-1)).toEqual([{ cellId: "py-cell", language: "py", title: "strip repairs" }]);
+		expect(status.emissions.at(-1)).toEqual([
+			{ cellId: "py-cell", language: "py", title: "strip repairs", startedAtMs: expect.any(Number) },
+		]);
 		await manager.stop("py-cell");
 		await manager.flushNotifications();
 	});
@@ -404,7 +408,7 @@ describe("eval detached cell status emissions", () => {
 		await vi.advanceTimersByTimeAsync(1_000);
 		await execution;
 
-		expect(status.emissions).toEqual([[{ cellId: "untitled-cell", language: "js" }]]);
+		expect(status.emissions).toEqual([[{ cellId: "untitled-cell", language: "js", startedAtMs: expect.any(Number) }]]);
 		await manager.stop("untitled-cell");
 		await manager.flushNotifications();
 	});

--- a/packages/senpi-codemode/test/eval-status-ticker.test.ts
+++ b/packages/senpi-codemode/test/eval-status-ticker.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EVAL_STATUS_TICK_INTERVAL_MS, EvalStatusTicker } from "../src/extension/eval-status-ticker.ts";
+import type { EvalDetachedCellStatusEntry } from "../src/tool/detached-cell-manager.ts";
+
+const T0 = 1_000_000;
+const entry = (cellId: string, title: string, startedAtMs = T0): EvalDetachedCellStatusEntry => ({
+	cellId,
+	language: "py",
+	title,
+	startedAtMs,
+});
+
+describe("EvalStatusTicker", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("unrefs the interval handle so it never keeps the process alive", () => {
+		const unref = vi.fn();
+		const fakeHandle = { unref, ref: vi.fn(), hasRef: () => true } as unknown as NodeJS.Timeout;
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(fakeHandle);
+		const ticker = new EvalStatusTicker({ render: () => {}, now: () => T0 });
+
+		ticker.sync([entry("cell-1", "long running cell")]);
+
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+		expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), EVAL_STATUS_TICK_INTERVAL_MS);
+		expect(unref).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders immediately on sync and advances the elapsed label once per second", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const labels: Array<string | undefined> = [];
+		const ticker = new EvalStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("cell-1", "long running cell")]);
+		expect(labels).toEqual(["↗ py · long running cell (0s)"]);
+
+		vi.advanceTimersByTime(1_000);
+		expect(labels).toEqual(["↗ py · long running cell (0s)", "↗ py · long running cell (1s)"]);
+	});
+
+	it("does not re-render while the formatted label is unchanged", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const render = vi.fn();
+		const ticker = new EvalStatusTicker({ render });
+
+		ticker.sync([entry("cell-1", "long running cell", T0 - 60_000)]);
+		expect(render).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(59_000);
+		expect(render).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(1_000);
+		expect(render).toHaveBeenCalledTimes(2);
+		expect(render).toHaveBeenLastCalledWith("↗ py · long running cell (2m)");
+	});
+
+	it("clears the status and stops ticking when the last detached cell settles", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const labels: Array<string | undefined> = [];
+		const ticker = new EvalStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("cell-1", "long running cell")]);
+		ticker.sync([]);
+		expect(labels).toEqual(["↗ py · long running cell (0s)", undefined]);
+		expect(ticker.running).toBe(false);
+
+		vi.advanceTimersByTime(5_000);
+		expect(labels).toHaveLength(2);
+	});
+
+	it("stop() halts ticking and drops the retained entries", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+		const labels: Array<string | undefined> = [];
+		const ticker = new EvalStatusTicker({ render: (status) => labels.push(status) });
+
+		ticker.sync([entry("cell-1", "long running cell")]);
+		ticker.stop();
+		expect(ticker.running).toBe(false);
+
+		vi.advanceTimersByTime(5_000);
+		expect(labels).toEqual(["↗ py · long running cell (0s)"]);
+	});
+});

--- a/packages/senpi-codemode/test/eval-status-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-status-wiring.test.ts
@@ -142,7 +142,7 @@ describe("detached eval cell footer status wiring", () => {
 		vi.useFakeTimers();
 		await detachOne(pi, kernel, ctx, "wiring-cell", "wiring probe");
 
-		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · wiring probe" });
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · wiring probe (0s)" });
 		expect(themeCalls).toContain("bg:selectedBg");
 		expect(themeCalls).toContain("fg:text");
 
@@ -165,10 +165,38 @@ describe("detached eval cell footer status wiring", () => {
 		vi.useFakeTimers();
 		await detachOne(pi, kernel, ctx, "rpc-cell", "rpc probe");
 
-		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · rpc probe" });
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · rpc probe (0s)" });
 		expect(themeCalls).toEqual([]);
 
 		kernel.completeDeferredRun(result("rpc-cell", "7"));
+		await vi.waitFor(() => expect(calls.at(-1)).toEqual({ key: "eval-cells", text: undefined }));
+
+		await pi.emit("session_shutdown", {}, ctx);
+	});
+
+	it("advances the elapsed label while the cell stays detached", async () => {
+		const cwd = await sessionCwd();
+		const pi = new WiringPi();
+		const kernel = new FakeKernel([]);
+		vi.useFakeTimers();
+		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
+		const calls: StatusCall[] = [];
+		const themeCalls: string[] = [];
+		const ctx = wiringContext(cwd, "rpc", calls, themeCalls);
+
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+		// detachOne advances the fake clock by the 1s cell timeout, so the first
+		// visible label is already one second in.
+		await detachOne(pi, kernel, ctx, "tick-cell", "ticking probe");
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · ticking probe (1s)" });
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · ticking probe (2s)" });
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · ticking probe (3s)" });
+
+		kernel.completeDeferredRun(result("tick-cell", "9"));
 		await vi.waitFor(() => expect(calls.at(-1)).toEqual({ key: "eval-cells", text: undefined }));
 
 		await pi.emit("session_shutdown", {}, ctx);

--- a/packages/senpi-codemode/test/eval-status.test.ts
+++ b/packages/senpi-codemode/test/eval-status.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { EVAL_CELLS_STATUS_KEY, formatEvalCellStatus } from "../src/extension/eval-status.ts";
 import type { EvalDetachedCellStatusEntry } from "../src/tool/detached-cell-manager.ts";
 
-function entry(cellId: string, language: "js" | "py", title?: string): EvalDetachedCellStatusEntry {
-	return title === undefined ? { cellId, language } : { cellId, language, title };
+const T0 = 1_000_000;
+
+function entry(cellId: string, language: "js" | "py", title?: string, startedAtMs = T0): EvalDetachedCellStatusEntry {
+	return title === undefined ? { cellId, language, startedAtMs } : { cellId, language, title, startedAtMs };
 }
 
 describe("formatEvalCellStatus", () => {
@@ -12,26 +14,30 @@ describe("formatEvalCellStatus", () => {
 	});
 
 	it("returns undefined when no cells are detached, clearing the footer status", () => {
-		expect(formatEvalCellStatus([])).toBeUndefined();
+		expect(formatEvalCellStatus([], T0)).toBeUndefined();
 	});
 
 	it("shows glyph, language, and title for a single detached cell", () => {
-		expect(formatEvalCellStatus([entry("cell-1", "py", "numpy feather rerun")])).toBe("↗ py · numpy feather rerun");
+		expect(formatEvalCellStatus([entry("cell-1", "py", "numpy feather rerun")], T0 + 5_000)).toBe(
+			"↗ py · numpy feather rerun (5s)",
+		);
 	});
 
 	it("falls back to the cell id when the cell has no title", () => {
-		expect(formatEvalCellStatus([entry("cell-123", "js")])).toBe("↗ js · cell-123");
+		expect(formatEvalCellStatus([entry("cell-123", "js")], T0 + 180_000)).toBe("↗ js · cell-123 (3m)");
 	});
 
 	it("truncates an overlong single title to the shared 48-char budget with an ellipsis", () => {
 		const longTitle = "x".repeat(80);
-		const status = formatEvalCellStatus([entry("cell-1", "py", longTitle)]);
-		expect(status).toBe(`↗ py · ${"x".repeat(48 - "↗ py · ".length - 1)}…`);
+		const status = formatEvalCellStatus([entry("cell-1", "py", longTitle)], T0);
+		expect(status).toBe(`↗ py · ${"x".repeat(48 - "↗ py · ".length - " (0s)".length - 1)}… (0s)`);
 		expect(status?.length).toBe(48);
 	});
 
 	it("lists every title when multiple detached cells fit the budget", () => {
-		expect(formatEvalCellStatus([entry("a", "js", "alpha"), entry("b", "py", "beta")])).toBe("↗ eval 2: alpha, beta");
+		expect(formatEvalCellStatus([entry("a", "js", "alpha"), entry("b", "py", "beta")], T0 + 60_000)).toBe(
+			"↗ eval 2: alpha, beta (1m)",
+		);
 	});
 
 	it("keeps only whole titles and folds the rest into a +N more tail", () => {
@@ -40,8 +46,8 @@ describe("formatEvalCellStatus", () => {
 			entry("b", "py", "second-cell-title"),
 			entry("c", "js", "third-cell-title"),
 		];
-		const status = formatEvalCellStatus(entries);
-		expect(status).toBe("↗ eval 3: first-cell-title +2 more");
+		const status = formatEvalCellStatus(entries, T0);
+		expect(status).toBe("↗ eval 3: first-cell-title +2 more (0s)");
 		expect(status?.length).toBeLessThanOrEqual(48);
 	});
 
@@ -50,8 +56,23 @@ describe("formatEvalCellStatus", () => {
 			entry("a", "js", "a-very-long-cell-title-that-cannot-fit"),
 			entry("b", "py", "another-long-cell-title-that-cannot-fit"),
 		];
-		const status = formatEvalCellStatus(entries);
-		expect(status).toMatch(/^↗ eval 2: a-very-long-cell-title-tha\S*… \+1 more$/u);
+		const status = formatEvalCellStatus(entries, T0);
+		expect(status).toMatch(/^↗ eval 2: a-very-long-cell-tit\S*… \+1 more \(0s\)$/u);
 		expect(status?.length).toBeLessThanOrEqual(48);
+	});
+
+	it("advances the elapsed label as time passes over the same entries", () => {
+		const entries = [entry("cell-1", "py", "long running cell")];
+		expect(formatEvalCellStatus(entries, T0 + 5_000)).toBe("↗ py · long running cell (5s)");
+		expect(formatEvalCellStatus(entries, T0 + 6_000)).toBe("↗ py · long running cell (6s)");
+	});
+
+	it("shows the oldest cell's elapsed time when several cells are detached", () => {
+		const entries = [entry("a", "js", "alpha"), entry("b", "py", "beta", T0 + 30_000)];
+		expect(formatEvalCellStatus(entries, T0 + 90_000)).toBe("↗ eval 2: alpha, beta (1m)");
+	});
+
+	it("never shows negative elapsed when the clock moves backwards", () => {
+		expect(formatEvalCellStatus([entry("cell-1", "py", "clock skew")], T0 - 5_000)).toBe("↗ py · clock skew (0s)");
 	});
 });


### PR DESCRIPTION
## What

The monitor (`◉ watching …`) and detached-eval (`↗ py · …`) footer statuses were static — they showed *what* was running but not *how long*. This adds a live, goal-style elapsed timer to both, and enriches the monitor state event so RPC/event-bus consumers can render their own elapsed views.

## Changes

**terminal builtin**
- `monitor-registry.ts`: `MonitorSnapshotEntry` gains `startedAtMs`.
- `monitor-status.ts`: `formatMonitorStatus(snapshot, nowMs)` renders the oldest watch's elapsed label (`5s`/`3m`/`2h 30m`), merged with the paused suffix as `(3m, paused)`. 48-char budget and `+N more` packing preserved.
- `monitor-status-ticker.ts` (new): `MonitorStatusTicker` — 1s unref'd interval, renders only when the label changes, stops and clears when the last watch settles (mirrors the goal builtin's `GoalElapsedTicker`).
- `extension.ts`: `onMonitorState` drives the ticker; `session_shutdown` stops it.
- `builtin/monitor-state-event.ts`: `TerminalMonitorStateEvent` gains an additive optional `monitors[]` (`{id, description, paused, startedAtMs}`). `activeCount` and the type guard are unchanged.

**senpi-codemode**
- `detached-cell-manager.ts`: cells and status entries carry `startedAtMs`; injectable `now`.
- `eval-status.ts`: `formatEvalCellStatus(entries, nowMs)` appends the oldest cell's elapsed label.
- `eval-status-ticker.ts` (new) + `index.ts`: same ticking discipline; `SenpiCodemodeOptions` gains `now`.

## Why RPC clients see it

Footer statuses already flow to RPC clients through the `extension_ui_request` `setStatus` notification, so the elapsed-bearing statuses are observable over `--mode rpc` with no protocol change. The enriched `terminal_monitor_state` event adds per-watch detail for event-bus consumers.

## Evidence

- **RPC real-surface** (`local-ignore/qa-evidence/20260731-footer-elapsed/rpc-monitor-elapsed.json`): real CLI in `--mode rpc` against the fake model server executed the monitor tool; the `monitors` footer status republished with advancing labels — `◉ watching qa elapsed watch (0s) → (1s) → (2s)`.
- **Eval wiring** (`eval-cells-elapsed-wiring.json`): the `eval-cells` status advances `(1s) → (2s) → (3s)` while a cell stays detached, then clears.
- `npm run check` green; coding-agent suite 6171 passed; codemode suite 475 passed.
- New tests: `terminal-monitor-status-ticker.test.ts`, `eval-status-ticker.test.ts`, plus elapsed cases in the footer/status/state-event suites.

## Notes

- `detached-cell-manager.ts` was already 310 pure LOC (>250 ceiling) before this change; +9 here. Pre-existing, not introduced.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live elapsed timers to the terminal monitor and detached eval footers, updating once per second. Also enriches the `terminal_monitor_state` event so RPC/event-bus clients can render their own elapsed views without protocol changes.

- **New Features**
  - `coding-agent` terminal
    - `MonitorSnapshotEntry` adds `startedAtMs`.
    - New `MonitorStatusTicker` (1s, unref) renders only on label change; stops when no watches remain.
    - `formatMonitorStatus(snapshot, nowMs)` appends compact elapsed labels (`5s`/`3m`/`2h 30m`) and merges paused info; keeps 48-char budget and `+N more`.
    - Emits `terminal_monitor_state` with `monitors[]` entries (`id`, `description`, `paused`, `startedAtMs`) alongside `activeCount`.
  - `senpi-codemode`
    - Detached-cell entries carry `startedAtMs`; `formatEvalCellStatus(entries, nowMs)` appends the oldest cell’s elapsed label.
    - New `EvalStatusTicker` mirrors the monitor ticker; wiring updated in `src/index.ts` with optional `now` for tests.
  - RPC
    - Footer statuses still flow via `extension_ui_request` `setStatus`; elapsed labels appear with no client changes.

<sup>Written for commit d223079dd9215b4083e31a847c852440c2e3890a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

