### PR TITLE
docs: document Claude Code opt-out

### DIFF
--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -46,13 +46,13 @@ The `claude-sdk-oauth` provider routes LLM calls through the official [Claude Ag
   - `systemPromptMode` — controls how the system prompt is delivered. **`full`** (default) sends senpi's composed system prompt verbatim; the lane no longer rebuilds from the SDK `claude_code` preset, so all prompt regions (project rules, response-language instructions, etc.) reach the model. **`preset-append`** is the previous behaviour (deprecated, kept for one release; emits a one-time warning). **`override`** loads the system prompt from a file (`systemPromptFile`). The legacy `appendSystemPrompt` key still works: `false` → `preset-append`, `true`/unset → `full`; setting both keys makes `systemPromptMode` win and warns.
   - In `full` and `override` modes, `settingSources` defaults to `[]` on every lane because senpi's prompt already carries project context — loading the SDK's own CLAUDE.md would double-inject it. The CLI always prepends its own `"You are a Claude agent, built on Anthropic's Claude Agent SDK."` block, which senpi cannot suppress; `full` means the prompt is delivered intact, not that it is the only system-prompt text.
   - `settingSources` (filesystem settings load only in the ambient lane, so they cannot override your selected account), `strictMcpConfig`, `pinnedAccount`, `tokenInjection` (`oauth-slots` | `config-dir` | `ambient`), `resumeMode` (`auto` default | `off` restores per-turn sessions), `systemPromptFile`.
-- To opt out of the Claude Code auto-detection/provider entirely, disable the builtin by id in `settings.json`:
+- To prevent the Claude Code provider from loading on startup, disable the builtin by id in global `~/.senpi/agent/settings.json` or project `.senpi/settings.json`:
   ```json
   {
     "disabledBuiltinExtensions": ["claude-sdk-oauth"]
   }
   ```
-  This prevents the provider extension from loading while leaving other built-in extensions enabled. Remove the id (or remove the setting) to enable it again.
+  Restart senpi after changing this setting. Project settings override global settings, so a project-level `disabledBuiltinExtensions` list must also include `claude-sdk-oauth` to preserve a global opt-out. The setting prevents the provider extension from loading while leaving unrelated built-ins enabled. Remove the id (or remove the setting) to enable it again.
 - **Environment overrides** (precedence: `env > project settings > global settings > default`; no new CLI flags):
 
   | Variable | Purpose |

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -46,6 +46,13 @@ The `claude-sdk-oauth` provider routes LLM calls through the official [Claude Ag
   - `systemPromptMode` — controls how the system prompt is delivered. **`full`** (default) sends senpi's composed system prompt verbatim; the lane no longer rebuilds from the SDK `claude_code` preset, so all prompt regions (project rules, response-language instructions, etc.) reach the model. **`preset-append`** is the previous behaviour (deprecated, kept for one release; emits a one-time warning). **`override`** loads the system prompt from a file (`systemPromptFile`). The legacy `appendSystemPrompt` key still works: `false` → `preset-append`, `true`/unset → `full`; setting both keys makes `systemPromptMode` win and warns.
   - In `full` and `override` modes, `settingSources` defaults to `[]` on every lane because senpi's prompt already carries project context — loading the SDK's own CLAUDE.md would double-inject it. The CLI always prepends its own `"You are a Claude agent, built on Anthropic's Claude Agent SDK."` block, which senpi cannot suppress; `full` means the prompt is delivered intact, not that it is the only system-prompt text.
   - `settingSources` (filesystem settings load only in the ambient lane, so they cannot override your selected account), `strictMcpConfig`, `pinnedAccount`, `tokenInjection` (`oauth-slots` | `config-dir` | `ambient`), `resumeMode` (`auto` default | `off` restores per-turn sessions), `systemPromptFile`.
+- To opt out of the Claude Code auto-detection/provider entirely, disable the builtin by id in `settings.json`:
+  ```json
+  {
+    "disabledBuiltinExtensions": ["claude-sdk-oauth"]
+  }
+  ```
+  This prevents the provider extension from loading while leaving other built-in extensions enabled. Remove the id (or remove the setting) to enable it again.
 - **Environment overrides** (precedence: `env > project settings > global settings > default`; no new CLI flags):
 
   | Variable | Purpose |

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -3,7 +3,9 @@
 ## 2026-08-01 - Document the Claude Code opt-out
 
 - Documented `disabledBuiltinExtensions: ["claude-sdk-oauth"]` as the supported way to prevent the Claude SDK OAuth builtin from loading.
-- This is configuration-only; it leaves unrelated builtin extensions enabled and does not change the provider's default behavior.
+- Clarified the global and project settings paths, project-over-global precedence, and the restart required after changing the setting.
+- Added a regression test that proves the disabled builtin does not register the provider while unrelated builtins remain loaded.
+- The runtime behavior is unchanged; this only documents and locks the existing opt-out.
 - Merge-conflict risk: low. Expected conflict zone is the top of this extension change log.
 
 ## 2026-07-31 - Native system prompt, session reuse, env overrides, and transcript hardening

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,11 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-01 - Document the Claude Code opt-out
+
+- Documented `disabledBuiltinExtensions: ["claude-sdk-oauth"]` as the supported way to prevent the Claude SDK OAuth builtin from loading.
+- This is configuration-only; it leaves unrelated builtin extensions enabled and does not change the provider's default behavior.
+- Merge-conflict risk: low. Expected conflict zone is the top of this extension change log.
+
 ## 2026-07-31 - Native system prompt, session reuse, env overrides, and transcript hardening
 
 - **System prompt modes (new default: `full`).** Added a `systemPromptMode` setting with three values. `full` (new default) sends senpi's own composed system prompt verbatim — previously the lane rebuilt a prompt from the SDK `claude_code` preset plus three extracted regions, so any region without a dedicated extractor was silently dropped (a persistent response-language instruction never reached the model). `preset-append` is the previous behaviour, now DEPRECATED and kept for one release; selecting it emits a one-time warning. `override` loads the system prompt verbatim from a file (`systemPromptFile`). The legacy `appendSystemPrompt` key still works and maps onto the modes: `false` → `preset-append`, `true`/unset → `full`. Setting both `appendSystemPrompt` and `systemPromptMode` makes `systemPromptMode` win and emits a warning.

--- a/packages/coding-agent/test/agent-session-services-providers.test.ts
+++ b/packages/coding-agent/test/agent-session-services-providers.test.ts
@@ -94,4 +94,34 @@ describe("createAgentSessionServices provider registration order", () => {
 			"config:claude-sdk-oauth",
 		]);
 	});
+
+	it("skips the Claude SDK OAuth provider when its builtin is disabled", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "senpi-services-provider-disabled-"));
+		tempDirs.push(tempDir);
+		const agentDir = join(tempDir, "agent");
+		const projectDir = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(projectDir, { recursive: true });
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			`${JSON.stringify({ disabledBuiltinExtensions: ["claude-sdk-oauth"] })}\n`,
+		);
+
+		const modelRuntime = getModelRuntime(await createInMemoryModelRegistry(AuthStorage.inMemory()));
+		const applied: string[] = [];
+		const registerProvider = modelRuntime.registerProvider.bind(modelRuntime);
+		modelRuntime.registerProvider = (name, config) => {
+			applied.push(name);
+			return registerProvider(name, config);
+		};
+
+		const services = await createAgentSessionServices({ cwd: projectDir, agentDir, modelRuntime });
+
+		expect(applied).not.toContain("claude-sdk-oauth");
+		expect(
+			services.resourceLoader
+				.getExtensions()
+				.extensions.some((extension) => extension.path === "<builtin:todowrite>"),
+		).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary
- Document the existing `disabledBuiltinExtensions` opt-out for the `claude-sdk-oauth` builtin.
- Explain that disabling `claude-sdk-oauth` prevents the Claude Code provider extension from loading while preserving other builtins.
- Record the configuration-only change in the extension changelog.

## Verification
- `npm exec vitest -- --run test/claude-sdk-oauth-options.test.ts test/suite/claude-sdk-oauth-extension.test.ts` ✅ (44 tests)
- `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` ✅ (8/8)
- `git diff --check` ✅
- `npm run check` ⚠️ reaches repository checks, but the existing `packages/web-ui` check fails because `lit` is unavailable in the workspace environment; no changed-file errors were reported.

Closes no issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to opt out of the Claude Code provider by disabling the `claude-sdk-oauth` builtin via `disabledBuiltinExtensions`. Adds a JSON example, restart and precedence notes (project overrides global), updates the extension changelog, and includes a regression test confirming the provider is skipped while other built-ins remain loaded.

<sup>Written for commit 379f0e6ba7c4d2b2bc1944b3fd7d5007b1bea72c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

