### PR TITLE
fix(deps): remediate PostCSS path traversal advisory

### DIFF
--- a/.omo/plans/postcss-ghsa-r28c.md
+++ b/.omo/plans/postcss-ghsa-r28c.md
@@ -1,0 +1,75 @@
+# Remediate PostCSS GHSA-r28c-9q8g-f849
+
+## Objective
+
+Eliminate the repository's only high-severity npm advisory with the smallest
+deterministic dependency change and no unrelated lockfile drift.
+
+## Diagnosis
+
+- `npm audit --json` reports one HIGH advisory:
+  GHSA-r28c-9q8g-f849, PostCSS path traversal through previous source-map
+  auto-loading.
+- Vulnerable range: `<=8.5.17`.
+- Current lock resolution: `postcss@8.5.15`.
+- Exact dependency path:
+  `@code-yeongyu/senpi-evals -> vitest@4.1.10 -> vite@8.0.16 ->
+  postcss@8.5.15`.
+- First patched version: `8.5.18`.
+- PostCSS is dev/build-time only, absent from the coding-agent install lock,
+  and has no lifecycle scripts.
+
+## Tier and topology
+
+This PR is LIGHT and independent from the WebSocket recovery PR. A quick
+implementation child may own the lockfile lane; the lead retains delivery,
+review, CI, merge, and cleanup.
+
+## Success criteria
+
+### 1. Failing-first advisory proof
+
+Before edits:
+
+```text
+npm audit --json -> high=1
+npm ls postcss -> postcss@8.5.15
+```
+
+### 2. Surgical remediation
+
+Add exact root override:
+
+```json
+"postcss": "8.5.18"
+```
+
+Refresh the lock with `PI_ALLOW_LOCKFILE_CHANGE=1` and
+`npm install --package-lock-only --ignore-scripts`.
+
+PASS: only `package.json`, `package-lock.json`, and this plan change; the lock
+updates PostCSS version/resolution/integrity without unrelated dependency
+movement.
+
+### 3. Security and project validation
+
+```text
+npm audit --json -> high=0, total=0
+npm ls postcss -> postcss@8.5.18
+npm run check -> exit 0
+npm run build -> exit 0
+```
+
+No lifecycle scripts may execute during the refresh.
+
+## Delivery
+
+Commit the plan first, open a draft PR, implement the exact override and lock
+refresh, record RED/GREEN audit evidence, obtain review and CI, merge with a
+merge commit, and remove
+`/Users/yeongyu/local-workspaces/senpi-wt/postcss-ghsa-r28c`.
+
+## Stop condition
+
+Stop when the advisory PR is merged, npm audit reports no vulnerabilities, and
+the task worktree is absent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6967,9 +6967,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+			"integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 	},
 	"overrides": {
 		"@hono/node-server": "2.0.10",
+		"postcss": "8.5.18",
 		"brace-expansion": "5.0.8",
 		"esbuild": "0.28.1",
 		"fast-uri": "3.1.4",


### PR DESCRIPTION
## Summary

Remediate the repository's only high-severity npm advisory:
GHSA-r28c-9q8g-f849 in PostCSS.

## RED -> GREEN

- RED: `npm audit --json` reported HIGH=1 / total=1 and the dependency
  resolved to `postcss@8.5.15`.
- Fix: exact root override `postcss: 8.5.18`; lock refreshed with lifecycle
  scripts disabled.
- GREEN: `npm audit --json` reports zero vulnerabilities and
  `npm ls postcss` resolves 8.5.18.

## Scope

- PostCSS is dev/build-time only through Vite.
- PostCSS 8.5.18 is the first patched version for
  GHSA-r28c-9q8g-f849.
- The package has no lifecycle scripts.
- Diff is surgical: root override plus PostCSS lock version, tarball, and
  integrity metadata. No unrelated dependency drift.

## Validation

- Root `npm run check`: passed.
- Full workspace `npm run build`: passed.
- Coding-agent install lock remains unchanged.

## Plan

`.omo/plans/postcss-ghsa-r28c.md`

Security advisory: https://github.com/advisories/GHSA-r28c-9q8g-f849
