### PR TITLE
feat(prompt-preset): add DeepSeek V4 flash, flash-0731, and pro presets

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -84,7 +84,7 @@ Permission rules are a confirmation policy, not a sandbox. Senpi, extensions, pa
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
-| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"kimi-k3"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, `"gpt-5.5"`, or `"gpt-5.6"` |
+| `promptPreset` | string | `"auto"` | Force a system prompt preset: `"auto"`, `"kimi-k2-6"`, `"kimi-k2-7"`, `"kimi-k3"`, `"glm-5.2"`, `"claude-fable-5"`, `"claude-opus-5"`, `"claude-opus-4-5"`, `"claude-opus-4-6"`, `"claude-opus-4-7"`, `"claude-opus-4-8"`, `"deepseek-v4-flash"`, `"deepseek-v4-flash-0731"`, `"deepseek-v4-pro"`, `"gpt-5"`, `"gpt-5.2"`, `"gpt-5.3-codex"`, `"gpt-5.4"`, `"gpt-5.5"`, or `"gpt-5.6"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -9,7 +9,7 @@
 | 1 | `hooks` | `hooks/` | Settings-configured lifecycle command hooks (PreToolUse/PostToolUse-style) with trust hashing + live status |
 | 2 | `permission-system` | `permission-system/` | Full opencode-style permission port: rules, JSONL storage, prompts |
 | 3 | `gpt-apply-patch` | `gpt-apply-patch/` | Codex-style `apply_patch` tool with rich render + freeform grammar |
-| 4 | `prompt-preset` | `prompt-preset/` | Per-model system prompts (gpt-5.x, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3) |
+| 4 | `prompt-preset` | `prompt-preset/` | Per-model system prompts (gpt-5.x, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, deepseek-v4-{flash,flash-0731,pro}, kimi-k2-{6,7}, kimi-k3) |
 | 5 | `todowrite` | `todotools/` | Op-based oh-my-pi todo port + `/todo` command; fully diverged from `../pi-extensions/pi-todotools` |
 | 6 | `redraws` | `redraws.ts` | Force-redraw event hooks for stable streaming visuals |
 | 7 | `anthropic-web-search` | `anthropic-web-search/` | Anthropic-native web search tool |
@@ -48,7 +48,7 @@ Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by
 
 - **Subdirectory extensions** ship multi-file: `index.ts` + supporting `.ts` (`registry.ts`, `types.ts`, `parsers.ts`, etc.).
 - **Single-file extensions** are kept flat (`diff.ts`, `files.ts`, `redraws.ts`, `service-tier.ts`, `tps.ts`, `prompt-url-widget.ts`).
-- **`prompt-preset/`** has per-model files (`gpt-5.5.ts`, `claude-opus-4-7.ts`, …) and a shared `file-operations.ts` tuning block. New model = new preset file + entry in `presets.ts`. Models covered: gpt-5.x, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3.
+- **`prompt-preset/`** has per-model files (`gpt-5.5.ts`, `claude-opus-4-7.ts`, …) and a shared `file-operations.ts` tuning block. New model = new preset file + entry in `presets.ts`. Models covered: gpt-5.x, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, deepseek-v4-{flash,flash-0731,pro}, kimi-k2-{6,7}, kimi-k3.
 - **`permission-system/` is a full port** of opencode's permission flow.
 - **`compaction/`** is policy-rich (`policy.ts`, `speculative.ts`, `restoration-tracker.ts`, `circuit-breaker.ts`, `degradation-monitor.ts`, `per-turn-cap.ts`, `tool-truncation.ts`, `checkpoint-state.ts`, `context-reduction.ts`, `openai-remote.ts`, `repair-tool-pairs.ts`, `state.ts`, `todo-bridge.ts`, `prompts.ts`). Touch only with policy tests in lock-step.
 - **External versions**: `external-versions.json` pins versions of sibling `../pi-extensions` packages used as vendored builtins; refresh with `packages/coding-agent/scripts/sync-builtin-extensions.mjs`.

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/prompt-preset
 
-Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
+Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, deepseek-v4-{flash,flash-0731,pro}, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
 
 ## FILES
 
@@ -24,6 +24,10 @@ prompt-preset/
 ├── claude-opus-4-7.ts   # Claude Opus 4.7 preset
 ├── claude-opus-4-8.ts   # Claude Opus 4.8 preset
 ├── glm-5-2.ts           # GLM 5.2 preset
+├── deepseek-v4.ts       # Shared DeepSeek V4 rule data (`DEEPSEEK_V4_RULES`) + tuning builders (directive authority, todo discipline, missing-info, settled-reading, reasoning-aim)
+├── deepseek-v4-flash.ts # DeepSeek V4 Flash preset (thin tuningSection over the shared core)
+├── deepseek-v4-flash-0731.ts # DeepSeek V4 Flash 0731 snapshot preset — dated snapshot resolves before the generic flash alias
+├── deepseek-v4-pro.ts   # DeepSeek V4 Pro preset (deep-reasoner calibration)
 ├── kimi-k2-6.ts         # Kimi K2.6 preset
 ├── kimi-k2-7.ts         # Kimi K2.7 preset
 ├── kimi-k3.ts           # Kimi K3 preset — full-core rewrite via `corePrompt` (K3 tuning merged into a leaner Kimi-shaped core; K2-family loop discipline + Opus 4.8/Fable 5 distillation traits) + binding stop contract (declared stop condition in the routing line)

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,26 @@
 # prompt-preset Extension Changes
 
+## DeepSeek V4 presets: flash, flash-0731, pro (2026-07-31)
+
+### What changed
+
+- New presets `deepseek-v4-flash`, `deepseek-v4-flash-0731`, and `deepseek-v4-pro`: thin `tuningSection` wrappers over the shared dynamic core (post-2026-04-30 architecture), with the family's shared behavior carried as typed rule data in `deepseek-v4.ts` (`DEEPSEEK_V4_RULES`, gpt-5.6 `GPT56_EXECUTION_RULES` precedent). Rules: `injected-directive-authority` + `todo-discipline` + `missing-info` (all three presets), `settled-reading` (flash line), `reasoning-aim` (pro). Workstation dialect: `claude`.
+- `presets.ts`: three matchers on normalized id OR display name with `[/@:._-]` boundaries, verified against the OpenRouter live API, models.dev, and senpi's generated catalogs (official `deepseek-v4-flash`/`deepseek-v4-pro`, OpenRouter `deepseek/deepseek-v4-flash-0731`, HF-style `deepseek-ai/DeepSeek-V4-*`, fireworks `accounts/fireworks/models/deepseek-v4-*`, aihubmix `alicloud-`/`deep-` prefixes, trailing `:free`/`-free`/`:thinking`/`-nothinking`/`-cheaper`/`-lightning`/`-el` tags). The dated 0731 snapshot resolves before the generic flash alias.
+- `settings.ts`: `PromptPresetName` + `VALID_PRESETS` gain the three names; `docs/settings.md` value list updated.
+- `test/suite/prompt-presets-deepseek-v4.test.ts` (new): table-driven matcher cases from the researched real-world ID shapes, a catalog sweep asserting zero misses across every built-in catalog model with a DeepSeek V4 signal, rule-data placement (each directive rendered exactly once per owning preset, zero leakage into kimi-k3 / gpt-5.6 / glm-5.2), and settings-override coverage.
+
+### Why
+
+- DeepSeek-V4-Flash-0731 running senpi's fallback prompt showed reproducible failure modes: it audits the provenance of harness-injected directives ("the user didn't say ulw-loop... probably residual context"), downsizes mandated workflows as too heavy, oscillates on settled readings ("Actually wait - let me reconsider"), and never updates the todo list. Each rule replaces one of those trained priors with a positive decision rule; the chat-deep.ai DeepSeek prompt guide's structure-compliance findings motivated keeping the presets as decision-rule tuning over the shared structured core rather than a full-core rewrite.
+
+### Why extension system couldn't handle this differently
+
+- Entirely inside the builtin `prompt-preset` extension; no core prompt code changed.
+
+### Expected merge conflict zones on next upstream sync
+
+- NONE expected: `deepseek-v4*.ts` and `prompt-presets-deepseek-v4.test.ts` are fork-only files. `presets.ts`/`settings.ts` additions sit in fork-owned lists that upstream does not carry.
+
 ## Preset messaging: optimized-prompt wording, silent fallback (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4-flash-0731.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4-flash-0731.ts
@@ -1,0 +1,13 @@
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+import { buildDeepseekV4FlashIntro, buildDeepseekV4Tuning } from "./deepseek-v4.ts";
+
+export function buildDeepseekV4Flash0731Prompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildDeepseekV4Tuning(
+			"deepseek-v4-flash-0731",
+			buildDeepseekV4FlashIntro("DeepSeek V4 Flash (0731 snapshot)"),
+		),
+		workstationDialect: "claude",
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4-flash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4-flash.ts
@@ -1,0 +1,10 @@
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+import { buildDeepseekV4FlashIntro, buildDeepseekV4Tuning } from "./deepseek-v4.ts";
+
+export function buildDeepseekV4FlashPrompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildDeepseekV4Tuning("deepseek-v4-flash", buildDeepseekV4FlashIntro("DeepSeek V4 Flash")),
+		workstationDialect: "claude",
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4-pro.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4-pro.ts
@@ -1,0 +1,13 @@
+import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
+import { buildDeepseekV4Tuning } from "./deepseek-v4.ts";
+
+const PRO_INTRO =
+	"You are running on DeepSeek V4 Pro - a deep reasoner with a decisive finish. Reasoning depth is a budget spent on the problem, not a ritual: routine classification, file edits, and lookups are decided directly, while hard design and debugging work gets the full depth.";
+
+export function buildDeepseekV4ProPrompt(options: BuildDynamicSystemPromptOptions): string {
+	return buildDynamicSystemPrompt({
+		...options,
+		tuningSection: buildDeepseekV4Tuning("deepseek-v4-pro", PRO_INTRO),
+		workstationDialect: "claude",
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4.ts
@@ -1,0 +1,86 @@
+// Shared DeepSeek V4 family tuning.
+//
+// DeepSeek V4 is a structure-follower: the chat-deep.ai prompt guide's live
+// benchmark (2026-07-28) measured explicit task/constraint/verification
+// structure lifting compliance from 7.1/10 to 9.6/10, and DeepSeek's own docs
+// route behavior through settings, not incantations. The presets therefore
+// stay thin tuningSection wrappers over the shared dynamic core and carry only
+// trained-prior overrides, stated once each as typed rule data (gpt-5.6.ts
+// precedent) so tests assert parsed rules instead of pinned sentences.
+//
+// The overrides come from observed failure transcripts on
+// DeepSeek-V4-Flash-0731 (2026-07-31): the model audits the provenance of
+// harness-injected directives ("the user didn't say ulw-loop... probably
+// residual context"), downsizes mandated workflows as too heavy, oscillates on
+// settled readings ("Actually wait - let me reconsider"), and never updates
+// the todo list. Each rule replaces that prior with a positive decision rule
+// and a terminal condition; none of them restate behavior the shared core
+// already carries.
+
+export type DeepseekV4RuleId =
+	| "injected-directive-authority"
+	| "todo-discipline"
+	| "missing-info"
+	| "settled-reading"
+	| "reasoning-aim";
+
+export type DeepseekV4Concern = "harness-contract" | "todo" | "grounding" | "deliberation";
+
+export type DeepseekV4PresetName = "deepseek-v4-flash" | "deepseek-v4-flash-0731" | "deepseek-v4-pro";
+
+export interface DeepseekV4Rule {
+	readonly id: DeepseekV4RuleId;
+	readonly concern: DeepseekV4Concern;
+	readonly presets: readonly DeepseekV4PresetName[];
+	readonly directive: string;
+}
+
+const ALL_PRESETS: readonly DeepseekV4PresetName[] = ["deepseek-v4-flash", "deepseek-v4-flash-0731", "deepseek-v4-pro"];
+const FLASH_LINE: readonly DeepseekV4PresetName[] = ["deepseek-v4-flash", "deepseek-v4-flash-0731"];
+
+export const DEEPSEEK_V4_RULES: readonly DeepseekV4Rule[] = [
+	{
+		id: "injected-directive-authority",
+		concern: "harness-contract",
+		presets: ALL_PRESETS,
+		directive:
+			'Injected directives are binding: skill contents, mode directives such as ultrawork or ulw-loop, and hook or system messages that appear in the conversation carry the same authority as words the user typed. Presence means it applies to the current task at its prescribed weight - the harness already decided by injecting it. Whether it was "really requested", is "residual context", or feels "too heavy" for the task are settled questions: spend zero reasoning on them and execute the directive as written.',
+	},
+	{
+		id: "todo-discipline",
+		concern: "todo",
+		presets: ALL_PRESETS,
+		directive:
+			"On any multi-step task, write the todo list before the first edit and keep it live: one atomic item per step, exactly one item in progress, and each item marked completed the moment it finishes. Update the list at every state transition - never batch updates at the end, and never work a step the list does not show. A todo list that lags reality is a defect to fix before continuing, not an optimization to skip.",
+	},
+	{
+		id: "missing-info",
+		concern: "grounding",
+		presets: ALL_PRESETS,
+		directive:
+			"When required information is missing, name it and get it - a file read, a tool call, or one specific question - instead of inventing it.",
+	},
+	{
+		id: "settled-reading",
+		concern: "deliberation",
+		presets: FLASH_LINE,
+		directive:
+			'Commit to one reading and act on it: once you settle an interpretation of the request or an instruction, reopen it only when a tool result contradicts it. "Wait, let me reconsider" loops over the same evidence add no information - decide, verify with a cheap tool call, and move on.',
+	},
+	{
+		id: "reasoning-aim",
+		concern: "deliberation",
+		presets: ["deepseek-v4-pro"],
+		directive:
+			"Aim extended reasoning at the problem - the code, the design, the failure - and end it in an action. When reasoning stalls on a missing fact, stop deliberating and fetch the fact; a cheap read beats a long internal debate. Deliver a conclusion and a recommendation, not a survey of options.",
+	},
+];
+
+export function buildDeepseekV4FlashIntro(modelLabel: string): string {
+	return `You are running on ${modelLabel} - fast, literal, and structure-first. Read instructions as decision rules: literal scopes are literal ("every", "all", and "each" mean the full set), mechanical or already-specified work is executed directly, and deliberation is saved for genuine risk - ambiguity, failure, irreversible operations.`;
+}
+
+export function buildDeepseekV4Tuning(preset: DeepseekV4PresetName, intro: string): string {
+	const directives = DEEPSEEK_V4_RULES.filter((rule) => rule.presets.includes(preset)).map((rule) => rule.directive);
+	return [intro, ...directives].join("\n\n");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -6,6 +6,9 @@ import { buildClaudeOpus46Prompt } from "./claude-opus-4-6.ts";
 import { buildClaudeOpus47Prompt } from "./claude-opus-4-7.ts";
 import { buildClaudeOpus48Prompt } from "./claude-opus-4-8.ts";
 import { buildClaudeOpus5Prompt } from "./claude-opus-5.ts";
+import { buildDeepseekV4FlashPrompt } from "./deepseek-v4-flash.ts";
+import { buildDeepseekV4Flash0731Prompt } from "./deepseek-v4-flash-0731.ts";
+import { buildDeepseekV4ProPrompt } from "./deepseek-v4-pro.ts";
 import { buildGlm52Prompt } from "./glm-5-2.ts";
 import { buildGpt52Prompt } from "./gpt-5.2.ts";
 import { buildGpt53CodexPrompt } from "./gpt-5.3-codex.ts";
@@ -81,6 +84,37 @@ function hasKimiK3Signal(value: string): boolean {
 
 function isKimiK3Model(model: ModelWithPromptPresetMetadata): boolean {
 	return hasKimiK3Signal(model.id) || (model.name !== undefined && hasKimiK3Signal(model.name));
+}
+
+// DeepSeek V4 id shapes verified against the OpenRouter live API, models.dev,
+// and senpi's generated provider catalogs (2026-07-31): deepseek-v4-flash,
+// deepseek/deepseek-v4-flash-0731, deepseek-ai/DeepSeek-V4-Pro,
+// accounts/fireworks/models/deepseek-v4-flash, aihubmix's alicloud-deepseek-v4-*,
+// and trailing tags (:free, -free, :thinking, -nothinking, -cheaper, -lightning, -el).
+function hasDeepseekV4Flash0731Signal(value: string): boolean {
+	return /(?:^|[/@:._-])deepseek[._-]v4[._-]flash[._-]0731(?:$|[/@:._-])/.test(normalizeModelId(value));
+}
+
+function isDeepseekV4Flash0731Model(model: ModelWithPromptPresetMetadata): boolean {
+	return (
+		hasDeepseekV4Flash0731Signal(model.id) || (model.name !== undefined && hasDeepseekV4Flash0731Signal(model.name))
+	);
+}
+
+function hasDeepseekV4FlashSignal(value: string): boolean {
+	return /(?:^|[/@:._-])deepseek[._-]v4[._-]flash(?:$|[/@:._-])/.test(normalizeModelId(value));
+}
+
+function isDeepseekV4FlashModel(model: ModelWithPromptPresetMetadata): boolean {
+	return hasDeepseekV4FlashSignal(model.id) || (model.name !== undefined && hasDeepseekV4FlashSignal(model.name));
+}
+
+function hasDeepseekV4ProSignal(value: string): boolean {
+	return /(?:^|[/@:._-])deepseek[._-]v4[._-]pro(?:$|[/@:._-])/.test(normalizeModelId(value));
+}
+
+function isDeepseekV4ProModel(model: ModelWithPromptPresetMetadata): boolean {
+	return hasDeepseekV4ProSignal(model.id) || (model.name !== undefined && hasDeepseekV4ProSignal(model.name));
 }
 
 function hasGlm52Signal(value: string): boolean {
@@ -167,6 +201,16 @@ export function resolvePresetName(
 	if (isGlm52Model(model)) {
 		return "glm-5.2";
 	}
+	// The dated snapshot must resolve before the generic flash alias.
+	if (isDeepseekV4Flash0731Model(model)) {
+		return "deepseek-v4-flash-0731";
+	}
+	if (isDeepseekV4FlashModel(model)) {
+		return "deepseek-v4-flash";
+	}
+	if (isDeepseekV4ProModel(model)) {
+		return "deepseek-v4-pro";
+	}
 	if (isGrok45Model(model)) {
 		return "grok-4.5";
 	}
@@ -189,6 +233,12 @@ function buildPreset(name: ResolvedPresetName, options: BuildDynamicSystemPrompt
 			return { name, prompt: buildGpt5Prompt(options) };
 		case "glm-5.2":
 			return { name, prompt: buildGlm52Prompt(options) };
+		case "deepseek-v4-flash":
+			return { name, prompt: buildDeepseekV4FlashPrompt(options) };
+		case "deepseek-v4-flash-0731":
+			return { name, prompt: buildDeepseekV4Flash0731Prompt(options) };
+		case "deepseek-v4-pro":
+			return { name, prompt: buildDeepseekV4ProPrompt(options) };
 		case "grok-4.5":
 			return { name, prompt: buildGrok45Prompt(options) };
 		case "kimi-k3":

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/settings.ts
@@ -8,6 +8,9 @@ export type PromptPresetName =
 	| "claude-opus-4-7"
 	| "claude-opus-4-6"
 	| "claude-opus-4-5"
+	| "deepseek-v4-flash"
+	| "deepseek-v4-flash-0731"
+	| "deepseek-v4-pro"
 	| "glm-5.2"
 	| "grok-4.5"
 	| "kimi-k3"
@@ -34,6 +37,9 @@ const VALID_PRESETS: ReadonlySet<string> = new Set<PromptPresetName>([
 	"claude-opus-4-7",
 	"claude-opus-4-6",
 	"claude-opus-4-5",
+	"deepseek-v4-flash",
+	"deepseek-v4-flash-0731",
+	"deepseek-v4-pro",
 	"glm-5.2",
 	"grok-4.5",
 	"kimi-k3",

--- a/packages/coding-agent/test/suite/prompt-presets-deepseek-v4.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-deepseek-v4.test.ts
@@ -1,0 +1,299 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import {
+	DEEPSEEK_V4_RULES,
+	type DeepseekV4PresetName,
+} from "../../src/core/extensions/builtin/prompt-preset/deepseek-v4.ts";
+import {
+	type PromptPresetSettings,
+	resolvePreset,
+	resolvePresetName,
+} from "../../src/core/extensions/builtin/prompt-preset/presets.ts";
+
+function createModel(id: string, provider: string, api: Api = "openai-completions"): Model<Api> {
+	return {
+		id,
+		name: id,
+		api,
+		provider,
+		baseUrl: "https://example.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	};
+}
+
+// Real-world ID shapes verified against the OpenRouter live API, models.dev
+// (opencode), and senpi's own generated provider catalogs on 2026-07-31.
+const FLASH_MODEL_IDS = [
+	"deepseek-v4-flash", // DeepSeek official API, alibaba/qwen token plans, azure, opencode
+	"deepseek/deepseek-v4-flash", // OpenRouter, vercel-ai-gateway, novita
+	"deepseek-ai/DeepSeek-V4-Flash", // huggingface, deepinfra, siliconflow
+	"deepseek-ai/deepseek-v4-flash", // nvidia
+	"accounts/fireworks/models/deepseek-v4-flash", // fireworks
+	"alicloud-deepseek-v4-flash", // aihubmix (alibaba route)
+	"deep-deepseek-v4-flash", // aihubmix (deepseek route)
+	"cline-pass/deepseek-v4-flash",
+	"deepseek-v4-flash:free", // kenari, unorouter
+	"deepseek-v4-flash-free", // opencode free tier
+	"deepseek/deepseek-v4-flash:thinking", // nano-gpt
+	"deepseek-v4-flash-nothinking", // ds2api-style gateways
+	"empiriolabs/deepseek-v4-flash-el", // poe
+	"DeepSeek-V4-Flash", // ebcloud
+	"DeepSeek V4 Flash", // display-name matching
+];
+
+const FLASH_0731_MODEL_IDS = [
+	"deepseek/deepseek-v4-flash-0731", // OpenRouter dated snapshot
+	"deepseek-v4-flash-0731", // aggregator pricing catalogs
+	"deepseek-ai/DeepSeek-V4-Flash-0731", // HF-style snapshot
+	"DeepSeek V4 Flash 0731", // display-name matching
+];
+
+const PRO_MODEL_IDS = [
+	"deepseek-v4-pro", // DeepSeek official API, digitalocean, venice
+	"deepseek/deepseek-v4-pro", // OpenRouter, vercel-ai-gateway
+	"deepseek-ai/DeepSeek-V4-Pro", // huggingface, together, nebius
+	"accounts/fireworks/models/deepseek-v4-pro", // fireworks
+	"TEE/deepseek-v4-pro:thinking", // nano-gpt TEE
+	"deepseek/deepseek-v4-pro-cheaper:thinking", // nano-gpt
+	"deepseek-v4-pro-lightning", // crof
+	"deepseek-v4-pro-nothinking", // ds2api-style gateways
+	"deepseek-v4-pro:free", // unorouter
+	"DeepSeek V4 Pro", // display-name matching
+];
+
+const NON_MATCHING_MODEL_IDS = [
+	"deepseek-v3.2",
+	"deepseek/deepseek-chat-v3-0324",
+	"deepseek/deepseek-chat",
+	"deepseek/deepseek-r1-0528",
+	"deepseek.v3-v1:0", // bedrock
+	"deepseek-v4", // no variant
+	"v4-flash", // no deepseek signal
+	"mimo-v2-pro",
+	"some-deepseek-router",
+];
+
+function hasFlash0731Signal(searchable: string): boolean {
+	return /(?:^|[/@:._-])deepseek[._-]v4[._-]flash[._-]0731(?:$|[/@:._-])/.test(searchable);
+}
+
+function hasFlashSignal(searchable: string): boolean {
+	return /(?:^|[/@:._-])deepseek[._-]v4[._-]flash(?:$|[/@:._-])/.test(searchable);
+}
+
+function hasProSignal(searchable: string): boolean {
+	return /(?:^|[/@:._-])deepseek[._-]v4[._-]pro(?:$|[/@:._-])/.test(searchable);
+}
+
+function expectedCatalogPreset(model: Model<Api>): string | undefined {
+	const searchable = `${model.id} ${model.name}`.toLowerCase().replace(/\s+/g, "-");
+	if (hasFlash0731Signal(searchable)) {
+		return "deepseek-v4-flash-0731";
+	}
+	if (hasFlashSignal(searchable)) {
+		return "deepseek-v4-flash";
+	}
+	if (hasProSignal(searchable)) {
+		return "deepseek-v4-pro";
+	}
+	return undefined;
+}
+
+function getDeepseekV4CatalogModels(): Array<{ model: Model<Api>; expected: string }> {
+	return getProviders().flatMap((provider) =>
+		(getModels(provider) as Model<Api>[])
+			.map((model) => ({ model, expected: expectedCatalogPreset(model) }))
+			.filter((entry): entry is { model: Model<Api>; expected: string } => entry.expected !== undefined),
+	);
+}
+
+describe("DeepSeek V4 prompt presets", () => {
+	it.each(FLASH_MODEL_IDS)("resolves %s to the deepseek-v4-flash preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "openrouter");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("deepseek-v4-flash");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt).not.toContain("apply_patch");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it.each(FLASH_0731_MODEL_IDS)("resolves %s to the deepseek-v4-flash-0731 preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "openrouter");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("deepseek-v4-flash-0731");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it.each(PRO_MODEL_IDS)("resolves %s to the deepseek-v4-pro preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "openrouter");
+
+		// when
+		const preset = resolvePreset(model, settings);
+
+		// then
+		expect(preset?.name).toBe("deepseek-v4-pro");
+		expect(preset?.prompt).toContain("You are senpi");
+		expect(preset?.prompt.length).toBeGreaterThan(2_000);
+	});
+
+	it.each(NON_MATCHING_MODEL_IDS)("does not route %s to any deepseek-v4 preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "openrouter");
+
+		// when
+		const name = resolvePresetName(model, settings);
+
+		// then
+		expect(name === undefined || !name.startsWith("deepseek")).toBe(true);
+	});
+
+	it("matches by display name when the raw id carries no signal", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = { ...createModel("gateway-alias-77", "custom"), name: "DeepSeek V4 Flash 0731" };
+
+		// when
+		const name = resolvePresetName(model, settings);
+
+		// then
+		expect(name).toBe("deepseek-v4-flash-0731");
+	});
+
+	it.each(["deepseek-v4-flash", "deepseek-v4-flash-0731", "deepseek-v4-pro"] as const)(
+		"allows settings.json to force %s regardless of model id",
+		(presetName) => {
+			// given
+			const settings = { promptPreset: presetName } as PromptPresetSettings;
+			const model = createModel("some-random-model", "custom");
+
+			// when
+			const preset = resolvePreset(model, settings);
+
+			// then
+			expect(preset?.name).toBe(presetName);
+		},
+	);
+
+	it("returns the correct preset for every DeepSeek V4 built-in catalog model", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const catalogEntries = getDeepseekV4CatalogModels();
+		const catalogModelIds = catalogEntries.map(({ model }) => `${model.provider}/${model.id}`);
+
+		// when
+		const misses = catalogEntries
+			.filter(({ model, expected }) => resolvePresetName(model, settings) !== expected)
+			.map(({ model, expected }) => `${model.provider}/${model.id} != ${expected}`);
+
+		// then
+		expect(catalogModelIds).toEqual(
+			expect.arrayContaining([
+				"deepseek/deepseek-v4-flash",
+				"deepseek/deepseek-v4-pro",
+				"openrouter/deepseek/deepseek-v4-flash-0731",
+				"openrouter/deepseek/deepseek-v4-flash",
+				"openrouter/deepseek/deepseek-v4-pro",
+				"opencode/deepseek-v4-flash-free",
+				"huggingface/deepseek-ai/DeepSeek-V4-Flash",
+				"together/deepseek-ai/DeepSeek-V4-Pro",
+			]),
+		);
+		expect(misses).toEqual([]);
+	});
+});
+
+function countOccurrences(haystack: string, needle: string): number {
+	let count = 0;
+	let index = haystack.indexOf(needle);
+	while (index !== -1) {
+		count += 1;
+		index = haystack.indexOf(needle, index + needle.length);
+	}
+	return count;
+}
+
+function buildPresetPrompt(presetName: DeepseekV4PresetName): string {
+	const settings = { promptPreset: presetName } as PromptPresetSettings;
+	const preset = resolvePreset(createModel("any-model", "custom"), settings);
+	if (!preset) {
+		throw new Error(`preset ${presetName} did not resolve`);
+	}
+	return preset.prompt;
+}
+
+describe("DeepSeek V4 rule data", () => {
+	const presetNames: readonly DeepseekV4PresetName[] = [
+		"deepseek-v4-flash",
+		"deepseek-v4-flash-0731",
+		"deepseek-v4-pro",
+	];
+
+	it("keeps the rule set well-formed", () => {
+		const ids = DEEPSEEK_V4_RULES.map((rule) => rule.id);
+		expect(new Set(ids).size).toBe(ids.length);
+		for (const rule of DEEPSEEK_V4_RULES) {
+			expect(rule.presets.length).toBeGreaterThan(0);
+			expect(rule.directive.length).toBeGreaterThan(80);
+		}
+		// The documented 0731 failure modes each have an owning rule on the 0731 preset.
+		const on0731 = DEEPSEEK_V4_RULES.filter((rule) => rule.presets.includes("deepseek-v4-flash-0731"));
+		const concerns = new Set(on0731.map((rule) => rule.concern));
+		expect(concerns.has("harness-contract")).toBe(true);
+		expect(concerns.has("todo")).toBe(true);
+		expect(concerns.has("deliberation")).toBe(true);
+	});
+
+	it.each(presetNames)("renders every owning rule exactly once in %s", (presetName) => {
+		// given
+		const prompt = buildPresetPrompt(presetName);
+
+		// then
+		for (const rule of DEEPSEEK_V4_RULES) {
+			const expected = rule.presets.includes(presetName) ? 1 : 0;
+			expect(countOccurrences(prompt, rule.directive), `${rule.id} in ${presetName}`).toBe(expected);
+		}
+	});
+
+	it("differentiates the 0731 snapshot prompt from the generic flash prompt", () => {
+		expect(buildPresetPrompt("deepseek-v4-flash-0731")).not.toBe(buildPresetPrompt("deepseek-v4-flash"));
+	});
+
+	it("does not leak DeepSeek rules into other presets", () => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const otherPrompts = [
+			resolvePreset(createModel("kimi-k3", "moonshot"), settings)?.prompt,
+			resolvePreset(createModel("gpt-5.6-sol", "openai"), settings)?.prompt,
+			resolvePreset(createModel("glm-5.2", "zai"), settings)?.prompt,
+		];
+
+		// then
+		for (const prompt of otherPrompts) {
+			expect(prompt).toBeDefined();
+			for (const rule of DEEPSEEK_V4_RULES) {
+				expect(prompt).not.toContain(rule.directive);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds model-optimized system prompt presets for the DeepSeek V4 family: `deepseek-v4-flash`, `deepseek-v4-flash-0731`, and `deepseek-v4-pro`.

Presets are thin `tuningSection` wrappers over the shared dynamic core (post-2026-04-30 architecture). Family behavior ships as typed rule data in `deepseek-v4.ts` (`DEEPSEEK_V4_RULES`, `GPT56_EXECUTION_RULES` precedent):

| Rule | Concern | Presets |
|---|---|---|
| `injected-directive-authority` | harness-contract | all three |
| `todo-discipline` | todo | all three |
| `missing-info` | grounding | all three |
| `settled-reading` | deliberation | flash, flash-0731 |
| `reasoning-aim` | deliberation | pro |

These target reproducible DeepSeek-V4-Flash-0731 failure modes observed under the fallback prompt: auditing the provenance of harness-injected directives ("the user didn't say ulw-loop... probably residual context"), downsizing mandated workflows as "too heavy", oscillating reconsideration loops ("Actually wait - let me reconsider"), and a never-updated todo list. Prompt shape follows the chat-deep.ai DeepSeek guide findings (structure-follower; decision rules over incantations).

## Model matching

Matchers were verified against the OpenRouter live `/api/v1/models` payload, `models.dev/api.json` (113 DeepSeek V4 entries), and senpi's own generated provider catalogs:

- official `deepseek-v4-flash` / `deepseek-v4-pro` (the flash alias currently serves the 0731 weights per DeepSeek's API news)
- OpenRouter `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash-0731`, `deepseek/deepseek-v4-pro`
- HF-style `deepseek-ai/DeepSeek-V4-{Flash,Pro}` (huggingface, deepinfra, siliconflow, nvidia, together...)
- fireworks `accounts/fireworks/models/deepseek-v4-*`, aihubmix `alicloud-`/`deep-` prefixes
- trailing tags `:free`, `-free`, `:thinking`, `-nothinking`, `-cheaper`, `-lightning`, `-el`, and display names ("DeepSeek V4 Flash 0731")

The dated 0731 snapshot resolves before the generic flash alias. Negatives (v3.2, r1, deepseek-chat, bedrock v3, bare `v4-flash`) stay unmatched.

## Tests (RED -> GREEN)

- `test/suite/prompt-presets-deepseek-v4.test.ts` written first: RED 34 failed / 9 passed, GREEN 49/49.
- Table-driven matcher cases from the researched ID shapes + catalog sweep asserting zero misses across every built-in catalog model with a DeepSeek V4 signal (incl. `openrouter/deepseek/deepseek-v4-flash-0731` -> `deepseek-v4-flash-0731`).
- Rule-data placement: each directive renders exactly once per owning preset; zero leakage into kimi-k3 / gpt-5.6 / glm-5.2. Mutation-proofed (narrowing `FLASH_LINE` fails the suite; restore passes).
- Full preset family: 11 test files, 208/208. Root `npm run check`: exit 0.

## QA evidence (senpi-qa)

Saved under `local-ignore/qa-evidence/20260731-deepseek-v4-presets/` (gitignored):

- Wire-level driver on the harness lib (real CLI from source via tsx, fake model server, hermetic sandbox): 29/29 PASS - recorded wire requests show each model id receives its owning directives and the control `mock-model` receives none.
- TUI driver (tmux): header `Optimized system prompt applied: deepseek-v4-flash-0731` captured, session torn down, real auth.json guard unchanged.

## Docs

- `prompt-preset/changes.md` fork entry, `prompt-preset/AGENTS.md` + `builtin/AGENTS.md` family tables, `docs/settings.md` `promptPreset` value list.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DeepSeek V4 system prompt presets to improve reliability and decision discipline on Flash, Flash-0731, and Pro. Presets are thin `tuningSection` layers over the shared dynamic core and auto-select via robust model ID matching.

- New Features
  - Presets: `deepseek-v4-flash`, `deepseek-v4-flash-0731`, `deepseek-v4-pro`. Shared rules: injected-directive authority, todo discipline, missing-info. Flash adds settled-reading; Pro adds reasoning-aim. Uses workstation dialect `claude`.
  - Matchers in `presets.ts` cover official and provider aliases (`deepseek/...`, `deepseek-ai/...`, `accounts/fireworks/...`, aihubmix prefixes, trailing tags). `flash-0731` resolves before generic flash.
  - Settings and docs updated to include the three presets. Startup header shows the active preset.
  - Tests: table-driven matching, catalog sweep (no misses), and rule rendering exactly once with no leakage into other presets.

- Migration
  - No changes required. Models auto-detect. Optionally set `promptPreset` to force a preset.

<sup>Written for commit b4f46a24781203aed6dfa18fbf47ab3d765c2fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

