### PR TITLE
fix(ai): recover Codex WebSocket fallback sessions

### DIFF
--- a/.omo/plans/issue-589-websocket-fallback-recovery.md
+++ b/.omo/plans/issue-589-websocket-fallback-recovery.md
@@ -1,0 +1,92 @@
+# Issue 589: recover from transient WebSocket fallback
+
+## Objective
+
+Prevent one transient OpenAI Codex WebSocket failure from pinning a long-lived
+session to the more expensive SSE path forever, while preserving the guard
+that never retries an already-started response.
+
+## Diagnosis
+
+- Issue #589's expensive cache-miss burst happened after WebSocket transport
+  failures moved the session to SSE.
+- `websocketSseFallbackSessions` is currently a process-lifetime
+  `Set<string>`. Once added, a session has no production recovery path.
+- `closeOpenAICodexWebSocketSessions` closes sockets but leaves fallback and
+  debug state behind.
+- PR #597 fixed the SSE request-affinity tuple. This plan fixes the remaining
+  client-controlled exposure: permanent degradation after a transient failure.
+- Provider-side prefix caching is still best-effort. The mitigation is to
+  return future fresh requests to WebSocket continuation after a bounded
+  cooldown, not to retry a completed cache miss.
+
+## Tier and topology
+
+Tier: **HEAVY** because this changes external-provider transport recovery and
+shared session state.
+
+The lead session owns implementation. A separate dependency PR handles the
+unrelated PostCSS advisory.
+
+## Success criteria
+
+### 1. Time-bounded recovery
+
+Drive the real adapter through a pre-start WebSocket failure and safe SSE
+fallback. A request inside 60 seconds remains on SSE. After advancing the
+clock by 60,001 ms, the next fresh request must attempt WebSocket and complete
+without an additional HTTP request.
+
+RED: current permanent fallback sends the post-cooldown request through SSE.
+
+### 2. Cleanup clears degradation state
+
+Trigger fallback, call `closeOpenAICodexWebSocketSessions(sessionId)`, then
+issue a fresh same-session request with a working WebSocket.
+
+PASS: WebSocket is attempted immediately and stale fallback/debug state is
+gone.
+
+RED: current cleanup leaves the session pinned to SSE.
+
+### 3. Safety boundaries remain
+
+- Transport errors after the first streamed event still propagate and never
+  cause an SSE retry.
+- Immediate requests during cooldown still use SSE.
+- Existing continuation, connection-limit, stale-response, and
+  `cacheRetention:"none"` tests remain green.
+
+### 4. Real-surface proof
+
+A TypeScript QA driver controls `Date.now`, observes one local HTTP fallback,
+advances 60,001 ms, then observes the next request complete over WebSocket
+with no second fetch. It must close all sockets/server resources. The required
+real CLI mock-loop self-test must also pass.
+
+## Implementation
+
+1. Add focused integration tests outside the oversized existing stream test.
+2. Capture both intended RED failures.
+3. Extract fallback/debug-state ownership into
+   `src/api/openai-codex-responses/fallback-state.ts`.
+4. Replace the permanent set with a timestamped 60-second circuit.
+5. Clear scoped/all circuit and debug state during production cleanup.
+6. Keep the adapter net-smaller than before.
+7. Document the semantics in `packages/ai/src/changes.md`.
+
+## Verification
+
+- Focused fallback tests.
+- Existing Codex stream and cache-affinity tests.
+- Full AI package tests.
+- Root `npm run check`.
+- Real library QA artifact and cleanup receipt.
+- `mock-loop.mjs --self-test`.
+- Independent reviewer, GitHub CI, and Cubic unless quota-exhausted.
+
+## Stop condition
+
+Stop when the PR is merged with a merge commit and
+`/Users/yeongyu/local-workspaces/senpi-wt/issue-589-fallback-recovery` is
+absent.

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -49,6 +49,15 @@ import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { extractOpenAiCodexAccountId } from "../utils/openai-codex-auth.ts";
 import { uuidv7 } from "../utils/uuid.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
+import {
+	clearWebSocketFallbackState,
+	getOrCreateWebSocketDebugStats,
+	getWebSocketDebugStats,
+	isWebSocketSseFallbackActive,
+	type OpenAICodexWebSocketDebugStats,
+	recordWebSocketFailure,
+	recordWebSocketSseFallback,
+} from "./openai-codex-responses/fallback-state.ts";
 import { buildCodexReasoning, type CodexReasoningSummaryInput } from "./openai-codex-responses/reasoning.ts";
 import { applyOpenAICodexCacheAffinityHeaders, clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
@@ -887,60 +896,16 @@ interface CachedWebSocketConnection {
 	continuation?: CachedWebSocketContinuationState;
 }
 
-export interface OpenAICodexWebSocketDebugStats {
-	requests: number;
-	connectionsCreated: number;
-	connectionsReused: number;
-	cachedContextRequests: number;
-	storeTrueRequests: number;
-	fullContextRequests: number;
-	deltaRequests: number;
-	lastInputItems: number;
-	lastDeltaInputItems?: number;
-	lastPreviousResponseId?: string;
-	websocketFailures: number;
-	sseFallbacks: number;
-	websocketFallbackActive?: boolean;
-	lastWebSocketError?: string;
-}
+export type { OpenAICodexWebSocketDebugStats } from "./openai-codex-responses/fallback-state.ts";
 
 const websocketSessionCache = new Map<string, CachedWebSocketConnection>();
-const websocketDebugStats = new Map<string, OpenAICodexWebSocketDebugStats>();
-const websocketSseFallbackSessions = new Set<string>();
-
-function getOrCreateWebSocketDebugStats(sessionId: string): OpenAICodexWebSocketDebugStats {
-	let stats = websocketDebugStats.get(sessionId);
-	if (!stats) {
-		stats = {
-			requests: 0,
-			connectionsCreated: 0,
-			connectionsReused: 0,
-			cachedContextRequests: 0,
-			storeTrueRequests: 0,
-			fullContextRequests: 0,
-			deltaRequests: 0,
-			lastInputItems: 0,
-			websocketFailures: 0,
-			sseFallbacks: 0,
-		};
-		websocketDebugStats.set(sessionId, stats);
-	}
-	return stats;
-}
 
 export function getOpenAICodexWebSocketDebugStats(sessionId: string): OpenAICodexWebSocketDebugStats | undefined {
-	const stats = websocketDebugStats.get(sessionId);
-	return stats ? { ...stats } : undefined;
+	return getWebSocketDebugStats(sessionId);
 }
 
 export function resetOpenAICodexWebSocketDebugStats(sessionId?: string): void {
-	if (sessionId) {
-		websocketDebugStats.delete(sessionId);
-		websocketSseFallbackSessions.delete(sessionId);
-		return;
-	}
-	websocketDebugStats.clear();
-	websocketSseFallbackSessions.clear();
+	clearWebSocketFallbackState(sessionId);
 }
 
 export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
@@ -952,36 +917,17 @@ export function closeOpenAICodexWebSocketSessions(sessionId?: string): void {
 		const entry = websocketSessionCache.get(sessionId);
 		if (entry) closeEntry(entry);
 		websocketSessionCache.delete(sessionId);
+		clearWebSocketFallbackState(sessionId);
 		return;
 	}
 	for (const entry of websocketSessionCache.values()) {
 		closeEntry(entry);
 	}
 	websocketSessionCache.clear();
+	clearWebSocketFallbackState();
 }
 
 registerSessionResourceCleanup(closeOpenAICodexWebSocketSessions);
-
-function isWebSocketSseFallbackActive(sessionId: string | undefined): boolean {
-	return sessionId ? websocketSseFallbackSessions.has(sessionId) : false;
-}
-
-function recordWebSocketSseFallback(sessionId: string | undefined): void {
-	if (!sessionId) return;
-	const stats = getOrCreateWebSocketDebugStats(sessionId);
-	stats.sseFallbacks++;
-	stats.websocketFallbackActive = isWebSocketSseFallbackActive(sessionId);
-}
-
-function recordWebSocketFailure(sessionId: string | undefined, error: unknown): void {
-	if (!sessionId) return;
-	websocketSseFallbackSessions.add(sessionId);
-
-	const stats = getOrCreateWebSocketDebugStats(sessionId);
-	stats.websocketFailures++;
-	stats.lastWebSocketError = formatThrownValue(error);
-	stats.websocketFallbackActive = true;
-}
 
 type WebSocketConstructor = new (
 	url: string,

--- a/packages/ai/src/api/openai-codex-responses/fallback-state.ts
+++ b/packages/ai/src/api/openai-codex-responses/fallback-state.ts
@@ -1,0 +1,91 @@
+import { formatThrownValue } from "../../utils/diagnostics.ts";
+
+export const CODEX_WEBSOCKET_FALLBACK_COOLDOWN_MS = 60_000;
+
+export interface OpenAICodexWebSocketDebugStats {
+	requests: number;
+	connectionsCreated: number;
+	connectionsReused: number;
+	cachedContextRequests: number;
+	storeTrueRequests: number;
+	fullContextRequests: number;
+	deltaRequests: number;
+	lastInputItems: number;
+	lastDeltaInputItems?: number;
+	lastPreviousResponseId?: string;
+	websocketFailures: number;
+	sseFallbacks: number;
+	websocketFallbackActive?: boolean;
+	lastWebSocketError?: string;
+}
+
+const websocketDebugStats = new Map<string, OpenAICodexWebSocketDebugStats>();
+const websocketSseFallbackUntil = new Map<string, number>();
+
+export function getOrCreateWebSocketDebugStats(sessionId: string): OpenAICodexWebSocketDebugStats {
+	let stats = websocketDebugStats.get(sessionId);
+	if (!stats) {
+		stats = {
+			requests: 0,
+			connectionsCreated: 0,
+			connectionsReused: 0,
+			cachedContextRequests: 0,
+			storeTrueRequests: 0,
+			fullContextRequests: 0,
+			deltaRequests: 0,
+			lastInputItems: 0,
+			websocketFailures: 0,
+			sseFallbacks: 0,
+		};
+		websocketDebugStats.set(sessionId, stats);
+	}
+	return stats;
+}
+
+export function getWebSocketDebugStats(sessionId: string): OpenAICodexWebSocketDebugStats | undefined {
+	const stats = websocketDebugStats.get(sessionId);
+	return stats ? { ...stats } : undefined;
+}
+
+export function clearWebSocketFallbackState(sessionId?: string): void {
+	if (sessionId) {
+		websocketDebugStats.delete(sessionId);
+		websocketSseFallbackUntil.delete(sessionId);
+		return;
+	}
+	websocketDebugStats.clear();
+	websocketSseFallbackUntil.clear();
+}
+
+export function isWebSocketSseFallbackActive(sessionId: string | undefined): boolean {
+	if (!sessionId) return false;
+	const fallbackUntil = websocketSseFallbackUntil.get(sessionId);
+	if (fallbackUntil === undefined) return false;
+
+	const stats = websocketDebugStats.get(sessionId);
+	if (fallbackUntil > Date.now()) {
+		if (stats) stats.websocketFallbackActive = true;
+		return true;
+	}
+
+	websocketSseFallbackUntil.delete(sessionId);
+	if (stats) stats.websocketFallbackActive = false;
+	return false;
+}
+
+export function recordWebSocketSseFallback(sessionId: string | undefined): void {
+	if (!sessionId) return;
+	const stats = getOrCreateWebSocketDebugStats(sessionId);
+	stats.sseFallbacks++;
+	stats.websocketFallbackActive = true;
+}
+
+export function recordWebSocketFailure(sessionId: string | undefined, error: unknown): void {
+	if (!sessionId) return;
+	websocketSseFallbackUntil.set(sessionId, Date.now() + CODEX_WEBSOCKET_FALLBACK_COOLDOWN_MS);
+
+	const stats = getOrCreateWebSocketDebugStats(sessionId);
+	stats.websocketFailures++;
+	stats.lastWebSocketError = formatThrownValue(error);
+	stats.websocketFallbackActive = true;
+}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,36 @@
 # AI Source Changes
 
+## 2026-07-31 - Recover Codex WebSocket fallback sessions
+
+### What changed and why
+
+- A transient pre-start Codex WebSocket failure no longer pins the session to
+  SSE for the rest of the process lifetime. The fallback circuit now keeps
+  immediate requests on SSE for 60 seconds, then lets the next fresh request
+  probe WebSocket again.
+- Recovery changes only a future request. The existing guard still propagates
+  transport failures after the response stream starts, so no already-started
+  or potentially billed response is retried through SSE.
+- Production session cleanup now removes both live WebSocket resources and
+  the session's fallback/debug state. Long-lived app-server processes no
+  longer retain degraded routing after a session is closed.
+- Fallback and debug-state ownership moved into
+  `api/openai-codex-responses/fallback-state.ts`, reducing the oversized
+  adapter while keeping the public debug API stable.
+
+### Coverage
+
+- `../test/openai-codex-fallback-recovery.test.ts` proves the immediate SSE
+  cooldown boundary, post-cooldown WebSocket recovery, and immediate recovery
+  after production cleanup.
+- Existing Codex stream tests retain the post-start no-fallback guard,
+  continuation recovery, connection-limit handling, and one-shot
+  `cacheRetention: "none"` behavior.
+
+### Expected merge conflict zones
+
+- MEDIUM: Codex WebSocket debug/fallback state and session cleanup.
+
 ## 2026-07-31 - Align Codex prompt-cache affinity headers
 
 ### What changed and why

--- a/packages/ai/test/openai-codex-fallback-recovery.test.ts
+++ b/packages/ai/test/openai-codex-fallback-recovery.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	closeOpenAICodexWebSocketSessions,
+	getOpenAICodexWebSocketDebugStats,
+	resetOpenAICodexWebSocketDebugStats,
+	stream as streamOpenAICodexResponses,
+} from "../src/api/openai-codex-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const FALLBACK_COOLDOWN_MS = 60_000;
+
+const model: Model<"openai-codex-responses"> = {
+	id: "gpt-5.6-sol",
+	name: "GPT-5.6 Sol",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+const context: Context = {
+	systemPrompt: "You are a helpful assistant.",
+	messages: [{ role: "user", content: "Say hello", timestamp: 1 }],
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	closeOpenAICodexWebSocketSessions();
+	resetOpenAICodexWebSocketDebugStats();
+});
+
+function mockToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+		"utf8",
+	).toString("base64");
+	return `aaa.${payload}.bbb`;
+}
+
+function completedSSE(): string {
+	return `data: ${JSON.stringify({
+		type: "response.completed",
+		response: {
+			status: "completed",
+			usage: {
+				input_tokens: 5,
+				output_tokens: 3,
+				total_tokens: 8,
+				input_tokens_details: { cached_tokens: 0 },
+			},
+		},
+	})}\n\n`;
+}
+
+function completedWebSocketEvents(): unknown[] {
+	return [
+		{
+			type: "response.output_item.added",
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		},
+		{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+		{ type: "response.output_text.delta", delta: "Hello" },
+		{
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "Hello" }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_recovered",
+				status: "completed",
+				usage: {
+					input_tokens: 5,
+					output_tokens: 3,
+					total_tokens: 8,
+					input_tokens_details: { cached_tokens: 0 },
+				},
+			},
+		},
+	];
+}
+
+function installTransportHarness(): { connections: () => number; fetches: () => number } {
+	let connectionCount = 0;
+	let fetchCount = 0;
+	const encoder = new TextEncoder();
+
+	class MockWebSocket {
+		static readonly OPEN = 1;
+		static readonly CLOSED = 3;
+		readyState = MockWebSocket.OPEN;
+		private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+		private readonly shouldFail: boolean;
+
+		constructor() {
+			connectionCount++;
+			this.shouldFail = connectionCount === 1;
+			queueMicrotask(() => {
+				if (this.shouldFail) {
+					this.dispatch("error", { error: new Error("transient websocket failure") });
+				} else {
+					this.dispatch("open", {});
+				}
+			});
+		}
+
+		addEventListener(type: string, listener: (event: unknown) => void): void {
+			const listeners = this.listeners.get(type) ?? new Set<(event: unknown) => void>();
+			listeners.add(listener);
+			this.listeners.set(type, listeners);
+		}
+
+		removeEventListener(type: string, listener: (event: unknown) => void): void {
+			this.listeners.get(type)?.delete(listener);
+		}
+
+		send(): void {
+			if (this.shouldFail) return;
+			queueMicrotask(() => {
+				for (const event of completedWebSocketEvents()) {
+					this.dispatch("message", { data: JSON.stringify(event) });
+				}
+			});
+		}
+
+		close(): void {
+			this.readyState = MockWebSocket.CLOSED;
+			this.dispatch("close", { code: 1000, reason: "test cleanup" });
+		}
+
+		private dispatch(type: string, event: unknown): void {
+			for (const listener of this.listeners.get(type) ?? []) listener(event);
+		}
+	}
+
+	vi.stubGlobal("WebSocket", MockWebSocket);
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => {
+			fetchCount++;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode(completedSSE()));
+						controller.close();
+					},
+				}),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}),
+	);
+
+	return {
+		connections: () => connectionCount,
+		fetches: () => fetchCount,
+	};
+}
+
+async function runSession(sessionId: string): Promise<void> {
+	await streamOpenAICodexResponses(model, context, {
+		apiKey: mockToken(),
+		sessionId,
+		transport: "auto",
+	}).result();
+}
+
+describe("OpenAI Codex WebSocket fallback recovery", () => {
+	it("keeps immediate requests on SSE during the fallback cooldown", async () => {
+		const transport = installTransportHarness();
+
+		await runSession("fallback-cooldown");
+		await runSession("fallback-cooldown");
+
+		expect(transport.connections()).toBe(1);
+		expect(transport.fetches()).toBe(2);
+	});
+
+	it("retries WebSocket after the fallback cooldown", async () => {
+		let now = 1_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		const transport = installTransportHarness();
+
+		await runSession("fallback-recovery");
+		expect(transport.connections()).toBe(1);
+		expect(transport.fetches()).toBe(1);
+
+		await runSession("fallback-recovery");
+		expect(transport.connections()).toBe(1);
+		expect(transport.fetches()).toBe(2);
+
+		now += FALLBACK_COOLDOWN_MS + 1;
+		await runSession("fallback-recovery");
+
+		expect(transport.connections()).toBe(2);
+		expect(transport.fetches()).toBe(2);
+	});
+
+	it("recovers WebSocket immediately after production cleanup", async () => {
+		const transport = installTransportHarness();
+
+		await runSession("fallback-cleanup");
+		expect(getOpenAICodexWebSocketDebugStats("fallback-cleanup")?.websocketFallbackActive).toBe(true);
+
+		closeOpenAICodexWebSocketSessions("fallback-cleanup");
+		await runSession("fallback-cleanup");
+
+		expect(transport.connections()).toBe(2);
+		expect(transport.fetches()).toBe(1);
+		const stats = getOpenAICodexWebSocketDebugStats("fallback-cleanup");
+		expect(stats?.websocketFallbackActive).not.toBe(true);
+		expect(stats?.websocketFailures).toBe(0);
+		expect(stats?.sseFallbacks).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Prevent one transient Codex WebSocket failure from pinning a long-lived
session to SSE forever.

The fallback circuit now keeps immediate requests on SSE for 60 seconds, then
lets the next fresh request probe WebSocket again. Production session cleanup
also clears degraded routing and debug state.

## Safety

- Recovery changes only a future request.
- The existing post-start guard remains unchanged, so an already-started or
  potentially billed response is never retried through SSE.
- Immediate requests inside the cooldown continue to use SSE.

## RED -> GREEN

- RED cooldown recovery: after simulated +60,001 ms, WebSocket connections
  remained 1 instead of increasing to 2.
- RED cleanup recovery: after production cleanup, WebSocket connections
  remained 1 instead of increasing to 2.
- GREEN focused recovery suite: 3/3.
- Existing Codex stream + cache-affinity + recovery suites: 45/45.

## Validation

- Full AI package: 174 files passed, 25 skipped; 1,574 tests passed.
- Root `npm run check`: passed.
- Real library QA: first request used one local HTTP fallback; after simulated
  +60,001 ms the second completed through WebSocket; total HTTP requests stayed
  at one; server and port cleaned.
- Real CLI mock-loop QA: 43/43 passed.
- Adapter shrank by 54 net lines; extracted fallback module is 79 pure LOC.

## Plan

`.omo/plans/issue-589-websocket-fallback-recovery.md`

## Residual scope

Provider-side prefix caching remains best-effort. This change removes the
client-controlled permanent-SSE exposure without claiming to make upstream
cache routing deterministic.

Related to #589
