### PR TITLE
fix(ai): make reasoning capability metadata authoritative

### DIFF
--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -6,7 +6,8 @@
 
 - Runtime capability detection now recognizes `max` for map-less OpenAI-compatible `gpt-5.6-sol` models while
   preserving explicit map omissions and `null` vetoes.
-- OpenAI-compatible request builders serialize the selected level as `reasoning.effort: "max"`.
+- OpenAI-compatible request builders serialize the selected level as `reasoning.effort: "max"`
+  (`reasoning_effort: "max"` on Completions).
 
 ### Why
 

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,18 +1,19 @@
 # changes.md — ai
 
-## Map-less GPT-5.6 Sol max reasoning (2026-07-30)
+## Shared reasoning-tier capability detection (2026-07-30)
 
 ### What changed
 
-- Runtime capability detection now recognizes `max` for map-less OpenAI-compatible `gpt-5.6-sol` models while
-  preserving explicit map omissions and `null` vetoes.
-- OpenAI-compatible request builders serialize the selected level as `reasoning.effort: "max"`
-  (`reasoning_effort: "max"` on Completions).
+- Shared `xhigh` / `max` model-family constants are hoisted in `models.ts`, and map-less inference now uses
+  one case-normalized, boundary-aware family matcher instead of unbounded substring checks.
+- `getSupportedThinkingLevels` delegates extended-tier precedence to the exported `supportsXhigh` and
+  `supportsMax` predicates rather than duplicating their map-omission and `null`-veto rules.
 
 ### Why
 
-- Custom providers such as `codex-lb` can supply Sol without generated model metadata. The UI and provider
-  payload must agree instead of displaying `max` while silently sending `high`.
+- Capability inference for custom map-less models should reject unrelated ids and case-normalize legitimate
+  aliases while keeping one precedence implementation. Generated catalog models retain their explicit maps,
+  so behavior for real catalog models is intentionally unchanged.
 
 ## Browser-safe prompt-cache TTL resolver (2026-07-28)
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -6,10 +6,10 @@
 
 - OpenAI-compatible map-less `gpt-5.6-sol` models now expose `xhigh` and `max` without requiring a generated
   `thinkingLevelMap`.
-- Explicit maps remain authoritative: a missing level on an existing map stays unavailable, and `null` still
-  vetoes the heuristic.
-- OpenAI Responses, Azure Responses, Codex Responses, and Completions send `max` on the wire instead of
-  clamping a UI-selected map-less Sol level to `high`.
+- Explicit maps remain authoritative: a missing level on an existing map stays unavailable, and `null` vetoes the
+  heuristic. `supportsXhigh` and `supportsMax` share that precedence.
+- `supportsMax` is exported from `models.ts` so OpenAI Responses, Azure Responses, Codex Responses, and
+  Completions send `max` on the wire instead of clamping a UI-selected map-less Sol level to `high`.
 - Coverage pins capability, negative non-Sol boundaries, and captured request payloads without live tokens.
 
 ## 2026-07-30 - Recover Kimi XTML response channels from thinking

--- a/packages/ai/src/model.ts
+++ b/packages/ai/src/model.ts
@@ -20,7 +20,8 @@ export interface Model<TApi extends Api> {
 	reasoning: boolean;
 	/**
 	 * Maps pi thinking levels to provider/model-specific values.
-	 * Missing keys use provider defaults. null marks a level as unsupported.
+	 * In a present map, omitting `xhigh` or `max` disables that extended tier; ordinary missing levels
+	 * use provider defaults. null marks any level as unsupported.
 	 */
 	thinkingLevelMap?: ThinkingLevelMap;
 	input: ("text" | "image" | "video")[];

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -697,6 +697,13 @@ export function clampThinkingLevel<TApi extends Api>(
 	return availableLevels[0] ?? "off";
 }
 
+/**
+ * Whether the model exposes the `xhigh` tier.
+ *
+ * An explicit `thinkingLevelMap` is authoritative: `null` vetoes the tier and a map that omits
+ * `xhigh` disables it. Only map-less models fall back to id-based inference, so custom providers
+ * that ship a reasoning model without generated catalog metadata still surface the tier.
+ */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 	const mapped = model.thinkingLevelMap?.xhigh;
 	if (mapped === null) return false;
@@ -705,28 +712,35 @@ export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
 	return model.reasoning && supportsXhighModelId(model.id);
 }
 
+const XHIGH_MODEL_IDS = [
+	"gpt-5.2",
+	"gpt-5.3",
+	"gpt-5.4",
+	"gpt-5.5",
+	"gpt-5.6",
+	"deepseek-v4-pro",
+	"deepseek-v4-flash",
+	"opus-4-6",
+	"opus-4.6",
+	"opus-4-7",
+	"opus-4.7",
+	"opus-4-8",
+	"opus-4.8",
+	"opus-5",
+	"sonnet-5",
+	"fable-5",
+];
+
 function supportsXhighModelId(modelId: string): boolean {
-	const xhighModelIds = [
-		"gpt-5.2",
-		"gpt-5.3",
-		"gpt-5.4",
-		"gpt-5.5",
-		"gpt-5.6",
-		"deepseek-v4-pro",
-		"deepseek-v4-flash",
-		"opus-4-6",
-		"opus-4.6",
-		"opus-4-7",
-		"opus-4.7",
-		"opus-4-8",
-		"opus-4.8",
-		"opus-5",
-		"sonnet-5",
-		"fable-5",
-	];
-	return xhighModelIds.some((id) => modelId.includes(id));
+	return XHIGH_MODEL_IDS.some((id) => modelId.includes(id));
 }
 
+/**
+ * Whether the model exposes the `max` tier.
+ *
+ * Mirrors {@link supportsXhigh}: an explicit `thinkingLevelMap` wins, and only map-less models
+ * are inferred from the id.
+ */
 export function supportsMax<TApi extends Api>(model: Model<TApi>): boolean {
 	const mapped = model.thinkingLevelMap?.max;
 	if (mapped === null) return false;
@@ -735,31 +749,33 @@ export function supportsMax<TApi extends Api>(model: Model<TApi>): boolean {
 	return supportsMaxModel(model);
 }
 
+/** OpenAI-compatible APIs that accept a native `max` reasoning effort on the wire. */
+const OPENAI_MAX_APIS: Api[] = [
+	"openai-responses",
+	"azure-openai-responses",
+	"openai-codex-responses",
+	"openai-completions",
+];
+
+/** Matches `gpt-5.6-sol` and its suffixed variants, with or without a provider path prefix. */
+const GPT_56_SOL_ID = /(?:^|\/)gpt-5\.6-sol(?:$|-)/;
+
+const MAX_MODEL_IDS = [
+	"opus-4-6",
+	"opus-4.6",
+	"opus-4-7",
+	"opus-4.7",
+	"opus-4-8",
+	"opus-4.8",
+	"opus-5",
+	"sonnet-5",
+	"fable-5",
+];
+
 function supportsMaxModel<TApi extends Api>(model: Model<TApi>): boolean {
 	if (!model.reasoning) return false;
-
-	const openAiMaxApis: Api[] = [
-		"openai-responses",
-		"azure-openai-responses",
-		"openai-codex-responses",
-		"openai-completions",
-	];
-	if (openAiMaxApis.includes(model.api) && /(?:^|\/)gpt-5\.6-sol(?:$|-)/.test(model.id)) {
-		return true;
-	}
-
-	const maxModelIds = [
-		"opus-4-6",
-		"opus-4.6",
-		"opus-4-7",
-		"opus-4.7",
-		"opus-4-8",
-		"opus-4.8",
-		"opus-5",
-		"sonnet-5",
-		"fable-5",
-	];
-	return maxModelIds.some((id) => model.id.includes(id));
+	if (OPENAI_MAX_APIS.includes(model.api) && GPT_56_SOL_ID.test(model.id)) return true;
+	return MAX_MODEL_IDS.some((id) => model.id.includes(id));
 }
 
 /**

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -666,12 +666,8 @@ export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>)
 	return EXTENDED_THINKING_LEVELS.filter((level) => {
 		const mapped = model.thinkingLevelMap?.[level];
 		if (mapped === null) return false;
-		if (level === "xhigh") {
-			return mapped !== undefined || (model.thinkingLevelMap === undefined && supportsXhighModelId(model.id));
-		}
-		if (level === "max") {
-			return mapped !== undefined || (model.thinkingLevelMap === undefined && supportsMaxModel(model));
-		}
+		if (level === "xhigh") return supportsXhigh(model);
+		if (level === "max") return supportsMax(model);
 		return true;
 	});
 }
@@ -717,7 +713,9 @@ const XHIGH_MODEL_IDS = [
 	"gpt-5.3",
 	"gpt-5.4",
 	"gpt-5.5",
-	"gpt-5.6",
+	"gpt-5.6-luna",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
 	"deepseek-v4-pro",
 	"deepseek-v4-flash",
 	"opus-4-6",
@@ -731,8 +729,21 @@ const XHIGH_MODEL_IDS = [
 	"fable-5",
 ];
 
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Match a complete model family marker, not an alphanumeric substring of another id. */
+function matchesModelFamily(modelId: string, family: string): boolean {
+	const normalizedId = modelId.toLowerCase();
+	const escapedFamily = escapeRegex(family.toLowerCase());
+	// GPT aliases use a complete id or provider namespace; a hyphenated word prefix is not a provider namespace.
+	const leadingBoundary = family.startsWith("gpt-") ? "(?:^|[/.:_])" : "(?:^|[/.:_-])";
+	return new RegExp(`${leadingBoundary}${escapedFamily}(?=$|[^a-z0-9])`).test(normalizedId);
+}
+
 function supportsXhighModelId(modelId: string): boolean {
-	return XHIGH_MODEL_IDS.some((id) => modelId.includes(id));
+	return XHIGH_MODEL_IDS.some((id) => matchesModelFamily(modelId, id));
 }
 
 /**
@@ -757,8 +768,8 @@ const OPENAI_MAX_APIS: Api[] = [
 	"openai-completions",
 ];
 
-/** Matches `gpt-5.6-sol` and its suffixed variants, with or without a provider path prefix. */
-const GPT_56_SOL_ID = /(?:^|\/)gpt-5\.6-sol(?:$|-)/;
+/** Model family that accepts native `max` effort on OpenAI-compatible APIs. */
+const GPT_56_SOL_ID = "gpt-5.6-sol";
 
 const MAX_MODEL_IDS = [
 	"opus-4-6",
@@ -774,8 +785,8 @@ const MAX_MODEL_IDS = [
 
 function supportsMaxModel<TApi extends Api>(model: Model<TApi>): boolean {
 	if (!model.reasoning) return false;
-	if (OPENAI_MAX_APIS.includes(model.api) && GPT_56_SOL_ID.test(model.id)) return true;
-	return MAX_MODEL_IDS.some((id) => model.id.includes(id));
+	if (OPENAI_MAX_APIS.includes(model.api) && matchesModelFamily(model.id, GPT_56_SOL_ID)) return true;
+	return MAX_MODEL_IDS.some((id) => matchesModelFamily(model.id, id));
 }
 
 /**

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -1,9 +1,41 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { getModel, getSupportedThinkingLevels, supportsMax, supportsXhigh } from "../src/compat.ts";
 import type { Model } from "../src/model.ts";
 import type { Api } from "../src/types.ts";
 
+/** A custom-provider model with no thinkingLevelMap unless supplied in overrides. */
+function maplessModel<TApi extends Api>(api: TApi, id: string, overrides: Partial<Model<TApi>> = {}): Model<TApi> {
+	return {
+		id,
+		name: id,
+		api,
+		provider: "codex-lb",
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+		...overrides,
+	};
+}
+
 describe("getSupportedThinkingLevels", () => {
+	it("delegates extended-tier precedence to the exported capability predicates", () => {
+		const source = readFileSync(fileURLToPath(new URL("../src/models.ts", import.meta.url)), "utf8");
+		const functionSource = source.slice(
+			source.indexOf("export function getSupportedThinkingLevels"),
+			source.indexOf("export function clampThinkingLevel"),
+		);
+
+		expect(functionSource).toContain('if (level === "xhigh") return supportsXhigh(model);');
+		expect(functionSource).toContain('if (level === "max") return supportsMax(model);');
+		expect(functionSource).not.toContain("supportsXhighModelId");
+		expect(functionSource).not.toContain("supportsMaxModel");
+	});
+
 	it("includes max but not xhigh for Anthropic Opus 4.6 on anthropic-messages API", () => {
 		const model = getModel("anthropic", "claude-opus-4-6");
 		expect(model).toBeDefined();
@@ -199,23 +231,6 @@ describe("supportsXhigh tier detection for map-less models", () => {
 });
 
 describe("supportsMax tier detection for map-less models", () => {
-	/** A custom-provider model with no thinkingLevelMap: tier detection must come from api + id. */
-	function maplessModel<TApi extends Api>(api: TApi, id: string, overrides: Partial<Model<TApi>> = {}): Model<TApi> {
-		return {
-			id,
-			name: id,
-			api,
-			provider: "codex-lb",
-			baseUrl: "https://example.invalid",
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 400000,
-			maxTokens: 128000,
-			...overrides,
-		};
-	}
-
 	it.each(["openai-responses", "azure-openai-responses", "openai-codex-responses", "openai-completions"] as const)(
 		"infers max for a map-less gpt-5.6-sol model on %s",
 		(api) => {
@@ -227,6 +242,29 @@ describe("supportsMax tier detection for map-less models", () => {
 
 	it.each(["gpt-5.6-sol-fast", "openai/gpt-5.6-sol"])("infers max for the map-less Sol variant %s", (id) => {
 		expect(supportsMax(maplessModel("openai-responses", id))).toBe(true);
+	});
+
+	it.each(["gpt-5.6-solar", "gpt-5.6-solaris", "my-gpt-5.6-sol", "xgpt-5.6-sol", "legacy-gpt-5.6-solstice"])(
+		"rejects %s",
+		(id) => {
+			expect(supportsMax(maplessModel("openai-responses", id))).toBe(false);
+		},
+	);
+
+	it.each([
+		["my-gpt-5.60", false, false],
+		["notopus-5ive", false, false],
+		["opus-50", false, false],
+		["not-sonnet-500", false, false],
+		["xgpt-5.2y", false, false],
+		["gpt-5.6-solar", false, false],
+		["GPT-5.6-SOL", true, true],
+		["openai/gpt-5.6-sol", true, true],
+		["quotio-openai/gpt-5.6-sol-fast", true, true],
+	] as const)("matches model-family boundaries for %s", (id, xhigh, max) => {
+		const model = maplessModel("openai-responses", id);
+		expect(supportsXhigh(model)).toBe(xhigh);
+		expect(supportsMax(model)).toBe(max);
 	});
 
 	it("does not infer max for a map-less gpt-5.6-sol model on a non-OpenAI-compatible api", () => {
@@ -244,9 +282,19 @@ describe("supportsMax tier detection for map-less models", () => {
 		expect(supportsMax(maplessModel("openai-responses", "gpt-5.6-sol", { reasoning: false }))).toBe(false);
 	});
 
+	it("treats an empty thinking-level map as authoritative", () => {
+		const model = maplessModel("openai-responses", "gpt-5.6-sol", { thinkingLevelMap: {} });
+		expect(supportsXhigh(model)).toBe(false);
+		expect(supportsMax(model)).toBe(false);
+		expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
+		expect(getSupportedThinkingLevels(model)).not.toContain("max");
+	});
+
 	it("honors an explicit max veto on gpt-5.6-sol", () => {
 		const model = maplessModel("openai-responses", "gpt-5.6-sol", { thinkingLevelMap: { max: null } });
+		expect(supportsXhigh(model)).toBe(false);
 		expect(supportsMax(model)).toBe(false);
+		expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
 		expect(getSupportedThinkingLevels(model)).not.toContain("max");
 	});
 

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { getModel, getSupportedThinkingLevels, supportsXhigh } from "../src/compat.ts";
+import { getModel, getSupportedThinkingLevels, supportsMax, supportsXhigh } from "../src/compat.ts";
+import type { Model } from "../src/model.ts";
+import type { Api } from "../src/types.ts";
 
 describe("getSupportedThinkingLevels", () => {
 	it("includes max but not xhigh for Anthropic Opus 4.6 on anthropic-messages API", () => {
@@ -194,4 +196,79 @@ describe("supportsXhigh tier detection for map-less models", () => {
 			"max",
 		);
 	});
+});
+
+describe("supportsMax tier detection for map-less models", () => {
+	/** A custom-provider model with no thinkingLevelMap: tier detection must come from api + id. */
+	function maplessModel<TApi extends Api>(api: TApi, id: string, overrides: Partial<Model<TApi>> = {}): Model<TApi> {
+		return {
+			id,
+			name: id,
+			api,
+			provider: "codex-lb",
+			baseUrl: "https://example.invalid",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+			...overrides,
+		};
+	}
+
+	it.each(["openai-responses", "azure-openai-responses", "openai-codex-responses", "openai-completions"] as const)(
+		"infers max for a map-less gpt-5.6-sol model on %s",
+		(api) => {
+			const model = maplessModel(api, "gpt-5.6-sol");
+			expect(supportsMax(model)).toBe(true);
+			expect(getSupportedThinkingLevels(model)).toContain("max");
+		},
+	);
+
+	it.each(["gpt-5.6-sol-fast", "openai/gpt-5.6-sol"])("infers max for the map-less Sol variant %s", (id) => {
+		expect(supportsMax(maplessModel("openai-responses", id))).toBe(true);
+	});
+
+	it("does not infer max for a map-less gpt-5.6-sol model on a non-OpenAI-compatible api", () => {
+		expect(supportsMax(maplessModel("anthropic-messages", "gpt-5.6-sol"))).toBe(false);
+	});
+
+	it.each(["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6", "gpt-5.5", "upstage/solar-pro-3"])(
+		"does not infer max for a map-less non-Sol %s model",
+		(id) => {
+			expect(supportsMax(maplessModel("openai-responses", id))).toBe(false);
+		},
+	);
+
+	it("does not infer max for a map-less non-reasoning gpt-5.6-sol model", () => {
+		expect(supportsMax(maplessModel("openai-responses", "gpt-5.6-sol", { reasoning: false }))).toBe(false);
+	});
+
+	it("honors an explicit max veto on gpt-5.6-sol", () => {
+		const model = maplessModel("openai-responses", "gpt-5.6-sol", { thinkingLevelMap: { max: null } });
+		expect(supportsMax(model)).toBe(false);
+		expect(getSupportedThinkingLevels(model)).not.toContain("max");
+	});
+
+	it("treats a map omitting max as authoritative for gpt-5.6-sol", () => {
+		const model = maplessModel("openai-responses", "gpt-5.6-sol", { thinkingLevelMap: { xhigh: "xhigh" } });
+		expect(supportsMax(model)).toBe(false);
+		expect(getSupportedThinkingLevels(model)).not.toContain("max");
+		expect(getSupportedThinkingLevels(model)).toContain("xhigh");
+	});
+
+	it("treats a map omitting xhigh as authoritative for gpt-5.6-sol", () => {
+		const model = maplessModel("openai-responses", "gpt-5.6-sol", { thinkingLevelMap: { max: "max" } });
+		expect(supportsXhigh(model)).toBe(false);
+		expect(supportsMax(model)).toBe(true);
+		expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
+		expect(getSupportedThinkingLevels(model)).toContain("max");
+	});
+
+	it.each(["claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5"])(
+		"keeps inferring max for map-less Anthropic %s",
+		(id) => {
+			expect(supportsMax(maplessModel("anthropic-messages", id))).toBe(true);
+		},
+	);
 });

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -12,10 +12,9 @@
 
 ### Why
 
-- The two copies had already drifted: `packages/ai` treated an explicit `thinkingLevelMap` as authoritative
-  while the coding-agent copy inferred tiers from the id regardless, so a map-less `gpt-5.6-sol` could show
-  `max` in the UI while the provider payload clamped to `high`. Delegating keeps capability display and wire
-  payload derived from one rule set.
+- Tier rules belong to `packages/ai`; delegating removes the coding-agent's duplicate model-id lists and
+  precedence logic so future capability changes have one implementation. Generated catalog models retain
+  their explicit maps, so behavior for real catalog models is intentionally unchanged.
 
 ### Why extension system couldn't handle this alone
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Thinking-level tier detection delegates to packages/ai (2026-07-30)
+
+### What changed
+
+- `thinking-levels.ts` no longer re-implements the `xhigh` / `max` model-id lists. `supportsXhigh`,
+  `supportsMax`, and `getSupportedThinkingLevels` now wrap the canonical `@earendil-works/pi-ai` helpers
+  and only keep the coding-agent's `ThinkingLevel` vocabulary plus the non-empty `["off"]` fallback.
+- The local `ModelWithThinkingLevelMap` cast is gone: `Model.thinkingLevelMap` is already part of the
+  public `pi-ai` model type.
+
+### Why
+
+- The two copies had already drifted: `packages/ai` treated an explicit `thinkingLevelMap` as authoritative
+  while the coding-agent copy inferred tiers from the id regardless, so a map-less `gpt-5.6-sol` could show
+  `max` in the UI while the provider payload clamped to `high`. Delegating keeps capability display and wire
+  payload derived from one rule set.
+
+### Why extension system couldn't handle this alone
+
+- Tier detection feeds session thinking-level clamping and the model/RPC surfaces inside core; it is not
+  reachable from an extension.
+
 ## Codex fast-variant service-tier metadata lookup (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/thinking-levels.ts
+++ b/packages/coding-agent/src/core/thinking-levels.ts
@@ -1,70 +1,25 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import {
+	getSupportedThinkingLevels as getSupportedModelThinkingLevels,
+	supportsMax as modelSupportsMax,
+	supportsXhigh as modelSupportsXhigh,
+} from "@earendil-works/pi-ai";
 
-const THINKING_LEVELS_WITH_MAX: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
-
+/**
+ * Tier detection is owned by `packages/ai`, which already treats an explicit `thinkingLevelMap` as
+ * authoritative and infers tiers from the model id only when no map is present. These wrappers keep
+ * the coding-agent's `ThinkingLevel` vocabulary without duplicating the capability rules.
+ */
 export function supportsXhigh(model: Model<Api>): boolean {
-	const mappedLevel = model.thinkingLevelMap?.xhigh;
-	if (mappedLevel === null) return false;
-	if (mappedLevel !== undefined) return true;
-	if (model.thinkingLevelMap !== undefined) return false;
-
-	return (
-		model.id.includes("gpt-5.2") ||
-		model.id.includes("gpt-5.3") ||
-		model.id.includes("gpt-5.4") ||
-		model.id.includes("gpt-5.5") ||
-		model.id.includes("gpt-5.6") ||
-		model.id.includes("deepseek-v4-pro") ||
-		model.id.includes("deepseek-v4-flash") ||
-		model.id.includes("opus-4-6") ||
-		model.id.includes("opus-4.6") ||
-		model.id.includes("opus-4-7") ||
-		model.id.includes("opus-4.7") ||
-		model.id.includes("opus-4-8") ||
-		model.id.includes("opus-4.8") ||
-		model.id.includes("opus-5") ||
-		model.id.includes("sonnet-5") ||
-		model.id.includes("fable-5")
-	);
+	return modelSupportsXhigh(model);
 }
 
 export function supportsMax(model: Model<Api>): boolean {
-	const mappedLevel = model.thinkingLevelMap?.max;
-	if (mappedLevel === null) return false;
-	if (mappedLevel !== undefined) return true;
-	if (model.thinkingLevelMap !== undefined) return false;
-
-	const openAiMaxApis: Api[] = [
-		"openai-responses",
-		"azure-openai-responses",
-		"openai-codex-responses",
-		"openai-completions",
-	];
-	return (
-		(openAiMaxApis.includes(model.api) && /(?:^|\/)gpt-5\.6-sol(?:$|-)/.test(model.id)) ||
-		model.id.includes("opus-4-6") ||
-		model.id.includes("opus-4.6") ||
-		model.id.includes("opus-4-7") ||
-		model.id.includes("opus-4.7") ||
-		model.id.includes("opus-4-8") ||
-		model.id.includes("opus-4.8") ||
-		model.id.includes("opus-5") ||
-		model.id.includes("sonnet-5") ||
-		model.id.includes("fable-5")
-	);
+	return modelSupportsMax(model);
 }
 
 export function getSupportedThinkingLevels(model: Model<Api>): ThinkingLevel[] {
-	if (!model.reasoning) return ["off"];
-
-	const supportedLevels = THINKING_LEVELS_WITH_MAX.filter((level) => {
-		const mappedLevel = model.thinkingLevelMap?.[level];
-		if (mappedLevel === null) return false;
-		if (level === "xhigh") return mappedLevel !== undefined || supportsXhigh(model);
-		if (level === "max") return mappedLevel !== undefined || supportsMax(model);
-		return true;
-	});
-
+	const supportedLevels = getSupportedModelThinkingLevels(model);
 	return supportedLevels.length > 0 ? supportedLevels : ["off"];
 }

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -214,6 +214,17 @@ describe("AgentSession model and extension characterization", () => {
 		expect(harness.session.cycleThinkingLevel()).toBe("off");
 	});
 
+	it("cycles a map-less gpt-5.6-sol model from xhigh to max", async () => {
+		const harness = await createHarness({ models: [{ id: "gpt-5.6-sol", reasoning: true }] });
+		harnesses.push(harness);
+		harness.getModel().api = "openai-responses";
+
+		harness.session.setThinkingLevel("xhigh");
+		expect(harness.session.cycleThinkingLevel()).toBe("max");
+		expect(harness.session.thinkingLevel).toBe("max");
+		expect(harness.session.cycleThinkingLevel()).toBe("off");
+	});
+
 	it("throws when setModel is called without configured auth", async () => {
 		const harness = await createHarness({
 			models: [


### PR DESCRIPTION
## Summary

Follow-up to #552: current `main` already carries the map-less `max` baseline (`aa13d734c`, including the OpenAI wire serialization). This PR intentionally contains only the remaining capability hardening, so the front-end/agent and the provider payload share one authoritative rule:

- **`packages/ai/src/models.ts`** — `supportsXhigh` / `supportsMax` keep an explicit `thinkingLevelMap` authoritative (omitted level = unsupported, `null` = veto) and infer tiers from the model id only for map-less models; the id lists and the OpenAI-compatible `gpt-5.6-sol` matcher are extracted into module constants with documentation.
- **`packages/coding-agent/src/core/thinking-levels.ts`** — tier detection delegates to `@earendil-works/pi-ai` instead of duplicating the capability rules.
- **Docs** (`packages/ai/changes.md`, `packages/ai/src/changes.md`, `packages/coding-agent/src/core/changes.md`) and focused tests (`supports-xhigh.test.ts`, `agent-session-model-extension.test.ts`) updated.

## Branch status

The previously published head (`24fbc07c`) accidentally carried ~100 files from the pre-merge #552 delivery branches. The branch has been replaced (force-updated) with the clean reconstruction on current `main` (`f4705697b`): the current head `57d6ebabd` is a **7-file delta, all in the AI capability domain**. Validation on this tree (tree `13a92850b`):

- `npm run check` (biome + pinned deps + ts-imports + shrinkwrap + tsgo + browser smoke)
- `npm run build`
- Focused suites: `packages/ai` supports-xhigh + thinking-matrix (**83/83**); `packages/coding-agent` agent-session-model-extension + thinking-levels-tiers (**26/26**)
- CI is re-running on the updated head.
