### PR TITLE
fix(coding-agent): respect explicitly saved system default in recommended-models

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
@@ -4,8 +4,9 @@ import { SettingsManager } from "../../../settings-manager.ts";
 import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
 
 const FLAG_NAME = "no-recommended-models";
+// Only implicit fallbacks auto-switch. A `settings` provenance means the user explicitly
+// configured a system default model, which must be respected rather than overridden.
 const AUTO_SWITCH_PROVENANCE = new Set<NonNullable<SessionStartEvent["initialModelProvenance"]>>([
-	"settings",
 	"provider-default",
 	"first-available",
 ]);

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,22 @@
 # Core Extensions Changes
 
+## 2026-08-01 - recommended-models respects an explicitly saved system default
+
+### What changed and why
+
+- The `recommended-models` builtin no longer auto-switches when the startup model comes from the user's own `settings` provenance. It now auto-switches only on implicit fallback paths (`provider-default` and `first-available`), so an explicitly configured `defaultProvider`/`defaultModel` is never silently overridden by a recommendation.
+- Previously a user who had set a non-recommended system default still got switched to the recommended model on every start (with the notice `Switched to recommended model '...'.`), in TUI persisting the recommendation back over their chosen default.
+- Explicit CLI and scoped selections were already excluded; `settings` (an explicitly configured system default) is now excluded too, aligning the extension with the original intent of preserving explicit user choice.
+
+### Files modified
+
+- `builtin/recommended-models/index.ts` (`AUTO_SWITCH_PROVENANCE`)
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `builtin/recommended-models/index.ts` if upstream re-introduces `settings` as an auto-switch path; keep it out of `AUTO_SWITCH_PROVENANCE`.
+
+
 ## 2026-07-31 - Correlated input dispositions
 
 ### What changed and why

--- a/packages/coding-agent/test/suite/recommended-models-extension.test.ts
+++ b/packages/coding-agent/test/suite/recommended-models-extension.test.ts
@@ -17,23 +17,23 @@ afterEach(() => {
 });
 
 describe("recommended-models builtin", () => {
-	it("#given an off-list saved default #when settings provenance starts #then it switches, persists, and notifies", async () => {
-		const kimi = model("kimi-k3", "kimi-coding");
-		const harness = createHarness({ active: model("off-list"), available: [kimi] });
+	it("#given an off-list saved default #when settings provenance starts #then it keeps the saved default without switching, persisting, or notifying", async () => {
+		const offList = model("off-list");
+		const harness = createHarness({ active: offList, available: [model("kimi-k3", "kimi-coding")] });
 
 		await harness.start("settings");
 
-		expect(harness.getActiveModel()).toBe(kimi);
-		expect(harness.settings.getDefaultProvider()).toBe("kimi-coding");
-		expect(harness.settings.getDefaultModel()).toBe("kimi-k3");
-		expect(harness.settings.getDefaultThinkingLevel()).toBe("max");
-		expect(harness.notices).toEqual([{ message: "Switched to recommended model 'kimi-k3'.", type: "info" }]);
+		expect(harness.getActiveModel()).toBe(offList);
+		expect(harness.settings.getDefaultProvider()).toBeUndefined();
+		expect(harness.settings.getDefaultModel()).toBeUndefined();
+		expect(harness.settings.getDefaultThinkingLevel()).toBeUndefined();
+		expect(harness.notices).toEqual([]);
 	});
 
-	it("#given no available recommendation #when settings provenance starts #then it warns once with the prescribed text", async () => {
+	it("#given no available recommendation #when an implicit-fallback provenance starts #then it warns once with the prescribed text", async () => {
 		const harness = createHarness({ active: model("off-list"), available: [] });
 
-		await harness.start("settings");
+		await harness.start("first-available");
 		await harness.select(model("another-off-list"), "fallback");
 
 		expect(harness.notices).toEqual([

--- a/packages/coding-agent/test/suite/recommended-models-session-scope.test.ts
+++ b/packages/coding-agent/test/suite/recommended-models-session-scope.test.ts
@@ -6,12 +6,12 @@ afterEach(() => {
 });
 
 describe("recommended-models headless session scope", () => {
-	it("#given a headless session #when settings provenance starts #then it switches without persisting defaults", async () => {
+	it("#given a headless session #when an implicit-fallback provenance starts #then it switches without persisting defaults", async () => {
 		for (const mode of ["print", "rpc", "json"] as const) {
 			const kimi = model("kimi-k3", "kimi-coding");
 			const harness = createHarness({ active: model("off-list"), available: [kimi], mode });
 
-			await harness.start("settings");
+			await harness.start("first-available");
 
 			expect(harness.getActiveModel()).toBe(kimi);
 			expect(harness.getThinkingLevel()).toBe("max");
@@ -22,11 +22,11 @@ describe("recommended-models headless session scope", () => {
 		}
 	});
 
-	it("#given a tui session #when settings provenance starts #then it still persists the recommendation", async () => {
+	it("#given a tui session #when an implicit-fallback provenance starts #then it still persists the recommendation", async () => {
 		const kimi = model("kimi-k3", "kimi-coding");
 		const harness = createHarness({ active: model("off-list"), available: [kimi], mode: "tui" });
 
-		await harness.start("settings");
+		await harness.start("first-available");
 
 		expect(harness.getActiveModel()).toBe(kimi);
 		expect(harness.settings.getDefaultProvider()).toBe("kimi-coding");


### PR DESCRIPTION
## Summary

The `recommended-models` builtin was auto-switching the model even when the
startup model came from the user's **own saved system default** (`settings`
provenance). A user who configured a non-recommended `defaultModel` still got
silently switched to the recommended model on start, with the notice
`Switched to recommended model 'kimi-k3'.`, and — in TUI mode — the
recommendation was **persisted back over their chose default**.

Now the auto-switch applies **only to implicit fallback paths**
(`provider-default`, `first-available`). `cli` and `scoped` were already
excluded; `settings` (an explicitly configured system default) is excluded
too, so an explicit user configuration is always respected.

## Changes

- `builtin/recommended-models/index.ts` — drop `"settings"` from
  `AUTO_SWITCH_PROVENANCE` (with an explanatory comment).
- `extensions/changes.md` — document the behavior change.
- Tests updated to lock in the corrected behavior
  (`recommended-models-extension.test.ts`, `recommended-models-session-scope.test.ts`):
  - a `settings`-provenance start with an off-list **saved default** now keeps
    the saved model, persists nothing, and notifies nothing;
  - the auto-switch and mode-scoped-persistence paths now exercise the
    `first-available` implicit-fallback provenance.

## Verification

- `packages/coding-agent` vitest (both recommended-models suites): **12/12 passed**
- root `npm run check`: **exit 0** (biome, pinned-deps, ts-imports, shrinkwrap,
  install-lock, tsgo, browser smoke, web-ui)

QA receipt (gitignored): `local-ignore/qa-evidence/20260801-recommended-model-respects-default/qa.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the `recommended-models` builtin from auto-switching when the startup model comes from an explicitly saved system default (`settings` provenance). Auto-switch now occurs only for implicit fallbacks (`provider-default`, `first-available`), so user defaults are no longer overridden or persisted over in TUI.

<sup>Written for commit 7471d81276cef91bfb795fd2d6198d50dc9ddd47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

