### PR TITLE
test(coding-agent): cover pending assistant rendering

### DIFF
--- a/packages/coding-agent/test/suite/regressions/pending-assistant-stop-reason-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pending-assistant-stop-reason-render.test.ts
@@ -1,0 +1,62 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { AssistantMessageComponent } from "../../../src/modes/interactive/components/assistant-message.ts";
+import { StreamingRevealController } from "../../../src/modes/interactive/streaming-reveal.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../../src/utils/ansi.ts";
+
+function assistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5.6-sol-fast",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: 0,
+	};
+}
+
+describe("pending assistant stop-reason rendering", () => {
+	test("renders an empty pending assistant message without throwing", () => {
+		// given
+		initTheme("dark");
+		const givenMessage = assistantMessage([], "pending");
+
+		// when
+		const whenRendered = new AssistantMessageComponent(givenMessage).render(80);
+
+		// then
+		expect(whenRendered).toEqual([]);
+	});
+
+	test("transitions from a pending start to visible streamed text", () => {
+		// given
+		initTheme("dark");
+		const givenComponent = new AssistantMessageComponent();
+		const givenController = new StreamingRevealController({
+			getSmoothStreaming: () => false,
+			getSmoothStreamingFps: () => 30,
+			getHideThinkingBlock: () => false,
+			requestRender: () => {},
+		});
+
+		// when
+		givenController.begin(givenComponent, assistantMessage([], "pending"));
+		givenController.setTarget(assistantMessage([{ type: "text", text: "stable answer" }], "stop"));
+
+		// then
+		expect(stripAnsi(givenComponent.render(80).join("\n"))).toContain("stable answer");
+	});
+});


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the historical TUI crash:

```text
TypeError: Unexpected assistant render variant: pending
```

The exact crashed session was `019fbc3e-a443-7ec1-b6aa-689f94af634a`. Current `main` already contains the production fix (`case "pending"` in the assistant stop-reason renderer), but no test pinned that contract.

## Changes

- Cover constructing/rendering an empty assistant message with `stopReason: "pending"`.
- Cover the real streaming path from `StreamingRevealController.begin()` with a pending message to a completed visible text message.
- Keep the regression isolated in `test/suite/regressions/`; no production source changes.

## QA & Evidence

- Mutation proof: removing only `case "pending"` made both new tests fail with the exact historical exception.
- Restored focused test: 2/2 passed.
- Adjacent rendering suites: 5 files, 53 tests passed.
- `npm run check`: passed.
- Real TUI smoke via tmux: 5/5 passed (boot, render, input, teardown, auth unchanged).
- Xterm.js/Chrome screenshot captured locally at:
  `local-ignore/qa-evidence/20260802-20260801-pending-render/tui-xterm/terminal.png`

## Risks & Residuals

- Test-only change; runtime behavior is unchanged.
- `lsp_diagnostics` could not target the linked worktree because the harness restricts paths to the original request cwd. Root TypeScript/Biome validation passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests for rendering assistant messages with `stopReason: "pending"` in the interactive TUI to prevent the historical “Unexpected assistant render variant: pending” crash from regressing. Tests cover an empty pending message and the streaming transition from pending to visible text; no production changes.

<sup>Written for commit 32dd1d594ed2ebb317a157974f92c7726a679be0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

