### PR TITLE
fix(codemode): preserve rich detached eval peeks

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Fixed
 
+- Preserve rich live and terminal `eval` details when peeking detached cells,
+  including code, title, output, phase, status events, tool-call summaries,
+  duration, and structured displays; cancellation now remains authoritative
+  over late completion races.
+
 ### Removed
 
 ## [2026.7.31-2] - 2026-07-31

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -11,9 +11,12 @@ task-tool names are known.
 - Persistent JavaScript, Python, Ruby, and Julia cells. State survives later
   cells in the same language until reset, restart, or session disposal.
 - Timeout detachment for interactive `eval`: long pure-compute cells return a
-  handle and continue in their existing kernel. Completion is injected with the
-  final value/error and buffered output; use `eval({ action: "peek"|"stop",
-  cell_id })` to inspect or terminate a detached cell.
+	handle and continue in their existing kernel. Completion is injected with the
+	final value/error and buffered output; use `eval({ action: "peek"|"stop",
+	cell_id })` to inspect or terminate a detached cell. A running peek preserves
+	the original code and title together with current output, phase, status
+	events, tool-call summaries, elapsed duration, and structured display state;
+	a terminal peek preserves the exact final result.
 - Loopback, bearer-authenticated kernel bridge with bounded JSONL frames.
 - Structured status events for file operations, environment access, phases,
   bridge activity, and delegated task progress.

--- a/packages/senpi-codemode/scripts/qa-detached-peek.ts
+++ b/packages/senpi-codemode/scripts/qa-detached-peek.ts
@@ -1,0 +1,229 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { AgentToolResult, ExtensionContext } from "@code-yeongyu/senpi";
+import { startBridgeServer } from "../src/bridge/http-server.ts";
+import { createInterpreterDetector } from "../src/interpreters/detect.ts";
+import { PythonKernel } from "../src/kernels/py/kernel.ts";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { renderEvalResult } from "../src/tool/render.ts";
+import type {
+	EvalKernel,
+	EvalKernelManager,
+	EvalToolDetails,
+	EvalToolRequest,
+} from "../src/tool/types.ts";
+
+const execFileAsync = promisify(execFile);
+
+class QaScenarioError extends Error {
+	readonly name = "QaScenarioError";
+}
+
+function qaContext(cwd: string): ExtensionContext {
+	return Object.assign(Object.create(null), {
+		mode: "tui",
+		hasUI: true,
+		cwd,
+		model: undefined,
+		signal: undefined,
+	});
+}
+
+function render(
+	result: AgentToolResult<EvalToolDetails>,
+	args: EvalToolRequest,
+	cwd: string,
+): string {
+	const context = Object.assign(Object.create(null), {
+		args,
+		toolCallId: "qa-render",
+		invalidate: () => {},
+		lastComponent: undefined,
+		state: {},
+		cwd,
+		executionStarted: true,
+		argsComplete: true,
+		isPartial: false,
+		expanded: true,
+		showImages: false,
+		imageProtocol: null,
+		isError: result.details.isError === true,
+		hasResult: true,
+		spinnerFrame: 0,
+	});
+	return renderEvalResult(
+		result,
+		{ expanded: true, isPartial: false },
+		undefined,
+		context,
+	)
+		.render(100)
+		.join("\n");
+}
+
+function requireText(
+	text: string,
+	expected: string,
+	label: string,
+): void {
+	if (!text.includes(expected))
+		throw new QaScenarioError(`${label} missing ${JSON.stringify(expected)}`);
+}
+
+async function main(): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "senpi-detached-peek-"));
+	const fifoPath = join(root, "release.fifo");
+	const inputPath = join(root, "input.json");
+	await writeFile(inputPath, JSON.stringify({ answer: 42 }));
+	await execFileAsync("/usr/bin/mkfifo", [fifoPath]);
+	const detected = await createInterpreterDetector().detect("py");
+	if (!detected.ok)
+		throw new QaScenarioError("No Python interpreter is available");
+	const bridge = await startBridgeServer({
+		onCall: async (request) => {
+			throw new QaScenarioError(`unexpected tool call: ${request.toolName}`);
+		},
+		onEmit: async () => {},
+		onCompletion: async () => {
+			throw new QaScenarioError("unexpected completion call");
+		},
+	});
+	let kernel: PythonKernel | undefined;
+	const kernelManager: EvalKernelManager = {
+		async getKernel(
+			_language: string,
+			onMessage: Parameters<EvalKernelManager["getKernel"]>[1],
+		): Promise<EvalKernel> {
+			if (kernel === undefined) {
+				kernel = await PythonKernel.start({
+					interpreterPath: detected.path,
+					sessionId: `qa-detached-${crypto.randomUUID()}`,
+					cwd: root,
+					connection: { port: bridge.port, token: bridge.token },
+					onMessage,
+				});
+			}
+			return kernel;
+		},
+	};
+	const manager = new EvalDetachedCellManager({ artifactsDir: root });
+	const tool = createEvalTool({
+		enabledLanguages: { js: false, py: true, rb: false, jl: false },
+		kernelManager,
+		cellTimeoutSeconds: 1,
+		executeTool: async (name) => {
+			throw new QaScenarioError(`unexpected host tool call: ${name}`);
+		},
+		cellManager: manager,
+	});
+	const code = [
+		'phase("waiting")',
+		`payload = read(${JSON.stringify(inputPath)})`,
+		'display("before detach")',
+		`with open(${JSON.stringify(fifoPath)}, "r") as gate:`,
+		"    gate.readline()",
+		'display("terminal value")',
+	].join("\n");
+	let cleanup = "not started";
+	try {
+		console.log("QA_STAGE: execute");
+		const ready = Promise.withResolvers<void>();
+		const execution = tool.execute(
+			"qa-detached",
+			{
+				language: "py",
+				code,
+				title: "real detached peek",
+				on_timeout: "detach",
+			},
+			undefined,
+			(update) => {
+				const cell = update.details.cells?.[0];
+				console.log(
+					`QA_UPDATE: phase=${update.details.phase ?? "none"} output=${JSON.stringify(cell?.output ?? "")} status=${update.details.statusEvents?.map((event) => event.op).join(",") ?? "none"}`,
+				);
+				if (
+					update.details.phase === "waiting" &&
+					cell?.output.includes("before detach") === true &&
+					update.details.statusEvents?.some(
+						(event) => event.op === "read",
+					)
+				)
+					ready.resolve(undefined);
+			},
+			qaContext(root),
+		);
+		await ready.promise;
+		console.log("QA_STAGE: rich update observed");
+		await execution;
+		console.log("QA_STAGE: detached");
+		const running = await tool.execute(
+			"qa-peek-running",
+			{ action: "peek", cell_id: "qa-detached" },
+			undefined,
+			undefined,
+			qaContext(root),
+		);
+		const runningRender = render(
+			running,
+			{ action: "peek", cell_id: "qa-detached" },
+			root,
+		);
+		for (const expected of [
+			"real detached peek",
+			'phase("waiting")',
+			"detached",
+			"before detach",
+			"waiting",
+			"read",
+			inputPath,
+		])
+			requireText(runningRender, expected, "running render");
+		console.log("RUNNING_PEEK_PASS: true");
+		console.log("--- RUNNING RENDER ---");
+		console.log(runningRender);
+
+		await writeFile(fifoPath, "release\n");
+		console.log("QA_STAGE: fifo released");
+		await manager.waitForTerminal("qa-detached");
+		console.log("QA_STAGE: terminal");
+		const terminal = await tool.execute(
+			"qa-peek-terminal",
+			{ action: "peek", cell_id: "qa-detached" },
+			undefined,
+			undefined,
+			qaContext(root),
+		);
+		const terminalRender = render(
+			terminal,
+			{ action: "peek", cell_id: "qa-detached" },
+			root,
+		);
+		requireText(terminalRender, "terminal value", "terminal render");
+		if (terminal.details.cells?.[0]?.status !== "complete")
+			throw new QaScenarioError("terminal cell status was not complete");
+		if (terminal.details.durationMs <= 0)
+			throw new QaScenarioError("terminal duration was not positive");
+		console.log("TERMINAL_PEEK_PASS: true");
+		console.log("--- TERMINAL RENDER ---");
+		console.log(terminalRender);
+	} finally {
+		await manager.dispose();
+		await kernel?.close();
+		await bridge.close();
+		await rm(root, { recursive: true, force: true });
+		cleanup = `removed ${root}; kernel closed; bridge closed`;
+		console.log(`CLEANUP: ${cleanup}`);
+	}
+}
+
+await main().catch((error: unknown) => {
+	console.error(
+		error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+	);
+	process.exitCode = 1;
+});

--- a/packages/senpi-codemode/src/tool/cell-execution.ts
+++ b/packages/senpi-codemode/src/tool/cell-execution.ts
@@ -1,0 +1,146 @@
+import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
+import type { EvalKernel } from "./types.ts";
+
+const INTERRUPT_DELIVERY_GRACE_MS = 100;
+
+export interface EvalTimeoutFactory {
+	create(options: IdleTimeoutOptions): TimeoutPauseHandle & { dispose(): void };
+}
+
+export const defaultTimeoutFactory: EvalTimeoutFactory = {
+	create(options): IdleTimeout {
+		return new IdleTimeout(options);
+	},
+};
+
+export interface CellExecutionOptions {
+	readonly callerSignal: AbortSignal;
+	readonly cellId: string;
+	readonly timeoutMs: number;
+	readonly timeoutFactory: EvalTimeoutFactory;
+	readonly onTimeout: (error: Error) => void;
+	readonly onAbort: (error: Error) => void;
+}
+
+export class CellExecution {
+	readonly #callerSignal: AbortSignal;
+	readonly #onAbort: (error: Error) => void;
+	readonly #abortPromise: Promise<never>;
+	readonly #detachedPromise: Promise<void>;
+	readonly #watchdog: TimeoutPauseHandle & { dispose(): void };
+	#rejectAbort: ((reason?: unknown) => void) | undefined;
+	#resolveDetached: (() => void) | undefined;
+	#kernel: EvalKernel | undefined;
+	#interruptDeadline: ReturnType<typeof setTimeout> | undefined;
+	#active = true;
+
+	constructor(options: CellExecutionOptions) {
+		this.#callerSignal = options.callerSignal;
+		this.#onAbort = options.onAbort;
+		this.#abortPromise = new Promise<never>((_resolve, reject) => {
+			this.#rejectAbort = reject;
+		});
+		this.#detachedPromise = new Promise<void>((resolve) => {
+			this.#resolveDetached = resolve;
+		});
+		this.#watchdog = options.timeoutFactory.create({
+			cellId: options.cellId,
+			timeoutMs: options.timeoutMs,
+			onTimeout: ({ error }) => options.onTimeout(error),
+		});
+		this.#callerSignal.addEventListener("abort", this.#handleCallerAbort, {
+			once: true,
+		});
+	}
+
+	get detached(): Promise<void> {
+		return this.#detachedPromise;
+	}
+
+	pause(): void {
+		this.#watchdog.pause();
+	}
+
+	resume(): void {
+		this.#watchdog.resume();
+	}
+
+	setKernel(kernel: EvalKernel): void {
+		this.#kernel = kernel;
+	}
+
+	detach(): void {
+		if (!this.#active) return;
+		this.#watchdog.dispose();
+		this.#resolveDetached?.();
+		this.#resolveDetached = undefined;
+	}
+
+	cancel(reason: unknown): void {
+		this.#abort(reason);
+	}
+
+	finish(): void {
+		this.#active = false;
+		this.#cleanup();
+	}
+
+	async wait<Result>(operation: Promise<Result>): Promise<Result> {
+		const guarded = operation.then(
+			(value): Result | Promise<never> => (this.#active ? value : this.#abortPromise),
+			(reason: unknown): Promise<never> => (this.#active ? Promise.reject(reason) : this.#abortPromise),
+		);
+		return await Promise.race([guarded, this.#abortPromise]);
+	}
+
+	readonly #handleCallerAbort = (): void => {
+		this.#abort(this.#callerSignal.reason);
+	};
+
+	interruptStateRetained: Promise<boolean> | undefined;
+
+	#abort(reason: unknown): void {
+		if (!this.#active) return;
+		this.#active = false;
+		this.#cleanup();
+		const error = abortError(reason);
+		this.#onAbort(error);
+		const kernel = this.#kernel;
+		if (kernel === undefined) {
+			this.#settleAbort(error);
+			return;
+		}
+		this.#interruptDeadline = setTimeout(() => this.#settleAbort(error), INTERRUPT_DELIVERY_GRACE_MS);
+		void Promise.resolve()
+			.then(async () => {
+				const handle = await kernel.interrupt(error.message);
+				this.interruptStateRetained = handle?.stateRetained;
+			})
+			.then(
+				() => this.#settleAbort(error),
+				(interruptError: unknown) => this.#settleAbort(interruptError),
+			);
+	}
+
+	#settleAbort(reason: unknown): void {
+		const reject = this.#rejectAbort;
+		if (reject === undefined) return;
+		this.#rejectAbort = undefined;
+		if (this.#interruptDeadline !== undefined) clearTimeout(this.#interruptDeadline);
+		reject(reason);
+	}
+
+	#cleanup(): void {
+		this.#callerSignal.removeEventListener("abort", this.#handleCallerAbort);
+		this.#watchdog.dispose();
+		if (this.#interruptDeadline !== undefined) clearTimeout(this.#interruptDeadline);
+		this.#interruptDeadline = undefined;
+	}
+}
+
+export function abortError(reason: unknown): Error {
+	if (reason instanceof Error && reason.name !== "AbortError") return reason;
+	const error = new Error(typeof reason === "string" ? reason : "Eval interrupted", { cause: reason });
+	error.name = "AbortError";
+	return error;
+}

--- a/packages/senpi-codemode/src/tool/cell-handler.ts
+++ b/packages/senpi-codemode/src/tool/cell-handler.ts
@@ -1,9 +1,4 @@
-import {
-	type AgentToolResult,
-	type AgentToolUpdateCallback,
-	type ExtensionContext,
-	sanitizeTerminalLabel,
-} from "@code-yeongyu/senpi";
+import { type AgentToolResult, type ExtensionContext, sanitizeTerminalLabel } from "@code-yeongyu/senpi";
 import type { KernelToHostMessage } from "../bridge/protocol.ts";
 import type { AgentExecuteTool } from "../bridges/agent-bridge.ts";
 import { isReservedToolName, runReservedTool } from "../bridges/reserved-dispatch.ts";
@@ -13,15 +8,12 @@ import type { CompletionRequest, CompletionResult } from "../completion/handler.
 import { handleCompletionToolCall } from "../completion/tool-bridge.ts";
 import type { ResolvedCodemodeSettings } from "../config/settings.ts";
 import { boundToolCallArgs, capCodePoints, MAX_ENRICHED_TOOL_CALLS, toolCallResultPreview } from "./call-capture.ts";
-import {
-	type EvalImageResizer,
-	EvalOutputCollector,
-	type EvalOutputResult,
-	marshalToolResult,
-	toolResultIsError,
-} from "./image.ts";
+import { CellResultBuilder, type CellState } from "./cell-runtime.ts";
+import { type EvalImageResizer, marshalToolResult, toolResultIsError } from "./image.ts";
 import { upsertStatusEvent } from "./status-events.ts";
-import type { EvalKernel, EvalStatusEvent, EvalToolDetails, EvalToolInput } from "./types.ts";
+import type { EvalKernel, EvalStatusEvent, EvalToolDetails } from "./types.ts";
+
+export type { CellState } from "./cell-runtime.ts";
 
 type ResolvedToolReply = {
 	readonly value: unknown;
@@ -37,22 +29,6 @@ type ToolCallEnrichment = {
 	readonly argsTruncated?: true;
 };
 
-const LIVE_OUTPUT_PREVIEW_LINES = 8;
-
-export interface CellState {
-	readonly input: EvalToolInput;
-	readonly signal: AbortSignal;
-	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
-	readonly toolCalls: EvalToolDetails["toolCalls"] extends readonly (infer Item)[] ? Item[] : never;
-	readonly pendingBridgeCalls: Promise<void>[];
-	readonly statusEvents: EvalStatusEvent[];
-	active: boolean;
-	output: string;
-	phase: string | undefined;
-	durationMs: number;
-	status: "pending" | "running" | "complete" | "error";
-}
-
 export interface CellBridgeRuntime {
 	readonly executeTool: AgentExecuteTool;
 	readonly listTools?: () => readonly EvalSchemaToolInfo[];
@@ -67,46 +43,40 @@ export class CellHandler {
 	readonly #kernel: EvalKernel;
 	readonly #state: CellState;
 	readonly #runtime: CellBridgeRuntime;
-	readonly #output: EvalOutputCollector;
+	readonly #resultBuilder: CellResultBuilder;
 
 	constructor(kernel: EvalKernel, state: CellState, runtime: CellBridgeRuntime) {
 		this.#kernel = kernel;
 		this.#state = state;
 		this.#runtime = runtime;
 		const settings = runtime.settings.outputSink;
-		this.#output = new EvalOutputCollector({
+		this.#resultBuilder = new CellResultBuilder({
+			state,
 			headBytes: settings.headBytes,
 			maxColumns: settings.maxColumns,
 			model: runtime.ctx.model,
 			...(runtime.artifactPath === undefined ? {} : { artifactPath: runtime.artifactPath }),
 			...(runtime.imageResizer === undefined ? {} : { imageResizer: runtime.imageResizer }),
-			onChunk: (_aggregate, cell) => {
-				state.output = cell;
-				this.#emitUpdate(false);
-			},
 		});
-		state.status = "running";
-		this.#emitUpdate(false);
 	}
 
 	async handle(message: KernelToHostMessage): Promise<void> {
 		if (!this.#state.active) return;
 		switch (message.type) {
 			case "text":
-				this.#output.push(message.data);
+				this.#resultBuilder.push(message.data);
 				return;
 			case "phase":
-				this.#state.phase = message.title;
-				this.#emitUpdate(false);
+				this.#resultBuilder.setPhase(message.title);
 				return;
 			case "status":
 				this.#recordStatus(message.event);
 				return;
 			case "log":
-				this.#output.push(`${message.message}\n`);
+				this.#resultBuilder.push(`${message.message}\n`);
 				return;
 			case "display":
-				this.#output.display(message);
+				this.#resultBuilder.display(message);
 				return;
 			case "tool-call": {
 				const pending = this.#handleToolCall(message);
@@ -125,38 +95,19 @@ export class CellHandler {
 	}
 
 	async finalize(result: Extract<KernelToHostMessage, { type: "result" }>): Promise<AgentToolResult<EvalToolDetails>> {
-		this.#state.durationMs = result.durationMs;
-		if (result.ok) {
-			if (result.valueRepr) this.#output.push(`${result.valueRepr}\n`);
-			this.#state.status = "complete";
-		} else {
-			this.#output.push(`${result.error.message}\n`);
-			this.#state.status = "error";
-		}
-		return await this.#finish(!result.ok);
+		return await this.#resultBuilder.finalize(result);
 	}
 
 	async finalizeCancellation(error: Error): Promise<AgentToolResult<EvalToolDetails>> {
-		this.#output.push(`${error.message}\n`);
-		this.#state.status = "error";
-		return await this.#finish(true);
+		return await this.#resultBuilder.finalizeCancellation(error);
 	}
 
 	async flushOutput(): Promise<void> {
-		await this.#output.flush();
+		await this.#resultBuilder.flushOutput();
 	}
 
-	async #finish(isError: boolean): Promise<AgentToolResult<EvalToolDetails>> {
-		const output = await this.#output.finish();
-		this.#state.output = output.output;
-		const details = this.#details(output, isError);
-		this.#emitUpdate(isError);
-		const text =
-			output.output ||
-			(output.images.length > 0
-				? `(displayed ${output.images.length} image${output.images.length === 1 ? "" : "s"}; no text output)`
-				: "(no output)");
-		return { content: [{ type: "text", text }, ...output.images], details };
+	liveResult(): AgentToolResult<EvalToolDetails> {
+		return this.#resultBuilder.liveResult();
 	}
 
 	async #handleToolCall(message: Extract<KernelToHostMessage, { type: "tool-call" }>): Promise<void> {
@@ -202,7 +153,7 @@ export class CellHandler {
 					? { name: message.toolName, ok: true }
 					: { name: message.toolName, ok: false, error: result.error },
 			);
-			this.#emitUpdate(false);
+			this.#resultBuilder.emitUpdate(false);
 			return;
 		}
 		const capturedArgs = boundToolCallArgs(message.args);
@@ -268,7 +219,7 @@ export class CellHandler {
 				error: { message: text },
 			});
 		}
-		this.#emitUpdate(false);
+		this.#resultBuilder.emitUpdate(false);
 	}
 
 	#pushToolCall(
@@ -301,55 +252,6 @@ export class CellHandler {
 	#recordStatus(event: EvalStatusEvent): void {
 		if (!this.#runtime.settings.statusEvents) return;
 		upsertStatusEvent(this.#state.statusEvents, event);
-		this.#emitUpdate(false);
-	}
-
-	#details(output: EvalOutputResult | undefined, isError: boolean): EvalToolDetails {
-		const statusEvents = this.#state.statusEvents.length > 0 ? [...this.#state.statusEvents] : undefined;
-		return {
-			language: this.#state.input.language,
-			languages: [this.#state.input.language],
-			...(this.#state.input.title === undefined ? {} : { title: this.#state.input.title }),
-			durationMs: this.#state.durationMs,
-			toolCalls: [...this.#state.toolCalls],
-			truncated: output?.truncated ?? false,
-			...(isError ? { isError: true } : {}),
-			...(this.#state.phase === undefined ? {} : { phase: this.#state.phase }),
-			cells: [
-				{
-					index: 0,
-					...(this.#state.input.title === undefined ? {} : { title: this.#state.input.title }),
-					code: this.#state.input.code,
-					language: this.#state.input.language,
-					output: this.#state.output,
-					status: this.#state.status,
-					durationMs: this.#state.durationMs,
-					...(statusEvents === undefined ? {} : { statusEvents }),
-					...(output?.hasMarkdown ? { hasMarkdown: true } : {}),
-				},
-			],
-			...(statusEvents === undefined ? {} : { statusEvents }),
-			...(output === undefined || output.jsonOutputs.length === 0 ? {} : { jsonOutputs: output.jsonOutputs }),
-			...(output?.notice === undefined ? {} : { notice: output.notice }),
-			...(output?.meta === undefined ? {} : { meta: output.meta }),
-		};
-	}
-
-	#liveUpdateText(): string {
-		const title = this.#state.input.title === undefined ? "" : ` ${this.#state.input.title}`;
-		const aggregateOutput = this.#output.aggregateText();
-		const outputLines = aggregateOutput.split("\n");
-		const hasTrailingNewline = aggregateOutput.endsWith("\n");
-		if (hasTrailingNewline) outputLines.pop();
-		const output = `${outputLines.slice(-LIVE_OUTPUT_PREVIEW_LINES).join("\n")}${hasTrailingNewline ? "\n" : ""}`;
-		return `1/1 cells ${this.#state.status}\n[1] ${this.#state.input.language}${title} ${this.#state.status}${output.length === 0 ? "" : `\n${output}`}`;
-	}
-
-	#emitUpdate(isError: boolean): void {
-		if (!this.#state.active) return;
-		this.#state.onUpdate?.({
-			content: [{ type: "text", text: this.#liveUpdateText() }],
-			details: this.#details(undefined, isError),
-		});
+		this.#resultBuilder.emitUpdate(false);
 	}
 }

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -1,0 +1,157 @@
+import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@code-yeongyu/senpi";
+import type { KernelToHostMessage } from "../bridge/protocol.ts";
+import { type EvalImageResizer, EvalOutputCollector, type EvalOutputResult } from "./image.ts";
+import type { EvalStatusEvent, EvalToolDetails, EvalToolInput } from "./types.ts";
+
+type KernelResult = Extract<KernelToHostMessage, { type: "result" }>;
+type DisplayMessage = Extract<KernelToHostMessage, { type: "display" }>;
+type ToolCall = EvalToolDetails["toolCalls"] extends readonly (infer Item)[] ? Item : never;
+
+export interface CellState {
+	readonly input: EvalToolInput;
+	readonly signal: AbortSignal;
+	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
+	readonly toolCalls: ToolCall[];
+	readonly pendingBridgeCalls: Promise<void>[];
+	readonly statusEvents: EvalStatusEvent[];
+	active: boolean;
+	output: string;
+	phase: string | undefined;
+	durationMs: number;
+	status: "pending" | "running" | "complete" | "error";
+}
+
+export interface CellResultBuilderOptions {
+	readonly artifactPath?: string;
+	readonly headBytes: number;
+	readonly imageResizer?: EvalImageResizer;
+	readonly maxColumns: number;
+	readonly model: ExtensionContext["model"];
+	readonly state: CellState;
+}
+
+export class CellResultBuilder {
+	readonly #output: EvalOutputCollector;
+	readonly #state: CellState;
+
+	constructor(options: CellResultBuilderOptions) {
+		this.#state = options.state;
+		this.#output = new EvalOutputCollector({
+			headBytes: options.headBytes,
+			maxColumns: options.maxColumns,
+			model: options.model,
+			...(options.artifactPath === undefined ? {} : { artifactPath: options.artifactPath }),
+			...(options.imageResizer === undefined ? {} : { imageResizer: options.imageResizer }),
+			onChunk: (_aggregate, cell) => {
+				options.state.output = cell;
+				this.emitUpdate(false);
+			},
+		});
+		options.state.status = "running";
+		this.emitUpdate(false);
+	}
+
+	push(text: string): void {
+		this.#output.push(text);
+	}
+
+	display(message: DisplayMessage): void {
+		this.#output.display(message);
+	}
+
+	setPhase(title: string): void {
+		this.#state.phase = title;
+		this.emitUpdate(false);
+	}
+
+	async finalize(result: KernelResult): Promise<AgentToolResult<EvalToolDetails>> {
+		this.#state.durationMs = result.durationMs;
+		if (result.ok) {
+			if (result.valueRepr) this.#output.push(`${result.valueRepr}\n`);
+			this.#state.status = "complete";
+		} else {
+			this.#output.push(`${result.error.message}\n`);
+			this.#state.status = "error";
+		}
+		return await this.#finish(!result.ok);
+	}
+
+	async finalizeCancellation(error: Error): Promise<AgentToolResult<EvalToolDetails>> {
+		this.#output.push(`${error.message}\n`);
+		this.#state.status = "error";
+		return await this.#finish(true);
+	}
+
+	async flushOutput(): Promise<void> {
+		await this.#output.flush();
+	}
+
+	liveResult(): AgentToolResult<EvalToolDetails> {
+		return {
+			content: [{ type: "text", text: this.#liveUpdateText() }],
+			details: this.#details(undefined, this.#state.status === "error"),
+		};
+	}
+
+	emitUpdate(isError: boolean): void {
+		if (!this.#state.active) return;
+		this.#state.onUpdate?.({
+			content: [{ type: "text", text: this.#liveUpdateText() }],
+			details: this.#details(undefined, isError),
+		});
+	}
+
+	async #finish(isError: boolean): Promise<AgentToolResult<EvalToolDetails>> {
+		const output = await this.#output.finish();
+		this.#state.output = output.output;
+		const details = this.#details(output, isError);
+		this.emitUpdate(isError);
+		const text =
+			output.output ||
+			(output.images.length > 0
+				? `(displayed ${output.images.length} image${output.images.length === 1 ? "" : "s"}; no text output)`
+				: "(no output)");
+		return { content: [{ type: "text", text }, ...output.images], details };
+	}
+
+	#details(output: EvalOutputResult | undefined, isError: boolean): EvalToolDetails {
+		const statusEvents = this.#state.statusEvents.length > 0 ? [...this.#state.statusEvents] : undefined;
+		return {
+			language: this.#state.input.language,
+			languages: [this.#state.input.language],
+			...(this.#state.input.title === undefined ? {} : { title: this.#state.input.title }),
+			durationMs: this.#state.durationMs,
+			toolCalls: [...this.#state.toolCalls],
+			truncated: output?.truncated ?? false,
+			...(isError ? { isError: true } : {}),
+			...(this.#state.phase === undefined ? {} : { phase: this.#state.phase }),
+			cells: [
+				{
+					index: 0,
+					...(this.#state.input.title === undefined ? {} : { title: this.#state.input.title }),
+					code: this.#state.input.code,
+					language: this.#state.input.language,
+					output: this.#state.output,
+					status: this.#state.status,
+					durationMs: this.#state.durationMs,
+					...(statusEvents === undefined ? {} : { statusEvents }),
+					...(output?.hasMarkdown ? { hasMarkdown: true } : {}),
+				},
+			],
+			...(statusEvents === undefined ? {} : { statusEvents }),
+			...(output === undefined || output.jsonOutputs.length === 0 ? {} : { jsonOutputs: output.jsonOutputs }),
+			...(output?.notice === undefined ? {} : { notice: output.notice }),
+			...(output?.meta === undefined ? {} : { meta: output.meta }),
+		};
+	}
+
+	#liveUpdateText(): string {
+		const title = this.#state.input.title === undefined ? "" : ` ${this.#state.input.title}`;
+		const aggregateOutput = this.#output.aggregateText();
+		const outputLines = aggregateOutput.split("\n");
+		const hasTrailingNewline = aggregateOutput.endsWith("\n");
+		if (hasTrailingNewline) outputLines.pop();
+		const output = `${outputLines.slice(-8).join("\n")}${hasTrailingNewline ? "\n" : ""}`;
+		return `1/1 cells ${this.#state.status}\n[1] ${this.#state.input.language}${title} ${this.#state.status}${output.length === 0 ? "" : `\n${output}`}`;
+	}
+}

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -1,27 +1,32 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
 import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { detachedNotificationSpillPath } from "./detached-cell-notification.ts";
+import { currentDetachedResult, detachedErrorResult, snapshotDetachedCell } from "./detached-cell-snapshot.ts";
+import {
+	activeDetachedCellReuseError,
+	allowsDetachedCellTransition,
+	detachedCellIsActive,
+} from "./detached-cell-state.ts";
+import { DetachedNotificationQueue } from "./detached-notification-queue.ts";
 import type { EvalKernel, EvalLanguage, EvalToolDetails, EvalToolInput } from "./types.ts";
 
-const NOTIFICATION_TAIL_BYTES = 512;
-
 export type EvalDetachedCellState = "running" | "detached" | "completed" | "failed" | "cancelled";
+
+type LiveResultProvider = () => AgentToolResult<EvalToolDetails>;
 
 type ManagedCell = {
 	readonly cellId: string;
 	readonly input: EvalToolInput;
 	readonly spillPath: string | undefined;
 	readonly startedAtMs: number;
+	readonly terminal: PromiseWithResolvers<EvalDetachedCellSnapshot>;
 	state: EvalDetachedCellState;
 	canDetach: boolean;
 	wasDetached: boolean;
 	kernel: EvalKernel | undefined;
-	/** Set after an interrupt-driven stop; undefined until the kernel reports its fate. */
 	stateRetained: boolean | undefined;
-	outputTail: (() => string) | undefined;
-	result: AgentToolResult<EvalToolDetails> | undefined;
+	liveResult: LiveResultProvider | undefined;
+	terminalResult: AgentToolResult<EvalToolDetails> | undefined;
 	notificationQueued: boolean;
-	readonly terminal: PromiseWithResolvers<EvalDetachedCellSnapshot>;
 };
 
 export interface EvalDetachedCellSnapshot {
@@ -29,7 +34,7 @@ export interface EvalDetachedCellSnapshot {
 	readonly language: EvalLanguage;
 	readonly state: EvalDetachedCellState;
 	readonly outputTail: string;
-	readonly result: AgentToolResult<EvalToolDetails> | undefined;
+	readonly result: AgentToolResult<EvalToolDetails>;
 	readonly stateRetained: boolean | undefined;
 }
 
@@ -42,70 +47,53 @@ export interface EvalDetachedCellNotifier {
 	notify(cells: readonly EvalDetachedCellNotification[]): void;
 }
 
-/** One live detached cell, as shown in the footer status line. */
 export interface EvalDetachedCellStatusEntry {
 	readonly cellId: string;
 	readonly language: EvalLanguage;
 	readonly title?: string;
-	/** Epoch milliseconds when the cell was created; feeds the footer's live elapsed label. */
 	readonly startedAtMs: number;
 }
 
 export interface EvalDetachedCellManagerOptions {
 	readonly artifactsDir?: string;
 	readonly notifier?: EvalDetachedCellNotifier;
-	/** Called with every detached cell whenever that set changes; empty clears the status. */
 	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
-	/** Injectable clock for tests; defaults to Date.now. */
 	readonly now?: () => number;
 }
 
-/**
- * Session-owned lifecycle owner for eval cells that outlive their tool call.
- *
- * All state changes are synchronous and funnel through #transition. That is the
- * atomic boundary for timeout, kernel completion, explicit stop, and session
- * disposal races; exactly one path can release a language's detached busy mark.
- */
 export class EvalDetachedCellManager {
 	readonly #artifactsDir: string | undefined;
-	readonly #notifier: EvalDetachedCellNotifier | undefined;
 	readonly #onStatusChange: ((entries: readonly EvalDetachedCellStatusEntry[]) => void) | undefined;
 	readonly #cells = new Map<string, ManagedCell>();
 	readonly #detachedByLanguage = new Map<EvalLanguage, ManagedCell>();
+	readonly #notificationQueue: DetachedNotificationQueue;
 	readonly #now: () => number;
-	#notificationQueue: ManagedCell[] = [];
-	#notificationFlush: Promise<void> | undefined;
 
 	constructor(options: EvalDetachedCellManagerOptions = {}) {
 		this.#artifactsDir = options.artifactsDir;
-		this.#notifier = options.notifier;
 		this.#onStatusChange = options.onStatusChange;
+		this.#notificationQueue = new DetachedNotificationQueue(options.notifier, options.artifactsDir);
 		this.#now = options.now ?? Date.now;
 	}
 
 	create(cellId: string, input: EvalToolInput): ManagedCell {
 		const existing = this.#cells.get(cellId);
 		if (existing !== undefined) {
-			if (existing.state === "running" || existing.state === "detached") throw activeCellReuseError(existing);
+			if (detachedCellIsActive(existing.state)) throw activeDetachedCellReuseError(existing);
 			this.#cells.delete(cellId);
 		}
-		const spillPath =
-			this.#artifactsDir === undefined
-				? undefined
-				: join(this.#artifactsDir, "local", `detached-eval-${safeCellId(cellId)}.log`);
 		const cell: ManagedCell = {
 			cellId,
 			input,
-			spillPath,
+			spillPath: detachedNotificationSpillPath(this.#artifactsDir, cellId),
 			startedAtMs: this.#now(),
 			state: "running",
 			canDetach: false,
 			wasDetached: false,
 			kernel: undefined,
 			stateRetained: undefined,
-			outputTail: undefined,
-			result: undefined,
+			liveResult: undefined,
+			terminalResult: undefined,
 			notificationQueued: false,
 			terminal: Promise.withResolvers<EvalDetachedCellSnapshot>(),
 		};
@@ -113,15 +101,16 @@ export class EvalDetachedCellManager {
 		return cell;
 	}
 
-	markRunning(cell: ManagedCell, kernel: EvalKernel, outputTail: () => string): void {
+	markRunning(cell: ManagedCell, kernel: EvalKernel, liveResult: LiveResultProvider): void {
 		if (cell.state !== "running") return;
 		cell.kernel = kernel;
-		cell.outputTail = outputTail;
+		cell.liveResult = liveResult;
 		cell.canDetach = true;
 	}
 
 	detach(cell: ManagedCell): boolean {
-		if (!cell.canDetach || !this.#transition(cell, "detached")) return false;
+		if (!cell.canDetach || !allowsDetachedCellTransition(cell.state, "detached")) return false;
+		cell.state = "detached";
 		cell.wasDetached = true;
 		this.#detachedByLanguage.set(cell.input.language, cell);
 		this.#emitStatus();
@@ -129,22 +118,19 @@ export class EvalDetachedCellManager {
 	}
 
 	complete(cell: ManagedCell, result: AgentToolResult<EvalToolDetails>): boolean {
-		cell.result = result;
-		return this.#transition(cell, result.details.isError === true ? "failed" : "completed");
+		return this.#settle(cell, result.details.isError === true ? "failed" : "completed", result);
 	}
 
 	fail(cell: ManagedCell, error: Error): boolean {
-		const result = errorResult(cell, error);
-		cell.result = result;
-		return this.#transition(cell, "failed");
+		return this.#settle(cell, "failed", detachedErrorResult(cell, error));
 	}
 
 	async stop(cellId: string, reason = "Stopped detached eval cell"): Promise<EvalDetachedCellSnapshot> {
 		const cell = this.#get(cellId);
-		if (cell.state === "detached" && this.#transition(cell, "cancelled")) {
-			const kernel = cell.kernel;
-			if (kernel !== undefined) {
-				const handle = await kernel.interrupt(reason);
+		if (cell.state === "detached") {
+			const claimed = this.#settle(cell, "cancelled", currentDetachedResult(cell));
+			if (claimed && cell.kernel !== undefined) {
+				const handle = await cell.kernel.interrupt(reason);
 				cell.stateRetained = await handle.stateRetained;
 			}
 		}
@@ -169,31 +155,40 @@ export class EvalDetachedCellManager {
 		await Promise.allSettled(
 			detached.map(async (cell) => await this.stop(cell.cellId, "Session ended; detached eval cell cancelled")),
 		);
-		await this.flushNotifications();
+		await this.#notificationQueue.flush();
 	}
 
 	async flushNotifications(): Promise<void> {
-		const flush = this.#notificationFlush;
-		if (flush !== undefined) await flush;
+		await this.#notificationQueue.flush();
 	}
 
-	#transition(cell: ManagedCell, next: EvalDetachedCellState): boolean {
-		if (!allowsTransition(cell.state, next)) return false;
-		cell.state = next;
-		if (next !== "running" && next !== "detached") cell.terminal.resolve(this.#snapshot(cell));
-		if (cell.wasDetached && next !== "detached") {
+	#settle(
+		cell: ManagedCell,
+		state: "completed" | "failed" | "cancelled",
+		result: AgentToolResult<EvalToolDetails>,
+	): boolean {
+		if (!allowsDetachedCellTransition(cell.state, state)) return false;
+		cell.state = state;
+		cell.terminalResult = result;
+		cell.liveResult = undefined;
+		cell.terminal.resolve(this.#snapshot(cell));
+		if (cell.wasDetached) {
 			if (this.#detachedByLanguage.get(cell.input.language) === cell)
 				this.#detachedByLanguage.delete(cell.input.language);
 			this.#emitStatus();
-			this.#queueNotification(cell);
+			if (!cell.notificationQueued) {
+				cell.notificationQueued = true;
+				this.#notificationQueue.enqueue({
+					snapshot: () => this.#snapshot(cell),
+					spillPath: cell.spillPath,
+				});
+			}
 		}
 		return true;
 	}
 
 	#emitStatus(): void {
-		const emit = this.#onStatusChange;
-		if (emit === undefined) return;
-		emit(
+		this.#onStatusChange?.(
 			[...this.#detachedByLanguage.values()].map((cell) => ({
 				cellId: cell.cellId,
 				language: cell.input.language,
@@ -203,52 +198,8 @@ export class EvalDetachedCellManager {
 		);
 	}
 
-	#queueNotification(cell: ManagedCell): void {
-		if (cell.notificationQueued) return;
-		cell.notificationQueued = true;
-		this.#notificationQueue.push(cell);
-		this.#scheduleNotificationFlush();
-	}
-
-	#scheduleNotificationFlush(): void {
-		if (this.#notificationFlush !== undefined) return;
-		const flush = Promise.resolve().then(async () => {
-			const cells = this.#notificationQueue.splice(0);
-			const notifications = await Promise.all(cells.map(async (candidate) => await this.#notification(candidate)));
-			this.#notifier?.notify(notifications);
-		});
-		this.#notificationFlush = flush;
-		void flush.then(
-			() => this.#finishNotificationFlush(flush),
-			() => this.#finishNotificationFlush(flush),
-		);
-	}
-
-	#finishNotificationFlush(flush: Promise<void>): void {
-		if (this.#notificationFlush !== flush) return;
-		this.#notificationFlush = undefined;
-		if (this.#notificationQueue.length > 0) this.#scheduleNotificationFlush();
-	}
-
-	async #notification(cell: ManagedCell): Promise<EvalDetachedCellNotification> {
-		const snapshot = this.#snapshot(cell);
-		const body = notificationBody(snapshot);
-		const overflow = Buffer.byteLength(body, "utf8") > NOTIFICATION_TAIL_BYTES;
-		let spillNotice = "";
-		if (overflow && cell.spillPath !== undefined) {
-			try {
-				await mkdir(dirname(cell.spillPath), { recursive: true });
-				await writeFile(cell.spillPath, body, "utf8");
-				spillNotice = `\nBuffered output overflowed; full output: ${localUri(cell.spillPath, this.#artifactsDir)}`;
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				spillNotice = `\nBuffered output overflow could not be spilled: ${message}`;
-			}
-		}
-		return {
-			cellId: cell.cellId,
-			content: `${overflow ? notificationPreview(snapshot) : body}${overflow ? "\n[…notification tail capped…]" : ""}${spillNotice}`,
-		};
+	#snapshot(cell: ManagedCell): EvalDetachedCellSnapshot {
+		return snapshotDetachedCell(cell, this.#now());
 	}
 
 	#get(cellId: string): ManagedCell {
@@ -256,110 +207,4 @@ export class EvalDetachedCellManager {
 		if (cell === undefined) throw new Error(`Unknown detached eval cell "${cellId}"`);
 		return cell;
 	}
-
-	#snapshot(cell: ManagedCell): EvalDetachedCellSnapshot {
-		return {
-			cellId: cell.cellId,
-			language: cell.input.language,
-			state: cell.state,
-			outputTail: cell.outputTail?.() ?? "",
-			result: cell.result,
-			stateRetained: cell.stateRetained,
-		};
-	}
-}
-
-function activeCellReuseError(cell: ManagedCell): Error {
-	return new Error(
-		`Eval cell ${cell.cellId} from a previous call is still ${cell.state} in the ${cell.input.language} kernel. Use eval({ action: "peek", cell_id: "${cell.cellId}" }) to read it or eval({ action: "stop", cell_id: "${cell.cellId}" }) to end it before its id can be reused.`,
-	);
-}
-
-function allowsTransition(from: EvalDetachedCellState, to: EvalDetachedCellState): boolean {
-	if (from === "running") return to === "detached" || to === "completed" || to === "failed" || to === "cancelled";
-	if (from === "detached") return to === "completed" || to === "failed" || to === "cancelled";
-	return false;
-}
-
-function errorResult(cell: ManagedCell, error: Error): AgentToolResult<EvalToolDetails> {
-	const output = cell.outputTail?.() ?? "";
-	return {
-		content: [{ type: "text", text: output.length > 0 ? `${output}\n${error.message}` : error.message }],
-		details: {
-			language: cell.input.language,
-			languages: [cell.input.language],
-			durationMs: 0,
-			toolCalls: [],
-			truncated: false,
-			isError: true,
-			cells: [
-				{
-					index: 0,
-					code: cell.input.code,
-					language: cell.input.language,
-					output,
-					status: "error",
-				},
-			],
-		},
-	};
-}
-
-function notificationBody(cell: EvalDetachedCellSnapshot): string {
-	const outcome = cell.state === "completed" ? "completed" : cell.state === "cancelled" ? "cancelled" : "failed";
-	const resultText =
-		cell.result?.content
-			.filter((part) => part.type === "text")
-			.map((part) => part.text)
-			.join("\n") ?? cell.outputTail;
-	const stateNote =
-		cell.state === "cancelled" && cell.language === "js"
-			? "JavaScript worker was restarted; VM state was lost."
-			: cell.state === "cancelled" && cell.language === "py"
-				? "Python kernel was interrupted; its existing variables are preserved."
-				: "Kernel state updated - variables are available to the next eval cell.";
-	return [
-		`<system-reminder>Detached eval cell ${cell.cellId} (${cell.language}) ${outcome}.`,
-		resultText.length === 0 ? "(no output)" : resultText,
-		`${stateNote}</system-reminder>`,
-	].join("\n");
-}
-
-function notificationPreview(cell: EvalDetachedCellSnapshot): string {
-	const outcome = cell.state === "completed" ? "completed" : cell.state === "cancelled" ? "cancelled" : "failed";
-	const resultText =
-		cell.result?.content
-			.filter((part) => part.type === "text")
-			.map((part) => part.text)
-			.join("\n") ?? cell.outputTail;
-	const stateNote =
-		cell.state === "cancelled" && cell.language === "js"
-			? "JavaScript worker was restarted; VM state was lost."
-			: cell.state === "cancelled" && cell.language === "py"
-				? "Python kernel was interrupted; its existing variables are preserved."
-				: "Kernel state updated - variables are available to the next eval cell.";
-	return [
-		`<system-reminder>Detached eval cell ${cell.cellId} (${cell.language}) ${outcome}.`,
-		"Buffered output tail:",
-		truncateTailUtf8(resultText, NOTIFICATION_TAIL_BYTES),
-		`${stateNote}</system-reminder>`,
-	].join("\n");
-}
-
-function safeCellId(cellId: string): string {
-	return cellId.replace(/[^a-zA-Z0-9_-]/gu, "_");
-}
-
-function localUri(path: string, artifactsDir: string | undefined): string {
-	if (artifactsDir === undefined) return `local://${path}`;
-	const root = join(artifactsDir, "local");
-	return path.startsWith(`${root}/`) ? `local://${path.slice(root.length + 1)}` : `local://${path}`;
-}
-
-function truncateTailUtf8(text: string, maxBytes: number): string {
-	if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
-	const bytes = Buffer.from(text, "utf8");
-	let start = bytes.length - maxBytes;
-	while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start++;
-	return bytes.subarray(start).toString("utf8");
 }

--- a/packages/senpi-codemode/src/tool/detached-cell-notification.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-notification.ts
@@ -1,0 +1,98 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { EvalDetachedCellNotification, EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
+
+const NOTIFICATION_TAIL_BYTES = 512;
+
+export function detachedNotificationSpillPath(artifactsDir: string | undefined, cellId: string): string | undefined {
+	if (artifactsDir === undefined) return undefined;
+	return join(artifactsDir, "local", `detached-eval-${safeCellId(cellId)}.log`);
+}
+
+export async function buildDetachedCellNotification(
+	snapshot: EvalDetachedCellSnapshot,
+	spillPath: string | undefined,
+	artifactsDir: string | undefined,
+): Promise<EvalDetachedCellNotification> {
+	const body = notificationBody(snapshot);
+	const overflow = Buffer.byteLength(body, "utf8") > NOTIFICATION_TAIL_BYTES;
+	let spillNotice = "";
+	if (overflow && spillPath !== undefined) {
+		try {
+			await mkdir(dirname(spillPath), { recursive: true });
+			await writeFile(spillPath, body, "utf8");
+			spillNotice = `\nBuffered output overflowed; full output: ${localUri(spillPath, artifactsDir)}`;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			spillNotice = `\nBuffered output overflow could not be spilled: ${message}`;
+		}
+	}
+	return {
+		cellId: snapshot.cellId,
+		content: `${overflow ? notificationPreview(snapshot) : body}${overflow ? "\n[…notification tail capped…]" : ""}${spillNotice}`,
+	};
+}
+
+function notificationBody(cell: EvalDetachedCellSnapshot): string {
+	const outcome = outcomeOf(cell);
+	const resultText = textContent(cell);
+	const stateNote = stateNoteOf(cell);
+	return [
+		`<system-reminder>Detached eval cell ${cell.cellId} (${cell.language}) ${outcome}.`,
+		resultText.length === 0 ? "(no output)" : resultText,
+		`${stateNote}</system-reminder>`,
+	].join("\n");
+}
+
+function notificationPreview(cell: EvalDetachedCellSnapshot): string {
+	const outcome = outcomeOf(cell);
+	const resultText = textContent(cell);
+	const stateNote = stateNoteOf(cell);
+	return [
+		`<system-reminder>Detached eval cell ${cell.cellId} (${cell.language}) ${outcome}.`,
+		"Buffered output tail:",
+		truncateTailUtf8(resultText, NOTIFICATION_TAIL_BYTES),
+		`${stateNote}</system-reminder>`,
+	].join("\n");
+}
+
+function textContent(cell: EvalDetachedCellSnapshot): string {
+	return (
+		cell.result.content
+			.filter((part) => part.type === "text")
+			.map((part) => part.text)
+			.join("\n") || cell.outputTail
+	);
+}
+
+function outcomeOf(cell: EvalDetachedCellSnapshot): string {
+	if (cell.state === "completed") return "completed";
+	if (cell.state === "cancelled") return "cancelled";
+	return "failed";
+}
+
+function stateNoteOf(cell: EvalDetachedCellSnapshot): string {
+	if (cell.state === "cancelled" && cell.language === "js")
+		return "JavaScript worker was restarted; VM state was lost.";
+	if (cell.state === "cancelled" && cell.language === "py")
+		return "Python kernel was interrupted; its existing variables are preserved.";
+	return "Kernel state updated - variables are available to the next eval cell.";
+}
+
+function safeCellId(cellId: string): string {
+	return cellId.replace(/[^a-zA-Z0-9_-]/gu, "_");
+}
+
+function localUri(path: string, artifactsDir: string | undefined): string {
+	if (artifactsDir === undefined) return `local://${path}`;
+	const root = join(artifactsDir, "local");
+	return path.startsWith(`${root}/`) ? `local://${path.slice(root.length + 1)}` : `local://${path}`;
+}
+
+function truncateTailUtf8(text: string, maxBytes: number): string {
+	if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+	const bytes = Buffer.from(text, "utf8");
+	let start = bytes.length - maxBytes;
+	while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start++;
+	return bytes.subarray(start).toString("utf8");
+}

--- a/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
@@ -1,0 +1,81 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import type { EvalDetachedCellSnapshot, EvalDetachedCellState } from "./detached-cell-manager.ts";
+import { resultForDetachedState } from "./detached-eval-result.ts";
+import type { EvalKernel, EvalToolDetails, EvalToolInput } from "./types.ts";
+
+export interface DetachedCellResultSource {
+	readonly cellId: string;
+	readonly input: EvalToolInput;
+	readonly startedAtMs: number;
+	state: EvalDetachedCellState;
+	kernel: EvalKernel | undefined;
+	stateRetained: boolean | undefined;
+	liveResult: (() => AgentToolResult<EvalToolDetails>) | undefined;
+	terminalResult: AgentToolResult<EvalToolDetails> | undefined;
+}
+
+export function snapshotDetachedCell(cell: DetachedCellResultSource, nowMs: number): EvalDetachedCellSnapshot {
+	const durationMs = Math.max(0, nowMs - cell.startedAtMs);
+	const result = resultForDetachedState(currentDetachedResult(cell), cell.state, durationMs);
+	return {
+		cellId: cell.cellId,
+		language: cell.input.language,
+		state: cell.state,
+		outputTail: detachedOutputTail(result),
+		result,
+		stateRetained: cell.stateRetained,
+	};
+}
+
+export function currentDetachedResult(cell: DetachedCellResultSource): AgentToolResult<EvalToolDetails> {
+	return cell.terminalResult ?? cell.liveResult?.() ?? fallbackResult(cell.input);
+}
+
+export function detachedErrorResult(cell: DetachedCellResultSource, error: Error): AgentToolResult<EvalToolDetails> {
+	const current = currentDetachedResult(cell);
+	const output = detachedOutputTail(current);
+	return {
+		content: [
+			{
+				type: "text",
+				text: output.length > 0 ? `${output}\n${error.message}` : error.message,
+			},
+			...current.content.filter((part) => part.type === "image"),
+		],
+		details: { ...current.details, isError: true },
+	};
+}
+
+function fallbackResult(input: EvalToolInput): AgentToolResult<EvalToolDetails> {
+	return {
+		content: [{ type: "text", text: "(no output)" }],
+		details: {
+			language: input.language,
+			languages: [input.language],
+			...(input.title === undefined ? {} : { title: input.title }),
+			durationMs: 0,
+			toolCalls: [],
+			truncated: false,
+			cells: [
+				{
+					index: 0,
+					...(input.title === undefined ? {} : { title: input.title }),
+					code: input.code,
+					language: input.language,
+					output: "",
+					status: "running",
+					durationMs: 0,
+				},
+			],
+		},
+	};
+}
+
+function detachedOutputTail(result: AgentToolResult<EvalToolDetails>): string {
+	const cellOutput = result.details.cells?.[0]?.output;
+	if (cellOutput !== undefined) return cellOutput;
+	return result.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}

--- a/packages/senpi-codemode/src/tool/detached-cell-state.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-state.ts
@@ -1,0 +1,24 @@
+import type { EvalDetachedCellState } from "./detached-cell-manager.ts";
+import type { EvalToolInput } from "./types.ts";
+
+interface DetachedCellIdentity {
+	readonly cellId: string;
+	readonly input: EvalToolInput;
+	readonly state: EvalDetachedCellState;
+}
+
+export function activeDetachedCellReuseError(cell: DetachedCellIdentity): Error {
+	return new Error(
+		`Eval cell ${cell.cellId} from a previous call is still ${cell.state} in the ${cell.input.language} kernel. Use eval({ action: "peek", cell_id: "${cell.cellId}" }) to read it or eval({ action: "stop", cell_id: "${cell.cellId}" }) to end it before its id can be reused.`,
+	);
+}
+
+export function allowsDetachedCellTransition(from: EvalDetachedCellState, to: EvalDetachedCellState): boolean {
+	if (from === "running") return to === "detached" || to === "completed" || to === "failed" || to === "cancelled";
+	if (from === "detached") return to === "completed" || to === "failed" || to === "cancelled";
+	return false;
+}
+
+export function detachedCellIsActive(state: EvalDetachedCellState): boolean {
+	return state === "running" || state === "detached";
+}

--- a/packages/senpi-codemode/src/tool/detached-eval-result.ts
+++ b/packages/senpi-codemode/src/tool/detached-eval-result.ts
@@ -1,0 +1,140 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import type {
+	EvalDetachedCellManager,
+	EvalDetachedCellSnapshot,
+	EvalDetachedCellState,
+} from "./detached-cell-manager.ts";
+import { interruptionStateNote } from "./interrupt-note.ts";
+import type { EvalCellResult, EvalControlInput, EvalToolDetails, EvalToolInput } from "./types.ts";
+
+export async function executeEvalControl(
+	cellManager: EvalDetachedCellManager,
+	request: EvalControlInput,
+): Promise<AgentToolResult<EvalToolDetails>> {
+	const snapshot =
+		request.action === "stop" ? await cellManager.stop(request.cell_id) : cellManager.peek(request.cell_id);
+	return createDetachedControlResult(snapshot);
+}
+
+export function resultAfterDetach(
+	snapshot: EvalDetachedCellSnapshot,
+	input: EvalToolInput,
+): AgentToolResult<EvalToolDetails> {
+	if (snapshot.state !== "detached" && snapshot.state !== "running") return createDetachedControlResult(snapshot);
+	return {
+		content: [
+			{
+				type: "text",
+				text: `Eval cell ${snapshot.cellId} detached and is still running in the ${input.language} kernel. Completion will arrive as a notification. Use eval({ action: "peek", cell_id: "${snapshot.cellId}" }) or eval({ action: "stop", cell_id: "${snapshot.cellId}" }).`,
+			},
+		],
+		details: snapshot.result.details,
+	};
+}
+
+export function createDetachedControlResult(snapshot: EvalDetachedCellSnapshot): AgentToolResult<EvalToolDetails> {
+	const terminationNote =
+		snapshot.state === "cancelled" ? interruptionStateNote(snapshot.language, snapshot.stateRetained) : undefined;
+	const output = textContent(snapshot.result);
+	const text = [
+		`Eval cell ${snapshot.cellId} (${snapshot.language}) is ${snapshot.state}.`,
+		output.length === 0 ? "(no buffered output)" : output,
+		...(terminationNote === undefined ? [] : [terminationNote]),
+	].join("\n");
+	return {
+		content: [{ type: "text", text }, ...snapshot.result.content.filter((part) => part.type === "image")],
+		details: {
+			...snapshot.result.details,
+			...(snapshot.state === "failed" ? { isError: true } : {}),
+		},
+	};
+}
+
+export function resultForDetachedState(
+	result: AgentToolResult<EvalToolDetails>,
+	state: EvalDetachedCellState,
+	durationMs: number,
+): AgentToolResult<EvalToolDetails> {
+	const details = result.details;
+	const cells = details.cells ?? [];
+	const nextCells =
+		cells.length === 0
+			? []
+			: cells.map((cell, index) =>
+					index === 0
+						? {
+								...cell,
+								durationMs: terminalDuration(cell, state, durationMs),
+								status: cellStatus(state),
+							}
+						: { ...cell },
+				);
+	return {
+		content: result.content.map((part) => ({ ...part })),
+		details: {
+			...details,
+			durationMs: terminalDuration(details, state, durationMs),
+			toolCalls: details.toolCalls.map((toolCall) => ({ ...toolCall })),
+			...(details.statusEvents === undefined
+				? {}
+				: {
+						statusEvents: details.statusEvents.map((event) => ({
+							...event,
+						})),
+					}),
+			...(nextCells.length === 0
+				? {}
+				: {
+						cells: nextCells.map((cell) => ({
+							...cell,
+							...(cell.statusEvents === undefined
+								? {}
+								: {
+										statusEvents: cell.statusEvents.map((event) => ({
+											...event,
+										})),
+									}),
+						})),
+					}),
+			...(details.jsonOutputs === undefined ? {} : { jsonOutputs: structuredClone(details.jsonOutputs) }),
+		},
+	};
+}
+
+export function detachedKernelBusyError(snapshot: EvalDetachedCellSnapshot): Error {
+	const tail = snapshot.outputTail.length === 0 ? "(no output yet)" : snapshot.outputTail;
+	return new Error(
+		`The ${snapshot.language} eval kernel is busy running detached cell ${snapshot.cellId}. Do not re-run it; use eval({ action: "peek", cell_id: "${snapshot.cellId}" }). Current output tail:\n${tail}`,
+	);
+}
+
+function textContent(result: AgentToolResult<EvalToolDetails>): string {
+	return result.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function terminalDuration(
+	value: { readonly durationMs?: number },
+	state: EvalDetachedCellState,
+	liveDurationMs: number,
+): number {
+	if (state === "completed" || state === "failed" || state === "cancelled") return value.durationMs ?? liveDurationMs;
+	return liveDurationMs;
+}
+
+function cellStatus(state: EvalDetachedCellState): EvalCellResult["status"] {
+	switch (state) {
+		case "running":
+			return "running";
+		case "detached":
+			return "detached";
+		case "completed":
+			return "complete";
+		case "failed":
+			return "error";
+		case "cancelled":
+			return "cancelled";
+	}
+}

--- a/packages/senpi-codemode/src/tool/detached-notification-queue.ts
+++ b/packages/senpi-codemode/src/tool/detached-notification-queue.ts
@@ -1,0 +1,53 @@
+import type { EvalDetachedCellNotifier, EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
+import { buildDetachedCellNotification } from "./detached-cell-notification.ts";
+
+export interface PendingDetachedNotification {
+	readonly snapshot: () => EvalDetachedCellSnapshot;
+	readonly spillPath: string | undefined;
+}
+
+export class DetachedNotificationQueue {
+	readonly #artifactsDir: string | undefined;
+	readonly #notifier: EvalDetachedCellNotifier | undefined;
+	#pending: PendingDetachedNotification[] = [];
+	#flush: Promise<void> | undefined;
+
+	constructor(notifier: EvalDetachedCellNotifier | undefined, artifactsDir: string | undefined) {
+		this.#notifier = notifier;
+		this.#artifactsDir = artifactsDir;
+	}
+
+	enqueue(notification: PendingDetachedNotification): void {
+		this.#pending.push(notification);
+		this.#schedule();
+	}
+
+	async flush(): Promise<void> {
+		const flush = this.#flush;
+		if (flush !== undefined) await flush;
+	}
+
+	#schedule(): void {
+		if (this.#flush !== undefined) return;
+		const flush = Promise.resolve().then(async () => {
+			const pending = this.#pending.splice(0);
+			const notifications = await Promise.all(
+				pending.map(
+					async (item) => await buildDetachedCellNotification(item.snapshot(), item.spillPath, this.#artifactsDir),
+				),
+			);
+			this.#notifier?.notify(notifications);
+		});
+		this.#flush = flush;
+		void flush.then(
+			() => this.#finish(flush),
+			() => this.#finish(flush),
+		);
+	}
+
+	#finish(flush: Promise<void>): void {
+		if (this.#flush !== flush) return;
+		this.#flush = undefined;
+		if (this.#pending.length > 0) this.#schedule();
+	}
+}

--- a/packages/senpi-codemode/src/tool/eval-request.ts
+++ b/packages/senpi-codemode/src/tool/eval-request.ts
@@ -1,0 +1,45 @@
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { EvalControlInput, EvalToolInput, EvalToolRequest } from "./types.ts";
+
+const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
+
+export function parseEvalRequest(params: unknown): EvalToolRequest {
+	if (!isRecord(params)) throw new TypeError("eval parameters must be an object");
+	if (params.action === "peek" || params.action === "stop") {
+		if (typeof params.cell_id !== "string" || params.cell_id.length === 0)
+			throw new TypeError(`eval action "${params.action}" requires cell_id`);
+		return { action: params.action, cell_id: params.cell_id };
+	}
+	if (params.action !== undefined && params.action !== "run")
+		throw new TypeError(`Unknown eval action "${String(params.action)}"`);
+	if (!isEvalLanguage(params.language)) throw new TypeError("eval run requires language");
+	if (typeof params.code !== "string") throw new TypeError("eval run requires code");
+	if (params.on_timeout !== undefined && params.on_timeout !== "detach" && params.on_timeout !== "error")
+		throw new TypeError(`Unknown eval on_timeout value "${String(params.on_timeout)}"`);
+	return {
+		language: params.language,
+		code: params.code,
+		...(params.action === "run" ? { action: "run" as const } : {}),
+		...(typeof params.title === "string" ? { title: params.title } : {}),
+		...(typeof params.timeout === "number" ? { timeout: params.timeout } : {}),
+		...(params.on_timeout === "detach" || params.on_timeout === "error" ? { on_timeout: params.on_timeout } : {}),
+		...(typeof params.reset === "boolean" ? { reset: params.reset } : {}),
+	};
+}
+
+export function isEvalControlRequest(request: EvalToolRequest): request is EvalControlInput {
+	return request.action === "peek" || request.action === "stop";
+}
+
+export function evalTimeoutBehavior(input: EvalToolInput, ctx: ExtensionContext): "detach" | "error" {
+	if (input.on_timeout !== undefined) return input.on_timeout;
+	return NON_INTERACTIVE_MODES.has(ctx.mode) ? "error" : "detach";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isEvalLanguage(value: unknown): value is EvalToolInput["language"] {
+	return value === "py" || value === "js" || value === "rb" || value === "jl";
+}

--- a/packages/senpi-codemode/src/tool/eval-tool-options.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool-options.ts
@@ -1,0 +1,45 @@
+import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext, ToolDefinition } from "@code-yeongyu/senpi";
+import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
+import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
+import type { ResolvedCodemodeSettings } from "../config/settings.ts";
+import type { EvalExecutionTracker } from "../extension/session-manager.ts";
+import type { EvalTimeoutFactory } from "./cell-execution.ts";
+import type { EvalDetachedCellManager } from "./detached-cell-manager.ts";
+import type { EvalImageResizer } from "./image.ts";
+import type {
+	EnabledEvalLanguages,
+	EvalInputSchema,
+	EvalKernelManager,
+	EvalToolDetails,
+	EvalToolInput,
+	ExecuteTool,
+} from "./types.ts";
+
+export interface CreateEvalToolOptions {
+	readonly enabledLanguages: EnabledEvalLanguages;
+	readonly kernelManager: EvalKernelManager;
+	readonly cellTimeoutSeconds: number;
+	readonly executeTool: ExecuteTool;
+	readonly listTools?: () => readonly EvalSchemaToolInfo[];
+	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
+	readonly settings?: ResolvedCodemodeSettings;
+	readonly artifactsDir?: string;
+	readonly imageResizer?: EvalImageResizer;
+	readonly executionTracker?: EvalExecutionTracker;
+	readonly cellManager?: EvalDetachedCellManager;
+	readonly timeoutFactory?: EvalTimeoutFactory;
+	readonly proxyExecutor?: (params: EvalToolInput, signal?: AbortSignal) => Promise<AgentToolResult<EvalToolDetails>>;
+	readonly renderers?: Pick<ToolDefinition<EvalInputSchema, EvalToolDetails>, "renderCall" | "renderResult">;
+	readonly spawns?: boolean;
+	readonly spawnDefaultAgent?: string;
+	readonly modelId?: string;
+	readonly hostLine?: string;
+}
+
+export interface EvalCellInvocation {
+	readonly cellId: string;
+	readonly input: EvalToolInput;
+	readonly signal: AbortSignal;
+	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
+	readonly ctx: ExtensionContext;
+}

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -1,205 +1,21 @@
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
-import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext, ToolDefinition } from "@code-yeongyu/senpi";
-import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
-import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
-import { defaultCodemodeSettings, type ResolvedCodemodeSettings } from "../config/settings.ts";
-import type { EvalExecutionTracker } from "../extension/session-manager.ts";
+import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@code-yeongyu/senpi";
+import { defaultCodemodeSettings } from "../config/settings.ts";
 import { buildEvalPrompt } from "../prompt/eval-prompt.ts";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP } from "../timeouts/bridge-timeout.ts";
-import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
+import { abortError, CellExecution, defaultTimeoutFactory } from "./cell-execution.ts";
 import { CellHandler, type CellState } from "./cell-handler.ts";
-import { EvalDetachedCellManager, type EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
-import type { EvalImageResizer } from "./image.ts";
-import { describeTimeoutState, interruptionStateNote } from "./interrupt-note.ts";
-import {
-	createEvalInputSchema,
-	type EnabledEvalLanguages,
-	type EvalCellResult,
-	type EvalControlInput,
-	type EvalInputSchema,
-	type EvalKernel,
-	type EvalKernelManager,
-	type EvalToolDetails,
-	type EvalToolInput,
-	type EvalToolRequest,
-	type ExecuteTool,
-	enabledLanguageList,
-} from "./types.ts";
+import { EvalDetachedCellManager } from "./detached-cell-manager.ts";
+import { detachedKernelBusyError, executeEvalControl, resultAfterDetach } from "./detached-eval-result.ts";
+import { evalTimeoutBehavior, isEvalControlRequest, parseEvalRequest } from "./eval-request.ts";
+import type { CreateEvalToolOptions, EvalCellInvocation } from "./eval-tool-options.ts";
+import { describeTimeoutState } from "./interrupt-note.ts";
+import { createEvalInputSchema, type EvalInputSchema, type EvalToolDetails, enabledLanguageList } from "./types.ts";
 
+export type { EvalTimeoutFactory } from "./cell-execution.ts";
+export type { CreateEvalToolOptions } from "./eval-tool-options.ts";
 export type { EnabledEvalLanguages, EvalKernel, EvalKernelManager } from "./types.ts";
-
-export interface EvalTimeoutFactory {
-	create(options: IdleTimeoutOptions): TimeoutPauseHandle & { dispose(): void };
-}
-
-export interface CreateEvalToolOptions {
-	readonly enabledLanguages: EnabledEvalLanguages;
-	readonly kernelManager: EvalKernelManager;
-	readonly cellTimeoutSeconds: number;
-	readonly executeTool: ExecuteTool;
-	readonly listTools?: () => readonly EvalSchemaToolInfo[];
-	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;
-	readonly settings?: ResolvedCodemodeSettings;
-	readonly artifactsDir?: string;
-	readonly imageResizer?: EvalImageResizer;
-	readonly executionTracker?: EvalExecutionTracker;
-	readonly cellManager?: EvalDetachedCellManager;
-	readonly timeoutFactory?: EvalTimeoutFactory;
-	readonly proxyExecutor?: (params: EvalToolInput, signal?: AbortSignal) => Promise<AgentToolResult<EvalToolDetails>>;
-	readonly renderers?: Pick<ToolDefinition<EvalInputSchema, EvalToolDetails>, "renderCall" | "renderResult">;
-	/** Whether the task-tool spawn helpers (agent()/output()/<dag>) are advertised in the prompt. */
-	readonly spawns?: boolean;
-	/** Default agent name surfaced in the agent() helper docs when spawns are enabled. */
-	readonly spawnDefaultAgent?: string;
-	/** Active model id; selects the emphasis dialect of the eval prompt. */
-	readonly modelId?: string;
-	/** Preformatted host line rendered into the prompt's host-sizing note. */
-	readonly hostLine?: string;
-}
-
-interface EvalCellInvocation {
-	readonly cellId: string;
-	readonly input: EvalToolInput;
-	readonly signal: AbortSignal;
-	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
-	readonly ctx: ExtensionContext;
-}
-
-interface CellExecutionOptions {
-	readonly callerSignal: AbortSignal;
-	readonly cellId: string;
-	readonly timeoutMs: number;
-	readonly timeoutFactory: EvalTimeoutFactory;
-	readonly onTimeout: (error: Error) => void;
-	readonly onAbort: (error: Error) => void;
-}
-
-const INTERRUPT_DELIVERY_GRACE_MS = 100;
-const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
-
-const defaultTimeoutFactory: EvalTimeoutFactory = {
-	create(options): IdleTimeout {
-		return new IdleTimeout(options);
-	},
-};
-
-class CellExecution {
-	readonly #callerSignal: AbortSignal;
-	readonly #onAbort: (error: Error) => void;
-	readonly #abortPromise: Promise<never>;
-	readonly #detachedPromise: Promise<void>;
-	readonly #watchdog: TimeoutPauseHandle & { dispose(): void };
-	#rejectAbort: ((reason?: unknown) => void) | undefined;
-	#resolveDetached: (() => void) | undefined;
-	#kernel: EvalKernel | undefined;
-	#interruptDeadline: ReturnType<typeof setTimeout> | undefined;
-	#active = true;
-
-	constructor(options: CellExecutionOptions) {
-		this.#callerSignal = options.callerSignal;
-		this.#onAbort = options.onAbort;
-		this.#abortPromise = new Promise<never>((_resolve, reject) => {
-			this.#rejectAbort = reject;
-		});
-		this.#detachedPromise = new Promise<void>((resolve) => {
-			this.#resolveDetached = resolve;
-		});
-		this.#watchdog = options.timeoutFactory.create({
-			cellId: options.cellId,
-			timeoutMs: options.timeoutMs,
-			onTimeout: ({ error }) => options.onTimeout(error),
-		});
-		this.#callerSignal.addEventListener("abort", this.#handleCallerAbort, { once: true });
-	}
-
-	get detached(): Promise<void> {
-		return this.#detachedPromise;
-	}
-
-	pause(): void {
-		this.#watchdog.pause();
-	}
-
-	resume(): void {
-		this.#watchdog.resume();
-	}
-
-	setKernel(kernel: EvalKernel): void {
-		this.#kernel = kernel;
-	}
-
-	detach(): void {
-		if (!this.#active) return;
-		this.#watchdog.dispose();
-		this.#resolveDetached?.();
-		this.#resolveDetached = undefined;
-	}
-
-	cancel(reason: unknown): void {
-		this.#abort(reason);
-	}
-
-	finish(): void {
-		this.#active = false;
-		this.#cleanup();
-	}
-
-	async wait<Result>(operation: Promise<Result>): Promise<Result> {
-		const guarded = operation.then(
-			(value): Result | Promise<never> => (this.#active ? value : this.#abortPromise),
-			(reason: unknown): Promise<never> => (this.#active ? Promise.reject(reason) : this.#abortPromise),
-		);
-		return await Promise.race([guarded, this.#abortPromise]);
-	}
-
-	readonly #handleCallerAbort = (): void => {
-		this.#abort(this.#callerSignal.reason);
-	};
-
-	/** Outcome of the most recent interrupt, when a kernel was interrupted. */
-	interruptStateRetained: Promise<boolean> | undefined;
-
-	#abort(reason: unknown): void {
-		if (!this.#active) return;
-		this.#active = false;
-		this.#cleanup();
-		const error = abortError(reason);
-		this.#onAbort(error);
-		const kernel = this.#kernel;
-		if (kernel === undefined) {
-			this.#settleAbort(error);
-			return;
-		}
-		this.#interruptDeadline = setTimeout(() => this.#settleAbort(error), INTERRUPT_DELIVERY_GRACE_MS);
-		void Promise.resolve()
-			.then(async () => {
-				const handle = await kernel.interrupt(error.message);
-				// Kernels predating the interrupt-outcome contract resolve void; leave
-				// the outcome undefined so callers report an honest unknown state.
-				this.interruptStateRetained = handle?.stateRetained;
-			})
-			.then(
-				() => this.#settleAbort(error),
-				(interruptError: unknown) => this.#settleAbort(interruptError),
-			);
-	}
-
-	#settleAbort(reason: unknown): void {
-		const reject = this.#rejectAbort;
-		if (reject === undefined) return;
-		this.#rejectAbort = undefined;
-		if (this.#interruptDeadline !== undefined) clearTimeout(this.#interruptDeadline);
-		reject(reason);
-	}
-
-	#cleanup(): void {
-		this.#callerSignal.removeEventListener("abort", this.#handleCallerAbort);
-		this.#watchdog.dispose();
-		if (this.#interruptDeadline !== undefined) clearTimeout(this.#interruptDeadline);
-		this.#interruptDeadline = undefined;
-	}
-}
 
 export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<EvalInputSchema, EvalToolDetails> {
 	const parameters = createEvalInputSchema(options.enabledLanguages);
@@ -222,15 +38,15 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		...(options.renderers?.renderCall === undefined ? {} : { renderCall: options.renderers.renderCall }),
 		...(options.renderers?.renderResult === undefined ? {} : { renderResult: options.renderers.renderResult }),
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
-			const request = requestFrom(params);
-			if (isControlRequest(request)) return await executeControl(cellManager, request);
+			const request = parseEvalRequest(params);
+			if (isEvalControlRequest(request)) return await executeEvalControl(cellManager, request);
 			if (options.proxyExecutor) return await options.proxyExecutor(request, signal);
 			if (!languages.includes(request.language))
 				throw new RangeError(
 					`Unsupported eval language "${request.language}". Enabled languages: ${languages.join(", ")}`,
 				);
 			const busy = cellManager.busyFor(request.language);
-			if (busy !== undefined) throw kernelBusyError(busy);
+			if (busy !== undefined) throw detachedKernelBusyError(busy);
 			options.executionTracker?.assertEvalExecutionAllowed();
 			const lifecycleController = new AbortController();
 			const combinedSignal = signal
@@ -257,7 +73,7 @@ async function runEvalCell(
 ): Promise<AgentToolResult<EvalToolDetails>> {
 	if (invocation.signal.aborted) throw abortError(invocation.signal.reason);
 	const timeoutMs = Math.floor((invocation.input.timeout ?? options.cellTimeoutSeconds) * 1_000);
-	const timeoutBehavior = timeoutBehaviorFor(invocation.input, invocation.ctx);
+	const timeoutBehavior = evalTimeoutBehavior(invocation.input, invocation.ctx);
 	const bridgeAbortController = new AbortController();
 	const cellSignal = AbortSignal.any([invocation.signal, bridgeAbortController.signal]);
 	const bridgeContext: ExtensionContext = { ...invocation.ctx, signal: cellSignal };
@@ -317,7 +133,7 @@ async function runEvalCell(
 		finalized.then((result) => ({ kind: "result" as const, result })),
 		execution.detached.then(() => ({ kind: "detached" as const })),
 	]);
-	if (outcome.kind === "detached") return detachedResult(cellManager.peek(invocation.cellId), invocation.input);
+	if (outcome.kind === "detached") return resultAfterDetach(cellManager.peek(invocation.cellId), invocation.input);
 	return outcome.result;
 }
 
@@ -351,7 +167,7 @@ async function executeCell(
 			}),
 		);
 		execution.setKernel(kernel);
-		handler = new CellHandler(kernel, state, {
+		const activeHandler = new CellHandler(kernel, state, {
 			executeTool: options.executeTool,
 			...(options.listTools === undefined ? {} : { listTools: options.listTools }),
 			settings: options.settings ?? defaultCodemodeSettings,
@@ -362,7 +178,8 @@ async function executeCell(
 				: { artifactPath: join(options.artifactsDir, `eval-${randomUUID()}.log`) }),
 			...(options.imageResizer === undefined ? {} : { imageResizer: options.imageResizer }),
 		});
-		cellManager.markRunning(cell, kernel, () => state.output);
+		handler = activeHandler;
+		cellManager.markRunning(cell, kernel, () => activeHandler.liveResult());
 		if ("setContext" in options.kernelManager && typeof options.kernelManager.setContext === "function") {
 			options.kernelManager.setContext(bridgeContext);
 		}
@@ -381,143 +198,4 @@ async function executeCell(
 		execution.finish();
 		if (handler) await handler.flushOutput();
 	}
-}
-
-function requestFrom(params: unknown): EvalToolRequest {
-	if (typeof params !== "object" || params === null) throw new TypeError("eval parameters must be an object");
-	const value = params as Record<string, unknown>;
-	if (value.action === "peek" || value.action === "stop") {
-		if (typeof value.cell_id !== "string" || value.cell_id.length === 0)
-			throw new TypeError(`eval action "${value.action}" requires cell_id`);
-		return { action: value.action, cell_id: value.cell_id };
-	}
-	if (value.action !== undefined && value.action !== "run")
-		throw new TypeError(`Unknown eval action "${String(value.action)}"`);
-	if (!isEvalLanguage(value.language)) throw new TypeError("eval run requires language");
-	if (typeof value.code !== "string") throw new TypeError("eval run requires code");
-	if (value.on_timeout !== undefined && value.on_timeout !== "detach" && value.on_timeout !== "error")
-		throw new TypeError(`Unknown eval on_timeout value "${String(value.on_timeout)}"`);
-	return {
-		language: value.language,
-		code: value.code,
-		...(value.action === "run" ? { action: "run" as const } : {}),
-		...(typeof value.title === "string" ? { title: value.title } : {}),
-		...(typeof value.timeout === "number" ? { timeout: value.timeout } : {}),
-		...(value.on_timeout === "detach" || value.on_timeout === "error" ? { on_timeout: value.on_timeout } : {}),
-		...(typeof value.reset === "boolean" ? { reset: value.reset } : {}),
-	};
-}
-
-function isControlRequest(request: EvalToolRequest): request is EvalControlInput {
-	return request.action === "peek" || request.action === "stop";
-}
-
-function isEvalLanguage(value: unknown): value is EvalToolInput["language"] {
-	return value === "py" || value === "js" || value === "rb" || value === "jl";
-}
-
-async function executeControl(
-	cellManager: EvalDetachedCellManager,
-	request: EvalControlInput,
-): Promise<AgentToolResult<EvalToolDetails>> {
-	const snapshot =
-		request.action === "stop" ? await cellManager.stop(request.cell_id) : cellManager.peek(request.cell_id);
-	return snapshotResult(snapshot);
-}
-
-function detachedResult(snapshot: EvalDetachedCellSnapshot, input: EvalToolInput): AgentToolResult<EvalToolDetails> {
-	return {
-		content: [
-			{
-				type: "text",
-				text: `Eval cell ${snapshot.cellId} detached and is still running in the ${input.language} kernel. Completion will arrive as a notification. Use eval({ action: "peek", cell_id: "${snapshot.cellId}" }) or eval({ action: "stop", cell_id: "${snapshot.cellId}" }).`,
-			},
-		],
-		details: {
-			language: input.language,
-			languages: [input.language],
-			...(input.title === undefined ? {} : { title: input.title }),
-			durationMs: 0,
-			toolCalls: [],
-			truncated: false,
-			statusEvents: [{ op: "detached", cellId: snapshot.cellId }],
-			cells: [
-				{
-					index: 0,
-					...(input.title === undefined ? {} : { title: input.title }),
-					code: input.code,
-					language: input.language,
-					output: snapshot.outputTail,
-					status: "detached",
-					statusEvents: [{ op: "detached", cellId: snapshot.cellId }],
-				},
-			],
-		},
-	};
-}
-
-function snapshotResult(snapshot: EvalDetachedCellSnapshot): AgentToolResult<EvalToolDetails> {
-	const terminationNote =
-		snapshot.state === "cancelled" ? interruptionStateNote(snapshot.language, snapshot.stateRetained) : undefined;
-	const text = [
-		`Eval cell ${snapshot.cellId} (${snapshot.language}) is ${snapshot.state}.`,
-		snapshot.outputTail.length === 0 ? "(no buffered output)" : snapshot.outputTail,
-		...(terminationNote === undefined ? [] : [terminationNote]),
-	].join("\n");
-	return {
-		content: [{ type: "text", text }],
-		details: {
-			language: snapshot.language,
-			languages: [snapshot.language],
-			durationMs: snapshot.result?.details.durationMs ?? 0,
-			toolCalls: snapshot.result?.details.toolCalls ?? [],
-			truncated: snapshot.result?.details.truncated ?? false,
-			...(snapshot.state === "failed" ? { isError: true } : {}),
-			statusEvents: [{ op: snapshot.state, cellId: snapshot.cellId }],
-			cells: [
-				{
-					index: 0,
-					code: "",
-					language: snapshot.language,
-					output: snapshot.outputTail,
-					status: cellStatus(snapshot.state),
-					statusEvents: [{ op: snapshot.state, cellId: snapshot.cellId }],
-				},
-			],
-		},
-	};
-}
-
-function cellStatus(state: EvalDetachedCellSnapshot["state"]): EvalCellResult["status"] {
-	switch (state) {
-		case "running":
-			return "running";
-		case "detached":
-			return "detached";
-		case "completed":
-			return "complete";
-		case "failed":
-			return "error";
-		case "cancelled":
-			return "cancelled";
-	}
-}
-
-function kernelBusyError(snapshot: EvalDetachedCellSnapshot): Error {
-	const tail = snapshot.outputTail.length === 0 ? "(no output yet)" : snapshot.outputTail;
-	return new Error(
-		`The ${snapshot.language} eval kernel is busy running detached cell ${snapshot.cellId}. Do not re-run it; use eval({ action: "peek", cell_id: "${snapshot.cellId}" }). Current output tail:\n${tail}`,
-	);
-}
-
-function timeoutBehaviorFor(input: EvalToolInput, ctx: ExtensionContext): "detach" | "error" {
-	if (input.on_timeout !== undefined) return input.on_timeout;
-	return NON_INTERACTIVE_MODES.has(ctx.mode) ? "error" : "detach";
-}
-
-function abortError(reason: unknown): Error {
-	if (reason instanceof Error && reason.name !== "AbortError") return reason;
-	const error = new Error(typeof reason === "string" ? reason : "Eval interrupted", { cause: reason });
-	error.name = "AbortError";
-	return error;
 }

--- a/packages/senpi-codemode/test/eval-detached-peek.test.ts
+++ b/packages/senpi-codemode/test/eval-detached-peek.test.ts
@@ -1,0 +1,198 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+import { Deferred, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "tui" as const };
+}
+
+function textOf(resultValue: AgentToolResult<unknown>): string {
+	return resultValue.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function createTool(manager: EvalDetachedCellManager, kernelManager: FakeManager) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager,
+		cellTimeoutSeconds: 1,
+		executeTool: async () => ({
+			content: [{ type: "text", text: "loaded configuration" }],
+			details: {},
+		}),
+		cellManager: manager,
+	});
+}
+
+function requireCell(resultValue: AgentToolResult<EvalToolDetails>) {
+	const cell = resultValue.details.cells?.[0];
+	if (cell === undefined) throw new Error("expected one eval cell");
+	return cell;
+}
+
+async function startRichDetachedCell() {
+	vi.useFakeTimers();
+	const manager = new EvalDetachedCellManager();
+	const kernel = new FakeKernel([]);
+	const tool = createTool(manager, new FakeManager([["js", kernel]]));
+	const started = kernel.deferNextRun();
+	const richUpdate = new Deferred<void>();
+	const laterUpdate = new Deferred<void>();
+	const source = "await new Promise(() => {})";
+	const execution = tool.execute(
+		"rich-cell",
+		{
+			language: "js",
+			code: source,
+			title: "collect progress",
+			on_timeout: "detach",
+		},
+		undefined,
+		(update) => {
+			if (
+				update.details.phase === "waiting" &&
+				update.details.toolCalls.length === 1 &&
+				update.details.statusEvents?.some((event) => event.op === "read")
+			) {
+				richUpdate.resolve(undefined);
+			}
+			if (update.details.phase === "finishing") laterUpdate.resolve(undefined);
+		},
+		interactiveContext(),
+	);
+	await started;
+	kernel.emit({ type: "phase", title: "waiting" });
+	kernel.emit({ type: "text", stream: "stdout", data: "before detach\n" });
+	kernel.emit({ type: "status", event: { op: "read", path: "/tmp/input.json", chars: 12 } });
+	kernel.emit({ type: "tool-call", callId: "read-1", toolName: "read", args: { path: "/tmp/input.json" } });
+	await richUpdate.promise;
+	await vi.advanceTimersByTimeAsync(1_000);
+	await execution;
+	return { kernel, laterUpdate, manager, source, tool };
+}
+
+describe("detached eval peek", () => {
+	it("returns the latest rich detached result", async () => {
+		const { manager, source, tool } = await startRichDetachedCell();
+
+		const peek = await tool.execute(
+			"peek-rich",
+			{ action: "peek", cell_id: "rich-cell" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		const cell = requireCell(peek);
+
+		expect(cell).toMatchObject({
+			code: source,
+			language: "js",
+			status: "detached",
+			title: "collect progress",
+		});
+		expect(cell.output).toContain("before detach");
+		expect(cell.durationMs).toBeGreaterThanOrEqual(1_000);
+		expect(peek.details.phase).toBe("waiting");
+		expect(peek.details.toolCalls).toMatchObject([
+			{ args: { path: "/tmp/input.json" }, callId: "read-1", name: "read", ok: true },
+		]);
+		expect(peek.details.statusEvents).toEqual([{ op: "read", path: "/tmp/input.json", chars: 12 }]);
+		expect(peek.details.statusEvents).not.toContainEqual({ op: "detached", cellId: "rich-cell" });
+
+		await manager.stop("rich-cell");
+		await manager.flushNotifications();
+	});
+
+	it("keeps earlier live snapshots immutable across later kernel messages", async () => {
+		const { kernel, laterUpdate, manager, tool } = await startRichDetachedCell();
+		const first = await tool.execute(
+			"peek-first",
+			{ action: "peek", cell_id: "rich-cell" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+
+		kernel.emit({ type: "phase", title: "finishing" });
+		kernel.emit({ type: "text", stream: "stdout", data: "after detach\n" });
+		kernel.emit({ type: "status", event: { op: "write", path: "/tmp/output.json", chars: 7 } });
+		await laterUpdate.promise;
+		const second = await tool.execute(
+			"peek-second",
+			{ action: "peek", cell_id: "rich-cell" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+
+		expect(first.details.phase).toBe("waiting");
+		expect(requireCell(first).output).not.toContain("after detach");
+		expect(first.details.statusEvents).toEqual([{ op: "read", path: "/tmp/input.json", chars: 12 }]);
+		expect(second.details.phase).toBe("finishing");
+		expect(requireCell(second).output).toContain("after detach");
+		expect(second.details.statusEvents).toContainEqual({ op: "write", path: "/tmp/output.json", chars: 7 });
+
+		await manager.stop("rich-cell");
+		await manager.flushNotifications();
+	});
+
+	it("gives the committed terminal result precedence over live state", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, new FakeManager([["js", kernel]]));
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"terminal-cell",
+			{
+				language: "js",
+				code: "display({ answer: 42 })",
+				title: "terminal result",
+				on_timeout: "detach",
+			},
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		kernel.emit({ type: "phase", title: "finalizing" });
+		kernel.emit({ type: "status", event: { op: "read", path: "/tmp/final.json", chars: 2 } });
+		kernel.emit({
+			type: "display",
+			mimeType: "application/json",
+			dataBase64: Buffer.from(JSON.stringify({ answer: 42 })).toString("base64"),
+		});
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+		kernel.completeDeferredRun(result("terminal-cell", "done", 75));
+		await manager.waitForTerminal("terminal-cell");
+
+		const peek = await tool.execute(
+			"peek-terminal",
+			{ action: "peek", cell_id: "terminal-cell" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+
+		expect(requireCell(peek)).toMatchObject({
+			code: "display({ answer: 42 })",
+			durationMs: 75,
+			status: "complete",
+			title: "terminal result",
+		});
+		expect(peek.details.phase).toBe("finalizing");
+		expect(peek.details.jsonOutputs).toEqual([{ answer: 42 }]);
+		expect(peek.details.statusEvents).toEqual([{ op: "read", path: "/tmp/final.json", chars: 2 }]);
+		expect(textOf(peek)).toContain("done");
+	});
+});

--- a/packages/senpi-codemode/test/eval-detached-settlement.test.ts
+++ b/packages/senpi-codemode/test/eval-detached-settlement.test.ts
@@ -1,0 +1,110 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+import {
+	Deferred,
+	FakeKernel,
+	fakeExtensionContext,
+	PendingInterruptKernel,
+	result,
+	SingleKernelManager,
+} from "./eval/fakes.ts";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "tui" as const };
+}
+
+function textOf(resultValue: AgentToolResult<unknown>): string {
+	return resultValue.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function requireCell(resultValue: AgentToolResult<EvalToolDetails>) {
+	const cell = resultValue.details.cells?.[0];
+	if (cell === undefined) throw new Error("expected one eval cell");
+	return cell;
+}
+
+describe("detached eval settlement", () => {
+	it("stops reading the live provider after terminal settlement", () => {
+		const manager = new EvalDetachedCellManager();
+		const input = { language: "js" as const, code: "42", title: "provider" };
+		const cell = manager.create("provider-cell", input);
+		const provider = vi.fn(
+			(): AgentToolResult<EvalToolDetails> => ({
+				content: [{ type: "text", text: "live" }],
+				details: {
+					language: "js",
+					languages: ["js"],
+					title: "provider",
+					durationMs: 0,
+					toolCalls: [],
+					truncated: false,
+					cells: [{ index: 0, ...input, output: "live", status: "running" }],
+				},
+			}),
+		);
+		manager.markRunning(cell, new FakeKernel([]), provider);
+		manager.detach(cell);
+		manager.peek("provider-cell");
+		expect(provider).toHaveBeenCalledOnce();
+		expect(manager.complete(cell, provider())).toBe(true);
+		provider.mockClear();
+
+		expect(manager.peek("provider-cell").result.details.cells?.[0]?.output).toBe("live");
+		expect(provider).not.toHaveBeenCalled();
+	});
+
+	it("keeps cancellation authoritative over a late completion", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new PendingInterruptKernel();
+		const tool = createEvalTool({
+			enabledLanguages: { js: true, py: false, rb: false, jl: false },
+			kernelManager: new SingleKernelManager(kernel),
+			cellTimeoutSeconds: 1,
+			executeTool: async () => ({
+				content: [{ type: "text", text: "unused" }],
+				details: {},
+			}),
+			cellManager: manager,
+		});
+		const lateCompletion = new Deferred<void>();
+		const execution = tool.execute(
+			"cancelled-cell",
+			{ language: "js", code: "await forever", on_timeout: "detach" },
+			undefined,
+			(update) => {
+				if (update.details.cells?.[0]?.status === "complete") lateCompletion.resolve(undefined);
+			},
+			interactiveContext(),
+		);
+		await kernel.runStarted.promise;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+		const stopping = tool.execute(
+			"stop-cancelled",
+			{ action: "stop", cell_id: "cancelled-cell" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await kernel.interruptStarted.promise;
+		kernel.runResult.resolve(result("cancelled-cell", "late value", 77));
+		await lateCompletion.promise;
+		kernel.interruptResult.resolve(undefined);
+		const stopped = await stopping;
+
+		expect(textOf(stopped)).not.toContain("late value");
+		expect(requireCell(stopped).status).toBe("cancelled");
+		expect(manager.peek("cancelled-cell").state).toBe("cancelled");
+	});
+});


### PR DESCRIPTION
## Summary

- preserve the live `CellHandler` result when an eval cell detaches so `peek`
  shows the original code/title, current output, phase, structured status
  events, tool-call summaries, elapsed duration, and structured display state
- make terminal settlement first-writer-wins, clear the live provider, prefer
  the committed terminal result, and keep cancellation authoritative over late
  completion
- split result building, timeout execution, request parsing, snapshot/state,
  notification queue, and control-result responsibilities into focused modules
  that remain under the repository's 250 pure-LOC ceiling
- add deterministic unit coverage, a real Python-kernel + real-renderer QA
  driver, README documentation, and an Unreleased changelog entry

## Design

`EvalDetachedCellManager` retains one synchronous immutable live-result
provider while a cell is active and one committed terminal result after
settlement. Snapshot reads and settlement contain no `await`, so Node
run-to-completion keeps them coherent without a mutex or event log. The
provider is cleared synchronously on every terminal transition.

The renderer is unchanged: the lifecycle layer now preserves the rich
`EvalToolDetails` contract the renderer already understands.

## RED -> GREEN

Before production edits, `test/eval-detached-peek.test.ts` failed all four
behavior scenarios:

- running peek reconstructed `code: ""` and dropped title/phase/status/tool data
- successive peeks had no rich state to compare
- terminal peek lost code/title/JSON/status metadata
- cancelled stop leaked a distinct late completion value

After implementation and test splitting:

- 6 focused files, 29 tests passed
- provider-release mutation proof failed when live reads were deliberately made
  authoritative after settlement, then passed after restoring terminal-first
  precedence and provider clearing

## Verification

- `npm test` in `packages/senpi-codemode`: 71 files passed, 1 skipped; 480
  tests passed, 6 skipped
- repository `npm run check`: passed with no final Biome changes
- changed TypeScript files: all <=250 pure LOC
- changed-file LSP diagnostics: clean where the server returned a fresh result;
  repository typecheck passed for the two files that hit the fixed LSP
  freshness timeout
- post-`origin/main` merge: focused 29 tests and root checks passed again

## Real QA

`packages/senpi-codemode/scripts/qa-detached-peek.ts` uses:

- a real Python kernel
- a real FIFO for exact release synchronization (no polling)
- the real eval renderer

Observed:

- running render: original code/title, `detached`, 1s duration,
  `before detach`, structured read row/path, and phase `waiting`
- terminal render: the same context plus `terminal value`, done status, and
  real duration
- cleanup: FIFO temp directory removed, kernel closed, bridge closed, and no
  matching process remained


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves rich live and terminal details when peeking detached eval cells, showing original code/title and full structured state. Also makes terminal settlement authoritative so cancellations win over late completions.

- **Bug Fixes**
  - Peek (running): shows original code and title, current output, phase, status events, tool-call summaries, elapsed duration, and structured displays.
  - Peek (terminal): returns the committed final result with accurate duration and JSON outputs; snapshots are immutable across later kernel messages.
  - Settlement: first-writer-wins; clears the live provider at terminal states; cancellation remains authoritative over late completion races.

- **Refactors**
  - Split lifecycle into focused modules: `cell-execution`, `cell-runtime`, `detached-cell-manager`, `detached-cell-snapshot`, `detached-cell-state`, `detached-notification-queue`, `detached-eval-result`, `eval-request`.
  - Added unit tests and a real QA script (`scripts/qa-detached-peek.ts`) using a Python kernel and the real renderer.
  - Updated README and CHANGELOG.

<sup>Written for commit c9d2bc2021dd1c2dd01aaf455298fdc4b1a528dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

