### PR TITLE
fix(ai): stabilize Codex prompt-cache affinity

### DIFF
--- a/.omo/plans/issue-589-codex-cache-affinity.md
+++ b/.omo/plans/issue-589-codex-cache-affinity.md
@@ -1,0 +1,164 @@
+# Issue 589: stabilize Codex prompt-cache affinity
+
+## Objective
+
+Diagnose GitHub issue #589 from the attached 25-hour session, align Senpi's
+OpenAI Codex request affinity metadata with the official Codex client, prove the
+old SSE and WebSocket request shapes fail the official contract, verify the
+cache-disabled boundary, ship through a reviewed PR, merge it, and remove the
+task worktree.
+
+## Evidence-backed diagnosis
+
+- The reported 08:38:04Z-08:46:59Z window contains 28 assistant responses:
+  18 cache misses with `cacheRead=22,016` and roughly 175k-180k uncached input,
+  plus 10 hits with roughly 196k-199k cache reads and under 5k uncached input.
+- No model, thinking-level, compaction, custom-message, or branch transition
+  occurred inside that burst.
+- Four earlier assistant diagnostics recorded WebSocket transport failures.
+  Each was followed by a full-context HTTP/SSE request and later cache recovery.
+  The final transport failure preceded the issue burst, so the expensive burst
+  happened while the session used SSE fallback.
+- Senpi currently sends `session-id` and `x-client-request-id`, but omits the
+  official `thread-id` affinity header on both SSE and WebSocket.
+- Official Codex sends:
+  - body `prompt_cache_key = session_id`
+  - header `session-id = session_id`
+  - header `thread-id = thread_id`
+  - header `x-client-request-id = thread_id`
+  on both transports.
+- Senpi has one durable conversation identifier at this layer, so the minimal
+  compatible mapping is to use the stable Senpi session ID for all three
+  headers and `prompt_cache_key`.
+- Open upstream reports show residual server-side intermittent misses even with
+  stable bodies and keys. This patch therefore fixes Senpi's client-controlled
+  protocol divergence without claiming to make a best-effort upstream cache
+  deterministic.
+- Explicit GPT-5.6 cache breakpoints are not the incident fix: this transcript
+  already preserved the approximately 22k startup prefix, while the expensive
+  losses were the append-only conversation history.
+
+## Tier and topology
+
+Tier: **HEAVY** because this changes an external provider integration.
+
+Topology:
+
+- Completed independent read-only lanes:
+  - full transcript forensics;
+  - Senpi cache-path and test-seam trace;
+  - official Codex protocol and upstream-issue research.
+- Lead session owns the cohesive test/source/changelog/QA lane because every
+  edit shares one request-affinity contract.
+- One independent reviewer runs after evidence is complete.
+- No team: concurrent writers would collide in the same provider contract and
+  add coordination without independent deliverables.
+
+## Success criteria
+
+### Criterion 1: diagnosis is reproducible
+
+The PR must record the 18-miss/10-hit burst, lack of local context transitions,
+prior WebSocket failure and SSE fallback, Senpi's missing `thread-id`, and the
+upstream residual.
+
+### Criterion 2: SSE carries complete affinity
+
+Invocation:
+
+```text
+streamOpenAICodexResponses(model, context, {
+  apiKey: token,
+  sessionId: "issue-589-session",
+  transport: "sse"
+})
+```
+
+PASS iff the fake endpoint captures:
+
+```text
+session-id = issue-589-session
+thread-id = issue-589-session
+x-client-request-id = issue-589-session
+prompt_cache_key = issue-589-session
+```
+
+RED must fail before production edits because `thread-id` is missing.
+
+### Criterion 3: WebSocket carries the same affinity
+
+Invocation:
+
+```text
+streamOpenAICodexResponses(model, context, {
+  apiKey: token,
+  sessionId: "issue-589-session",
+  transport: "auto"
+})
+```
+
+PASS iff the WebSocket handshake contains the same three headers and the sent
+request body keeps the same `prompt_cache_key`.
+
+RED must fail before production edits because `thread-id` is missing.
+
+### Criterion 4: disabled caching remains isolated
+
+Invocation:
+
+```text
+streamOpenAICodexResponses(model, context, {
+  apiKey: token,
+  cacheRetention: "none",
+  sessionId: "one-off-summary",
+  transport: "sse"
+})
+```
+
+PASS iff all three affinity headers and `prompt_cache_key` are absent. A
+temporary mutation that forces affinity headers must make the test fail; the
+mutation is then reverted and GREEN restored.
+
+## Implementation
+
+1. Add a focused regression test file smaller than the repository's file-size
+   ceiling; do not grow the already oversized broad stream test.
+2. Capture RED for SSE and WebSocket missing `thread-id`.
+3. Add a small shared affinity-header helper beside the existing prompt-cache
+   key clamp.
+4. Replace the duplicate SSE/WebSocket header assignments with the helper,
+   reducing the oversized adapter rather than growing it.
+5. Capture GREEN.
+6. Add a `packages/ai/src/changes.md` entry describing evidence, mitigation,
+   tests, conflict zones, and the upstream residual.
+
+## Verification and QA
+
+1. LSP diagnostics on all changed TypeScript files.
+2. Focused AI test file.
+3. Affected package validation and root `npm run check`.
+4. Library-surface QA driver under
+   `local-ignore/qa-evidence/20260731-issue-589-cache-affinity/`:
+   start a local fake Codex Responses endpoint, invoke the real source adapter,
+   capture exact headers/body, close the endpoint, and record the cleanup.
+5. Required real CLI QA:
+
+```text
+node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test
+```
+
+6. Re-read the diff and verify no unrelated change.
+7. Independent evidence reviewer, then GitHub CI and Cubic gates.
+
+## Delivery
+
+Commit the plan first, open a draft PR, register the binding goal, implement
+test-first, make atomic verified commits, mark the PR ready, resolve every
+criterion-cited review or gate failure, merge with a merge commit, and remove
+the worktree.
+
+## Stop condition
+
+Stop immediately when GitHub reports the PR `MERGED`, every criterion has
+current evidence and cleanup receipts, and
+`/Users/yeongyu/local-workspaces/senpi-wt/issue-589-cache-affinity` is absent.

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -50,7 +50,7 @@ import { extractOpenAiCodexAccountId } from "../utils/openai-codex-auth.ts";
 import { uuidv7 } from "../utils/uuid.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
 import { buildCodexReasoning, type CodexReasoningSummaryInput } from "./openai-codex-responses/reasoning.ts";
-import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
+import { applyOpenAICodexCacheAffinityHeaders, clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import {
 	applyExtraBody,
@@ -1692,10 +1692,7 @@ function buildSSEHeaders(
 	headers.set("accept", "text/event-stream");
 	headers.set("content-type", "application/json");
 
-	if (sessionId) {
-		headers.set("session-id", sessionId);
-		headers.set("x-client-request-id", sessionId);
-	}
+	applyOpenAICodexCacheAffinityHeaders(headers, sessionId);
 
 	return headers;
 }
@@ -1713,7 +1710,6 @@ function buildWebSocketHeaders(
 	headers.delete("OpenAI-Beta");
 	headers.delete("openai-beta");
 	headers.set("OpenAI-Beta", OPENAI_BETA_RESPONSES_WEBSOCKETS);
-	headers.set("x-client-request-id", requestId);
-	headers.set("session-id", requestId);
+	applyOpenAICodexCacheAffinityHeaders(headers, requestId);
 	return headers;
 }

--- a/packages/ai/src/api/openai-prompt-cache.ts
+++ b/packages/ai/src/api/openai-prompt-cache.ts
@@ -6,3 +6,10 @@ export function clampOpenAIPromptCacheKey(key: string | undefined): string | und
 	if (chars.length <= OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH) return key;
 	return chars.slice(0, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH).join("");
 }
+
+export function applyOpenAICodexCacheAffinityHeaders(headers: Headers, sessionId: string | undefined): void {
+	if (!sessionId) return;
+	headers.set("session-id", sessionId);
+	headers.set("thread-id", sessionId);
+	headers.set("x-client-request-id", sessionId);
+}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,38 @@
 # AI Source Changes
 
+## 2026-07-31 - Align Codex prompt-cache affinity headers
+
+### What changed and why
+
+- Issue #589's donated 25-hour session contained an 8.5-minute HTTP/SSE
+  fallback burst where 18 requests reused only 22,016 cached tokens and resent
+  roughly 175k-180k uncached tokens, interleaved with 10 normal roughly
+  196k-199k cache hits. No model, thinking-level, compaction, or custom-message
+  transition occurred inside the burst.
+- The session had previously recorded Codex WebSocket transport failures and
+  fallen back to SSE. Senpi's Codex adapter sent the stable session ID as
+  `prompt_cache_key`, `session-id`, and `x-client-request-id`, but omitted the
+  official Codex `thread-id` affinity header on both SSE and WebSocket.
+- `api/openai-prompt-cache.ts` now applies the complete stable affinity tuple,
+  and both transports use it. Senpi has one durable conversation identifier at
+  this layer, so `session-id`, `thread-id`, and `x-client-request-id` all carry
+  the clamped Senpi session ID while `prompt_cache_key` remains unchanged.
+- `cacheRetention: "none"` keeps its existing no-affinity SSE behavior.
+- This fixes the client-controlled protocol divergence. Open upstream Codex
+  reports show that the provider cache can still miss intermittently with
+  byte-identical bodies and stable keys, so the change does not claim that a
+  best-effort upstream cache becomes deterministic.
+
+### Coverage
+
+- `../test/openai-codex-cache-affinity.test.ts` drives the real SSE and
+  WebSocket request builders, pins the complete header/body mapping, and
+  preserves the disabled-cache boundary.
+
+### Expected merge conflict zones
+
+- LOW: additive prompt-cache header helper and the two Codex header builders.
+
 ## 2026-07-31 - Reshape unavailable Anthropic tool transcript records
 
 ### What changed and why

--- a/packages/ai/test/openai-codex-cache-affinity.test.ts
+++ b/packages/ai/test/openai-codex-cache-affinity.test.ts
@@ -1,0 +1,234 @@
+import { zstdDecompressSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	closeOpenAICodexWebSocketSessions,
+	resetOpenAICodexWebSocketDebugStats,
+	stream as streamOpenAICodexResponses,
+} from "../src/api/openai-codex-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const SESSION_ID = "issue-589-session";
+
+const model: Model<"openai-codex-responses"> = {
+	id: "gpt-5.6-sol",
+	name: "GPT-5.6 Sol",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+const context: Context = {
+	systemPrompt: "You are a helpful assistant.",
+	messages: [{ role: "user", content: "Say hello", timestamp: 1 }],
+};
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	closeOpenAICodexWebSocketSessions();
+	resetOpenAICodexWebSocketDebugStats();
+});
+
+function mockToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+		"utf8",
+	).toString("base64");
+	return `aaa.${payload}.bbb`;
+}
+
+function completedSSE(): string {
+	return `data: ${JSON.stringify({
+		type: "response.completed",
+		response: {
+			status: "completed",
+			usage: {
+				input_tokens: 5,
+				output_tokens: 3,
+				total_tokens: 8,
+				input_tokens_details: { cached_tokens: 0 },
+			},
+		},
+	})}\n\n`;
+}
+
+function decodeRequestBody(body: RequestInit["body"] | undefined): unknown {
+	if (typeof body === "string") return JSON.parse(body);
+	if (body instanceof Uint8Array) {
+		return JSON.parse(Buffer.from(zstdDecompressSync(body)).toString("utf8"));
+	}
+	if (body instanceof ArrayBuffer) {
+		return JSON.parse(Buffer.from(zstdDecompressSync(new Uint8Array(body))).toString("utf8"));
+	}
+	return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function expectCacheAffinity(headers: Headers | undefined, body: unknown): void {
+	expect(headers?.get("session-id")).toBe(SESSION_ID);
+	expect(headers?.get("thread-id")).toBe(SESSION_ID);
+	expect(headers?.get("x-client-request-id")).toBe(SESSION_ID);
+	expect(isRecord(body) ? body.prompt_cache_key : undefined).toBe(SESSION_ID);
+}
+
+describe("OpenAI Codex cache affinity", () => {
+	it("sends complete cache affinity over SSE", async () => {
+		const encoder = new TextEncoder();
+		let capturedHeaders: Headers | undefined;
+		let capturedBody: unknown;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL, init?: RequestInit) => {
+				capturedHeaders = init?.headers instanceof Headers ? init.headers : undefined;
+				capturedBody = decodeRequestBody(init?.body);
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode(completedSSE()));
+							controller.close();
+						},
+					}),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}),
+		);
+
+		await streamOpenAICodexResponses(model, context, {
+			apiKey: mockToken(),
+			sessionId: SESSION_ID,
+			transport: "sse",
+		}).result();
+
+		expectCacheAffinity(capturedHeaders, capturedBody);
+	});
+
+	it("sends complete cache affinity over WebSocket", async () => {
+		let capturedHeaders: Record<string, string> | undefined;
+		let capturedBody: unknown;
+
+		class MockWebSocket {
+			private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+
+			constructor(_url: string, protocols?: string | string[] | { headers?: Record<string, string> }) {
+				if (protocols && typeof protocols === "object" && !Array.isArray(protocols)) {
+					capturedHeaders = protocols.headers;
+				}
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+
+			addEventListener(type: string, listener: (event: unknown) => void): void {
+				const listeners = this.listeners.get(type) ?? new Set<(event: unknown) => void>();
+				listeners.add(listener);
+				this.listeners.set(type, listeners);
+			}
+
+			removeEventListener(type: string, listener: (event: unknown) => void): void {
+				this.listeners.get(type)?.delete(listener);
+			}
+
+			send(data: string): void {
+				capturedBody = JSON.parse(data);
+				const events = [
+					{
+						type: "response.output_item.added",
+						item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+					},
+					{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+					{ type: "response.output_text.delta", delta: "Hello" },
+					{
+						type: "response.output_item.done",
+						item: {
+							type: "message",
+							id: "msg_1",
+							role: "assistant",
+							status: "completed",
+							content: [{ type: "output_text", text: "Hello" }],
+						},
+					},
+					{
+						type: "response.completed",
+						response: {
+							id: "resp_issue_589",
+							status: "completed",
+							usage: {
+								input_tokens: 5,
+								output_tokens: 3,
+								total_tokens: 8,
+								input_tokens_details: { cached_tokens: 0 },
+							},
+						},
+					},
+				];
+				queueMicrotask(() => {
+					for (const event of events) {
+						this.dispatch("message", { data: JSON.stringify(event) });
+					}
+				});
+			}
+
+			close(): void {}
+
+			private dispatch(type: string, event: unknown): void {
+				for (const listener of this.listeners.get(type) ?? []) listener(event);
+			}
+		}
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("unexpected fetch", { status: 500 })),
+		);
+		vi.stubGlobal("WebSocket", MockWebSocket);
+
+		await streamOpenAICodexResponses(model, context, {
+			apiKey: mockToken(),
+			sessionId: SESSION_ID,
+			transport: "auto",
+		}).result();
+
+		expectCacheAffinity(capturedHeaders ? new Headers(capturedHeaders) : undefined, capturedBody);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it("omits cache affinity when caching is disabled", async () => {
+		const encoder = new TextEncoder();
+		let capturedHeaders: Headers | undefined;
+		let capturedBody: unknown;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL, init?: RequestInit) => {
+				capturedHeaders = init?.headers instanceof Headers ? init.headers : undefined;
+				capturedBody = decodeRequestBody(init?.body);
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode(completedSSE()));
+							controller.close();
+						},
+					}),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}),
+		);
+
+		await streamOpenAICodexResponses(model, context, {
+			apiKey: mockToken(),
+			cacheRetention: "none",
+			sessionId: "one-off-summary",
+			transport: "sse",
+		}).result();
+
+		expect(capturedHeaders?.has("session-id")).toBe(false);
+		expect(capturedHeaders?.has("thread-id")).toBe(false);
+		expect(capturedHeaders?.has("x-client-request-id")).toBe(false);
+		expect(isRecord(capturedBody) ? capturedBody.prompt_cache_key : undefined).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Align the OpenAI Codex SSE and WebSocket request affinity metadata with the
official Codex client.

Senpi already used the stable session ID for `prompt_cache_key`, `session-id`,
and `x-client-request-id`, but omitted the official `thread-id` header. The
adapter now applies one complete stable affinity tuple to both transports while
preserving the `cacheRetention: "none"` no-affinity SSE boundary.

## Issue #589 diagnosis

The donated 25-hour session contains an 8.5-minute burst with:

- 18 requests re-sending roughly 175k-180k uncached tokens with
  `cacheRead=22,016`;
- 10 interleaved requests reusing roughly 196k-199k cached tokens;
- no model, thinking-level, compaction, custom-message, or branch transition
  inside the burst.

Earlier diagnostics recorded WebSocket transport failures followed by
HTTP/SSE fallback. The expensive burst therefore occurred on the fallback path
where Senpi's request shape diverged from official Codex.

Official Codex sends the stable body/header mapping below on both transports:

```text
prompt_cache_key = session_id
session-id       = session_id
thread-id        = thread_id
x-client-request-id = thread_id
```

Senpi has one durable conversation identifier at this layer, so this change
uses the clamped Senpi session ID for all three headers and the body key.

## RED -> GREEN evidence

- SSE RED: `thread-id` was `null`.
- WebSocket RED: `thread-id` was `null`.
- GREEN: `packages/ai/test/openai-codex-cache-affinity.test.ts` passes 3/3.
- Mutation proof: forcing affinity while `cacheRetention: "none"` made the
  disabled-cache assertion fail; reverting restored 3/3 GREEN.

## Validation

- AI package tests: 173 files passed, 25 skipped; 1,571 tests passed.
- Root `npm run check`: passed, including Biome, pinned-dependency checks,
  import checks, shrinkwrap/install-lock checks, `tsgo --noEmit`, browser smoke,
  and web UI checks.
- Real adapter QA: a live local endpoint captured `session-id`, `thread-id`,
  `x-client-request-id`, and `prompt_cache_key` all equal to
  `issue-589-session`; server cleanup completed and the port was closed.
- Real CLI QA: `mock-loop.mjs --self-test` passed 43/43; an additional
  OpenAI Responses real-CLI smoke produced local evidence.

The harness LSP cannot inspect a sibling worktree, so the repository's own
worktree-scoped `tsgo --noEmit` is the recorded diagnostic substitute.

## Residual risk

Open upstream Codex reports show intermittent provider-side cache misses can
still occur with byte-identical bodies and stable keys. This fixes Senpi's
client-controlled protocol divergence; it does not claim to make a best-effort
upstream cache deterministic.

## Plan

`.omo/plans/issue-589-codex-cache-affinity.md`

Fixes #589
