### PR TITLE
fix(coding-agent): preserve reasoning preference across model switches

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3296,8 +3296,6 @@ export class AgentSession {
 
 		if (opts.ephemeralThinkingLevel !== undefined) {
 			this._applyEphemeralThinkingLevel(thinkingLevel);
-		} else if (opts.persistDefault) {
-			this.setThinkingLevel(thinkingLevel);
 		} else {
 			this.setSessionThinkingLevel(thinkingLevel);
 		}
@@ -3360,10 +3358,10 @@ export class AgentSession {
 		this._currentServiceTier = this._resolveServiceTier(next.model, next.serviceTier);
 
 		// Apply thinking level.
-		// - Explicit favorite model thinking level overrides current session level
-		// - Undefined favorite model thinking level inherits the current session preference
-		// setThinkingLevel clamps to model capabilities.
-		this.setThinkingLevel(thinkingLevel);
+		// - Explicit favorite model thinking level overrides the effective session level
+		// - Undefined favorite model thinking level restores the remembered user preference
+		// setSessionThinkingLevel clamps without replacing that preference.
+		this.setSessionThinkingLevel(thinkingLevel);
 
 		const systemPromptChange = await this._emitModelSelect(next.model, currentModel, "cycle");
 
@@ -3494,10 +3492,7 @@ export class AgentSession {
 		if (explicitLevel !== undefined) {
 			return explicitLevel;
 		}
-		if (!this.supportsThinking()) {
-			return this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
-		}
-		return this.thinkingLevel;
+		return this.settingsManager.getDefaultThinkingLevel() ?? this.thinkingLevel ?? DEFAULT_THINKING_LEVEL;
 	}
 
 	private _clampThinkingLevel(level: ThinkingLevel, availableLevels: ThinkingLevel[]): ThinkingLevel {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Preserve the user's reasoning preference across model switches (2026-07-31)
+
+### What changed
+
+- `agent-session.ts`: manual model selection and favorite-model cycling now
+  apply model-specific overrides and capability clamps as session-effective
+  levels without replacing `defaultThinkingLevel`.
+- Model switches without an explicit favorite tier restore the remembered
+  `defaultThinkingLevel` before clamping it to the selected model.
+
+### Why
+
+- Switching from a max-capable model to a basic reasoning model persisted the
+  clamped `high` tier, so switching back no longer restored the user's last
+  selected `max` tier. Explicit favorite tiers could likewise replace the
+  global preference even though they are model-specific overrides.
+
+### Expected merge conflict zones
+
+- LOW: `agent-session.ts` around `_switchActiveModel()`,
+  `_cycleFavoriteModel()`, and `_getThinkingLevelForModelSwitch()`.
+
 ## Thinking-level tier detection delegates to packages/ai (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/model-switch-preserves-reasoning.test.ts
+++ b/packages/coding-agent/test/suite/regressions/model-switch-preserves-reasoning.test.ts
@@ -1,0 +1,90 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+function requireModel(harness: Harness, id: string): Model<string> {
+	const model = harness.getModel(id);
+	if (!model) throw new Error(`Missing test model: ${id}`);
+	return model;
+}
+
+describe("model switching preserves the preferred reasoning level", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("preserves the preferred reasoning level across manual model switches", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "claude-opus-4-8", reasoning: true },
+				{ id: "faux-basic", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const maxModel = requireModel(harness, "claude-opus-4-8");
+		const basicModel = requireModel(harness, "faux-basic");
+		harness.session.setThinkingLevel("max");
+
+		await harness.session.setModel(basicModel);
+
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("max");
+
+		await harness.session.setModel(maxModel);
+
+		expect(harness.session.thinkingLevel).toBe("max");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("max");
+	});
+
+	it("preserves the preferred reasoning level across favorite model cycling", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "claude-opus-4-8", reasoning: true },
+				{ id: "faux-basic", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const maxModel = requireModel(harness, "claude-opus-4-8");
+		const basicModel = requireModel(harness, "faux-basic");
+		harness.session.setFavoriteModels([{ model: maxModel }, { model: basicModel }]);
+		harness.session.setThinkingLevel("max");
+
+		await harness.session.cycleModel();
+
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("max");
+
+		await harness.session.cycleModel();
+
+		expect(harness.session.thinkingLevel).toBe("max");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("max");
+	});
+
+	it("does not replace the preferred reasoning level with a favorite override", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "claude-opus-4-8", reasoning: true },
+				{ id: "faux-basic", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const maxModel = requireModel(harness, "claude-opus-4-8");
+		const basicModel = requireModel(harness, "faux-basic");
+		harness.session.setFavoriteModels([{ model: maxModel }, { model: basicModel, thinkingLevel: "low" }]);
+		harness.session.setThinkingLevel("max");
+
+		await harness.session.cycleModel();
+
+		expect(harness.session.thinkingLevel).toBe("low");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("max");
+
+		await harness.session.cycleModel();
+
+		expect(harness.session.thinkingLevel).toBe("max");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("max");
+	});
+});


### PR DESCRIPTION
## Problem

Changing the model through `/model` or Ctrl+P could permanently replace the
user's most recently selected reasoning level. Switching from a max-capable
model (e.g. Opus 4.8 at `max`) to a basic reasoning model clamped the level to
`high` and wrote that clamp back as the new `defaultThinkingLevel`, so switching
back to the max-capable model no longer restored `max`. Favorite models with an
explicit reasoning override could likewise promote that model-specific override
into the global preference.

## Fix

`AgentSession` now treats reasoning preference and effective reasoning as two
separate concepts:

- Manual model selection and favorite-model cycling apply the requested level
  (explicit favorite override, or the remembered preference) as a
  **session-effective** level that is clamped to the target model's
  capabilities.
- Model switches without an explicit favorite tier restore the remembered
  `defaultThinkingLevel` before clamping, instead of inheriting the previous
  model's effective clamp.
- `defaultThinkingLevel` is only written when the user actually changes the
  reasoning level.

## Tests

New regression file
`packages/coding-agent/test/suite/regressions/model-switch-preserves-reasoning.test.ts`:

- manual `setModel()` max -> basic -> max: effective `high` then `max`, stored
  preference stays `max` (failing before the fix)
- favorite `cycleModel()` max -> basic -> max: effective `high` then `max`,
  stored preference stays `max` (failing before the fix)
- explicit favorite `low` override: effective `low` while the stored preference
  stays `max`, and the next cycle restores `max` (failing before the fix)

## Verification

- All three regressions were captured failing (RED) before the fix and passing
  (GREEN) after it.
- Related model-switch and thinking-level tests: 50 passed.
- Real CLI JSONL RPC scenario (isolated sandbox, synthetic max/basic models):
  manual `set_model` and `cycle_model` transitions observed `high -> max` with
  `defaultThinkingLevel` retained as `max`; cleanup receipt recorded.
- Root `npm run check` passes; full coding-agent suite: 762 files / 6347 tests
  passed.
- Evidence under `local-ignore/qa-evidence/20260731-model-switch-reasoning/`.

## Notes

- No public extension API changed. `setThinkingLevel()` keeps its existing
  "user changed the level" semantics; model selection uses the session-scoped
  apply path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the user's preferred reasoning level across model switches in `packages/coding-agent`. Switching between max-capable and basic models no longer overwrites `defaultThinkingLevel`, and cycling returns to the preferred tier.

- **Bug Fixes**
  - Separate saved preference from session-effective level; clamp to model without persisting.
  - On switches without a favorite override, restore `defaultThinkingLevel` before clamping.
  - Persist only when the user changes the level; added regression tests for manual switches, favorite cycling, and favorite overrides.

<sup>Written for commit 30d0018114aa02476bb73cdc3753b6f92ae86e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

