### PR TITLE
test(coding-agent): await the asserted goal continuation signal

### DIFF
--- a/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
@@ -9,7 +9,8 @@ import {
 	type GoalHarness,
 	makeGoalContext,
 	runGoalHandlers,
-	waitForGoalContinuationCount,
+	waitForEventCount,
+	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
 const ENTRY_TYPE = "goal-cache-warmup";
@@ -97,11 +98,12 @@ describe("goal cache-warm continuation story", () => {
 
 	it("celebrates the cache-warm wake when the deferred continuation fires", async () => {
 		vi.useFakeTimers();
-		const { harness, notices, ctx } = await setupWarmHarness("thread-cache-warm-resumed");
+		const { harness, notices } = await setupWarmHarness("thread-cache-warm-resumed");
 
-		const delayedDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
+		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
+		const resumedEventRecorded = waitForEventCount(harness.events, "goal_continuation_resumed", 1);
 		await vi.advanceTimersByTimeAsync(240_000);
-		await delayedDeliveryRecorded;
+		await Promise.all([delayedDeliveryRecorded, resumedEventRecorded]);
 
 		expect(harness.sent).toHaveLength(1);
 		expect(harness.sent[0]?.message.customType).toBe("goal-continuation");

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -20,11 +20,12 @@ import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
 	createGoalHarness,
+	createSentMessageHarness,
 	type GoalHandler,
 	makeGoalContext,
 	runGoalHandlers,
 	TestEventBus,
-	waitForGoalContinuationCount,
+	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
 function goalStoreRef(ctx: ExtensionContext) {
@@ -85,14 +86,14 @@ function activeGoal(id: string): Goal {
 	};
 }
 
-function createDirectMonitorHarness(): { monitor: MonitorAwareGoalContinuation; sent: string[]; events: TestEventBus } {
-	const sent: string[] = [];
+function createDirectMonitorHarness() {
+	const harness = createSentMessageHarness();
 	const events = new TestEventBus();
 	const pi = {
-		sendMessage: (message: { readonly content: string }) => sent.push(message.content),
+		sendMessage: harness.sendMessage,
 		events,
 	} as unknown as ExtensionAPI;
-	return { monitor: new MonitorAwareGoalContinuation(pi), sent, events };
+	return { monitor: new MonitorAwareGoalContinuation(pi), harness, events };
 }
 
 async function runUserInitiatedTurn(handlers: Map<string, GoalHandler[]>, ctx: ExtensionContext): Promise<void> {
@@ -306,7 +307,8 @@ describe("goal continuation while a monitor is active", () => {
 	it("keeps overlapping rejected and handled inputs keyed while restoring the armed timer", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent, events } = createGoalHarness();
+		const harness = createGoalHarness();
+		const { tools, handlers, sent, events } = harness;
 		const ctx = await makeGoalContext(notices, "thread-overlapping-input-holds");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
@@ -331,7 +333,7 @@ describe("goal continuation while a monitor is active", () => {
 		);
 		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
 		expect(sent).toHaveLength(0);
-		const restoredDelivery = waitForGoalContinuationCount(ctx, 1);
+		const restoredDelivery = waitForSentCount(harness, 1);
 		await runGoalHandlers(
 			handlers,
 			"input_disposition",
@@ -347,7 +349,8 @@ describe("goal continuation while a monitor is active", () => {
 	it("restores the armed timer when Goal lookup fails before input disposition", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent, events } = createGoalHarness();
+		const harness = createGoalHarness();
+		const { tools, handlers, sent, events } = harness;
 		const ctx = await makeGoalContext(notices, "thread-input-read-failure");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
@@ -371,7 +374,7 @@ describe("goal continuation while a monitor is active", () => {
 		).rejects.toBeInstanceOf(SyntaxError);
 		await writeGoal(ref, persisted);
 
-		const restoredDelivery = waitForGoalContinuationCount(ctx, 1);
+		const restoredDelivery = waitForSentCount(harness, 1);
 		await runGoalHandlers(
 			handlers,
 			"input_disposition",
@@ -386,7 +389,8 @@ describe("goal continuation while a monitor is active", () => {
 	it("waits four minutes before continuing and announces the schedule", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent, events } = createGoalHarness();
+		const harness = createGoalHarness();
+		const { tools, handlers, sent, events } = harness;
 		const ctx = await makeGoalContext(notices, "thread-monitor-cadence");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
@@ -405,7 +409,7 @@ describe("goal continuation while a monitor is active", () => {
 
 		await vi.advanceTimersByTimeAsync(239_999);
 		expect(sent).toHaveLength(0);
-		const delayedDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
+		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
 		await vi.advanceTimersByTimeAsync(1);
 		await delayedDeliveryRecorded;
 		expect(sent).toHaveLength(1);
@@ -415,13 +419,21 @@ describe("goal continuation while a monitor is active", () => {
 	it("continues immediately after a clean continuation turn when no monitor is active", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
-		const { tools, handlers, sent } = createGoalHarness();
+		const harness = createGoalHarness();
+		const { tools, handlers, sent } = harness;
 		const ctx = await makeGoalContext(notices, "thread-no-monitor");
 		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
-		await runGoalHandlers(handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
+		const deliveryRecorded = waitForSentCount(harness, 1);
+		const turnCompleted = runGoalHandlers(
+			handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStop()] },
+			ctx,
+		);
+		await Promise.all([turnCompleted, deliveryRecorded]);
 
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
@@ -448,7 +460,8 @@ describe("goal continuation while a monitor is active", () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
 		const ctx = await makeGoalContext(notices, "thread-monitor-repetition-resume");
-		const { monitor, sent, events } = createDirectMonitorHarness();
+		const { monitor, harness, events } = createDirectMonitorHarness();
+		const { sent } = harness;
 		const goal = activeGoal("goal-monitor-repetition-resume");
 		await writeGoal(goalStoreRef(ctx), goal);
 		monitor.start(ctx);
@@ -461,7 +474,7 @@ describe("goal continuation while a monitor is active", () => {
 				goal,
 				messages: [cleanAssistantStopWithText("unchanged monitor output")],
 			});
-			const delayedDeliveryRecorded = waitForGoalContinuationCount(ctx, turn);
+			const delayedDeliveryRecorded = waitForSentCount(harness, turn);
 			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
 			await delayedDeliveryRecorded;
 		}
@@ -475,7 +488,7 @@ describe("goal continuation while a monitor is active", () => {
 			goal: resumed,
 			messages: [cleanAssistantStopWithText("unchanged monitor output")],
 		});
-		const resumedDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
+		const resumedDeliveryRecorded = waitForSentCount(harness, 3);
 		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
 		await resumedDeliveryRecorded;
 
@@ -486,7 +499,8 @@ describe("goal continuation while a monitor is active", () => {
 	it("resets truncation recovery state when a goal pauses and resumes", async () => {
 		const notices: string[] = [];
 		const ctx = await makeGoalContext(notices, "thread-length-resume");
-		const { monitor, sent } = createDirectMonitorHarness();
+		const { monitor, harness } = createDirectMonitorHarness();
+		const { sent } = harness;
 		const goal = activeGoal("goal-length-resume");
 		await writeGoal(goalStoreRef(ctx), goal);
 		monitor.start(ctx);

--- a/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
@@ -8,7 +8,7 @@ import {
 	type GoalHarness,
 	makeGoalContext,
 	runGoalHandlers,
-	waitForGoalContinuationCount,
+	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
 interface ActiveMonitorHarness {
@@ -52,7 +52,7 @@ describe("goal monitor continuation lifecycle", () => {
 
 		expect(harness.sent).toHaveLength(0);
 		expect(notices).toHaveLength(1);
-		const delayedDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
+		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
 		await vi.advanceTimersByTimeAsync(240_000);
 		await delayedDeliveryRecorded;
 		expect(harness.sent).toHaveLength(1);

--- a/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readGoal, resetContinuationStreak } from "../../src/core/extensions/builtin/goal/store.ts";
+import { resetContinuationStreak } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionContext } from "../../src/core/extensions/types.ts";
 import {
 	cleanAssistantStop,
@@ -10,7 +10,7 @@ import {
 	type GoalHarness,
 	makeGoalContext,
 	runGoalHandlers,
-	waitForGoalContinuationCount,
+	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
 const STALL_MARKER = "<goal_stall_check>";
@@ -75,13 +75,7 @@ async function runContinuationCycle(
 
 async function runMonitorContinuationCycle(harness: GoalHarness, ctx: ExtensionContext): Promise<void> {
 	await runContinuationCycle(harness, ctx);
-	const ref = {
-		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
-		threadId: ctx.sessionManager.getSessionId(),
-	};
-	const goal = await readGoal(ref);
-	if (goal === null) throw new Error("Expected persisted goal");
-	const delayedDeliveryRecorded = waitForGoalContinuationCount(ctx, (goal.consecutiveContinuations ?? 0) + 1);
+	const delayedDeliveryRecorded = waitForSentCount(harness, harness.sent.length + 1);
 	await vi.advanceTimersByTimeAsync(240_000);
 	await delayedDeliveryRecorded;
 }

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -56,6 +56,19 @@ export interface GoalHarness {
 	readonly entries: AppendedGoalEntry[];
 }
 
+type SentCountWaiter = {
+	readonly expectedCount: number;
+	readonly complete: (error?: Error) => void;
+};
+
+const sentCountWaiters = new WeakMap<GoalHarness, Set<SentCountWaiter>>();
+
+function getSentCountWaiters(harness: GoalHarness): Set<SentCountWaiter> {
+	const waiters = sentCountWaiters.get(harness);
+	if (waiters === undefined) throw new Error("Cannot observe sent messages for an unknown goal harness");
+	return waiters;
+}
+
 export interface GoalContextState {
 	pendingMessages: boolean;
 	model?: Model<Api>;
@@ -65,6 +78,7 @@ export function createGoalHarness(): GoalHarness {
 	const tools = new Map<string, AnyTool>();
 	const handlers = new Map<string, GoalHandler[]>();
 	const sent: SentGoalMessage[] = [];
+	const waiters = new Set<SentCountWaiter>();
 	const events = new TestEventBus();
 	const entries: AppendedGoalEntry[] = [];
 	const pi = {
@@ -77,11 +91,18 @@ export function createGoalHarness(): GoalHarness {
 			registered.push(handler);
 			handlers.set(event, registered);
 		},
-		sendMessage: (message: SentGoalMessage["message"], options: unknown) => sent.push({ message, options }),
+		sendMessage: (message: SentGoalMessage["message"], options: unknown) => {
+			sent.push({ message, options });
+			for (const waiter of waiters) {
+				if (sent.length >= waiter.expectedCount) waiter.complete();
+			}
+		},
 		events,
 	} as unknown as ExtensionAPI;
 	goalExtension(pi);
-	return { tools, handlers, sent, events, entries };
+	const harness = { tools, handlers, sent, events, entries };
+	sentCountWaiters.set(harness, waiters);
+	return harness;
 }
 
 const tempDirs: string[] = [];
@@ -115,6 +136,35 @@ export async function makeGoalContext(
 
 export async function cleanupGoalMonitorTempDirs(): Promise<void> {
 	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+}
+
+export function waitForSentCount(
+	harness: GoalHarness,
+	expectedCount: number,
+	options: { readonly timeoutMs?: number } = {},
+): Promise<void> {
+	if (harness.sent.length >= expectedCount) return Promise.resolve();
+	const waiters = getSentCountWaiters(harness);
+
+	return new Promise((resolve, reject) => {
+		let completed = false;
+		let timeout: ReturnType<typeof setRealTimeout> | undefined;
+		const waiter: SentCountWaiter = { expectedCount, complete };
+		waiters.add(waiter);
+		timeout = setRealTimeout(
+			() => complete(new Error(`Timed out waiting for ${expectedCount} sent goal message(s)`)),
+			options.timeoutMs ?? 5_000,
+		);
+
+		function complete(error: Error | undefined = undefined): void {
+			if (completed) return;
+			completed = true;
+			if (timeout !== undefined) clearRealTimeout(timeout);
+			waiters.delete(waiter);
+			if (error === undefined) resolve();
+			else reject(error);
+		}
+	});
 }
 
 export function waitForGoalContinuationCount(ctx: ExtensionContext, expectedCount: number): Promise<void> {

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -48,25 +48,24 @@ export class TestEventBus {
 
 export type AppendedGoalEntry = { readonly customType: string; readonly data: unknown };
 
-export interface GoalHarness {
-	readonly tools: Map<string, AnyTool>;
-	readonly handlers: Map<string, GoalHandler[]>;
-	readonly sent: SentGoalMessage[];
-	readonly events: TestEventBus;
-	readonly entries: AppendedGoalEntry[];
-}
+const sentCountWaiters = Symbol("sentCountWaiters");
 
 type SentCountWaiter = {
 	readonly expectedCount: number;
 	readonly complete: (error?: Error) => void;
 };
 
-const sentCountWaiters = new WeakMap<GoalHarness, Set<SentCountWaiter>>();
+export interface SentMessageHarness {
+	readonly sent: SentGoalMessage[];
+	readonly sendMessage: (message: SentGoalMessage["message"], options: unknown) => void;
+	readonly [sentCountWaiters]: Set<SentCountWaiter>;
+}
 
-function getSentCountWaiters(harness: GoalHarness): Set<SentCountWaiter> {
-	const waiters = sentCountWaiters.get(harness);
-	if (waiters === undefined) throw new Error("Cannot observe sent messages for an unknown goal harness");
-	return waiters;
+export interface GoalHarness extends SentMessageHarness {
+	readonly tools: Map<string, AnyTool>;
+	readonly handlers: Map<string, GoalHandler[]>;
+	readonly events: TestEventBus;
+	readonly entries: AppendedGoalEntry[];
 }
 
 export interface GoalContextState {
@@ -74,11 +73,22 @@ export interface GoalContextState {
 	model?: Model<Api>;
 }
 
+export function createSentMessageHarness(): SentMessageHarness {
+	const sent: SentGoalMessage[] = [];
+	const waiters = new Set<SentCountWaiter>();
+	const sendMessage = (message: SentGoalMessage["message"], options: unknown): void => {
+		sent.push({ message, options });
+		for (const waiter of waiters) {
+			if (sent.length >= waiter.expectedCount) waiter.complete();
+		}
+	};
+	return { sent, sendMessage, [sentCountWaiters]: waiters };
+}
+
 export function createGoalHarness(): GoalHarness {
 	const tools = new Map<string, AnyTool>();
 	const handlers = new Map<string, GoalHandler[]>();
-	const sent: SentGoalMessage[] = [];
-	const waiters = new Set<SentCountWaiter>();
+	const messages = createSentMessageHarness();
 	const events = new TestEventBus();
 	const entries: AppendedGoalEntry[] = [];
 	const pi = {
@@ -91,18 +101,11 @@ export function createGoalHarness(): GoalHarness {
 			registered.push(handler);
 			handlers.set(event, registered);
 		},
-		sendMessage: (message: SentGoalMessage["message"], options: unknown) => {
-			sent.push({ message, options });
-			for (const waiter of waiters) {
-				if (sent.length >= waiter.expectedCount) waiter.complete();
-			}
-		},
+		sendMessage: messages.sendMessage,
 		events,
 	} as unknown as ExtensionAPI;
 	goalExtension(pi);
-	const harness = { tools, handlers, sent, events, entries };
-	sentCountWaiters.set(harness, waiters);
-	return harness;
+	return { tools, handlers, events, entries, ...messages };
 }
 
 const tempDirs: string[] = [];
@@ -139,12 +142,12 @@ export async function cleanupGoalMonitorTempDirs(): Promise<void> {
 }
 
 export function waitForSentCount(
-	harness: GoalHarness,
+	harness: SentMessageHarness,
 	expectedCount: number,
 	options: { readonly timeoutMs?: number } = {},
 ): Promise<void> {
 	if (harness.sent.length >= expectedCount) return Promise.resolve();
-	const waiters = getSentCountWaiters(harness);
+	const waiters = harness[sentCountWaiters];
 
 	return new Promise((resolve, reject) => {
 		let completed = false;
@@ -161,6 +164,36 @@ export function waitForSentCount(
 			completed = true;
 			if (timeout !== undefined) clearRealTimeout(timeout);
 			waiters.delete(waiter);
+			if (error === undefined) resolve();
+			else reject(error);
+		}
+	});
+}
+
+export function waitForEventCount(
+	events: TestEventBus,
+	channel: string,
+	expectedCount: number,
+	options: { readonly timeoutMs?: number } = {},
+): Promise<void> {
+	const emittedCount = () => events.emitted.filter((event) => event.channel === channel).length;
+	if (emittedCount() >= expectedCount) return Promise.resolve();
+
+	return new Promise((resolve, reject) => {
+		let timeout: ReturnType<typeof setRealTimeout> | undefined;
+		const unsubscribe = events.on(channel, () => {
+			if (emittedCount() >= expectedCount) complete();
+		});
+		timeout = setRealTimeout(
+			() => complete(new Error(`Timed out waiting for ${expectedCount} ${channel} event(s)`)),
+			options.timeoutMs ?? 5_000,
+		);
+
+		function complete(error: Error | undefined = undefined): void {
+			if (timeout === undefined) return;
+			clearRealTimeout(timeout);
+			timeout = undefined;
+			unsubscribe();
 			if (error === undefined) resolve();
 			else reject(error);
 		}

--- a/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
@@ -12,9 +12,11 @@ import type { ExtensionAPI, ExtensionContext } from "../../../src/core/extension
 import {
 	cleanAssistantStop,
 	cleanupGoalMonitorTempDirs,
+	createSentMessageHarness,
 	makeGoalContext,
 	TestEventBus,
 	waitForGoalContinuationCount,
+	waitForSentCount,
 } from "../goal-monitor-test-harness.ts";
 
 function goalStoreRef(ctx: ExtensionContext) {
@@ -54,10 +56,10 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
 		const ctx = await makeGoalContext(notices, "issue-506-monitor-delayed-cap");
-		const sent: string[] = [];
+		const harness = createSentMessageHarness();
 		const events = new TestEventBus();
 		const pi = {
-			sendMessage: (message: { readonly content: string }) => sent.push(message.content),
+			sendMessage: harness.sendMessage,
 			events,
 		} as unknown as ExtensionAPI;
 		const monitor = new MonitorAwareGoalContinuation(pi);
@@ -72,11 +74,11 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 			goal,
 			messages: [assistantStopWithText("still waiting")],
 		});
-		const delayedDeliveryRecorded = waitForGoalContinuationCount(ctx, 8);
+		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
 		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
 		await delayedDeliveryRecorded;
 
-		expect(sent).toHaveLength(1);
+		expect(harness.sent).toHaveLength(1);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
 			status: "active",
 			consecutiveContinuations: 8,
@@ -93,7 +95,7 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
 		await blockedGoalRecorded;
 
-		expect(sent).toHaveLength(1);
+		expect(harness.sent).toHaveLength(1);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
 			status: "blocked",
 			blockedReason: "continuation cap reached",


### PR DESCRIPTION
## Summary

`goal-monitor-lifecycle.test.ts` intermittently failed on ubuntu CI (job `Test (coding-agent 2/3)`) with:

```
AssertionError: expected [] to have a length of 1 but got +0
  ❯ test/suite/goal-monitor-lifecycle.test.ts:58
```

Green on macOS, red on CI — a timing flake, not a production bug. This PR makes the affected goal tests wait on the observable they actually assert.

## Root cause: the wait subscribed to the wrong signal

`waitForGoalContinuationCount()` used `fs.watch` on the goal-store directory and resolved once the **persisted goal file** showed `consecutiveContinuations === n`. But the assertions check `harness.sent`, which is populated by a **separate** `sendMessage` callback.

`deliverGoalContinuation` (`lifecycle-helpers.ts`) makes the ordering explicit:

```ts
const recordedGoal = await recordContinuationDelivered(...);  // ① persists  -> fires the fs.watch event
if (recordedGoal === null) throw new Error(...);
queueHiddenGoalPrompt(pi, options.content(verdict));          // ② sendMessage -> sent.push
```

The helper resolved on ①, while the assertion reads the result of ②. With an `await` boundary between them this is a guaranteed window; ubuntu CI simply loses the race more often.

## Proof the old helper subscribes to the wrong signal

Injecting a yield between ① and ② (uncommitted probe) makes the send never land within the test. The two helpers then fail in *different ways*, which is the discriminating evidence:

| helper | result | meaning |
|---|---|---|
| old `waitForGoalContinuationCount` | `expected [] to have a length of 1 but got +0` | resolved **even though no send happened at all** |
| new `waitForSentCount` | `Timed out waiting for 1 sent goal message(s)` | correctly refused to resolve without the send |

Reproduced 5/5. The old helper's failure is byte-identical to the CI signature.

Note: `vi.useFakeTimers()` mocks `setImmediate`, so that probe *prevents* the send rather than delaying it — hence the failure-mode comparison rather than pass/fail.

## Scope: this was never only one test

The same wrong-signal pattern existed at 11 call sites across 5 files. Under the probe, **11 tests** failed on unmodified `main`:

- `goal-monitor-lifecycle.test.ts` — 1
- `goal-monitor-continuation.test.ts` — 5
- `goal-monitor-stall.test.ts` — 3
- `goal-cache-warmup.test.ts` — 1
- `regressions/issue-506-monitor-delayed-cap.test.ts` — 1

Fixing only the test CI happened to catch would have left 10 latent flakes.

## Changes

- Added `waitForSentCount(harness, n)` — subscribes to the `sendMessage` invocation, resolves immediately when already satisfied (no missed-event window), bounded by a **real** timer so it stays correct under fake timers, no sleeps or polling.
- Added a matching waiter for appended entries / channel events, used where a test asserts on state emitted *after* the send (`goal-cache-warmup`'s `goal_continuation_resumed` + warmup entries). Waiting on `sent` alone resolves too early there.
- Migrated each call site to the count that test actually asserts, derived per test rather than copied: `issue-506` counter `8` → sent `1`; `continuation` counter `1` → sent `3`; `stall` → relative `sent.length + 1`.
- **Kept** `waitForGoalContinuationCount` at `issue-506:94`, where the assertion genuinely reads persisted state (counter reset + `status: "blocked"`). That is a legitimate use, so the helper is not dead code.

Test-infrastructure only — no production source changed.

## Verification

- All five suites, clean tree: **5 passed (5)**
- **20× consecutive** `CI=1` runs of all five suites: **0 failures**
- Full `goal-*` suite: **17 passed (17)**
- `npm run check`: **exit 0**, tree clean afterwards
- No test deleted, skipped, `.only`'d, or weakened; no sleeps or polling introduced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky goal-monitor tests by waiting on the real send signal instead of file persistence. Stabilizes Ubuntu CI without changing production code.

- **Bug Fixes**
  - Added `waitForSentCount` that subscribes to `sendMessage` with a real timeout.
  - Added `waitForEventCount` for channel-based assertions.
  - Introduced `createSentMessageHarness`; updated test harness to support sent-count waiters.
  - Replaced `waitForGoalContinuationCount` with `waitForSentCount` where tests assert on sent messages; kept the former only where persisted state is asserted (issue-506).
  - Updated tests to await delivery effects where needed (e.g., `agent_end` turn).

<sup>Written for commit a8f0fcf35f3753da94e5d19ccf9de87aed9acb96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

