### PR TITLE
feat(coding-agent): add loop-guard builtin for tool-call loop detection

### DIFF
--- a/.agents/skills/senpi-qa/scripts/loop-guard-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/loop-guard-qa.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// senpi-qa driver for the loop-guard builtin extension.
+// Scripts tool-call loops through the REAL CLI against the local fake model
+// server (zero tokens, sandboxed agent dir) and asserts the steered
+// <system-reminder> reaches the provider's NEXT request body — the observable
+// proof that the reminder entered the model's context. Also asserts a control
+// scenario with varied calls fires nothing.
+//
+//   node .agents/skills/senpi-qa/scripts/loop-guard-qa.mjs --self-test
+//   node .agents/skills/senpi-qa/scripts/loop-guard-qa.mjs --self-test --evidence loop-guard
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	runCli,
+} from "./lib/common.mjs";
+import { startFakeModelServer } from "./lib/fake-model-server.mjs";
+import { API_PRESETS, checkRealAuthUnchanged, hermeticEnv, writeMockModelsJson } from "./lib/mock-loop-support.mjs";
+
+const argv = process.argv.slice(2);
+const evidenceSlug = argv.includes("--evidence") ? argv[argv.indexOf("--evidence") + 1] : undefined;
+const API = "openai-completions";
+const IDENTICAL_HEADLINE = "LOOP GUARD - IDENTICAL TOOL CALLS";
+const SIMILAR_HEADLINE = "LOOP GUARD - NEAR-IDENTICAL TOOL CALLS";
+const CYCLE_HEADLINE = "LOOP GUARD - REPEATING TOOL-CALL PATTERN";
+
+function rawBody(request) {
+	return request.raw ?? JSON.stringify(request.body ?? {});
+}
+
+async function drive({ turns, extraArgs = [] }) {
+	const preset = API_PRESETS[API];
+	const box = makeSandbox("loop-guard-qa");
+	const server = await startFakeModelServer({ turns });
+	writeMockModelsJson(box.agentDir, server, API);
+	const args = [
+		"--provider",
+		preset.provider,
+		"--model",
+		preset.modelId,
+		"--no-context-files",
+		"--no-extensions",
+		...extraArgs,
+		"--print",
+		"Run the scripted tools, then reply done.",
+	];
+	const result = await runCli(args, { env: hermeticEnv(box.env), cwd: box.cwd, timeoutMs: 120000 });
+	return { box, server, result };
+}
+
+async function expectReminder(checks, { name, turns, headline, minRequests, extraArgs }) {
+	const { box, server, result } = await drive({ turns, extraArgs });
+	const bodies = server.requests.map(rawBody);
+	const hitIndex = bodies.findIndex((body, index) => index >= 1 && body.includes(headline));
+	const pass = result.code === 0 && server.requests.length >= minRequests && hitIndex >= 1;
+	checks.ok(
+		`${name}: reminder steered into a later provider request`,
+		pass,
+		`code=${result.code} requests=${server.requests.length} hitAt=${hitIndex}`,
+	);
+	if (!pass) {
+		process.stderr.write(`\n--- ${name} stderr tail ---\n${result.stderr.slice(-800)}\n`);
+	}
+	if (evidenceSlug !== undefined) {
+		const dir = evidenceDir(evidenceSlug);
+		writeFileSync(
+			join(dir, `${name}.json`),
+			JSON.stringify(
+				{
+					headline,
+					hitAt: hitIndex,
+					requestCount: server.requests.length,
+					exitCode: result.code,
+					requestBodies: server.requests.map((request, index) => ({ index, url: request.url, raw: rawBody(request) })),
+				},
+				null,
+				2,
+			),
+		);
+	}
+	await server.stop();
+	box.cleanup();
+	return pass;
+}
+
+async function selfTest() {
+	installCleanupHooks();
+	const checks = createChecks("loop-guard-qa.mjs --self-test");
+	const guard = guardRealAuth();
+
+	const identicalCall = { name: "bash", args: { command: "echo LOOP-GUARD-QA-IDENTICAL" } };
+	await expectReminder(checks, {
+		name: "identical",
+		headline: IDENTICAL_HEADLINE,
+		minRequests: 4,
+		extraArgs: ["--approve"],
+		turns: [{ toolCalls: [identicalCall] }, { toolCalls: [identicalCall] }, { toolCalls: [identicalCall] }, { text: "done" }],
+	});
+
+	const similarTurns = [1, 201, 401, 601, 801, 1001].map((offset) => ({
+		toolCalls: [{ name: "bash", args: { command: `sed -n '${offset},${offset + 199}p' /tmp/loop-guard-qa-corpus.txt` } }],
+	}));
+	similarTurns.push({ text: "done" });
+	await expectReminder(checks, {
+		name: "similar",
+		headline: SIMILAR_HEADLINE,
+		minRequests: 6,
+		extraArgs: ["--approve"],
+		turns: similarTurns,
+	});
+
+	const cyclePair = [
+		{ name: "bash", args: { command: "echo LOOP-GUARD-QA-CYCLE-A" } },
+		{ name: "bash", args: { command: "echo LOOP-GUARD-QA-CYCLE-B" } },
+	];
+	const cycleTurns = [];
+	for (let i = 0; i < 3; i++) {
+		cycleTurns.push({ toolCalls: [cyclePair[0]] }, { toolCalls: [cyclePair[1]] });
+	}
+	cycleTurns.push({ text: "done" });
+	await expectReminder(checks, {
+		name: "cycle",
+		headline: CYCLE_HEADLINE,
+		minRequests: 7,
+		extraArgs: ["--approve"],
+		turns: cycleTurns,
+	});
+
+	{
+		const { box, server, result } = await drive({
+			extraArgs: ["--approve"],
+			turns: [
+				{ toolCalls: [{ name: "bash", args: { command: "echo QA-VARIED-1" } }] },
+				{ toolCalls: [{ name: "bash", args: { command: "git status --short" } }] },
+				{ toolCalls: [{ name: "bash", args: { command: "npm run check" } }] },
+				{ text: "done" },
+			],
+		});
+		const leaked = server.requests
+			.map(rawBody)
+			.some((body) => body.includes(IDENTICAL_HEADLINE) || body.includes(SIMILAR_HEADLINE) || body.includes(CYCLE_HEADLINE));
+		checks.ok("control: varied calls fire no reminder", result.code === 0 && !leaked, `code=${result.code} leaked=${leaked}`);
+		await server.stop();
+		box.cleanup();
+	}
+
+	checkRealAuthUnchanged(checks, guard);
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+await selfTest();

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions/builtin
 
-26 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
+27 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
 
 ## INVENTORY (registration order from `builtin/index.ts`)
 
@@ -32,6 +32,7 @@
 | 24 | `config-reload` | `config-reload/` | Hash-gated watcher for trusted global/project config surfaces that defers a full session reload until idle and exposes the `config-watch:*` event protocol; registered after settings-dependent builtins so a reload rebuilds their resolved settings, and before final MCP observation |
 | 25 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — see `mcp/changes.md` |
 | 26 | `ttsr` | `ttsr/` | Stream-rule detection (collapse + control-token-leak) with abort→remediate→retry; ported from oh-my-pi — see `ttsr/changes.md` |
+| 27 | `loop-guard` | `loop-guard/` | Tool-call loop detection (identical / near-identical / cyclic) that steers a `<system-reminder>` into the running turn with a cache-warm-style TUI notice — see `loop-guard/changes.md` |
 
 Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by resource-loader.ts) and 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`).
 

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,23 @@
 # Builtin extensions changes
 
+## loop-guard: tool-call loop detection with steered reminders (2026-07-31)
+
+- New builtin extension `loop-guard` (registered before `config-reload`; MCP stays last)
+  that watches the pure `tool_execution_start` stream and steers a
+  `<system-reminder>` CustomMessage into the running turn on three loop shapes:
+  identical calls (trailing run >= 3 of byte-identical tool+canonical-args),
+  near-identical same-tool runs (>= 5 calls at mean adjacent bigram-Dice >= 0.85),
+  and cyclic rotations (period 2..6 repeated >= 3 times). Each kind gets its own
+  reminder prompt; a shared gate re-fires only at 2x the last notified count and
+  resets on `session_start` / real user input.
+- TUI notice via `pi.registerMessageRenderer("loop-guard:notice", ...)` in the goal
+  cache-warm Box style. Threshold rationale (gemini-cli / OpenHands prior art plus a
+  400-session local corpus) is recorded in `loop-guard/changes.md` and `policy.ts`.
+- Tests: `test/suite/loop-guard-detectors.test.ts` and
+  `test/suite/loop-guard-extension.test.ts` (fake-pi harness, zero tokens).
+- Expected merge conflict zones: LOW in `builtin/index.ts` (one import + one array
+  entry before `config-reload`); NONE in `types.ts` (no public API change).
+
 ## service-tier: mirror the Codex fast toggle into the session indicator (2026-07-31)
 
 - The session toggle added on 2026-07-31 lived only inside this extension, so no host surface could

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -15,6 +15,7 @@ import historySearchExtension from "./history-search/index.ts";
 import hooksExtension from "./hooks/index.ts";
 import importReproExtension from "./import-repro.ts";
 import lookAtExtension from "./look-at/index.ts";
+import loopGuardExtension from "./loop-guard/index.ts";
 import mcpExtension from "./mcp/index.ts";
 import modelFallbackExtension from "./model-fallback/index.ts";
 import nestedAgentsMdExtension from "./nested-agents-md/index.ts";
@@ -81,6 +82,8 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "ttsr", factory: ttsrExtension },
 	{ id: "btw", factory: btwExtension },
 	{ id: "claude-sdk-oauth", factory: claudeSdkOauthExtension },
+	// Loop guard is a pure observer of tool_execution_start; it never mutates payloads, so it slots before config-reload and leaves MCP last.
+	{ id: "loop-guard", factory: loopGuardExtension },
 	// Config reload follows settings-dependent builtins so reloads rebuild their resolved settings before MCP observes them.
 	{ id: "config-reload", factory: configReloadExtension },
 	// Keep MCP last so its eventual provider-payload tap observes all co-resident builtin mutations.

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/changes.md
@@ -1,0 +1,43 @@
+# loop-guard changes
+
+## loop-guard: tool-call loop detection with steered reminders (2026-07-31)
+
+- New builtin extension `loop-guard` that observes the pure tool-call stream
+  (`tool_execution_start`, tool-call only — no adjacency assumption) and steers a
+  `<system-reminder>` CustomMessage into the running turn when the agent loops.
+- Three detectors over a 64-entry ring of `(toolName, canonicalArgsJson)` signatures
+  (key-order-insensitive canonicalization), evaluated per call with priority
+  identical > cycle > similar, one notice max per call:
+  - `identical`: trailing run of byte-identical signature ≥ 3 → firm reminder
+    ("same call ×N, the result will not change, snap out of it").
+  - `similar`: trailing same-tool run ≥ 5 with mean adjacent bigram-Dice ≥ 0.85 and
+    not all identical → softer attention-check reminder.
+  - `cycle`: trailing period-k (k=2..6) repetition ≥ 3 full cycles with ≥ 2 distinct
+    signatures → rotation-break reminder.
+- Threshold evidence base: gemini-cli `LoopDetectionService` (sha256 name+args
+  signatures, cycle periods 1..5, threshold 5 — but it HALTS the turn; loop-guard
+  only nudges, so it fires earlier) and OpenHands stuck detector (4+ identical
+  action-observation pairs, 6+ ping-pong cycles). Similarity calibrated on 400 real
+  senpi sessions: productive same-tool runs (bash/eval/edit/todo) sit at mean
+  adjacent bigram-Dice ~0.52–0.55 (p90 ≤ 0.72), while repetitive classes (read
+  pagination, bash_output/task_output polling) sit at 0.84–0.93 — 0.85 separates them.
+- Escalation gating (`NoticeGate`): fires once at threshold per pattern fingerprint,
+  re-fires only when the count reaches 2× the last notified count; a fingerprint
+  break clears the entry. State resets on `session_start` and on user `input`
+  (interactive/rpc sources; extension-sourced input does not reset, so goal
+  continuations cannot accidentally clear a tracked loop).
+- Delivery: `pi.sendMessage({ customType: "loop-guard:notice", display: true,
+  details }, { triggerTurn: false, deliverAs: "steer" })` — steers into the active
+  turn without synthesizing a new one. TUI rendering via `pi.registerMessageRenderer`
+  in the goal cache-warm Box style (bold accent title `⚠ Loop guard · …`, dim
+  why-line, expanded detail line).
+- Registration: appended in `builtin/index.ts` before `config-reload` (pure observer,
+  never mutates payloads; MCP stays last). `builtin/AGENTS.md` inventory updated to
+  27 extensions.
+- Tests: `test/suite/loop-guard-detectors.test.ts` (units for canonicalization,
+  similarity, all three detectors, gate escalation, tracker window) and
+  `test/suite/loop-guard-extension.test.ts` (fake-pi harness: renderer registration,
+  silent-on-varied-work, per-kind prompt text, escalation, input/session resets,
+  rendered box content). Faux provider only; zero tokens.
+- Expected merge conflict zones: LOW in `builtin/index.ts` (one import + one array
+  entry); NONE in `types.ts` (no public API change); NONE elsewhere (new directory).

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/detectors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/detectors.ts
@@ -1,0 +1,134 @@
+import {
+	CYCLE_MAX_PERIOD,
+	CYCLE_MIN_PERIOD,
+	CYCLE_REPETITION_THRESHOLD,
+	ESCALATION_FACTOR,
+	IDENTICAL_RUN_THRESHOLD,
+	SIMILAR_RUN_THRESHOLD,
+	SIMILARITY_THRESHOLD,
+} from "./policy.ts";
+import { meanAdjacentSimilarity } from "./similarity.ts";
+import type { ToolCallRecord } from "./tracker.ts";
+
+export type LoopGuardDetection =
+	| { readonly kind: "identical"; readonly toolName: string; readonly count: number; readonly fingerprint: string }
+	| {
+			readonly kind: "similar";
+			readonly toolName: string;
+			readonly count: number;
+			readonly similarity: number;
+			readonly fingerprint: string;
+	  }
+	| {
+			readonly kind: "cycle";
+			readonly period: number;
+			readonly count: number;
+			readonly cycleTools: readonly string[];
+			readonly fingerprint: string;
+	  };
+
+export type LoopGuardKind = LoopGuardDetection["kind"];
+
+export function detectIdenticalRun(records: readonly ToolCallRecord[]): LoopGuardDetection | undefined {
+	const last = records[records.length - 1];
+	if (last === undefined) return undefined;
+	let run = 1;
+	for (let i = records.length - 2; i >= 0; i--) {
+		if (records[i]?.signature !== last.signature) break;
+		run++;
+	}
+	if (run < IDENTICAL_RUN_THRESHOLD) return undefined;
+	return { kind: "identical", toolName: last.toolName, count: run, fingerprint: last.signature };
+}
+
+export function detectSimilarRun(records: readonly ToolCallRecord[]): LoopGuardDetection | undefined {
+	const last = records[records.length - 1];
+	if (last === undefined) return undefined;
+	let run = 1;
+	for (let i = records.length - 2; i >= 0; i--) {
+		if (records[i]?.toolName !== last.toolName) break;
+		run++;
+	}
+	if (run < SIMILAR_RUN_THRESHOLD) return undefined;
+	const argStrings = records.slice(records.length - run).map((record) => record.argsJson);
+	if (new Set(argStrings).size === 1) return undefined;
+	const similarity = meanAdjacentSimilarity(argStrings);
+	if (similarity < SIMILARITY_THRESHOLD) return undefined;
+	return { kind: "similar", toolName: last.toolName, count: run, similarity, fingerprint: last.toolName };
+}
+
+export function detectCycle(records: readonly ToolCallRecord[]): LoopGuardDetection | undefined {
+	const total = records.length;
+	for (let period = CYCLE_MIN_PERIOD; period <= CYCLE_MAX_PERIOD; period++) {
+		if (total < period * CYCLE_REPETITION_THRESHOLD) continue;
+		const cycle = records.slice(total - period);
+		if (new Set(cycle.map((record) => record.signature)).size < 2) continue;
+		let repetitions = 1;
+		while (repetitions * period + period <= total) {
+			const blockStart = total - (repetitions + 1) * period;
+			let matches = true;
+			for (let offset = 0; offset < period; offset++) {
+				if (records[blockStart + offset]?.signature !== cycle[offset]?.signature) {
+					matches = false;
+					break;
+				}
+			}
+			if (!matches) break;
+			repetitions++;
+		}
+		if (repetitions < CYCLE_REPETITION_THRESHOLD) continue;
+		return {
+			kind: "cycle",
+			period,
+			count: repetitions,
+			cycleTools: cycle.map((record) => record.toolName),
+			fingerprint: cycle.map((record) => record.signature).join("\u0001"),
+		};
+	}
+	return undefined;
+}
+
+interface GateEntry {
+	fingerprint: string;
+	lastNotifiedCount: number;
+}
+
+export class NoticeGate {
+	private entries = new Map<LoopGuardKind, GateEntry>();
+
+	admit(detection: LoopGuardDetection): boolean {
+		const existing = this.entries.get(detection.kind);
+		if (existing === undefined || existing.fingerprint !== detection.fingerprint) {
+			this.entries.set(detection.kind, { fingerprint: detection.fingerprint, lastNotifiedCount: detection.count });
+			return true;
+		}
+		if (detection.count >= existing.lastNotifiedCount * ESCALATION_FACTOR) {
+			existing.lastNotifiedCount = detection.count;
+			return true;
+		}
+		return false;
+	}
+
+	prune(active: ReadonlyMap<LoopGuardKind, string>): void {
+		for (const [kind, entry] of this.entries) {
+			if (active.get(kind) !== entry.fingerprint) this.entries.delete(kind);
+		}
+	}
+
+	reset(): void {
+		this.entries.clear();
+	}
+}
+
+export function detectLoop(records: readonly ToolCallRecord[], gate: NoticeGate): LoopGuardDetection | undefined {
+	const detections = [detectIdenticalRun(records), detectCycle(records), detectSimilarRun(records)];
+	const active = new Map<LoopGuardKind, string>();
+	for (const detection of detections) {
+		if (detection !== undefined) active.set(detection.kind, detection.fingerprint);
+	}
+	gate.prune(active);
+	for (const detection of detections) {
+		if (detection !== undefined && gate.admit(detection)) return detection;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/index.ts
@@ -1,0 +1,38 @@
+import type { ExtensionAPI } from "../../types.ts";
+import { detectLoop, NoticeGate } from "./detectors.ts";
+import { buildLoopGuardReminder, LOOP_GUARD_NOTICE_CUSTOM_TYPE } from "./notice.ts";
+import { renderLoopGuardNotice } from "./renderer.ts";
+import { ToolCallTracker } from "./tracker.ts";
+
+export default function loopGuardExtension(pi: ExtensionAPI): void {
+	const tracker = new ToolCallTracker();
+	const gate = new NoticeGate();
+
+	const reset = (): void => {
+		tracker.reset();
+		gate.reset();
+	};
+
+	pi.registerMessageRenderer(LOOP_GUARD_NOTICE_CUSTOM_TYPE, renderLoopGuardNotice);
+
+	pi.on("session_start", () => reset());
+
+	pi.on("input", (event) => {
+		if (event.source !== "extension") reset();
+	});
+
+	pi.on("tool_execution_start", (event) => {
+		tracker.record(event.toolName, event.args);
+		const detection = detectLoop(tracker.records, gate);
+		if (detection === undefined) return;
+		pi.sendMessage(
+			{
+				customType: LOOP_GUARD_NOTICE_CUSTOM_TYPE,
+				content: buildLoopGuardReminder(detection),
+				display: true,
+				details: detection,
+			},
+			{ triggerTurn: false, deliverAs: "steer" },
+		);
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/notice.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/notice.ts
@@ -1,0 +1,46 @@
+import type { LoopGuardDetection } from "./detectors.ts";
+
+export const LOOP_GUARD_NOTICE_CUSTOM_TYPE = "loop-guard:notice";
+
+export type LoopGuardNoticeDetails = LoopGuardDetection;
+
+export function buildLoopGuardReminder(detection: LoopGuardDetection): string {
+	switch (detection.kind) {
+		case "identical": {
+			const { toolName, count } = detection;
+			return [
+				`<system-reminder>`,
+				`LOOP GUARD - IDENTICAL TOOL CALLS: you called \`${toolName}\` ${count} times in a row with the EXACT same arguments. This is the tool-call stream, not consecutive text - another tool ran between these calls and it changed nothing about your plan. Re-issuing the same call returns the same result. Snap out of it:`,
+				`- reuse the result you already received from this exact call;`,
+				`- if you were re-checking for new output or state, switch to the monitor/watch tool or change one parameter deliberately (filter, offset, query);`,
+				`- if nothing is actually changing, stop calling this tool, state what is blocking you, and try a different tool or ask the user.`,
+				`Do not call \`${toolName}\` again with identical arguments.`,
+				`</system-reminder>`,
+			].join("\n");
+		}
+		case "similar": {
+			const { toolName, count, similarity } = detection;
+			const percent = Math.round(similarity * 100);
+			return [
+				`<system-reminder>`,
+				`LOOP GUARD - NEAR-IDENTICAL TOOL CALLS: your last ${count} calls to \`${toolName}\` had arguments about ${percent}% identical (bigram similarity over canonical args). This may be legitimate batch work - or it may be a lazy loop that only LOOKS like progress. Attention check:`,
+				`- if these calls target genuinely different inputs (distinct files, queries, offsets), continue deliberately - but consider batching or widening the scope instead of one call per tiny variation;`,
+				`- if you are scanning output incrementally (reads, peeks, polls), widen the window once or use the monitor/watch tool rather than nudging parameters;`,
+				`- if the results keep saying the same thing, change strategy now - a different tool, a wider query, or asking the user beats a sixth near-copy.`,
+				`</system-reminder>`,
+			].join("\n");
+		}
+		case "cycle": {
+			const { period, count, cycleTools } = detection;
+			const pattern = cycleTools.join(" -> ");
+			return [
+				`<system-reminder>`,
+				`LOOP GUARD - REPEATING TOOL-CALL PATTERN: your recent tool calls repeat the cycle [${pattern}] ${count} times (period ${period}), with other calls possibly interleaved between repetitions. A fixed rotation usually means waiting, guessing, or searching without a discriminator:`,
+				`- if this is a wait/poll rotation (spawn then peek, write then check), replace the rotation with the monitor/watch tool and react to the decisive event instead;`,
+				`- if this is a search rotation, change ONE axis decisively: broader query, different tool, or a different source - repeating the same rotation at the same parameters will not find new information;`,
+				`- if the cycle is genuinely progressing (each rotation moves distinct work forward), keep going - but say what each rotation accomplished so the next rotation can end.`,
+				`</system-reminder>`,
+			].join("\n");
+		}
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/policy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/policy.ts
@@ -1,0 +1,36 @@
+/**
+ * Loop-guard thresholds.
+ *
+ * Evidence base (see changes.md for the full rationale):
+ * - gemini-cli LoopDetectionService: sha256(name+args) signatures, cycle periods 1..5,
+ *   threshold 5 repetitions — but it HALTS the run. Loop-guard only steers a reminder,
+ *   so it can afford to fire earlier.
+ * - OpenHands stuck detector: 4+ identical action-observation pairs, 3+ error cycles,
+ *   6+ alternating ping-pong cycles — also halting behavior.
+ * - Corpus of 400 real senpi sessions: productive same-tool runs (bash/eval/edit/todo)
+ *   show mean adjacent-args bigram-Dice ~0.52-0.55 (p90 <= 0.72), while repetitive
+ *   classes (read pagination, bash_output/task_output polling) sit at 0.84-0.93.
+ *   0.85 cleanly separates distinct work from near-identical repetition.
+ */
+
+/** Max tool-call records kept per prompt segment. Covers 6-period cycles at escalated counts. */
+export const TRACK_WINDOW = 64;
+
+/** Consecutive byte-identical (tool + canonical args) calls before the firm reminder fires. */
+export const IDENTICAL_RUN_THRESHOLD = 3;
+
+/** Consecutive same-tool calls with near-identical args before the caution fires. */
+export const SIMILAR_RUN_THRESHOLD = 5;
+
+/** Mean adjacent bigram-Dice similarity over canonical args that counts as "near-identical". */
+export const SIMILARITY_THRESHOLD = 0.85;
+
+/** Cycle period bounds (period 1 is the identical detector's job). */
+export const CYCLE_MIN_PERIOD = 2;
+export const CYCLE_MAX_PERIOD = 6;
+
+/** Full cycle repetitions before the pattern notice fires. */
+export const CYCLE_REPETITION_THRESHOLD = 3;
+
+/** A pattern that keeps growing re-notifies only when its count reaches this multiple of the last notice. */
+export const ESCALATION_FACTOR = 2;

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/renderer.ts
@@ -1,0 +1,55 @@
+import { Box, Text } from "@earendil-works/pi-tui";
+import type { MessageRenderer } from "../../types.ts";
+import type { LoopGuardDetection } from "./detectors.ts";
+
+const BOLD = "\u001b[1m";
+const BOLD_OFF = "\u001b[22m";
+
+export const renderLoopGuardNotice: MessageRenderer<LoopGuardDetection> = (message, options, theme) => {
+	const details = message.details;
+	if (details === undefined) return undefined;
+	const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+	box.addChild(new Text(theme.fg("accent", `${BOLD}${titleLine(details)}${BOLD_OFF}`), 0, 0));
+	box.addChild(new Text(theme.fg("dim", whyLine(details)), 0, 0));
+	if (options.expanded) {
+		box.addChild(new Text(theme.fg("dim", expandedLine(details)), 0, 0));
+	}
+	return box;
+};
+
+function titleLine(detection: LoopGuardDetection): string {
+	switch (detection.kind) {
+		case "identical":
+			return `⚠ Loop guard · identical calls ×${detection.count} (${detection.toolName})`;
+		case "similar":
+			return `⚠ Loop guard · near-identical calls ×${detection.count} (${detection.toolName})`;
+		case "cycle":
+			return `⚠ Loop guard · repeating pattern ×${detection.count} (period ${detection.period})`;
+	}
+}
+
+function whyLine(detection: LoopGuardDetection): string {
+	switch (detection.kind) {
+		case "identical":
+			return "Same tool, same arguments, again. The agent was told to reuse the result or change the call.";
+		case "similar": {
+			const percent = Math.round(detection.similarity * 100);
+			return `Argument similarity ~${percent}%. The agent was told to verify this is distinct work, not a lazy loop.`;
+		}
+		case "cycle": {
+			const pattern = detection.cycleTools.join(" -> ");
+			return `Tool-call cycle [${pattern}]. The agent was told to break the rotation or justify the progress.`;
+		}
+	}
+}
+
+function expandedLine(detection: LoopGuardDetection): string {
+	switch (detection.kind) {
+		case "identical":
+			return `tool ${detection.toolName} · ${detection.count} consecutive identical calls when the reminder fired`;
+		case "similar":
+			return `tool ${detection.toolName} · ${detection.count} consecutive same-tool calls at ~${Math.round(detection.similarity * 100)}% args similarity`;
+		case "cycle":
+			return `cycle ${detection.cycleTools.join(" -> ")} · ${detection.count} full repetitions in the tracked window`;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/similarity.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/similarity.ts
@@ -1,0 +1,48 @@
+/**
+ * Character-bigram Sørensen–Dice similarity over canonical argument JSON.
+ *
+ * Chosen over token-level or edit-distance metrics because canonical JSON keeps
+ * structure stable (sorted keys, fixed separators), making bigram overlap a cheap
+ * and order-insensitive-enough proxy for "same call shape, slightly different values".
+ */
+
+export type BigramCounts = Map<string, number>;
+
+export function bigramCounts(text: string): BigramCounts {
+	const counts: BigramCounts = new Map();
+	for (let i = 0; i < text.length - 1; i++) {
+		const gram = text.slice(i, i + 2);
+		counts.set(gram, (counts.get(gram) ?? 0) + 1);
+	}
+	return counts;
+}
+
+export function diceSimilarity(a: BigramCounts, b: BigramCounts): number {
+	let totalA = 0;
+	for (const count of a.values()) totalA += count;
+	let totalB = 0;
+	for (const count of b.values()) totalB += count;
+	if (totalA === 0 && totalB === 0) return 1;
+	if (totalA === 0 || totalB === 0) return 0;
+	let intersection = 0;
+	const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+	for (const [gram, count] of small) {
+		const other = large.get(gram);
+		if (other !== undefined) intersection += Math.min(count, other);
+	}
+	return (2 * intersection) / (totalA + totalB);
+}
+
+/** Mean similarity between each adjacent pair of argument strings. */
+export function meanAdjacentSimilarity(argStrings: readonly string[]): number {
+	if (argStrings.length < 2) return 1;
+	const grams = argStrings.map(bigramCounts);
+	let total = 0;
+	for (let i = 0; i < grams.length - 1; i++) {
+		const current = grams[i];
+		const next = grams[i + 1];
+		if (current === undefined || next === undefined) continue;
+		total += diceSimilarity(current, next);
+	}
+	return total / (grams.length - 1);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/tracker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/tracker.ts
@@ -1,0 +1,45 @@
+import { TRACK_WINDOW } from "./policy.ts";
+
+export interface ToolCallRecord {
+	readonly toolName: string;
+	readonly argsJson: string;
+	readonly signature: string;
+}
+
+export function canonicalizeArgs(args: unknown): string {
+	return stableStringify(args ?? {});
+}
+
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+	if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+	const record = value as Record<string, unknown>;
+	const keys = Object.keys(record).sort();
+	const parts: string[] = [];
+	for (const key of keys) {
+		const entry = record[key];
+		if (entry === undefined) continue;
+		parts.push(`${JSON.stringify(key)}:${stableStringify(entry)}`);
+	}
+	return `{${parts.join(",")}}`;
+}
+
+export class ToolCallTracker {
+	private calls: ToolCallRecord[] = [];
+
+	record(toolName: string, args: unknown): void {
+		const argsJson = canonicalizeArgs(args);
+		this.calls.push({ toolName, argsJson, signature: `${toolName}\u0000${argsJson}` });
+		if (this.calls.length > TRACK_WINDOW) {
+			this.calls = this.calls.slice(-TRACK_WINDOW);
+		}
+	}
+
+	get records(): readonly ToolCallRecord[] {
+		return this.calls;
+	}
+
+	reset(): void {
+		this.calls = [];
+	}
+}

--- a/packages/coding-agent/test/suite/loop-guard-detectors.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-detectors.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import {
+	detectCycle,
+	detectIdenticalRun,
+	detectLoop,
+	detectSimilarRun,
+	NoticeGate,
+} from "../../src/core/extensions/builtin/loop-guard/detectors.ts";
+import { buildLoopGuardReminder } from "../../src/core/extensions/builtin/loop-guard/notice.ts";
+import {
+	IDENTICAL_RUN_THRESHOLD,
+	SIMILAR_RUN_THRESHOLD,
+	SIMILARITY_THRESHOLD,
+} from "../../src/core/extensions/builtin/loop-guard/policy.ts";
+import {
+	bigramCounts,
+	diceSimilarity,
+	meanAdjacentSimilarity,
+} from "../../src/core/extensions/builtin/loop-guard/similarity.ts";
+import type { ToolCallRecord } from "../../src/core/extensions/builtin/loop-guard/tracker.ts";
+import { canonicalizeArgs, ToolCallTracker } from "../../src/core/extensions/builtin/loop-guard/tracker.ts";
+
+function rec(toolName: string, args: unknown): ToolCallRecord {
+	const argsJson = canonicalizeArgs(args);
+	return { toolName, argsJson, signature: `${toolName}\u0000${argsJson}` };
+}
+
+function recs(...calls: Array<[string, unknown]>): ToolCallRecord[] {
+	return calls.map(([name, args]) => rec(name, args));
+}
+
+describe("canonicalizeArgs", () => {
+	it("is insensitive to key order", () => {
+		expect(canonicalizeArgs({ a: 1, b: { d: 2, c: [3] } })).toBe(canonicalizeArgs({ b: { c: [3], d: 2 }, a: 1 }));
+	});
+
+	it("defaults missing args to an empty object", () => {
+		expect(canonicalizeArgs(undefined)).toBe(canonicalizeArgs({}));
+	});
+});
+
+describe("similarity metrics", () => {
+	it("scores identical strings at 1", () => {
+		expect(diceSimilarity(bigramCounts("abcdef"), bigramCounts("abcdef"))).toBe(1);
+	});
+
+	it("scores disjoint strings at 0", () => {
+		expect(diceSimilarity(bigramCounts("aaaa"), bigramCounts("zzzz"))).toBe(0);
+	});
+
+	it("meanAdjacentSimilarity separates pagination from distinct queries", () => {
+		const pagination = meanAdjacentSimilarity([
+			'{"path":"src/app.ts","offset":1,"limit":200}',
+			'{"path":"src/app.ts","offset":201,"limit":200}',
+			'{"path":"src/app.ts","offset":401,"limit":200}',
+		]);
+		const distinct = meanAdjacentSimilarity([
+			'{"query":"tool call loop detection"}',
+			'{"query":"typescript vitest fake timers"}',
+			'{"query":"kubernetes pod eviction policy"}',
+		]);
+		expect(pagination).toBeGreaterThanOrEqual(SIMILARITY_THRESHOLD);
+		expect(distinct).toBeLessThan(SIMILARITY_THRESHOLD);
+	});
+});
+
+describe("detectIdenticalRun", () => {
+	it("returns undefined below the threshold", () => {
+		const records = recs(["read", { path: "a.ts" }], ["read", { path: "a.ts" }]);
+		expect(detectIdenticalRun(records)).toBeUndefined();
+	});
+
+	it("fires at the threshold with the full run count", () => {
+		const records = recs(
+			["bash", { command: "echo 1" }],
+			["read", { path: "a.ts" }],
+			["read", { path: "a.ts" }],
+			["read", { path: "a.ts" }],
+		);
+		const detection = detectIdenticalRun(records);
+		expect(detection?.kind).toBe("identical");
+		if (detection?.kind !== "identical") return;
+		expect(detection.count).toBe(IDENTICAL_RUN_THRESHOLD);
+		expect(detection.toolName).toBe("read");
+	});
+
+	it("counts key-order-insensitive duplicates as identical", () => {
+		const records = recs(
+			["read", { path: "a.ts", limit: 50 }],
+			["read", { limit: 50, path: "a.ts" }],
+			["read", { path: "a.ts", limit: 50 }],
+		);
+		expect(detectIdenticalRun(records)?.count).toBe(3);
+	});
+});
+
+describe("detectSimilarRun", () => {
+	it("returns undefined for productive runs with distinct args", () => {
+		const records = recs(
+			["bash", { command: "vitest run test/a.test.ts" }],
+			["bash", { command: "git status --short" }],
+			["bash", { command: "npm run check" }],
+			["bash", { command: "rg -n 'loopGuard' packages" }],
+			["bash", { command: "node scripts/build.mjs --watch" }],
+		);
+		expect(detectSimilarRun(records)).toBeUndefined();
+	});
+
+	it("returns undefined while the run is all-identical (identical detector owns it)", () => {
+		const records = recs(
+			...Array.from({ length: SIMILAR_RUN_THRESHOLD }, () => ["read", { path: "a.ts" }] as [string, unknown]),
+		);
+		expect(detectSimilarRun(records)).toBeUndefined();
+	});
+
+	it("fires for near-identical pagination runs at the threshold", () => {
+		const records = recs(
+			["read", { path: "src/app.ts", offset: 1, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 201, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 401, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 601, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 801, limit: 200 }],
+		);
+		const detection = detectSimilarRun(records);
+		expect(detection?.kind).toBe("similar");
+		expect(detection?.count).toBe(SIMILAR_RUN_THRESHOLD);
+		if (detection?.kind === "similar") {
+			expect(detection.similarity).toBeGreaterThanOrEqual(SIMILARITY_THRESHOLD);
+		}
+	});
+});
+
+describe("detectCycle", () => {
+	it("returns undefined for a pattern repeated only twice", () => {
+		const records = recs(
+			["read", { path: "a" }],
+			["bash", { command: "x" }],
+			["read", { path: "a" }],
+			["bash", { command: "x" }],
+		);
+		expect(detectCycle(records)).toBeUndefined();
+	});
+
+	it("fires on a period-2 cycle repeated three times", () => {
+		const cycle: Array<[string, unknown]> = [
+			["eval", { code: "poll()" }],
+			["bash_output", { bash_id: "s1" }],
+		];
+		const records = recs(...cycle, ...cycle, ...cycle);
+		const detection = detectCycle(records);
+		expect(detection?.kind).toBe("cycle");
+		if (detection?.kind !== "cycle") return;
+		expect(detection.period).toBe(2);
+		expect(detection.count).toBe(3);
+	});
+
+	it("tolerates a leading prefix before the cycle", () => {
+		const cycle: Array<[string, unknown]> = [
+			["a", { n: 1 }],
+			["b", { n: 2 }],
+		];
+		const records = recs(["seed", { n: 0 }], ...cycle, ...cycle, ...cycle);
+		expect(detectCycle(records)?.kind).toBe("cycle");
+	});
+
+	it("ignores all-identical windows (identical detector owns period 1)", () => {
+		const records = recs(
+			["read", { path: "a" }],
+			["read", { path: "a" }],
+			["read", { path: "a" }],
+			["read", { path: "a" }],
+		);
+		expect(detectCycle(records)).toBeUndefined();
+	});
+
+	it("fires on a period-3 cycle", () => {
+		const cycle: Array<[string, unknown]> = [
+			["read", { path: "a" }],
+			["edit", { path: "a", n: 1 }],
+			["bash", { command: "tsc" }],
+		];
+		const records = recs(...cycle, ...cycle, ...cycle);
+		const detection = detectCycle(records);
+		expect(detection?.kind).toBe("cycle");
+		if (detection?.kind !== "cycle") return;
+		expect(detection.period).toBe(3);
+		expect(detection.count).toBe(3);
+	});
+});
+
+describe("NoticeGate escalation", () => {
+	it("suppresses intermediate counts and re-fires at the doubled count", () => {
+		const gate = new NoticeGate();
+		const records = recs(["read", { path: "a.ts" }], ["read", { path: "a.ts" }], ["read", { path: "a.ts" }]);
+		expect(detectLoop(records, gate)?.kind).toBe("identical");
+		records.push(rec("read", { path: "a.ts" }), rec("read", { path: "a.ts" }));
+		expect(detectLoop(records, gate)).toBeUndefined();
+		records.push(rec("read", { path: "a.ts" }));
+		expect(detectLoop(records, gate)?.count).toBe(6);
+	});
+
+	it("resumes firing when the pattern breaks and re-forms", () => {
+		const gate = new NoticeGate();
+		const first = recs(["read", { path: "a.ts" }], ["read", { path: "a.ts" }], ["read", { path: "a.ts" }]);
+		expect(detectLoop(first, gate)?.kind).toBe("identical");
+		first.push(rec("bash", { command: "ls" }));
+		expect(detectLoop(first, gate)).toBeUndefined();
+		first.push(rec("read", { path: "b.ts" }), rec("read", { path: "b.ts" }), rec("read", { path: "b.ts" }));
+		expect(detectLoop(first, gate)?.kind).toBe("identical");
+	});
+
+	it("prefers the identical detector over similar and cycle", () => {
+		const gate = new NoticeGate();
+		const records = recs(...Array.from({ length: 5 }, () => ["read", { path: "a.ts" }] as [string, unknown]));
+		expect(detectLoop(records, gate)?.kind).toBe("identical");
+	});
+});
+
+describe("ToolCallTracker", () => {
+	it("caps the window at the policy limit", () => {
+		const tracker = new ToolCallTracker();
+		for (let i = 0; i < 100; i++) tracker.record("bash", { command: `cmd ${i}` });
+		expect(tracker.records.length).toBe(64);
+	});
+
+	it("reset clears the records", () => {
+		const tracker = new ToolCallTracker();
+		tracker.record("bash", { command: "x" });
+		tracker.reset();
+		expect(tracker.records.length).toBe(0);
+	});
+});
+
+describe("buildLoopGuardReminder", () => {
+	it("wraps every kind in system-reminder tags with the kind-specific headline", () => {
+		const identical = buildLoopGuardReminder({ kind: "identical", toolName: "read", count: 3, fingerprint: "fp" });
+		expect(identical).toContain("<system-reminder>");
+		expect(identical).toContain("IDENTICAL TOOL CALLS");
+		expect(identical).toContain("`read` 3 times");
+
+		const similar = buildLoopGuardReminder({
+			kind: "similar",
+			toolName: "read",
+			count: 5,
+			similarity: 0.92,
+			fingerprint: "fp",
+		});
+		expect(similar).toContain("NEAR-IDENTICAL TOOL CALLS");
+		expect(similar).toContain("92%");
+
+		const cycle = buildLoopGuardReminder({
+			kind: "cycle",
+			period: 2,
+			count: 3,
+			cycleTools: ["eval", "bash_output"],
+			fingerprint: "fp",
+		});
+		expect(cycle).toContain("REPEATING TOOL-CALL PATTERN");
+		expect(cycle).toContain("[eval -> bash_output] 3 times");
+	});
+});

--- a/packages/coding-agent/test/suite/loop-guard-extension.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-extension.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { LoopGuardDetection } from "../../src/core/extensions/builtin/loop-guard/detectors.ts";
+import loopGuardExtension from "../../src/core/extensions/builtin/loop-guard/index.ts";
+import { LOOP_GUARD_NOTICE_CUSTOM_TYPE } from "../../src/core/extensions/builtin/loop-guard/notice.ts";
+import { renderLoopGuardNotice } from "../../src/core/extensions/builtin/loop-guard/renderer.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+type SentMessage = {
+	message: { customType: string; content: string; display: boolean; details?: LoopGuardDetection };
+	options: { triggerTurn?: boolean; deliverAs?: string } | undefined;
+};
+
+interface LoopGuardHarness {
+	handlers: Map<string, Handler[]>;
+	sent: SentMessage[];
+	renderers: Map<string, unknown>;
+	fire: (eventName: string, event: unknown) => void;
+}
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+function createLoopGuardHarness(): LoopGuardHarness {
+	const handlers = new Map<string, Handler[]>();
+	const sent: SentMessage[] = [];
+	const renderers = new Map<string, unknown>();
+	const pi = {
+		on: (event: string, handler: Handler) => {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		},
+		sendMessage: (message: SentMessage["message"], options: SentMessage["options"]) => {
+			sent.push({ message, options });
+		},
+		registerMessageRenderer: (customType: string, renderer: unknown) => {
+			renderers.set(customType, renderer);
+		},
+	} as unknown as ExtensionAPI;
+	loopGuardExtension(pi);
+	const fire = (eventName: string, event: unknown): void => {
+		for (const handler of handlers.get(eventName) ?? []) {
+			void handler(event, {} as ExtensionContext);
+		}
+	};
+	return { handlers, sent, renderers, fire };
+}
+
+function toolStart(fire: LoopGuardHarness["fire"], toolName: string, args: unknown, callId = "c1"): void {
+	fire("tool_execution_start", { type: "tool_execution_start", toolCallId: callId, toolName, args });
+}
+
+function userInput(fire: LoopGuardHarness["fire"], source: "interactive" | "rpc" | "extension"): void {
+	fire("input", { type: "input", text: "go", source });
+}
+
+describe("loop-guard extension", () => {
+	it("registers the notice renderer under the notice custom type", () => {
+		const harness = createLoopGuardHarness();
+		expect(harness.renderers.get(LOOP_GUARD_NOTICE_CUSTOM_TYPE)).toBe(renderLoopGuardNotice);
+	});
+
+	it("stays silent for ordinary varied tool use", () => {
+		const harness = createLoopGuardHarness();
+		toolStart(harness.fire, "bash", { command: "git status" });
+		toolStart(harness.fire, "read", { path: "src/a.ts" });
+		toolStart(harness.fire, "bash", { command: "npm run check" });
+		toolStart(harness.fire, "read", { path: "src/b.ts" });
+		expect(harness.sent).toHaveLength(0);
+	});
+
+	it("fires the identical reminder on the third identical call and steers it", () => {
+		const harness = createLoopGuardHarness();
+		for (let i = 0; i < 3; i++) {
+			toolStart(harness.fire, "webfetch", { url: "https://example.com", format: "markdown" });
+		}
+		expect(harness.sent).toHaveLength(1);
+		const notice = harness.sent[0];
+		expect(notice?.message.customType).toBe(LOOP_GUARD_NOTICE_CUSTOM_TYPE);
+		expect(notice?.message.display).toBe(true);
+		expect(notice?.message.content).toContain("IDENTICAL TOOL CALLS");
+		expect(notice?.message.content).toContain("`webfetch` 3 times");
+		expect(notice?.options?.deliverAs).toBe("steer");
+		expect(notice?.options?.triggerTurn).toBe(false);
+	});
+
+	it("escalates instead of spamming: silent at 4-5, fires again at 6", () => {
+		const harness = createLoopGuardHarness();
+		for (let i = 0; i < 5; i++) toolStart(harness.fire, "bash", { command: "echo stuck" });
+		expect(harness.sent).toHaveLength(1);
+		toolStart(harness.fire, "bash", { command: "echo stuck" });
+		expect(harness.sent).toHaveLength(2);
+		expect(harness.sent[1]?.message.content).toContain("6 times");
+	});
+
+	it("uses the distinct similar-call prompt for near-identical runs", () => {
+		const harness = createLoopGuardHarness();
+		const offsets = [1, 201, 401, 601, 801];
+		for (const offset of offsets) {
+			toolStart(harness.fire, "read", { path: "src/app.ts", offset, limit: 200 });
+		}
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.content).toContain("NEAR-IDENTICAL TOOL CALLS");
+		expect(harness.sent[0]?.message.content).not.toContain("LOOP GUARD - IDENTICAL TOOL CALLS");
+	});
+
+	it("uses the distinct cycle prompt for repeating rotations", () => {
+		const harness = createLoopGuardHarness();
+		for (let i = 0; i < 3; i++) {
+			toolStart(harness.fire, "eval", { code: "peek()" }, `eval-${i}`);
+			toolStart(harness.fire, "bash_output", { bash_id: "s1" }, `out-${i}`);
+		}
+		expect(harness.sent).toHaveLength(1);
+		expect(harness.sent[0]?.message.content).toContain("REPEATING TOOL-CALL PATTERN");
+		expect(harness.sent[0]?.message.content).toContain("[eval -> bash_output] 3 times");
+	});
+
+	it("resets on real user input and does not reset on extension input", () => {
+		const harness = createLoopGuardHarness();
+		toolStart(harness.fire, "read", { path: "a.ts" });
+		toolStart(harness.fire, "read", { path: "a.ts" });
+		userInput(harness.fire, "extension");
+		toolStart(harness.fire, "read", { path: "a.ts" });
+		expect(harness.sent).toHaveLength(1);
+		userInput(harness.fire, "interactive");
+		for (let i = 0; i < 3; i++) toolStart(harness.fire, "read", { path: "a.ts" });
+		expect(harness.sent).toHaveLength(2);
+	});
+
+	it("resets on session_start", () => {
+		const harness = createLoopGuardHarness();
+		for (let i = 0; i < 3; i++) toolStart(harness.fire, "read", { path: "a.ts" });
+		expect(harness.sent).toHaveLength(1);
+		harness.fire("session_start", { type: "session_start" });
+		for (let i = 0; i < 3; i++) toolStart(harness.fire, "read", { path: "a.ts" });
+		expect(harness.sent).toHaveLength(2);
+	});
+
+	it("renders the notice as an accent box with a title and why line", () => {
+		initTheme("dark");
+		const harness = createLoopGuardHarness();
+		for (let i = 0; i < 3; i++) toolStart(harness.fire, "read", { path: "a.ts" });
+		const notice = harness.sent[0];
+		expect(notice).toBeDefined();
+		if (notice === undefined) return;
+		const component = renderLoopGuardNotice(
+			{
+				role: "custom",
+				customType: LOOP_GUARD_NOTICE_CUSTOM_TYPE,
+				content: notice.message.content,
+				display: true,
+				timestamp: 0,
+				...(notice.message.details !== undefined ? { details: notice.message.details } : {}),
+			},
+			{ expanded: false, outputPad: 0 },
+			theme,
+		);
+		const text = (component?.render(100) ?? []).join("\n").replace(ANSI_PATTERN, "");
+		expect(text).toContain("Loop guard");
+		expect(text).toContain("identical calls ×3 (read)");
+		expect(text).toContain("reuse the result or change the call");
+	});
+});


### PR DESCRIPTION
## What

New builtin extension **`loop-guard`** (#27) that watches the pure tool-call stream (`tool_execution_start`, tool-call only — no adjacency assumption) and steers a `<system-reminder>` CustomMessage into the running turn when the agent loops, rendered in the TUI with the goal cache-warm Box style.

Three detectors over a 64-entry ring of `(toolName, canonicalArgsJson)` signatures (key-order-insensitive), priority identical > cycle > similar, one notice per call:

| Detector | Trigger | Prompt |
|---|---|---|
| `identical` | trailing run ≥ 3 of byte-identical tool+args | firm "same call ×N, result won't change — snap out of it" |
| `similar` | ≥ 5 same-tool calls at mean adjacent bigram-Dice ≥ 0.85 | softer attention check |
| `cycle` | period 2..6 rotation repeated ≥ 3 full cycles | rotation-break ("if waiting, use monitor; else change strategy") |

A shared gate re-fires only at 2× the last notified count; state resets on `session_start` and real user input (extension-sourced input does not reset, so goal continuations can't clear a tracked loop).

## Why these thresholds (evidence)

- **Prior art**: gemini-cli `LoopDetectionService` (sha256 name+args signatures, cycle periods 1..5, threshold 5) and OpenHands stuck detector (4+ identical action-observation pairs, 6+ ping-pong cycles) — both *halt* the run. loop-guard only nudges, so it fires earlier.
- **Local corpus** (400 real senpi sessions): productive same-tool runs (bash/eval/edit/todo) sit at mean adjacent bigram-Dice ~0.52–0.55 (p90 ≤ 0.72); repetitive classes (read pagination, `bash_output`/`task_output` polling) sit at 0.84–0.93. **0.85** cleanly separates distinct work from near-identical repetition.
- Period-2 poll loops (`eval`↔`bash_output`) are the most common cycle shape in real sessions, so the cycle prompt explicitly routes waiting behavior to `monitor`.

## Registration & docs

- `builtin/index.ts`: appended before `config-reload` (pure observer, never mutates payloads; MCP stays last).
- `builtin/AGENTS.md` inventory → 27 extensions; `builtin/changes.md` + `loop-guard/changes.md` record the design and expected merge-conflict zones (LOW in `builtin/index.ts`, NONE in `types.ts` — no public API change).

## Verification

- `test/suite/loop-guard-detectors.test.ts` + `loop-guard-extension.test.ts`: **31 tests pass** (fake-pi harness, faux provider, zero tokens).
- `npm run check`: clean.
- `senpi-qa` (`loop-guard-qa.mjs`, new QA driver): real CLI against the local fake model server — identical/similar/cycle reminders each steered into the exact next provider request; varied-call control fires nothing. **5/5 pass.**
- `tui-smoke --self-test`: 5/5 pass with the new builtin registered.
- Evidence: `local-ignore/qa-evidence/20260731-loop-guard/` (per-scenario request captures + TUI smoke).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `loop-guard` builtin to detect tool-call loops and steer a `<system-reminder>` into the active turn, helping the agent break unproductive cycles. Covers identical, near-identical, and cyclic patterns with a clear TUI notice.

- **New Features**
  - Detects three patterns with tuned thresholds:
    - identical: 3 identical tool+args in a row
    - similar: 5 same-tool calls with mean args similarity ≥ 0.85
    - cycle: period 2–6 repeated ≥ 3 times
  - Tracks a 64-call ring using key-order-insensitive args canonicalization.
  - Escalation gate re-notifies only at 2× the last count; resets on `session_start` and real user input.
  - Steers a `loop-guard:notice` `<system-reminder>` (cache-warm box style) without starting a new turn.
  - Registered before `config-reload`; no public API changes. Tests (31) and a real-CLI QA script validate identical/similar/cycle paths and a control that stays silent.

<sup>Written for commit 8f451e1dd833f5467edcc170729f76340819b534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

