### PR TITLE
perf(tui): memoize line normalization and default viewport-bounded rendering

### DIFF
--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,38 @@
 # TUI delta rendering fork changes
 
+## 2026-07-31: memoized line normalization and viewport-bounded rendering by default
+
+### What changed
+
+- `tui.ts` reuses `normalizeTerminalOutput` results across frames through a per-instance memo keyed by the raw
+  line string. Full normalization passes swap in a fresh map holding only the lines used by the current frame, so
+  the memo never outgrows the transcript it mirrors (whose normalized strings it shares by reference). Unchanged
+  lines now keep their string identity across frames, which also restores O(1) reference-equality diff compares
+  that fresh normalization allocations previously defeated. Image lines keep bypassing normalization unchanged.
+- `mux.ts` `viewportRenderEnabled()` now defaults on; `PI_TUI_VIEWPORT_RENDER=0` opts out of viewport-bounded
+  normalize+diff and `1` still forces it on. Output byte-equivalence between the bounded and full paths is pinned
+  by `test/viewport-render.test.ts` (streaming, offscreen line-count changes, offscreen in-place mutations).
+- `scripts/perf-trend-local.sh` pins the two baseline frame-cost lanes to `PI_TUI_VIEWPORT_RENDER=0` so their
+  historical meaning (unbounded full pass) survives the default flip.
+- `bench/frame-cost.ts` 300-frame p50 on Apple M5 Max, stable components: 100k-line transcript 16.20ms -> 1.97ms
+  (new default; 8.2x) and 16.20ms -> 12.34ms with bounding opted out (memo only); 30k lines 4.51ms -> 1.66ms;
+  10k lines 2.23ms -> 1.34ms. Emitted bytes per frame stay identical (131) across all lanes.
+- Coverage: `test/viewport-render.test.ts` proves the unset-flag default bounds normalization, the opted-out full
+  pass renormalizes only new content after the first frame, and byte-identical writes across both paths;
+  `test/mux.test.ts` pins the default-on/opt-out switch semantics.
+
+### Why this cannot be expressed externally
+
+The normalize/diff pipeline is private render state inside `TUI.doRender()` (`previousLines`, `previousRawLines`,
+viewport offsets). No component or extension seam can deduplicate normalization work or change the bounded-path
+default without owning that state.
+
+### Expected merge conflict zones
+
+- MEDIUM: `tui.ts` `normalizeLine()` / `applyLineResets()` bodies and the render-state field block.
+- LOW: `mux.ts` `viewportRenderEnabled()`, `test/mux.test.ts`, `test/viewport-render.test.ts`,
+  `scripts/perf-trend-local.sh` bench lanes.
+
 ## 2026-07-29: Native Unicode LaTeX in Markdown conversations
 
 ### What changed

--- a/packages/tui/src/mux.ts
+++ b/packages/tui/src/mux.ts
@@ -7,5 +7,5 @@ export function useLegacyMuxRender(): boolean {
 }
 
 export function viewportRenderEnabled(): boolean {
-	return process.env.PI_TUI_VIEWPORT_RENDER === "1";
+	return process.env.PI_TUI_VIEWPORT_RENDER !== "0";
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -495,6 +495,7 @@ export class TUI extends Container {
 	public terminal: Terminal;
 	private previousLines: string[] = [];
 	private previousRawLines: string[] = [];
+	private normalizeMemo = new Map<string, string>();
 	private previousKittyImageIds = new Set<number>();
 	private previousWidth = 0;
 	private previousHeight = 0;
@@ -1401,21 +1402,35 @@ export class TUI extends Container {
 		if (isImageLine(line)) {
 			return { line, normalized: false };
 		}
-		return { line: normalizeTerminalOutput(line) + TUI.SEGMENT_RESET, normalized: true };
+		const cached = this.normalizeMemo.get(line);
+		if (cached !== undefined) {
+			return { line: cached, normalized: false };
+		}
+		const normalized = normalizeTerminalOutput(line) + TUI.SEGMENT_RESET;
+		this.normalizeMemo.set(line, normalized);
+		return { line: normalized, normalized: true };
 	}
 
 	private applyLineResets(lines: string[], mode: "escaped" | "full" = "full"): NormalizedLinesResult {
+		const previousMemo = this.normalizeMemo;
+		const nextMemo = new Map<string, string>();
 		const normalizedLines: string[] = [];
 		let normalizedCount = 0;
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 			if (isImageLine(line)) {
 				normalizedLines.push(line);
-			} else {
-				normalizedLines.push(normalizeTerminalOutput(line) + TUI.SEGMENT_RESET);
+				continue;
+			}
+			let normalized = nextMemo.get(line) ?? previousMemo.get(line);
+			if (normalized === undefined) {
+				normalized = normalizeTerminalOutput(line) + TUI.SEGMENT_RESET;
 				normalizedCount += 1;
 			}
+			nextMemo.set(line, normalized);
+			normalizedLines.push(normalized);
 		}
+		this.normalizeMemo = nextMemo;
 		recordViewportRenderStats(normalizedCount, mode);
 		return {
 			lines: normalizedLines,

--- a/packages/tui/test/mux.test.ts
+++ b/packages/tui/test/mux.test.ts
@@ -87,15 +87,21 @@ describe("useLegacyMuxRender", () => {
 });
 
 describe("viewportRenderEnabled", () => {
-	it("returns true only when the viewport render switch is exactly 1", () => {
+	it("defaults to enabled when the viewport render switch is unset", () => {
 		clearEnv();
-		process.env.PI_TUI_VIEWPORT_RENDER = "1";
-		assert.equal(viewportRenderEnabled(), true);
 
-		for (const value of ["", "0", "true", "yes"] as const) {
+		assert.equal(viewportRenderEnabled(), true);
+	});
+
+	it("disables only when the viewport render switch is exactly 0", () => {
+		clearEnv();
+		process.env.PI_TUI_VIEWPORT_RENDER = "0";
+		assert.equal(viewportRenderEnabled(), false);
+
+		for (const value of ["1", "", "true", "yes"] as const) {
 			process.env.PI_TUI_VIEWPORT_RENDER = value;
 
-			assert.equal(viewportRenderEnabled(), false, value);
+			assert.equal(viewportRenderEnabled(), true, value);
 		}
 	});
 });

--- a/packages/tui/test/viewport-render.test.ts
+++ b/packages/tui/test/viewport-render.test.ts
@@ -111,7 +111,7 @@ async function captureBytes(
 	enabled: boolean,
 	run: (tui: tuiModule.TUI, terminal: LoggingVirtualTerminal) => Promise<void>,
 ): Promise<string> {
-	return await withEnv({ [VIEWPORT_ENV]: enabled ? "1" : undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+	return await withEnv({ [VIEWPORT_ENV]: enabled ? "1" : "0", PI_TUI_TEST_SEAMS: "1" }, async () => {
 		const terminal = new LoggingVirtualTerminal(72, 8);
 		const tui = new tuiModule.TUI(terminal);
 		await run(tui, terminal);
@@ -186,6 +186,22 @@ describe("viewport-bounded render", () => {
 		assert.strictEqual(await captureBytes(true, run), await captureBytes(false, run));
 	});
 
+	it("bounds normalization to the viewport by default when the flag is unset", async () => {
+		await withEnv({ [VIEWPORT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+			const terminal = new VirtualTerminal(80, 40);
+			const tui = new tuiModule.TUI(terminal);
+			const component = new LargeStatusComponent();
+			tui.addChild(component);
+
+			await driveRender(tui, terminal);
+			component.status = "status frame changed";
+			await driveRender(tui, terminal);
+
+			assert.ok(viewportStats().lastNormalizedLines <= terminal.rows + 2 * OVERSCAN + 1);
+			tui.stop();
+		});
+	});
+
 	it("normalizes only the viewport plus overscan when one status line changes", async () => {
 		await withEnv({ [VIEWPORT_ENV]: "1", PI_TUI_TEST_SEAMS: "1" }, async () => {
 			const terminal = new VirtualTerminal(80, 40);
@@ -203,18 +219,20 @@ describe("viewport-bounded render", () => {
 		});
 	});
 
-	it("normalizes every line when the flag is off", async () => {
-		await withEnv({ [VIEWPORT_ENV]: undefined, PI_TUI_TEST_SEAMS: "1" }, async () => {
+	it("memoizes unchanged lines so opted-out full passes renormalize only new content", async () => {
+		await withEnv({ [VIEWPORT_ENV]: "0", PI_TUI_TEST_SEAMS: "1" }, async () => {
 			const terminal = new VirtualTerminal(80, 40);
 			const tui = new tuiModule.TUI(terminal);
 			const component = new LargeStatusComponent();
 			tui.addChild(component);
 
 			await driveRender(tui, terminal);
+			assert.strictEqual(viewportStats().lastNormalizedLines, component.transcript.length + 1);
+
 			component.status = "status frame changed";
 			await driveRender(tui, terminal);
 
-			assert.strictEqual(viewportStats().lastNormalizedLines, component.transcript.length + 1);
+			assert.strictEqual(viewportStats().lastNormalizedLines, 1);
 			tui.stop();
 		});
 	});

--- a/scripts/perf-trend-local.sh
+++ b/scripts/perf-trend-local.sh
@@ -71,8 +71,8 @@ run_bench() {
 	rm -f "$bench_output"
 }
 
-run_bench "frame-cost-n${frame_small_n}" frame-cost npx tsx bench/frame-cost.ts --n "$frame_small_n"
-run_bench "frame-cost-n${frame_large_n}" frame-cost npx tsx bench/frame-cost.ts --n "$frame_large_n"
+run_bench "frame-cost-n${frame_small_n}" frame-cost env PI_TUI_VIEWPORT_RENDER=0 npx tsx bench/frame-cost.ts --n "$frame_small_n"
+run_bench "frame-cost-n${frame_large_n}" frame-cost env PI_TUI_VIEWPORT_RENDER=0 npx tsx bench/frame-cost.ts --n "$frame_large_n"
 run_bench "frame-cost-n${frame_large_n}-viewport" frame-cost env PI_TUI_VIEWPORT_RENDER=1 npx tsx bench/frame-cost.ts --n "$frame_large_n"
 if [[ -n "${PERF_TREND_ITERATIONS:-}" ]]; then
 	run_bench "editor-layout" suite npx tsx bench/editor-layout.ts --iterations "$PERF_TREND_ITERATIONS"


### PR DESCRIPTION
## What

Two zero-behavior-change render-pipeline optimizations for large-session TUI lag:

1. **Per-line normalization memo** (`packages/tui/src/tui.ts`): `normalizeTerminalOutput(line) + SEGMENT_RESET` results are reused across frames via a `Map<string, string>` keyed by the raw line. Full passes swap in a fresh map holding only the lines used by the current frame, so memory stays bounded by the live transcript (whose normalized strings it shares by reference). Unchanged lines keep their string identity across frames, restoring O(1) reference-equality diff compares that fresh allocations previously defeated. Image lines still bypass normalization.
2. **Viewport-bounded normalize+diff becomes the default** (`packages/tui/src/mux.ts`): `viewportRenderEnabled()` now returns true unless `PI_TUI_VIEWPORT_RENDER=0` (`1` still forces on). The bounded path (added in f636f3252) was already proven byte-identical to the full path by `test/viewport-render.test.ts`; it was just never enabled outside benches.

`scripts/perf-trend-local.sh` baseline frame-cost lanes now pin `PI_TUI_VIEWPORT_RENDER=0` so their historical meaning (unbounded full pass) survives the flip.

## Why

Real-world trigger: a 23.2MB / 11,355-entry session (~3,000 live entries after compaction) makes interactive rendering visibly lag. `doRender()` re-normalized every transcript line and byte-compared full line arrays every frame - O(total lines) work per frame at up to 60fps.

## Baselines (bench/frame-cost.ts, 300 measured frames, Apple M5 Max)

BEFORE = base commit e698f68ba, env unset (old default = full path).
AFTER = this branch, env unset (new default = bounded + memo).

| lane | BEFORE p50 | AFTER p50 | speedup | BEFORE p95 | AFTER p95 |
|---|---|---|---|---|---|
| stable 10k lines | 2.229ms | 1.337ms | 1.67x | 2.429ms | 1.604ms |
| stable 30k lines | 4.505ms | 1.660ms | 2.71x | 5.809ms | 1.858ms |
| stable 100k lines | 16.200ms | 1.970ms | **8.23x** | 21.985ms | 2.776ms |
| unstable 30k lines | 92.353ms | 73.761ms | 1.25x | 120.797ms | 90.813ms |

Frame cost is now essentially transcript-size-independent on the default path (1.34ms @10k -> 1.97ms @100k; previously 2.2ms -> 16.2ms).

Memo-only effect (opt-out `PI_TUI_VIEWPORT_RENDER=0` AFTER vs BEFORE): stable-100k 16.200ms -> 12.340ms; unstable-30k 92.353ms -> 89.784ms.

`bytesPerFrameP50` identical (131) and `initialBytes` identical per n in every lane -> emitted terminal bytes unchanged.

## No behavior change

- `normalizeTerminalOutput` is pure; the memo returns identical string content.
- Byte-equivalence between bounded and full paths pinned by `viewport-render.test.ts` (streaming, offscreen line-count changes, offscreen in-place mutations), now comparing `1` vs `0`.
- New assertions: unset flag bounds normalization by default; opted-out full passes renormalize only new content after the first frame (memo proof); `mux.test.ts` pins default-on/opt-out switch semantics.

## QA / evidence

- `packages/tui` full suite: `npm test` exit 0 (zero `not ok`); changed files verbose: 13/13 pass.
- Root `npm run check`: exit 0 (biome, tsgo, shrinkwrap/install-lock gates, browser smoke, web-ui check).
- Real-CLI TUI smoke: `.agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence tui` -> 5/5 pass (boot, render, keystroke, teardown, real auth untouched).
- Evidence bundle: `local-ignore/qa-evidence/20260731-tui-frame-normalize-memo/` (bench JSONLs before/after, test log, SUMMARY.md) + `local-ignore/qa-evidence/20260731-tui/` (smoke capture).
- `packages/tui/src/changes.md` updated with the fork-change record.

## Residual risk

- The bounded path now runs for all users; escape hatch is `PI_TUI_VIEWPORT_RENDER=0`. Any change outside the viewport+overscan window, dimension change, or line-count change still escapes to the full (byte-identical) path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up TUI rendering by memoizing per-line normalization and enabling viewport-bounded normalize+diff by default. Output bytes are unchanged, and frame time no longer grows with transcript size.

- **Refactors**
  - `tui.ts`: Cache `normalizeTerminalOutput(line) + SEGMENT_RESET` per raw line across frames and refresh the map each full pass to keep memory bounded; image lines still bypass normalization. Restores O(1) reference-equality diffs for unchanged lines.
  - `mux.ts`: `viewportRenderEnabled()` is on by default unless `PI_TUI_VIEWPORT_RENDER=0` (`1` still forces on). Tests pin byte-identical output between bounded and full paths.
  - Benchmarks (p50, 300 frames): 100k lines 16.20ms → 1.97ms; 30k 4.51ms → 1.66ms; 10k 2.23ms → 1.34ms. Opted-out full path with memo: 16.20ms → 12.34ms. Emitted bytes are identical.

- **Migration**
  - To keep the old unbounded behavior, set `PI_TUI_VIEWPORT_RENDER=0`. `scripts/perf-trend-local.sh` pins baseline lanes to `0`.

<sup>Written for commit 09e72d0945b0cbfbca2a7896f43b19583919e087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

