### PR TITLE
docs(changelog): detail changes since v2026.7.31

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- Mark every primary agent-loop model request with `streamKind: "main"`, allowing providers to reserve persistent
+  session state for real conversation turns while treating unlabeled compaction, title, and helper streams as
+  auxiliary one-shot work.
+
 ### Fixed
 
 ### Removed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,9 +6,21 @@
 
 ### Added
 
+- Expose `StreamOptions.streamKind` so provider implementations can distinguish the primary agent loop from
+  auxiliary compaction, title-generation, and helper requests. Main-loop callers opt in explicitly; an absent value
+  remains auxiliary so providers fail safe instead of accidentally retaining one-shot work in a resident session.
+
+- Support `max` reasoning for map-less GPT-5.6 Sol models across OpenAI Responses, Azure OpenAI Responses, Codex
+  Responses, and OpenAI Completions. Explicit `thinkingLevelMap` values remain authoritative: a missing level on a
+  present map stays unavailable, and `null` continues to veto model-ID capability detection.
+
 ### Changed
 
 ### Fixed
+
+- Serialize unavailable Anthropic tool history into non-imitable XML-style records that omit historical call inputs,
+  neutralize case-variant result envelopes, and retain only safe result context plus guidance derived from the tools
+  that are actually available on the current request.
 
 ### Removed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,13 +4,83 @@
 
 ### New Features
 
+- Add the builtin loop guard, which canonicalizes tool-call signatures and detects byte-identical repetitions,
+  high-similarity same-tool runs, and short repeating cycles. It injects one detector-specific system reminder
+  without blocking tool execution, prioritizes identical over cycle over similar matches, and resets after
+  observable progress.
+
+- Make Claude SDK OAuth a native persistent provider lane: deliver Senpi's complete composed system prompt, reuse one
+  resident SDK query per session, serialize turn drains through a single consumer, fence stale generations, and
+  enforce lifecycle and idle bounds while retaining the hardened fallback path.
+
+- Show live elapsed time for active monitor watches in the terminal footer and publish monitor start metadata through
+  RPC state events. Paused-state formatting, the existing width budget, and `+N more` packing remain intact.
+
+- Make `/fast` switch ChatGPT-subscription Codex sessions to the priority service tier, and show a footer bolt for
+  both session-selected priority mode and model-configured `-fast` variants.
+
+- Expose `xhigh` and `max` in the CLI thinking-level cycle for map-less GPT-5.6 Sol models while treating explicit
+  thinking maps as authoritative, so a missing mapped tier or `null` veto is never re-enabled by model-ID heuristics.
+
 ### Breaking Changes
+
+- Rename the SDK-backed Claude subscription provider from `claude-agent-sdk` to `claude-sdk-oauth`, including its
+  provider and model IDs, builtin path, settings key, account storage, TypeScript symbols, documentation, tests, and
+  QA surfaces. Anthropic's upstream package name and platform sidecar names remain unchanged.
 
 ### Added
 
 ### Changed
 
+- Deliver discovered project rules on every agent start and include the complete `## Project Instructions` region on
+  the Claude SDK OAuth lane, rather than silently dropping it after the first turn or rebuilding a partial prompt
+  that omits rules.
+
+- Announce `Optimized system prompt applied: <preset>` only when a real model preset matches. Unmatched models no
+  longer display a misleading `fallback (senpi-current)` preset at startup or after model selection.
+
+- Show a truncated objective and elapsed duration in the achieved-goal footer, and let the release script skip its
+  duplicate local `npm test` gate only when the exact `main` HEAD already has a successful `Check and test` CI run.
+  Lookup failures, non-green checks, and `--force-tests` continue to run the local gate.
+
 ### Fixed
+
+- Harden Claude SDK OAuth session reuse by draining each turn through the terminal SDK result, preserving final usage
+  and stop metadata, scrubbing `SENPI_*` variables from child processes, bounding aborts, applying idle TTL to real
+  usage, and failing closed when the resident transcript or reasoning configuration diverges.
+
+- Prevent unavailable-tool transcript imitation by demoting historical Anthropic calls to safe records and adding a
+  default TTSR detector that interrupts fabricated legacy and current unavailable-tool envelopes. `/ttsr` rule
+  disablement now applies consistently, and removed debug output can no longer corrupt terminal rendering.
+
+- Repair Anthropic `tool_use` / `tool_result` adjacency at the final provider boundary after pruning, interruption,
+  or model switching. Missing results become explicit error results, while misplaced and duplicate results are
+  removed before ordinary user content so Anthropic no longer rejects the request with HTTP 400.
+
+- Route compaction summarization through the active model runtime so extension-registered providers, header-auth
+  providers, and runtime-owned OpenAI remote transports compact through the same working transport as normal agent
+  turns instead of failing with an unregistered-provider or missing-API-key error.
+
+- Make required-compaction recovery durable and chronological: deterministic fallbacks retain the full suffix,
+  queued input preserves global order, recovery fails closed outside required paths, and legacy budget-limited goal
+  state migrates without overriding current-store data.
+
+- Defer idle-compaction application until the next admitted prompt, enforce breaker and per-turn cap guards on
+  blocking routes, admit valid prompts during breaker cooldown, and prevent queue-drain bookkeeping from leaking a
+  false abort state into a later idle session.
+
+- Pause stale goals only for accepted direct input, keep accepted-input goals active, cancel or defer monitor
+  continuations safely, migrate legacy goal stores, and correlate input-disposition events so hidden stale work
+  cannot resume after the user changes direction.
+
+- Make mechanical goal blocks recoverable from both idle and queued user prompts, explain the one-message recovery
+  path, count monitor-delayed continuations toward the durable cap, and clear repetition streaks whenever a turn
+  uses tools or records observable progress.
+
+- Reset exhausted classifier-refusal retry state and emit the matching retry-end event so Escape returns to normal
+  behavior and double-Escape can open Session Tree after a fallback abort.
+
+- Remove internal web-search strategy suffixes from displayed result labels.
 
 ### Removed
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Changed
 
+- Include a live elapsed label in detached `eval` footer status. The ticker updates only when the rendered duration
+  changes and is disposed when the cell completes, fails, or is stopped.
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
## Summary

Audits the complete `v2026.7.31..main` release graph before the next CalVer release and adds detailed package changelog coverage for every user-facing change. The audit reviewed 129 commits: 121 commits across 27 merged pull requests plus eight direct or housekeeping commits.

## Changes

- **AI runtime:** documents stream-role metadata, map-less GPT-5.6 Sol `max` reasoning, and safe unavailable-tool transcript demotion.
- **Agent loop:** documents primary-turn stream marking for providers with resident session state.
- **Coding agent:** documents the loop guard, native persistent Claude SDK OAuth lane, provider rename, live monitor timing, Codex fast tier, project-rule delivery, prompt-preset messaging, compaction and goal recovery fixes, Anthropic tool-pair repair, fallback-abort cleanup, and web-search label cleanup.
- **Codemode:** documents live elapsed timing for detached eval cells.
- Leaves TUI, web UI, server, and PTY changelogs untouched because their only range touch was release scaffolding or no runtime change.

## QA & Evidence

- **Failing-first audit:** all repository-governed `[Unreleased]` sections were empty while the range contained 129 commits.
- **Coverage audit:** all 27 merged PRs are classified; 23 map to changelog behavior and four are policy-allowed CI/test/infrastructure skips. All eight direct commits are individually classified.
- **Document validation:** `git diff --check` passes; each changed changelog contains exactly one ordered `[Unreleased]` block with non-empty entries.
- **Scope check:** four changelog files only, 89 inserted lines, no released section edited.

## Risks & Residuals

- The five delegated audit lanes encountered provider quota/server failures and were closed as inconclusive; they are not counted as approval. The parent audit independently inspected the complete git graph, PR commit lists, changed paths, PR bodies, and relevant direct diffs.
- No runtime code changes are included, so runtime QA is not required for this documentation-only PR.

## Release Range

- Base tag: `v2026.7.31`
- Audited head: `f44d1d873`
- Changelog commit: `6c18e3ed1`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audit and update changelogs for all user-facing work since `v2026.7.31` across `packages/ai`, `packages/agent`, `packages/coding-agent`, and `packages/senpi-codemode`. Docs-only; no runtime code changes.

- **New Features**
  - Expose `StreamOptions.streamKind` and mark primary agent-loop requests as `streamKind: "main"`.
  - Add `max` reasoning for map-less `GPT-5.6 Sol`; CLI adds `xhigh`/`max` tiers when allowed.
  - Coding agent updates: loop guard; native persistent Claude SDK OAuth lane (renamed to `claude-sdk-oauth` from `claude-agent-sdk`); `/fast` Codex tier; live monitor timing. Codemode: elapsed label for detached evals.

- **Bug Fixes**
  - Safely serialize unavailable Anthropic tool history and block transcript imitation.
  - Fix Anthropic `tool_use`/`tool_result` pairing; compact via active runtime; sturdier compaction and goal recovery.
  - Improve preset messages, session reuse and fencing, stale-goal handling, retry resets, and clean web-search labels.

<sup>Written for commit 6c18e3ed1d44f389b9d915f6abe05c26b0c6ee44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

