### PR TITLE
fix(coding-agent): publish migrated goals without clobbering

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,112 +1,52 @@
 # goal Extension Changes
 
-## Migrate legacy pi-goal state into the builtin goal store (2026-07-31)
+## Legacy `pi-goal` state is imported once at session start (2026-07-31)
 
 ### What changed
 
-- Session startup now migrates a legacy sibling `pi-goal` file when the builtin `goal` store does not yet exist.
-- Legacy `budgetLimited` / `budget_limited` goals resume as active, and `tokenBudget` is stripped from runtime state while the original legacy file remains untouched.
-- Existing builtin goal files remain authoritative and are never overwritten by migration.
+- `persistence.ts` exports `migrateLegacyGoalFile(ref)`, which imports a legacy
+  standalone `pi-goal` file from `<sessionDir>/extensions/pi-goal/` into the
+  current budget-free store at `<sessionDir>/extensions/goal/`.
+- `index.ts` `session_start` awaits the migration **before** `readGoal`, so an
+  imported goal participates in the session that migrated it rather than the
+  next one.
+- `parseGoalFile` gained an opt-in `{ legacy: true }` mode. Only that mode runs
+  `normalizeLegacyGoal`, which deletes `tokenBudget` and rewrites the removed
+  `budgetLimited` / `budget_limited` statuses to `active`. Migrated goals still
+  pass the normal `isGoal` validation and `sanitizeContinuationState`.
+- Precedence is absolute: an existing current file short-circuits the migration
+  and is never overwritten. A missing legacy file is a silent no-op, and a
+  legacy file holding an explicit `null` goal migrates nothing.
+- The legacy directory is derived by replacing the `goal` path segment itself
+  (`legacyBaseDirFor`), which is correct for both store layouts:
+  `<sessionDir>/extensions/goal` and the print/in-memory fallback
+  `<agentDir>/extensions/goal/no-session/<cwdKey>`. Swapping `dirname(baseDir)`
+  handles only the first; in the fallback it resolves *inside* the current store
+  tree, so real legacy state is missed and a stray nested `pi-goal` directory
+  could be imported instead. Real-CLI RPC QA caught this; both cases are pinned
+  by regression tests.
 
 ### Why
 
-- Moving the extension store from `pi-goal` to `goal` otherwise made existing objectives appear lost, and legacy budget metadata is incompatible with the builtin goal extension's budget-free design.
-
-### Verification
-
-- Goal-store coverage pins migration, runtime budget stripping, destination persistence, source preservation, and the existing app-server wire contract.
-
-||||||| a2efa4076
-## Accepted direct input leaves an active Goal idle (2026-07-31)
-
-### What changed
-
-- Removed the 60-second user-grace continuation path. An accepted ordinary direct input disarms any pending continuation, and its completed user turn leaves an active Goal active but idle instead of auto-pausing or resurrecting it later.
-- Input candidates and reversible monitor-continuation holds remain keyed by `inputId`, so handled/rejected and overlapping prompts neither mutate Goal persistence nor lose an already armed monitor continuation. Extension input remains inert; admitted steer input gets the same recovery accounting as other direct input.
-- Accepted direct input, including admitted steering, reactivates only the mechanical block reasons owned by `continuation-recovery.ts`; provider, interruption, and model-authored blocks stay blocked.
-- Continuation-cap admission remains universal across immediate, monitor-delayed, and session-start delivery, and candidate goal-ID checks prevent input races from migrating state to another Goal.
-
-### Expected merge conflict zones
-
-- MEDIUM in `index.ts` lifecycle wiring and `monitor-continuation.ts` timer ownership.
-- LOW in the focused direct-input lifecycle module.
-||||||| de5de53a7
-## Achieved footer shows elapsed time and truncated objective (2026-07-31)
-
-### What changed
-
-- `ui.ts` `goalStatusText` renders the `complete` status as
-  `<truncated objective> · Goal achieved (<elapsed>)`, mirroring the elapsed
-  suffix that `Pursuing goal (…)` already shows while a goal is active. The
-  elapsed suffix is omitted only when `timeUsedSeconds` is 0.
-- New exported `truncateGoalObjective` normalizes whitespace and truncates the
-  objective to 32 characters with a trailing ellipsis for the footer preview.
-- `goal-modules.test.ts` pins the new achieved-footer format, including the
-  long-objective truncation case.
-
-### Why
-
-- The achieved footer previously dropped both the objective and the total time
-  spent, so a finished goal gave no at-a-glance context about what completed or
-  how long it took.
+- Users upgrading from standalone `pi-goal` silently lost an in-flight goal: the
+  builtin reads a different directory, so the legacy file was never seen.
+- Normalization is deliberately confined to the legacy read path. Applying it to
+  every current-store read (the alternative considered) is destructive: it
+  strips the inert `tokenBudget` that `00571304e` added as required app-server
+  wire metadata, and it silently resurrects the removed `budgetLimited` status
+  instead of surfacing the existing `InvalidGoalStoreError`. Both regressions
+  were reproduced against `app-server-goal-wire.test.ts` before being rejected.
+- Budget-free means budgets are **not enforced**, not that budget metadata is
+  destroyed on sight. Legacy budgets are dropped because they are enforcement
+  inputs; current-store budgets are preserved because they are wire compatibility
+  metadata.
 
 ### Expected merge conflict zones on the next sync
 
-- LOW in `ui.ts` around the `goalStatusText` switch.
-
-## Mechanically blocked goals resume on a prompt queued while streaming (2026-07-31)
-
-### What changed
-
-- `index.ts` adds an `input` handler that reactivates a mechanically blocked goal
-  (cap, repetition, truncation) from a direct prompt even when that prompt is
-  queued as steer/follow-up while the agent is streaming.
-- The idle path already unblocks in `before_agent_start`, but a queued prompt
-  returns from `prompt()` before that hook runs, so a message sent mid-turn left
-  the goal blocked. The new handler covers it; extension-sourced input is ignored.
-
-### Why
-
-- The recovery hint added in #562 tells the user "Send any message to resume",
-  but a message typed while the agent was streaming was queued and returned
-  before `before_agent_start`, so it did not resume. Users who act on the hint
-  at the most natural moment saw no recovery.
-
-### Expected merge conflict zones on the next sync
-
-- LOW in `index.ts` around the new `input` handler.
-- NONE in the verdict engine, goal store schema, persistence, or public extension API.
-
-## Tool-using turns clear the output-repetition window (2026-07-31)
-
-### What changed
-
-- `monitor-continuation.ts` computes `turnUsedTools` before recording assistant
-  output, and `#recordAssistantOutput` now clears
-  `#recentNormalizedOutputHashes` for a tool-using turn instead of appending its
-  final text hash. Only three consecutive **toolless** identical outputs can
-  trip the `repetition` verdict and block the goal with
-  "repeated assistant output".
-- Coverage adds the issue #566 regression: tool-using turns with identical
-  final text stay active, a mid-streak tool turn resets the window, and the
-  three-toolless-identical-outputs block is pinned unchanged.
-
-### Why
-
-- The repetition guard recorded the last assistant text hash on every
-  `agent_end`, so a goal doing real tool work each turn but ending turns with
-  an identical status line (the monitor-wait pattern) was blocked after three
-  turns — exactly the state a live resumption channel was about to wake. The
-  cap already treats tool use as progress (#539); the repetition window now
-  follows the same principle. The stale-signature guard still suppresses
-  continuation spam for identical no-progress turns without blocking.
-
-### Expected merge conflict zones on the next sync
-
-- LOW in `monitor-continuation.ts` around `afterAgentEnd` ordering and
-  `#recordAssistantOutput`.
-- NONE in `continuation.ts`, the goal store schema, or the public extension
-  API.
+- LOW in `persistence.ts` around `parseGoalFile`'s new `legacy` parameter and the
+  `parseGoalFileJson` split; standalone `pi-goal` has no migration path.
+- LOW in `index.ts` at the `session_start` migration call.
+- NONE in the store schema, tool schemas, status transitions, or public API.
 
 ## Mechanical continuation blocks tell the user how to resume (2026-07-31)
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -15,8 +15,11 @@
   `budgetLimited` / `budget_limited` statuses to `active`. Migrated goals still
   pass the normal `isGoal` validation and `sanitizeContinuationState`.
 - Precedence is absolute: an existing current file short-circuits the migration
-  and is never overwritten. A missing legacy file is a silent no-op, and a
-  legacy file holding an explicit `null` goal migrates nothing.
+  and is never overwritten. Publication writes a restrictive `0600` private temp
+  sibling, then atomically hard-links it to the current path without replacement;
+  `EEXIST` means a concurrent current writer won and migration returns no import.
+  A missing legacy file is a silent no-op, and a legacy file holding an explicit
+  `null` goal migrates nothing.
 - The legacy directory is derived by replacing the `goal` path segment itself
   (`legacyBaseDirFor`), which is correct for both store layouts:
   `<sessionDir>/extensions/goal` and the print/in-memory fallback
@@ -30,6 +33,10 @@
 
 - Users upgrading from standalone `pi-goal` silently lost an in-flight goal: the
   builtin reads a different directory, so the legacy file was never seen.
+- A destination absence check followed by ordinary POSIX `rename` was racy:
+  `rename` replaces a current file created between the check and publication.
+  Same-directory hard-link publication gives macOS/Linux an atomic no-clobber
+  operation while retaining private temp cleanup and exact-file writes.
 - Normalization is deliberately confined to the legacy read path. Applying it to
   every current-store read (the alternative considered) is destructive: it
   strips the inert `tokenBudget` that `00571304e` added as required app-server

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -4,54 +4,50 @@
 
 ### What changed
 
-- `persistence.ts` exports `migrateLegacyGoalFile(ref)`, which imports a legacy
-  standalone `pi-goal` file from `<sessionDir>/extensions/pi-goal/` into the
-  current budget-free store at `<sessionDir>/extensions/goal/`.
-- `index.ts` `session_start` awaits the migration **before** `readGoal`, so an
-  imported goal participates in the session that migrated it rather than the
-  next one.
-- `parseGoalFile` gained an opt-in `{ legacy: true }` mode. Only that mode runs
-  `normalizeLegacyGoal`, which deletes `tokenBudget` and rewrites the removed
-  `budgetLimited` / `budget_limited` statuses to `active`. Migrated goals still
-  pass the normal `isGoal` validation and `sanitizeContinuationState`.
-- Precedence is absolute: an existing current file short-circuits the migration
-  and is never overwritten. Publication writes a restrictive `0600` private temp
-  sibling, then atomically hard-links it to the current path without replacement;
-  `EEXIST` means a concurrent current writer won and migration returns no import.
-  A missing legacy file is a silent no-op, and a legacy file holding an explicit
-  `null` goal migrates nothing.
-- The legacy directory is derived by replacing the `goal` path segment itself
-  (`legacyBaseDirFor`), which is correct for both store layouts:
-  `<sessionDir>/extensions/goal` and the print/in-memory fallback
-  `<agentDir>/extensions/goal/no-session/<cwdKey>`. Swapping `dirname(baseDir)`
-  handles only the first; in the fallback it resolves *inside* the current store
-  tree, so real legacy state is missed and a stray nested `pi-goal` directory
-  could be imported instead. Real-CLI RPC QA caught this; both cases are pinned
-  by regression tests.
+- `persistence.ts` exports `migrateLegacyGoalFile(ref)`, and `index.ts` awaits it
+  before the session's first `readGoal`, so imported state participates
+  immediately.
+- Legacy-only parsing deletes the old `tokenBudget` enforcement input and maps
+  `budgetLimited` / `budget_limited` to `active`. Current-store reads do not run
+  that normalization, so inert wire metadata and existing typed validation errors
+  are preserved.
+- Migration publication now uses `writeFile` with `flag: "wx"` and mode `0600`.
+  This keeps atomic exclusive-create precedence without hard-link support, temp
+  cleanup machinery, or a temp sibling that can be orphaned by `SIGKILL`.
+- Invalid, unsupported-version, and malformed legacy files are best-effort dead
+  data: they remain on disk, return no import, and do not brick the live current
+  store. Unexpected filesystem errors still propagate.
+- Successfully imported files, explicit-null files, and files that lose the
+  exclusive-create race are renamed to a sibling `.migrated` archive on a
+  best-effort basis, so completed migration is not retried on every startup.
+- Segment-aware `goal` -> `pi-goal` mapping accepts both `/` and `\\` separators
+  while retaining exact path-segment matching; names such as `my-goal` are never
+  rewritten.
+- Session-backed migration keeps its stable thread-id lookup. No-session migration
+  instead enumerates the cwd-keyed `*.json` bucket because ephemeral sessions get
+  a new id on every run. It searches both the legacy bucket beside the redirected
+  Senpi root and `PI_CODING_AGENT_DIR` (default `~/.pi/agent`), and reports an
+  explicit conflict when multiple valid live goals exist rather than guessing.
 
 ### Why
 
-- Users upgrading from standalone `pi-goal` silently lost an in-flight goal: the
-  builtin reads a different directory, so the legacy file was never seen.
-- A destination absence check followed by ordinary POSIX `rename` was racy:
-  `rename` replaces a current file created between the check and publication.
-  Same-directory hard-link publication gives macOS/Linux an atomic no-clobber
-  operation while retaining private temp cleanup and exact-file writes.
-- Normalization is deliberately confined to the legacy read path. Applying it to
-  every current-store read (the alternative considered) is destructive: it
-  strips the inert `tokenBudget` that `00571304e` added as required app-server
-  wire metadata, and it silently resurrects the removed `budgetLimited` status
-  instead of surfacing the existing `InvalidGoalStoreError`. Both regressions
-  were reproduced against `app-server-goal-wire.test.ts` before being rejected.
-- Budget-free means budgets are **not enforced**, not that budget metadata is
-  destroyed on sight. Legacy budgets are dropped because they are enforcement
-  inputs; current-store budgets are preserved because they are wire compatibility
-  metadata.
+- Standalone `pi-goal` and the builtin can use different agent roots, and
+  no-session filenames contain an old ephemeral session id. Rewriting only the
+  current Senpi path and looking up the new id silently missed the headline
+  print/in-memory upgrade path.
+- Hard links fail on common non-POSIX and network filesystems. Exclusive `wx`
+  creation provides the same no-clobber result portably and removes the crash-time
+  orphan-temp-file durability wart.
+- A stale corrupt migration source is not authoritative live state. Ignoring its
+  expected parse/schema failures keeps goal creation usable while preserving the
+  source for manual recovery.
+- Retiring a consumed source makes migration genuinely one-shot without deleting
+  the user's old data.
 
 ### Expected merge conflict zones on the next sync
 
-- LOW in `persistence.ts` around `parseGoalFile`'s new `legacy` parameter and the
-  `parseGoalFileJson` split; standalone `pi-goal` has no migration path.
+- LOW in `persistence.ts` around legacy candidate discovery and `parseGoalFile`'s
+  `legacy` option; standalone `pi-goal` has no migration path.
 - LOW in `index.ts` at the `session_start` migration call.
 - NONE in the store schema, tool schemas, status transitions, or public API.
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { link, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, sep } from "node:path";
 import { InvalidGoalStoreError, UnsupportedGoalStoreVersionError } from "./errors.ts";
 import type { Goal, GoalFile, GoalStatus, GoalStoreRef } from "./types.ts";
@@ -57,8 +57,7 @@ export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | n
 		throw error;
 	}
 	if (legacyGoal === null) return null;
-	await writeGoalFile(ref, legacyGoal);
-	return legacyGoal;
+	return (await publishMigratedGoalFile(ref, legacyGoal)) ? legacyGoal : null;
 }
 
 /**
@@ -104,6 +103,40 @@ async function writeGoalFileAtomic(filePath: string, contents: string): Promise<
 		}
 		throw error;
 	}
+}
+
+async function publishMigratedGoalFile(ref: GoalStoreRef, goal: Goal): Promise<boolean> {
+	const filePath = goalFilePath(ref);
+	await mkdir(dirname(filePath), { recursive: true });
+	const contents = `${JSON.stringify({ version: STORE_VERSION, goal }, null, 2)}\n`;
+	const tempPath = join(dirname(filePath), `.goal-${randomUUID()}.tmp`);
+	let published = false;
+	let publicationFailed = false;
+	let publicationError: unknown;
+	try {
+		await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600 });
+		await link(tempPath, filePath);
+		published = true;
+	} catch (error) {
+		if (!isFileSystemError(error, "EEXIST")) {
+			publicationFailed = true;
+			publicationError = error;
+		}
+	}
+
+	try {
+		await rm(tempPath, { force: true });
+	} catch (cleanupError) {
+		if (publicationFailed) {
+			throw new AggregateError(
+				[publicationError, cleanupError],
+				"goal migration publication failed and its temporary file could not be removed",
+			);
+		}
+		throw cleanupError;
+	}
+	if (publicationFailed) throw publicationError;
+	return published;
 }
 
 function parseGoalFile(raw: string, { legacy = false }: { legacy?: boolean } = {}): GoalFile {
@@ -219,5 +252,9 @@ function sanitizeContinuationState(goal: Goal): Goal {
 }
 
 function isMissingFile(error: unknown): boolean {
-	return error instanceof Error && "code" in error && error.code === "ENOENT";
+	return isFileSystemError(error, "ENOENT");
+}
+
+function isFileSystemError(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
@@ -1,12 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { InvalidGoalStoreError, UnsupportedGoalStoreVersionError } from "./errors.ts";
 import type { Goal, GoalFile, GoalStatus, GoalStoreRef } from "./types.ts";
 import { isRecord } from "./types.ts";
 import { isGoalStatus, isNonNegativeSafeInteger } from "./validation.ts";
 
 const STORE_VERSION = 1;
+const CURRENT_STORE_DIRECTORY = "goal";
+const LEGACY_STORE_DIRECTORY = "pi-goal";
+const LEGACY_BUDGET_LIMITED_STATUSES = ["budgetLimited", "budget_limited"];
 
 export function encodedThreadId(ref: GoalStoreRef): string {
 	return encodeURIComponent(ref.threadId);
@@ -25,6 +28,16 @@ export async function readGoalFile(ref: GoalStoreRef): Promise<Goal | null> {
 	}
 }
 
+/**
+ * Imports a legacy standalone `pi-goal` file into the current budget-free store.
+ *
+ * The current store always wins: an existing current file (even one carrying inert
+ * `tokenBudget` wire metadata) is never overwritten, and a missing legacy file is a
+ * no-op. Legacy normalization is deliberately confined to this path so ordinary
+ * current-store reads keep their exact bytes and their existing typed errors.
+ *
+ * Returns the imported goal, or null when nothing was migrated.
+ */
 export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | null> {
 	try {
 		await readFile(goalFilePath(ref), "utf8");
@@ -33,10 +46,12 @@ export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | n
 		if (!isMissingFile(error)) throw error;
 	}
 
-	const legacyRef = { ...ref, baseDir: join(dirname(ref.baseDir), "pi-goal") };
+	const legacyBaseDir = legacyBaseDirFor(ref.baseDir);
+	if (legacyBaseDir === undefined) return null;
+	const legacyRef: GoalStoreRef = { ...ref, baseDir: legacyBaseDir };
 	let legacyGoal: Goal | null;
 	try {
-		legacyGoal = parseGoalFile(await readFile(goalFilePath(legacyRef), "utf8")).goal;
+		legacyGoal = parseGoalFile(await readFile(goalFilePath(legacyRef), "utf8"), { legacy: true }).goal;
 	} catch (error) {
 		if (isMissingFile(error)) return null;
 		throw error;
@@ -44,6 +59,27 @@ export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | n
 	if (legacyGoal === null) return null;
 	await writeGoalFile(ref, legacyGoal);
 	return legacyGoal;
+}
+
+/**
+ * Maps a current goal-store directory to its legacy `pi-goal` counterpart by replacing
+ * the `goal` path segment itself.
+ *
+ * Both store layouts must map correctly:
+ *   <sessionDir>/extensions/goal            -> <sessionDir>/extensions/pi-goal
+ *   <agentDir>/extensions/goal/no-session/<cwdKey>
+ *                                           -> <agentDir>/extensions/pi-goal/no-session/<cwdKey>
+ *
+ * Swapping `dirname(baseDir)` only works for the first layout; in the no-session
+ * fallback it points inside the current store tree, which both misses real legacy
+ * state and can import an unrelated nested directory.
+ */
+function legacyBaseDirFor(baseDir: string): string | undefined {
+	const segments = baseDir.split(sep);
+	const goalIndex = segments.lastIndexOf(CURRENT_STORE_DIRECTORY);
+	if (goalIndex === -1) return undefined;
+	segments[goalIndex] = LEGACY_STORE_DIRECTORY;
+	return segments.join(sep);
 }
 
 export async function writeGoalFile(ref: GoalStoreRef, goal: Goal | null): Promise<void> {
@@ -70,17 +106,13 @@ async function writeGoalFileAtomic(filePath: string, contents: string): Promise<
 	}
 }
 
-function parseGoalFile(raw: string): GoalFile {
+function parseGoalFile(raw: string, { legacy = false }: { legacy?: boolean } = {}): GoalFile {
 	const parsed = parseGoalFileJson(raw);
 	if (!isRecord(parsed)) throw new InvalidGoalStoreError("goal store must be a JSON object");
 	if (parsed.version !== STORE_VERSION) throw new UnsupportedGoalStoreVersionError("unsupported goal store version");
-	const normalizedGoal = normalizeLegacyGoal(parsed.goal);
-	if (normalizedGoal !== null && !isGoal(normalizedGoal))
-		throw new InvalidGoalStoreError("goal store contains an invalid goal");
-	return {
-		version: STORE_VERSION,
-		goal: normalizedGoal === null ? null : sanitizeContinuationState(normalizedGoal),
-	};
+	const goal = legacy ? normalizeLegacyGoal(parsed.goal) : parsed.goal;
+	if (goal !== null && !isGoal(goal)) throw new InvalidGoalStoreError("goal store contains an invalid goal");
+	return { version: STORE_VERSION, goal: goal === null ? null : sanitizeContinuationState(goal) };
 }
 
 function parseGoalFileJson(raw: string): unknown {
@@ -100,11 +132,16 @@ function parseGoalFileJson(raw: string): unknown {
 	return parsed;
 }
 
+/**
+ * Drops legacy budget enforcement: `tokenBudget` is a budgeting input in `pi-goal`, and
+ * `budgetLimited` is a status this fork removed, so a budget-limited legacy goal resumes
+ * as `active`. This runs only on the legacy import path.
+ */
 function normalizeLegacyGoal(value: unknown): unknown {
 	if (!isRecord(value)) return value;
 	const normalized = { ...value };
 	delete normalized.tokenBudget;
-	if (normalized.status === "budgetLimited" || normalized.status === "budget_limited") {
+	if (typeof normalized.status === "string" && LEGACY_BUDGET_LIMITED_STATUSES.includes(normalized.status)) {
 		normalized.status = "active";
 	}
 	return normalized;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { link, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { dirname, join, sep } from "node:path";
 import { InvalidGoalStoreError, UnsupportedGoalStoreVersionError } from "./errors.ts";
 import type { Goal, GoalFile, GoalStatus, GoalStoreRef } from "./types.ts";
@@ -29,12 +31,17 @@ export async function readGoalFile(ref: GoalStoreRef): Promise<Goal | null> {
 }
 
 /**
- * Imports a legacy standalone `pi-goal` file into the current budget-free store.
+ * Imports legacy standalone `pi-goal` state into the current budget-free store.
  *
- * The current store always wins: an existing current file (even one carrying inert
- * `tokenBudget` wire metadata) is never overwritten, and a missing legacy file is a
- * no-op. Legacy normalization is deliberately confined to this path so ordinary
- * current-store reads keep their exact bytes and their existing typed errors.
+ * The current store always wins and legacy normalization is confined to this path.
+ * Invalid, unsupported, or malformed legacy files are best-effort dead-data imports:
+ * they remain untouched and do not block the live current store. Unexpected filesystem
+ * failures still propagate.
+ *
+ * Session-backed stores use their stable thread id. No-session stores enumerate the
+ * cwd-keyed legacy bucket because each ephemeral run receives a new thread id, and they
+ * inspect both the redirected Senpi-root sibling and the standalone pi agent root.
+ * Multiple valid live candidates are reported as a conflict rather than guessed.
  *
  * Returns the imported goal, or null when nothing was migrated.
  */
@@ -46,18 +53,89 @@ export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | n
 		if (!isMissingFile(error)) throw error;
 	}
 
+	const legacyCandidates = await readLegacyGoalCandidates(ref);
+	if (legacyCandidates.length > 1) {
+		throw new Error(
+			`multiple legacy goals found for no-session store: ${legacyCandidates.map(({ path }) => path).join(", ")}`,
+		);
+	}
+	const candidate = legacyCandidates[0];
+	if (candidate === undefined) return null;
+	const published = await publishMigratedGoalFile(ref, candidate.goal);
+	await retireLegacyGoalFile(candidate.path);
+	return published ? candidate.goal : null;
+}
+
+interface LegacyGoalCandidate {
+	path: string;
+	goal: Goal;
+}
+
+async function readLegacyGoalCandidates(ref: GoalStoreRef): Promise<LegacyGoalCandidate[]> {
 	const legacyBaseDir = legacyBaseDirFor(ref.baseDir);
-	if (legacyBaseDir === undefined) return null;
-	const legacyRef: GoalStoreRef = { ...ref, baseDir: legacyBaseDir };
-	let legacyGoal: Goal | null;
+	if (legacyBaseDir === undefined) return [];
+	const cwdKey = noSessionCwdKey(ref.baseDir);
+	if (cwdKey === undefined) {
+		const candidate = await readLegacyGoalCandidate(goalFilePath({ ...ref, baseDir: legacyBaseDir }));
+		return candidate === null ? [] : [candidate];
+	}
+
+	const standaloneAgentDir = process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	const baseDirs = new Set([
+		legacyBaseDir,
+		join(standaloneAgentDir, "extensions", LEGACY_STORE_DIRECTORY, "no-session", cwdKey),
+	]);
+	const candidatePaths: string[] = [];
+	for (const baseDir of baseDirs) {
+		let entries: Dirent<string>[];
+		try {
+			entries = await readdir(baseDir, { withFileTypes: true });
+		} catch (error) {
+			if (isMissingFile(error)) continue;
+			throw error;
+		}
+		for (const entry of entries) {
+			if (entry.isFile() && entry.name.endsWith(".json")) candidatePaths.push(join(baseDir, entry.name));
+		}
+	}
+
+	const candidates: LegacyGoalCandidate[] = [];
+	for (const path of candidatePaths.sort()) {
+		const candidate = await readLegacyGoalCandidate(path);
+		if (candidate !== null) candidates.push(candidate);
+	}
+	return candidates;
+}
+
+async function readLegacyGoalCandidate(path: string): Promise<LegacyGoalCandidate | null> {
+	let goal: Goal | null;
 	try {
-		legacyGoal = parseGoalFile(await readFile(goalFilePath(legacyRef), "utf8"), { legacy: true }).goal;
+		goal = parseGoalFile(await readFile(path, "utf8"), { legacy: true }).goal;
 	} catch (error) {
-		if (isMissingFile(error)) return null;
+		if (isMissingFile(error) || isIgnoredLegacyStoreError(error)) return null;
 		throw error;
 	}
-	if (legacyGoal === null) return null;
-	return (await publishMigratedGoalFile(ref, legacyGoal)) ? legacyGoal : null;
+	if (goal === null) {
+		await retireLegacyGoalFile(path);
+		return null;
+	}
+	return { path, goal };
+}
+
+async function retireLegacyGoalFile(path: string): Promise<void> {
+	try {
+		await rename(path, `${path}.migrated`);
+	} catch {
+		// Retirement is best-effort: a preserved legacy file must never fail live migration.
+	}
+}
+
+function isIgnoredLegacyStoreError(error: unknown): boolean {
+	return (
+		error instanceof InvalidGoalStoreError ||
+		error instanceof UnsupportedGoalStoreVersionError ||
+		error instanceof SyntaxError
+	);
 }
 
 /**
@@ -74,11 +152,22 @@ export async function migrateLegacyGoalFile(ref: GoalStoreRef): Promise<Goal | n
  * state and can import an unrelated nested directory.
  */
 function legacyBaseDirFor(baseDir: string): string | undefined {
-	const segments = baseDir.split(sep);
+	const segments = pathSegments(baseDir);
 	const goalIndex = segments.lastIndexOf(CURRENT_STORE_DIRECTORY);
 	if (goalIndex === -1) return undefined;
 	segments[goalIndex] = LEGACY_STORE_DIRECTORY;
 	return segments.join(sep);
+}
+
+function noSessionCwdKey(baseDir: string): string | undefined {
+	const segments = pathSegments(baseDir);
+	const goalIndex = segments.lastIndexOf(CURRENT_STORE_DIRECTORY);
+	if (goalIndex === -1 || segments[goalIndex + 1] !== "no-session") return undefined;
+	return segments[goalIndex + 2];
+}
+
+function pathSegments(path: string): string[] {
+	return path.split(/[\\/]/);
 }
 
 export async function writeGoalFile(ref: GoalStoreRef, goal: Goal | null): Promise<void> {
@@ -109,34 +198,13 @@ async function publishMigratedGoalFile(ref: GoalStoreRef, goal: Goal): Promise<b
 	const filePath = goalFilePath(ref);
 	await mkdir(dirname(filePath), { recursive: true });
 	const contents = `${JSON.stringify({ version: STORE_VERSION, goal }, null, 2)}\n`;
-	const tempPath = join(dirname(filePath), `.goal-${randomUUID()}.tmp`);
-	let published = false;
-	let publicationFailed = false;
-	let publicationError: unknown;
 	try {
-		await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600 });
-		await link(tempPath, filePath);
-		published = true;
+		await writeFile(filePath, contents, { encoding: "utf8", mode: 0o600, flag: "wx" });
+		return true;
 	} catch (error) {
-		if (!isFileSystemError(error, "EEXIST")) {
-			publicationFailed = true;
-			publicationError = error;
-		}
+		if (isFileSystemError(error, "EEXIST")) return false;
+		throw error;
 	}
-
-	try {
-		await rm(tempPath, { force: true });
-	} catch (cleanupError) {
-		if (publicationFailed) {
-			throw new AggregateError(
-				[publicationError, cleanupError],
-				"goal migration publication failed and its temporary file could not be removed",
-			);
-		}
-		throw cleanupError;
-	}
-	if (publicationFailed) throw publicationError;
-	return published;
 }
 
 function parseGoalFile(raw: string, { legacy = false }: { legacy?: boolean } = {}): GoalFile {

--- a/packages/coding-agent/test/suite/app-server-goal-wire.test.ts
+++ b/packages/coding-agent/test/suite/app-server-goal-wire.test.ts
@@ -67,8 +67,8 @@ describe("app-server goal wire adapter", () => {
 		expect(loaded).not.toHaveProperty("tokenBudget");
 	});
 
-	it("normalizes legacy budget metadata out of runtime goal state", async () => {
-		// Given: a legacy-compatible goal object still carrying a numeric budget.
+	it("keeps an inert tokenBudget field in current-store reads", async () => {
+		// Given: a goal object still carrying a numeric compatibility budget.
 		const baseDir = await mkdtemp(join(tmpdir(), "senpi-goal-wire-"));
 		tempDirs.push(baseDir);
 		const ref: GoalStoreRef = { baseDir, threadId: "thread-budget" };
@@ -78,8 +78,9 @@ describe("app-server goal wire adapter", () => {
 		await writeGoal(ref, goal);
 		const loaded = await readGoal(ref);
 
-		// Then: the serialized compatibility field remains inert and never reactivates runtime budgeting.
-		expect(loaded).not.toHaveProperty("tokenBudget");
+		// Then: the compatibility field is preserved inert on current-store reads; legacy budget
+		// stripping happens only on the migration import path (covered by goal-store tests).
+		expect(loaded).toHaveProperty("tokenBudget", 8192);
 		expect(JSON.parse(await readFile(goalFilePath(ref), "utf8"))).toMatchObject({
 			goal: { tokenBudget: 8192 },
 		});

--- a/packages/coding-agent/test/suite/app-server-thread-goal.test.ts
+++ b/packages/coding-agent/test/suite/app-server-thread-goal.test.ts
@@ -45,14 +45,15 @@ describe("app-server thread goal handlers", () => {
 			params: { threadId },
 		});
 
-		// Then: the create response preserves wire compatibility, but persisted Goal state is budgetless.
+		// Then: the create response preserves wire compatibility, the compatibility field stays
+		// inert on reads until explicitly cleared, and no limiter state is persisted.
 		expect(objectAt(responseResult(created), "goal")).toMatchObject({
 			threadId,
 			objective: "Ship the parity lane",
 			status: "active",
 			tokenBudget: 4096,
 		});
-		expect(objectAt(responseResult(preserved), "goal").tokenBudget).toBeNull();
+		expect(objectAt(responseResult(preserved), "goal").tokenBudget).toBe(4096);
 		expect(objectAt(responseResult(cleared), "goal").tokenBudget).toBeNull();
 		expect(objectAt(responseResult(read), "goal").tokenBudget).toBeNull();
 	});

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -666,6 +666,78 @@ describe("goal extension session_start migration-lite admission", () => {
 		expect(sent).toHaveLength(0);
 		expect(notices).toEqual([]);
 		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+	});
+});
+
+describe("goal extension session_start legacy pi-goal migration", () => {
+	async function writeLegacyGoalFile(ctx: ExtensionContext, goal: Record<string, unknown>): Promise<void> {
+		const legacyDir = join(ctx.sessionManager.getSessionDir(), "extensions", "pi-goal");
+		await mkdir(legacyDir, { recursive: true });
+		await writeFile(
+			join(legacyDir, `${encodeURIComponent(ctx.sessionManager.getSessionId())}.json`),
+			`${JSON.stringify({ version: 1, goal })}\n`,
+			"utf8",
+		);
+	}
+
+	function legacyGoal(ctx: ExtensionContext, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+		return {
+			id: "legacy-goal-id",
+			threadId: ctx.sessionManager.getSessionId(),
+			objective: "Finish the legacy goal",
+			status: "budgetLimited",
+			tokenBudget: 100,
+			tokensUsed: 40,
+			timeUsedSeconds: 8,
+			createdAt: 1,
+			updatedAt: 2,
+			...overrides,
+		};
+	}
+
+	it("imports a legacy budget-limited goal at startup and resumes it as active", async () => {
+		const { handlers, sent } = createGoalHarness();
+		const ctx = await makeCtx("thread-legacy-startup");
+		await writeLegacyGoalFile(ctx, legacyGoal(ctx));
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		const migrated = await readGoal(storeRefFor(ctx));
+		expect(migrated).toMatchObject({ id: "legacy-goal-id", status: "active", tokensUsed: 40 });
+		expect(migrated).not.toHaveProperty("tokenBudget");
+		// Migration runs before startup accounting, so the imported goal is picked up this session.
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
+	});
+
+	it("keeps an existing current goal instead of the legacy file", async () => {
+		const { tools, handlers } = createGoalHarness();
+		const ctx = await makeCtx("thread-legacy-current-wins");
+		await tools.get("create_goal")?.execute("c1", { objective: "Current goal" }, undefined, undefined, ctx);
+		const current = await readGoal(storeRefFor(ctx));
+		await writeLegacyGoalFile(ctx, legacyGoal(ctx));
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		// The current goal keeps its identity and objective; only ordinary continuation
+		// bookkeeping may advance. The legacy goal is never imported over it.
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
+			id: current?.id,
+			objective: "Current goal",
+			status: "active",
+			tokensUsed: 0,
+		});
+		expect((await readGoal(storeRefFor(ctx)))?.id).not.toBe("legacy-goal-id");
+	});
+
+	it("starts cleanly when no legacy file exists", async () => {
+		const { handlers, sent } = createGoalHarness();
+		const ctx = await makeCtx("thread-legacy-absent");
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(await readGoal(storeRefFor(ctx))).toBeNull();
+		expect(sent).toHaveLength(0);
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -1,7 +1,29 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const migrationRace = vi.hoisted(() => ({
+	legacyPath: undefined as string | undefined,
+	beforeLegacyRead: undefined as (() => Promise<void>) | undefined,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		readFile: async (...args: Parameters<typeof actual.readFile>) => {
+			if (String(args[0]) === migrationRace.legacyPath) {
+				const beforeLegacyRead = migrationRace.beforeLegacyRead;
+				migrationRace.legacyPath = undefined;
+				migrationRace.beforeLegacyRead = undefined;
+				await beforeLegacyRead?.();
+			}
+			return actual.readFile(...args);
+		},
+	};
+});
+
 import { migrateLegacyGoalFile } from "../../src/core/extensions/builtin/goal/persistence.ts";
 import {
 	accountGoalUsage,
@@ -232,6 +254,44 @@ describe("legacy pi-goal store migration", () => {
 		expect(migrated).not.toHaveProperty("consecutiveContinuations");
 		expect(migrated).not.toHaveProperty("lastContinuationSignature");
 		expect(await readGoal(ref)).toEqual(migrated);
+	});
+
+	it("gives a current goal created during migration precedence over the legacy goal", async () => {
+		// Given: migration has observed no current file and is about to consume legacy state.
+		const ref = await tempStore("thread-current-race-wins");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref));
+		let currentGoal: Awaited<ReturnType<typeof createGoal>> | undefined;
+		migrationRace.legacyPath = goalFilePath(legacyStoreRef(ref));
+		migrationRace.beforeLegacyRead = async () => {
+			currentGoal = await createGoal(ref, "Current goal created during migration");
+		};
+
+		// When: the exact legacy-read boundary creates current state after migration's
+		// initial destination check but before it publishes the migrated bytes.
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then: publication must not clobber the current writer that won the race.
+		expect(currentGoal).toBeDefined();
+		expect(migrated).toBeNull();
+		expect(await readGoal(ref)).toEqual(currentGoal);
+		expect(await readdir(ref.baseDir)).toEqual([basename(goalFilePath(ref))]);
+	});
+
+	it.skipIf(process.platform === "win32")("publishes a migrated goal with mode 0600", async () => {
+		// Given
+		const ref = await tempStore("thread-private-migration");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref));
+		const previousUmask = process.umask(0o022);
+
+		// When
+		try {
+			await migrateLegacyGoalFile(ref);
+		} finally {
+			process.umask(previousUmask);
+		}
+
+		// Then
+		expect((await stat(goalFilePath(ref))).mode & 0o777).toBe(0o600);
 	});
 
 	it("never overwrites an existing current goal with a legacy file", async () => {

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -1,25 +1,41 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, sep } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const migrationRace = vi.hoisted(() => ({
-	legacyPath: undefined as string | undefined,
-	beforeLegacyRead: undefined as (() => Promise<void>) | undefined,
+	exclusivePath: undefined as string | undefined,
+	beforeExclusiveWrite: undefined as (() => Promise<void>) | undefined,
+	linkError: undefined as NodeJS.ErrnoException | undefined,
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs/promises")>();
 	return {
 		...actual,
-		readFile: async (...args: Parameters<typeof actual.readFile>) => {
-			if (String(args[0]) === migrationRace.legacyPath) {
-				const beforeLegacyRead = migrationRace.beforeLegacyRead;
-				migrationRace.legacyPath = undefined;
-				migrationRace.beforeLegacyRead = undefined;
-				await beforeLegacyRead?.();
+		writeFile: async (...args: Parameters<typeof actual.writeFile>) => {
+			const options = args[2];
+			if (
+				String(args[0]) === migrationRace.exclusivePath &&
+				typeof options === "object" &&
+				options !== null &&
+				"flag" in options &&
+				options.flag === "wx"
+			) {
+				const beforeExclusiveWrite = migrationRace.beforeExclusiveWrite;
+				migrationRace.exclusivePath = undefined;
+				migrationRace.beforeExclusiveWrite = undefined;
+				await beforeExclusiveWrite?.();
 			}
-			return actual.readFile(...args);
+			return actual.writeFile(...args);
+		},
+		link: async (...args: Parameters<typeof actual.link>) => {
+			if (migrationRace.linkError !== undefined) {
+				const error = migrationRace.linkError;
+				migrationRace.linkError = undefined;
+				throw error;
+			}
+			return actual.link(...args);
 		},
 	};
 });
@@ -39,6 +55,7 @@ import {
 import type { GoalStoreRef } from "../../src/core/extensions/builtin/goal/types.ts";
 
 const tempDirs: string[] = [];
+const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
 
 async function tempStore(threadId = "thread-test"): Promise<GoalStoreRef> {
 	const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
@@ -74,6 +91,11 @@ function legacyGoalRecord(ref: GoalStoreRef, overrides: Record<string, unknown> 
 }
 
 afterEach(async () => {
+	migrationRace.exclusivePath = undefined;
+	migrationRace.beforeExclusiveWrite = undefined;
+	migrationRace.linkError = undefined;
+	if (originalPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
 	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -257,24 +279,43 @@ describe("legacy pi-goal store migration", () => {
 	});
 
 	it("gives a current goal created during migration precedence over the legacy goal", async () => {
-		// Given: migration has observed no current file and is about to consume legacy state.
+		// Given: migration has parsed legacy state and is about to publish it exclusively.
 		const ref = await tempStore("thread-current-race-wins");
+		const legacyRef = legacyStoreRef(ref);
 		await writeLegacyGoalFile(ref, legacyGoalRecord(ref));
 		let currentGoal: Awaited<ReturnType<typeof createGoal>> | undefined;
-		migrationRace.legacyPath = goalFilePath(legacyStoreRef(ref));
-		migrationRace.beforeLegacyRead = async () => {
+		migrationRace.exclusivePath = goalFilePath(ref);
+		migrationRace.beforeExclusiveWrite = async () => {
 			currentGoal = await createGoal(ref, "Current goal created during migration");
 		};
 
-		// When: the exact legacy-read boundary creates current state after migration's
-		// initial destination check but before it publishes the migrated bytes.
+		// When: a current writer creates the destination at the exclusive-write boundary.
 		const migrated = await migrateLegacyGoalFile(ref);
 
-		// Then: publication must not clobber the current writer that won the race.
+		// Then: EEXIST is a no-op, the current writer wins, and migration terminates cleanly.
 		expect(currentGoal).toBeDefined();
 		expect(migrated).toBeNull();
 		expect(await readGoal(ref)).toEqual(currentGoal);
 		expect(await readdir(ref.baseDir)).toEqual([basename(goalFilePath(ref))]);
+		await expect(readFile(goalFilePath(legacyRef), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await readFile(`${goalFilePath(legacyRef)}.migrated`, "utf8")).toContain("legacy-goal-id");
+		expect(await migrateLegacyGoalFile(ref)).toBeNull();
+	});
+
+	it("does not depend on hard-link support when publishing a migrated goal", async () => {
+		// Given: the filesystem rejects hard links, as portable exclusive file creation must not care.
+		const ref = await tempStore("thread-no-hard-link");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref));
+		const error = new Error("hard links are unsupported") as NodeJS.ErrnoException;
+		error.code = "EOPNOTSUPP";
+		migrationRace.linkError = error;
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toMatchObject({ id: "legacy-goal-id" });
+		expect(await readGoal(ref)).toEqual(migrated);
 	});
 
 	it.skipIf(process.platform === "win32")("publishes a migrated goal with mode 0600", async () => {
@@ -350,49 +391,134 @@ describe("legacy pi-goal store migration", () => {
 		expect(await readGoal(ref)).toBeNull();
 	});
 
-	it("keeps the typed unsupported-version error for a legacy file", async () => {
+	it("ignores an unsupported legacy version and leaves the current store usable", async () => {
 		// Given
 		const ref = await tempStore("thread-legacy-version");
 		await writeRawGoalFile(legacyStoreRef(ref), '{"version":2,"goal":null}\n');
 
 		// When / Then
-		await expect(migrateLegacyGoalFile(ref)).rejects.toThrow("unsupported goal store version");
+		await expect(migrateLegacyGoalFile(ref)).resolves.toBeNull();
+		const current = await createGoal(ref, "Start a current goal after ignored legacy state");
+		expect(await readGoal(ref)).toEqual(current);
+		expect(await readFile(goalFilePath(legacyStoreRef(ref)), "utf8")).toContain('"version":2');
 	});
 
-	it("keeps the typed invalid-goal error for a legacy file", async () => {
+	it("ignores an invalid legacy goal and leaves the current store usable", async () => {
 		// Given
 		const ref = await tempStore("thread-legacy-invalid");
 		await writeRawGoalFile(legacyStoreRef(ref), '{"version":1,"goal":{"id":1}}\n');
 
 		// When / Then
-		await expect(migrateLegacyGoalFile(ref)).rejects.toThrow("goal store contains an invalid goal");
+		await expect(migrateLegacyGoalFile(ref)).resolves.toBeNull();
+		const current = await createGoal(ref, "Recover from invalid legacy state");
+		expect(await readGoal(ref)).toEqual(current);
+		expect(await readFile(goalFilePath(legacyStoreRef(ref)), "utf8")).toContain('"id":1');
 	});
 
-	it("finds the legacy store in the no-session fallback layout", async () => {
-		// Given: print/in-memory mode nests the store under no-session/<cwdKey>, so the
-		// legacy sibling is extensions/pi-goal/no-session/<cwdKey>, not a sibling of <cwdKey>.
+	it("ignores truncated legacy JSON and leaves the current store usable", async () => {
+		// Given
+		const ref = await tempStore("thread-legacy-truncated");
+		await writeRawGoalFile(legacyStoreRef(ref), '{"version":1,"goal":');
+
+		// When / Then
+		await expect(migrateLegacyGoalFile(ref)).resolves.toBeNull();
+		const current = await createGoal(ref, "Recover from truncated legacy state");
+		expect(await readGoal(ref)).toEqual(current);
+	});
+
+	it.each(["/", "\\"])("finds a legacy store when baseDir uses %s separators", async (separator) => {
+		// Given: persisted paths may have been assembled with either separator convention.
+		const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
+		tempDirs.push(dir);
+		const nativeBaseDir = join(dir, "extensions", "goal", "no-session", "separators");
+		const ref: GoalStoreRef = {
+			baseDir: nativeBaseDir.replaceAll(/[\\/]/g, separator),
+			threadId: `thread-separators-${separator === "/" ? "slash" : "backslash"}`,
+		};
+		if (separator !== sep) tempDirs.push(ref.baseDir);
+		const legacyRef: GoalStoreRef = {
+			...ref,
+			baseDir: join(dir, "extensions", "pi-goal", "no-session", "separators"),
+		};
+		await writeRawGoalFile(legacyRef, `${JSON.stringify({ version: 1, goal: legacyGoalRecord(ref) })}\n`);
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toMatchObject({ id: "legacy-goal-id" });
+	});
+
+	it("finds a no-session legacy goal whose persisted thread id differs from the new session id", async () => {
+		// Given: print/in-memory sessions generate a new id, while the cwd-keyed bucket survives.
 		const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
 		tempDirs.push(dir);
 		const cwdKey = "a".repeat(24);
 		const ref: GoalStoreRef = {
 			baseDir: join(dir, "extensions", "goal", "no-session", cwdKey),
-			threadId: "thread-no-session-legacy",
+			threadId: "new-ephemeral-thread",
 		};
 		const legacyRef: GoalStoreRef = {
-			...ref,
 			baseDir: join(dir, "extensions", "pi-goal", "no-session", cwdKey),
+			threadId: "old-ephemeral-thread",
 		};
 		await writeRawGoalFile(
 			legacyRef,
-			`${JSON.stringify({ version: 1, goal: legacyGoalRecord(ref, { status: "budgetLimited", tokenBudget: 100 }) })}\n`,
+			`${JSON.stringify({ version: 1, goal: legacyGoalRecord(legacyRef, { status: "budgetLimited", tokenBudget: 100 }) })}\n`,
 		);
 
 		// When
 		const migrated = await migrateLegacyGoalFile(ref);
 
 		// Then
-		expect(migrated).toMatchObject({ id: "legacy-goal-id", status: "active" });
+		expect(migrated).toMatchObject({ id: "legacy-goal-id", threadId: "old-ephemeral-thread", status: "active" });
 		expect(migrated).not.toHaveProperty("tokenBudget");
+		expect(await readGoal(ref)).toEqual(migrated);
+	});
+
+	it("surfaces a conflict instead of guessing between multiple no-session legacy goals", async () => {
+		// Given
+		const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
+		tempDirs.push(dir);
+		const cwdKey = "c".repeat(24);
+		const ref: GoalStoreRef = {
+			baseDir: join(dir, "extensions", "goal", "no-session", cwdKey),
+			threadId: "new-conflicted-thread",
+		};
+		const legacyBaseDir = join(dir, "extensions", "pi-goal", "no-session", cwdKey);
+		for (const threadId of ["old-thread-one", "old-thread-two"]) {
+			const legacyRef = { baseDir: legacyBaseDir, threadId };
+			await writeRawGoalFile(legacyRef, `${JSON.stringify({ version: 1, goal: legacyGoalRecord(legacyRef) })}\n`);
+		}
+
+		// When / Then
+		await expect(migrateLegacyGoalFile(ref)).rejects.toThrow("multiple legacy goals");
+		expect(await readGoal(ref)).toBeNull();
+	});
+
+	it("finds no-session legacy state under a distinct standalone pi agent root", async () => {
+		// Given: builtin and standalone stores use genuinely different agent roots.
+		const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
+		tempDirs.push(dir);
+		const cwdKey = "d".repeat(24);
+		const senpiAgentDir = join(dir, ".senpi", "agent");
+		const piAgentDir = join(dir, ".pi", "agent");
+		process.env.PI_CODING_AGENT_DIR = piAgentDir;
+		const ref: GoalStoreRef = {
+			baseDir: join(senpiAgentDir, "extensions", "goal", "no-session", cwdKey),
+			threadId: "new-cross-root-thread",
+		};
+		const legacyRef: GoalStoreRef = {
+			baseDir: join(piAgentDir, "extensions", "pi-goal", "no-session", cwdKey),
+			threadId: "old-cross-root-thread",
+		};
+		await writeRawGoalFile(legacyRef, `${JSON.stringify({ version: 1, goal: legacyGoalRecord(legacyRef) })}\n`);
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toMatchObject({ id: "legacy-goal-id", threadId: "old-cross-root-thread" });
 		expect(await readGoal(ref)).toEqual(migrated);
 	});
 
@@ -533,7 +659,9 @@ describe("goal store (budget-free)", () => {
 		expect(migrated).not.toHaveProperty("tokenBudget");
 		expect(await readGoal(ref)).toEqual(migrated);
 		expect(await readFile(goalFilePath(ref), "utf8")).not.toContain("tokenBudget");
-		expect(await readFile(goalFilePath(legacyRef), "utf8")).toContain('"tokenBudget": 512');
+		await expect(readFile(goalFilePath(legacyRef), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await readFile(`${goalFilePath(legacyRef)}.migrated`, "utf8")).toContain('"tokenBudget": 512');
+		expect(await migrateLegacyGoalFile(ref)).toBeNull();
 	});
 
 	it("creates a persisted active goal with no budget field", async () => {

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -24,9 +24,31 @@ async function tempStore(threadId = "thread-test"): Promise<GoalStoreRef> {
 	return { baseDir: join(dir, "extensions", "goal"), threadId };
 }
 
+function legacyStoreRef(ref: GoalStoreRef): GoalStoreRef {
+	return { ...ref, baseDir: join(ref.baseDir, "..", "pi-goal") };
+}
+
 async function writeRawGoalFile(ref: GoalStoreRef, contents: string): Promise<void> {
 	await mkdir(ref.baseDir, { recursive: true });
 	await writeFile(goalFilePath(ref), contents, "utf8");
+}
+
+async function writeLegacyGoalFile(ref: GoalStoreRef, goal: Record<string, unknown> | null): Promise<void> {
+	await writeRawGoalFile(legacyStoreRef(ref), `${JSON.stringify({ version: 1, goal })}\n`);
+}
+
+function legacyGoalRecord(ref: GoalStoreRef, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		id: "legacy-goal-id",
+		threadId: ref.threadId,
+		objective: "Resume the legacy goal",
+		status: "active",
+		tokensUsed: 40,
+		timeUsedSeconds: 8,
+		createdAt: 1,
+		updatedAt: 2,
+		...overrides,
+	};
 }
 
 afterEach(async () => {
@@ -44,6 +66,20 @@ describe("goal store JSON recovery", () => {
 
 		// Then
 		expect(persisted).toEqual(goal);
+	});
+
+	it("preserves an inert token budget in the current goal store", async () => {
+		// Given: current-store goals may carry tokenBudget as inert app-server wire metadata.
+		const ref = await tempStore("thread-current-token-budget");
+		const goal = { ...(await createGoal(ref, "Keep the current token budget")), tokenBudget: 8_192 };
+		await writeGoal(ref, goal);
+
+		// When
+		const persisted = await readGoal(ref);
+
+		// Then: reading the current store never strips the field.
+		expect(persisted).toEqual(goal);
+		expect(persisted?.tokenBudget).toBe(8_192);
 	});
 
 	it("recovers a complete goal file followed by stale closing braces", async () => {
@@ -127,6 +163,208 @@ describe("goal store JSON recovery", () => {
 		// Given
 		const ref = await tempStore("thread-invalid-goal");
 		await writeRawGoalFile(ref, '{"version":1,"goal":{"id":1}}\n}\n');
+
+		// When / Then
+		await expect(readGoal(ref)).rejects.toThrow("goal store contains an invalid goal");
+	});
+});
+
+describe("legacy pi-goal store migration", () => {
+	it("migrates a budgetLimited legacy goal into an active budget-free current goal", async () => {
+		// Given: only a legacy pi-goal file exists, in the removed budget-limited status.
+		const ref = await tempStore("thread-legacy-budget-limited");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref, { status: "budgetLimited", tokenBudget: 100 }));
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then: budget enforcement is dropped, usage metrics survive.
+		expect(migrated).toMatchObject({
+			id: "legacy-goal-id",
+			objective: "Resume the legacy goal",
+			status: "active",
+			tokensUsed: 40,
+			timeUsedSeconds: 8,
+		});
+		expect(migrated).not.toHaveProperty("tokenBudget");
+		expect(await readGoal(ref)).toEqual(migrated);
+	});
+
+	it("migrates the snake_case legacy budget_limited status the same way", async () => {
+		// Given
+		const ref = await tempStore("thread-legacy-budget-limited-snake");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref, { status: "budget_limited", tokenBudget: 7 }));
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated?.status).toBe("active");
+		expect(migrated).not.toHaveProperty("tokenBudget");
+	});
+
+	it("drops a legacy token budget even when the legacy status is already supported", async () => {
+		// Given: legacy budgets are enforcement metadata, so migration must not carry them forward.
+		const ref = await tempStore("thread-legacy-paused-budget");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref, { status: "paused", tokenBudget: 4_096 }));
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated?.status).toBe("paused");
+		expect(migrated).not.toHaveProperty("tokenBudget");
+		expect(await readFile(goalFilePath(ref), "utf8")).not.toContain("tokenBudget");
+	});
+
+	it("sanitizes migrated continuation state", async () => {
+		// Given: legacy continuation bookkeeping may be malformed.
+		const ref = await tempStore("thread-legacy-continuation");
+		await writeLegacyGoalFile(
+			ref,
+			legacyGoalRecord(ref, { consecutiveContinuations: "many", lastContinuationSignature: 42 }),
+		);
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).not.toHaveProperty("consecutiveContinuations");
+		expect(migrated).not.toHaveProperty("lastContinuationSignature");
+		expect(await readGoal(ref)).toEqual(migrated);
+	});
+
+	it("never overwrites an existing current goal with a legacy file", async () => {
+		// Given: both stores exist.
+		const ref = await tempStore("thread-current-wins");
+		const current = await createGoal(ref, "Keep the current goal");
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref, { status: "budgetLimited", tokenBudget: 100 }));
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then: the current store always wins and is left byte-identical.
+		expect(migrated).toBeNull();
+		expect(await readGoal(ref)).toEqual(current);
+	});
+
+	it("leaves an existing current goal that carries an inert token budget untouched", async () => {
+		// Given: current-store wire metadata must survive a migration attempt.
+		const ref = await tempStore("thread-current-wins-budget");
+		const current = { ...(await createGoal(ref, "Keep the budget metadata")), tokenBudget: 2_048 };
+		await writeGoal(ref, current);
+		await writeLegacyGoalFile(ref, legacyGoalRecord(ref, { status: "budgetLimited", tokenBudget: 100 }));
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toBeNull();
+		expect(await readGoal(ref)).toEqual(current);
+		expect((await readGoal(ref))?.tokenBudget).toBe(2_048);
+	});
+
+	it("is a no-op when no legacy file exists", async () => {
+		// Given: a fresh install with neither store populated.
+		const ref = await tempStore("thread-no-legacy");
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then: nothing is created.
+		expect(migrated).toBeNull();
+		expect(await readGoal(ref)).toBeNull();
+		await expect(readdir(ref.baseDir)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("treats a legacy file holding an explicit null goal as nothing to migrate", async () => {
+		// Given
+		const ref = await tempStore("thread-legacy-null");
+		await writeLegacyGoalFile(ref, null);
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toBeNull();
+		expect(await readGoal(ref)).toBeNull();
+	});
+
+	it("keeps the typed unsupported-version error for a legacy file", async () => {
+		// Given
+		const ref = await tempStore("thread-legacy-version");
+		await writeRawGoalFile(legacyStoreRef(ref), '{"version":2,"goal":null}\n');
+
+		// When / Then
+		await expect(migrateLegacyGoalFile(ref)).rejects.toThrow("unsupported goal store version");
+	});
+
+	it("keeps the typed invalid-goal error for a legacy file", async () => {
+		// Given
+		const ref = await tempStore("thread-legacy-invalid");
+		await writeRawGoalFile(legacyStoreRef(ref), '{"version":1,"goal":{"id":1}}\n');
+
+		// When / Then
+		await expect(migrateLegacyGoalFile(ref)).rejects.toThrow("goal store contains an invalid goal");
+	});
+
+	it("finds the legacy store in the no-session fallback layout", async () => {
+		// Given: print/in-memory mode nests the store under no-session/<cwdKey>, so the
+		// legacy sibling is extensions/pi-goal/no-session/<cwdKey>, not a sibling of <cwdKey>.
+		const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
+		tempDirs.push(dir);
+		const cwdKey = "a".repeat(24);
+		const ref: GoalStoreRef = {
+			baseDir: join(dir, "extensions", "goal", "no-session", cwdKey),
+			threadId: "thread-no-session-legacy",
+		};
+		const legacyRef: GoalStoreRef = {
+			...ref,
+			baseDir: join(dir, "extensions", "pi-goal", "no-session", cwdKey),
+		};
+		await writeRawGoalFile(
+			legacyRef,
+			`${JSON.stringify({ version: 1, goal: legacyGoalRecord(ref, { status: "budgetLimited", tokenBudget: 100 }) })}\n`,
+		);
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toMatchObject({ id: "legacy-goal-id", status: "active" });
+		expect(migrated).not.toHaveProperty("tokenBudget");
+		expect(await readGoal(ref)).toEqual(migrated);
+	});
+
+	it("does not treat a pi-goal directory nested inside the current store as legacy state", async () => {
+		// Given: a stray pi-goal directory *inside* the current goal tree must never be
+		// mistaken for the legacy store (the naive dirname swap did exactly this).
+		const dir = await mkdtemp(join(tmpdir(), "senpi-goal-"));
+		tempDirs.push(dir);
+		const ref: GoalStoreRef = {
+			baseDir: join(dir, "extensions", "goal", "no-session", "b".repeat(24)),
+			threadId: "thread-nested-decoy",
+		};
+		await writeRawGoalFile(
+			{ ...ref, baseDir: join(dir, "extensions", "goal", "no-session", "pi-goal") },
+			`${JSON.stringify({ version: 1, goal: legacyGoalRecord(ref, { id: "decoy-goal-id" }) })}\n`,
+		);
+
+		// When
+		const migrated = await migrateLegacyGoalFile(ref);
+
+		// Then
+		expect(migrated).toBeNull();
+		expect(await readGoal(ref)).toBeNull();
+	});
+
+	it("does not resurrect the removed budgetLimited status through the current store reader", async () => {
+		// Given: normalization is migration-only, so a corrupt current file stays invalid.
+		const ref = await tempStore("thread-current-budget-limited");
+		await writeRawGoalFile(
+			ref,
+			`${JSON.stringify({ version: 1, goal: legacyGoalRecord(ref, { status: "budgetLimited" }) })}\n`,
+		);
 
 		// When / Then
 		await expect(readGoal(ref)).rejects.toThrow("goal store contains an invalid goal");


### PR DESCRIPTION
## Summary

Follow-up to #552/#553: the legacy `pi-goal` migration that landed on `main` normalizes **every** current-store read (`parseGoalFile` unconditionally applies `normalizeLegacyGoal`), which strips the inert `tokenBudget` wire-compatibility metadata from current goals and breaks the app-server round-trip contract. This PR intentionally contains only the two focused corrections:

- **`persistence.ts`** — `parseGoalFile(raw, { legacy: true })` gates legacy normalization to the import path only; the legacy directory is derived by replacing the `goal` path segment (`legacyBaseDirFor`), which is correct for both the session layout and the `no-session` fallback; migrated goals are published **without clobbering** an existing destination (destination wins).
- **Tests** — `goal-store.test.ts` + `goal-extension.test.ts` pin migration-only normalization, current-store precedence with inert `tokenBudget`, the `no-session` layout mapping, and destination-wins publication.

## Branch status

The previously published head (`488dd7ad0`) accidentally carried ~100 files from the pre-merge #552 delivery branches, and its CI failed in unrelated app-server/model-catalog tests. The branch has been replaced (force-updated) with the clean reconstruction on current `main` (`f4705697b`): the current head `839b8874f` is a **5-file delta, all in the builtin goal extension** (migration-only normalization + atomic publish + their test updates). Validation on this tree (tree `fb73764c6`):

- `npm run check` (biome + pinned deps + ts-imports + shrinkwrap + tsgo + browser smoke)
- `npm run build`
- Focused suites: `goal-store`, `goal-extension`, `app-server-goal-wire`, `app-server-thread-goal` (**99/99**)
- The four app-server/model-catalog tests that previously failed on the polluted head pass on this tree when no ambient provider credentials are present (**8/8** with API keys unset; CI runs hermetically)
- CI is re-running on the updated head.
