### PR TITLE
fix(coding-agent): surface apply_patch failures

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## Failed apply_patch outcomes are explicit errors (2026-07-31)
+
+### What changed
+
+- `extension.ts`: completed `apply_patch` results with one or more failed operations now set the tool-result
+  `isError` flag, including partial successes where earlier file actions were already applied.
+- `tool.ts`: failed results render an error-background card titled `Patch failed` or
+  `Patch partially failed`, preserving both any successful diff preview and the recovery text.
+- Tests cover the model-facing error flag plus complete- and partial-failure TUI output.
+
+### Why
+
+- A failed operation was returned as a successful tool result, so the model did not receive an error signal.
+- The custom TUI renderer hid the failure text and could leave a completed failure labeled `Applying patch`.
+
+### Why extension system couldn't handle this
+
+- The error classification and renderer belong to the builtin `apply_patch` extension itself; no core agent-loop or
+  TUI change is required.
+
+### Expected merge conflict zones
+
+- LOW: `extension.ts` result-hook registration and `tool.ts` completed-result rendering.
+
 ## Source-backed apply_patch result patches (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/extension.ts
@@ -50,6 +50,14 @@ function replaceEditToolsWithApplyPatch(toolNames: string[]): string[] {
 	return [...filteredToolNames.slice(0, at), APPLY_PATCH_NAME, ...filteredToolNames.slice(at)];
 }
 
+function hasApplyPatchFailures(details: unknown): boolean {
+	if (typeof details !== "object" || details === null) return false;
+	const result = Reflect.get(details, "result");
+	if (typeof result !== "object" || result === null) return false;
+	const failures = Reflect.get(result, "failures");
+	return Array.isArray(failures) && failures.length > 0;
+}
+
 function syncToolset(
 	pi: ApplyPatchExtensionAPI,
 	model: Model<string> | undefined,
@@ -87,6 +95,12 @@ export function registerApplyPatchExtension(pi: ApplyPatchExtensionAPI): void {
 	} as const;
 	state.activeVariant = "freeform";
 	pi.registerTool(variants.freeform);
+	pi.on("tool_result", async (event) => {
+		if (event.toolName !== APPLY_PATCH_NAME || event.isError || !hasApplyPatchFailures(event.details)) {
+			return undefined;
+		}
+		return { isError: true };
+	});
 	pi.on("session_start", async (_event, ctx) => {
 		syncToolset(pi, ctx.model, state, variants);
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
@@ -61,12 +61,42 @@ function renderTextResult(
 	theme: ApplyPatchTheme,
 ): Container {
 	const component = new Container();
-	const text = result.content
+	const text = resultText(result);
+	if (text) component.addChild(new Text(theme.fg("toolOutput", text), 0, 0));
+	return component;
+}
+
+function resultText(result: AgentToolResult<ApplyPatchToolDetails | undefined>): string {
+	return result.content
 		.filter((block) => block.type === "text")
 		.map((block) => block.text)
 		.filter((value) => typeof value === "string" && value.length > 0)
 		.join("\n");
-	if (text) component.addChild(new Text(theme.fg("toolOutput", text), 0, 0));
+}
+
+function renderFailureBox(
+	result: AgentToolResult<ApplyPatchToolDetails>,
+	cwd: string,
+	expanded: boolean,
+	theme: ApplyPatchTheme,
+): Container {
+	const patchResult = result.details?.result;
+	if (!patchResult) return renderTextResult(result, theme);
+	const component = new Container();
+	const appliedCount = patchResult.appliedFiles.length;
+	const title = appliedCount > 0 ? "Patch partially failed" : "Patch failed";
+	const box = new Box(1, 1, (text: string) => theme.bg("toolErrorBg", text));
+	box.addChild(new Text(theme.fg("toolTitle", theme.bold(title)), 0, 0));
+	if (result.details.preview) {
+		box.addChild(new Spacer(1));
+		box.addChild(new Text(renderPatchPreview(result.details.preview, cwd, theme, expanded), 0, 0));
+	}
+	const text = resultText(result);
+	if (text) {
+		box.addChild(new Spacer(1));
+		box.addChild(new Text(theme.fg("toolOutput", text), 0, 0));
+	}
+	component.addChild(box);
 	return component;
 }
 
@@ -129,6 +159,9 @@ export function createApplyPatchTool(variant: "freeform" | "json" = "freeform"):
 			return new Text(theme.fg("toolTitle", theme.bold(text)), 0, 0);
 		},
 		renderResult(result, options, theme, context) {
+			if (context.isError && result.details?.result?.failures.length) {
+				return renderFailureBox(result as AgentToolResult<ApplyPatchToolDetails>, context.cwd, true, theme);
+			}
 			if (result.details?.preview) {
 				const expanded = true;
 				return renderPreviewBox(

--- a/packages/coding-agent/test/suite/gpt-apply-patch-failure-disclosure.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-failure-disclosure.test.ts
@@ -5,11 +5,31 @@ import {
 	applyPatchDetailed,
 	buildPartialFailureText,
 } from "../../src/core/extensions/builtin/gpt-apply-patch/apply.ts";
+import { registerApplyPatchExtension } from "../../src/core/extensions/builtin/gpt-apply-patch/extension.ts";
 import { createApplyPatchTool } from "../../src/core/extensions/builtin/gpt-apply-patch/tool.ts";
+import type { ApplyPatchExtensionAPI } from "../../src/core/extensions/builtin/gpt-apply-patch/types.ts";
+import type { ExtensionHandler, ToolResultEvent, ToolResultEventResult } from "../../src/core/extensions/types.ts";
 import type { Harness } from "./harness.ts";
 import { createHarness } from "./harness.ts";
 
 const harnesses: Harness[] = [];
+type ToolResultHandler = ExtensionHandler<ToolResultEvent, ToolResultEventResult>;
+
+function captureToolResultHandler(): ToolResultHandler {
+	let toolResultHandler: ToolResultHandler | undefined;
+	const api = {
+		registerTool: () => {},
+		on: (event: string, handler: unknown) => {
+			if (event === "tool_result") toolResultHandler = handler as ToolResultHandler;
+		},
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+	} as unknown as ApplyPatchExtensionAPI;
+	registerApplyPatchExtension(api);
+	if (!toolResultHandler) throw new Error("apply_patch did not register a tool_result handler");
+	return toolResultHandler;
+}
 
 afterEach(async () => {
 	await Promise.all(harnesses.splice(0).map((h) => h.cleanup()));
@@ -78,6 +98,69 @@ describe("gpt-apply-patch failure disclosure (#31)", () => {
 		const text = result.content.find((block) => block.type === "text")?.text ?? "";
 		expect(text).toContain("broken.txt");
 		expect(text).toMatch(/expected lines|context|find/i);
+	});
+
+	it("marks partial patch failures as errors for the model", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "existing.txt"), "actual\n", "utf-8");
+		const patch = `*** Begin Patch
+*** Add File: created.txt
++created
+*** Update File: existing.txt
+@@
+-expected
++changed
+*** End Patch`;
+		const tool = createApplyPatchTool();
+		const result = await tool.execute("partial-failure", { input: patch }, undefined, undefined, {
+			cwd: harness.tempDir,
+		} as never);
+		const hookResult = await captureToolResultHandler()(
+			{
+				type: "tool_result",
+				toolName: "apply_patch",
+				toolCallId: "partial-failure",
+				input: { input: patch },
+				content: result.content,
+				details: result.details,
+				isError: false,
+			},
+			{} as never,
+		);
+
+		expect(hookResult).toEqual({ isError: true });
+	});
+
+	it("marks complete patch failures as errors for the model", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "existing.txt"), "actual\n", "utf-8");
+		const patch = `*** Begin Patch
+*** Update File: existing.txt
+@@
+-expected
++changed
+*** End Patch`;
+		const tool = createApplyPatchTool();
+		const result = await tool.execute("complete-failure", { input: patch }, undefined, undefined, {
+			cwd: harness.tempDir,
+		} as never);
+
+		const hookResult = await captureToolResultHandler()(
+			{
+				type: "tool_result",
+				toolName: "apply_patch",
+				toolCallId: "complete-failure",
+				input: { input: patch },
+				content: result.content,
+				details: result.details,
+				isError: false,
+			},
+			{} as never,
+		);
+
+		expect(hookResult).toEqual({ isError: true });
 	});
 });
 

--- a/packages/coding-agent/test/suite/gpt-apply-patch-failure-render.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-failure-render.test.ts
@@ -1,0 +1,109 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createApplyPatchTool } from "../../src/core/extensions/builtin/gpt-apply-patch/tool.ts";
+import type { ToolRenderContext } from "../../src/core/extensions/types.ts";
+import type { Harness } from "./harness.ts";
+import { createHarness } from "./harness.ts";
+
+type ApplyPatchTool = ReturnType<typeof createApplyPatchTool>;
+type ApplyPatchArgs = { input: string };
+
+const markerTheme = {
+	fg: (name: string, text: string) => `<fg:${name}>${text}</fg:${name}>`,
+	bg: (name: string, text: string) => `<bg:${name}>${text}</bg:${name}>`,
+	bold: (text: string) => `<bold>${text}</bold>`,
+	inverse: (text: string) => `<inverse>${text}</inverse>`,
+};
+
+function renderContext(cwd: string, args: ApplyPatchArgs) {
+	return {
+		args,
+		toolCallId: "failed-patch",
+		invalidate: () => {},
+		lastComponent: undefined,
+		state: {},
+		cwd,
+		executionStarted: true,
+		argsComplete: true,
+		isPartial: false,
+		expanded: true,
+		showImages: true,
+		isError: true,
+		hasResult: true,
+	} satisfies ToolRenderContext<Record<string, unknown>, ApplyPatchArgs>;
+}
+
+describe("gpt apply_patch failure rendering", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(async () => {
+		await Promise.all(harnesses.splice(0).map((harness) => harness.cleanup()));
+	});
+
+	it("renders a partial failure instead of a successful patch", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "existing.txt"), "actual\n", "utf-8");
+		const args = {
+			input: `*** Begin Patch
+*** Add File: created.txt
++created
+*** Update File: existing.txt
+@@
+-expected
++changed
+*** End Patch`,
+		};
+		const tool = createApplyPatchTool();
+		const result = await tool.execute("partial-failure", args, undefined, undefined, {
+			cwd: harness.tempDir,
+		} as Parameters<ApplyPatchTool["execute"]>[4]);
+
+		const component = tool.renderResult?.(
+			result,
+			{ expanded: true, isPartial: false },
+			markerTheme as never,
+			renderContext(harness.tempDir, args),
+		);
+		const rendered = component?.render(160).join("\n") ?? "";
+
+		expect(rendered).toContain("<bg:toolErrorBg>");
+		expect(rendered).toContain("<bold>Patch partially failed</bold>");
+		expect(rendered).toContain("created.txt (+1 -0)");
+		expect(rendered).toContain("existing.txt");
+		expect(rendered).not.toContain("Applied patch");
+		expect(rendered).not.toContain("Applying patch");
+	});
+
+	it("renders a complete failure as no file actions applied", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		await writeFile(path.join(harness.tempDir, "existing.txt"), "actual\n", "utf-8");
+		const args = {
+			input: `*** Begin Patch
+*** Update File: existing.txt
+@@
+-expected
++changed
+*** End Patch`,
+		};
+		const tool = createApplyPatchTool();
+		const result = await tool.execute("complete-failure", args, undefined, undefined, {
+			cwd: harness.tempDir,
+		} as Parameters<ApplyPatchTool["execute"]>[4]);
+
+		const component = tool.renderResult?.(
+			result,
+			{ expanded: true, isPartial: false },
+			markerTheme as never,
+			renderContext(harness.tempDir, args),
+		);
+		const rendered = component?.render(160).join("\n") ?? "";
+
+		expect(rendered).toContain("<bg:toolErrorBg>");
+		expect(rendered).toContain("<bold>Patch failed</bold>");
+		expect(rendered).toContain("No file actions were applied.");
+		expect(rendered).not.toContain("Applying patch");
+	});
+});


### PR DESCRIPTION
## Summary

- classify completed `apply_patch` results with failed operations as tool errors for the agent/model loop
- render complete and partial failures with an explicit error card instead of stale `Applying patch` / successful styling
- preserve successful partial diffs and recovery guidance, with deterministic coverage for complete and partial failures

## Validation

- `npm test -- test/suite/gpt-apply-patch-failure-disclosure.test.ts test/suite/gpt-apply-patch-failure-render.test.ts --reporter=dot` — 8 passed
- `npm test -- test/suite/gpt-apply-patch-*.test.ts test/suite/regressions/tui-apply-patch-rendering.test.ts test/suite/app-server-task24-apply-patch-identity.test.ts --reporter=dot` — 64 passed
- `npm run check` — passed
- exact real-CLI QA — passed all checks:
  - partial mutation observed
  - failure text reached the next model request
  - session stored the `apply_patch` result with `isError: true`
  - TUI renderer showed `Patch partially failed` with the applied diff and recovery text
- isolated tmux TUI smoke — 5/5, with visible Senpi startup chrome, composer, and footer

## Evidence

- `local-ignore/qa-evidence/20260731-apply-patch-failure-status/result.json`
- `local-ignore/qa-evidence/20260731-apply-patch-failure-status/tui.txt`
- `local-ignore/qa-evidence/20260731-apply-patch-failure-status-tui-isolated/tui-smoke-tmux.txt`

## Known pre-existing issue

The full coding-agent suite reaches an unrelated package-alias failure for
`@earendil-works/pi-ai/node/provider-scope`. The same failure reproduces on a
clean `origin/main` worktree and comes from the unchanged extension loader's
prefix alias for `@earendil-works/pi-ai`; apply-patch-focused tests and static
validation are green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces `apply_patch` failures as explicit tool errors and renders them clearly in the TUI, so the model reacts to failures and users see accurate status. Partial successes keep their diffs and recovery text.

- **Bug Fixes**
  - Mark completed `apply_patch` results with any failures as `isError: true` via the tool_result hook.
  - Show an error card titled “Patch failed” or “Patch partially failed”, including any diff preview and guidance.
  - Add tests for error signaling and failure rendering (complete and partial).

<sup>Written for commit ea07bfcbbeef0ff165bffbaf1829bfcb4a968dd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

