### PR TITLE
fix(ai): enforce final Anthropic tool pairing

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -49,7 +49,7 @@ import {
 import { normalizeToolCallId } from "../utils/tool-call-id.ts";
 import { isForcedToolChoiceUnsupportedError, omitToolChoiceParam } from "../utils/tool-choice-fallback.ts";
 import { demotedToolCallText, demotedToolResultText } from "../utils/unavailable-tool-text.ts";
-
+import { sanitizeAnthropicToolPairs } from "./anthropic-tool-pairs.ts";
 import { resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
@@ -1258,7 +1258,9 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				}
 				params = sanitizeAdaptiveThinkingPayload(model, params, options);
 				params = sanitizeUnsupportedNativeTools(model, params);
-				params = demoteUnavailableToolReferences(params);
+				params = sanitizeAnthropicToolPairs(
+					demoteUnavailableToolReferences(params),
+				) as MessageCreateParamsStreaming;
 				const payloadRequestMetadata = extractPayloadRequestMetadata(params);
 				params = payloadRequestMetadata.params;
 				const requestOptions = {

--- a/packages/ai/src/api/anthropic-tool-pairs.ts
+++ b/packages/ai/src/api/anthropic-tool-pairs.ts
@@ -100,8 +100,8 @@ function removeOrphanResults(message: MessageParam & { role: "user"; content: Co
 	return { message: { ...message, content }, changed: true };
 }
 
-/** Repairs Anthropic client tool_use/tool_result adjacency at the final provider boundary. */
-export function sanitizeAnthropicPayload(payload: unknown): unknown {
+/** Repairs Anthropic client tool_use/tool_result adjacency without mutating the input payload. */
+export function sanitizeAnthropicToolPairs(payload: unknown): unknown {
 	if (!hasMessagesArray(payload)) return payload;
 
 	let changed = false;

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,24 @@
 # AI Source Changes
 
+## 2026-08-01 - Final Anthropic tool-pair normalization
+
+### What changed and why
+
+- `api/anthropic-tool-pairs.ts` owns the browser-safe wire sanitizer for Anthropic client `tool_use` /
+  `tool_result` adjacency, deduplication, orphan removal, and interrupted-result synthesis.
+- `api/anthropic-messages.ts` applies that sanitizer after `onPayload` and every built-in Anthropic request
+  rewrite, immediately before request metadata extraction and SDK submission.
+- The final boundary no longer depends on extension-runner liveness or hook registration order. A reload,
+  extension, or late payload transform can remove one result from a parallel tool-call turn without sending an
+  invalid request to Anthropic.
+- `test/anthropic-final-tool-pair-guard.test.ts` deterministically removes one result in the last payload hook
+  and asserts that the SDK receives both immediate result blocks, including a synthetic error result.
+
+### Expected merge conflict zones
+
+- MEDIUM: `api/anthropic-messages.ts` around the final request-sanitization pipeline.
+- LOW: `api/anthropic-tool-pairs.ts` if upstream adds equivalent Anthropic wire normalization.
+
 ## 2026-07-31 - Recover Codex WebSocket fallback sessions
 
 ### What changed and why

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -6,6 +6,7 @@ export { Type } from "typebox";
 // "@earendil-works/pi-ai/api/*", the old global API under
 // "@earendil-works/pi-ai/compat".
 export type { AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay } from "./api/anthropic-messages.ts";
+export { sanitizeAnthropicToolPairs } from "./api/anthropic-tool-pairs.ts";
 export type { AzureOpenAIResponsesOptions } from "./api/azure-openai-responses.ts";
 export type { BedrockOptions, BedrockThinkingDisplay } from "./api/bedrock-converse-stream.ts";
 export type { GoogleOptions } from "./api/google-generative-ai.ts";

--- a/packages/ai/test/anthropic-final-tool-pair-guard.test.ts
+++ b/packages/ai/test/anthropic-final-tool-pair-guard.test.ts
@@ -1,0 +1,122 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/compat.ts";
+import { streamAnthropic } from "../src/providers/anthropic.ts";
+import { fauxAssistantMessage, fauxToolCall } from "../src/providers/faux.ts";
+import type { Context, Tool, ToolResultMessage, UserMessage } from "../src/types.ts";
+
+const FIRST_TOOL_USE_ID = "toolu_first";
+const SECOND_TOOL_USE_ID = "toolu_second";
+
+type WireBlock = {
+	type: string;
+	tool_use_id?: string;
+	content?: unknown;
+	is_error?: boolean;
+};
+
+type WireMessage = {
+	role: string;
+	content: WireBlock[];
+};
+
+type WirePayload = {
+	messages: WireMessage[];
+};
+
+function createSseResponse(): Response {
+	const events = [
+		[
+			"message_start",
+			{ type: "message_start", message: { id: "msg_test", usage: { input_tokens: 1, output_tokens: 0 } } },
+		],
+		["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+		["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		["message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } }],
+		["message_stop", { type: "message_stop" }],
+	] as const;
+	return new Response(events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n`).join("\n"), {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function userMessage(content: string): UserMessage {
+	return { role: "user", content, timestamp: Date.now() };
+}
+
+function toolResultMessage(toolCallId: string, toolName: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text: `${toolName} result` }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+function makeTool(name: string): Tool {
+	return { name, description: name, parameters: Type.Object({}) };
+}
+
+function immediateResultMessage(payload: WirePayload): WireMessage {
+	const assistantIndex = payload.messages.findIndex(
+		(message) => message.role === "assistant" && message.content.some((block) => block.type === "tool_use"),
+	);
+	const message = payload.messages[assistantIndex + 1];
+	if (message?.role !== "user") throw new Error("tool result message missing");
+	return message;
+}
+
+describe("Anthropic final tool-pair guard", () => {
+	it("repairs a result removed by the last payload hook before SDK submission", async () => {
+		let captured: WirePayload | undefined;
+		const client = {
+			messages: {
+				create: (params: unknown) => {
+					captured = params as WirePayload;
+					return { asResponse: async () => createSseResponse() };
+				},
+			},
+		} as Anthropic;
+		const context: Context = {
+			messages: [
+				userMessage("run both tools"),
+				fauxAssistantMessage(
+					[
+						fauxToolCall("read", {}, { id: FIRST_TOOL_USE_ID }),
+						fauxToolCall("bash", {}, { id: SECOND_TOOL_USE_ID }),
+					],
+					{ stopReason: "toolUse" },
+				),
+				toolResultMessage(FIRST_TOOL_USE_ID, "read"),
+				toolResultMessage(SECOND_TOOL_USE_ID, "bash"),
+				userMessage("continue"),
+			],
+			tools: [makeTool("read"), makeTool("bash")],
+		};
+
+		const stream = streamAnthropic(getModel("anthropic", "claude-haiku-4-5"), context, {
+			apiKey: "fake-key",
+			client,
+			onPayload: (payload) => {
+				const rewritten = structuredClone(payload) as WirePayload;
+				const resultMessage = immediateResultMessage(rewritten);
+				resultMessage.content = resultMessage.content.filter((block) => block.tool_use_id !== SECOND_TOOL_USE_ID);
+				return rewritten;
+			},
+		});
+		await stream.result();
+
+		if (!captured) throw new Error("Anthropic request was not captured");
+		const results = immediateResultMessage(captured).content.filter((block) => block.type === "tool_result");
+		expect(results.map((block) => block.tool_use_id)).toEqual([FIRST_TOOL_USE_ID, SECOND_TOOL_USE_ID]);
+		expect(results[1]).toMatchObject({
+			tool_use_id: SECOND_TOOL_USE_ID,
+			is_error: true,
+		});
+	});
+});

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -9,6 +9,7 @@ import {
 	type Message,
 	type Model,
 	type StreamOptions,
+	sanitizeAnthropicToolPairs as sanitizeAnthropicPayload,
 	type TextContent,
 	type Tool,
 } from "@earendil-works/pi-ai";
@@ -30,7 +31,6 @@ import { convertToLlm } from "../../../messages.ts";
 import type { ModelRegistry } from "../../../model-registry.ts";
 import type { ReadonlySessionManager } from "../../../session-manager.ts";
 import type { ApplyCompactionResult, ContextUsage, ProviderRequestPreparation } from "../../types.ts";
-import { sanitizeAnthropicPayload } from "../tool-pair-guard/sanitize-anthropic-payload.ts";
 import { computeEffectiveKeepRecentTokens, computeEffectiveThreshold } from "./policy.ts";
 import { buildPrompt, type MergedCompactionPromptVariant } from "./prompts.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";

--- a/packages/coding-agent/src/core/extensions/builtin/tool-pair-guard/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/tool-pair-guard/index.ts
@@ -1,5 +1,5 @@
+import { sanitizeAnthropicToolPairs as sanitizeAnthropicPayload } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "../../types.ts";
-import { sanitizeAnthropicPayload } from "./sanitize-anthropic-payload.ts";
 import { sanitizeOpenAIChatCompletionsPayload } from "./sanitize-openai-chat-completions-payload.ts";
 import { sanitizeOpenAIResponsesPayload } from "./sanitize-openai-responses-payload.ts";
 

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,22 @@
 # Core Extensions Changes
 
+## 2026-08-01 - Anthropic pair guards share the provider-final sanitizer
+
+### What changed and why
+
+- The `tool-pair-guard` request hook and direct compaction summarization now use the browser-safe
+  `sanitizeAnthropicToolPairs` export from `@earendil-works/pi-ai`.
+- The duplicate coding-agent sanitizer was removed so normal turns, extension hooks, and direct summarization
+  cannot drift across separate Anthropic repair implementations.
+- The coding-agent hook remains an early defensive repair, while the pi-ai Anthropic adapter owns the final
+  pre-SDK invariant after all payload mutations.
+
+### Expected merge conflict zones
+
+- LOW: `builtin/tool-pair-guard/index.ts` and `builtin/compaction/speculative.ts` if upstream changes direct
+  provider-request hooks.
+- LOW: `test/tool-pair-guard/sanitize-anthropic-payload.test.ts` if upstream relocates wire sanitizer coverage.
+
 ## Backfill: extension context and reload stability (2026-08-01)
 
 ### What changed
@@ -53,7 +70,7 @@
 
 ### What changed
 
-- `builtin/tool-pair-guard/sanitize-anthropic-payload.ts` now pairs client `tool_use` blocks only with
+- The tool-pair guard sanitizer pairs client `tool_use` blocks only with
   `tool_result` blocks in the immediately following user message, removes misplaced or duplicate results,
   and synthesizes error results for calls whose outputs were interrupted or pruned.
 - Repaired result blocks are placed before ordinary user content, including when the following user message
@@ -67,13 +84,14 @@
   message. A persisted session can be valid before context hooks run but lose one result during pruning or
   payload transformation, so switching from a larger-context non-Anthropic model to Claude could wedge every
   follow-up request with HTTP 400.
-- The provider-request hook is the final safe repair boundary after context reduction and wire conversion.
-  Repairing there preserves the durable transcript while guaranteeing the request sent to Anthropic is valid.
+- The provider-request hook repairs after context reduction and wire conversion without changing the durable
+  transcript. The 2026-08-01 provider-final guard supersedes the earlier assumption that no later payload
+  mutation could invalidate the pair.
 
 ### Expected merge conflict zones
 
-- LOW: `builtin/tool-pair-guard/sanitize-anthropic-payload.ts` if upstream adds equivalent Anthropic
-  tool-pair normalization.
+- LOW: `@earendil-works/pi-ai` `sanitizeAnthropicToolPairs` if upstream adds equivalent Anthropic tool-pair
+  normalization.
 - LOW: `test/tool-pair-guard/sanitize-anthropic-payload.test.ts` if upstream expands the same sanitizer cases.
 
 ## 2026-07-31 - `pi.setSessionFastMode()` for the fast-mode indicator

--- a/packages/coding-agent/test/tool-pair-guard/sanitize-anthropic-payload.test.ts
+++ b/packages/coding-agent/test/tool-pair-guard/sanitize-anthropic-payload.test.ts
@@ -1,5 +1,5 @@
+import { sanitizeAnthropicToolPairs as sanitizeAnthropicPayload } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import { sanitizeAnthropicPayload } from "../../src/core/extensions/builtin/tool-pair-guard/sanitize-anthropic-payload.ts";
 
 describe("sanitizeAnthropicPayload", () => {
 	it("returns same reference for payload without messages", () => {


### PR DESCRIPTION
## Summary

- move Anthropic wire-pair normalization into one browser-safe `pi-ai` module
- enforce `tool_use` / `tool_result` adjacency after every payload hook and internal Anthropic rewrite, immediately before SDK submission
- reuse the canonical sanitizer from the coding-agent request guard and direct compaction path

## Root cause

The recovered session `019fb813-883f-7a0c-a03a-f68422434037` failed twice after reload boundaries with:

```text
messages.2: `tool_use` ids were found without `tool_result` blocks immediately after:
toolu_016vK2LB2WtGBARfC6WTZ2ck
```

Earlier repairs protected context conversion and the coding-agent `before_provider_request` hook, but that hook was not the true final request boundary. A later payload mutation could still remove one result from a parallel tool-call turn before the Anthropic SDK received the request.

This change makes the provider adapter itself enforce the invariant after `onPayload`, native-tool compatibility rewrites, and unavailable-tool demotion.

## Verification

- RED regression captured: late `onPayload` mutation removed the second result
- focused Anthropic/coding-agent matrix: 30 tests passed
- `npm run check`
- `npm run build`
- real source CLI Anthropic mock loop
- isolated CLI smoke: 8/8 passed, including `--help`, `--version`, `--list-models`, and bad input
- recovered-session replay: 920 context messages, 877 wire messages, target result removed by the last hook, synthesized before SDK submission, 0 pair violations

QA receipts:

```text
local-ignore/qa-evidence/20260801-anthropic-final-tool-pair-guard/
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces final Anthropic `tool_use`/`tool_result` pairing at the provider boundary to prevent invalid requests when late payload hooks drop a result. This stops flaky 400s after reloads or extensions mutate the payload.

- **Bug Fixes**
  - Normalize Anthropic tool pairs immediately before SDK submission, after `onPayload`, native-tool rewrites, and unavailable-tool demotion.
  - Consolidate to a single browser-safe sanitizer in `packages/ai` (`sanitizeAnthropicToolPairs`) for adjacency, deduping, orphan cleanup, and synthetic error results.
  - Export `sanitizeAnthropicToolPairs` from `@earendil-works/pi-ai`; coding-agent hooks and compaction now reuse it, removing the duplicate implementation.
  - Add a test that deletes one result in the last payload hook and verifies both results (including a synthetic error) reach the SDK.

<sup>Written for commit fe3c3712707779d206eabf49db5fc547a4a17025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

