### PR TITLE
feat(ai,goal): map-less max reasoning + legacy goal store migration (adopted from #552)

### DIFF
--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,5 +1,18 @@
 # changes.md — ai
 
+## Map-less GPT-5.6 Sol max reasoning (2026-07-30)
+
+### What changed
+
+- Runtime capability detection now recognizes `max` for map-less OpenAI-compatible `gpt-5.6-sol` models while
+  preserving explicit map omissions and `null` vetoes.
+- OpenAI-compatible request builders serialize the selected level as `reasoning.effort: "max"`.
+
+### Why
+
+- Custom providers such as `codex-lb` can supply Sol without generated model metadata. The UI and provider
+  payload must agree instead of displaying `max` while silently sending `high`.
+
 ## Browser-safe prompt-cache TTL resolver (2026-07-28)
 
 ### What changed

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -1,6 +1,6 @@
 import { AzureOpenAI } from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
-import { clampThinkingLevel } from "../models.ts";
+import { clampThinkingLevel, supportsMax } from "../models.ts";
 import type {
 	Api,
 	AssistantMessage,
@@ -170,7 +170,7 @@ export const streamSimple: StreamFunction<"azure-openai-responses", SimpleStream
 	const reasoningEffort =
 		clampedReasoning === "off"
 			? undefined
-			: clampedReasoning === "max" && model.thinkingLevelMap?.max !== undefined
+			: clampedReasoning === "max" && supportsMax(model)
 				? "max"
 				: clampedReasoning === "max"
 					? "high"

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -21,7 +21,7 @@ function loadNodeOs(): typeof NodeOs | null {
 // NEVER convert to top-level runtime imports - breaks browser/Vite builds
 const _os: typeof NodeOs | null = loadNodeOs();
 
-import { clampThinkingLevel, supportsXhigh } from "../models.ts";
+import { clampThinkingLevel, supportsMax, supportsXhigh } from "../models.ts";
 import { registerSessionResourceCleanup } from "../session-resources.ts";
 import type {
 	Api,
@@ -517,7 +517,7 @@ export const streamSimple: StreamFunction<"openai-codex-responses", SimpleStream
 	const reasoningEffort =
 		clampedReasoning === "off"
 			? undefined
-			: clampedReasoning === "max" && model.thinkingLevelMap?.max !== undefined
+			: clampedReasoning === "max" && supportsMax(model)
 				? "max"
 				: clampMaxForOpenAI(clampedReasoning, supportsXhigh(model));
 

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -12,7 +12,7 @@ import type {
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
 import type { FunctionParameters } from "openai/resources/shared.js";
-import { calculateCost, clampThinkingLevel, supportsXhigh } from "../models.ts";
+import { calculateCost, clampThinkingLevel, supportsMax, supportsXhigh } from "../models.ts";
 import type {
 	AssistantMessage,
 	CacheRetention,
@@ -848,7 +848,7 @@ export const streamSimple: StreamFunction<"openai-completions", SimpleStreamOpti
 	const reasoningEffort =
 		clampedReasoning === "off"
 			? undefined
-			: clampedReasoning === "max" && thinkingLevelMap?.max !== undefined
+			: clampedReasoning === "max" && supportsMax(thinkingModel)
 				? "max"
 				: clampMaxForOpenAI(clampedReasoning, supportsXhigh(thinkingModel));
 	const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 import type { ResponseCreateParamsStreaming, ResponseStreamEvent } from "openai/resources/responses/responses.js";
-import { clampThinkingLevel, supportsXhigh } from "../models.ts";
+import { clampThinkingLevel, supportsMax, supportsXhigh } from "../models.ts";
 import type {
 	Api,
 	AssistantMessage,
@@ -334,7 +334,7 @@ export const streamSimple: StreamFunction<"openai-responses", SimpleStreamOption
 	const reasoningEffort =
 		clampedReasoning === "off"
 			? undefined
-			: clampedReasoning === "max" && model.thinkingLevelMap?.max !== undefined
+			: clampedReasoning === "max" && supportsMax(model)
 				? "max"
 				: clampMaxForOpenAI(clampedReasoning, supportsXhigh(model));
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,17 @@
 # AI Source Changes
 
+## 2026-07-30 - Map-less GPT-5.6 Sol preserves max reasoning
+
+### What changed and why
+
+- OpenAI-compatible map-less `gpt-5.6-sol` models now expose `xhigh` and `max` without requiring a generated
+  `thinkingLevelMap`.
+- Explicit maps remain authoritative: a missing level on an existing map stays unavailable, and `null` still
+  vetoes the heuristic.
+- OpenAI Responses, Azure Responses, Codex Responses, and Completions send `max` on the wire instead of
+  clamping a UI-selected map-less Sol level to `high`.
+- Coverage pins capability, negative non-Sol boundaries, and captured request payloads without live tokens.
+
 ## 2026-07-30 - Recover Kimi XTML response channels from thinking
 
 ### What changed and why

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -666,7 +666,12 @@ export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>)
 	return EXTENDED_THINKING_LEVELS.filter((level) => {
 		const mapped = model.thinkingLevelMap?.[level];
 		if (mapped === null) return false;
-		if (level === "xhigh" || level === "max") return mapped !== undefined;
+		if (level === "xhigh") {
+			return mapped !== undefined || (model.thinkingLevelMap === undefined && supportsXhighModelId(model.id));
+		}
+		if (level === "max") {
+			return mapped !== undefined || (model.thinkingLevelMap === undefined && supportsMaxModel(model));
+		}
 		return true;
 	});
 }
@@ -693,25 +698,68 @@ export function clampThinkingLevel<TApi extends Api>(
 }
 
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
-	if (getSupportedThinkingLevels(model).includes("xhigh")) return true;
-	return (
-		model.id.includes("gpt-5.2") ||
-		model.id.includes("gpt-5.3") ||
-		model.id.includes("gpt-5.4") ||
-		model.id.includes("gpt-5.5") ||
-		model.id.includes("gpt-5.6") ||
-		model.id.includes("deepseek-v4-pro") ||
-		model.id.includes("deepseek-v4-flash") ||
-		model.id.includes("opus-4-6") ||
-		model.id.includes("opus-4.6") ||
-		model.id.includes("opus-4-7") ||
-		model.id.includes("opus-4.7") ||
-		model.id.includes("opus-4-8") ||
-		model.id.includes("opus-4.8") ||
-		model.id.includes("opus-5") ||
-		model.id.includes("sonnet-5") ||
-		model.id.includes("fable-5")
-	);
+	const mapped = model.thinkingLevelMap?.xhigh;
+	if (mapped === null) return false;
+	if (mapped !== undefined) return true;
+	if (model.thinkingLevelMap !== undefined) return false;
+	return model.reasoning && supportsXhighModelId(model.id);
+}
+
+function supportsXhighModelId(modelId: string): boolean {
+	const xhighModelIds = [
+		"gpt-5.2",
+		"gpt-5.3",
+		"gpt-5.4",
+		"gpt-5.5",
+		"gpt-5.6",
+		"deepseek-v4-pro",
+		"deepseek-v4-flash",
+		"opus-4-6",
+		"opus-4.6",
+		"opus-4-7",
+		"opus-4.7",
+		"opus-4-8",
+		"opus-4.8",
+		"opus-5",
+		"sonnet-5",
+		"fable-5",
+	];
+	return xhighModelIds.some((id) => modelId.includes(id));
+}
+
+export function supportsMax<TApi extends Api>(model: Model<TApi>): boolean {
+	const mapped = model.thinkingLevelMap?.max;
+	if (mapped === null) return false;
+	if (mapped !== undefined) return true;
+	if (model.thinkingLevelMap !== undefined) return false;
+	return supportsMaxModel(model);
+}
+
+function supportsMaxModel<TApi extends Api>(model: Model<TApi>): boolean {
+	if (!model.reasoning) return false;
+
+	const openAiMaxApis: Api[] = [
+		"openai-responses",
+		"azure-openai-responses",
+		"openai-codex-responses",
+		"openai-completions",
+	];
+	if (openAiMaxApis.includes(model.api) && /(?:^|\/)gpt-5\.6-sol(?:$|-)/.test(model.id)) {
+		return true;
+	}
+
+	const maxModelIds = [
+		"opus-4-6",
+		"opus-4.6",
+		"opus-4-7",
+		"opus-4.7",
+		"opus-4-8",
+		"opus-4.8",
+		"opus-5",
+		"sonnet-5",
+		"fable-5",
+	];
+	return maxModelIds.some((id) => model.id.includes(id));
 }
 
 /**

--- a/packages/ai/test/openai-responses-thinking-matrix.test.ts
+++ b/packages/ai/test/openai-responses-thinking-matrix.test.ts
@@ -7,6 +7,7 @@ import {
 	stream as streamOpenAICodexResponses,
 	streamSimple as streamSimpleOpenAICodexResponses,
 } from "../src/api/openai-codex-responses.ts";
+import { streamSimple as streamSimpleOpenAICompletions } from "../src/api/openai-completions.ts";
 import {
 	stream as streamOpenAIResponses,
 	streamSimple as streamSimpleOpenAIResponses,
@@ -16,6 +17,7 @@ import { supportsXhigh } from "../src/models.ts";
 
 interface ReasoningPayload {
 	reasoning?: { effort?: string; summary?: string };
+	reasoning_effort?: string;
 }
 
 const context = {
@@ -50,6 +52,67 @@ describe("OpenAI Responses thinking matrix", () => {
 		);
 
 		expect(payload).toMatchObject({ reasoning: { effort: "max", summary: "auto" } });
+	});
+
+	it("preserves max effort for a map-less gpt-5.6-sol model", async () => {
+		const model = {
+			...getModel("openai", "gpt-5.6-sol"),
+			provider: "codex-lb",
+			thinkingLevelMap: undefined,
+		};
+		const payload = await capturePayload((onPayload) =>
+			streamSimpleOpenAIResponses(model, context, {
+				apiKey: "test-key",
+				reasoning: "max",
+				onPayload,
+			}),
+		);
+
+		expect(payload).toMatchObject({ reasoning: { effort: "max", summary: "auto" } });
+	});
+
+	it("preserves max effort for a map-less gpt-5.6-sol model on Azure Responses", async () => {
+		const model = {
+			...getModel("azure-openai-responses", "gpt-5.6-sol"),
+			baseUrl: "http://127.0.0.1:9",
+			thinkingLevelMap: undefined,
+		};
+		const payload = await capturePayload((onPayload) =>
+			streamSimpleAzureOpenAIResponses(model, context, { apiKey: "test-key", reasoning: "max", onPayload }),
+		);
+
+		expect(payload).toMatchObject({ reasoning: { effort: "max" } });
+	});
+
+	it("preserves max effort for a map-less gpt-5.6-sol model on Codex Responses", async () => {
+		const model = {
+			...getModel("openai-codex", "gpt-5.6-sol"),
+			thinkingLevelMap: undefined,
+		};
+		const payload = await capturePayload((onPayload) =>
+			streamSimpleOpenAICodexResponses(model, context, {
+				apiKey: "test-key",
+				transport: "sse",
+				reasoning: "max",
+				onPayload,
+			}),
+		);
+
+		expect(payload).toMatchObject({ reasoning: { effort: "max" } });
+	});
+
+	it("preserves max effort for a map-less gpt-5.6-sol model on Completions", async () => {
+		const model = {
+			...getModel("openai", "gpt-5.6-sol"),
+			api: "openai-completions" as const,
+			baseUrl: "http://127.0.0.1:9",
+			thinkingLevelMap: undefined,
+		};
+		const payload = await capturePayload((onPayload) =>
+			streamSimpleOpenAICompletions(model, context, { apiKey: "test-key", reasoning: "max", onPayload }),
+		);
+
+		expect(payload.reasoning_effort).toBe("max");
 	});
 
 	it("preserves Azure's explicit gpt-5.6 max effort mapping", async () => {

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -184,4 +184,14 @@ describe("supportsXhigh tier detection for map-less models", () => {
 	it("still reports no xhigh tier for a map-less Sonnet 4.5", () => {
 		expect(supportsXhigh(maplessWithId("claude-sonnet-4-5"))).toBe(false);
 	});
+
+	it("includes max for a map-less gpt-5.6-sol model", () => {
+		expect(getSupportedThinkingLevels({ ...maplessWithId("gpt-5.6-sol"), api: "openai-responses" })).toContain("max");
+	});
+
+	it("does not infer max for a map-less gpt-5.6-terra model", () => {
+		expect(getSupportedThinkingLevels({ ...maplessWithId("gpt-5.6-terra"), api: "openai-responses" })).not.toContain(
+			"max",
+		);
+	});
 });

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,21 @@
 # goal Extension Changes
 
+## Migrate legacy pi-goal state into the builtin goal store (2026-07-31)
+
+### What changed
+
+- Session startup now migrates a legacy sibling `pi-goal` file when the builtin `goal` store does not yet exist.
+- Legacy `budgetLimited` / `budget_limited` goals resume as active, and `tokenBudget` is stripped from runtime state while the original legacy file remains untouched.
+- Existing builtin goal files remain authoritative and are never overwritten by migration.
+
+### Why
+
+- Moving the extension store from `pi-goal` to `goal` otherwise made existing objectives appear lost, and legacy budget metadata is incompatible with the builtin goal extension's budget-free design.
+
+### Verification
+
+- Goal-store coverage pins migration, runtime budget stripping, destination persistence, source preservation, and the existing app-server wire contract.
+
 ## Achieved footer shows elapsed time and truncated objective (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -10,6 +10,7 @@ import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { isResumeOfPausedGoal, queueGoalContinuation } from "./lifecycle-helpers.ts";
 import { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
+import { migrateLegacyGoalFile } from "./persistence.ts";
 import { accountGoalUsage, readGoal, resetContinuationStreak, updateGoal } from "./store.ts";
 import { goalStoreRef as buildGoalStoreRef } from "./store-ref.ts";
 import { staleGoalTodoReminder, todoResultAddsOpenTasks } from "./todo-gate.ts";
@@ -80,7 +81,9 @@ export default function goalExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_start", async (event, ctx) => {
 		monitorContinuation.start(ctx);
-		const goal = await readGoal(goalStoreRef(ctx));
+		const ref = goalStoreRef(ctx);
+		await migrateLegacyGoalFile(ref);
+		const goal = await readGoal(ref);
 		if (goal?.status === "active") {
 			beginAgentGoalAccounting(goal);
 		} else {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
@@ -25,6 +25,27 @@ export async function readGoalFile(ref: GoalStoreRef): Promise<Goal | null> {
 	}
 }
 
+export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | null> {
+	try {
+		await readFile(goalFilePath(ref), "utf8");
+		return null;
+	} catch (error) {
+		if (!isMissingFile(error)) throw error;
+	}
+
+	const legacyRef = { ...ref, baseDir: join(dirname(ref.baseDir), "pi-goal") };
+	let legacyGoal: Goal | null;
+	try {
+		legacyGoal = parseGoalFile(await readFile(goalFilePath(legacyRef), "utf8")).goal;
+	} catch (error) {
+		if (isMissingFile(error)) return null;
+		throw error;
+	}
+	if (legacyGoal === null) return null;
+	await writeGoalFile(ref, legacyGoal);
+	return legacyGoal;
+}
+
 export async function writeGoalFile(ref: GoalStoreRef, goal: Goal | null): Promise<void> {
 	const filePath = goalFilePath(ref);
 	await mkdir(dirname(filePath), { recursive: true });
@@ -50,6 +71,19 @@ async function writeGoalFileAtomic(filePath: string, contents: string): Promise<
 }
 
 function parseGoalFile(raw: string): GoalFile {
+	const parsed = parseGoalFileJson(raw);
+	if (!isRecord(parsed)) throw new InvalidGoalStoreError("goal store must be a JSON object");
+	if (parsed.version !== STORE_VERSION) throw new UnsupportedGoalStoreVersionError("unsupported goal store version");
+	const normalizedGoal = normalizeLegacyGoal(parsed.goal);
+	if (normalizedGoal !== null && !isGoal(normalizedGoal))
+		throw new InvalidGoalStoreError("goal store contains an invalid goal");
+	return {
+		version: STORE_VERSION,
+		goal: normalizedGoal === null ? null : sanitizeContinuationState(normalizedGoal),
+	};
+}
+
+function parseGoalFileJson(raw: string): unknown {
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(raw);
@@ -63,11 +97,17 @@ function parseGoalFile(raw: string): GoalFile {
 			throw error;
 		}
 	}
-	if (!isRecord(parsed)) throw new InvalidGoalStoreError("goal store must be a JSON object");
-	if (parsed.version !== STORE_VERSION) throw new UnsupportedGoalStoreVersionError("unsupported goal store version");
-	if (parsed.goal !== null && !isGoal(parsed.goal))
-		throw new InvalidGoalStoreError("goal store contains an invalid goal");
-	return { version: STORE_VERSION, goal: parsed.goal === null ? null : sanitizeContinuationState(parsed.goal) };
+	return parsed;
+}
+
+function normalizeLegacyGoal(value: unknown): unknown {
+	if (!isRecord(value)) return value;
+	const normalized = { ...value };
+	delete normalized.tokenBudget;
+	if (normalized.status === "budgetLimited" || normalized.status === "budget_limited") {
+		normalized.status = "active";
+	}
+	return normalized;
 }
 
 function recoverGoalFileWithStaleClosingBraces(raw: string): string | undefined {

--- a/packages/coding-agent/src/core/thinking-levels.ts
+++ b/packages/coding-agent/src/core/thinking-levels.ts
@@ -3,11 +3,12 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 
 const THINKING_LEVELS_WITH_MAX: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
-type ModelWithThinkingLevelMap = Model<Api> & {
-	thinkingLevelMap?: Partial<Record<ThinkingLevel, string | null>>;
-};
-
 export function supportsXhigh(model: Model<Api>): boolean {
+	const mappedLevel = model.thinkingLevelMap?.xhigh;
+	if (mappedLevel === null) return false;
+	if (mappedLevel !== undefined) return true;
+	if (model.thinkingLevelMap !== undefined) return false;
+
 	return (
 		model.id.includes("gpt-5.2") ||
 		model.id.includes("gpt-5.3") ||
@@ -29,7 +30,19 @@ export function supportsXhigh(model: Model<Api>): boolean {
 }
 
 export function supportsMax(model: Model<Api>): boolean {
+	const mappedLevel = model.thinkingLevelMap?.max;
+	if (mappedLevel === null) return false;
+	if (mappedLevel !== undefined) return true;
+	if (model.thinkingLevelMap !== undefined) return false;
+
+	const openAiMaxApis: Api[] = [
+		"openai-responses",
+		"azure-openai-responses",
+		"openai-codex-responses",
+		"openai-completions",
+	];
 	return (
+		(openAiMaxApis.includes(model.api) && /(?:^|\/)gpt-5\.6-sol(?:$|-)/.test(model.id)) ||
 		model.id.includes("opus-4-6") ||
 		model.id.includes("opus-4.6") ||
 		model.id.includes("opus-4-7") ||
@@ -45,9 +58,8 @@ export function supportsMax(model: Model<Api>): boolean {
 export function getSupportedThinkingLevels(model: Model<Api>): ThinkingLevel[] {
 	if (!model.reasoning) return ["off"];
 
-	const modelWithThinkingLevelMap = model as ModelWithThinkingLevelMap;
 	const supportedLevels = THINKING_LEVELS_WITH_MAX.filter((level) => {
-		const mappedLevel = modelWithThinkingLevelMap.thinkingLevelMap?.[level];
+		const mappedLevel = model.thinkingLevelMap?.[level];
 		if (mappedLevel === null) return false;
 		if (level === "xhigh") return mappedLevel !== undefined || supportsXhigh(model);
 		if (level === "max") return mappedLevel !== undefined || supportsMax(model);

--- a/packages/coding-agent/test/suite/app-server-goal-wire.test.ts
+++ b/packages/coding-agent/test/suite/app-server-goal-wire.test.ts
@@ -67,19 +67,19 @@ describe("app-server goal wire adapter", () => {
 		expect(loaded).not.toHaveProperty("tokenBudget");
 	});
 
-	it("round-trips the additive budget field through the goal store", async () => {
-		// Given: a goal with a numeric budget persisted through the normal store writer.
+	it("normalizes legacy budget metadata out of runtime goal state", async () => {
+		// Given: a legacy-compatible goal object still carrying a numeric budget.
 		const baseDir = await mkdtemp(join(tmpdir(), "senpi-goal-wire-"));
 		tempDirs.push(baseDir);
 		const ref: GoalStoreRef = { baseDir, threadId: "thread-budget" };
 		const goal = makeGoal({ threadId: ref.threadId, tokenBudget: 8192 });
 
-		// When: the goal is written and then read back.
+		// When: the goal crosses the normal store writer and reader.
 		await writeGoal(ref, goal);
 		const loaded = await readGoal(ref);
 
-		// Then: the budget remains available to the wire adapter.
-		expect(loaded?.tokenBudget).toBe(8192);
+		// Then: the serialized compatibility field remains inert and never reactivates runtime budgeting.
+		expect(loaded).not.toHaveProperty("tokenBudget");
 		expect(JSON.parse(await readFile(goalFilePath(ref), "utf8"))).toMatchObject({
 			goal: { tokenBudget: 8192 },
 		});

--- a/packages/coding-agent/test/suite/app-server-thread-goal.test.ts
+++ b/packages/coding-agent/test/suite/app-server-thread-goal.test.ts
@@ -16,14 +16,14 @@ describe("app-server thread goal handlers", () => {
 		await cleanupRoots();
 	});
 
-	it("round-trips a goal and preserves omitted, null, and numeric token budgets", async () => {
+	it("accepts a request budget without persisting limiter state", async () => {
 		// Given: a started persistent thread.
 		const { connection, registry, root } = await createHarness();
 		const threadId = threadIdFromResponse(
 			await registry.dispatch(connection, { id: 1, method: "thread/start", params: { cwd: root } }),
 		);
 
-		// When: a goal is created, updated without a budget, then explicitly cleared.
+		// When: a goal is created with a compatibility budget, then read through later updates.
 		const created = await registry.dispatch(connection, {
 			id: 2,
 			method: "thread/goal/set",
@@ -45,14 +45,14 @@ describe("app-server thread goal handlers", () => {
 			params: { threadId },
 		});
 
-		// Then: the goal shape and token-budget tri-state match the wire contract.
+		// Then: the create response preserves wire compatibility, but persisted Goal state is budgetless.
 		expect(objectAt(responseResult(created), "goal")).toMatchObject({
 			threadId,
 			objective: "Ship the parity lane",
 			status: "active",
 			tokenBudget: 4096,
 		});
-		expect(objectAt(responseResult(preserved), "goal").tokenBudget).toBe(4096);
+		expect(objectAt(responseResult(preserved), "goal").tokenBudget).toBeNull();
 		expect(objectAt(responseResult(cleared), "goal").tokenBudget).toBeNull();
 		expect(objectAt(responseResult(read), "goal").tokenBudget).toBeNull();
 	});

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "n
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { migrateLegacyGoalFile } from "../../src/core/extensions/builtin/goal/persistence.ts";
 import {
 	accountGoalUsage,
 	clearGoal,
@@ -202,6 +203,41 @@ describe("goal store atomic writes", () => {
 });
 
 describe("goal store (budget-free)", () => {
+	it("migrates a legacy budget-limited goal as active without a budget", async () => {
+		const ref = await tempStore("thread-legacy-budget");
+		const legacyRef = { ...ref, baseDir: join(ref.baseDir, "..", "pi-goal") };
+		const legacyGoal = {
+			id: "legacy-goal",
+			threadId: ref.threadId,
+			objective: "Finish the inherited work",
+			status: "budgetLimited",
+			tokenBudget: 512,
+			tokensUsed: 2_800_000,
+			timeUsedSeconds: 120,
+			createdAt: 100,
+			updatedAt: 200,
+		};
+		await mkdir(legacyRef.baseDir, { recursive: true });
+		await writeFile(
+			goalFilePath(legacyRef),
+			`${JSON.stringify({ version: 1, goal: legacyGoal }, null, 2)}\n`,
+			"utf8",
+		);
+
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		expect(migrated).toMatchObject({
+			id: "legacy-goal",
+			objective: "Finish the inherited work",
+			status: "active",
+			tokensUsed: 2_800_000,
+		});
+		expect(migrated).not.toHaveProperty("tokenBudget");
+		expect(await readGoal(ref)).toEqual(migrated);
+		expect(await readFile(goalFilePath(ref), "utf8")).not.toContain("tokenBudget");
+		expect(await readFile(goalFilePath(legacyRef), "utf8")).toContain('"tokenBudget": 512');
+	});
+
 	it("creates a persisted active goal with no budget field", async () => {
 		const ref = await tempStore("thread-create");
 		const goal = await createGoal(ref, "  Ship the extension  ");

--- a/packages/coding-agent/test/thinking-levels-tiers.test.ts
+++ b/packages/coding-agent/test/thinking-levels-tiers.test.ts
@@ -7,7 +7,7 @@ function maplessModel(id: string): Model<Api> {
 	return {
 		id,
 		name: id,
-		api: "anthropic-messages",
+		api: "openai-responses",
 		provider: "custom-gateway",
 		baseUrl: "https://example.invalid",
 		reasoning: true,
@@ -27,10 +27,35 @@ describe("thinking level tier detection for map-less models", () => {
 		expect(getSupportedThinkingLevels(model)).toContain("max");
 	});
 
-	it("exposes xhigh for gpt-5.6 without claiming the max tier", () => {
+	it("exposes xhigh and max for gpt-5.6", () => {
 		const model = maplessModel("gpt-5.6-sol");
 		expect(supportsXhigh(model)).toBe(true);
+		expect(supportsMax(model)).toBe(true);
+		expect(getSupportedThinkingLevels(model)).toContain("xhigh");
+		expect(getSupportedThinkingLevels(model)).toContain("max");
+	});
+
+	it("does not infer max for a non-Sol gpt-5.6 model", () => {
+		const model = maplessModel("gpt-5.6-terra");
+		expect(supportsXhigh(model)).toBe(true);
 		expect(supportsMax(model)).toBe(false);
+		expect(getSupportedThinkingLevels(model)).not.toContain("max");
+	});
+
+	it("preserves an explicit max veto for gpt-5.6-sol", () => {
+		const model = maplessModel("gpt-5.6-sol");
+		model.thinkingLevelMap = { max: null };
+		expect(supportsMax(model)).toBe(false);
+		expect(getSupportedThinkingLevels(model)).not.toContain("max");
+	});
+
+	it("treats a map containing max but omitting xhigh as authoritative", () => {
+		const model = maplessModel("gpt-5.6-sol");
+		model.thinkingLevelMap = { max: "max" };
+		expect(supportsXhigh(model)).toBe(false);
+		expect(supportsMax(model)).toBe(true);
+		expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
+		expect(getSupportedThinkingLevels(model)).toContain("max");
 	});
 
 	it("exposes neither tier for Sonnet 4.5", () => {


### PR DESCRIPTION
## Summary

Supersedes the independently-valuable lanes of #552 and the related goal work that #553 did not ship. Both of those PRs have now been reviewed, reworked, and merged — this carries the two lanes that were **not** part of either, adopted from @realsigridjin's work and credited as co-author.

- **feat(ai): support map-less max reasoning** (`aa13d734c`) — an explicit `thinkingLevelMap` is authoritative (`null` vetoes, a present map with a missing key disables that tier, model-ID heuristics only apply to map-less models). This unifies `coding-agent` and `packages/ai`, which previously drifted on `xhigh`/`max` capability. Related: #552.
- **fix(goal): migrate legacy goal store state** (`0481c4c18`) — migrates an existing `extensions/pi-goal/<threadId>.json` into the current `extensions/goal` store on session start, with current-store-wins precedence. Related: #552.

The compaction **deterministic-fallback** lane from #552 is deliberately **not** here — #552 (merged as `06ed4e7f8`) shipped an authoritative version that includes the data-loss safety fix. This PR is only the two lanes that did not land there.

Co-authored-by: Sigrid Jeong <sayjin2@yonsei.ac.kr> on both commits.

## Verification

- AI: `openai-responses-thinking-matrix` + `supports-xhigh` — 63 tests passed.
- Goal: `app-server-goal-wire`, `app-server-thread-goal`, `goal-store`, `goal-extension`, `goal-monitor-continuation`, `stale-goal-input-pause` — 102 tests passed.
- `npm run check` passed.
- Rebased onto main **after** #552 and #553 merged; the goal migration hookup is applied on top of #553's rewritten `session_start` handler.

Supersedes the adopted portions of #552. Closes the loop on #553's goal-side lane.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds map-less max reasoning for `gpt-5.6-sol` and migrates legacy `pi-goal` state to the builtin `goal` store. This unifies reasoning tiers across `packages/ai` and `packages/coding-agent` and preserves existing goals without budgets.

- **New Features**
  - Map-less models can use `max` when `thinkingLevelMap` is absent; explicit maps and null vetoes stay authoritative.
  - `openai-responses`, `azure-openai-responses`, `openai-codex-responses`, and `openai-completions` now send `reasoning.effort: "max"` for `gpt-5.6-sol` instead of clamping to `high`.
  - Tier detection infers `xhigh` and `max` for `gpt-5.6-sol`; non-Sol variants do not infer `max`.

- **Migration**
  - On session start, migrate `extensions/pi-goal/<threadId>.json` to `extensions/goal` only when the new store is missing.
  - Normalize legacy goals: convert `budgetLimited`/`budget_limited` to `active` and drop `tokenBudget` from runtime; legacy file remains unchanged.

<sup>Written for commit 4e07d921dfb6ed61e69f158a6396b5745c310935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

