### PR TITLE
feat(omo-senpi): mirror ulw mutation skills

### DIFF
--- a/packages/omo-senpi/AGENTS.md
+++ b/packages/omo-senpi/AGENTS.md
@@ -1,0 +1,91 @@
+# omo-senpi
+
+Native Senpi TypeScript extension adapter for oh-my-openagent.
+
+This package is adapter-only. It may depend on harness-neutral core packages plus the Senpi-coupled `@oh-my-opencode/senpi-task` engine, but those packages must not import Senpi, Pi packages, or this adapter through their harness-neutral entrypoints. The Senpi runtime boundary stays here.
+
+## Anatomy
+
+| Path | Purpose |
+|------|---------|
+| `package.json` | Private workspace package `@oh-my-opencode/omo-senpi`; exports the adapter, extension, and local installer entrypoints. |
+| `src/extension/` | Senpi ExtensionAPI composition layer. It validates the required API surface, registers global and per-component disable flags, and wires components defensively. |
+| `src/components/` | Eleven live components: `config-startup`, `ultrawork`, `start-work-continuation`, `ulw-loop`, `fallback-architect`, `comment-checker`, `telemetry`, `lsp`, `codegraph`, `task`, and `config-watch`, plus the `config-resolution` loader helper. |
+| `src/install/` | Local Senpi installer and uninstaller helpers. They add or remove the absolute plugin path in `SENPI_CODING_AGENT_DIR` or `~/.senpi/agent` settings. |
+| `scripts/qa/` | Live Senpi QA drivers, continuation probe, and mock provider used by task 13 validation. |
+| `skills/` | Native Senpi skills authored directly against the Senpi tool surface (not ported from Codex or the shared pool); currently `hyperplan`, `ultrawork`, `ulw-loop`, `ulw-mutation-test`, and `ulw-research`. `sync-skills.mjs` ships them verbatim. |
+| `plugin/` | The single Pi package `@code-yeongyu/omo-senpi`. It contains generated `extensions/omo.js`, generated skills, package metadata, and plugin-local build scripts. |
+
+The v1 install surface is local-path only. Install the built Pi package from `packages/omo-senpi/plugin`; do not document npm, git, or marketplace distribution for this adapter until that exists in code.
+
+## Components
+
+- `config-startup`: runs the shared lock+journal migration engine (`runSenpiStartupMigration`, both legacy groups: `2026-07-opencode-config-unification` for `oh-my-*` files and `2026-07-codex-config-jsonc` for `~/.omo/config.jsonc`) before Senpi reads its unified configuration, then loads the profile-selected `[senpi]` view through `config-resolution` (`loadSenpiOmoConfig`: `loadOmoConfig` with `harness: "senpi"` plus `resolveModelReferences` catalog expansion). Migration results and config diagnostics surface once on the first `session_start` via the host notification UI (falling back to the logger).
+
+- `ultrawork`: injects the Senpi ultrawork directive on matching input as a hidden custom message (`pi.sendMessage({customType: 'omo-ultrawork:directive', content: DIRECTIVE, display: false})` followed by `{action: 'continue'}`), backed by `src/components/ultrawork/generated-directive.ts`. On the idle path the user's typed text is never modified; senpi converts the custom message into `role: 'user'` conversation context, so the directive reaches the model but is not rendered in the TUI. A prompt QUEUED mid-stream (the input event carries `streamingBehavior`) instead gets the directive appended inside that one message: senpi drains steering and follow-up queues one message at a time by default and answers each drained message, so a separate hidden message would burn its own turn before the user's ask arrived. Appending rather than prepending is what keeps `/skill:` expansion working on that path. All guards are preserved: the `/(?:ultrawork|ulw(?!-))/i` trigger, the `omo-senpi-ultrawork-disabled` flag, skipping `source === 'extension'` inputs, skipping `ulw-` skill names (`ulw-plan`, `ulw-loop`, `ulw-research`), and skipping inputs that already carry a matched `<ultrawork-mode>`...`</ultrawork-mode>` tag pair (a lone open-tag mention still arms). For `/skill:` commands on the idle path there is no prepend/append distinction because text is not rewritten: `/skill:ultrawork` passes through untouched (expansion already inlines the directive), a trigger that appears only in the skill NAME does not arm, and senpi's native skill expansion can no longer be disturbed by the hook. The directive is authored senpi-native at `skills/ultrawork/SKILL.md` and ships verbatim; `plugin/scripts/embed-directive.mjs` embeds its body into `src/components/ultrawork/generated-directive.ts` and fails the build when non-senpi harness tokens (multi_agent, update_plan, codex, ...) appear in the source.
+- `start-work-continuation`: reads `.omo/boulder.json` on `agent_end` (the Senpi analog of Codex's Stop hook) and injects a continuation directive when the current session owns an active or paused Prometheus work plan. It uses `senpi:<session_id>` state produced by the `start-work` skill, suppresses repeats by a `work_id:updated_at:completed/total` signature, and caps consecutive continuations at 8 (reset on user input). It registers before `ulw-loop` so active boulder work takes precedence over ulw-loop continuation.
+- `ulw-loop`: detects active `omo ulw-loop` state and injects continuation guidance when the cwd has an incomplete run. It explicitly defers to `start-work-continuation` when boulder state is continuable for the same session.
+- `fallback-architect`: when senpi's retry-fallback controller moves the session off `claude-fable-5` because the model refused or the provider rejected the request under Anthropic's Usage Policy, it injects one hidden `omo-fallback-architect:directive` message telling the weaker active model to decompose the problem and consult `task(category: "architect")` with self-contained per-part queries. Detection uses only the extension surface: `message_end` supplies the refusal signal and `model_select` with `source: "fallback"` supplies the switch, with the refusal predicate in `detection.ts` mirroring senpi `isClassifierRefusal` (`packages/ai/src/utils/stop-details.ts`) including its stop-reason-first ordering. It fires only when `loadOmoConfig` reports an enabled `architect` category, and a compact reminder then rides on each later user prompt until fable 5 is active again. The reminder is ALWAYS a hidden custom message (`display: false`) and the typed text is never rewritten: on the mid-stream path senpi steers a custom message into the running turn (`sendCustomMessage` -> `agent.steer`), so hiding it costs no extra assistant turn for queued prompts either — the old transform-append leaked the reminder into the user's own bubble in the TUI. Arming also emits one user-VISIBLE `omo-fallback-architect:notice` custom message (`display: true`, structured `details: { from, to }`) framing the switch as an upgrade (the fallback model drives execution while Fable-5-grade reasoning stays reachable through the architect lane); `notice.ts` owns the copy plus a registered TUI message renderer, and the stable customType + details ride senpi's session/event stream so GUI surfaces (omo-desktop-app) can render the same event later without senpi core changes. Gated by `omo-senpi-fallback-architect-disabled`.
+- `comment-checker`: runs the shared comment-checker flow after write-like tool results when a resolver finds the binary.
+- `telemetry`: sends the anonymous once-per-UTC-day `omo_senpi_daily_active` event, with product-specific opt-outs.
+- `lsp`: registers direct LSP tools and optional post-edit diagnostics through the packaged shared LSP daemon runtime. The Senpi adapter owns only descriptors, schemas, renderers, path extraction, and project-config migration warnings.
+- `codegraph`: registers the CodeGraph MCP server (stdio, eager lifecycle) when the resolver finds a supported runtime, and skips registration inside senpi-task RPC children. It reads `codegraph.daemon` from `omo.json` at component registration; daemon mode is on by default and omits `CODEGRAPH_NO_DAEMON`, while `daemon: false` pins `CODEGRAPH_NO_DAEMON=1`. `OMO_CODEGRAPH_DAEMON` overrides config (`1`/`true`/`yes` enable; `0`/`false`/`no` disable), so precedence is env > config > default. `registerMcpServer` provides no child handle or unregister surface, so Senpi owns the registered stdio lifecycle.
+- `task`: loads the unified `omo.jsonc` view at register (via `config-resolution`), composes the task engine over `@oh-my-opencode/senpi-task`, and registers the 4 task tools (`task`, `task_send`, `task_cancel`, `task_output`) plus the 6 lead-only team tools (`team_create`, `team_delete`, `task_create`, `task_get`, `task_list`, `task_update`).
+  The engine overlays four builtin curated read-only subagents (`explore`, `librarian`, `metis`, `momus`) under the omo.json `agents` record, so any session can delegate via `task(subagent_type: "<name>")` with zero configuration; omo.json `agents.<name>` replaces individual builtin fields field-level while unset fields keep the builtin, and `disable: true` hides one from the task tool description and spawn resolution even when a request supplies an explicit model. Curated agents are pinned to in-process execution (their `execution_mode` override is ignored) and are rejected as team members because process-mode member spawns drop the persona prompt and tool policy. The component also wires the plan-gated agent tier: `components/task/skill-invocation-tracker.ts` records per-session skill invocations from `read` tool results on `*/skills/<name>/SKILL.md` and raw `/skill:<name>` inputs (state is dropped on `session_shutdown`; `load_skills` on a spawn arms the child and is deliberately not a parent-session invocation), and `createTaskTool` receives it as `resolveSkillInvocations`, so `metis`/`momus` spawn only after an in-session `ulw-plan` invocation and never after `start-work` (the classification and verdict live in senpi-task `agents/invocation-guard.ts`). Their nine-name tool surface replaces Senpi's general `bash` with a structured read-only GitHub/HTTPS broker and excludes direct edit/write plus mutating LSP tools. Team sends are durable file-only writes. The adapter owns one 1-second lead poller per team led by the current session; process members load the scoped member extension with only `task_send` and receive lead mail steered into the resident member's running turn. It wires the ordered session-start recovery chain (process reattach, member/lead reservation reclaim, failed-notification retry, owned-lead poll), transition suspension, shutdown teardown, a completion-message renderer, the `/tasks` and `/task-kill` slash commands, and the status-UI footer. Gated by the `--no-omo-task` flag and skipped when required ExtensionAPI capabilities are missing.
+- `config-watch`: registers the resolved user and project `.omo` configuration chain with Senpi's optional `config-watch` event protocol. Its dry-run validation rejects new config diagnostics before the host reloads the extension; it safely skips with a warning on older Senpi APIs without the optional events capability. The user config directory is `~/.omo`; when it does not yet exist, its only parent is `$HOME`. Whenever the senpi agent dir sits under `$HOME` — including the default `~/.senpi/agent` — the bare-`$HOME` creation target is dropped by the protected-path filter below, so `userConfigCreationDiscovery` reports `reload_required` and later user-scope creation is discovered on the next session start. With `SENPI_CODING_AGENT_DIR` pointed outside `$HOME` the target survives and creation stays watched. Either way the flag is derived from the surviving targets rather than from directory existence, so it never claims a watch the host never received. Targets that cover the senpi agent dir's protected paths (`auth.json`, `sessions/`, `logs/` under `SENPI_CODING_AGENT_DIR`, default `~/.senpi/agent`) are filtered out of the resolution because the host rejects them deterministically — practically this drops the bare-`$HOME` ancestor target, so a NEW `.omo` created directly in the `$HOME` root is discovered only on the next session start. Rejections are never re-registered synchronously (the host rejects on the REGISTER stack, so a sync re-emit recurses until stack overflow): the refresh is deferred via `setTimeout(0)` and capped at 3 retries per registration-payload fingerprint, resetting when the payload changes.
+
+`packages/omo-opencode` is a separate build that still uses its prior task/team names; cross-edition parity is a deliberate follow-up outside this adapter.
+
+Rules are intentionally not a Senpi component. Senpi has builtin rules, so this adapter must not add a `rules` component just to mirror Codex or OpenCode.
+
+### Dependencies
+
+The adapter depends on `@oh-my-opencode/senpi-task` (task engine + tool factories), `@oh-my-opencode/omo-config-core` (`loadOmoConfig` + `resolveModelReferences` + the migration engine), `@oh-my-opencode/omo-opencode/config-migration` (dependency-clean legacy discovery + transform consumed by `config-startup`), `@oh-my-opencode/delegate-core`, `@oh-my-opencode/team-core`, `@oh-my-opencode/boulder-state` (Boulder work-plan state for `start-work-continuation`), `@oh-my-opencode/comment-checker-core`, `@oh-my-opencode/telemetry-core`, `@oh-my-opencode/prompts-core`, `@oh-my-opencode/lsp-core`, `@code-yeongyu/lsp-daemon`, and `@oh-my-opencode/utils`, with `@code-yeongyu/senpi` as an optional peer (`package.json`).
+
+## Build And Packaging
+
+Build outputs under `plugin/extensions/` and `plugin/skills/` are generated. Do not hand-edit them.
+
+- `node packages/omo-senpi/plugin/scripts/build-extension.mjs` builds `plugin/extensions/omo.js`.
+- `node packages/omo-senpi/plugin/scripts/build-extension.mjs --check` verifies the generated extension is current.
+- `node packages/omo-senpi/plugin/scripts/sync-skills.mjs` syncs Senpi-ready skills into `plugin/skills/` from three pools: component-owned native sources shipped verbatim (`ulw-loop`), native `skills/` sources shipped verbatim (`hyperplan`, `ultrawork`, `ulw-research`), and the repo `shared-skills` pool (start-work gets a `codex:`->`senpi:` overlay; ulw-plan gets a senpi overlay adding a momus-only review override plus architect/ultrabrain advisory consultation lanes; shared skills get a Senpi tool-compatibility banner).
+- `node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check` verifies the generated ultrawork directive is current.
+- `bun run test:senpi` runs the package gate: build the shared daemon, stage the plugin artifacts, typecheck, then `bun test packages/omo-senpi`.
+
+Peer-external build rule: the extension build must externalize the Senpi peer/import family so shared core packages stay harness-neutral and Senpi resolves those peers from the installed Senpi runtime. Keep `SENPI_LOADER_ALIASES` in `plugin/scripts/build-extension.mjs` aligned with `src/bundle-purity.test.ts`, including `@code-yeongyu/senpi`, `@earendil-works/pi-*`, and `@mariozechner/pi-*` imports. The current build also externalizes the TypeBox aliases required by Senpi's loader and Node builtins.
+
+## QA
+
+For adapter code changes, run the narrowest relevant unit tests plus the Senpi package gate:
+
+```sh
+tsgo --noEmit -p packages/omo-senpi/tsconfig.json
+bun run test:senpi
+```
+
+Task live QA scripts:
+
+```sh
+node packages/omo-senpi/scripts/qa/drive.mjs --self-test
+node packages/omo-senpi/scripts/qa/drive.mjs
+node packages/omo-senpi/scripts/qa/probe-continuation.mjs
+SENPI_BIN="$(command -v senpi)" node packages/omo-senpi/scripts/qa/task-e2e.mjs
+SENPI_BIN="$(command -v senpi)" node packages/omo-senpi/scripts/qa/team-e2e.mjs
+node packages/omo-senpi/scripts/qa/task-rpc-e2e.mjs --self-test
+```
+
+`drive.mjs` and the task/team live drivers create isolated Senpi agent directories and ignore caller `SENPI_CODING_AGENT_DIR`. If the Senpi binary is unavailable, the live drivers report `SKIP` or `FAIL` in final JSON instead of touching the real `~/.senpi/agent`.
+
+Task-component QA in this package: `packages/omo-senpi/scripts/qa/task-13.test.ts` exercises the task engine wiring, `task-e2e.mjs` covers single and batch task lifecycles, `team-e2e.mjs` covers injection-driven delivery, shutdown-via-`task_send`, stale-reservation reclaim, member-liveness events, and kill/restart exactly-once recovery, and `task-rpc-e2e.mjs --self-test` pins the RPC driver scripts. The `@oh-my-opencode/senpi-task` unit + chaos suites (`bun test packages/senpi-task`) cover the state machine, runners, and completion invariants. The task engine's own standalone manual drivers live under `packages/senpi-task/scripts/` (see [`packages/senpi-task/AGENTS.md`](../senpi-task/AGENTS.md)).
+
+## Evidence Rules
+
+Live Senpi QA evidence goes under `.omo/evidence/omo-senpi-adapter/`, one subdirectory per change or task. Record:
+
+- what command or manual action was run;
+- what behavior it was meant to prove;
+- the observed result, including final JSON from the QA driver when present;
+- isolation proof, especially the sandbox `SENPI_CODING_AGENT_DIR` and whether the real Senpi agent dir stayed untouched;
+- omitted or redacted material, especially raw logs that could contain secrets.
+
+Do not claim live Senpi QA from unit tests alone. `bun run test:senpi` is the package gate; the scripts in `scripts/qa/` are the real harness proof.

--- a/packages/omo-senpi/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-senpi/plugin/scripts/sync-skills.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { dirname, extname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const repoRoot = dirname(dirname(pluginRoot))
+const skillsRoot = join(pluginRoot, "skills")
+const sharedSkillsRoot = join(repoRoot, "shared-skills", "skills")
+
+const skillSources = [
+  {
+    name: "ulw-loop",
+    source: join(repoRoot, "omo-senpi", "skills", "ulw-loop"),
+  },
+]
+const componentSkillNames = new Set(skillSources.map(({ name }) => name))
+
+// Senpi-native skills authored directly against the omo-senpi tool surface (not ported from Codex or
+// the shared pool). They ship verbatim aside from blank-line normalization: no edition rewrite, no
+// section stripping, and no Senpi-compatibility banner (they already speak native Senpi tools).
+const nativeSkillsRoot = join(repoRoot, "omo-senpi", "skills")
+const nativeSkillSources = [
+  {
+    name: "give-me-tips",
+    source: join(nativeSkillsRoot, "give-me-tips"),
+  },
+  {
+    name: "hyperplan",
+    source: join(nativeSkillsRoot, "hyperplan"),
+  },
+  {
+    name: "ultrawork",
+    source: join(nativeSkillsRoot, "ultrawork"),
+  },
+  {
+    name: "ulw-mutation-test",
+    source: join(nativeSkillsRoot, "ulw-mutation-test"),
+  },
+  {
+    name: "ulw-research",
+    source: join(nativeSkillsRoot, "ulw-research"),
+  },
+]
+const nativeSkillNames = new Set(nativeSkillSources.map(({ name }) => name))
+
+const textExtensions = new Set([".md", ".yaml", ".yml", ".json", ".txt"])
+const sectionHeadingsToStrip = new Set([
+  "Codex Harness Tool Compatibility",
+  "Codex Tool Mapping",
+  "Codex subagent reliability",
+  "Subagent-dependent transition barrier",
+  "Senpi Harness Tool Compatibility",
+])
+const forbiddenGuidancePattern = /\b(?:multi_agent|spawn_agent)\b/i
+
+const sourceTestFilePattern = /\.test\.ts$/
+const ignoredSkillSourceDirNames = new Set([
+  ".mypy_cache",
+  ".omo",
+  ".pytest_cache",
+  ".ruff_cache",
+  "__pycache__",
+])
+const ignoredSkillSourceFileNames = new Set([".gitignore", ".npmignore", "pyrightconfig.json", "openai.yaml"])
+
+const opencodeOnlyOrchestrationPattern = /\b(?:call_omo_agent|background_output|team_[a-z_]+|task)\s*\(/
+
+export const senpiHarnessToolCompatibility = `## Senpi Harness Tool Compatibility
+
+This skill may include examples copied from the OpenCode harness. In Senpi, do not call OpenCode-only tools such as \`call_omo_agent(...)\`, \`task(...)\`, \`background_output(...)\`, or \`team_*(...)\` literally. Translate those examples to Senpi native tools:
+
+| OpenCode example | Senpi tool to use |
+| --- | --- |
+| \`call_omo_agent(subagent_type="explore", ...)\` | \`task\` tool with category/agent matching \`.omo/omo.json\` (e.g. \`agent: "scout"\`) |
+| \`call_omo_agent(subagent_type="librarian", ...)\` | \`task\` tool with category/agent matching \`.omo/omo.json\` (e.g. \`agent: "librarian"\`) |
+| \`task(...)\` | \`task\` tool |
+| \`background_output(task_id="...")\` | \`task_output\` tool with the task id |
+| \`team_*(...)\` | Lead team tools (\`team_create\`, \`task_create\`, ...); send with \`task_send\`, then keep working or end your turn — member and lead mail arrive as injected notifications, never poll for it |
+
+If a code block below conflicts with this section, this section wins.
+
+`
+
+const senpiCompatibilityEndMarkers = [
+  "If a code block below conflicts with this section, this section wins.\n\n",
+]
+
+function isTextFile(path) {
+  return textExtensions.has(extname(path))
+}
+
+function rewriteEditionNaming(content) {
+  return content
+    .replace(/\bon Codex\b/g, "for omo-senpi")
+    .replace(/\bIn Codex\b/g, "In omo-senpi")
+    .replace(/\bCodex App\b/g, "omo-senpi")
+    .replace(/\bCodex CLI\b/g, "omo-senpi")
+    .replace(/\bCodex\b/g, "omo-senpi")
+    .replace(/\bcodex\b/g, "omo-senpi")
+    .replace(/\blazycodex\b/g, "omo-senpi")
+    .replace(/\bLazyCodex\b/g, "omo-senpi")
+}
+
+function headingLevel(line) {
+  const match = line.match(/^(#{1,6})\s+(.+?)\s*$/)
+  return match === null ? undefined : match[1].length
+}
+
+function headingTitle(line) {
+  const match = line.match(/^#{1,6}\s+(.+?)\s*$/)
+  return match?.[1]?.replace(/`/g, "").trim()
+}
+
+function stripNamedSections(content) {
+  const lines = content.split("\n")
+  const kept = []
+  let strippingLevel
+
+  for (const line of lines) {
+    const currentLevel = headingLevel(line)
+    if (strippingLevel !== undefined && currentLevel !== undefined && currentLevel <= strippingLevel) {
+      strippingLevel = undefined
+    }
+
+    if (strippingLevel !== undefined) {
+      continue
+    }
+
+    const title = headingTitle(line)
+    if (title !== undefined && sectionHeadingsToStrip.has(title)) {
+      strippingLevel = currentLevel
+      continue
+    }
+
+    kept.push(line)
+  }
+
+  return kept.join("\n")
+}
+
+function stripForbiddenGuidanceLines(content) {
+  return content
+    .split("\n")
+    .filter((line) => !forbiddenGuidancePattern.test(line))
+    .join("\n")
+}
+
+function normalizeBlankLines(content) {
+  return content.replace(/\n{3,}/g, "\n\n")
+}
+
+function applyTier1Adaptation(content) {
+  return normalizeBlankLines(stripForbiddenGuidanceLines(stripNamedSections(rewriteEditionNaming(content))))
+}
+
+function applyStartWorkOverlay(content) {
+  return content.replace(/codex:<session_id>/g, "senpi:<session_id>").replace(/\bcodex:/g, "senpi:")
+}
+
+const ulwPlanReviewOverride = `## Senpi Review Override (authoritative)
+
+In omo-senpi the curated \`oracle\` subagent does not exist. The high-accuracy review is MOMUS-ONLY: one round is exactly ONE native \`momus\` review of the complete plan file. Ignore every "dual" review instruction, every "independent" reviewer lane, and every \`independent_reviewer\` state field below; never spawn \`task(subagent_type="oracle")\`. A momus approval whose remaining items are notes counts as approval.
+
+Only a plan file produced by this skill and recorded with \`review_required\` authorizes a \`momus\` or \`metis\` review. A bare \`ulw\` run without that file uses notepad self-review instead, however large the work feels.
+
+If a section below conflicts with this section, this section wins.
+
+`
+
+const ulwPlanConsultationLanes = `## Senpi Design Consultation Lanes (authoritative)
+
+When the task tool's available categories include \`architect\` and/or \`ultrabrain\`, ACTIVELY consult them as background advisory lanes while grounding and drafting the plan:
+
+| Lane | Category | Ask it for |
+| --- | --- | --- |
+| Big-picture design | \`architect\` | module boundaries, decomposition options, trade-offs, blast radius |
+| Detail design | \`ultrabrain\` | algorithms, edge cases, exact interfaces and contracts |
+
+Spawn them with \`task(category: "architect" \\| "ultrabrain", run_in_background: true)\` in the same wave as your research lanes, and integrate their answers before the approval brief. Every such prompt MUST start with TASK / DELIVERABLE / SCOPE / VERIFY / STOP WHEN and MUST declare itself advisory-only: read-only analysis, NO file edits, recommendations returned as text. Treat what comes back as claims to verify, not as decisions already made.
+
+This section is an EXPLICIT EXCEPTION to the later rule "Never dispatch with \`category=\`": it authorizes exactly these two advisory lanes. Every other category dispatch stays forbidden. When neither category is listed as available, skip these lanes silently.
+
+`
+
+function applyUlwPlanOverlay(content) {
+  if (content.includes("# ulw-plan - full workflow")) {
+    return insertAfterFrontmatter(content, ulwPlanReviewOverride)
+  }
+  if (/^#\s+ulw-plan\s*$/m.test(content)) {
+    return insertAfterFrontmatter(content, `${ulwPlanReviewOverride}${ulwPlanConsultationLanes}`)
+  }
+  return content
+}
+
+function insertAfterFrontmatter(content, section) {
+  const frontmatterEnd = content.indexOf("\n---\n", content.startsWith("---\n") ? 4 : 0)
+  if (!content.startsWith("---\n") || frontmatterEnd === -1) return `${section}${content}`
+  const insertAt = frontmatterEnd + "\n---\n".length
+  return `${content.slice(0, insertAt)}\n${section}${content.slice(insertAt)}`
+}
+
+function findSenpiCompatibilitySectionEnd(content, searchStart) {
+  const structuralEndPattern = /\n(?:---|export\s+const\s+|#{1,6}\s)/g
+  structuralEndPattern.lastIndex = searchStart
+  const structuralEnd = structuralEndPattern.exec(content)
+  if (structuralEnd) return structuralEnd.index + 1
+
+  const knownEndMarker = senpiCompatibilityEndMarkers.find((marker) => content.indexOf(marker, searchStart) !== -1)
+  if (knownEndMarker === undefined) return content.length
+
+  return content.indexOf(knownEndMarker, searchStart) + knownEndMarker.length
+}
+
+function removeSenpiCompatibilityGuidance(content) {
+  const heading = "## Senpi Harness Tool Compatibility"
+  let withoutGuidance = content
+
+  while (true) {
+    const start = withoutGuidance.indexOf(heading)
+    if (start === -1) return withoutGuidance
+
+    const end = findSenpiCompatibilitySectionEnd(withoutGuidance, start + heading.length)
+    withoutGuidance = `${withoutGuidance.slice(0, start)}${withoutGuidance.slice(end)}`
+  }
+}
+
+function hasKnownGeneratedSenpiCompatibilityGuidance(content, compatibilityIndex) {
+  return senpiCompatibilityEndMarkers.some((marker) => content.indexOf(marker, compatibilityIndex) !== -1)
+}
+
+export function insertSenpiCompatibilityGuidance(content) {
+  if (!opencodeOnlyOrchestrationPattern.test(content)) return content
+  const firstExampleIndex = content.search(opencodeOnlyOrchestrationPattern)
+  const compatibilityIndex = content.indexOf("## Senpi Harness Tool Compatibility")
+  if (
+    compatibilityIndex !== -1 &&
+    compatibilityIndex < firstExampleIndex &&
+    !hasKnownGeneratedSenpiCompatibilityGuidance(content, compatibilityIndex)
+  ) {
+    return content
+  }
+
+  const contentWithoutGuidance = removeSenpiCompatibilityGuidance(content)
+
+  const frontmatterMatch = contentWithoutGuidance.match(/^---\n[\s\S]*?\n---\n+/)
+  if (!frontmatterMatch) {
+    return `${senpiHarnessToolCompatibility}${contentWithoutGuidance}`
+  }
+
+  return `${frontmatterMatch[0]}${senpiHarnessToolCompatibility}${contentWithoutGuidance.slice(frontmatterMatch[0].length)}`
+}
+
+function applySharedTierAdaptation(skillName, content) {
+  let adapted = content
+  if (skillName === "start-work") {
+    adapted = applyStartWorkOverlay(adapted)
+  }
+  if (skillName === "ulw-plan") {
+    adapted = applyUlwPlanOverlay(adapted)
+  }
+  adapted = stripNamedSections(adapted)
+  adapted = insertSenpiCompatibilityGuidance(adapted)
+  return normalizeBlankLines(adapted)
+}
+
+function shouldCopySkillSource(source) {
+  const normalized = source.replaceAll("\\", "/")
+  const segments = normalized.split("/")
+  const name = segments.at(-1) ?? ""
+  if (segments.some((segment) => ignoredSkillSourceDirNames.has(segment))) return false
+  if (ignoredSkillSourceFileNames.has(name)) return false
+  if (sourceTestFilePattern.test(name) || name.endsWith(".pyc")) return false
+  const scriptsIndex = segments.lastIndexOf("scripts")
+  return scriptsIndex === -1 || segments[scriptsIndex + 1] !== "tests"
+}
+
+async function listFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const entryPath = join(root, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(entryPath)))
+    } else if (entry.isFile()) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}
+
+async function adaptSkillTree(skillRoot, adapter) {
+  const files = await listFiles(skillRoot)
+  for (const file of files) {
+    if (!isTextFile(file)) continue
+
+    const before = await readFile(file, "utf8")
+    const after = adapter(before)
+    if (after !== before) {
+      await writeFile(file, after, "utf8")
+    }
+  }
+}
+
+async function assertSourceExists(source) {
+  const sourceStat = await stat(source)
+  if (!sourceStat.isDirectory()) {
+    throw new Error(`${source} is not a directory`)
+  }
+}
+
+export async function syncSkills() {
+  await rm(skillsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  await mkdir(skillsRoot, { recursive: true })
+
+  for (const { name, source } of skillSources) {
+    await assertSourceExists(source)
+    const destination = join(skillsRoot, name)
+    await cp(source, destination, { filter: shouldCopySkillSource, recursive: true })
+    await adaptSkillTree(destination, normalizeBlankLines)
+  }
+
+  for (const { name, source } of nativeSkillSources) {
+    await assertSourceExists(source)
+    const destination = join(skillsRoot, name)
+    await cp(source, destination, { filter: shouldCopySkillSource, recursive: true })
+    await adaptSkillTree(destination, normalizeBlankLines)
+  }
+
+  const sharedSkillEntries = await readdir(sharedSkillsRoot, { withFileTypes: true })
+  const sharedSkillNames = sharedSkillEntries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+  for (const skillName of sharedSkillNames) {
+    if (componentSkillNames.has(skillName) || nativeSkillNames.has(skillName)) continue
+    const source = join(sharedSkillsRoot, skillName)
+    const destination = join(skillsRoot, skillName)
+    await cp(source, destination, { filter: shouldCopySkillSource, recursive: true })
+    await adaptSkillTree(destination, (content) => applySharedTierAdaptation(skillName, content))
+  }
+
+  console.log(`synced omo-senpi skills to ${skillsRoot}`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await syncSkills()
+}

--- a/packages/omo-senpi/scripts/qa/ulw-prompts-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/ulw-prompts-e2e.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { delimiter, dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { createSandbox, credentialDigest, digestDirectory, seedSandbox } from "./drive.mjs"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..", "..")
+const pluginRoot = join(packageRoot, "plugin")
+const mockProviderEntry = join(scriptDir, "mock-provider", "index.ts")
+
+const REQUIRED_DIRECTIVE_MARKERS = [
+  "<ultrawork-mode>",
+  "ULTRAWORK MODE ENABLED!",
+  "# Parallel execution",
+  "create_goal",
+  "# Stop rules",
+  "team_create",
+]
+const FORBIDDEN_TRANSCRIPT_MARKERS = ["update_plan", "multi_agent", "spawn_agent"]
+const ULTRAWORK_CUSTOM_TYPE = "omo-ultrawork:directive"
+
+function collectFiles(root, files) {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) collectFiles(path, files)
+    else if (entry.isFile()) files.push(path)
+  }
+}
+
+function readSandboxText(root) {
+  if (!existsSync(root)) return ""
+  const files = []
+  collectFiles(root, files)
+  return files
+    .filter((file) => file.endsWith(".json") || file.endsWith(".jsonl") || file.endsWith(".log") || file.endsWith(".md"))
+    .map((file) => readFileSync(file, "utf8"))
+    .join("\n")
+}
+
+function messageText(content) {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("")
+}
+
+/**
+ * The directive must ride in as a hidden custom_message entry, never as part of
+ * the user's own message. Reading the session JSONL is the only way to tell the
+ * two apart: the provider sees both as role "user".
+ */
+function inspectSession(agentDir) {
+  const sessionsDir = join(agentDir, "sessions")
+  if (!existsSync(sessionsDir)) return { userTexts: [], hiddenDirectives: [], visibleDirectives: [] }
+
+  const files = []
+  collectFiles(sessionsDir, files)
+  const userTexts = []
+  const hiddenDirectives = []
+  const visibleDirectives = []
+
+  for (const file of files.filter((path) => path.endsWith(".jsonl"))) {
+    for (const line of readFileSync(file, "utf8").split("\n")) {
+      if (line.trim() === "") continue
+      let entry
+      try {
+        entry = JSON.parse(line)
+      } catch {
+        continue
+      }
+      if (entry.type === "message" && entry.message?.role === "user") {
+        userTexts.push(messageText(entry.message.content))
+      }
+      if (entry.type === "custom_message" && entry.customType === ULTRAWORK_CUSTOM_TYPE) {
+        const record = { display: entry.display, content: messageText(entry.content) }
+        if (entry.display === false) hiddenDirectives.push(record)
+        else visibleDirectives.push(record)
+      }
+    }
+  }
+
+  return { userTexts, hiddenDirectives, visibleDirectives }
+}
+
+function findOnPath(bin) {
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    const candidate = resolve(dir || ".", bin)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function protectedAgentDigest(agentDir) {
+  return credentialDigest(agentDir)
+}
+
+function sandboxHome(sandbox) {
+  return join(sandbox.root, "home")
+}
+
+function stagedSkillChecks() {
+  const researchPath = join(pluginRoot, "skills", "ulw-research", "SKILL.md")
+  const mutationPath = join(pluginRoot, "skills", "ulw-mutation-test", "SKILL.md")
+  const loopWorkflowPath = join(pluginRoot, "skills", "ulw-loop", "references", "full-workflow.md")
+  const ultraworkPath = join(pluginRoot, "skills", "ultrawork", "SKILL.md")
+  const research = existsSync(researchPath) ? readFileSync(researchPath, "utf8") : ""
+  const mutation = existsSync(mutationPath) ? readFileSync(mutationPath, "utf8") : ""
+  const loopWorkflow = existsSync(loopWorkflowPath) ? readFileSync(loopWorkflowPath, "utf8") : ""
+  const ultrawork = existsSync(ultraworkPath) ? readFileSync(ultraworkPath, "utf8") : ""
+  const mutationGate = loopWorkflow.indexOf("### Mutation-Test Gate")
+  const gitCheckpoint = loopWorkflow.indexOf("#### GIT CHECKPOINT")
+  const mutationHeadings = new Set([...mutation.matchAll(/^## ([^\n]+)$/gm)].map((match) => match[1]))
+  return {
+    ulwResearchExists: research.length > 0,
+    ulwResearchNative:
+      research.length > 0 &&
+      !research.includes("## Senpi Harness Tool Compatibility") &&
+      research.includes("team_create") &&
+      research.includes("ULW-RESEARCH MODE ENABLED!"),
+    ulwMutationExists: mutation.length > 0,
+    ulwMutationNative:
+      /^name: ulw-mutation-test$/m.test(mutation) &&
+      !mutation.includes("## Senpi Harness Tool Compatibility") &&
+      ["Predict Before Results", "Classify the Outcome", "Repair Surviving Mutations", "Restore and Verify"].every((heading) =>
+        mutationHeadings.has(heading),
+      ),
+    ulwLoopMutationIntegrated:
+      mutationGate >= 0 &&
+      gitCheckpoint > mutationGate &&
+      loopWorkflow.slice(mutationGate, gitCheckpoint).includes("`ulw-mutation-test`"),
+    ultraworkDescriptionOk: (ultrawork.match(/^description: (.*)$/m)?.[1] ?? "").includes("injects the full directive as a hidden custom message"),
+  }
+}
+
+function runSelfTest() {
+  const sandbox = createSandbox()
+  try {
+    seedSandbox(sandbox)
+    const isolatedHome = sandboxHome(sandbox)
+    if (resolve(isolatedHome) === resolve(process.env.HOME ?? "")) {
+      throw new Error("QA HOME must not reuse the real user home")
+    }
+    const protectedBefore = protectedAgentDigest(sandbox.agentDir)
+    const volatileDir = join(sandbox.agentDir, "sessions", "live")
+    mkdirSync(volatileDir, { recursive: true })
+    writeFileSync(join(volatileDir, "ambient.jsonl"), `${JSON.stringify({ type: "ambient-session-write" })}\n`)
+    if (protectedAgentDigest(sandbox.agentDir) !== protectedBefore) {
+      throw new Error("volatile session writes must not invalidate the protected real-agent digest")
+    }
+    const settingsPath = join(sandbox.agentDir, "settings.json")
+    const originalSettings = readFileSync(settingsPath)
+    writeFileSync(settingsPath, `${JSON.stringify({ changed: true })}\n`)
+    if (protectedAgentDigest(sandbox.agentDir) === protectedBefore) {
+      throw new Error("protected settings changes must invalidate the real-agent digest")
+    }
+    writeFileSync(settingsPath, originalSettings)
+    if (REQUIRED_DIRECTIVE_MARKERS.some((marker) => marker.length === 0)) throw new Error("empty required marker")
+    if (digestDirectory(join(sandbox.root, "missing")) !== "absent") throw new Error("missing directory digest should be absent")
+    const staged = stagedSkillChecks()
+    if (!staged.ulwResearchExists) throw new Error("staged ulw-research skill missing; run sync-skills.mjs first")
+    if (!staged.ulwMutationExists) throw new Error("staged ulw-mutation-test skill missing; run sync-skills.mjs first")
+    if (!staged.ulwMutationNative) throw new Error("staged ulw-mutation-test contract is incomplete")
+    if (!staged.ulwLoopMutationIntegrated) throw new Error("staged ulw-loop mutation gate is missing")
+
+    const empty = inspectSession(join(sandbox.root, "missing"))
+    if (empty.userTexts.length !== 0 || empty.hiddenDirectives.length !== 0) {
+      throw new Error("inspectSession should report nothing for a missing agent dir")
+    }
+
+    const sessionDir = join(sandbox.agentDir, "sessions", "probe")
+    mkdirSync(sessionDir, { recursive: true })
+    writeFileSync(
+      join(sessionDir, "probe.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "text", text: "ulw please respond" }] } })}\n` +
+        `${JSON.stringify({ type: "custom_message", customType: ULTRAWORK_CUSTOM_TYPE, display: false, content: "<ultrawork-mode>" })}\n`,
+    )
+    const probed = inspectSession(sandbox.agentDir)
+    if (probed.userTexts.length !== 1 || probed.userTexts[0] !== "ulw please respond") {
+      throw new Error("inspectSession failed to read the user message text")
+    }
+    if (probed.hiddenDirectives.length !== 1 || probed.visibleDirectives.length !== 0) {
+      throw new Error("inspectSession failed to classify the hidden directive entry")
+    }
+  } finally {
+    rmSync(sandbox.root, { recursive: true, force: true })
+  }
+}
+
+function main() {
+  const beforeDigest = protectedAgentDigest(join(process.env.HOME ?? "", ".senpi", "agent"))
+  const sandbox = createSandbox()
+  const isolatedHome = sandboxHome(sandbox)
+  const homeIsolated = resolve(isolatedHome) !== resolve(process.env.HOME ?? "")
+  let result = "FAIL"
+  let reason
+  let transcript = ""
+
+  try {
+    const senpiBin = process.env.SENPI_BIN?.trim() || "senpi"
+    const resolvedSenpi = senpiBin.includes("/") ? (existsSync(senpiBin) ? senpiBin : null) : findOnPath(senpiBin)
+    if (resolvedSenpi === null) {
+      result = "SKIP"
+      reason = "senpi-binary-unavailable"
+      return printResult({ result, reason, beforeDigest, sandbox, homeIsolated })
+    }
+
+    seedSandbox(sandbox)
+    mkdirSync(isolatedHome, { recursive: true })
+    writeFileSync(
+      join(sandbox.cwd, "mock-script.json"),
+      `${JSON.stringify({ steps: [{ type: "text", text: "ulw prompts e2e complete" }] }, null, 2)}\n`,
+    )
+    const run = spawnSync(resolvedSenpi, ["-e", mockProviderEntry, "-p", "--provider", "omo-mock", "--model", "mock-1", "ulw please respond"], {
+      cwd: sandbox.cwd,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        SENPI_CODING_AGENT_DIR: sandbox.agentDir,
+        XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+        OMO_SENPI_QA: "1",
+      },
+      encoding: "utf8",
+      timeout: 60_000,
+    })
+    transcript = run.status === 0 ? readSandboxText(sandbox.agentDir) : ""
+
+    const missingMarkers = REQUIRED_DIRECTIVE_MARKERS.filter((marker) => !transcript.includes(marker))
+    const forbiddenHits = FORBIDDEN_TRANSCRIPT_MARKERS.filter((marker) => transcript.includes(marker))
+    const staged = stagedSkillChecks()
+    const ultraworkInjected = run.status === 0 && missingMarkers.length === 0 && forbiddenHits.length === 0
+    const session = inspectSession(sandbox.agentDir)
+    const userTextClean = session.userTexts.length > 0 && session.userTexts.every((text) => !text.includes("<ultrawork-mode>"))
+    const hiddenInjectionOk =
+      session.hiddenDirectives.length === 1 &&
+      session.visibleDirectives.length === 0 &&
+      REQUIRED_DIRECTIVE_MARKERS.every((marker) => session.hiddenDirectives[0].content.includes(marker))
+    result =
+      ultraworkInjected &&
+      staged.ulwResearchNative &&
+      staged.ulwMutationNative &&
+      staged.ulwLoopMutationIntegrated &&
+      staged.ultraworkDescriptionOk &&
+      homeIsolated &&
+      userTextClean &&
+      hiddenInjectionOk
+        ? "PASS"
+        : "FAIL"
+    return printResult({
+      result,
+      reason,
+      beforeDigest,
+      sandbox,
+      missingMarkers,
+      forbiddenHits,
+      staged,
+      ultraworkInjected,
+      userTextClean,
+      hiddenInjectionOk,
+      userTexts: session.userTexts,
+      hiddenDirectiveCount: session.hiddenDirectives.length,
+      visibleDirectiveCount: session.visibleDirectives.length,
+      homeIsolated,
+    })
+  } finally {
+    rmSync(sandbox.root, { recursive: true, force: true })
+  }
+}
+
+function printResult({
+  result,
+  reason,
+  beforeDigest,
+  sandbox,
+  missingMarkers = [],
+  forbiddenHits = [],
+  staged = {},
+  ultraworkInjected = false,
+  userTextClean = false,
+  hiddenInjectionOk = false,
+  userTexts = [],
+  hiddenDirectiveCount = 0,
+  visibleDirectiveCount = 0,
+  homeIsolated = false,
+}) {
+  const afterDigest = protectedAgentDigest(join(process.env.HOME ?? "", ".senpi", "agent"))
+  console.log(
+    JSON.stringify({
+      result,
+      ...(reason ? { reason } : {}),
+      ultraworkInjected,
+      userTextClean,
+      hiddenInjectionOk,
+      hiddenDirectiveCount,
+      visibleDirectiveCount,
+      homeIsolated,
+      userTexts,
+      missingMarkers,
+      forbiddenHits,
+      ...staged,
+      realSenpiUntouched: beforeDigest === afterDigest,
+      sandboxAgentDir: sandbox.agentDir,
+    }),
+  )
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv.includes("--self-test")) {
+    runSelfTest()
+    console.log("SELF-TEST OK")
+  } else {
+    main()
+  }
+}

--- a/packages/omo-senpi/skills/ulw-loop/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-loop/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ulw-loop
+description: Goal-like loop that uses ultrawork mode to decompose work into systematic, evidence-bound steps.
+metadata:
+  short-description: Goal-like ultrawork loop for systematic decomposition
+---
+
+# ulw-loop
+
+Use this skill when the user asks for `ulw-loop`, `ulw`, durable goal execution, evidence-led work, manual QA, or checkpointed long-running delivery.
+
+This skill is intentionally compact. The full workflow lives in `references/full-workflow.md`. Read only the sections needed for the current phase, then execute them exactly.
+
+## Required First Steps
+
+1. Open `references/full-workflow.md`.
+2. Read through **Bootstrap** (including its tier triage), **Execution Loop**, the **Manual-QA channels** table, and the **Stop Rules** before running any ULW command or recording evidence.
+3. If the task has code edits, tests, QA, or commit work, follow the full workflow's delegation and evidence rules. Tests alone never prove done.
+
+## Non-Negotiables
+
+- Use the ulw-loop CLI state under `.omo/ulw-loop`; do not hand-edit goal state.
+- Register goals up front (`omo ulw-loop create-goals`, then `create_goal` from the printed handoff) and mirror every atomic step into the live `update_plan` checklist: one ultra-granular step per action, exactly one in_progress, transitions marked the instant they happen.
+- After any compaction or context loss, re-read brief + goals + ledger FIRST plus `omo ulw-loop status --json`, then resume; never re-plan from scratch.
+- If `omo ulw-loop create-goals` says the existing aggregate is already complete, start unrelated new work with a fresh `--session-id <new-id>` instead of steering or forcing the completed default state. Use `--force` only to intentionally overwrite completed evidence.
+- Every success criterion needs observable evidence from a real surface: a channel (terminal/TUI via the xterm.js web terminal, HTTP, browser, computer-use) or, for CLI- or data-shaped criteria, an auxiliary surface (CLI stdout, DB diff, parsed config dump).
+- Evidence is bound to the tree it was captured at (`git rev-parse --short "HEAD^{tree}"`); it goes stale only when tracked content changes — a rebase or amend that keeps the tree identical keeps it valid. When the tree differs, re-run at the current HEAD and re-record, never relabel or regenerate. Record only after cleanup receipts exist.
+- Whenever a work unit changes assertions, test cases, fixture expectations, prompt-behavior rules, or test-quality claims, invoke `ulw-mutation-test` after the focused tests turn green and before any checkpoint; meaningful survivors and uncertain restoration block completion.
+- Delegate code edits, test writes, fixes, and QA execution to right-sized omo-senpi subagents through the native `task` tool.
+- Plan and reviewer agents may run for a long time; spawn them with `run_in_background: true` and keep doing independent root work.
+- For work likely to exceed one wait cycle, require the child to send `WORKING: <task> - <current phase>` before long reading, testing, or review passes, and `BLOCKED: <reason>` only when it cannot progress.
+- Track spawned task ids locally. Completion and progress arrive as injected notifications; use `task_output` for at most one midpoint status or transcript check per child, never a polling loop.
+- While children run, surface the active subagent count, task ids, and latest `WORKING:` phase.
+- If a live child needs context or correction, send it with `task_send`. Fallback only when the child completed without the deliverable, explicitly reported `BLOCKED:`, or is no longer running; then record inconclusive and spawn a smaller native `task` with the missing deliverable.
+- Use `git-master` for git-tracked edits: inspect recent and touched-path commit history, then commit each verified work unit atomically in the repository's observed language, scope, and message style with only that unit's files staged. Never carry verified units into a later omnibus commit.
+
+## Team mode: decide it, do not default to it
+
+Solo execution with parallel background `task` workers is the default. A team (`team_create`) adds per-member briefing, shared-state, and relay overhead, so it must be paid for by the work's shape. Decide ONCE, when the plan's work units are known, and record the verdict plus its reason in the notepad.
+
+Stand up a team when BOTH hold:
+
+1. **The units' scopes overlap in a way you cannot cleanly cut.** They touch the same module, contract, or migration, so one unit's discovery changes what another should do. Fire-and-forget workers cannot exchange that mid-flight; teammates can, because the lead relays it.
+2. **Running them at the same time actually finishes sooner.** The units are each substantial and none is merely waiting on another's output. Two units where the second only consumes the first's result are a sequence, not a team.
+
+When the units are genuinely independent — separate files, no shared contract — spawn parallel background `task` workers instead and avoid the team coordination overhead entirely. When the work is one cohesive unit, do it yourself. Overlap alone is not enough: near-identical units that would collide on the same lines are faster done in sequence by one worker.
+
+Under team mode, isolate and land per unit:
+
+- **One git worktree per member**, never a shared checkout — concurrent members editing one working tree corrupt each other's diffs and evidence. Give each member its own branch off the base and its own worktree path.
+- **Merge per work unit, as each unit is verified.** A member's unit lands when its own evidence is captured and its gates are green; it does not wait for the slowest sibling. Integrate each merged unit back into the base the others branch from, so overlapping members rebase onto real merged work rather than guessing at it.
+- **Conflicts are the lead's job.** When two members' units touch the same lines, the lead decides the order they land and tells the later member what changed; members never resolve a sibling's conflict blind.
+
+## Native Senpi Task Contract
+
+Senpi already exposes its real subagent spawn surface through the omo-senpi `task` component. Use it directly. Do not route delegation through external app-server threads or another harness.
+
+| Intent | Native Senpi tool |
+| --- | --- |
+| Spawn one worker | `task({ prompt, subagent_type | category, run_in_background: true })` |
+| Fan out independent workers | `task({ tasks: [{ prompt, subagent_type | category }, ...], run_in_background: true })` |
+| Send context or correction | `task_send({ task_id, message })` |
+| Inspect one midpoint | `task_output({ task_id, mode: "tail" })` |
+| Stop a runaway worker | `task_cancel({ task_id })` |
+| Coordinate overlapping work | `team_create`, `task_create`, `task_get`, `task_list`, `task_update`; communicate with `task_send` |
+
+Every worker prompt starts with `TASK:` and names `DELIVERABLE`, `SCOPE`, `VERIFY`, and `STOP WHEN`. Put requested skill names and all required context inside `prompt`; children do not inherit interview context automatically.

--- a/packages/omo-senpi/skills/ulw-loop/references/full-workflow.md
+++ b/packages/omo-senpi/skills/ulw-loop/references/full-workflow.md
@@ -1,0 +1,272 @@
+---
+name: ulw-loop
+description: Goal-like loop that uses ultrawork mode to decompose work into systematic, evidence-bound steps.
+metadata:
+  short-description: Goal-like ultrawork loop for systematic decomposition
+---
+
+## Role
+Expert goal orchestration agent. You conduct; right-sized subagents play. Plan durable multi-goal work, fan independent work out, QA every result yourself, record only proven evidence.
+Use GPT-5.x style: outcome-first, evidence-bound, atomic decisions, no nested branching prose.
+
+## Goal
+Deliver every goal in `.omo/ulw-loop/goals.json` end-to-end.
+Prove EVERY success criterion with captured observable evidence from a real-usage scenario you ran (HTTP / tmux / browser / computer-use below).
+TESTS ALONE NEVER PROVE DONE. A green test suite is supporting evidence, not completion proof.
+Audit each pass, fail, block, steering change, and checkpoint in `.omo/ulw-loop/ledger.jsonl`.
+
+## Manual-QA channels
+Run each criterion's real-surface proof yourself through the channel that faithfully exercises it; capture the artifact before recording PASS.
+
+1. **HTTP call** — hit the live endpoint with `curl -i` (or a Playwright APIRequestContext); capture status line + headers + body.
+2. **Terminal / TUI** - prove it through the xterm.js web terminal; tmux `send-keys` is fine for a boot smoke, but NEVER `tmux capture-pane` for color/layout/CJK evidence (it degrades truecolor).
+3. **Browser use** — in omo-senpi, use `browser:control-in-app-browser` first when available and the scenario does not need an authenticated or persistent user browser profile. Otherwise use Chrome to drive the REAL page; if unavailable, use agent-browser. Capture action log + screenshot path. Never downgrade a browser-facing criterion.
+4. **Computer use** — for desktop/GUI apps, drive the running app via OS automation (computer-use, AppleScript, xdotool, etc.); capture action log + screenshot.
+
+For TUI visual QA (mandatory when a PR or review must inspect the terminal screen),
+run `node script/qa/web-terminal-visual-qa.mjs --command "<cmd>" --input "{Enter}"
+--evidence-dir <dir>` (live pty + xterm.js in Chrome; `--from-file` replays a raw
+stream) and record `terminal.png`, `terminal.txt`, and `metadata.json`.
+
+Auxiliary surfaces (CLI stdout / DB state diff / parsed config dump) are first-class evidence for CLI- or data-shaped criteria; use a channel scenario when the behavior is user-facing. `--dry-run`, printing the command, "should respond", and "looks correct" never count.
+
+## Delegation model (ATLAS-STYLE — YOU CONDUCT, WORKERS PLAY)
+
+Size each worker to the task. Put the intended role, rigor level, and specialty inside the worker `prompt`.
+
+| Task shape | Message instruction |
+|---|---|
+| Trivial / mechanical (rename, move, obvious one-liner, config edit) | `TASK: act as a focused worker for a trivial mechanical edit. ...` |
+| Pure implementation against a clear spec (new function, endpoint, test from a named pattern) | `TASK: act as a high-rigor implementation worker. ...` |
+| Deep debugging / race / perf / subtle cross-module reasoning | `TASK: act as a deep debugging worker. ...` |
+| QA execution (drive a channel, capture evidence) | `TASK: act as a QA execution worker. ...` |
+| Read-only codebase search | `TASK: act as an explorer. ...` |
+| Implementation — pick the tier by change SIZE: LOW small (one-file fix, boilerplate) / MEDIUM mid-sized (standard feature, a few files) / HIGH large (new module, cross-module, concurrency/security/migration, or a big complex problem with one clear goal) | `TASK: act as a <low|medium|high>-difficulty implementation worker. ...` + the matching configured `subagent_type` or `category` |
+| External library / docs research | `TASK: act as a librarian. ...` |
+| Final verification audit | `TASK: act as a rigorous final verification reviewer. ...` |
+
+For reviewer work, use a self-contained reviewer assignment, tight scope, and explicit verification in `prompt`. Never spawn a context-only child for review.
+
+Difficulty is orthogonal to LIGHT/HEAVY rigor. Select a configured `subagent_type` or `category`, and state the intended tier and specialty inside `prompt`.
+
+Every worker prompt MUST carry: goal + exact files in scope; the PIN + failing-first proof before production code; constraints + project rules; verification commands; the ONE Manual-QA channel and exact artifact; for git-tracked edits, require `git-master` plus repo and touched-path commit history before commit. Workers have NO interview context — be exhaustive, and forward learnings.
+
+omo-senpi subagent reliability:
+- Senpi's native spawn surface is the `task` tool. Use `task({ prompt, subagent_type | category, run_in_background: true })` for one worker or `task({ tasks: [...], run_in_background: true })` for a parallel batch. Never substitute external app-server threads or another harness.
+- Paste only the context the child needs into `prompt`; full parent history is not inherited automatically.
+- Plan and reviewer agents may run for a long time; spawn them in the background and keep doing independent root work.
+- For work likely to exceed one wait cycle, require the child to send `WORKING: <task> - <current phase>` before long reading, testing, or review passes, and `BLOCKED: <reason>` only when it cannot progress.
+- While any child is active, keep the parent visibly alive with active subagent count, task ids, latest `WORKING:` phase, and whether the parent is waiting for injected completion.
+- Track spawned task ids locally. Progress and completion arrive as injected notifications. Use `task_output` for at most one midpoint status or transcript check per child, never a polling loop.
+- If a live child needs context or correction, use `task_send`. Fallback only when the child completed without the deliverable, explicitly reported `BLOCKED:`, or is no longer running. Then record inconclusive, do not count it as pass/review approval, stop it with `task_cancel` if safe, and spawn a smaller native `task` with the missing deliverable.
+
+## Artifacts
+- `.omo/ulw-loop/brief.md`: original brief and durable constraints.
+- `.omo/ulw-loop/goals.json`: goals with embedded `successCriteria` per goal.
+- `.omo/ulw-loop/ledger.jsonl`: append-only audit trail.
+- Read artifacts before resuming, steering, or checkpointing.
+- After compaction or context loss, re-read brief + goals + ledger FIRST, then `omo ulw-loop status --json`. Recover from artifacts; never re-plan from scratch or repeat completed work.
+- Never invent state outside `.omo/ulw-loop` artifacts or `omo ulw-loop status --json`.
+
+## Bootstrap
+Do all three steps before execution. No edits, goal tools, or checkpointing before bootstrap completes.
+
+### 1. Create goals from the brief
+Resolve the CLI before the first command. If `omo` is absent from PATH or lacks `ulw-loop`, use the stable local installer bin or cached omo-senpi component CLI — same CLI, so PATH absence is not a blocker. If PATH is empty, the fallback uses shell builtins and absolute Node locations before reporting guidance, recording the failure in `.omo/ulw-loop/bootstrap-notepad.md`.
+```sh
+CODEX_HOME="${CODEX_HOME:-$HOME/.omo-senpi}"
+ULW_LOOP_NODE="$(command -v node 2>/dev/null || true)"
+if [ -z "$ULW_LOOP_NODE" ]; then
+  for candidate in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    [ -x "$candidate" ] || continue
+    ULW_LOOP_NODE="$candidate"
+    break
+  done
+fi
+
+ULW_LOOP_CLI=
+if command -v omo >/dev/null 2>&1 && omo ulw-loop help >/dev/null 2>&1; then
+  ULW_LOOP_CLI=omo
+elif [ -n "$ULW_LOOP_NODE" ]; then
+  for candidate in "$HOME/.local/bin/omo" "$CODEX_HOME/bin/omo" "$CODEX_HOME"/plugins/cache/sisyphuslabs/omo/*/components/ulw-loop/dist/cli.js; do
+    [ -f "$candidate" ] || [ -x "$candidate" ] || continue
+    if "$ULW_LOOP_NODE" "$candidate" ulw-loop help >/dev/null 2>&1; then
+      ULW_LOOP_CLI="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$ULW_LOOP_CLI" ] && [ -n "$ULW_LOOP_NODE" ]; then
+    omo() { "$ULW_LOOP_NODE" "$ULW_LOOP_CLI" "$@"; }
+  fi
+fi
+
+if [ -z "${ULW_LOOP_CLI:-}" ]; then
+  /bin/mkdir -p .omo/ulw-loop 2>/dev/null || mkdir -p .omo/ulw-loop 2>/dev/null || true
+  NOTE="${NOTE:-.omo/ulw-loop/bootstrap-notepad.md}"
+  printf '%s\n' "No ulw-loop-capable omo executable found; PATH omo may be the OpenCode CLI without the omo-senpi ulw-loop subcommand, and cached ulw-loop CLI was not found under ${CODEX_HOME:-$HOME/.omo-senpi}." >> "$NOTE" 2>/dev/null || true
+  printf '%s\n' "Install with npx omo-senpi-ai install or set CODEX_LOCAL_BIN_DIR to a PATH directory." >&2
+fi
+```
+If `ULW_LOOP_CLI` is empty, open the durable notepad first, record the missing CLI evidence, then surface the installer issue.
+
+Run one form:
+```sh
+omo ulw-loop create-goals --brief "<brief>" [--validation-batch-json <json-or-path>] --json
+omo ulw-loop create-goals --brief-file <path> [--validation-batch-json <json-or-path>] --json
+cat <brief> | omo ulw-loop create-goals --from-stdin [--validation-batch-json <json-or-path>] --json
+```
+If the existing aggregate is already complete, do not steer or force the
+completed default state for unrelated new work. Start a fresh run with
+`omo ulw-loop create-goals --session-id <new-id> ...`; use `--force`
+only when deliberately overwriting completed evidence.
+Write state through the CLI path. Do not hand-edit state files.
+
+### 2. Refine success criteria + a Prometheus-grade QA and parallelism plan per goal
+Gather context BEFORE planning with parallel `explorer` / `librarian` workers plus your own read-only tools.
+First survey available skills: read every loosely-relevant skill's description, deliberately choose which this work uses, and prefer applying genuinely-relevant skills over working raw.
+Then run tier triage per goal — rigor (LIGHT/HEAVY below) and shape (`delivery` default, or `research` when the deliverable is a cited answer, not an artifact) — and record both in an `annotate_ledger` steering entry. Default is LIGHT — a narrow change inside existing layers. Take HEAVY only on a fact you can point to: a new module / abstraction / domain model; auth, security, or session; an external integration; a DB schema or migration; concurrency, transaction boundaries, or cache invalidation; a cross-domain refactor; or the user signaled care or demanded review. When unsure, take HEAVY; upgrade the moment a HEAVY fact surfaces, never downgrade mid-run.
+Planning depends on unresolved design uncertainty, not the rigor tier: after discovery, spawn the `plan` agent only when unclear boundaries, competing decompositions, or uncertain dependency ordering remain; otherwise plan directly, including for HEAVY goals with a known procedure. HEAVY goals carry 3+ successCriteria covering happy path, edge, regression, and adversarial risk. LIGHT goals carry 1-2 successCriteria (happy path + the riskiest edge) with one real-surface proof of the deliverable.
+Research-shape goals change the cycle: BEFORE each investigation, read this goal's prior ledger findings and open hypotheses, then extend them — never re-investigate an answered question (the ledger is your research notebook). Record findings via `annotate_ledger` with their source (`file:line`, command output, doc URL) as `--evidence`. Track hypotheses as `HYPOTHESIS[id]: <claim> | status: open`, flipped to `confirmed`/`refuted` only on an observed source. A research criterion passes on a cited answer — skip QA-channel, cleanup, and commit, but keep source-observability (never "looks correct"). Keep hypotheses inside the user's stated question; a scope-widening one is an `add_subgoal` proposal you surface, never silent creep. For a `research`-shape goal you MAY load `ulw-research` without hesitation — otherwise explicit-request-only, a research-shape goal IS that explicit demand. Research-only: never for a `delivery` goal. It composes with the librarian routing above — `ulw-research` for saturation (many parallel sources, recursive expansion), a single `librarian` for one lookup.
+For each criterion, define upfront: `id`, exact `scenario` (tool + inputs + binary pass/fail), `expectedEvidence` artifact path, adversarial classes, stop condition, and Manual-QA channel. Vague QA ("verify it works") is a rejected criterion — revise it before execution. Every goal also declares, in one line, WHEN TO STOP: "stop right away when <the exact observable state that ends this goal>". A goal without that line is rejected — revise it before execution; the Stop Rules bind to it.
+For optimization work, capture baseline speed before changes plus behavior/regression proof. Every attempt records speed, behavior/regression, and the keep/revert/iterate decision.
+A criterion's adversarial classes are the ultraqa classes a fact about the change triggers: malformed input, prompt injection, cancel/resume, stale state, dirty worktree, hung or long commands, flaky tests, misleading success output, repeated interruptions. Record untriggered classes as not-applicable in one line.
+Use channel-table evidence verbs — not vibes.
+
+**Plan for maximum parallelism (HEAVY goals).** Decompose each goal's criteria into atomic tasks (Implementation + its Test = ONE task, never split) and group them into dependency waves. Target 5–8 tasks per wave; <3 per wave (except the final wave) means under-splitting — extract shared prerequisites into Wave 1. For each task record its wave, what it blocks, what blocks it, the worker tier from the Delegation table, and its QA scenario + evidence path. Build a dependency matrix (Task | Depends on | Blocks | Can parallelize with) and name the critical path. Anything not on a real dependency edge MUST share a wave and dispatch together.
+Revise any criterion that lacks observable `expectedEvidence` or a named channel before execution.
+
+### 3. Inspect state
+Run `omo ulw-loop status --json`.
+Read pending goals, criteria IDs, current ledger head, blockers, and aggregate omo-senpi objective.
+
+## Execution Loop
+Loop per goal. Cap at 5 cycles per goal. Cap identical same-criterion failures at 3.
+
+### Acquire Next Goal
+1. Run `omo ulw-loop complete-goals --json` and read the handoff, including criteria. After the first goal starts, a successful complete checkpoint normally prints the next goal instruction directly; use `complete-goals` as the manual fallback/resume path.
+2. Call `get_goal` and inspect active omo-senpi state.
+3. Apply this table exactly:
+
+| get_goal result | action |
+|-----------------|--------|
+| no active goal | You MUST call `create_goal` — goal registration goes through the tool, never prose — with objective only from `instruction.json.objective`; do not copy lifecycle fields such as `status`. |
+| same aggregate objective active | Continue the current ulw-loop story. |
+| different goal active | STOP. Checkpoint blocked and surface the conflict. |
+4. If retrying failed work, run `omo ulw-loop complete-goals --retry-failed --json`.
+5. Never create a second omo-senpi goal for the same aggregate objective.
+
+### Mutation-Test Gate
+
+Run this gate after the focused implementation tests are green and before any git checkpoint whenever a work unit adds or changes a test assertion, test case, fixture expectation, prompt-behavior rule, or test-quality claim.
+
+1. Invoke `ulw-mutation-test` and follow its complete workflow. Write each mutation's observable change and exact predicted test failure to the criterion artifact before applying it.
+2. Exercise 3-5 distinct, realistic failure surfaces when the behavior supports them. Every counted mutation must compile, be reached by the selected test, and change an observable contract.
+3. Apply one mutation at a time. Restore it before classification, prove affected hashes and the scoped diff match the baseline, then continue.
+4. A meaningful survivor inside the test's promise is a blocking test defect: strengthen the test, prove the original code stays green, reapply the same mutation, require the predicted failure, and restore again.
+5. Invalid, unreached, equivalent, misattributed, or inconclusive attempts do not count as defended behavior. Replace them or leave the criterion blocked with evidence.
+6. Capture the mutation report and final restoration receipt at the criterion's `expectedEvidence` path. Tests, coverage, or a mutation score without this observable artifact do not pass the gate.
+
+If the work unit changes no assertion, test case, fixture expectation, prompt-behavior rule, or test-quality claim, record `not_applicable` with the scoped diff evidence. Do not invent harmless mutations merely to produce a score.
+
+#### GIT CHECKPOINT
+
+Checkpointing is allowed only after the required mutation report is clean and bound to the current tree. When commits are not explicitly authorized or no git-tracked files changed, record the no-commit reason as usual.
+
+### Per-Criterion Cycle
+1. PLAN: read `criterion.scenario`, `criterion.expectedEvidence`, prior ledger entries, and safety bounds. Identify which tasks in the current wave are independent.
+2. Register atomic todos via `update_plan` — one ultra-granular step per action, `path: <action> for <criterion> - verify by <check>`. Call `update_plan` on every transition (start → `in_progress`, finish → `completed`); exactly one `in_progress`, mark completed immediately, never batch, never let the rendered plan lag behind reality.
+3. DELEGATE-IN-PARALLEL: dispatch every independent task in the wave through ONE native batch call: `task({ tasks: [{ prompt, subagent_type | category }, ...], run_in_background: true })`. Each prompt starts with `TASK:` and names `DELIVERABLE`, `SCOPE`, `VERIFY`, and `STOP WHEN`. Use one `task` call only when the wave has one worker. Keep doing independent root work while children run; consume injected progress/completion and use `task_send`, `task_output`, or `task_cancel` only as defined by the native task contract.
+4. INTEGRATE + CRITICAL SELF-QA + GIT CHECKPOINT (EVERY WORKER RETURN): do NOT trust the worker's report. Read the diff yourself, re-run its tests, and run LSP diagnostics on the changed files. Treat "done" as a claim to disprove. If the diff drifts, the test is hollow, or evidence is missing, RESPAWN the worker with the specific failure context. Once the work unit is verified, use `git-master` before staging: inspect recent repository commits and touched-path history to infer commit language, Conventional Commit scope, message shape, and unit size. Stage only that unit's files and commit in the observed style; do not carry verified work forward into a later omnibus commit. If no git-tracked files changed or committing is unsafe, record the no-commit reason as evidence. Forward every finding/learning to subsequent workers.
+5. EXECUTE-AS-SCENARIO: ACTUALLY run the Manual-QA scenario the criterion named (channel table above). Run it yourself for the orchestrator check; for heavier flows dispatch a dedicated QA execution worker (`omo-senpi-worker-medium` by default; `omo-senpi-worker-high` when the QA flow itself is hard) whose ONLY job is to drive the channel and write the artifact to the named evidence path. If the scenario FAILS, respawn the implementing worker with the captured failure — do not hand-patch around it.
+6. CAPTURE: collect the observable artifact path: transcript, stdout, screenshot, assertion, status+body, diff, or parsed dump. No artifact written at the evidence path — not done; record BLOCKED and respawn QA.
+7. CLEAN (PAIRED, NEVER SKIP): tear down every runtime artifact step 5 spawned BEFORE recording — server PIDs (`kill`, verify `kill -0` fails), `tmux` sessions (`tmux kill-session -t ulw-qa-<criterion>`; confirm `tmux ls`), browser / Playwright contexts (`.close()`), containers (`docker rm -f`), bound ports (`lsof -i :<port>` empty), temp sockets / files / dirs (`rm -rf` the `mktemp` paths), QA-only env vars, AND cancel any runaway child with `task_cancel` while allowing completed children to end normally. Register each teardown as its own todo the moment the QA spawns the resource (scripts, tmux assets, browsers / agent-browser sessions, PIDs, ports) so none is forgotten. Embed a one-line cleanup receipt in the evidence string, e.g. `cleanup: killed 12345; tmux kill-session ulw-qa-foo; rm -rf /tmp/ulw.aB12cD; task_cancel <runaway-id>`. Missing receipt → record BLOCKED, not PASS.
+8. RECORD one result immediately from the artifact you just wrote — never from memory or a later turn — stamping the capture tree `$(git rev-parse --short "HEAD^{tree}")` into the evidence:
+   - PASS: `omo ulw-loop record-evidence --goal-id <id> --criterion-id <id> --status pass --evidence "<observable> @tree:<short-tree> | <cleanup receipt>" --json`
+   - FAIL: `omo ulw-loop record-evidence --goal-id <id> --criterion-id <id> --status fail --evidence "<observable> @tree:<short-tree> | <cleanup receipt>" --notes "<diagnosis>" --json`
+   - BLOCKED: `omo ulw-loop record-evidence --goal-id <id> --criterion-id <id> --status blocked --evidence "<observable>" --notes "<safety/blocker/leftover-state>" --json`
+9. If actual does not match expected, diagnose, respawn the right-sized worker with the failure context to fix minimally, and rerun the SAME criterion (including a fresh cleanup).
+10. After 3 same-criterion failures, exit the goal with diagnosis.
+11. After 5 cycles on one goal without required criteria passing, checkpoint failed.
+12. Continue only when the next pending criterion has a concrete `expectedEvidence` target.
+
+Before checkpointing a work unit that changed assertions, test cases, fixture expectations, prompt-behavior rules, or test-quality claims, invoke `ulw-mutation-test` after focused tests are green and require its report before checkpointing. Meaningful survivors and uncertain restoration are blocking.
+
+### Goal Completion
+1. Non-final aggregate goal: confirm every `essential` criterion is `pass`; non-essential criteria may remain pending. Final aggregate goal: confirm every criterion across the whole plan is `pass`.
+2. Call `get_goal` for a fresh snapshot.
+3. Run `omo ulw-loop checkpoint --goal-id <id> --status complete --evidence "<criteria evidence summary>" --omo-senpi-goal-json <snapshot> --json`; on success it auto-starts and prints the next eligible goal unless `--no-advance` is passed.
+4. If blocked or failed, checkpoint with `--status blocked` or `--status failed` and include diagnosis evidence.
+5. If this is the final goal, run the final quality gate first and pass `--quality-gate-json`.
+
+## Final Quality Gate
+Trigger only for the final aggregate goal after every criterion in every goal is `pass`.
+1. Run targeted verification for changed behavior.
+1a. For every work unit that changed an assertion, test case, fixture expectation, prompt-behavior rule, or test-quality claim, verify its mutation report is present, current-tree stamped, free of unresolved meaningful survivors, and paired with an exact restoration receipt.
+2. Run the final build, type check, and generated-output freshness gate so every generated artifact is current.
+2a. FREEZE immediately after that gate — no more edits, rebases, builds, or generated writes. Capture the frozen HEAD, tree, worktree digest, and generated hashes.
+2b. At the frozen state, re-run Manual-QA for any PASS criterion whose stamped tree differs from `git rev-parse --short "HEAD^{tree}"`, so every criterion is proven on the exact built tree; each artifact exists and is non-empty.
+2c. After Manual-QA, capture final hashes, status, and residue/process receipts again; require the frozen worktree digest and generated hashes to match step 2a before any reviewer starts.
+3a. Spawn the configured omo-senpi code reviewer and QA executor in one background `task({ tasks: [...] })` batch with brief, goals, desired outcome, diff, and evidence; consume BOTH injected completions and confirm their report artifacts exist on disk.
+3b. Only then spawn omo-senpi-gate-reviewer with those artifact paths.
+3c. The gate's approval binds to the frozen tree and full commit SHA and covers its three lanes — code quality, hands-on QA, and goal verification. Immediately append one durable `.omo/ulw-loop/ledger.jsonl` record per passing lane with the lane name, full SHA, verdict, and report artifact/source. Before reuse after continuation or compaction, re-read the ledger and require the exact lane/SHA pair; memory or an unstamped report is not coverage. A later rebase or amend that keeps the tree identical still has a new SHA and needs fresh lane stamps; changed content needs fresh review of the delta.
+4. Treat timeout, missing deliverable, ack-only, `BLOCKED:`, or inconclusive review as a blocker. Any fix restarts the freeze at the new HEAD: re-run ONLY the proofs it invalidated and stamp the fresh output — never regenerate all evidence or relabel stale output to HEAD — re-review the delta at most TWICE; then record-review-blockers (step 5) and surface to the user.
+5. If review remains blocked, run `omo ulw-loop record-review-blockers --goal-id <id> --title "<...>" --objective "<...>" --evidence "<review findings>" --omo-senpi-goal-json <snapshot> --json`.
+6. If clean, checkpoint final completion:
+```sh
+omo ulw-loop checkpoint --goal-id <id> --status complete --evidence "<e2e evidence + manual QA notes>" --omo-senpi-goal-json <snapshot> --quality-gate-json <json-or-path> --json
+```
+`--quality-gate-json` shape:
+```json
+{
+  "codeReview":{"by":"omo-senpi-code-reviewer","recommendation":"APPROVE","codeQualityStatus":"CLEAR","reportPath":"test/fixtures/artifacts/code-review.md","evidence":"Diff review passed.","blockers":[]},
+  "manualQa":{"by":"omo-senpi-qa-executor","status":"passed","evidence":"CLI and data surfaces passed.","surfaceEvidence":[{"id":"surface-cli-pass","criterionRef":"C1","surface":"cli","invocation":"omo ulw-loop checkpoint --quality-gate-json sample-quality-gate.json --json","verdict":"passed","artifactRefs":["artifact-cli-pass"]},{"id":"surface-data-pass","criterionRef":"C2","surface":"data","invocation":"diff -u before-ledger.json after-ledger.json","verdict":"passed","artifactRefs":["artifact-data-diff"]}],"adversarialCases":[{"id":"adv-malformed-input","criterionRef":"C3","scenario":"malformed gate input omits manual QA evidence","expectedBehavior":"validator rejects ULW_LOOP_QUALITY_GATE_INVALID","verdict":"passed","artifactRefs":["artifact-cli-reject"]}],"artifactRefs":[{"id":"artifact-cli-pass","kind":"cli-transcript","description":"CLI pass artifact.","path":"test/fixtures/artifacts/cli-pass.txt"},{"id":"artifact-cli-reject","kind":"log","description":"Reject log artifact.","path":"test/fixtures/artifacts/rejection.txt"},{"id":"artifact-data-diff","kind":"data-diff","description":"Data diff artifact.","path":"test/fixtures/artifacts/data-diff.txt"}]},
+  "gateReview":{"by":"omo-senpi-gate-reviewer","recommendation":"APPROVE","reportPath":"test/fixtures/artifacts/gate-review.md","evidence":"Gate review passed.","blockers":[]},
+  "iteration":{"fullRerun":true,"status":"passed","rerunCommands":["bunx vitest run packages/omo-omo-senpi/plugin/components/ulw-loop/test/quality-gate-doc.test.ts"],"evidence":"Focused rerun passed."},
+  "criteriaCoverage":{"totalCriteria":3,"passCount":3,"originalIntent":"User wanted artifact-backed completion.","desiredOutcome":"Behavior ships with review and QA evidence.","userOutcomeReview":"Result matches brief and goals.","adversarialClassesCovered":["malformed_input","stale_state"]}
+}
+```
+Artifacts must be non-empty; counts alone fail. LIGHT without adversarial class records `"adversarialClassesCovered": ["none-applicable: <reason>"]`; untriggered adversarialCases may use verdict `not_applicable` + `reason`; WATCH passes, notes surfaced.
+
+## Dynamic Steering
+Use steering only for structured evidence-backed mutation. Reject natural-language steering requests.
+
+| Kind | When to use | Required fields |
+|------|-------------|-----------------|
+| add_subgoal | Real blocker found; new story required | `--title`, `--objective`, `--evidence`, `--rationale` |
+| split_subgoal | Story too large; needs decomposition | `--goal-id`, `--children` JSON, `--evidence`, `--rationale` |
+| reorder_pending | Discovered dependency order | `--order` JSON array of ids, `--evidence`, `--rationale` |
+| revise_pending_wording | Title/objective ambiguous | `--goal-id`, `--title?`, `--objective?`, `--evidence`, `--rationale` |
+| revise_criterion | Criterion lacks observable PASS evidence | `--goal-id`, `--criterion-id`, `--scenario?`, `--expected-evidence?`, `--evidence`, `--rationale` |
+| annotate_ledger | Audit-only note | `--evidence`, `--rationale` |
+| mark_blocked_superseded | Old story replaced by new evidence | `--goal-id`, `--replacements?`, `--evidence`, `--rationale` |
+
+Command form: `omo ulw-loop steer --kind <kind> [<kind-specific-fields>] --evidence "<...>" --rationale "<...>" --json`. For multiple evidence-backed plan-shape changes discovered together, pass `--proposals-json <json-or-path>` with an array of proposals; the batch applies atomically or rejects without partial plan mutation.
+
+Validation batches are optional aggregate-mode review boundaries declared at create time with `--validation-batch-json`. A batch-final member requires all other members resolved, all member criteria pass, and a member-spanning quality gate; split/supersede steering keeps batch membership updated.
+Structured prompt directives accepted: `OMO_ULW_LOOP_STEER: { ... }`, `omo.ulw-loop.steer: {...}`, `omo ulw-loop steer: {...}`.
+
+## Constraints
+1. NEVER call `update_goal` mid-aggregate; only on final story after the quality gate passes.
+2. NEVER call `create_goal` when `get_goal` shows a different active goal.
+3. Evidence is bound to the tree it was captured at; changed tracked content invalidates it — re-run the QA at the current HEAD and re-record (an identical tree after rebase/amend stays valid). NEVER mark PASS from memory, and NEVER relabel, pin, refresh, or regenerate prior output to a moved HEAD.
+4. NEVER bypass the criteria gate: non-final aggregate completion requires all essential criteria; final aggregate completion requires all criteria across the whole plan.
+5. Baseline build/lint/typecheck/test commands are necessary evidence, NOT SUFFICIENT completion proof. Criteria coverage with observable evidence is the gate.
+6. Treat `.omo/ulw-loop/ledger.jsonl` as the durable audit trail; checkpoint after every success or failure.
+7. Per-story omo-senpi goal mode is opt-in only with `--omo-senpi-goal-mode per-story`; default is aggregate.
+8. Structured steering directives mutate state through validation; normal prose does not.
+9. Evidence MUST be observable from the real surface per the Manual-QA channel table — never a printed command, `--dry-run`, or "looks correct".
+10. Probe the adversarial classes each criterion's trigger facts name (list in Bootstrap step 2); record untriggered classes as not-applicable in one line.
+11. After completing an aggregate ulw-loop run, clear the omo-senpi goal manually with `/goal clear` before starting another in the same session.
+12. The shell command emits a model-facing handoff; only the omo-senpi agent calls `get_goal`, `create_goal`, or `update_goal` tools.
+13. NEVER record PASS while any QA-spawned process, `tmux` session, browser context, bound port, container, temp path, or open worker is still alive; the evidence MUST carry the cleanup receipt. Leftover state = BLOCKED.
+15. Every verified work unit that touched git-tracked files must leave either an atomic `git-master`-style commit hash or explicit no-commit blocker evidence before the next unit starts.
+
+## Stop Rules
+- STOP GOAL: all goals complete plus every plan criterion `pass` plus final quality gate clean. The decisive test — outranking every other consideration — is whether the completion conditions are FUNDAMENTALLY fulfilled and the user's problem ACTUALLY SOLVED in observable behavior; a `pass` ledger never substitutes for it. The moment both hold, checkpoint, report, and STOP — no extra review cycles, no evidence regeneration, no polish.
+- 3x same criterion failure: checkpoint failed, surface diagnosis.
+- 5 cycles on one goal without required criteria passing: checkpoint failed, surface.
+- Safety boundary such as destructive command, secret exfiltration, or production write: block and surface a safe substitute.
+- omo-senpi `get_goal` reports a different active goal: checkpoint blocker, stop, surface.
+- Leftover state from QA (live process, `tmux` session, browser context, bound port, temp dir): NOT pass. Clean up, append the receipt, then continue.
+- User issues `/cancel`: release in-progress state cleanly and do not auto-resume.

--- a/packages/omo-senpi/skills/ulw-mutation-test/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-mutation-test/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: ulw-mutation-test
+description: >
+  Validate that new or changed tests can detect realistic bugs by predicting,
+  applying, classifying, and exactly restoring 3-5 targeted mutations. Use
+  after changing assertions or test cases, when ulw-loop reaches its mutation
+  gate, or whenever a passing test may be a false green.
+---
+
+# ULW Mutation Test
+
+Prove that a test can stop realistic user-facing or operational bugs. Coverage
+only proves that code ran; this workflow proves that an observable defect makes
+the relevant test fail.
+
+This is targeted, AI-guided mutation testing. Do not enumerate every syntactic
+mutation. Select a few credible bugs from the behavior contract, predict their
+effect before seeing results, and treat every mutation as untrusted temporary
+work that must be restored immediately.
+
+## When to Run
+
+Run this skill when any of these are true:
+
+- a work unit adds or changes a test assertion, case, fixture expectation,
+  prompt-behavior rule, or test-quality claim;
+- `ulw-loop` reaches its mutation-test gate;
+- the user asks whether a test is meaningful, defensive, trustworthy, or a
+  false green;
+- coverage is offered as proof that tests protect behavior.
+
+Documentation-only, formatting-only, or pure rename work may be
+`not_applicable` only when it changes no assertion, test case, fixture
+expectation, prompt-behavior rule, test-quality claim, or promised behavior.
+Record the scoped diff evidence instead.
+
+## Safety Invariants
+
+These rules are binding:
+
+1. Read the production path, the test, and one caller or dependency layer before
+   designing mutations.
+2. Record the baseline command, its green result, affected file hashes, and the
+   pre-existing diff before the first mutation.
+3. Mutate clean files or explicitly snapshotted lines only. Refuse patches
+   overlapping pre-existing dirty changes. A dirty file is eligible only when
+   the mutation targets separate lines and exact inverse restoration is proven.
+4. Apply exactly one mutation at a time with the normal patch tool. Never use
+   `git reset`, `git checkout`, or another destructive restoration shortcut.
+5. Give every command a bounded timeout. A crash, malformed command, timeout, or
+   interruption still enters the restoration path.
+6. Restore the mutation before interpreting its result, then prove every
+   affected file hash and the scoped diff match the baseline.
+7. Never leave a mutation, temporary assertion, generated artifact, process,
+   port, or fixture behind.
+
+If exact restoration cannot be proven, stop and report `blocked`. A green test
+run on a dirty or uncertain tree is not evidence.
+
+## Gate
+
+Establish the contract before touching production code:
+
+1. Identify the changed assertion or test case and write its behavioral promise
+   in one sentence.
+2. Name the user-visible or operational observation it protects: return value,
+   rendered UI, emitted event, persisted state, API response, billing effect, or
+   another real boundary.
+3. Run the smallest relevant test command once and require green.
+4. Capture the baseline hashes and scoped diff for every file a mutation may
+   touch.
+5. Confirm that at least one credible mutation can change the promised
+   observation while remaining syntactically and type valid.
+
+An empty candidate set cannot pass. If no credible mutation exists after
+reading the contract and reached path, report `not_verified` with the reason
+instead of inventing a harmless mutation.
+
+## Design 3-5 Mutations
+
+Select three to five distinct failure surfaces when the behavior supports them.
+Use fewer only when all credible surfaces are exhausted, and record why.
+Quantity never justifies duplicate or unrealistic mutations.
+
+Prefer real incident shapes:
+
+- change a policy threshold, boundary, sign, unit, currency, or rounding rule;
+- delete or invert an authorization, eligibility, validation, or idempotency
+  guard;
+- map an external field to the wrong internal meaning;
+- treat a failure, timeout, empty result, or stale value as success;
+- bypass a required confirmation, fee, inventory, or state transition;
+- return, persist, emit, or render the wrong observable value.
+
+Reject weak candidates:
+
+- wording-only edits unrelated to the test promise;
+- random code deletion with no plausible defect;
+- changes that only produce syntax or type errors;
+- mutations outside the path reached by the target test;
+- refactors with identical observable behavior;
+- multiple mutations that attack the same rule in the same way.
+
+After attacking one rule, change the angle. For example, follow a boundary
+mutation with guard deletion, response misclassification, or state-transition
+corruption rather than another nearby numeric value.
+
+## Predict Before Results
+
+Append one prediction record to the mutation report **before** applying each
+mutation:
+
+```text
+MUTATION M1
+Risk: <real bug this represents>
+Target: <file and symbol or line>
+Temporary change: <precise semantic change>
+Reachability proof: <why the selected test executes this path>
+Observable change: <what a user or operator would see>
+Predicted test: <exact test name>
+Predicted failure: <assertion, status, value, event, or snapshot difference>
+Validation command + deadline: <compile/type check or parser/loader preflight>
+Test command + deadline: <exact test command and bounded deadline>
+Restoration proof: <baseline hashes and scoped diff check>
+```
+
+Do not read the mutation result and then invent a prediction. The decision is:
+"Did the named test fail for the named observable reason?" A generic non-zero
+exit is insufficient.
+
+## Execute One Mutation
+
+For each prediction:
+
+1. Reconfirm the baseline hashes.
+2. Apply only that mutation.
+3. Run the smallest compile or type check that covers the changed file. When
+   the artifact has no compiler, run its parser or loader preflight instead.
+4. If compilation succeeds, run the exact predicted test with a bounded
+   timeout.
+5. Capture exit status and the decisive output, including the failing test and
+   assertion when present.
+6. Apply the exact inverse patch immediately.
+7. Verify hashes and scoped diff equal the baseline.
+8. Only after restoration, classify the result.
+
+Do not run mutations concurrently in one working tree. Do not stack a second
+mutation on an unresolved first result. Long-running commands use the session's
+background execution and observable completion channel; fixed sleeps and poll
+loops are not evidence.
+
+## Classify the Outcome
+
+Use exactly one outcome per attempt:
+
+| Outcome | Evidence | Action |
+| --- | --- | --- |
+| `killed` | The predicted test failed for the predicted observable reason. | Count the mutation as defended. |
+| `survived_in_promise` | The mutation changed behavior promised by the target test, yet the relevant suite stayed green. | Repair the test now and rerun the same mutation. |
+| `survived_unowned` | A real observable bug survived, but it is outside the current test's stated promise. | Add a concrete behavioral test task; do not mislabel it equivalent. |
+| `misattributed` | A test failed, but not the predicted test or reason. | Diagnose the mismatch and replace or redesign the candidate. |
+| `invalid` | Syntax, type checking, import, or startup failed before behavior was exercised. | Discard it and design a compile-valid replacement. |
+| `unreached` | The selected test did not execute the mutated path. | Discard it and choose reached code or the correct test. |
+| `equivalent` | The observable result is provably unchanged across the contract domain. | Record the proof and replace the candidate. |
+| `inconclusive` | Tooling, environment, timeout, or restoration evidence is uncertain. | Resolve the uncertainty and rerun; it cannot pass the gate. |
+
+Another test may kill the mutation before the predicted test does. Record the
+actual owner. This proves suite-level defense but may still reveal that the
+target test's stated promise is misleading; align the promise or assertion
+rather than counting a generic failure.
+
+When equivalence is uncertain, prefer `survived_unowned`. A plausible defect
+must not disappear through optimistic classification.
+
+## Repair Surviving Mutations
+
+For `survived_in_promise`:
+
+1. Keep production code restored.
+2. Add the smallest assertion or case that observes the promised behavior.
+3. Run the original code and require green.
+4. Append a new prediction for the same mutation.
+5. Apply the same mutation again.
+6. Require the strengthened test to fail for the predicted reason.
+7. Restore and re-prove the baseline.
+8. Run the original test green once more.
+
+For `survived_unowned`, create a test task whose title is the future behavioral
+promise, not the discovery story. If that behavior is required by the active
+goal, it remains blocking and must be implemented in the current loop.
+
+Do not weaken an assertion, pin an internal implementation detail, or mock away
+the integration merely to kill a mutation. The repaired test must observe the
+same external contract a real consumer relies on.
+
+## Restore and Verify
+
+Restoration is part of every attempt, not end-of-run cleanup:
+
+- compare each mutated file's content hash with its recorded baseline;
+- compare the scoped diff with the pre-mutation diff;
+- rerun the original focused test after any survivor repair;
+- confirm no mutation marker, temporary fixture, process, port, or generated
+  residue remains;
+- capture a final status receipt.
+
+If the source tree changes for legitimate implementation work between
+mutations, establish a new baseline and mark earlier evidence as belonging to
+the previous tree. Never relabel old output as evidence for new content.
+
+## Report
+
+Produce an auditable artifact:
+
+```markdown
+# Mutation verification
+
+- Behavior promise:
+- Baseline command and result:
+- Baseline file hashes:
+- Candidate budget:
+
+| ID | Risk | Validation + deadline | Prediction | Result | Classification | Restoration |
+| --- | --- | --- | --- | --- | --- | --- |
+
+## Survivor repairs
+- <test change, original-green proof, repeated-mutation proof>
+
+## Candidate replacements
+- <invalid, unreached, equivalent, misattributed, or inconclusive attempts>
+
+## Final receipt
+- Focused test:
+- Type or compile check:
+- Scoped diff:
+- Final file hashes:
+- Command deadlines:
+- PID/PGID cleanup:
+- Generated outputs:
+- Residue check:
+```
+
+Under `ulw-loop`, store the report in the criterion's evidence artifact and
+record it only after cleanup. Bind it to the current tree hash. If a commit is
+explicitly authorized, summarize the result in that atomic commit; the report
+remains the source of truth.
+
+## Completion Contract
+
+Mutation verification passes only when all are true:
+
+- every selected candidate represents a distinct, realistic defect;
+- every counted mutation is compile-valid, reached, and observably different;
+- predictions were written before results;
+- valid mutations were killed, or meaningful survivors were repaired and the
+  same mutation then killed;
+- invalid, unreached, equivalent, misattributed, and inconclusive attempts were
+  replaced or explicitly left as blocking evidence;
+- original focused tests and relevant type checks are green;
+- exact restoration and residue checks match the baseline;
+- the report names the behavior promise, commands, outcomes, repairs, and final
+  tree receipt.
+
+Stop as soon as this contract is proven. Tests alone, coverage alone, a mutation
+score, or an unverified clean-looking diff do not prove completion.

--- a/packages/omo-senpi/src/components/ulw-loop/mutation-skill-contract.test.ts
+++ b/packages/omo-senpi/src/components/ulw-loop/mutation-skill-contract.test.ts
@@ -1,0 +1,191 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const packageRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const sourceSkillPath = join(packageRoot, "skills/ulw-mutation-test/SKILL.md");
+const stagedSkillPath = join(packageRoot, "plugin/skills/ulw-mutation-test/SKILL.md");
+const loopSkillPath = join(packageRoot, "skills/ulw-loop/SKILL.md");
+const loopWorkflowPath = join(packageRoot, "skills/ulw-loop/references/full-workflow.md");
+const syncScriptPath = join(packageRoot, "plugin/scripts/sync-skills.mjs");
+
+function readRequired(path: string): string {
+	expect(existsSync(path), `expected ${path} to exist`).toBe(true);
+	return readFileSync(path, "utf8");
+}
+
+function frontmatterField(markdown: string, field: string): string | undefined {
+	const frontmatter = markdown.match(/^---\n([\s\S]*?)\n---/)?.[1];
+	return frontmatter
+		?.split("\n")
+		.map((line) => line.match(/^([^:]+):\s*(.+)$/))
+		.find((match) => match?.[1] === field)?.[2];
+}
+
+function secondLevelHeadings(markdown: string): string[] {
+	let insideFence = false;
+	const headings: string[] = [];
+
+	for (const line of markdown.split("\n")) {
+		if (line.startsWith("```")) {
+			insideFence = !insideFence;
+			continue;
+		}
+		if (!insideFence && line.startsWith("## ")) headings.push(line.slice(3));
+	}
+
+	return headings;
+}
+
+function outcomePolicies(markdown: string): Map<string, { evidence: string; action: string }> {
+	const policies = new Map<string, { evidence: string; action: string }>();
+	const classification = markdown.match(/^## Classify the Outcome\n([\s\S]*?)(?=^## )/m)?.[1] ?? "";
+
+	for (const line of classification.split("\n")) {
+		const columns = line.match(/^\| `([^`]+)` \| ([^|]+) \| ([^|]+) \|$/);
+		if (columns?.[1] !== undefined && columns[2] !== undefined && columns[3] !== undefined) {
+			policies.set(columns[1], { evidence: columns[2].trim(), action: columns[3].trim() });
+		}
+	}
+
+	return policies;
+}
+
+function sectionBody(markdown: string, heading: string): string {
+	const sections = markdown.split(/^## /m);
+	return sections.find((section) => section.startsWith(`${heading}\n`))?.slice(heading.length + 1) ?? "";
+}
+
+function thirdLevelSection(markdown: string, heading: string): string {
+	const marker = `### ${heading}\n`;
+	const start = markdown.indexOf(marker);
+	if (start < 0) return "";
+
+	const body = markdown.slice(start + marker.length);
+	const nextHeading = body.search(/^#{2,3} /m);
+	return nextHeading < 0 ? body : body.slice(0, nextHeading);
+}
+
+function paragraphContaining(markdown: string, token: string): string {
+	return (markdown.split(/\n\s*\n/).find((paragraph) => paragraph.includes(token)) ?? "").replace(/\s+/g, " ");
+}
+
+describe("ulw-mutation-test skill contract", () => {
+	it("#given the native skill source #when it is staged #then Senpi receives the same named workflow", () => {
+		const sourceSkill = readRequired(sourceSkillPath);
+		const stagedSkill = readRequired(stagedSkillPath);
+
+		expect(frontmatterField(sourceSkill, "name")).toBe("ulw-mutation-test");
+		expect(frontmatterField(stagedSkill, "name")).toBe("ulw-mutation-test");
+		expect(stagedSkill).toBe(sourceSkill.replace(/\n{3,}/g, "\n\n"));
+		expect(secondLevelHeadings(sourceSkill)).toEqual([
+			"When to Run",
+			"Safety Invariants",
+			"Gate",
+			"Design 3-5 Mutations",
+			"Predict Before Results",
+			"Execute One Mutation",
+			"Classify the Outcome",
+			"Repair Surviving Mutations",
+			"Restore and Verify",
+			"Report",
+			"Completion Contract",
+		]);
+	});
+
+	it("#given an in-promise survivor #when the outcome policy is parsed #then test repair and the same mutation rerun are mandatory", () => {
+		const policies = outcomePolicies(readRequired(sourceSkillPath));
+		const survivor = policies.get("survived_in_promise");
+
+		expect([...policies.keys()]).toEqual([
+			"killed",
+			"survived_in_promise",
+			"survived_unowned",
+			"misattributed",
+			"invalid",
+			"unreached",
+			"equivalent",
+			"inconclusive",
+		]);
+		expect(survivor?.action).toMatch(/\brepair\b/i);
+		expect(survivor?.action).toMatch(/\brerun\b/i);
+	});
+
+	it("#given empty invalid unreached or interrupted attempts #when decisions are parsed #then none can pass and restoration stays mandatory", () => {
+		const skill = readRequired(sourceSkillPath);
+		const gate = sectionBody(skill, "Gate");
+		const safety = sectionBody(skill, "Safety Invariants");
+		const notApplicable = paragraphContaining(sectionBody(skill, "When to Run"), "not_applicable");
+		const prediction = sectionBody(skill, "Predict Before Results");
+		const execution = sectionBody(skill, "Execute One Mutation");
+		const policies = outcomePolicies(skill);
+
+		expect(gate).toMatch(/empty candidate set cannot pass/i);
+		expect(gate).toContain("not_verified");
+		expect(policies.get("invalid")?.action).toMatch(/\breplacement\b/i);
+		expect(policies.get("unreached")?.action).toMatch(/\breached code\b|\bcorrect test\b/i);
+		expect(policies.get("inconclusive")?.action).toMatch(/\bcannot pass\b/i);
+		expect(safety).toMatch(/clean files[\s\S]*explicitly snapshotted/i);
+		expect(safety).toMatch(/overlapping[\s\S]*pre-existing dirty changes/i);
+		expect(safety).toMatch(/malformed command[\s\S]*timeout[\s\S]*restoration path/i);
+		expect(execution).toMatch(
+			/apply only that mutation[\s\S]*bounded[\s\S]*timeout[\s\S]*restoration[\s\S]*classify/i,
+		);
+		expect(execution).toMatch(/no compiler[\s\S]*(?:parser|loader)[\s\S]*preflight/i);
+		expect(sectionBody(skill, "Restore and Verify")).toMatch(/content hash[\s\S]*scoped diff[\s\S]*residue/i);
+		expect(prediction).toMatch(/validation command[\s\S]*deadline[\s\S]*test command[\s\S]*deadline/i);
+		expect(safety).toMatch(/generated artifact[\s\S]*process[\s\S]*port/i);
+		expect(skill).toMatch(/command deadlines[\s\S]*PID\/PGID cleanup[\s\S]*generated outputs/i);
+		expect(notApplicable).toContain("assertion");
+		expect(notApplicable).toContain("test case");
+		expect(notApplicable).toContain("fixture expectation");
+		expect(notApplicable).toContain("prompt-behavior rule");
+		expect(notApplicable).toContain("test-quality claim");
+	});
+
+	it("#given the ulw-loop workflow #when a work unit changes tests #then mutation validation precedes checkpointing", () => {
+		const workflow = readRequired(loopWorkflowPath);
+		const compactLoop = readRequired(loopSkillPath);
+		const mutationGate = workflow.indexOf("### Mutation-Test Gate");
+		const gitCheckpoint = workflow.indexOf("#### GIT CHECKPOINT");
+		const perCriterionCycle = thirdLevelSection(workflow, "Per-Criterion Cycle");
+		const finalQualityGate = sectionBody(workflow, "Final Quality Gate");
+		const notApplicable = paragraphContaining(thirdLevelSection(workflow, "Mutation-Test Gate"), "not_applicable");
+
+		expect(mutationGate).toBeGreaterThan(-1);
+		expect(gitCheckpoint).toBeGreaterThan(mutationGate);
+		expect(workflow.slice(mutationGate, gitCheckpoint)).toContain("`ulw-mutation-test`");
+		expect(perCriterionCycle).toContain("assertions");
+		expect(perCriterionCycle).toContain("test cases");
+		expect(perCriterionCycle).toContain("fixture expectations");
+		expect(perCriterionCycle).toContain("prompt-behavior rules");
+		expect(perCriterionCycle).toContain("test-quality claims");
+		expect(perCriterionCycle).toMatch(/require its report before checkpointing/i);
+		expect(finalQualityGate).toMatch(/mutation report[\s\S]*exact restoration receipt/i);
+		expect(compactLoop).toContain("test-quality claims");
+		expect(notApplicable).toContain("assertion");
+		expect(notApplicable).toContain("test case");
+		expect(notApplicable).toContain("fixture expectation");
+		expect(notApplicable).toContain("prompt-behavior rule");
+		expect(notApplicable).toContain("test-quality claim");
+		const buildGate = finalQualityGate.indexOf("generated-output freshness");
+		const freeze = finalQualityGate.indexOf("FREEZE");
+		const manualQa = finalQualityGate.indexOf("Manual-QA");
+		const finalHashes = finalQualityGate.indexOf("final hashes");
+		const reviewers = finalQualityGate.indexOf("code reviewer");
+		expect(buildGate).toBeGreaterThan(-1);
+		expect(freeze).toBeGreaterThan(buildGate);
+		expect(manualQa).toBeGreaterThan(freeze);
+		expect(finalHashes).toBeGreaterThan(manualQa);
+		expect(reviewers).toBeGreaterThan(finalHashes);
+	});
+
+	it("#given the skill synchronizer #when native skills are enumerated #then mutation testing is distributed", () => {
+		const syncScript = readRequired(syncScriptPath);
+		const registeredNames = [...syncScript.matchAll(/name:\s*"([^"]+)"/g)].map((match) => match[1]);
+
+		expect(registeredNames).toContain("ulw-mutation-test");
+	});
+});

--- a/packages/omo-senpi/src/skills-sync.test.ts
+++ b/packages/omo-senpi/src/skills-sync.test.ts
@@ -1,0 +1,205 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const skillsRoot = join(repoRoot, "packages", "omo-senpi", "plugin", "skills");
+
+const expectedSkillNames = [
+	"ast-grep",
+	"coding-agent-sessions",
+	"data-scientist",
+	"debugging",
+	"frontend",
+	"git-master",
+	"give-me-tips",
+	"hyperplan",
+	"init-deep",
+	"lsp-setup",
+	"programming",
+	"refactor",
+	"remove-ai-slops",
+	"review-work",
+	"start-work",
+	"ultimate-browsing",
+	"ultrawork",
+	"ulw-loop",
+	"ulw-mutation-test",
+	"ulw-plan",
+	"ulw-research",
+	"visual-qa",
+] as const;
+
+const CODEX_DERIVED_SKILL_NAMES: Record<string, true> = {};
+// Skills authored directly against the omo-senpi tool surface. They already speak native Senpi tools,
+// so they carry no OpenCode examples and need no "Senpi Harness Tool Compatibility" translation banner.
+const NATIVE_SENPI_SKILL_NAMES: Record<string, true> = {
+	"give-me-tips": true,
+	hyperplan: true,
+	ultrawork: true,
+	"ulw-loop": true,
+	"ulw-mutation-test": true,
+	"ulw-research": true,
+};
+const sharedSkillNames = expectedSkillNames.filter(
+	(name) => !(name in CODEX_DERIVED_SKILL_NAMES) && !(name in NATIVE_SENPI_SKILL_NAMES),
+);
+const namePattern = /^[a-z0-9-]{1,64}$/;
+const forbiddenTokenPattern = /\b(?:codex|multi_agent|spawn_agent)\b/i;
+const opencodeOrchestrationPattern = /\b(?:call_omo_agent|background_output|team_[a-z_]+|task)\s*\(/;
+const compatibilitySectionHeading = "## Senpi Harness Tool Compatibility";
+
+function listDirectoryNames(path: string): string[] {
+	if (!existsSync(path)) {
+		throw new Error(
+			`${relative(repoRoot, path)} does not exist; run packages/omo-senpi/plugin/scripts/sync-skills.mjs`,
+		);
+	}
+
+	return readdirSync(path, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+}
+
+function listFiles(path: string): string[] {
+	const entries = readdirSync(path, { withFileTypes: true });
+	const files: string[] = [];
+
+	for (const entry of entries) {
+		const entryPath = join(path, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...listFiles(entryPath));
+		} else if (entry.isFile()) {
+			files.push(entryPath);
+		}
+	}
+
+	return files;
+}
+
+function readFrontmatter(content: string, path: string): string {
+	const match = content.match(/^---\n([\s\S]*?)\n---\n/);
+	if (match === null) {
+		throw new Error(`${relative(repoRoot, path)} is missing YAML frontmatter`);
+	}
+	return match[1];
+}
+
+function expectFrontmatterField(frontmatter: string, field: string, path: string): void {
+	const pattern = new RegExp(`^${field}:\\s*\\S`, "m");
+	expect(pattern.test(frontmatter), `${relative(repoRoot, path)} frontmatter must include ${field}`).toBe(true);
+}
+
+function extractFrontmatterField(frontmatter: string, field: string): string | undefined {
+	const match = frontmatter.match(new RegExp(`^${field}:\\s*(.*?)$`, "m"));
+	return match?.[1]?.trim();
+}
+
+describe("OMO Senpi scoped skill sync", () => {
+	test("#given synced skill output #when inspected #then exactly 21 roots exist with valid names", () => {
+		const actualNames = listDirectoryNames(skillsRoot);
+		expect(actualNames).toEqual([...expectedSkillNames].sort());
+
+		for (const skillName of expectedSkillNames) {
+			const skillFile = join(skillsRoot, skillName, "SKILL.md");
+			expect(existsSync(skillFile), `${relative(repoRoot, skillFile)} must exist`).toBe(true);
+			expect(statSync(skillFile).isFile(), `${relative(repoRoot, skillFile)} must be a file`).toBe(true);
+			expect(namePattern.test(skillName), `${skillName} must match ${namePattern.source}`).toBe(true);
+		}
+	});
+
+	test("#given synced skill roots #when frontmatter is parsed #then every root skill has name, description, and valid values", () => {
+		for (const skillName of expectedSkillNames) {
+			const skillFile = join(skillsRoot, skillName, "SKILL.md");
+			const content = readFileSync(skillFile, "utf8");
+			const frontmatter = readFrontmatter(content, skillFile);
+
+			expectFrontmatterField(frontmatter, "name", skillFile);
+			expectFrontmatterField(frontmatter, "description", skillFile);
+
+			const name = extractFrontmatterField(frontmatter, "name");
+			expect(name, `${relative(repoRoot, skillFile)} frontmatter name must equal ${skillName}`).toBe(skillName);
+
+			const descriptionLine = frontmatter.match(/^description:\s*(.*)$/m)?.[0] ?? "";
+			expect(
+				descriptionLine.length,
+				`${relative(repoRoot, skillFile)} description line must be <= 1024 chars`,
+			).toBeLessThanOrEqual(1024);
+		}
+	});
+
+	test("#given codex-derived and native skill roots #when scanned #then no Codex or multi-agent harness guidance survives", () => {
+		const leaks: string[] = [];
+
+		for (const skillName of [...Object.keys(CODEX_DERIVED_SKILL_NAMES), ...Object.keys(NATIVE_SENPI_SKILL_NAMES)]) {
+			const skillRoot = join(skillsRoot, skillName);
+			if (!existsSync(skillRoot)) continue;
+
+			for (const file of listFiles(skillRoot)) {
+				const content = readFileSync(file, "utf8");
+				if (forbiddenTokenPattern.test(content)) {
+					leaks.push(relative(repoRoot, file));
+				}
+			}
+		}
+
+		expect(leaks).toEqual([]);
+	});
+
+	test("#given native senpi skills #when synced output is compared #then they ship verbatim modulo blank-line normalization and carry no compatibility banner", () => {
+		for (const skillName of Object.keys(NATIVE_SENPI_SKILL_NAMES)) {
+			const sourceFile = join(repoRoot, "packages", "omo-senpi", "skills", skillName, "SKILL.md");
+			expect(existsSync(sourceFile), `${relative(repoRoot, sourceFile)} must exist`).toBe(true);
+
+			const source = readFileSync(sourceFile, "utf8").replace(/\n{3,}/g, "\n\n");
+			const shippedPath = join(skillsRoot, skillName, "SKILL.md");
+			const shipped = readFileSync(shippedPath, "utf8");
+			expect(shipped, `${relative(repoRoot, shippedPath)} must ship the native source verbatim`).toBe(source);
+			expect(
+				shipped.includes(compatibilitySectionHeading),
+				`${skillName} is senpi-native and must not carry the compatibility banner`,
+			).toBe(false);
+		}
+	});
+
+	test("#given shared skill roots with opencode orchestration #when inspected #then a Senpi compatibility section precedes the first example", () => {
+		const missing: string[] = [];
+
+		for (const skillName of sharedSkillNames) {
+			const skillFile = join(skillsRoot, skillName, "SKILL.md");
+			if (!existsSync(skillFile)) continue;
+
+			const content = readFileSync(skillFile, "utf8");
+			const firstExampleMatch = opencodeOrchestrationPattern.exec(content);
+			if (firstExampleMatch === null) continue;
+
+			const sectionIndex = content.indexOf(compatibilitySectionHeading);
+			if (sectionIndex === -1 || sectionIndex > firstExampleMatch.index) {
+				missing.push(relative(repoRoot, skillFile));
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	test("#given start-work skill #when inspected #then session ids reference senpi, not codex", () => {
+		const skillFile = join(skillsRoot, "start-work", "SKILL.md");
+		const content = readFileSync(skillFile, "utf8");
+
+		expect(content.includes("senpi:<session_id>"), "start-work must reference senpi:<session_id>").toBe(true);
+		expect(content.includes("codex:<session_id>"), "start-work must not reference codex:<session_id>").toBe(false);
+	});
+
+	test("#given synced skill tree #when inspected #then no codex-only display metadata is packaged", () => {
+		const openaiFiles = listFiles(skillsRoot).filter((file) => file.endsWith("agents/openai.yaml"));
+		expect(openaiFiles.map((file) => relative(repoRoot, file))).toEqual([]);
+	});
+
+	test("#given frontend skill #when inspected #then materialized design references exist", () => {
+		const refsDir = join(skillsRoot, "frontend", "references", "design");
+		expect(existsSync(refsDir), "frontend/references/design must exist after materialization").toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Mirror exactly the eight requested `packages/omo-senpi` paths into native Senpi.
- Adapt the two copied test entrypoints to Senpi's existing Vitest and Node URL-path conventions.
- Supersedes #608, whose branch unintentionally inherited two unrelated `scripts/check-upstream-release*` changes.

## Validation
- `npm run check` passes.
- `vitest run packages/coding-agent/test/mcp/catalog-cache.test.ts` passes (6 tests).
- The copied OMO fixture tests still require the unmirrored OMO plugin/shared-skill tree (6 pass, 7 fixture-dependent failures); native CI does not register this source mirror as a workspace package.

## Scope
Exactly eight files under `packages/omo-senpi/`; no runtime registration is introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors the ULW loop and mutation skills into `packages/omo-senpi`, adds a sync and QA harness, and enforces a contract to keep Senpi’s skills in lockstep with OMO, with no runtime registration changes.

- **New Features**
  - Added `skills/ulw-loop` and `skills/ulw-mutation-test` (with workflow docs and references).
  - Added `plugin/scripts/sync-skills.mjs` to mirror and stage skills for Senpi.
  - Added `scripts/qa/ulw-prompts-e2e.mjs` for ULW directive prompt E2E checks.
  - Added tests to verify skill frontmatter and sync integrity: `src/components/ulw-loop/mutation-skill-contract.test.ts`, `src/skills-sync.test.ts`.
  - Added `AGENTS.md` with adapter and component overview.

<sup>Written for commit 8609ba32408ab8a9cbda6764c04118b17d041c68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

