### PR TITLE
feat(coding-agent): animate todo widget completions

### DIFF
--- a/.omo/plans/todo-widget-strike-animation.md
+++ b/.omo/plans/todo-widget-strike-animation.md
@@ -1,0 +1,161 @@
+# Todo Widget Strike Animation
+
+## Objective
+
+Keep a task that has just completed visible in the input-bar `Todo` widget when
+the active phase remains the same, and animate the completed row with the same
+left-to-right strikethrough reveal already used by the inline `todo` tool
+result. Preserve the existing active-phase selection, 10-line window, restored
+session behavior, and all-completed widget hiding.
+
+## Tier
+
+HEAVY. The change adds an animated TUI widget component with timer,
+render-request, replacement, and disposal lifecycle.
+
+## Applicable Skills
+
+- `programming`: strict TypeScript, deterministic TDD, no suppressed failures.
+- `visual-qa`: browser-rendered xterm.js screenshots for TUI motion evidence.
+- `senpi-qa`: isolated real-source CLI smoke and auth-safe evidence.
+- `work-with-pr`: task-owned worktree, reviewer-readable PR, CI/Cubic loop,
+  merge commit, and cleanup.
+- `ulw-loop`: binding evidence ledger and RED -> GREEN -> surface execution.
+- `commit` and `git-master`: repository-style atomic commits and explicit
+  staging.
+
+`frontend` is not used: this is a terminal widget extending an existing shipped
+visual/motion contract, not a browser UI or a new design system.
+
+## Confirmed Existing Flow
+
+- `todotools/index.ts` syncs `todo-sidebar` with static lines from
+  `getTodoWidgetLines(currentPhases)`.
+- `tools/todo.ts` already computes exact `TodoCompletionTransition[]` on live
+  mutations, but passes them only to the inline tool result.
+- `todo-strike.ts` already owns the code-point-safe hold/reveal timing,
+  partial-strike helper, and 65ms/14-frame contract.
+- Extension widgets support a `(tui, theme) => Component` factory and dispose
+  replaced components.
+- `todo-widget.test.ts` pins the current active-phase window and all-completed
+  hiding behavior.
+
+## Design Decision
+
+Use the extension widget factory form and a small todo-specific component.
+The component receives current phases plus only the live completion transitions
+from the mutation that triggered the sync. It derives the active phase using
+the existing query, retains a just-completed row only when that transition
+belongs to the still-active phase, renders the row with the existing theme and
+strike helpers, advances a bounded unref'd timer, requests TUI renders, and
+self-settles. Session start/tree rebuilds and command-driven syncs receive no
+transition set and therefore render settled static content with no replay.
+
+Do not change the general 10-line window policy. The temporary retained row
+must fit inside the existing body budget by replacing the row that the active
+task advance would otherwise displace; after the animation settles, the model
+returns to the ordinary window.
+
+## Delegation Topology
+
+- Completed read-only `explore` child: traced widget flow, disappearance rules,
+  animation primitives, and test seams.
+- Lead owns tests, implementation, QA, and delivery because the model,
+  component lifecycle, and extension wiring are one coupled contract.
+- No team: parallel writers would collide on the same todotools module and
+  animation lifecycle.
+
+## Execution Waves
+
+### Setup
+
+1. Commit this plan alone, push the branch, and open a draft PR.
+2. Register the binding goal and mirror this plan into the live todo list.
+3. Re-read worktree source, tests, and nearest `changes.md` files.
+
+### RED
+
+4. Add a widget render/model test:
+   - phase `Delivery`
+   - `Monitor CI and resolve active review gates` transitions to completed
+   - `Merge PR with merge commit` becomes/remains active
+   - assert completed row is retained at frame 0, partially struck mid-frame,
+     and fully struck at settle.
+5. Add deterministic fake-timer lifecycle coverage:
+   - interval starts only for same-active-phase completion
+   - render is requested while frames advance
+   - interval stops after total frames
+   - replacement/dispose clears it immediately.
+6. Add edge/regression coverage:
+   - completion from a phase that is no longer active is not retained/animated
+   - session restore starts settled and does not start a timer
+   - existing line-budget matrix and all-completed hide tests remain unchanged.
+7. Run the focused tests after each new case and save failure output proving
+   each RED fails for the missing behavior, not syntax/import errors.
+
+### GREEN
+
+8. Add the smallest todo-widget view model needed for temporary same-phase
+   retention and frame-aware themed formatting.
+9. Add the disposable component that reuses `TODO_STRIKE_*`,
+   `strikeRevealCount`, and `partialStrikethrough`.
+10. Extend `syncWidget` so the live `todo` tool path can pass exact completion
+    transitions; all other callers pass none.
+11. Keep restored/static calls settled and preserve existing active-phase and
+    line-budget semantics.
+12. Update the nearest todotools `changes.md`.
+13. Run focused tests, LSP diagnostics, and `npm run check`.
+
+### Surface Verification
+
+14. Run:
+
+    ```bash
+    node .agents/skills/senpi-qa/scripts/tui-smoke.mjs \
+      --self-test --driver pty --evidence todo-widget-strike
+    ```
+
+15. Drive an isolated real source TUI with a deterministic local model scenario
+    that performs `todo init` then completes the first `Delivery` task while the
+    second task stays active. Capture rest, mid, and settled frames with:
+
+    ```bash
+    node /Users/yeongyu/local-workspaces/omo/script/qa/web-terminal-visual-qa.mjs \
+      --title "Senpi todo widget strike" \
+      --command "<isolated source-TUI todo scenario>" \
+      --cwd "/Users/yeongyu/local-workspaces/senpi-wt/feat/todo-widget-strike-animation" \
+      --cols 120 --rows 34 \
+      --evidence-dir "local-ignore/qa-evidence/20260731-todo-widget-strike/<frame>"
+    ```
+
+16. PASS requires `Delivery`, completed
+    `Monitor CI and resolve active review gates`, and active
+    `Merge PR with merge commit` to be simultaneously visible, with strike
+    progression on only the completed row.
+17. Record cleanup receipts for PTY/browser, fake server, sandbox, ports, temp
+    files, and timers.
+
+### Delivery
+
+18. Self-review the diff and map current-tree evidence to every criterion.
+19. Commit implementation plus direct tests atomically, push, and update the PR
+    body with sanitized evidence.
+20. Monitor CI and Cubic; fix and re-QA any valid failure until every active
+    gate passes.
+21. Merge with a merge commit, verify GitHub reports `MERGED`, remove/prune the
+    worktree, complete the goal, and report evidence.
+
+## Success Criteria
+
+1. Same-phase completion remains visible and visibly progresses from unstruck
+   to partially struck to fully struck while the next task is active.
+2. Prior-phase/restored completions do not replay; timer/render work stops on
+   settle and dispose with no leak.
+3. Existing widget windowing, all-completed hiding, static validation, and real
+   TUI boot/input behavior remain green.
+
+## Stop Condition
+
+Stop immediately when GitHub reports the PR merged, all criteria have
+current-tree RED -> GREEN and real-surface evidence plus cleanup receipts, and
+the task worktree has been removed and pruned.

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -1,5 +1,36 @@
 # todotools Fork Tracker
 
+## 2026-07-31 - Animate same-phase completions in the todo sidebar
+
+### What changed
+
+- The `todo-sidebar` now uses the extension widget factory form and a
+  disposable `TodoWidgetComponent` instead of static string rows.
+- Visible task rows share the inline todo result's status styling: completed
+  rows are dimmed and struck, the active row is accent/bold, abandoned rows are
+  dimmed, and pending rows remain plain.
+- Live `todo` tool mutations pass their exact `TodoCompletionTransition[]` into
+  widget sync. A newly completed row animates only when its transition belongs
+  to the still-active phase and the row remains inside the existing 10-line
+  window.
+- The component reuses the shipped two-frame hold, twelve-frame left-to-right
+  reveal, 65ms cadence, code-point-safe splitting, and themed strikethrough
+  callback. Its interval is unref'd, self-terminates, and is cleared when the
+  host replaces or disposes the widget.
+- Session start/tree rebuilds and `/todo` command updates pass no live
+  transitions, so restored and user-edited completed rows render fully settled
+  without replaying animation.
+- The existing active-phase selection, line budget, omission counts, and
+  all-completed widget hiding remain unchanged.
+
+### Expected merge conflict zones
+
+- MEDIUM: `todo-widget.ts` around the new row model that preserves the existing
+  window algorithm.
+- MEDIUM: `index.ts` and `tools/todo.ts` around widget sync and live completion
+  transition plumbing.
+- LOW: `todo-widget-component.ts` and its focused fake-timer tests (fork-only).
+
 ## 2026-07-30 - Bulk-clear rm when both targets arrive blank
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/commands.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/commands.ts
@@ -17,6 +17,7 @@ import {
 	clonePhases,
 	DEFAULT_INIT_PHASE,
 	TODO_STATE_ENTRY_TYPE,
+	type TodoCompletionTransition,
 	type TodoItem,
 	type TodoPhase,
 	type TodoStateEntry,
@@ -41,7 +42,7 @@ const VERBS = ["edit", "copy", "export", "import", "append", "start", "done", "d
 export type TodoCommandAccessors = {
 	getCurrentPhases: () => TodoPhase[];
 	setCurrentPhases: (phases: TodoPhase[]) => void;
-	syncWidget: (ctx: ExtensionContext) => void;
+	syncWidget: (ctx: ExtensionContext, completedTasks?: readonly TodoCompletionTransition[]) => void;
 };
 
 /** Tokenizer honoring double-quoted strings and backslash escapes. */

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/index.ts
@@ -1,7 +1,14 @@
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { registerTodoCommand } from "./commands.ts";
 import { TASK_MANAGEMENT_SECTION } from "./prompt.ts";
-import { clonePhases, getLatestPhasesFromBranchEntries, getTodoWidgetLines, type TodoPhase } from "./state.ts";
+import {
+	clonePhases,
+	getLatestPhasesFromBranchEntries,
+	type TodoCompletionTransition,
+	type TodoPhase,
+} from "./state.ts";
+import { getTodoWidgetModel } from "./todo-widget.ts";
+import { TodoWidgetComponent } from "./todo-widget-component.ts";
 import { registerTodoTool } from "./tools/todo.ts";
 
 function getLatestPhases(ctx: ExtensionContext): TodoPhase[] {
@@ -17,8 +24,12 @@ export default function todotoolsExtension(pi: ExtensionAPI): void {
 		currentPhases = clonePhases(phases);
 	};
 
-	const syncWidget = (ctx: ExtensionContext): void => {
-		ctx.ui.setWidget("todo-sidebar", getTodoWidgetLines(currentPhases));
+	const syncWidget = (ctx: ExtensionContext, completedTasks: readonly TodoCompletionTransition[] = []): void => {
+		const model = getTodoWidgetModel(currentPhases);
+		ctx.ui.setWidget(
+			"todo-sidebar",
+			model ? (tui, theme) => new TodoWidgetComponent(tui, theme, model, completedTasks) : undefined,
+		);
 	};
 
 	const syncFromSession = (ctx: ExtensionContext): void => {

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/state.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/state.ts
@@ -49,4 +49,9 @@ export {
 	type TodoStatus,
 	type TodoToolDetails,
 } from "./todo-types.ts";
-export { getTodoWidgetLines } from "./todo-widget.ts";
+export {
+	getTodoWidgetLines,
+	getTodoWidgetModel,
+	type TodoWidgetModel,
+	type TodoWidgetRow,
+} from "./todo-widget.ts";

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/todo-widget-component.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/todo-widget-component.ts
@@ -1,0 +1,113 @@
+import { Text, type TUI } from "@earendil-works/pi-tui";
+import {
+	partialStrikethrough,
+	strikeRevealCount,
+	TODO_STRIKE_FRAME_INTERVAL_MS,
+	TODO_STRIKE_TOTAL_FRAMES,
+} from "../../../../modes/interactive/components/todo-strike.ts";
+import type { Theme } from "../../../../modes/interactive/theme/theme.ts";
+import { getTodoMarker, sanitizeTodoText } from "./todo-format.ts";
+import type { TodoCompletionTransition, TodoItem } from "./todo-types.ts";
+import type { TodoWidgetModel } from "./todo-widget.ts";
+
+function formatTask(
+	task: TodoItem,
+	theme: Theme,
+	completionKeys: ReadonlySet<string>,
+	frame: number | undefined,
+): string {
+	const line = `${getTodoMarker(task.status)} ${sanitizeTodoText(task.content)}`;
+	switch (task.status) {
+		case "completed": {
+			const reveal = completionKeys.has(task.content) ? strikeRevealCount(line, frame) : undefined;
+			return reveal === undefined
+				? theme.fg("dim", theme.strikethrough(line))
+				: theme.fg(
+						"dim",
+						partialStrikethrough(line, reveal, (text) => theme.strikethrough(text)),
+					);
+		}
+		case "in_progress":
+			return theme.fg("accent", theme.bold(line));
+		case "abandoned":
+			return theme.fg("dim", line);
+		case "pending":
+			return line;
+	}
+}
+
+function getAnimatedCompletionKeys(
+	model: TodoWidgetModel,
+	completedTasks: readonly TodoCompletionTransition[],
+): ReadonlySet<string> {
+	const visibleCompletedTasks = new Set<string>();
+	for (const row of model.rows) {
+		if (row.kind === "task" && row.task.status === "completed") {
+			visibleCompletedTasks.add(row.task.content);
+		}
+	}
+	return new Set(
+		completedTasks
+			.filter((transition) => transition.phase === model.phaseName && visibleCompletedTasks.has(transition.content))
+			.map((transition) => transition.content),
+	);
+}
+
+export class TodoWidgetComponent extends Text {
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private readonly model: TodoWidgetModel;
+	private readonly completionKeys: ReadonlySet<string>;
+	private frame: number | undefined;
+	private intervalId: NodeJS.Timeout | undefined;
+
+	constructor(tui: TUI, theme: Theme, model: TodoWidgetModel, completedTasks: readonly TodoCompletionTransition[]) {
+		super("", 1, 0);
+		this.tui = tui;
+		this.theme = theme;
+		this.model = model;
+		this.completionKeys = getAnimatedCompletionKeys(model, completedTasks);
+		this.frame = this.completionKeys.size > 0 ? 0 : undefined;
+		this.updateDisplay();
+		if (this.frame !== undefined) this.startAnimation();
+	}
+
+	dispose(): void {
+		this.stopAnimation();
+	}
+
+	private startAnimation(): void {
+		const handle = setInterval(() => this.tick(), TODO_STRIKE_FRAME_INTERVAL_MS);
+		handle.unref();
+		this.intervalId = handle;
+	}
+
+	private stopAnimation(): void {
+		if (this.intervalId === undefined) return;
+		clearInterval(this.intervalId);
+		this.intervalId = undefined;
+	}
+
+	private tick(): void {
+		if (this.frame === undefined) return;
+		const nextFrame = this.frame + 1;
+		if (nextFrame >= TODO_STRIKE_TOTAL_FRAMES) {
+			this.frame = undefined;
+			this.stopAnimation();
+		} else {
+			this.frame = nextFrame;
+		}
+		this.updateDisplay();
+		this.tui.requestRender();
+	}
+
+	private updateDisplay(): void {
+		this.setText(
+			this.model.rows
+				.map((row) =>
+					row.kind === "label" ? row.text : formatTask(row.task, this.theme, this.completionKeys, this.frame),
+				)
+				.join("\n"),
+		);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/todo-widget.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/todo-widget.ts
@@ -11,6 +11,21 @@ const TODO_WIDGET_MAX_LINES = 10;
 const TODO_WIDGET_HEADER_LINES = 2;
 const TODO_WIDGET_RECENT_TASKS = 2;
 
+export type TodoWidgetRow =
+	| {
+			readonly kind: "label";
+			readonly text: string;
+	  }
+	| {
+			readonly kind: "task";
+			readonly task: TodoItem;
+	  };
+
+export type TodoWidgetModel = {
+	readonly phaseName: string;
+	readonly rows: readonly TodoWidgetRow[];
+};
+
 function getActivePhase(phases: readonly TodoPhase[]): TodoPhase | undefined {
 	const activeTask = nextActionableTask(phases);
 	if (!activeTask) return undefined;
@@ -25,12 +40,25 @@ function formatTask(todo: TodoItem): string {
 	return `${getTodoMarker(todo.status)} ${sanitizeTodoText(todo.content)}`;
 }
 
-export function getTodoWidgetLines(phases: readonly TodoPhase[]): string[] | undefined {
+function label(text: string): TodoWidgetRow {
+	return { kind: "label", text };
+}
+
+function taskRow(task: TodoItem): TodoWidgetRow {
+	return { kind: "task", task };
+}
+
+export function getTodoWidgetModel(phases: readonly TodoPhase[]): TodoWidgetModel | undefined {
 	const activePhase = getActivePhase(phases);
 	if (!activePhase) return undefined;
-	const header = ["Todo", sanitizeTodoText(activePhase.name)];
-	const taskLines = activePhase.tasks.map(formatTask);
-	if (header.length + taskLines.length <= TODO_WIDGET_MAX_LINES) return [...header, ...taskLines];
+	const header = [label("Todo"), label(sanitizeTodoText(activePhase.name))];
+	const taskRows = activePhase.tasks.map(taskRow);
+	if (header.length + taskRows.length <= TODO_WIDGET_MAX_LINES) {
+		return {
+			phaseName: activePhase.name,
+			rows: [...header, ...taskRows],
+		};
+	}
 
 	const activeTask = nextActionableTask([activePhase]);
 	if (!activeTask) return undefined;
@@ -38,7 +66,7 @@ export function getTodoWidgetLines(phases: readonly TodoPhase[]): string[] | und
 	const firstVisibleTask = Math.max(0, activeIndex - TODO_WIDGET_RECENT_TASKS);
 	const earlierOmitted = firstVisibleTask;
 	const bodyBudget = TODO_WIDGET_MAX_LINES - TODO_WIDGET_HEADER_LINES;
-	const recentAndActive = taskLines.slice(firstVisibleTask, activeIndex + 1);
+	const recentAndActive = activePhase.tasks.slice(firstVisibleTask, activeIndex + 1).map(taskRow);
 	const earlierMarkerRows = earlierOmitted > 0 ? 1 : 0;
 	const pendingAfterActive = activePhase.tasks.slice(activeIndex + 1).filter((todo) => todo.status === "pending");
 	const upcomingBudget = bodyBudget - recentAndActive.length - earlierMarkerRows;
@@ -46,12 +74,20 @@ export function getTodoWidgetLines(phases: readonly TodoPhase[]): string[] | und
 		pendingAfterActive.length > upcomingBudget ? Math.max(0, upcomingBudget - 1) : pendingAfterActive.length;
 	const laterOmitted = pendingAfterActive.length - visibleUpcomingCount;
 
-	return [
-		"Todo",
-		sanitizeTodoText(activePhase.name),
-		...(earlierOmitted > 0 ? [formatOmittedTasks(earlierOmitted, "earlier")] : []),
-		...recentAndActive,
-		...pendingAfterActive.slice(0, visibleUpcomingCount).map(formatTask),
-		...(laterOmitted > 0 ? [formatOmittedTasks(laterOmitted, "later")] : []),
-	];
+	return {
+		phaseName: activePhase.name,
+		rows: [
+			...header,
+			...(earlierOmitted > 0 ? [label(formatOmittedTasks(earlierOmitted, "earlier"))] : []),
+			...recentAndActive,
+			...pendingAfterActive.slice(0, visibleUpcomingCount).map(taskRow),
+			...(laterOmitted > 0 ? [label(formatOmittedTasks(laterOmitted, "later"))] : []),
+		],
+	};
+}
+
+export function getTodoWidgetLines(phases: readonly TodoPhase[]): string[] | undefined {
+	const model = getTodoWidgetModel(phases);
+	if (!model) return undefined;
+	return model.rows.map((row) => (row.kind === "label" ? row.text : formatTask(row.task)));
 }

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/tools/todo.ts
@@ -72,7 +72,7 @@ type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
 type TodoAccessors = {
 	getCurrentPhases: () => TodoPhase[];
 	setCurrentPhases: (phases: TodoPhase[]) => void;
-	syncWidget: (ctx: ExtensionContext) => void;
+	syncWidget: (ctx: ExtensionContext, completedTasks?: readonly TodoCompletionTransition[]) => void;
 };
 
 function countInitItems(params: TodoParams): { phases: number; tasks: number } {
@@ -315,7 +315,7 @@ export function registerTodoTool(pi: ExtensionAPI, accessors: TodoAccessors): vo
 					phases: clonePhases(applied.phases),
 				} satisfies TodoStateEntry);
 				accessors.setCurrentPhases(clonePhases(applied.phases));
-				accessors.syncWidget(ctx);
+				accessors.syncWidget(ctx, completedTasks);
 			}
 
 			const details: TodoToolDetails = {

--- a/packages/coding-agent/test/todo-widget-component.test.ts
+++ b/packages/coding-agent/test/todo-widget-component.test.ts
@@ -1,0 +1,227 @@
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import type { Static } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import todotoolsExtension from "../src/core/extensions/builtin/todotools/index.ts";
+import { TODO_STATE_ENTRY_TYPE, type TodoStateEntry } from "../src/core/extensions/builtin/todotools/state.ts";
+import type { TODO_PARAMS_SCHEMA } from "../src/core/extensions/builtin/todotools/tools/todo.ts";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../src/core/extensions/types.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import {
+	TODO_STRIKE_FRAME_INTERVAL_MS,
+	TODO_STRIKE_TOTAL_FRAMES,
+} from "../src/modes/interactive/components/todo-strike.ts";
+import type { Theme } from "../src/modes/interactive/theme/theme.ts";
+
+type TodoParams = Static<typeof TODO_PARAMS_SCHEMA>;
+type WidgetFactory = (tui: TUI, theme: Theme) => Component & { dispose?(): void };
+type CapturedWidget = string[] | WidgetFactory | undefined;
+
+const completedTask = "Monitor CI and resolve active review gates";
+const activeTask = "Merge PR with merge commit";
+
+const markerTheme = {
+	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
+	bold: (text: string) => `<bold>${text}</bold>`,
+	strikethrough: (text: string) => `<s>${text}</s>`,
+} as Theme;
+
+function createTodoHarness(
+	options: { readonly mountWidgets?: boolean; readonly sessionManager?: SessionManager } = {},
+): {
+	readonly ctx: ExtensionContext;
+	readonly getTool: () => ToolDefinition<typeof TODO_PARAMS_SCHEMA>;
+	readonly getWidget: () => CapturedWidget;
+	readonly getMountedComponent: () => (Component & { dispose?(): void }) | undefined;
+	readonly requestRender: ReturnType<typeof vi.fn>;
+	readonly emitSessionStart: () => Promise<void>;
+} {
+	let tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA> | undefined;
+	let widget: CapturedWidget;
+	let mountedComponent: (Component & { dispose?(): void }) | undefined;
+	const requestRender = vi.fn();
+	const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+	const pi = {
+		on: (event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
+			const eventHandlers = handlers.get(event) ?? [];
+			eventHandlers.push(handler);
+			handlers.set(event, eventHandlers);
+		},
+		registerCommand: () => {},
+		registerTool: (definition: ToolDefinition<typeof TODO_PARAMS_SCHEMA>) => {
+			tool = definition;
+		},
+		appendEntry: () => {},
+	} as unknown as ExtensionAPI;
+	const ctx = {
+		ui: {
+			setWidget: (_key: string, content: CapturedWidget) => {
+				widget = content;
+				if (!options.mountWidgets) return;
+				mountedComponent?.dispose?.();
+				mountedComponent =
+					typeof content === "function" ? content({ requestRender } as unknown as TUI, markerTheme) : undefined;
+			},
+		},
+		sessionManager: options.sessionManager ?? {
+			getSessionFile: () => undefined,
+		},
+	} as unknown as ExtensionContext;
+
+	todotoolsExtension(pi);
+
+	return {
+		ctx,
+		getTool: () => {
+			if (!tool) throw new Error("Expected the todo tool to register");
+			return tool;
+		},
+		getWidget: () => widget,
+		getMountedComponent: () => mountedComponent,
+		requestRender,
+		emitSessionStart: async () => {
+			for (const handler of handlers.get("session_start") ?? []) {
+				await handler({ type: "session_start", reason: "startup" }, ctx);
+			}
+		},
+	};
+}
+
+async function executeTodo(
+	tool: ToolDefinition<typeof TODO_PARAMS_SCHEMA>,
+	ctx: ExtensionContext,
+	params: TodoParams,
+): Promise<void> {
+	if (!tool.execute) throw new Error("Expected the todo tool to execute");
+	await tool.execute("todo-test", params, new AbortController().signal, () => {}, ctx);
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("todo sidebar completion animation", () => {
+	it("retains and progressively strikes a same-phase completion", async () => {
+		// Given a Delivery phase whose first task is active.
+		vi.useFakeTimers();
+		const harness = createTodoHarness();
+		const tool = harness.getTool();
+		await executeTodo(tool, harness.ctx, {
+			op: "init",
+			list: [{ phase: "Delivery", items: [completedTask, activeTask] }],
+		});
+
+		// When the active task completes and the next task is promoted in the same phase.
+		await executeTodo(tool, harness.ctx, { op: "done", task: completedTask });
+
+		// Then the widget keeps the completed row and reveals its strike left-to-right.
+		const widget = harness.getWidget();
+		expect(typeof widget).toBe("function");
+		if (typeof widget !== "function") throw new Error("Expected an animated widget factory");
+		const requestRender = vi.fn();
+		const component = widget({ requestRender } as unknown as TUI, markerTheme);
+
+		const initial = component.render(120).join("\n");
+		expect(initial).toContain(`<fg:dim>[✓] ${completedTask}</fg:dim>`);
+		expect(initial).toContain(`<fg:accent><bold>[•] ${activeTask}</bold></fg:accent>`);
+
+		await vi.advanceTimersByTimeAsync(TODO_STRIKE_FRAME_INTERVAL_MS * 8);
+		const midpoint = component.render(120).join("\n");
+		expect(midpoint).toContain("<fg:dim><s>[✓] Monitor CI and reso</s>lve active review gates</fg:dim>");
+
+		await vi.advanceTimersByTimeAsync(TODO_STRIKE_FRAME_INTERVAL_MS * (TODO_STRIKE_TOTAL_FRAMES - 8));
+		const settled = component.render(120).join("\n");
+		expect(settled).toContain(`<fg:dim><s>[✓] ${completedTask}</s></fg:dim>`);
+		component.dispose?.();
+	});
+
+	it("stops requesting renders after settle and clears its timer on dispose", async () => {
+		// Given a mounted todo widget that receives a live same-phase completion.
+		vi.useFakeTimers();
+		const settledHarness = createTodoHarness({ mountWidgets: true });
+		const settledTool = settledHarness.getTool();
+		await executeTodo(settledTool, settledHarness.ctx, {
+			op: "init",
+			list: [{ phase: "Delivery", items: [completedTask, activeTask] }],
+		});
+		await executeTodo(settledTool, settledHarness.ctx, { op: "done", task: completedTask });
+
+		// When the bounded animation reaches its final frame.
+		expect(vi.getTimerCount()).toBe(1);
+		await vi.advanceTimersByTimeAsync(TODO_STRIKE_FRAME_INTERVAL_MS * TODO_STRIKE_TOTAL_FRAMES);
+
+		// Then it has requested each repaint and leaves no timer running.
+		expect(settledHarness.requestRender).toHaveBeenCalledTimes(TODO_STRIKE_TOTAL_FRAMES);
+		expect(vi.getTimerCount()).toBe(0);
+
+		// Given a second widget disposed while its strike is still in flight.
+		const disposedHarness = createTodoHarness({ mountWidgets: true });
+		const disposedTool = disposedHarness.getTool();
+		await executeTodo(disposedTool, disposedHarness.ctx, {
+			op: "init",
+			list: [{ phase: "Delivery", items: [completedTask, activeTask] }],
+		});
+		await executeTodo(disposedTool, disposedHarness.ctx, { op: "done", task: completedTask });
+		expect(vi.getTimerCount()).toBe(1);
+
+		// When the host disposes the widget.
+		disposedHarness.getMountedComponent()?.dispose?.();
+
+		// Then the component tears down the interval immediately.
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("does not replay prior-phase or restored completions", async () => {
+		// Given a later phase completion that returns the active pointer to Foundation.
+		vi.useFakeTimers();
+		const liveHarness = createTodoHarness({ mountWidgets: true });
+		const liveTool = liveHarness.getTool();
+		await executeTodo(liveTool, liveHarness.ctx, {
+			op: "init",
+			list: [
+				{ phase: "Foundation", items: ["Build core"] },
+				{ phase: "Verification", items: ["Run checks"] },
+			],
+		});
+		await executeTodo(liveTool, liveHarness.ctx, { op: "start", task: "Run checks" });
+
+		// When the Verification task completes and Foundation becomes active again.
+		await executeTodo(liveTool, liveHarness.ctx, { op: "done", task: "Run checks" });
+
+		// Then the active widget is settled, excludes the prior phase, and starts no animation.
+		const liveComponent = liveHarness.getMountedComponent();
+		expect(liveComponent).toBeDefined();
+		const liveRender = liveComponent?.render(120).join("\n") ?? "";
+		expect(liveRender).toContain("Foundation");
+		expect(liveRender).toContain("<fg:accent><bold>[•] Build core</bold></fg:accent>");
+		expect(liveRender).not.toContain("Verification");
+		expect(liveRender).not.toContain("Run checks");
+		expect(vi.getTimerCount()).toBe(0);
+
+		// Given a restored Delivery phase containing a previously completed row.
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendCustomEntry(TODO_STATE_ENTRY_TYPE, {
+			schema: "v2",
+			phases: [
+				{
+					name: "Delivery",
+					tasks: [
+						{ content: completedTask, status: "completed" },
+						{ content: activeTask, status: "in_progress" },
+					],
+				},
+			],
+		} satisfies TodoStateEntry);
+		const restoredHarness = createTodoHarness({ mountWidgets: true, sessionManager });
+
+		// When the extension rebuilds its widget from the session branch.
+		await restoredHarness.emitSessionStart();
+
+		// Then the completed row is fully struck without replaying the interval.
+		const restoredComponent = restoredHarness.getMountedComponent();
+		expect(restoredComponent).toBeDefined();
+		const restoredRender = restoredComponent?.render(120).join("\n") ?? "";
+		expect(restoredRender).toContain(`<fg:dim><s>[✓] ${completedTask}</s></fg:dim>`);
+		expect(restoredRender).toContain(`<fg:accent><bold>[•] ${activeTask}</bold></fg:accent>`);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

The phased `todo` widget above the input bar now animates a visible task that
completes while its phase remains active. The row uses the same bounded
left-to-right strikethrough reveal as the inline todo tool result, while the
next active row remains accent/bold.

## Changes

- Reuses the existing code-point-safe two-frame hold, twelve-frame reveal, and
  65ms cadence.
- Renders the sidebar through a disposable themed component with an unref'd,
  self-terminating interval.
- Passes exact live completion transitions only from the `todo` mutation path.
- Filters animation to visible completions in the still-active phase.
- Renders restored/prior-phase completions settled without replay.
- Preserves the active-phase selection, 10-line window, omission counts, and
  all-completed hiding behavior.

## QA & Evidence

- Plan: `.omo/plans/todo-widget-strike-animation.md`
- RED proofs:
  - current widget was a static array (`object`, expected factory `function`)
  - no animation timer started (`0`, expected `1`)
  - prior-phase/restored widget component was absent
- Focused current-tree tests:
  - `npx vitest --run test/todo-widget-component.test.ts test/suite/todo-widget.test.ts test/suite/todo-extension.test.ts test/todo-strike.test.ts`
  - 4 files passed, 53 tests passed
- Static validation:
  - `npm run check`
  - exit 0; Biome, pinned deps, import rules, shrinkwrap/install lock, root
    TypeScript, browser smoke, and web UI checks passed
- Isolated real-source TUI smoke:
  - `tui-smoke.mjs --self-test --driver pty --evidence todo-widget-strike`
  - 5/5 passed: boot, render, composer input, teardown, auth integrity
- Chrome/xterm.js motion proof:
  - completed row strike cells: hold `0/46`, midpoint `20/46`, settled `46/46`
  - active row strike cells: `0` in every frame
  - all frames showed `Todo`, `Delivery`, the completed row, and the active row
- Cleanup:
  - PTY exited, browser closed, fake server stopped, sandbox removed
  - QA ports clear; no QA processes or temp sandboxes remain

## Risks & Residuals

- The repository LSP tool cannot address sibling worktrees; equivalent
  worktree diagnostics used `npx tsgo --noEmit` and passed after one narrowing
  fix.
- No remaining known functional risk. The timer, replacement/dispose,
  historical replay, prior-phase filtering, and narrow-widget matrix are
  directly covered.
