### PR TITLE
fix(ai): strip non-standard 'optional' keyword from tool JSON schema  parameters

### DIFF
--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -282,6 +282,7 @@ const JSON_SCHEMA_META_DECLARATIONS = new Set([
 	"$comment",
 	"$defs",
 	"definitions", // pre-draft-2019-09 equivalent of $defs
+	"optional",
 ]);
 
 /**
@@ -296,6 +297,26 @@ function sanitizeForOpenApi(schema: unknown): unknown {
 	for (const [key, value] of Object.entries(schema)) {
 		if (JSON_SCHEMA_META_DECLARATIONS.has(key)) continue;
 		result[key] = sanitizeForOpenApi(value);
+	}
+	return result;
+}
+
+/**
+ * Strip non-standard 'optional' keyword recursively from a JSON schema object.
+ */
+function stripOptional(schema: unknown): unknown {
+	if (typeof schema !== "object" || schema === null) {
+		return schema;
+	}
+
+	if (Array.isArray(schema)) {
+		return schema.map(stripOptional);
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (key === "optional") continue;
+		result[key] = stripOptional(value);
 	}
 	return result;
 }
@@ -320,7 +341,7 @@ export function convertTools(
 				description: tool.description,
 				...(useParameters
 					? { parameters: sanitizeForOpenApi(tool.parameters) }
-					: { parametersJsonSchema: tool.parameters }),
+					: { parametersJsonSchema: stripOptional(tool.parameters) }),
 			})),
 		},
 	];

--- a/packages/ai/src/utils/tool-schema-compat.ts
+++ b/packages/ai/src/utils/tool-schema-compat.ts
@@ -145,6 +145,8 @@ function normalizeNode(node: unknown): unknown {
 		return node;
 	}
 
+	delete node.optional;
+
 	const hasCombiner = COMBINER_KEYS.some((key) => Array.isArray(node[key]));
 	if (hasCombiner) {
 		moveTypeIntoCombinerBranches(node);

--- a/packages/ai/test/google-shared-convert-tools.test.ts
+++ b/packages/ai/test/google-shared-convert-tools.test.ts
@@ -160,6 +160,32 @@ describe("google-shared convertTools", () => {
 		});
 	});
 
+	it("strips non-standard 'optional' keyword from parametersJsonSchema when useParameters=false", () => {
+		const tools = [
+			makeTool({
+				$schema: "http://json-schema.org/draft-07/schema#",
+				type: "object",
+				properties: {
+					command: { type: "string", optional: true },
+				},
+				required: ["command"],
+			}),
+		];
+
+		const result = convertTools(tools, false);
+		const decl = result?.[0]?.functionDeclarations?.[0];
+
+		expect(decl).toBeDefined();
+		expect(decl?.parametersJsonSchema).toEqual({
+			$schema: "http://json-schema.org/draft-07/schema#",
+			type: "object",
+			properties: {
+				command: { type: "string" },
+			},
+			required: ["command"],
+		});
+	});
+
 	it("handles tools without $schema gracefully", () => {
 		const tools = [
 			makeTool({


### PR DESCRIPTION
Fixes 400 Bad Request error on Gemini API and proxies (e.g. Quotio) caused by non-  standard 'optional' fields inside tool parameter JSON schemas.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips the non-standard 'optional' keyword from tool parameter JSON schemas to prevent 400 Bad Request errors on Gemini and proxies like Quotio. Applies to normalized schemas and Gemini `parametersJsonSchema`.

- **Bug Fixes**
  - Recursively remove `optional` from `parametersJsonSchema` when `useParameters=false` in `convertTools`.
  - Ignore `optional` during validation and drop it in schema normalization.

<sup>Written for commit ddb2531aa09934f3967316415b3cb9f89e71b393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

