### PR TITLE
docs(changelog): detail changes since v2026.7.31-2

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,29 @@
 
 ### Fixed
 
+- Make explicit reasoning capability metadata authoritative across model
+  discovery and request construction: a present `thinkingLevelMap` now
+  supports only the listed levels, `null` remains an explicit veto, and
+  model-ID inference applies only to map-less models. This prevents the CLI
+  and provider payload from advertising `xhigh` or `max` when catalog metadata
+  intentionally omits them
+  ([#586](https://github.com/code-yeongyu/senpi/pull/586) by
+  [@realsigridjin](https://github.com/realsigridjin)).
+
+- Align Codex SSE and WebSocket prompt-cache affinity with the official client
+  by sending one stable session tuple across `prompt_cache_key`, `session-id`,
+  `thread-id`, and `x-client-request-id`. The no-affinity SSE boundary for
+  `cacheRetention: "none"` remains unchanged, while ordinary sessions avoid
+  repeatedly re-uploading large uncached prefixes
+  ([#597](https://github.com/code-yeongyu/senpi/pull/597)).
+
+- Recover Codex WebSocket sessions after transient transport degradation.
+  Immediate follow-up requests stay on SSE during a 60-second cooldown, the
+  next fresh request may probe WebSocket again, production cleanup clears the
+  degraded-route state, and the existing post-start billing guard still
+  prevents replaying a response that may already have started
+  ([#600](https://github.com/code-yeongyu/senpi/pull/600)).
+
 ### Removed
 
 ## [2026.7.31-2] - 2026-07-31

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,13 +4,142 @@
 
 ### New Features
 
+- Add model-optimized prompt presets for `deepseek-v4-flash`,
+  `deepseek-v4-flash-0731`, and `deepseek-v4-pro`. The presets use typed
+  family rules over the shared dynamic prompt core to preserve harness
+  authority, todo discipline, grounded missing-information handling, and the
+  distinct concise-versus-deliberative reasoning behavior expected from each
+  DeepSeek V4 variant
+  ([#593](https://github.com/code-yeongyu/senpi/pull/593)).
+
+- Add DeepSeek's official API as a first-party `web_search` provider and route
+  official `deepseek-v4-*` models to the native DeepSeek search tool only when
+  the active model provider is actually `deepseek`. The integration uses the
+  Anthropic-compatible Messages endpoint, normalizes native citations and
+  results into Senpi's common search format, and prevents proxied or foreign
+  models from accidentally binding the DeepSeek route
+  ([#595](https://github.com/code-yeongyu/senpi/pull/595)).
+
+- Animate visible todo rows when they complete inside the still-active phase.
+  The widget reuses the code-point-safe bounded strikethrough reveal, keeps the
+  next active task highlighted, skips restored and prior-phase completions,
+  and disposes its unreferenced timer after the short animation finishes
+  ([#602](https://github.com/code-yeongyu/senpi/pull/602)).
+
 ### Breaking Changes
 
 ### Added
 
 ### Changed
 
+- Override the development/build-time PostCSS dependency to patched `8.5.18`,
+  removing the repository's high-severity
+  [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)
+  path-traversal advisory without changing runtime package behavior or adding
+  lifecycle scripts
+  ([#601](https://github.com/code-yeongyu/senpi/pull/601)).
+
+- Reduce large-session terminal rendering work by reusing normalized line
+  strings across frames and making viewport-bounded normalization and diffing
+  the default. The renderer retains full fallback passes for resize and
+  recovery paths, preserves image handling, bounds memoized state to the live
+  transcript, and keeps output behavior unchanged while restoring cheap
+  reference-equality comparisons
+  ([#604](https://github.com/code-yeongyu/senpi/pull/604)).
+
+- Translate the remaining user-visible risky-model warning and tracked Korean
+  fixtures to English while preserving wide-character, UTF-8 framing, IME,
+  Markdown, and terminal-width coverage with equivalent non-Korean CJK sample
+  data. No identifiers, settings keys, or runtime control flow changed
+  ([#613](https://github.com/code-yeongyu/senpi/pull/613)).
+
 ### Fixed
+
+- Treat explicit model reasoning metadata as the single source of truth for
+  `xhigh` and `max` support. The model picker, favorite cycling, and provider
+  request path now agree that omitted mapped levels are unsupported, `null`
+  vetoes inference, and model-ID heuristics apply only when no map exists
+  ([#586](https://github.com/code-yeongyu/senpi/pull/586) by
+  [@realsigridjin](https://github.com/realsigridjin)).
+
+- Complete legacy goal-store migration without rewriting current-format goals
+  or overwriting an existing destination. Legacy normalization is restricted
+  to legacy reads, migration derives the correct legacy directory for session
+  and no-session layouts, publication is atomic, and inert wire-compatible
+  fields such as `tokenBudget` survive ordinary current-store round trips
+  ([#587](https://github.com/code-yeongyu/senpi/pull/587) by
+  [@realsigridjin](https://github.com/realsigridjin)).
+
+- Scope automatic native web-search route discovery to the active model's
+  provider for every provider family, preventing unrelated models from
+  inheriting routes such as `z-ai/native`. Search progress labels also stop
+  exposing the internal `(max N)` planning suffix while retaining result-count
+  progress and explicit user-configured routes
+  ([#592](https://github.com/code-yeongyu/senpi/pull/592)).
+
+- Preserve the user's preferred reasoning effort across `/model`, Ctrl+P, and
+  favorite-model switches. Senpi now separates the remembered global
+  preference from the effective level clamped for the current model, so
+  temporarily selecting a lower-capability model or a favorite override no
+  longer permanently replaces a preference such as `max`
+  ([#594](https://github.com/code-yeongyu/senpi/pull/594)).
+
+- Stabilize Codex prompt caching by applying the official stable affinity tuple
+  to both SSE and WebSocket requests. Long-running sessions retain one
+  `prompt_cache_key`, `session-id`, `thread-id`, and `x-client-request-id`
+  identity instead of intermittently re-sending large uncached histories;
+  explicit no-retention requests still disable affinity
+  ([#597](https://github.com/code-yeongyu/senpi/pull/597)).
+
+- Measure the builtin TPS indicator with a monotonic clock rather than wall
+  time. Backward system-clock adjustments can no longer produce a
+  non-positive interval that silently suppresses a valid throughput
+  notification, while stream-open timing and tool-wait exclusion remain
+  unchanged
+  ([#598](https://github.com/code-yeongyu/senpi/pull/598)).
+
+- Show the prominent high-reasoning warning only once per sensitive
+  provider/model identity during an `AgentSession`. Cycling among `xhigh`,
+  `max`, and lower efforts or switching away and back no longer re-arms the
+  same warning, while selecting a different sensitive model still produces its
+  own first warning
+  ([#599](https://github.com/code-yeongyu/senpi/pull/599)).
+
+- Let Codex sessions recover from transient WebSocket fallback instead of
+  remaining pinned to SSE for the rest of the process. Requests inside the
+  60-second degradation window continue safely on SSE, later fresh requests
+  can probe WebSocket, cleanup clears fallback state, and potentially billed
+  started responses are never replayed
+  ([#600](https://github.com/code-yeongyu/senpi/pull/600)).
+
+- Preserve rich detached `eval` peeks from the bundled codemode extension,
+  including the submitted code and title, live output, phase, structured
+  status events, nested tool-call summaries, elapsed duration, and structured
+  displays. Terminal settlement is first-writer-wins and an explicit
+  cancellation remains authoritative over a late kernel completion
+  ([#603](https://github.com/code-yeongyu/senpi/pull/603)).
+
+- Surface failed and partially failed `apply_patch` operations as actual tool
+  errors to both the model loop and interactive renderer. Complete failures no
+  longer remain styled as a successful or indefinitely applying patch, while
+  partial results retain successful diffs together with concrete recovery
+  guidance for the failed operations
+  ([#605](https://github.com/code-yeongyu/senpi/pull/605)).
+
+- Suppress byte-identical monitor notification batches before they wake an
+  idle session. Repeated status redraws from commands such as
+  `gh pr checks --watch` no longer replay the full agent context every refresh;
+  genuinely changed output still resets duplicate suppression, and explicit
+  `rearm` keeps its existing wake-budget semantics
+  ([#612](https://github.com/code-yeongyu/senpi/pull/612)).
+
+- Respect an explicitly saved system `defaultModel` when the
+  `recommended-models` builtin starts. Automatic recommendation switching now
+  applies only to implicit `provider-default` and `first-available` fallback
+  selections; models chosen through saved settings, CLI input, or scoped
+  configuration are kept without a notification or persistence write that
+  could overwrite the user's choice
+  ([#625](https://github.com/code-yeongyu/senpi/pull/625)).
 
 ### Removed
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Preserve rich live and terminal `eval` details when peeking detached cells,
   including code, title, output, phase, status events, tool-call summaries,
   duration, and structured displays; cancellation now remains authoritative
-  over late completion races.
+  over late completion races
+  ([#603](https://github.com/code-yeongyu/senpi/pull/603)).
 
 ### Removed
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Changed
 
+- Reuse normalized terminal-line strings across frames and make
+  viewport-bounded normalization and diffing the default for ordinary
+  rendering. Memoized state remains bounded to the current transcript, image
+  lines continue to bypass normalization, and full-frame fallbacks remain for
+  resize and recovery paths, reducing large-session lag without changing
+  visible output
+  ([#604](https://github.com/code-yeongyu/senpi/pull/604)).
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
## Summary

Prepare Senpi's next CalVer release by auditing every commit after
`v2026.7.31-2` and adding reviewer-readable, package-correct Unreleased notes.
The audit covers the current `main` range through PR #625: 62 commits and 40
non-merge commits.

## Changes

- Document AI reasoning-capability, Codex cache-affinity, and WebSocket recovery
  fixes in both the AI package and the user-facing coding-agent changelog.
- Document DeepSeek V4 presets and first-party search, goal migration,
  reasoning preference, TPS timing, warning deduplication, apply-patch failure
  disclosure, monitor duplicate suppression, todo animation, and saved-default
  model preservation in the coding-agent changelog.
- Document the TUI normalization/viewport performance improvement in the TUI
  package and its user-facing coding-agent surface.
- Add the missing PR reference to the existing rich detached-eval peek note.
- Preserve all previously released changelog sections byte-for-byte.

## QA & Evidence

- **RED audit:** 18 initially in-range product/release PRs had zero explicit
  references in Unreleased sections; only one unreferenced codemode bullet
  existed.
  - Artifact: `local-ignore/qa-evidence/20260801-release-install/changelog-red.txt`
- **GREEN audit:** every non-skippable PR now has package coverage; AI/TUI
  user-visible changes are duplicated into coding-agent; external PRs #586 and
  #587 include contributor attribution; newly merged PR #625 is included.
  - Artifact: `local-ignore/qa-evidence/20260801-release-install/changelog-green.txt`
- **Released-section immutability:** all four modified changelogs match
  `origin/main` byte-for-byte from `2026.7.31-2` downward.
- **Focused release validation:** `node --test scripts/release-test-gate.test.mjs`
  passed 9/9; `git diff --check` passed.
- **Mandatory review:** `momus` returned unconditional `APPROVED`.

## Risks & Residuals

- This PR changes release notes only; it does not alter runtime or release
  scripts.
- PR #596 is intentionally accounted for but omitted from package release notes
  because it synchronizes test waits with the asserted signal and changes no
  production behavior or public contract.

## Plan

`.omo/plans/release-2026-08-01.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update changelogs to capture all Unreleased changes since v2026.7.31-2 across `packages/ai`, `packages/coding-agent`, `packages/tui`, and `packages/senpi-codemode`. Highlights include reasoning metadata alignment, DeepSeek V4 presets and native search, terminal viewport performance, and several coding-agent fixes; released sections are preserved byte-for-byte.

<sup>Written for commit b2a6917e651eb0042489072e9166a4e7d900089f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

