### PR TITLE
test(claude-sdk-oauth): full-stack continuity probe and gated live spikes

### DIFF
--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -135,6 +135,10 @@ async function runArm({ settings, probeManual }) {
 	};
 	async function consume() {
 		for await (const message of stream) {
+			// Record the session id from EVERY message that carries one — a lineage
+			// split during compaction (compact_boundary/result messages) must trip
+			// the stability assertion, not slip past an init-only set.
+			if (typeof message.session_id === "string") state.sessionIds.add(message.session_id);
 			if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
 				state.sessionIds.add(message.session_id);
 			}
@@ -182,6 +186,9 @@ async function runArm({ settings, probeManual }) {
 	if (outcome) reject(outcome, "", secrets);
 	if (state.failure) reject(state.failure, "", secrets);
 	if (state.sessionIds.size !== 1) reject("session_lineage_split");
+	// Coherence is enforced, not just recorded: the arm exists to prove
+	// post-compaction turn continuity, and a failed recall must not ACCEPT.
+	if (!state.coherent) reject("recall_incoherent", "", secrets);
 	return state;
 }
 
@@ -215,4 +222,6 @@ process.stdout.write(
 	`armB boundaries=${JSON.stringify(armB.boundaries)} turns=${armB.turn} coherent=${armB.coherent}\n`,
 );
 console.log(`ACCEPTED autocompact=${autocompact} boundary=${boundary} manual_compact=${manual}`);
-process.exit(0);
+// exitCode, not exit(): a forced exit can truncate the per-arm evidence or the
+// ACCEPTED line when stdout is a pipe; assigning lets Node flush it first.
+process.exitCode = 0;

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -176,9 +176,12 @@ async function runArm({ settings, probeManual }) {
 	if (outcome) reject(outcome, "", secrets);
 	if (state.failure) reject(state.failure, "", secrets);
 	if (state.sessionIds.size !== 1) reject("session_lineage_split");
-	// Coherence is enforced, not just recorded: the arm exists to prove
-	// post-compaction turn continuity, and a failed recall must not ACCEPT.
-	if (!state.coherent) reject("recall_incoherent", "", secrets);
+	// Coherence is enforced only when compaction actually happened: the arm
+	// exists to prove POST-COMPACTION continuity. With no boundary, the recall
+	// must survive ~130k tokens of uncompacted filler — a genuinely hard model
+	// task whose failure would mask the actual finding (autocompact=absent),
+	// so it is recorded in the evidence line but not gated.
+	if (!state.coherent && state.boundaries.length > 0) reject("recall_incoherent", "", secrets);
 	return state;
 }
 

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -62,7 +62,7 @@ if (loaded.error) reject(loaded.error);
 const AUTO_COMPACT_WINDOW = 100_000;
 const FILLER = "Summarize this instruction back to me in one sentence: ".concat("context filler. ".repeat(33_000));
 
-function nextPrompt(state, probeManual, token) {
+function nextPrompt(state, probeManual) {
 	// Turn 2 is the single oversized stimulus that overflows the 100k window.
 	if (state.turn === 1) return FILLER;
 	if (state.autoBoundaryTurn !== null || !probeManual || state.manualCompactSent) {
@@ -80,6 +80,10 @@ function nextPrompt(state, probeManual, token) {
 
 async function runArm({ settings, probeManual }) {
 	const token = `COMPACT_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+	// Every reject path that can carry an SDK error string redacts the access
+	// token and the generated recall token first — safeSignal is a shape
+	// sanitizer, not a secret redactor.
+	const secrets = [loaded.credential.access, token];
 	// Setup runs inside the guarded path: an SDK import, a missing Claude binary
 	// or a query-construction failure must exit through the sanitized REJECTED
 	// contract, never as a raw stack trace on exit 1.
@@ -105,7 +109,18 @@ async function runArm({ settings, probeManual }) {
 			},
 		});
 	} catch (error) {
-		reject(error instanceof Error ? error.message : String(error));
+		reject(error instanceof Error ? error.message : String(error), "", secrets);
+	}
+
+	// Signal-aware cleanup: Ctrl-C/SIGTERM skips `finally`, so without a handler
+	// the Claude Code subprocess would be orphaned mid-arm and keep burning
+	// quota. Closing the query handle reaps the subprocess before exiting.
+	for (const signal of ["SIGINT", "SIGTERM"]) {
+		process.once(signal, () => {
+			input.close();
+			closeQuietly(stream);
+			reject(`interrupted_${signal.toLowerCase()}`, "", secrets);
+		});
 	}
 
 	const state = {
@@ -118,11 +133,6 @@ async function runArm({ settings, probeManual }) {
 		turn: 0,
 		phase: "auto",
 	};
-	let resolveDone;
-	const done = new Promise((resolve) => {
-		resolveDone = resolve;
-	});
-
 	async function consume() {
 		for await (const message of stream) {
 			if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
@@ -153,16 +163,15 @@ async function runArm({ settings, probeManual }) {
 			if (state.phase === "recall") break;
 			// nextPrompt() owns the manual->recall transition, so the `/compact`
 			// send happens in exactly one place.
-			input.push(userMessage(nextPrompt(state, probeManual, token), randomUUID()));
+			input.push(userMessage(nextPrompt(state, probeManual), randomUUID()));
 		}
-		resolveDone();
 	}
 
 	let outcome = null;
 	try {
-		// Await the consumer itself, not just `done`: a rejected consumer would
-		// otherwise hang to the deadline and misreport the real failure as a timeout.
-		await withTimeout(Promise.race([consume(), done]), "spike", 600_000);
+		// Await the consumer itself: a rejected consumer surfaces its real error
+		// immediately, and withTimeout is what actually bounds a hang.
+		await withTimeout(consume(), "spike", 600_000);
 	} catch (error) {
 		outcome = error instanceof Error ? error.message : String(error);
 	} finally {
@@ -170,8 +179,8 @@ async function runArm({ settings, probeManual }) {
 		closeQuietly(stream);
 	}
 
-	if (outcome) reject(outcome);
-	if (state.failure) reject(state.failure);
+	if (outcome) reject(outcome, "", secrets);
+	if (state.failure) reject(state.failure, "", secrets);
 	if (state.sessionIds.size !== 1) reject("session_lineage_split");
 	return state;
 }

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -40,13 +40,12 @@ import {
 	assistantText,
 	claudeExecutable,
 	closeQuietly,
-	controlledInput,
-	importClaudeSdk,
 	loadCredential,
 	managedEnvironment,
 	reject,
 	requireLiveGate,
 	requireSandbox,
+	startGuardedQuery,
 	userMessage,
 	withTimeout,
 } from "./lib/claude-sdk-oauth-spike-support.mjs";
@@ -89,49 +88,25 @@ async function runArm({ settings, probeManual }) {
 	// token and the generated recall token first — safeSignal is a shape
 	// sanitizer, not a secret redactor.
 	const secrets = [loaded.credential.access, token];
-	// Setup runs inside the guarded path: an SDK import, a missing Claude binary
-	// or a query-construction failure must exit through the sanitized REJECTED
-	// contract, never as a raw stack trace on exit 1.
-	let query;
-	let input;
-	let stream;
-	try {
-		({ query } = await importClaudeSdk());
-		input = controlledInput(
-			userMessage(`Remember this token for later: ${token}. Reply with exactly: ACK`, randomUUID()),
-		);
-		stream = query({
-			prompt: input,
-			options: {
-				model: "claude-haiku-4-5",
-				tools: [],
-				permissionMode: "dontAsk",
-				settingSources: [],
-				systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-				settings,
-				pathToClaudeCodeExecutable: claudeExecutable(),
-				env: managedEnvironment(loaded.credential.access),
-			},
-		});
-	} catch (error) {
-		reject(error instanceof Error ? error.message : String(error), "", secrets);
-	}
-
-	// Signal-aware cleanup: Ctrl-C/SIGTERM skips `finally`, so without a handler
-	// the Claude Code subprocess would be orphaned mid-arm and keep burning
-	// quota. Closing the query handle reaps the subprocess before exiting. The
-	// handlers are removed when the arm finishes — a stale arm-A listener would
-	// otherwise fire during arm B and exit before arm B's stream is reaped.
-	const signalHandlers = [];
-	for (const signal of ["SIGINT", "SIGTERM"]) {
-		const handler = () => {
-			input.close();
-			closeQuietly(stream);
-			reject(`interrupted_${signal.toLowerCase()}`, "", secrets);
-		};
-		process.once(signal, handler);
-		signalHandlers.push([signal, handler]);
-	}
+	// Guarded setup + signal-aware cleanup live in spike-support: handlers are
+	// installed BEFORE setup (a signal during SDK import/binary resolution is
+	// covered), setup failures exit through the sanitized REJECTED contract,
+	// and disarm() removes the handlers at arm end so a stale arm-A listener
+	// cannot fire during arm B and exit before arm B's stream is reaped.
+	const { input, stream, disarm } = await startGuardedQuery({
+		firstMessage: userMessage(`Remember this token for later: ${token}. Reply with exactly: ACK`, randomUUID()),
+		options: {
+			model: "claude-haiku-4-5",
+			tools: [],
+			permissionMode: "dontAsk",
+			settingSources: [],
+			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+			settings,
+			pathToClaudeCodeExecutable: claudeExecutable(),
+			env: managedEnvironment(loaded.credential.access),
+		},
+		secrets,
+	});
 
 	const state = {
 		sessionIds: new Set(),
@@ -195,7 +170,7 @@ async function runArm({ settings, probeManual }) {
 	} finally {
 		input.close();
 		closeQuietly(stream);
-		for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
+		disarm();
 	}
 
 	if (outcome) reject(outcome, "", secrets);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Live spike: native auto-compaction on a streaming-input query (Wave A todo 4).
+ *
+ * Drives ONE resident streaming-input query whose `autoCompactWindow` is shrunk
+ * through the inline settings surface (Options.settings, sdk.d.ts:1875 ->
+ * Settings.autoCompactWindow, sdk.d.ts:6325) so compaction triggers cheaply, and
+ * records:
+ *   - which switch actually enabled auto-compaction (settings key vs default-on
+ *     with `settingSources: []`, which is what senpi's options.ts uses today),
+ *   - the `compact_boundary` system message as received through the iterator,
+ *   - post-compaction session-id stability + turn coherence,
+ *   - whether a `/compact` user message sent through the streaming input
+ *     triggers compaction (the manual fallback channel for todo 13).
+ * extraArgs is CLI-flags-only (sdk.d.ts:1463-1468) and is deliberately NOT probed.
+ *
+ * Usage:
+ *   SENPI_LIVE_CLAUDE_SDK_OAUTH=1 SENPI_CODING_AGENT_DIR=<sandbox> \
+ *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+ *
+ * Outcomes (final line):
+ *   exit 0 "ACCEPTED autocompact=<default-on|settings:autoCompactWindow|absent> boundary=<received|absent> manual_compact=<slash-ok|absent>"
+ *   exit 2 "REJECTED signal=<sanitized>"
+ * Never prints token material. Bounded to ~2 compaction cycles of quota.
+ */
+import { randomUUID } from "node:crypto";
+import {
+	assistantText,
+	claudeExecutable,
+	closeQuietly,
+	controlledInput,
+	importClaudeSdk,
+	loadCredential,
+	managedEnvironment,
+	reject,
+	requireLiveGate,
+	requireSandbox,
+	userMessage,
+	withDeadline,
+} from "./lib/claude-sdk-oauth-spike-support.mjs";
+
+requireLiveGate();
+const sandbox = requireSandbox();
+const loaded = loadCredential(sandbox);
+if (loaded.error) reject(loaded.error);
+
+const AUTO_COMPACT_WINDOW = 4_000;
+const MAX_FILLER_TURNS = 12;
+const MEMORY_TOKEN = `COMPACT_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+const FILLER = "Summarize this instruction back to me in one sentence: ".concat("context filler. ".repeat(60));
+
+const { query } = await importClaudeSdk();
+const input = controlledInput(
+	userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
+);
+const stream = query({
+	prompt: input,
+	options: {
+		model: "claude-haiku-4-5",
+		tools: [],
+		permissionMode: "dontAsk",
+		settingSources: [],
+		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+		settings: { autoCompactWindow: AUTO_COMPACT_WINDOW, autoCompactEnabled: true },
+		pathToClaudeCodeExecutable: claudeExecutable(),
+		env: managedEnvironment(loaded.credential.access),
+	},
+});
+
+const state = {
+	sessionIds: new Set(),
+	boundaries: [],
+	autoBoundaryTurn: null,
+	manualBoundary: false,
+	coherent: false,
+	failure: null,
+	turn: 0,
+	phase: "auto",
+};
+let resolveDone;
+const done = new Promise((resolve) => {
+	resolveDone = resolve;
+});
+
+function nextAutoPrompt() {
+	if (state.autoBoundaryTurn !== null) {
+		state.phase = "recall";
+		return "Repeat the token I gave you at the very start, prefixed with RECALL.";
+	}
+	if (state.turn >= MAX_FILLER_TURNS) {
+		state.phase = "manual";
+		return "/compact";
+	}
+	return FILLER;
+}
+
+async function consume() {
+	for await (const message of stream) {
+		if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
+			state.sessionIds.add(message.session_id);
+		}
+		if (message.type === "system" && message.subtype === "compact_boundary") {
+			state.boundaries.push({
+				trigger: message.compact_metadata?.trigger ?? "unknown",
+				preTokens: message.compact_metadata?.pre_tokens ?? null,
+				postTokens: message.compact_metadata?.post_tokens ?? null,
+				phase: state.phase,
+			});
+			if (state.phase === "manual") state.manualBoundary = true;
+			else state.autoBoundaryTurn ??= state.turn;
+		}
+		if (message.type === "assistant") {
+			if (message.error) state.failure ??= "assistant_error";
+			if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
+			if (state.phase === "recall" && assistantText(message).includes(MEMORY_TOKEN)) state.coherent = true;
+		}
+		if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
+		if (message.type !== "result") continue;
+		// A 401/refusal arrives as subtype:"success" with is_error:true.
+		if (message.subtype !== "success" || message.is_error === true) {
+			state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
+			break;
+		}
+		state.turn += 1;
+		if (state.phase === "recall") break;
+		if (state.phase === "manual" && state.turn > MAX_FILLER_TURNS + 1) {
+			state.phase = "recall";
+			input.push(
+				userMessage("Repeat the token I gave you at the very start, prefixed with RECALL.", randomUUID()),
+			);
+			continue;
+		}
+		input.push(userMessage(nextAutoPrompt(), randomUUID()));
+	}
+	resolveDone();
+}
+
+let outcome = null;
+try {
+	void consume();
+	await withDeadline(done, "spike", 600_000);
+} catch (error) {
+	outcome = error instanceof Error ? error.message : String(error);
+} finally {
+	input.close();
+	closeQuietly(stream);
+}
+
+if (outcome) reject(outcome);
+if (state.failure) reject(state.failure);
+if (state.sessionIds.size !== 1) reject("session_lineage_split");
+
+const autoBoundary = state.boundaries.find((boundary) => boundary.phase !== "manual");
+const autocompact = autoBoundary
+	? autoBoundary.trigger === "auto"
+		? "settings:autoCompactWindow"
+		: "default-on"
+	: "absent";
+const boundary = state.boundaries.length > 0 ? "received" : "absent";
+const manual = state.manualBoundary ? "slash-ok" : "absent";
+process.stdout.write(
+	`boundaries=${JSON.stringify(state.boundaries)} turns=${state.turn} coherent=${state.coherent}\n`,
+);
+console.log(`ACCEPTED autocompact=${autocompact} boundary=${boundary} manual_compact=${manual}`);
+process.exit(0);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -203,13 +203,13 @@ const armB = await runArm({
 	probeManual: false,
 });
 
-// The verdict reads the SDK-provided compact_metadata.trigger, not the spike's
-// own phase bookkeeping — a boundary's origin (native auto vs /compact) is what
-// the arms measure. `unknown` (metadata absent) falls back to the phase.
-const isAutoBoundary = (boundary) =>
-	boundary.trigger === "unknown" ? boundary.phase !== "manual" : boundary.trigger === "auto";
-const isManualBoundary = (boundary) =>
-	boundary.trigger === "unknown" ? boundary.phase === "manual" : boundary.trigger === "manual";
+// The verdict reads ONLY the SDK-provided compact_metadata.trigger — never
+// the spike's own mutable phase bookkeeping. A boundary whose trigger is
+// absent counts toward boundary=received but is attributed to NEITHER arm:
+// attributing it via the phase field could misreport a late auto-compaction
+// as the /compact send (or vice versa).
+const isAutoBoundary = (boundary) => boundary.trigger === "auto";
+const isManualBoundary = (boundary) => boundary.trigger === "manual";
 const autoA = armA.boundaries.some(isAutoBoundary);
 const autoB = armB.boundaries.some(isAutoBoundary);
 // arm B (no enabled key) firing proves default-on; only arm A firing proves the

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -114,13 +114,18 @@ async function runArm({ settings, probeManual }) {
 
 	// Signal-aware cleanup: Ctrl-C/SIGTERM skips `finally`, so without a handler
 	// the Claude Code subprocess would be orphaned mid-arm and keep burning
-	// quota. Closing the query handle reaps the subprocess before exiting.
+	// quota. Closing the query handle reaps the subprocess before exiting. The
+	// handlers are removed when the arm finishes — a stale arm-A listener would
+	// otherwise fire during arm B and exit before arm B's stream is reaped.
+	const signalHandlers = [];
 	for (const signal of ["SIGINT", "SIGTERM"]) {
-		process.once(signal, () => {
+		const handler = () => {
 			input.close();
 			closeQuietly(stream);
 			reject(`interrupted_${signal.toLowerCase()}`, "", secrets);
-		});
+		};
+		process.once(signal, handler);
+		signalHandlers.push([signal, handler]);
 	}
 
 	const state = {
@@ -158,9 +163,13 @@ async function runArm({ settings, probeManual }) {
 			}
 			if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
 			if (message.type !== "result") continue;
-			// A 401/refusal arrives as subtype:"success" with is_error:true.
+			// A 401/refusal arrives as subtype:"success" with is_error:true; that
+			// combination must map to result_error, never to signal=success.
 			if (message.subtype !== "success" || message.is_error === true) {
-				state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
+				state.failure ??=
+					message.is_error === true && message.subtype === "success"
+						? "result_error"
+						: (message.subtype ?? message.terminal_reason ?? "result_error");
 				break;
 			}
 			state.turn += 1;
@@ -181,6 +190,7 @@ async function runArm({ settings, probeManual }) {
 	} finally {
 		input.close();
 		closeQuietly(stream);
+		for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
 	}
 
 	if (outcome) reject(outcome, "", secrets);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -56,11 +56,16 @@ const sandbox = requireSandbox();
 const loaded = loadCredential(sandbox);
 if (loaded.error) reject(loaded.error);
 
-// 100,000 is the minimum autoCompactWindow SDK 0.3.220 honors; the stimulus
-// below is sized ~130k tokens (16 chars ~= 4 tokens) so one user message
-// overflows the window and auto-compaction cannot be skipped.
+// 100,000 is the minimum autoCompactWindow SDK 0.3.220 honors. The stimulus
+// must RELIABLY overflow that window: a repeated phrase compresses under BPE
+// ("context filler. " collapses to ~3 tokens per repetition, which would land
+// the message BELOW the window and produce a false autocompact=absent), so
+// each repetition carries a unique hex segment. 18,000 varied repetitions at
+// ~8 tokens each ~= 144k tokens — over the window, under the 200k context.
 const AUTO_COMPACT_WINDOW = 100_000;
-const FILLER = "Summarize this instruction back to me in one sentence: ".concat("context filler. ".repeat(33_000));
+const FILLER = "Summarize this instruction back to me in one sentence: ".concat(
+	Array.from({ length: 18_000 }, (_, index) => `context filler ${index.toString(16)}${randomUUID().slice(0, 6)}`).join(" "),
+);
 
 function nextPrompt(state, probeManual) {
 	// Turn 2 is the single oversized stimulus that overflows the 100k window.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -112,7 +112,6 @@ async function runArm({ settings, probeManual }) {
 		sessionIds: new Set(),
 		boundaries: [],
 		autoBoundaryTurn: null,
-		manualBoundary: false,
 		manualCompactSent: false,
 		coherent: false,
 		failure: null,
@@ -136,8 +135,7 @@ async function runArm({ settings, probeManual }) {
 					postTokens: message.compact_metadata?.post_tokens ?? null,
 					phase: state.phase,
 				});
-				if (state.phase === "manual") state.manualBoundary = true;
-				else state.autoBoundaryTurn ??= state.turn;
+				if (state.phase !== "manual") state.autoBoundaryTurn ??= state.turn;
 			}
 			if (message.type === "assistant") {
 				if (message.error) state.failure ??= "assistant_error";
@@ -187,13 +185,20 @@ const armB = await runArm({
 	probeManual: false,
 });
 
-const autoA = armA.boundaries.some((boundary) => boundary.phase !== "manual");
-const autoB = armB.boundaries.some((boundary) => boundary.phase !== "manual");
+// The verdict reads the SDK-provided compact_metadata.trigger, not the spike's
+// own phase bookkeeping — a boundary's origin (native auto vs /compact) is what
+// the arms measure. `unknown` (metadata absent) falls back to the phase.
+const isAutoBoundary = (boundary) =>
+	boundary.trigger === "unknown" ? boundary.phase !== "manual" : boundary.trigger === "auto";
+const isManualBoundary = (boundary) =>
+	boundary.trigger === "unknown" ? boundary.phase === "manual" : boundary.trigger === "manual";
+const autoA = armA.boundaries.some(isAutoBoundary);
+const autoB = armB.boundaries.some(isAutoBoundary);
 // arm B (no enabled key) firing proves default-on; only arm A firing proves the
 // explicit autoCompactEnabled key is required; neither means absent.
 const autocompact = autoB ? "default-on" : autoA ? "settings:autoCompactEnabled" : "absent";
 const boundary = autoA || autoB ? "received" : "absent";
-const manual = armA.manualBoundary ? "slash-ok" : "absent";
+const manual = armA.boundaries.some(isManualBoundary) ? "slash-ok" : "absent";
 process.stdout.write(
 	`armA boundaries=${JSON.stringify(armA.boundaries)} turns=${armA.turn} coherent=${armA.coherent}\n`,
 );

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -2,19 +2,27 @@
 /**
  * Live spike: native auto-compaction on a streaming-input query (Wave A todo 4).
  *
- * Drives ONE resident streaming-input query whose `autoCompactWindow` is set to
+ * Drives resident streaming-input queries whose `autoCompactWindow` is set to
  * the SMALLEST value SDK 0.3.220 accepts (100,000 tokens — the Settings schema
  * is `number().int().min(1e5).max(1e6).optional().catch(void 0)`, so anything
  * smaller is silently dropped and the arm would probe nothing) through the
  * inline settings surface (Options.settings, sdk.d.ts:1875 ->
  * Settings.autoCompactWindow, sdk.d.ts:6325), then overflows that window with a
- * single oversized filler message so auto-compaction must trigger, and records:
- *   - which switch actually enabled auto-compaction (settings key vs default-on
- *     with `settingSources: []`, which is what senpi's options.ts uses today),
- *   - the `compact_boundary` system message as received through the iterator,
- *   - post-compaction session-id stability + turn coherence,
- *   - whether a `/compact` user message sent through the streaming input
- *     triggers compaction (the manual fallback channel for todo 13).
+ * single oversized filler message so auto-compaction cannot be skipped.
+ *
+ * TWO arms discriminate WHICH switch enables auto-compaction (the todo-4
+ * question a single arm cannot answer — a boundary's trigger is "auto" either
+ * way):
+ *   arm A "keyed":   settings {autoCompactWindow, autoCompactEnabled: true}
+ *   arm B "default": settings {autoCompactWindow} only — no enabled key
+ * arm B producing an auto boundary means the window key alone suffices
+ * (default-on under `settingSources: []`, which is what senpi's options.ts
+ * uses); only arm A producing one means the explicit enabled key is required.
+ *
+ * Also records, per arm: the `compact_boundary` system message as received
+ * through the iterator, and post-compaction session-id stability + turn
+ * coherence. The manual `/compact` streaming-input fallback (todo 13) is
+ * probed once, inside arm A, only when arm A produced no auto boundary.
  * extraArgs is CLI-flags-only (sdk.d.ts:1463-1468) and is deliberately NOT probed.
  *
  * Usage:
@@ -22,10 +30,10 @@
  *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
  *
  * Outcomes (final line):
- *   exit 0 "ACCEPTED autocompact=<default-on|settings:autoCompactWindow|absent> boundary=<received|absent> manual_compact=<slash-ok|absent>"
+ *   exit 0 "ACCEPTED autocompact=<default-on|settings:autoCompactEnabled|absent> boundary=<received|absent> manual_compact=<slash-ok|absent>"
  *   exit 2 "REJECTED signal=<sanitized>"
- * Never prints token material. Bounded to one ~130k-token stimulus plus one
- * compaction cycle of quota.
+ * Never prints token material. Bounded to two ~130k-token stimuli plus one
+ * compaction cycle of quota (~2 compaction cycles, per the todo-4 budget).
  */
 import { randomUUID } from "node:crypto";
 import {
@@ -52,136 +60,145 @@ if (loaded.error) reject(loaded.error);
 // below is sized ~130k tokens (16 chars ~= 4 tokens) so one user message
 // overflows the window and auto-compaction cannot be skipped.
 const AUTO_COMPACT_WINDOW = 100_000;
-const MEMORY_TOKEN = `COMPACT_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
 const FILLER = "Summarize this instruction back to me in one sentence: ".concat("context filler. ".repeat(33_000));
 
-// Setup runs inside the guarded path: an SDK import, a missing Claude binary or
-// a query-construction failure must exit through the sanitized REJECTED
-// contract, never as a raw stack trace on exit 1.
-let query;
-let input;
-let stream;
-try {
-	({ query } = await importClaudeSdk());
-	input = controlledInput(
-		userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
-	);
-	stream = query({
-		prompt: input,
-		options: {
-			model: "claude-haiku-4-5",
-			tools: [],
-			permissionMode: "dontAsk",
-			settingSources: [],
-			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-			settings: { autoCompactWindow: AUTO_COMPACT_WINDOW, autoCompactEnabled: true },
-			pathToClaudeCodeExecutable: claudeExecutable(),
-			env: managedEnvironment(loaded.credential.access),
-		},
-	});
-} catch (error) {
-	reject(error instanceof Error ? error.message : String(error));
-}
-
-const state = {
-	sessionIds: new Set(),
-	boundaries: [],
-	autoBoundaryTurn: null,
-	manualBoundary: false,
-	/** Guards the manual arm to exactly one `/compact` send. */
-	manualCompactSent: false,
-	coherent: false,
-	failure: null,
-	turn: 0,
-	phase: "auto",
-};
-let resolveDone;
-const done = new Promise((resolve) => {
-	resolveDone = resolve;
-});
-
-function nextAutoPrompt() {
+function nextPrompt(state, probeManual, token) {
 	// Turn 2 is the single oversized stimulus that overflows the 100k window.
 	if (state.turn === 1) return FILLER;
-	if (state.autoBoundaryTurn !== null) {
+	if (state.autoBoundaryTurn !== null || !probeManual || state.manualCompactSent) {
 		state.phase = "recall";
-		return "Repeat the token I gave you at the very start, prefixed with RECALL.";
+		return `Repeat the token I gave you at the very start, prefixed with RECALL.`;
 	}
 	// Exactly ONE `/compact` may be sent: a second one would compact an
 	// already-compacted transcript and make the manual_compact observation
 	// unattributable to either send. The manual arm only runs when the
 	// oversized stimulus produced no auto boundary.
-	if (!state.manualCompactSent) {
-		state.phase = "manual";
-		state.manualCompactSent = true;
-		return "/compact";
+	state.phase = "manual";
+	state.manualCompactSent = true;
+	return "/compact";
+}
+
+async function runArm({ settings, probeManual }) {
+	const token = `COMPACT_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+	// Setup runs inside the guarded path: an SDK import, a missing Claude binary
+	// or a query-construction failure must exit through the sanitized REJECTED
+	// contract, never as a raw stack trace on exit 1.
+	let query;
+	let input;
+	let stream;
+	try {
+		({ query } = await importClaudeSdk());
+		input = controlledInput(
+			userMessage(`Remember this token for later: ${token}. Reply with exactly: ACK`, randomUUID()),
+		);
+		stream = query({
+			prompt: input,
+			options: {
+				model: "claude-haiku-4-5",
+				tools: [],
+				permissionMode: "dontAsk",
+				settingSources: [],
+				systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+				settings,
+				pathToClaudeCodeExecutable: claudeExecutable(),
+				env: managedEnvironment(loaded.credential.access),
+			},
+		});
+	} catch (error) {
+		reject(error instanceof Error ? error.message : String(error));
 	}
-	state.phase = "recall";
-	return "Repeat the token I gave you at the very start, prefixed with RECALL.";
-}
 
-async function consume() {
-	for await (const message of stream) {
-		if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
-			state.sessionIds.add(message.session_id);
+	const state = {
+		sessionIds: new Set(),
+		boundaries: [],
+		autoBoundaryTurn: null,
+		manualBoundary: false,
+		manualCompactSent: false,
+		coherent: false,
+		failure: null,
+		turn: 0,
+		phase: "auto",
+	};
+	let resolveDone;
+	const done = new Promise((resolve) => {
+		resolveDone = resolve;
+	});
+
+	async function consume() {
+		for await (const message of stream) {
+			if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
+				state.sessionIds.add(message.session_id);
+			}
+			if (message.type === "system" && message.subtype === "compact_boundary") {
+				state.boundaries.push({
+					trigger: message.compact_metadata?.trigger ?? "unknown",
+					preTokens: message.compact_metadata?.pre_tokens ?? null,
+					postTokens: message.compact_metadata?.post_tokens ?? null,
+					phase: state.phase,
+				});
+				if (state.phase === "manual") state.manualBoundary = true;
+				else state.autoBoundaryTurn ??= state.turn;
+			}
+			if (message.type === "assistant") {
+				if (message.error) state.failure ??= "assistant_error";
+				if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
+				if (state.phase === "recall" && assistantText(message).includes(token)) state.coherent = true;
+			}
+			if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
+			if (message.type !== "result") continue;
+			// A 401/refusal arrives as subtype:"success" with is_error:true.
+			if (message.subtype !== "success" || message.is_error === true) {
+				state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
+				break;
+			}
+			state.turn += 1;
+			if (state.phase === "recall") break;
+			// nextPrompt() owns the manual->recall transition, so the `/compact`
+			// send happens in exactly one place.
+			input.push(userMessage(nextPrompt(state, probeManual, token), randomUUID()));
 		}
-		if (message.type === "system" && message.subtype === "compact_boundary") {
-			state.boundaries.push({
-				trigger: message.compact_metadata?.trigger ?? "unknown",
-				preTokens: message.compact_metadata?.pre_tokens ?? null,
-				postTokens: message.compact_metadata?.post_tokens ?? null,
-				phase: state.phase,
-			});
-			if (state.phase === "manual") state.manualBoundary = true;
-			else state.autoBoundaryTurn ??= state.turn;
-		}
-		if (message.type === "assistant") {
-			if (message.error) state.failure ??= "assistant_error";
-			if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
-			if (state.phase === "recall" && assistantText(message).includes(MEMORY_TOKEN)) state.coherent = true;
-		}
-		if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
-		if (message.type !== "result") continue;
-		// A 401/refusal arrives as subtype:"success" with is_error:true.
-		if (message.subtype !== "success" || message.is_error === true) {
-			state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
-			break;
-		}
-		state.turn += 1;
-		if (state.phase === "recall") break;
-		// nextAutoPrompt() owns the manual->recall transition, so the `/compact`
-		// send happens in exactly one place.
-		input.push(userMessage(nextAutoPrompt(), randomUUID()));
+		resolveDone();
 	}
-	resolveDone();
+
+	let outcome = null;
+	try {
+		// Await the consumer itself, not just `done`: a rejected consumer would
+		// otherwise hang to the deadline and misreport the real failure as a timeout.
+		await withTimeout(Promise.race([consume(), done]), "spike", 600_000);
+	} catch (error) {
+		outcome = error instanceof Error ? error.message : String(error);
+	} finally {
+		input.close();
+		closeQuietly(stream);
+	}
+
+	if (outcome) reject(outcome);
+	if (state.failure) reject(state.failure);
+	if (state.sessionIds.size !== 1) reject("session_lineage_split");
+	return state;
 }
 
-let outcome = null;
-try {
-	// Await the consumer itself, not just `done`: a rejected consumer would
-	// otherwise hang to the deadline and misreport the real failure as a timeout.
-	await withTimeout(Promise.race([consume(), done]), "spike", 600_000);
-} catch (error) {
-	outcome = error instanceof Error ? error.message : String(error);
-} finally {
-	input.close();
-	closeQuietly(stream);
-}
+const armA = await runArm({
+	settings: { autoCompactWindow: AUTO_COMPACT_WINDOW, autoCompactEnabled: true },
+	probeManual: true,
+});
+const armB = await runArm({
+	settings: { autoCompactWindow: AUTO_COMPACT_WINDOW },
+	probeManual: false,
+});
 
-if (outcome) reject(outcome);
-if (state.failure) reject(state.failure);
-if (state.sessionIds.size !== 1) reject("session_lineage_split");
-
-const autoBoundary = state.boundaries.find((boundary) => boundary.phase !== "manual");
-const autocompact = autoBoundary
-	? autoBoundary.trigger === "auto"
-		? "settings:autoCompactWindow"
-		: "default-on"
-	: "absent";
-const boundary = state.boundaries.length > 0 ? "received" : "absent";
-const manual = state.manualBoundary ? "slash-ok" : "absent";
+const autoA = armA.boundaries.some((boundary) => boundary.phase !== "manual");
+const autoB = armB.boundaries.some((boundary) => boundary.phase !== "manual");
+// arm B (no enabled key) firing proves default-on; only arm A firing proves the
+// explicit autoCompactEnabled key is required; neither means absent.
+const autocompact = autoB ? "default-on" : autoA ? "settings:autoCompactEnabled" : "absent";
+const boundary = autoA || autoB ? "received" : "absent";
+const manual = armA.manualBoundary ? "slash-ok" : "absent";
 process.stdout.write(
-	`boundaries=${JSON.stringify(state.boundaries)} turns=${state.turn} coherent=${state.coherent}\n`,
+	`armA boundaries=${JSON.stringify(armA.boundaries)} turns=${armA.turn} coherent=${armA.coherent}\n`,
+);
+process.stdout.write(
+	`armB boundaries=${JSON.stringify(armB.boundaries)} turns=${armB.turn} coherent=${armB.coherent}\n`,
 );
 console.log(`ACCEPTED autocompact=${autocompact} boundary=${boundary} manual_compact=${manual}`);
 process.exit(0);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -2,10 +2,13 @@
 /**
  * Live spike: native auto-compaction on a streaming-input query (Wave A todo 4).
  *
- * Drives ONE resident streaming-input query whose `autoCompactWindow` is shrunk
- * through the inline settings surface (Options.settings, sdk.d.ts:1875 ->
- * Settings.autoCompactWindow, sdk.d.ts:6325) so compaction triggers cheaply, and
- * records:
+ * Drives ONE resident streaming-input query whose `autoCompactWindow` is set to
+ * the SMALLEST value SDK 0.3.220 accepts (100,000 tokens — the Settings schema
+ * is `number().int().min(1e5).max(1e6).optional().catch(void 0)`, so anything
+ * smaller is silently dropped and the arm would probe nothing) through the
+ * inline settings surface (Options.settings, sdk.d.ts:1875 ->
+ * Settings.autoCompactWindow, sdk.d.ts:6325), then overflows that window with a
+ * single oversized filler message so auto-compaction must trigger, and records:
  *   - which switch actually enabled auto-compaction (settings key vs default-on
  *     with `settingSources: []`, which is what senpi's options.ts uses today),
  *   - the `compact_boundary` system message as received through the iterator,
@@ -21,7 +24,8 @@
  * Outcomes (final line):
  *   exit 0 "ACCEPTED autocompact=<default-on|settings:autoCompactWindow|absent> boundary=<received|absent> manual_compact=<slash-ok|absent>"
  *   exit 2 "REJECTED signal=<sanitized>"
- * Never prints token material. Bounded to ~2 compaction cycles of quota.
+ * Never prints token material. Bounded to one ~130k-token stimulus plus one
+ * compaction cycle of quota.
  */
 import { randomUUID } from "node:crypto";
 import {
@@ -36,7 +40,7 @@ import {
 	requireLiveGate,
 	requireSandbox,
 	userMessage,
-	withDeadline,
+	withTimeout,
 } from "./lib/claude-sdk-oauth-spike-support.mjs";
 
 requireLiveGate();
@@ -44,28 +48,40 @@ const sandbox = requireSandbox();
 const loaded = loadCredential(sandbox);
 if (loaded.error) reject(loaded.error);
 
-const AUTO_COMPACT_WINDOW = 4_000;
-const MAX_FILLER_TURNS = 12;
+// 100,000 is the minimum autoCompactWindow SDK 0.3.220 honors; the stimulus
+// below is sized ~130k tokens (16 chars ~= 4 tokens) so one user message
+// overflows the window and auto-compaction cannot be skipped.
+const AUTO_COMPACT_WINDOW = 100_000;
 const MEMORY_TOKEN = `COMPACT_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
-const FILLER = "Summarize this instruction back to me in one sentence: ".concat("context filler. ".repeat(60));
+const FILLER = "Summarize this instruction back to me in one sentence: ".concat("context filler. ".repeat(33_000));
 
-const { query } = await importClaudeSdk();
-const input = controlledInput(
-	userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
-);
-const stream = query({
-	prompt: input,
-	options: {
-		model: "claude-haiku-4-5",
-		tools: [],
-		permissionMode: "dontAsk",
-		settingSources: [],
-		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-		settings: { autoCompactWindow: AUTO_COMPACT_WINDOW, autoCompactEnabled: true },
-		pathToClaudeCodeExecutable: claudeExecutable(),
-		env: managedEnvironment(loaded.credential.access),
-	},
-});
+// Setup runs inside the guarded path: an SDK import, a missing Claude binary or
+// a query-construction failure must exit through the sanitized REJECTED
+// contract, never as a raw stack trace on exit 1.
+let query;
+let input;
+let stream;
+try {
+	({ query } = await importClaudeSdk());
+	input = controlledInput(
+		userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
+	);
+	stream = query({
+		prompt: input,
+		options: {
+			model: "claude-haiku-4-5",
+			tools: [],
+			permissionMode: "dontAsk",
+			settingSources: [],
+			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+			settings: { autoCompactWindow: AUTO_COMPACT_WINDOW, autoCompactEnabled: true },
+			pathToClaudeCodeExecutable: claudeExecutable(),
+			env: managedEnvironment(loaded.credential.access),
+		},
+	});
+} catch (error) {
+	reject(error instanceof Error ? error.message : String(error));
+}
 
 const state = {
 	sessionIds: new Set(),
@@ -85,23 +101,23 @@ const done = new Promise((resolve) => {
 });
 
 function nextAutoPrompt() {
+	// Turn 2 is the single oversized stimulus that overflows the 100k window.
+	if (state.turn === 1) return FILLER;
 	if (state.autoBoundaryTurn !== null) {
 		state.phase = "recall";
 		return "Repeat the token I gave you at the very start, prefixed with RECALL.";
 	}
 	// Exactly ONE `/compact` may be sent: a second one would compact an
 	// already-compacted transcript and make the manual_compact observation
-	// unattributable to either send.
-	if (state.turn >= MAX_FILLER_TURNS && !state.manualCompactSent) {
+	// unattributable to either send. The manual arm only runs when the
+	// oversized stimulus produced no auto boundary.
+	if (!state.manualCompactSent) {
 		state.phase = "manual";
 		state.manualCompactSent = true;
 		return "/compact";
 	}
-	if (state.manualCompactSent) {
-		state.phase = "recall";
-		return "Repeat the token I gave you at the very start, prefixed with RECALL.";
-	}
-	return FILLER;
+	state.phase = "recall";
+	return "Repeat the token I gave you at the very start, prefixed with RECALL.";
 }
 
 async function consume() {
@@ -142,8 +158,9 @@ async function consume() {
 
 let outcome = null;
 try {
-	void consume();
-	await withDeadline(done, "spike", 600_000);
+	// Await the consumer itself, not just `done`: a rejected consumer would
+	// otherwise hang to the deadline and misreport the real failure as a timeout.
+	await withTimeout(Promise.race([consume(), done]), "spike", 600_000);
 } catch (error) {
 	outcome = error instanceof Error ? error.message : String(error);
 } finally {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -215,7 +215,10 @@ const autoB = armB.boundaries.some(isAutoBoundary);
 // arm B (no enabled key) firing proves default-on; only arm A firing proves the
 // explicit autoCompactEnabled key is required; neither means absent.
 const autocompact = autoB ? "default-on" : autoA ? "settings:autoCompactEnabled" : "absent";
-const boundary = autoA || autoB ? "received" : "absent";
+// boundary=received means a compact_boundary was OBSERVED, regardless of
+// whether its trigger metadata allowed auto/manual attribution — a
+// trigger-absent boundary must never report absent.
+const boundary = armA.boundaries.length > 0 || armB.boundaries.length > 0 ? "received" : "absent";
 const manual = armA.boundaries.some(isManualBoundary) ? "slash-ok" : "absent";
 process.stdout.write(
 	`armA boundaries=${JSON.stringify(armA.boundaries)} turns=${armA.turn} coherent=${armA.coherent}\n`,

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -38,7 +38,6 @@
 import { randomUUID } from "node:crypto";
 import {
 	assistantText,
-	claudeExecutable,
 	closeQuietly,
 	loadCredential,
 	managedEnvironment,
@@ -102,7 +101,6 @@ async function runArm({ settings, probeManual }) {
 			settingSources: [],
 			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
 			settings,
-			pathToClaudeCodeExecutable: claudeExecutable(),
 			env: managedEnvironment(loaded.credential.access),
 		},
 		secrets,

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -72,6 +72,8 @@ const state = {
 	boundaries: [],
 	autoBoundaryTurn: null,
 	manualBoundary: false,
+	/** Guards the manual arm to exactly one `/compact` send. */
+	manualCompactSent: false,
 	coherent: false,
 	failure: null,
 	turn: 0,
@@ -87,9 +89,17 @@ function nextAutoPrompt() {
 		state.phase = "recall";
 		return "Repeat the token I gave you at the very start, prefixed with RECALL.";
 	}
-	if (state.turn >= MAX_FILLER_TURNS) {
+	// Exactly ONE `/compact` may be sent: a second one would compact an
+	// already-compacted transcript and make the manual_compact observation
+	// unattributable to either send.
+	if (state.turn >= MAX_FILLER_TURNS && !state.manualCompactSent) {
 		state.phase = "manual";
+		state.manualCompactSent = true;
 		return "/compact";
+	}
+	if (state.manualCompactSent) {
+		state.phase = "recall";
+		return "Repeat the token I gave you at the very start, prefixed with RECALL.";
 	}
 	return FILLER;
 }
@@ -123,13 +133,8 @@ async function consume() {
 		}
 		state.turn += 1;
 		if (state.phase === "recall") break;
-		if (state.phase === "manual" && state.turn > MAX_FILLER_TURNS + 1) {
-			state.phase = "recall";
-			input.push(
-				userMessage("Repeat the token I gave you at the very start, prefixed with RECALL.", randomUUID()),
-			);
-			continue;
-		}
+		// nextAutoPrompt() owns the manual->recall transition, so the `/compact`
+		// send happens in exactly one place.
 		input.push(userMessage(nextAutoPrompt(), randomUUID()));
 	}
 	resolveDone();

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -114,6 +114,7 @@ async function runArm({ settings, probeManual }) {
 		autoBoundaryTurn: null,
 		manualCompactSent: false,
 		coherent: false,
+		recallResult: false,
 		failure: null,
 		turn: 0,
 		phase: "auto",
@@ -153,7 +154,12 @@ async function runArm({ settings, probeManual }) {
 				break;
 			}
 			state.turn += 1;
-			if (state.phase === "recall") break;
+			if (state.phase === "recall") {
+				// The recall turn's terminal result is what proves the arm completed
+				// — a prematurely ended stream must not ACCEPT on prompts alone.
+				state.recallResult = true;
+				break;
+			}
 			// nextPrompt() owns the manual->recall transition, so the `/compact`
 			// send happens in exactly one place.
 			input.push(userMessage(nextPrompt(state, probeManual), randomUUID()));
@@ -182,6 +188,9 @@ async function runArm({ settings, probeManual }) {
 	// task whose failure would mask the actual finding (autocompact=absent),
 	// so it is recorded in the evidence line but not gated.
 	if (!state.coherent && state.boundaries.length > 0) reject("recall_incoherent", "", secrets);
+	// A prematurely ended stream (recall prompt pushed, terminal result never
+	// received) must not ACCEPT — the arm proved nothing about recall.
+	if (!state.recallResult) reject("recall_incomplete", "", secrets);
 	return state;
 }
 

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-autocompact-spike.mjs
@@ -58,11 +58,13 @@ if (loaded.error) reject(loaded.error);
 // must RELIABLY overflow that window: a repeated phrase compresses under BPE
 // ("context filler. " collapses to ~3 tokens per repetition, which would land
 // the message BELOW the window and produce a false autocompact=absent), so
-// each repetition carries a unique hex segment. 18,000 varied repetitions at
-// ~8 tokens each ~= 144k tokens — over the window, under the 200k context.
+// each repetition carries a unique hex segment. Estimates for the varied
+// repetition range ~5-7 tokens (compressed prefix + incompressible hex), so
+// 24,000 repetitions land ~120-170k tokens by any estimate — comfortably
+// over the window, under the 200k context.
 const AUTO_COMPACT_WINDOW = 100_000;
 const FILLER = "Summarize this instruction back to me in one sentence: ".concat(
-	Array.from({ length: 18_000 }, (_, index) => `context filler ${index.toString(16)}${randomUUID().slice(0, 6)}`).join(" "),
+	Array.from({ length: 24_000 }, (_, index) => `context filler ${index.toString(16)}${randomUUID().slice(0, 6)}`).join(" "),
 );
 
 function nextPrompt(state, probeManual) {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -233,6 +233,11 @@ if (infrastructureFailure) {
 	// legitimate first-payload shape): any later non-delta submission means
 	// history was re-synthesized inside a resident session.
 	const nonDeltaContinuations = turns.filter((turn) => turn.index !== 1 && turn.kind !== "delta").length;
+	// Wire evidence is gated, not just tabled: the classified user payload must
+	// actually reach the provider — exactly one loopback request per turn,
+	// each carrying at least one message.
+	const wireEvidence =
+		providerRequests.length === TURNS && providerRequests.every((request) => request.messages >= 1);
 	const passed =
 		!fatal &&
 		turns.length === TURNS &&
@@ -240,10 +245,11 @@ if (infrastructureFailure) {
 		lineages.size === 1 &&
 		flattenTurns === 0 &&
 		nonResidentTurns === 0 &&
-		nonDeltaContinuations === 0;
+		nonDeltaContinuations === 0 &&
+		wireEvidence;
 	if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
 	process.stdout.write(
-		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns} non_delta=${nonDeltaContinuations}\n`,
+		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns} non_delta=${nonDeltaContinuations} wire_reqs=${providerRequests.length}\n`,
 	);
 	// exitCode, not exit(): a forced exit can truncate the table/verdict when
 	// stdout is a pipe; assigning lets Node flush the QA output first.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -33,6 +33,7 @@ import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot, track } from
 import {
 	classifyPayload,
 	createModelCaptureHandler,
+	extractPayloadText,
 	formatTurnTable,
 	seedProbeAgentDir,
 	withTimeout,
@@ -115,6 +116,11 @@ try {
 	});
 
 	const sourceRoot = join(ROOT, "packages", "coding-agent", "src");
+	// Imported eagerly so BOTH the normal-path finally and the signal-path
+	// cleanup shim can close the resident registry entry.
+	const { closeSession } = await import(
+		pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "session-registry.ts")).href
+	);
 	const boundaryModule = await import(
 		pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "sdk-boundary.ts")).href
 	);
@@ -160,9 +166,18 @@ try {
 	});
 	session = created.session;
 	// Register the session with the cleanup harness: an interrupt after the
-	// Claude session starts must dispose it (reaping the real Claude Code
-	// subprocess) — the finally path only runs on normal completion.
-	track({ exitCode: null, kill: () => session.dispose() });
+	// Claude session starts must close the resident registry entry AND dispose
+	// the session (reaping both Claude Code subprocesses) — the finally path
+	// only runs on normal completion.
+	track({
+		exitCode: null,
+		kill: () => {
+			try {
+				if (session?.id) closeSession(session.id, "probe_shutdown");
+			} catch {}
+			session.dispose();
+		},
+	});
 	const model = session.modelRuntime.getModel("claude-sdk-oauth", MODEL_ID);
 	if (!model) throw new Error("claude-sdk-oauth provider did not register its models");
 	await session.setModel(model);
@@ -184,6 +199,8 @@ try {
 		turns.push({
 			index,
 			queries: newQueries.length,
+			// The submitted payload text, for the wire-evidence digest gate.
+			payloadText: extractPayloadText(currentTurn.payloads.map((entry) => entry.message)),
 			path: currentTurn.payloads.at(-1)?.path ?? newQueries.at(-1)?.path ?? "none",
 			lineage: creations.at(-1)?.sessionId ?? "none",
 			kind: classified.some((item) => item.kind === "flatten")
@@ -210,9 +227,6 @@ try {
 	// resident OAuth query owns its own Claude Code subprocess, and disposing
 	// the session alone does not guarantee that subprocess is reaped.
 	try {
-		const { closeSession } = await import(
-			pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "session-registry.ts")).href
-		);
 		if (session?.id) closeSession(session.id, "probe_shutdown");
 	} catch {}
 	try {
@@ -249,9 +263,17 @@ if (infrastructureFailure) {
 	const nonDeltaContinuations = turns.filter((turn) => turn.index !== 1 && turn.kind !== "delta").length;
 	// Wire evidence is gated, not just tabled: the classified user payload must
 	// actually reach the provider — exactly one loopback request per turn,
-	// each carrying at least one message.
+	// each carrying at least one message, and each turn's submitted payload
+	// text must appear in the corresponding wire request (a dropped or
+	// replaced prompt can no longer masquerade as continuity success).
 	const wireEvidence =
-		providerRequests.length === TURNS && providerRequests.every((request) => request.messages >= 1);
+		providerRequests.length === TURNS &&
+		providerRequests.every((request) => request.messages >= 1) &&
+		turns.every((turn) => {
+			const request = providerRequests[turn.index - 1];
+			const slice = (turn.payloadText ?? "").replace(/\s+/g, " ").trim().slice(0, 60);
+			return slice.length === 0 || (request?.text ?? "").includes(slice);
+		});
 	const passed =
 		!fatal &&
 		turns.length === TURNS &&

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * Full-stack continuity probe for the claude-sdk-oauth lane.
+ *
+ * Unlike claude-sdk-oauth-registry-probe.mjs (which drives the registry APIs
+ * directly), this probe drives the REAL stack: createAgentSession() ->
+ * AgentSession.prompt() -> provider streamSimple -> resident session registry
+ * or the flattened <conversation_history> path. SDK query creation is
+ * intercepted at overrideSdkBoundary — the single choke point BOTH paths share
+ * (session-registry.ts queryFactory for the resident path, stream.ts for the
+ * non-resident flatten path) — so every query, its lineage, and every submitted
+ * user payload is measured on the real code path.
+ *
+ * The Claude Code subprocess is real; its Anthropic traffic is pinned to a
+ * loopback-only SSE server via ANTHROPIC_BASE_URL, so no credentials and no
+ * network egress are involved.
+ *
+ * Run with:
+ *   node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs --baseline
+ *
+ * Modes:
+ *   --baseline  always exits 0 — the per-turn table IS the deliverable
+ *   (default)   gate mode: VERDICT FAIL exits 1
+ * Exit 2 is reserved for probe-infrastructure failures (e.g. loopback down).
+ */
+
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot, track } from "./lib/common.mjs";
+import {
+	classifyPayload,
+	formatTurnTable,
+	loopbackSseBody,
+	safeDetail,
+	seedProbeAgentDir,
+	withTimeout,
+} from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+
+const ROOT = repoRoot();
+const INNER_FLAG = "SENPI_CLAUDE_SDK_FULLSTACK_PROBE_INNER";
+const BASELINE = process.argv.includes("--baseline");
+const TURNS = 6;
+const MODEL_ID = "claude-haiku-4-5";
+
+if (process.env[INNER_FLAG] !== "1") {
+	const child = spawnSync(process.execPath, ["--import", "tsx", import.meta.filename, ...process.argv.slice(2)], {
+		cwd: ROOT,
+		env: { ...process.env, [INNER_FLAG]: "1" },
+		stdio: "inherit",
+	});
+	if (child.error) {
+		process.stderr.write(`probe launcher failed: ${child.error.message}\n`);
+		process.exit(2);
+	}
+	process.exit(child.status ?? 2);
+}
+
+installCleanupHooks();
+
+const authGuard = guardRealAuth();
+const box = makeSandbox("claude-sdk-fullstack-probe");
+const providerRequests = [];
+let server;
+let session;
+let fatal;
+let infrastructureFailure;
+
+const turns = [];
+const creations = [];
+let currentTurn = null;
+
+try {
+	server = track(
+		createServer((request, response) => {
+			if (request.method !== "POST") {
+				response.writeHead(200);
+				response.end();
+				return;
+			}
+			let raw = "";
+			request.setEncoding("utf8");
+			request.on("data", (chunk) => {
+				raw += chunk;
+			});
+			request.on("end", () => {
+				let body;
+				try {
+					body = JSON.parse(raw);
+				} catch {
+					body = { messages: [] };
+				}
+				providerRequests.push({ bytes: raw.length, messages: Array.isArray(body.messages) ? body.messages.length : 0 });
+				response.writeHead(200, {
+					"content-type": "text/event-stream",
+					"cache-control": "no-cache",
+					connection: "keep-alive",
+				});
+				response.end(loopbackSseBody(`probe-reply-${providerRequests.length}`, providerRequests.length));
+			});
+		}),
+	);
+	await new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string" || address.address !== "127.0.0.1") {
+		throw new Error("probe server did not bind exclusively to 127.0.0.1");
+	}
+	const baseUrl = `http://127.0.0.1:${address.port}`;
+
+	seedProbeAgentDir(box.agentDir);
+	Object.assign(process.env, {
+		HOME: box.dir,
+		USERPROFILE: box.dir,
+		TMPDIR: box.dir,
+		SENPI_CODING_AGENT_DIR: box.agentDir,
+		SENPI_CODING_AGENT_SESSION_DIR: box.sessionDir,
+		PI_OFFLINE: "1",
+		PI_TELEMETRY: "0",
+		ANTHROPIC_BASE_URL: baseUrl,
+		ANTHROPIC_API_KEY: "fullstack-probe-dummy-key",
+		CLAUDE_CONFIG_DIR: join(box.dir, "claude-config"),
+		CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+		CLAUDE_CODE_DISABLE_TELEMETRY: "1",
+		SENPI_CLAUDE_SDK_OAUTH_TOKEN_INJECTION: "ambient",
+		NO_PROXY: "127.0.0.1,localhost",
+		no_proxy: "127.0.0.1,localhost",
+	});
+
+	const sourceRoot = join(ROOT, "packages", "coding-agent", "src");
+	const boundaryModule = await import(
+		pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "sdk-boundary.ts")).href
+	);
+	const baseQuery = boundaryModule.getSdkBoundary().query;
+	boundaryModule.overrideSdkBoundary({
+		query: (input) => {
+			const options = input.options ?? {};
+			// The resident registry always creates its query with an explicit
+			// sessionId plus the replay-user-messages extraArg (session-registry.ts);
+			// the non-resident flatten branch in stream.ts never does either.
+			const resident =
+				typeof options.sessionId === "string" &&
+				options.extraArgs !== undefined &&
+				"replay-user-messages" in options.extraArgs;
+			const record = {
+				index: creations.length + 1,
+				path: resident ? "resident-registry" : "flatten-stream",
+				sessionId: options.sessionId ?? null,
+				resume: options.resume ?? null,
+				forked: options.forkSession === true,
+				payloads: [],
+			};
+			creations.push(record);
+			const prompt = input.prompt;
+			if (typeof prompt === "string") return baseQuery(input);
+			const observed = (async function* () {
+				for await (const message of prompt) {
+					record.payloads.push(message);
+					if (currentTurn) currentTurn.payloads.push({ creation: record.index, path: record.path, message });
+					yield message;
+				}
+			})();
+			return baseQuery({ ...input, prompt: observed });
+		},
+	});
+
+	const { createAgentSession } = await import(pathToFileURL(join(sourceRoot, "index.ts")).href);
+	const created = await createAgentSession({
+		cwd: box.cwd,
+		agentDir: box.agentDir,
+		noTools: "all",
+		autoTitleSessions: false,
+	});
+	session = created.session;
+	const model = session.modelRuntime.getModel("claude-sdk-oauth", MODEL_ID);
+	if (!model) throw new Error("claude-sdk-oauth provider did not register its models");
+	await session.setModel(model);
+
+	for (let index = 1; index <= TURNS; index++) {
+		const creationsBefore = creations.length;
+		const requestsBefore = providerRequests.length;
+		currentTurn = { index, payloads: [] };
+		await withTimeout(
+			session.prompt(`Turn ${index}: reply with TOKEN_T${index}.`, { sessionTitlePrompt: false }),
+			`turn ${index}`,
+			120_000,
+		);
+		const newQueries = creations.slice(creationsBefore);
+		const classified = currentTurn.payloads.map((entry) => classifyPayload(entry.message));
+		turns.push({
+			index,
+			queries: newQueries.length,
+			path: currentTurn.payloads.at(-1)?.path ?? newQueries.at(-1)?.path ?? "none",
+			lineage: creations.at(-1)?.sessionId ?? "none",
+			kind: classified.at(-1)?.kind ?? "none",
+			bytes: classified.reduce((total, item) => total + item.bytes, 0),
+			wireRequests: providerRequests.length - requestsBefore,
+			wireBytes: providerRequests.slice(requestsBefore).reduce((total, item) => total + item.bytes, 0),
+		});
+		currentTurn = null;
+	}
+} catch (error) {
+	fatal = error instanceof Error ? error : new Error(String(error));
+	infrastructureFailure = /loopback|ECONNREFUSED|did not bind/i.test(fatal.message);
+} finally {
+	try {
+		session?.dispose?.();
+	} catch {}
+	if (server) await new Promise((resolve) => server.close(resolve));
+	try {
+		authGuard.assertUnchanged();
+	} catch (error) {
+		fatal = error instanceof Error ? error : new Error(String(error));
+	}
+	box.cleanup();
+}
+
+if (infrastructureFailure) {
+	process.stdout.write(`REJECTED signal=loopback_unreachable detail=${safeDetail(fatal.message)}\n`);
+	process.exit(2);
+}
+
+process.stdout.write(formatTurnTable(turns));
+const lineages = new Set(creations.map((record) => record.sessionId ?? "none"));
+const flattenTurns = turns.filter((turn) => turn.kind === "flatten").length;
+const passed =
+	!fatal && turns.length === TURNS && creations.length === 1 && lineages.size === 1 && flattenTurns === 0;
+if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
+process.stdout.write(
+	`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns}\n`,
+);
+process.exit(BASELINE ? 0 : passed ? 0 : 1);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -213,7 +213,10 @@ try {
 	try {
 		authGuard.assertUnchanged();
 	} catch (error) {
-		fatal = error instanceof Error ? error : new Error(String(error));
+		// Preserve the original error: an auth-assertion failure in teardown
+		// must not overwrite an earlier probe/turn failure (and with it the
+		// already-computed infrastructure classification).
+		fatal = fatal ?? (error instanceof Error ? error : new Error(String(error)));
 	}
 	box.cleanup();
 }

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -224,7 +224,9 @@ if (infrastructureFailure) {
 	process.exitCode = 2;
 } else {
 	process.stdout.write(formatTurnTable(turns));
-	const lineages = new Set(creations.map((record) => record.sessionId ?? "none"));
+	// The single-query budget (creations.length === 1) IS the lineage gate:
+	// with one SDK query creation there is exactly one lineage by
+	// construction, so a separate lineages.size check would be redundant.
 	const flattenTurns = turns.filter((turn) => turn.kind === "flatten").length;
 	// Gate the ROUTE, not just the payload shape: a bootstrap payload on a
 	// non-resident (flatten-stream) query must not masquerade as resident-path.
@@ -242,14 +244,13 @@ if (infrastructureFailure) {
 		!fatal &&
 		turns.length === TURNS &&
 		creations.length === 1 &&
-		lineages.size === 1 &&
 		flattenTurns === 0 &&
 		nonResidentTurns === 0 &&
 		nonDeltaContinuations === 0 &&
 		wireEvidence;
 	if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
 	process.stdout.write(
-		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns} non_delta=${nonDeltaContinuations} wire_reqs=${providerRequests.length}\n`,
+		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns} non_delta=${nonDeltaContinuations} wire_reqs=${providerRequests.length}\n`,
 	);
 	// exitCode, not exit(): a forced exit can truncate the table/verdict when
 	// stdout is a pipe; assigning lets Node flush the QA output first.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -206,6 +206,15 @@ try {
 			fatal.message,
 		);
 } finally {
+	// Close the resident registry entry BEFORE disposing the session: the
+	// resident OAuth query owns its own Claude Code subprocess, and disposing
+	// the session alone does not guarantee that subprocess is reaped.
+	try {
+		const { closeSession } = await import(
+			pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "session-registry.ts")).href
+		);
+		if (session?.id) closeSession(session.id, "probe_shutdown");
+	} catch {}
 	try {
 		session?.dispose?.();
 	} catch {}

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -252,16 +252,21 @@ if (infrastructureFailure) {
 	// Gate the ROUTE, not just the payload shape: a bootstrap payload on a
 	// non-resident (flatten-stream) query must not masquerade as resident-path.
 	const nonResidentTurns = turns.filter((turn) => turn.path !== "resident-registry").length;
+	// The resident happy path is delta-only after turn 1 (bootstrap is the
+	// legitimate first-payload shape): any later non-delta submission means
+	// history was re-synthesized inside a resident session.
+	const nonDeltaContinuations = turns.filter((turn) => turn.index !== 1 && turn.kind !== "delta").length;
 	const passed =
 		!fatal &&
 		turns.length === TURNS &&
 		creations.length === 1 &&
 		lineages.size === 1 &&
 		flattenTurns === 0 &&
-		nonResidentTurns === 0;
+		nonResidentTurns === 0 &&
+		nonDeltaContinuations === 0;
 	if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
 	process.stdout.write(
-		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns}\n`,
+		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns} non_delta=${nonDeltaContinuations}\n`,
 	);
 	// exitCode, not exit(): a forced exit can truncate the table/verdict when
 	// stdout is a pipe; assigning lets Node flush the QA output first.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -31,8 +31,8 @@ import { pathToFileURL } from "node:url";
 import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot, track } from "./lib/common.mjs";
 import {
 	classifyPayload,
+	createModelCaptureHandler,
 	formatTurnTable,
-	loopbackSseBody,
 	safeDetail,
 	seedProbeAgentDir,
 	withTimeout,
@@ -53,9 +53,11 @@ if (process.env[INNER_FLAG] !== "1") {
 	});
 	if (child.error) {
 		process.stderr.write(`probe launcher failed: ${child.error.message}\n`);
-		process.exit(2);
+		// exitCode, not exit(): a forced exit can truncate the diagnostic on a pipe.
+		process.exitCode = 2;
+	} else {
+		process.exitCode = child.status ?? 2;
 	}
-	process.exit(child.status ?? 2);
 }
 
 installCleanupHooks();
@@ -73,58 +75,7 @@ const creations = [];
 let currentTurn = null;
 
 try {
-	server = track(
-		createServer((request, response) => {
-			if (request.method !== "POST") {
-				response.writeHead(200);
-				response.end();
-				return;
-			}
-			// Route-check POSTs: the fixture exists only for Anthropic messages
-			// calls — answering any other POST with a 200 fixture would manufacture
-			// false continuity evidence.
-			if (!request.url?.includes("/messages")) {
-				response.writeHead(404, { "content-type": "application/json" });
-				response.end(JSON.stringify({ error: "unknown_route" }));
-				return;
-			}
-			let raw = "";
-			request.setEncoding("utf8");
-			request.on("data", (chunk) => {
-				raw += chunk;
-			});
-			request.on("end", () => {
-				let body;
-				try {
-					body = JSON.parse(raw);
-				} catch {
-					// Fail closed: a malformed POST must not be answered with the SSE
-					// fixture — that would manufacture false continuity evidence for a
-					// broken request path.
-					response.writeHead(400, { "content-type": "application/json" });
-					response.end(JSON.stringify({ error: "malformed_request" }));
-					return;
-				}
-				if (typeof body.model !== "string" || !Array.isArray(body.messages)) {
-					response.writeHead(400, { "content-type": "application/json" });
-					response.end(JSON.stringify({ error: "malformed_shape" }));
-					return;
-				}
-				// Buffer.byteLength, not raw.length: the column is labeled bytes, and
-				// raw.length counts UTF-16 code units, not HTTP body bytes.
-				providerRequests.push({
-					bytes: Buffer.byteLength(raw, "utf8"),
-					messages: Array.isArray(body.messages) ? body.messages.length : 0,
-				});
-				response.writeHead(200, {
-					"content-type": "text/event-stream",
-					"cache-control": "no-cache",
-					connection: "keep-alive",
-				});
-				response.end(loopbackSseBody(`probe-reply-${providerRequests.length}`, providerRequests.length));
-			});
-		}),
-	);
+	server = track(createServer(createModelCaptureHandler((entry) => providerRequests.push(entry))));
 	await new Promise((resolve, reject) => {
 		server.once("error", reject);
 		server.listen(0, "127.0.0.1", resolve);
@@ -220,13 +171,20 @@ try {
 			120_000,
 		);
 		const newQueries = creations.slice(creationsBefore);
+		// Classify EVERY payload in the turn: the LAST one alone cannot surface a
+		// divergence buried mid-turn. A turn is flatten if ANY payload is, then
+		// bootstrap if ANY is, else delta.
 		const classified = currentTurn.payloads.map((entry) => classifyPayload(entry.message));
 		turns.push({
 			index,
 			queries: newQueries.length,
 			path: currentTurn.payloads.at(-1)?.path ?? newQueries.at(-1)?.path ?? "none",
 			lineage: creations.at(-1)?.sessionId ?? "none",
-			kind: classified.at(-1)?.kind ?? "none",
+			kind: classified.some((item) => item.kind === "flatten")
+				? "flatten"
+				: classified.some((item) => item.kind === "bootstrap")
+					? "bootstrap"
+					: (classified.at(-1)?.kind ?? "none"),
 			bytes: classified.reduce((total, item) => total + item.bytes, 0),
 			wireRequests: providerRequests.length - requestsBefore,
 			wireBytes: providerRequests.slice(requestsBefore).reduce((total, item) => total + item.bytes, 0),

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -159,6 +159,10 @@ try {
 		autoTitleSessions: false,
 	});
 	session = created.session;
+	// Register the session with the cleanup harness: an interrupt after the
+	// Claude session starts must dispose it (reaping the real Claude Code
+	// subprocess) — the finally path only runs on normal completion.
+	track({ exitCode: null, kill: () => session.dispose() });
 	const model = session.modelRuntime.getModel("claude-sdk-oauth", MODEL_ID);
 	if (!model) throw new Error("claude-sdk-oauth provider did not register its models");
 	await session.setModel(model);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -90,7 +90,12 @@ try {
 				try {
 					body = JSON.parse(raw);
 				} catch {
-					body = { messages: [] };
+					// Fail closed: a malformed POST must not be answered with the SSE
+					// fixture — that would manufacture false continuity evidence for a
+					// broken request path.
+					response.writeHead(400, { "content-type": "application/json" });
+					response.end(JSON.stringify({ error: "malformed_request" }));
+					return;
 				}
 				// Buffer.byteLength, not raw.length: the column is labeled bytes, and
 				// raw.length counts UTF-16 code units, not HTTP body bytes.
@@ -217,7 +222,12 @@ try {
 	}
 } catch (error) {
 	fatal = error instanceof Error ? error : new Error(String(error));
-	infrastructureFailure = /loopback|ECONNREFUSED|EADDRINUSE|EACCES|did not bind/i.test(fatal.message);
+	// A missing Claude binary is setup failure (REJECTED exit 2), not a
+	// behavioral continuity FAIL — keep the two distinguishable in CI.
+	infrastructureFailure =
+		/loopback|ECONNREFUSED|EADDRINUSE|EACCES|did not bind|claude_binary_not_found|Native CLI binary.*not found/i.test(
+			fatal.message,
+		);
 } finally {
 	try {
 		session?.dispose?.();

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -34,10 +34,10 @@ import {
 	classifyPayload,
 	createModelCaptureHandler,
 	formatTurnTable,
-	safeDetail,
 	seedProbeAgentDir,
 	withTimeout,
 } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { safeDetail } from "./lib/output-safety.mjs";
 import { stripCredentialEnvironment } from "./lib/claude-sdk-oauth-spike-support.mjs";
 
 const ROOT = repoRoot();
@@ -202,7 +202,7 @@ try {
 	// A missing Claude binary is setup failure (REJECTED exit 2), not a
 	// behavioral continuity FAIL — keep the two distinguishable in CI.
 	infrastructureFailure =
-		/loopback|ECONNREFUSED|EADDRINUSE|EACCES|did not bind|claude_binary_not_found|Native CLI binary.*not found/i.test(
+		/loopback|ECONNREFUSED|EADDRINUSE|EACCES|did not bind|claude_binary_not_found|Native CLI binary.*not found|Claude native binary.*not found/i.test(
 			fatal.message,
 		);
 } finally {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -37,6 +37,7 @@ import {
 	seedProbeAgentDir,
 	withTimeout,
 } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { stripCredentialEnvironment } from "./lib/claude-sdk-oauth-spike-support.mjs";
 
 const ROOT = repoRoot();
 const INNER_FLAG = "SENPI_CLAUDE_SDK_FULLSTACK_PROBE_INNER";
@@ -112,6 +113,13 @@ try {
 	const baseUrl = `http://127.0.0.1:${address.port}`;
 
 	seedProbeAgentDir(box.agentDir);
+	// Hermetic no-credentials contract: ambient Anthropic/OAuth credential and
+	// custom-header channels (inherited from the operator's shell) would
+	// otherwise be sent to the loopback capture server. ANTHROPIC_API_KEY and
+	// ANTHROPIC_BASE_URL are pinned to dummy loopback values below; every other
+	// credential channel is stripped first. The probe re-adds exactly the
+	// SENPI_* surface it needs in the assignment that follows.
+	stripCredentialEnvironment(process.env);
 	Object.assign(process.env, {
 		HOME: box.dir,
 		USERPROFILE: box.dir,

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -25,6 +25,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { writeSync } from "node:fs";
 import { createServer } from "node:http";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -52,12 +53,13 @@ if (process.env[INNER_FLAG] !== "1") {
 		stdio: "inherit",
 	});
 	if (child.error) {
-		process.stderr.write(`probe launcher failed: ${child.error.message}\n`);
-		// exitCode, not exit(): a forced exit can truncate the diagnostic on a pipe.
-		process.exitCode = 2;
-	} else {
-		process.exitCode = child.status ?? 2;
+		// writeSync: a forced exit after an async pipe write can truncate the line.
+		writeSync(2, `probe launcher failed: ${child.error.message}\n`);
+		process.exit(2);
 	}
+	// The outer process must EXIT here: continuing past the launcher would
+	// re-execute the entire probe body (sandbox, server, session, verdict).
+	process.exit(child.status ?? 2);
 }
 
 installCleanupHooks();

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -80,6 +80,14 @@ try {
 				response.end();
 				return;
 			}
+			// Route-check POSTs: the fixture exists only for Anthropic messages
+			// calls — answering any other POST with a 200 fixture would manufacture
+			// false continuity evidence.
+			if (!request.url?.includes("/messages")) {
+				response.writeHead(404, { "content-type": "application/json" });
+				response.end(JSON.stringify({ error: "unknown_route" }));
+				return;
+			}
 			let raw = "";
 			request.setEncoding("utf8");
 			request.on("data", (chunk) => {
@@ -95,6 +103,11 @@ try {
 					// broken request path.
 					response.writeHead(400, { "content-type": "application/json" });
 					response.end(JSON.stringify({ error: "malformed_request" }));
+					return;
+				}
+				if (typeof body.model !== "string" || !Array.isArray(body.messages)) {
+					response.writeHead(400, { "content-type": "application/json" });
+					response.end(JSON.stringify({ error: "malformed_shape" }));
 					return;
 				}
 				// Buffer.byteLength, not raw.length: the column is labeled bytes, and

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -92,7 +92,12 @@ try {
 				} catch {
 					body = { messages: [] };
 				}
-				providerRequests.push({ bytes: raw.length, messages: Array.isArray(body.messages) ? body.messages.length : 0 });
+				// Buffer.byteLength, not raw.length: the column is labeled bytes, and
+				// raw.length counts UTF-16 code units, not HTTP body bytes.
+				providerRequests.push({
+					bytes: Buffer.byteLength(raw, "utf8"),
+					messages: Array.isArray(body.messages) ? body.messages.length : 0,
+				});
 				response.writeHead(200, {
 					"content-type": "text/event-stream",
 					"cache-control": "no-cache",
@@ -234,10 +239,18 @@ if (infrastructureFailure) {
 process.stdout.write(formatTurnTable(turns));
 const lineages = new Set(creations.map((record) => record.sessionId ?? "none"));
 const flattenTurns = turns.filter((turn) => turn.kind === "flatten").length;
+// Gate the ROUTE, not just the payload shape: a bootstrap payload on a
+// non-resident (flatten-stream) query must not masquerade as resident-path.
+const nonResidentTurns = turns.filter((turn) => turn.path !== "resident-registry").length;
 const passed =
-	!fatal && turns.length === TURNS && creations.length === 1 && lineages.size === 1 && flattenTurns === 0;
+	!fatal &&
+	turns.length === TURNS &&
+	creations.length === 1 &&
+	lineages.size === 1 &&
+	flattenTurns === 0 &&
+	nonResidentTurns === 0;
 if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
 process.stdout.write(
-	`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns}\n`,
+	`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns}\n`,
 );
 process.exit(BASELINE ? 0 : passed ? 0 : 1);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -233,24 +233,27 @@ try {
 
 if (infrastructureFailure) {
 	process.stdout.write(`REJECTED signal=loopback_unreachable detail=${safeDetail(fatal.message)}\n`);
-	process.exit(2);
+	// exitCode, not exit(): a forced exit can truncate piped QA output.
+	process.exitCode = 2;
+} else {
+	process.stdout.write(formatTurnTable(turns));
+	const lineages = new Set(creations.map((record) => record.sessionId ?? "none"));
+	const flattenTurns = turns.filter((turn) => turn.kind === "flatten").length;
+	// Gate the ROUTE, not just the payload shape: a bootstrap payload on a
+	// non-resident (flatten-stream) query must not masquerade as resident-path.
+	const nonResidentTurns = turns.filter((turn) => turn.path !== "resident-registry").length;
+	const passed =
+		!fatal &&
+		turns.length === TURNS &&
+		creations.length === 1 &&
+		lineages.size === 1 &&
+		flattenTurns === 0 &&
+		nonResidentTurns === 0;
+	if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
+	process.stdout.write(
+		`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns}\n`,
+	);
+	// exitCode, not exit(): a forced exit can truncate the table/verdict when
+	// stdout is a pipe; assigning lets Node flush the QA output first.
+	process.exitCode = BASELINE ? 0 : passed ? 0 : 1;
 }
-
-process.stdout.write(formatTurnTable(turns));
-const lineages = new Set(creations.map((record) => record.sessionId ?? "none"));
-const flattenTurns = turns.filter((turn) => turn.kind === "flatten").length;
-// Gate the ROUTE, not just the payload shape: a bootstrap payload on a
-// non-resident (flatten-stream) query must not masquerade as resident-path.
-const nonResidentTurns = turns.filter((turn) => turn.path !== "resident-registry").length;
-const passed =
-	!fatal &&
-	turns.length === TURNS &&
-	creations.length === 1 &&
-	lineages.size === 1 &&
-	flattenTurns === 0 &&
-	nonResidentTurns === 0;
-if (fatal) process.stderr.write(`PROBE ERROR: ${safeDetail(fatal.stack ?? fatal.message)}\n`);
-process.stdout.write(
-	`VERDICT: ${passed ? "PASS" : "FAIL"} fullstack-baseline queries=${creations.length} lineages=${lineages.size} flatten_turns=${flattenTurns} non_resident=${nonResidentTurns}\n`,
-);
-process.exit(BASELINE ? 0 : passed ? 0 : 1);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-fullstack-probe.mjs
@@ -204,7 +204,7 @@ try {
 	}
 } catch (error) {
 	fatal = error instanceof Error ? error : new Error(String(error));
-	infrastructureFailure = /loopback|ECONNREFUSED|did not bind/i.test(fatal.message);
+	infrastructureFailure = /loopback|ECONNREFUSED|EADDRINUSE|EACCES|did not bind/i.test(fatal.message);
 } finally {
 	try {
 		session?.dispose?.();

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -50,6 +50,10 @@ if (loaded.error) reject(loaded.error);
 const FIRST_MODEL = "claude-haiku-4-5";
 const SECOND_MODEL = "claude-sonnet-4-5";
 const MEMORY_TOKEN = `SPIKE_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+// Every reject path that can carry an SDK error string redacts the access
+// token and the generated recall token first — safeSignal is a shape
+// sanitizer, not a secret redactor.
+const SECRETS = [loaded.credential.access, MEMORY_TOKEN];
 
 // Setup runs inside the guarded path: an SDK import, a missing Claude binary or
 // a query-construction failure must exit through the sanitized REJECTED
@@ -76,7 +80,18 @@ try {
 		},
 	});
 } catch (error) {
-	reject(error instanceof Error ? error.message : String(error));
+	reject(error instanceof Error ? error.message : String(error), "", SECRETS);
+}
+
+// Signal-aware cleanup: Ctrl-C/SIGTERM skips `finally`, so without a handler
+// the Claude Code subprocess would be orphaned mid-turn and keep burning
+// quota. Closing the query handle reaps the subprocess before exiting.
+for (const signal of ["SIGINT", "SIGTERM"]) {
+	process.once(signal, () => {
+		input.close();
+		closeQuietly(stream);
+		reject(`interrupted_${signal.toLowerCase()}`, "", SECRETS);
+	});
 }
 
 const state = {
@@ -93,11 +108,6 @@ const state = {
 	failure: null,
 	turn: 1,
 };
-let resolveDone;
-const done = new Promise((resolve) => {
-	resolveDone = resolve;
-});
-
 function recordModel(message) {
 	if (message.type === "assistant" && typeof message.message?.model === "string") {
 		state.models[state.turn] = message.message.model;
@@ -204,14 +214,13 @@ async function consume() {
 		}
 		if (state.turn === 4) break;
 	}
-	resolveDone();
 }
 
 let outcome = null;
 try {
-	// Await the consumer itself, not just `done`: a rejected consumer would
-	// otherwise be dropped and surface 240s later as a meaningless timeout.
-	await withTimeout(Promise.race([consume(), done]), "spike", 240_000);
+	// Await the consumer itself: a rejected consumer surfaces its real error
+	// immediately, and withTimeout is what actually bounds a hang.
+	await withTimeout(consume(), "spike", 240_000);
 } catch (error) {
 	outcome = error instanceof Error ? error.message : String(error);
 } finally {
@@ -219,8 +228,8 @@ try {
 	closeQuietly(stream);
 }
 
-if (outcome) reject(outcome);
-if (state.failure) reject(state.failure);
+if (outcome) reject(outcome, "", SECRETS);
+if (state.failure) reject(state.failure, "", SECRETS);
 if (state.sessionIds.size !== 1) reject("session_lineage_split");
 if (state.interruptReceipt === "failed") reject("interrupt_failed");
 if (state.interruptReceipt === "pending") reject("interrupt_never_issued");

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -39,7 +39,7 @@ import {
 	requireLiveGate,
 	requireSandbox,
 	userMessage,
-	withDeadline,
+	withTimeout,
 } from "./lib/claude-sdk-oauth-spike-support.mjs";
 
 requireLiveGate();
@@ -148,9 +148,12 @@ async function consume() {
 			if (message.error) state.failure ??= "assistant_error";
 			if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
 			if (state.turn === 3) {
-				// The turn finalized without a single streamed delta to interrupt from.
-				await interruptTurn3();
-				continue;
+				// The turn finalized without a single streamed delta to interrupt
+				// from. Interrupting now would cancel an already-complete turn, and
+				// an accepted receipt would be a false positive — the spike proved
+				// nothing about interruption, so it must REJECT.
+				state.failure ??= "interrupt_delta_absent";
+				break;
 			}
 			if (state.turn === 4 && assistantText(message).includes(MEMORY_TOKEN)) state.coherent = true;
 		}
@@ -191,7 +194,7 @@ let outcome = null;
 try {
 	// Await the consumer itself, not just `done`: a rejected consumer would
 	// otherwise be dropped and surface 240s later as a meaningless timeout.
-	await withDeadline(Promise.race([consume(), done]), "spike", 240_000);
+	await withTimeout(Promise.race([consume(), done]), "spike", 240_000);
 } catch (error) {
 	outcome = error instanceof Error ? error.message : String(error);
 } finally {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -150,7 +150,7 @@ async function consume() {
 			recordModel(message);
 			if (message.error) state.failure ??= "assistant_error";
 			if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
-			if (state.turn === 3) {
+			if (state.turn === 3 && !state.interruptIssued) {
 				// The turn finalized without a single streamed delta to interrupt
 				// from. Interrupting now would cancel an already-complete turn, and
 				// an accepted receipt would be a false positive — the spike proved
@@ -158,6 +158,10 @@ async function consume() {
 				state.failure ??= "interrupt_delta_absent";
 				break;
 			}
+			// When the interrupt WAS issued, the residual turn-3 assistant message
+			// is expected: it is recorded as turn 3 above and skipped here — never
+			// fed through the turn-4 coherence scan below.
+			if (state.turn === 3) continue;
 			if (state.turn === 4 && assistantText(message).includes(MEMORY_TOKEN)) state.coherent = true;
 		}
 		if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Live spike: in-session mechanisms of one resident streaming-input query
+ * (Wave A todo 2).
+ *
+ * One query, four turns:
+ *   turn 1  normal exchange, records the system/init session_id + capabilities
+ *   setModel(<other claude model>) between turns
+ *   turn 2  asserts the SAME session_id and that the response model changed
+ *   turn 3  interrupted mid-flight; the interrupt receipt shape is recorded
+ *           (still_queued present => interrupt_receipt_v1, undefined => legacy)
+ *   turn 4  continuation on the SAME query; coherence is proven by the model
+ *           recalling the turn-1 token
+ *
+ * Usage:
+ *   SENPI_LIVE_CLAUDE_SDK_OAUTH=1 SENPI_CODING_AGENT_DIR=<sandbox> \
+ *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+ *
+ * Outcomes (final line):
+ *   exit 0 "ACCEPTED setmodel=<ok|absent> interrupt_receipt=<v1|legacy> continue=<coherent|degraded>"
+ *   exit 2 "REJECTED signal=<sanitized>"
+ * Never prints token material.
+ */
+import { randomUUID } from "node:crypto";
+import {
+	assistantText,
+	claudeExecutable,
+	closeQuietly,
+	controlledInput,
+	importClaudeSdk,
+	loadCredential,
+	managedEnvironment,
+	reject,
+	requireLiveGate,
+	requireSandbox,
+	userMessage,
+	withDeadline,
+} from "./lib/claude-sdk-oauth-spike-support.mjs";
+
+requireLiveGate();
+const sandbox = requireSandbox();
+const loaded = loadCredential(sandbox);
+if (loaded.error) reject(loaded.error);
+
+const FIRST_MODEL = "claude-haiku-4-5";
+const SECOND_MODEL = "claude-sonnet-4-5";
+const MEMORY_TOKEN = `SPIKE_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+
+const { query } = await importClaudeSdk();
+const input = controlledInput(
+	userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
+);
+
+const stream = query({
+	prompt: input,
+	options: {
+		model: FIRST_MODEL,
+		tools: [],
+		permissionMode: "dontAsk",
+		settingSources: [],
+		includePartialMessages: true,
+		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+		pathToClaudeCodeExecutable: claudeExecutable(),
+		env: managedEnvironment(loaded.credential.access),
+	},
+});
+
+const state = {
+	sessionIds: new Set(),
+	models: [],
+	interruptReceipt: "legacy",
+	interruptError: null,
+	setModelError: false,
+	pendingInterruptResult: false,
+	coherent: false,
+	failure: null,
+	turn: 1,
+};
+let resolveDone;
+const done = new Promise((resolve) => {
+	resolveDone = resolve;
+});
+
+function recordModel(message) {
+	if (message.type === "assistant" && typeof message.message?.model === "string") {
+		state.models[state.turn] = message.message.model;
+	}
+}
+
+async function interruptTurn3() {
+	try {
+		const receipt = await stream.interrupt();
+		state.interruptReceipt = receipt && Array.isArray(receipt.still_queued) ? "v1" : "legacy";
+	} catch (error) {
+		state.interruptReceipt = "legacy";
+		state.interruptError = error instanceof Error ? error.message : String(error);
+	}
+	state.turn = 4;
+	state.pendingInterruptResult = true;
+	input.push(
+		userMessage(
+			"Stop counting. Repeat the token I asked you to remember at the very start, prefixed with RECALL.",
+			randomUUID(),
+		),
+	);
+}
+
+async function consume() {
+	for await (const message of stream) {
+		if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
+			state.sessionIds.add(message.session_id);
+		}
+		if (message.type === "assistant") {
+			recordModel(message);
+			if (message.error) state.failure ??= "assistant_error";
+			if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
+			if (state.turn === 3) {
+				await interruptTurn3();
+				continue;
+			}
+			if (state.turn === 4 && assistantText(message).includes(MEMORY_TOKEN)) state.coherent = true;
+		}
+		if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
+		if (message.type !== "result") continue;
+		// A 401/refusal arrives as subtype:"success" with is_error:true, so both
+		// fields gate the turn. The interrupted turn's own terminal result is
+		// expected to be non-success and is consumed once.
+		const interrupted = state.pendingInterruptResult;
+		state.pendingInterruptResult = false;
+		if ((message.subtype !== "success" || message.is_error === true) && !interrupted) {
+			state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
+			break;
+		}
+		if (state.turn === 1) {
+			try {
+				await stream.setModel(SECOND_MODEL);
+			} catch {
+				state.setModelError = true;
+			}
+			state.turn = 2;
+			input.push(userMessage("Reply with exactly: SECOND", randomUUID()));
+			continue;
+		}
+		if (state.turn === 2) {
+			state.turn = 3;
+			input.push(
+				userMessage("Count slowly from 1 to 40, one number per line, no other text.", randomUUID()),
+			);
+			continue;
+		}
+		if (state.turn === 4 && !interrupted) break;
+	}
+	resolveDone();
+}
+
+let outcome = null;
+try {
+	void consume();
+	await withDeadline(done, "spike", 240_000);
+} catch (error) {
+	outcome = error instanceof Error ? error.message : String(error);
+} finally {
+	input.close();
+	closeQuietly(stream);
+}
+
+if (outcome) reject(outcome);
+if (state.failure) reject(state.failure);
+if (state.sessionIds.size !== 1) reject("session_lineage_split");
+
+const setModel =
+	state.setModelError || state.models[2] === undefined
+		? "absent"
+		: state.models[2] !== state.models[1]
+			? "ok"
+			: "absent";
+const continueOutcome = state.coherent ? "coherent" : "degraded";
+console.log(
+	`ACCEPTED setmodel=${setModel} interrupt_receipt=${state.interruptReceipt} continue=${continueOutcome}`,
+);
+process.exit(0);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -107,6 +107,11 @@ function recordModel(message) {
 async function interruptTurn3() {
 	if (state.interruptIssued) return;
 	state.interruptIssued = true;
+	// Mark the pending interrupted result BEFORE awaiting the receipt, and leave
+	// state.turn at 3: the counter only advances on terminal results, so the
+	// interrupted turn's residual assistant message is recorded as turn 3 (not
+	// misfiled as turn 4) and never fed through the turn-4 coherence scan.
+	state.pendingInterruptResult = true;
 	try {
 		const receipt = await stream.interrupt();
 		state.interruptReceipt = receipt && Array.isArray(receipt.still_queued) ? "v1" : "legacy";
@@ -116,8 +121,6 @@ async function interruptTurn3() {
 		state.interruptReceipt = "failed";
 		state.interruptError = error instanceof Error ? error.message : String(error);
 	}
-	state.turn = 4;
-	state.pendingInterruptResult = true;
 	input.push(
 		userMessage(
 			"Stop counting. Repeat the token I asked you to remember at the very start, prefixed with RECALL.",
@@ -160,11 +163,21 @@ async function consume() {
 		if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
 		if (message.type !== "result") continue;
 		// A 401/refusal arrives as subtype:"success" with is_error:true, so both
-		// fields gate the turn. The interrupted turn's own terminal result is
-		// expected to be non-success and is consumed once.
+		// fields gate the turn.
 		const interrupted = state.pendingInterruptResult;
 		state.pendingInterruptResult = false;
-		if ((message.subtype !== "success" || message.is_error === true) && !interrupted) {
+		if (interrupted) {
+			// The interrupted turn's terminal result must be NON-success: a clean
+			// success means the turn completed normally and the interrupt cancelled
+			// nothing, so the receipt would be a false positive.
+			if (message.subtype === "success" && message.is_error !== true) {
+				state.failure ??= "interrupt_ineffective";
+				break;
+			}
+			state.turn = 4;
+			continue;
+		}
+		if (message.subtype !== "success" || message.is_error === true) {
 			state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
 			break;
 		}
@@ -185,7 +198,7 @@ async function consume() {
 			);
 			continue;
 		}
-		if (state.turn === 4 && !interrupted) break;
+		if (state.turn === 4) break;
 	}
 	resolveDone();
 }

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -32,11 +32,9 @@ import {
 	closeQuietly,
 	loadCredential,
 	managedEnvironment,
-	redactSecrets,
 	reject,
 	requireLiveGate,
 	requireSandbox,
-	safeSignal,
 	startGuardedQuery,
 	userMessage,
 	withTimeout,
@@ -252,11 +250,9 @@ if (outcome) reject(outcome, "", SECRETS);
 // branch would otherwise emit a bare interrupt_failed and drop the captured
 // (redacted + sanitized) diagnostic.
 if (state.interruptReceipt === "failed") {
-	reject(
-		"interrupt_failed",
-		state.interruptError ? `detail=${safeSignal(redactSecrets(state.interruptError, SECRETS))}` : "",
-		SECRETS,
-	);
+	// reject() sanitizes and redacts the detail itself — no caller may append
+	// raw error text to the contract line.
+	reject("interrupt_failed", state.interruptError ?? "", SECRETS);
 }
 if (state.failure) reject(state.failure, "", SECRETS);
 if (state.sessionIds.size !== 1) reject("session_lineage_split");

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -259,6 +259,9 @@ if (state.interruptReceipt === "pending") reject("interrupt_never_issued");
 // before turn 4's successful terminal result means the continuation never
 // completed, so the spike cannot ACCEPT.
 if (!state.continuationResult) reject("continuation_incomplete");
+// A failed turn-4 recall means the continuation did not prove continuity —
+// the spike must not ACCEPT a degraded continuation as success.
+if (!state.coherent) reject("continuation_incoherent", "", SECRETS);
 
 const setModel =
 	state.setModelError || state.models[2] === undefined

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -85,6 +85,7 @@ const state = {
 	setModelError: false,
 	pendingInterruptResult: false,
 	coherent: false,
+	continuationQueued: false,
 	continuationResult: false,
 	interruptAbortedEvidence: false,
 	failure: null,
@@ -122,12 +123,10 @@ async function interruptTurn3() {
 		closeQuietly(stream);
 		return;
 	}
-	input.push(
-		userMessage(
-			"Stop counting. Repeat the token I asked you to remember at the very start, prefixed with RECALL.",
-			randomUUID(),
-		),
-	);
+	// The continuation is NOT pushed here: it is queued only when the
+	// interrupted turn's terminal result arrives (see the result gate), so the
+	// handoff never depends on SDK message-ordering assumptions.
+	state.continuationQueued = true;
 }
 
 async function consume() {
@@ -196,6 +195,18 @@ async function consume() {
 				break;
 			}
 			state.turn = 4;
+			// The continuation is queued HERE — after the interrupted turn's
+			// terminal result — so turn bookkeeping never assumes the SDK
+			// delivers queued input after the current turn's result.
+			if (state.continuationQueued) {
+				state.continuationQueued = false;
+				input.push(
+					userMessage(
+						"Stop counting. Repeat the token I asked you to remember at the very start, prefixed with RECALL.",
+						randomUUID(),
+					),
+				);
+			}
 			continue;
 		}
 		if (message.subtype !== "success" || message.is_error === true) {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -148,6 +148,10 @@ async function consume() {
 			!state.interruptIssued
 		) {
 			await interruptTurn3();
+			// A failed interrupt closes the input and the stream: iterating
+			// further would surface the SDK's closed-stream rejection as the
+			// outcome and bury the actual interrupt_failed signal.
+			if (state.failure) break;
 			continue;
 		}
 		if (message.type === "assistant") {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -20,7 +20,7 @@
  *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
  *
  * Outcomes (final line):
- *   exit 0 "ACCEPTED setmodel=<ok|absent> interrupt_receipt=<v1|legacy> continue=<coherent|degraded>"
+ *   exit 0 "ACCEPTED setmodel=<ok|absent> interrupt_receipt=<v1|legacy> continue=coherent"
  *   exit 2 "REJECTED signal=<sanitized>"
  * An interrupt that never happened REJECTS (interrupt_failed) instead of being
  * reported as a legacy receipt — a spike that proved nothing must not ACCEPT.
@@ -29,13 +29,14 @@
 import { randomUUID } from "node:crypto";
 import {
 	assistantText,
-	claudeExecutable,
 	closeQuietly,
 	loadCredential,
 	managedEnvironment,
+	redactSecrets,
 	reject,
 	requireLiveGate,
 	requireSandbox,
+	safeSignal,
 	startGuardedQuery,
 	userMessage,
 	withTimeout,
@@ -70,7 +71,6 @@ const { input, stream } = await startGuardedQuery({
 		settingSources: [],
 		includePartialMessages: true,
 		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-		pathToClaudeCodeExecutable: claudeExecutable(),
 		env: managedEnvironment(loaded.credential.access),
 	},
 	secrets: SECRETS,
@@ -88,6 +88,7 @@ const state = {
 	pendingInterruptResult: false,
 	coherent: false,
 	continuationResult: false,
+	interruptAbortedEvidence: false,
 	failure: null,
 	turn: 1,
 };
@@ -166,8 +167,13 @@ async function consume() {
 			}
 			// When the interrupt WAS issued, the residual turn-3 assistant message
 			// is expected: it is recorded as turn 3 above and skipped here — never
-			// fed through the turn-4 coherence scan below.
-			if (state.turn === 3) continue;
+			// fed through the turn-4 coherence scan below. Its aborted:true marker
+			// (sdk.d.ts:2873) is the interrupt-specific evidence that separates a
+			// real cancellation from a turn-3 refusal/execution failure.
+			if (state.turn === 3) {
+				if (message.aborted === true) state.interruptAbortedEvidence = true;
+				continue;
+			}
 			if (state.turn === 4 && assistantText(message).includes(MEMORY_TOKEN)) state.coherent = true;
 		}
 		if (message.type === "auth_status" && message.error) state.failure ??= "authentication_failed";
@@ -182,6 +188,13 @@ async function consume() {
 			// nothing, so the receipt would be a false positive.
 			if (message.subtype === "success" && message.is_error !== true) {
 				state.failure ??= "interrupt_ineffective";
+				break;
+			}
+			// A non-success alone is not interrupt evidence: a turn-3 refusal or
+			// execution failure would also be non-success. The residual assistant
+			// message must carry the SDK's aborted:true marker.
+			if (!state.interruptAbortedEvidence) {
+				state.failure ??= "interrupt_evidence_absent";
 				break;
 			}
 			state.turn = 4;
@@ -235,7 +248,15 @@ try {
 if (outcome) reject(outcome, "", SECRETS);
 if (state.failure) reject(state.failure, "", SECRETS);
 if (state.sessionIds.size !== 1) reject("session_lineage_split");
-if (state.interruptReceipt === "failed") reject("interrupt_failed");
+if (state.interruptReceipt === "failed") {
+	// Surface the captured interrupt error (redacted + sanitized) instead of a
+	// bare interrupt_failed that hides the actual cause.
+	reject(
+		"interrupt_failed",
+		state.interruptError ? `detail=${safeSignal(redactSecrets(state.interruptError, SECRETS))}` : "",
+		SECRETS,
+	);
+}
 if (state.interruptReceipt === "pending") reject("interrupt_never_issued");
 // A coherent turn-4 assistant message is not enough: the iterator ending
 // before turn 4's successful terminal result means the continuation never
@@ -251,9 +272,10 @@ const setModel =
 		: state.models[2] !== state.models[1]
 			? "ok"
 			: "absent";
-const continueOutcome = state.coherent ? "coherent" : "degraded";
+// continue is always coherent here: a failed recall rejected above, so the
+// degraded branch is unreachable by construction.
 console.log(
-	`ACCEPTED setmodel=${setModel} interrupt_receipt=${state.interruptReceipt} continue=${continueOutcome}`,
+	`ACCEPTED setmodel=${setModel} interrupt_receipt=${state.interruptReceipt} continue=coherent`,
 );
 // exitCode, not exit(): a forced exit can truncate the ACCEPTED line when
 // stdout is a pipe; assigning lets Node flush the QA output first.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -105,6 +105,7 @@ const state = {
 	setModelError: false,
 	pendingInterruptResult: false,
 	coherent: false,
+	continuationResult: false,
 	failure: null,
 	turn: 1,
 };
@@ -127,9 +128,15 @@ async function interruptTurn3() {
 		state.interruptReceipt = receipt && Array.isArray(receipt.still_queued) ? "v1" : "legacy";
 	} catch (error) {
 		// Distinct from "legacy": interruption never happened, so nothing downstream
-		// can be trusted and the spike must REJECT rather than ACCEPT.
+		// can be trusted and the spike must REJECT rather than ACCEPT. Stop driving
+		// the query immediately — queueing the continuation would spend a live
+		// model call (and can hang) before the intended interrupt_failed rejection.
 		state.interruptReceipt = "failed";
 		state.interruptError = error instanceof Error ? error.message : String(error);
+		state.pendingInterruptResult = false;
+		state.failure ??= "interrupt_failed";
+		input.close();
+		return;
 	}
 	input.push(
 		userMessage(
@@ -212,7 +219,10 @@ async function consume() {
 			);
 			continue;
 		}
-		if (state.turn === 4) break;
+		if (state.turn === 4) {
+			state.continuationResult = true;
+			break;
+		}
 	}
 }
 
@@ -233,6 +243,10 @@ if (state.failure) reject(state.failure, "", SECRETS);
 if (state.sessionIds.size !== 1) reject("session_lineage_split");
 if (state.interruptReceipt === "failed") reject("interrupt_failed");
 if (state.interruptReceipt === "pending") reject("interrupt_never_issued");
+// A coherent turn-4 assistant message is not enough: the iterator ending
+// before turn 4's successful terminal result means the continuation never
+// completed, so the spike cannot ACCEPT.
+if (!state.continuationResult) reject("continuation_incomplete");
 
 const setModel =
 	state.setModelError || state.models[2] === undefined
@@ -244,4 +258,6 @@ const continueOutcome = state.coherent ? "coherent" : "degraded";
 console.log(
 	`ACCEPTED setmodel=${setModel} interrupt_receipt=${state.interruptReceipt} continue=${continueOutcome}`,
 );
-process.exit(0);
+// exitCode, not exit(): a forced exit can truncate the ACCEPTED line when
+// stdout is a pipe; assigning lets Node flush the QA output first.
+process.exitCode = 0;

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -239,6 +239,14 @@ async function consume() {
 			);
 			continue;
 		}
+		if (state.turn === 3) {
+			// A turn-3 success that never went through the interrupt path (no
+			// delta, no assistant content) means the spike never exercised
+			// interruption — reject with the precise signal, not a downstream
+			// continuation_incomplete.
+			state.failure ??= "interrupt_never_issued";
+			break;
+		}
 		if (state.turn === 4) {
 			state.continuationResult = true;
 			break;

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -31,13 +31,12 @@ import {
 	assistantText,
 	claudeExecutable,
 	closeQuietly,
-	controlledInput,
-	importClaudeSdk,
 	loadCredential,
 	managedEnvironment,
 	reject,
 	requireLiveGate,
 	requireSandbox,
+	startGuardedQuery,
 	userMessage,
 	withTimeout,
 } from "./lib/claude-sdk-oauth-spike-support.mjs";
@@ -55,44 +54,27 @@ const MEMORY_TOKEN = `SPIKE_${randomUUID().replaceAll("-", "").slice(0, 10).toUp
 // sanitizer, not a secret redactor.
 const SECRETS = [loaded.credential.access, MEMORY_TOKEN];
 
-// Setup runs inside the guarded path: an SDK import, a missing Claude binary or
-// a query-construction failure must exit through the sanitized REJECTED
-// contract, never as a raw stack trace on exit 1.
-let query;
-let input;
-let stream;
-try {
-	({ query } = await importClaudeSdk());
-	input = controlledInput(
-		userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
-	);
-	stream = query({
-		prompt: input,
-		options: {
-			model: FIRST_MODEL,
-			tools: [],
-			permissionMode: "dontAsk",
-			settingSources: [],
-			includePartialMessages: true,
-			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-			pathToClaudeCodeExecutable: claudeExecutable(),
-			env: managedEnvironment(loaded.credential.access),
-		},
-	});
-} catch (error) {
-	reject(error instanceof Error ? error.message : String(error), "", SECRETS);
-}
-
-// Signal-aware cleanup: Ctrl-C/SIGTERM skips `finally`, so without a handler
-// the Claude Code subprocess would be orphaned mid-turn and keep burning
-// quota. Closing the query handle reaps the subprocess before exiting.
-for (const signal of ["SIGINT", "SIGTERM"]) {
-	process.once(signal, () => {
-		input.close();
-		closeQuietly(stream);
-		reject(`interrupted_${signal.toLowerCase()}`, "", SECRETS);
-	});
-}
+// Guarded setup + signal-aware cleanup live in spike-support: handlers are
+// installed BEFORE setup (a signal during SDK import/binary resolution is
+// covered), setup failures exit through the sanitized REJECTED contract, and
+// the handlers reap the subprocess before exiting.
+const { input, stream } = await startGuardedQuery({
+	firstMessage: userMessage(
+		`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`,
+		randomUUID(),
+	),
+	options: {
+		model: FIRST_MODEL,
+		tools: [],
+		permissionMode: "dontAsk",
+		settingSources: [],
+		includePartialMessages: true,
+		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+		pathToClaudeCodeExecutable: claudeExecutable(),
+		env: managedEnvironment(loaded.credential.access),
+	},
+	secrets: SECRETS,
+});
 
 const state = {
 	sessionIds: new Set(),

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -7,8 +7,11 @@
  *   turn 1  normal exchange, records the system/init session_id + capabilities
  *   setModel(<other claude model>) between turns
  *   turn 2  asserts the SAME session_id and that the response model changed
- *   turn 3  interrupted mid-flight; the interrupt receipt shape is recorded
- *           (still_queued present => interrupt_receipt_v1, undefined => legacy)
+ *   turn 3  interrupted mid-flight — the interrupt is issued from the FIRST
+ *           streamed content delta, while the model is still producing output,
+ *           so the spike actually exercises interruption instead of cancelling
+ *           an already-finished turn; the receipt shape is recorded
+ *           (still_queued present => v1, undefined => legacy, throw => failed)
  *   turn 4  continuation on the SAME query; coherence is proven by the model
  *           recalling the turn-1 token
  *
@@ -19,6 +22,8 @@
  * Outcomes (final line):
  *   exit 0 "ACCEPTED setmodel=<ok|absent> interrupt_receipt=<v1|legacy> continue=<coherent|degraded>"
  *   exit 2 "REJECTED signal=<sanitized>"
+ * An interrupt that never happened REJECTS (interrupt_failed) instead of being
+ * reported as a legacy receipt — a spike that proved nothing must not ACCEPT.
  * Never prints token material.
  */
 import { randomUUID } from "node:crypto";
@@ -46,30 +51,42 @@ const FIRST_MODEL = "claude-haiku-4-5";
 const SECOND_MODEL = "claude-sonnet-4-5";
 const MEMORY_TOKEN = `SPIKE_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
 
-const { query } = await importClaudeSdk();
-const input = controlledInput(
-	userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
-);
-
-const stream = query({
-	prompt: input,
-	options: {
-		model: FIRST_MODEL,
-		tools: [],
-		permissionMode: "dontAsk",
-		settingSources: [],
-		includePartialMessages: true,
-		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-		pathToClaudeCodeExecutable: claudeExecutable(),
-		env: managedEnvironment(loaded.credential.access),
-	},
-});
+// Setup runs inside the guarded path: an SDK import, a missing Claude binary or
+// a query-construction failure must exit through the sanitized REJECTED
+// contract, never as a raw stack trace on exit 1.
+let query;
+let input;
+let stream;
+try {
+	({ query } = await importClaudeSdk());
+	input = controlledInput(
+		userMessage(`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`, randomUUID()),
+	);
+	stream = query({
+		prompt: input,
+		options: {
+			model: FIRST_MODEL,
+			tools: [],
+			permissionMode: "dontAsk",
+			settingSources: [],
+			includePartialMessages: true,
+			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+			pathToClaudeCodeExecutable: claudeExecutable(),
+			env: managedEnvironment(loaded.credential.access),
+		},
+	});
+} catch (error) {
+	reject(error instanceof Error ? error.message : String(error));
+}
 
 const state = {
 	sessionIds: new Set(),
 	models: [],
-	interruptReceipt: "legacy",
+	// "pending" until an interrupt actually resolves; a throw records "failed" so
+	// a failed interrupt can never masquerade as a supported legacy receipt.
+	interruptReceipt: "pending",
 	interruptError: null,
+	interruptIssued: false,
 	setModelError: false,
 	pendingInterruptResult: false,
 	coherent: false,
@@ -88,11 +105,15 @@ function recordModel(message) {
 }
 
 async function interruptTurn3() {
+	if (state.interruptIssued) return;
+	state.interruptIssued = true;
 	try {
 		const receipt = await stream.interrupt();
 		state.interruptReceipt = receipt && Array.isArray(receipt.still_queued) ? "v1" : "legacy";
 	} catch (error) {
-		state.interruptReceipt = "legacy";
+		// Distinct from "legacy": interruption never happened, so nothing downstream
+		// can be trusted and the spike must REJECT rather than ACCEPT.
+		state.interruptReceipt = "failed";
 		state.interruptError = error instanceof Error ? error.message : String(error);
 	}
 	state.turn = 4;
@@ -110,11 +131,24 @@ async function consume() {
 		if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
 			state.sessionIds.add(message.session_id);
 		}
+		// Interrupt from the first STREAMED content delta of turn 3: the model is
+		// mid-output there. Waiting for the finalized assistant message would cancel
+		// an already-complete turn and prove nothing about interruption.
+		if (
+			state.turn === 3 &&
+			message.type === "stream_event" &&
+			message.event?.type === "content_block_delta" &&
+			!state.interruptIssued
+		) {
+			await interruptTurn3();
+			continue;
+		}
 		if (message.type === "assistant") {
 			recordModel(message);
 			if (message.error) state.failure ??= "assistant_error";
 			if (message.message?.model === "<synthetic>") state.failure ??= "synthetic_assistant";
 			if (state.turn === 3) {
+				// The turn finalized without a single streamed delta to interrupt from.
 				await interruptTurn3();
 				continue;
 			}
@@ -155,8 +189,9 @@ async function consume() {
 
 let outcome = null;
 try {
-	void consume();
-	await withDeadline(done, "spike", 240_000);
+	// Await the consumer itself, not just `done`: a rejected consumer would
+	// otherwise be dropped and surface 240s later as a meaningless timeout.
+	await withDeadline(Promise.race([consume(), done]), "spike", 240_000);
 } catch (error) {
 	outcome = error instanceof Error ? error.message : String(error);
 } finally {
@@ -167,6 +202,8 @@ try {
 if (outcome) reject(outcome);
 if (state.failure) reject(state.failure);
 if (state.sessionIds.size !== 1) reject("session_lineage_split");
+if (state.interruptReceipt === "failed") reject("interrupt_failed");
+if (state.interruptReceipt === "pending") reject("interrupt_never_issued");
 
 const setModel =
 	state.setModelError || state.models[2] === undefined

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -59,7 +59,7 @@ const SECRETS = [loaded.credential.access, MEMORY_TOKEN];
 // installed BEFORE setup (a signal during SDK import/binary resolution is
 // covered), setup failures exit through the sanitized REJECTED contract, and
 // the handlers reap the subprocess before exiting.
-const { input, stream } = await startGuardedQuery({
+const { input, stream, disarm } = await startGuardedQuery({
 	firstMessage: userMessage(
 		`Remember this token for later: ${MEMORY_TOKEN}. Reply with exactly: ACK`,
 		randomUUID(),
@@ -243,20 +243,23 @@ try {
 } finally {
 	input.close();
 	closeQuietly(stream);
+	disarm();
 }
 
 if (outcome) reject(outcome, "", SECRETS);
-if (state.failure) reject(state.failure, "", SECRETS);
-if (state.sessionIds.size !== 1) reject("session_lineage_split");
+// The dedicated interrupt-failure branch runs BEFORE the generic failure
+// rejection: state.failure is also set on interrupt failure, and the generic
+// branch would otherwise emit a bare interrupt_failed and drop the captured
+// (redacted + sanitized) diagnostic.
 if (state.interruptReceipt === "failed") {
-	// Surface the captured interrupt error (redacted + sanitized) instead of a
-	// bare interrupt_failed that hides the actual cause.
 	reject(
 		"interrupt_failed",
 		state.interruptError ? `detail=${safeSignal(redactSecrets(state.interruptError, SECRETS))}` : "",
 		SECRETS,
 	);
 }
+if (state.failure) reject(state.failure, "", SECRETS);
+if (state.sessionIds.size !== 1) reject("session_lineage_split");
 if (state.interruptReceipt === "pending") reject("interrupt_never_issued");
 // A coherent turn-4 assistant message is not enough: the iterator ending
 // before turn 4's successful terminal result means the continuation never

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-native-inline-spike.mjs
@@ -136,6 +136,9 @@ async function interruptTurn3() {
 		state.pendingInterruptResult = false;
 		state.failure ??= "interrupt_failed";
 		input.close();
+		// Reap the query handle immediately: without this the live query keeps
+		// running (and burning quota) until the 240s spike deadline.
+		closeQuietly(stream);
 		return;
 	}
 	input.push(
@@ -148,6 +151,10 @@ async function interruptTurn3() {
 
 async function consume() {
 	for await (const message of stream) {
+		// Record the session id from EVERY message that carries one — a lineage
+		// split on a non-init message must trip the stability assertion, not
+		// slip past an init-only set.
+		if (typeof message.session_id === "string") state.sessionIds.add(message.session_id);
 		if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
 			state.sessionIds.add(message.session_id);
 		}
@@ -199,7 +206,12 @@ async function consume() {
 			continue;
 		}
 		if (message.subtype !== "success" || message.is_error === true) {
-			state.failure ??= message.subtype ?? message.terminal_reason ?? "result_error";
+			// subtype:"success" + is_error:true (a 401/refusal) must map to
+			// result_error, never to signal=success.
+			state.failure ??=
+				message.is_error === true && message.subtype === "success"
+					? "result_error"
+					: (message.subtype ?? message.terminal_reason ?? "result_error");
 			break;
 		}
 		if (state.turn === 1) {

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -23,7 +23,7 @@
  *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
  *
  * Outcomes (final line):
- *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied|incoherent|unseeded> config_root=<env-honored|default-only>"
+ *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied|incoherent|lineage_mismatch|unseeded> config_root=<env-honored|default-only>"
  *   exit 2 "REJECTED signal=<sanitized>"   (e.g. resume_not_found)
  * cross_account is `unseeded` — never `ok` — when no distinct second account slot
  * (claude-sdk-oauth-spike-b) was seeded, so an untested arm cannot read as proven;
@@ -83,6 +83,8 @@ if (process.argv.includes(WORKER_FLAG)) {
 	// Signal-aware cleanup: an interrupted spike must take every live worker
 	// (and its Claude Code grandchild) down and remove temp config roots BEFORE
 	// exiting — a detached child outliving the parent keeps burning quota.
+	// SIGHUP is included: a closed terminal would otherwise orphan the detached
+	// worker and its grandchild.
 	const cleanupRuntime = () => {
 		for (const child of activeChildren) terminateChild(child);
 		for (const root of scopedRoots) {
@@ -92,7 +94,7 @@ if (process.argv.includes(WORKER_FLAG)) {
 		}
 	};
 	process.once("exit", cleanupRuntime);
-	for (const signal of ["SIGINT", "SIGTERM"]) {
+	for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
 		process.once(signal, () => {
 			cleanupRuntime();
 			reject(`interrupted_${signal.toLowerCase()}`);
@@ -134,13 +136,17 @@ if (process.argv.includes(WORKER_FLAG)) {
 
 /** Kill a timed-out/failed worker AND its Claude Code grandchild (process group on POSIX, process tree on Windows). */
 function terminateChild(child) {
-	if (!child || child.exitCode !== null || child.signalCode !== null) return;
+	if (!child || child.pid === undefined) return;
 	try {
 		if (process.platform === "win32") {
 			// child.kill() cannot reach the grandchild on Windows — there is no
 			// process group to signal — so take the whole tree down instead.
+			// taskkill on an exited worker fails harmlessly into the catch.
 			execFileSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" });
 		} else {
+			// Group-kill even when the worker already exited: a grandchild in the
+			// detached group can outlive the worker, and an exited group leader
+			// leaves the group addressable until the last member dies.
 			process.kill(-child.pid, "SIGKILL");
 		}
 	} catch {
@@ -196,8 +202,16 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 		const denial = crossed.error === "resume_failed" || crossed.error === "authentication_failed";
 		if (crossed.error && !denial) reject(crossed.error, "", secrets);
 		// A successful resume whose model simply misses the recall is inconclusive
-		// evidence about cross-account addressing, not a denial.
-		crossAccount = crossed.error ? "denied" : crossed.coherent ? "ok" : "incoherent";
+		// evidence about cross-account addressing, not a denial. And ok requires
+		// the SAME lineage: a cross-account resume that silently became a fresh
+		// session proves neither denial nor continuity.
+		crossAccount = crossed.error
+			? "denied"
+			: crossed.sessionId !== seeded.sessionId
+				? "lineage_mismatch"
+				: crossed.coherent
+					? "ok"
+					: "incoherent";
 	}
 
 	// (c) config-root addressing: seed INTO the scoped root, then check both
@@ -240,8 +254,10 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 	}
 	// staticFound is the direct visibility measurement; a model recall miss
 	// would be a coherence observation, not a config-root verdict, so it stays
-	// out of this gate.
-	const scopedFound = !scoped.error && scoped.staticFound === true;
+	// out of this gate. The resumed query must also report the SCOPED-SEEDED
+	// session id — a fresh lineage proves addressing failed even when the
+	// static read and the turn both succeeded.
+	const scopedFound = !scoped.error && scoped.staticFound === true && scoped.sessionId === scopedSeed.sessionId;
 	let configRoot;
 	if (defaultRead.staticFound === true) {
 		// Visible under the default root: the SDK ignored CLAUDE_CONFIG_DIR.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -17,8 +17,10 @@
  *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
  *
  * Outcomes (final line):
- *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied> config_root=<env-honored|default-only>"
+ *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied|unseeded> config_root=<env-honored|default-only>"
  *   exit 2 "REJECTED signal=<sanitized>"   (e.g. resume_not_found)
+ * cross_account is `unseeded` — never `ok` — when no distinct second account slot
+ * (claude-sdk-oauth-spike-b) was seeded, so an untested arm cannot read as proven.
  * Never prints token material.
  */
 import { fork } from "node:child_process";
@@ -29,6 +31,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	loadCredential,
+	loadCredentialStrict,
 	reject,
 	requireLiveGate,
 	requireSandbox,
@@ -51,7 +54,9 @@ if (process.argv.includes(WORKER_FLAG)) {
 	const sandbox = requireSandbox();
 	const primary = loadCredential(sandbox);
 	if (primary.error) reject(primary.error);
-	const secondary = loadCredential(sandbox, "claude-sdk-oauth-spike-b");
+	// STRICT: the forgiving loader falls back to the primary slot, which would let
+	// the cross-account arm report `ok` without ever using a second account.
+	const secondary = loadCredentialStrict(sandbox, "claude-sdk-oauth-spike-b");
 	const token = `REATTACH_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
 
 	const runChild = (request) =>
@@ -95,9 +100,15 @@ if (process.argv.includes(WORKER_FLAG)) {
 	const promptTokens = Math.max(1, (resumed.usage?.input ?? 0) + cacheRead + (resumed.usage?.cacheCreation ?? 0));
 	const ratio = (cacheRead / promptTokens).toFixed(2);
 
-	// (b) cross-account resume under the same config root.
+	// (b) cross-account resume under the same config root. Without a genuinely
+	// distinct slot B the arm is reported as `unseeded` — never as `ok` — so a
+	// missing second account can never be mistaken for a proven capability.
 	let crossAccount = "unseeded";
-	if (!secondary.error) {
+	if (secondary.error) {
+		if (!secondary.error.startsWith("slot_missing_")) reject(secondary.error);
+	} else if (secondary.credential.access === primary.credential.access) {
+		reject("cross_account_slots_identical");
+	} else {
 		const crossed = await runChild({
 			access: secondary.credential.access,
 			resume: seeded.sessionId,

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -8,9 +8,15 @@
  *     tokens on the resumed turn.
  * (b) cross-account resume: the resumed query authenticates as a DIFFERENT
  *     seeded sandbox slot under the SAME config root.
- * (c) config-root addressing: getSessionInfo/getSessionMessages + a resume are
- *     run from an env-scoped CHILD with CLAUDE_CONFIG_DIR=<non-default root>,
- *     because the static-API option types expose no config-root parameter.
+ * (c) config-root addressing: a session is seeded INTO a non-default root
+ *     (CLAUDE_CONFIG_DIR=<scoped root> on the seeding child), then
+ *     getSessionInfo/getSessionMessages + a resume run from a second child
+ *     under the SAME scoped root, plus a static-only read under the default
+ *     root. env-honored requires "visible under the scoped root AND absent
+ *     from the default root"; visible under the default root means the SDK
+ *     ignored CLAUDE_CONFIG_DIR (default-only). Seeding into the scoped root
+ *     first is what makes env-honored reachable — probing a default-root
+ *     session from an empty scoped root could only ever fail.
  *
  * Usage:
  *   SENPI_LIVE_CLAUDE_SDK_OAUTH=1 SENPI_CODING_AGENT_DIR=<sandbox> \
@@ -37,7 +43,7 @@ import {
 	requireLiveGate,
 	requireSandbox,
 	safeSignal,
-	withDeadline,
+	withTimeout,
 } from "./lib/claude-sdk-oauth-spike-support.mjs";
 import { runTurns, TOKEN_PROMPT } from "./lib/claude-sdk-oauth-reattach-worker.mjs";
 
@@ -63,24 +69,49 @@ if (process.argv.includes(WORKER_FLAG)) {
 	const secondary = loadCredentialStrict(sandbox, "claude-sdk-oauth-spike-b");
 	const token = `REATTACH_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
 
-	const runChild = (request) =>
-		withDeadline(
-			new Promise((resolve, rejectRun) => {
-				const child = fork(SELF, [WORKER_FLAG], { silent: true });
-				child.send(request);
-				let received;
-				child.once("message", (message) => {
-					received = message;
-				});
-				child.once("error", rejectRun);
-				child.once("exit", (code, signal) =>
-					received ? resolve(received) : rejectRun(new Error(`worker_${signal ?? code ?? "exit"}`)),
-				);
-			}),
-			"worker",
-			240_000,
-		);
+	const runChild = (request) => {
+		let child;
+		const run = new Promise((resolve, rejectRun) => {
+			// detached: the worker gets its own process group so a timeout can
+			// take its Claude Code grandchild down with it instead of orphaning
+			// the grandchild to keep burning subscription quota.
+			child = fork(SELF, [WORKER_FLAG], { silent: true, detached: process.platform !== "win32" });
+			child.send(request);
+			let received;
+			child.once("message", (message) => {
+				received = message;
+			});
+			child.once("error", rejectRun);
+			child.once("exit", (code, signal) =>
+				received ? resolve(received) : rejectRun(new Error(`worker_${signal ?? code ?? "exit"}`)),
+			);
+		});
+		return withTimeout(run, "worker", 240_000).finally(() => terminateChild(child));
+	};
 
+	try {
+		await main(runChild, primary, secondary, token);
+	} catch (error) {
+		// Spawn/IPC failures and worker timeouts must surface through the same
+		// sanitized REJECTED contract as in-spike failures, never a raw exit 1.
+		reject(error instanceof Error ? error.message : String(error));
+	}
+}
+
+/** Kill a timed-out/failed worker AND its Claude Code grandchild (process group on POSIX). */
+function terminateChild(child) {
+	if (!child || child.exitCode !== null || child.signalCode !== null) return;
+	try {
+		if (process.platform === "win32") child.kill("SIGKILL");
+		else process.kill(-child.pid, "SIGKILL");
+	} catch {
+		try {
+			child.kill("SIGKILL");
+		} catch {}
+	}
+}
+
+async function main(runChild, primary, secondary, token) {
 	// (a) seed the session in a child process, then let that process die.
 	const seeded = await runChild({
 		access: primary.credential.access,
@@ -120,21 +151,45 @@ if (process.argv.includes(WORKER_FLAG)) {
 		crossAccount = crossed.error || !crossed.coherent ? "denied" : "ok";
 	}
 
-	// (c) config-root addressing through an env-scoped child.
+	// (c) config-root addressing: seed INTO the scoped root, then check both
+	// roots. The default-root read is static-only (no Claude Code spawn).
 	const scopedRoot = mkdtempSync(join(tmpdir(), "claude-sdk-oauth-config-root-"));
 	process.once("exit", () => {
 		try {
 			rmSync(scopedRoot, { recursive: true, force: true });
 		} catch {}
 	});
+	const scopedSeed = await runChild({
+		access: primary.credential.access,
+		configDir: scopedRoot,
+		prompts: [TOKEN_PROMPT(token)],
+	});
+	if (scopedSeed.error) reject(scopedSeed.error);
+	if (!scopedSeed.sessionId) reject("session_id_absent");
+	const defaultRead = await runChild({
+		access: primary.credential.access,
+		staticRead: scopedSeed.sessionId,
+		staticOnly: true,
+	});
+	if (defaultRead.error) reject(defaultRead.error);
 	const scoped = await runChild({
 		access: primary.credential.access,
 		configDir: scopedRoot,
-		staticRead: seeded.sessionId,
-		resume: seeded.sessionId,
-		prompts: ["Reply with exactly: SCOPED"],
+		staticRead: scopedSeed.sessionId,
+		resume: scopedSeed.sessionId,
+		prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
+		expectToken: token,
 	});
-	const configRoot = scoped.error || scoped.staticFound === false ? "default-only" : "env-honored";
+	const scopedFound = !scoped.error && scoped.staticFound !== false && scoped.coherent === true;
+	let configRoot;
+	if (defaultRead.staticFound === true) {
+		// Visible under the default root: the SDK ignored CLAUDE_CONFIG_DIR.
+		configRoot = "default-only";
+	} else if (scopedFound) {
+		configRoot = "env-honored";
+	} else {
+		reject("config_root_unaddressable");
+	}
 
 	console.log(
 		`ACCEPTED resume=ok cache_read_ratio=${ratio} cross_account=${safeSignal(crossAccount)} config_root=${configRoot}`,

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -165,6 +165,9 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 	});
 	if (resumed.error) reject(resumed.error === "resume_failed" ? "resume_not_found" : resumed.error, "", secrets);
 	if (!resumed.coherent) reject("resume_incoherent");
+	// The resumed query must report the SEEDED session id — a new or different
+	// lineage cannot pass on model text alone.
+	if (resumed.sessionId !== seeded.sessionId) reject("resume_lineage_mismatch");
 	const cacheRead = resumed.usage?.cacheRead ?? 0;
 	const promptTokens = Math.max(1, (resumed.usage?.input ?? 0) + cacheRead + (resumed.usage?.cacheCreation ?? 0));
 	const ratio = (cacheRead / promptTokens).toFixed(2);
@@ -184,8 +187,12 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 			prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
 			expectToken: token,
 		});
-		// `denied` is the security verdict and requires the resume itself to fail;
-		// a successful resume whose model simply misses the recall is inconclusive
+		// `denied` is the security verdict and is reserved for known resume/auth
+		// failures; infrastructure failures (worker spawn/IPC/timeout) and other
+		// turn-level errors reject the spike instead of masquerading as a denial.
+		const denial = crossed.error === "resume_failed" || crossed.error === "authentication_failed";
+		if (crossed.error && !denial) reject(crossed.error, "", secrets);
+		// A successful resume whose model simply misses the recall is inconclusive
 		// evidence about cross-account addressing, not a denial.
 		crossAccount = crossed.error ? "denied" : crossed.coherent ? "ok" : "incoherent";
 	}
@@ -219,10 +226,12 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 	});
 	// A static-read FAILURE is infrastructure, not evidence of absence.
 	if (scoped.staticError) reject(scoped.staticError, "", secrets);
-	// staticFound is the direct visibility measurement; a resume that executes
-	// without error already proves the session was addressable. A model recall
-	// miss would be a coherence observation, not a config-root verdict, so it
-	// stays out of this gate.
+	// Turn-level resume failures (subscription, model refusal, worker timeout)
+	// are infrastructure too — only resume_failed is addressing evidence.
+	if (scoped.error && scoped.error !== "resume_failed") reject(scoped.error, "", secrets);
+	// staticFound is the direct visibility measurement; a model recall miss
+	// would be a coherence observation, not a config-root verdict, so it stays
+	// out of this gate.
 	const scopedFound = !scoped.error && scoped.staticFound === true;
 	let configRoot;
 	if (defaultRead.staticFound === true) {
@@ -237,5 +246,7 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 	console.log(
 		`ACCEPTED resume=ok cache_read_ratio=${ratio} cross_account=${safeSignal(crossAccount)} config_root=${configRoot}`,
 	);
-	process.exit(0);
+	// exitCode, not exit(): a forced exit can truncate the ACCEPTED line when
+	// stdout is a pipe; assigning lets Node flush the QA output first.
+	process.exitCode = 0;
 }

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -229,6 +229,12 @@ async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 	// Turn-level resume failures (subscription, model refusal, worker timeout)
 	// are infrastructure too — only resume_failed is addressing evidence.
 	if (scoped.error && scoped.error !== "resume_failed") reject(scoped.error, "", secrets);
+	// A successful scoped static read followed by resume_failed is contradictory
+	// evidence (visible but not resumable): reject it instead of letting it
+	// collapse into config_root_unaddressable.
+	if (scoped.error === "resume_failed" && scoped.staticFound === true) {
+		reject("config_root_contradictory");
+	}
 	// staticFound is the direct visibility measurement; a model recall miss
 	// would be a coherence observation, not a config-root verdict, so it stays
 	// out of this gate.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -56,8 +56,18 @@ if (process.argv.includes(WORKER_FLAG)) {
 	// The request carries an OAuth access token, so it arrives over the IPC channel
 	// rather than the environment: env is inherited by the Claude Code subprocess
 	// this worker spawns, which would put the token in that process's environment.
+	// The exit hook is the last-resort grandchild reap: a worker dying by any
+	// path (including a hard crash) closes its query handle so the Claude Code
+	// subprocess cannot outlive it. The worker's own 210s turn timeout bounds
+	// the grandchild even in the worst case.
+	let activeStream;
+	process.once("exit", () => {
+		closeQuietly(activeStream);
+	});
 	const request = await new Promise((resolve) => process.once("message", resolve));
-	const result = await runTurns(request).catch((error) => ({
+	const result = await runTurns(request, (stream) => {
+		activeStream = stream;
+	}).catch((error) => ({
 		error: error instanceof Error ? error.message : String(error),
 	}));
 	process.send?.(result, () => process.exit(0));
@@ -101,13 +111,25 @@ if (process.argv.includes(WORKER_FLAG)) {
 		});
 	}
 
+	// Every worker runs with an isolated HOME/USERPROFILE: when the SDK
+	// ignores CLAUDE_CONFIG_DIR (the default-only outcome), the seeded session
+	// must land in a THROWAWAY default root — never the operator's real
+	// ~/.claude — and the default-root control read must measure that same
+	// isolated root.
+	const sandboxHome = mkdtempSync(join(tmpdir(), "claude-sdk-oauth-home-"));
+	scopedRoots.add(sandboxHome);
+
 	const runChild = (request) => {
 		let child;
 		const run = new Promise((resolve, rejectRun) => {
 			// detached: the worker gets its own process group so a timeout can
 			// take its Claude Code grandchild down with it instead of orphaning
 			// the grandchild to keep burning subscription quota.
-			child = fork(SELF, [WORKER_FLAG], { silent: true, detached: process.platform !== "win32" });
+			child = fork(SELF, [WORKER_FLAG], {
+				silent: true,
+				detached: process.platform !== "win32",
+				env: { ...process.env, HOME: sandboxHome, USERPROFILE: sandboxHome },
+			});
 			activeChildren.add(child);
 			child.send(request);
 			let received;

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -23,10 +23,12 @@
  *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
  *
  * Outcomes (final line):
- *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied|unseeded> config_root=<env-honored|default-only>"
+ *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied|incoherent|unseeded> config_root=<env-honored|default-only>"
  *   exit 2 "REJECTED signal=<sanitized>"   (e.g. resume_not_found)
  * cross_account is `unseeded` — never `ok` — when no distinct second account slot
- * (claude-sdk-oauth-spike-b) was seeded, so an untested arm cannot read as proven.
+ * (claude-sdk-oauth-spike-b) was seeded, so an untested arm cannot read as proven;
+ * it is `denied` only when the resume itself errors — a model recall miss on a
+ * successful resume is `incoherent`, never folded into the security verdict.
  * Never prints token material.
  */
 import { execFileSync, fork } from "node:child_process";
@@ -69,6 +71,27 @@ if (process.argv.includes(WORKER_FLAG)) {
 	const secondary = loadCredentialStrict(sandbox, "claude-sdk-oauth-spike-b");
 	const token = `REATTACH_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
 
+	const activeChildren = new Set();
+	const scopedRoots = new Set();
+	// Signal-aware cleanup: an interrupted spike must take every live worker
+	// (and its Claude Code grandchild) down and remove temp config roots BEFORE
+	// exiting — a detached child outliving the parent keeps burning quota.
+	const cleanupRuntime = () => {
+		for (const child of activeChildren) terminateChild(child);
+		for (const root of scopedRoots) {
+			try {
+				rmSync(root, { recursive: true, force: true });
+			} catch {}
+		}
+	};
+	process.once("exit", cleanupRuntime);
+	for (const signal of ["SIGINT", "SIGTERM"]) {
+		process.once(signal, () => {
+			cleanupRuntime();
+			reject(`interrupted_${signal.toLowerCase()}`);
+		});
+	}
+
 	const runChild = (request) => {
 		let child;
 		const run = new Promise((resolve, rejectRun) => {
@@ -76,6 +99,7 @@ if (process.argv.includes(WORKER_FLAG)) {
 			// take its Claude Code grandchild down with it instead of orphaning
 			// the grandchild to keep burning subscription quota.
 			child = fork(SELF, [WORKER_FLAG], { silent: true, detached: process.platform !== "win32" });
+			activeChildren.add(child);
 			child.send(request);
 			let received;
 			child.once("message", (message) => {
@@ -86,11 +110,14 @@ if (process.argv.includes(WORKER_FLAG)) {
 				received ? resolve(received) : rejectRun(new Error(`worker_${signal ?? code ?? "exit"}`)),
 			);
 		});
-		return withTimeout(run, "worker", 240_000).finally(() => terminateChild(child));
+		return withTimeout(run, "worker", 240_000).finally(() => {
+			activeChildren.delete(child);
+			terminateChild(child);
+		});
 	};
 
 	try {
-		await main(runChild, primary, secondary, token);
+		await main(runChild, primary, secondary, token, scopedRoots);
 	} catch (error) {
 		// Spawn/IPC failures and worker timeouts must surface through the same
 		// sanitized REJECTED contract as in-spike failures, never a raw exit 1.
@@ -116,7 +143,7 @@ function terminateChild(child) {
 	}
 }
 
-async function main(runChild, primary, secondary, token) {
+async function main(runChild, primary, secondary, token, scopedRoots) {
 	// (a) seed the session in a child process, then let that process die.
 	const seeded = await runChild({
 		access: primary.credential.access,
@@ -153,17 +180,16 @@ async function main(runChild, primary, secondary, token) {
 			prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
 			expectToken: token,
 		});
-		crossAccount = crossed.error || !crossed.coherent ? "denied" : "ok";
+		// `denied` is the security verdict and requires the resume itself to fail;
+		// a successful resume whose model simply misses the recall is inconclusive
+		// evidence about cross-account addressing, not a denial.
+		crossAccount = crossed.error ? "denied" : crossed.coherent ? "ok" : "incoherent";
 	}
 
 	// (c) config-root addressing: seed INTO the scoped root, then check both
 	// roots. The default-root read is static-only (no Claude Code spawn).
 	const scopedRoot = mkdtempSync(join(tmpdir(), "claude-sdk-oauth-config-root-"));
-	process.once("exit", () => {
-		try {
-			rmSync(scopedRoot, { recursive: true, force: true });
-		} catch {}
-	});
+	scopedRoots.add(scopedRoot);
 	const scopedSeed = await runChild({
 		access: primary.credential.access,
 		configDir: scopedRoot,
@@ -185,7 +211,11 @@ async function main(runChild, primary, secondary, token) {
 		prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
 		expectToken: token,
 	});
-	const scopedFound = !scoped.error && scoped.staticFound !== false && scoped.coherent === true;
+	// staticFound is the direct visibility measurement; a resume that executes
+	// without error already proves the session was addressable. A model recall
+	// miss would be a coherence observation, not a config-root verdict, so it
+	// stays out of this gate.
+	const scopedFound = !scoped.error && scoped.staticFound === true;
 	let configRoot;
 	if (defaultRead.staticFound === true) {
 		// Visible under the default root: the SDK ignored CLAUDE_CONFIG_DIR.

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -74,6 +74,9 @@ if (process.argv.includes(WORKER_FLAG)) {
 	// access token and the generated recall token first — safeSignal is a shape
 	// sanitizer, not a secret redactor.
 	const secrets = [primary.credential.access, token];
+	// The secondary account's token must be redacted too — a cross-account SDK
+	// error string could otherwise echo it into the REJECTED line.
+	if (!secondary.error) secrets.push(secondary.credential.access);
 
 	const activeChildren = new Set();
 	const scopedRoots = new Set();

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -24,6 +24,7 @@
  * Never prints token material.
  */
 import { fork } from "node:child_process";
+import { rmSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -44,7 +45,10 @@ const WORKER_FLAG = "--reattach-worker";
 const SELF = fileURLToPath(import.meta.url);
 
 if (process.argv.includes(WORKER_FLAG)) {
-	const request = JSON.parse(process.env.SENPI_REATTACH_WORKER_REQUEST ?? "{}");
+	// The request carries an OAuth access token, so it arrives over the IPC channel
+	// rather than the environment: env is inherited by the Claude Code subprocess
+	// this worker spawns, which would put the token in that process's environment.
+	const request = await new Promise((resolve) => process.once("message", resolve));
 	const result = await runTurns(request).catch((error) => ({
 		error: error instanceof Error ? error.message : String(error),
 	}));
@@ -62,10 +66,8 @@ if (process.argv.includes(WORKER_FLAG)) {
 	const runChild = (request) =>
 		withDeadline(
 			new Promise((resolve, rejectRun) => {
-				const child = fork(SELF, [WORKER_FLAG], {
-					env: { ...process.env, SENPI_REATTACH_WORKER_REQUEST: JSON.stringify(request) },
-					silent: true,
-				});
+				const child = fork(SELF, [WORKER_FLAG], { silent: true });
+				child.send(request);
 				let received;
 				child.once("message", (message) => {
 					received = message;
@@ -120,6 +122,11 @@ if (process.argv.includes(WORKER_FLAG)) {
 
 	// (c) config-root addressing through an env-scoped child.
 	const scopedRoot = mkdtempSync(join(tmpdir(), "claude-sdk-oauth-config-root-"));
+	process.once("exit", () => {
+		try {
+			rmSync(scopedRoot, { recursive: true, force: true });
+		} catch {}
+	});
 	const scoped = await runChild({
 		access: primary.credential.access,
 		configDir: scopedRoot,

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -70,6 +70,10 @@ if (process.argv.includes(WORKER_FLAG)) {
 	// the cross-account arm report `ok` without ever using a second account.
 	const secondary = loadCredentialStrict(sandbox, "claude-sdk-oauth-spike-b");
 	const token = `REATTACH_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+	// Every reject path that can carry an SDK/worker error string redacts the
+	// access token and the generated recall token first — safeSignal is a shape
+	// sanitizer, not a secret redactor.
+	const secrets = [primary.credential.access, token];
 
 	const activeChildren = new Set();
 	const scopedRoots = new Set();
@@ -117,11 +121,11 @@ if (process.argv.includes(WORKER_FLAG)) {
 	};
 
 	try {
-		await main(runChild, primary, secondary, token, scopedRoots);
+		await main(runChild, primary, secondary, token, scopedRoots, secrets);
 	} catch (error) {
 		// Spawn/IPC failures and worker timeouts must surface through the same
 		// sanitized REJECTED contract as in-spike failures, never a raw exit 1.
-		reject(error instanceof Error ? error.message : String(error));
+		reject(error instanceof Error ? error.message : String(error), "", secrets);
 	}
 }
 
@@ -143,13 +147,13 @@ function terminateChild(child) {
 	}
 }
 
-async function main(runChild, primary, secondary, token, scopedRoots) {
+async function main(runChild, primary, secondary, token, scopedRoots, secrets) {
 	// (a) seed the session in a child process, then let that process die.
 	const seeded = await runChild({
 		access: primary.credential.access,
 		prompts: [TOKEN_PROMPT(token), "Reply with exactly: SECOND"],
 	});
-	if (seeded.error) reject(seeded.error);
+	if (seeded.error) reject(seeded.error, "", secrets);
 	if (!seeded.sessionId) reject("session_id_absent");
 
 	// (a) resume the dead session from this process.
@@ -159,7 +163,7 @@ async function main(runChild, primary, secondary, token, scopedRoots) {
 		prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
 		expectToken: token,
 	});
-	if (resumed.error) reject(resumed.error === "resume_failed" ? "resume_not_found" : resumed.error);
+	if (resumed.error) reject(resumed.error === "resume_failed" ? "resume_not_found" : resumed.error, "", secrets);
 	if (!resumed.coherent) reject("resume_incoherent");
 	const cacheRead = resumed.usage?.cacheRead ?? 0;
 	const promptTokens = Math.max(1, (resumed.usage?.input ?? 0) + cacheRead + (resumed.usage?.cacheCreation ?? 0));
@@ -195,14 +199,16 @@ async function main(runChild, primary, secondary, token, scopedRoots) {
 		configDir: scopedRoot,
 		prompts: [TOKEN_PROMPT(token)],
 	});
-	if (scopedSeed.error) reject(scopedSeed.error);
+	if (scopedSeed.error) reject(scopedSeed.error, "", secrets);
 	if (!scopedSeed.sessionId) reject("session_id_absent");
 	const defaultRead = await runChild({
 		access: primary.credential.access,
 		staticRead: scopedSeed.sessionId,
 		staticOnly: true,
 	});
-	if (defaultRead.error) reject(defaultRead.error);
+	if (defaultRead.error) reject(defaultRead.error, "", secrets);
+	// A static-read FAILURE is infrastructure, not evidence of absence.
+	if (defaultRead.staticError) reject(defaultRead.staticError, "", secrets);
 	const scoped = await runChild({
 		access: primary.credential.access,
 		configDir: scopedRoot,
@@ -211,6 +217,8 @@ async function main(runChild, primary, secondary, token, scopedRoots) {
 		prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
 		expectToken: token,
 	});
+	// A static-read FAILURE is infrastructure, not evidence of absence.
+	if (scoped.staticError) reject(scoped.staticError, "", secrets);
 	// staticFound is the direct visibility measurement; a resume that executes
 	// without error already proves the session was addressable. A model recall
 	// miss would be a coherence observation, not a config-root verdict, so it

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Live spike: re-attach mechanisms for the claude-sdk-oauth lane (Wave A todo 3).
+ *
+ * (a) resume-after-process-exit: a CHILD process owns query A (2 turns) and then
+ *     exits entirely; the parent opens a new query with `resume: <same id>`,
+ *     asserts coherence, and reports cache_read_input_tokens vs total prompt
+ *     tokens on the resumed turn.
+ * (b) cross-account resume: the resumed query authenticates as a DIFFERENT
+ *     seeded sandbox slot under the SAME config root.
+ * (c) config-root addressing: getSessionInfo/getSessionMessages + a resume are
+ *     run from an env-scoped CHILD with CLAUDE_CONFIG_DIR=<non-default root>,
+ *     because the static-API option types expose no config-root parameter.
+ *
+ * Usage:
+ *   SENPI_LIVE_CLAUDE_SDK_OAUTH=1 SENPI_CODING_AGENT_DIR=<sandbox> \
+ *     node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+ *
+ * Outcomes (final line):
+ *   exit 0 "ACCEPTED resume=<ok> cache_read_ratio=<r> cross_account=<ok|denied> config_root=<env-honored|default-only>"
+ *   exit 2 "REJECTED signal=<sanitized>"   (e.g. resume_not_found)
+ * Never prints token material.
+ */
+import { fork } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	loadCredential,
+	reject,
+	requireLiveGate,
+	requireSandbox,
+	safeSignal,
+	withDeadline,
+} from "./lib/claude-sdk-oauth-spike-support.mjs";
+import { runTurns, TOKEN_PROMPT } from "./lib/claude-sdk-oauth-reattach-worker.mjs";
+
+const WORKER_FLAG = "--reattach-worker";
+const SELF = fileURLToPath(import.meta.url);
+
+if (process.argv.includes(WORKER_FLAG)) {
+	const request = JSON.parse(process.env.SENPI_REATTACH_WORKER_REQUEST ?? "{}");
+	const result = await runTurns(request).catch((error) => ({
+		error: error instanceof Error ? error.message : String(error),
+	}));
+	process.send?.(result, () => process.exit(0));
+} else {
+	requireLiveGate();
+	const sandbox = requireSandbox();
+	const primary = loadCredential(sandbox);
+	if (primary.error) reject(primary.error);
+	const secondary = loadCredential(sandbox, "claude-sdk-oauth-spike-b");
+	const token = `REATTACH_${randomUUID().replaceAll("-", "").slice(0, 10).toUpperCase()}`;
+
+	const runChild = (request) =>
+		withDeadline(
+			new Promise((resolve, rejectRun) => {
+				const child = fork(SELF, [WORKER_FLAG], {
+					env: { ...process.env, SENPI_REATTACH_WORKER_REQUEST: JSON.stringify(request) },
+					silent: true,
+				});
+				let received;
+				child.once("message", (message) => {
+					received = message;
+				});
+				child.once("error", rejectRun);
+				child.once("exit", (code, signal) =>
+					received ? resolve(received) : rejectRun(new Error(`worker_${signal ?? code ?? "exit"}`)),
+				);
+			}),
+			"worker",
+			240_000,
+		);
+
+	// (a) seed the session in a child process, then let that process die.
+	const seeded = await runChild({
+		access: primary.credential.access,
+		prompts: [TOKEN_PROMPT(token), "Reply with exactly: SECOND"],
+	});
+	if (seeded.error) reject(seeded.error);
+	if (!seeded.sessionId) reject("session_id_absent");
+
+	// (a) resume the dead session from this process.
+	const resumed = await runChild({
+		access: primary.credential.access,
+		resume: seeded.sessionId,
+		prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
+		expectToken: token,
+	});
+	if (resumed.error) reject(resumed.error === "resume_failed" ? "resume_not_found" : resumed.error);
+	if (!resumed.coherent) reject("resume_incoherent");
+	const cacheRead = resumed.usage?.cacheRead ?? 0;
+	const promptTokens = Math.max(1, (resumed.usage?.input ?? 0) + cacheRead + (resumed.usage?.cacheCreation ?? 0));
+	const ratio = (cacheRead / promptTokens).toFixed(2);
+
+	// (b) cross-account resume under the same config root.
+	let crossAccount = "unseeded";
+	if (!secondary.error) {
+		const crossed = await runChild({
+			access: secondary.credential.access,
+			resume: seeded.sessionId,
+			prompts: ["Repeat the token I gave you at the start, prefixed with RECALL."],
+			expectToken: token,
+		});
+		crossAccount = crossed.error || !crossed.coherent ? "denied" : "ok";
+	}
+
+	// (c) config-root addressing through an env-scoped child.
+	const scopedRoot = mkdtempSync(join(tmpdir(), "claude-sdk-oauth-config-root-"));
+	const scoped = await runChild({
+		access: primary.credential.access,
+		configDir: scopedRoot,
+		staticRead: seeded.sessionId,
+		resume: seeded.sessionId,
+		prompts: ["Reply with exactly: SCOPED"],
+	});
+	const configRoot = scoped.error || scoped.staticFound === false ? "default-only" : "env-honored";
+
+	console.log(
+		`ACCEPTED resume=ok cache_read_ratio=${ratio} cross_account=${safeSignal(crossAccount)} config_root=${configRoot}`,
+	);
+	process.exit(0);
+}

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-reattach-spike.mjs
@@ -29,7 +29,7 @@
  * (claude-sdk-oauth-spike-b) was seeded, so an untested arm cannot read as proven.
  * Never prints token material.
  */
-import { fork } from "node:child_process";
+import { execFileSync, fork } from "node:child_process";
 import { rmSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { mkdtempSync } from "node:fs";
@@ -98,12 +98,17 @@ if (process.argv.includes(WORKER_FLAG)) {
 	}
 }
 
-/** Kill a timed-out/failed worker AND its Claude Code grandchild (process group on POSIX). */
+/** Kill a timed-out/failed worker AND its Claude Code grandchild (process group on POSIX, process tree on Windows). */
 function terminateChild(child) {
 	if (!child || child.exitCode !== null || child.signalCode !== null) return;
 	try {
-		if (process.platform === "win32") child.kill("SIGKILL");
-		else process.kill(-child.pid, "SIGKILL");
+		if (process.platform === "win32") {
+			// child.kill() cannot reach the grandchild on Windows — there is no
+			// process group to signal — so take the whole tree down instead.
+			execFileSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+		} else {
+			process.kill(-child.pid, "SIGKILL");
+		}
 	} catch {
 		try {
 			child.kill("SIGKILL");

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-registry-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-registry-probe.mjs
@@ -23,6 +23,7 @@ import {
 	repoRoot,
 	track,
 } from "./lib/common.mjs";
+import { withTimeout } from "./lib/with-timeout.mjs";
 
 const ROOT = repoRoot();
 const INNER_FLAG = "SENPI_CLAUDE_SDK_REGISTRY_PROBE_INNER";
@@ -155,14 +156,6 @@ function outputText(messages) {
 	return parts.join("\n");
 }
 
-function withTimeout(promise, label, timeoutMs = 45_000) {
-	let timer;
-	const timeout = new Promise((_, reject) => {
-		timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
-	});
-	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
-}
-
 function safeDetail(value) {
 	return String(value).replace(/[\r\n]+/g, " ").slice(0, 500);
 }
@@ -284,7 +277,11 @@ try {
 	});
 
 	const firstMessage = { role: "user", content: [{ type: "text", text: FIRST_TOKEN }] };
-	firstTurn = await withTimeout(submitSessionTurn(registry, entry, { message: firstMessage }), "first registry turn");
+	firstTurn = await withTimeout(
+		submitSessionTurn(registry, entry, { message: firstMessage }),
+		"first registry turn",
+		45_000,
+	);
 
 	const firstContextMessages = [{ role: "user", content: FIRST_TOKEN }];
 	const firstHashes = sync.sentMessageHashes(firstContextMessages);
@@ -323,6 +320,7 @@ try {
 	secondTurn = await withTimeout(
 		submitSessionTurn(registry, secondLookup, { message: { role: "user", content: secondBlocks } }),
 		"second registry turn",
+		45_000,
 	);
 
 	const requestWithFirst = providerRequests.find((body) => requestUserTexts(body).some((text) => text.includes(FIRST_TOKEN)));

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-registry-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-registry-probe.mjs
@@ -23,7 +23,7 @@ import {
 	repoRoot,
 	track,
 } from "./lib/common.mjs";
-import { safeDetail } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { safeDetail } from "./lib/output-safety.mjs";
 import { withTimeout } from "./lib/with-timeout.mjs";
 
 const ROOT = repoRoot();

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-registry-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-registry-probe.mjs
@@ -23,6 +23,7 @@ import {
 	repoRoot,
 	track,
 } from "./lib/common.mjs";
+import { safeDetail } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
 import { withTimeout } from "./lib/with-timeout.mjs";
 
 const ROOT = repoRoot();
@@ -154,10 +155,6 @@ function outputText(messages) {
 		}
 	}
 	return parts.join("\n");
-}
-
-function safeDetail(value) {
-	return String(value).replace(/[\r\n]+/g, " ").slice(0, 500);
 }
 
 const facts = new Map();

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
@@ -71,12 +71,6 @@ export function createModelCaptureHandler(onModelRequest) {
 	};
 }
 
-export function safeDetail(value) {
-	return String(value)
-		.replace(/[\r\n]+/g, " ")
-		.slice(0, 500);
-}
-
 function payloadText(message) {
 	const content = message?.message?.content;
 	if (typeof content === "string") return content;

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
@@ -25,6 +25,30 @@ export const FLATTEN_TRAILER = "The above is the conversation history so far";
  * wrong-route or wrong-shape request can never receive a 200 fixture and
  * manufacture false continuity evidence.
  */
+/**
+ * Extract concatenated text from Anthropic API messages (string or block
+ * content) or SDK user messages ({message: {content}}). Used to prove the
+ * classified user payload actually reached the provider on the wire.
+ */
+export function extractPayloadText(input) {
+	const texts = [];
+	const visit = (content) => {
+		if (typeof content === "string") {
+			texts.push(content);
+			return;
+		}
+		if (Array.isArray(content)) {
+			for (const block of content) {
+				if (block && typeof block === "object" && typeof block.text === "string") texts.push(block.text);
+			}
+		}
+	};
+	for (const message of Array.isArray(input) ? input : [input]) {
+		visit(message?.content ?? message?.message?.content);
+	}
+	return texts.join("\n");
+}
+
 export function createModelCaptureHandler(onModelRequest) {
 	let count = 0;
 	return (request, response) => {
@@ -79,7 +103,13 @@ export function createModelCaptureHandler(onModelRequest) {
 			count += 1;
 			// Buffer.byteLength, not raw.length: the column is labeled bytes, and
 			// raw.length counts UTF-16 code units, not HTTP body bytes.
-			onModelRequest({ bytes: Buffer.byteLength(raw, "utf8"), messages: body.messages.length });
+			// The text digest lets the probe prove the classified payload reached
+			// the wire, not just that some nonempty request arrived.
+			onModelRequest({
+				bytes: Buffer.byteLength(raw, "utf8"),
+				messages: body.messages.length,
+				text: extractPayloadText(body.messages).slice(0, 4_000),
+			});
 			response.writeHead(200, {
 				"content-type": "text/event-stream",
 				"cache-control": "no-cache",

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
@@ -33,7 +33,11 @@ export function createModelCaptureHandler(onModelRequest) {
 			response.end();
 			return;
 		}
-		if (!request.url?.includes("/messages")) {
+		// Match the parsed pathname exactly (query parameters allowed): a
+		// substring check would treat a mistyped route containing "/messages"
+		// as a valid model request and manufacture false continuity evidence.
+		const pathname = new URL(request.url ?? "/", "http://loopback.invalid").pathname;
+		if (pathname !== "/v1/messages") {
 			response.writeHead(404, { "content-type": "application/json" });
 			response.end(JSON.stringify({ error: "unknown_route" }));
 			return;
@@ -43,6 +47,13 @@ export function createModelCaptureHandler(onModelRequest) {
 		request.on("data", (chunk) => {
 			raw += chunk;
 		});
+		// A dropped mid-upload connection must settle the response: without an
+		// error listener the 'end' handler never runs and the probe hangs to
+		// the turn timeout instead of failing fast with diagnostics.
+		request.on("error", () => {
+			if (!response.headersSent) response.writeHead(400, { "content-type": "application/json" });
+			response.end(JSON.stringify({ error: "request_dropped" }));
+		});
 		request.on("end", () => {
 			let body;
 			try {
@@ -50,6 +61,14 @@ export function createModelCaptureHandler(onModelRequest) {
 			} catch {
 				response.writeHead(400, { "content-type": "application/json" });
 				response.end(JSON.stringify({ error: "malformed_request" }));
+				return;
+			}
+			// JSON.parse can yield a primitive: validate the container before
+			// reading properties, or a malformed body crashes the handler
+			// instead of producing the fail-closed 400.
+			if (typeof body !== "object" || body === null || Array.isArray(body)) {
+				response.writeHead(400, { "content-type": "application/json" });
+				response.end(JSON.stringify({ error: "malformed_shape" }));
 				return;
 			}
 			if (typeof body.model !== "string" || !Array.isArray(body.messages)) {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
@@ -16,6 +16,61 @@ export const FLATTEN_MARKER = "<conversation_history>";
 /** Trailer buildPromptBlocks always appends, even when there is no history yet. */
 export const FLATTEN_TRAILER = "The above is the conversation history so far";
 
+/**
+ * Loopback Anthropic-messages handler for the fullstack probe.
+ *
+ * Route-checks POSTs (/messages only, 404 otherwise), fails closed on
+ * malformed JSON or a wrong request shape (400), records byte-accurate
+ * metrics through onModelRequest, and answers with the SSE fixture — a
+ * wrong-route or wrong-shape request can never receive a 200 fixture and
+ * manufacture false continuity evidence.
+ */
+export function createModelCaptureHandler(onModelRequest) {
+	let count = 0;
+	return (request, response) => {
+		if (request.method !== "POST") {
+			response.writeHead(200);
+			response.end();
+			return;
+		}
+		if (!request.url?.includes("/messages")) {
+			response.writeHead(404, { "content-type": "application/json" });
+			response.end(JSON.stringify({ error: "unknown_route" }));
+			return;
+		}
+		let raw = "";
+		request.setEncoding("utf8");
+		request.on("data", (chunk) => {
+			raw += chunk;
+		});
+		request.on("end", () => {
+			let body;
+			try {
+				body = JSON.parse(raw);
+			} catch {
+				response.writeHead(400, { "content-type": "application/json" });
+				response.end(JSON.stringify({ error: "malformed_request" }));
+				return;
+			}
+			if (typeof body.model !== "string" || !Array.isArray(body.messages)) {
+				response.writeHead(400, { "content-type": "application/json" });
+				response.end(JSON.stringify({ error: "malformed_shape" }));
+				return;
+			}
+			count += 1;
+			// Buffer.byteLength, not raw.length: the column is labeled bytes, and
+			// raw.length counts UTF-16 code units, not HTTP body bytes.
+			onModelRequest({ bytes: Buffer.byteLength(raw, "utf8"), messages: body.messages.length });
+			response.writeHead(200, {
+				"content-type": "text/event-stream",
+				"cache-control": "no-cache",
+				connection: "keep-alive",
+			});
+			response.end(loopbackSseBody(`probe-reply-${count}`, count));
+		});
+	};
+}
+
 export function safeDetail(value) {
 	return String(value)
 		.replace(/[\r\n]+/g, " ")

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
@@ -1,0 +1,125 @@
+/**
+ * Shared helpers for claude-sdk-oauth-fullstack-probe.mjs.
+ *
+ * Kept out of the probe so each script stays under the 250 pure-LOC ceiling.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Marker emitted by prompt-bridge.ts buildPromptBlocks when senpi flattens history. */
+export const FLATTEN_MARKER = "<conversation_history>";
+/** Trailer buildPromptBlocks always appends, even when there is no history yet. */
+export const FLATTEN_TRAILER = "The above is the conversation history so far";
+
+export function safeDetail(value) {
+	return String(value)
+		.replace(/[\r\n]+/g, " ")
+		.slice(0, 500);
+}
+
+export function withTimeout(promise, label, timeoutMs = 60_000) {
+	let timer;
+	const timeout = new Promise((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function payloadText(message) {
+	const content = message?.message?.content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((block) => (block && typeof block === "object" && typeof block.text === "string" ? block.text : ""))
+		.join("\n");
+}
+
+/**
+ * Classify one submitted SDK user message:
+ *   flatten   - carries a rebuilt <conversation_history> transcript
+ *   bootstrap - buildPromptBlocks shape with no prior history (first turn)
+ *   delta     - only the new user content (the resident-session happy path)
+ */
+export function classifyPayload(message) {
+	const text = payloadText(message);
+	const bytes = Buffer.byteLength(text, "utf8");
+	if (text.includes(FLATTEN_MARKER)) return { kind: "flatten", bytes };
+	if (text.includes(FLATTEN_TRAILER)) return { kind: "bootstrap", bytes };
+	return { kind: "delta", bytes };
+}
+
+export function formatTurnTable(turns) {
+	const header = ["turn", "queries", "path", "payload", "bytes", "wire_reqs", "wire_bytes", "lineage"];
+	const rows = turns.map((turn) => [
+		String(turn.index),
+		String(turn.queries),
+		turn.path,
+		turn.kind,
+		String(turn.bytes),
+		String(turn.wireRequests),
+		String(turn.wireBytes),
+		String(turn.lineage).slice(0, 8),
+	]);
+	const widths = header.map((label, column) =>
+		Math.max(label.length, ...rows.map((row) => row[column].length), 0),
+	);
+	const line = (cells) => cells.map((cell, column) => cell.padEnd(widths[column])).join("  ").trimEnd();
+	return [line(header), line(widths.map((width) => "-".repeat(width))), ...rows.map(line), ""].join("\n");
+}
+
+/** SSE body the loopback server returns for one Anthropic /v1/messages request. */
+export function loopbackSseBody(text, sequence) {
+	const events = [
+		[
+			"message_start",
+			{
+				type: "message_start",
+				message: {
+					id: `msg_fullstack_probe_${sequence}`,
+					type: "message",
+					role: "assistant",
+					model: "claude-haiku-4-5",
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 12, output_tokens: 1, cache_read_input_tokens: 0 },
+				},
+			},
+		],
+		["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+		["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text } }],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		[
+			"message_delta",
+			{
+				type: "message_delta",
+				delta: { stop_reason: "end_turn", stop_sequence: null },
+				usage: { output_tokens: 2 },
+			},
+		],
+		["message_stop", { type: "message_stop" }],
+	];
+	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+/**
+ * Seed the sandbox agent dir with a DUMMY claude-sdk-oauth credential so the
+ * provider counts as configured. The token is never used: the Claude Code
+ * subprocess talks only to the loopback server.
+ */
+export function seedProbeAgentDir(agentDir) {
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(
+		join(agentDir, "auth.json"),
+		JSON.stringify({
+			"claude-sdk-oauth": {
+				type: "oauth",
+				access: "fullstack-probe-dummy-access",
+				refresh: "fullstack-probe-dummy-refresh",
+				expires: Date.now() + 3_600_000,
+			},
+		}),
+		{ mode: 0o600 },
+	);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-fullstack-support.mjs
@@ -7,6 +7,10 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+// Canonical timeout helper lives in with-timeout.mjs; re-exported so existing
+// probe imports keep working and no second copy of the pattern drifts.
+export { withTimeout } from "./with-timeout.mjs";
+
 /** Marker emitted by prompt-bridge.ts buildPromptBlocks when senpi flattens history. */
 export const FLATTEN_MARKER = "<conversation_history>";
 /** Trailer buildPromptBlocks always appends, even when there is no history yet. */
@@ -16,14 +20,6 @@ export function safeDetail(value) {
 	return String(value)
 		.replace(/[\r\n]+/g, " ")
 		.slice(0, 500);
-}
-
-export function withTimeout(promise, label, timeoutMs = 60_000) {
-	let timer;
-	const timeout = new Promise((_resolve, reject) => {
-		timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
-	});
-	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 function payloadText(message) {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -92,6 +92,9 @@ export async function runTurns(request) {
 				result.sessionId ??= message.session_id;
 			}
 			if (message.type === "assistant") {
+				// An assistant-level SDK failure must fail the turn, not pass
+				// through as usage/coherence evidence.
+				if (message.error) throw new Error("assistant_error");
 				if (message.message?.model === "<synthetic>") throw new Error("synthetic_assistant");
 				result.usage = readUsage(message.message) ?? result.usage;
 				if (request.expectToken && assistantText(message).includes(request.expectToken)) result.coherent = true;

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -17,7 +17,7 @@ import {
 	importClaudeSdk,
 	managedEnvironment,
 	userMessage,
-	withDeadline,
+	withTimeout,
 } from "./claude-sdk-oauth-spike-support.mjs";
 
 export const TOKEN_PROMPT = (token) => `Remember this token for later: ${token}. Reply with exactly: ACK`;
@@ -45,13 +45,19 @@ async function staticRead(sessionId) {
 }
 
 /**
- * @param {{access: string, prompts: string[], resume?: string, configDir?: string,
- *          expectToken?: string, staticRead?: string}} request
+ * @param {{access: string, prompts?: string[], resume?: string, configDir?: string,
+ *          expectToken?: string, staticRead?: string, staticOnly?: boolean}} request
  */
 export async function runTurns(request) {
 	const result = { sessionId: null, coherent: false, usage: undefined };
 	if (request.configDir) process.env.CLAUDE_CONFIG_DIR = request.configDir;
 	if (request.staticRead) result.staticFound = await staticRead(request.staticRead);
+	// A static-only probe answers "is this session visible under this config
+	// root?" without spawning Claude Code or spending quota at all.
+	if (request.staticOnly) {
+		result.coherent = true;
+		return result;
+	}
 
 	const { query } = await importClaudeSdk();
 	const prompts = [...request.prompts];
@@ -91,7 +97,7 @@ export async function runTurns(request) {
 	})();
 
 	try {
-		await withDeadline(drain, "worker_turns", 210_000);
+		await withTimeout(drain, "worker_turns", 210_000);
 	} finally {
 		input.close();
 		closeQuietly(stream);

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -101,9 +101,13 @@ export async function runTurns(request) {
 			}
 			if (message.type === "assistant") {
 				// An assistant-level SDK failure must fail the turn, not pass
-				// through as usage/coherence evidence.
+				// through as usage/coherence evidence. On a resume, a synthetic
+				// assistant message is the cross-account/session-invisibility
+				// denial shape, so it maps to the denial signal.
 				if (message.error) throw new Error("assistant_error");
-				if (message.message?.model === "<synthetic>") throw new Error("synthetic_assistant");
+				if (message.message?.model === "<synthetic>") {
+					throw new Error(request.resume ? "resume_failed" : "synthetic_assistant");
+				}
 				// Pass the whole message: usage can live on the assistant envelope OR
 				// directly on the message (result shape) — nested-only reads silently
 				// fall back to a 0.00 cache ratio.
@@ -140,6 +144,12 @@ export async function runTurns(request) {
 
 	try {
 		await withTimeout(drain, "worker_turns", 210_000);
+	} catch (error) {
+		// Attach the error to the result instead of throwing: the supervisor's
+		// verdicts need the static-read evidence (staticFound/staticError) even
+		// when the turn phase fails — dropping it would make contradictory
+		// evidence indistinguishable from absence.
+		result.error = error instanceof Error ? error.message : String(error);
 	} finally {
 		input.close();
 		closeQuietly(stream);

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -1,0 +1,101 @@
+/**
+ * Worker half of claude-sdk-oauth-reattach-spike.mjs.
+ *
+ * Runs one streaming-input query (optionally with `resume: <sessionId>` and/or
+ * an env-scoped CLAUDE_CONFIG_DIR), plays the requested prompts, and reports
+ * the session id, coherence, and prompt-cache usage back to the supervisor.
+ * Runs inside a forked child so "resume after the owning process exited" is a
+ * real process death, not a closed handle.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+	assistantText,
+	claudeExecutable,
+	closeQuietly,
+	controlledInput,
+	importClaudeSdk,
+	managedEnvironment,
+	userMessage,
+	withDeadline,
+} from "./claude-sdk-oauth-spike-support.mjs";
+
+export const TOKEN_PROMPT = (token) => `Remember this token for later: ${token}. Reply with exactly: ACK`;
+
+function readUsage(message) {
+	const usage = message?.usage ?? message?.message?.usage;
+	if (!usage) return undefined;
+	return {
+		input: usage.input_tokens ?? 0,
+		cacheRead: usage.cache_read_input_tokens ?? 0,
+		cacheCreation: usage.cache_creation_input_tokens ?? 0,
+	};
+}
+
+/** Static read of a session transcript under whatever config root this process has. */
+async function staticRead(sessionId) {
+	const sdk = await importClaudeSdk();
+	try {
+		const info = await sdk.getSessionInfo(sessionId);
+		const messages = await sdk.getSessionMessages(sessionId, { includeSystemMessages: true });
+		return info !== undefined || messages.length > 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * @param {{access: string, prompts: string[], resume?: string, configDir?: string,
+ *          expectToken?: string, staticRead?: string}} request
+ */
+export async function runTurns(request) {
+	const result = { sessionId: null, coherent: false, usage: undefined };
+	if (request.configDir) process.env.CLAUDE_CONFIG_DIR = request.configDir;
+	if (request.staticRead) result.staticFound = await staticRead(request.staticRead);
+
+	const { query } = await importClaudeSdk();
+	const prompts = [...request.prompts];
+	const input = controlledInput(userMessage(prompts.shift(), randomUUID()));
+	const options = {
+		model: "claude-haiku-4-5",
+		tools: [],
+		permissionMode: "dontAsk",
+		settingSources: [],
+		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+		pathToClaudeCodeExecutable: claudeExecutable(),
+		env: managedEnvironment(request.access, request.configDir ? { CLAUDE_CONFIG_DIR: request.configDir } : {}),
+	};
+	if (request.resume) options.resume = request.resume;
+	const stream = query({ prompt: input, options });
+
+	const drain = (async () => {
+		for await (const message of stream) {
+			if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
+				result.sessionId ??= message.session_id;
+			}
+			if (message.type === "assistant") {
+				if (message.message?.model === "<synthetic>") throw new Error("synthetic_assistant");
+				result.usage = readUsage(message.message) ?? result.usage;
+				if (request.expectToken && assistantText(message).includes(request.expectToken)) result.coherent = true;
+			}
+			if (message.type === "auth_status" && message.error) throw new Error("authentication_failed");
+			if (message.type !== "result") continue;
+			// A 401/refusal arrives as subtype:"success" with is_error:true and a
+			// <synthetic> assistant message, so both must be checked.
+			if (message.subtype !== "success" || message.is_error === true) {
+				throw new Error(request.resume ? "resume_failed" : (message.subtype ?? "result_error"));
+			}
+			if (prompts.length === 0) break;
+			input.push(userMessage(prompts.shift(), randomUUID()));
+		}
+	})();
+
+	try {
+		await withDeadline(drain, "worker_turns", 210_000);
+	} finally {
+		input.close();
+		closeQuietly(stream);
+	}
+	if (!request.expectToken) result.coherent = true;
+	return result;
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -85,6 +85,8 @@ export async function runTurns(request) {
 	};
 	if (request.resume) options.resume = request.resume;
 	const stream = query({ prompt: input, options });
+	const expectedTurns = prompts.length;
+	let completedTurns = 0;
 
 	const drain = (async () => {
 		for await (const message of stream) {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -64,7 +64,7 @@ async function staticRead(sessionId) {
  * @param {{access: string, prompts?: string[], resume?: string, configDir?: string,
  *          expectToken?: string, staticRead?: string, staticOnly?: boolean}} request
  */
-export async function runTurns(request) {
+export async function runTurns(request, onStream) {
 	const result = { sessionId: null, coherent: false, usage: undefined };
 	// An absent configDir must mean the SDK DEFAULT root: an operator-set
 	// CLAUDE_CONFIG_DIR inherited from the spike's shell would silently
@@ -116,6 +116,9 @@ export async function runTurns(request) {
 		result.error = error instanceof Error ? error.message : String(error);
 		return result;
 	}
+	// Hand the live stream to the worker's exit hook so a dying worker reaps
+	// its Claude Code subprocess instead of orphaning it.
+	onStream?.(stream);
 	let completedTurns = 0;
 
 	const drain = (async () => {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -50,7 +50,11 @@ async function staticRead(sessionId) {
  */
 export async function runTurns(request) {
 	const result = { sessionId: null, coherent: false, usage: undefined };
+	// An absent configDir must mean the SDK DEFAULT root: an operator-set
+	// CLAUDE_CONFIG_DIR inherited from the spike's shell would silently
+	// re-address the "default-root" reads and corrupt the config-root verdict.
 	if (request.configDir) process.env.CLAUDE_CONFIG_DIR = request.configDir;
+	else delete process.env.CLAUDE_CONFIG_DIR;
 	if (request.staticRead) result.staticFound = await staticRead(request.staticRead);
 	// A static-only probe answers "is this session visible under this config
 	// root?" without spawning Claude Code or spending quota at all.

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -38,9 +38,13 @@ async function staticRead(sessionId) {
 	try {
 		const info = await sdk.getSessionInfo(sessionId);
 		const messages = await sdk.getSessionMessages(sessionId, { includeSystemMessages: true });
-		return info !== undefined || messages.length > 0;
-	} catch {
-		return false;
+		return { found: info !== undefined || messages.length > 0 };
+	} catch (error) {
+		// A read FAILURE (SDK method missing, permission denied, malformed
+		// response) is not evidence of absence — report it separately so the
+		// config-root verdict cannot mistake an infrastructure error for
+		// "not found under this root".
+		return { found: false, error: error instanceof Error ? error.message : String(error) };
 	}
 }
 
@@ -55,7 +59,11 @@ export async function runTurns(request) {
 	// re-address the "default-root" reads and corrupt the config-root verdict.
 	if (request.configDir) process.env.CLAUDE_CONFIG_DIR = request.configDir;
 	else delete process.env.CLAUDE_CONFIG_DIR;
-	if (request.staticRead) result.staticFound = await staticRead(request.staticRead);
+	if (request.staticRead) {
+		const read = await staticRead(request.staticRead);
+		result.staticFound = read.found;
+		if (read.error) result.staticError = read.error;
+	}
 	// A static-only probe answers "is this session visible under this config
 	// root?" without spawning Claude Code or spending quota at all.
 	if (request.staticOnly) {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -128,7 +128,12 @@ export async function runTurns(request) {
 						? "result_error"
 						: (message.subtype ?? "result_error");
 				if (request.resume) {
-					throw new Error(message.is_error === true ? "resume_failed" : `resume_error_${reason}`);
+					// resume_failed is reserved for the documented denial shape
+					// (subtype:success + is_error:true — a refusal-class envelope).
+					// A non-success subtype (quota/execution/timeout) is a turn-level
+					// failure and must never read as an addressing/auth denial.
+					const denial = message.subtype === "success" && message.is_error === true;
+					throw new Error(denial ? "resume_failed" : `resume_error_${reason}`);
 				}
 				throw new Error(reason);
 			}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -32,6 +32,18 @@ function readUsage(message) {
 	};
 }
 
+/** Merge per-field by max: a later message carrying no cache fields must not
+ * overwrite an earlier message's cacheRead evidence with zeros. */
+function mergeUsage(current, next) {
+	if (!next) return current;
+	if (!current) return next;
+	return {
+		input: Math.max(current.input, next.input),
+		cacheRead: Math.max(current.cacheRead, next.cacheRead),
+		cacheCreation: Math.max(current.cacheCreation, next.cacheCreation),
+	};
+}
+
 /** Static read of a session transcript under whatever config root this process has. */
 async function staticRead(sessionId) {
 	const sdk = await importClaudeSdk();
@@ -124,16 +136,16 @@ export async function runTurns(request) {
 				if (message.message?.model === "<synthetic>") {
 					throw new Error(request.resume ? "resume_failed" : "synthetic_assistant");
 				}
-				// Pass the whole message: usage can live on the assistant envelope OR
-				// directly on the message (result shape) — nested-only reads silently
-				// fall back to a 0.00 cache ratio.
-				result.usage = readUsage(message) ?? result.usage;
+				// Pass the whole message and MERGE by max per field: a later message
+				// carrying no cache fields must not zero out earlier cacheRead
+				// evidence (the ratio would fall back to 0.00).
+				result.usage = mergeUsage(result.usage, readUsage(message));
 				if (request.expectToken && assistantText(message).includes(request.expectToken)) result.coherent = true;
 			}
 			if (message.type === "auth_status" && message.error) throw new Error("authentication_failed");
 			if (message.type !== "result") continue;
-			// Result envelopes can carry usage directly — record before the gates.
-			result.usage = readUsage(message) ?? result.usage;
+			// Result envelopes can carry usage directly — merge before the gates.
+			result.usage = mergeUsage(result.usage, readUsage(message));
 			// A 401/refusal arrives as subtype:"success" with is_error:true; that
 			// shape on a resume IS the addressing/auth denial (resume_failed).
 			// Any other non-success (quota, refusal, content filter) is a

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -73,6 +73,9 @@ export async function runTurns(request) {
 
 	const { query } = await importClaudeSdk();
 	const prompts = [...request.prompts];
+	// Count BEFORE the initial shift: every requested prompt — including the
+	// first — must reach a successful terminal result for the run to be whole.
+	const expectedTurns = prompts.length;
 	const input = controlledInput(userMessage(prompts.shift(), randomUUID()));
 	const options = {
 		model: "claude-haiku-4-5",
@@ -85,7 +88,6 @@ export async function runTurns(request) {
 	};
 	if (request.resume) options.resume = request.resume;
 	const stream = query({ prompt: input, options });
-	const expectedTurns = prompts.length;
 	let completedTurns = 0;
 
 	const drain = (async () => {
@@ -109,13 +111,18 @@ export async function runTurns(request) {
 			// Result envelopes can carry usage directly — record before the gates.
 			result.usage = readUsage(message) ?? result.usage;
 			// A 401/refusal arrives as subtype:"success" with is_error:true; that
-			// combination must map to result_error, never to signal=success.
+			// shape on a resume IS the addressing/auth denial (resume_failed).
+			// Any other non-success (quota, refusal, content filter) is a
+			// turn-level error and must NOT be folded into the denial signal.
 			if (message.subtype !== "success" || message.is_error === true) {
 				const reason =
 					message.is_error === true && message.subtype === "success"
 						? "result_error"
 						: (message.subtype ?? "result_error");
-				throw new Error(request.resume ? "resume_failed" : reason);
+				if (request.resume) {
+					throw new Error(message.is_error === true ? "resume_failed" : `resume_error_${reason}`);
+				}
+				throw new Error(reason);
 			}
 			completedTurns += 1;
 			if (prompts.length === 0) break;

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -96,19 +96,32 @@ export async function runTurns(request) {
 				// through as usage/coherence evidence.
 				if (message.error) throw new Error("assistant_error");
 				if (message.message?.model === "<synthetic>") throw new Error("synthetic_assistant");
-				result.usage = readUsage(message.message) ?? result.usage;
+				// Pass the whole message: usage can live on the assistant envelope OR
+				// directly on the message (result shape) — nested-only reads silently
+				// fall back to a 0.00 cache ratio.
+				result.usage = readUsage(message) ?? result.usage;
 				if (request.expectToken && assistantText(message).includes(request.expectToken)) result.coherent = true;
 			}
 			if (message.type === "auth_status" && message.error) throw new Error("authentication_failed");
 			if (message.type !== "result") continue;
-			// A 401/refusal arrives as subtype:"success" with is_error:true and a
-			// <synthetic> assistant message, so both must be checked.
+			// Result envelopes can carry usage directly — record before the gates.
+			result.usage = readUsage(message) ?? result.usage;
+			// A 401/refusal arrives as subtype:"success" with is_error:true; that
+			// combination must map to result_error, never to signal=success.
 			if (message.subtype !== "success" || message.is_error === true) {
-				throw new Error(request.resume ? "resume_failed" : (message.subtype ?? "result_error"));
+				const reason =
+					message.is_error === true && message.subtype === "success"
+						? "result_error"
+						: (message.subtype ?? "result_error");
+				throw new Error(request.resume ? "resume_failed" : reason);
 			}
+			completedTurns += 1;
 			if (prompts.length === 0) break;
 			input.push(userMessage(prompts.shift(), randomUUID()));
 		}
+		// An iterator that ends before every requested prompt completed its
+		// terminal result means the seed/resume is incomplete — never accept it.
+		if (completedTurns < expectedTurns) throw new Error("turns_incomplete");
 	})();
 
 	try {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -91,7 +91,11 @@ export async function runTurns(request) {
 	let completedTurns = 0;
 
 	const drain = (async () => {
+		const sessionIds = new Set();
 		for await (const message of stream) {
+			// Record EVERY session id the stream reports: a mid-run lineage split
+			// must surface to the supervisor, not hide behind the first init id.
+			if (typeof message.session_id === "string") sessionIds.add(message.session_id);
 			if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
 				result.sessionId ??= message.session_id;
 			}
@@ -131,6 +135,7 @@ export async function runTurns(request) {
 		// An iterator that ends before every requested prompt completed its
 		// terminal result means the seed/resume is incomplete — never accept it.
 		if (completedTurns < expectedTurns) throw new Error("turns_incomplete");
+		if (sessionIds.size > 1) throw new Error("lineage_split");
 	})();
 
 	try {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-reattach-worker.mjs
@@ -71,23 +71,39 @@ export async function runTurns(request) {
 		return result;
 	}
 
-	const { query } = await importClaudeSdk();
+	// Setup failures (SDK import, executable resolution, query construction)
+	// attach to the result like turn-phase failures: the supervisor's verdicts
+	// need the static-read evidence even when setup fails.
+	let query;
+	try {
+		({ query } = await importClaudeSdk());
+	} catch (error) {
+		result.error = error instanceof Error ? error.message : String(error);
+		return result;
+	}
 	const prompts = [...request.prompts];
 	// Count BEFORE the initial shift: every requested prompt — including the
 	// first — must reach a successful terminal result for the run to be whole.
 	const expectedTurns = prompts.length;
 	const input = controlledInput(userMessage(prompts.shift(), randomUUID()));
-	const options = {
-		model: "claude-haiku-4-5",
-		tools: [],
-		permissionMode: "dontAsk",
-		settingSources: [],
-		systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
-		pathToClaudeCodeExecutable: claudeExecutable(),
-		env: managedEnvironment(request.access, request.configDir ? { CLAUDE_CONFIG_DIR: request.configDir } : {}),
-	};
-	if (request.resume) options.resume = request.resume;
-	const stream = query({ prompt: input, options });
+	let stream;
+	try {
+		const options = {
+			model: "claude-haiku-4-5",
+			tools: [],
+			permissionMode: "dontAsk",
+			settingSources: [],
+			systemPrompt: "Answer briefly. Obey the exact reply format the user asks for.",
+			pathToClaudeCodeExecutable: claudeExecutable(),
+			env: managedEnvironment(request.access, request.configDir ? { CLAUDE_CONFIG_DIR: request.configDir } : {}),
+		};
+		if (request.resume) options.resume = request.resume;
+		stream = query({ prompt: input, options });
+	} catch (error) {
+		input.close();
+		result.error = error instanceof Error ? error.message : String(error);
+		return result;
+	}
 	let completedTurns = 0;
 
 	const drain = (async () => {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-credentials.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-credentials.mjs
@@ -40,8 +40,13 @@ function asOauthCredential(credential) {
 export function loadCredential(sandbox, slot = "claude-sdk-oauth-spike") {
 	const { stored, error } = readAuthFile(sandbox);
 	if (error) return { error };
-	const credential = asOauthCredential(stored[slot] ?? stored["claude-sdk-oauth"] ?? stored.anthropic);
-	return credential ? { credential } : { error: "credential_unavailable" };
+	// Try each candidate in order and take the first USABLE one: a present but
+	// malformed primary slot must not shadow a valid fallback.
+	for (const candidate of [stored[slot], stored["claude-sdk-oauth"], stored.anthropic]) {
+		const credential = asOauthCredential(candidate);
+		if (credential) return { credential };
+	}
+	return { error: "credential_unavailable" };
 }
 
 /**

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-credentials.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-credentials.mjs
@@ -1,0 +1,61 @@
+/**
+ * Credential loading for the claude-sdk-oauth live spikes.
+ *
+ * Kept in its own concept-named file so spike-support stays under the 250
+ * pure-LOC ceiling. Never logs token material.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readAuthFile(sandbox) {
+	try {
+		const stored = JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8"));
+		// Valid JSON is not enough: a null/array/primitive auth.json must produce
+		// the documented credential rejection, not a raw TypeError on indexing.
+		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
+			return { error: "credential_unreadable" };
+		}
+		return { stored };
+	} catch {
+		return { error: "credential_unreadable" };
+	}
+}
+
+function asOauthCredential(credential) {
+	// Fail closed on blank tokens too: an empty/whitespace access string would
+	// otherwise be pinned as CLAUDE_CODE_OAUTH_TOKEN and surface as an opaque
+	// auth failure deep in the SDK instead of the documented rejection.
+	if (
+		!credential ||
+		credential.type !== "oauth" ||
+		typeof credential.access !== "string" ||
+		credential.access.trim().length === 0
+	) {
+		return undefined;
+	}
+	return credential;
+}
+
+/** Load a dummy-safe oauth credential from <sandbox>/auth.json. Never logs it. */
+export function loadCredential(sandbox, slot = "claude-sdk-oauth-spike") {
+	const { stored, error } = readAuthFile(sandbox);
+	if (error) return { error };
+	const credential = asOauthCredential(stored[slot] ?? stored["claude-sdk-oauth"] ?? stored.anthropic);
+	return credential ? { credential } : { error: "credential_unavailable" };
+}
+
+/**
+ * Load a credential from EXACTLY the named slot, with no fallback.
+ *
+ * The forgiving `loadCredential` fallback is wrong for multi-account scenarios:
+ * it silently returns the primary slot when the second one was never seeded, so
+ * a cross-account assertion would report success without ever exercising a
+ * second account. Callers that need a distinct account must use this.
+ */
+export function loadCredentialStrict(sandbox, slot) {
+	const { stored, error } = readAuthFile(sandbox);
+	if (error) return { error };
+	if (stored[slot] === undefined) return { error: `slot_missing_${slot}` };
+	const credential = asOauthCredential(stored[slot]);
+	return credential ? { credential } : { error: `slot_unusable_${slot}` };
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -1,0 +1,178 @@
+/**
+ * Shared harness for the live claude-sdk-oauth spikes (Wave A todos 2-4).
+ *
+ * Every spike is gated on SENPI_LIVE_CLAUDE_SDK_OAUTH=1 and reads its OAuth
+ * credential from the seeded sandbox pointed at by SENPI_CODING_AGENT_DIR.
+ * Nothing here ever prints token material.
+ */
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { repoRoot } from "./common.mjs";
+
+export const LIVE_GATE = "SENPI_LIVE_CLAUDE_SDK_OAUTH";
+
+/** Print SKIPPED + exit 0 unless the live gate is set. Keeps default suites token-free. */
+export function requireLiveGate() {
+	if (process.env[LIVE_GATE] === "1") return;
+	console.log(`SKIPPED: set ${LIVE_GATE}=1 to run the live spike`);
+	process.exit(0);
+}
+
+/** Sandbox agent dir (SENPI_CODING_AGENT_DIR); rejects when absent. */
+export function requireSandbox() {
+	const sandbox = process.env.SENPI_CODING_AGENT_DIR;
+	if (sandbox) return sandbox;
+	console.error("REJECTED signal=sandbox_missing");
+	process.exit(2);
+}
+
+/** Load a dummy-safe oauth credential from <sandbox>/auth.json. Never logs it. */
+export function loadCredential(sandbox, slot = "claude-sdk-oauth-spike") {
+	let stored;
+	try {
+		stored = JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8"));
+	} catch {
+		return { error: "credential_unreadable" };
+	}
+	const credential = stored[slot] ?? stored["claude-sdk-oauth"] ?? stored.anthropic;
+	if (!credential || credential.type !== "oauth" || typeof credential.access !== "string") {
+		return { error: "credential_unavailable" };
+	}
+	return { credential };
+}
+
+/** Sanitize any signal/reason into the fixed terminal-line vocabulary shape. */
+export function safeSignal(value) {
+	return String(value ?? "unknown")
+		.toLowerCase()
+		.replace(/[^a-z0-9_.-]+/g, "_")
+		.slice(0, 80);
+}
+
+/** Parent env with every ambient Anthropic/Claude credential channel removed. */
+export function managedEnvironment(access, extra = {}) {
+	const env = { ...process.env };
+	delete env.ANTHROPIC_API_KEY;
+	delete env.ANTHROPIC_AUTH_TOKEN;
+	delete env.ANTHROPIC_BASE_URL;
+	delete env.ANTHROPIC_CUSTOM_HEADERS;
+	delete env.CLAUDECODE;
+	delete env.CLAUDE_CODE_USE_BEDROCK;
+	delete env.CLAUDE_CODE_USE_FOUNDRY;
+	delete env.CLAUDE_CODE_USE_GATEWAY;
+	delete env.CLAUDE_CODE_USE_VERTEX;
+	for (const name of Object.keys(env)) {
+		if (/^CLAUDE_CODE_OAUTH_TOKEN(?:_\d+)?$/.test(name)) delete env[name];
+	}
+	return { ...env, CLAUDE_CODE_OAUTH_TOKEN: access, ...extra };
+}
+
+/** SDKUserMessage envelope for streaming input. */
+export function userMessage(text, uuid) {
+	return { type: "user", message: { role: "user", content: text }, parent_tool_use_id: null, uuid };
+}
+
+/** Push-driven async iterable used as a streaming-input prompt. */
+export function controlledInput(initialMessage) {
+	const pending = initialMessage ? [initialMessage] : [];
+	const waiters = [];
+	let closed = false;
+	return {
+		push(message) {
+			const waiter = waiters.shift();
+			if (waiter) waiter({ value: message, done: false });
+			else pending.push(message);
+		},
+		close() {
+			closed = true;
+			for (const waiter of waiters.splice(0)) waiter({ value: undefined, done: true });
+		},
+		[Symbol.asyncIterator]() {
+			return {
+				next() {
+					const message = pending.shift();
+					if (message) return Promise.resolve({ value: message, done: false });
+					if (closed) return Promise.resolve({ value: undefined, done: true });
+					return new Promise((resolve) => waiters.push(resolve));
+				},
+			};
+		},
+	};
+}
+
+function codingAgentRequire() {
+	return createRequire(join(repoRoot(), "packages/coding-agent/package.json"));
+}
+
+/**
+ * Import the SAME @anthropic-ai/claude-agent-sdk build senpi runs against.
+ * A bare specifier would resolve against the script's own directory and can
+ * pick up an unrelated globally installed SDK.
+ */
+export async function importClaudeSdk() {
+	return import(pathToFileURL(codingAgentRequire().resolve("@anthropic-ai/claude-agent-sdk")).href);
+}
+
+/**
+ * Resolve the real Claude Code binary the same way senpi's executable.ts does
+ * (platform package first, CLAUDE_CODE_EXECUTABLE override wins). Resolved here
+ * rather than by importing the TypeScript module so the spikes run under plain
+ * `node`, without tsx.
+ */
+export function claudeExecutable() {
+	const override = process.env.CLAUDE_CODE_EXECUTABLE;
+	if (override) return override;
+	const require_ = codingAgentRequire();
+	const extension = process.platform === "win32" ? ".exe" : "";
+	const candidates =
+		process.platform === "linux"
+			? [
+					`@anthropic-ai/claude-agent-sdk-linux-${process.arch}-musl/claude${extension}`,
+					`@anthropic-ai/claude-agent-sdk-linux-${process.arch}/claude${extension}`,
+				]
+			: [`@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}/claude${extension}`];
+	for (const candidate of candidates) {
+		try {
+			return require_.resolve(candidate);
+		} catch {
+			// try the next platform package
+		}
+	}
+	throw new Error("claude_binary_not_found");
+}
+
+/** Concatenated assistant text of an SDK assistant message. */
+export function assistantText(message) {
+	if (message?.type !== "assistant" || !Array.isArray(message.message?.content)) return "";
+	return message.message.content
+		.filter((block) => block?.type === "text" && typeof block.text === "string")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+/** Reject with a sanitized signal and exit 2. */
+export function reject(signal, extra = "") {
+	console.error(`REJECTED signal=${safeSignal(signal)}${extra ? ` ${extra}` : ""}`);
+	process.exit(2);
+}
+
+/** Race a promise against a bounded deadline (no polling, no fixed sleeps). */
+export function withDeadline(promise, label, timeoutMs) {
+	let timer;
+	const deadline = new Promise((_resolve, reject_) => {
+		timer = setTimeout(() => reject_(new Error(`${label}_timeout`)), timeoutMs);
+	});
+	return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
+
+/** Close a query handle without letting a close error mask the real outcome. */
+export function closeQuietly(handle) {
+	try {
+		handle?.close?.();
+	} catch {
+		// best-effort teardown
+	}
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -12,6 +12,10 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { repoRoot } from "./common.mjs";
 
+// Canonical timeout helper lives in with-timeout.mjs; re-exported so the spikes
+// share ONE race-a-promise-against-a-timer implementation instead of drifting copies.
+export { withTimeout } from "./with-timeout.mjs";
+
 export const LIVE_GATE = "SENPI_LIVE_CLAUDE_SDK_OAUTH";
 
 /** Print SKIPPED + exit 0 unless the live gate is set. Keeps default suites token-free. */
@@ -74,9 +78,16 @@ export function safeSignal(value) {
 		.slice(0, 80);
 }
 
-/** Parent env with every ambient Anthropic/Claude credential channel removed. */
-export function managedEnvironment(access, extra = {}) {
-	const env = { ...process.env };
+/**
+ * Remove every ambient Anthropic/Claude/senpi credential channel from `env`.
+ *
+ * Known credential names are not enough: token-bearing SENPI_* variables
+ * (spike harness internals) would otherwise be inherited by the Claude Code
+ * subprocess, so the whole SENPI_ prefix is stripped — matching the
+ * production OAuth lane, which never forwards senpi internals either.
+ * Callers re-add exactly what the child needs via the `extra` argument.
+ */
+export function stripCredentialEnvironment(env) {
 	delete env.ANTHROPIC_API_KEY;
 	delete env.ANTHROPIC_AUTH_TOKEN;
 	delete env.ANTHROPIC_BASE_URL;
@@ -88,7 +99,14 @@ export function managedEnvironment(access, extra = {}) {
 	delete env.CLAUDE_CODE_USE_VERTEX;
 	for (const name of Object.keys(env)) {
 		if (/^CLAUDE_CODE_OAUTH_TOKEN(?:_\d+)?$/.test(name)) delete env[name];
+		if (name.startsWith("SENPI_")) delete env[name];
 	}
+	return env;
+}
+
+/** Child env with every ambient credential channel removed and the spike token pinned. */
+export function managedEnvironment(access, extra = {}) {
+	const env = stripCredentialEnvironment({ ...process.env });
 	return { ...env, CLAUDE_CODE_OAUTH_TOKEN: access, ...extra };
 }
 
@@ -179,15 +197,6 @@ export function assistantText(message) {
 export function reject(signal, extra = "") {
 	console.error(`REJECTED signal=${safeSignal(signal)}${extra ? ` ${extra}` : ""}`);
 	process.exit(2);
-}
-
-/** Race a promise against a bounded deadline (no polling, no fixed sleeps). */
-export function withDeadline(promise, label, timeoutMs) {
-	let timer;
-	const deadline = new Promise((_resolve, reject_) => {
-		timer = setTimeout(() => reject_(new Error(`${label}_timeout`)), timeoutMs);
-	});
-	return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
 }
 
 /** Close a query handle without letting a close error mask the real outcome. */

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -29,19 +29,41 @@ export function requireSandbox() {
 	process.exit(2);
 }
 
-/** Load a dummy-safe oauth credential from <sandbox>/auth.json. Never logs it. */
-export function loadCredential(sandbox, slot = "claude-sdk-oauth-spike") {
-	let stored;
+function readAuthFile(sandbox) {
 	try {
-		stored = JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8"));
+		return { stored: JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8")) };
 	} catch {
 		return { error: "credential_unreadable" };
 	}
-	const credential = stored[slot] ?? stored["claude-sdk-oauth"] ?? stored.anthropic;
-	if (!credential || credential.type !== "oauth" || typeof credential.access !== "string") {
-		return { error: "credential_unavailable" };
-	}
-	return { credential };
+}
+
+function asOauthCredential(credential) {
+	if (!credential || credential.type !== "oauth" || typeof credential.access !== "string") return undefined;
+	return credential;
+}
+
+/** Load a dummy-safe oauth credential from <sandbox>/auth.json. Never logs it. */
+export function loadCredential(sandbox, slot = "claude-sdk-oauth-spike") {
+	const { stored, error } = readAuthFile(sandbox);
+	if (error) return { error };
+	const credential = asOauthCredential(stored[slot] ?? stored["claude-sdk-oauth"] ?? stored.anthropic);
+	return credential ? { credential } : { error: "credential_unavailable" };
+}
+
+/**
+ * Load a credential from EXACTLY the named slot, with no fallback.
+ *
+ * The forgiving `loadCredential` fallback is wrong for multi-account scenarios:
+ * it silently returns the primary slot when the second one was never seeded, so
+ * a cross-account assertion would report success without ever exercising a
+ * second account. Callers that need a distinct account must use this.
+ */
+export function loadCredentialStrict(sandbox, slot) {
+	const { stored, error } = readAuthFile(sandbox);
+	if (error) return { error };
+	if (stored[slot] === undefined) return { error: `slot_missing_${slot}` };
+	const credential = asOauthCredential(stored[slot]);
+	return credential ? { credential } : { error: `slot_unusable_${slot}` };
 }
 
 /** Sanitize any signal/reason into the fixed terminal-line vocabulary shape. */

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -6,7 +6,7 @@
  * Nothing here ever prints token material.
  */
 
-import { readFileSync, writeSync } from "node:fs";
+import { writeSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -34,48 +34,10 @@ export function requireSandbox() {
 	process.exit(2);
 }
 
-function readAuthFile(sandbox) {
-	try {
-		const stored = JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8"));
-		// Valid JSON is not enough: a null/array/primitive auth.json must produce
-		// the documented credential rejection, not a raw TypeError on indexing.
-		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
-			return { error: "credential_unreadable" };
-		}
-		return { stored };
-	} catch {
-		return { error: "credential_unreadable" };
-	}
-}
-
-function asOauthCredential(credential) {
-	if (!credential || credential.type !== "oauth" || typeof credential.access !== "string") return undefined;
-	return credential;
-}
-
-/** Load a dummy-safe oauth credential from <sandbox>/auth.json. Never logs it. */
-export function loadCredential(sandbox, slot = "claude-sdk-oauth-spike") {
-	const { stored, error } = readAuthFile(sandbox);
-	if (error) return { error };
-	const credential = asOauthCredential(stored[slot] ?? stored["claude-sdk-oauth"] ?? stored.anthropic);
-	return credential ? { credential } : { error: "credential_unavailable" };
-}
-
-/**
- * Load a credential from EXACTLY the named slot, with no fallback.
- *
- * The forgiving `loadCredential` fallback is wrong for multi-account scenarios:
- * it silently returns the primary slot when the second one was never seeded, so
- * a cross-account assertion would report success without ever exercising a
- * second account. Callers that need a distinct account must use this.
- */
-export function loadCredentialStrict(sandbox, slot) {
-	const { stored, error } = readAuthFile(sandbox);
-	if (error) return { error };
-	if (stored[slot] === undefined) return { error: `slot_missing_${slot}` };
-	const credential = asOauthCredential(stored[slot]);
-	return credential ? { credential } : { error: `slot_unusable_${slot}` };
-}
+// Credential loading lives in claude-sdk-oauth-spike-credentials.mjs (split
+// out so this module stays under the 250 pure-LOC ceiling); re-exported so
+// existing spike imports keep working.
+export { loadCredential, loadCredentialStrict } from "./claude-sdk-oauth-spike-credentials.mjs";
 
 /** Sanitize any signal/reason into the fixed terminal-line vocabulary shape. */
 export function safeSignal(value) {

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -118,7 +118,9 @@ export function managedEnvironment(access, extra = {}) {
 	// operator-set value would silently re-address every grandchild, so it is
 	// cleared here too; callers re-add a scoped root deliberately via `extra`.
 	delete env.CLAUDE_CONFIG_DIR;
-	return { ...env, CLAUDE_CODE_OAUTH_TOKEN: access, ...extra };
+	// The token pin is applied LAST so nothing a caller re-adds through `extra`
+	// can silently overwrite it — the pin is the function's contract.
+	return { ...env, ...extra, CLAUDE_CODE_OAUTH_TOKEN: access };
 }
 
 /** SDKUserMessage envelope for streaming input. */
@@ -272,7 +274,14 @@ export async function startGuardedQuery({ firstMessage, options, secrets }) {
 	try {
 		const { query } = await importClaudeSdk();
 		input = controlledInput(firstMessage);
-		stream = query({ prompt: input, options });
+		// The executable is resolved INSIDE the guarded path: resolving it at the
+		// call site would throw a missing-binary error outside the REJECTED
+		// contract.
+		const resolved = {
+			...options,
+			pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable ?? claudeExecutable(),
+		};
+		stream = query({ prompt: input, options: resolved });
 	} catch (error) {
 		reject(error instanceof Error ? error.message : String(error), "", secrets);
 	}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -6,7 +6,7 @@
  * Nothing here ever prints token material.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -21,7 +21,8 @@ export const LIVE_GATE = "SENPI_LIVE_CLAUDE_SDK_OAUTH";
 /** Print SKIPPED + exit 0 unless the live gate is set. Keeps default suites token-free. */
 export function requireLiveGate() {
 	if (process.env[LIVE_GATE] === "1") return;
-	console.log(`SKIPPED: set ${LIVE_GATE}=1 to run the live spike`);
+	// writeSync: a forced exit after an async pipe write can truncate the line.
+	writeSync(1, `SKIPPED: set ${LIVE_GATE}=1 to run the live spike\n`);
 	process.exit(0);
 }
 
@@ -29,7 +30,7 @@ export function requireLiveGate() {
 export function requireSandbox() {
 	const sandbox = process.env.SENPI_CODING_AGENT_DIR;
 	if (sandbox) return sandbox;
-	console.error("REJECTED signal=sandbox_missing");
+	writeSync(2, "REJECTED signal=sandbox_missing\n");
 	process.exit(2);
 }
 
@@ -229,7 +230,9 @@ export function redactSecrets(text, secrets = []) {
 
 /** Reject with a sanitized, secret-redacted signal and exit 2. */
 export function reject(signal, extra = "", secrets = []) {
-	console.error(`REJECTED signal=${safeSignal(redactSecrets(signal, secrets))}${extra ? ` ${extra}` : ""}`);
+	// writeSync: the REJECTED line is the spike's machine-readable contract and
+	// a forced exit after an async pipe write can truncate it.
+	writeSync(2, `REJECTED signal=${safeSignal(redactSecrets(signal, secrets))}${extra ? ` ${extra}` : ""}\n`);
 	process.exit(2);
 }
 

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -35,7 +35,13 @@ export function requireSandbox() {
 
 function readAuthFile(sandbox) {
 	try {
-		return { stored: JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8")) };
+		const stored = JSON.parse(readFileSync(join(sandbox, "auth.json"), "utf8"));
+		// Valid JSON is not enough: a null/array/primitive auth.json must produce
+		// the documented credential rejection, not a raw TypeError on indexing.
+		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
+			return { error: "credential_unreadable" };
+		}
+		return { stored };
 	} catch {
 		return { error: "credential_unreadable" };
 	}
@@ -107,6 +113,10 @@ export function stripCredentialEnvironment(env) {
 /** Child env with every ambient credential channel removed and the spike token pinned. */
 export function managedEnvironment(access, extra = {}) {
 	const env = stripCredentialEnvironment({ ...process.env });
+	// CLAUDE_CONFIG_DIR is a config-root channel, not a credential, but an
+	// operator-set value would silently re-address every grandchild, so it is
+	// cleared here too; callers re-add a scoped root deliberately via `extra`.
+	delete env.CLAUDE_CONFIG_DIR;
 	return { ...env, CLAUDE_CODE_OAUTH_TOKEN: access, ...extra };
 }
 
@@ -122,6 +132,9 @@ export function controlledInput(initialMessage) {
 	let closed = false;
 	return {
 		push(message) {
+			// A closed input is terminal: late pushes (timeout/cleanup races) must
+			// not be yielded to the query after close().
+			if (closed) return;
 			const waiter = waiters.shift();
 			if (waiter) waiter({ value: message, done: false });
 			else pending.push(message);

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -59,6 +59,7 @@ export function safeSignal(value) {
 export function stripCredentialEnvironment(env) {
 	delete env.ANTHROPIC_API_KEY;
 	delete env.ANTHROPIC_AUTH_TOKEN;
+	delete env.ANTHROPIC_OAUTH_TOKEN;
 	delete env.ANTHROPIC_BASE_URL;
 	delete env.ANTHROPIC_CUSTOM_HEADERS;
 	delete env.CLAUDECODE;

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -244,3 +244,43 @@ export function closeQuietly(handle) {
 		// best-effort teardown
 	}
 }
+
+/**
+ * Guarded spike query setup shared by the live spikes.
+ *
+ * SIGINT/SIGTERM handlers are installed BEFORE setup so the whole arm
+ * lifecycle is covered (a signal during SDK import/binary resolution would
+ * otherwise bypass cleanup); they tolerate a not-yet-created input/stream.
+ * SDK import, missing-binary, and query-construction failures exit through
+ * the sanitized REJECTED contract, never a raw exit 1. The returned disarm()
+ * removes the handlers at arm end so a stale listener cannot fire during a
+ * later arm and exit before that arm's stream is reaped.
+ */
+export async function startGuardedQuery({ firstMessage, options, secrets }) {
+	let input;
+	let stream;
+	const signalHandlers = [];
+	for (const signal of ["SIGINT", "SIGTERM"]) {
+		const handler = () => {
+			input?.close();
+			closeQuietly(stream);
+			reject(`interrupted_${signal.toLowerCase()}`, "", secrets);
+		};
+		process.once(signal, handler);
+		signalHandlers.push([signal, handler]);
+	}
+	try {
+		const { query } = await importClaudeSdk();
+		input = controlledInput(firstMessage);
+		stream = query({ prompt: input, options });
+	} catch (error) {
+		reject(error instanceof Error ? error.message : String(error), "", secrets);
+	}
+	return {
+		input,
+		stream,
+		disarm() {
+			for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
+		},
+	};
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -206,9 +206,24 @@ export function assistantText(message) {
 		.join("\n");
 }
 
-/** Reject with a sanitized signal and exit 2. */
-export function reject(signal, extra = "") {
-	console.error(`REJECTED signal=${safeSignal(signal)}${extra ? ` ${extra}` : ""}`);
+/**
+ * Redact known secret values from an arbitrary error string.
+ *
+ * safeSignal() is a shape sanitizer, NOT a secret redactor: hyphenated
+ * credential material and generated recall tokens survive it. Any error text
+ * that could echo a prompt or a credential must pass through here first.
+ */
+export function redactSecrets(text, secrets = []) {
+	let out = String(text ?? "");
+	for (const secret of secrets) {
+		if (typeof secret === "string" && secret.length >= 8) out = out.split(secret).join("[redacted]");
+	}
+	return out;
+}
+
+/** Reject with a sanitized, secret-redacted signal and exit 2. */
+export function reject(signal, extra = "", secrets = []) {
+	console.error(`REJECTED signal=${safeSignal(redactSecrets(signal, secrets))}${extra ? ` ${extra}` : ""}`);
 	process.exit(2);
 }
 

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -233,8 +233,11 @@ export function redactSecrets(text, secrets = []) {
 /** Reject with a sanitized, secret-redacted signal and exit 2. */
 export function reject(signal, extra = "", secrets = []) {
 	// writeSync: the REJECTED line is the spike's machine-readable contract and
-	// a forced exit after an async pipe write can truncate it.
-	writeSync(2, `REJECTED signal=${safeSignal(redactSecrets(signal, secrets))}${extra ? ` ${extra}` : ""}\n`);
+	// a forced exit after an async pipe write can truncate it. The extra detail
+	// is sanitized/redacted by the helper itself — no caller may append raw
+	// error text to the contract line.
+	const detail = extra ? ` ${safeSignal(redactSecrets(extra, secrets))}` : "";
+	writeSync(2, `REJECTED signal=${safeSignal(redactSecrets(signal, secrets))}${detail}\n`);
 	process.exit(2);
 }
 

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-spike-support.mjs
@@ -141,6 +141,10 @@ export function controlledInput(initialMessage) {
 		},
 		close() {
 			closed = true;
+			// Buffered-but-undelivered prompts must not reach the query after
+			// close: cleanup racing a turn boundary would otherwise drive one
+			// more SDK turn after the spike considers the stream closed.
+			pending.length = 0;
 			for (const waiter of waiters.splice(0)) waiter({ value: undefined, done: true });
 		},
 		[Symbol.asyncIterator]() {
@@ -216,7 +220,9 @@ export function assistantText(message) {
 export function redactSecrets(text, secrets = []) {
 	let out = String(text ?? "");
 	for (const secret of secrets) {
-		if (typeof secret === "string" && secret.length >= 8) out = out.split(secret).join("[redacted]");
+		// Every non-empty secret is redacted — a length cutoff would let short
+		// credentials through the no-token-material contract.
+		if (typeof secret === "string" && secret.length > 0) out = out.split(secret).join("[redacted]");
 	}
 	return out;
 }

--- a/.agents/skills/senpi-qa/scripts/lib/output-safety.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/output-safety.mjs
@@ -1,0 +1,13 @@
+/**
+ * Output-safety helpers shared by every senpi-qa probe.
+ *
+ * Kept in their own concept-named file so no probe is forced to depend on a
+ * module named for a sibling probe.
+ */
+
+/** Collapse an arbitrary value into a single-line, length-capped detail string. */
+export function safeDetail(value) {
+	return String(value)
+		.replace(/[\r\n]+/g, " ")
+		.slice(0, 500);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/terminal-screenshot.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/terminal-screenshot.mjs
@@ -109,8 +109,8 @@ async function connectCdp(url) {
 			socket.addEventListener("open", resolve, { once: true });
 			socket.addEventListener("error", reject, { once: true });
 		}),
-		10_000,
 		"Chrome DevTools socket",
+		10_000,
 	);
 	let sequence = 0;
 	const pending = new Map();
@@ -153,18 +153,3 @@ async function stopProcess(child) {
 	}
 }
 
-function withTimeout(promise, timeoutMs, label) {
-	return new Promise((resolve, reject) => {
-		const timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
-		promise.then(
-			(value) => {
-				clearTimeout(timer);
-				resolve(value);
-			},
-			(error) => {
-				clearTimeout(timer);
-				reject(error);
-			},
-		);
-	});
-}

--- a/.agents/skills/senpi-qa/scripts/lib/terminal-screenshot.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/terminal-screenshot.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { withTimeout } from "./with-timeout.mjs";
 
 const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 
@@ -48,8 +49,8 @@ export async function renderTerminalScreenshot(root, evidence, raw) {
 		const port = await devToolsPort(chrome);
 		const targets = await withTimeout(
 			fetch(`http://127.0.0.1:${port}/json/list`).then((response) => response.json()),
-			10_000,
 			"Chrome target list",
+			10_000,
 		);
 		const page = targets.find((target) => target.type === "page");
 		if (!page?.webSocketDebuggerUrl) throw new Error("Chrome did not expose a page target");
@@ -97,8 +98,8 @@ function devToolsPort(chrome) {
 			});
 			chrome.once("exit", (code) => reject(new Error(`Chrome exited before DevTools startup (${code})`)));
 		}),
-		15_000,
 		"Chrome DevTools startup",
+		15_000,
 	);
 }
 
@@ -131,8 +132,8 @@ async function connectCdp(url) {
 					pending.set(id, { resolve, reject });
 					socket.send(JSON.stringify({ id, method, params }));
 				}),
-				15_000,
 				`Chrome command ${method}`,
+				15_000,
 			);
 		},
 		close() {
@@ -146,10 +147,10 @@ async function stopProcess(child) {
 	const exited = new Promise((resolve) => child.once("exit", resolve));
 	child.kill("SIGTERM");
 	try {
-		await withTimeout(exited, 5_000, "Chrome shutdown");
+		await withTimeout(exited, "Chrome shutdown", 5_000);
 	} catch {
 		child.kill("SIGKILL");
-		await withTimeout(exited, 5_000, "Chrome forced shutdown");
+		await withTimeout(exited, "Chrome forced shutdown", 5_000);
 	}
 }
 

--- a/.agents/skills/senpi-qa/scripts/lib/with-timeout.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/with-timeout.mjs
@@ -1,0 +1,16 @@
+/**
+ * Canonical bounded-deadline helper for every senpi-qa script.
+ *
+ * Kept in its own file so common.mjs (already over the 250 pure-LOC ceiling)
+ * does not grow, and so no second copy of the race-a-promise-against-a-timer
+ * pattern drifts across probes and spikes.
+ */
+
+/** Race a promise against a bounded deadline (no polling, no fixed sleeps). */
+export function withTimeout(promise, label, timeoutMs = 60_000) {
+	let timer;
+	const timeout = new Promise((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}


### PR DESCRIPTION
## What

Wave A of the resume-first session-continuity work (plan `.omo/plans/claude-sdk-oauth-resident-reuse-e2e-fix.md`, todos 1-4). **QA scripts only — zero runtime change.**

- `claude-sdk-oauth-fullstack-probe.mjs` drives the REAL stack (`createAgentSession` -> `AgentSession.prompt` -> provider) with SDK query creation intercepted at `overrideSdkBoundary`, the choke point the resident and flatten paths share. Loopback-only SSE server; no credentials, no egress.
- Three live spikes (`native-inline`, `reattach`, `autocompact`) gated behind `SENPI_LIVE_CLAUDE_SDK_OAUTH=1`; ungated they print `SKIPPED` and exit 0.

## Why it matters

The baseline probe run against current `main` produced the finding that reframed the whole project:

```
turn  queries  path               payload    lineage
1     1        resident-registry  bootstrap  019fbc9f
2-6   0        resident-registry  delta      019fbc9f
VERDICT: PASS fullstack-baseline queries=1 lineages=1 flatten_turns=0
```

A plain 6-turn conversation **already** reuses one session. The reported cache-hit decay therefore comes from divergence boundaries (compaction, abort, model switch, restart, midnight churn, failover), not ordinary turns — which is what the follow-up PRs fix.

## Evidence

- Baseline table + VERDICT captured; three ungated `SKIPPED` runs captured.
- Cleanup receipts: loopback server closed, no orphan Claude Code subprocesses, sandboxes removed.
- No live spike was executed: zero subscription quota spent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hermetic full‑stack continuity probe and three gated live spikes for `claude-sdk-oauth` to validate session reuse, resume/reattach, interrupts, model switches, and auto‑compaction with zero runtime changes. Tightens env isolation and teardown; infrastructure/setup failures return sanitized rejections.

- **Hardening**
  - Env isolation: strip all Anthropic/OAuth channels (incl. `ANTHROPIC_OAUTH_TOKEN`); spike tokens are pinned via a managed env and never forwarded.
  - Process/cleanup: workers run with isolated HOME/USERPROFILE; exit hooks reap the Claude Code grandchild; kill POSIX process groups/Windows process trees on timeout/SIGINT/SIGTERM/SIGHUP; temp config roots are removed. Full‑stack probe now closes the resident registry entry before disposing the session so the resident OAuth subprocess is reaped.
  - Autocompact spike: boundaries are attributed by `compact_metadata.trigger` only (trigger‑absent still counts as received, but unattributed); `/compact` is sent once; the recall turn must reach a terminal result or `recall_incomplete`.
  - Full‑stack probe: wrong‑route/shape POSTs fail closed (404/400); per‑turn wire evidence is required; teardown preserves the original fatal error.
  - Lineage gates: cross‑account `ok` and scoped `env‑honored` require the resumed query to report the seeded `session_id`; otherwise `lineage_mismatch`. Reattach worker merges usage by max so `cache_read_ratio` stays accurate.

<sup>Written for commit f825fe37c9ca400671dbc2215084a122d6655fb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

