### PR TITLE
fix(claude-sdk-oauth): fail closed after logout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Claude SDK OAuth classifies Fable-style "requires usage credits" failures as a non-retryable entitlement instead of a rate limit, so the account is not blocked for 60s and AgentSession can fall through to the next model ([#709](https://github.com/code-yeongyu/senpi/issues/709)).
 - Print mode (`-p` / `--mode json`) now writes a stderr notice when retry fallback substitutes a model, so silent wrong-model answers are visible without corrupting JSON stdout ([oh-my-openagent#7626](https://github.com/code-yeongyu/oh-my-openagent/issues/7626)).
 - Claude SDK OAuth host-tool denial now states that Senpi executes the tool on the host and returns the result as the next user message, so models no longer treat "Do not retry with other tools; end the turn." as a failure ([#784](https://github.com/code-yeongyu/senpi/issues/784), [oh-my-openagent#7115](https://github.com/code-yeongyu/oh-my-openagent/issues/7115)).
+- Claude SDK OAuth no longer falls back to the host `claude` CLI login when a managed lane is selected and its account pool is empty: `oauth-slots` and `config-dir` now fail with `No Claude SDK OAuth accounts configured for the managed lane` instead of silently answering with ambient credentials after `/logout`. The ambient lane (no `tokenInjection` and no stored accounts) is unchanged.
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
@@ -113,7 +113,12 @@ async function managedPool(
 	const configuredLane = resolveEffectiveLane(settings, accounts);
 	const lane =
 		configuredLane === "config-dir" && hasRequestOauthToken(requestEnvironment) ? "oauth-slots" : configuredLane;
-	if (lane === "ambient" || accounts.length === 0) return undefined;
+	if (lane === "ambient") return undefined;
+	if (accounts.length === 0) {
+		throw new Error(
+			"authentication_failed: No Claude SDK OAuth accounts configured. Add one with /claude-account add.",
+		);
+	}
 	const stored = credential?.type === "oauth" ? (credential as ClaudeSdkOauthCredential) : undefined;
 	return { accounts, environment, lane, pinnedAccount: settings.pinnedAccount ?? stored?.pinned, store };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
@@ -27,6 +27,11 @@ export { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./account-management.ts";
 
 export const EXPIRING_WITHIN_MS = 5 * 60_000;
 
+/** A managed lane with an empty pool must refuse rather than spawn the SDK against ambient host credentials. */
+const NO_MANAGED_ACCOUNTS_ERROR =
+	"authentication_failed: No Claude SDK OAuth accounts configured for the managed lane; " +
+	"run /login claude-sdk-oauth or set CLAUDE_CODE_OAUTH_TOKEN";
+
 type AuthLaneBoundary = {
 	createStore: () => CredentialStore;
 	env: () => NodeJS.ProcessEnv;
@@ -114,11 +119,7 @@ async function managedPool(
 	const lane =
 		configuredLane === "config-dir" && hasRequestOauthToken(requestEnvironment) ? "oauth-slots" : configuredLane;
 	if (lane === "ambient") return undefined;
-	if (accounts.length === 0) {
-		throw new Error(
-			"authentication_failed: No Claude SDK OAuth accounts configured. Add one with /claude-account add.",
-		);
-	}
+	if (accounts.length === 0) throw new Error(NO_MANAGED_ACCOUNTS_ERROR);
 	const stored = credential?.type === "oauth" ? (credential as ClaudeSdkOauthCredential) : undefined;
 	return { accounts, environment, lane, pinnedAccount: settings.pinnedAccount ?? stored?.pinned, store };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -20,6 +20,7 @@
 - MEDIUM in `errors.ts` around `classifySdkError` prose matchers and the `SdkErrorKind` union.
 - LOW in `guidance.ts` around `sdkErrorGuidance`.
 ## 2026-09-03 - State host-tool denial as a fact, not an instruction to end the turn
+## 2026-09-03 - Fail closed when a managed lane has no accounts (LAB-27)
 
 ### What changed
 
@@ -38,6 +39,22 @@
 
 - LOW: `tools.ts` denial constants and `HOST_TOOL_POLICY_FINGERPRINT`.
 - LOW: `session-sync.ts` `configFingerprint` `hostToolPolicy` field.
+### What changed
+
+- `auth-lane.ts`: `managedPool` no longer folds an empty account pool into the ambient return. The ambient lane still returns `undefined` and spawns the host Claude CLI lane; an explicit or resolved managed lane (`oauth-slots`, `config-dir`) with zero stored and zero environment accounts now throws `NO_MANAGED_ACCOUNTS_ERROR` (`authentication_failed: No Claude SDK OAuth accounts configured for the managed lane; run /login claude-sdk-oauth or set CLAUDE_CODE_OAUTH_TOKEN`) before any subprocess is spawned.
+
+### Why
+
+- After `/logout claude-sdk-oauth` (or with a hand-written `tokenInjection: "oauth-slots"` and no slots), the combined `lane === "ambient" || accounts.length === 0` guard returned `undefined`, and `queryWithAuthLane` then built an ambient child environment and ran the SDK against whatever the host `claude` CLI happened to be logged into. A user who chose a managed lane silently got answers billed to an unrelated local Claude login, and `/logout` was not authoritative. The availability predicate in `oauth-login.ts` can hide the provider, but `streamClaudeSdkOauth` reaches `queryWithAuthLane` directly, so the spawn path had to refuse on its own.
+- The ambient default of oh-my-openagent#6784 is preserved deliberately: unset `tokenInjection` with an empty store still resolves to `ambient` through `resolveEffectiveLane` and keeps spawning ambiently.
+
+### Why an extension could not handle it
+
+- Lane resolution and the pre-spawn credential decision live inside this builtin provider's `managedPool`/`queryWithAuthLane`; no extension hook runs between lane selection and the SDK subprocess spawn.
+
+### Expected merge conflict zones
+
+- LOW in `auth-lane.ts` around the `managedPool` lane guard (one condition split into two statements plus one module-level message constant).
 ## 2026-09-03 - Never resume an SDK session id the SDK never acknowledged
 
 ### What changed
@@ -795,13 +812,6 @@ LOW in `oauth-login.ts` (added `check` to the returned shape + optional `readSet
 ### Expected merge conflict zones
 
 - `auth-lane.ts`, provider error classification, and account failover tests.
-
-## 2026-08-01 - Fail closed after managed-account logout
-
-- Managed `oauth-slots` and `config-dir` modes now report that login is required when their account pool is empty instead of silently falling back to ambient Claude CLI credentials.
-- This makes `/logout` authoritative for the selected managed provider: a fallback attempt cannot reuse an unrelated local Claude login and appear to answer successfully.
-- Ambient mode remains unchanged and still intentionally inherits non-Senpi Claude authentication.
-- Merge-conflict risk: low. The only overlap surface is the empty-pool branch in `managedPool`.
 
 ## 2026-07-31 - Native system prompt, session reuse, env overrides, and transcript hardening
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -796,6 +796,13 @@ LOW in `oauth-login.ts` (added `check` to the returned shape + optional `readSet
 
 - `auth-lane.ts`, provider error classification, and account failover tests.
 
+## 2026-08-01 - Fail closed after managed-account logout
+
+- Managed `oauth-slots` and `config-dir` modes now report that login is required when their account pool is empty instead of silently falling back to ambient Claude CLI credentials.
+- This makes `/logout` authoritative for the selected managed provider: a fallback attempt cannot reuse an unrelated local Claude login and appear to answer successfully.
+- Ambient mode remains unchanged and still intentionally inherits non-Senpi Claude authentication.
+- Merge-conflict risk: low. The only overlap surface is the empty-pool branch in `managedPool`.
+
 ## 2026-07-31 - Native system prompt, session reuse, env overrides, and transcript hardening
 
 - **System prompt modes (new default: `full`).** Added a `systemPromptMode` setting with three values. `full` (new default) sends senpi's own composed system prompt verbatim — previously the lane rebuilt a prompt from the SDK `claude_code` preset plus three extracted regions, so any region without a dedicated extractor was silently dropped (a persistent response-language instruction never reached the model). `preset-append` is the previous behaviour, now DEPRECATED and kept for one release; selecting it emits a one-time warning. `override` loads the system prompt verbatim from a file (`systemPromptFile`). The legacy `appendSystemPrompt` key still works and maps onto the modes: `false` → `preset-append`, `true`/unset → `full`. Setting both `appendSystemPrompt` and `systemPromptMode` makes `systemPromptMode` win and emits a warning.

--- a/packages/coding-agent/test/suite/regressions/lab-27-claude-oauth-logout.test.ts
+++ b/packages/coding-agent/test/suite/regressions/lab-27-claude-oauth-logout.test.ts
@@ -1,0 +1,44 @@
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	overrideAuthLaneBoundary,
+	queryWithAuthLane,
+	resetAuthLaneBoundary,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts";
+import type {
+	Options,
+	SDKMessage,
+	SdkQuery,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+
+async function consume(messages: AsyncGenerator<SDKMessage>): Promise<void> {
+	for await (const _message of messages) void _message;
+}
+
+afterEach(() => {
+	resetAuthLaneBoundary();
+});
+
+describe("LAB-27 Claude OAuth logout", () => {
+	it("requires login instead of falling back to ambient Claude credentials", async () => {
+		overrideAuthLaneBoundary({
+			createStore: () => new InMemoryCredentialStore(),
+			env: () => ({ PATH: "/usr/bin" }),
+		});
+		const query = vi.fn(() => {
+			throw new Error("ambient Claude query must not run");
+		}) as unknown as SdkQuery;
+
+		const messages = queryWithAuthLane({
+			prompt: "resume",
+			query,
+			buildOptions: () => ({}) as Options,
+			providerSettings: { tokenInjection: "oauth-slots" },
+		});
+
+		await expect(consume(messages)).rejects.toThrow(
+			"No Claude SDK OAuth accounts configured. Add one with /claude-account add.",
+		);
+		expect(query).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/lab-27-claude-oauth-logout.test.ts
+++ b/packages/coding-agent/test/suite/regressions/lab-27-claude-oauth-logout.test.ts
@@ -10,9 +10,34 @@ import type {
 	SDKMessage,
 	SdkQuery,
 } from "../../../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import type { ClaudeSdkOauthTokenInjection } from "../../../src/core/extensions/builtin/claude-sdk-oauth/settings.ts";
+
+const EXPECTED_ERROR =
+	"authentication_failed: No Claude SDK OAuth accounts configured for the managed lane; " +
+	"run /login claude-sdk-oauth or set CLAUDE_CODE_OAUTH_TOKEN";
 
 async function consume(messages: AsyncGenerator<SDKMessage>): Promise<void> {
 	for await (const _message of messages) void _message;
+}
+
+function loggedOutLane(lane: ClaudeSdkOauthTokenInjection | undefined): {
+	messages: AsyncGenerator<SDKMessage>;
+	query: SdkQuery;
+} {
+	overrideAuthLaneBoundary({
+		createStore: () => new InMemoryCredentialStore(),
+		env: () => ({ PATH: "/usr/bin" }),
+	});
+	const query = vi.fn(() => {
+		throw new Error("ambient Claude query must not run");
+	}) as unknown as SdkQuery;
+	const messages = queryWithAuthLane({
+		prompt: "resume",
+		query,
+		buildOptions: () => ({}) as Options,
+		providerSettings: lane === undefined ? {} : { tokenInjection: lane },
+	});
+	return { messages, query };
 }
 
 afterEach(() => {
@@ -20,25 +45,26 @@ afterEach(() => {
 });
 
 describe("LAB-27 Claude OAuth logout", () => {
-	it("requires login instead of falling back to ambient Claude credentials", async () => {
-		overrideAuthLaneBoundary({
-			createStore: () => new InMemoryCredentialStore(),
-			env: () => ({ PATH: "/usr/bin" }),
-		});
-		const query = vi.fn(() => {
-			throw new Error("ambient Claude query must not run");
-		}) as unknown as SdkQuery;
+	for (const lane of ["oauth-slots", "config-dir"] as const) {
+		it(`requires login instead of falling back to ambient Claude credentials on the ${lane} lane`, async () => {
+			const { messages, query } = loggedOutLane(lane);
 
-		const messages = queryWithAuthLane({
-			prompt: "resume",
-			query,
-			buildOptions: () => ({}) as Options,
-			providerSettings: { tokenInjection: "oauth-slots" },
+			await expect(consume(messages)).rejects.toThrow(EXPECTED_ERROR);
+			expect(query).not.toHaveBeenCalled();
 		});
+	}
 
-		await expect(consume(messages)).rejects.toThrow(
-			"No Claude SDK OAuth accounts configured. Add one with /claude-account add.",
-		);
-		expect(query).not.toHaveBeenCalled();
+	it("still resolves to the ambient lane when no tokenInjection is configured (issue #6784)", async () => {
+		const { messages, query } = loggedOutLane(undefined);
+
+		await expect(consume(messages)).rejects.toThrow("ambient Claude query must not run");
+		expect(query).toHaveBeenCalledTimes(1);
+	});
+
+	it("still resolves to the ambient lane when tokenInjection is explicitly ambient", async () => {
+		const { messages, query } = loggedOutLane("ambient");
+
+		await expect(consume(messages)).rejects.toThrow("ambient Claude query must not run");
+		expect(query).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
https://linear.app/jgplabs/issue/LAB-27/claude-fallback-responses-keep-occurring-after-logout

## Problem

With `tokenInjection: oauth-slots`, `/logout` deletes the managed pool but the next Claude request silently falls back to ambient Claude CLI credentials. The fallback chain can therefore report `Fallback model claude-sdk-oauth/... responded` even though the user explicitly logged out.

## Fix

Managed `oauth-slots` and `config-dir` lanes now fail closed when their pool has no accounts. Intentional `ambient` mode is unchanged.

## Verification

- Added LAB-27 regression proving the SDK query is not called after logout
- Claude auth-lane tests: 11 passed
- `npm run check`: passed
- Full workspace build: passed
- Sandboxed CLI with an empty agent directory: exits 1 with `authentication_failed: No Claude SDK OAuth accounts configured`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops silent fallback to ambient Claude credentials after logout in the `claude-sdk-oauth` auth lane. Managed modes now fail closed with a clear error when the account pool is empty, making `/logout` authoritative (LAB-27).

- **Bug Fixes**
  - `oauth-slots` and `config-dir` now throw `authentication_failed: No Claude SDK OAuth accounts configured for the managed lane; run /login claude-sdk-oauth or set CLAUDE_CODE_OAUTH_TOKEN` when no accounts exist.
  - `ambient` mode behavior is unchanged.
  - Added a regression test proving the SDK query is never called post-logout; the sandboxed CLI with an empty agent dir exits 1 with the same error.

<sup>Written for commit 718cc3d355a5f24ed7e9bcda95ae5ffe21c2345c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

