### PR TITLE
fix(coding-agent): use monotonic TPS timing

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,24 @@
 # Builtin extensions changes
 
+## tps: monotonic elapsed-time source for assistant intervals (2026-07-31)
+
+- `tps.ts` now derives assistant-message elapsed time from the monotonic
+  `performance.now()` clock instead of wall-clock `Date.now()`. A wall-clock
+  jump backward (NTP skew or manual time change) between `message_start` and
+  `message_end` previously produced a non-positive `Date.now() - start`
+  interval, which the `> 0` guard dropped, suppressing a valid TPS notice.
+- Preserved: the stream-open start timestamp is still recorded at
+  `message_start`; `finishActiveAssistantTiming` still runs at every
+  `message_start`/`message_end`/`agent_end` so tool and permission waits stay
+  excluded; the output numerator, notification text, and the `agent_start`
+  reset behavior are unchanged.
+- Coverage: `test/suite/tps-extension.test.ts` adds a deterministic regression
+  where one second of fake monotonic time elapses but wall time is moved
+  backward between `message_start` and `message_end`; the existing lockstep
+  fake-timer case still pins TPS/token/elapsed text.
+- Expected merge conflict zones: LOW in `tps.ts` around the two
+  `performance.now()` call sites; NONE in the public extension API.
+
 ## loop-guard: tool-call loop detection with steered reminders (2026-07-31)
 
 - New builtin extension `loop-guard` (registered before `config-reload`; MCP stays last)

--- a/packages/coding-agent/src/core/extensions/builtin/tps.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/tps.ts
@@ -24,7 +24,10 @@ export default function (pi: ExtensionAPI) {
 	const finishActiveAssistantTiming = () => {
 		if (activeAssistantStartMs === null) return;
 
-		const elapsedMs = Date.now() - activeAssistantStartMs;
+		// Use the monotonic clock so a wall-clock jump backward (NTP skew or
+		// manual time change) between message_start and message_end cannot
+		// produce a non-positive interval that suppresses a valid TPS notice.
+		const elapsedMs = performance.now() - activeAssistantStartMs;
 		if (elapsedMs > 0) {
 			assistantElapsedMs += elapsedMs;
 		}
@@ -40,7 +43,7 @@ export default function (pi: ExtensionAPI) {
 		if (!isAssistantMessage(event.message)) return;
 
 		finishActiveAssistantTiming();
-		activeAssistantStartMs = Date.now();
+		activeAssistantStartMs = performance.now();
 	});
 
 	pi.on("message_end", (event) => {

--- a/packages/coding-agent/test/suite/tps-extension.test.ts
+++ b/packages/coding-agent/test/suite/tps-extension.test.ts
@@ -93,4 +93,30 @@ describe("tps builtin extension", () => {
 		expect(notifications[0]).toContain("3.0s");
 		expect(notifications[0]).not.toContain("21.4 tok/s");
 	});
+
+	it("reports TPS when wall clock jumps backward between message_start and message_end", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const notifications: string[] = [];
+		const ctx = createContext(notifications);
+		const harness = createHarness();
+		const message = createAssistantMessage(100);
+
+		await harness.emit("agent_start", { type: "agent_start" }, ctx);
+		vi.advanceTimersByTime(1_000);
+
+		await harness.emit("message_start", { type: "message_start", message }, ctx);
+		vi.advanceTimersByTime(1_000);
+		// Wall clock jumps backward (NTP adjustment / manual change) while
+		// monotonic time keeps moving forward.
+		vi.setSystemTime(0);
+		await harness.emit("message_end", { type: "message_end", message }, ctx);
+
+		await harness.emit("agent_end", { type: "agent_end", messages: [message] }, ctx);
+
+		expect(notifications).toHaveLength(1);
+		expect(notifications[0]).toContain("TPS 100.0 tok/s");
+		expect(notifications[0]).toContain("out 100");
+		expect(notifications[0]).toContain("1.0s");
+	});
 });


### PR DESCRIPTION
## Summary

- use a monotonic clock for the built-in TPS extension's elapsed assistant timing
- keep the existing stream-open throughput contract and tool-wait exclusion unchanged
- add a deterministic regression for backward wall-clock jumps

## Why

The TPS extension used `Date.now()` for elapsed intervals. If the system clock moved backward between `message_start` and `message_end`, the interval became non-positive and the extension silently suppressed an otherwise valid TPS notification.

## Verification

- RED: new regression failed with `expected [] to have a length of 1 but got +0`
- GREEN: `npm --prefix packages/coding-agent test -- test/suite/tps-extension.test.ts` — 2 tests passed
- Static: `npm run check` — exit 0
- Real TUI: isolated senpi-qa mock server driven through xterm.js/Chrome emitted:
  - `TPS 0.4 tok/s. out 2, in 2, cache r/w 0/0, total 4, 4.5s`
  - tool-call and final-response markers both rendered
- Evidence: `local-ignore/qa-evidence/20260731-tps-monotonic/`
- Cleanup: PTY and mock server stopped, port released, auth file hash unchanged, mock sandbox removed

## Scope

No TPS numerator, rounding, notification-format, or tool/permission-wait behavior changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch TPS timing to a monotonic clock to prevent missing TPS notifications when the system clock jumps backward. Existing throughput contract, wait exclusions, and output format remain unchanged.

- **Bug Fixes**
  - Use `performance.now()` for assistant elapsed time instead of `Date.now()`.
  - Add a regression test for backward wall-clock jumps; no changes to numerator, stream-open start, or `agent_start` reset.

<sup>Written for commit 7f6097bf36c9d1c4fcee7420e0a52d83c58c8bc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

